### PR TITLE
fix(people-lists): stop background sync when curated lists turns off

### DIFF
--- a/mobile/lib/features/people_lists/bloc/people_lists_bloc.dart
+++ b/mobile/lib/features/people_lists/bloc/people_lists_bloc.dart
@@ -205,6 +205,10 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
       // Drops the snapshot and any pending mutations, but keeps the owner: the
       // owner stream is not seeded, so state is the only place a later flag-on
       // can learn who is signed in.
+      //
+      // A mutation still in flight resumes against the snapshot it captured
+      // before this emit and puts it back — the pre-existing account-switch
+      // race, tracked in #6504.
       emit(PeopleListsState(ownerPubkey: state.ownerPubkey, enabled: false));
       return;
     }

--- a/mobile/lib/features/people_lists/bloc/people_lists_bloc.dart
+++ b/mobile/lib/features/people_lists/bloc/people_lists_bloc.dart
@@ -27,10 +27,18 @@ typedef PeopleListsClock = DateTime Function();
 /// changes, and applies optimistic updates for user-initiated mutations
 /// before the repository returns.
 ///
-/// It depends only on the repository, an owner-pubkey stream, and a
-/// repository stream — it does not import other BLoCs. Owner transitions
-/// cancel the prior subscription, clear pending mutations, and start a new
-/// subscription plus an out-of-band sync.
+/// It depends only on the repository, an owner-pubkey stream, a repository
+/// stream, and an enabled stream — it does not import other BLoCs. Owner
+/// transitions cancel the prior subscription, clear pending mutations, and
+/// start a new subscription plus an out-of-band sync.
+///
+/// ## Feature-flag lifecycle
+///
+/// The bloc is registered unconditionally above `MaterialApp.router`, so it
+/// outlives `FeatureFlag.curatedLists` going off (#6477). While the flag is
+/// off it holds no repository subscription, runs no `syncOwner`, and publishes
+/// nothing — it only keeps following the owner so that turning the flag back
+/// on wires up the account that is signed in *then* (#6494).
 ///
 /// ## Failure recovery contract
 ///
@@ -54,6 +62,13 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
   /// change, so a caller that omits the stream silently reverts #6480. Pass
   /// `const Stream.empty()` when the repository genuinely cannot change.
   ///
+  /// [enabledStream] must emit whether `FeatureFlag.curatedLists` is enabled,
+  /// seeded with its current value. Required for the same reason
+  /// [repositoryStream] is: this bloc outlives the flag, so a caller that omits
+  /// the stream silently reverts #6494 and leaves a disabled feature syncing in
+  /// the background. Pass `Stream.value(true)` when the flag genuinely cannot
+  /// change.
+  ///
   /// [clock] stamps optimistic `updatedAt` values and mutation ids.
   /// Defaults to [DateTime.now] in UTC. Tests inject a fixed clock for
   /// determinism.
@@ -61,14 +76,20 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
     required PeopleListsRepository repository,
     required Stream<String?> ownerPubkeyStream,
     required Stream<PeopleListsRepository> repositoryStream,
+    required Stream<bool> enabledStream,
     String? initialOwnerPubkey,
     PeopleListsClock? clock,
   }) : _repository = repository,
        _ownerPubkeyStream = ownerPubkeyStream,
        _repositoryStream = repositoryStream,
+       _enabledStream = enabledStream,
        _clock = clock ?? _defaultClock,
        super(PeopleListsState(ownerPubkey: initialOwnerPubkey)) {
     on<PeopleListsStarted>(_onStarted);
+    on<PeopleListsEnabledChanged>(
+      _onEnabledChanged,
+      transformer: sequential(),
+    );
     on<PeopleListsRepositoryChanged>(
       _onRepositoryChanged,
       transformer: sequential(),
@@ -110,17 +131,20 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
   PeopleListsRepository _repository;
   final Stream<String?> _ownerPubkeyStream;
   final Stream<PeopleListsRepository> _repositoryStream;
+  final Stream<bool> _enabledStream;
   final PeopleListsClock _clock;
 
   StreamSubscription<String?>? _ownerSubscription;
   StreamSubscription<List<UserList>>? _listsSubscription;
   StreamSubscription<PeopleListsRepository>? _repositorySubscription;
+  StreamSubscription<bool>? _enabledSubscription;
 
   @override
   Future<void> close() async {
     await _ownerSubscription?.cancel();
     await _listsSubscription?.cancel();
     await _repositorySubscription?.cancel();
+    await _enabledSubscription?.cancel();
     return super.close();
   }
 
@@ -148,10 +172,53 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
       },
     );
 
+    await _enabledSubscription?.cancel();
+    _enabledSubscription = _enabledStream.listen(
+      (enabled) => add(PeopleListsEnabledChanged(enabled: enabled)),
+      onError: (Object error, StackTrace stackTrace) {
+        addError(error, stackTrace);
+      },
+    );
+
     final currentOwner = state.ownerPubkey;
     if (currentOwner != null && currentOwner.isNotEmpty) {
       add(PeopleListsOwnerChanged(ownerPubkey: currentOwner));
     }
