### PR TITLE
fix(support): preserve relay deletion intent

### DIFF
--- a/mobile/integration_test/helpers/test_nostr_service.dart
+++ b/mobile/integration_test/helpers/test_nostr_service.dart
@@ -269,7 +269,7 @@ class TestNostrService implements NostrClient {
   @override
   Future<bool> removeRelay(
     String relayUrl, {
-    RelayRemoveSource source = RelayRemoveSource.user,
+    required RelayRemoveSource source,
   }) async {
     // No-op for tests
     return true;

--- a/mobile/integration_test/helpers/test_nostr_service.dart
+++ b/mobile/integration_test/helpers/test_nostr_service.dart
@@ -267,7 +267,10 @@ class TestNostrService implements NostrClient {
   }
 
   @override
-  Future<bool> removeRelay(String relayUrl) async {
+  Future<bool> removeRelay(
+    String relayUrl, {
+    RelayRemoveSource source = RelayRemoveSource.user,
+  }) async {
     // No-op for tests
     return true;
   }

--- a/mobile/integration_test/helpers/test_nostr_service.dart
+++ b/mobile/integration_test/helpers/test_nostr_service.dart
@@ -258,7 +258,10 @@ class TestNostrService implements NostrClient {
   List<String> get connectedRelays => _isConnected ? ['wss://test.relay'] : [];
 
   @override
-  Future<bool> addRelay(String relayUrl) async {
+  Future<bool> addRelay(
+    String relayUrl, {
+    RelayAddSource source = RelayAddSource.automatic,
+  }) async {
     // No-op for tests
     return true;
   }

--- a/mobile/lib/blocs/relay_settings/relay_settings_cubit.dart
+++ b/mobile/lib/blocs/relay_settings/relay_settings_cubit.dart
@@ -100,7 +100,10 @@ class RelaySettingsCubit extends Cubit<RelaySettingsState> {
     if (!isRelayUrlAllowed(trimmed)) return AddRelayOutcome.insecureUrl;
 
     try {
-      final success = await _nostrClient.addRelay(trimmed);
+      final success = await _nostrClient.addRelay(
+        trimmed,
+        source: RelayAddSource.user,
+      );
       if (!success) return AddRelayOutcome.failed;
       refreshRelays();
       return AddRelayOutcome.added;
@@ -124,7 +127,10 @@ class RelaySettingsCubit extends Cubit<RelaySettingsState> {
 
   Future<RestoreDefaultRelayOutcome> restoreDefaultRelay() async {
     try {
-      final success = await _nostrClient.addRelay(defaultRelayUrl);
+      final success = await _nostrClient.addRelay(
+        defaultRelayUrl,
+        source: RelayAddSource.user,
+      );
       if (!success) return RestoreDefaultRelayOutcome.failed;
       refreshRelays();
       return RestoreDefaultRelayOutcome.restored;

--- a/mobile/lib/blocs/relay_settings/relay_settings_cubit.dart
+++ b/mobile/lib/blocs/relay_settings/relay_settings_cubit.dart
@@ -134,8 +134,12 @@ class RelaySettingsCubit extends Cubit<RelaySettingsState> {
         defaultRelayUrl,
         source: RelayAddSource.user,
       );
-      if (!success) return RestoreDefaultRelayOutcome.failed;
       refreshRelays();
+      if (!success) {
+        return _hasDefaultRelayConfigured()
+            ? RestoreDefaultRelayOutcome.restoredConnectionPending
+            : RestoreDefaultRelayOutcome.failed;
+      }
       return RestoreDefaultRelayOutcome.restored;
     } catch (e, stackTrace) {
       addError(e, stackTrace);
@@ -162,5 +166,19 @@ class RelaySettingsCubit extends Cubit<RelaySettingsState> {
     final updated = Map<String, RelayCapabilityEntry>.from(state.capabilities)
       ..[relayUrl] = entry;
     emit(state.copyWith(capabilities: updated));
+  }
+
+  bool _hasDefaultRelayConfigured() {
+    final normalizedDefault = _withoutTrailingSlash(defaultRelayUrl.trim());
+    return state.relays
+        .map((relay) => _withoutTrailingSlash(relay.trim()))
+        .contains(normalizedDefault);
+  }
+
+  String _withoutTrailingSlash(String relayUrl) {
+    if (relayUrl.endsWith('/')) {
+      return relayUrl.substring(0, relayUrl.length - 1);
+    }
+    return relayUrl;
   }
 }

--- a/mobile/lib/blocs/relay_settings/relay_settings_cubit.dart
+++ b/mobile/lib/blocs/relay_settings/relay_settings_cubit.dart
@@ -169,16 +169,8 @@ class RelaySettingsCubit extends Cubit<RelaySettingsState> {
   }
 
   bool _hasDefaultRelayConfigured() {
-    final normalizedDefault = _withoutTrailingSlash(defaultRelayUrl.trim());
-    return state.relays
-        .map((relay) => _withoutTrailingSlash(relay.trim()))
-        .contains(normalizedDefault);
-  }
-
-  String _withoutTrailingSlash(String relayUrl) {
-    if (relayUrl.endsWith('/')) {
-      return relayUrl.substring(0, relayUrl.length - 1);
-    }
-    return relayUrl;
+    return state.relays.any(
+      (relay) => relayUrlsEquivalent(relay, defaultRelayUrl),
+    );
   }
 }

--- a/mobile/lib/blocs/relay_settings/relay_settings_cubit.dart
+++ b/mobile/lib/blocs/relay_settings/relay_settings_cubit.dart
@@ -115,7 +115,10 @@ class RelaySettingsCubit extends Cubit<RelaySettingsState> {
 
   Future<RemoveRelayOutcome> removeRelay(String relayUrl) async {
     try {
-      final success = await _nostrClient.removeRelay(relayUrl);
+      final success = await _nostrClient.removeRelay(
+        relayUrl,
+        source: RelayRemoveSource.user,
+      );
       if (!success) return RemoveRelayOutcome.failed;
       refreshRelays();
       return RemoveRelayOutcome.removed;

--- a/mobile/lib/blocs/relay_settings/relay_settings_cubit.dart
+++ b/mobile/lib/blocs/relay_settings/relay_settings_cubit.dart
@@ -104,8 +104,12 @@ class RelaySettingsCubit extends Cubit<RelaySettingsState> {
         trimmed,
         source: RelayAddSource.user,
       );
-      if (!success) return AddRelayOutcome.failed;
       refreshRelays();
+      if (!success) {
+        return _hasRelayConfigured(trimmed)
+            ? AddRelayOutcome.addedConnectionPending
+            : AddRelayOutcome.failed;
+      }
       return AddRelayOutcome.added;
     } catch (e, stackTrace) {
       addError(e, stackTrace);
@@ -169,8 +173,12 @@ class RelaySettingsCubit extends Cubit<RelaySettingsState> {
   }
 
   bool _hasDefaultRelayConfigured() {
+    return _hasRelayConfigured(defaultRelayUrl);
+  }
+
+  bool _hasRelayConfigured(String relayUrl) {
     return state.relays.any(
-      (relay) => relayUrlsEquivalent(relay, defaultRelayUrl),
+      (relay) => relayUrlsEquivalent(relay, relayUrl),
     );
   }
 }

--- a/mobile/lib/blocs/relay_settings/relay_settings_cubit.dart
+++ b/mobile/lib/blocs/relay_settings/relay_settings_cubit.dart
@@ -123,8 +123,12 @@ class RelaySettingsCubit extends Cubit<RelaySettingsState> {
         relayUrl,
         source: RelayRemoveSource.user,
       );
-      if (!success) return RemoveRelayOutcome.failed;
       refreshRelays();
+      if (!success) {
+        return _hasRelayConfigured(relayUrl)
+            ? RemoveRelayOutcome.failed
+            : RemoveRelayOutcome.removed;
+      }
       return RemoveRelayOutcome.removed;
     } catch (e, stackTrace) {
       addError(e, stackTrace);
@@ -177,8 +181,6 @@ class RelaySettingsCubit extends Cubit<RelaySettingsState> {
   }
 
   bool _hasRelayConfigured(String relayUrl) {
-    return state.relays.any(
-      (relay) => relayUrlsEquivalent(relay, relayUrl),
-    );
+    return state.relays.any((relay) => relayUrlsEquivalent(relay, relayUrl));
   }
 }

--- a/mobile/lib/blocs/relay_settings/relay_settings_state.dart
+++ b/mobile/lib/blocs/relay_settings/relay_settings_state.dart
@@ -77,6 +77,9 @@ enum AddRelayOutcome {
   /// URL used cleartext `ws://` against a non-loopback host (#3362).
   insecureUrl,
 
+  /// URL was saved, but the relay did not accept a connection yet.
+  addedConnectionPending,
+
   /// The service refused the URL or threw.
   failed,
 }

--- a/mobile/lib/blocs/relay_settings/relay_settings_state.dart
+++ b/mobile/lib/blocs/relay_settings/relay_settings_state.dart
@@ -85,7 +85,11 @@ enum AddRelayOutcome {
 enum RemoveRelayOutcome { removed, failed }
 
 /// Outcome of `RelaySettingsCubit.restoreDefaultRelay()`.
-enum RestoreDefaultRelayOutcome { restored, failed }
+enum RestoreDefaultRelayOutcome {
+  restored,
+  restoredConnectionPending,
+  failed,
+}
 
 /// Outcome of `RelaySettingsCubit.retryConnection()`.
 ///

--- a/mobile/lib/config/bug_report_config.dart
+++ b/mobile/lib/config/bug_report_config.dart
@@ -14,11 +14,6 @@ class BugReportConfig {
   /// Email address for receiving bug reports (fallback only)
   static const String supportEmail = 'contact@divine.video';
 
-  /// Explicit NIP-17 target relays for support bug-report DMs.
-  static const List<String> supportDmTargetRelays = [
-    'wss://relay.divine.video',
-  ];
-
   /// Maximum log entries to include in bug report
   static const int maxLogEntries = 5000;
 

--- a/mobile/lib/config/bug_report_config.dart
+++ b/mobile/lib/config/bug_report_config.dart
@@ -15,7 +15,9 @@ class BugReportConfig {
   static const String supportEmail = 'contact@divine.video';
 
   /// Explicit NIP-17 target relays for support bug-report DMs.
-  static const List<String> supportDmTargetRelays = ['wss://relay.nos.social'];
+  static const List<String> supportDmTargetRelays = [
+    'wss://relay.divine.video',
+  ];
 
   /// Maximum log entries to include in bug report
   static const int maxLogEntries = 5000;

--- a/mobile/lib/config/bug_report_config.dart
+++ b/mobile/lib/config/bug_report_config.dart
@@ -14,6 +14,12 @@ class BugReportConfig {
   /// Email address for receiving bug reports (fallback only)
   static const String supportEmail = 'contact@divine.video';
 
+  /// Static fallback DM target for support bug reports when the support
+  /// account's advertised NIP-17 inbox relays cannot be resolved.
+  static const List<String> supportDmTargetRelays = [
+    'wss://relay.divine.video',
+  ];
+
   /// Maximum log entries to include in bug report
   static const int maxLogEntries = 5000;
 

--- a/mobile/lib/config/bug_report_config.dart
+++ b/mobile/lib/config/bug_report_config.dart
@@ -14,6 +14,9 @@ class BugReportConfig {
   /// Email address for receiving bug reports (fallback only)
   static const String supportEmail = 'contact@divine.video';
 
+  /// Explicit NIP-17 target relays for support bug-report DMs.
+  static const List<String> supportDmTargetRelays = ['wss://relay.nos.social'];
+
   /// Maximum log entries to include in bug report
   static const int maxLogEntries = 5000;
 

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4963,5 +4963,6 @@
         "type": "String"
       }
     }
-  }
+  },
+  "relaySettingsRemoveRelayTooltip": "Remove relay"
 }

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4954,5 +4954,14 @@
     "libraryStopMotionClipLabel": "የስቶፕ-ሞሽን ክሊፕ",
   "profileNotifyBellOff": "ስለ አዲስ ቫይኖች አሳውቀኝ",
   "profileNotifyBellOn": "ስለ አዲስ ቫይኖች አታሳውቀኝ",
-  "profileNotifyUpdateFailed": "ማስቀመጥ አልተቻለም። እንደገና ይሞክሩ?"
+  "profileNotifyUpdateFailed": "ማስቀመጥ አልተቻለም። እንደገና ይሞክሩ?",
+  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
+  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4955,8 +4955,8 @@
   "profileNotifyBellOff": "ስለ አዲስ ቫይኖች አሳውቀኝ",
   "profileNotifyBellOn": "ስለ አዲስ ቫይኖች አታሳውቀኝ",
   "profileNotifyUpdateFailed": "ማስቀመጥ አልተቻለም። እንደገና ይሞክሩ?",
-  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
-  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "relaySettingsRemoveDefaultRelayTitle": "የDivine ቅብብሎሽ ይወገድ?",
+  "relaySettingsRemoveDefaultRelayMessage": "የDivine ቅብብሎሽን ማስወገድ የመተግበሪያውን አጠቃቀም ያዳክማል። ቪዲዮዎች፣ ልጥፎች እና ማመሳሰል አስተማማኝ ላይሆኑ ይችላሉ። ይህን ማድረግ ያለባቸው ልምድ ያላቸው የNostr ተጠቃሚዎች ብቻ ናቸው።\n\n{relayUrl}",
   "@relaySettingsRemoveDefaultRelayMessage": {
     "placeholders": {
       "relayUrl": {
@@ -4964,5 +4964,5 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Remove relay"
+  "relaySettingsRemoveRelayTooltip": "ቅብብሎሽ አስወግድ"
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4829,5 +4829,14 @@
     "libraryStopMotionClipLabel": "مقطع الحركة الإيقافية",
   "profileNotifyBellOff": "أبلغني عن المقاطع الجديدة",
   "profileNotifyBellOn": "أوقف إشعارات المقاطع الجديدة",
-  "profileNotifyUpdateFailed": "لم نتمكن من الحفظ. أعد المحاولة؟"
+  "profileNotifyUpdateFailed": "لم نتمكن من الحفظ. أعد المحاولة؟",
+  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
+  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4838,5 +4838,6 @@
         "type": "String"
       }
     }
-  }
+  },
+  "relaySettingsRemoveRelayTooltip": "Remove relay"
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4830,8 +4830,8 @@
   "profileNotifyBellOff": "أبلغني عن المقاطع الجديدة",
   "profileNotifyBellOn": "أوقف إشعارات المقاطع الجديدة",
   "profileNotifyUpdateFailed": "لم نتمكن من الحفظ. أعد المحاولة؟",
-  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
-  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "relaySettingsRemoveDefaultRelayTitle": "إزالة محوّل Divine؟",
+  "relaySettingsRemoveDefaultRelayMessage": "إزالة محوّل Divine ستضعف تجربتك في التطبيق. قد تصبح الفيديوهات والنشر والمزامنة أقل موثوقية. يُفضّل ألا يفعل ذلك إلا مستخدمو Nostr ذوو الخبرة.\n\n{relayUrl}",
   "@relaySettingsRemoveDefaultRelayMessage": {
     "placeholders": {
       "relayUrl": {
@@ -4839,5 +4839,5 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Remove relay"
+  "relaySettingsRemoveRelayTooltip": "إزالة المحوّل"
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4961,8 +4961,8 @@
   "profileNotifyBellOff": "Получавай известия за нови видеа",
   "profileNotifyBellOn": "Спри известията за нови видеа",
   "profileNotifyUpdateFailed": "Не се запази. Опитай пак?",
-  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
-  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "relaySettingsRemoveDefaultRelayTitle": "Премахване на релето на Divine?",
+  "relaySettingsRemoveDefaultRelayMessage": "Премахването на релето на Divine ще влоши работата на приложението. Видеата, публикуването и синхронизацията може да станат по-малко надеждни. Прави го само ако си опитен потребител на Nostr.\n\n{relayUrl}",
   "@relaySettingsRemoveDefaultRelayMessage": {
     "placeholders": {
       "relayUrl": {
@@ -4970,5 +4970,5 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Remove relay"
+  "relaySettingsRemoveRelayTooltip": "Премахване на релето"
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4969,5 +4969,6 @@
         "type": "String"
       }
     }
-  }
+  },
+  "relaySettingsRemoveRelayTooltip": "Remove relay"
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4960,5 +4960,14 @@
     "libraryStopMotionClipLabel": "Стоп-моушън клип",
   "profileNotifyBellOff": "Получавай известия за нови видеа",
   "profileNotifyBellOn": "Спри известията за нови видеа",
-  "profileNotifyUpdateFailed": "Не се запази. Опитай пак?"
+  "profileNotifyUpdateFailed": "Не се запази. Опитай пак?",
+  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
+  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4829,5 +4829,14 @@
     "libraryStopMotionClipLabel": "Stop-Motion-Clip",
   "profileNotifyBellOff": "Über neue Vines benachrichtigen",
   "profileNotifyBellOn": "Keine Benachrichtigungen über neue Vines",
-  "profileNotifyUpdateFailed": "Konnte nicht gespeichert werden. Nochmal?"
+  "profileNotifyUpdateFailed": "Konnte nicht gespeichert werden. Nochmal?",
+  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
+  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4830,8 +4830,8 @@
   "profileNotifyBellOff": "Über neue Vines benachrichtigen",
   "profileNotifyBellOn": "Keine Benachrichtigungen über neue Vines",
   "profileNotifyUpdateFailed": "Konnte nicht gespeichert werden. Nochmal?",
-  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
-  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "relaySettingsRemoveDefaultRelayTitle": "Divine-Relay entfernen?",
+  "relaySettingsRemoveDefaultRelayMessage": "Wenn du Divines Relay entfernst, wird die App-Erfahrung schlechter. Videos, Posten und Synchronisierung können unzuverlässiger werden. Das sollten nur erfahrene Nostr-Nutzer tun.\n\n{relayUrl}",
   "@relaySettingsRemoveDefaultRelayMessage": {
     "placeholders": {
       "relayUrl": {
@@ -4839,5 +4839,5 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Remove relay"
+  "relaySettingsRemoveRelayTooltip": "Relay entfernen"
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4838,5 +4838,6 @@
         "type": "String"
       }
     }
-  }
+  },
+  "relaySettingsRemoveRelayTooltip": "Remove relay"
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1162,6 +1162,15 @@
       }
     }
   },
+  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
+  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  },
   "relaySettingsCancel": "Cancel",
   "relaySettingsRemove": "Remove",
   "relaySettingsRemovedRelay": "Removed relay: {relayUrl}",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1171,6 +1171,7 @@
       }
     }
   },
+  "relaySettingsRemoveRelayTooltip": "Remove relay",
   "relaySettingsCancel": "Cancel",
   "relaySettingsRemove": "Remove",
   "relaySettingsRemovedRelay": "Removed relay: {relayUrl}",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4838,5 +4838,6 @@
         "type": "String"
       }
     }
-  }
+  },
+  "relaySettingsRemoveRelayTooltip": "Remove relay"
 }

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4829,5 +4829,14 @@
     "libraryStopMotionClipLabel": "Clip de stop motion",
   "profileNotifyBellOff": "Avisarme de nuevos vines",
   "profileNotifyBellOn": "Dejar de avisarme de nuevos vines",
-  "profileNotifyUpdateFailed": "No se pudo guardar. ¿Reintentar?"
+  "profileNotifyUpdateFailed": "No se pudo guardar. ¿Reintentar?",
+  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
+  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4830,8 +4830,8 @@
   "profileNotifyBellOff": "Avisarme de nuevos vines",
   "profileNotifyBellOn": "Dejar de avisarme de nuevos vines",
   "profileNotifyUpdateFailed": "No se pudo guardar. ¿Reintentar?",
-  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
-  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "relaySettingsRemoveDefaultRelayTitle": "¿Quitar el relay de Divine?",
+  "relaySettingsRemoveDefaultRelayMessage": "Quitar el relay de Divine empeorará la experiencia en la app. Los videos, las publicaciones y la sincronización pueden ser menos fiables. Esto solo deberían hacerlo usuarios con experiencia en Nostr.\n\n{relayUrl}",
   "@relaySettingsRemoveDefaultRelayMessage": {
     "placeholders": {
       "relayUrl": {
@@ -4839,5 +4839,5 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Remove relay"
+  "relaySettingsRemoveRelayTooltip": "Quitar relay"
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -3412,5 +3412,14 @@
     "libraryStopMotionClipLabel": "Stop-motion na clip",
   "profileNotifyBellOff": "Ipaalam ang mga bagong vine",
   "profileNotifyBellOn": "Itigil ang pagpaalam sa mga bagong vine",
-  "profileNotifyUpdateFailed": "Hindi nai-save. Subukan muli?"
+  "profileNotifyUpdateFailed": "Hindi nai-save. Subukan muli?",
+  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
+  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -3413,8 +3413,8 @@
   "profileNotifyBellOff": "Ipaalam ang mga bagong vine",
   "profileNotifyBellOn": "Itigil ang pagpaalam sa mga bagong vine",
   "profileNotifyUpdateFailed": "Hindi nai-save. Subukan muli?",
-  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
-  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "relaySettingsRemoveDefaultRelayTitle": "Alisin ang relay ng Divine?",
+  "relaySettingsRemoveDefaultRelayMessage": "Kapag inalis mo ang relay ng Divine, hihina ang karanasan mo sa app. Baka maging hindi maaasahan ang video, pag-post, at pag-sync. Para lang ito sa mga sanay nang gumamit ng Nostr.\n\n{relayUrl}",
   "@relaySettingsRemoveDefaultRelayMessage": {
     "placeholders": {
       "relayUrl": {
@@ -3422,5 +3422,5 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Remove relay"
+  "relaySettingsRemoveRelayTooltip": "Alisin ang relay"
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -3421,5 +3421,6 @@
         "type": "String"
       }
     }
-  }
+  },
+  "relaySettingsRemoveRelayTooltip": "Remove relay"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4838,5 +4838,6 @@
         "type": "String"
       }
     }
-  }
+  },
+  "relaySettingsRemoveRelayTooltip": "Remove relay"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4830,8 +4830,8 @@
   "profileNotifyBellOff": "M'avertir des nouvelles vines",
   "profileNotifyBellOn": "Ne plus m'avertir des nouvelles vines",
   "profileNotifyUpdateFailed": "Échec de l'enregistrement. Réessayer ?",
-  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
-  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "relaySettingsRemoveDefaultRelayTitle": "Retirer le relay Divine ?",
+  "relaySettingsRemoveDefaultRelayMessage": "Retirer le relay de Divine dégradera l'expérience dans l'app. Les vidéos, la publication et la synchronisation risquent d'être moins fiables. À réserver aux utilisateurs Nostr expérimentés.\n\n{relayUrl}",
   "@relaySettingsRemoveDefaultRelayMessage": {
     "placeholders": {
       "relayUrl": {
@@ -4839,5 +4839,5 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Remove relay"
+  "relaySettingsRemoveRelayTooltip": "Retirer le relay"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4829,5 +4829,14 @@
     "libraryStopMotionClipLabel": "Clip stop-motion",
   "profileNotifyBellOff": "M'avertir des nouvelles vines",
   "profileNotifyBellOn": "Ne plus m'avertir des nouvelles vines",
-  "profileNotifyUpdateFailed": "Échec de l'enregistrement. Réessayer ?"
+  "profileNotifyUpdateFailed": "Échec de l'enregistrement. Réessayer ?",
+  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
+  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4830,8 +4830,8 @@
   "profileNotifyBellOff": "Beri tahu tentang vine baru",
   "profileNotifyBellOn": "Hentikan pemberitahuan vine baru",
   "profileNotifyUpdateFailed": "Gagal menyimpan. Coba lagi?",
-  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
-  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "relaySettingsRemoveDefaultRelayTitle": "Hapus relay Divine?",
+  "relaySettingsRemoveDefaultRelayMessage": "Menghapus relay Divine bakal menurunkan pengalaman di app. Video, posting, dan sinkronisasi bisa jadi kurang andal. Ini sebaiknya cuma dilakukan pengguna Nostr yang berpengalaman.\n\n{relayUrl}",
   "@relaySettingsRemoveDefaultRelayMessage": {
     "placeholders": {
       "relayUrl": {
@@ -4839,5 +4839,5 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Remove relay"
+  "relaySettingsRemoveRelayTooltip": "Hapus relay"
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4829,5 +4829,14 @@
     "libraryStopMotionClipLabel": "Klip stop-motion",
   "profileNotifyBellOff": "Beri tahu tentang vine baru",
   "profileNotifyBellOn": "Hentikan pemberitahuan vine baru",
-  "profileNotifyUpdateFailed": "Gagal menyimpan. Coba lagi?"
+  "profileNotifyUpdateFailed": "Gagal menyimpan. Coba lagi?",
+  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
+  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4838,5 +4838,6 @@
         "type": "String"
       }
     }
-  }
+  },
+  "relaySettingsRemoveRelayTooltip": "Remove relay"
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4829,5 +4829,14 @@
     "libraryStopMotionClipLabel": "Clip stop-motion",
   "profileNotifyBellOff": "Avvisami dei nuovi vine",
   "profileNotifyBellOn": "Non avvisarmi più dei nuovi vine",
-  "profileNotifyUpdateFailed": "Salvataggio non riuscito. Riprovare?"
+  "profileNotifyUpdateFailed": "Salvataggio non riuscito. Riprovare?",
+  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
+  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4838,5 +4838,6 @@
         "type": "String"
       }
     }
-  }
+  },
+  "relaySettingsRemoveRelayTooltip": "Remove relay"
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4830,8 +4830,8 @@
   "profileNotifyBellOff": "Avvisami dei nuovi vine",
   "profileNotifyBellOn": "Non avvisarmi più dei nuovi vine",
   "profileNotifyUpdateFailed": "Salvataggio non riuscito. Riprovare?",
-  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
-  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "relaySettingsRemoveDefaultRelayTitle": "Rimuovere il relay di Divine?",
+  "relaySettingsRemoveDefaultRelayMessage": "Rimuovere il relay di Divine peggiorerà l'esperienza nell'app. Video, pubblicazione e sincronizzazione potrebbero essere meno affidabili. Fallo solo se sei un utente Nostr esperto.\n\n{relayUrl}",
   "@relaySettingsRemoveDefaultRelayMessage": {
     "placeholders": {
       "relayUrl": {
@@ -4839,5 +4839,5 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Remove relay"
+  "relaySettingsRemoveRelayTooltip": "Rimuovi relay"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4838,5 +4838,6 @@
         "type": "String"
       }
     }
-  }
+  },
+  "relaySettingsRemoveRelayTooltip": "Remove relay"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4830,8 +4830,8 @@
   "profileNotifyBellOff": "新しい動画を通知する",
   "profileNotifyBellOn": "新しい動画の通知を停止",
   "profileNotifyUpdateFailed": "保存できませんでした。もう一度試しますか？",
-  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
-  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "relaySettingsRemoveDefaultRelayTitle": "Divine のリレーを削除する？",
+  "relaySettingsRemoveDefaultRelayMessage": "Divine のリレーを削除すると、アプリの使い心地が悪くなるよ。動画の読み込みや投稿、同期が不安定になることがある。Nostr に慣れている人だけにおすすめだよ。\n\n{relayUrl}",
   "@relaySettingsRemoveDefaultRelayMessage": {
     "placeholders": {
       "relayUrl": {
@@ -4839,5 +4839,5 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Remove relay"
+  "relaySettingsRemoveRelayTooltip": "リレーを削除"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4829,5 +4829,14 @@
     "libraryStopMotionClipLabel": "ストップモーションクリップ",
   "profileNotifyBellOff": "新しい動画を通知する",
   "profileNotifyBellOn": "新しい動画の通知を停止",
-  "profileNotifyUpdateFailed": "保存できませんでした。もう一度試しますか？"
+  "profileNotifyUpdateFailed": "保存できませんでした。もう一度試しますか？",
+  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
+  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -4161,8 +4161,8 @@
   "profileNotifyBellOff": "새 영상 알림 받기",
   "profileNotifyBellOn": "새 영상 알림 끄기",
   "profileNotifyUpdateFailed": "저장하지 못했습니다. 다시 시도할까요?",
-  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
-  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "relaySettingsRemoveDefaultRelayTitle": "Divine 릴레이를 제거할까요?",
+  "relaySettingsRemoveDefaultRelayMessage": "Divine 릴레이를 제거하면 앱 사용 경험이 나빠져요. 영상, 게시, 동기화가 불안정해질 수 있어요. Nostr에 익숙한 사용자만 하는 게 좋아요.\n\n{relayUrl}",
   "@relaySettingsRemoveDefaultRelayMessage": {
     "placeholders": {
       "relayUrl": {
@@ -4170,5 +4170,5 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Remove relay"
+  "relaySettingsRemoveRelayTooltip": "릴레이 제거"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -4160,5 +4160,14 @@
     "libraryStopMotionClipLabel": "스톱모션 클립",
   "profileNotifyBellOff": "새 영상 알림 받기",
   "profileNotifyBellOn": "새 영상 알림 끄기",
-  "profileNotifyUpdateFailed": "저장하지 못했습니다. 다시 시도할까요?"
+  "profileNotifyUpdateFailed": "저장하지 못했습니다. 다시 시도할까요?",
+  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
+  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -4169,5 +4169,6 @@
         "type": "String"
       }
     }
-  }
+  },
+  "relaySettingsRemoveRelayTooltip": "Remove relay"
 }

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -6682,5 +6682,15 @@
   },
   "profileNotifyBellOff": "Beritahu saya tentang vine baharu",
   "profileNotifyBellOn": "Berhenti beritahu saya tentang vine baharu",
