### PR TITLE
fix(feature-flags): stop the curated-lists toggle from popping the screen

### DIFF
--- a/mobile/lib/features/people_lists/curated_lists_gate.dart
+++ b/mobile/lib/features/people_lists/curated_lists_gate.dart
@@ -1,0 +1,25 @@
+// ABOUTME: Reads FeatureFlag.curatedLists off a BuildContext.
+// ABOUTME: Backstop gate for entry points that would construct PeopleListsBloc.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+
+/// Whether curated lists are enabled for the current user.
+///
+/// The global `PeopleListsBloc` is registered unconditionally in `main.dart`
+/// — a conditional entry changed the provider chain's shape and re-inflated
+/// the Navigator on every flag flip. `BlocProvider` laziness gates it
+/// instead, which only holds while every entry point that would read the
+/// bloc checks the flag first.
+///
+/// Widgets that can rebuild on a flip should `ref.watch` the flag directly;
+/// this is for imperative call sites (`show...Sheet` helpers) that only need
+/// a one-shot read.
+bool curatedListsEnabled(BuildContext context) {
+  return ProviderScope.containerOf(
+    context,
+    listen: false,
+  ).read(isFeatureEnabledProvider(FeatureFlag.curatedLists));
+}

--- a/mobile/lib/features/people_lists/view/add_to_people_lists_sheet.dart
+++ b/mobile/lib/features/people_lists/view/add_to_people_lists_sheet.dart
@@ -5,7 +5,9 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/people_lists/bloc/people_lists_bloc.dart';
+import 'package:openvine/features/people_lists/curated_lists_gate.dart';
 import 'package:openvine/features/people_lists/models/people_list_entry_point.dart';
 import 'package:openvine/features/people_lists/view/widgets/widgets.dart';
 import 'package:openvine/l10n/l10n.dart';
@@ -15,7 +17,9 @@ import 'package:openvine/widgets/profile/new_people_list_sheet.dart';
 /// lists and lets them toggle membership for the given [pubkey].
 ///
 /// Consumers should call [AddToPeopleListsSheet.show] from within a
-/// subtree that has a [PeopleListsBloc] provided above it.
+/// subtree that has a [PeopleListsBloc] provided above it. Callers should
+/// also hide their affordance when [FeatureFlag.curatedLists] is off;
+/// [AddToPeopleListsSheet.show] enforces the same gate as a backstop.
 ///
 /// The sheet filters out read-only lists (`isEditable == false`). When
 /// there are no editable lists, an empty state offers a `Create list`
