### PR TITLE
fix(profile): close vanished account leaks

### DIFF
--- a/mobile/lib/providers/user_profile_providers.dart
+++ b/mobile/lib/providers/user_profile_providers.dart
@@ -12,6 +12,14 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'user_profile_providers.g.dart';
 
+final _vanishedProfilePubkeysProvider = StreamProvider<Set<String>>((ref) {
+  return ref
+      .watch(databaseProvider)
+      .vanishedProfilesDao
+      .watchAllPubkeys()
+      .map((pubkeys) => pubkeys.toSet());
+});
+
 // ignore: specify_nonobvious_property_types
 final userProfileStatsReactiveProvider =
     StreamProvider.family<ProfileStats?, String>((ref, pubkey) {
@@ -97,8 +105,7 @@ Future<UserProfile?> fetchUserProfile(Ref ref, String pubkey) async {
 /// treatment in the inbox and the following bar.
 @riverpod
 Stream<bool> profileVanished(Ref ref, String pubkey) {
-  return ref
-      .watch(databaseProvider)
-      .vanishedProfilesDao
-      .watchIsVanished(pubkey);
+  final pubkeys =
+      ref.watch(_vanishedProfilePubkeysProvider).value ?? const <String>{};
+  return Stream.value(pubkeys.contains(pubkey));
 }

--- a/mobile/lib/providers/user_profile_providers.g.dart
+++ b/mobile/lib/providers/user_profile_providers.g.dart
@@ -301,7 +301,7 @@ final class ProfileVanishedProvider
   }
 }
 
-String _$profileVanishedHash() => r'cb1f9c9ef27a29577e5299d468dc777a052a86b1';
+String _$profileVanishedHash() => r'9c15d7c790f73dd872f1cf8e8c690ef0f411ba17';
 
 /// Whether the account behind [pubkey] has requested NIP-62 deletion.
 ///

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -245,8 +245,10 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
                                   participantPubkeys: widget.participantPubkeys,
                                   blockedPubkeys: blockedReactors,
                                   displayName: displayName,
-                                  imageUrl: profile?.picture,
-                                  nip05: profile?.shortDisplayNip05,
+                                  imageUrl: isDeleted ? null : profile?.picture,
+                                  nip05: isDeleted
+                                      ? null
+                                      : profile?.shortDisplayNip05,
                                   onViewProfile: () {
                                     final npub = NostrKeyUtils.encodePubKey(
                                       otherPubkey,

--- a/mobile/lib/widgets/profile/profile_banner_layer.dart
+++ b/mobile/lib/widgets/profile/profile_banner_layer.dart
@@ -48,9 +48,15 @@ class _ProfileBannerLayerState extends ConsumerState<ProfileBannerLayer> {
 
   @override
   Widget build(BuildContext context) {
+    final isVanished =
+        !widget.isOwnProfile &&
+        (ref.watch(profileVanishedProvider(widget.userIdHex)).value ?? false);
+
     // Resolve effective profile (same logic as ProfileHeaderWidget).
     final UserProfile? effectiveProfile;
-    if (widget.isOwnProfile) {
+    if (isVanished) {
+      effectiveProfile = null;
+    } else if (widget.isOwnProfile) {
       effectiveProfile = _readOwnProfileBanner(context);
     } else if (widget.profile != null) {
       effectiveProfile = widget.profile;

--- a/mobile/packages/db_client/lib/src/app_db_client.dart
+++ b/mobile/packages/db_client/lib/src/app_db_client.dart
@@ -4,6 +4,7 @@
 
 import 'package:db_client/db_client.dart';
 import 'package:drift/drift.dart';
+import 'package:meta/meta.dart';
 
 /// {@template app_db_client}
 /// A typed database client that wraps [DbClient] with domain-specific methods.
@@ -210,6 +211,7 @@ class AppDbClient {
   }
 
   /// Insert or update a user profile.
+  @visibleForTesting
   Future<UserProfileRow> upsertProfile(UserProfilesCompanion profile) async {
     final result = await _dbClient.insert(
       _db.userProfiles,

--- a/mobile/packages/db_client/lib/src/database/daos/vanished_profiles_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/vanished_profiles_dao.dart
@@ -29,8 +29,8 @@ class VanishedProfilesDao extends DatabaseAccessor<AppDatabase>
   /// Forgets that [pubkey] ever vanished.
   ///
   /// Called when the server reports the account as live again, so a wrong
-  /// vanish classification is recoverable instead of erasing the user from
-  /// this device permanently.
+  /// `has_vanish_request: true` classification is recoverable instead of
+  /// erasing the user from this device permanently.
   Future<int> clearVanished(String pubkey) {
     return (delete(
       vanishedProfiles,
@@ -51,6 +51,13 @@ class VanishedProfilesDao extends DatabaseAccessor<AppDatabase>
       ..where((t) => t.pubkey.equals(pubkey))
       ..limit(1);
     return query.watchSingleOrNull().map((row) => row != null).distinct();
+  }
+
+  /// Emits the whole vanished-pubkey set whenever the tombstone table changes.
+  Stream<List<String>> watchAllPubkeys() {
+    return select(vanishedProfiles).watch().map(
+      (rows) => rows.map((row) => row.pubkey).toList(growable: false),
+    );
   }
 
   /// Every vanished pubkey, for warming an in-memory set at startup.

--- a/mobile/packages/db_client/test/src/database/daos/vanished_profiles_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/vanished_profiles_dao_test.dart
@@ -62,8 +62,9 @@ void main() {
     });
 
     test('clearVanished forgets the pubkey', () async {
-      // The self-heal path: a wrong vanish classification must be recoverable
-      // rather than erasing the account from this device forever.
+      // The self-heal path: a wrong `has_vanish_request: true` classification
+      // must be recoverable rather than erasing the account from this device
+      // forever.
       await dao.markVanished(_pubkey);
 
       final removed = await dao.clearVanished(_pubkey);
@@ -123,6 +124,31 @@ void main() {
 
         await subscription.cancel();
         expect(emissions, equals([false]));
+      });
+    });
+
+    group('watchAllPubkeys', () {
+      test('emits the whole vanished set when rows change', () async {
+        final emissions = <List<String>>[];
+        final subscription = dao.watchAllPubkeys().listen((pubkeys) {
+          emissions.add([...pubkeys]..sort());
+        });
+
+        await pumpEventQueue();
+        await dao.markVanished(_pubkey);
+        await pumpEventQueue();
+        await dao.markVanished(_otherPubkey);
+        await pumpEventQueue();
+        await dao.clearVanished(_pubkey);
+        await pumpEventQueue();
+
+        await subscription.cancel();
+        expect(emissions, [
+          <String>[],
+          [_pubkey],
+          [_otherPubkey, _pubkey]..sort(),
+          [_otherPubkey],
+        ]);
       });
     });
   });

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -1752,23 +1752,19 @@ class FunnelcakeApiClient {
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body) as Map<String, dynamic>;
         final profileJson = data['profile'] as Map<String, dynamic>?;
-
-        // Both halves are required. `has_vanish_request` is read from the
-        // permanent vanish-request record, so it stays true after the erasure
-        // sweep completes and the account publishes again — which the server
-        // then serves as a live profile. It marks a deletion only while the
-        // server is *also* withholding the profile: a pending request
-        // suppresses the Kind 0 server-side, and a completed one erased it.
-        // Reading the flag alone would hide a republished account forever,
-        // because it never goes false again. Absent means the server predates
-        // the field, which preserves the previous behaviour.
-        if (data['has_vanish_request'] == true && profileJson == null) {
-          return UserProfileVanished(pubkey: pubkey);
-        }
-
         final socialJson = data['social'] as Map<String, dynamic>?;
         final statsJson = data['stats'] as Map<String, dynamic>?;
         final engagementJson = data['engagement'] as Map<String, dynamic>?;
+        final hasVanishRequest = data['has_vanish_request'] == true;
+
+        // `has_vanish_request` is historical, not a tombstone by itself. A
+        // completed vanish can later publish post-boundary Kind 0 metadata and
+        // the server serves that as live. Only a suppressed/missing profile with
+        // the flag should render as a deleted account. Absent means the server
+        // predates the field, preserving the previous not-published behaviour.
+        if (hasVanishRequest && profileJson == null) {
+          return UserProfileVanished(pubkey: pubkey);
+        }
 
         final social = socialJson != null
             ? ProfileSocialData.fromJson(socialJson)
@@ -2154,19 +2150,17 @@ class FunnelcakeApiClient {
             if (pubkey == null || pubkey.isEmpty) continue;
 
             final profileJson = user['profile'] as Map<String, dynamic>?;
-
-            // Same rule as getUserProfile, and narrower here: the server
-            // strips a pending vanish request out of bulk hydration entirely,
-            // so on this path the flag is only ever visible for a request the
-            // erasure sweep already completed.
-            if (user['has_vanish_request'] == true && profileJson == null) {
-              result[pubkey] = UserProfileVanished(pubkey: pubkey);
-              continue;
-            }
-
             final socialJson = user['social'] as Map<String, dynamic>?;
             final statsJson = user['stats'] as Map<String, dynamic>?;
             final engagementJson = user['engagement'] as Map<String, dynamic>?;
+            final hasVanishRequest = user['has_vanish_request'] == true;
+
+            // Same contract as getUserProfile: the flag alone is historical,
+            // while flag + null profile is the suppressed/deleted-account shape.
+            if (hasVanishRequest && profileJson == null) {
+              result[pubkey] = UserProfileVanished(pubkey: pubkey);
+              continue;
+            }
 
             final social = socialJson != null
                 ? ProfileSocialData.fromJson(socialJson)

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -3719,6 +3719,17 @@ void main() {
         expect((result! as UserProfileVanished).pubkey, equals(testPubkey));
       });
 
+      test('ignores the legacy deleted field', () async {
+        const legacyDeletedResponse = '{"deleted": true, "profile": null}';
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response(legacyDeletedResponse, 200));
+
+        final result = await client.getUserProfile(testPubkey);
+
+        expect(result, isA<UserProfileNotPublished>());
+      });
+
       test('a vanish request alongside a served profile is live', () async {
         // `has_vanish_request` is historical and never goes false again, so a
         // completed vanish that republished a Kind 0 still carries it while
@@ -4667,6 +4678,65 @@ void main() {
           expect(
             (result.profiles['pub2']! as UserProfileFound).profile.name,
             equals('Valid'),
+          );
+        },
+      );
+
+      test(
+        'returns UserProfileVanished for has_vanish_request with null profile',
+        () async {
+          const response = '''
+{
+  "users": [
+    {"pubkey": "pub1", "has_vanish_request": true, "profile": null}
+  ]
+}
+''';
+          when(
+            () => mockHttpClient.post(
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer((_) async => http.Response(response, 200));
+
+          final result = await client.getBulkProfiles(['pub1']);
+
+          expect(result.profiles, hasLength(1));
+          expect(result.profiles['pub1'], isA<UserProfileVanished>());
+        },
+      );
+
+      test(
+        'returns UserProfileFound for has_vanish_request with populated '
+        'profile',
+        () async {
+          const response = '''
+{
+  "users": [
+    {
+      "pubkey": "pub1",
+      "has_vanish_request": true,
+      "profile": {"name": "Restored", "display_name": "Restored User"}
+    }
+  ]
+}
+''';
+          when(
+            () => mockHttpClient.post(
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer((_) async => http.Response(response, 200));
+
+          final result = await client.getBulkProfiles(['pub1']);
+
+          expect(result.profiles, hasLength(1));
+          expect(result.profiles['pub1'], isA<UserProfileFound>());
+          expect(
+            (result.profiles['pub1']! as UserProfileFound).profile.name,
+            equals('Restored'),
           );
         },
       );

--- a/mobile/packages/models/lib/src/user_profile_result.dart
+++ b/mobile/packages/models/lib/src/user_profile_result.dart
@@ -127,11 +127,11 @@ final class UserProfileNotPublished extends UserProfileResult {
 /// The account has a NIP-62 request to vanish on record **and** the server is
 /// serving no profile for it.
 ///
-/// Both halves are load-bearing. The server's `has_vanish_request` flag comes
-/// from the permanent vanish-request record, so it stays `true` after the
-/// erasure sweep completes and the account publishes a new Kind 0 — which the
-/// server then serves as live. Reading the flag alone would hide those accounts
-/// permanently, because it never goes `false` again.
+/// Returned only when the server reports `has_vanish_request: true` and does
+/// not include a profile. The flag is historical erasure-request state, not a
+/// tombstone by itself: a completed vanish can later publish post-boundary
+/// profile metadata and the server serves that as live. Callers must treat this
+/// variant as "there is nothing to show".
 ///
 /// Callers must treat this variant as "there is nothing to show". [social],
 /// [stats], and [engagement] are always `null` here so it is structurally

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -269,8 +269,9 @@ class ProfileRepository {
     _confirmedMissing.add(pubkey);
     // This response *is* this session's re-check. Without it the next
     // [fetchFreshProfile] would immediately spend a second request to be told
-    // the same thing; recovery from a wrong vanish classification rides on
-    // the next session instead, which every session performs exactly once.
+    // the same thing; recovery from a wrong `has_vanish_request: true` +
+    // null-profile classification rides on the next session instead, which
+    // every session performs exactly once.
     _vanishRevalidated.add(pubkey);
     // Load-bearing: stops the raw-Kind-0 retry ladder from re-querying relays
     // for a profile that is never coming back.
@@ -286,8 +287,8 @@ class ProfileRepository {
   /// Forgets a previously recorded vanish.
   ///
   /// Called whenever the server reports the account as live again, so a wrong
-  /// vanish classification is recoverable instead of erasing the account from
-  /// this device permanently.
+  /// `has_vanish_request: true` classification is recoverable instead of
+  /// erasing the account from this device permanently.
   ///
   /// Deliberately **not** gated on [_vanished]. That set is one mirror per
   /// repository instance, hydrated asynchronously, of a table every instance
@@ -298,6 +299,7 @@ class ProfileRepository {
   /// matching nothing dirties no page; that disagreement is costlier.
   Future<void> _clearVanish(String pubkey) async {
     _vanished.remove(pubkey);
+    _rawKind0ConfirmedMissing.remove(pubkey);
     await _vanishedProfilesDao?.clearVanished(pubkey);
   }
 
@@ -305,9 +307,10 @@ class ProfileRepository {
   /// the read path that never otherwise reaches the network: an
   /// already-vanished pubkey, which [fetchFreshProfile] and
   /// [fetchBatchProfiles] both answer from the durable marker. This is
-  /// therefore the only channel that can clear a wrong vanish classification,
-  /// and it runs once in *every* session — including after a restart — so
-  /// recovery is not limited to the session that recorded the vanish.
+  /// therefore the only channel that can clear a wrong
+  /// `has_vanish_request: true` + null-profile classification, and it runs
+  /// once in *every* session. That includes after a restart, so recovery is
+  /// not limited to the session that recorded the vanish.
   ///
   /// Deliberately calls the unguarded fetch: the guarded entry point would
   /// bounce straight back here for a vanished pubkey.
@@ -717,7 +720,8 @@ class ProfileRepository {
           case UserProfileFound():
             // Self-heal: the server says this account is live, so forget any
             // vanish we recorded earlier. Without this a single wrong
-            // classification would erase the account from this device forever.
+            // `has_vanish_request: true` + null profile would erase the account
+            // from this device forever.
             await _clearVanish(pubkey);
             final funnelcakeProfile = UserProfile.fromUserProfileFound(result);
             await _cacheProfileStatsFromResult(pubkey, result);

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -834,9 +834,9 @@ void main() {
             mockVanishedDao = MockVanishedProfilesDao();
             mockIdentityDao = MockIdentityEventsDao();
 
-            when(() => mockVanishedDao.markVanished(any())).thenAnswer(
-              (_) async {},
-            );
+            when(
+              () => mockVanishedDao.markVanished(any()),
+            ).thenAnswer((_) async {});
             when(
               () => mockVanishedDao.clearVanished(any()),
             ).thenAnswer((_) async => 1);

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -173,6 +173,7 @@ void main() {
     Widget buildSubject({
       ConversationState? state,
       UserProfile? otherProfile,
+      bool otherProfileVanished = false,
       MockGoRouter? goRouter,
       DmRestoreStatusState? restoreStatus,
     }) {
@@ -202,6 +203,9 @@ void main() {
           fetchUserProfileProvider(
             otherPubkey,
           ).overrideWith((ref) async => otherProfile),
+          profileVanishedProvider(
+            otherPubkey,
+          ).overrideWith((ref) => Stream.value(otherProfileVanished)),
           // The view now reads the blocklist eagerly in build() to filter
           // reaction reactors, so every pump needs a stubbed repository.
           contentBlocklistRepositoryProvider.overrideWithValue(mockBlocklist),
@@ -398,6 +402,36 @@ void main() {
 
         expect(find.byType(EmptyConversation), findsOneWidget);
       });
+
+      testWidgets(
+        'empty conversation hides stale avatar and nip05 for deleted account',
+        (tester) async {
+          await tester.pumpWidget(
+            buildSubject(
+              state: const ConversationState(status: ConversationStatus.loaded),
+              otherProfile: UserProfile(
+                pubkey: otherPubkey,
+                name: 'Stale Name',
+                displayName: 'Stale Display',
+                picture: 'https://example.com/stale.jpg',
+                nip05: 'stale@example.com',
+                rawData: const {},
+                createdAt: now,
+                eventId: 'stale-profile',
+              ),
+              otherProfileVanished: true,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final empty = tester.widget<EmptyConversation>(
+            find.byType(EmptyConversation),
+          );
+          expect(empty.displayName, l10n.profileDeletedAccountName);
+          expect(empty.imageUrl, isNull);
+          expect(empty.nip05, isNull);
+        },
+      );
 
       testWidgets(
         'empty conversation stays unqualified when recovery is complete',

--- a/mobile/test/widgets/profile/profile_banner_layer_test.dart
+++ b/mobile/test/widgets/profile/profile_banner_layer_test.dart
@@ -37,6 +37,7 @@ void main() {
       UserProfile? suppliedProfile,
       UserProfile? myProfile,
       UserProfile? riverpodProfile,
+      bool isVanished = false,
       bool provideMyProfileBloc = true,
     }) {
       Widget layer = ProfileBannerLayer(
@@ -63,6 +64,9 @@ void main() {
           fetchUserProfileProvider(
             _testUserHex,
           ).overrideWith((ref) async => riverpodProfile),
+          profileVanishedProvider(
+            _testUserHex,
+          ).overrideWith((ref) => Stream.value(isVanished)),
         ],
         child: MaterialApp(home: Scaffold(body: layer)),
       );
@@ -144,6 +148,23 @@ void main() {
 
       final banner = tester.widget<ProfileBanner>(find.byType(ProfileBanner));
       expect(banner.bannerUrl, equals('https://example.com/relay.jpg'));
+    });
+
+    testWidgets('does not render cached banner for a vanished other profile', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildSubject(
+          isOwnProfile: false,
+          isVanished: true,
+          riverpodProfile: _profileWithBanner('https://example.com/stale.jpg'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final banner = tester.widget<ProfileBanner>(find.byType(ProfileBanner));
+      expect(banner.bannerUrl, isNull);
+      expect(banner.profileColor, isNull);
     });
 
     testWidgets(


### PR DESCRIPTION
## Description

Follow-up to #6464, which merged while this takeover was in progress.

This closes the pieces from the review that still make sense on top of `main`:

- treats `has_vanish_request` as historical erasure-request state, not a tombstone by itself
- returns `UserProfileVanished` only for `has_vanish_request: true` with `profile: null`
- treats `has_vanish_request: true` with a populated profile as `UserProfileFound`, so a republished account self-heals
- ignores the obsolete `deleted` field
- stops the profile banner and empty DM state from rendering stale cached avatar/banner/NIP-05 for vanished accounts
- shares one vanished-pubkey watch stream across profile rows instead of opening one Drift query stream per row
- clears `_rawKind0ConfirmedMissing` when a vanish self-heals
- marks `AppDbClient.upsertProfile` as testing-only so it does not look like a safe production write path

## Product Decision

@rabble please decide the remaining bulk-path edge:

`POST /api/users/bulk` returning `has_vanish_request: true` with `profile: null` is currently treated as `UserProfileVanished`, matching the single-profile endpoint and avoiding split rendering between profile screen and inbox. If completed-vanish-with-post-boundary-activity-but-no-kind-0 should instead remain live-unknown/not-published, this is the behavior to flip before merge.

## Verification

- `flutter test test/src/funnelcake_api_client_test.dart` from `mobile/packages/funnelcake_api_client` — 302 passed
- `flutter test test/src/profile_repository_test.dart` from `mobile/packages/profile_repository` — 238 passed
- `flutter test test/src/database/daos/vanished_profiles_dao_test.dart test/src/app_db_client_test.dart` from `mobile/packages/db_client` — 50 passed
- `flutter test test/widgets/profile/profile_banner_layer_test.dart test/screens/inbox/conversation/conversation_view_test.dart` from `mobile` — 51 passed
- `flutter analyze lib test` from `mobile/packages/funnelcake_api_client` — clean
- `flutter analyze lib test` from `mobile/packages/profile_repository` — clean
- `flutter analyze lib test` from `mobile/packages/db_client` — clean
- `flutter analyze lib test/widgets/profile/profile_banner_layer_test.dart test/screens/inbox/conversation/conversation_view_test.dart` from `mobile` — clean
- pre-push hook — analyzer clean, generated files clean, changed-file test suite 616 passed

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