-  "profileNotifyUpdateFailed": "Tidak dapat disimpan. Cuba lagi?"
+  "profileNotifyUpdateFailed": "Tidak dapat disimpan. Cuba lagi?",
+  "relaySettingsRemoveDefaultRelayTitle": "Buang relay Divine?",
+  "relaySettingsRemoveDefaultRelayMessage": "Membuang relay Divine akan menjejaskan pengalaman dalam apl. Video, siaran dan penyegerakan mungkin kurang boleh dipercayai. Ini hanya patut dilakukan oleh pengguna Nostr yang berpengalaman.\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  },
+  "relaySettingsRemoveRelayTooltip": "Buang relay"
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4829,5 +4829,14 @@
     "libraryStopMotionClipLabel": "Stop-motion-clip",
   "profileNotifyBellOff": "Melden bij nieuwe vines",
   "profileNotifyBellOn": "Niet meer melden bij nieuwe vines",
-  "profileNotifyUpdateFailed": "Kon niet opslaan. Opnieuw proberen?"
+  "profileNotifyUpdateFailed": "Kon niet opslaan. Opnieuw proberen?",
+  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
+  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4830,8 +4830,8 @@
   "profileNotifyBellOff": "Melden bij nieuwe vines",
   "profileNotifyBellOn": "Niet meer melden bij nieuwe vines",
   "profileNotifyUpdateFailed": "Kon niet opslaan. Opnieuw proberen?",
-  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
-  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "relaySettingsRemoveDefaultRelayTitle": "Divine-relay verwijderen?",
+  "relaySettingsRemoveDefaultRelayMessage": "Als je Divines relay verwijdert, gaat de app-ervaring achteruit. Video's, posten en synchroniseren worden mogelijk minder betrouwbaar. Doe dit alleen als je ervaring hebt met Nostr.\n\n{relayUrl}",
   "@relaySettingsRemoveDefaultRelayMessage": {
     "placeholders": {
       "relayUrl": {
@@ -4839,5 +4839,5 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Remove relay"
+  "relaySettingsRemoveRelayTooltip": "Relay verwijderen"
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4838,5 +4838,6 @@
         "type": "String"
       }
     }
-  }
+  },
+  "relaySettingsRemoveRelayTooltip": "Remove relay"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4838,5 +4838,6 @@
         "type": "String"
       }
     }
-  }
+  },
+  "relaySettingsRemoveRelayTooltip": "Remove relay"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4830,8 +4830,8 @@
   "profileNotifyBellOff": "Powiadamiaj o nowych vine'ach",
   "profileNotifyBellOn": "Nie powiadamiaj o nowych vine'ach",
   "profileNotifyUpdateFailed": "Nie udało się zapisać. Spróbować ponownie?",
-  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
-  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "relaySettingsRemoveDefaultRelayTitle": "Usunąć przekaźnik Divine?",
+  "relaySettingsRemoveDefaultRelayMessage": "Usunięcie przekaźnika Divine pogorszy działanie aplikacji. Filmy, publikowanie i synchronizacja mogą być mniej niezawodne. Rób to tylko, jeśli znasz się na Nostr.\n\n{relayUrl}",
   "@relaySettingsRemoveDefaultRelayMessage": {
     "placeholders": {
       "relayUrl": {
@@ -4839,5 +4839,5 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Remove relay"
+  "relaySettingsRemoveRelayTooltip": "Usuń przekaźnik"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4829,5 +4829,14 @@
     "libraryStopMotionClipLabel": "Klip poklatkowy",
   "profileNotifyBellOff": "Powiadamiaj o nowych vine'ach",
   "profileNotifyBellOn": "Nie powiadamiaj o nowych vine'ach",
-  "profileNotifyUpdateFailed": "Nie udało się zapisać. Spróbować ponownie?"
+  "profileNotifyUpdateFailed": "Nie udało się zapisać. Spróbować ponownie?",
+  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
+  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4829,5 +4829,14 @@
     "libraryStopMotionClipLabel": "Clipe de stop motion",
   "profileNotifyBellOff": "Avisar sobre novos vines",
   "profileNotifyBellOn": "Parar de avisar sobre novos vines",
-  "profileNotifyUpdateFailed": "Não foi possível salvar. Tentar de novo?"
+  "profileNotifyUpdateFailed": "Não foi possível salvar. Tentar de novo?",
+  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
+  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4838,5 +4838,6 @@
         "type": "String"
       }
     }
-  }
+  },
+  "relaySettingsRemoveRelayTooltip": "Remove relay"
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4830,8 +4830,8 @@
   "profileNotifyBellOff": "Avisar sobre novos vines",
   "profileNotifyBellOn": "Parar de avisar sobre novos vines",
   "profileNotifyUpdateFailed": "Não foi possível salvar. Tentar de novo?",
-  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
-  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "relaySettingsRemoveDefaultRelayTitle": "Remover o relay do Divine?",
+  "relaySettingsRemoveDefaultRelayMessage": "Remover o relay do Divine vai piorar a experiência no app. Vídeos, publicações e sincronização podem ficar menos confiáveis. Isso só deve ser feito por usuários experientes em Nostr.\n\n{relayUrl}",
   "@relaySettingsRemoveDefaultRelayMessage": {
     "placeholders": {
       "relayUrl": {
@@ -4839,5 +4839,5 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Remove relay"
+  "relaySettingsRemoveRelayTooltip": "Remover relay"
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4838,5 +4838,6 @@
         "type": "String"
       }
     }
-  }
+  },
+  "relaySettingsRemoveRelayTooltip": "Remove relay"
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4829,5 +4829,14 @@
     "libraryStopMotionClipLabel": "Clip stop-motion",
   "profileNotifyBellOff": "Anunță-mă despre videoclipuri noi",
   "profileNotifyBellOn": "Nu mă mai anunța despre videoclipuri noi",
-  "profileNotifyUpdateFailed": "Nu s-a salvat. Reîncerci?"
+  "profileNotifyUpdateFailed": "Nu s-a salvat. Reîncerci?",
+  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
+  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4830,8 +4830,8 @@
   "profileNotifyBellOff": "Anunță-mă despre videoclipuri noi",
   "profileNotifyBellOn": "Nu mă mai anunța despre videoclipuri noi",
   "profileNotifyUpdateFailed": "Nu s-a salvat. Reîncerci?",
-  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
-  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "relaySettingsRemoveDefaultRelayTitle": "Elimini relay-ul Divine?",
+  "relaySettingsRemoveDefaultRelayMessage": "Eliminarea relay-ului Divine va înrăutăți experiența în aplicație. Videoclipurile, publicarea și sincronizarea pot deveni mai puțin fiabile. Fă asta doar dacă ești un utilizator Nostr experimentat.\n\n{relayUrl}",
   "@relaySettingsRemoveDefaultRelayMessage": {
     "placeholders": {
       "relayUrl": {
@@ -4839,5 +4839,5 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Remove relay"
+  "relaySettingsRemoveRelayTooltip": "Elimină relay-ul"
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4829,5 +4829,14 @@
     "libraryStopMotionClipLabel": "Stop motion-klipp",
   "profileNotifyBellOff": "Meddela om nya vines",
   "profileNotifyBellOn": "Sluta meddela om nya vines",
-  "profileNotifyUpdateFailed": "Kunde inte sparas. Försök igen?"
+  "profileNotifyUpdateFailed": "Kunde inte sparas. Försök igen?",
+  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
+  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4838,5 +4838,6 @@
         "type": "String"
       }
     }
-  }
+  },
+  "relaySettingsRemoveRelayTooltip": "Remove relay"
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4830,8 +4830,8 @@
   "profileNotifyBellOff": "Meddela om nya vines",
   "profileNotifyBellOn": "Sluta meddela om nya vines",
   "profileNotifyUpdateFailed": "Kunde inte sparas. Försök igen?",
-  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
-  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "relaySettingsRemoveDefaultRelayTitle": "Ta bort Divines rel?",
+  "relaySettingsRemoveDefaultRelayMessage": "Att ta bort Divines rel försämrar upplevelsen i appen. Videor, publicering och synk kan bli mindre pålitliga. Gör bara det här om du är en van Nostr-användare.\n\n{relayUrl}",
   "@relaySettingsRemoveDefaultRelayMessage": {
     "placeholders": {
       "relayUrl": {
@@ -4839,5 +4839,5 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Remove relay"
+  "relaySettingsRemoveRelayTooltip": "Ta bort rel"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4838,5 +4838,6 @@
         "type": "String"
       }
     }
-  }
+  },
+  "relaySettingsRemoveRelayTooltip": "Remove relay"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4830,8 +4830,8 @@
   "profileNotifyBellOff": "Yeni vine'lardan haberdar et",
   "profileNotifyBellOn": "Yeni vine bildirimlerini kapat",
   "profileNotifyUpdateFailed": "Kaydedilemedi. Tekrar denensin mi?",
-  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
-  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "relaySettingsRemoveDefaultRelayTitle": "Divine rölesi kaldırılsın mı?",
+  "relaySettingsRemoveDefaultRelayMessage": "Divine'ın rölesini kaldırmak uygulama deneyimini kötüleştirir. Videolar, paylaşım ve senkronizasyon daha az güvenilir olabilir. Bunu yalnızca deneyimli Nostr kullanıcıları yapmalı.\n\n{relayUrl}",
   "@relaySettingsRemoveDefaultRelayMessage": {
     "placeholders": {
       "relayUrl": {
@@ -4839,5 +4839,5 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Remove relay"
+  "relaySettingsRemoveRelayTooltip": "Röleyi kaldır"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4829,5 +4829,14 @@
     "libraryStopMotionClipLabel": "Stop motion klibi",
   "profileNotifyBellOff": "Yeni vine'lardan haberdar et",
   "profileNotifyBellOn": "Yeni vine bildirimlerini kapat",
-  "profileNotifyUpdateFailed": "Kaydedilemedi. Tekrar denensin mi?"
+  "profileNotifyUpdateFailed": "Kaydedilemedi. Tekrar denensin mi?",
+  "relaySettingsRemoveDefaultRelayTitle": "Remove Divine Relay?",
+  "relaySettingsRemoveDefaultRelayMessage": "Removing Divine's relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -6682,5 +6682,15 @@
   },
   "profileNotifyBellOff": "نئی ویڈیوز کی اطلاع دیں",
   "profileNotifyBellOn": "نئی ویڈیوز کی اطلاعات بند کریں",
-  "profileNotifyUpdateFailed": "محفوظ نہیں ہو سکا۔ دوبارہ کوشش کریں؟"
+  "profileNotifyUpdateFailed": "محفوظ نہیں ہو سکا۔ دوبارہ کوشش کریں؟",
+  "relaySettingsRemoveDefaultRelayTitle": "Divine کا ریلے ہٹائیں؟",
+  "relaySettingsRemoveDefaultRelayMessage": "Divine کا ریلے ہٹانے سے ایپ کا تجربہ خراب ہو جائے گا۔ ویڈیوز، پوسٹنگ اور سنک کم قابلِ بھروسہ ہو سکتے ہیں۔ یہ صرف تجربہ کار Nostr صارفین کو کرنا چاہیے۔\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  },
+  "relaySettingsRemoveRelayTooltip": "ریلے ہٹائیں"
 }

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -6682,5 +6682,15 @@
   },
   "profileNotifyBellOff": "Nhận thông báo về vine mới",
   "profileNotifyBellOn": "Ngừng thông báo về vine mới",
-  "profileNotifyUpdateFailed": "Không lưu được. Thử lại nhé?"
+  "profileNotifyUpdateFailed": "Không lưu được. Thử lại nhé?",
+  "relaySettingsRemoveDefaultRelayTitle": "Xoá relay của Divine?",
+  "relaySettingsRemoveDefaultRelayMessage": "Xoá relay của Divine sẽ làm giảm trải nghiệm trong ứng dụng. Video, đăng bài và đồng bộ có thể kém ổn định hơn. Chỉ nên làm điều này nếu bạn đã quen dùng Nostr.\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  },
+  "relaySettingsRemoveRelayTooltip": "Xoá relay"
 }

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -6682,5 +6682,15 @@
   },
   "profileNotifyBellOff": "接收新视频通知",
   "profileNotifyBellOn": "停止新视频通知",
-  "profileNotifyUpdateFailed": "没能保存，再试一次？"
+  "profileNotifyUpdateFailed": "没能保存，再试一次？",
+  "relaySettingsRemoveDefaultRelayTitle": "移除 Divine 中继？",
+  "relaySettingsRemoveDefaultRelayMessage": "移除 Divine 的中继会让应用体验变差。视频、发布和同步可能变得不太可靠。建议只有熟悉 Nostr 的用户才这么做。\n\n{relayUrl}",
+  "@relaySettingsRemoveDefaultRelayMessage": {
+    "placeholders": {
+      "relayUrl": {
+        "type": "String"
+      }
+    }
+  },
+  "relaySettingsRemoveRelayTooltip": "移除中继"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -3514,6 +3514,12 @@ abstract class AppLocalizations {
   /// **'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}'**
   String relaySettingsRemoveDefaultRelayMessage(String relayUrl);
 
+  /// No description provided for @relaySettingsRemoveRelayTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove relay'**
+  String get relaySettingsRemoveRelayTooltip;
+
   /// No description provided for @relaySettingsCancel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -3502,6 +3502,18 @@ abstract class AppLocalizations {
   /// **'Are you sure you want to remove this relay?\n\n{relayUrl}'**
   String relaySettingsRemoveRelayMessage(String relayUrl);
 
+  /// No description provided for @relaySettingsRemoveDefaultRelayTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove Divine Relay?'**
+  String get relaySettingsRemoveDefaultRelayTitle;
+
+  /// No description provided for @relaySettingsRemoveDefaultRelayMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n{relayUrl}'**
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl);
+
   /// No description provided for @relaySettingsCancel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1963,15 +1963,15 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
-  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+  String get relaySettingsRemoveDefaultRelayTitle => 'የDivine ቅብብሎሽ ይወገድ?';
 
   @override
   String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
-    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+    return 'የDivine ቅብብሎሽን ማስወገድ የመተግበሪያውን አጠቃቀም ያዳክማል። ቪዲዮዎች፣ ልጥፎች እና ማመሳሰል አስተማማኝ ላይሆኑ ይችላሉ። ይህን ማድረግ ያለባቸው ልምድ ያላቸው የNostr ተጠቃሚዎች ብቻ ናቸው።\n\n$relayUrl';
   }
 
   @override
-  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+  String get relaySettingsRemoveRelayTooltip => 'ቅብብሎሽ አስወግድ';
 
   @override
   String get relaySettingsCancel => 'ሰርዝ';

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1963,6 +1963,14 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+  }
+
+  @override
   String get relaySettingsCancel => 'ሰርዝ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1971,6 +1971,9 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+
+  @override
   String get relaySettingsCancel => 'ሰርዝ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1984,15 +1984,15 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+  String get relaySettingsRemoveDefaultRelayTitle => 'إزالة محوّل Divine؟';
 
   @override
   String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
-    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+    return 'إزالة محوّل Divine ستضعف تجربتك في التطبيق. قد تصبح الفيديوهات والنشر والمزامنة أقل موثوقية. يُفضّل ألا يفعل ذلك إلا مستخدمو Nostr ذوو الخبرة.\n\n$relayUrl';
   }
 
   @override
-  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+  String get relaySettingsRemoveRelayTooltip => 'إزالة المحوّل';
 
   @override
   String get relaySettingsCancel => 'إلغاء';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1992,6 +1992,9 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+
+  @override
   String get relaySettingsCancel => 'إلغاء';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1984,6 +1984,14 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+  }
+
+  @override
   String get relaySettingsCancel => 'إلغاء';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -2032,15 +2032,16 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+  String get relaySettingsRemoveDefaultRelayTitle =>
+      'Премахване на релето на Divine?';
 
   @override
   String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
-    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+    return 'Премахването на релето на Divine ще влоши работата на приложението. Видеата, публикуването и синхронизацията може да станат по-малко надеждни. Прави го само ако си опитен потребител на Nostr.\n\n$relayUrl';
   }
 
   @override
-  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+  String get relaySettingsRemoveRelayTooltip => 'Премахване на релето';
 
   @override
   String get relaySettingsCancel => 'Отказ';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -2032,6 +2032,14 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+  }
+
+  @override
   String get relaySettingsCancel => 'Отказ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -2040,6 +2040,9 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+
+  @override
   String get relaySettingsCancel => 'Отказ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -2019,15 +2019,15 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+  String get relaySettingsRemoveDefaultRelayTitle => 'Divine-Relay entfernen?';
 
   @override
   String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
-    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+    return 'Wenn du Divines Relay entfernst, wird die App-Erfahrung schlechter. Videos, Posten und Synchronisierung können unzuverlässiger werden. Das sollten nur erfahrene Nostr-Nutzer tun.\n\n$relayUrl';
   }
 
   @override
-  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+  String get relaySettingsRemoveRelayTooltip => 'Relay entfernen';
 
   @override
   String get relaySettingsCancel => 'Abbrechen';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -2027,6 +2027,9 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+
+  @override
   String get relaySettingsCancel => 'Abbrechen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -2019,6 +2019,14 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+  }
+
+  @override
   String get relaySettingsCancel => 'Abbrechen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -2006,6 +2006,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+
+  @override
   String get relaySettingsCancel => 'Cancel';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1998,6 +1998,14 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+  }
+
+  @override
   String get relaySettingsCancel => 'Cancel';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -2027,6 +2027,9 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+
+  @override
   String get relaySettingsCancel => 'Cancelar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -2019,6 +2019,14 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+  }
+
+  @override
   String get relaySettingsCancel => 'Cancelar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -2019,15 +2019,16 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+  String get relaySettingsRemoveDefaultRelayTitle =>
+      '¿Quitar el relay de Divine?';
 
   @override
   String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
-    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+    return 'Quitar el relay de Divine empeorará la experiencia en la app. Los videos, las publicaciones y la sincronización pueden ser menos fiables. Esto solo deberían hacerlo usuarios con experiencia en Nostr.\n\n$relayUrl';
   }
 
   @override
-  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+  String get relaySettingsRemoveRelayTooltip => 'Quitar relay';
 
   @override
   String get relaySettingsCancel => 'Cancelar';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -2032,6 +2032,14 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+  }
+
+  @override
   String get relaySettingsCancel => 'Kanselahin';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -2040,6 +2040,9 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+
+  @override
   String get relaySettingsCancel => 'Kanselahin';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -2032,15 +2032,16 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
-  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+  String get relaySettingsRemoveDefaultRelayTitle =>
+      'Alisin ang relay ng Divine?';
 
   @override
   String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
-    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+    return 'Kapag inalis mo ang relay ng Divine, hihina ang karanasan mo sa app. Baka maging hindi maaasahan ang video, pag-post, at pag-sync. Para lang ito sa mga sanay nang gumamit ng Nostr.\n\n$relayUrl';
   }
 
   @override
-  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+  String get relaySettingsRemoveRelayTooltip => 'Alisin ang relay';
 
   @override
   String get relaySettingsCancel => 'Kanselahin';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -2028,6 +2028,14 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+  }
+
+  @override
   String get relaySettingsCancel => 'Annuler';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -2028,15 +2028,16 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+  String get relaySettingsRemoveDefaultRelayTitle =>
+      'Retirer le relay Divine ?';
 
   @override
   String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
-    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+    return 'Retirer le relay de Divine dégradera l\'expérience dans l\'app. Les vidéos, la publication et la synchronisation risquent d\'être moins fiables. À réserver aux utilisateurs Nostr expérimentés.\n\n$relayUrl';
   }
 
   @override
-  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+  String get relaySettingsRemoveRelayTooltip => 'Retirer le relay';
 
   @override
   String get relaySettingsCancel => 'Annuler';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -2036,6 +2036,9 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+
+  @override
   String get relaySettingsCancel => 'Annuler';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1959,6 +1959,14 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+  }
+
+  @override
   String get relaySettingsCancel => 'Batal';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1967,6 +1967,9 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+
+  @override
   String get relaySettingsCancel => 'Batal';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1959,15 +1959,15 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+  String get relaySettingsRemoveDefaultRelayTitle => 'Hapus relay Divine?';
 
   @override
   String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
-    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+    return 'Menghapus relay Divine bakal menurunkan pengalaman di app. Video, posting, dan sinkronisasi bisa jadi kurang andal. Ini sebaiknya cuma dilakukan pengguna Nostr yang berpengalaman.\n\n$relayUrl';
   }
 
   @override
-  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+  String get relaySettingsRemoveRelayTooltip => 'Hapus relay';
 
   @override
   String get relaySettingsCancel => 'Batal';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -2021,15 +2021,16 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+  String get relaySettingsRemoveDefaultRelayTitle =>
+      'Rimuovere il relay di Divine?';
 
   @override
   String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
-    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+    return 'Rimuovere il relay di Divine peggiorerà l\'esperienza nell\'app. Video, pubblicazione e sincronizzazione potrebbero essere meno affidabili. Fallo solo se sei un utente Nostr esperto.\n\n$relayUrl';
   }
 
   @override
-  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+  String get relaySettingsRemoveRelayTooltip => 'Rimuovi relay';
 
   @override
   String get relaySettingsCancel => 'Annulla';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -2029,6 +2029,9 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+
+  @override
   String get relaySettingsCancel => 'Annulla';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -2021,6 +2021,14 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+  }
+
+  @override
   String get relaySettingsCancel => 'Annulla';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1880,6 +1880,14 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+  }
+
+  @override
   String get relaySettingsCancel => 'キャンセル';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1880,15 +1880,15 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+  String get relaySettingsRemoveDefaultRelayTitle => 'Divine のリレーを削除する？';
 
   @override
   String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
-    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+    return 'Divine のリレーを削除すると、アプリの使い心地が悪くなるよ。動画の読み込みや投稿、同期が不安定になることがある。Nostr に慣れている人だけにおすすめだよ。\n\n$relayUrl';
   }
 
   @override
-  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+  String get relaySettingsRemoveRelayTooltip => 'リレーを削除';
 
   @override
   String get relaySettingsCancel => 'キャンセル';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1888,6 +1888,9 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+
+  @override
   String get relaySettingsCancel => 'キャンセル';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1898,6 +1898,9 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+
+  @override
   String get relaySettingsCancel => '취소';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1890,15 +1890,15 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+  String get relaySettingsRemoveDefaultRelayTitle => 'Divine 릴레이를 제거할까요?';
 
   @override
   String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
-    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+    return 'Divine 릴레이를 제거하면 앱 사용 경험이 나빠져요. 영상, 게시, 동기화가 불안정해질 수 있어요. Nostr에 익숙한 사용자만 하는 게 좋아요.\n\n$relayUrl';
   }
 
   @override
-  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+  String get relaySettingsRemoveRelayTooltip => '릴레이 제거';
 
   @override
   String get relaySettingsCancel => '취소';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1890,6 +1890,14 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+  }
+
+  @override
   String get relaySettingsCancel => '취소';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -2015,6 +2015,17 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => 'Buang relay Divine?';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return 'Membuang relay Divine akan menjejaskan pengalaman dalam apl. Video, siaran dan penyegerakan mungkin kurang boleh dipercayai. Ini hanya patut dilakukan oleh pengguna Nostr yang berpengalaman.\n\n$relayUrl';
+  }
+
+  @override
+  String get relaySettingsRemoveRelayTooltip => 'Buang relay';
+
+  @override
   String get relaySettingsCancel => 'Batal';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -2008,6 +2008,14 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+  }
+
+  @override
   String get relaySettingsCancel => 'Annuleren';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -2016,6 +2016,9 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+
+  @override
   String get relaySettingsCancel => 'Annuleren';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -2008,15 +2008,16 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+  String get relaySettingsRemoveDefaultRelayTitle =>
+      'Divine-relay verwijderen?';
 
   @override
   String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
-    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+    return 'Als je Divines relay verwijdert, gaat de app-ervaring achteruit. Video\'s, posten en synchroniseren worden mogelijk minder betrouwbaar. Doe dit alleen als je ervaring hebt met Nostr.\n\n$relayUrl';
   }
 
   @override
-  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+  String get relaySettingsRemoveRelayTooltip => 'Relay verwijderen';
 
   @override
   String get relaySettingsCancel => 'Annuleren';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -2032,6 +2032,14 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+  }
+
+  @override
   String get relaySettingsCancel => 'Anuluj';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -2040,6 +2040,9 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+
+  @override
   String get relaySettingsCancel => 'Anuluj';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -2032,15 +2032,16 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+  String get relaySettingsRemoveDefaultRelayTitle =>
+      'Usunąć przekaźnik Divine?';
 
   @override
   String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
-    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+    return 'Usunięcie przekaźnika Divine pogorszy działanie aplikacji. Filmy, publikowanie i synchronizacja mogą być mniej niezawodne. Rób to tylko, jeśli znasz się na Nostr.\n\n$relayUrl';
   }
 
   @override
-  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+  String get relaySettingsRemoveRelayTooltip => 'Usuń przekaźnik';
 
   @override
   String get relaySettingsCancel => 'Anuluj';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -2017,6 +2017,14 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+  }
+
+  @override
   String get relaySettingsCancel => 'Cancelar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -2017,15 +2017,16 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+  String get relaySettingsRemoveDefaultRelayTitle =>
+      'Remover o relay do Divine?';
 
   @override
   String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
-    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+    return 'Remover o relay do Divine vai piorar a experiência no app. Vídeos, publicações e sincronização podem ficar menos confiáveis. Isso só deve ser feito por usuários experientes em Nostr.\n\n$relayUrl';
   }
 
   @override
-  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+  String get relaySettingsRemoveRelayTooltip => 'Remover relay';
 
   @override
   String get relaySettingsCancel => 'Cancelar';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -2025,6 +2025,9 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+
+  @override
   String get relaySettingsCancel => 'Cancelar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -2042,15 +2042,15 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+  String get relaySettingsRemoveDefaultRelayTitle => 'Elimini relay-ul Divine?';
 
   @override
   String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
-    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+    return 'Eliminarea relay-ului Divine va înrăutăți experiența în aplicație. Videoclipurile, publicarea și sincronizarea pot deveni mai puțin fiabile. Fă asta doar dacă ești un utilizator Nostr experimentat.\n\n$relayUrl';
   }
 
   @override
-  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+  String get relaySettingsRemoveRelayTooltip => 'Elimină relay-ul';
 
   @override
   String get relaySettingsCancel => 'Anulează';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -2042,6 +2042,14 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+  }
+
+  @override
   String get relaySettingsCancel => 'Anulează';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -2050,6 +2050,9 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+
+  @override
   String get relaySettingsCancel => 'Anulează';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1992,15 +1992,15 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+  String get relaySettingsRemoveDefaultRelayTitle => 'Ta bort Divines rel?';
 
   @override
   String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
-    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+    return 'Att ta bort Divines rel försämrar upplevelsen i appen. Videor, publicering och synk kan bli mindre pålitliga. Gör bara det här om du är en van Nostr-användare.\n\n$relayUrl';
   }
 
   @override
-  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+  String get relaySettingsRemoveRelayTooltip => 'Ta bort rel';
 
   @override
   String get relaySettingsCancel => 'Avbryt';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1992,6 +1992,14 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+  }
+
+  @override
   String get relaySettingsCancel => 'Avbryt';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -2000,6 +2000,9 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+
+  @override
   String get relaySettingsCancel => 'Avbryt';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1973,6 +1973,9 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+
+  @override
   String get relaySettingsCancel => 'İptal';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1965,15 +1965,16 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+  String get relaySettingsRemoveDefaultRelayTitle =>
+      'Divine rölesi kaldırılsın mı?';
 
   @override
   String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
-    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+    return 'Divine\'ın rölesini kaldırmak uygulama deneyimini kötüleştirir. Videolar, paylaşım ve senkronizasyon daha az güvenilir olabilir. Bunu yalnızca deneyimli Nostr kullanıcıları yapmalı.\n\n$relayUrl';
   }
 
   @override
-  String get relaySettingsRemoveRelayTooltip => 'Remove relay';
+  String get relaySettingsRemoveRelayTooltip => 'Röleyi kaldır';
 
   @override
   String get relaySettingsCancel => 'İptal';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1965,6 +1965,14 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => 'Remove Divine Relay?';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return 'Removing Divine\'s relay will degrade the app experience. Videos, posting, and sync may be less reliable. This should only be done by experienced Nostr users.\n\n$relayUrl';
+  }
+
+  @override
   String get relaySettingsCancel => 'İptal';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -2002,6 +2002,17 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => 'Divine کا ریلے ہٹائیں؟';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return 'Divine کا ریلے ہٹانے سے ایپ کا تجربہ خراب ہو جائے گا۔ ویڈیوز، پوسٹنگ اور سنک کم قابلِ بھروسہ ہو سکتے ہیں۔ یہ صرف تجربہ کار Nostr صارفین کو کرنا چاہیے۔\n\n$relayUrl';