@@ -50,6 +54,11 @@ class AddToPeopleListsSheet extends StatelessWidget {
 
   /// Shows the sheet as a modal [VineBottomSheet].
   ///
+  /// Does nothing when [FeatureFlag.curatedLists] is off. The global
+  /// [PeopleListsBloc] is registered unconditionally and lazily, so opening
+  /// this sheet is what would construct it — starting a repository and relay
+  /// subscription for a feature the user turned off.
+  ///
   /// Returns a [Future] that completes when the sheet is dismissed.
   static Future<void> show(
     BuildContext context, {
@@ -58,6 +67,8 @@ class AddToPeopleListsSheet extends StatelessWidget {
     String? displayName,
     UserProfile? initialCollaborator,
   }) {
+    if (!curatedListsEnabled(context)) return Future<void>.value();
+
     return VineBottomSheet.show<void>(
       context: context,
       title: Text(context.l10n.peopleListsSheetTitle),

--- a/mobile/lib/features/people_lists/view/add_to_people_lists_sheet.dart
+++ b/mobile/lib/features/people_lists/view/add_to_people_lists_sheet.dart
@@ -56,7 +56,7 @@ class AddToPeopleListsSheet extends StatelessWidget {
   ///
   /// Does nothing when [FeatureFlag.curatedLists] is off. The global
   /// [PeopleListsBloc] is registered unconditionally and lazily, so opening
-  /// this sheet is what would construct it — starting a repository and relay
+  /// this sheet is what would construct it — starting a relay query and cache
   /// subscription for a feature the user turned off.
   ///
   /// Returns a [Future] that completes when the sheet is dismissed.

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2827,19 +2827,25 @@ class _DivineAppState extends ConsumerState<DivineApp>
             //
             // Deliberately not wrapped in `if (curatedLists enabled)`: a
             // conditional entry changes this provider chain's shape, so
-            // flipping the flag re-inflated everything below it — including
-            // the Navigator, which silently dropped imperatively pushed
-            // routes (users toggling the flag were thrown back to Settings).
+            // flipping the flag re-inflated everything below it — the whole
+            // MaterialApp.router subtree, feed state, video controllers, and
+            // the upload-listener dedupe sets with it. The reported symptom
+            // was landing back on Settings from the imperatively pushed
+            // feature-flag screen (#6477); only the re-inflation is
+            // reproduced, the Navigator-level step from there to route loss
+            // is not, and the re-inflation alone justifies this shape.
+            //
             // Laziness does the gating instead: every entry point into the
             // people-lists UI checks FeatureFlag.curatedLists before reading
             // the bloc — the lists routes redirect home, the profile and
             // search affordances stay hidden, and both sheets refuse to
             // open — so nothing constructs it while the flag is off.
             //
-            // ref.read in `create` is safe here: peopleListsRepositoryProvider
-            // is keepAlive over the equally stable nostrServiceProvider, and
-            // without the conditional entry this bloc lives for the whole app
-            // run, so there is no rebuild that could strand the capture.
+            // Known gap (#6480): peopleListsRepositoryProvider is keepAlive
+            // but not identity-stable — it watches nostrServiceProvider,
+            // which recreates its client on auth change. With no conditional
+            // entry `create` never re-runs, so the captured repository is
+            // stale by construction after an account switch.
             BlocProvider(
               create: (_) {
                 final authService = ref.read(authServiceProvider);

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2829,11 +2829,13 @@ class _DivineAppState extends ConsumerState<DivineApp>
             // conditional entry changes this provider chain's shape, so
             // flipping the flag re-inflated everything below it — the whole
             // MaterialApp.router subtree, feed state, video controllers, and
-            // the upload-listener dedupe sets with it. The reported symptom
-            // was landing back on Settings from the imperatively pushed
-            // feature-flag screen (#6477); only the re-inflation is
-            // reproduced, the Navigator-level step from there to route loss
-            // is not, and the re-inflation alone justifies this shape.
+            // the upload-listener dedupe sets with it. Users were thrown back
+            // to Settings from the imperatively pushed feature-flag screen;
+            // both the symptom and its disappearance under this shape are
+            // verified on device (#6477). What is not pinned is the
+            // Navigator-level step in between — a synthetic probe of the same
+            // shape kept the pushed route — so do not read the chain below
+            // re-inflation as established.
             //
             // Laziness does the gating instead: every entry point into the
             // people-lists UI checks FeatureFlag.curatedLists before reading

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2837,17 +2837,22 @@ class _DivineAppState extends ConsumerState<DivineApp>
             // shape kept the pushed route — so do not read the chain below
             // re-inflation as established.
             //
-            // Laziness does the gating instead: every entry point into the
-            // people-lists UI checks FeatureFlag.curatedLists before reading
-            // the bloc — the lists routes redirect home, the profile and
-            // search affordances stay hidden, and both sheets refuse to
-            // open — so nothing constructs it while the flag is off.
+            // Laziness does the creation gate instead: every entry point into
+            // the people-lists UI checks FeatureFlag.curatedLists before
+            // reading the bloc — the lists routes redirect home, the profile
+            // and search affordances stay hidden, and both sheets refuse to
+            // open — so a disabled feature does not construct the bloc.
             //
-            // Known gap (#6480): peopleListsRepositoryProvider is keepAlive
-            // but not identity-stable — it watches nostrServiceProvider,
-            // which recreates its client on auth change. With no conditional
-            // entry `create` never re-runs, so the captured repository is
-            // stale by construction after an account switch.
+            // Once constructed while the flag is on, the bloc remains session-
+            // lifetime even if the flag flips off. Stopping already-started
+            // repository work on a flag-off transition is tracked in #6494.
+            //
+            // peopleListsRepositoryProvider is keepAlive but not identity-
+            // stable: it watches nostrServiceProvider, which recreates its
+            // client on auth change. This provider is intentionally still not
+            // keyed; repositoryStream keeps the app-lifetime bloc pointed at
+            // the current repository without re-inflating MaterialApp.router
+            // (#6480, #6482).
             BlocProvider(
               create: (_) {
                 final authService = ref.read(authServiceProvider);
@@ -2856,11 +2861,6 @@ class _DivineAppState extends ConsumerState<DivineApp>
                     .distinct();
                 return PeopleListsBloc(
                   repository: ref.read(peopleListsRepositoryProvider),
-                  // peopleListsRepositoryProvider is keepAlive but not
-                  // identity-stable: it watches nostrServiceProvider, which
-                  // disposes its client on every identity change. This create
-                  // runs once, so the bloc subscribes to the successive
-                  // instances rather than keeping its capture (#6480).
                   repositoryStream: ref.read(
                     peopleListsRepositoryIdentityStreamProvider,
                   ),

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2687,15 +2687,6 @@ class _DivineAppState extends ConsumerState<DivineApp>
 
     const forceOpenOnboarding = AppConfig.isGhActionsPrPreviewBuild;
 
-    // Gate the global PeopleListsBloc on the curated-lists feature flag.
-    // When enabled we provision it above MaterialApp.router so every route
-    // (including ones outside AppShell) sees the same lists state. The
-    // bloc only depends on the repository and a pubkey stream; we derive
-    // the latter from AuthService.
-    final peopleListsEnabled = ref.watch(
-      isFeatureEnabledProvider(FeatureFlag.curatedLists),
-    );
-
     // Eagerly create the outgoing-DM retry service so its foreground
     // subscription is wired up at app shell setup. The service has no
     // UI consumer (it operates on the durable outgoing_dms queue), so
@@ -2831,28 +2822,38 @@ class _DivineAppState extends ConsumerState<DivineApp>
                 ),
               )..add(const AppUpdateCheckRequested()),
             ),
-            if (peopleListsEnabled)
-              BlocProvider(
-                create: (_) {
-                  final authService = ref.read(authServiceProvider);
-                  final ownerPubkeyStream = authService.authStateStream
-                      .map((_) => authService.currentPublicKeyHex)
-                      .distinct();
-                  return PeopleListsBloc(
-                    repository: ref.read(peopleListsRepositoryProvider),
-                    // peopleListsRepositoryProvider is keepAlive but not
-                    // identity-stable: it watches nostrServiceProvider, which
-                    // disposes its client on every identity change. This create
-                    // runs once, so the bloc subscribes to the successive
-                    // instances rather than keeping its capture (#6480).
-                    repositoryStream: ref.read(
-                      peopleListsRepositoryIdentityStreamProvider,
-                    ),
-                    ownerPubkeyStream: ownerPubkeyStream,
-                    initialOwnerPubkey: authService.currentPublicKeyHex,
-                  )..add(const PeopleListsStarted());
-                },
-              ),
+            // Provisioned above MaterialApp.router so every route (including
+            // ones outside AppShell) sees the same lists state.
+            //
+            // Deliberately not wrapped in `if (curatedLists enabled)`: a
+            // conditional entry changes this provider chain's shape, so
+            // flipping the flag re-inflated everything below it — including
+            // the Navigator, which silently dropped imperatively pushed
+            // routes (users toggling the flag were thrown back to Settings).
+            // Laziness does the gating instead: every consumer checks
+            // FeatureFlag.curatedLists first, so the bloc is never created
+            // while the flag is off.
+            BlocProvider(
+              create: (_) {
+                final authService = ref.read(authServiceProvider);
+                final ownerPubkeyStream = authService.authStateStream
+                    .map((_) => authService.currentPublicKeyHex)
+                    .distinct();
+                return PeopleListsBloc(
+                  repository: ref.read(peopleListsRepositoryProvider),
+                  // peopleListsRepositoryProvider is keepAlive but not
+                  // identity-stable: it watches nostrServiceProvider, which
+                  // disposes its client on every identity change. This create
+                  // runs once, so the bloc subscribes to the successive
+                  // instances rather than keeping its capture (#6480).
+                  repositoryStream: ref.read(
+                    peopleListsRepositoryIdentityStreamProvider,
+                  ),
+                  ownerPubkeyStream: ownerPubkeyStream,
+                  initialOwnerPubkey: authService.currentPublicKeyHex,
+                )..add(const PeopleListsStarted());
+              },
+            ),
           ],
           // Global listener for email verification failures - shows snackbar
           // when verification times out or fails while user is elsewhere in app

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2830,9 +2830,16 @@ class _DivineAppState extends ConsumerState<DivineApp>
             // flipping the flag re-inflated everything below it — including
             // the Navigator, which silently dropped imperatively pushed
             // routes (users toggling the flag were thrown back to Settings).
-            // Laziness does the gating instead: every consumer checks
-            // FeatureFlag.curatedLists first, so the bloc is never created
-            // while the flag is off.
+            // Laziness does the gating instead: every entry point into the
+            // people-lists UI checks FeatureFlag.curatedLists before reading
+            // the bloc — the lists routes redirect home, the profile and
+            // search affordances stay hidden, and both sheets refuse to
+            // open — so nothing constructs it while the flag is off.
+            //
+            // ref.read in `create` is safe here: peopleListsRepositoryProvider
+            // is keepAlive over the equally stable nostrServiceProvider, and
+            // without the conditional entry this bloc lives for the whole app
+            // run, so there is no rebuild that could strand the capture.
             BlocProvider(
               create: (_) {
                 final authService = ref.read(authServiceProvider);

--- a/mobile/lib/router/routes/lists_routes.dart
+++ b/mobile/lib/router/routes/lists_routes.dart
@@ -72,10 +72,8 @@ List<RouteBase> listsRoutes(Ref ref) {
     // `initialPubkey` query param lets callers (e.g., the share-video
     // "Add to list" sheet) seed the new list with a target person in
     // the same submit so the URL remains reloadable.
-    // Gated on FeatureFlag.curatedLists — the PeopleListsBloc this page
-    // depends on is only provided in main.dart when the flag is on, so
-    // a deep link here with the flag off would crash with
-    // ProviderNotFoundException. Redirect home instead.
+    // Gated on FeatureFlag.curatedLists — a deep link here with the flag
+    // off would open a feature the user turned off, so redirect home.
     GoRoute(
       path: CreatePeopleListPage.path,
       name: CreatePeopleListPage.routeName,
@@ -132,9 +130,8 @@ List<RouteBase> listsRoutes(Ref ref) {
 /// Redirects deep links for people-lists routes to the home feed when the
 /// [FeatureFlag.curatedLists] feature flag is off.
 ///
-/// The people-lists screens depend on a `PeopleListsBloc` that is only
-/// provided in `main.dart` when the flag is enabled. Without this guard a
-/// deep link / push / saved URL would crash with `ProviderNotFoundException`.
+/// Without this guard a deep link / push / saved URL would open the
+/// people-lists screens even though the user turned the feature off.
 /// Returns `null` (no redirect) when the flag is on.
 String? _peopleListsRedirectIfDisabled(Ref ref, GoRouterState state) {
   final enabled = ref.read(isFeatureEnabledProvider(FeatureFlag.curatedLists));

--- a/mobile/lib/screens/other_profile_screen.dart
+++ b/mobile/lib/screens/other_profile_screen.dart
@@ -294,6 +294,10 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
         final npub = NostrKeyUtils.encodePubKey(widget.pubkey);
         await ClipboardUtils.copyPubkey(context, npub);
       case MoreSheetResult.addToList:
+        if (!ref.read(isFeatureEnabledProvider(FeatureFlag.curatedLists))) {
+          return;
+        }
+
         final profile = ref
             .read(userProfileReactiveProvider(widget.pubkey))
             .value;

--- a/mobile/lib/screens/other_profile_screen.dart
+++ b/mobile/lib/screens/other_profile_screen.dart
@@ -255,12 +255,19 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
     final displayName =
         profile?.bestDisplayName ?? widget.displayNameHint ?? fallbackName;
 
-    final curatedListsEnabled = ref.read(
+    final profileListFeaturesEnabled = ref.read(
       isFeatureEnabledProvider(FeatureFlag.profileListFeatures),
+    );
+    // curatedLists is the master switch for people lists; profileListFeatures
+    // only adds this surface on top of it. Without both, tapping would
+    // construct the lazily-registered PeopleListsBloc for a disabled feature.
+    final curatedListsEnabled = ref.read(
+      isFeatureEnabledProvider(FeatureFlag.curatedLists),
     );
     final isOwnProfile =
         widget.pubkey == ref.read(authServiceProvider).currentPublicKeyHex;
-    final showAddToList = curatedListsEnabled && !isOwnProfile;
+    final showAddToList =
+        profileListFeaturesEnabled && curatedListsEnabled && !isOwnProfile;
 
     final result = await VineBottomSheet.show<MoreSheetResult>(
       context: context,

--- a/mobile/lib/screens/search_results/widgets/search_user_tile.dart
+++ b/mobile/lib/screens/search_results/widgets/search_user_tile.dart
@@ -43,9 +43,17 @@ class SearchUserTile extends ConsumerWidget {
     final profileListFeaturesEnabled = ref.watch(
       isFeatureEnabledProvider(FeatureFlag.profileListFeatures),
     );
+    // curatedLists is the master switch for people lists; profileListFeatures
+    // only adds this surface on top of it. Without both, tapping would
+    // construct the lazily-registered PeopleListsBloc for a disabled feature.
+    final curatedListsEnabled = ref.watch(
+      isFeatureEnabledProvider(FeatureFlag.curatedLists),
+    );
     final ownPubkey = ref.watch(authServiceProvider).currentPublicKeyHex;
     final showAddToList =
-        profileListFeaturesEnabled && profile.pubkey != ownPubkey;
+        profileListFeaturesEnabled &&
+        curatedListsEnabled &&
+        profile.pubkey != ownPubkey;
 
     return Semantics(
       identifier: 'search_user_tile_${profile.pubkey}',

--- a/mobile/lib/widgets/profile/new_people_list_sheet.dart
+++ b/mobile/lib/widgets/profile/new_people_list_sheet.dart
@@ -21,7 +21,8 @@ import 'package:openvine/widgets/user_picker_sheet.dart';
 ///
 /// Does nothing when [FeatureFlag.curatedLists] is off: the global
 /// [PeopleListsBloc] is registered lazily, so opening this sheet is what
-/// would construct it for a feature the user turned off.
+/// would start a relay query and cache subscription for a feature the user
+/// turned off.
 Future<void> showNewPeopleListSheet(
   BuildContext context, {
   UserProfile? initialCollaborator,
@@ -33,9 +34,7 @@ Future<void> showNewPeopleListSheet(
   return VineBottomSheet.show<void>(
     context: context,
     scrollable: false,
-    title: Builder(
-      builder: (context) => Text(context.l10n.listNewPeopleList),
-    ),
+    title: Builder(builder: (context) => Text(context.l10n.listNewPeopleList)),
     onComplete: () async {
       await bodyKey.currentState?._createList();
     },
@@ -47,10 +46,7 @@ Future<void> showNewPeopleListSheet(
 }
 
 class _NewPeopleListSheetBody extends StatefulWidget {
-  const _NewPeopleListSheetBody({
-    this.initialCollaborator,
-    super.key,
-  });
+  const _NewPeopleListSheetBody({this.initialCollaborator, super.key});
 
   final UserProfile? initialCollaborator;
 

--- a/mobile/lib/widgets/profile/new_people_list_sheet.dart
+++ b/mobile/lib/widgets/profile/new_people_list_sheet.dart
@@ -5,7 +5,9 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/people_lists/bloc/people_lists_bloc.dart';
+import 'package:openvine/features/people_lists/curated_lists_gate.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/widgets/user_picker_sheet.dart';
 
@@ -16,10 +18,16 @@ import 'package:openvine/widgets/user_picker_sheet.dart';
 ///
 /// [initialCollaborator] is pre-added as the first member — useful when
 /// opening the sheet directly from a profile.
+///
+/// Does nothing when [FeatureFlag.curatedLists] is off: the global
+/// [PeopleListsBloc] is registered lazily, so opening this sheet is what
+/// would construct it for a feature the user turned off.
 Future<void> showNewPeopleListSheet(
   BuildContext context, {
   UserProfile? initialCollaborator,
 }) {
+  if (!curatedListsEnabled(context)) return Future<void>.value();
+
   final bodyKey = GlobalKey<_NewPeopleListSheetBodyState>();
 
   return VineBottomSheet.show<void>(

--- a/mobile/lib/widgets/user_profile_tile.dart
+++ b/mobile/lib/widgets/user_profile_tile.dart
@@ -69,7 +69,14 @@ class UserProfileTile extends ConsumerWidget {
     final profileListFeaturesEnabled = ref.watch(
       isFeatureEnabledProvider(FeatureFlag.profileListFeatures),
     );
-    final showAddToList = profileListFeaturesEnabled && !isCurrentUser;
+    // curatedLists is the master switch for people lists; profileListFeatures
+    // only adds this surface on top of it. Without both, tapping would
+    // construct the lazily-registered PeopleListsBloc for a disabled feature.
+    final curatedListsEnabled = ref.watch(
+      isFeatureEnabledProvider(FeatureFlag.curatedLists),
+    );
+    final showAddToList =
+        profileListFeaturesEnabled && curatedListsEnabled && !isCurrentUser;
 
     // Get display name or truncated npub (fallback for users without Kind 0)
     final truncatedNpub = NostrKeyUtils.truncateNpub(pubkey);

--- a/mobile/test/features/people_lists/view/add_to_people_lists_sheet_test.dart
+++ b/mobile/test/features/people_lists/view/add_to_people_lists_sheet_test.dart
@@ -71,6 +71,7 @@ void main() {
   });
 
   group(AddToPeopleListsSheet, () {
+    final l10n = lookupAppLocalizations(const Locale('en'));
     late _MockPeopleListsBloc bloc;
 
     setUp(() {
@@ -110,13 +111,11 @@ void main() {
             name: 'Divine Team',
             isEditable: false,
           );
-          when(() => bloc.state).thenReturn(
-            _stateWith(lists: [editable, readOnly]),
-          );
+          when(
+            () => bloc.state,
+          ).thenReturn(_stateWith(lists: [editable, readOnly]));
 
-          await tester.pumpWidget(
-            buildSubject(pubkey: _targetPubkey),
-          );
+          await tester.pumpWidget(buildSubject(pubkey: _targetPubkey));
 
           expect(find.text('Close Friends'), findsOneWidget);
           expect(find.text('Divine Team'), findsNothing);
@@ -133,13 +132,11 @@ void main() {
             pubkeys: [_targetPubkey],
           );
           final nonMemberList = _buildList(id: 'list-2', name: 'Work');
-          when(() => bloc.state).thenReturn(
-            _stateWith(lists: [memberList, nonMemberList]),
-          );
+          when(
+            () => bloc.state,
+          ).thenReturn(_stateWith(lists: [memberList, nonMemberList]));
 
-          await tester.pumpWidget(
-            buildSubject(pubkey: _targetPubkey),
-          );
+          await tester.pumpWidget(buildSubject(pubkey: _targetPubkey));
 
           final checkboxes = tester
               .widgetList<DivineSpriteCheckbox>(
@@ -149,14 +146,8 @@ void main() {
           expect(checkboxes, hasLength(2));
           // Sheet renders lists in the bloc's declared order; first list
           // contains the target pubkey so its checkbox is selected.
-          expect(
-            checkboxes[0].state,
-            equals(DivineCheckboxState.selected),
-          );
-          expect(
-            checkboxes[1].state,
-            equals(DivineCheckboxState.unselected),
-          );
+          expect(checkboxes[0].state, equals(DivineCheckboxState.selected));
+          expect(checkboxes[1].state, equals(DivineCheckboxState.unselected));
         },
       );
     });
@@ -169,9 +160,7 @@ void main() {
           final list = _buildList(id: 'list-42', name: 'Close Friends');
           when(() => bloc.state).thenReturn(_stateWith(lists: [list]));
 
-          await tester.pumpWidget(
-            buildSubject(pubkey: _targetPubkey),
-          );
+          await tester.pumpWidget(buildSubject(pubkey: _targetPubkey));
 
           await tester.tap(find.byType(PeopleListRow));
           await tester.pump();
@@ -194,11 +183,9 @@ void main() {
         (tester) async {
           when(() => bloc.state).thenReturn(_stateWith(lists: const []));
 
-          await tester.pumpWidget(
-            buildSubject(pubkey: _targetPubkey),
-          );
+          await tester.pumpWidget(buildSubject(pubkey: _targetPubkey));
 
-          expect(find.text('No lists yet'), findsOneWidget);
+          expect(find.text(l10n.peopleListsEmptyTitle), findsOneWidget);
           // The Create list button lives in the VineBottomSheet bottomInput
           // slot, not inside the sheet body widget — so it is not present
           // when rendering AddToPeopleListsSheet directly.
@@ -217,11 +204,9 @@ void main() {
           );
           when(() => bloc.state).thenReturn(_stateWith(lists: [readOnly]));
 
-          await tester.pumpWidget(
-            buildSubject(pubkey: _targetPubkey),
-          );
+          await tester.pumpWidget(buildSubject(pubkey: _targetPubkey));
 
-          expect(find.text('No lists yet'), findsOneWidget);
+          expect(find.text(l10n.peopleListsEmptyTitle), findsOneWidget);
           expect(find.byType(DivineButton), findsNothing);
         },
       );
@@ -275,10 +260,7 @@ void main() {
           await tester.pumpAndSettle();
 
           // The new list sheet is shown — identified by its title key.
-          expect(
-            find.text('New people list'),
-            findsOneWidget,
-          );
+          expect(find.text(l10n.listNewPeopleList), findsOneWidget);
         },
       );
     });
@@ -286,7 +268,7 @@ void main() {
     // The global PeopleListsBloc is registered unconditionally in main.dart
     // (a conditional entry re-inflated the Navigator on every flag flip), so
     // BlocProvider laziness is what keeps it unbuilt while curated lists are
-    // off. These pin that: `create` firing means a repository and relay
+    // off. These pin that: `create` firing means a relay query and cache
     // subscription started for a disabled feature.
     group('curatedLists gate', () {
       testWidgetsWithSurfaceSize(
@@ -345,9 +327,7 @@ void main() {
     group('theming', () {
       testWidgetsWithSurfaceSize(
         'renders inside $VineBottomSheet when shown as a modal',
-        (
-          tester,
-        ) async {
+        (tester) async {
           final list = _buildList(id: 'list-1', name: 'Close Friends');
           when(() => bloc.state).thenReturn(_stateWith(lists: [list]));
 

--- a/mobile/test/features/people_lists/view/add_to_people_lists_sheet_test.dart
+++ b/mobile/test/features/people_lists/view/add_to_people_lists_sheet_test.dart
@@ -5,9 +5,12 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/features/people_lists/bloc/people_lists_bloc.dart';
 import 'package:openvine/features/people_lists/models/people_list_entry_point.dart';
 import 'package:openvine/features/people_lists/view/add_to_people_lists_sheet.dart';
@@ -232,20 +235,24 @@ void main() {
           // BlocProvider must sit above the navigator so the bloc is
           // reachable from the modal route.
           await tester.pumpWidget(
-            BlocProvider<PeopleListsBloc>.value(
-              value: bloc,
-              child: MaterialApp(
-                localizationsDelegates: AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                home: Scaffold(
-                  body: Builder(
-                    builder: (innerContext) => ElevatedButton(
-                      onPressed: () => AddToPeopleListsSheet.show(
-                        innerContext,
-                        pubkey: _targetPubkey,
-                        entryPoint: PeopleListEntryPoint.shareMenu,
+            _withCuratedListsFlag(
+              enabled: true,
+              child: BlocProvider<PeopleListsBloc>.value(
+                value: bloc,
+                child: MaterialApp(
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  home: Scaffold(
+                    body: Builder(
+                      builder: (innerContext) => ElevatedButton(
+                        onPressed: () => AddToPeopleListsSheet.show(
+                          innerContext,
+                          pubkey: _targetPubkey,
+                          entryPoint: PeopleListEntryPoint.shareMenu,
+                        ),
+                        child: const Text('open'),
                       ),
-                      child: const Text('open'),
                     ),
                   ),
                 ),
@@ -276,6 +283,65 @@ void main() {
       );
     });
 
+    // The global PeopleListsBloc is registered unconditionally in main.dart
+    // (a conditional entry re-inflated the Navigator on every flag flip), so
+    // BlocProvider laziness is what keeps it unbuilt while curated lists are
+    // off. These pin that: `create` firing means a repository and relay
+    // subscription started for a disabled feature.
+    group('curatedLists gate', () {
+      testWidgetsWithSurfaceSize(
+        'show does not open the sheet or construct $PeopleListsBloc when '
+        'curatedLists is off',
+        (tester) async {
+          var blocCreated = false;
+
+          await tester.pumpWidget(
+            _buildLazyBlocSubject(
+              curatedListsEnabled: false,
+              createBloc: () {
+                blocCreated = true;
+                return bloc;
+              },
+            ),
+          );
+
+          await tester.tap(find.text('open'));
+          await tester.pumpAndSettle();
+
+          expect(blocCreated, isFalse);
+          expect(find.byType(AddToPeopleListsSheet), findsNothing);
+        },
+      );
+
+      testWidgetsWithSurfaceSize(
+        'show opens the sheet when curatedLists is on',
+        (tester) async {
+          var blocCreated = false;
+          whenListen(
+            bloc,
+            const Stream<PeopleListsState>.empty(),
+            initialState: _stateWith(lists: const []),
+          );
+
+          await tester.pumpWidget(
+            _buildLazyBlocSubject(
+              curatedListsEnabled: true,
+              createBloc: () {
+                blocCreated = true;
+                return bloc;
+              },
+            ),
+          );
+
+          await tester.tap(find.text('open'));
+          await tester.pumpAndSettle();
+
+          expect(blocCreated, isTrue);
+          expect(find.byType(AddToPeopleListsSheet), findsOneWidget);
+        },
+      );
+    });
+
     group('theming', () {
       testWidgetsWithSurfaceSize(
         'renders inside $VineBottomSheet when shown as a modal',
@@ -289,23 +355,27 @@ void main() {
           // reachable from the modal route. Wrapping the MaterialApp does
           // this because MaterialApp builds the root Navigator below it.
           await tester.pumpWidget(
-            BlocProvider<PeopleListsBloc>.value(
-              value: bloc,
-              child: MaterialApp(
-                localizationsDelegates: AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                home: Scaffold(
-                  body: Builder(
-                    builder: (context) {
-                      return ElevatedButton(
-                        onPressed: () => AddToPeopleListsSheet.show(
-                          context,
-                          pubkey: _targetPubkey,
-                          entryPoint: PeopleListEntryPoint.shareMenu,
-                        ),
-                        child: const Text('open'),
-                      );
-                    },
+            _withCuratedListsFlag(
+              enabled: true,
+              child: BlocProvider<PeopleListsBloc>.value(
+                value: bloc,
+                child: MaterialApp(
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  home: Scaffold(
+                    body: Builder(
+                      builder: (context) {
+                        return ElevatedButton(
+                          onPressed: () => AddToPeopleListsSheet.show(
+                            context,
+                            pubkey: _targetPubkey,
+                            entryPoint: PeopleListEntryPoint.shareMenu,
+                          ),
+                          child: const Text('open'),
+                        );
+                      },
+                    ),
                   ),
                 ),
               ),
@@ -321,6 +391,49 @@ void main() {
       );
     });
   });
+}
+
+/// Mirrors the app shell: a lazy `BlocProvider` above the navigator, so
+/// [createBloc] only runs if something below actually reads the bloc.
+Widget _buildLazyBlocSubject({
+  required bool curatedListsEnabled,
+  required PeopleListsBloc Function() createBloc,
+}) {
+  return _withCuratedListsFlag(
+    enabled: curatedListsEnabled,
+    child: BlocProvider<PeopleListsBloc>(
+      create: (_) => createBloc(),
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => AddToPeopleListsSheet.show(
+                context,
+                pubkey: _targetPubkey,
+                entryPoint: PeopleListEntryPoint.profile,
+              ),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+/// Scopes [child] with an explicit [FeatureFlag.curatedLists] value —
+/// `AddToPeopleListsSheet.show` reads it before opening.
+Widget _withCuratedListsFlag({required bool enabled, required Widget child}) {
+  return ProviderScope(
+    overrides: [
+      isFeatureEnabledProvider(
+        FeatureFlag.curatedLists,
+      ).overrideWithValue(enabled),
+    ],
+    child: child,
+  );
 }
 
 void testWidgetsWithSurfaceSize(

--- a/mobile/test/widgets/profile/new_people_list_sheet_test.dart
+++ b/mobile/test/widgets/profile/new_people_list_sheet_test.dart
@@ -1,0 +1,104 @@
+// ABOUTME: Tests showNewPeopleListSheet's curatedLists gate.
+// ABOUTME: The sheet reads the lazily-registered global PeopleListsBloc.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+import 'package:openvine/features/people_lists/bloc/people_lists_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/profile/new_people_list_sheet.dart';
+
+class _MockPeopleListsBloc extends MockBloc<PeopleListsEvent, PeopleListsState>
+    implements PeopleListsBloc {}
+
+void main() {
+  group('showNewPeopleListSheet', () {
+    late _MockPeopleListsBloc bloc;
+
+    setUp(() {
+      bloc = _MockPeopleListsBloc();
+      whenListen(
+        bloc,
+        const Stream<PeopleListsState>.empty(),
+        initialState: const PeopleListsState(),
+      );
+    });
+
+    tearDown(() async {
+      await bloc.close();
+    });
+
+    // The global PeopleListsBloc is registered unconditionally in main.dart
+    // (a conditional entry re-inflated the Navigator on every flag flip), so
+    // BlocProvider laziness is what keeps it unbuilt while curated lists are
+    // off. `create` firing means a repository and relay subscription started
+    // for a disabled feature.
+    testWidgets(
+      'does not open or construct $PeopleListsBloc when curatedLists is off',
+      (tester) async {
+        var blocCreated = false;
+
+        await tester.pumpWidget(
+          _buildSubject(
+            curatedListsEnabled: false,
+            createBloc: () {
+              blocCreated = true;
+              return bloc;
+            },
+          ),
+        );
+
+        await tester.tap(find.text('open'));
+        await tester.pumpAndSettle();
+
+        expect(blocCreated, isFalse);
+        expect(find.text('New people list'), findsNothing);
+      },
+    );
+
+    testWidgets('opens when curatedLists is on', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(curatedListsEnabled: true, createBloc: () => bloc),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('New people list'), findsOneWidget);
+    });
+  });
+}
+
+/// Mirrors the app shell: a lazy `BlocProvider` above the navigator, so
+/// [createBloc] only runs if something below actually reads the bloc.
+Widget _buildSubject({
+  required bool curatedListsEnabled,
+  required PeopleListsBloc Function() createBloc,
+}) {
+  return ProviderScope(
+    overrides: [
+      isFeatureEnabledProvider(
+        FeatureFlag.curatedLists,
+      ).overrideWithValue(curatedListsEnabled),
+    ],
+    child: BlocProvider<PeopleListsBloc>(
+      create: (_) => createBloc(),
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => showNewPeopleListSheet(context),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/mobile/test/widgets/profile/new_people_list_sheet_test.dart
+++ b/mobile/test/widgets/profile/new_people_list_sheet_test.dart
@@ -17,6 +17,7 @@ class _MockPeopleListsBloc extends MockBloc<PeopleListsEvent, PeopleListsState>
 
 void main() {
   group('showNewPeopleListSheet', () {
+    final l10n = lookupAppLocalizations(const Locale('en'));
     late _MockPeopleListsBloc bloc;
 
     setUp(() {
@@ -35,7 +36,7 @@ void main() {
     // The global PeopleListsBloc is registered unconditionally in main.dart
     // (a conditional entry re-inflated the Navigator on every flag flip), so
     // BlocProvider laziness is what keeps it unbuilt while curated lists are
-    // off. `create` firing means a repository and relay subscription started
+    // off. `create` firing means a relay query and cache subscription started
     // for a disabled feature.
     testWidgets(
       'does not open or construct $PeopleListsBloc when curatedLists is off',
@@ -56,7 +57,7 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(blocCreated, isFalse);
-        expect(find.text('New people list'), findsNothing);
+        expect(find.text(l10n.listNewPeopleList), findsNothing);
       },
     );
 
@@ -68,7 +69,7 @@ void main() {
       await tester.tap(find.text('open'));
       await tester.pumpAndSettle();
 
-      expect(find.text('New people list'), findsOneWidget);
+      expect(find.text(l10n.listNewPeopleList), findsOneWidget);
     });
   });
 }

--- a/mobile/test/widgets/user_profile_tile_feature_flag_test.dart
+++ b/mobile/test/widgets/user_profile_tile_feature_flag_test.dart
@@ -60,6 +60,26 @@ void main() {
       },
     );
 
+    // curatedLists is the master switch. The action opens a sheet that reads
+    // the lazily-registered global PeopleListsBloc, so showing it here would
+    // spin up a repository and relay subscription for a disabled feature.
+    testWidgets(
+      'hides add-to-list action when curatedLists is disabled',
+      (tester) async {
+        await tester.pumpWidget(
+          _buildSubject(
+            authService: authService,
+            profileListFeaturesEnabled: true,
+            curatedListsEnabled: false,
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(_divineIcon(DivineIconName.listPlus), findsNothing);
+      },
+    );
+
     testWidgets('tile responds when tapping the avatar-name gap', (
       tester,
     ) async {
@@ -96,6 +116,7 @@ void main() {
 Widget _buildSubject({
   required _TestAuthService authService,
   required bool profileListFeaturesEnabled,
+  bool curatedListsEnabled = true,
   VoidCallback? onTap,
 }) {
   return MaterialApp(
@@ -107,6 +128,9 @@ Widget _buildSubject({
         isFeatureEnabledProvider(
           FeatureFlag.profileListFeatures,
         ).overrideWithValue(profileListFeaturesEnabled),
+        isFeatureEnabledProvider(
+          FeatureFlag.curatedLists,
+        ).overrideWithValue(curatedListsEnabled),
       ],
       child: Scaffold(
         body: UserProfileTile(

--- a/mobile/test/widgets/user_profile_tile_feature_flag_test.dart
+++ b/mobile/test/widgets/user_profile_tile_feature_flag_test.dart
@@ -62,23 +62,22 @@ void main() {
 
     // curatedLists is the master switch. The action opens a sheet that reads
     // the lazily-registered global PeopleListsBloc, so showing it here would
-    // spin up a repository and relay subscription for a disabled feature.
-    testWidgets(
-      'hides add-to-list action when curatedLists is disabled',
-      (tester) async {
-        await tester.pumpWidget(
-          _buildSubject(
-            authService: authService,
-            profileListFeaturesEnabled: true,
-            curatedListsEnabled: false,
-          ),
-        );
+    // spin up a relay query and cache subscription for a disabled feature.
+    testWidgets('hides add-to-list action when curatedLists is disabled', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          authService: authService,
+          profileListFeaturesEnabled: true,
+          curatedListsEnabled: false,
+        ),
+      );
 
-        await tester.pumpAndSettle();
+      await tester.pumpAndSettle();
 
-        expect(_divineIcon(DivineIconName.listPlus), findsNothing);
-      },
-    );
+      expect(_divineIcon(DivineIconName.listPlus), findsNothing);
+    });
 
     testWidgets('tile responds when tapping the avatar-name gap', (
       tester,
@@ -100,12 +99,7 @@ void main() {
 
       final avatarRect = tester.getRect(avatar);
 
-      await tester.tapAt(
-        Offset(
-          avatarRect.right + 6,
-          avatarRect.center.dy,
-        ),
-      );
+      await tester.tapAt(Offset(avatarRect.right + 6, avatarRect.center.dy));
       await tester.pump();
 
       expect(tapped, isTrue);


### PR DESCRIPTION
Closes #6477

## Description

Users reported that toggling **Curated Lists** in Settings -> Experimental Features threw them back to Settings. No other flag did this.

The app shell watched `isFeatureEnabledProvider(FeatureFlag.curatedLists)` and used it to add a conditional `BlocProvider<PeopleListsBloc>` to `MultiBlocProvider`. A conditional entry changes the shape of the provider chain, so flipping that flag re-inflated the subtree below it: `MaterialApp.router`, feed state, video controllers, and app-shell listeners included.

The fix registers `PeopleListsBloc` unconditionally above `MaterialApp.router`, so the app shell no longer changes structural shape on a curated-lists flag flip.

## Gating after the change

`BlocProvider` remains lazy. To keep the disabled-feature path clean:

- `curatedLists` is now required alongside `profileListFeatures` in all three add-to-list affordance computations: `user_profile_tile.dart`, `search_user_tile.dart`, and `other_profile_screen.dart`.
- `AddToPeopleListsSheet.show` and `showNewPeopleListSheet` check `FeatureFlag.curatedLists` themselves as imperative-entry backstops.
- `other_profile_screen.dart` also re-checks `curatedLists` at the top of the `MoreSheetResult.addToList` branch before reading `PeopleListsBloc`.
- Tests pin that the lazy bloc is not constructed when the feature is off.

## Rebase on current main

This branch is rebased on current `origin/main` and preserves #6482: the app-lifetime `PeopleListsBloc` still receives `peopleListsRepositoryIdentityStreamProvider`, so account/repository changes do not leave it on a stale captured repository.

Remaining lifecycle behavior is explicit and tracked in #6494: if the bloc was already constructed while `curatedLists` was on, it remains session-lifetime after the flag flips off. Follow-up should stop already-started people-list repository work without reintroducing a conditional provider above `MaterialApp.router`.

## Out of Scope

The feature-flag screen still bypasses go_router (#6481), so it does not survive a router refresh from another source.

The Navigator-level step from subtree re-inflation to losing the imperatively pushed route is not fully explained. The symptom was reproduced on device before the change and was gone on device after the provider-shape fix; the comment in `main.dart` scopes the mechanism to what was verified.

## Verification

Local takeover verification:

- `flutter pub get`
- `flutter test test/features/people_lists/view/add_to_people_lists_sheet_test.dart test/widgets/profile/new_people_list_sheet_test.dart test/widgets/user_profile_tile_feature_flag_test.dart test/screens/other_profile_screen_test.dart test/screens/search_results` — 122 passed
- `flutter test test/main_app_shell_repository_sync_test.dart test/providers/provider_identity_stream_test.dart test/providers/list_providers_test.dart test/features/people_lists/bloc/people_lists_bloc_test.dart` — 45 passed
- `flutter test test/features/people_lists/view/add_to_people_lists_sheet_test.dart test/widgets/profile/new_people_list_sheet_test.dart test/widgets/user_profile_tile_feature_flag_test.dart` — 15 passed after l10n assertion cleanup
- `flutter analyze lib test` — no issues
- Pre-push hook: merge-conflict check passed, analyzer passed, changed-file tests passed

Original author verification: tested on a real Samsung Galaxy that toggling Curated Lists keeps the user on the Experimental Features screen.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore