### PR TITLE
fix(proofmode): scope App Attest to the publishing account

### DIFF
--- a/mobile/docs/NOSTR_VIDEO_EVENTS.md
+++ b/mobile/docs/NOSTR_VIDEO_EVENTS.md
@@ -138,6 +138,20 @@ from cache on every later proof. A verifier needs two branches:
   attestation nonce binds the current proof hash and the plain nonce check
   applies.
 
+Both branches check against the client data hash the app signs, which is not the
+proof hash itself but `SHA-256(UTF-8(proofHash))` — one more hash over the
+hex-encoded digest, where `proofHash` is the same string the `proofmode` tag
+carries as `videoHash`.
+
+**Replay boundary.** Nothing in this payload binds the event pubkey, and the
+challenge is derivable by anyone holding the video. The three fields can be
+lifted from one event and republished verbatim under a different pubkey carrying
+the same media, and both branches above still pass. A verifier following this
+contract learns that a genuine Apple device attested *this media hash* — not
+that *this publisher's* device did, and not that the publisher holds the key.
+Binding the payload to the publisher means mixing the event pubkey into the
+challenge, which changes what the client signs and is not part of this shape.
+
 Because the key lives for the life of the install, `keyID` and
 `attestationString` are a stable public identifier: every video published from
 one install carries the same pair, including videos published from different

--- a/mobile/docs/NOSTR_VIDEO_EVENTS.md
+++ b/mobile/docs/NOSTR_VIDEO_EVENTS.md
@@ -147,6 +147,13 @@ challenge from the event alone. Because the pubkey is inside it, the payload
 cannot be lifted from one event and republished under a different pubkey
 carrying the same media: the challenge no longer matches.
 
+Legacy iOS payloads published before PR #6490 used
+`SHA-256(UTF-8("<proofHash>"))` and minted a fresh key during proof generation.
+Those payloads have no `assertionString` and are not bound to the event pubkey.
+Verifiers that need to evaluate historical events must branch on publication
+date or another release cutover signal instead of applying the publish-time
+challenge above to every existing iOS event.
+
 **Two branches.** Apple rate limits `generateKey` and `attestKey`, so the Secure
 Enclave key is provisioned on an account's first publish and `keyID` plus
 `attestationString` are replayed from cache afterwards:

