### PR TITLE
fix(attestation): run iOS App Attest off the main thread

### DIFF
--- a/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrityPlugin.swift
+++ b/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrityPlugin.swift
@@ -19,34 +19,42 @@ public class AppDeviceIntegrityPlugin: NSObject, FlutterPlugin {
                 return
             }
 
-            guard let deviceIntegrity = AppDeviceIntegrity(challengeString: challengeString) else {
-                result(FlutterError(code: "-4", message: "Failed to initialize AppDeviceIntegrity", details: nil))
-                return
-            }
+            // App Attest hits the Secure Enclave and Apple's attestation
+            // servers. Flutter delivers channel calls on the main thread, so
+            // doing that work here froze the UI for ~200ms after every
+            // recording. Stay off-main and only hop back to deliver the result.
+            DispatchQueue.global(qos: .userInitiated).async {
+                guard let deviceIntegrity = AppDeviceIntegrity(challengeString: challengeString) else {
+                    DispatchQueue.main.async {
+                        result(FlutterError(code: "-4", message: "Failed to initialize AppDeviceIntegrity", details: nil))
+                    }
+                    return
+                }
 
-            // Directly generate key and attest
-            deviceIntegrity.generateKeyAndAttest { success in
-                DispatchQueue.main.async {
-                    if success {
-                        // Attestation successful, return the attestationString
-                        let attestationResult = [
-                            "attestationString": deviceIntegrity.attestationString ?? "",
-                            "keyID": deviceIntegrity.keyIdentifier()
-                        ]
+                // Directly generate key and attest
+                deviceIntegrity.generateKeyAndAttest { success in
+                    DispatchQueue.main.async {
+                        if success {
+                            // Attestation successful, return the attestationString
+                            let attestationResult = [
+                                "attestationString": deviceIntegrity.attestationString ?? "",
+                                "keyID": deviceIntegrity.keyIdentifier()
+                            ]
 
-                        do {
-                            let jsonData = try JSONEncoder().encode(attestationResult)
-                            if let jsonString = String(data: jsonData, encoding: .utf8) {
-                                result(jsonString)
-                            } else {
-                                result(FlutterError(code: "-6", message: "Failed to convert JSON data to String", details: nil))
+                            do {
+                                let jsonData = try JSONEncoder().encode(attestationResult)
+                                if let jsonString = String(data: jsonData, encoding: .utf8) {
+                                    result(jsonString)
+                                } else {
+                                    result(FlutterError(code: "-6", message: "Failed to convert JSON data to String", details: nil))
+                                }
+                            } catch {
+                                result(FlutterError(code: "-7", message: "JSON encoding error: \(error.localizedDescription)", details: nil))
                             }
-                        } catch {
-                            result(FlutterError(code: "-7", message: "JSON encoding error: \(error.localizedDescription)", details: nil))
+                        } else {
+                            // Attestation or key generation failed
+                            result(FlutterError(code: "-5", message: "Attestation failed", details: nil))
                         }
-                    } else {
-                        // Attestation or key generation failed
-                        result(FlutterError(code: "-5", message: "Attestation failed", details: nil))
                     }
                 }
             }

--- a/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrityPlugin.swift
+++ b/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrityPlugin.swift
@@ -33,28 +33,33 @@ public class AppDeviceIntegrityPlugin: NSObject, FlutterPlugin {
 
                 // Directly generate key and attest
                 deviceIntegrity.generateKeyAndAttest { success in
-                    DispatchQueue.main.async {
-                        if success {
-                            // Attestation successful, return the attestationString
-                            let attestationResult = [
-                                "attestationString": deviceIntegrity.attestationString ?? "",
-                                "keyID": deviceIntegrity.keyIdentifier()
-                            ]
+                    // Encode here, still off-main: the attestation string is
+                    // several KB of base64.
+                    let payload: Any
+                    if success {
+                        // Attestation successful, return the attestationString
+                        let attestationResult = [
+                            "attestationString": deviceIntegrity.attestationString ?? "",
+                            "keyID": deviceIntegrity.keyIdentifier()
+                        ]
 
-                            do {
-                                let jsonData = try JSONEncoder().encode(attestationResult)
-                                if let jsonString = String(data: jsonData, encoding: .utf8) {
-                                    result(jsonString)
-                                } else {
-                                    result(FlutterError(code: "-6", message: "Failed to convert JSON data to String", details: nil))
-                                }
-                            } catch {
-                                result(FlutterError(code: "-7", message: "JSON encoding error: \(error.localizedDescription)", details: nil))
+                        do {
+                            let jsonData = try JSONEncoder().encode(attestationResult)
+                            if let jsonString = String(data: jsonData, encoding: .utf8) {
+                                payload = jsonString
+                            } else {
+                                payload = FlutterError(code: "-6", message: "Failed to convert JSON data to String", details: nil)
                             }
-                        } else {
-                            // Attestation or key generation failed
-                            result(FlutterError(code: "-5", message: "Attestation failed", details: nil))
+                        } catch {
+                            payload = FlutterError(code: "-7", message: "JSON encoding error: \(error.localizedDescription)", details: nil)
                         }
+                    } else {
+                        // Attestation or key generation failed
+                        payload = FlutterError(code: "-5", message: "Attestation failed", details: nil)
+                    }
+
+                    DispatchQueue.main.async {
+                        result(payload)
                     }
                 }
             }


### PR DESCRIPTION
## Description

The app froze for ~200ms after every recording on iOS. Recording a clip kicks off proof generation (`ClipManagerNotifier._generateClipProof`), which calls `getAttestationServiceSupport` on the vendored `app_device_integrity` plugin. Flutter delivers method channel calls on the main thread, and the plugin did its App Attest work right there — `DCAppAttestService.isSupported` in the initializer, plus Secure Enclave key generation — so the UI stalled while it ran.

The fix moves the whole handler onto a background queue and hops back to main only to deliver the `FlutterResult`. That includes the initializer-failure path (`-4`), which previously returned on main as well. The plugin is vendored under `mobile/overrides/app_device_integrity-1.1.0` (see the `dependency_overrides` entry in `mobile/pubspec.yaml`), so no upstream change is needed.

Device logs show what was actually sitting on that thread — the attestation round-trip takes roughly two seconds per clip:

```
15:56:01.099  🔐 Native proof hash: 1c5f4798…
15:56:03.198  🔐 Getting native ProofMode proof directory…   → ~2.1s
15:56:05.445  🔐 Native proof hash: fab3006c…
15:56:07.302  🔐 Getting native ProofMode proof directory…   → ~1.86s
```

Both clips ended at `verified_mobile` with a ~7.9 KB device attestation written, so the proof chain is unchanged — it just no longer blocks the UI.

**Related Issue:** Closes #3214

## Out of Scope

- **#3324** (attestation hangs indefinitely on jailbroken devices) sits at the same call site and needs a timeout on the Dart side. Kept separate to keep this diff to the threading fix.
- **Pre-existing robustness bug, not filed yet:** every attestation error arrives in Dart as a `PlatformException` and lands in the broad `catch` at `native_proofmode_service.dart:270`, so `proofFile` returns `null` and the clip loses its *entire* ProofMode/C2PA proof — not just the attestation. This triggers when the device is offline, when Apple rate-limits attestation, and on any device without App Attest support (including the Simulator, where `isSupported` is false).
- **No automated test.** The vendored plugin has no iOS test target, only an Android/Kotlin one, and the behaviour is a threading property of a native platform channel. Verified on device instead.

## Verification

- `swiftc -typecheck` against `Flutter.xcframework/ios-arm64` (Flutter 3.44.0) and the iphoneos SDK, target `arm64-apple-ios14.0`, together with `AppDeviceIntegrity.swift` — clean.
- Full Xcode device build via `flutter run`: `Xcode build done. 115.7s`.
- Manually verified on a physical **iPad (iOS 26.5.2)**: recorded multiple clips, no freeze on stopping the recording. Attestation still succeeds (`Attestation successful`, `verified_mobile`, device attestation file written). Note this is an iOS-only path — it cannot be exercised on Android or in the Simulator.
- No Dart files changed, so no Flutter tests are affected; the pre-push hook confirmed the same.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
