### PR TITLE
fix(profile): stop the publish seed from erasing Kind 0 fields

### DIFF
--- a/mobile/packages/models/lib/src/user_profile_data.dart
+++ b/mobile/packages/models/lib/src/user_profile_data.dart
@@ -50,19 +50,35 @@ class UserProfileData {
   factory UserProfileData.fromJson(String pubkey, Map<String, dynamic> json) {
     return UserProfileData(
       pubkey: pubkey,
-      name: json['name'] as String?,
-      displayName: json['display_name'] as String?,
-      about: json['about'] as String?,
-      picture: json['picture'] as String?,
-      banner: json['banner'] as String?,
-      website: json['website'] as String?,
-      nip05: json['nip05'] as String?,
-      lud16: json['lud16'] as String?,
+      name: _absentIfEmpty(json['name']),
+      displayName: _absentIfEmpty(json['display_name']),
+      about: _absentIfEmpty(json['about']),
+      picture: _absentIfEmpty(json['picture']),
+      banner: _absentIfEmpty(json['banner']),
+      website: _absentIfEmpty(json['website']),
+      nip05: _absentIfEmpty(json['nip05']),
+      lud16: _absentIfEmpty(json['lud16']),
       createdAt: switch (json['profile_updated']) {
         final String value => DateTime.tryParse(value),
         _ => null,
       },
     );
+  }
+
+  /// Reads a Funnelcake profile string field, mapping `''` to `null`.
+  ///
+  /// Funnelcake's profile response models every metadata field as a
+  /// non-nullable Rust `String`, so a Kind 0 key that simply does not exist is
+  /// serialized as `''`. Keeping that `''` would make an absent field
+  /// indistinguishable from a deliberately-blank one, and downstream that is
+  /// destructive rather than cosmetic: `UserProfile.fromUserProfileFound`
+  /// admits every non-null field into `rawData`, so the REST-derived profile
+  /// out-counts the real Kind 0 and wins `_resolvePublishSeed`'s richness
+  /// comparison — after which the publish path's `isNotEmpty` guards delete the
+  /// fields that were only ever `''` placeholders.
+  static String? _absentIfEmpty(dynamic value) {
+    if (value is! String || value.isEmpty) return null;
+    return value;
   }
 
   final String pubkey;

--- a/mobile/packages/models/test/src/user_profile_result_test.dart
+++ b/mobile/packages/models/test/src/user_profile_result_test.dart
@@ -40,6 +40,43 @@ void main() {
       expect(data.createdAt, isNull);
     });
 
