### PR TITLE
chore(infinite-video-feed): delete the loop seek nothing calls

### DIFF
--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -80,7 +80,8 @@ const _maxConcurrentCacheDownloads = 1;
 ///
 /// **Playback hooks integration:**
 /// - Background caching triggered via [FullscreenFeedVideoCacheStarted]
-/// - Loop enforcement handled by the FeedVideos player configuration
+/// - Looping and the playback-length cap handled by the FeedVideos player
+///   configuration
 /// - Cache resolution happens at the player/repository level
 class FullscreenFeedBloc
     extends Bloc<FullscreenFeedEvent, FullscreenFeedState> {

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -366,9 +366,8 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
         },
         // Nothing in the feed plays longer than a Vine, not even a 60s file a
         // foreign Nostr client points at. The cap is a native clip end, so the
-        // loop point stays in the platform player — deliberately NOT
-        // maxLoopDuration, whose Dart seek at the 6.3s recording limit both
-        // truncated classic Vines and created an audible seam (#5544, #6421).
+        // loop point stays in the platform player and the join stays seamless
+        // (#5544, #6421).
         maxPlaybackDuration: AppConstants.maxFeedPlaybackDuration,
         onVideoLoopCompleted: _handleAutoAdvanceCompleted,
         shouldPortraitExpand: widget.shouldPortraitExpand,

--- a/mobile/packages/infinite_video_feed/lib/src/services/controller_subscriptions.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/services/controller_subscriptions.dart
@@ -3,8 +3,8 @@ import 'dart:async';
 import 'package:divine_video_player/divine_video_player.dart';
 
 /// Bundles the state-stream subscriptions the feed maintains per
-/// active player controller (errors, loop enforcement, auto-advance loop
-/// detection, dimensions, first-frame).
+/// active player controller (errors, auto-advance loop detection,
+/// dimensions, first-frame).
 ///
 /// Each `subscribeTo*` call cancels any prior subscription of the same
 /// kind for that index. [unsubscribe] cancels all of them for one index;
@@ -13,7 +13,6 @@ class ControllerSubscriptions {
   final _dimensions = <int, StreamSubscription<DivineVideoPlayerState>>{};
   final _firstFrame = <int, StreamSubscription<DivineVideoPlayerState>>{};
   final _errors = <int, StreamSubscription<DivineVideoPlayerState>>{};
-  final _loop = <int, StreamSubscription<DivineVideoPlayerState>>{};
   final _autoAdvance = <int, StreamSubscription<DivineVideoPlayerState>>{};
 
   /// Subscribes to runtime playback errors. Calls [onError] with the
@@ -37,46 +36,19 @@ class ControllerSubscriptions {
     });
   }
 
-  /// Subscribes to loop enforcement: when the active video crosses
-  /// [maxLoopDuration] while playing, [onSeekToZero] is invoked. The
-  /// caller is responsible for guarding against repeated triggers
-  /// (`isSeekInProgress`/`onSeekStarted`/`onSeekFinished`).
-  void subscribeToLoopEnforcement(
-    int index,
-    DivineVideoPlayerController controller, {
-    required Duration maxLoopDuration,
-    required bool Function() isCurrent,
-    required bool Function() isSeekInProgress,
-    required void Function() onSeekStarted,
-    required void Function() onPositionBelowMax,
-    required void Function() onSeekToZero,
-  }) {
-    unawaited(_loop[index]?.cancel());
-    _loop[index] = controller.stateStream.listen((state) {
-      if (!isCurrent()) return;
-
-      if (state.position < maxLoopDuration) {
-        onPositionBelowMax();
-        return;
-      }
-
-      if (!state.isPlaying || isSeekInProgress()) return;
-
-      onSeekStarted();
-      onSeekToZero();
-    });
-  }
-
   /// Subscribes to loop-completion detection. Fires [onLoopCompleted] when