+  }
+
+  /// Starts or stops all people-list work when `FeatureFlag.curatedLists`
+  /// flips.
+  ///
+  /// Turning the flag off cannot be expressed by dropping the `BlocProvider`:
+  /// a conditional entry changes the app-shell provider chain's shape and
+  /// re-inflates everything below it (#6477). So the already-constructed bloc
+  /// has to stand down on its own — otherwise its cache subscription and
+  /// `syncOwner` calls keep running for the rest of the session (#6494).
+  void _onEnabledChanged(
+    PeopleListsEnabledChanged event,
+    Emitter<PeopleListsState> emit,
+  ) {
+    if (event.enabled == state.enabled) return;
+
+    if (!event.enabled) {
+      _stopWatchingLists();
+      // Drops the snapshot and any pending mutations, but keeps the owner: the
+      // owner stream is not seeded, so state is the only place a later flag-on
+      // can learn who is signed in.
+      emit(PeopleListsState(ownerPubkey: state.ownerPubkey, enabled: false));
+      return;
+    }
+
+    final owner = state.ownerPubkey;
+    if (owner == null || owner.isEmpty) {
+      emit(state.copyWith(enabled: true));
+      return;
+    }
+
+    emit(state.copyWith(status: PeopleListsStatus.loading, enabled: true));
+    // Re-subscribing goes through the owner bucket so [_onOwnerChanged] stays
+    // the only handler that opens a lists subscription.
+    add(const PeopleListsOwnerChanged.rewire());
   }
 
   /// Re-points the bloc at a freshly built repository.
@@ -192,14 +259,23 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
         );
   }
 
-  /// Owns [_listsSubscription] — the only handler that writes it.
+  /// Closes [_listsSubscription], if any.
   ///
-  /// Deliberately synchronous. Suspending here would let another handler run
-  /// between the read and the write of [_listsSubscription] and orphan a
-  /// subscription that then outlives [close]; staying synchronous makes this
-  /// the sole, uninterruptible writer. `cancel()` stops delivery to the
-  /// listener synchronously — its future only reports resource cleanup, so
-  /// nothing below depends on awaiting it.
+  /// Called from [_onOwnerChanged] and [_onEnabledChanged], both of which are
+  /// deliberately synchronous: what would orphan a subscription is a *writer
+  /// that suspends* between reading and nulling the field, not a second writer
+  /// (#6482). Do not make either handler `async`. `cancel()` stops delivery to
+  /// the listener synchronously — its future only reports resource cleanup, so
+  /// nothing depends on awaiting it.
+  void _stopWatchingLists() {
+    unawaited(_listsSubscription?.cancel());
+    _listsSubscription = null;
+  }
+
+  /// Opens [_listsSubscription] — the only handler that does.
+  ///
+  /// Deliberately synchronous, for the reason spelled out on
+  /// [_stopWatchingLists].
   ///
   /// A re-wire ([PeopleListsOwnerChanged.rewire]) reuses the owner already in
   /// state and deliberately emits nothing: the repository swap fires on every
@@ -218,11 +294,21 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
       return;
     }
 
-    unawaited(_listsSubscription?.cancel());
-    _listsSubscription = null;
+    _stopWatchingLists();
 
     if (newOwner == null || newOwner.isEmpty) {
-      if (!event.isRewire) emit(const PeopleListsState());
+      if (!event.isRewire) {
+        emit(PeopleListsState(enabled: state.enabled));
+      }
+      return;
+    }
+
+    // Flag off: keep following the owner so a later flag-on wires up whoever is
+    // signed in then, but open no subscription and run no sync.
+    if (!state.enabled) {
+      if (!event.isRewire) {
+        emit(PeopleListsState(ownerPubkey: newOwner, enabled: false));
+      }
       return;
     }
 
@@ -231,6 +317,7 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
         PeopleListsState(
           status: PeopleListsStatus.loading,
           ownerPubkey: newOwner,
+          enabled: state.enabled,
         ),
       );
     }
@@ -247,8 +334,9 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
     PeopleListsRepositoryListsChanged event,
     Emitter<PeopleListsState> emit,
   ) {
-    // Ignore late emissions from a previous owner.
-    if (event.ownerPubkey != state.ownerPubkey) {
+    // Ignore late emissions from a previous owner, or ones already queued when
+    // the feature was turned off.
+    if (!state.enabled || event.ownerPubkey != state.ownerPubkey) {
       return;
     }
 
@@ -269,7 +357,7 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
     PeopleListsCreateRequested event,
     Emitter<PeopleListsState> emit,
   ) async {
-    final owner = state.ownerPubkey;
+    final owner = state.activeOwnerPubkey;
     if (owner == null || owner.isEmpty) {
       return;
     }
@@ -296,7 +384,7 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
     PeopleListsDeleteRequested event,
     Emitter<PeopleListsState> emit,
   ) async {
-    final owner = state.ownerPubkey;
+    final owner = state.activeOwnerPubkey;
     if (owner == null || owner.isEmpty) {
       return;
     }
@@ -401,7 +489,7 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
     required String pubkey,
     required Emitter<PeopleListsState> emit,
   }) async {
-    final owner = state.ownerPubkey;
+    final owner = state.activeOwnerPubkey;
     if (owner == null || owner.isEmpty) {
       return;
     }
@@ -471,7 +559,7 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
     required String pubkey,
     required Emitter<PeopleListsState> emit,
   }) async {
-    final owner = state.ownerPubkey;
+    final owner = state.activeOwnerPubkey;
     if (owner == null || owner.isEmpty) {
       return;
     }

--- a/mobile/lib/features/people_lists/bloc/people_lists_event.dart
+++ b/mobile/lib/features/people_lists/bloc/people_lists_event.dart
@@ -34,6 +34,24 @@ class PeopleListsRepositoryChanged extends PeopleListsEvent {
   List<Object?> get props => [repository];
 }
 
+/// Internal event emitted when the injected enabled stream reports that
+/// `FeatureFlag.curatedLists` flipped.
+///
+/// The app-shell `BlocProvider` is deliberately unconditional — a conditional
+/// entry changed the provider chain's shape and re-inflated the Navigator on
+/// every flip (#6477) — so a bloc constructed while the flag was on outlives
+/// the flag going off. This event is how it stops (#6494).
+class PeopleListsEnabledChanged extends PeopleListsEvent {
+  /// Creates a feature-enabled-change event.
+  const PeopleListsEnabledChanged({required this.enabled});
+
+  /// Whether the curated-lists feature is enabled from now on.
+  final bool enabled;
+
+  @override
+  List<Object?> get props => [enabled];
+}
+
 /// Internal event emitted when the owner pubkey stream changes.
 ///
 /// Also carries the repository re-wire (see [PeopleListsOwnerChanged.rewire]).

--- a/mobile/lib/features/people_lists/bloc/people_lists_state.dart
+++ b/mobile/lib/features/people_lists/bloc/people_lists_state.dart
@@ -40,6 +40,7 @@ class PeopleListsState extends Equatable {
     this.listIdsByPubkey = const {},
     this.pendingMutations = const {},
     this.lastSubmittedEventId,
+    this.enabled = true,
   });
 
   /// Current status of the bloc.