+  }
+
+  @override
+  String get relaySettingsRemoveRelayTooltip => 'ریلے ہٹائیں';
+
+  @override
   String get relaySettingsCancel => 'منسوخ کریں';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -2008,6 +2008,17 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => 'Xoá relay của Divine?';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return 'Xoá relay của Divine sẽ làm giảm trải nghiệm trong ứng dụng. Video, đăng bài và đồng bộ có thể kém ổn định hơn. Chỉ nên làm điều này nếu bạn đã quen dùng Nostr.\n\n$relayUrl';
+  }
+
+  @override
+  String get relaySettingsRemoveRelayTooltip => 'Xoá relay';
+
+  @override
   String get relaySettingsCancel => 'Hủy';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -1903,6 +1903,17 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get relaySettingsRemoveDefaultRelayTitle => '移除 Divine 中继？';
+
+  @override
+  String relaySettingsRemoveDefaultRelayMessage(String relayUrl) {
+    return '移除 Divine 的中继会让应用体验变差。视频、发布和同步可能变得不太可靠。建议只有熟悉 Nostr 的用户才这么做。\n\n$relayUrl';
+  }
+
+  @override
+  String get relaySettingsRemoveRelayTooltip => '移除中继';
+
+  @override
   String get relaySettingsCancel => '取消';
 
   @override

--- a/mobile/lib/providers/bug_report_providers.dart
+++ b/mobile/lib/providers/bug_report_providers.dart
@@ -5,6 +5,7 @@
 import 'package:dm_repository/dm_repository.dart';
 import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/providers/storage_providers.dart';
 import 'package:openvine/providers/upload_media_providers.dart';
@@ -36,5 +37,7 @@ BugReportService bugReportService(Ref ref) {
     blossomUploadService: blossomService,
     errorTracker: ref.watch(errorAnalyticsTrackerProvider),
     storageManagementService: ref.watch(storageManagementServiceProvider),
+    targetRelayResolver: (pubkey) =>
+        ref.read(dmRepositoryProvider).resolveDmInboxRelays(pubkey),
   );
 }

--- a/mobile/lib/providers/bug_report_providers.dart
+++ b/mobile/lib/providers/bug_report_providers.dart
@@ -37,6 +37,7 @@ BugReportService bugReportService(Ref ref) {
     blossomUploadService: blossomService,
     errorTracker: ref.watch(errorAnalyticsTrackerProvider),
     storageManagementService: ref.watch(storageManagementServiceProvider),
+    fallbackTargetRelays: [nostrService.defaultRelayUrl],
     targetRelayResolver: (pubkey) =>
         ref.read(dmRepositoryProvider).resolveDmInboxRelays(pubkey),
   );

--- a/mobile/lib/providers/bug_report_providers.g.dart
+++ b/mobile/lib/providers/bug_report_providers.g.dart
@@ -60,4 +60,4 @@ final class BugReportServiceProvider
   }
 }
 
-String _$bugReportServiceHash() => r'ec307fae9f0410ed4542ea3fd633c4b92a305979';
+String _$bugReportServiceHash() => r'8e528256c51891701756460d3f34c86eb43030ec';

--- a/mobile/lib/providers/bug_report_providers.g.dart
+++ b/mobile/lib/providers/bug_report_providers.g.dart
@@ -60,4 +60,4 @@ final class BugReportServiceProvider
   }
 }
 
-String _$bugReportServiceHash() => r'8e528256c51891701756460d3f34c86eb43030ec';
+String _$bugReportServiceHash() => r'f45cd35080b1bab710c84ddb049230ea25c5bf8b';

--- a/mobile/lib/providers/relay_providers.dart
+++ b/mobile/lib/providers/relay_providers.dart
@@ -19,7 +19,7 @@ import 'package:unified_logger/unified_logger.dart';
 
 part 'relay_providers.g.dart';
 
-/// Current configured relay URLs, including the environment default relay.
+/// Current configured relay URLs.
 ///
 /// Updated by [relaySetChangeBridge] from the active relay status map so UI
 /// that only needs the relay set can react without constructing its own client.

--- a/mobile/lib/providers/relay_providers.dart
+++ b/mobile/lib/providers/relay_providers.dart
@@ -247,11 +247,7 @@ class _RelaySetChangeCoordinator {
         }
       }
 
-      if (!_operationIsCurrent(
-        attachment,
-        transaction,
-        transactionVersion,
-      )) {
+      if (!_operationIsCurrent(attachment, transaction, transactionVersion)) {
         _rescheduleAfterOperation = _pendingTransaction != null;
         return;
       }
@@ -277,11 +273,7 @@ class _RelaySetChangeCoordinator {
         );
       }
 
-      if (!_operationIsCurrent(
-        attachment,
-        transaction,
-        transactionVersion,
-      )) {
+      if (!_operationIsCurrent(attachment, transaction, transactionVersion)) {
         _rescheduleAfterOperation = _pendingTransaction != null;
         return;
       }
@@ -296,11 +288,7 @@ class _RelaySetChangeCoordinator {
         );
       }
 