-  /// the playback position resets from near the effective end (min of
-  /// [maxLoopDuration] and the natural duration) back to near zero.
+  /// the playback position resets from near the reported duration back to
+  /// near zero.
+  ///
+  /// The duration is the clip's, so a feed that caps playback with a native
+  /// clip end already reports the capped length here — detection needs no
+  /// separate limit.
   ///
   /// [endThreshold] / [startThreshold] define the windows for "near end"
   /// and "near start".
   void subscribeToAutoAdvance(
     int index,
     DivineVideoPlayerController controller, {
-    required Duration? maxLoopDuration,
     required Duration endThreshold,
     required Duration startThreshold,
     required bool Function() isCurrent,
@@ -88,21 +60,11 @@ class ControllerSubscriptions {
     var armed = false;
     var lastPosition = initialState.position;
 
-    Duration? effectiveEnd;
     final initialDuration = initialState.duration;
-    if (initialDuration > Duration.zero) {
-      effectiveEnd =
-          (maxLoopDuration != null && maxLoopDuration < initialDuration)
-          ? maxLoopDuration
-          : initialDuration;
-    } else if (maxLoopDuration != null) {
-      effectiveEnd = maxLoopDuration;
-    }
     if (isCurrent() &&
         initialState.isPlaying &&
-        effectiveEnd != null &&
-        effectiveEnd > Duration.zero &&
-        lastPosition >= effectiveEnd - endThreshold) {
+        initialDuration > Duration.zero &&
+        lastPosition >= initialDuration - endThreshold) {
       armed = true;
     }
 
@@ -112,19 +74,8 @@ class ControllerSubscriptions {
       final position = state.position;
       final duration = state.duration;
 
-      Duration? effectiveEnd;
-      if (duration > Duration.zero) {
-        effectiveEnd = (maxLoopDuration != null && maxLoopDuration < duration)
-            ? maxLoopDuration
-            : duration;
-      } else if (maxLoopDuration != null) {
-        effectiveEnd = maxLoopDuration;
-      }
-
-      if (effectiveEnd != null && effectiveEnd > Duration.zero) {
-        if (position >= effectiveEnd - endThreshold) {
-          armed = true;
-        }
+      if (duration > Duration.zero && position >= duration - endThreshold) {
+        armed = true;
       }
 
       if (armed && position <= startThreshold && lastPosition > position) {
@@ -197,7 +148,6 @@ class ControllerSubscriptions {
     unawaited(_dimensions.remove(index)?.cancel());
     unawaited(_firstFrame.remove(index)?.cancel());
     unawaited(_errors.remove(index)?.cancel());
-    unawaited(_loop.remove(index)?.cancel());
     unawaited(_autoAdvance.remove(index)?.cancel());
   }
 
@@ -215,10 +165,6 @@ class ControllerSubscriptions {
       unawaited(s.cancel());
     }
     _errors.clear();
-    for (final s in _loop.values) {
-      unawaited(s.cancel());
-    }
-    _loop.clear();
     for (final s in _autoAdvance.values) {
       unawaited(s.cancel());
     }

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -54,7 +54,6 @@ class InfiniteVideoFeed extends StatefulWidget {
     this.prefetchCount = 8,
     this.shouldPortraitExpand = true,
     this.maxPlaybackDuration,
-    this.maxLoopDuration,
     this.onActiveVideoChanged,
     this.onNearEnd,
     this.nearEndThreshold = 10,
@@ -243,15 +242,6 @@ class InfiniteVideoFeed extends StatefulWidget {
   /// When `null`, every source plays to its full length.
   final Duration? maxPlaybackDuration;
 
-  /// Seeks active playback back to zero once this position is reached.
-  ///
-  /// When `null`, timeline-length loop enforcement is disabled and native
-  /// looping behavior applies.
-  ///
-  /// Prefer [maxPlaybackDuration] for length enforcement: a Dart-side seek
-  /// produces an audible seam at the loop point (#5544).
-  final Duration? maxLoopDuration;
-
   /// Called when the active video changes.
   final OnActiveVideoChanged? onActiveVideoChanged;
 
@@ -263,10 +253,9 @@ class InfiniteVideoFeed extends StatefulWidget {
 
   /// Called each time the active video completes a loop.
   ///
-  /// Fires when the playback position resets from near the end back to the
-  /// beginning, either because [maxLoopDuration] was reached and the feed
-  /// enforced a seek-to-zero, or because the video reached its natural end
-  /// and looped on its own.
+  /// Fires when the playback position resets from near the end of the clip
+  /// back to the beginning — the native player looping the clip it was
+  /// opened with, which [maxPlaybackDuration] may already have shortened.
   ///
   /// The `currentIndex` argument is the feed index of the video that looped.
   /// Use this to implement auto-advance logic in the owning widget.
@@ -361,7 +350,6 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   final _errors = <int>{};
   final _errorTypes = <int, VideoErrorType>{};
   final _terminalErrorTypesByVideoId = <String, VideoErrorType>{};
-  final _loopSeekInProgress = <int>{};
   // Viewer auth headers per index, applied to every resolved playback source
   // for that index. The age-gate token is a hash-bound BUD-01 (kind 24242)
   // auth, valid for any variant URL of the same blob, so one header set covers
@@ -1034,7 +1022,6 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     _autoRetryTimers.clear();
     _autoRetryAttempts.clear();
 
-    _loopSeekInProgress.clear();
     _failoverInFlight.clear();
     _processingRetryInFlight.clear();
     _processingRetryAttempts.clear();
@@ -1062,7 +1049,6 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     _staleDetector.forget(index);
     _cancelAutoRetry(index);
     _errors.remove(index);
-    _loopSeekInProgress.remove(index);
     _failoverInFlight.remove(index);
     _processingRetryInFlight.remove(index);
     _processingRetryAttempts.remove(index);
@@ -1736,37 +1722,10 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
         },
       );
 
-    final maxLoopDuration = widget.maxLoopDuration;
-    if (maxLoopDuration != null) {
-      _subscriptions.subscribeToLoopEnforcement(
-        index,
-        controller,
-        maxLoopDuration: maxLoopDuration,
-        isCurrent: () => index == _currentIndex,
-        isSeekInProgress: () => _loopSeekInProgress.contains(index),
-        onSeekStarted: () {
-          _loopSeekInProgress.add(index);
-          _log(
-            'Loop enforcement index $index: '
-            'maxMs=${maxLoopDuration.inMilliseconds}',
-          );
-        },
-        onPositionBelowMax: () => _loopSeekInProgress.remove(index),
-        // Do NOT clear _loopSeekInProgress in whenComplete: native seekTo
-        // returns immediately (before ExoPlayer finishes seeking), so
-        // clearing the guard here lets stale position events retrigger
-        // the seek before position 0 is reported. The guard is cleared by
-        // onPositionBelowMax once ExoPlayer actually emits the post-seek
-        // position.
-        onSeekToZero: () => unawaited(controller.seekTo(Duration.zero)),
-      );
-    }
-
     if (widget.onVideoLoopCompleted != null) {
       _subscriptions.subscribeToAutoAdvance(
         index,
         controller,
-        maxLoopDuration: widget.maxLoopDuration,
         endThreshold: _loopEndThreshold,
         startThreshold: _loopStartThreshold,
         isCurrent: () => index == _currentIndex,

--- a/mobile/packages/infinite_video_feed/test/src/services/controller_subscriptions_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/services/controller_subscriptions_test.dart
@@ -78,142 +78,6 @@ void main() {
     });
 
     // ------------------------------------------------------------------
-    group('subscribeToLoopEnforcement', () {
-      test('fires onSeekToZero when position >= maxLoopDuration', () async {
-        final controller = FakeController();
-        var seekCalled = false;
-
-        subs.subscribeToLoopEnforcement(
-          0,
-          controller,
-          maxLoopDuration: const Duration(seconds: 5),
-          isCurrent: () => true,
-          isSeekInProgress: () => false,
-          onSeekStarted: () {},
-          onPositionBelowMax: () {},
-          onSeekToZero: () => seekCalled = true,
-        );
-
-        controller.pushState(
-          const DivineVideoPlayerState(
-            status: PlaybackStatus.playing,
-            position: Duration(seconds: 5),
-          ),
-        );
-        await Future<void>.delayed(Duration.zero);
-
-        expect(seekCalled, isTrue);
-      });
-
-      test(
-        'does not fire onSeekToZero when position < maxLoopDuration',
-        () async {
-          final controller = FakeController();
-          var seekCalled = false;
-
-          subs.subscribeToLoopEnforcement(
-            0,
-            controller,
-            maxLoopDuration: const Duration(seconds: 5),
-            isCurrent: () => true,
-            isSeekInProgress: () => false,
-            onSeekStarted: () {},
-            onPositionBelowMax: () {},
-            onSeekToZero: () => seekCalled = true,
-          );
-
-          controller.pushState(
-            const DivineVideoPlayerState(
-              status: PlaybackStatus.playing,
-              position: Duration(seconds: 4),
-            ),
-          );
-          await Future<void>.delayed(Duration.zero);
-
-          expect(seekCalled, isFalse);
-        },
-      );
-
-      test('does not fire when isCurrent returns false', () async {
-        final controller = FakeController();
-        var seekCalled = false;
-
-        subs.subscribeToLoopEnforcement(
-          0,
-          controller,
-          maxLoopDuration: const Duration(seconds: 5),
-          isCurrent: () => false,
-          isSeekInProgress: () => false,
-          onSeekStarted: () {},
-          onPositionBelowMax: () {},
-          onSeekToZero: () => seekCalled = true,
-        );
-
-        controller.pushState(
-          const DivineVideoPlayerState(
-            status: PlaybackStatus.playing,
-            position: Duration(seconds: 5),
-          ),
-        );
-        await Future<void>.delayed(Duration.zero);
-
-        expect(seekCalled, isFalse);
-      });
-
-      test('does not fire when isSeekInProgress returns true', () async {
-        final controller = FakeController();
-        var seekCalled = false;
-
-        subs.subscribeToLoopEnforcement(
-          0,
-          controller,
-          maxLoopDuration: const Duration(seconds: 5),
-          isCurrent: () => true,
-          isSeekInProgress: () => true,
-          onSeekStarted: () {},
-          onPositionBelowMax: () {},
-          onSeekToZero: () => seekCalled = true,
-        );
-
-        controller.pushState(
-          const DivineVideoPlayerState(
-            status: PlaybackStatus.playing,
-            position: Duration(seconds: 6),
-          ),
-        );
-        await Future<void>.delayed(Duration.zero);
-
-        expect(seekCalled, isFalse);
-      });
-
-      test('calls onPositionBelowMax when position is below limit', () async {
-        final controller = FakeController();
-        var belowCalled = false;
-
-        subs.subscribeToLoopEnforcement(
-          0,
-          controller,
-          maxLoopDuration: const Duration(seconds: 5),
-          isCurrent: () => true,
-          isSeekInProgress: () => false,
-          onSeekStarted: () {},
-          onPositionBelowMax: () => belowCalled = true,
-          onSeekToZero: () {},
-        );
-
-        controller.pushState(
-          const DivineVideoPlayerState(
-            status: PlaybackStatus.playing,
-            position: Duration(seconds: 3),
-          ),
-        );
-        await Future<void>.delayed(Duration.zero);
-
-        expect(belowCalled, isTrue);
-      });
-    });
-
-    // ------------------------------------------------------------------
     group('subscribeToAutoAdvance', () {
       test(
         'fires onLoopCompleted when position resets from near end',
@@ -224,7 +88,6 @@ void main() {
           subs.subscribeToAutoAdvance(
             0,
             controller,
-            maxLoopDuration: const Duration(seconds: 10),
             endThreshold: const Duration(milliseconds: 200),
             startThreshold: const Duration(milliseconds: 100),
             isCurrent: () => true,
@@ -271,7 +134,6 @@ void main() {
           subs.subscribeToAutoAdvance(
             0,
             controller,
-            maxLoopDuration: const Duration(seconds: 10),
             endThreshold: const Duration(milliseconds: 200),
             startThreshold: const Duration(milliseconds: 100),
             isCurrent: () => true,
@@ -300,7 +162,6 @@ void main() {
           subs.subscribeToAutoAdvance(
             0,
             controller,
-            maxLoopDuration: const Duration(seconds: 10),
             endThreshold: const Duration(milliseconds: 200),
             startThreshold: const Duration(milliseconds: 100),
             isCurrent: () => true,
@@ -347,7 +208,6 @@ void main() {
         subs.subscribeToAutoAdvance(
           0,
           controller,
-          maxLoopDuration: null,
           endThreshold: const Duration(milliseconds: 200),
           startThreshold: const Duration(milliseconds: 100),
           isCurrent: () => false,
@@ -581,31 +441,21 @@ void main() {
 
       test('cancels all four subscription types', () async {
         final controller = FakeController();
-        var seekCalled = false;
+        var errorCalled = false;
         var loopFired = false;
         var dimCalled = false;
+        var firstFrameCalled = false;
 
         subs
           ..subscribeToPlaybackErrors(
             0,
             controller,
             isAlreadyError: () => false,
-            onError: (_, _) {},
-          )
-          ..subscribeToLoopEnforcement(
-            0,
-            controller,
-            maxLoopDuration: const Duration(seconds: 10),
-            isCurrent: () => true,
-            isSeekInProgress: () => false,
-            onSeekStarted: () {},
-            onPositionBelowMax: () {},
-            onSeekToZero: () => seekCalled = true,
+            onError: (_, _) => errorCalled = true,
           )
           ..subscribeToAutoAdvance(
             0,
             controller,
-            maxLoopDuration: const Duration(seconds: 10),
             endThreshold: const Duration(milliseconds: 200),
             startThreshold: const Duration(milliseconds: 100),
             isCurrent: () => true,
@@ -616,6 +466,11 @@ void main() {
             controller,
             onDimensionsReady: () => dimCalled = true,
           )
+          ..subscribeToFirstFrame(
+            0,
+            controller,
+            onFirstFrame: () => firstFrameCalled = true,
+          )
           ..disposeAll();
 
         // After disposeAll none of the callbacks should fire.
@@ -623,17 +478,31 @@ void main() {
           ..pushState(
             const DivineVideoPlayerState(
               status: PlaybackStatus.playing,
-              position: Duration(seconds: 11),
+              position: Duration(milliseconds: 9900),
+              duration: Duration(seconds: 10),
             ),
           )
           ..pushState(
-            const DivineVideoPlayerState(videoWidth: 1920, videoHeight: 1080),
+            const DivineVideoPlayerState(
+              status: PlaybackStatus.playing,
+              position: Duration(milliseconds: 50),
+              duration: Duration(seconds: 10),
+            ),
+          )
+          ..pushState(
+            const DivineVideoPlayerState(
+              status: PlaybackStatus.error,
+              videoWidth: 1920,
+              videoHeight: 1080,
+              isFirstFrameRendered: true,
+            ),
           );
         await Future<void>.delayed(Duration.zero);
 
-        expect(seekCalled, isFalse);
+        expect(errorCalled, isFalse);
         expect(loopFired, isFalse);
         expect(dimCalled, isFalse);
+        expect(firstFrameCalled, isFalse);
       });
     });
   });

--- a/mobile/packages/infinite_video_feed/test/src/services/controller_subscriptions_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/services/controller_subscriptions_test.dart
@@ -201,6 +201,42 @@ void main() {
         },
       );
 
+      test('does not fire when the jump back starts mid-clip', () async {
+        final controller = FakeController();
+        var loopFired = false;
+
+        subs.subscribeToAutoAdvance(
+          0,
+          controller,
+          endThreshold: const Duration(milliseconds: 200),
+          startThreshold: const Duration(milliseconds: 100),
+          isCurrent: () => true,
+          onLoopCompleted: () => loopFired = true,
+        );
+
+        // A stale-playback recovery seek jumps backward from the middle of
+        // the clip. Arming on that would auto-advance a video the viewer is
+        // still watching.
+        controller
+          ..pushState(
+            const DivineVideoPlayerState(
+              status: PlaybackStatus.playing,
+              position: Duration(seconds: 1),
+              duration: Duration(seconds: 10),
+            ),
+          )
+          ..pushState(
+            const DivineVideoPlayerState(
+              status: PlaybackStatus.playing,
+              position: Duration(milliseconds: 50),
+              duration: Duration(seconds: 10),
+            ),
+          );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(loopFired, isFalse);
+      });
+
       test('does not fire when not current', () async {
         final controller = FakeController();
         var loopFired = false;

--- a/mobile/test/widgets/video_feed_item/feed_looping_contract_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_looping_contract_test.dart
@@ -21,6 +21,13 @@ void main() {
     // guard covers all three rather than the one the deleted wiring sat in:
     // the subscription service owns the position stream the old seek fired
     // from, and the app-side call site configures both.
+    //
+    // It matches the spelling, not the value. `_seekKick` already seeks with
+    // a computed duration for stale recovery, so widening to a `seekTo(`
+    // regex would collide with it — the cost is that `seekTo(const
+    // Duration())` reaches zero unseen. Read this as a tripwire for the
+    // regression that shipped three times, not as proof no Dart seek can
+    // reach zero.
     const subscriptionsPath =
         'packages/infinite_video_feed/lib/src/services/'
         'controller_subscriptions.dart';

--- a/mobile/test/widgets/video_feed_item/feed_looping_contract_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_looping_contract_test.dart
@@ -5,22 +5,21 @@ import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 
 void main() {
-  test('feed playback uses native looping instead of 6.3s seek enforcement', () {
-    final feedVideosSource = _dartCodeOnly(
-      'lib/widgets/video_feed_item/feed_videos.dart',
-    );
+  test('feed playback loops natively rather than seeking back to zero', () {
+    // The seek-based enforcement this replaced no longer exists to be passed
+    // (#6445), so what is left to pin is that the loop still happens in the
+    // platform player.
     final pooledPlayerSource = _dartCodeOnly(
       'packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart',
     );
 
     expect(pooledPlayerSource, contains('setLooping(looping: true)'));
-    expect(feedVideosSource, isNot(contains('maxLoopDuration:')));
     expect(
-      feedVideosSource,
-      isNot(contains('maxLoopDuration: VideoEditorConstants.maxDuration')),
+      pooledPlayerSource,
+      isNot(contains('seekTo(Duration.zero)')),
       reason:
-          'Feed playback must not restart long videos with a Dart seek at the '
-          '6.3s recording limit; seek-based restarts create audible seams.',
+          'Feed playback must not restart a video with a Dart seek; '
+          'seek-based restarts create audible seams (#5544).',
     );
   });
 

--- a/mobile/test/widgets/video_feed_item/feed_looping_contract_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_looping_contract_test.dart
@@ -9,18 +9,36 @@ void main() {
     // The seek-based enforcement this replaced no longer exists to be passed
     // (#6445), so what is left to pin is that the loop still happens in the
     // platform player.
-    final pooledPlayerSource = _dartCodeOnly(
-      'packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart',
+    const pooledPlayerPath =
+        'packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart';
+
+    expect(
+      _dartCodeOnly(pooledPlayerPath),
+      contains('setLooping(looping: true)'),
     );
 
-    expect(pooledPlayerSource, contains('setLooping(looping: true)'));
-    expect(
-      pooledPlayerSource,
-      isNot(contains('seekTo(Duration.zero)')),
-      reason:
-          'Feed playback must not restart a video with a Dart seek; '
-          'seek-based restarts create audible seams (#5544).',
-    );
+    // Every layer that holds a controller can hand-roll the restart, so the
+    // guard covers all three rather than the one the deleted wiring sat in:
+    // the subscription service owns the position stream the old seek fired
+    // from, and the app-side call site configures both.
+    const subscriptionsPath =
+        'packages/infinite_video_feed/lib/src/services/'
+        'controller_subscriptions.dart';
+    const seekFreePaths = [
+      pooledPlayerPath,
+      subscriptionsPath,
+      'lib/widgets/video_feed_item/feed_videos.dart',
+    ];
+
+    for (final path in seekFreePaths) {
+      expect(
+        _dartCodeOnly(path),
+        isNot(contains('seekTo(Duration.zero)')),
+        reason:
+            '$path must not restart a video with a Dart seek; '
+            'seek-based restarts create audible seams (#5544).',
+      );
+    }
   });
 
   test('every feed source is opened with the cap applied', () {

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -1184,13 +1184,6 @@ void main() {
             'Without the cap a 60s file referenced by a foreign Nostr client '
             'plays in full in the feed.',
       );
-      expect(
-        feed.maxLoopDuration,
-        isNull,
-        reason:
-            'Length enforcement is a native clip end; a Dart seek back to zero '
-            'creates the audible loop seam #5544 reported.',
-      );
     });
   });
 


### PR DESCRIPTION
## Description

PR #5551 fixed the audible loop seam (#5544) by stopping the feed from passing `maxLoopDuration` — restarting a video with a Dart `seekTo(Duration.zero)` at the 6.3s recording limit both truncated classic Vines and left a seam at the join. The fix was made at the call site; the mechanism itself stayed behind, reachable through a public widget parameter and kept alive only by its own unit tests. A code comment was the only thing standing between us and a regression of a bug users have now reported three separate times (#5544, #6386, #6442). Seamless looping is the thing people cite as what made Vine feel like Vine, so the guard should be structural rather than advisory.

This deletes the machinery:

- `subscribeToLoopEnforcement` and its `_loop` subscription map, plus the matching cancel/dispose handling. This was the seam-producing seek.
- `InfiniteVideoFeed.maxLoopDuration` — field, constructor parameter, and the `if (maxLoopDuration != null)` wiring block — along with the now-orphaned `_loopSeekInProgress` guard set.
- The `maxLoopDuration` plumbing in `subscribeToAutoAdvance`. Auto-advance detection itself is live and needed; the parameter only fed `effectiveEnd = min(maxLoopDuration, duration)`, and with it always null that reduces to `effectiveEnd = duration`, collapsing four dead branches across the initial-state and stream-listener paths.

Behaviour-neutral on `main` by construction — every deleted branch was already unreachable, because no production code supplied the parameter.

**The 7s playback cap is untouched.** It is a separate mechanism: `maxPlaybackDuration` (`AppConstants.maxFeedPlaybackDuration`), applied as a native clip end (`VideoClip.end`) so the loop point stays inside the platform player. Both tests that pin it — the per-`VideoClip` cap-parity check and the app-side wiring assertion — are left in place.

Two deviations from the issue's proposed change, both deliberate:

- The issue asks to delete the explanatory comment at `feed_videos.dart:367`. Half of it is live rationale for why `maxPlaybackDuration` exists and why the cap sits above the recording limit, so only the "deliberately NOT `maxLoopDuration`" warning is gone.
- The issue asks to retire the source-string assertion in `feed_looping_contract_test.dart`. The `maxLoopDuration` half is retired — the type system enforces it now — but it is replaced with `isNot(contains('seekTo(Duration.zero)'))`. That is a different property, not type-enforced, and it is the tripwire the issue actually wants: someone hand-rolling a Dart loop-restart trips it. It scans all three layers that hold a controller — the pooled player, `controller_subscriptions.dart` (where the deleted seek's stream listener lived), and the app-side call site — because scanning only the file the *wiring* sat in would have let the same seek back in one file over. Verified it can fail from both directions: the repo's `dart_code_only.awk` filter over `origin/main`'s copy of the pooled player hits the string once, and injecting the seek into `subscribeToAutoAdvance` turns the test red on the service path.

One test is added rather than deleted. Collapsing `effectiveEnd` rewrote `subscribeToAutoAdvance`'s arming condition, and that condition had no negative case — replacing it with a bare `armed = true;` left the suite green. Since `onVideoLoopCompleted` drives auto-advance, an over-eager arm would skip the viewer to the next video on any backward jump, including the stale-playback recovery seek. The new case pins it: a jump back from mid-clip must not fire.

Also corrected a stale doc line in `fullscreen_feed_bloc.dart` that still credited "loop enforcement" to the FeedVideos player configuration.

**Related Issue:** Closes #6445

The tripwire's comment also names what it does *not* catch, from review: it matches the literal spelling, and `_seekKick` already seeks with a computed duration, so widening to a `seekTo(` regex would collide with stale-playback recovery. `seekTo(const Duration())` reaches zero unseen. It is a tripwire for the regression that shipped three times, not a proof.

## Out of Scope

- `mobile/docs/plans/2025-12-20-video-6s-loop-limit.md` still describes the old seek-based approach. It is a historical planning document, left as a record.
- `_LoadingIndicator` in `pooled_fullscreen_video_feed_screen.dart` carries the last non-doc reference to "loop-enforcement seeks", but the widget is never instantiated — the fix is deleting it, not trimming its comment, and that file is untouched here. Tracked as #6492.
- #6386 ("Perfect Loop") closed as completed on 2026-07-28 via #6430, which trims local clips to the point where both tracks still have content. That landed in the native player and is independent of this cleanup; nothing here touches it.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test --coverage` in `mobile/packages/infinite_video_feed` — 228/228 pass, 726/726 lines (100%, the package's effective floor)
- `flutter test test/widgets/video_feed_item/ test/blocs/fullscreen_feed/` — 394/394 pass
- `git grep maxLoopDuration` returns nothing across the repo
- Mutation-checked both new guards: a bare `armed = true;` fails only the new arming case, and a `seekTo(Duration.zero)` injected into `subscribeToAutoAdvance` fails the widened contract test
- Pre-push hook green
- Manual check on a real Samsung Galaxy: **not run**, deliberately. The sole `InfiniteVideoFeed` construction site never supplied `maxLoopDuration`, so every deleted branch was already unreachable in a shipped build, and the surviving conditions are algebraically identical to the ones they replace. There is no runtime path here for a device to exercise that CI does not. Recording it rather than implying otherwise.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