--- a/mobile/docs/NOSTR_VIDEO_EVENTS.md
+++ b/mobile/docs/NOSTR_VIDEO_EVENTS.md
@@ -127,35 +127,51 @@ On iOS the tag value is the App Attest payload verbatim:
 }
 ```
 
-Apple rate limits `generateKey` and `attestKey`, so the Secure Enclave key is
-provisioned once per install and `keyID` plus `attestationString` are replayed
-from cache on every later proof. A verifier needs two branches:
+The payload is minted when the event is signed, not when the video is recorded.
+The account a clip goes out under is not fixed until then — a clip can be
+recorded, sit in the library, and be published from an account the user switched
+to afterwards — so only the publish step knows which identity the attestation
+should speak for.
 
-- **`assertionString` present** — verify the assertion against *this* proof's
-  hash. The attestation still proves the key came from a genuine Apple device,
-  but its embedded nonce binds the proof that provisioned the key, not this one.
-- **`assertionString` absent** — this is the provisioning proof, so the
-  attestation nonce binds the current proof hash and the plain nonce check
+**What the client signs.** The challenge is the proof hash and the event pubkey
+joined by a colon, and Apple's client data hash is `SHA-256` over its UTF-8
+bytes:
+
+```
+clientDataHash = SHA-256(UTF-8("<proofHash>:<pubkeyHex>"))
+```
+
+`proofHash` is the same string the `proofmode` tag carries as `videoHash`, and
+`pubkeyHex` is the event's own `pubkey` — so a verifier reconstructs the
+challenge from the event alone. Because the pubkey is inside it, the payload
+cannot be lifted from one event and republished under a different pubkey
+carrying the same media: the challenge no longer matches.
+
+**Two branches.** Apple rate limits `generateKey` and `attestKey`, so the Secure
+Enclave key is provisioned on an account's first publish and `keyID` plus
+`attestationString` are replayed from cache afterwards:
+
+- **`assertionString` present** — verify the assertion against *this* event's
+  client data hash. The attestation still proves the key came from a genuine
+  Apple device, but its embedded nonce binds the event that provisioned the key,
+  not this one.
+- **`assertionString` absent** — this is the provisioning event, so the
+  attestation nonce binds the current client data hash and the plain nonce check
   applies.
 
-Both branches check against the client data hash the app signs, which is not the
-proof hash itself but `SHA-256(UTF-8(proofHash))` — one more hash over the
-hex-encoded digest, where `proofHash` is the same string the `proofmode` tag
-carries as `videoHash`.
+**Assertion counter.** Apple's assertion verification requires checking the
+counter in the assertion's `authenticatorData`: it increments per assertion of
+that key and must be strictly greater than the highest value already seen for
+that `keyID`. A verifier that skips this accepts replayed assertions.
 
-**Replay boundary.** Nothing in this payload binds the event pubkey, and the
-challenge is derivable by anyone holding the video. The three fields can be
-lifted from one event and republished verbatim under a different pubkey carrying
-the same media, and both branches above still pass. A verifier following this
-contract learns that a genuine Apple device attested *this media hash* — not
-that *this publisher's* device did, and not that the publisher holds the key.
-Binding the payload to the publisher means mixing the event pubkey into the
-challenge, which changes what the client signs and is not part of this shape.
-
-Because the key lives for the life of the install, `keyID` and
-`attestationString` are a stable public identifier: every video published from
-one install carries the same pair, including videos published from different
-Nostr accounts on that device. The cache is wiped on uninstall and on a
+**Linkability.** The key is scoped to the Nostr account, not the install: every
+video published from one account carries the same `keyID` and
+`attestationString`, and the counter above is a monotonic sequence over that
+account's publishes. That correlates only videos the account already signed with
+its own pubkey, so it exposes nothing the event does not already carry. It also
+follows Apple's guidance against sharing one App Attest key among several users
+of a device — switching accounts provisions a separate key rather than reusing
+one across identities. Caches are wiped on uninstall and on a
 `DCError.invalidKey` recovery (device restore, OS reset). Nothing consumes these
 fields yet.
 

--- a/mobile/docs/NOSTR_VIDEO_EVENTS.md
+++ b/mobile/docs/NOSTR_VIDEO_EVENTS.md
@@ -115,6 +115,36 @@ parsing is enforced in `mobile/packages/models/lib/src/video_event.dart` and
 | `pgp_fingerprint` | `["pgp_fingerprint", "ABCD1234EFGH5678"]` | PGP public key fingerprint for signature verification |
 | `c2pa_manifest_id` | `["c2pa_manifest_id", "<manifest-id>"]` | Active C2PA manifest identifier when available |
 
+#### `device_attestation` payload (iOS)
+
+On iOS the tag value is the App Attest payload verbatim:
+
+```json
+{
+  "keyID": "<key identifier>",
+  "attestationString": "<base64 attestation object>",
+  "assertionString": "<base64 assertion>"
+}
+```
+
+Apple rate limits `generateKey` and `attestKey`, so the Secure Enclave key is
+provisioned once per install and `keyID` plus `attestationString` are replayed
+from cache on every later proof. A verifier needs two branches:
+
+- **`assertionString` present** — verify the assertion against *this* proof's
+  hash. The attestation still proves the key came from a genuine Apple device,
+  but its embedded nonce binds the proof that provisioned the key, not this one.
+- **`assertionString` absent** — this is the provisioning proof, so the
+  attestation nonce binds the current proof hash and the plain nonce check
+  applies.
+
+Because the key lives for the life of the install, `keyID` and
+`attestationString` are a stable public identifier: every video published from
+one install carries the same pair, including videos published from different
+Nostr accounts on that device. The cache is wiped on uninstall and on a
+`DCError.invalidKey` recovery (device restore, OS reset). Nothing consumes these
+fields yet.
+
 ### Creator Identity Hints
 
 These tags are discovery hints only. They do not replace the event pubkey as the

--- a/mobile/docs/PROOFMODE_ARCHITECTURE.md
+++ b/mobile/docs/PROOFMODE_ARCHITECTURE.md
@@ -92,7 +92,9 @@ final isValid = await keyService.verifySignature(
 **iOS (App Attest)**:
 - Uses `app_device_integrity` plugin
 - Generates hardware-backed attestation tokens
-- Includes challenge nonce to prevent replay attacks
+- Signs a challenge derived from the media proof hash, which binds the payload
+  to the media but not to the publisher — see the replay boundary in
+  [NOSTR_VIDEO_EVENTS.md](NOSTR_VIDEO_EVENTS.md#device_attestation-payload-ios)
 - Always hardware-backed on iOS 14+
 
 **Android (Play Integrity)**:

--- a/mobile/docs/PROOFMODE_ARCHITECTURE.md
+++ b/mobile/docs/PROOFMODE_ARCHITECTURE.md
@@ -90,10 +90,12 @@ final isValid = await keyService.verifySignature(
 **Platform-specific Implementation**:
 
 **iOS (App Attest)**:
-- Uses `app_device_integrity` plugin
+- Uses `app_device_integrity` plugin via `IosDeviceAttestationService`
 - Generates hardware-backed attestation tokens
-- Signs a challenge derived from the media proof hash, which binds the payload
-  to the media but not to the publisher — see the replay boundary in
+- Runs at publish time, not during proof generation: the account the proof is
+  published under is not fixed until the event is signed
+- Signs a challenge over both the media proof hash and the event pubkey, and
+  uses a key scoped to that account — see
   [NOSTR_VIDEO_EVENTS.md](NOSTR_VIDEO_EVENTS.md#device_attestation-payload-ios)
 - Always hardware-backed on iOS 14+
 
@@ -531,12 +533,15 @@ See `docs/MANUAL_TEST_VIDEO_UPLOAD.md` for manual upload verification procedures
 - Non-blocking (async)
 
 **Device Attestation**:
-- iOS App Attest: one network round trip to Apple on first use (`generateKey` +
-  `attestKey`, both rate limited), then local `generateAssertion` per proof. The
-  key id and attestation object are cached in `UserDefaults` for the lifetime of
-  the install. A key that was generated but not attested — Apple throttled or
-  offline — is recorded too, so the next proof retries `attestKey` on it instead
-  of spending a second rate-limited generation.
+- iOS App Attest: one network round trip to Apple on an account's first publish
+  (`generateKey` + `attestKey`, both rate limited), then local
+  `generateAssertion` per publish. The key id and attestation object are cached
+  in `UserDefaults` per account, so switching accounts costs one more round trip
+  rather than re-using another identity's key. A key that was generated but not
+  attested — Apple throttled or offline — is recorded too, so the next publish
+  retries `attestKey` on it instead of spending a second rate-limited
+  generation. A wedged Apple callback is abandoned after 30s so it cannot stall
+  later publishes.
 - Android Play Integrity: ~200-500ms
 - A failed attestation degrades the proof to no `device_attestation` field; it
   never discards the PGP signature or C2PA manifest.

--- a/mobile/docs/PROOFMODE_ARCHITECTURE.md
+++ b/mobile/docs/PROOFMODE_ARCHITECTURE.md
@@ -532,7 +532,9 @@ See `docs/MANUAL_TEST_VIDEO_UPLOAD.md` for manual upload verification procedures
 - iOS App Attest: one network round trip to Apple on first use (`generateKey` +
   `attestKey`, both rate limited), then local `generateAssertion` per proof. The
   key id and attestation object are cached in `UserDefaults` for the lifetime of
-  the install.
+  the install. A key that was generated but not attested — Apple throttled or
+  offline — is recorded too, so the next proof retries `attestKey` on it instead
+  of spending a second rate-limited generation.
 - Android Play Integrity: ~200-500ms
 - A failed attestation degrades the proof to no `device_attestation` field; it
   never discards the PGP signature or C2PA manifest.

--- a/mobile/docs/PROOFMODE_ARCHITECTURE.md
+++ b/mobile/docs/PROOFMODE_ARCHITECTURE.md
@@ -536,6 +536,8 @@ See `docs/MANUAL_TEST_VIDEO_UPLOAD.md` for manual upload verification procedures
 - Android Play Integrity: ~200-500ms
 - A failed attestation degrades the proof to no `device_attestation` field; it
   never discards the PGP signature or C2PA manifest.
+- The published payload shape and the verifier rule that follows from the cache
+  are documented in [NOSTR_VIDEO_EVENTS.md](NOSTR_VIDEO_EVENTS.md#device_attestation-payload-ios).
 
 ## Future Enhancements
 

--- a/mobile/docs/PROOFMODE_ARCHITECTURE.md
+++ b/mobile/docs/PROOFMODE_ARCHITECTURE.md
@@ -529,10 +529,13 @@ See `docs/MANUAL_TEST_VIDEO_UPLOAD.md` for manual upload verification procedures
 - Non-blocking (async)
 
 **Device Attestation**:
-- iOS App Attest: ~100-200ms
+- iOS App Attest: one network round trip to Apple on first use (`generateKey` +
+  `attestKey`, both rate limited), then local `generateAssertion` per proof. The
+  key id and attestation object are cached in `UserDefaults` for the lifetime of
+  the install.
 - Android Play Integrity: ~200-500ms
-- Done once at session start
-- Cached for session duration
+- A failed attestation degrades the proof to no `device_attestation` field; it
+  never discards the PGP signature or C2PA manifest.
 
 ## Future Enhancements
 

--- a/mobile/lib/services/ios_device_attestation_service.dart
+++ b/mobile/lib/services/ios_device_attestation_service.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Mints the iOS App Attest payload that a published video event carries
 // ABOUTME: Binds the media proof hash and the publishing pubkey into the challenge
 
+import 'dart:async';
+
 import 'package:app_device_integrity/app_device_integrity.dart';
 import 'package:flutter/foundation.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -14,10 +16,16 @@ import 'package:unified_logger/unified_logger.dart';
 /// so generation time can neither pick the right key nor bind the challenge to
 /// the identity that ends up on the event.
 class IosDeviceAttestationService {
-  IosDeviceAttestationService({AppDeviceIntegrity? deviceIntegrity})
-    : _deviceIntegrity = deviceIntegrity ?? AppDeviceIntegrity();
+  IosDeviceAttestationService({
+    AppDeviceIntegrity? deviceIntegrity,
+    Duration attestationTimeout = _defaultAttestationTimeout,
+  }) : _deviceIntegrity = deviceIntegrity ?? AppDeviceIntegrity(),
+       _attestationTimeout = attestationTimeout;
 
   final AppDeviceIntegrity _deviceIntegrity;
+  final Duration _attestationTimeout;
+
+  static const _defaultAttestationTimeout = Duration(seconds: 10);
 
   /// Whether this platform mints its device attestation at publish time.
   ///
@@ -63,13 +71,25 @@ class IosDeviceAttestationService {
     }
 
     try {
-      return await _deviceIntegrity.getAttestationServiceSupport(
-        challengeString: challengeFor(
-          proofHash: proofHash,
-          pubkeyHex: pubkeyHex,
-        ),
-        keyScope: pubkeyHex,
-      );
+      return await _deviceIntegrity
+          .getAttestationServiceSupport(
+            challengeString: challengeFor(
+              proofHash: proofHash,
+              pubkeyHex: pubkeyHex,
+            ),
+            keyScope: pubkeyHex,
+          )
+          .timeout(
+            _attestationTimeout,
+            onTimeout: () {
+              Log.warning(
+                '🔐 Device attestation timed out, continuing without it',
+                name: 'IosDeviceAttestation',
+                category: LogCategory.system,
+              );
+              return null;
+            },
+          );
     } catch (e) {
       Log.warning(
         '🔐 Device attestation unavailable, continuing without it: $e',

--- a/mobile/lib/services/ios_device_attestation_service.dart
+++ b/mobile/lib/services/ios_device_attestation_service.dart
@@ -1,0 +1,82 @@
+// ABOUTME: Mints the iOS App Attest payload that a published video event carries
+// ABOUTME: Binds the media proof hash and the publishing pubkey into the challenge
+
+import 'package:app_device_integrity/app_device_integrity.dart';
+import 'package:flutter/foundation.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Produces the iOS App Attest payload attached to a video event at publish
+/// time.
+///
+/// Deliberately not part of proof generation. The account a clip goes out under
+/// is not fixed until the event is signed — a clip can be recorded, sit in the
+/// library, and be published from an account the user switched to afterwards —
+/// so generation time can neither pick the right key nor bind the challenge to
+/// the identity that ends up on the event.
+class IosDeviceAttestationService {
+  IosDeviceAttestationService({AppDeviceIntegrity? deviceIntegrity})
+    : _deviceIntegrity = deviceIntegrity ?? AppDeviceIntegrity();
+
+  final AppDeviceIntegrity _deviceIntegrity;
+
+  /// Whether this platform mints its device attestation at publish time.
+  ///
+  /// Android attests during proof generation with a throwaway hardware key, so
+  /// its payload is already in the proof and publishing must leave it alone.
+  static bool get handlesPublishTimeAttestation =>
+      !kIsWeb && defaultTargetPlatform == TargetPlatform.iOS;
+
+  /// The challenge App Attest signs for [proofHash] published by [pubkeyHex].
+  ///
+  /// Both halves carry weight: the proof hash ties the payload to this media,
+  /// and the pubkey ties it to the account signing the event, so the payload
+  /// cannot be lifted onto someone else's event carrying the same media. What
+  /// Apple actually signs is `SHA-256` over the UTF-8 bytes of this string;
+  /// the verifier contract is written up in
+  /// `mobile/docs/NOSTR_VIDEO_EVENTS.md`.
+  static String challengeFor({
+    required String proofHash,
+    required String pubkeyHex,
+  }) => '$proofHash:$pubkeyHex';
+
+  /// Returns the App Attest payload binding [proofHash] to [pubkeyHex], or
+  /// `null` when the platform cannot produce one.
+  ///
+  /// App Attest needs Apple's attestation servers the first time an account
+  /// uses it, so it fails on the Simulator, offline, and whenever Apple
+  /// throttles the app. None of that invalidates the proof itself — the PGP
+  /// signature and the C2PA manifest stand on their own — so a failure here
+  /// only drops the `device_attestation` field.
+  Future<String?> attestationFor({
+    required String proofHash,
+    required String pubkeyHex,
+  }) async {
+    if (!handlesPublishTimeAttestation) return null;
+
+    if (pubkeyHex.isEmpty) {
+      Log.warning(
+        '🔐 No publishing pubkey to scope device attestation to',
+        name: 'IosDeviceAttestation',
+        category: LogCategory.system,
+      );
+      return null;
+    }
+
+    try {
+      return await _deviceIntegrity.getAttestationServiceSupport(
+        challengeString: challengeFor(
+          proofHash: proofHash,
+          pubkeyHex: pubkeyHex,
+        ),
+        keyScope: pubkeyHex,
+      );
+    } catch (e) {
+      Log.warning(
+        '🔐 Device attestation unavailable, continuing without it: $e',
+        name: 'IosDeviceAttestation',
+        category: LogCategory.system,
+      );
+      return null;
+    }
+  }
+}

--- a/mobile/lib/services/native_proofmode_service.dart
+++ b/mobile/lib/services/native_proofmode_service.dart
@@ -233,17 +233,7 @@ class NativeProofModeService {
 
       //add iOS specific device attestation
       if (!kIsWeb && defaultTargetPlatform == TargetPlatform.iOS) {
-        final appAttestationPlugin = AppDeviceIntegrity();
-        final tokenReceived = await appAttestationPlugin
-            .getAttestationServiceSupport(challengeString: proofHash);
-        if (tokenReceived != null) {
-          final String? proofDir = await _channel.invokeMethod('getProofDir', {
-            'proofHash': proofHash,
-          });
-
-          final deviceAttestation = File('$proofDir/$proofHash.attest');
-          deviceAttestation.writeAsString(tokenReceived);
-        }
+        await _writeIosDeviceAttestation(proofHash);
       }
 
       // Read proof metadata from native library
@@ -295,6 +285,39 @@ class NativeProofModeService {
         category: .video,
       );
       return null;
+    }
+  }
+
+  /// Writes the iOS App Attest token for [proofHash] into its proof directory.
+  ///
+  /// App Attest needs Apple's attestation servers on first use, so it fails on
+  /// the Simulator, offline, and whenever Apple throttles the app. None of that
+  /// invalidates the proof itself — the PGP signature and C2PA manifest stand on
+  /// their own — so a failure here only drops the `device_attestation` field
+  /// instead of discarding the whole proof.
+  static Future<void> _writeIosDeviceAttestation(String proofHash) async {
+    try {
+      final tokenReceived = await AppDeviceIntegrity()
+          .getAttestationServiceSupport(challengeString: proofHash);
+      if (tokenReceived == null) return;
+
+      final proofDir = await getProofDir(proofHash);
+      if (proofDir == null) {
+        Log.warning(
+          '🔐 No proof directory to store device attestation',
+          name: 'NativeProofMode',
+          category: LogCategory.system,
+        );
+        return;
+      }
+
+      await File('$proofDir/$proofHash.attest').writeAsString(tokenReceived);
+    } catch (e) {
+      Log.warning(
+        '🔐 Device attestation unavailable, continuing without it: $e',
+        name: 'NativeProofMode',
+        category: LogCategory.system,
+      );
     }
   }
 

--- a/mobile/lib/services/native_proofmode_service.dart
+++ b/mobile/lib/services/native_proofmode_service.dart
@@ -4,7 +4,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:app_device_integrity/app_device_integrity.dart';
 import 'package:c2pa_flutter/c2pa.dart';
 import 'package:crypto/crypto.dart' as crypto;
 import 'package:flutter/foundation.dart';
@@ -231,10 +230,9 @@ class NativeProofModeService {
         category: .video,
       );
 
-      //add iOS specific device attestation
-      if (!kIsWeb && defaultTargetPlatform == TargetPlatform.iOS) {
-        await _writeIosDeviceAttestation(proofHash);
-      }
+      // iOS App Attest is deliberately absent here: it runs at publish time,
+      // where the account the proof goes out under is known. See
+      // [IosDeviceAttestationService].
 
       // Read proof metadata from native library
       final metadata = await NativeProofModeService.readProofMetadata(
@@ -285,39 +283,6 @@ class NativeProofModeService {
         category: .video,
       );
       return null;
-    }
-  }
-
-  /// Writes the iOS App Attest token for [proofHash] into its proof directory.
-  ///
-  /// App Attest needs Apple's attestation servers on first use, so it fails on
-  /// the Simulator, offline, and whenever Apple throttles the app. None of that
-  /// invalidates the proof itself — the PGP signature and C2PA manifest stand on
-  /// their own — so a failure here only drops the `device_attestation` field
-  /// instead of discarding the whole proof.
-  static Future<void> _writeIosDeviceAttestation(String proofHash) async {
-    try {
-      final tokenReceived = await AppDeviceIntegrity()
-          .getAttestationServiceSupport(challengeString: proofHash);
-      if (tokenReceived == null) return;
-
-      final proofDir = await getProofDir(proofHash);
-      if (proofDir == null) {
-        Log.warning(
-          '🔐 No proof directory to store device attestation',
-          name: 'NativeProofMode',
-          category: LogCategory.system,
-        );
-        return;
-      }
-
-      await File('$proofDir/$proofHash.attest').writeAsString(tokenReceived);
-    } catch (e) {
-      Log.warning(
-        '🔐 Device attestation unavailable, continuing without it: $e',
-        name: 'NativeProofMode',
-        category: LogCategory.system,
-      );
     }
   }
 
@@ -494,7 +459,8 @@ class NativeProofModeService {
         );
       }
 
-      // Read local device attestation info
+      // Written by Android's notarization provider during generation. iOS
+      // leaves this absent and attests at publish time instead.
       final deviceAttestation = File('$proofDir/$proofHash.attest');
       if (deviceAttestation.existsSync()) {
         metadata[NativeProofData.metadataDeviceAttestationKey] =

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -27,6 +27,7 @@ import 'package:openvine/services/audio_extraction_service.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
 import 'package:openvine/services/c2pa_signing_service.dart';
 import 'package:openvine/services/event_api_client.dart';
+import 'package:openvine/services/ios_device_attestation_service.dart';
 import 'package:openvine/services/personal_event_cache_service.dart';
 import 'package:openvine/services/saved_sounds_service.dart';
 import 'package:openvine/services/upload_manager.dart';
@@ -177,7 +178,10 @@ class VideoEventPublisher {
     SavedSoundsService? savedSoundsService,
     EventApiClient? eventApiClient,
     AudioReuseConsentChecker? audioReuseConsentChecker,
-  }) : _uploadManager = uploadManager,
+    IosDeviceAttestationService? iosDeviceAttestationService,
+  }) : _iosDeviceAttestation =
+           iosDeviceAttestationService ?? IosDeviceAttestationService(),
+       _uploadManager = uploadManager,
        _nostrService = nostrService,
        _authService = authService,
        _personalEventCache = personalEventCache,
@@ -199,6 +203,7 @@ class VideoEventPublisher {
   final AudioExtractionService? _audioExtractionService;
   final ProfileStatsDao? _profileStatsDao;
   final SavedSoundsService? _savedSoundsService;
+  final IosDeviceAttestationService _iosDeviceAttestation;
 
   /// REST-first publish client. When non-null, video events are published
   /// via `POST /api/events` first and only fall back to the WebSocket relay
@@ -1610,12 +1615,16 @@ class VideoEventPublisher {
       // Add ProofMode tags if native proof exists
       if (upload.hasProofMode) {
         try {
-          final nativeProof = upload.nativeProof;
-          if (nativeProof != null) {
+          final storedProof = upload.nativeProof;
+          if (storedProof != null) {
             Log.info(
               '📜 Adding ProofMode verification tags to Nostr event',
               name: 'VideoEventPublisher',
               category: LogCategory.video,
+            );
+
+            final nativeProof = await _withPublishDeviceAttestation(
+              storedProof,
             );
 
             //check C2PA metadata
@@ -2025,6 +2034,40 @@ class VideoEventPublisher {
   static bool _isHttpUrl(String? url) {
     if (url == null || url.isEmpty) return false;
     return url.startsWith('http://') || url.startsWith('https://');
+  }
+
+  /// Returns [proof] carrying the device attestation this publish should
+  /// broadcast.
+  ///
+  /// On iOS the payload is minted here rather than at proof generation, because
+  /// only now is the publishing account fixed — the challenge binds it, and the
+  /// App Attest key is scoped to it. That makes the value computed here
+  /// authoritative: it replaces whatever the stored proof carried, so a token
+  /// left behind for a different account cannot ride along. Platforms that
+  /// attest during generation keep what they produced.
+  Future<NativeProofData> _withPublishDeviceAttestation(
+    NativeProofData proof,
+  ) async {
+    if (!IosDeviceAttestationService.handlesPublishTimeAttestation) {
+      return proof;
+    }
+
+    final pubkeyHex = _authService?.currentPublicKeyHex;
+    if (pubkeyHex == null) {
+      Log.warning(
+        'No signing pubkey available - publishing without device attestation',
+        name: 'VideoEventPublisher',
+        category: LogCategory.video,
+      );
+      return proof.withDeviceAttestation(null);
+    }
+
+    return proof.withDeviceAttestation(
+      await _iosDeviceAttestation.attestationFor(
+        proofHash: proof.videoHash,
+        pubkeyHex: pubkeyHex,
+      ),
+    );
   }
 
   void _addIdentityDiscoveryTags(

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -1612,6 +1612,9 @@ class VideoEventPublisher {
         }
       }
 
+      NativeProofData? proofUsedForTags;
+      String? publishDeviceAttestationPubkeyHex;
+
       // Add ProofMode tags if native proof exists
       if (upload.hasProofMode) {
         try {
@@ -1623,9 +1626,13 @@ class VideoEventPublisher {
               category: LogCategory.video,
             );
 
-            final nativeProof = await _withPublishDeviceAttestation(
+            final attestationResult = await _withPublishDeviceAttestation(
               storedProof,
             );
+            final nativeProof = attestationResult.proof;
+            proofUsedForTags = nativeProof;
+            publishDeviceAttestationPubkeyHex =
+                attestationResult.attestedPubkeyHex;
 
             //check C2PA metadata
             final C2paSigningService c2paSigningService = C2paSigningService();
@@ -1743,16 +1750,27 @@ class VideoEventPublisher {
         category: LogCategory.video,
       );
 
-      final reusedEvent = _loadRetryableSignedEvent(upload);
       final signWatch = Stopwatch()..start();
-      final event =
-          reusedEvent ??
-          await _authService.createAndSignEvent(
-            kind:
-                NIP71VideoKinds.getPreferredAddressableKind(), // NIP-71 addressable short video
-            content: content,
-            tags: tags,
-          );
+      final reusedEvent = _loadRetryableSignedEvent(upload);
+      final Event? event;
+      if (reusedEvent != null) {
+        event = reusedEvent;
+      } else {
+        final expectedPubkeyHex = publishDeviceAttestationPubkeyHex;
+        final proof = proofUsedForTags;
+        if (expectedPubkeyHex != null &&
+            proof != null &&
+            _authService.currentPublicKeyHex != expectedPubkeyHex) {
+          _clearPublishDeviceAttestationTags(tags: tags, proof: proof);
+        }
+
+        event = await _authService.createAndSignEvent(
+          kind:
+              NIP71VideoKinds.getPreferredAddressableKind(), // NIP-71 addressable short video
+          content: content,
+          tags: tags,
+        );
+      }
       signWatch.stop();
       logPublishPhase(
         'nostr.sign',
@@ -2045,11 +2063,11 @@ class VideoEventPublisher {
   /// authoritative: it replaces whatever the stored proof carried, so a token
   /// left behind for a different account cannot ride along. Platforms that
   /// attest during generation keep what they produced.
-  Future<NativeProofData> _withPublishDeviceAttestation(
+  Future<_PublishDeviceAttestationResult> _withPublishDeviceAttestation(
     NativeProofData proof,
   ) async {
     if (!IosDeviceAttestationService.handlesPublishTimeAttestation) {
-      return proof;
+      return _PublishDeviceAttestationResult(proof: proof);
     }
 
     final pubkeyHex = _authService?.currentPublicKeyHex;
@@ -2059,14 +2077,64 @@ class VideoEventPublisher {
         name: 'VideoEventPublisher',
         category: LogCategory.video,
       );
-      return proof.withDeviceAttestation(null);
+      return _PublishDeviceAttestationResult(
+        proof: proof.withDeviceAttestation(null),
+      );
     }
 
-    return proof.withDeviceAttestation(
-      await _iosDeviceAttestation.attestationFor(
-        proofHash: proof.videoHash,
-        pubkeyHex: pubkeyHex,
-      ),
+    final attestation = await _iosDeviceAttestation.attestationFor(
+      proofHash: proof.videoHash,
+      pubkeyHex: pubkeyHex,
+    );
+
+    if (attestation == null) {
+      return _PublishDeviceAttestationResult(
+        proof: proof.withDeviceAttestation(null),
+      );
+    }
+
+    if (_authService?.currentPublicKeyHex != pubkeyHex) {
+      Log.warning(
+        'Signing account changed while minting device attestation - '
+        'publishing without device attestation',
+        name: 'VideoEventPublisher',
+        category: LogCategory.video,
+      );
+      return _PublishDeviceAttestationResult(
+        proof: proof.withDeviceAttestation(null),
+      );
+    }
+
+    return _PublishDeviceAttestationResult(
+      proof: proof.withDeviceAttestation(attestation),
+      attestedPubkeyHex: pubkeyHex,
+    );
+  }
+
+  void _clearPublishDeviceAttestationTags({
+    required List<List<String>> tags,
+    required NativeProofData proof,
+  }) {
+    final clearedProof = proof.withDeviceAttestation(null);
+
+    for (var i = 0; i < tags.length; i++) {
+      final tag = tags[i];
+      if (tag.isEmpty) continue;
+
+      switch (tag[0]) {
+        case 'proofmode':
+          tags[i] = ['proofmode', createProofManifestTag(clearedProof)];
+        case 'verification':
+          tags[i] = ['verification', getVerificationLevel(clearedProof)];
+      }
+    }
+
+    tags.removeWhere((tag) => tag.isNotEmpty && tag[0] == 'device_attestation');
+    Log.warning(
+      'Signing account changed before event signing - publishing without '
+      'device attestation',
+      name: 'VideoEventPublisher',
+      category: LogCategory.video,
     );
   }
 
@@ -2129,4 +2197,14 @@ class VideoEventPublisher {
       category: LogCategory.video,
     );
   }
+}
+
+class _PublishDeviceAttestationResult {
+  const _PublishDeviceAttestationResult({
+    required this.proof,
+    this.attestedPubkeyHex,
+  });
+
+  final NativeProofData proof;
+  final String? attestedPubkeyHex;
 }

--- a/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrity.swift
+++ b/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrity.swift
@@ -48,6 +48,21 @@ final class AppDeviceIntegrity {
     private static var isProvisioning = false
     private static var pendingProvisioning: [(Credential?) -> Void] = []
 
+    /// Identifies the in-flight provisioning round.
+    ///
+    /// Incremented by whichever of the real callback or the watchdog finishes
+    /// the round first, so the loser becomes a no-op instead of draining a
+    /// queue that now belongs to a later round.
+    private static var provisioningRound = 0
+
+    /// How long a provisioning round may run before it is failed.
+    ///
+    /// `generateKey` and `attestKey` are network calls to Apple, and nothing
+    /// here can cancel them. Without this, one wedged callback strands every
+    /// later proof behind `isProvisioning` until the app restarts — turning a
+    /// single native hang into a process-wide proof stall.
+    private static let provisioningTimeout: DispatchTimeInterval = .seconds(30)
+
     init?(challengeString: String) {
         self.inputString = challengeString
 
@@ -174,10 +189,21 @@ final class AppDeviceIntegrity {
         }
 
         Self.isProvisioning = true
+        let round = Self.provisioningRound
         Self.lock.unlock()
 
+        Self.startProvisioningWatchdog(for: round)
         provision { credential in
-            self.finishProvisioning(with: credential)
+            Self.finishProvisioning(with: credential, round: round)
+        }
+    }
+
+    /// Fails [round] if it is still running once [provisioningTimeout] elapses.
+    private static func startProvisioningWatchdog(for round: Int) {
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(
+            deadline: .now() + provisioningTimeout
+        ) {
+            finishProvisioning(with: nil, round: round, timedOut: true)
         }
     }
 
@@ -300,19 +326,41 @@ final class AppDeviceIntegrity {
         defaults.removeObject(forKey: StorageKey.pendingClientDataHash)
     }
 
-    private func finishProvisioning(with credential: Credential?) {
-        Self.lock.lock()
+    /// Ends [round], storing [credential] and releasing everyone queued behind
+    /// it.
+    ///
+    /// Runs at most once per round: the real callback and the watchdog race,
+    /// and the loser returns without touching the queue. A late real
+    /// credential is therefore dropped rather than stored, which costs one
+    /// rate-limited generation on the next proof but keeps the cache from
+    /// gaining a key no waiter was told about.
+    private static func finishProvisioning(
+        with credential: Credential?,
+        round: Int,
+        timedOut: Bool = false
+    ) {
+        lock.lock()
+
+        guard isProvisioning, round == provisioningRound else {
+            lock.unlock()
+            return
+        }
+        provisioningRound &+= 1
 
         if let credential = credential {
-            Self.defaults.set(credential.keyID, forKey: StorageKey.keyID)
-            Self.defaults.set(credential.attestation, forKey: StorageKey.attestation)
-            Self.clearPendingKey()
+            defaults.set(credential.keyID, forKey: StorageKey.keyID)
+            defaults.set(credential.attestation, forKey: StorageKey.attestation)
+            clearPendingKey()
         }
 
-        Self.isProvisioning = false
-        let waiting = Self.pendingProvisioning
-        Self.pendingProvisioning = []
-        Self.lock.unlock()
+        isProvisioning = false
+        let waiting = pendingProvisioning
+        pendingProvisioning = []
+        lock.unlock()
+
+        if timedOut {
+            print("App Attest provisioning timed out, failing \(waiting.count) queued challenge(s)")
+        }
 
         // Only the caller that triggered provisioning gets the fresh-attestation
         // shortcut, and only when Apple bound the attestation to that caller's

--- a/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrity.swift
+++ b/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrity.swift
@@ -29,6 +29,8 @@ final class AppDeviceIntegrity {
     private enum StorageKey {
         static let keyID = "AppAttestKeyIdentifier"
         static let attestation = "AppAttestAttestationObject"
+        static let pendingKeyID = "AppAttestPendingKeyIdentifier"
+        static let pendingClientDataHash = "AppAttestPendingClientDataHash"
     }
 
     let inputString: String
@@ -179,7 +181,34 @@ final class AppDeviceIntegrity {
         }
     }
 
+    /// Provisions the install's credential, resuming a key an earlier round
+    /// generated but could not attest.
+    ///
+    /// Apple rate limits `generateKey`, so the identifier is recorded before
+    /// `attestKey` runs and only dropped once the key is either attested or
+    /// rejected outright. A throttled or offline `attestKey` therefore leaves a
+    /// resumable key behind rather than burning a second generation on the next
+    /// proof, which is what Apple's guidance to retry attestation with the same
+    /// key and client data hash amounts to here.
     private func provision(completion: @escaping (Credential?) -> Void) {
+        guard let pending = Self.pendingKey() else {
+            generateAndAttest(completion: completion)
+            return
+        }
+
+        attest(keyID: pending.keyID, clientDataHash: pending.clientDataHash) { credential, keyIsDead in
+            // A resumed key Apple no longer recognises — a device restore
+            // between the two calls — can never be attested. Start over
+            // instead of leaving this proof unattested for nothing.
+            guard keyIsDead else {
+                completion(credential)
+                return
+            }
+            self.generateAndAttest(completion: completion)
+        }
+    }
+
+    private func generateAndAttest(completion: @escaping (Credential?) -> Void) {
         // Captured strongly on purpose: a provisioning round must reach
         // `finishProvisioning` to release the queued challenges, even if the
         // instance that started it is already gone.
@@ -196,28 +225,79 @@ final class AppDeviceIntegrity {
                 return
             }
 
-            self.attestService.attestKey(keyIdentifier, clientDataHash: self.challengeHash) { attestation, error in
-                if let error = error {
-                    print("Attestation error: \(error.localizedDescription)")
-                    completion(nil)
-                    return
-                }
+            let clientDataHash = self.challengeHash
+            Self.storePendingKey(keyID: keyIdentifier, clientDataHash: clientDataHash)
 
-                guard let attestation = attestation else {
-                    print("No attestation object received")
-                    completion(nil)
-                    return
-                }
-
-                completion(
-                    Credential(
-                        keyID: keyIdentifier,
-                        attestation: attestation.base64EncodedString(),
-                        isFresh: true
-                    )
-                )
+            self.attest(keyID: keyIdentifier, clientDataHash: clientDataHash) { credential, _ in
+                completion(credential)
             }
         }
+    }
+
+    /// Attests [keyID] against the [clientDataHash] it was generated for.
+    ///
+    /// [clientDataHash] predates the current challenge whenever a previous
+    /// round generated the key but failed to attest it: Apple attests a key
+    /// once, for the request it accepted, so a retry has to repeat the original
+    /// inputs. The attestation that comes back then binds that earlier proof,
+    /// which is why only a hash matching the current challenge yields a fresh
+    /// credential — anything else has to sign its own assertion.
+    ///
+    /// The completion's second value reports a key Apple rejected as dead,
+    /// which no later retry can revive.
+    private func attest(
+        keyID: String,
+        clientDataHash: Data,
+        completion: @escaping (Credential?, Bool) -> Void
+    ) {
+        attestService.attestKey(keyID, clientDataHash: clientDataHash) { attestation, error in
+            if let error = error {
+                print("Attestation error: \(error.localizedDescription)")
+
+                let keyIsDead = (error as? DCError)?.code == .invalidKey
+                if keyIsDead {
+                    Self.clearPendingKey()
+                }
+                completion(nil, keyIsDead)
+                return
+            }
+
+            guard let attestation = attestation else {
+                print("No attestation object received")
+                completion(nil, false)
+                return
+            }
+
+            completion(
+                Credential(
+                    keyID: keyID,
+                    attestation: attestation.base64EncodedString(),
+                    isFresh: clientDataHash == self.challengeHash
+                ),
+                false
+            )
+        }
+    }
+
+    // The pending slot is only ever touched inside a provisioning round, and
+    // `isProvisioning` admits one of those at a time, so these need no lock of
+    // their own.
+    private static func pendingKey() -> (keyID: String, clientDataHash: Data)? {
+        guard let keyID = defaults.string(forKey: StorageKey.pendingKeyID),
+              let clientDataHash = defaults.data(forKey: StorageKey.pendingClientDataHash) else {
+            return nil
+        }
+        return (keyID, clientDataHash)
+    }
+
+    private static func storePendingKey(keyID: String, clientDataHash: Data) {
+        defaults.set(keyID, forKey: StorageKey.pendingKeyID)
+        defaults.set(clientDataHash, forKey: StorageKey.pendingClientDataHash)
+    }
+
+    private static func clearPendingKey() {
+        defaults.removeObject(forKey: StorageKey.pendingKeyID)
+        defaults.removeObject(forKey: StorageKey.pendingClientDataHash)
     }
 
     private func finishProvisioning(with credential: Credential?) {
@@ -226,6 +306,7 @@ final class AppDeviceIntegrity {
         if let credential = credential {
             Self.defaults.set(credential.keyID, forKey: StorageKey.keyID)
             Self.defaults.set(credential.attestation, forKey: StorageKey.attestation)
+            Self.clearPendingKey()
         }
 
         Self.isProvisioning = false
@@ -234,8 +315,9 @@ final class AppDeviceIntegrity {
         Self.lock.unlock()
 
         // Only the caller that triggered provisioning gets the fresh-attestation
-        // shortcut; the queued challenges were not bound by Apple's attestation
-        // and must sign themselves with an assertion.
+        // shortcut, and only when Apple bound the attestation to that caller's
+        // challenge — a resumed key carries the hash of the proof that
+        // generated it. Everyone else must sign themselves with an assertion.
         for (index, callback) in waiting.enumerated() {
             guard let credential = credential else {
                 callback(nil)
@@ -245,7 +327,7 @@ final class AppDeviceIntegrity {
                 Credential(
                     keyID: credential.keyID,
                     attestation: credential.attestation,
-                    isFresh: index == 0
+                    isFresh: index == 0 && credential.isFresh
                 )
             )
         }

--- a/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrity.swift
+++ b/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrity.swift
@@ -2,18 +2,26 @@ import CryptoKit
 import DeviceCheck
 import Foundation
 
-/// App Attest wrapper that provisions one Secure Enclave key per install and
+/// App Attest wrapper that provisions one Secure Enclave key per key scope and
 /// answers every later challenge with a local assertion.
 ///
 /// `DCAppAttestService.generateKey` and `attestKey` are network round trips to
 /// Apple's attestation servers and Apple rate limits them, so both run only on
-/// first use. The key identifier and attestation object are cached in
-/// `UserDefaults` rather than the Keychain, which survives uninstall: a wiped
-/// cache cannot strand a reinstall on a key that is already gone. A restored
-/// device backup can still hand back an identifier without its Secure Enclave
-/// key, since those keys never leave the device — that is what the
-/// `DCError.invalidKey` re-provisioning path below exists for. Subsequent
+/// the first challenge for a scope. The key identifier and attestation object
+/// are cached in `UserDefaults` rather than the Keychain, which survives
+/// uninstall: a wiped cache cannot strand a reinstall on a key that is already
+/// gone. A restored device backup can still hand back an identifier without its
+/// Secure Enclave key, since those keys never leave the device — that is what
+/// the `DCError.invalidKey` re-provisioning path below exists for. Subsequent
 /// challenges go through `generateAssertion`, which stays on device.
+///
+/// The scope is the account the proof will be published under, not the install.
+/// Apple's App Attest guidance is against sharing one key among several users of
+/// a device, and a per-account key adds no public linkability the event does not
+/// already carry: it can only correlate videos that account already signed.
+/// Every piece of cached state below therefore hangs off the scope, including
+/// the queue of challenges waiting on an in-flight provisioning round — a flat
+/// queue would hand one scope's credential to another scope's waiter.
 @available(iOS 14.0, *)
 final class AppDeviceIntegrity {
     /// A provisioned App Attest key plus the attestation object Apple issued
@@ -26,45 +34,58 @@ final class AppDeviceIntegrity {
         let isFresh: Bool
     }
 
+    /// An in-flight provisioning round and the challenges queued behind it.
+    ///
+    /// `id` is unique across scopes so a watchdog can only ever end the round
+    /// it was armed for.
+    private struct ProvisioningRound {
+        let id: Int
+        var waiting: [(Credential?) -> Void]
+    }
+
     private enum StorageKey {
-        static let keyID = "AppAttestKeyIdentifier"
-        static let attestation = "AppAttestAttestationObject"
-        static let pendingKeyID = "AppAttestPendingKeyIdentifier"
-        static let pendingClientDataHash = "AppAttestPendingClientDataHash"
+        static func keyID(_ scope: String) -> String { "AppAttestKeyIdentifier.\(scope)" }
+        static func attestation(_ scope: String) -> String { "AppAttestAttestationObject.\(scope)" }
+        static func pendingKeyID(_ scope: String) -> String { "AppAttestPendingKeyIdentifier.\(scope)" }
+        static func pendingClientDataHash(_ scope: String) -> String { "AppAttestPendingClientDataHash.\(scope)" }
     }
 
     let inputString: String
+    let keyScope: String
     var attestationString: String?
     var assertionString: String?
 
     private let attestService = DCAppAttestService.shared
     private var keyID: String?
 
-    /// Guards provisioning so concurrent challenges share one key instead of
-    /// racing `generateKey` and burning Apple's rate limit. The cache is static
-    /// alongside it: the queue is shared, so the store it drains into has to be.
+    /// Guards the caches and the provisioning queues so concurrent challenges
+    /// for one scope share a key instead of racing `generateKey` and burning
+    /// Apple's rate limit. The state is static alongside it: the lock is shared,
+    /// so everything it protects has to be.
     private static let defaults = UserDefaults.standard
     private static let lock = NSLock()
-    private static var isProvisioning = false
-    private static var pendingProvisioning: [(Credential?) -> Void] = []
-
-    /// Identifies the in-flight provisioning round.
-    ///
-    /// Incremented by whichever of the real callback or the watchdog finishes
-    /// the round first, so the loser becomes a no-op instead of draining a
-    /// queue that now belongs to a later round.
-    private static var provisioningRound = 0
+    private static var rounds: [String: ProvisioningRound] = [:]
+    private static var nextRoundID = 0
 
     /// How long a provisioning round may run before it is failed.
     ///
     /// `generateKey` and `attestKey` are network calls to Apple, and nothing
     /// here can cancel them. Without this, one wedged callback strands every
-    /// later proof behind `isProvisioning` until the app restarts — turning a
-    /// single native hang into a process-wide proof stall.
+    /// later publish from that account behind its round until the app restarts
+    /// — turning a single native hang into an account-wide publish stall.
     private static let provisioningTimeout: DispatchTimeInterval = .seconds(30)
 
-    init?(challengeString: String) {
+    /// - Parameter keyScope: identifies whose key this is. An empty scope would
+    ///   silently collapse every account back onto one shared key, so it is
+    ///   rejected rather than defaulted.
+    init?(challengeString: String, keyScope: String) {
         self.inputString = challengeString
+        self.keyScope = keyScope
+
+        guard !keyScope.isEmpty else {
+            print("[!] Attest key scope missing")
+            return nil
+        }
 
         guard attestService.isSupported else {
             print("[!] Attest service not available")
@@ -73,7 +94,7 @@ final class AppDeviceIntegrity {
     }
 
     func keyIdentifier() -> String {
-        keyID ?? Self.defaults.string(forKey: StorageKey.keyID) ?? "Error in Key ID"
+        keyID ?? Self.defaults.string(forKey: StorageKey.keyID(keyScope)) ?? "Error in Key ID"
     }
 
     private var challengeHash: Data {
@@ -156,12 +177,13 @@ final class AppDeviceIntegrity {
         }
     }
 
-    /// Hands back the install's credential, provisioning one if the cache is
+    /// Hands back the scope's credential, provisioning one if its cache is
     /// empty. Pass the key that just failed as [staleKeyID] to replace it.
     private func resolveCredential(
         replacing staleKeyID: String?,
         completion: @escaping (Credential?) -> Void
     ) {
+        let scope = keyScope
         Self.lock.lock()
 
         // Clear only while the cache still points at the key that failed. Two
@@ -169,45 +191,45 @@ final class AppDeviceIntegrity {
         // replacement the first recovery already stored would spend another
         // rate-limited key generation for nothing.
         if let staleKeyID = staleKeyID,
-           Self.defaults.string(forKey: StorageKey.keyID) == staleKeyID {
-            Self.defaults.removeObject(forKey: StorageKey.keyID)
-            Self.defaults.removeObject(forKey: StorageKey.attestation)
+           Self.defaults.string(forKey: StorageKey.keyID(scope)) == staleKeyID {
+            Self.defaults.removeObject(forKey: StorageKey.keyID(scope))
+            Self.defaults.removeObject(forKey: StorageKey.attestation(scope))
         }
 
-        if let keyID = Self.defaults.string(forKey: StorageKey.keyID),
-           let attestation = Self.defaults.string(forKey: StorageKey.attestation) {
+        if let keyID = Self.defaults.string(forKey: StorageKey.keyID(scope)),
+           let attestation = Self.defaults.string(forKey: StorageKey.attestation(scope)) {
             Self.lock.unlock()
             completion(Credential(keyID: keyID, attestation: attestation, isFresh: false))
             return
         }
 
-        Self.pendingProvisioning.append(completion)
-
-        if Self.isProvisioning {
+        if Self.rounds[scope] != nil {
+            Self.rounds[scope]?.waiting.append(completion)
             Self.lock.unlock()
             return
         }
 
-        Self.isProvisioning = true
-        let round = Self.provisioningRound
+        let roundID = Self.nextRoundID
+        Self.nextRoundID &+= 1
+        Self.rounds[scope] = ProvisioningRound(id: roundID, waiting: [completion])
         Self.lock.unlock()
 
-        Self.startProvisioningWatchdog(for: round)
+        Self.startProvisioningWatchdog(scope: scope, round: roundID)
         provision { credential in
-            Self.finishProvisioning(with: credential, round: round)
+            Self.finishProvisioning(with: credential, scope: scope, round: roundID)
         }
     }
 
     /// Fails [round] if it is still running once [provisioningTimeout] elapses.
-    private static func startProvisioningWatchdog(for round: Int) {
+    private static func startProvisioningWatchdog(scope: String, round: Int) {
         DispatchQueue.global(qos: .userInitiated).asyncAfter(
             deadline: .now() + provisioningTimeout
         ) {
-            finishProvisioning(with: nil, round: round, timedOut: true)
+            finishProvisioning(with: nil, scope: scope, round: round, timedOut: true)
         }
     }
 
-    /// Provisions the install's credential, resuming a key an earlier round
+    /// Provisions the scope's credential, resuming a key an earlier round
     /// generated but could not attest.
     ///
     /// Apple rate limits `generateKey`, so the identifier is recorded before
@@ -217,7 +239,7 @@ final class AppDeviceIntegrity {
     /// proof, which is what Apple's guidance to retry attestation with the same
     /// key and client data hash amounts to here.
     private func provision(completion: @escaping (Credential?) -> Void) {
-        guard let pending = Self.pendingKey() else {
+        guard let pending = Self.pendingKey(scope: keyScope) else {
             generateAndAttest(completion: completion)
             return
         }
@@ -252,7 +274,7 @@ final class AppDeviceIntegrity {
             }
 
             let clientDataHash = self.challengeHash
-            Self.storePendingKey(keyID: keyIdentifier, clientDataHash: clientDataHash)
+            Self.storePendingKey(scope: self.keyScope, keyID: keyIdentifier, clientDataHash: clientDataHash)
 
             self.attest(keyID: keyIdentifier, clientDataHash: clientDataHash) { credential, _ in
                 completion(credential)
@@ -282,7 +304,7 @@ final class AppDeviceIntegrity {
 
                 let keyIsDead = (error as? DCError)?.code == .invalidKey
                 if keyIsDead {
-                    Self.clearPendingKey()
+                    Self.clearPendingKey(scope: self.keyScope)
                 }
                 completion(nil, keyIsDead)
                 return
@@ -305,29 +327,33 @@ final class AppDeviceIntegrity {
         }
     }
 
-    // The pending slot is only ever touched inside a provisioning round, and
-    // `isProvisioning` admits one of those at a time, so these need no lock of
-    // their own.
-    private static func pendingKey() -> (keyID: String, clientDataHash: Data)? {
-        guard let keyID = defaults.string(forKey: StorageKey.pendingKeyID),
-              let clientDataHash = defaults.data(forKey: StorageKey.pendingClientDataHash) else {
+    // A scope's pending slot is only touched inside its own provisioning round,
+    // and `rounds` admits one of those per scope at a time, so these need no
+    // lock of their own. The one overlap the watchdog opens is a timed-out
+    // round whose Apple callback lands during a later round and clears the
+    // slot that round is using. That costs one rate-limited `generateKey` on
+    // the next publish and can never surface a wrong key, so it is left
+    // unguarded rather than threading round identity through every write.
+    private static func pendingKey(scope: String) -> (keyID: String, clientDataHash: Data)? {
+        guard let keyID = defaults.string(forKey: StorageKey.pendingKeyID(scope)),
+              let clientDataHash = defaults.data(forKey: StorageKey.pendingClientDataHash(scope)) else {
             return nil
         }
         return (keyID, clientDataHash)
     }
 
-    private static func storePendingKey(keyID: String, clientDataHash: Data) {
-        defaults.set(keyID, forKey: StorageKey.pendingKeyID)
-        defaults.set(clientDataHash, forKey: StorageKey.pendingClientDataHash)
+    private static func storePendingKey(scope: String, keyID: String, clientDataHash: Data) {
+        defaults.set(keyID, forKey: StorageKey.pendingKeyID(scope))
+        defaults.set(clientDataHash, forKey: StorageKey.pendingClientDataHash(scope))
     }
 
-    private static func clearPendingKey() {
-        defaults.removeObject(forKey: StorageKey.pendingKeyID)
-        defaults.removeObject(forKey: StorageKey.pendingClientDataHash)
+    private static func clearPendingKey(scope: String) {
+        defaults.removeObject(forKey: StorageKey.pendingKeyID(scope))
+        defaults.removeObject(forKey: StorageKey.pendingClientDataHash(scope))
     }
 
-    /// Ends [round], storing [credential] and releasing everyone queued behind
-    /// it.
+    /// Ends [round] for [scope], storing [credential] and releasing everyone
+    /// queued behind it.
     ///
     /// Runs at most once per round: the real callback and the watchdog race,
     /// and the loser returns without touching the queue. A late real
@@ -336,26 +362,25 @@ final class AppDeviceIntegrity {
     /// gaining a key no waiter was told about.
     private static func finishProvisioning(
         with credential: Credential?,
+        scope: String,
         round: Int,
         timedOut: Bool = false
     ) {
         lock.lock()
 
-        guard isProvisioning, round == provisioningRound else {
+        guard let active = rounds[scope], active.id == round else {
             lock.unlock()
             return
         }
-        provisioningRound &+= 1
+        rounds[scope] = nil
 
         if let credential = credential {
-            defaults.set(credential.keyID, forKey: StorageKey.keyID)
-            defaults.set(credential.attestation, forKey: StorageKey.attestation)
-            clearPendingKey()
+            defaults.set(credential.keyID, forKey: StorageKey.keyID(scope))
+            defaults.set(credential.attestation, forKey: StorageKey.attestation(scope))
+            clearPendingKey(scope: scope)
         }
 
-        isProvisioning = false
-        let waiting = pendingProvisioning
-        pendingProvisioning = []
+        let waiting = active.waiting
         lock.unlock()
 
         if timedOut {

--- a/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrity.swift
+++ b/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrity.swift
@@ -48,6 +48,7 @@ final class AppDeviceIntegrity {
         static func attestation(_ scope: String) -> String { "AppAttestAttestationObject.\(scope)" }
         static func pendingKeyID(_ scope: String) -> String { "AppAttestPendingKeyIdentifier.\(scope)" }
         static func pendingClientDataHash(_ scope: String) -> String { "AppAttestPendingClientDataHash.\(scope)" }
+        static func pendingAttestAttempts(_ scope: String) -> String { "AppAttestPendingAttestAttempts.\(scope)" }
     }
 
     let inputString: String
@@ -66,6 +67,12 @@ final class AppDeviceIntegrity {
     private static let lock = NSLock()
     private static var rounds: [String: ProvisioningRound] = [:]
     private static var nextRoundID = 0
+
+    /// A generated-but-unattested key is retried once with its original client
+    /// data hash, per Apple's guidance. If that retry still cannot produce an
+    /// attestation, the slot is abandoned so one bad pending key cannot strand
+    /// a scope permanently.
+    private static let maxPendingAttestAttempts = 1
 
     /// How long a provisioning round may run before it is failed.
     ///
@@ -244,6 +251,13 @@ final class AppDeviceIntegrity {
             return
         }
 
+        guard pending.attestAttempts < Self.maxPendingAttestAttempts else {
+            Self.clearPendingKey(scope: keyScope)
+            generateAndAttest(completion: completion)
+            return
+        }
+
+        Self.incrementPendingAttestAttempts(scope: keyScope)
         attest(keyID: pending.keyID, clientDataHash: pending.clientDataHash) { credential, keyIsDead in
             // A resumed key Apple no longer recognises — a device restore
             // between the two calls — can never be attested. Start over
@@ -329,27 +343,37 @@ final class AppDeviceIntegrity {
 
     // A scope's pending slot is only touched inside its own provisioning round,
     // and `rounds` admits one of those per scope at a time, so these need no
-    // lock of their own. The one overlap the watchdog opens is a timed-out
-    // round whose Apple callback lands during a later round and clears the
-    // slot that round is using. That costs one rate-limited `generateKey` on
-    // the next publish and can never surface a wrong key, so it is left
-    // unguarded rather than threading round identity through every write.
-    private static func pendingKey(scope: String) -> (keyID: String, clientDataHash: Data)? {
+    // lock of their own. The watchdog can still make a pending key stale: a
+    // timed-out `attestKey` may later succeed, leaving behind a key that Apple
+    // has already attested but the app deliberately did not cache. Bounded
+    // retries below keep that stale slot from surviving forever.
+    private static func pendingKey(scope: String) -> (keyID: String, clientDataHash: Data, attestAttempts: Int)? {
         guard let keyID = defaults.string(forKey: StorageKey.pendingKeyID(scope)),
               let clientDataHash = defaults.data(forKey: StorageKey.pendingClientDataHash(scope)) else {
             return nil
         }
-        return (keyID, clientDataHash)
+        return (
+            keyID,
+            clientDataHash,
+            defaults.integer(forKey: StorageKey.pendingAttestAttempts(scope))
+        )
     }
 
     private static func storePendingKey(scope: String, keyID: String, clientDataHash: Data) {
         defaults.set(keyID, forKey: StorageKey.pendingKeyID(scope))
         defaults.set(clientDataHash, forKey: StorageKey.pendingClientDataHash(scope))
+        defaults.set(0, forKey: StorageKey.pendingAttestAttempts(scope))
+    }
+
+    private static func incrementPendingAttestAttempts(scope: String) {
+        let attemptsKey = StorageKey.pendingAttestAttempts(scope)
+        defaults.set(defaults.integer(forKey: attemptsKey) + 1, forKey: attemptsKey)
     }
 
     private static func clearPendingKey(scope: String) {
         defaults.removeObject(forKey: StorageKey.pendingKeyID(scope))
         defaults.removeObject(forKey: StorageKey.pendingClientDataHash(scope))
+        defaults.removeObject(forKey: StorageKey.pendingAttestAttempts(scope))
     }
 
     /// Ends [round] for [scope], storing [credential] and releasing everyone
@@ -357,9 +381,9 @@ final class AppDeviceIntegrity {
     ///
     /// Runs at most once per round: the real callback and the watchdog race,
     /// and the loser returns without touching the queue. A late real
-    /// credential is therefore dropped rather than stored, which costs one
-    /// rate-limited generation on the next proof but keeps the cache from
-    /// gaining a key no waiter was told about.
+    /// credential is therefore dropped rather than stored. A generated key may
+    /// remain in the pending slot for one later retry, but that retry is bounded
+    /// so a late callback cannot make a scope reuse a doomed pending key forever.
     private static func finishProvisioning(
         with credential: Credential?,
         scope: String,

--- a/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrity.swift
+++ b/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrity.swift
@@ -2,16 +2,49 @@ import CryptoKit
 import DeviceCheck
 import Foundation
 
+/// App Attest wrapper that provisions one Secure Enclave key per install and
+/// answers every later challenge with a local assertion.
+///
+/// `DCAppAttestService.generateKey` and `attestKey` are network round trips to
+/// Apple's attestation servers and Apple rate limits them, so both run only on
+/// first use. The key identifier and attestation object are cached in
+/// `UserDefaults`, which is wiped on uninstall — the same lifetime as the
+/// Secure Enclave key itself, so a stale identifier can never outlive its key.
+/// Subsequent challenges go through `generateAssertion`, which stays on device.
 @available(iOS 14.0, *)
 final class AppDeviceIntegrity {
+    /// A provisioned App Attest key plus the attestation object Apple issued
+    /// for it. `isFresh` marks the credential Apple minted during this call —
+    /// its attestation already binds the current challenge, so no separate
+    /// assertion is needed.
+    private struct Credential {
+        let keyID: String
+        let attestation: String
+        let isFresh: Bool
+    }
+
+    private enum StorageKey {
+        static let keyID = "AppAttestKeyIdentifier"
+        static let attestation = "AppAttestAttestationObject"
+    }
+
     let inputString: String
     var attestationString: String?
-    private let keyName = "AppAttestKeyIdentifier"
+    var assertionString: String?
+
     private let attestService = DCAppAttestService.shared
+    private let defaults: UserDefaults
     private var keyID: String?
 
-    init?(challengeString: String) {
+    /// Guards provisioning so concurrent challenges share one key instead of
+    /// racing `generateKey` and burning Apple's rate limit.
+    private static let lock = NSLock()
+    private static var isProvisioning = false
+    private static var pendingProvisioning: [(Credential?) -> Void] = []
+
+    init?(challengeString: String, defaults: UserDefaults = .standard) {
         self.inputString = challengeString
+        self.defaults = defaults
 
         guard attestService.isSupported else {
             print("[!] Attest service not available")
@@ -19,60 +52,190 @@ final class AppDeviceIntegrity {
         }
     }
 
-    func generateKeyAndAttest(completion: @escaping (Bool) -> Void) {
-        attestService.generateKey { [weak self] keyIdentifier, error in
-            guard let self = self else { return }
+    func keyIdentifier() -> String {
+        keyID ?? defaults.string(forKey: StorageKey.keyID) ?? "Error in Key ID"
+    }
 
+    private var challengeHash: Data {
+        Data(SHA256.hash(data: Data(inputString.utf8)))
+    }
+
+    func generateKeyAndAttest(completion: @escaping (Bool) -> Void) {
+        resolveCredential(forceRefresh: false) { [weak self] credential in
+            guard let self = self, let credential = credential else {
+                completion(false)
+                return
+            }
+            self.bind(credential, allowReprovision: true, completion: completion)
+        }
+    }
+
+    /// Ties [credential] to the current challenge, re-provisioning once if the
+    /// cached key turns out to be dead.
+    private func bind(
+        _ credential: Credential,
+        allowReprovision: Bool,
+        completion: @escaping (Bool) -> Void
+    ) {
+        keyID = credential.keyID
+        attestationString = credential.attestation
+
+        if credential.isFresh {
+            completion(true)
+            return
+        }
+
+        makeAssertion(keyID: credential.keyID) { [weak self] assertion, errorCode in
+            guard let self = self else {
+                completion(false)
+                return
+            }
+
+            if let assertion = assertion {
+                self.assertionString = assertion
+                completion(true)
+                return
+            }
+
+            // Anything but a dead key is a transient failure; re-provisioning
+            // would only spend another rate-limited key generation.
+            guard allowReprovision, errorCode == .invalidKey else {
+                completion(false)
+                return
+            }
+
+            print("App Attest key no longer valid, re-provisioning")
+            self.resolveCredential(forceRefresh: true) { refreshed in
+                guard let refreshed = refreshed else {
+                    completion(false)
+                    return
+                }
+                self.bind(refreshed, allowReprovision: false, completion: completion)
+            }
+        }
+    }
+
+    private func makeAssertion(
+        keyID: String,
+        completion: @escaping (String?, DCError.Code?) -> Void
+    ) {
+        attestService.generateAssertion(keyID, clientDataHash: challengeHash) { assertion, error in
+            if let error = error {
+                print("Assertion error: \(error.localizedDescription)")
+                completion(nil, (error as? DCError)?.code)
+                return
+            }
+
+            guard let assertion = assertion else {
+                print("No assertion object received")
+                completion(nil, nil)
+                return
+            }
+
+            completion(assertion.base64EncodedString(), nil)
+        }
+    }
+
+    private func resolveCredential(
+        forceRefresh: Bool,
+        completion: @escaping (Credential?) -> Void
+    ) {
+        Self.lock.lock()
+
+        if forceRefresh {
+            defaults.removeObject(forKey: StorageKey.keyID)
+            defaults.removeObject(forKey: StorageKey.attestation)
+        } else if let keyID = defaults.string(forKey: StorageKey.keyID),
+                  let attestation = defaults.string(forKey: StorageKey.attestation) {
+            Self.lock.unlock()
+            completion(Credential(keyID: keyID, attestation: attestation, isFresh: false))
+            return
+        }
+
+        Self.pendingProvisioning.append(completion)
+
+        if Self.isProvisioning {
+            Self.lock.unlock()
+            return
+        }
+
+        Self.isProvisioning = true
+        Self.lock.unlock()
+
+        provision { credential in
+            self.finishProvisioning(with: credential)
+        }
+    }
+
+    private func provision(completion: @escaping (Credential?) -> Void) {
+        // Captured strongly on purpose: a provisioning round must reach
+        // `finishProvisioning` to release the queued challenges, even if the
+        // instance that started it is already gone.
+        attestService.generateKey { keyIdentifier, error in
             if let error = error {
                 print("Key generation error: \(error.localizedDescription)")
-                completion(false)
+                completion(nil)
                 return
             }
 
             guard let keyIdentifier = keyIdentifier else {
                 print("Failed to generate key identifier")
-                completion(false)
+                completion(nil)
                 return
             }
 
-            self.keyID = keyIdentifier
-            self.preAttestation(completion: completion)
+            self.attestService.attestKey(keyIdentifier, clientDataHash: self.challengeHash) { attestation, error in
+                if let error = error {
+                    print("Attestation error: \(error.localizedDescription)")
+                    completion(nil)
+                    return
+                }
+
+                guard let attestation = attestation else {
+                    print("No attestation object received")
+                    completion(nil)
+                    return
+                }
+
+                completion(
+                    Credential(
+                        keyID: keyIdentifier,
+                        attestation: attestation.base64EncodedString(),
+                        isFresh: true
+                    )
+                )
+            }
         }
     }
 
-    func keyIdentifier() -> String {
-        return ("\(self.keyID ?? "Error in Key ID")")
-    }
+    private func finishProvisioning(with credential: Credential?) {
+        Self.lock.lock()
 
-    // Pre-attestation process
-    private func preAttestation(completion: @escaping (Bool) -> Void) {
-        guard let keyID = self.keyID else {
-            print("No key ID available for attestation")
-            completion(false)
-            return
+        if let credential = credential {
+            defaults.set(credential.keyID, forKey: StorageKey.keyID)
+            defaults.set(credential.attestation, forKey: StorageKey.attestation)
         }
 
-        let challenge = Data(self.inputString.utf8)
-        let hash = Data(SHA256.hash(data: challenge))
+        Self.isProvisioning = false
+        let waiting = Self.pendingProvisioning
+        Self.pendingProvisioning = []
+        Self.lock.unlock()
 
-        attestService.attestKey(keyID, clientDataHash: hash) { [weak self] attestation, error in
-            guard let self = self else { return }
-
-            if let error = error {
-                print("Attestation error: \(error.localizedDescription)")
-                completion(false)
-                return
+        // Only the caller that triggered provisioning gets the fresh-attestation
+        // shortcut; the queued challenges were not bound by Apple's attestation
+        // and must sign themselves with an assertion.
+        for (index, callback) in waiting.enumerated() {
+            guard let credential = credential else {
+                callback(nil)
+                continue
             }
-
-            guard let attestationObject = attestation else {
-                print("No attestation object received")
-                completion(false)
-                return
-            }
-
-            self.attestationString = attestationObject.base64EncodedString()
-            print("Attestation successful")
-            completion(true)
+            callback(
+                Credential(
+                    keyID: credential.keyID,
+                    attestation: credential.attestation,
+                    isFresh: index == 0
+                )
+            )
         }
     }
 }

--- a/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrity.swift
+++ b/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrity.swift
@@ -8,9 +8,12 @@ import Foundation
 /// `DCAppAttestService.generateKey` and `attestKey` are network round trips to
 /// Apple's attestation servers and Apple rate limits them, so both run only on
 /// first use. The key identifier and attestation object are cached in
-/// `UserDefaults`, which is wiped on uninstall — the same lifetime as the
-/// Secure Enclave key itself, so a stale identifier can never outlive its key.
-/// Subsequent challenges go through `generateAssertion`, which stays on device.
+/// `UserDefaults` rather than the Keychain, which survives uninstall: a wiped
+/// cache cannot strand a reinstall on a key that is already gone. A restored
+/// device backup can still hand back an identifier without its Secure Enclave
+/// key, since those keys never leave the device — that is what the
+/// `DCError.invalidKey` re-provisioning path below exists for. Subsequent
+/// challenges go through `generateAssertion`, which stays on device.
 @available(iOS 14.0, *)
 final class AppDeviceIntegrity {
     /// A provisioned App Attest key plus the attestation object Apple issued
@@ -33,18 +36,18 @@ final class AppDeviceIntegrity {
     var assertionString: String?
 
     private let attestService = DCAppAttestService.shared
-    private let defaults: UserDefaults
     private var keyID: String?
 
     /// Guards provisioning so concurrent challenges share one key instead of
-    /// racing `generateKey` and burning Apple's rate limit.
+    /// racing `generateKey` and burning Apple's rate limit. The cache is static
+    /// alongside it: the queue is shared, so the store it drains into has to be.
+    private static let defaults = UserDefaults.standard
     private static let lock = NSLock()
     private static var isProvisioning = false
     private static var pendingProvisioning: [(Credential?) -> Void] = []
 
-    init?(challengeString: String, defaults: UserDefaults = .standard) {
+    init?(challengeString: String) {
         self.inputString = challengeString
-        self.defaults = defaults
 
         guard attestService.isSupported else {
             print("[!] Attest service not available")
@@ -53,7 +56,7 @@ final class AppDeviceIntegrity {
     }
 
     func keyIdentifier() -> String {
-        keyID ?? defaults.string(forKey: StorageKey.keyID) ?? "Error in Key ID"
+        keyID ?? Self.defaults.string(forKey: StorageKey.keyID) ?? "Error in Key ID"
     }
 
     private var challengeHash: Data {
@@ -143,10 +146,10 @@ final class AppDeviceIntegrity {
         Self.lock.lock()
 
         if forceRefresh {
-            defaults.removeObject(forKey: StorageKey.keyID)
-            defaults.removeObject(forKey: StorageKey.attestation)
-        } else if let keyID = defaults.string(forKey: StorageKey.keyID),
-                  let attestation = defaults.string(forKey: StorageKey.attestation) {
+            Self.defaults.removeObject(forKey: StorageKey.keyID)
+            Self.defaults.removeObject(forKey: StorageKey.attestation)
+        } else if let keyID = Self.defaults.string(forKey: StorageKey.keyID),
+                  let attestation = Self.defaults.string(forKey: StorageKey.attestation) {
             Self.lock.unlock()
             completion(Credential(keyID: keyID, attestation: attestation, isFresh: false))
             return
@@ -212,8 +215,8 @@ final class AppDeviceIntegrity {
         Self.lock.lock()
 
         if let credential = credential {
-            defaults.set(credential.keyID, forKey: StorageKey.keyID)
-            defaults.set(credential.attestation, forKey: StorageKey.attestation)
+            Self.defaults.set(credential.keyID, forKey: StorageKey.keyID)
+            Self.defaults.set(credential.attestation, forKey: StorageKey.attestation)
         }
 
         Self.isProvisioning = false

--- a/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrity.swift
+++ b/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrity.swift
@@ -64,7 +64,7 @@ final class AppDeviceIntegrity {
     }
 
     func generateKeyAndAttest(completion: @escaping (Bool) -> Void) {
-        resolveCredential(forceRefresh: false) { [weak self] credential in
+        resolveCredential(replacing: nil) { [weak self] credential in
             guard let self = self, let credential = credential else {
                 completion(false)
                 return
@@ -108,7 +108,7 @@ final class AppDeviceIntegrity {
             }
 
             print("App Attest key no longer valid, re-provisioning")
-            self.resolveCredential(forceRefresh: true) { refreshed in
+            self.resolveCredential(replacing: credential.keyID) { refreshed in
                 guard let refreshed = refreshed else {
                     completion(false)
                     return
@@ -139,17 +139,26 @@ final class AppDeviceIntegrity {
         }
     }
 
+    /// Hands back the install's credential, provisioning one if the cache is
+    /// empty. Pass the key that just failed as [staleKeyID] to replace it.
     private func resolveCredential(
-        forceRefresh: Bool,
+        replacing staleKeyID: String?,
         completion: @escaping (Credential?) -> Void
     ) {
         Self.lock.lock()
 
-        if forceRefresh {
+        // Clear only while the cache still points at the key that failed. Two
+        // assertions can fail on the same dead key, and dropping the
+        // replacement the first recovery already stored would spend another
+        // rate-limited key generation for nothing.
+        if let staleKeyID = staleKeyID,
+           Self.defaults.string(forKey: StorageKey.keyID) == staleKeyID {
             Self.defaults.removeObject(forKey: StorageKey.keyID)
             Self.defaults.removeObject(forKey: StorageKey.attestation)
-        } else if let keyID = Self.defaults.string(forKey: StorageKey.keyID),
-                  let attestation = Self.defaults.string(forKey: StorageKey.attestation) {
+        }
+
+        if let keyID = Self.defaults.string(forKey: StorageKey.keyID),
+           let attestation = Self.defaults.string(forKey: StorageKey.attestation) {
             Self.lock.unlock()
             completion(Credential(keyID: keyID, attestation: attestation, isFresh: false))
             return

--- a/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrityPlugin.swift
+++ b/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrityPlugin.swift
@@ -13,7 +13,8 @@ public class AppDeviceIntegrityPlugin: NSObject, FlutterPlugin {
         switch call.method {
         case "getAttestationServiceSupport":
             guard let args = call.arguments as? [String: Any],
-                let challengeString = args["challengeString"] as? String
+                let challengeString = args["challengeString"] as? String,
+                let keyScope = args["keyScope"] as? String
             else {
                 result(FlutterError(code: "-3", message: "Invalid arguments", details: nil))
                 return
@@ -21,10 +22,10 @@ public class AppDeviceIntegrityPlugin: NSObject, FlutterPlugin {
 
             // App Attest hits the Secure Enclave and Apple's attestation
             // servers. Flutter delivers channel calls on the main thread, so
-            // doing that work here froze the UI for ~200ms after every
-            // recording. Stay off-main and only hop back to deliver the result.
+            // doing that work here froze the UI for ~200ms on every call.
+            // Stay off-main and only hop back to deliver the result.
             DispatchQueue.global(qos: .userInitiated).async {
-                guard let deviceIntegrity = AppDeviceIntegrity(challengeString: challengeString) else {
+                guard let deviceIntegrity = AppDeviceIntegrity(challengeString: challengeString, keyScope: keyScope) else {
                     DispatchQueue.main.async {
                         result(FlutterError(code: "-4", message: "Failed to initialize AppDeviceIntegrity", details: nil))
                     }

--- a/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrityPlugin.swift
+++ b/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrityPlugin.swift
@@ -37,11 +37,17 @@ public class AppDeviceIntegrityPlugin: NSObject, FlutterPlugin {
                     // several KB of base64.
                     let payload: Any
                     if success {
-                        // Attestation successful, return the attestationString
-                        let attestationResult = [
+                        // The attestation proves the key came from a genuine
+                        // Apple device; the assertion — present on every
+                        // challenge after the key was provisioned — proves this
+                        // specific challenge was signed by that key.
+                        var attestationResult = [
                             "attestationString": deviceIntegrity.attestationString ?? "",
                             "keyID": deviceIntegrity.keyIdentifier()
                         ]
+                        if let assertion = deviceIntegrity.assertionString {
+                            attestationResult["assertionString"] = assertion
+                        }
 
                         do {
                             let jsonData = try JSONEncoder().encode(attestationResult)

--- a/mobile/overrides/app_device_integrity-1.1.0/lib/app_device_integrity.dart
+++ b/mobile/overrides/app_device_integrity-1.1.0/lib/app_device_integrity.dart
@@ -3,14 +3,18 @@ import 'dart:io';
 import 'app_device_integrity_platform_interface.dart';
 
 class AppDeviceIntegrity {
+  /// [keyScope] selects which cached App Attest key answers the challenge on
+  /// iOS. Apple's guidance is against sharing one key among several users of a
+  /// device, so callers pass the identity the attestation speaks for. Ignored
+  /// on Android, which mints a throwaway key per call.
   Future<String?> getAttestationServiceSupport(
-      {required String challengeString, int? gcp}) {
+      {required String challengeString, int? gcp, String? keyScope}) {
     if (Platform.isAndroid) {
       return AppDeviceIntegrityPlatform.instance.getAttestationServiceSupport(
           challengeString: challengeString, gcp: gcp!);
     }
 
-    return AppDeviceIntegrityPlatform.instance
-        .getAttestationServiceSupport(challengeString: challengeString);
+    return AppDeviceIntegrityPlatform.instance.getAttestationServiceSupport(
+        challengeString: challengeString, keyScope: keyScope);
   }
 }

--- a/mobile/overrides/app_device_integrity-1.1.0/lib/app_device_integrity_method_channel.dart
+++ b/mobile/overrides/app_device_integrity-1.1.0/lib/app_device_integrity_method_channel.dart
@@ -11,10 +11,13 @@ class MethodChannelAppDeviceIntegrity extends AppDeviceIntegrityPlatform {
 
   @override
   Future<String?> getAttestationServiceSupport(
-      {required String challengeString, int? gcp}) async {
-    final token = await methodChannel.invokeMethod<String>(
-        'getAttestationServiceSupport',
-        <String, dynamic>{'challengeString': challengeString, 'gcp': gcp});
+      {required String challengeString, int? gcp, String? keyScope}) async {
+    final token = await methodChannel
+        .invokeMethod<String>('getAttestationServiceSupport', <String, dynamic>{
+      'challengeString': challengeString,
+      'gcp': gcp,
+      'keyScope': keyScope,
+    });
     return token;
   }
 }

--- a/mobile/overrides/app_device_integrity-1.1.0/lib/app_device_integrity_platform_interface.dart
+++ b/mobile/overrides/app_device_integrity-1.1.0/lib/app_device_integrity_platform_interface.dart
@@ -24,8 +24,12 @@ abstract class AppDeviceIntegrityPlatform extends PlatformInterface {
     _instance = instance;
   }
 
+  /// [keyScope] selects which cached App Attest key answers the challenge on
+  /// iOS. Apple's guidance is against sharing one key among several users of a
+  /// device, so callers pass the identity the attestation speaks for. Ignored
+  /// on Android, which mints a throwaway key per call.
   Future<String?> getAttestationServiceSupport(
-      {required String challengeString, int? gcp}) {
+      {required String challengeString, int? gcp, String? keyScope}) {
     throw UnimplementedError('platformVersion() has not been implemented.');
   }
 }

--- a/mobile/packages/models/lib/src/native_proof_data.dart
+++ b/mobile/packages/models/lib/src/native_proof_data.dart
@@ -109,6 +109,25 @@ class NativeProofData {
       'verifiedIdentityBundleJson': verifiedIdentityBundleJson,
   };
 
+  /// Copy carrying exactly [attestation] as its device attestation.
+  ///
+  /// Takes the value verbatim, `null` included, so a caller that owns the field
+  /// can clear a stale token as well as set a fresh one — which a nullable
+  /// `copyWith` parameter cannot express.
+  NativeProofData withDeviceAttestation(String? attestation) => NativeProofData(
+    videoHash: videoHash,
+    sensorDataCsv: sensorDataCsv,
+    pgpSignature: pgpSignature,
+    publicKey: publicKey,
+    deviceAttestation: attestation,
+    timestamp: timestamp,
+    c2paManifestId: c2paManifestId,
+    creatorBindingAssertionLabel: creatorBindingAssertionLabel,
+    cawgIdentityAssertionLabel: cawgIdentityAssertionLabel,
+    creatorBindingPayloadJson: creatorBindingPayloadJson,
+    verifiedIdentityBundleJson: verifiedIdentityBundleJson,
+  );
+
   /// Check if creator identity metadata was attached to the proof payload
   bool get hasCreatorIdentityMetadata =>
       creatorBindingAssertionLabel != null ||

--- a/mobile/packages/models/test/src/pending_upload_proofmode_test.dart
+++ b/mobile/packages/models/test/src/pending_upload_proofmode_test.dart
@@ -200,6 +200,26 @@ void main() {
       expect(noAttestation.hasMobileAttestation, isFalse);
     });
 
+    test('NativeProofData withDeviceAttestation swaps only that field', () {
+      final replaced = testProofData.withDeviceAttestation('fresh_token');
+
+      expect(replaced.deviceAttestation, equals('fresh_token'));
+      expect(
+        replaced.toJson()..remove('deviceAttestation'),
+        equals(testProofData.toJson()..remove('deviceAttestation')),
+        reason:
+            'dropping a field here would silently weaken the published '
+            'proof',
+      );
+    });
+
+    test('NativeProofData withDeviceAttestation clears the field', () {
+      expect(
+        testProofData.withDeviceAttestation(null).deviceAttestation,
+        isNull,
+      );
+    });
+
     test('NativeProofData verificationLevel returns correct levels', () {
       // Full mobile verification
       expect(testProofData.verificationLevel, equals('verified_mobile'));

--- a/mobile/packages/models/test/src/pending_upload_proofmode_test.dart
+++ b/mobile/packages/models/test/src/pending_upload_proofmode_test.dart
@@ -25,6 +25,11 @@ void main() {
             '-----BEGIN PGP PUBLIC KEY BLOCK-----\ntest_public_key\n-----END PGP PUBLIC KEY BLOCK-----',
         deviceAttestation: 'attestation_token_xyz',
         timestamp: '2025-01-01T10:00:06Z',
+        c2paManifestId: 'urn:c2pa:test-manifest',
+        creatorBindingAssertionLabel: 'nostr.creator',
+        cawgIdentityAssertionLabel: 'cawg.identity',
+        creatorBindingPayloadJson: '{"pubkey":"pubkey123"}',
+        verifiedIdentityBundleJson: '{"issuer":"identity.example"}',
       );
 
       testProofJson = jsonEncode(testProofData.toJson());

--- a/mobile/scripts/baseline/skip_tests.txt
+++ b/mobile/scripts/baseline/skip_tests.txt
@@ -52,7 +52,6 @@ test/services/nostr_key_manager_contacts_fetch_test.dart
 test/services/profile_editing_test.dart
 test/services/reactive_pagination_test.dart
 test/services/upload_manager_thumbnail_test.dart
-test/services/video_event_publisher_native_proof_test.dart
 test/services/video_event_service_deduplication_test.dart
 test/services/video_event_service_replaceable_test.dart
 test/services/video_event_service_repost_test.dart

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -3044,6 +3044,15 @@ void main() {
       return orphan;
     }
 
+    Future<void> expectFileReaped(File file, {required String reason}) async {
+      for (var attempt = 0; attempt < 20; attempt++) {
+        await pumpEventQueue();
+        if (!file.existsSync()) return;
+      }
+
+      expect(file.existsSync(), isFalse, reason: reason);
+    }
+
     test('an autosave keeps its orphaned files alive', () async {
       final orphan = stubDeferringAutosave();
       final notifier = container.read(videoEditorProvider.notifier);
@@ -3086,11 +3095,9 @@ void main() {
 
       // Drives the real ref.onDispose wiring, not the @visibleForTesting flush.
       disposeContainer();
-      await pumpEventQueue();
 
-      expect(
-        orphan.existsSync(),
-        isFalse,
+      await expectFileReaped(
+        orphan,
         reason: 'onDispose reaps deferred files left when reset never ran',
       );
     });

--- a/mobile/test/services/ios_device_attestation_service_test.dart
+++ b/mobile/test/services/ios_device_attestation_service_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/ios_device_attestation_service.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const attestationChannel = MethodChannel('app_attestation');
+  const proofHash =
+      'bfe97053586981c5d2373625c3ee921d8af88c79fca442e189a82230d99bdc78';
+  const pubkeyHex =
+      '3f8a1c5d2e4b6079a1c3e5d7b9f0246813579bdf02468ace13579bdf02468ace';
+
+  late IosDeviceAttestationService service;
+
+  setUp(() async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    service = IosDeviceAttestationService();
+    await LogCaptureService().clearAllLogs();
+  });
+
+  tearDown(() async {
+    debugDefaultTargetPlatformOverride = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(attestationChannel, null);
+    await LogCaptureService().clearAllLogs();
+  });
+
+  group(IosDeviceAttestationService, () {
+    test('signs a challenge binding the proof hash to the publisher', () async {
+      MethodCall? received;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(attestationChannel, (call) async {
+            received = call;
+            return '{"keyID":"k1","attestationString":"a1"}';
+          });
+
+      final payload = await service.attestationFor(
+        proofHash: proofHash,
+        pubkeyHex: pubkeyHex,
+      );
+
+      expect(payload, '{"keyID":"k1","attestationString":"a1"}');
+      final arguments = received!.arguments as Map<Object?, Object?>;
+      expect(arguments['challengeString'], '$proofHash:$pubkeyHex');
+      expect(
+        arguments['keyScope'],
+        pubkeyHex,
+        reason: 'the key must be scoped to the account, not the install',
+      );
+    });
+
+    test('degrades to no attestation when App Attest fails', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(attestationChannel, (call) async {
+            throw PlatformException(code: '-5', message: 'Attestation failed');
+          });
+
+      final payload = await service.attestationFor(
+        proofHash: proofHash,
+        pubkeyHex: pubkeyHex,
+      );
+
+      expect(payload, isNull);
+      expect(
+        LogCaptureService().getRecentLogs().where(
+          (log) => log.message.contains('Device attestation unavailable'),
+        ),
+        isNotEmpty,
+      );
+    });
+
+    test('does not attest without an account to scope the key to', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            attestationChannel,
+            (call) async => fail('App Attest must not run unscoped'),
+          );
+
+      final payload = await service.attestationFor(
+        proofHash: proofHash,
+        pubkeyHex: '',
+      );
+
+      expect(payload, isNull);
+    });
+
+    test('leaves platforms that attest at generation time alone', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            attestationChannel,
+            (call) async => fail('Android attests during proof generation'),
+          );
+
+      expect(
+        IosDeviceAttestationService.handlesPublishTimeAttestation,
+        isFalse,
+      );
+      expect(
+        await service.attestationFor(
+          proofHash: proofHash,
+          pubkeyHex: pubkeyHex,
+        ),
+        isNull,
+      );
+    });
+  });
+}

--- a/mobile/test/services/ios_device_attestation_service_test.dart
+++ b/mobile/test/services/ios_device_attestation_service_test.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:app_device_integrity/app_device_integrity.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -72,6 +75,26 @@ void main() {
       );
     });
 
+    test('times out when App Attest never answers', () async {
+      service = IosDeviceAttestationService(
+        deviceIntegrity: _NeverCompletingAppDeviceIntegrity(),
+        attestationTimeout: const Duration(milliseconds: 1),
+      );
+
+      final payload = await service.attestationFor(
+        proofHash: proofHash,
+        pubkeyHex: pubkeyHex,
+      );
+
+      expect(payload, isNull);
+      expect(
+        LogCaptureService().getRecentLogs().where(
+          (log) => log.message.contains('Device attestation timed out'),
+        ),
+        isNotEmpty,
+      );
+    });
+
     test('does not attest without an account to scope the key to', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(
@@ -108,4 +131,13 @@ void main() {
       );
     });
   });
+}
+
+class _NeverCompletingAppDeviceIntegrity extends AppDeviceIntegrity {
+  @override
+  Future<String?> getAttestationServiceSupport({
+    required String challengeString,
+    int? gcp,
+    String? keyScope,
+  }) => Completer<String?>().future;
 }

--- a/mobile/test/services/native_proofmode_service_test.dart
+++ b/mobile/test/services/native_proofmode_service_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:c2pa_flutter/c2pa.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/c2pa_signing_service.dart';
@@ -12,6 +13,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   const proofModeChannel = MethodChannel('org.openvine/proofmode');
+  const attestationChannel = MethodChannel('app_attestation');
   const proofHash =
       'bfe97053586981c5d2373625c3ee921d8af88c79fca442e189a82230d99bdc78';
 
@@ -260,6 +262,100 @@ void main() {
       expect(proofData!.c2paManifestId, 'urn:c2pa:generated');
       expect(c2paService.signVideoCallCount, 1);
       expect(c2paService.readManifestCallCount, 1);
+    });
+  });
+
+  group('proofFile iOS device attestation', () {
+    late Directory directory;
+    late File video;
+    late Directory proofDir;
+
+    const generatedProofHash =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+    setUp(() async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      directory = await Directory.systemTemp.createTemp(
+        'native-proofmode-attest-test-',
+      );
+      video = File('${directory.path}/video.mp4');
+      await video.writeAsBytes(const [1, 2, 3, 4]);
+
+      proofDir = Directory('${directory.path}/$generatedProofHash');
+      await proofDir.create();
+      await File(
+        '${proofDir.path}/$generatedProofHash.asc',
+      ).writeAsString('signature');
+
+      NativeProofModeService.c2paSigningServiceFactoryOverride = () =>
+          _SuccessfulC2paSigningService(video.path);
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(proofModeChannel, (call) async {
+            switch (call.method) {
+              case 'isAvailable':
+                return true;
+              case 'getProofDir':
+                final args = call.arguments as Map<Object?, Object?>;
+                return args['proofHash'] == generatedProofHash
+                    ? proofDir.path
+                    : null;
+              case 'generateProof':
+                return generatedProofHash;
+              default:
+                fail('Unexpected proof mode method call: ${call.method}');
+            }
+          });
+    });
+
+    tearDown(() async {
+      debugDefaultTargetPlatformOverride = null;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(attestationChannel, null);
+      if (directory.existsSync()) {
+        await directory.delete(recursive: true);
+      }
+    });
+
+    test(
+      'persists the attestation token before reading proof metadata',
+      () async {
+        const token = '{"keyID":"k1","attestationString":"a1"}';
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              attestationChannel,
+              (call) async => token,
+            );
+
+        final proofData = await NativeProofModeService.proofFile(video);
+
+        expect(proofData, isNotNull);
+        expect(proofData!.deviceAttestation, token);
+        expect(
+          File(
+            '${proofDir.path}/$generatedProofHash.attest',
+          ).readAsStringSync(),
+          token,
+        );
+      },
+    );
+
+    test('keeps the proof when App Attest is unavailable', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(attestationChannel, (call) async {
+            throw PlatformException(code: '-4', message: 'Attestation failed');
+          });
+
+      final proofData = await NativeProofModeService.proofFile(video);
+
+      expect(proofData, isNotNull);
+      expect(proofData!.videoHash, generatedProofHash);
+      expect(proofData.deviceAttestation, isNull);
+      expect(
+        _latestLogContaining('Device attestation unavailable'),
+        isNotNull,
+      );
     });
   });
 }

--- a/mobile/test/services/native_proofmode_service_test.dart
+++ b/mobile/test/services/native_proofmode_service_test.dart
@@ -266,6 +266,9 @@ void main() {
   });
 
   group('proofFile iOS device attestation', () {
+    // Pins the split introduced with per-account App Attest keys: generation
+    // runs before the publishing account is fixed, so it cannot mint a payload
+    // that binds one. [IosDeviceAttestationService] does that at publish time.
     late Directory directory;
     late File video;
     late Directory proofDir;
@@ -318,34 +321,14 @@ void main() {
       }
     });
 
-    test(
-      'persists the attestation token before reading proof metadata',
-      () async {
-        const token = '{"keyID":"k1","attestationString":"a1"}';
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-              attestationChannel,
-              (call) async => token,
-            );
-
-        final proofData = await NativeProofModeService.proofFile(video);
-
-        expect(proofData, isNotNull);
-        expect(proofData!.deviceAttestation, token);
-        expect(
-          File(
-            '${proofDir.path}/$generatedProofHash.attest',
-          ).readAsStringSync(),
-          token,
-        );
-      },
-    );
-
-    test('keeps the proof when App Attest is unavailable', () async {
+    test('defers App Attest to publish time', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(attestationChannel, (call) async {
-            throw PlatformException(code: '-4', message: 'Attestation failed');
-          });
+          .setMockMethodCallHandler(
+            attestationChannel,
+            (call) async => fail(
+              'App Attest must wait for the publishing account to be known',
+            ),
+          );
 
       final proofData = await NativeProofModeService.proofFile(video);
 
@@ -353,8 +336,8 @@ void main() {
       expect(proofData!.videoHash, generatedProofHash);
       expect(proofData.deviceAttestation, isNull);
       expect(
-        _latestLogContaining('Device attestation unavailable'),
-        isNotNull,
+        File('${proofDir.path}/$generatedProofHash.attest').existsSync(),
+        isFalse,
       );
     });
   });

--- a/mobile/test/services/video_event_publisher_native_proof_test.dart
+++ b/mobile/test/services/video_event_publisher_native_proof_test.dart
@@ -492,6 +492,97 @@ void main() {
       },
     );
 
+    test(
+      'drops publish-time attestation when the account changes before signing',
+      () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+        var currentPubkey = 'account-a-pubkey';
+        final attestation = _RecordingAttestationService(
+          payload: 'attestation-for-account-a',
+          onAfterAttestation: () => currentPubkey = 'account-b-pubkey',
+        );
+        publisher = VideoEventPublisher(
+          uploadManager: mockUploadManager,
+          nostrService: mockNostrService,
+          authService: mockAuthService,
+          iosDeviceAttestationService: attestation,
+        );
+        when(
+          () => mockAuthService.currentPublicKeyHex,
+        ).thenAnswer((_) => currentPubkey);
+
+        const nativeProof = NativeProofData(
+          videoHash: 'abc123def456',
+          pgpSignature: 'signature',
+          publicKey: 'public_key',
+          deviceAttestation: 'attestation-for-the-previous-account',
+        );
+
+        final upload =
+            PendingUpload.create(
+              localVideoPath: '/tmp/test.mp4',
+              nostrPubkey: 'account-a-pubkey',
+              proofManifestJson: jsonEncode(nativeProof.toJson()),
+            ).copyWith(
+              status: UploadStatus.readyToPublish,
+              videoId: 'video123',
+              cdnUrl: 'https://cdn.example.com/video.mp4',
+            );
+
+        Event? capturedEvent;
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((invocation) {
+          capturedEvent = Event.fromJson({
+            'id': 'event996',
+            'pubkey': currentPubkey,
+            'created_at': DateTime.now().millisecondsSinceEpoch ~/ 1000,
+            'kind': 34236,
+            'tags': invocation.namedArguments[#tags],
+            'content': invocation.namedArguments[#content],
+            'sig': 'signature996',
+          });
+          return Future.value(capturedEvent);
+        });
+        when(
+          () => mockNostrService.publishEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (invocation) async => PublishOutcome(
+            eventId: (invocation.positionalArguments[0] as Event).id,
+            acceptedBy: const ['wss://relay.divine.video'],
+            rejectedBy: const {},
+            noResponseFrom: const [],
+          ),
+        );
+
+        await publisher.publishDirectUpload(upload);
+
+        expect(attestation.pubkeyHex, 'account-a-pubkey');
+        expect(capturedEvent, isNotNull);
+        expect(capturedEvent!.pubkey, 'account-b-pubkey');
+        expect(
+          capturedEvent!.tags.where(
+            (tag) => tag.isNotEmpty && tag[0] == 'device_attestation',
+          ),
+          isEmpty,
+          reason: 'account B must not publish account A device material',
+        );
+        final proofTag = capturedEvent!.tags.firstWhere(
+          (tag) => tag.isNotEmpty && tag[0] == 'proofmode',
+        );
+        expect(jsonDecode(proofTag[1])['deviceAttestation'], isNull);
+      },
+    );
+
     test('publishes without attestation when App Attest fails', () async {
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
       addTearDown(() => debugDefaultTargetPlatformOverride = null);
@@ -664,11 +755,15 @@ void main() {
 
 /// Stands in for App Attest, recording what the publisher asked it to bind.
 class _RecordingAttestationService extends IosDeviceAttestationService {
-  _RecordingAttestationService({this.payload = _boundPayload});
+  _RecordingAttestationService({
+    this.payload = _boundPayload,
+    this.onAfterAttestation,
+  });
 
   static const _boundPayload = 'attestation-for-signer-pubkey';
 
   final String? payload;
+  final VoidCallback? onAfterAttestation;
   String? proofHash;
   String? pubkeyHex;
 
@@ -679,6 +774,7 @@ class _RecordingAttestationService extends IosDeviceAttestationService {
   }) async {
     this.proofHash = proofHash;
     this.pubkeyHex = pubkeyHex;
+    onAfterAttestation?.call();
     return payload;
   }
 }

--- a/mobile/test/services/video_event_publisher_native_proof_test.dart
+++ b/mobile/test/services/video_event_publisher_native_proof_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' show NativeProofData;
@@ -12,6 +13,7 @@ import 'package:nostr_sdk/filter.dart';
 import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/ios_device_attestation_service.dart';
 import 'package:openvine/services/upload_manager.dart';
 import 'package:openvine/services/video_event_publisher.dart';
 
@@ -386,5 +388,203 @@ void main() {
       );
       // TODO(Any): Fix and re-enable these tests
     }, skip: true);
+
+    test(
+      'replaces a stale attestation with one bound to the publisher',
+      () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+        final attestation = _RecordingAttestationService();
+        publisher = VideoEventPublisher(
+          uploadManager: mockUploadManager,
+          nostrService: mockNostrService,
+          authService: mockAuthService,
+          iosDeviceAttestationService: attestation,
+        );
+        when(
+          () => mockAuthService.currentPublicKeyHex,
+        ).thenReturn('signer-pubkey');
+
+        // Carries a payload minted for a different account, as an upload
+        // recorded before an account switch would.
+        const nativeProof = NativeProofData(
+          videoHash: 'abc123def456',
+          pgpSignature: 'signature',
+          publicKey: 'public_key',
+          deviceAttestation: 'attestation-for-the-previous-account',
+        );
+
+        final upload =
+            PendingUpload.create(
+              localVideoPath: '/tmp/test.mp4',
+              nostrPubkey: 'signer-pubkey',
+              proofManifestJson: jsonEncode(nativeProof.toJson()),
+            ).copyWith(
+              status: UploadStatus.readyToPublish,
+              videoId: 'video123',
+              cdnUrl: 'https://cdn.example.com/video.mp4',
+            );
+
+        Event? capturedEvent;
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((invocation) {
+          capturedEvent = Event.fromJson({
+            'id': 'event999',
+            'pubkey': 'signer-pubkey',
+            'created_at': DateTime.now().millisecondsSinceEpoch ~/ 1000,
+            'kind': 34236,
+            'tags': invocation.namedArguments[#tags],
+            'content': invocation.namedArguments[#content],
+            'sig': 'signature999',
+          });
+          return Future.value(capturedEvent);
+        });
+        when(
+          () => mockNostrService.publishEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (invocation) async => PublishOutcome(
+            eventId: (invocation.positionalArguments[0] as Event).id,
+            acceptedBy: const ['wss://relay.divine.video'],
+            rejectedBy: const {},
+            noResponseFrom: const [],
+          ),
+        );
+
+        await publisher.publishDirectUpload(upload);
+
+        expect(attestation.proofHash, 'abc123def456');
+        expect(attestation.pubkeyHex, 'signer-pubkey');
+
+        final attestationTag = capturedEvent!.tags.firstWhere(
+          (tag) => tag.isNotEmpty && tag[0] == 'device_attestation',
+        );
+        expect(attestationTag[1], 'attestation-for-signer-pubkey');
+
+        final proofTag = capturedEvent!.tags.firstWhere(
+          (tag) => tag.isNotEmpty && tag[0] == 'proofmode',
+        );
+        expect(
+          jsonDecode(proofTag[1])['deviceAttestation'],
+          'attestation-for-signer-pubkey',
+          reason: 'the embedded JSON publishes the same payload as the tag',
+        );
+      },
+    );
+
+    test('publishes without attestation when App Attest fails', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      publisher = VideoEventPublisher(
+        uploadManager: mockUploadManager,
+        nostrService: mockNostrService,
+        authService: mockAuthService,
+        iosDeviceAttestationService: _RecordingAttestationService(
+          payload: null,
+        ),
+      );
+      when(
+        () => mockAuthService.currentPublicKeyHex,
+      ).thenReturn('signer-pubkey');
+
+      const nativeProof = NativeProofData(
+        videoHash: 'abc123def456',
+        pgpSignature: 'signature',
+        publicKey: 'public_key',
+        deviceAttestation: 'attestation-for-the-previous-account',
+      );
+
+      final upload =
+          PendingUpload.create(
+            localVideoPath: '/tmp/test.mp4',
+            nostrPubkey: 'signer-pubkey',
+            proofManifestJson: jsonEncode(nativeProof.toJson()),
+          ).copyWith(
+            status: UploadStatus.readyToPublish,
+            videoId: 'video123',
+            cdnUrl: 'https://cdn.example.com/video.mp4',
+          );
+
+      Event? capturedEvent;
+      when(
+        () => mockAuthService.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer((invocation) {
+        capturedEvent = Event.fromJson({
+          'id': 'event998',
+          'pubkey': 'signer-pubkey',
+          'created_at': DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          'kind': 34236,
+          'tags': invocation.namedArguments[#tags],
+          'content': invocation.namedArguments[#content],
+          'sig': 'signature998',
+        });
+        return Future.value(capturedEvent);
+      });
+      when(
+        () => mockNostrService.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (invocation) async => PublishOutcome(
+          eventId: (invocation.positionalArguments[0] as Event).id,
+          acceptedBy: const ['wss://relay.divine.video'],
+          rejectedBy: const {},
+          noResponseFrom: const [],
+        ),
+      );
+
+      await publisher.publishDirectUpload(upload);
+
+      expect(capturedEvent, isNotNull, reason: 'the event still gets signed');
+      expect(
+        capturedEvent!.tags.where(
+          (tag) => tag.isNotEmpty && tag[0] == 'device_attestation',
+        ),
+        isEmpty,
+        reason: 'a stale payload must not survive a failed mint',
+      );
+      expect(
+        capturedEvent!.tags.where(
+          (tag) => tag.isNotEmpty && tag[0] == 'proofmode',
+        ),
+        hasLength(1),
+        reason: 'the rest of the proof still publishes',
+      );
+    });
   });
+}
+
+/// Stands in for App Attest, recording what the publisher asked it to bind.
+class _RecordingAttestationService extends IosDeviceAttestationService {
+  _RecordingAttestationService({this.payload = _boundPayload});
+
+  static const _boundPayload = 'attestation-for-signer-pubkey';
+
+  final String? payload;
+  String? proofHash;
+  String? pubkeyHex;
+
+  @override
+  Future<String?> attestationFor({
+    required String proofHash,
+    required String pubkeyHex,
+  }) async {
+    this.proofHash = proofHash;
+    this.pubkeyHex = pubkeyHex;
+    return payload;
+  }
 }

--- a/mobile/test/services/video_event_publisher_native_proof_test.dart
+++ b/mobile/test/services/video_event_publisher_native_proof_test.dart
@@ -59,6 +59,16 @@ void main() {
 
       // Mock auth service to return authenticated and create events
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(() => mockNostrService.isInitialized).thenReturn(true);
+      when(() => mockNostrService.configuredRelayCount).thenReturn(1);
+      when(() => mockNostrService.connectedRelayCount).thenReturn(1);
+      when(
+        () => mockNostrService.configuredRelays,
+      ).thenReturn(const ['wss://relay.divine.video']);
+      when(
+        () => mockNostrService.connectedRelays,
+      ).thenReturn(const ['wss://relay.divine.video']);
+      when(() => mockNostrService.publicKey).thenReturn('');
 
       // Mock upload manager updateUploadStatus
       when(
@@ -77,6 +87,9 @@ void main() {
     });
 
     test('MUST publish native ProofMode data to Nostr tags', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
       // Create native proof data (from Guardian Project library)
       const nativeProof = NativeProofData(
         videoHash: 'abc123def456',
@@ -386,8 +399,7 @@ void main() {
         isEmpty,
         reason: 'Should not have ProofMode tags when no proof data',
       );
-      // TODO(Any): Fix and re-enable these tests
-    }, skip: true);
+    });
 
     test(
       'replaces a stale attestation with one bound to the publisher',
@@ -565,6 +577,88 @@ void main() {
         reason: 'the rest of the proof still publishes',
       );
     });
+
+    test(
+      'publishes without stale attestation when the signing pubkey is absent',
+      () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+        publisher = VideoEventPublisher(
+          uploadManager: mockUploadManager,
+          nostrService: mockNostrService,
+          authService: mockAuthService,
+          iosDeviceAttestationService: _ThrowingAttestationService(),
+        );
+        when(() => mockAuthService.currentPublicKeyHex).thenReturn(null);
+
+        const nativeProof = NativeProofData(
+          videoHash: 'abc123def456',
+          pgpSignature: 'signature',
+          publicKey: 'public_key',
+          deviceAttestation: 'attestation-for-the-previous-account',
+        );
+
+        final upload =
+            PendingUpload.create(
+              localVideoPath: '/tmp/test.mp4',
+              nostrPubkey: 'signer-pubkey',
+              proofManifestJson: jsonEncode(nativeProof.toJson()),
+            ).copyWith(
+              status: UploadStatus.readyToPublish,
+              videoId: 'video123',
+              cdnUrl: 'https://cdn.example.com/video.mp4',
+            );
+
+        Event? capturedEvent;
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((invocation) {
+          capturedEvent = Event.fromJson({
+            'id': 'event997',
+            'pubkey': 'signer-pubkey',
+            'created_at': DateTime.now().millisecondsSinceEpoch ~/ 1000,
+            'kind': 34236,
+            'tags': invocation.namedArguments[#tags],
+            'content': invocation.namedArguments[#content],
+            'sig': 'signature997',
+          });
+          return Future.value(capturedEvent);
+        });
+        when(
+          () => mockNostrService.publishEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (invocation) async => PublishOutcome(
+            eventId: (invocation.positionalArguments[0] as Event).id,
+            acceptedBy: const ['wss://relay.divine.video'],
+            rejectedBy: const {},
+            noResponseFrom: const [],
+          ),
+        );
+
+        await publisher.publishDirectUpload(upload);
+
+        expect(capturedEvent, isNotNull, reason: 'the event still gets signed');
+        expect(
+          capturedEvent!.tags.where(
+            (tag) => tag.isNotEmpty && tag[0] == 'device_attestation',
+          ),
+          isEmpty,
+          reason: 'a stale payload must not publish without a scoped signer',
+        );
+        final proofTag = capturedEvent!.tags.firstWhere(
+          (tag) => tag.isNotEmpty && tag[0] == 'proofmode',
+        );
+        expect(jsonDecode(proofTag[1])['deviceAttestation'], isNull);
+      },
+    );
   });
 }
 
@@ -586,5 +680,15 @@ class _RecordingAttestationService extends IosDeviceAttestationService {
     this.proofHash = proofHash;
     this.pubkeyHex = pubkeyHex;
     return payload;
+  }
+}
+
+class _ThrowingAttestationService extends IosDeviceAttestationService {
+  @override
+  Future<String?> attestationFor({
+    required String proofHash,
+    required String pubkeyHex,
+  }) {
+    throw StateError('attestation service should not be called');
   }
 }


### PR DESCRIPTION
Closes #6491

## Description

This PR scopes iOS App Attest caching to the publishing Nostr account and mints the payload at publish time, where the signing pubkey is known. The App Attest challenge is now `SHA-256(UTF-8("<proofHash>:<pubkeyHex>"))`, so the payload is bound to both the media proof hash and the event pubkey.

The publish-time payload is authoritative: iOS replaces any stored proof-generation attestation, clears stale values when no signing pubkey is available, and drops the field when App Attest fails or times out. Android remains unchanged and continues to publish generation-time hardware attestation from the stored proof.

The native iOS cache now scopes key id, attestation object, pending-key slot, and provisioning queue by account. Provisioning still has the 30s native watchdog, and a generated-but-unattested pending key is retried once with its original client data hash before being abandoned so a stale pending slot cannot wedge an account permanently.

`mobile/docs/NOSTR_VIDEO_EVENTS.md` documents the current verifier contract, assertion-counter requirement, per-account linkability boundary, and the legacy pre-PR iOS challenge shape for already-published events.

## Still Required Before Merge

- Physical iPhone verification. App Attest is unavailable on Simulator, so first-publish provisioning and later-publish assertion paths still need a real device run.

## Verification

- `flutter analyze lib test integration_test` — no issues.
- `flutter test test/services/ios_device_attestation_service_test.dart test/services/video_event_publisher_native_proof_test.dart` — 11 passed.
- Pre-push hook: analyzer passed and changed-file tests passed for `packages/models/test/src/pending_upload_proofmode_test.dart`, `test/services/ios_device_attestation_service_test.dart`, `test/services/native_proofmode_service_test.dart`, `test/services/video_event_publisher_native_proof_test.dart`, and `test/services/video_event_publisher_test.dart` — 67 passed.
- `swiftc -parse -target arm64-apple-ios14.0 overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrity.swift` — parses, with the host sysroot warning from invoking `swiftc` directly on macOS.

## Type of Change

- [x] Bug fix
- [x] Documentation