@@ -64,6 +65,21 @@ class PeopleListsState extends Equatable {
   /// relay socket — not relay `OK` confirmation.
   final String? lastSubmittedEventId;
 
+  /// Whether the curated-lists feature is currently enabled.
+  ///
+  /// Defaults to `true`; the bloc's `enabledStream` corrects it on the seed it
+  /// receives at startup. While `false` the bloc holds no repository
+  /// subscription and runs no sync — see [activeOwnerPubkey].
+  final bool enabled;
+
+  /// The owner the bloc may do repository work for.
+  ///
+  /// [ownerPubkey] while [enabled], `null` while the feature is off. Mutation
+  /// handlers read this rather than [ownerPubkey] so a disabled feature
+  /// publishes nothing, reusing the unauthenticated no-op path instead of
+  /// adding a second guard to each handler.
+  String? get activeOwnerPubkey => enabled ? ownerPubkey : null;
+
   /// Creates a copy with updated fields.
   PeopleListsState copyWith({
     PeopleListsStatus? status,
@@ -74,6 +90,7 @@ class PeopleListsState extends Equatable {
     Map<String, PeopleListsMutation>? pendingMutations,
     String? lastSubmittedEventId,
     bool clearLastSubmittedEventId = false,
+    bool? enabled,
   }) {
     return PeopleListsState(
       status: status ?? this.status,
@@ -84,6 +101,7 @@ class PeopleListsState extends Equatable {
       lastSubmittedEventId: clearLastSubmittedEventId
           ? null
           : (lastSubmittedEventId ?? this.lastSubmittedEventId),
+      enabled: enabled ?? this.enabled,
     );
   }
 
@@ -95,5 +113,6 @@ class PeopleListsState extends Equatable {
     listIdsByPubkey,
     pendingMutations,
     lastSubmittedEventId,
+    enabled,
   ];
 }

--- a/mobile/lib/features/people_lists/curated_lists_gate.dart
+++ b/mobile/lib/features/people_lists/curated_lists_gate.dart
@@ -1,10 +1,12 @@
-// ABOUTME: Reads FeatureFlag.curatedLists off a BuildContext.
-// ABOUTME: Backstop gate for entry points that would construct PeopleListsBloc.
+// ABOUTME: Access points for FeatureFlag.curatedLists outside the flag's own
+// ABOUTME: providers: a one-shot BuildContext read for imperative entry points,
+// ABOUTME: and a seeded stream for the app-lifetime PeopleListsBloc.
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+import 'package:openvine/providers/provider_identity_stream.dart';
 
 /// Whether curated lists are enabled for the current user.
 ///
@@ -23,3 +25,20 @@ bool curatedListsEnabled(BuildContext context) {
     listen: false,
   ).read(isFeatureEnabledProvider(FeatureFlag.curatedLists));
 }
+
+/// Successive `FeatureFlag.curatedLists` values, seeded with the current one,
+/// for the app-shell `PeopleListsBloc` (#6494).
+///
+/// Laziness gates *construction* of that bloc, and the entry points above keep
+/// that gate honest. What laziness cannot do is tear a bloc down again: the
+/// `BlocProvider` is unconditional on purpose (#6477), so one constructed while
+/// the flag was on stays alive for the session and has to stand down on its own
+/// when the flag goes off.
+///
+/// Unlike [identityStreamOf]'s usual subjects, the value here is a `bool`, so
+/// Riverpod's `==` change detection is plain value equality — exactly the
+/// signal wanted, rather than the identity proxy the helper's doc describes.
+final Provider<Stream<bool>> curatedListsEnabledStreamProvider =
+    identityStreamOf<bool>(
+      isFeatureEnabledProvider(FeatureFlag.curatedLists),
+    );

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -50,6 +50,7 @@ import 'package:openvine/features/appearance/models/appearance_mode.dart';
 import 'package:openvine/features/appearance/providers/appearance_providers.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+import 'package:openvine/features/people_lists/curated_lists_gate.dart';
 import 'package:openvine/features/people_lists/people_lists.dart';
 import 'package:openvine/l10n/current_app_l10n.dart';
 import 'package:openvine/l10n/email_verification_error_l10n.dart';
@@ -2844,8 +2845,10 @@ class _DivineAppState extends ConsumerState<DivineApp>
             // open — so a disabled feature does not construct the bloc.
             //
             // Once constructed while the flag is on, the bloc remains session-
-            // lifetime even if the flag flips off. Stopping already-started
-            // repository work on a flag-off transition is tracked in #6494.
+            // lifetime even if the flag flips off — laziness gates construction,
+            // not teardown. enabledStream is how it stands down instead: on a
+            // flag-off it drops its cache subscription and stops syncing, and on
+            // a flag-on it rewires to whoever is signed in then (#6494).
             //
             // peopleListsRepositoryProvider is keepAlive but not identity-
             // stable: it watches nostrServiceProvider, which recreates its
@@ -2864,6 +2867,7 @@ class _DivineAppState extends ConsumerState<DivineApp>
                   repositoryStream: ref.read(
                     peopleListsRepositoryIdentityStreamProvider,
                   ),
+                  enabledStream: ref.read(curatedListsEnabledStreamProvider),
                   ownerPubkeyStream: ownerPubkeyStream,
                   initialOwnerPubkey: authService.currentPublicKeyHex,
                 )..add(const PeopleListsStarted());