-      if (!_operationIsCurrent(
-        attachment,
-        transaction,
-        transactionVersion,
-      )) {
+      if (!_operationIsCurrent(attachment, transaction, transactionVersion)) {
         _rescheduleAfterOperation = _pendingTransaction != null;
         return;
       }
@@ -326,16 +314,19 @@ class _RelaySetChangeCoordinator {
     final targetRelaySet = Set.of(transaction.targetRelaySet);
     try {
       final currentRelaySet = client.configuredRelays.toSet();
-      final additions = targetRelaySet.difference(currentRelaySet).toList();
+      final additions = <String>[];
+      for (final relay in targetRelaySet.difference(currentRelaySet)) {
+        if (await client.isUserRemovedRelay(relay)) {
+          targetRelaySet.remove(relay);
+        } else {
+          additions.add(relay);
+        }
+      }
       final removals = currentRelaySet.difference(targetRelaySet).toList();
 
       if (additions.isNotEmpty) {
         final addedCount = await client.addRelays(additions);
-        if (!_operationIsCurrent(
-          attachment,
-          transaction,
-          transactionVersion,
-        )) {
+        if (!_operationIsCurrent(attachment, transaction, transactionVersion)) {
           return const _RelayReconciliationResult.superseded();
         }
         if (addedCount != additions.length) {
@@ -349,11 +340,7 @@ class _RelaySetChangeCoordinator {
           relay,
           source: RelayRemoveSource.automatic,
         );
-        if (!_operationIsCurrent(
-          attachment,
-          transaction,
-          transactionVersion,
-        )) {
+        if (!_operationIsCurrent(attachment, transaction, transactionVersion)) {
           return const _RelayReconciliationResult.superseded();
         }
         if (!removed) {
@@ -371,11 +358,7 @@ class _RelaySetChangeCoordinator {
       }
       return const _RelayReconciliationResult.complete();
     } catch (e) {
-      if (!_operationIsCurrent(
-        attachment,
-        transaction,
-        transactionVersion,
-      )) {
+      if (!_operationIsCurrent(attachment, transaction, transactionVersion)) {
         return const _RelayReconciliationResult.superseded();
       }
       return _RelayReconciliationResult.incomplete(e.toString());

--- a/mobile/lib/providers/relay_providers.dart
+++ b/mobile/lib/providers/relay_providers.dart
@@ -7,7 +7,7 @@ import 'dart:async';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nostr_client/nostr_client.dart'
-    show NostrClient, RelayConnectionStatus, RelayState;
+    show NostrClient, RelayConnectionStatus, RelayRemoveSource, RelayState;
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/video_providers.dart';
 import 'package:openvine/services/connection_status_service.dart';
@@ -323,8 +323,7 @@ class _RelaySetChangeCoordinator {
     required int transactionVersion,
   }) async {
     final client = attachment.client;
-    final targetRelaySet = Set.of(transaction.targetRelaySet)
-      ..add(client.defaultRelayUrl);
+    final targetRelaySet = Set.of(transaction.targetRelaySet);
     try {
       final currentRelaySet = client.configuredRelays.toSet();
       final additions = targetRelaySet.difference(currentRelaySet).toList();
@@ -346,7 +345,10 @@ class _RelaySetChangeCoordinator {
         }
       }
       for (final relay in removals) {
-        final removed = await client.removeRelay(relay);
+        final removed = await client.removeRelay(
+          relay,
+          source: RelayRemoveSource.automatic,
+        );
         if (!_operationIsCurrent(
           attachment,
           transaction,

--- a/mobile/lib/screens/relay_settings_screen.dart
+++ b/mobile/lib/screens/relay_settings_screen.dart
@@ -708,6 +708,7 @@ Future<void> _showAddRelayDialog(BuildContext context) async {
   final outcome = await cubit.addRelay(relayUrl);
   switch (outcome) {
     case AddRelayOutcome.added:
+    case AddRelayOutcome.addedConnectionPending:
       messenger.showSnackBar(
         DivineSnackbarContainer.snackBar(
           l10n.relaySettingsAddedRelay(relayUrl),

--- a/mobile/lib/screens/relay_settings_screen.dart
+++ b/mobile/lib/screens/relay_settings_screen.dart
@@ -708,7 +708,6 @@ Future<void> _showAddRelayDialog(BuildContext context) async {
   final outcome = await cubit.addRelay(relayUrl);
   switch (outcome) {
     case AddRelayOutcome.added:
-    case AddRelayOutcome.addedConnectionPending:
       messenger.showSnackBar(
         DivineSnackbarContainer.snackBar(
           l10n.relaySettingsAddedRelay(relayUrl),
@@ -716,6 +715,17 @@ Future<void> _showAddRelayDialog(BuildContext context) async {
       );
       Log.info(
         'Successfully added relay: $relayUrl',
+        name: 'RelaySettingsScreen',
+      );
+    case AddRelayOutcome.addedConnectionPending:
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(l10n.relaySettingsFailedToConnectCheck),
+          backgroundColor: VineTheme.warning,
+        ),
+      );
+      Log.info(
+        'Added relay without connection: $relayUrl',
         name: 'RelaySettingsScreen',
       );
     case AddRelayOutcome.invalidUrl:

--- a/mobile/lib/screens/relay_settings_screen.dart
+++ b/mobile/lib/screens/relay_settings_screen.dart
@@ -854,6 +854,17 @@ Future<void> _restoreDefaultRelay(BuildContext context) async {
         ),
       );
       Log.info('Restored default relay', name: 'RelaySettingsScreen');
+    case RestoreDefaultRelayOutcome.restoredConnectionPending:
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(l10n.relaySettingsFailedToConnectCheck),
+          backgroundColor: VineTheme.warning,
+        ),
+      );
+      Log.info(
+        'Restored default relay without connection',
+        name: 'RelaySettingsScreen',
+      );
     case RestoreDefaultRelayOutcome.failed:
       _showError(messenger, l10n.relaySettingsFailedToRestoreDefault);
   }

--- a/mobile/lib/screens/relay_settings_screen.dart
+++ b/mobile/lib/screens/relay_settings_screen.dart
@@ -262,6 +262,8 @@ class _RelayTile extends ConsumerWidget {
     final stats = statsAsync.whenData((allStats) => allStats[relayUrl]).value;
     final isConnected = stats?.isConnected ?? false;
     final statusSummary = _relayStatusSummary(context, stats);
+    final isDefaultRelay =
+        relayUrl == context.read<RelaySettingsCubit>().defaultRelayUrl;
 
     return Theme(
       data: Theme.of(context).copyWith(dividerColor: VineTheme.transparent),
@@ -301,7 +303,11 @@ class _RelayTile extends ConsumerWidget {
               foregroundColor: VineTheme.error,
               showShadow: false,
               tooltip: context.l10n.relaySettingsRemove,
-              onPressed: () => _confirmRemoveRelay(context, relayUrl),
+              onPressed: () => _confirmRemoveRelay(
+                context,
+                relayUrl,
+                isDefaultRelay: isDefaultRelay,
+              ),
             ),
             const SizedBox(width: 8),
             DivineIcon(
@@ -702,7 +708,11 @@ Future<void> _showAddRelayDialog(BuildContext context) async {
   }
 }
 
-Future<void> _confirmRemoveRelay(BuildContext context, String relayUrl) async {
+Future<void> _confirmRemoveRelay(
+  BuildContext context,
+  String relayUrl, {
+  required bool isDefaultRelay,
+}) async {
   final cubit = context.read<RelaySettingsCubit>();
   final messenger = ScaffoldMessenger.of(context);
   final l10n = context.l10n;
@@ -710,12 +720,16 @@ Future<void> _confirmRemoveRelay(BuildContext context, String relayUrl) async {
   final confirm = await VineBottomSheet.show<bool>(
     context: context,
     scrollable: false,
-    contentTitle: l10n.relaySettingsRemoveRelayTitle,
+    contentTitle: isDefaultRelay
+        ? l10n.relaySettingsRemoveDefaultRelayTitle
+        : l10n.relaySettingsRemoveRelayTitle,
     children: [
       Padding(
         padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
         child: Text(
-          l10n.relaySettingsRemoveRelayMessage(relayUrl),
+          isDefaultRelay
+              ? l10n.relaySettingsRemoveDefaultRelayMessage(relayUrl)
+              : l10n.relaySettingsRemoveRelayMessage(relayUrl),
           style: VineTheme.bodyMediumFont(
             color: context.vineColors.secondaryText,
           ),

--- a/mobile/lib/screens/relay_settings_screen.dart
+++ b/mobile/lib/screens/relay_settings_screen.dart
@@ -13,6 +13,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/services/relay_statistics_service.dart';
+import 'package:openvine/utils/relay_url_utils.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -214,7 +215,7 @@ class _RelayList extends StatelessWidget {
   Widget build(BuildContext context) {
     final defaultRelayUrl = context.read<RelaySettingsCubit>().defaultRelayUrl;
     final hasDefaultRelay = relays.any(
-      (relay) => _relayUrlsEquivalent(relay, defaultRelayUrl),
+      (relay) => relayUrlsEquivalent(relay, defaultRelayUrl),
     );
 
     return Column(
@@ -277,7 +278,7 @@ class _RelayTile extends ConsumerWidget {
     final stats = statsAsync.whenData((allStats) => allStats[relayUrl]).value;
     final isConnected = stats?.isConnected ?? false;
     final statusSummary = _relayStatusSummary(context, stats);
-    final isDefaultRelay = _relayUrlsEquivalent(
+    final isDefaultRelay = relayUrlsEquivalent(
       relayUrl,
       context.read<RelaySettingsCubit>().defaultRelayUrl,
     );
@@ -685,26 +686,6 @@ class _AddRelaySheetState extends State<_AddRelaySheet> {
       ),
     );
   }
-}
-
-String? _normalizeRelayUrlForComparison(String url) {
-  final trimmed = url.trim();
-  if (trimmed.isEmpty) return null;
-  final uri = Uri.tryParse(trimmed);
-  if (uri == null || !uri.hasAuthority || uri.host.isEmpty) return null;
-  var normalized = uri.replace(scheme: uri.scheme.toLowerCase()).toString();
-  if (normalized.endsWith('/')) {
-    normalized = normalized.substring(0, normalized.length - 1);
-  }
-  return normalized;
-}
-
-bool _relayUrlsEquivalent(String a, String b) {
-  final normalizedA = _normalizeRelayUrlForComparison(a);
-  final normalizedB = _normalizeRelayUrlForComparison(b);
-  return normalizedA != null &&
-      normalizedB != null &&
-      normalizedA == normalizedB;
 }
 
 // Action helpers — pulled to top-level functions so the private widget

--- a/mobile/lib/screens/relay_settings_screen.dart
+++ b/mobile/lib/screens/relay_settings_screen.dart
@@ -212,6 +212,11 @@ class _RelayList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final defaultRelayUrl = context.read<RelaySettingsCubit>().defaultRelayUrl;
+    final hasDefaultRelay = relays.any(
+      (relay) => _relayUrlsEquivalent(relay, defaultRelayUrl),
+    );
+
     return Column(
       children: [
         Container(
@@ -239,6 +244,16 @@ class _RelayList extends StatelessWidget {
             ],
           ),
         ),
+        if (!hasDefaultRelay)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+            child: DivineButton(
+              label: context.l10n.relaySettingsRestoreDefaultRelay,
+              leadingIcon: DivineIconName.arrowCounterClockwise,
+              expanded: true,
+              onPressed: () => _restoreDefaultRelay(context),
+            ),
+          ),
         Expanded(
           child: ListView.builder(
             itemCount: relays.length,
@@ -262,8 +277,10 @@ class _RelayTile extends ConsumerWidget {
     final stats = statsAsync.whenData((allStats) => allStats[relayUrl]).value;
     final isConnected = stats?.isConnected ?? false;
     final statusSummary = _relayStatusSummary(context, stats);
-    final isDefaultRelay =
-        relayUrl == context.read<RelaySettingsCubit>().defaultRelayUrl;
+    final isDefaultRelay = _relayUrlsEquivalent(
+      relayUrl,
+      context.read<RelaySettingsCubit>().defaultRelayUrl,
+    );
 
     return Theme(
       data: Theme.of(context).copyWith(dividerColor: VineTheme.transparent),
@@ -302,7 +319,7 @@ class _RelayTile extends ConsumerWidget {
               backgroundColor: VineTheme.transparent,
               foregroundColor: VineTheme.error,
               showShadow: false,
-              tooltip: context.l10n.relaySettingsRemove,
+              tooltip: context.l10n.relaySettingsRemoveRelayTooltip,
               onPressed: () => _confirmRemoveRelay(
                 context,
                 relayUrl,
@@ -668,6 +685,26 @@ class _AddRelaySheetState extends State<_AddRelaySheet> {
       ),
     );
   }
+}
+
+String? _normalizeRelayUrlForComparison(String url) {
+  final trimmed = url.trim();
+  if (trimmed.isEmpty) return null;
+  final uri = Uri.tryParse(trimmed);
+  if (uri == null || !uri.hasAuthority || uri.host.isEmpty) return null;
+  var normalized = uri.replace(scheme: uri.scheme.toLowerCase()).toString();
+  if (normalized.endsWith('/')) {
+    normalized = normalized.substring(0, normalized.length - 1);
+  }
+  return normalized;
+}
+
+bool _relayUrlsEquivalent(String a, String b) {
+  final normalizedA = _normalizeRelayUrlForComparison(a);
+  final normalizedB = _normalizeRelayUrlForComparison(b);
+  return normalizedA != null &&
+      normalizedB != null &&
+      normalizedA == normalizedB;
 }
 
 // Action helpers — pulled to top-level functions so the private widget

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -9,7 +9,8 @@ import 'package:cache_sync/cache_sync.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
-import 'package:nostr_client/nostr_client.dart' show BlockListSigner;
+import 'package:nostr_client/nostr_client.dart'
+    show BlockListSigner, SharedPreferencesRelayStorage;
 import 'package:nostr_key_manager/nostr_key_manager.dart'
     show SecureKeyContainer, SecureKeyStorage, SecureKeyStorageException;
 import 'package:nostr_sdk/nostr_sdk.dart';
@@ -3353,7 +3354,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       }
 
       // Clear configured relays so next login re-discovers from NIP-65
-      await prefs.remove('configured_relays');
+      await prefs.remove(SharedPreferencesRelayStorage.defaultKey);
+      await prefs.remove(SharedPreferencesRelayStorage.defaultRemovedRelaysKey);
 
       // Clear relay discovery cache so next login re-queries indexers
       // (even for same-user re-login, relays may have changed)
@@ -3678,7 +3680,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     await prefs.remove(_kSessionRecoveryAnchorKey);
     await prefs.remove('age_verified_16_plus');
     await prefs.remove('terms_accepted_at');
-    await prefs.remove('configured_relays');
+    await prefs.remove(SharedPreferencesRelayStorage.defaultKey);
+    await prefs.remove(SharedPreferencesRelayStorage.defaultRemovedRelaysKey);
     await prefs.remove('current_user_pubkey_hex');
     await _resetRecoveryAfterLocalAccountRemoval(prefs);
 

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -390,17 +390,19 @@ class BugReportService {
 
   Future<List<String>?> _resolveTargetRelays(String recipientPubkey) async {
     final resolver = _targetRelayResolver;
-    if (resolver == null) return null;
+    if (resolver == null) return BugReportConfig.supportDmTargetRelays;
     try {
       final relays = await resolver(recipientPubkey);
-      if (relays == null || relays.isEmpty) return null;
+      if (relays == null || relays.isEmpty) {
+        return BugReportConfig.supportDmTargetRelays;
+      }
       return relays;
     } catch (e) {
       Log.warning(
-        'Failed to resolve bug-report DM target relays; using default relay pool: $e',
+        'Failed to resolve bug-report DM target relays; using static support relay fallback: $e',
         category: LogCategory.system,
       );
-      return null;
+      return BugReportConfig.supportDmTargetRelays;
     }
   }
 

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -320,7 +320,7 @@ class BugReportService {
       final result = await _nip17MessageService.sendPrivateMessage(
         recipientPubkey: recipientPubkey,
         content: messageContent,
-        targetRelays: const ['wss://relay.nos.social'],
+        targetRelays: BugReportConfig.supportDmTargetRelays,
         awaitRecipientOk: true,
         selfWrapOnSoftUnconfirmed: false,
         additionalTags: [

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -31,6 +31,9 @@ import 'package:unified_logger/unified_logger.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:uuid/uuid.dart';
 
+typedef BugReportTargetRelayResolver =
+    Future<List<String>?> Function(String recipientPubkey);
+
 /// Service for creating and managing bug reports
 class BugReportService {
   BugReportService({
@@ -38,16 +41,19 @@ class BugReportService {
     BlossomUploadService? blossomUploadService,
     ErrorAnalyticsTracker? errorTracker,
     StorageManagementService? storageManagementService,
+    BugReportTargetRelayResolver? targetRelayResolver,
   }) : _nip17MessageService = nip17MessageService,
        _blossomUploadService = blossomUploadService,
        _errorTracker = errorTracker ?? ErrorAnalyticsTracker(),
-       _storageManagementService = storageManagementService;
+       _storageManagementService = storageManagementService,
+       _targetRelayResolver = targetRelayResolver;
 
   static const _uuid = Uuid();
   final NIP17MessageService? _nip17MessageService;
   final BlossomUploadService? _blossomUploadService;
   final ErrorAnalyticsTracker _errorTracker;
   final StorageManagementService? _storageManagementService;
+  final BugReportTargetRelayResolver? _targetRelayResolver;
 
   /// Collect comprehensive diagnostics for bug report
   Future<BugReportData> collectDiagnostics({
@@ -315,12 +321,13 @@ class BugReportService {
         sanitizedData,
         bugReportUrl,
       );
+      final targetRelays = await _resolveTargetRelays(recipientPubkey);
 
       // Send via NIP-17 encrypted message
       final result = await _nip17MessageService.sendPrivateMessage(
         recipientPubkey: recipientPubkey,
         content: messageContent,
-        targetRelays: BugReportConfig.supportDmTargetRelays,
+        targetRelays: targetRelays,
         awaitRecipientOk: true,
         selfWrapOnSoftUnconfirmed: false,
         additionalTags: [
@@ -378,6 +385,22 @@ class BugReportService {
         category: LogCategory.system,
       );
       return sendBugReportViaEmail(data);
+    }
+  }
+
+  Future<List<String>?> _resolveTargetRelays(String recipientPubkey) async {
+    final resolver = _targetRelayResolver;
+    if (resolver == null) return null;
+    try {
+      final relays = await resolver(recipientPubkey);
+      if (relays == null || relays.isEmpty) return null;
+      return relays;
+    } catch (e) {
+      Log.warning(
+        'Failed to resolve bug-report DM target relays; using default relay pool: $e',
+        category: LogCategory.system,
+      );
+      return null;
     }
   }
 

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -316,26 +316,13 @@ class BugReportService {
         bugReportUrl,
       );
 
-      // Ensure backup relay is connected for bug reports
-      try {
-        await _nip17MessageService.nostrService.addRelay(
-          'wss://relay.nos.social',
-        );
-        Log.info(
-          'Added relay.nos.social as backup for bug report',
-          category: LogCategory.system,
-        );
-      } catch (e) {
-        Log.warning(
-          'Failed to add backup relay, continuing anyway: $e',
-          category: LogCategory.system,
-        );
-      }
-
       // Send via NIP-17 encrypted message
       final result = await _nip17MessageService.sendPrivateMessage(
         recipientPubkey: recipientPubkey,
         content: messageContent,
+        targetRelays: const ['wss://relay.nos.social'],
+        awaitRecipientOk: true,
+        selfWrapOnSoftUnconfirmed: false,
         additionalTags: [
           Nip89ClientTag.tag,
           ['report_id', data.reportId],

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -42,11 +42,13 @@ class BugReportService {
     ErrorAnalyticsTracker? errorTracker,
     StorageManagementService? storageManagementService,
     BugReportTargetRelayResolver? targetRelayResolver,
+    List<String> fallbackTargetRelays = BugReportConfig.supportDmTargetRelays,
   }) : _nip17MessageService = nip17MessageService,
        _blossomUploadService = blossomUploadService,
        _errorTracker = errorTracker ?? ErrorAnalyticsTracker(),
        _storageManagementService = storageManagementService,
-       _targetRelayResolver = targetRelayResolver;
+       _targetRelayResolver = targetRelayResolver,
+       _fallbackTargetRelays = List.unmodifiable(fallbackTargetRelays);
 
   static const _uuid = Uuid();
   final NIP17MessageService? _nip17MessageService;
@@ -54,6 +56,7 @@ class BugReportService {
   final ErrorAnalyticsTracker _errorTracker;
   final StorageManagementService? _storageManagementService;
   final BugReportTargetRelayResolver? _targetRelayResolver;
+  final List<String> _fallbackTargetRelays;
 
   /// Collect comprehensive diagnostics for bug report
   Future<BugReportData> collectDiagnostics({
@@ -390,19 +393,19 @@ class BugReportService {
 
   Future<List<String>?> _resolveTargetRelays(String recipientPubkey) async {
     final resolver = _targetRelayResolver;
-    if (resolver == null) return BugReportConfig.supportDmTargetRelays;
+    if (resolver == null) return _fallbackTargetRelays;
     try {
       final relays = await resolver(recipientPubkey);
       if (relays == null || relays.isEmpty) {
-        return BugReportConfig.supportDmTargetRelays;
+        return _fallbackTargetRelays;
       }
       return relays;
     } catch (e) {
       Log.warning(
-        'Failed to resolve bug-report DM target relays; using static support relay fallback: $e',
+        'Failed to resolve bug-report DM target relays; using fallback relays: $e',
         category: LogCategory.system,
       );
-      return BugReportConfig.supportDmTargetRelays;
+      return _fallbackTargetRelays;
     }
   }
 

--- a/mobile/lib/services/environment_service.dart
+++ b/mobile/lib/services/environment_service.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Handles developer mode unlock and environment switching
 
 import 'package:flutter/foundation.dart';
+import 'package:nostr_client/nostr_client.dart'
+    show SharedPreferencesRelayStorage;
 import 'package:openvine/models/environment_config.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -67,8 +69,10 @@ class EnvironmentService extends ChangeNotifier {
 
     await _prefs!.setString(_keyEnvironment, environment.name);
 
-    // Clear persisted relay list so new environment starts fresh with its default
-    await _prefs!.remove('configured_relays');
+    // Clear persisted relay state so new environment starts fresh with its
+    // default and does not inherit user-removal intent from another relay set.
+    await _prefs!.remove(SharedPreferencesRelayStorage.defaultKey);
+    await _prefs!.remove(SharedPreferencesRelayStorage.defaultRemovedRelaysKey);
 
     notifyListeners();
   }

--- a/mobile/lib/services/nostr_service_factory.dart
+++ b/mobile/lib/services/nostr_service_factory.dart
@@ -61,8 +61,7 @@ class NostrServiceFactory {
         ? null
         : relayHost;
 
-    // Create relay manager config with persistent storage
-    // The Divine relay is always the default relay (cannot be removed)
+    // Create relay manager config with persistent storage.
     final relayManagerConfig = RelayManagerConfig(
       defaultRelayUrl: divineRelayUrl,
       storage: SharedPreferencesRelayStorage(),

--- a/mobile/lib/utils/relay_url_utils.dart
+++ b/mobile/lib/utils/relay_url_utils.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Helpers for resolving API base URLs from Nostr relay WebSocket URLs.
 // ABOUTME: Keeps REST endpoints aligned with active relay configuration.
 
+import 'package:nostr_client/nostr_client.dart' as nostr_client;
 import 'package:nostr_sdk/nostr_sdk.dart' as nostr_sdk;
 
 const _divineRelayHost = 'relay.divine.video';
@@ -65,7 +66,7 @@ bool usesUserChosenRelay(
 /// and `ws://` is accepted only for a recognized loopback host. Any other
 /// scheme (`https://`, `http://`, `ftp://`, …), a malformed URL, or a missing
 /// host is rejected. This matches the acceptance rule enforced by
-/// `RelayManager._normalizeUrl` in `nostr_client`, so the predicate doubles
+/// `normalizeRelayUrl` in `nostr_client`, so the predicate doubles
 /// as the upstream "is this URL a usable relay endpoint" check.
 ///
 /// This predicate is the single source of truth for the application-layer
@@ -87,35 +88,10 @@ bool isRelayUrlAllowed(String url) {
 
 /// Normalizes a relay URL for identity comparison in UI state.
 ///
-/// Mirrors the connection-layer normalization closely enough for Settings:
-/// explicit `ws` / `wss` URLs are lowercased by Dart's URI parser, bare
-/// host[:port][/path] inputs are treated as `wss://`, and a single trailing
-/// slash is ignored.
-String? normalizeRelayUrlForComparison(String url) {
-  final trimmed = url.trim();
-  if (trimmed.isEmpty) return null;
-
-  String normalized;
-  final initial = Uri.tryParse(trimmed);
-  if (initial != null && initial.hasAuthority) {
-    final scheme = initial.scheme.toLowerCase();
-    if (scheme != 'wss' && scheme != 'ws') return null;
-    if (initial.path.startsWith('//')) return null;
-    normalized = initial.toString();
-  } else {
-    if (trimmed.contains('://')) return null;
-    normalized = 'wss://$trimmed';
-  }
-
-  if (normalized.endsWith('/')) {
-    normalized = normalized.substring(0, normalized.length - 1);
-  }
-
-  final uri = Uri.tryParse(normalized);
-  if (uri == null || uri.host.isEmpty) return null;
-  if (uri.scheme == 'ws' && !isLoopbackHost(uri.host)) return null;
-  return normalized;
-}
+/// Delegates to the connection-layer normalizer so Settings identity checks
+/// cannot drift from persisted relay identity.
+String? normalizeRelayUrlForComparison(String url) =>
+    nostr_client.normalizeRelayUrl(url);
 
 /// True when [a] and [b] identify the same relay endpoint.
 bool relayUrlsEquivalent(String a, String b) {

--- a/mobile/lib/utils/relay_url_utils.dart
+++ b/mobile/lib/utils/relay_url_utils.dart
@@ -65,9 +65,9 @@ bool usesUserChosenRelay(
 /// Nostr relays speak WebSocket only — `wss://` is accepted for any host,
 /// and `ws://` is accepted only for a recognized loopback host. Any other
 /// scheme (`https://`, `http://`, `ftp://`, …), a malformed URL, or a missing
-/// host is rejected. This matches the acceptance rule enforced by
-/// `normalizeRelayUrl` in `nostr_client`, so the predicate doubles
-/// as the upstream "is this URL a usable relay endpoint" check.
+/// host is rejected. Unlike `normalizeRelayUrl` in `nostr_client`, this
+/// requires an explicit scheme and rejects bare hosts because it validates
+/// user/app-layer input before the connection layer canonicalizes identity.
 ///
 /// This predicate is the single source of truth for the application-layer
 /// relay URL allowlist. The loopback host predicate itself lives in

--- a/mobile/lib/utils/relay_url_utils.dart
+++ b/mobile/lib/utils/relay_url_utils.dart
@@ -85,6 +85,47 @@ bool isRelayUrlAllowed(String url) {
   return false;
 }
 
+/// Normalizes a relay URL for identity comparison in UI state.
+///
+/// Mirrors the connection-layer normalization closely enough for Settings:
+/// explicit `ws` / `wss` URLs are lowercased by Dart's URI parser, bare
+/// host[:port][/path] inputs are treated as `wss://`, and a single trailing
+/// slash is ignored.
+String? normalizeRelayUrlForComparison(String url) {
+  final trimmed = url.trim();
+  if (trimmed.isEmpty) return null;
+
+  String normalized;
+  final initial = Uri.tryParse(trimmed);
+  if (initial != null && initial.hasAuthority) {
+    final scheme = initial.scheme.toLowerCase();
+    if (scheme != 'wss' && scheme != 'ws') return null;
+    if (initial.path.startsWith('//')) return null;
+    normalized = initial.toString();
+  } else {
+    if (trimmed.contains('://')) return null;
+    normalized = 'wss://$trimmed';
+  }
+
+  if (normalized.endsWith('/')) {
+    normalized = normalized.substring(0, normalized.length - 1);
+  }
+
+  final uri = Uri.tryParse(normalized);
+  if (uri == null || uri.host.isEmpty) return null;
+  if (uri.scheme == 'ws' && !isLoopbackHost(uri.host)) return null;
+  return normalized;
+}
+
+/// True when [a] and [b] identify the same relay endpoint.
+bool relayUrlsEquivalent(String a, String b) {
+  final normalizedA = normalizeRelayUrlForComparison(a);
+  final normalizedB = normalizeRelayUrlForComparison(b);
+  return normalizedA != null &&
+      normalizedB != null &&
+      normalizedA == normalizedB;
+}
+
 /// Convert a relay WebSocket URL to an HTTP(S) base URL.
 ///
 /// Examples:

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -109,9 +109,6 @@ class NIP17MessageService {
     BuildGiftWrapRequest request,
   ) => compute(buildGiftWrapBatch, request);
 
-  /// Access to the underlying NostrService for relay management
-  NostrClient get nostrService => _nostrService;
-
   /// Whether the injected [DmSendPolicy] permits delivering to
   /// [recipientPubkey]. Exposed so `DmRepository` can gate BEFORE enqueue
   /// (avoid storing a doomed intent) and enforce group all-or-nothing before
@@ -331,12 +328,15 @@ class NIP17MessageService {
   /// still published when the recipient publish ends soft-unconfirmed (frame
   /// written, no OK). Reactions keep the default `true` — a lost OK may mean
   /// the recipient already has the reaction, and their retry service owns
-  /// the follow-up (#5977). Message sends pass `false`: their durable queue
+  /// the follow-up (#5977). Durable message sends pass `false`: their queue
   /// re-drives the FULL send until the recipient wrap confirms (publishing
   /// both wraps on success), so a soft self-wrap buys no durability — but if
   /// it lands, its round-trip through the receive pipeline persists the
   /// message as a plain sent row, seeding a sent-looking bubble for a
-  /// message the recipient may never have received (#6046).
+  /// message the recipient may never have received (#6046). Non-queued callers
+  /// that also pass `false` are choosing a hard no-self-wrap confirmation
+  /// contract: soft-unconfirmed recipient publishes return retryable failure
+  /// and the caller owns any fallback behavior.
   Future<NIP17SendResult> sendRumor({
     required Event rumorEvent,
     required String recipientPubkey,

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -802,6 +802,9 @@ class NIP17MessageService {
     required String content,
     int eventKind = EventKind.privateDirectMessage,
     List<List<String>> additionalTags = const [],
+    List<String>? targetRelays,
+    bool awaitRecipientOk = false,
+    bool selfWrapOnSoftUnconfirmed = true,
   }) async {
     final rumor = buildRumor(
       recipientPubkey: recipientPubkey,
@@ -809,7 +812,13 @@ class NIP17MessageService {
       eventKind: eventKind,
       additionalTags: additionalTags,
     );
-    return sendRumor(rumorEvent: rumor, recipientPubkey: recipientPubkey);
+    return sendRumor(
+      rumorEvent: rumor,
+      recipientPubkey: recipientPubkey,
+      targetRelays: targetRelays,
+      awaitRecipientOk: awaitRecipientOk,
+      selfWrapOnSoftUnconfirmed: selfWrapOnSoftUnconfirmed,
+    );
   }
 
   /// Dummy relay generator - we don't use relays in this Nostr instance

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -1437,6 +1437,49 @@ void main() {
         expect(result.success, isTrue);
         expect(result.rumorEventId, isNotNull);
       });
+
+      test(
+        'sendPrivateMessage forwards target relay confirmation options',
+        () async {
+          const targetRelays = ['wss://relay.nos.social'];
+          when(
+            () => mockNostrClient.publishEventAwaitOk(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer(
+            (_) async => const PublishOutcome(
+              eventId: 'gift-wrap-id',
+              acceptedBy: ['wss://relay.nos.social'],
+              rejectedBy: {},
+              noResponseFrom: [],
+            ),
+          );
+          when(() => mockNostrClient.publishEvent(any())).thenAnswer(
+            (invocation) async => PublishSuccess(
+              event: invocation.positionalArguments[0] as Event,
+            ),
+          );
+
+          final result = await service.sendPrivateMessage(
+            recipientPubkey: _recipientPubkey,
+            content: 'targeted message',
+            targetRelays: targetRelays,
+            awaitRecipientOk: true,
+            selfWrapOnSoftUnconfirmed: false,
+          );
+
+          expect(result.success, isTrue);
+          verify(
+            () => mockNostrClient.publishEventAwaitOk(
+              any(),
+              targetRelays: targetRelays,
+              timeout: any(named: 'timeout'),
+            ),
+          ).called(1);
+        },
+      );
     });
 
     group('publishSelfWrap', () {

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -158,10 +158,6 @@ void main() {
       );
     });
 
-    test('nostrService getter returns the injected client', () {
-      expect(service.nostrService, same(mockNostrClient));
-    });
-
     group('send policy gate', () {
       test(
         'sendRumor blocked by policy returns failure and never publishes',

--- a/mobile/packages/nostr_client/lib/src/models/models.dart
+++ b/mobile/packages/nostr_client/lib/src/models/models.dart
@@ -3,4 +3,5 @@ export 'nostr_client_config.dart';
 export 'relay_add_source.dart';
 export 'relay_connection_status.dart';
 export 'relay_manager_config.dart';
+export 'relay_remove_source.dart';
 export 'shared_preferences_relay_storage.dart';

--- a/mobile/packages/nostr_client/lib/src/models/models.dart
+++ b/mobile/packages/nostr_client/lib/src/models/models.dart
@@ -1,5 +1,6 @@
 export 'count_result.dart';
 export 'nostr_client_config.dart';
+export 'relay_add_source.dart';
 export 'relay_connection_status.dart';
 export 'relay_manager_config.dart';
 export 'shared_preferences_relay_storage.dart';

--- a/mobile/packages/nostr_client/lib/src/models/relay_add_source.dart
+++ b/mobile/packages/nostr_client/lib/src/models/relay_add_source.dart
@@ -1,0 +1,9 @@
+/// Identifies why a relay is being added to the configured relay list.
+enum RelayAddSource {
+  /// The user explicitly added or restored the relay from settings.
+  user,
+
+  /// The app added the relay for discovery, fallback, bootstrap, or
+  /// reachability.
+  automatic,
+}

--- a/mobile/packages/nostr_client/lib/src/models/relay_connection_status.dart
+++ b/mobile/packages/nostr_client/lib/src/models/relay_connection_status.dart
@@ -82,7 +82,7 @@ class RelayConnectionStatus extends Equatable {
   /// Current connection state
   final RelayState state;
 
-  /// Whether this is the default relay that cannot be removed
+  /// Whether this is the environment default relay.
   final bool isDefault;
 
   /// Whether this relay is in the user's configured list

--- a/mobile/packages/nostr_client/lib/src/models/relay_manager_config.dart
+++ b/mobile/packages/nostr_client/lib/src/models/relay_manager_config.dart
@@ -14,6 +14,12 @@ abstract class RelayStorage {
 
   /// Saves the list of configured relay URLs to storage
   Future<void> saveRelays(List<String> relayUrls);
+
+  /// Loads the list of relays the user explicitly removed.
+  Future<List<String>> loadRemovedRelays();
+
+  /// Saves the list of relays the user explicitly removed.
+  Future<void> saveRemovedRelays(List<String> relayUrls);
 }
 
 /// {@template in_memory_relay_storage}
@@ -21,10 +27,14 @@ abstract class RelayStorage {
 /// {@endtemplate}
 class InMemoryRelayStorage implements RelayStorage {
   /// {@macro in_memory_relay_storage}
-  InMemoryRelayStorage([List<String>? initialRelays])
-    : _relays = initialRelays ?? [];
+  InMemoryRelayStorage([
+    List<String>? initialRelays,
+    List<String>? removedRelays,
+  ]) : _relays = initialRelays ?? [],
+       _removedRelays = removedRelays ?? [];
 
   final List<String> _relays;
+  final List<String> _removedRelays;
 
   @override
   Future<List<String>> loadRelays() async => List.from(_relays);
@@ -32,6 +42,16 @@ class InMemoryRelayStorage implements RelayStorage {
   @override
   Future<void> saveRelays(List<String> relayUrls) async {
     _relays
+      ..clear()
+      ..addAll(relayUrls);
+  }
+
+  @override
+  Future<List<String>> loadRemovedRelays() async => List.from(_removedRelays);
+
+  @override
+  Future<void> saveRemovedRelays(List<String> relayUrls) async {
+    _removedRelays
       ..clear()
       ..addAll(relayUrls);
   }

--- a/mobile/packages/nostr_client/lib/src/models/relay_manager_config.dart
+++ b/mobile/packages/nostr_client/lib/src/models/relay_manager_config.dart
@@ -72,7 +72,7 @@ class RelayManagerConfig {
     this.allowedRelayHost,
   });
 
-  /// The default relay URL that is always included and cannot be removed
+  /// The environment default relay URL.
   final String defaultRelayUrl;
 
   /// When set, only relays whose host equals this value are admitted.

--- a/mobile/packages/nostr_client/lib/src/models/relay_remove_source.dart
+++ b/mobile/packages/nostr_client/lib/src/models/relay_remove_source.dart
@@ -1,0 +1,8 @@
+/// Identifies why a relay is being removed from the configured relay list.
+enum RelayRemoveSource {
+  /// The user explicitly removed the relay from settings.
+  user,
+
+  /// The app removed the relay while reconciling or replacing clients.
+  automatic,
+}

--- a/mobile/packages/nostr_client/lib/src/models/shared_preferences_relay_storage.dart
+++ b/mobile/packages/nostr_client/lib/src/models/shared_preferences_relay_storage.dart
@@ -30,11 +30,15 @@ class SharedPreferencesRelayStorage implements RelayStorage {
   /// [removedRelaysKey] stores relays the user explicitly removed so
   /// automatic discovery and fallback paths do not re-add them.
   SharedPreferencesRelayStorage({String? key, String? removedRelaysKey})
-    : _key = key ?? _defaultKey,
-      _removedRelaysKey = removedRelaysKey ?? _defaultRemovedRelaysKey;
+    : _key = key ?? defaultKey,
+      _removedRelaysKey = removedRelaysKey ?? defaultRemovedRelaysKey;
 
-  static const String _defaultKey = 'configured_relays';
-  static const String _defaultRemovedRelaysKey = 'user_removed_relays';
+  /// Default SharedPreferences key for configured relays.
+  static const String defaultKey = 'configured_relays';
+
+  /// Default SharedPreferences key for relays explicitly removed by the user.
+  static const String defaultRemovedRelaysKey = 'user_removed_relays';
+
   final String _key;
   final String _removedRelaysKey;
 

--- a/mobile/packages/nostr_client/lib/src/models/shared_preferences_relay_storage.dart
+++ b/mobile/packages/nostr_client/lib/src/models/shared_preferences_relay_storage.dart
@@ -24,12 +24,19 @@ import 'package:shared_preferences/shared_preferences.dart';
 class SharedPreferencesRelayStorage implements RelayStorage {
   /// {@macro shared_preferences_relay_storage}
   ///
-  /// [key] is the SharedPreferences key to use for storage.
+  /// [key] is the SharedPreferences key to use for configured relay storage.
   /// Defaults to 'configured_relays'.
-  SharedPreferencesRelayStorage({String? key}) : _key = key ?? _defaultKey;
+  ///
+  /// [removedRelaysKey] stores relays the user explicitly removed so
+  /// automatic discovery and fallback paths do not re-add them.
+  SharedPreferencesRelayStorage({String? key, String? removedRelaysKey})
+    : _key = key ?? _defaultKey,
+      _removedRelaysKey = removedRelaysKey ?? _defaultRemovedRelaysKey;
 
   static const String _defaultKey = 'configured_relays';
+  static const String _defaultRemovedRelaysKey = 'user_removed_relays';
   final String _key;
+  final String _removedRelaysKey;
 
   @override
   Future<List<String>> loadRelays() async {
@@ -42,5 +49,18 @@ class SharedPreferencesRelayStorage implements RelayStorage {
   Future<void> saveRelays(List<String> relayUrls) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setStringList(_key, relayUrls);
+  }
+
+  @override
+  Future<List<String>> loadRemovedRelays() async {
+    final prefs = await SharedPreferences.getInstance();
+    final relays = prefs.getStringList(_removedRelaysKey);
+    return relays != null ? List<String>.from(relays) : <String>[];
+  }
+
+  @override
+  Future<void> saveRemovedRelays(List<String> relayUrls) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_removedRelaysKey, relayUrls);
   }
 }

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -496,9 +496,14 @@ class NostrClient {
       _cacheEvent(event);
     }
 
+    final hasExplicitTargets =
+        effectiveTargets != null && effectiveTargets.isNotEmpty;
+
     // Checks health of relays, attempts reconnection if none connected,
-    // and exits if reconnect is unsuccessful
-    if (_relayManager.connectedRelays.isEmpty) {
+    // and exits if reconnect is unsuccessful. Explicit target relays use
+    // temporary SDK connections, so they do not require the configured pool
+    // to already have a connected relay.
+    if (_relayManager.connectedRelays.isEmpty && !hasExplicitTargets) {
       await retryDisconnectedRelays();
       if (_relayManager.connectedRelays.isEmpty) {
         // Rollback optimistic cache on failure
@@ -1051,8 +1056,11 @@ class NostrClient {
   /// Adds a relay connection
   ///
   /// Delegates to RelayManager for persistence and status tracking.
-  Future<bool> addRelay(String relayUrl) async {
-    return _relayManager.addRelay(relayUrl);
+  Future<bool> addRelay(
+    String relayUrl, {
+    RelayAddSource source = RelayAddSource.automatic,
+  }) async {
+    return _relayManager.addRelay(relayUrl, source: source);
   }
 
   /// Adds multiple relay connections
@@ -1061,10 +1069,13 @@ class NostrClient {
   /// all relays are connected before the client starts making requests.
   ///
   /// Returns the number of relays successfully added.
-  Future<int> addRelays(List<String> relayUrls) async {
+  Future<int> addRelays(
+    List<String> relayUrls, {
+    RelayAddSource source = RelayAddSource.automatic,
+  }) async {
     var addedCount = 0;
     for (final relayUrl in relayUrls) {
-      final added = await addRelay(relayUrl);
+      final added = await addRelay(relayUrl, source: source);
       if (added) {
         addedCount++;
       }

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -1113,6 +1113,11 @@ class NostrClient {
   /// for the rule. Non-production builds lock to their own relay host.
   bool isRelayAllowed(String url) => _relayManager.isRelayAllowed(url);
 
+  /// Whether [url] is currently suppressed by user-removal intent.
+  Future<bool> isUserRemovedRelay(String url) {
+    return _relayManager.isUserRemovedRelay(url);
+  }
+
   /// The environment default relay URL.
   ///
   /// Resolves per environment (e.g. the staging relay on staging). Users can

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -1096,11 +1096,15 @@ class NostrClient {
     return allowed.isEmpty ? null : allowed;
   }
 
-  /// Removes a relay connection
+  /// Removes a relay connection.
   ///
-  /// Delegates to RelayManager.
-  Future<bool> removeRelay(String relayUrl) async {
-    return _relayManager.removeRelay(relayUrl);
+  /// User removals are remembered so automatic discovery does not re-add the
+  /// relay. Automatic removals are only reconciliation cleanup.
+  Future<bool> removeRelay(
+    String relayUrl, {
+    RelayRemoveSource source = RelayRemoveSource.user,
+  }) async {
+    return _relayManager.removeRelay(relayUrl, source: source);
   }
 
   /// Whether [url] is admissible under the configured environment lock.
@@ -1109,8 +1113,11 @@ class NostrClient {
   /// for the rule. Non-production builds lock to their own relay host.
   bool isRelayAllowed(String url) => _relayManager.isRelayAllowed(url);
 
-  /// The environment default relay URL that is always included and cannot be
-  /// removed. Resolves per environment (e.g. the staging relay on staging).
+  /// The environment default relay URL.
+  ///
+  /// Resolves per environment (e.g. the staging relay on staging). Users can
+  /// remove it from Settings, but doing so may degrade the app experience until
+  /// it is restored.
   String get defaultRelayUrl => _relayManager.defaultRelayUrl;
 
   /// Gets list of configured relay URLs

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -1102,7 +1102,7 @@ class NostrClient {
   /// relay. Automatic removals are only reconciliation cleanup.
   Future<bool> removeRelay(
     String relayUrl, {
-    RelayRemoveSource source = RelayRemoveSource.user,
+    required RelayRemoveSource source,
   }) async {
     return _relayManager.removeRelay(relayUrl, source: source);
   }

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -1143,7 +1143,7 @@ class NostrClient {
   /// Primary relay for client operations
   ///
   /// Returns the first connected relay, or first configured relay,
-  /// or the default relay URL if none are configured.
+  /// or the environment default relay URL if none are configured.
   String get primaryRelay {
     if (connectedRelays.isNotEmpty) {
       return connectedRelays.first;
@@ -1151,7 +1151,7 @@ class NostrClient {
     if (configuredRelays.isNotEmpty) {
       return configuredRelays.first;
     }
-    return 'wss://relay.divine.video';
+    return _relayManager.defaultRelayUrl;
   }
 
   /// Returns per-relay counters from the SDK's [RelayStatus].

--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -8,6 +8,7 @@ import 'package:meta/meta.dart';
 import 'package:nostr_client/src/models/relay_add_source.dart';
 import 'package:nostr_client/src/models/relay_connection_status.dart';
 import 'package:nostr_client/src/models/relay_manager_config.dart';
+import 'package:nostr_client/src/models/relay_remove_source.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostr_sdk/relay/client_connected.dart';
 
@@ -90,11 +91,14 @@ class RelayManager {
   /// Whether the manager has been initialized
   bool _initialized = false;
 
+  /// Whether persisted user-removal intent has been loaded.
+  bool _userRemovedRelaysLoaded = false;
+
   // ---------------------------------------------------------------------------
   // Public Getters
   // ---------------------------------------------------------------------------
 
-  /// The default relay URL that cannot be removed
+  /// The environment default relay URL.
   String get defaultRelayUrl => _config.defaultRelayUrl;
 
   /// List of relay URLs the user has configured (including default)
@@ -147,24 +151,9 @@ class RelayManager {
 
     _log('Initializing RelayManager');
 
-    // Load persisted relays
     final storage = _config.storage;
     if (storage != null) {
-      final savedRemovedRelays = await storage.loadRemovedRelays();
-      var removedDroppedCount = 0;
-      for (final url in savedRemovedRelays) {
-        final normalized = _normalizeUrl(url);
-        if (normalized == null || !isRelayAllowed(normalized)) {
-          removedDroppedCount++;
-          continue;
-        }
-        _userRemovedRelays.add(normalized);
-      }
-      if (removedDroppedCount > 0 ||
-          _userRemovedRelays.length != savedRemovedRelays.length) {
-        await storage.saveRemovedRelays(_userRemovedRelays.toList());
-        _log('Saved filtered user-removed relay list to storage');
-      }
+      await _ensureUserRemovedRelaysLoaded();
 
       final savedRelays = await storage.loadRelays();
       // Normalize loaded relays and filter out blocked/duplicate/invalid
@@ -198,6 +187,7 @@ class RelayManager {
           _configuredRelays.add(normalized);
         }
       }
+      droppedCount += _dropUserRemovedConfiguredRelays();
       if (blockedCount > 0) {
         _log('Filtered $blockedCount blocked relays from storage');
       }
@@ -213,11 +203,11 @@ class RelayManager {
       _log('Loaded ${_configuredRelays.length} relays from storage');
     }
 
-    // Ensure default relay is always included
-    // (uses normalized URL for comparison)
+    // Add the environment default unless the user explicitly removed it.
     final normalizedDefault = _normalizeUrl(_config.defaultRelayUrl);
     if (normalizedDefault != null &&
         isRelayAllowed(normalizedDefault) &&
+        !_userRemovedRelays.contains(normalizedDefault) &&
         !_configuredRelays.contains(normalizedDefault)) {
       _configuredRelays.insert(0, normalizedDefault);
       _log('Added default relay: $normalizedDefault');
@@ -254,6 +244,8 @@ class RelayManager {
     String url, {
     RelayAddSource source = RelayAddSource.automatic,
   }) async {
+    await _ensureUserRemovedRelaysLoaded();
+
     final normalizedUrl = _normalizeUrl(url);
 
     if (normalizedUrl == null) {
@@ -324,7 +316,12 @@ class RelayManager {
   ///
   /// Returns true if the relay was removed.
   /// Returns false if the relay URL is invalid or not configured.
-  Future<bool> removeRelay(String url) async {
+  Future<bool> removeRelay(
+    String url, {
+    RelayRemoveSource source = RelayRemoveSource.user,
+  }) async {
+    await _ensureUserRemovedRelaysLoaded();
+
     final normalizedUrl = _normalizeUrl(url);
 
     if (normalizedUrl == null) {
@@ -345,11 +342,13 @@ class RelayManager {
     // Remove from configured list and statuses
     _configuredRelays.remove(normalizedUrl);
     _relayStatuses.remove(normalizedUrl);
-    _userRemovedRelays.add(normalizedUrl);
 
     // Persist configuration
     await _saveConfiguration();
-    await _saveUserRemovedRelays();
+    if (source == RelayRemoveSource.user) {
+      _userRemovedRelays.add(normalizedUrl);
+      await _saveUserRemovedRelays();
+    }
 
     _notifyStatusChange();
     return true;
@@ -710,6 +709,45 @@ class RelayManager {
       _log('Saved ${_userRemovedRelays.length} user-removed relays to storage');
     }
   }
+
+  Future<void> _ensureUserRemovedRelaysLoaded() async {
+    if (_userRemovedRelaysLoaded) return;
+
+    final storage = _config.storage;
+    if (storage == null) {
+      _userRemovedRelaysLoaded = true;
+      return;
+    }
+
+    final savedRemovedRelays = await storage.loadRemovedRelays();
+    final normalizedRelays = <String>{};
+    for (final url in savedRemovedRelays) {
+      final normalized = _normalizeUrl(url);
+      if (normalized != null && isRelayAllowed(normalized)) {
+        normalizedRelays.add(normalized);
+      }
+    }
+
+    _userRemovedRelays
+      ..clear()
+      ..addAll(normalizedRelays);
+
+    if (savedRemovedRelays.length != normalizedRelays.length ||
+        !_setsEqual(normalizedRelays, savedRemovedRelays.toSet())) {
+      await storage.saveRemovedRelays(_userRemovedRelays.toList());
+      _log('Saved filtered user-removed relay list to storage');
+    }
+    _userRemovedRelaysLoaded = true;
+  }
+
+  int _dropUserRemovedConfiguredRelays() {
+    final before = _configuredRelays.length;
+    _configuredRelays.removeWhere(_userRemovedRelays.contains);
+    return before - _configuredRelays.length;
+  }
+
+  bool _setsEqual<T>(Set<T> a, Set<T> b) =>
+      a.length == b.length && a.containsAll(b);
 
   Future<void> _clearUserRemovedRelay(String normalizedUrl) async {
     if (_userRemovedRelays.remove(normalizedUrl)) {

--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'dart:developer' as developer;
 
 import 'package:meta/meta.dart';
+import 'package:nostr_client/src/models/relay_add_source.dart';
 import 'package:nostr_client/src/models/relay_connection_status.dart';
 import 'package:nostr_client/src/models/relay_manager_config.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
@@ -72,6 +73,9 @@ class RelayManager {
 
   /// Configured relay URLs (user's list, persisted)
   final List<String> _configuredRelays = [];
+
+  /// Relay URLs the user explicitly removed.
+  final Set<String> _userRemovedRelays = {};
 
   /// Status for each relay
   final Map<String, RelayConnectionStatus> _relayStatuses = {};
@@ -146,6 +150,22 @@ class RelayManager {
     // Load persisted relays
     final storage = _config.storage;
     if (storage != null) {
+      final savedRemovedRelays = await storage.loadRemovedRelays();
+      var removedDroppedCount = 0;
+      for (final url in savedRemovedRelays) {
+        final normalized = _normalizeUrl(url);
+        if (normalized == null || !isRelayAllowed(normalized)) {
+          removedDroppedCount++;
+          continue;
+        }
+        _userRemovedRelays.add(normalized);
+      }
+      if (removedDroppedCount > 0 ||
+          _userRemovedRelays.length != savedRemovedRelays.length) {
+        await storage.saveRemovedRelays(_userRemovedRelays.toList());
+        _log('Saved filtered user-removed relay list to storage');
+      }
+
       final savedRelays = await storage.loadRelays();
       // Normalize loaded relays and filter out blocked/duplicate/invalid
       // relays.
@@ -167,6 +187,10 @@ class RelayManager {
         if (!isRelayAllowed(normalized)) {
           // Persisted from another environment (e.g. a production relay
           // saved before switching to staging). Drop and re-save below.
+          droppedCount++;
+          continue;
+        }
+        if (_userRemovedRelays.contains(normalized)) {
           droppedCount++;
           continue;
         }
@@ -226,7 +250,10 @@ class RelayManager {
   ///
   /// Returns true if the relay was added and connected successfully.
   /// Returns false if the relay URL is invalid, blocked, or already configured.
-  Future<bool> addRelay(String url) async {
+  Future<bool> addRelay(
+    String url, {
+    RelayAddSource source = RelayAddSource.automatic,
+  }) async {
     final normalizedUrl = _normalizeUrl(url);
 
     if (normalizedUrl == null) {
@@ -244,6 +271,16 @@ class RelayManager {
     if (!isRelayAllowed(normalizedUrl)) {
       _log('Relay not allowed in this environment: $normalizedUrl');
       return false;
+    }
+
+    if (source == RelayAddSource.automatic &&
+        _userRemovedRelays.contains(normalizedUrl)) {
+      _log('Skipping user-removed automatic relay: $normalizedUrl');
+      return false;
+    }
+
+    if (source == RelayAddSource.user) {
+      await _clearUserRemovedRelay(normalizedUrl);
     }
 
     if (_configuredRelays.contains(normalizedUrl)) {
@@ -308,9 +345,11 @@ class RelayManager {
     // Remove from configured list and statuses
     _configuredRelays.remove(normalizedUrl);
     _relayStatuses.remove(normalizedUrl);
+    _userRemovedRelays.add(normalizedUrl);
 
     // Persist configuration
     await _saveConfiguration();
+    await _saveUserRemovedRelays();
 
     _notifyStatusChange();
     return true;
@@ -661,6 +700,20 @@ class RelayManager {
     if (storage != null) {
       await storage.saveRelays(_configuredRelays);
       _log('Saved ${_configuredRelays.length} relays to storage');
+    }
+  }
+
+  Future<void> _saveUserRemovedRelays() async {
+    final storage = _config.storage;
+    if (storage != null) {
+      await storage.saveRemovedRelays(_userRemovedRelays.toList());
+      _log('Saved ${_userRemovedRelays.length} user-removed relays to storage');
+    }
+  }
+
+  Future<void> _clearUserRemovedRelay(String normalizedUrl) async {
+    if (_userRemovedRelays.remove(normalizedUrl)) {
+      await _saveUserRemovedRelays();
     }
   }
 

--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -318,7 +318,7 @@ class RelayManager {
   /// Returns false if the relay URL is invalid or not configured.
   Future<bool> removeRelay(
     String url, {
-    RelayRemoveSource source = RelayRemoveSource.user,
+    required RelayRemoveSource source,
   }) async {
     await _ensureUserRemovedRelaysLoaded();
 

--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -196,10 +196,11 @@ class RelayManager {
       await _ensureUserRemovedRelaysLoaded();
 
       final savedRelays = await storage.loadRelays();
-      // Normalize loaded relays and filter out blocked/duplicate/invalid
-      // relays.
+      // Normalize loaded relays and filter out blocked, duplicate, invalid,
+      // disallowed, or user-suppressed relays.
       var blockedCount = 0;
       var droppedCount = 0;
+      var userRemovedCount = 0;
       for (final url in savedRelays) {
         final normalized = normalizeRelayUrl(url);
         if (normalized == null) {
@@ -220,7 +221,7 @@ class RelayManager {
           continue;
         }
         if (_userRemovedRelays.contains(normalized)) {
-          droppedCount++;
+          userRemovedCount++;
           continue;
         }
         if (!_configuredRelays.contains(normalized)) {
@@ -233,7 +234,10 @@ class RelayManager {
       if (droppedCount > 0) {
         _log('Filtered $droppedCount invalid relay URLs from storage');
       }
-      if (blockedCount > 0 || droppedCount > 0) {
+      if (userRemovedCount > 0) {
+        _log('Filtered $userRemovedCount user-removed relays from storage');
+      }
+      if (blockedCount > 0 || droppedCount > 0 || userRemovedCount > 0) {
         // Persist the filtered list so removed entries don't reappear
         // on the next launch.
         await storage.saveRelays(_configuredRelays);
@@ -397,6 +401,13 @@ class RelayManager {
   bool isRelayConfigured(String url) {
     final normalizedUrl = normalizeRelayUrl(url);
     return normalizedUrl != null && _configuredRelays.contains(normalizedUrl);
+  }
+
+  /// Check if a relay URL is currently suppressed by user-removal intent.
+  Future<bool> isUserRemovedRelay(String url) async {
+    await _ensureUserRemovedRelaysLoaded();
+    final normalizedUrl = normalizeRelayUrl(url);
+    return normalizedUrl != null && _userRemovedRelays.contains(normalizedUrl);
   }
 
   /// Check if a relay is currently connected

--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -12,6 +12,43 @@ import 'package:nostr_client/src/models/relay_remove_source.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostr_sdk/relay/client_connected.dart';
 
+/// Normalizes a relay URL into the canonical form used by [RelayManager].
+///
+/// Accepts explicit `ws://` / `wss://` relay URLs and bare
+/// host[:port][/path] values, which are upgraded to `wss://`. Returns `null`
+/// for unsupported schemes, malformed URLs, empty hosts, or cleartext
+/// non-loopback relays.
+String? normalizeRelayUrl(String url) {
+  final trimmed = url.trim();
+  if (trimmed.isEmpty) return null;
+
+  // Validate any explicit scheme BEFORE the bare-host upgrade. Without this
+  // gate, `http://attacker.example.com` would slip past the prefix check below
+  // and be string-prefixed into `wss://http://attacker.example.com` (a URL
+  // whose authority parses as host=`http`, path=`//attacker...` - routed to
+  // the wrong host rather than rejected).
+  String normalized;
+  final initial = Uri.tryParse(trimmed);
+  if (initial != null && initial.hasAuthority) {
+    final scheme = initial.scheme.toLowerCase();
+    if (scheme != 'wss' && scheme != 'ws') return null;
+    if (initial.path.startsWith('//')) return null;
+    normalized = initial.toString();
+  } else {
+    if (trimmed.contains('://')) return null;
+    normalized = 'wss://$trimmed';
+  }
+
+  if (normalized.endsWith('/')) {
+    normalized = normalized.substring(0, normalized.length - 1);
+  }
+
+  final uri = Uri.tryParse(normalized);
+  if (uri == null || uri.host.isEmpty) return null;
+  if (uri.scheme == 'ws' && !isLoopbackHost(uri.host)) return null;
+  return normalized;
+}
+
 /// {@template relay_manager}
 /// Manages relay configuration and connection status.
 ///
@@ -61,7 +98,7 @@ class RelayManager {
   /// source of truth for the rule — callers that bypass [addRelay] (e.g.
   /// one-off `tempRelays` in `NostrClient`) consult it directly.
   bool isRelayAllowed(String url) {
-    final normalized = _normalizeUrl(url);
+    final normalized = normalizeRelayUrl(url);
     if (normalized == null) return false;
     final allowedHost = _config.allowedRelayHost;
     if (allowedHost == null) return true;
@@ -164,7 +201,7 @@ class RelayManager {
       var blockedCount = 0;
       var droppedCount = 0;
       for (final url in savedRelays) {
-        final normalized = _normalizeUrl(url);
+        final normalized = normalizeRelayUrl(url);
         if (normalized == null) {
           // URL is malformed or now disallowed by the loopback gate
           // (#3362). Drop it from the in-memory list and re-save below so
@@ -206,7 +243,7 @@ class RelayManager {
     }
 
     // Add the environment default unless the user explicitly removed it.
-    final normalizedDefault = _normalizeUrl(_config.defaultRelayUrl);
+    final normalizedDefault = normalizeRelayUrl(_config.defaultRelayUrl);
     if (normalizedDefault != null &&
         isRelayAllowed(normalizedDefault) &&
         !_userRemovedRelays.contains(normalizedDefault) &&
@@ -248,7 +285,7 @@ class RelayManager {
   }) async {
     await _ensureUserRemovedRelaysLoaded();
 
-    final normalizedUrl = _normalizeUrl(url);
+    final normalizedUrl = normalizeRelayUrl(url);
 
     if (normalizedUrl == null) {
       _log('Invalid relay URL: $url');
@@ -324,7 +361,7 @@ class RelayManager {
   }) async {
     await _ensureUserRemovedRelaysLoaded();
 
-    final normalizedUrl = _normalizeUrl(url);
+    final normalizedUrl = normalizeRelayUrl(url);
 
     if (normalizedUrl == null) {
       _log('Invalid relay URL: $url');
@@ -358,13 +395,13 @@ class RelayManager {
 
   /// Check if a relay URL is configured
   bool isRelayConfigured(String url) {
-    final normalizedUrl = _normalizeUrl(url);
+    final normalizedUrl = normalizeRelayUrl(url);
     return normalizedUrl != null && _configuredRelays.contains(normalizedUrl);
   }
 
   /// Check if a relay is currently connected
   bool isRelayConnected(String url) {
-    final normalizedUrl = _normalizeUrl(url);
+    final normalizedUrl = normalizeRelayUrl(url);
     if (normalizedUrl == null) return false;
 
     final status = _relayStatuses[normalizedUrl];
@@ -373,7 +410,7 @@ class RelayManager {
 
   /// Get the status of a specific relay
   RelayConnectionStatus? getRelayStatus(String url) {
-    final normalizedUrl = _normalizeUrl(url);
+    final normalizedUrl = normalizeRelayUrl(url);
     if (normalizedUrl == null) return null;
     return _relayStatuses[normalizedUrl];
   }
@@ -503,7 +540,7 @@ class RelayManager {
 
   /// Reconnect to a specific relay
   Future<bool> reconnectRelay(String url) async {
-    final normalizedUrl = _normalizeUrl(url);
+    final normalizedUrl = normalizeRelayUrl(url);
     if (normalizedUrl == null || !_configuredRelays.contains(normalizedUrl)) {
       return false;
     }
@@ -737,7 +774,7 @@ class RelayManager {
     final savedRemovedRelays = await storage.loadRemovedRelays();
     final normalizedRelays = <String>{};
     for (final url in savedRemovedRelays) {
-      final normalized = _normalizeUrl(url);
+      final normalized = normalizeRelayUrl(url);
       if (normalized != null && isRelayAllowed(normalized)) {
         normalizedRelays.add(normalized);
       }
@@ -762,52 +799,6 @@ class RelayManager {
     if (_userRemovedRelays.remove(normalizedUrl)) {
       await _saveUserRemovedRelays();
     }
-  }
-
-  String? _normalizeUrl(String url) {
-    final trimmed = url.trim();
-    if (trimmed.isEmpty) return null;
-
-    // Validate any explicit scheme BEFORE the bare-host upgrade. Without this
-    // gate, `http://attacker.example.com` would slip past the prefix check
-    // below and be string-prefixed into `wss://http://attacker.example.com`
-    // (a URL whose authority parses as host=`http`, path=`//attacker…` —
-    // routed to the wrong host rather than rejected). Schemes are
-    // case-insensitive per RFC 3986 §3.1; Dart's Uri canonicalises them to
-    // lowercase, so `WSS://X` round-trips through `toString()` as `wss://X`.
-    String normalized;
-    final initial = Uri.tryParse(trimmed);
-    if (initial != null && initial.hasAuthority) {
-      final scheme = initial.scheme.toLowerCase();
-      if (scheme != 'wss' && scheme != 'ws') return null;
-      // `wss://http://x` parses with host=`http` and path=`//x`. Reject so
-      // an attacker can't smuggle a cleartext URL past us by pre-wrapping
-      // it inside a `wss://` prefix.
-      if (initial.path.startsWith('//')) return null;
-      normalized = initial.toString();
-    } else {
-      // No parsable authority → bare host[:port][/path]; upgrade to wss://.
-      // Reject inputs that contain `://` anywhere we couldn't parse, so we
-      // never silently rewrite something that looked scheme-shaped.
-      if (trimmed.contains('://')) return null;
-      normalized = 'wss://$trimmed';
-    }
-
-    // Remove trailing slash
-    if (normalized.endsWith('/')) {
-      normalized = normalized.substring(0, normalized.length - 1);
-    }
-
-    // Re-parse to apply host validation and the loopback gate. Only wss/ws
-    // can reach this point per the scheme check above; the second
-    // `tryParse` also catches inputs whose bare-host upgrade produced an
-    // unparseable authority (e.g. `wss:relay.example.com` →
-    // `wss://wss:relay.example.com`, where `relay.example.com` is not a
-    // valid port).
-    final uri = Uri.tryParse(normalized);
-    if (uri == null || uri.host.isEmpty) return null;
-    if (uri.scheme == 'ws' && !isLoopbackHost(uri.host)) return null;
-    return normalized;
   }
 
   void _log(String message) {

--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -101,7 +101,7 @@ class RelayManager {
   /// The environment default relay URL.
   String get defaultRelayUrl => _config.defaultRelayUrl;
 
-  /// List of relay URLs the user has configured (including default)
+  /// List of relay URLs the user has configured.
   List<String> get configuredRelays => List.unmodifiable(_configuredRelays);
 
   /// List of relay URLs currently connected

--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -94,6 +94,9 @@ class RelayManager {
   /// Whether persisted user-removal intent has been loaded.
   bool _userRemovedRelaysLoaded = false;
 
+  /// In-flight load of persisted user-removal intent.
+  Future<void>? _userRemovedRelaysLoadFuture;
+
   // ---------------------------------------------------------------------------
   // Public Getters
   // ---------------------------------------------------------------------------
@@ -187,7 +190,6 @@ class RelayManager {
           _configuredRelays.add(normalized);
         }
       }
-      droppedCount += _dropUserRemovedConfiguredRelays();
       if (blockedCount > 0) {
         _log('Filtered $blockedCount blocked relays from storage');
       }
@@ -712,7 +714,20 @@ class RelayManager {
 
   Future<void> _ensureUserRemovedRelaysLoaded() async {
     if (_userRemovedRelaysLoaded) return;
+    final existingLoad = _userRemovedRelaysLoadFuture;
+    if (existingLoad != null) return existingLoad;
 
+    final loadFuture = _loadUserRemovedRelays();
+    _userRemovedRelaysLoadFuture = loadFuture;
+    try {
+      await loadFuture;
+    } catch (_) {
+      _userRemovedRelaysLoadFuture = null;
+      rethrow;
+    }
+  }
+
+  Future<void> _loadUserRemovedRelays() async {
     final storage = _config.storage;
     if (storage == null) {
       _userRemovedRelaysLoaded = true;
@@ -738,12 +753,6 @@ class RelayManager {
       _log('Saved filtered user-removed relay list to storage');
     }
     _userRemovedRelaysLoaded = true;
-  }
-
-  int _dropUserRemovedConfiguredRelays() {
-    final before = _configuredRelays.length;
-    _configuredRelays.removeWhere(_userRemovedRelays.contains);
-    return before - _configuredRelays.length;
   }
 
   bool _setsEqual<T>(Set<T> a, Set<T> b) =>

--- a/mobile/packages/nostr_client/test/src/models/shared_preferences_relay_storage_test.dart
+++ b/mobile/packages/nostr_client/test/src/models/shared_preferences_relay_storage_test.dart
@@ -95,6 +95,46 @@ void main() {
       });
     });
 
+    group('removed relays', () {
+      test(
+        'loadRemovedRelays returns empty list when no relays stored',
+        () async {
+          final storage = SharedPreferencesRelayStorage();
+
+          final relays = await storage.loadRemovedRelays();
+
+          expect(relays, isEmpty);
+        },
+      );
+
+      test('saveRemovedRelays saves relay URLs to SharedPreferences', () async {
+        final storage = SharedPreferencesRelayStorage();
+
+        await storage.saveRemovedRelays([
+          'wss://relay1.example.com',
+          'wss://relay2.example.com',
+        ]);
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(
+          prefs.getStringList('user_removed_relays'),
+          equals(['wss://relay1.example.com', 'wss://relay2.example.com']),
+        );
+        expect(prefs.getStringList('configured_relays'), isNull);
+      });
+
+      test('loadRemovedRelays returns stored relays', () async {
+        SharedPreferences.setMockInitialValues({
+          'user_removed_relays': ['wss://removed.example.com'],
+        });
+        final storage = SharedPreferencesRelayStorage();
+
+        final relays = await storage.loadRemovedRelays();
+
+        expect(relays, equals(['wss://removed.example.com']));
+      });
+    });
+
     group('round-trip', () {
       test('load returns what was saved', () async {
         final storage = SharedPreferencesRelayStorage();
@@ -134,6 +174,23 @@ void main() {
         final relays = await storage.loadRelays();
 
         expect(relays, equals(['wss://relay.example.com']));
+      });
+
+      test('uses custom removed-relays key when provided', () async {
+        final storage = SharedPreferencesRelayStorage(
+          key: 'custom_relay_key',
+          removedRelaysKey: 'custom_removed_relay_key',
+        );
+
+        await storage.saveRemovedRelays(['wss://removed.example.com']);
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(
+          prefs.getStringList('custom_removed_relay_key'),
+          equals(['wss://removed.example.com']),
+        );
+        expect(prefs.getStringList('user_removed_relays'), isNull);
+        expect(prefs.getStringList('custom_relay_key'), isNull);
       });
     });
   });

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -132,6 +132,9 @@ void main() {
       // Default: no environment lock (production behavior). Tests that
       // exercise the lock override specific URLs to false.
       when(() => mockRelayManager.isRelayAllowed(any())).thenReturn(true);
+      when(
+        () => mockRelayManager.defaultRelayUrl,
+      ).thenReturn('wss://relay.example.com');
 
       client = NostrClient.forTesting(
         nostr: mockNostr,
@@ -2074,6 +2077,24 @@ void main() {
           ),
         ).called(1);
       });
+    });
+
+    group('primaryRelay', () {
+      test(
+        'falls back to environment default when no relays are configured',
+        () {
+          when(() => mockRelayManager.connectedRelays).thenReturn(const []);
+          when(() => mockRelayManager.configuredRelays).thenReturn(const []);
+          when(
+            () => mockRelayManager.defaultRelayUrl,
+          ).thenReturn('wss://relay.staging.divine.video');
+
+          expect(
+            client.primaryRelay,
+            equals('wss://relay.staging.divine.video'),
+          );
+        },
+      );
     });
 
     group('connectedRelays', () {

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -64,6 +64,9 @@ class _FakeRelay extends Fake implements Relay {
 
 const testPublicKey =
     '82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2';
+final RelayAddSource automaticRelayAddSource = RelayAddSource.values.byName(
+  'automatic',
+);
 
 Event _createTestEvent({
   String? id,
@@ -412,6 +415,36 @@ void main() {
 
         await client.publishEvent(event, targetRelays: targetRelays);
 
+        verify(
+          () => mockNostr.sendEvent(
+            event,
+            targetRelays: targetRelays,
+            tempRelays: targetRelays,
+          ),
+        ).called(1);
+      });
+
+      test('publishes event to explicit target relays without connected '
+          'pool relays', () async {
+        final event = _createTestEvent();
+        final targetRelays = ['wss://relay1.example.com'];
+        when(() => mockRelayManager.connectedRelays).thenReturn([]);
+        when(mockRelayManager.retryDisconnectedRelays).thenAnswer((_) async {});
+        when(
+          () => mockNostr.sendEvent(
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => event);
+
+        final result = await client.publishEvent(
+          event,
+          targetRelays: targetRelays,
+        );
+
+        expect(result, isA<PublishSuccess>());
+        verifyNever(mockRelayManager.retryDisconnectedRelays);
         verify(
           () => mockNostr.sendEvent(
             event,
@@ -1789,19 +1822,49 @@ void main() {
       test('delegates to RelayManager', () async {
         const relayUrl = 'wss://relay.example.com';
         when(
-          () => mockRelayManager.addRelay(relayUrl),
+          () => mockRelayManager.addRelay(
+            relayUrl,
+            source: automaticRelayAddSource,
+          ),
         ).thenAnswer((_) async => true);
 
         final result = await client.addRelay(relayUrl);
 
         expect(result, isTrue);
-        verify(() => mockRelayManager.addRelay(relayUrl)).called(1);
+        verify(
+          () => mockRelayManager.addRelay(
+            relayUrl,
+            source: automaticRelayAddSource,
+          ),
+        ).called(1);
+      });
+
+      test('forwards explicit add source to RelayManager', () async {
+        const relayUrl = 'wss://relay.example.com';
+        when(
+          () =>
+              mockRelayManager.addRelay(relayUrl, source: RelayAddSource.user),
+        ).thenAnswer((_) async => true);
+
+        final result = await client.addRelay(
+          relayUrl,
+          source: RelayAddSource.user,
+        );
+
+        expect(result, isTrue);
+        verify(
+          () =>
+              mockRelayManager.addRelay(relayUrl, source: RelayAddSource.user),
+        ).called(1);
       });
 
       test('returns false when RelayManager returns false', () async {
         const relayUrl = 'wss://relay.example.com';
         when(
-          () => mockRelayManager.addRelay(relayUrl),
+          () => mockRelayManager.addRelay(
+            relayUrl,
+            source: automaticRelayAddSource,
+          ),
         ).thenAnswer((_) async => false);
 
         final result = await client.addRelay(relayUrl);
@@ -1821,17 +1884,64 @@ void main() {
           ];
 
           when(
-            () => mockRelayManager.addRelay(any()),
+            () => mockRelayManager.addRelay(
+              any(),
+              source: automaticRelayAddSource,
+            ),
           ).thenAnswer((_) async => true);
 
           final result = await client.addRelays(relayUrls);
 
           expect(result, equals(3));
-          verify(() => mockRelayManager.addRelay(relayUrls[0])).called(1);
-          verify(() => mockRelayManager.addRelay(relayUrls[1])).called(1);
-          verify(() => mockRelayManager.addRelay(relayUrls[2])).called(1);
+          verify(
+            () => mockRelayManager.addRelay(
+              relayUrls[0],
+              source: automaticRelayAddSource,
+            ),
+          ).called(1);
+          verify(
+            () => mockRelayManager.addRelay(
+              relayUrls[1],
+              source: automaticRelayAddSource,
+            ),
+          ).called(1);
+          verify(
+            () => mockRelayManager.addRelay(
+              relayUrls[2],
+              source: automaticRelayAddSource,
+            ),
+          ).called(1);
         },
       );
+
+      test('forwards explicit source for multiple relays', () async {
+        final relayUrls = [
+          'wss://relay1.example.com',
+          'wss://relay2.example.com',
+        ];
+        when(
+          () => mockRelayManager.addRelay(any(), source: RelayAddSource.user),
+        ).thenAnswer((_) async => true);
+
+        final result = await client.addRelays(
+          relayUrls,
+          source: RelayAddSource.user,
+        );
+
+        expect(result, equals(2));
+        verify(
+          () => mockRelayManager.addRelay(
+            relayUrls[0],
+            source: RelayAddSource.user,
+          ),
+        ).called(1);
+        verify(
+          () => mockRelayManager.addRelay(
+            relayUrls[1],
+            source: RelayAddSource.user,
+          ),
+        ).called(1);
+      });
 
       test('returns 0 when empty list is provided', () async {
         final result = await client.addRelays([]);
@@ -1851,13 +1961,22 @@ void main() {
 
           // First and third succeed, second fails
           when(
-            () => mockRelayManager.addRelay('wss://relay1.example.com'),
+            () => mockRelayManager.addRelay(
+              'wss://relay1.example.com',
+              source: automaticRelayAddSource,
+            ),
           ).thenAnswer((_) async => true);
           when(
-            () => mockRelayManager.addRelay('wss://relay2.example.com'),
+            () => mockRelayManager.addRelay(
+              'wss://relay2.example.com',
+              source: automaticRelayAddSource,
+            ),
           ).thenAnswer((_) async => false);
           when(
-            () => mockRelayManager.addRelay('wss://relay3.example.com'),
+            () => mockRelayManager.addRelay(
+              'wss://relay3.example.com',
+              source: automaticRelayAddSource,
+            ),
           ).thenAnswer((_) async => true);
 
           final result = await client.addRelays(relayUrls);
@@ -1873,7 +1992,10 @@ void main() {
         ];
 
         when(
-          () => mockRelayManager.addRelay(any()),
+          () => mockRelayManager.addRelay(
+            any(),
+            source: automaticRelayAddSource,
+          ),
         ).thenAnswer((_) async => false);
 
         final result = await client.addRelays(relayUrls);
@@ -1885,14 +2007,20 @@ void main() {
         final relayUrls = ['wss://single-relay.example.com'];
 
         when(
-          () => mockRelayManager.addRelay(any()),
+          () => mockRelayManager.addRelay(
+            any(),
+            source: automaticRelayAddSource,
+          ),
         ).thenAnswer((_) async => true);
 
         final result = await client.addRelays(relayUrls);
 
         expect(result, equals(1));
         verify(
-          () => mockRelayManager.addRelay('wss://single-relay.example.com'),
+          () => mockRelayManager.addRelay(
+            'wss://single-relay.example.com',
+            source: automaticRelayAddSource,
+          ),
         ).called(1);
       });
     });

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -64,9 +64,6 @@ class _FakeRelay extends Fake implements Relay {
 
 const testPublicKey =
     '82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2';
-final RelayAddSource automaticRelayAddSource = RelayAddSource.values.byName(
-  'automatic',
-);
 
 Event _createTestEvent({
   String? id,
@@ -112,6 +109,8 @@ void main() {
       registerFallbackValue(<Map<String, dynamic>>[]);
       registerFallbackValue(<String>[]);
       registerFallbackValue(RelayType.all);
+      registerFallbackValue(RelayAddSource.automatic);
+      registerFallbackValue(RelayRemoveSource.user);
       registerFallbackValue(const Duration(seconds: 10));
       registerFallbackValue(const CountResponse(count: 0));
     });
@@ -1824,19 +1823,20 @@ void main() {
         when(
           () => mockRelayManager.addRelay(
             relayUrl,
-            source: automaticRelayAddSource,
+            source: any(named: 'source'),
           ),
         ).thenAnswer((_) async => true);
 
         final result = await client.addRelay(relayUrl);
 
         expect(result, isTrue);
-        verify(
+        final captured = verify(
           () => mockRelayManager.addRelay(
             relayUrl,
-            source: automaticRelayAddSource,
+            source: captureAny(named: 'source'),
           ),
-        ).called(1);
+        ).captured;
+        expect(captured, equals([RelayAddSource.automatic]));
       });
 
       test('forwards explicit add source to RelayManager', () async {
@@ -1863,7 +1863,7 @@ void main() {
         when(
           () => mockRelayManager.addRelay(
             relayUrl,
-            source: automaticRelayAddSource,
+            source: any(named: 'source'),
           ),
         ).thenAnswer((_) async => false);
 
@@ -1886,7 +1886,7 @@ void main() {
           when(
             () => mockRelayManager.addRelay(
               any(),
-              source: automaticRelayAddSource,
+              source: any(named: 'source'),
             ),
           ).thenAnswer((_) async => true);
 
@@ -1896,19 +1896,19 @@ void main() {
           verify(
             () => mockRelayManager.addRelay(
               relayUrls[0],
-              source: automaticRelayAddSource,
+              source: any(named: 'source'),
             ),
           ).called(1);
           verify(
             () => mockRelayManager.addRelay(
               relayUrls[1],
-              source: automaticRelayAddSource,
+              source: any(named: 'source'),
             ),
           ).called(1);
           verify(
             () => mockRelayManager.addRelay(
               relayUrls[2],
-              source: automaticRelayAddSource,
+              source: any(named: 'source'),
             ),
           ).called(1);
         },
@@ -1947,7 +1947,9 @@ void main() {
         final result = await client.addRelays([]);
 
         expect(result, equals(0));
-        verifyNever(() => mockRelayManager.addRelay(any()));
+        verifyNever(
+          () => mockRelayManager.addRelay(any(), source: any(named: 'source')),
+        );
       });
 
       test(
@@ -1963,19 +1965,19 @@ void main() {
           when(
             () => mockRelayManager.addRelay(
               'wss://relay1.example.com',
-              source: automaticRelayAddSource,
+              source: any(named: 'source'),
             ),
           ).thenAnswer((_) async => true);
           when(
             () => mockRelayManager.addRelay(
               'wss://relay2.example.com',
-              source: automaticRelayAddSource,
+              source: any(named: 'source'),
             ),
           ).thenAnswer((_) async => false);
           when(
             () => mockRelayManager.addRelay(
               'wss://relay3.example.com',
-              source: automaticRelayAddSource,
+              source: any(named: 'source'),
             ),
           ).thenAnswer((_) async => true);
 
@@ -1994,7 +1996,7 @@ void main() {
         when(
           () => mockRelayManager.addRelay(
             any(),
-            source: automaticRelayAddSource,
+            source: any(named: 'source'),
           ),
         ).thenAnswer((_) async => false);
 
@@ -2009,7 +2011,7 @@ void main() {
         when(
           () => mockRelayManager.addRelay(
             any(),
-            source: automaticRelayAddSource,
+            source: any(named: 'source'),
           ),
         ).thenAnswer((_) async => true);
 
@@ -2019,7 +2021,7 @@ void main() {
         verify(
           () => mockRelayManager.addRelay(
             'wss://single-relay.example.com',
-            source: automaticRelayAddSource,
+            source: any(named: 'source'),
           ),
         ).called(1);
       });
@@ -2029,13 +2031,45 @@ void main() {
       test('delegates to RelayManager', () async {
         const relayUrl = 'wss://relay.example.com';
         when(
-          () => mockRelayManager.removeRelay(relayUrl),
+          () => mockRelayManager.removeRelay(
+            relayUrl,
+            source: any(named: 'source'),
+          ),
         ).thenAnswer((_) async => true);
 
         final result = await client.removeRelay(relayUrl);
 
         expect(result, isTrue);
-        verify(() => mockRelayManager.removeRelay(relayUrl)).called(1);
+        final captured = verify(
+          () => mockRelayManager.removeRelay(
+            relayUrl,
+            source: captureAny(named: 'source'),
+          ),
+        ).captured;
+        expect(captured, equals([RelayRemoveSource.user]));
+      });
+
+      test('forwards explicit remove source to RelayManager', () async {
+        const relayUrl = 'wss://relay.example.com';
+        when(
+          () => mockRelayManager.removeRelay(
+            relayUrl,
+            source: RelayRemoveSource.automatic,
+          ),
+        ).thenAnswer((_) async => true);
+
+        final result = await client.removeRelay(
+          relayUrl,
+          source: RelayRemoveSource.automatic,
+        );
+
+        expect(result, isTrue);
+        verify(
+          () => mockRelayManager.removeRelay(
+            relayUrl,
+            source: RelayRemoveSource.automatic,
+          ),
+        ).called(1);
       });
     });
 

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -2037,7 +2037,10 @@ void main() {
           ),
         ).thenAnswer((_) async => true);
 
-        final result = await client.removeRelay(relayUrl);
+        final result = await client.removeRelay(
+          relayUrl,
+          source: RelayRemoveSource.user,
+        );
 
         expect(result, isTrue);
         final captured = verify(

--- a/mobile/packages/nostr_client/test/src/relay_manager_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_manager_test.dart
@@ -846,6 +846,45 @@ void main() {
         },
       );
 
+      test('concurrent ledger loads share one storage read', () async {
+        final removedRelaysCompleter = Completer<List<String>>();
+        var removedRelaysLoadCount = 0;
+        when(() => mockStorage.loadRemovedRelays()).thenAnswer((_) {
+          removedRelaysLoadCount++;
+          return removedRelaysCompleter.future;
+        });
+        when(() => mockStorage.loadRelays()).thenAnswer((_) async => []);
+        when(() => mockStorage.saveRelays(any())).thenAnswer((_) async {});
+        when(
+          () => mockStorage.saveRemovedRelays(any()),
+        ).thenAnswer((_) async {});
+
+        final managerWithStorage = RelayManager(
+          config: _createTestConfig(storage: mockStorage),
+          relayPool: mockRelayPool,
+        );
+
+        final initializeFuture = managerWithStorage.initialize();
+        await Future<void>.delayed(Duration.zero);
+        final restoreFuture = managerWithStorage.addRelay(
+          testCustomRelayUrl,
+          source: RelayAddSource.user,
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(removedRelaysLoadCount, equals(1));
+
+        removedRelaysCompleter.complete([testCustomRelayUrl]);
+        await initializeFuture;
+
+        expect(await restoreFuture, isTrue);
+        expect(
+          managerWithStorage.configuredRelays,
+          contains(testCustomRelayUrl),
+        );
+        verify(() => mockStorage.saveRemovedRelays([])).called(1);
+      });
+
       test('automatic removal does not persist user removal intent', () async {
         final storage = InMemoryRelayStorage([testCustomRelayUrl]);
         final managerWithStorage = RelayManager(

--- a/mobile/packages/nostr_client/test/src/relay_manager_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_manager_test.dart
@@ -501,7 +501,7 @@ void main() {
       });
 
       // Scheme validation before bare-host upgrade (#3362 review follow-up).
-      // Without this gate, `_normalizeUrl` would string-prefix `wss://` onto
+      // Without this gate, `normalizeRelayUrl` would string-prefix `wss://` onto
       // any input not already starting with `wss://`/`ws://`, turning
       // `http://attacker.example.com` into `wss://http://attacker.example.com`
       // (host=`http`, path=`//attacker…` — the wrong target).
@@ -584,7 +584,7 @@ void main() {
 
       test('case-folds uppercase scheme to canonical lowercase', () async {
         // Discovery accepts `WSS://relay.example.com` because Dart's Uri
-        // canonicalises the scheme to lowercase. `_normalizeUrl` must do
+        // canonicalises the scheme to lowercase. `normalizeRelayUrl` must do
         // the same so the URL is stored in canonical form and string-based
         // dedup / persistence checks compare equal across casings.
         final result = await manager.addRelay('WSS://relay.example.com');

--- a/mobile/packages/nostr_client/test/src/relay_manager_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_manager_test.dart
@@ -770,6 +770,74 @@ void main() {
         },
       );
 
+      test(
+        'initialize filters user-removed default relay from polluted storage',
+        () async {
+          final storage = InMemoryRelayStorage(
+            [testDefaultRelayUrl, testCustomRelayUrl],
+            [testDefaultRelayUrl],
+          );
+          final managerWithStorage = RelayManager(
+            config: _createTestConfig(storage: storage),
+            relayPool: mockRelayPool,
+          );
+
+          await managerWithStorage.initialize();
+
+          expect(
+            managerWithStorage.configuredRelays,
+            isNot(contains(testDefaultRelayUrl)),
+          );
+          expect(
+            managerWithStorage.configuredRelays,
+            contains(testCustomRelayUrl),
+          );
+          expect(
+            await storage.loadRelays(),
+            isNot(contains(testDefaultRelayUrl)),
+          );
+        },
+      );
+
+      test(
+        'automatic add before initialize honors persisted removal ledger',
+        () async {
+          final storage = InMemoryRelayStorage(
+            const [],
+            [testCustomRelayUrl],
+          );
+          final managerWithStorage = RelayManager(
+            config: _createTestConfig(storage: storage),
+            relayPool: mockRelayPool,
+          );
+
+          final result = await managerWithStorage.addRelay(testCustomRelayUrl);
+
+          expect(result, isFalse);
+          expect(
+            managerWithStorage.configuredRelays,
+            isNot(contains(testCustomRelayUrl)),
+          );
+          expect(await storage.loadRelays(), isEmpty);
+        },
+      );
+
+      test('automatic removal does not persist user removal intent', () async {
+        final storage = InMemoryRelayStorage([testCustomRelayUrl]);
+        final managerWithStorage = RelayManager(
+          config: _createTestConfig(storage: storage),
+          relayPool: mockRelayPool,
+        );
+
+        await managerWithStorage.initialize();
+        await managerWithStorage.removeRelay(
+          testCustomRelayUrl,
+          source: RelayRemoveSource.automatic,
+        );
+
+        expect(await storage.loadRemovedRelays(), isEmpty);
+      });
+
       test('emits status update when relay is removed', () async {
         final statusUpdates = <Map<String, RelayConnectionStatus>>[];
         manager.statusStream.listen(statusUpdates.add);

--- a/mobile/packages/nostr_client/test/src/relay_manager_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_manager_test.dart
@@ -378,6 +378,23 @@ void main() {
         );
       });
 
+      test('reports whether a relay is user-removed', () async {
+        final storage = InMemoryRelayStorage([], [testCustomRelayUrl]);
+        final managerWithStorage = RelayManager(
+          config: _createTestConfig(storage: storage),
+          relayPool: mockRelayPool,
+        );
+
+        expect(
+          await managerWithStorage.isUserRemovedRelay(testCustomRelayUrl),
+          isTrue,
+        );
+        expect(
+          await managerWithStorage.isUserRemovedRelay(testCustomRelayUrl2),
+          isFalse,
+        );
+      });
+
       test('user add clears removed relay ledger and succeeds', () async {
         final storage = InMemoryRelayStorage([], [testCustomRelayUrl]);
         final managerWithStorage = RelayManager(
@@ -826,10 +843,7 @@ void main() {
       test(
         'automatic add before initialize honors persisted removal ledger',
         () async {
-          final storage = InMemoryRelayStorage(
-            const [],
-            [testCustomRelayUrl],
-          );
+          final storage = InMemoryRelayStorage(const [], [testCustomRelayUrl]);
           final managerWithStorage = RelayManager(
             config: _createTestConfig(storage: storage),
             relayPool: mockRelayPool,

--- a/mobile/packages/nostr_client/test/src/relay_manager_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_manager_test.dart
@@ -666,7 +666,10 @@ void main() {
       });
 
       test('removes relay from configured list', () async {
-        final result = await manager.removeRelay(testCustomRelayUrl);
+        final result = await manager.removeRelay(
+          testCustomRelayUrl,
+          source: RelayRemoveSource.user,
+        );
 
         expect(result, isTrue);
         expect(manager.configuredRelays, isNot(contains(testCustomRelayUrl)));
@@ -674,32 +677,47 @@ void main() {
 
       test('disconnects from the relay via RelayPool', () async {
         clearInteractions(mockRelayPool);
-        await manager.removeRelay(testCustomRelayUrl);
+        await manager.removeRelay(
+          testCustomRelayUrl,
+          source: RelayRemoveSource.user,
+        );
 
         verify(() => mockRelayPool.remove(testCustomRelayUrl)).called(1);
       });
 
       test('allows removing default relay', () async {
-        final result = await manager.removeRelay(testDefaultRelayUrl);
+        final result = await manager.removeRelay(
+          testDefaultRelayUrl,
+          source: RelayRemoveSource.user,
+        );
 
         expect(result, isTrue);
         expect(manager.configuredRelays, isNot(contains(testDefaultRelayUrl)));
       });
 
       test('returns false for non-configured relay', () async {
-        final result = await manager.removeRelay('wss://unknown.relay.com');
+        final result = await manager.removeRelay(
+          'wss://unknown.relay.com',
+          source: RelayRemoveSource.user,
+        );
 
         expect(result, isFalse);
       });
 
       test('returns false for invalid URL', () async {
-        final result = await manager.removeRelay('invalid-url');
+        final result = await manager.removeRelay(
+          'invalid-url',
+          source: RelayRemoveSource.user,
+        );
 
         expect(result, isFalse);
       });
 
       test('removes status entry for relay', () async {
-        await manager.removeRelay(testCustomRelayUrl);
+        await manager.removeRelay(
+          testCustomRelayUrl,
+          source: RelayRemoveSource.user,
+        );
 
         final status = manager.getRelayStatus(testCustomRelayUrl);
         expect(status, isNull);
@@ -723,7 +741,10 @@ void main() {
         await managerWithStorage.addRelay(testCustomRelayUrl);
         clearInteractions(mockStorage);
 
-        await managerWithStorage.removeRelay(testCustomRelayUrl);
+        await managerWithStorage.removeRelay(
+          testCustomRelayUrl,
+          source: RelayRemoveSource.user,
+        );
 
         verify(() => mockStorage.saveRelays(any())).called(1);
       });
@@ -736,7 +757,10 @@ void main() {
         );
 
         await managerWithStorage.initialize();
-        await managerWithStorage.removeRelay(testCustomRelayUrl);
+        await managerWithStorage.removeRelay(
+          testCustomRelayUrl,
+          source: RelayRemoveSource.user,
+        );
 
         expect(await storage.loadRemovedRelays(), equals([testCustomRelayUrl]));
       });
@@ -842,7 +866,10 @@ void main() {
         final statusUpdates = <Map<String, RelayConnectionStatus>>[];
         manager.statusStream.listen(statusUpdates.add);
 
-        await manager.removeRelay(testCustomRelayUrl);
+        await manager.removeRelay(
+          testCustomRelayUrl,
+          source: RelayRemoveSource.user,
+        );
         await Future<void>.delayed(Duration.zero);
 
         expect(statusUpdates, isNotEmpty);

--- a/mobile/packages/nostr_client/test/src/relay_manager_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_manager_test.dart
@@ -90,6 +90,8 @@ void main() {
           mockRelayPool.add(any(), autoSubscribe: any(named: 'autoSubscribe')),
     ).thenAnswer((_) async => true);
     when(() => mockRelayPool.remove(any())).thenReturn(null);
+    when(() => mockStorage.loadRemovedRelays()).thenAnswer((_) async => []);
+    when(() => mockStorage.saveRemovedRelays(any())).thenAnswer((_) async {});
 
     manager = RelayManager(config: config, relayPool: mockRelayPool);
   });
@@ -335,6 +337,10 @@ void main() {
       test('saves configuration after adding relay', () async {
         when(() => mockStorage.loadRelays()).thenAnswer((_) async => []);
         when(() => mockStorage.saveRelays(any())).thenAnswer((_) async {});
+        when(() => mockStorage.loadRemovedRelays()).thenAnswer((_) async => []);
+        when(
+          () => mockStorage.saveRemovedRelays(any()),
+        ).thenAnswer((_) async {});
 
         final configWithStorage = _createTestConfig(storage: mockStorage);
         final managerWithStorage = RelayManager(
@@ -346,6 +352,51 @@ void main() {
         await managerWithStorage.addRelay(testCustomRelayUrl);
 
         verify(() => mockStorage.saveRelays(any())).called(1);
+      });
+
+      test('skips automatic add for a user-removed relay', () async {
+        final storage = InMemoryRelayStorage([], [testCustomRelayUrl]);
+        final managerWithStorage = RelayManager(
+          config: _createTestConfig(storage: storage),
+          relayPool: mockRelayPool,
+        );
+
+        await managerWithStorage.initialize();
+        clearInteractions(mockRelayPool);
+        final result = await managerWithStorage.addRelay(testCustomRelayUrl);
+
+        expect(result, isFalse);
+        expect(
+          managerWithStorage.configuredRelays,
+          isNot(contains(testCustomRelayUrl)),
+        );
+        verifyNever(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        );
+      });
+
+      test('user add clears removed relay ledger and succeeds', () async {
+        final storage = InMemoryRelayStorage([], [testCustomRelayUrl]);
+        final managerWithStorage = RelayManager(
+          config: _createTestConfig(storage: storage),
+          relayPool: mockRelayPool,
+        );
+
+        await managerWithStorage.initialize();
+        final result = await managerWithStorage.addRelay(
+          testCustomRelayUrl,
+          source: RelayAddSource.user,
+        );
+
+        expect(result, isTrue);
+        expect(
+          managerWithStorage.configuredRelays,
+          contains(testCustomRelayUrl),
+        );
+        expect(await storage.loadRemovedRelays(), isEmpty);
       });
 
       test('updates status to connected on success', () async {
@@ -657,6 +708,10 @@ void main() {
       test('saves configuration after removing relay', () async {
         when(() => mockStorage.loadRelays()).thenAnswer((_) async => []);
         when(() => mockStorage.saveRelays(any())).thenAnswer((_) async {});
+        when(() => mockStorage.loadRemovedRelays()).thenAnswer((_) async => []);
+        when(
+          () => mockStorage.saveRemovedRelays(any()),
+        ).thenAnswer((_) async {});
 
         final configWithStorage = _createTestConfig(storage: mockStorage);
         final managerWithStorage = RelayManager(
@@ -672,6 +727,48 @@ void main() {
 
         verify(() => mockStorage.saveRelays(any())).called(1);
       });
+
+      test('persists removed relay ledger after removing relay', () async {
+        final storage = InMemoryRelayStorage([testCustomRelayUrl]);
+        final managerWithStorage = RelayManager(
+          config: _createTestConfig(storage: storage),
+          relayPool: mockRelayPool,
+        );
+
+        await managerWithStorage.initialize();
+        await managerWithStorage.removeRelay(testCustomRelayUrl);
+
+        expect(await storage.loadRemovedRelays(), equals([testCustomRelayUrl]));
+      });
+
+      test(
+        'initialize filters user-removed relays from polluted storage',
+        () async {
+          final storage = InMemoryRelayStorage(
+            [testCustomRelayUrl, testCustomRelayUrl2],
+            [testCustomRelayUrl],
+          );
+          final managerWithStorage = RelayManager(
+            config: _createTestConfig(storage: storage),
+            relayPool: mockRelayPool,
+          );
+
+          await managerWithStorage.initialize();
+
+          expect(
+            managerWithStorage.configuredRelays,
+            isNot(contains(testCustomRelayUrl)),
+          );
+          expect(
+            managerWithStorage.configuredRelays,
+            contains(testCustomRelayUrl2),
+          );
+          expect(
+            await storage.loadRelays(),
+            isNot(contains(testCustomRelayUrl)),
+          );
+        },
+      );
 
       test('emits status update when relay is removed', () async {
         final statusUpdates = <Map<String, RelayConnectionStatus>>[];
@@ -1393,6 +1490,18 @@ void main() {
       expect(relays, isNot(contains(testDefaultRelayUrl)));
       expect(relays, contains(testCustomRelayUrl));
     });
+
+    test(
+      'removed relays persist independently from configured relays',
+      () async {
+        final storage = InMemoryRelayStorage([testDefaultRelayUrl]);
+
+        await storage.saveRemovedRelays([testCustomRelayUrl]);
+
+        expect(await storage.loadRelays(), equals([testDefaultRelayUrl]));
+        expect(await storage.loadRemovedRelays(), equals([testCustomRelayUrl]));
+      },
+    );
   });
 
   group('Blocked Relays', () {

--- a/mobile/test/blocs/relay_settings/relay_settings_cubit_test.dart
+++ b/mobile/test/blocs/relay_settings/relay_settings_cubit_test.dart
@@ -151,7 +151,9 @@ void main() {
       },
       expect: () => const <RelaySettingsState>[],
       verify: (_) {
-        verifyNever(() => nostr.addRelay(any()));
+        verifyNever(
+          () => nostr.addRelay(any(), source: any(named: 'source')),
+        );
       },
     );
 

--- a/mobile/test/blocs/relay_settings/relay_settings_cubit_test.dart
+++ b/mobile/test/blocs/relay_settings/relay_settings_cubit_test.dart
@@ -21,6 +21,7 @@ class _MockVideoEventService extends Mock implements VideoEventService {}
 void main() {
   setUpAll(() {
     registerFallbackValue(RelayAddSource.automatic);
+    registerFallbackValue(RelayRemoveSource.user);
   });
 
   group(RelaySettingsCubit, () {
@@ -37,7 +38,9 @@ void main() {
       when(
         () => nostr.addRelay(any(), source: any(named: 'source')),
       ).thenAnswer((_) async => true);
-      when(() => nostr.removeRelay(any())).thenAnswer((_) async => true);
+      when(
+        () => nostr.removeRelay(any(), source: any(named: 'source')),
+      ).thenAnswer((_) async => true);
       when(nostr.forceReconnectAll).thenAnswer((_) async {});
       when(videos.resetAndResubscribeAll).thenAnswer((_) async {});
     });
@@ -230,14 +233,21 @@ void main() {
         const RelaySettingsState(relays: ['wss://a.example']),
       ],
       verify: (_) {
-        verify(() => nostr.removeRelay('wss://b.example')).called(1);
+        verify(
+          () => nostr.removeRelay(
+            'wss://b.example',
+            source: RelayRemoveSource.user,
+          ),
+        ).called(1);
       },
     );
 
     blocTest<RelaySettingsCubit, RelaySettingsState>(
       'removeRelay returns failed when service returns false',
       setUp: () {
-        when(() => nostr.removeRelay(any())).thenAnswer((_) async => false);
+        when(
+          () => nostr.removeRelay(any(), source: any(named: 'source')),
+        ).thenAnswer((_) async => false);
       },
       build: buildCubit,
       act: (cubit) async {

--- a/mobile/test/blocs/relay_settings/relay_settings_cubit_test.dart
+++ b/mobile/test/blocs/relay_settings/relay_settings_cubit_test.dart
@@ -19,6 +19,10 @@ class _MockRelayCapabilityService extends Mock
 class _MockVideoEventService extends Mock implements VideoEventService {}
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(RelayAddSource.automatic);
+  });
+
   group(RelaySettingsCubit, () {
     late _MockNostrClient nostr;
     late _MockRelayCapabilityService capabilities;
@@ -30,7 +34,9 @@ void main() {
       videos = _MockVideoEventService();
       when(() => nostr.configuredRelays).thenReturn(const []);
       when(() => nostr.connectedRelayCount).thenReturn(0);
-      when(() => nostr.addRelay(any())).thenAnswer((_) async => true);
+      when(
+        () => nostr.addRelay(any(), source: any(named: 'source')),
+      ).thenAnswer((_) async => true);
       when(() => nostr.removeRelay(any())).thenAnswer((_) async => true);
       when(nostr.forceReconnectAll).thenAnswer((_) async {});
       when(videos.resetAndResubscribeAll).thenAnswer((_) async {});
@@ -45,10 +51,9 @@ void main() {
     blocTest<RelaySettingsCubit, RelaySettingsState>(
       'load snapshots configured relays',
       setUp: () {
-        when(() => nostr.configuredRelays).thenReturn([
-          'wss://a.example',
-          'wss://b.example',
-        ]);
+        when(
+          () => nostr.configuredRelays,
+        ).thenReturn(['wss://a.example', 'wss://b.example']);
       },
       build: buildCubit,
       act: (cubit) => cubit.load(),
@@ -88,11 +93,10 @@ void main() {
           isA<RelayCapabilityEntry>()
               .having((e) => e.loading, 'loading', isFalse)
               .having((e) => e.fetched, 'fetched', isTrue)
-              .having(
-                (e) => e.capabilities?.supportedNips,
-                'supportedNips',
-                [1, 11],
-              ),
+              .having((e) => e.capabilities?.supportedNips, 'supportedNips', [
+                1,
+                11,
+              ]),
         ),
       ],
     );
@@ -100,9 +104,7 @@ void main() {
     blocTest<RelaySettingsCubit, RelaySettingsState>(
       'fetchCapabilities short-circuits on second call',
       seed: () => const RelaySettingsState(
-        capabilities: {
-          'wss://a.example': RelayCapabilityEntry(fetched: true),
-        },
+        capabilities: {'wss://a.example': RelayCapabilityEntry(fetched: true)},
       ),
       build: buildCubit,
       act: (cubit) => cubit.fetchCapabilities('wss://a.example'),
@@ -156,9 +158,7 @@ void main() {
     blocTest<RelaySettingsCubit, RelaySettingsState>(
       'addRelay accepts wss:// and re-snapshots relays',
       setUp: () {
-        when(
-          () => nostr.configuredRelays,
-        ).thenReturn(['wss://added.example']);
+        when(() => nostr.configuredRelays).thenReturn(['wss://added.example']);
       },
       build: buildCubit,
       act: (cubit) async {
@@ -169,14 +169,21 @@ void main() {
         const RelaySettingsState(relays: ['wss://added.example']),
       ],
       verify: (_) {
-        verify(() => nostr.addRelay('wss://added.example')).called(1);
+        verify(
+          () => nostr.addRelay(
+            'wss://added.example',
+            source: RelayAddSource.user,
+          ),
+        ).called(1);
       },
     );
 
     blocTest<RelaySettingsCubit, RelaySettingsState>(
       'addRelay returns failed when service returns false',
       setUp: () {
-        when(() => nostr.addRelay(any())).thenAnswer((_) async => false);
+        when(
+          () => nostr.addRelay(any(), source: any(named: 'source')),
+        ).thenAnswer((_) async => false);
       },
       build: buildCubit,
       act: (cubit) async {
@@ -189,7 +196,9 @@ void main() {
     blocTest<RelaySettingsCubit, RelaySettingsState>(
       'addRelay surfaces service throw via addError + failed outcome',
       setUp: () {
-        when(() => nostr.addRelay(any())).thenThrow(StateError('boom'));
+        when(
+          () => nostr.addRelay(any(), source: any(named: 'source')),
+        ).thenThrow(StateError('boom'));
       },
       build: buildCubit,
       act: (cubit) async {
@@ -255,7 +264,10 @@ void main() {
       },
       verify: (_) {
         verify(
-          () => nostr.addRelay('wss://relay.staging.divine.video'),
+          () => nostr.addRelay(
+            'wss://relay.staging.divine.video',
+            source: RelayAddSource.user,
+          ),
         ).called(1);
       },
     );

--- a/mobile/test/blocs/relay_settings/relay_settings_cubit_test.dart
+++ b/mobile/test/blocs/relay_settings/relay_settings_cubit_test.dart
@@ -195,7 +195,27 @@ void main() {
         final outcome = await cubit.addRelay('wss://noop.example');
         expect(outcome, AddRelayOutcome.failed);
       },
-      expect: () => const <RelaySettingsState>[],
+      expect: () => [const RelaySettingsState()],
+    );
+
+    blocTest<RelaySettingsCubit, RelaySettingsState>(
+      'addRelay refreshes when relay is saved but connection is pending',
+      setUp: () {
+        when(
+          () => nostr.addRelay(any(), source: any(named: 'source')),
+        ).thenAnswer((_) async => false);
+        when(
+          () => nostr.configuredRelays,
+        ).thenReturn(['wss://pending.example']);
+      },
+      build: buildCubit,
+      act: (cubit) async {
+        final outcome = await cubit.addRelay('wss://pending.example');
+        expect(outcome, AddRelayOutcome.addedConnectionPending);
+      },
+      expect: () => [
+        const RelaySettingsState(relays: ['wss://pending.example']),
+      ],
     );
 
     blocTest<RelaySettingsCubit, RelaySettingsState>(

--- a/mobile/test/blocs/relay_settings/relay_settings_cubit_test.dart
+++ b/mobile/test/blocs/relay_settings/relay_settings_cubit_test.dart
@@ -154,9 +154,7 @@ void main() {
       },
       expect: () => const <RelaySettingsState>[],
       verify: (_) {
-        verifyNever(
-          () => nostr.addRelay(any(), source: any(named: 'source')),
-        );
+        verifyNever(() => nostr.addRelay(any(), source: any(named: 'source')));
       },
     );
 
@@ -268,6 +266,7 @@ void main() {
         when(
           () => nostr.removeRelay(any(), source: any(named: 'source')),
         ).thenAnswer((_) async => false);
+        when(() => nostr.configuredRelays).thenReturn(['wss://a.example']);
       },
       build: buildCubit,
       act: (cubit) async {
@@ -276,7 +275,28 @@ void main() {
           RemoveRelayOutcome.failed,
         );
       },
-      expect: () => const <RelaySettingsState>[],
+      expect: () => [
+        const RelaySettingsState(relays: ['wss://a.example']),
+      ],
+    );
+
+    blocTest<RelaySettingsCubit, RelaySettingsState>(
+      'removeRelay refreshes and reports removed when relay is already gone',
+      seed: () => const RelaySettingsState(relays: ['wss://stale.example']),
+      setUp: () {
+        when(
+          () => nostr.removeRelay(any(), source: any(named: 'source')),
+        ).thenAnswer((_) async => false);
+        when(() => nostr.configuredRelays).thenReturn(const []);
+      },
+      build: buildCubit,
+      act: (cubit) async {
+        expect(
+          await cubit.removeRelay('wss://stale.example'),
+          RemoveRelayOutcome.removed,
+        );
+      },
+      expect: () => [const RelaySettingsState()],
     );
 
     blocTest<RelaySettingsCubit, RelaySettingsState>(

--- a/mobile/test/blocs/relay_settings/relay_settings_cubit_test.dart
+++ b/mobile/test/blocs/relay_settings/relay_settings_cubit_test.dart
@@ -285,6 +285,42 @@ void main() {
     );
 
     blocTest<RelaySettingsCubit, RelaySettingsState>(
+      'restoreDefaultRelay refreshes when relay is configured but not connected',
+      setUp: () {
+        when(
+          () => nostr.defaultRelayUrl,
+        ).thenReturn('wss://relay.staging.divine.video');
+        when(
+          () => nostr.addRelay(
+            'wss://relay.staging.divine.video',
+            source: RelayAddSource.user,
+          ),
+        ).thenAnswer((_) async => false);
+        when(
+          () => nostr.configuredRelays,
+        ).thenReturn(['wss://relay.staging.divine.video']);
+      },
+      build: buildCubit,
+      act: (cubit) async {
+        expect(
+          await cubit.restoreDefaultRelay(),
+          RestoreDefaultRelayOutcome.restoredConnectionPending,
+        );
+      },
+      expect: () => [
+        const RelaySettingsState(relays: ['wss://relay.staging.divine.video']),
+      ],
+      verify: (_) {
+        verify(
+          () => nostr.addRelay(
+            'wss://relay.staging.divine.video',
+            source: RelayAddSource.user,
+          ),
+        ).called(1);
+      },
+    );
+
+    blocTest<RelaySettingsCubit, RelaySettingsState>(
       'retryConnection emits connected with count when relays reconnect',
       setUp: () {
         when(() => nostr.connectedRelayCount).thenReturn(2);

--- a/mobile/test/helpers/test_nostr_service.dart
+++ b/mobile/test/helpers/test_nostr_service.dart
@@ -269,7 +269,7 @@ class TestNostrService implements NostrClient {
   @override
   Future<bool> removeRelay(
     String relayUrl, {
-    RelayRemoveSource source = RelayRemoveSource.user,
+    required RelayRemoveSource source,
   }) async {
     // No-op for tests
     return true;

--- a/mobile/test/helpers/test_nostr_service.dart
+++ b/mobile/test/helpers/test_nostr_service.dart
@@ -267,7 +267,10 @@ class TestNostrService implements NostrClient {
   }
 
   @override
-  Future<bool> removeRelay(String relayUrl) async {
+  Future<bool> removeRelay(
+    String relayUrl, {
+    RelayRemoveSource source = RelayRemoveSource.user,
+  }) async {
     // No-op for tests
     return true;
   }

--- a/mobile/test/helpers/test_nostr_service.dart
+++ b/mobile/test/helpers/test_nostr_service.dart
@@ -258,7 +258,10 @@ class TestNostrService implements NostrClient {
   List<String> get connectedRelays => _isConnected ? ['wss://test.relay'] : [];
 
   @override
-  Future<bool> addRelay(String relayUrl) async {
+  Future<bool> addRelay(
+    String relayUrl, {
+    RelayAddSource source = RelayAddSource.automatic,
+  }) async {
     // No-op for tests
     return true;
   }

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -209,6 +209,7 @@ void main() {
       const mustDifferFromEnglish = {
         'relaySettingsRemoveDefaultRelayTitle',
         'relaySettingsRemoveDefaultRelayMessage',
+        'relaySettingsRemoveRelayTooltip',
       };
 
       for (final file in arbFiles) {

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -189,6 +189,46 @@ void main() {
       }
     });
 
+    test('default-relay removal copy is localized for every locale', () {
+      final l10nDir = Directory('lib/l10n');
+      final arbFiles =
+          l10nDir
+              .listSync()
+              .whereType<File>()
+              .where((file) => file.path.endsWith('.arb'))
+              .where((file) => !file.path.endsWith('app_en.arb'))
+              .toList()
+            ..sort((a, b) => a.path.compareTo(b.path));
+
+      final template = _readArb(File('lib/l10n/app_en.arb'));
+      const keys = [
+        'relaySettingsRemoveDefaultRelayTitle',
+        'relaySettingsRemoveDefaultRelayMessage',
+        'relaySettingsRemoveRelayTooltip',
+      ];
+
+      for (final file in arbFiles) {
+        final arb = _readArb(file);
+
+        for (final key in keys) {
+          final value = arb[key];
+
+          expect(
+            value,
+            isA<String>().having((s) => s.isNotEmpty, 'isNotEmpty', isTrue),
+            reason: '${file.path} must define a non-empty $key message',
+          );
+          expect(
+            value,
+            isNot(template[key]),
+            reason:
+                '${file.path} must not fall back to English for the '
+                'default-relay removal warning',
+          );
+        }
+      }
+    });
+
     test('every locale keeps the placeholders app_en.arb interpolates', () {
       final l10nDir = Directory('lib/l10n');
       final arbFiles =

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -206,6 +206,10 @@ void main() {
         'relaySettingsRemoveDefaultRelayMessage',
         'relaySettingsRemoveRelayTooltip',
       ];
+      const mustDifferFromEnglish = {
+        'relaySettingsRemoveDefaultRelayTitle',
+        'relaySettingsRemoveDefaultRelayMessage',
+      };
 
       for (final file in arbFiles) {
         final arb = _readArb(file);
@@ -218,13 +222,15 @@ void main() {
             isA<String>().having((s) => s.isNotEmpty, 'isNotEmpty', isTrue),
             reason: '${file.path} must define a non-empty $key message',
           );
-          expect(
-            value,
-            isNot(template[key]),
-            reason:
-                '${file.path} must not fall back to English for the '
-                'default-relay removal warning',
-          );
+          if (mustDifferFromEnglish.contains(key)) {
+            expect(
+              value,
+              isNot(template[key]),
+              reason:
+                  '${file.path} must not fall back to English for the '
+                  'default-relay removal warning',
+            );
+          }
         }
       }
     });

--- a/mobile/test/screens/relay_settings_screen_layout_test.dart
+++ b/mobile/test/screens/relay_settings_screen_layout_test.dart
@@ -333,6 +333,40 @@ void main() {
       ).called(1);
     });
 
+    testWidgets('warns when added relay is saved but not connected', (
+      tester,
+    ) async {
+      const relay = 'wss://pending.example.com';
+      final nostrService = _MockNostrService();
+      final configuredRelays = <String>[];
+      when(
+        () => nostrService.defaultRelayUrl,
+      ).thenReturn('wss://relay.divine.video');
+      when(
+        () => nostrService.configuredRelays,
+      ).thenAnswer((_) => List.unmodifiable(configuredRelays));
+      when(
+        () => nostrService.addRelay(relay, source: RelayAddSource.user),
+      ).thenAnswer((_) async {
+        configuredRelays.add(relay);
+        return false;
+      });
+
+      await pumpScreen(tester, nostrService: nostrService);
+      when(
+        () => nostrService.configuredRelays,
+      ).thenAnswer((_) => List.unmodifiable(configuredRelays));
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      await openAddSheetAndSubmit(tester, relay, l10n);
+
+      expect(find.text(l10n.relaySettingsFailedToConnectCheck), findsOneWidget);
+      expect(find.text(l10n.relaySettingsAddedRelay(relay)), findsNothing);
+      verify(
+        () => nostrService.addRelay(relay, source: RelayAddSource.user),
+      ).called(1);
+    });
+
     testWidgets('accepts uppercase WSS:// URL and forwards to NostrClient', (
       tester,
     ) async {

--- a/mobile/test/screens/relay_settings_screen_layout_test.dart
+++ b/mobile/test/screens/relay_settings_screen_layout_test.dart
@@ -28,6 +28,10 @@ class _MockRelayStatisticsService extends Mock
 class _MockVideoEventService extends Mock implements VideoEventService {}
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(RelayAddSource.automatic);
+  });
+
   testWidgets(
     'RelaySettingsScreen constrains menu content width on wide screens',
     (tester) async {
@@ -180,28 +184,42 @@ void main() {
       tester,
     ) async {
       final nostrService = _MockNostrService();
-      when(() => nostrService.addRelay(any())).thenAnswer((_) async => true);
+      when(
+        () => nostrService.addRelay(any(), source: any(named: 'source')),
+      ).thenAnswer((_) async => true);
 
       await pumpScreen(tester, nostrService: nostrService);
 
       final l10n = lookupAppLocalizations(const Locale('en'));
       await openAddSheetAndSubmit(tester, 'wss://relay.example.com', l10n);
 
-      verify(() => nostrService.addRelay('wss://relay.example.com')).called(1);
+      verify(
+        () => nostrService.addRelay(
+          'wss://relay.example.com',
+          source: RelayAddSource.user,
+        ),
+      ).called(1);
     });
 
     testWidgets('accepts uppercase WSS:// URL and forwards to NostrClient', (
       tester,
     ) async {
       final nostrService = _MockNostrService();
-      when(() => nostrService.addRelay(any())).thenAnswer((_) async => true);
+      when(
+        () => nostrService.addRelay(any(), source: any(named: 'source')),
+      ).thenAnswer((_) async => true);
 
       await pumpScreen(tester, nostrService: nostrService);
 
       final l10n = lookupAppLocalizations(const Locale('en'));
       await openAddSheetAndSubmit(tester, 'WSS://relay.example.com', l10n);
 
-      verify(() => nostrService.addRelay('WSS://relay.example.com')).called(1);
+      verify(
+        () => nostrService.addRelay(
+          'WSS://relay.example.com',
+          source: RelayAddSource.user,
+        ),
+      ).called(1);
     });
 
     testWidgets('shows malformed-URL message for empty-host wss://', (
@@ -262,14 +280,15 @@ void main() {
 
     testWidgets(
       'restore-default snackbar names the environment default relay',
-      (
-        tester,
-      ) async {
+      (tester) async {
         const envDefaultRelay = 'wss://relay.staging.divine.video';
         final nostrService = _MockNostrService();
         when(() => nostrService.defaultRelayUrl).thenReturn(envDefaultRelay);
         when(
-          () => nostrService.addRelay(envDefaultRelay),
+          () => nostrService.addRelay(
+            envDefaultRelay,
+            source: RelayAddSource.user,
+          ),
         ).thenAnswer((_) async => true);
 
         await pumpScreen(tester, nostrService: nostrService);
@@ -292,7 +311,12 @@ void main() {
           ),
           findsNothing,
         );
-        verify(() => nostrService.addRelay(envDefaultRelay)).called(1);
+        verify(
+          () => nostrService.addRelay(
+            envDefaultRelay,
+            source: RelayAddSource.user,
+          ),
+        ).called(1);
       },
     );
   });

--- a/mobile/test/screens/relay_settings_screen_layout_test.dart
+++ b/mobile/test/screens/relay_settings_screen_layout_test.dart
@@ -96,20 +96,22 @@ void main() {
   testWidgets('warns before removing the Divine relay', (tester) async {
     SharedPreferences.setMockInitialValues({});
 
-    const defaultRelay = 'wss://relay.divine.video';
+    const defaultRelay = 'wss://relay.divine.video/';
+    const configuredRelay = 'wss://relay.divine.video';
     final nostrService = _MockNostrService();
     final capabilityService = _MockRelayCapabilityService();
     final statsService = _MockRelayStatisticsService();
     final videoEventService = _MockVideoEventService();
-    final stats = RelayStatistics(relayUrl: defaultRelay)..isConnected = true;
+    final stats = RelayStatistics(relayUrl: configuredRelay)
+      ..isConnected = true;
 
     when(() => nostrService.defaultRelayUrl).thenReturn(defaultRelay);
-    when(() => nostrService.configuredRelays).thenReturn([defaultRelay]);
+    when(() => nostrService.configuredRelays).thenReturn([configuredRelay]);
     when(() => nostrService.connectedRelayCount).thenReturn(1);
-    when(statsService.getAllStatistics).thenReturn({defaultRelay: stats});
+    when(statsService.getAllStatistics).thenReturn({configuredRelay: stats});
     when(
       () => capabilityService.getRelayCapabilities(any()),
-    ).thenThrow(RelayCapabilityException('Not found', defaultRelay));
+    ).thenThrow(RelayCapabilityException('Not found', configuredRelay));
 
     final container = ProviderContainer(
       overrides: [
@@ -138,6 +140,10 @@ void main() {
     await tester.pumpAndSettle();
 
     final l10n = lookupAppLocalizations(const Locale('en'));
+    expect(
+      find.byTooltip(l10n.relaySettingsRemoveRelayTooltip),
+      findsOneWidget,
+    );
     await tester.tap(find.byType(IconButton).first);
     await tester.pumpAndSettle();
 
@@ -146,7 +152,72 @@ void main() {
       findsOneWidget,
     );
     expect(
-      find.text(l10n.relaySettingsRemoveDefaultRelayMessage(defaultRelay)),
+      find.text(l10n.relaySettingsRemoveDefaultRelayMessage(configuredRelay)),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('can restore Divine relay while custom relays remain', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+
+    const defaultRelay = 'wss://relay.divine.video';
+    const customRelay = 'wss://relay.example.com';
+    final nostrService = _MockNostrService();
+    final capabilityService = _MockRelayCapabilityService();
+    final statsService = _MockRelayStatisticsService();
+    final videoEventService = _MockVideoEventService();
+    final stats = RelayStatistics(relayUrl: customRelay)..isConnected = true;
+
+    when(() => nostrService.defaultRelayUrl).thenReturn(defaultRelay);
+    when(() => nostrService.configuredRelays).thenReturn([customRelay]);
+    when(() => nostrService.connectedRelayCount).thenReturn(1);
+    when(
+      () => nostrService.addRelay(defaultRelay, source: RelayAddSource.user),
+    ).thenAnswer((_) async => true);
+    when(statsService.getAllStatistics).thenReturn({customRelay: stats});
+    when(
+      () => capabilityService.getRelayCapabilities(any()),
+    ).thenThrow(RelayCapabilityException('Not found', customRelay));
+
+    final container = ProviderContainer(
+      overrides: [
+        nostrServiceProvider.overrideWithValue(nostrService),
+        relayCapabilityServiceProvider.overrideWithValue(capabilityService),
+        relayStatisticsServiceProvider.overrideWithValue(statsService),
+        relayStatisticsStreamProvider.overrideWith(
+          (_) => Stream.value({customRelay: stats}),
+        ),
+        videoEventServiceProvider.overrideWithValue(videoEventService),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: VineTheme.theme,
+          home: const RelaySettingsScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    expect(find.text(l10n.relaySettingsRestoreDefaultRelay), findsOneWidget);
+
+    await tester.tap(find.text(l10n.relaySettingsRestoreDefaultRelay));
+    await tester.pumpAndSettle();
+
+    verify(
+      () => nostrService.addRelay(defaultRelay, source: RelayAddSource.user),
+    ).called(1);
+    expect(
+      find.text(l10n.relaySettingsRestoredDefault(defaultRelay)),
       findsOneWidget,
     );
   });

--- a/mobile/test/screens/relay_settings_screen_layout_test.dart
+++ b/mobile/test/screens/relay_settings_screen_layout_test.dart
@@ -50,6 +50,9 @@ void main() {
       when(
         () => nostrService.configuredRelays,
       ).thenReturn(['wss://relay.divine.video']);
+      when(
+        () => nostrService.defaultRelayUrl,
+      ).thenReturn('wss://relay.divine.video');
       when(() => nostrService.connectedRelayCount).thenReturn(1);
       when(() => statsService.getStatistics(any())).thenReturn(stats);
       when(
@@ -89,6 +92,64 @@ void main() {
       expect(listViewWidth, moreOrLessEquals(600));
     },
   );
+
+  testWidgets('warns before removing the Divine relay', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+
+    const defaultRelay = 'wss://relay.divine.video';
+    final nostrService = _MockNostrService();
+    final capabilityService = _MockRelayCapabilityService();
+    final statsService = _MockRelayStatisticsService();
+    final videoEventService = _MockVideoEventService();
+    final stats = RelayStatistics(relayUrl: defaultRelay)..isConnected = true;
+
+    when(() => nostrService.defaultRelayUrl).thenReturn(defaultRelay);
+    when(() => nostrService.configuredRelays).thenReturn([defaultRelay]);
+    when(() => nostrService.connectedRelayCount).thenReturn(1);
+    when(statsService.getAllStatistics).thenReturn({defaultRelay: stats});
+    when(
+      () => capabilityService.getRelayCapabilities(any()),
+    ).thenThrow(RelayCapabilityException('Not found', defaultRelay));
+
+    final container = ProviderContainer(
+      overrides: [
+        nostrServiceProvider.overrideWithValue(nostrService),
+        relayCapabilityServiceProvider.overrideWithValue(capabilityService),
+        relayStatisticsServiceProvider.overrideWithValue(statsService),
+        relayStatisticsStreamProvider.overrideWith(
+          (_) => Stream.value({defaultRelay: stats}),
+        ),
+        videoEventServiceProvider.overrideWithValue(videoEventService),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: VineTheme.theme,
+          home: const RelaySettingsScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    await tester.tap(find.byType(IconButton).first);
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(l10n.relaySettingsRemoveDefaultRelayTitle),
+      findsOneWidget,
+    );
+    expect(
+      find.text(l10n.relaySettingsRemoveDefaultRelayMessage(defaultRelay)),
+      findsOneWidget,
+    );
+  });
 
   group('Add Relay validation (#3362)', () {
     Future<void> pumpScreen(
@@ -177,7 +238,9 @@ void main() {
       await openAddSheetAndSubmit(tester, 'ws://attacker.example.com', l10n);
 
       expect(find.text(l10n.relaySettingsInsecureUrl), findsOneWidget);
-      verifyNever(() => nostrService.addRelay(any()));
+      verifyNever(
+        () => nostrService.addRelay(any(), source: any(named: 'source')),
+      );
     });
 
     testWidgets('accepts wss:// URL and forwards to NostrClient', (
@@ -237,7 +300,9 @@ void main() {
 
       expect(find.text(l10n.relaySettingsInvalidUrl), findsOneWidget);
       expect(find.text(l10n.relaySettingsInsecureUrl), findsNothing);
-      verifyNever(() => nostrService.addRelay(any()));
+      verifyNever(
+        () => nostrService.addRelay(any(), source: any(named: 'source')),
+      );
     });
 
     testWidgets(
@@ -255,7 +320,9 @@ void main() {
 
         expect(find.text(l10n.relaySettingsInvalidUrl), findsOneWidget);
         expect(find.text(l10n.relaySettingsInsecureUrl), findsNothing);
-        verifyNever(() => nostrService.addRelay(any()));
+        verifyNever(
+          () => nostrService.addRelay(any(), source: any(named: 'source')),
+        );
       },
     );
 
@@ -274,7 +341,9 @@ void main() {
 
         expect(find.text(l10n.relaySettingsInvalidUrl), findsOneWidget);
         expect(find.text(l10n.relaySettingsInsecureUrl), findsNothing);
-        verifyNever(() => nostrService.addRelay(any()));
+        verifyNever(
+          () => nostrService.addRelay(any(), source: any(named: 'source')),
+        );
       },
     );
 

--- a/mobile/test/screens/relay_settings_screen_layout_test.dart
+++ b/mobile/test/screens/relay_settings_screen_layout_test.dart
@@ -378,7 +378,7 @@ void main() {
       'shows malformed-URL message for https:// input (relays are WS-only)',
       (tester) async {
         // Reviewer ask on PR #3806: form previously accepted https:// /
-        // http://, but `RelayManager._normalizeUrl` only accepts wss:// /
+        // http://, but `normalizeRelayUrl` only accepts wss:// /
         // loopback ws://, so they fell through to a generic "failed to add"
         // message. Surface the structurally-bad-input bucket instead.
         final nostrService = _MockNostrService();

--- a/mobile/test/screens/relay_settings_screen_layout_test.dart
+++ b/mobile/test/screens/relay_settings_screen_layout_test.dart
@@ -140,11 +140,9 @@ void main() {
     await tester.pumpAndSettle();
 
     final l10n = lookupAppLocalizations(const Locale('en'));
-    expect(
-      find.byTooltip(l10n.relaySettingsRemoveRelayTooltip),
-      findsOneWidget,
-    );
-    await tester.tap(find.byType(IconButton).first);
+    final removeButton = find.byTooltip(l10n.relaySettingsRemoveRelayTooltip);
+    expect(removeButton, findsOneWidget);
+    await tester.tap(removeButton);
     await tester.pumpAndSettle();
 
     expect(

--- a/mobile/test/services/auth_service_signout_cleanup_test.dart
+++ b/mobile/test/services/auth_service_signout_cleanup_test.dart
@@ -8,6 +8,8 @@ import 'package:fake_async/fake_async.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart'
+    show SharedPreferencesRelayStorage;
 import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:openvine/services/auth/nostr_identity.dart';
 import 'package:openvine/services/auth_service.dart';
@@ -159,6 +161,31 @@ void main() {
       expect(prefs.getString('terms_accepted_at'), isNull);
     });
 
+    test('signOut clears configured and user-removed relays', () async {
+      await prefs.setStringList(
+        SharedPreferencesRelayStorage.defaultKey,
+        ['wss://relay.divine.video'],
+      );
+      await prefs.setStringList(
+        SharedPreferencesRelayStorage.defaultRemovedRelaysKey,
+        ['wss://relay.divine.video'],
+      );
+      when(() => mockKeyStorage.clearCache()).thenReturn(null);
+
+      await authService.signOut();
+
+      expect(
+        prefs.getStringList(SharedPreferencesRelayStorage.defaultKey),
+        isNull,
+      );
+      expect(
+        prefs.getStringList(
+          SharedPreferencesRelayStorage.defaultRemovedRelaysKey,
+        ),
+        isNull,
+      );
+    });
+
     test('non-destructive signOut passes deleteUserData: false', () async {
       // Setup mock
       when(() => mockKeyStorage.clearCache()).thenReturn(null);
@@ -218,6 +245,36 @@ void main() {
       // Note: After deleteKeys=true, a new identity is auto-created,
       // which sets a new pubkey. So we verify cleanup was called,
       // not that pubkey is null (since new identity sets it).
+    });
+
+    test('remove-device signOut clears user-removed relays', () async {
+      await prefs.setStringList(
+        SharedPreferencesRelayStorage.defaultRemovedRelaysKey,
+        ['wss://relay.divine.video'],
+      );
+      when(() => mockKeyStorage.deleteKeys()).thenAnswer((_) async => {});
+      when(
+        () => mockKeyStorage.deleteIdentityKeyContainer(
+          any(),
+          biometricPrompt: any(named: 'biometricPrompt'),
+        ),
+      ).thenAnswer((_) async {});
+      when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
+      when(() => mockKeyStorage.initialize()).thenAnswer((_) async => {});
+      when(
+        () => mockKeyStorage.generateAndStoreKeys(
+          biometricPrompt: any(named: 'biometricPrompt'),
+        ),
+      ).thenAnswer((_) async => SecureKeyContainer.fromNsec(testNsec));
+
+      await authService.signOut(deleteKeys: true);
+
+      expect(
+        prefs.getStringList(
+          SharedPreferencesRelayStorage.defaultRemovedRelaysKey,
+        ),
+        isNull,
+      );
     });
 
     test('account deletion signOut deletes owner-scoped user data', () async {

--- a/mobile/test/services/bug_report_worker_api_test.dart
+++ b/mobile/test/services/bug_report_worker_api_test.dart
@@ -10,7 +10,6 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart'
     show BugReportData, LogCategory, LogEntry, LogLevel, NIP17SendResult;
 import 'package:nostr_client/nostr_client.dart';
-import 'package:openvine/config/bug_report_config.dart';
 import 'package:openvine/services/bug_report_service.dart';
 
 class _MockNIP17MessageService extends Mock implements NIP17MessageService {}
@@ -282,8 +281,10 @@ void main() {
     test(
       'uses static support relay fallback when DM inbox relay resolution is absent',
       () async {
+        const envFallbackRelay = ['wss://relay.test.dvines.org'];
         final serviceWithoutResolvedRelays = BugReportService(
           nip17MessageService: mockNip17,
+          fallbackTargetRelays: envFallbackRelay,
           targetRelayResolver: (_) async => null,
         );
 
@@ -316,21 +317,23 @@ void main() {
           () => mockNip17.sendPrivateMessage(
             recipientPubkey: 'test-pubkey',
             content: any(named: 'content'),
-            targetRelays: BugReportConfig.supportDmTargetRelays,
+            targetRelays: envFallbackRelay,
             awaitRecipientOk: true,
             selfWrapOnSoftUnconfirmed: false,
             additionalTags: any(named: 'additionalTags'),
           ),
         ).called(1);
-        expect(capturedTargetRelays, BugReportConfig.supportDmTargetRelays);
+        expect(capturedTargetRelays, envFallbackRelay);
       },
     );
 
     test(
       'uses static support relay fallback when relay resolution throws',
       () async {
+        const envFallbackRelay = ['wss://relay.test.dvines.org'];
         final serviceWithFailingResolver = BugReportService(
           nip17MessageService: mockNip17,
+          fallbackTargetRelays: envFallbackRelay,
           targetRelayResolver: (_) async => throw StateError('no relays'),
         );
 
@@ -359,7 +362,7 @@ void main() {
           'test-pubkey',
         );
 
-        expect(capturedTargetRelays, BugReportConfig.supportDmTargetRelays);
+        expect(capturedTargetRelays, envFallbackRelay);
       },
     );
   });

--- a/mobile/test/services/bug_report_worker_api_test.dart
+++ b/mobile/test/services/bug_report_worker_api_test.dart
@@ -84,6 +84,7 @@ void main() {
     service = BugReportService(
       nip17MessageService: mockNip17,
       blossomUploadService: mockBlossom,
+      targetRelayResolver: (_) async => const ['wss://relay.test.dvines.org'],
     );
   });
 
@@ -126,6 +127,16 @@ void main() {
       expect(result.success, isTrue);
       expect(result.reportId, equals('test-report-001'));
       expect(result.messageEventId, equals('event-abc123'));
+      verify(
+        () => mockNip17.sendPrivateMessage(
+          recipientPubkey: 'test-pubkey',
+          content: any(named: 'content'),
+          targetRelays: const ['wss://relay.test.dvines.org'],
+          awaitRecipientOk: true,
+          selfWrapOnSoftUnconfirmed: false,
+          additionalTags: any(named: 'additionalTags'),
+        ),
+      ).called(1);
       verifyNever(
         () => mockNostrClient.addRelay(any(), source: any(named: 'source')),
       );
@@ -223,7 +234,10 @@ void main() {
 
     test('sends summary only when Blossom upload not available', () async {
       // Create service with NIP-17 but without Blossom
-      final serviceNoBlossom = BugReportService(nip17MessageService: mockNip17);
+      final serviceNoBlossom = BugReportService(
+        nip17MessageService: mockNip17,
+        targetRelayResolver: (_) async => const ['wss://relay.test.dvines.org'],
+      );
 
       String? capturedContent;
       when(
@@ -256,12 +270,58 @@ void main() {
         () => mockNip17.sendPrivateMessage(
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
-          targetRelays: const ['wss://relay.divine.video'],
+          targetRelays: const ['wss://relay.test.dvines.org'],
           awaitRecipientOk: true,
           selfWrapOnSoftUnconfirmed: false,
           additionalTags: any(named: 'additionalTags'),
         ),
       ).called(1);
     });
+
+    test(
+      'falls back to default pool when DM inbox relay resolution is absent',
+      () async {
+        final serviceWithoutResolvedRelays = BugReportService(
+          nip17MessageService: mockNip17,
+          targetRelayResolver: (_) async => null,
+        );
+
+        List<String>? capturedTargetRelays;
+        when(
+          () => mockNip17.sendPrivateMessage(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            content: any(named: 'content'),
+            targetRelays: any(named: 'targetRelays'),
+            awaitRecipientOk: true,
+            selfWrapOnSoftUnconfirmed: false,
+            additionalTags: any(named: 'additionalTags'),
+          ),
+        ).thenAnswer((invocation) async {
+          capturedTargetRelays =
+              invocation.namedArguments[#targetRelays] as List<String>?;
+          return NIP17SendResult.success(
+            rumorEventId: 'rumor-no-target',
+            messageEventId: 'event-no-target',
+            recipientPubkey: 'test-pubkey',
+          );
+        });
+
+        await serviceWithoutResolvedRelays.sendBugReportToRecipient(
+          testData,
+          'test-pubkey',
+        );
+
+        verify(
+          () => mockNip17.sendPrivateMessage(
+            recipientPubkey: 'test-pubkey',
+            content: any(named: 'content'),
+            awaitRecipientOk: true,
+            selfWrapOnSoftUnconfirmed: false,
+            additionalTags: any(named: 'additionalTags'),
+          ),
+        ).called(1);
+        expect(capturedTargetRelays, isNull);
+      },
+    );
   });
 }

--- a/mobile/test/services/bug_report_worker_api_test.dart
+++ b/mobile/test/services/bug_report_worker_api_test.dart
@@ -47,6 +47,7 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(File(''));
+    registerFallbackValue(<String>[]);
   });
 
   setUp(() async {
@@ -79,10 +80,6 @@ void main() {
       },
     );
 
-    // Mock nostrService getter and addRelay for backup relay connection
-    when(() => mockNip17.nostrService).thenReturn(mockNostrClient);
-    when(() => mockNostrClient.addRelay(any())).thenAnswer((_) async => true);
-
     service = BugReportService(
       nip17MessageService: mockNip17,
       blossomUploadService: mockBlossom,
@@ -107,6 +104,9 @@ void main() {
         () => mockNip17.sendPrivateMessage(
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
+          targetRelays: any(named: 'targetRelays'),
+          awaitRecipientOk: true,
+          selfWrapOnSoftUnconfirmed: false,
           additionalTags: any(named: 'additionalTags'),
         ),
       ).thenAnswer(
@@ -125,6 +125,7 @@ void main() {
       expect(result.success, isTrue);
       expect(result.reportId, equals('test-report-001'));
       expect(result.messageEventId, equals('event-abc123'));
+      verifyNever(() => mockNostrClient.addRelay(any()));
     });
 
     test(
@@ -140,6 +141,9 @@ void main() {
           () => mockNip17.sendPrivateMessage(
             recipientPubkey: any(named: 'recipientPubkey'),
             content: any(named: 'content'),
+            targetRelays: any(named: 'targetRelays'),
+            awaitRecipientOk: true,
+            selfWrapOnSoftUnconfirmed: false,
             additionalTags: any(named: 'additionalTags'),
           ),
         ).thenAnswer(
@@ -186,6 +190,9 @@ void main() {
           () => mockNip17.sendPrivateMessage(
             recipientPubkey: any(named: 'recipientPubkey'),
             content: any(named: 'content'),
+            targetRelays: any(named: 'targetRelays'),
+            awaitRecipientOk: true,
+            selfWrapOnSoftUnconfirmed: false,
             additionalTags: any(named: 'additionalTags'),
           ),
         ).thenAnswer((invocation) async {
@@ -220,6 +227,9 @@ void main() {
         () => mockNip17.sendPrivateMessage(
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
+          targetRelays: any(named: 'targetRelays'),
+          awaitRecipientOk: true,
+          selfWrapOnSoftUnconfirmed: false,
           additionalTags: any(named: 'additionalTags'),
         ),
       ).thenAnswer((invocation) async {
@@ -243,6 +253,9 @@ void main() {
         () => mockNip17.sendPrivateMessage(
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
+          targetRelays: const ['wss://relay.nos.social'],
+          awaitRecipientOk: true,
+          selfWrapOnSoftUnconfirmed: false,
           additionalTags: any(named: 'additionalTags'),
         ),
       ).called(1);

--- a/mobile/test/services/bug_report_worker_api_test.dart
+++ b/mobile/test/services/bug_report_worker_api_test.dart
@@ -256,7 +256,7 @@ void main() {
         () => mockNip17.sendPrivateMessage(
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
-          targetRelays: const ['wss://relay.nos.social'],
+          targetRelays: const ['wss://relay.divine.video'],
           awaitRecipientOk: true,
           selfWrapOnSoftUnconfirmed: false,
           additionalTags: any(named: 'additionalTags'),

--- a/mobile/test/services/bug_report_worker_api_test.dart
+++ b/mobile/test/services/bug_report_worker_api_test.dart
@@ -48,6 +48,7 @@ void main() {
   setUpAll(() {
     registerFallbackValue(File(''));
     registerFallbackValue(<String>[]);
+    registerFallbackValue(RelayAddSource.automatic);
   });
 
   setUp(() async {
@@ -125,7 +126,9 @@ void main() {
       expect(result.success, isTrue);
       expect(result.reportId, equals('test-report-001'));
       expect(result.messageEventId, equals('event-abc123'));
-      verifyNever(() => mockNostrClient.addRelay(any()));
+      verifyNever(
+        () => mockNostrClient.addRelay(any(), source: any(named: 'source')),
+      );
     });
 
     test(

--- a/mobile/test/services/bug_report_worker_api_test.dart
+++ b/mobile/test/services/bug_report_worker_api_test.dart
@@ -10,6 +10,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart'
     show BugReportData, LogCategory, LogEntry, LogLevel, NIP17SendResult;
 import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/config/bug_report_config.dart';
 import 'package:openvine/services/bug_report_service.dart';
 
 class _MockNIP17MessageService extends Mock implements NIP17MessageService {}
@@ -279,7 +280,7 @@ void main() {
     });
 
     test(
-      'falls back to default pool when DM inbox relay resolution is absent',
+      'uses static support relay fallback when DM inbox relay resolution is absent',
       () async {
         final serviceWithoutResolvedRelays = BugReportService(
           nip17MessageService: mockNip17,
@@ -315,12 +316,50 @@ void main() {
           () => mockNip17.sendPrivateMessage(
             recipientPubkey: 'test-pubkey',
             content: any(named: 'content'),
+            targetRelays: BugReportConfig.supportDmTargetRelays,
             awaitRecipientOk: true,
             selfWrapOnSoftUnconfirmed: false,
             additionalTags: any(named: 'additionalTags'),
           ),
         ).called(1);
-        expect(capturedTargetRelays, isNull);
+        expect(capturedTargetRelays, BugReportConfig.supportDmTargetRelays);
+      },
+    );
+
+    test(
+      'uses static support relay fallback when relay resolution throws',
+      () async {
+        final serviceWithFailingResolver = BugReportService(
+          nip17MessageService: mockNip17,
+          targetRelayResolver: (_) async => throw StateError('no relays'),
+        );
+
+        List<String>? capturedTargetRelays;
+        when(
+          () => mockNip17.sendPrivateMessage(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            content: any(named: 'content'),
+            targetRelays: any(named: 'targetRelays'),
+            awaitRecipientOk: true,
+            selfWrapOnSoftUnconfirmed: false,
+            additionalTags: any(named: 'additionalTags'),
+          ),
+        ).thenAnswer((invocation) async {
+          capturedTargetRelays =
+              invocation.namedArguments[#targetRelays] as List<String>?;
+          return NIP17SendResult.success(
+            rumorEventId: 'rumor-fallback-target',
+            messageEventId: 'event-fallback-target',
+            recipientPubkey: 'test-pubkey',
+          );
+        });
+
+        await serviceWithFailingResolver.sendBugReportToRecipient(
+          testData,
+          'test-pubkey',
+        );
+
+        expect(capturedTargetRelays, BugReportConfig.supportDmTargetRelays);
       },
     );
   });

--- a/mobile/test/services/environment_service_test.dart
+++ b/mobile/test/services/environment_service_test.dart
@@ -135,6 +135,7 @@ void main() {
     test('setEnvironment clears configured_relays', () async {
       SharedPreferences.setMockInitialValues({
         'configured_relays': 'some_relay_value',
+        'user_removed_relays': ['wss://relay.divine.video'],
       });
 
       service = EnvironmentService();
@@ -144,6 +145,7 @@ void main() {
 
       final prefs = await SharedPreferences.getInstance();
       expect(prefs.getString('configured_relays'), isNull);
+      expect(prefs.getStringList('user_removed_relays'), isNull);
     });
   });
 }

--- a/mobile/test/services/relay_discovery_service_test.dart
+++ b/mobile/test/services/relay_discovery_service_test.dart
@@ -280,7 +280,7 @@ void main() {
 
     test('drops https:// relay tags (NIP-65 advertises WS endpoints only)', () {
       // A published kind:10002 tag like `["r", "https://relay.example.com"]`
-      // is not a usable relay endpoint — `RelayManager._normalizeUrl` will
+      // is not a usable relay endpoint — `normalizeRelayUrl` will
       // reject it downstream. If discovery kept it, `result.hasRelays`
       // would be true and the safe-fallback bootstrap (#2931) would be
       // suppressed, leaving the user with no relays.
@@ -327,8 +327,8 @@ void main() {
         // `wss://http://attacker` parses with host=`http` and path=`//attacker…`.
         // Without the `path.startsWith('//')` guard in `isRelayUrlAllowed`,
         // the predicate would accept it (scheme=wss) and discovery would
-        // surface a relay pointing at host `http`. `RelayManager.
-        // _normalizeUrl` would also reject it downstream, but we don't want
+        // surface a relay pointing at host `http`. `normalizeRelayUrl`
+        // would also reject it downstream, but we don't want
         // discovery's `hasRelays` to flip true on a malformed tag — that
         // would suppress the safe-fallback bootstrap (#2931).
         final relays = service.parseRelayListFromJson(

--- a/mobile/test/unit/providers/relay_set_change_bridge_test.dart
+++ b/mobile/test/unit/providers/relay_set_change_bridge_test.dart
@@ -42,6 +42,7 @@ class TestNostrSession extends NostrSession {
 void main() {
   setUpAll(() {
     registerFallbackValue(<String>[]);
+    registerFallbackValue(RelayRemoveSource.user);
   });
 
   group('relaySetChangeBridge', () {
@@ -481,7 +482,10 @@ void main() {
           return relays.length;
         });
         when(
-          () => replacementClient.removeRelay(any()),
+          () => replacementClient.removeRelay(
+            any(),
+            source: any(named: 'source'),
+          ),
         ).thenAnswer((call) async {
           final relay = call.positionalArguments.single as String;
           return replacementRelays.remove(relay);
@@ -540,8 +544,18 @@ void main() {
         expect(replacementRelays, contains(defaultRelay));
         expect(replacementRelays, isNot(contains(removedRelay)));
         verify(() => replacementClient.addRelays([addedRelay])).called(1);
-        verify(() => replacementClient.removeRelay(removedRelay)).called(1);
-        verifyNever(() => replacementClient.removeRelay(defaultRelay));
+        verify(
+          () => replacementClient.removeRelay(
+            removedRelay,
+            source: RelayRemoveSource.automatic,
+          ),
+        ).called(1);
+        verifyNever(
+          () => replacementClient.removeRelay(
+            defaultRelay,
+            source: any(named: 'source'),
+          ),
+        );
         verify(replacementClient.forceReconnectAll).called(1);
         verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
         verifyNever(() => mockNostrClient.forceReconnectAll());
@@ -587,7 +601,10 @@ void main() {
           () => replacementClient.addRelays(any()),
         ).thenAnswer((_) async => 1);
         when(
-          () => replacementClient.removeRelay(any()),
+          () => replacementClient.removeRelay(
+            any(),
+            source: any(named: 'source'),
+          ),
         ).thenAnswer((_) async => true);
         when(replacementClient.forceReconnectAll).thenAnswer((_) async {});
 
@@ -618,7 +635,12 @@ void main() {
 
         expect(replacementRelays, equals({stagingDefault}));
         verifyNever(() => replacementClient.addRelays(any()));
-        verifyNever(() => replacementClient.removeRelay(any()));
+        verifyNever(
+          () => replacementClient.removeRelay(
+            any(),
+            source: any(named: 'source'),
+          ),
+        );
         verifyNever(replacementClient.forceReconnectAll);
         verifyNever(() => mockVideoEventService.resetAndResubscribeAll());
 
@@ -668,7 +690,10 @@ void main() {
           () => replacementClient.addRelays(any()),
         ).thenAnswer((_) async => 1);
         when(
-          () => replacementClient.removeRelay(any()),
+          () => replacementClient.removeRelay(
+            any(),
+            source: any(named: 'source'),
+          ),
         ).thenAnswer((_) async => true);
         when(replacementClient.forceReconnectAll).thenAnswer((_) async {});
 
@@ -721,7 +746,12 @@ void main() {
 
         expect(replacementRelays, equals({defaultRelay}));
         verifyNever(() => replacementClient.addRelays(any()));
-        verifyNever(() => replacementClient.removeRelay(any()));
+        verifyNever(
+          () => replacementClient.removeRelay(
+            any(),
+            source: any(named: 'source'),
+          ),
+        );
         verifyNever(replacementClient.forceReconnectAll);
         verifyNever(() => mockVideoEventService.resetAndResubscribeAll());
 
@@ -934,7 +964,10 @@ void main() {
           return 1;
         });
         when(
-          () => replacementClient.removeRelay(removedRelay),
+          () => replacementClient.removeRelay(
+            removedRelay,
+            source: any(named: 'source'),
+          ),
         ).thenAnswer((_) async {
           removeAttempts++;
           if (removeAttempts == 1) return false;
@@ -974,7 +1007,12 @@ void main() {
         expect(replacementRelays, containsAll({defaultRelay, editedRelay}));
         expect(replacementRelays, isNot(contains(removedRelay)));
         verify(() => replacementClient.addRelays([editedRelay])).called(1);
-        verify(() => replacementClient.removeRelay(removedRelay)).called(2);
+        verify(
+          () => replacementClient.removeRelay(
+            removedRelay,
+            source: RelayRemoveSource.automatic,
+          ),
+        ).called(2);
         verify(replacementClient.forceReconnectAll).called(1);
         verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
 

--- a/mobile/test/unit/providers/relay_set_change_bridge_test.dart
+++ b/mobile/test/unit/providers/relay_set_change_bridge_test.dart
@@ -566,6 +566,140 @@ void main() {
       });
     });
 
+    test(
+      'reconciles a replacement client to a target without default relay',
+      () {
+        fakeAsync((async) {
+          final replacementClient = MockNostrClient();
+          final replacementStatuses =
+              StreamController<Map<String, RelayConnectionStatus>>.broadcast();
+          const removedRelay = 'wss://relay-old.example.com';
+          const addedRelay = 'wss://relay1.example.com';
+          final replacementRelays = <String>{defaultRelay, removedRelay};
+          var replacementPublicKey = '';
+
+          when(() => mockNostrClient.relayStatuses).thenReturn({
+            defaultRelay: RelayConnectionStatus.connected(defaultRelay),
+            removedRelay: RelayConnectionStatus.connected(removedRelay),
+          });
+          when(
+            () => mockNostrClient.relayStatusStream,
+          ).thenAnswer((_) => statusController.stream);
+          when(() => replacementClient.isInitialized).thenReturn(true);
+          when(
+            () => replacementClient.publicKey,
+          ).thenAnswer((_) => replacementPublicKey);
+          when(
+            () => replacementClient.defaultRelayUrl,
+          ).thenReturn(defaultRelay);
+          when(
+            () => replacementClient.relayStatuses,
+          ).thenAnswer(
+            (_) => {
+              for (final relay in replacementRelays)
+                relay: RelayConnectionStatus.connected(relay),
+            },
+          );
+          when(
+            () => replacementClient.relayStatusStream,
+          ).thenAnswer((_) => replacementStatuses.stream);
+          when(
+            () => replacementClient.configuredRelays,
+          ).thenAnswer((_) => replacementRelays.toList());
+          when(() => replacementClient.addRelays(any())).thenAnswer((
+            call,
+          ) async {
+            final relays = call.positionalArguments.single as List<String>;
+            replacementRelays.addAll(relays);
+            return relays.length;
+          });
+          when(
+            () => replacementClient.removeRelay(
+              any(),
+              source: any(named: 'source'),
+            ),
+          ).thenAnswer((call) async {
+            final relay = call.positionalArguments.single as String;
+            return replacementRelays.remove(relay);
+          });
+          when(replacementClient.forceReconnectAll).thenAnswer((_) async {});
+
+          final swappableService = SwappableNostrService(mockNostrClient);
+          final container = ProviderContainer(
+            overrides: [
+              nostrServiceProvider.overrideWith(() => swappableService),
+              nostrSessionProvider.overrideWith(() => testNostrSession),
+              videoEventServiceProvider.overrideWithValue(
+                mockVideoEventService,
+              ),
+            ],
+          );
+          final bridgeSubscription = container.listen<void>(
+            relaySetChangeBridgeProvider,
+            (_, _) {},
+            fireImmediately: true,
+          );
+
+          expect(mockNostrClient.publicKey, isEmpty);
+          clientPublicKey = pubkeyA;
+          testNostrSession.update(
+            NostrSessionReadiness.nostrReady(
+              pubkey: pubkeyA,
+              client: mockNostrClient,
+            ),
+          );
+          async.flushMicrotasks();
+
+          statusController.add({
+            addedRelay: RelayConnectionStatus.connected(addedRelay),
+          });
+          async.flushMicrotasks();
+          async.elapse(const Duration(seconds: 1));
+
+          swappableService.replaceWith(replacementClient);
+          async.flushMicrotasks();
+          expect(replacementClient.publicKey, isEmpty);
+          verifyNever(() => replacementClient.addRelays(any()));
+          verifyNever(replacementClient.forceReconnectAll);
+
+          replacementPublicKey = pubkeyA;
+          testNostrSession.update(
+            NostrSessionReadiness.nostrReady(
+              pubkey: pubkeyA,
+              client: replacementClient,
+            ),
+          );
+          async.flushMicrotasks();
+          async.elapse(const Duration(seconds: 2));
+          async.flushMicrotasks();
+
+          expect(replacementRelays, equals({addedRelay}));
+          verify(() => replacementClient.addRelays([addedRelay])).called(1);
+          verify(
+            () => replacementClient.removeRelay(
+              removedRelay,
+              source: RelayRemoveSource.automatic,
+            ),
+          ).called(1);
+          verify(
+            () => replacementClient.removeRelay(
+              defaultRelay,
+              source: RelayRemoveSource.automatic,
+            ),
+          ).called(1);
+          verify(replacementClient.forceReconnectAll).called(1);
+          verify(
+            () => mockVideoEventService.resetAndResubscribeAll(),
+          ).called(1);
+          verifyNever(() => mockNostrClient.forceReconnectAll());
+
+          bridgeSubscription.close();
+          container.dispose();
+          replacementStatuses.close();
+        });
+      },
+    );
+
     test('discards a pending relay edit when the environment changes', () {
       fakeAsync((async) {
         final replacementClient = MockNostrClient();

--- a/mobile/test/unit/providers/relay_set_change_bridge_test.dart
+++ b/mobile/test/unit/providers/relay_set_change_bridge_test.dart
@@ -39,6 +39,16 @@ class TestNostrSession extends NostrSession {
   NostrSessionReadiness build() => initialReadiness;
 }
 
+void stubUserRemovedRelays(
+  MockNostrClient client, {
+  Set<String> relays = const {},
+}) {
+  when(() => client.isUserRemovedRelay(any())).thenAnswer((call) async {
+    final relay = call.positionalArguments.single as String;
+    return relays.contains(relay);
+  });
+}
+
 void main() {
   setUpAll(() {
     registerFallbackValue(<String>[]);
@@ -74,6 +84,7 @@ void main() {
       when(() => mockNostrClient.forceReconnectAll()).thenAnswer((_) async {});
       when(() => mockNostrClient.defaultRelayUrl).thenReturn(defaultRelay);
       when(() => mockNostrClient.publicKey).thenAnswer((_) => clientPublicKey);
+      stubUserRemovedRelays(mockNostrClient);
     });
 
     tearDown(() {
@@ -108,6 +119,7 @@ void main() {
     }) {
       when(() => client.publicKey).thenReturn(pubkey);
       when(() => client.defaultRelayUrl).thenReturn(relay);
+      stubUserRemovedRelays(client);
     }
 
     test('does not trigger reset on initial activation', () {
@@ -459,12 +471,9 @@ void main() {
         when(
           () => replacementClient.publicKey,
         ).thenAnswer((_) => replacementPublicKey);
-        when(
-          () => replacementClient.defaultRelayUrl,
-        ).thenReturn(defaultRelay);
-        when(
-          () => replacementClient.relayStatuses,
-        ).thenAnswer(
+        when(() => replacementClient.defaultRelayUrl).thenReturn(defaultRelay);
+        stubUserRemovedRelays(replacementClient);
+        when(() => replacementClient.relayStatuses).thenAnswer(
           (_) => {
             for (final relay in replacementRelays)
               relay: RelayConnectionStatus.connected(relay),
@@ -592,9 +601,8 @@ void main() {
           when(
             () => replacementClient.defaultRelayUrl,
           ).thenReturn(defaultRelay);
-          when(
-            () => replacementClient.relayStatuses,
-          ).thenAnswer(
+          stubUserRemovedRelays(replacementClient);
+          when(() => replacementClient.relayStatuses).thenAnswer(
             (_) => {
               for (final relay in replacementRelays)
                 relay: RelayConnectionStatus.connected(relay),
@@ -717,9 +725,7 @@ void main() {
         ).thenAnswer((_) => statusController.stream);
         when(() => replacementClient.isInitialized).thenReturn(true);
         stubClientScope(replacementClient, relay: stagingDefault);
-        when(
-          () => replacementClient.relayStatuses,
-        ).thenAnswer(
+        when(() => replacementClient.relayStatuses).thenAnswer(
           (_) => {
             for (final relay in replacementRelays)
               relay: RelayConnectionStatus.connected(relay),
@@ -803,12 +809,9 @@ void main() {
         when(
           () => replacementClient.publicKey,
         ).thenAnswer((_) => replacementPublicKey);
-        when(
-          () => replacementClient.defaultRelayUrl,
-        ).thenReturn(defaultRelay);
-        when(
-          () => replacementClient.relayStatuses,
-        ).thenAnswer(
+        when(() => replacementClient.defaultRelayUrl).thenReturn(defaultRelay);
+        stubUserRemovedRelays(replacementClient);
+        when(() => replacementClient.relayStatuses).thenAnswer(
           (_) => {
             for (final relay in replacementRelays)
               relay: RelayConnectionStatus.connected(relay),
@@ -912,9 +915,7 @@ void main() {
         ).thenAnswer((_) => statusController.stream);
         when(() => replacementClient.isInitialized).thenReturn(true);
         stubClientScope(replacementClient);
-        when(
-          () => replacementClient.relayStatuses,
-        ).thenAnswer(
+        when(() => replacementClient.relayStatuses).thenAnswer(
           (_) => {
             for (final relay in replacementRelays)
               relay: RelayConnectionStatus.connected(relay),
@@ -978,6 +979,102 @@ void main() {
       });
     });
 
+    test(
+      'skips user-suppressed additions while reconciling a replacement client',
+      () {
+        fakeAsync((async) {
+          final replacementClient = MockNostrClient();
+          final replacementStatuses =
+              StreamController<Map<String, RelayConnectionStatus>>.broadcast();
+          const suppressedRelay = 'wss://removed.example.com';
+          const retainedRelay = 'wss://retained.example.com';
+          final replacementRelays = <String>{defaultRelay};
+
+          when(() => mockNostrClient.relayStatuses).thenReturn({
+            defaultRelay: RelayConnectionStatus.connected(defaultRelay),
+          });
+          when(
+            () => mockNostrClient.relayStatusStream,
+          ).thenAnswer((_) => statusController.stream);
+          when(() => replacementClient.isInitialized).thenReturn(true);
+          stubClientScope(replacementClient);
+          stubUserRemovedRelays(replacementClient, relays: {suppressedRelay});
+          when(() => replacementClient.relayStatuses).thenAnswer(
+            (_) => {
+              for (final relay in replacementRelays)
+                relay: RelayConnectionStatus.connected(relay),
+            },
+          );
+          when(
+            () => replacementClient.relayStatusStream,
+          ).thenAnswer((_) => replacementStatuses.stream);
+          when(
+            () => replacementClient.configuredRelays,
+          ).thenAnswer((_) => replacementRelays.toList());
+          when(() => replacementClient.addRelays(any())).thenAnswer((
+            call,
+          ) async {
+            final relays = call.positionalArguments.single as List<String>;
+            replacementRelays.addAll(relays);
+            return relays.length;
+          });
+          when(
+            () => replacementClient.removeRelay(
+              any(),
+              source: any(named: 'source'),
+            ),
+          ).thenAnswer((call) async {
+            final relay = call.positionalArguments.single as String;
+            return replacementRelays.remove(relay);
+          });
+          when(replacementClient.forceReconnectAll).thenAnswer((_) async {});
+
+          final swappableService = SwappableNostrService(mockNostrClient);
+          final container = ProviderContainer(
+            overrides: [
+              nostrServiceProvider.overrideWith(() => swappableService),
+              nostrSessionProvider.overrideWith(() => testNostrSession),
+              videoEventServiceProvider.overrideWithValue(
+                mockVideoEventService,
+              ),
+            ],
+          );
+          final bridgeSubscription = container.listen<void>(
+            relaySetChangeBridgeProvider,
+            (_, _) {},
+            fireImmediately: true,
+          );
+
+          statusController.add({
+            defaultRelay: RelayConnectionStatus.connected(defaultRelay),
+            retainedRelay: RelayConnectionStatus.connected(retainedRelay),
+            suppressedRelay: RelayConnectionStatus.connected(suppressedRelay),
+          });
+          async.flushMicrotasks();
+          async.elapse(const Duration(seconds: 1));
+          swappableService.replaceWith(replacementClient);
+          async.flushMicrotasks();
+          async.elapse(const Duration(seconds: 2));
+          async.flushMicrotasks();
+
+          expect(replacementRelays, contains(retainedRelay));
+          expect(replacementRelays, isNot(contains(suppressedRelay)));
+          verify(
+            () => replacementClient.isUserRemovedRelay(suppressedRelay),
+          ).called(1);
+          verify(() => replacementClient.addRelays([retainedRelay])).called(1);
+          verify(replacementClient.forceReconnectAll).called(1);
+          verify(
+            () => mockVideoEventService.resetAndResubscribeAll(),
+          ).called(1);
+
+          bridgeSubscription.close();
+          container.dispose();
+          replacementStatuses.close();
+        });
+      },
+    );
+
     test('retries a thrown replacement reconciliation before reset', () {
       fakeAsync((async) {
         final replacementClient = MockNostrClient();
@@ -995,9 +1092,7 @@ void main() {
         ).thenAnswer((_) => statusController.stream);
         when(() => replacementClient.isInitialized).thenReturn(true);
         stubClientScope(replacementClient);
-        when(
-          () => replacementClient.relayStatuses,
-        ).thenAnswer(
+        when(() => replacementClient.relayStatuses).thenAnswer(
           (_) => {
             for (final relay in replacementRelays)
               relay: RelayConnectionStatus.connected(relay),
@@ -1077,9 +1172,7 @@ void main() {
         ).thenAnswer((_) => statusController.stream);
         when(() => replacementClient.isInitialized).thenReturn(true);
         stubClientScope(replacementClient);
-        when(
-          () => replacementClient.relayStatuses,
-        ).thenAnswer(
+        when(() => replacementClient.relayStatuses).thenAnswer(
           (_) => {
             for (final relay in replacementRelays)
               relay: RelayConnectionStatus.connected(relay),
@@ -1172,9 +1265,7 @@ void main() {
         ).thenAnswer((_) => statusController.stream);
         when(() => replacementClient.isInitialized).thenReturn(true);
         stubClientScope(replacementClient);
-        when(
-          () => replacementClient.relayStatuses,
-        ).thenAnswer(
+        when(() => replacementClient.relayStatuses).thenAnswer(
           (_) => {
             for (final relay in replacementRelays)
               relay: RelayConnectionStatus.connected(relay),
@@ -1246,9 +1337,7 @@ void main() {
         ).thenAnswer((_) => statusController.stream);
         when(() => replacementClient.isInitialized).thenReturn(true);
         stubClientScope(replacementClient);
-        when(
-          () => replacementClient.relayStatuses,
-        ).thenAnswer(
+        when(() => replacementClient.relayStatuses).thenAnswer(
           (_) => {
             for (final relay in replacementRelays)
               relay: RelayConnectionStatus.connected(relay),
@@ -1324,9 +1413,7 @@ void main() {
           stubClientScope(client);
           when(client.forceReconnectAll).thenAnswer((_) async {});
         }
-        when(
-          () => firstReplacement.relayStatuses,
-        ).thenAnswer(
+        when(() => firstReplacement.relayStatuses).thenAnswer(
           (_) => {
             for (final relay in firstRelays)
               relay: RelayConnectionStatus.connected(relay),
@@ -1343,9 +1430,7 @@ void main() {
           firstRelays.addAll(call.positionalArguments.single as List<String>);
           return 1;
         });
-        when(
-          () => secondReplacement.relayStatuses,
-        ).thenAnswer(
+        when(() => secondReplacement.relayStatuses).thenAnswer(
           (_) => {
             for (final relay in secondRelays)
               relay: RelayConnectionStatus.connected(relay),

--- a/mobile/test/utils/relay_url_utils_test.dart
+++ b/mobile/test/utils/relay_url_utils_test.dart
@@ -45,8 +45,8 @@ void main() {
     });
 
     test('rejects https:// (relays are WebSocket-only)', () {
-      // NIP-65 only ever advertises WS endpoints, and `RelayManager.
-      // _normalizeUrl` only accepts WS — so an https:// URL is not a
+      // NIP-65 only ever advertises WS endpoints, and `normalizeRelayUrl`
+      // only accepts WS — so an https:// URL is not a
       // usable relay regardless of host. The capability service derives
       // its NIP-11 fetch URL from the WS form internally.
       expect(isRelayUrlAllowed('https://relay.divine.video'), isFalse);
@@ -117,6 +117,36 @@ void main() {
       expect(isRelayUrlAllowed('ws://10.0.2.2:1'), isTrue);
       expect(isRelayUrlAllowed('ws://[::1]:1'), isTrue);
       expect(isRelayUrlAllowed('ws://example.com'), isFalse);
+    });
+  });
+
+  group('normalizeRelayUrlForComparison', () {
+    test('matches relay manager identity normalization', () {
+      expect(
+        normalizeRelayUrlForComparison('  relay.example.com/path/  '),
+        'wss://relay.example.com/path',
+      );
+      expect(
+        normalizeRelayUrlForComparison('WSS://relay.example.com/'),
+        'wss://relay.example.com',
+      );
+      expect(
+        normalizeRelayUrlForComparison('ws://localhost:47777/'),
+        'ws://localhost:47777',
+      );
+    });
+
+    test('rejects URLs the relay manager rejects', () {
+      expect(normalizeRelayUrlForComparison(''), isNull);
+      expect(
+        normalizeRelayUrlForComparison('https://relay.example.com'),
+        isNull,
+      );
+      expect(normalizeRelayUrlForComparison('ws://relay.example.com'), isNull);
+      expect(
+        normalizeRelayUrlForComparison('wss://http://attacker.example.com'),
+        isNull,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- persist a user-removed relay ledger and suppress automatic relay re-adds from discovery/fallback paths
- mark settings relay adds/restores as user actions so manual re-add clears the ledger
- send support bug reports to the moderation account NIP-17 inbox relay on relay.divine.video as an explicit target without saving it to configured relays
- require explicit relay removal source intent and keep restore-default available even when custom relays remain

Closes #6471

## Tests
- flutter test --reporter compact test/src/relay_manager_test.dart test/src/models/shared_preferences_relay_storage_test.dart test/src/nostr_client_test.dart (mobile/packages/nostr_client)
- flutter test test/src/nip17_message_service_test.dart (mobile/packages/dm_repository)
- flutter test --reporter compact test/blocs/relay_settings/relay_settings_cubit_test.dart test/screens/relay_settings_screen_layout_test.dart test/services/bug_report_worker_api_test.dart test/services/auth_service_signout_cleanup_test.dart test/unit/providers/relay_set_change_bridge_test.dart (mobile)
- flutter analyze (mobile)
- pre-push analyzer + generated-file verification + changed-file tests