+    test('fromJson treats empty strings as absent', () {
+      // Funnelcake models every profile metadata field as a non-nullable Rust
+      // String, so a Kind 0 key that does not exist is serialized as ''.
+      // Keeping those placeholders let a REST-hydrated profile out-count the
+      // real Kind 0 in the publish-seed comparison, after which the publish
+      // path's isNotEmpty guards deleted the fields for real.
+      final data = UserProfileData.fromJson(_pubkey, const {
+        'name': '',
+        'display_name': 'Alice',
+        'about': '',
+        'picture': '',
+        'banner': '',
+        'nip05': '',
+        'lud16': '',
+        'website': '',
+      });
+
+      expect(data.displayName, equals('Alice'));
+      expect(data.name, isNull);
+      expect(data.about, isNull);
+      expect(data.picture, isNull);
+      expect(data.banner, isNull);
+      expect(data.nip05, isNull);
+      expect(data.lud16, isNull);
+      expect(data.website, isNull);
+    });
+
+    test('fromJson ignores non-String values', () {
+      final data = UserProfileData.fromJson(_pubkey, const {
+        'name': 42,
+        'display_name': true,
+      });
+
+      expect(data.name, isNull);
+      expect(data.displayName, isNull);
+    });
+
     test('fromJson parses profile_updated into createdAt', () {
       final data = UserProfileData.fromJson(_pubkey, const {
         'name': 'alice',

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -1284,7 +1284,8 @@ class ProfileRepository {
   /// - the relay fetch returns null (its documented failure mode — internal
   ///   errors are swallowed by [fetchFreshProfile]),
   /// - the relay fetch exceeds [_publishSeedRelayTimeout],
-  /// - the local seed is strictly newer, or strictly richer in meaningful keys.
+  /// - the local seed is strictly newer, or carries the same timestamp and
+  ///   strictly more meaningful keys.
   Future<UserProfile?> _resolvePublishSeed(UserProfile? currentProfile) async {
     // `??` short-circuits, so the signer is consulted only when the caller gave
     // us no profile to take a pubkey from.
@@ -1309,23 +1310,30 @@ class ProfileRepository {
       return fresh;
     }
 
-    // `fresh` is a raw Kind 0 (requireRawKind0), so it is authoritative by
-    // construction: it carries unknown keys and NIP-39 tags that the REST
-    // projection structurally cannot express. Keep the local seed only when it
-    // is strictly newer or strictly richer.
-    //
-    // Richness is counted over *meaningful* keys, not `rawData.length`. A
-    // REST-derived profile used to out-count the real Kind 0 on `''`
-    // placeholders alone — Funnelcake models every metadata field as a
-    // non-nullable String, so an absent key arrives as `''` — which inverted
-    // this comparison and handed the publish path a seed whose `isNotEmpty`
-    // guards then deleted the very fields it was meant to preserve.
-    if (localSeed.createdAt.isAfter(fresh.createdAt) ||
-        _meaningfulKeyCount(localSeed.rawData) >
-            _meaningfulKeyCount(fresh.rawData)) {
+    // Recency decides first. A field the user removed on another client leaves
+    // the newest Kind 0 both newer *and* sparser, so letting key count override
+    // recency would re-publish the deletion away.
+    if (fresh.createdAt.isAfter(localSeed.createdAt)) {
+      return fresh;
+    }
+    if (localSeed.createdAt.isAfter(fresh.createdAt)) {
       return localSeed;
     }
-    return fresh;
+
+    // Same timestamp — break the tie on richness, counted over *meaningful*
+    // keys rather than `rawData.length`. A REST-derived profile used to
+    // out-count the real Kind 0 on `''` placeholders alone (Funnelcake models
+    // every metadata field as a non-nullable String, so an absent key arrives
+    // as `''`), which handed the publish path a seed whose `isNotEmpty` guards
+    // then deleted the very fields it was meant to preserve.
+    //
+    // On a genuine tie `fresh` wins: it is a raw Kind 0 (requireRawKind0), so
+    // it carries unknown keys and NIP-39 tags the REST projection structurally
+    // cannot express.
+    return _meaningfulKeyCount(localSeed.rawData) >
+            _meaningfulKeyCount(fresh.rawData)
+        ? localSeed
+        : fresh;
   }
 
   /// The signing key this repository publishes as, or `null` when the client

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -1011,9 +1011,10 @@ class ProfileRepository {
     // Re-seed from the freshest Kind 0 we can get from relays. This is the
     // only path that preserves arbitrary unknown fields (custom client keys,
     // NIP-39 `i` tags, `bot`, future NIP additions) — the REST API does not
-    // expose them. Falls back to currentProfile on relay failure / timeout;
-    // currentProfile.rawData carries the typed REST fields per
-    // UserProfile.fromUserProfileFound.
+    // expose them. On relay failure or timeout it falls back to the best local
+    // seed: [currentProfile] when the caller supplied one (whose `rawData`
+    // carries the typed REST fields per `UserProfile.fromUserProfileFound`),
+    // otherwise the cached profile for the signing key.
     final seed = await _resolvePublishSeed(currentProfile);
 
     final newContent = Map<String, dynamic>.from(seed?.rawData ?? const {});
@@ -1269,32 +1270,83 @@ class ProfileRepository {
   /// been hydrated from the Funnelcake REST API and is missing keys the
   /// REST schema does not expose).
   ///
-  /// Returns [currentProfile] unchanged when:
-  /// - we have no pubkey to fetch with (cold publish, never published),
+  /// When [currentProfile] is null the subject is still known — this publish
+  /// signs through [_nostrClient], so its public key *is* the event's pubkey.
+  /// Seeding from it turns what was a destructive full replace into a
+  /// read-modify-write: previously a null [currentProfile] returned before any
+  /// fetch, so the published Kind 0 was composed from an empty map and every
+  /// field outside the form (`name`, `nip05`, `lud16`, `lud06`, `bot`,
+  /// monetization links, unknown client keys) plus every NIP-39 `i` tag was
+  /// erased on relays.
+  ///
+  /// Returns the local seed (or null) when:
+  /// - there is no pubkey at all — no [currentProfile] and no signer key,
   /// - the relay fetch returns null (its documented failure mode — internal
   ///   errors are swallowed by [fetchFreshProfile]),
   /// - the relay fetch exceeds [_publishSeedRelayTimeout],
-  /// - the relay event is older than [currentProfile] AND its rawData is no
-  ///   richer (i.e., currentProfile is already authoritative).
+  /// - the local seed is strictly newer, or strictly richer in meaningful keys.
   Future<UserProfile?> _resolvePublishSeed(UserProfile? currentProfile) async {
-    if (currentProfile == null) {
-      return null;
+    // `??` short-circuits, so the signer is consulted only when the caller gave
+    // us no profile to take a pubkey from.
+    final pubkey = currentProfile?.pubkey ?? _signerPubkeyOrNull();
+    if (pubkey == null) {
+      return currentProfile;
     }
+
+    // A caller that passed no profile may still have one cached locally; read
+    // it before falling back to a bare relay fetch so an offline publish is
+    // seeded rather than stripped.
+    final localSeed = currentProfile ?? await getCachedProfile(pubkey: pubkey);
+
     final fresh = await fetchFreshProfile(
-      pubkey: currentProfile.pubkey,
+      pubkey: pubkey,
       requireRawKind0: true,
     ).timeout(_publishSeedRelayTimeout, onTimeout: () => null);
     if (fresh == null) {
-      return currentProfile;
+      return localSeed;
     }
-    // Prefer fresh when it is newer or when currentProfile's rawData is
-    // sparse (REST-sourced) — the latter case is exactly the
-    // arbitrary-fields-loss bug this seed step exists to fix.
-    if (fresh.createdAt.isAfter(currentProfile.createdAt) ||
-        currentProfile.rawData.length < fresh.rawData.length) {
+    if (localSeed == null) {
       return fresh;
     }
-    return currentProfile;
+
+    // `fresh` is a raw Kind 0 (requireRawKind0), so it is authoritative by
+    // construction: it carries unknown keys and NIP-39 tags that the REST
+    // projection structurally cannot express. Keep the local seed only when it
+    // is strictly newer or strictly richer.
+    //
+    // Richness is counted over *meaningful* keys, not `rawData.length`. A
+    // REST-derived profile used to out-count the real Kind 0 on `''`
+    // placeholders alone — Funnelcake models every metadata field as a
+    // non-nullable String, so an absent key arrives as `''` — which inverted
+    // this comparison and handed the publish path a seed whose `isNotEmpty`
+    // guards then deleted the very fields it was meant to preserve.
+    if (localSeed.createdAt.isAfter(fresh.createdAt) ||
+        _meaningfulKeyCount(localSeed.rawData) >
+            _meaningfulKeyCount(fresh.rawData)) {
+      return localSeed;
+    }
+    return fresh;
+  }
+
+  /// The signing key this repository publishes as, or `null` when the client
+  /// has no key yet.
+  String? _signerPubkeyOrNull() {
+    final pubkey = _nostrClient.publicKey;
+    return pubkey.isEmpty ? null : pubkey;
+  }
+
+  /// Counts entries in a Kind 0 `rawData` map that carry an actual value.
+  ///
+  /// Null and empty-string values are placeholders, not content, so they must
+  /// not make one seed look richer than another.
+  static int _meaningfulKeyCount(Map<String, dynamic> rawData) {
+    var count = 0;
+    for (final value in rawData.values) {
+      if (value == null) continue;
+      if (value is String && value.isEmpty) continue;
+      count++;
+    }
+    return count;
   }
 
   /// Claims a username via NIP-98 authenticated request.

--- a/mobile/packages/profile_repository/test/src/profile_repository_pending_save_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_pending_save_test.dart
@@ -75,7 +75,13 @@ void main() {
       when(() => event.id).thenReturn('e' * 64);
       when(() => event.content).thenReturn('{"display_name":"Alice"}');
 
-      // No cached profile → seed short-circuits, no relay fetch.
+      // The publish seed is resolved from the signing key when the caller
+      // supplies no profile, so the client's pubkey is load-bearing here.
+      when(() => nostrClient.publicKey).thenReturn(pubkey);
+
+      // Nothing cached and nothing on relays → the seed resolves to null and
+      // the publish composes from an empty map. These tests are about the
+      // pending-save slot mechanics, not about seeding.
       when(
         () => userProfilesDao.getProfile(any()),
       ).thenAnswer((_) async => null);

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -2419,6 +2419,56 @@ void main() {
         });
       });
 
+      test(
+        'a newer, sparser relay Kind 0 outranks a stale, richer local seed',
+        () async {
+          // A field removed on another client leaves the newest Kind 0 both
+          // newer and sparser than our copy. Richness must not override
+          // recency here, or the save re-publishes the deletion away.
+          final staleLocalSeed = UserProfile(
+            pubkey: testPubkey,
+            displayName: 'Alice',
+            name: 'alice',
+            rawData: const {
+              'display_name': 'Alice',
+              'name': 'alice',
+              'lud16': 'alice@getalby.com',
+              'custom_client_key': 'deleted-elsewhere',
+            },
+            createdAt: DateTime(2026),
+            eventId: 'cached-$testPubkey',
+          );
+          final newerSparserKind0 = Event(
+            testPubkey,
+            0,
+            const [],
+            jsonEncode({'display_name': 'Alice', 'name': 'alice'}),
+            createdAt: DateTime(2026, 2).millisecondsSinceEpoch ~/ 1000,
+          );
+          when(
+            () => mockNostrClient.fetchProfile(
+              testPubkey,
+              useCache: any(named: 'useCache'),
+            ),
+          ).thenAnswer((_) async => newerSparserKind0);
+
+          await profileRepository.saveProfileEvent(
+            displayName: 'Alice',
+            currentProfile: staleLocalSeed,
+          );
+
+          final captured =
+              verify(
+                    () => mockNostrClient.sendProfileAwaitOk(
+                      profileContent: captureAny(named: 'profileContent'),
+                    ),
+                  ).captured.single
+                  as Map<String, dynamic>;
+          expect(captured.containsKey('lud16'), isFalse);
+          expect(captured.containsKey('custom_client_key'), isFalse);
+        },
+      );
+
       group('with currentProfile', () {
         test('requires raw Kind 0 when resolving the publish seed', () async {
           final funnelcakeApiClient = MockFunnelcakeApiClient();

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -79,6 +79,10 @@ void main() {
         httpClient: mockHttpClient,
       );
 
+      // The publish seed falls back to the signing key when the caller
+      // supplies no `currentProfile`, so this getter is on the save path.
+      when(() => mockNostrClient.publicKey).thenReturn(testPubkey);
+
       // Default mock event setup
       when(() => mockProfileEvent.kind).thenReturn(0);
       when(() => mockProfileEvent.pubkey).thenReturn(testPubkey);
@@ -139,6 +143,20 @@ void main() {
     ) async {
       when(() => mockProfileEvent.content).thenReturn(jsonEncode(content));
       return (await profileRepository.fetchFreshProfile(pubkey: testPubkey))!;
+    }
+
+    /// Makes the relay report no Kind 0 for [testPubkey], so a publish that
+    /// supplies no `currentProfile` resolves to an empty seed.
+    void stubNoRelayProfile() {
+      when(
+        () => mockNostrClient.fetchProfile(testPubkey),
+      ).thenAnswer((_) async => null);
+      when(
+        () => mockNostrClient.fetchProfile(
+          testPubkey,
+          useCache: any(named: 'useCache'),
+        ),
+      ).thenAnswer((_) async => null);
     }
 
     group('getCachedProfile', () {
@@ -1924,6 +1942,9 @@ void main() {
     group('saveProfileEvent', () {
       test('sends all provided fields to nostrClient and caches and returns '
           'user profile', () async {
+        // No pre-existing profile anywhere, so the publish composes from the
+        // provided fields alone and the only cache write is the published one.
+        stubNoRelayProfile();
         when(() => mockProfileEvent.content).thenReturn(
           jsonEncode({
             'display_name': 'New Name',
@@ -2034,6 +2055,11 @@ void main() {
       test(
         'omits unset about/picture/banner keys instead of writing nulls',
         () async {
+          // This test is about never emitting null values, which is only
+          // observable when there is no seed to preserve. Nothing is cached
+          // and the relay has nothing, so the seed resolves to null.
+          stubNoRelayProfile();
+
           await profileRepository.saveProfileEvent(displayName: 'Only Name');
 
           verify(
@@ -2044,7 +2070,8 @@ void main() {
         },
       );
 
-      test('omits nip05 when neither username nor nip05 is provided', () async {
+      test('preserves the existing nip05 when neither username nor nip05 is '
+          'provided', () async {
         await profileRepository.saveProfileEvent(displayName: 'Only Name');
 
         final captured =
@@ -2054,7 +2081,11 @@ void main() {
                   ),
                 ).captured.single
                 as Map<String, dynamic>;
-        expect(captured.containsKey('nip05'), isFalse);
+        // Not passing a nip05 means "leave it alone", not "delete it" —
+        // clearNip05 is the explicit removal path. Before the publish seed was
+        // resolved from the signer key, a caller that supplied no
+        // currentProfile silently dropped it.
+        expect(captured['nip05'], 'test@example.com');
       });
 
       test('includes banner when provided', () async {
@@ -2220,6 +2251,9 @@ void main() {
 
       test('throws ProfilePublishFailedException when no relay confirms '
           '(rejection or timeout)', () async {
+        // Isolate the failure path from the seed read, which legitimately
+        // caches whatever the relay reports.
+        stubNoRelayProfile();
         when(
           () => mockNostrClient.sendProfileAwaitOk(
             profileContent: any(named: 'profileContent'),
@@ -2236,6 +2270,9 @@ void main() {
       test(
         'throws NoRelaysConnectedException when no relays are connected',
         () async {
+          // Isolate the failure path from the seed read, which legitimately
+          // caches whatever the relay reports.
+          stubNoRelayProfile();
           when(
             () => mockNostrClient.sendProfileAwaitOk(
               profileContent: any(named: 'profileContent'),
@@ -2249,6 +2286,138 @@ void main() {
           verifyNever(() => mockUserProfilesDao.upsertProfile(any()));
         },
       );
+
+      group('with no currentProfile', () {
+        test('seeds from the signing key instead of publishing a stripped '
+            'Kind 0', () async {
+          final rawKind0 = Event(
+            testPubkey,
+            0,
+            [
+              ['i', 'github:alice', 'proof'],
+            ],
+            jsonEncode({
+              'display_name': 'Old Name',
+              'name': 'alice',
+              'lud16': 'alice@getalby.com',
+              'bot': false,
+              'custom_client_key': 'keep-me',
+            }),
+            createdAt: DateTime(2026).millisecondsSinceEpoch ~/ 1000,
+          );
+          when(
+            () => mockNostrClient.fetchProfile(
+              testPubkey,
+              useCache: any(named: 'useCache'),
+            ),
+          ).thenAnswer((_) async => rawKind0);
+          // A non-empty rawTags seed takes the tags-carrying overload.
+          when(
+            () => mockNostrClient.sendProfileAwaitOk(
+              profileContent: any(named: 'profileContent'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => PublishSuccess(event: mockProfileEvent));
+
+          // No currentProfile — previously this returned before any fetch and
+          // published from an empty map, erasing everything below.
+          await profileRepository.saveProfileEvent(displayName: 'New Name');
+
+          final captured =
+              verify(
+                    () => mockNostrClient.sendProfileAwaitOk(
+                      profileContent: captureAny(named: 'profileContent'),
+                      tags: [
+                        ['i', 'github:alice', 'proof'],
+                      ],
+                    ),
+                  ).captured.single
+                  as Map<String, dynamic>;
+          expect(captured['display_name'], 'New Name');
+          expect(captured['name'], 'alice');
+          expect(captured['lud16'], 'alice@getalby.com');
+          expect(captured['bot'], false);
+          expect(captured['custom_client_key'], 'keep-me');
+        });
+
+        test(
+          'does not consult the relay when the client has no signing key',
+          () async {
+            when(() => mockNostrClient.publicKey).thenReturn('');
+
+            await profileRepository.saveProfileEvent(displayName: 'Only Name');
+
+            verifyNever(
+              () => mockNostrClient.fetchProfile(
+                any(),
+                useCache: any(named: 'useCache'),
+              ),
+            );
+            verify(
+              () => mockNostrClient.sendProfileAwaitOk(
+                profileContent: {'display_name': 'Only Name'},
+              ),
+            ).called(1);
+          },
+        );
+
+        test('a REST seed padded with empty-string placeholders does not '
+            'outrank the raw Kind 0', () async {
+          // Funnelcake models every metadata field as a non-nullable String, so
+          // an absent Kind 0 key arrives as ''. Counting raw keys let that
+          // padding win the richness comparison; counting meaningful keys does
+          // not.
+          final restSeed = UserProfile(
+            pubkey: testPubkey,
+            displayName: 'Wolf M. Iversen',
+            rawData: const {
+              'display_name': 'Wolf M. Iversen',
+              'name': '',
+              'about': '',
+              'website': '',
+              'lud16': '',
+            },
+            createdAt: DateTime(2026),
+            eventId: 'rest-$testPubkey',
+          );
+          final rawKind0 = Event(
+            testPubkey,
+            0,
+            const [],
+            jsonEncode({
+              'display_name': 'Wolf M. Iversen',
+              'name': 'alice',
+              'custom_client_key': 'keep-me',
+            }),
+            // Same second as the REST seed: funnelcake exposes the original
+            // event timestamp, so the newer-than check cannot break the tie.
+            createdAt: DateTime(2026).millisecondsSinceEpoch ~/ 1000,
+          );
+          when(
+            () => mockNostrClient.fetchProfile(
+              testPubkey,
+              useCache: any(named: 'useCache'),
+            ),
+          ).thenAnswer((_) async => rawKind0);
+
+          await profileRepository.saveProfileEvent(
+            displayName: 'Wolf M. Iversen',
+            currentProfile: restSeed,
+          );
+
+          final captured =
+              verify(
+                    () => mockNostrClient.sendProfileAwaitOk(
+                      profileContent: captureAny(named: 'profileContent'),
+                    ),
+                  ).captured.single
+                  as Map<String, dynamic>;
+          // Both are present only in the raw Kind 0. If the '' -padded REST
+          // seed had won the comparison, both would be gone from the publish.
+          expect(captured['name'], 'alice');
+          expect(captured['custom_client_key'], 'keep-me');
+        });
+      });
 
       group('with currentProfile', () {
         test('requires raw Kind 0 when resolving the publish seed', () async {


### PR DESCRIPTION
## Description

Two defects in the same profile-publish path were destroying Kind 0 fields on relays.

**1. A null seed published an empty map.** `_resolvePublishSeed` returned before attempting any fetch when `currentProfile` was null, so the Kind 0 was composed from `{}`. The pubkey was available the whole time — this publish signs through `_nostrClient`, so its public key *is* the event's author. Everything outside the form set was erased: `name`, `nip05`, `lud16`, `lud06`, `bot`, monetization links, unknown client keys, and every NIP-39 `i` tag. This is reachable through `drivePendingSave`, the primary save path.

**2. The richness comparison inverted.** Funnelcake models every profile metadata field as a non-nullable Rust `String`, so a Kind 0 key that does not exist is served as `""`. `UserProfile.fromUserProfileFound` admits every non-null field into `rawData`, so a REST-hydrated profile out-counted the real Kind 0 on placeholders alone and won `_resolvePublishSeed`'s comparison — after which the publish path's `isNotEmpty` guards deleted those fields for real. `createdAt` could not break the tie because Funnelcake deliberately exposes the original event timestamp.

The second one is the fix for #4175 being defeated by a server-side representation gap. #4175 (and #4021 before it) fixed "REST-hydrated profiles lose every field"; this is the other side of that trade.

### Approach

- Normalize `""` to absent at the REST parser boundary (`UserProfileData.fromJson`) so placeholders never enter `rawData` in the first place.
- Count only *meaningful* keys (non-null, non-empty) when comparing seeds.
- Prefer the raw Kind 0 on a `createdAt` tie, since `requireRawKind0` makes it authoritative by construction — it carries unknown keys and NIP-39 tags the REST projection structurally cannot express.
- Seed from the signing key's cached-then-relay profile when the caller supplies none, turning a destructive full replace into a read-modify-write.

### Observed in the wild

Retrieving all four retained Kind 0 versions for one account with a multi-filter REQ (one `ids` filter per event, which bypasses the relay's per-filter replaceable dedup) shows the fingerprint: versions 1–3 each carry an `about` key; version 4, written by divine-mobile per its `client` tag, dropped `about` and gained `name: ""` and `lud16: ""`.

**Related Issue:** Relates to #4175, #4021, #6423

## Out of Scope

- The own-profile generated-name rendering bug (#6423 / #5851 / #5920) — a separate readiness-gate defect on the read path, not the publish path.
- `about`/`picture`/`banner` are removed when their parameter is *null*, not just empty, while `website` is preserved on null via a different guard shape. Pre-existing and deliberate-looking; left alone here.
- `drivePendingSave` re-reads the seed from Drift even though `ProfileEditorBloc` already holds a live profile it never threads through. Would remove a whole class of null seed; separate change.

## Verification

- `flutter test` in `packages/profile_repository` — 343 pass (340 pre-existing + 3 new).
- `flutter test` in `packages/models` — 829 pass (827 pre-existing + 2 new).
- `flutter test` in `packages/funnelcake_api_client` — 370 pass.
- `flutter analyze lib test integration_test` from `mobile/` — clean.
- `dart format --set-exit-if-changed` — 0 changed.
- App-level `test/blocs/monetization_links_settings`, `test/screens/settings/monetization_links_settings_screen_test.dart`, `test/blocs/profile_editor`, `test/providers` — pass.
- **The new regression tests were confirmed to fail without the production change.** Reverting it gives `Expected: 'alice' Actual: ''` on the placeholder test — precisely the inversion.

### Existing tests changed, and why

Four tests encoded the buggy output. Rather than weaken assertions, three now make their no-seed context explicit through a `stubNoRelayProfile()` helper, so they still test what their names claim (not emitting null values; a failed publish not caching). The fourth asserted that omitting the `nip05` argument **drops** an existing nip05 — that is inverted: `clearNip05` is the explicit removal path, and the method's own doc comment already described preservation as the contract. It now asserts preservation.

One setup comment read `// No cached profile → seed short-circuits, no relay fetch.` — the bug was documented as intended behaviour.

### Unrelated flake noticed

`test/providers/personal_event_cache_service_provider_test.dart` fails roughly 1 run in 4 in a multi-file run. It does so on an untouched `origin/main` too (verified by stashing), so it is not from this branch — but it will cause spurious CI reds and deserves its own issue.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