--- a/mobile/test/features/people_lists/bloc/people_lists_bloc_test.dart
+++ b/mobile/test/features/people_lists/bloc/people_lists_bloc_test.dart
@@ -52,12 +52,14 @@ void main() {
   group(PeopleListsBloc, () {
     late _MockPeopleListsRepository repository;
     late StreamController<String?> ownerPubkeyController;
+    late StreamController<bool> enabledController;
     late StreamController<List<UserList>> ownerAListsController;
     late StreamController<List<UserList>> ownerBListsController;
 
     setUp(() {
       repository = _MockPeopleListsRepository();
       ownerPubkeyController = StreamController<String?>.broadcast();
+      enabledController = StreamController<bool>.broadcast();
       ownerAListsController = StreamController<List<UserList>>.broadcast();
       ownerBListsController = StreamController<List<UserList>>.broadcast();
 
@@ -74,6 +76,7 @@ void main() {
 
     tearDown(() async {
       await ownerPubkeyController.close();
+      await enabledController.close();
       if (!ownerAListsController.isClosed) {
         await ownerAListsController.close();
       }
@@ -87,6 +90,7 @@ void main() {
         repository: repository,
         ownerPubkeyStream: ownerPubkeyController.stream,
         repositoryStream: const Stream.empty(),
+        enabledStream: enabledController.stream,
         initialOwnerPubkey: initialOwnerPubkey,
         clock: _fixedClock,
       );
@@ -978,6 +982,177 @@ void main() {
       expect(ownerBListsController.hasListener, isTrue);
     });
 
+    // #6494: the app-shell BlocProvider is unconditional (#6477), so laziness
+    // only gates construction. A bloc built while FeatureFlag.curatedLists was
+    // on used to keep its cache subscription and keep calling syncOwner for
+    // kind 30000 for the rest of the session after the flag went off.
+    group('curated-lists flag lifecycle', () {
+      Future<PeopleListsBloc> startedWithOwnerA() async {
+        final bloc = buildBloc()..add(const PeopleListsStarted());
+        await _flush();
+        ownerPubkeyController.add(_ownerA);
+        await _flush();
+        return bloc;
+      }
+
+      Future<void> disable() async {
+        enabledController.add(false);
+        await _flush();
+        await _flush();
+      }
+
+      test('turning the flag off cancels the lists subscription', () async {
+        final bloc = await startedWithOwnerA();
+        addTearDown(bloc.close);
+        expect(ownerAListsController.hasListener, isTrue);
+
+        await disable();
+
+        expect(ownerAListsController.hasListener, isFalse);
+        expect(bloc.state.lists, isEmpty);
+      });
+
+      test('drops a snapshot that crossed the flag-off teardown', () async {
+        final bloc = await startedWithOwnerA();
+        addTearDown(bloc.close);
+
+        // Same turn, flag first: the cancel is synchronous, but a snapshot the
+        // cache already handed over is queued behind the flag event.
+        enabledController.add(false);
+        ownerAListsController.add([
+          _buildList(id: 'l1', name: 'Friends', pubkeys: const [_memberAlice]),
+        ]);
+        await _flush();
+        await _flush();
+        await _flush();
+
+        expect(bloc.state.enabled, isFalse);
+        expect(bloc.state.lists, isEmpty);
+        expect(bloc.state.listIdsByPubkey, isEmpty);
+      });
+
+      test('a later owner change runs no sync while the flag is off', () async {
+        final bloc = await startedWithOwnerA();
+        addTearDown(bloc.close);
+        await disable();
+        clearInteractions(repository);
+
+        ownerPubkeyController.add(_ownerB);
+        await _flush();
+        await _flush();
+
+        verifyNever(
+          () => repository.syncOwner(ownerPubkey: any(named: 'ownerPubkey')),
+        );
+        verifyNever(
+          () => repository.watchLists(ownerPubkey: any(named: 'ownerPubkey')),
+        );
+        expect(ownerBListsController.hasListener, isFalse);
+      });
+
+      test('a repository swap runs no sync while the flag is off', () async {
+        final repositoryController =
+            StreamController<PeopleListsRepository>.broadcast();
+        addTearDown(repositoryController.close);
+        final nextRepository = _MockPeopleListsRepository();
+        when(
+          () =>
+              nextRepository.syncOwner(ownerPubkey: any(named: 'ownerPubkey')),
+        ).thenAnswer((_) async {});
+        when(
+          () => nextRepository.watchLists(ownerPubkey: _ownerA),
+        ).thenAnswer((_) => const Stream<List<UserList>>.empty());
+
+        final bloc = PeopleListsBloc(
+          repository: repository,
+          ownerPubkeyStream: ownerPubkeyController.stream,
+          repositoryStream: repositoryController.stream,
+          enabledStream: enabledController.stream,
+          clock: _fixedClock,
+        )..add(const PeopleListsStarted());
+        addTearDown(bloc.close);
+        await _flush();
+        ownerPubkeyController.add(_ownerA);
+        await _flush();
+        await disable();
+
+        repositoryController.add(nextRepository);
+        await _flush();
+        await _flush();
+
+        verifyNever(
+          () =>
+              nextRepository.syncOwner(ownerPubkey: any(named: 'ownerPubkey')),
+        );
+        verifyNever(
+          () =>
+              nextRepository.watchLists(ownerPubkey: any(named: 'ownerPubkey')),
+        );
+      });
+
+      test('mutations publish nothing while the flag is off', () async {
+        final bloc = await startedWithOwnerA();
+        addTearDown(bloc.close);
+        await disable();
+
+        bloc.add(const PeopleListsCreateRequested(name: 'Friends'));
+        await _flush();
+        await _flush();
+
+        verifyNever(
+          () => repository.createList(
+            ownerPubkey: any(named: 'ownerPubkey'),
+            name: any(named: 'name'),
+          ),
+        );
+      });
+
+      test('turning the flag back on resubscribes and syncs', () async {
+        final bloc = await startedWithOwnerA();
+        addTearDown(bloc.close);
+        await disable();
+        clearInteractions(repository);
+
+        enabledController.add(true);
+        await _flush();
+        await _flush();
+
+        expect(ownerAListsController.hasListener, isTrue);
+        verify(() => repository.syncOwner(ownerPubkey: _ownerA)).called(1);
+
+        ownerAListsController.add([
+          _buildList(id: 'l1', name: 'Friends', pubkeys: const [_memberAlice]),
+        ]);
+        await _flush();
+
+        expect(bloc.state.status, equals(PeopleListsStatus.ready));
+        expect(bloc.state.lists.single.id, equals('l1'));
+      });
+
+      // The owner stream is not seeded, so a flag-on can only learn the current
+      // account from state — which is why the bloc keeps following owner changes
+      // while it is standing down.
+      test('a flag-on syncs the account that signed in while off', () async {
+        final bloc = await startedWithOwnerA();
+        addTearDown(bloc.close);
+        await disable();
+
+        ownerPubkeyController.add(_ownerB);
+        await _flush();
+        await _flush();
+        clearInteractions(repository);
+
+        enabledController.add(true);
+        await _flush();
+        await _flush();
+
+        verify(() => repository.syncOwner(ownerPubkey: _ownerB)).called(1);
+        verifyNever(() => repository.syncOwner(ownerPubkey: _ownerA));
+        expect(ownerBListsController.hasListener, isTrue);
+        expect(ownerAListsController.hasListener, isFalse);
+      });
+    });
+
     // #6480: peopleListsRepositoryProvider is keepAlive but not
     // identity-stable — it watches nostrServiceProvider, whose client is
     // disposed on every identity change. The app-shell BlocProvider.create
@@ -1016,6 +1191,7 @@ void main() {
           repository: repository,
           ownerPubkeyStream: ownerPubkeyController.stream,
           repositoryStream: repositoryController.stream,
+          enabledStream: enabledController.stream,
           clock: _fixedClock,
         );
       }

--- a/mobile/test/features/people_lists/bloc/people_lists_bloc_test.dart
+++ b/mobile/test/features/people_lists/bloc/people_lists_bloc_test.dart
@@ -1006,6 +1006,12 @@ void main() {
         addTearDown(bloc.close);
         expect(ownerAListsController.hasListener, isTrue);
 
+        ownerAListsController.add([
+          _buildList(id: 'l1', name: 'Friends', pubkeys: const [_memberAlice]),
+        ]);
+        await _flush();
+        expect(bloc.state.lists, hasLength(1));
+
         await disable();
 
         expect(ownerAListsController.hasListener, isFalse);
@@ -1050,45 +1056,71 @@ void main() {
         expect(ownerBListsController.hasListener, isFalse);
       });
 
-      test('a repository swap runs no sync while the flag is off', () async {
-        final repositoryController =
-            StreamController<PeopleListsRepository>.broadcast();
-        addTearDown(repositoryController.close);
-        final nextRepository = _MockPeopleListsRepository();
-        when(
-          () =>
-              nextRepository.syncOwner(ownerPubkey: any(named: 'ownerPubkey')),
-        ).thenAnswer((_) async {});
-        when(
-          () => nextRepository.watchLists(ownerPubkey: _ownerA),
-        ).thenAnswer((_) => const Stream<List<UserList>>.empty());
+      test(
+        'a repository swap runs no sync while off but still lands',
+        () async {
+          final repositoryController =
+              StreamController<PeopleListsRepository>.broadcast();
+          addTearDown(repositoryController.close);
+          final nextRepository = _MockPeopleListsRepository();
+          when(
+            () => nextRepository.syncOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => nextRepository.watchLists(ownerPubkey: _ownerA),
+          ).thenAnswer((_) => const Stream<List<UserList>>.empty());
 
-        final bloc = PeopleListsBloc(
-          repository: repository,
-          ownerPubkeyStream: ownerPubkeyController.stream,
-          repositoryStream: repositoryController.stream,
-          enabledStream: enabledController.stream,
-          clock: _fixedClock,
-        )..add(const PeopleListsStarted());
-        addTearDown(bloc.close);
-        await _flush();
-        ownerPubkeyController.add(_ownerA);
-        await _flush();
-        await disable();
+          final bloc = PeopleListsBloc(
+            repository: repository,
+            ownerPubkeyStream: ownerPubkeyController.stream,
+            repositoryStream: repositoryController.stream,
+            enabledStream: enabledController.stream,
+            clock: _fixedClock,
+          )..add(const PeopleListsStarted());
+          addTearDown(bloc.close);
+          await _flush();
+          ownerPubkeyController.add(_ownerA);
+          await _flush();
+          await disable();
 
-        repositoryController.add(nextRepository);
-        await _flush();
-        await _flush();
+          repositoryController.add(nextRepository);
+          await _flush();
+          await _flush();
 
-        verifyNever(
-          () =>
-              nextRepository.syncOwner(ownerPubkey: any(named: 'ownerPubkey')),
-        );
-        verifyNever(
-          () =>
-              nextRepository.watchLists(ownerPubkey: any(named: 'ownerPubkey')),
-        );
-      });
+          verifyNever(
+            () => nextRepository.syncOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          );
+          verifyNever(
+            () => nextRepository.watchLists(
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          );
+
+          // The swap must still re-point the field while the feature is off:
+          // the flag-on rewires onto whatever `_repository` holds, and the
+          // pre-swap instance is bound to a disposed NostrClient (#6480). So
+          // `_onRepositoryChanged` deliberately does *not* stand down with the
+          // rest of the bloc.
+          clearInteractions(repository);
+          enabledController.add(true);
+          await _flush();
+          await _flush();
+
+          verify(
+            () => nextRepository.syncOwner(ownerPubkey: _ownerA),
+          ).called(1);
+          verify(
+            () => nextRepository.watchLists(ownerPubkey: _ownerA),
+          ).called(1);
+          verifyNever(
+            () => repository.syncOwner(ownerPubkey: any(named: 'ownerPubkey')),
+          );
+        },
+      );
 
       test('mutations publish nothing while the flag is off', () async {
         final bloc = await startedWithOwnerA();
@@ -1127,6 +1159,34 @@ void main() {
 
         expect(bloc.state.status, equals(PeopleListsStatus.ready));
         expect(bloc.state.lists.single.id, equals('l1'));
+      });
+
+      // The flag lives in SharedPreferences, not in auth scope, and
+      // `enabledStream` only seeds at subscribe time — so nothing would put
+      // `enabled` back to false if a sign-out dropped it. It would silently
+      // revert to the field's `true` default and the next sign-in would resume
+      // syncing kind 30000 with the feature still off, i.e. #6494 again.
+      test('a sign-out while the flag is off keeps the feature off', () async {
+        final bloc = await startedWithOwnerA();
+        addTearDown(bloc.close);
+        await disable();
+
+        ownerPubkeyController.add(null);
+        await _flush();
+        await _flush();
+
+        expect(bloc.state.enabled, isFalse);
+        expect(bloc.state.ownerPubkey, isNull);
+
+        clearInteractions(repository);
+        ownerPubkeyController.add(_ownerB);
+        await _flush();
+        await _flush();
+
+        verifyNever(
+          () => repository.syncOwner(ownerPubkey: any(named: 'ownerPubkey')),
+        );
+        expect(ownerBListsController.hasListener, isFalse);
       });
 
       // The owner stream is not seeded, so a flag-on can only learn the current

--- a/mobile/test/features/people_lists/curated_lists_gate_test.dart
+++ b/mobile/test/features/people_lists/curated_lists_gate_test.dart
@@ -1,0 +1,90 @@
+// ABOUTME: Pins that curatedListsEnabledStreamProvider actually reports flag
+// ABOUTME: flips through the real feature-flag provider chain — the app-shell
+// ABOUTME: PeopleListsBloc has no other way to learn the flag turned off.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+import 'package:openvine/features/people_lists/curated_lists_gate.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockSharedPreferences extends Mock implements SharedPreferences {}
+
+void main() {
+  group('curatedListsEnabledStreamProvider', () {
+    late _MockSharedPreferences prefs;
+
+    setUp(() {
+      prefs = _MockSharedPreferences();
+      for (final flag in FeatureFlag.values) {
+        when(() => prefs.getBool('ff_${flag.name}')).thenReturn(null);
+        when(() => prefs.containsKey('ff_${flag.name}')).thenReturn(false);
+        when(
+          () => prefs.setBool('ff_${flag.name}', any()),
+        ).thenAnswer((_) async => true);
+        when(
+          () => prefs.remove('ff_${flag.name}'),
+        ).thenAnswer((_) async => true);
+      }
+    });
+
+    // Nothing in the app `watch`es this provider — the bloc `ref.read`s it once
+    // from BlocProvider.create. That is exactly the case where a listener
+    // registered with `ref.listen` never fires (#6482), so the wiring is pinned
+    // end to end rather than at the helper.
+    test('seeds with the current value and emits on a flip', () async {
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+      addTearDown(container.dispose);
+
+      final emitted = <bool>[];
+      final subscription = container
+          .read(curatedListsEnabledStreamProvider)
+          .listen(emitted.add);
+      addTearDown(subscription.cancel);
+      await pumpEventQueue();
+
+      // FF_CURATED_LISTS defaults to true.
+      expect(emitted, equals([true]));
+
+      await container
+          .read(featureFlagServiceProvider)
+          .setFlag(FeatureFlag.curatedLists, false);
+      await pumpEventQueue();
+
+      expect(emitted, equals([true, false]));
+
+      await container
+          .read(featureFlagServiceProvider)
+          .setFlag(FeatureFlag.curatedLists, true);
+      await pumpEventQueue();
+
+      expect(emitted, equals([true, false, true]));
+    });
+
+    test('does not emit when an unrelated flag flips', () async {
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+      addTearDown(container.dispose);
+
+      final emitted = <bool>[];
+      final subscription = container
+          .read(curatedListsEnabledStreamProvider)
+          .listen(emitted.add);
+      addTearDown(subscription.cancel);
+      await pumpEventQueue();
+
+      await container
+          .read(featureFlagServiceProvider)
+          .setFlag(FeatureFlag.blueskyPublishing, true);
+      await pumpEventQueue();
+
+      expect(emitted, equals([true]));
+    });
+  });
+}

--- a/mobile/test/main_app_shell_repository_sync_test.dart
+++ b/mobile/test/main_app_shell_repository_sync_test.dart
@@ -186,11 +186,10 @@ void main() {
       expect(_mountCount, equals(1));
     });
 
-    // #6494. The flag flip must stop the bloc's work *without* the provider
-    // chain changing shape — a conditional entry here is what #6477 removed.
-    testWidgets('a curated-lists flag-off stops syncing without remounting', (
-      tester,
-    ) async {
+    // #6494. The flag flip has to stop the bloc's work from inside the bloc,
+    // because the provider chain cannot change shape — a conditional entry
+    // here is what #6477 removed.
+    testWidgets('a curated-lists flag-off stops syncing', (tester) async {
       final container = ProviderContainer(
         overrides: [_selector.overrideWith((_) => first)],
       );
@@ -219,8 +218,6 @@ void main() {
         () => second.syncOwner(ownerPubkey: any(named: 'ownerPubkey')),
       );
       expect(secondLists.hasListener, isFalse);
-
-      expect(_mountCount, equals(1));
     });
 
     testWidgets('renders lists from the swapped-in repository', (tester) async {

--- a/mobile/test/main_app_shell_repository_sync_test.dart
+++ b/mobile/test/main_app_shell_repository_sync_test.dart
@@ -38,6 +38,14 @@ final Provider<PeopleListsRepository> _repositoryProvider =
 final Provider<Stream<PeopleListsRepository>> _repositoryStreamProvider =
     identityStreamOf<PeopleListsRepository>(_repositoryProvider);
 
+/// Stand-in for `isFeatureEnabledProvider(FeatureFlag.curatedLists)`, which the
+/// app shell feeds to the bloc through `curatedListsEnabledStreamProvider`.
+final _enabledSelector = StateProvider<bool>((_) => true);
+
+final Provider<Stream<bool>> _enabledStreamProvider = identityStreamOf<bool>(
+  _enabledSelector,
+);
+
 int _mountCount = 0;
 
 /// Drains the bloc's event queue.
@@ -92,6 +100,7 @@ class _AppShellProbe extends ConsumerWidget {
       create: (_) => PeopleListsBloc(
         repository: ref.read(_repositoryProvider),
         repositoryStream: ref.read(_repositoryStreamProvider),
+        enabledStream: ref.read(_enabledStreamProvider),
         ownerPubkeyStream: ownerPubkeyStream,
         initialOwnerPubkey: _owner,
       )..add(const PeopleListsStarted()),
@@ -174,6 +183,43 @@ void main() {
 
       // And #4918's regression stays fixed: keying the BlocProvider on the
       // dependency would have remounted the whole subtree here.
+      expect(_mountCount, equals(1));
+    });
+
+    // #6494. The flag flip must stop the bloc's work *without* the provider
+    // chain changing shape — a conditional entry here is what #6477 removed.
+    testWidgets('a curated-lists flag-off stops syncing without remounting', (
+      tester,
+    ) async {
+      final container = ProviderContainer(
+        overrides: [_selector.overrideWith((_) => first)],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: _AppShellProbe(ownerPubkeyStream: ownerController.stream),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(firstLists.hasListener, isTrue);
+      clearInteractions(first);
+
+      container.read(_enabledSelector.notifier).state = false;
+      for (var i = 0; i < 10; i++) {
+        await tester.pump();
+      }
+
+      expect(firstLists.hasListener, isFalse);
+
+      // A repository flip while the feature is off must not restart the sync.
+      await _flipTo(tester, container, second);
+      verifyNever(
+        () => second.syncOwner(ownerPubkey: any(named: 'ownerPubkey')),
+      );
+      expect(secondLists.hasListener, isFalse);
+
       expect(_mountCount, equals(1));
     });
 


### PR DESCRIPTION
## Description

The app-shell `PeopleListsBloc` provider is unconditional on purpose (#6477): a conditional entry changes the provider chain's shape, so flipping `curatedLists` re-inflated everything below it, `MaterialApp.router` included. `BlocProvider` laziness gates *construction* instead — but laziness cannot tear a bloc down again. A bloc built while the flag was on kept its local-cache subscription and its auth owner listener for the rest of the session, so a later owner/account transition still called `syncOwner` for kind 30000 with the feature switched off.

`PeopleListsBloc` now takes an `enabledStream` and stands down on its own:

- **Flag off** — close the lists subscription, drop the snapshot and any pending mutations, run no repository work.
- **Flag on** — re-subscribe and re-sync the current owner.

### Why the bloc keeps following owner changes while it is off

While standing down it still tracks `state.ownerPubkey`, and that is load-bearing rather than leftover. The owner stream (`authStateStream.map(...).distinct()`) is **not** seeded, so a re-subscribe after a flag-on would learn nothing until the *next* auth event. State is the only place the flag-on path can find out who is signed in. Without it, switching accounts while curated lists is off and then turning it back on would sync the account the user left. Pinned by `a flag-on syncs the account that signed in while off`.

### Why the re-subscribe hops through the owner bucket

`_onOwnerChanged` is documented as the only handler that opens `_listsSubscription` (#6482). `_onEnabledChanged` keeps that true: on flag-on it emits and then dispatches `PeopleListsOwnerChanged.rewire()` rather than calling `watchLists` itself. The teardown side is now a shared `_stopWatchingLists()` called from both handlers, which is safe because both are fully synchronous — what orphaned a subscription in #6482 was a writer that *suspends* between reading and nulling the field, not a second writer. The doc comment says so, so the next reader does not have to re-derive it.

### Why `enabled` lives in state, not in a private field

`_repository` is a mutable field with a documented deviation because it is an injected dependency. A flag the user toggles is mutable data, which `state_management.md` requires to live in the state object. It also makes the transition assertable in `blocTest`. The three `PeopleListsState(...)` constructions in `_onOwnerChanged` therefore carry `enabled:` explicitly — the default `true` would silently re-enable the feature on a sign-out.

`state.activeOwnerPubkey` (`ownerPubkey` while enabled, `null` while off) lets the four mutation handlers reuse their existing unauthenticated no-op path instead of each growing a second guard. The UI entry points already gate on the flag, so this is a backstop, not the primary gate.

### Why `enabledStream` is required

Same reason `repositoryStream` is (#6482): the wiring in `main.dart` is the one line this fix exists for. Dropping `enabledStream:` now fails analysis with `missing_required_argument` instead of silently restoring the bug. Callers that cannot see the flag change pass `Stream.value(true)`.

### Constraints from the issue

- The provider chain above `MaterialApp.router` is unchanged in shape and unkeyed. `a curated-lists flag-off stops syncing without remounting` asserts the flag flip stops the sync while `_mountCount` stays at 1 — the #4918 regression stays fixed.
- `repositoryStream` behaviour from #6482 is untouched. A repository swap still re-points the field; it just starts no work while the flag is off.

### The wiring is pinned end to end, not at the helper

`curatedListsEnabledStreamProvider` uses the existing `identityStreamOf` helper, which listens with `container.listen` precisely because nothing `watch`es it — the bloc `ref.read`s it once from `create:`. That is the failure mode #6482 documented, so `curated_lists_gate_test.dart` drives the **real** feature-flag provider chain (mock `SharedPreferences` → `FeatureFlagService.setFlag` → `featureFlagStateProvider.invalidateSelf` → `isFeatureEnabledProvider`) and asserts the stream seeds `true` and emits on each flip, rather than trusting a test double of the same shape.

**Related Issue:** Closes #6494

## Out of Scope

- **An `initiallyEnabled` constructor argument.** If the bloc were ever constructed while the flag is already off, one `syncOwner` would fire before the stream's seed arrives a turn later. Every entry point gates on the flag before reading the bloc (#6476), so that path does not exist today, and adding the parameter would mean a second source of truth for the same value plus a test for an unreachable state.
- **Cancelling a mutation that is already in flight when the flag flips.** On the success path its completion handler resolves `pendingMutations` against the disabled state, moving `status` to `ready`. On the rollback path it does more than that: `!result.submitted` — the common failure shape, since `PeopleListsRepositoryImpl` returns `PeopleListPublishResult.failed()` rather than throwing — and the `catch` both re-emit the `previousLists`/`previousIndex` captured *before* the teardown, and `_withoutMutation(..., failed: true)` pins `status` to `failure`. So the snapshot the flag-off just dropped comes back, and if an account switch happened in between it comes back under the new owner. The same emit also clears `pendingMutations`, which `UserListPeopleScreen._deleteSettled` reads as "the delete settled" — a flag-off mid-delete announces `curatedListDeletedSnack` and pops a route whose delete never landed. Deferred rather than fixed here, because the race is the pre-existing one and not a flag-off invention: those four rollback blocks are unchanged from `main`, and both modes already reproduce on a plain account switch with the flag never involved — where they are worse, since the restored state lands on `enabled: true` and actually renders. Guarding the rollback emits on the owner still matching fixes both, and belongs in a PR that owns the general case. **Tracked in #6504**, with the confirmed repro for each mode, so the deferral does not leave with this description.
- The feature-flag screen still bypasses go_router (#6481).

## Verification

- `flutter analyze lib test integration_test` — clean
- `dart format --set-exit-if-changed` on all changed files — clean
- No generated-code inputs touched (`curatedListsEnabledStreamProvider` is a plain `Provider`, not codegen)
- `flutter test` over every PeopleLists and feature-flag suite — 566 passed, 3 skipped (`test/features/people_lists/`, `test/main_app_shell_repository_sync_test.dart`, `test/providers/list_providers_test.dart`, `test/providers/provider_identity_stream_test.dart`, `test/providers/feature_flag_provider_test.dart`, `test/services/feature_flag_service_test.dart`, `test/screens/feature_flag_screen_test.dart`, `test/screens/other_profile_screen_test.dart`, `test/screens/user_list_people_screen_test.dart`, `test/screens/search_results/`, `test/widgets/profile/`, `test/widgets/user_profile_tile_feature_flag_test.dart`, `test/blocs/list_search/`)
- Pre-push hook: merge-conflict check, analyzer, and changed-file tests all passed
- Review round: the `_mountCount` assertion added to `a curated-lists flag-off stops syncing` was dropped — `_AppShellProbe` is test-local, so no production change can move that counter and the assertion could not go red (thanks @realmeylisdev)

Each part of the fix was checked against a neutered version rather than assumed load-bearing. Three rows below were added in a follow-up commit: the sign-out `enabled:`, the un-gated `_onRepositoryChanged`, and the flag-off snapshot drop were all load-bearing but unpinned — the suite stayed green when each was neutered.

| Neutered | Tests that go red |
| --- | --- |
| `_onEnabledChanged` returns early | 9 |
| only the `!state.enabled` guard in `_onOwnerChanged` | 4 |
| `enabled:` dropped from the sign-out emit in `_onOwnerChanged` | 1 (`a sign-out while the flag is off keeps the feature off`) |
| `_onRepositoryChanged` made to stand down with the rest of the bloc | 1 (`a repository swap runs no sync while off but still lands`) |
| `activeOwnerPubkey` reverted to `ownerPubkey` | 1 (`mutations publish nothing while the flag is off`) |
| the `!state.enabled` guard in `_onRepositoryListsChanged` | 1 (`drops a snapshot that crossed the flag-off teardown`) |
| the flag-off emit relaxed to `state.copyWith(enabled: false)` | 1 (`turning the flag off cancels the lists subscription`) |

## Test plan

Manual verification on a real Samsung Galaxy — passed:

1. Settings → Experimental Features → toggle **Curated Lists** off. Expect to stay on the Experimental Features screen (the #6477 behaviour) and the lists affordances to disappear.
2. With the flag off, sign out and sign in as a different account, then turn **Curated Lists** back on. Expect the new account's lists, not the previous account's.
3. Turn the flag off and on a few times in a row and confirm the lists screen still loads and mutations (add/remove a pubkey) still publish.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore



