### PR TITLE
chore(deps): upgrade pro_video_editor to 2.11.1

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1839,10 +1839,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: "8b4b2ffa9c3dd8995b01800f40ca5a5fd37f5431734a5b9dd0f6759580800ffa"
+      sha256: b460f17b884e3e6d2f24a9bcc55909acd9f62d9fc819ed2a6973acbf60898e0b
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.11.1"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -330,7 +330,7 @@ dependencies:
   firebase_performance: ^0.11.1+4
   firebase_messaging: ^16.1.1
   audio_session: ^0.2.2
-  pro_video_editor: ^2.11.0
+  pro_video_editor: ^2.11.1
   pro_image_editor: ^13.2.3
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7


### PR DESCRIPTION
Closes #6506

## Description

Bumps `pro_video_editor` from 2.11.0 to 2.11.1, which fixes two cancellation races in the iOS/macOS bitrate-capped export path.

When the export watchdog cancelled a stalled render, `onCancel` tore the reader and writer down from the cancelling task's thread while the sample pumps were still running on their own queues — so the teardown landed *inside* a pump operation and killed the process. Users saw this as a permanently blank screen after tapping Next, followed by a crash, with no error and no retry.

Two crash signatures on 1.0.17 (813):

- `NSInternalInconsistencyException: -[AVAssetWriterInput requestMediaDataWhenReadyOnQueue:] Cannot call method when status is 4` — the writer was already cancelled when a pump armed its input.
- `EXC_BAD_ACCESS` in `copyNextSampleBuffer` — `cancelReading()` tore the reader down mid-read. The old cancellation flag was checked before the copy, but nothing kept the cancel out of the window between the check and the call.

Upstream commit `9b4441a4` (`fix: improve thread-safe cancellation handling in BitrateCappedExporter`) routes every reader/writer touch on both sides through one gate, so a teardown can only land *between* whole operations. Nothing changes in this repo beyond the dependency version: the app-side failure path (`renderFailed` plus the retry affordance from #6058) already existed, it was just never reached because the process died first. A stalled export now surfaces as a retry instead of a crash.

The constraint moves to `^2.11.1` rather than staying at `^2.11.0` so a fresh resolve cannot land on a version without the fix.

`2.11.1` also includes upstream image-orientation fixes from `21a01dfd` and a changelog correction from `c985c4cf`. Those touch Android, iOS, and macOS image decode paths for chroma-key backgrounds, image layers, and stop-motion frames. The Android-side changes are not the crash fix, but they are part of the package version being adopted.

**Related Issue:** Closes #6506. The existing retry affordance was introduced for #6058.

## Out of Scope

The crash fixed by `9b4441a4` is iOS/macOS only (AVFoundation). This PR does not change Divine application code, and it does not attempt to address unrelated Crashlytics issues.

Two other issues found in the same Crashlytics pass are deliberately left out: the `_NativeParagraphBuilder.addText` UTF-16 crash (unsanitized notification comment quotes) and the `SqliteException(26)` DB-open failures. Both are unrelated to this dependency and want their own PRs.

## Verification

- `flutter analyze lib test integration_test` — No issues found
- `flutter test test/services/video_editor test/providers/video_editor_provider_test.dart test/providers/video_publish_provider_test.dart` — 406 passed
- `flutter pub get` changed exactly one dependency; the lockfile diff is `pro_video_editor` only
- pub.dev lists `pro_video_editor` 2.11.1 with archive SHA `b460f17b884e3e6d2f24a9bcc55909acd9f62d9fc819ed2a6973acbf60898e0b`, matching `pubspec.lock`
- Upstream compare `v2.11.0...v2.11.1` contains the cancellation fix commit `9b4441a4`
- The upstream fix was verified in the app on device before 2.11.1 was published

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
