### PR TITLE
fix(upload): cap ProofMode headers so publishes stop dying at the edge

### DIFF
--- a/docs/protocol/blossom/2026-03-26-divine-resumable-upload-sessions-bud.md
+++ b/docs/protocol/blossom/2026-03-26-divine-resumable-upload-sessions-bud.md
@@ -108,8 +108,14 @@ Optional request headers:
 
 - `X-ProofMode-Manifest`
 - `X-ProofMode-Signature`
+- `X-ProofMode-PublicKey`
 - `X-ProofMode-Attestation`
 - `X-ProofMode-C2PA`
+
+`X-ProofMode-PublicKey` carries the PGP public key matching
+`X-ProofMode-Signature`. The two travel together because a signature cannot be
+verified from headers alone without it; a server that sees one without the
+other must treat the signature as unverified rather than invalid.
 
 When present, these headers carry the same ProofMode metadata that legacy
 `PUT /upload` accepts. Clients should send them on `complete` so resumable

--- a/docs/protocol/blossom/2026-03-26-divine-resumable-upload-sessions-bud.md
+++ b/docs/protocol/blossom/2026-03-26-divine-resumable-upload-sessions-bud.md
@@ -138,12 +138,13 @@ under **128 KiB over HTTP/1.1** (past it the edge answers 502) and under
 
 An uncapped client sends the device attestation twice — base64 inside
 `X-ProofMode-Manifest` and again in `X-ProofMode-Attestation` — so it crosses
-128 KiB once the raw attestation passes roughly 47.5 KB, and every upload from
-that device then fails with an opaque 502, or with a connection reset while
+128 KiB once the raw attestation passes roughly 47.5 KB, and the upload
+carrying it then fails with an opaque 502, or with a connection reset while
 the body is still streaming on the legacy `PUT /upload` path. Android
-attestation size is device-dependent (it is the `X509Certificate.toString()`
-dump of the whole chain), so an uncapped client fails on some devices and not
-others.
+attestation size is the `X509Certificate.toString()` dump of the whole chain,
+so it varies by device *and* by capture — the client stores it per file hash,
+and only for captures where attestation succeeded. An uncapped client
+therefore fails on some devices, and on those devices only for some uploads.
 
 Any future proof payload that can exceed the budget must travel in the
 `complete` request body, not in a header.

--- a/docs/protocol/blossom/2026-03-26-divine-resumable-upload-sessions-bud.md
+++ b/docs/protocol/blossom/2026-03-26-divine-resumable-upload-sessions-bud.md
@@ -134,12 +134,16 @@ not fit, cheapest-and-most-identifying first.
 
 Measured against `media.divine.video`, combined request headers must stay
 under **128 KiB over HTTP/1.1** (past it the edge answers 502) and under
-**64 KiB over HTTP/2** (past it the connection is closed mid-request). An
-Android hardware attestation chain base64-encodes to ~75 KB in
-`X-ProofMode-Manifest` and another ~72 KB in `X-ProofMode-Attestation`, so an
-uncapped client sends ~147 KB and fails every upload with an opaque 502 — or,
-on the legacy `PUT /upload` path, a connection reset while the body is still
-streaming.
+**64 KiB over HTTP/2** (past it the connection is closed mid-request).
+
+An uncapped client sends the device attestation twice — base64 inside
+`X-ProofMode-Manifest` and again in `X-ProofMode-Attestation` — so it crosses
+128 KiB once the raw attestation passes roughly 47.5 KB, and every upload from
+that device then fails with an opaque 502, or with a connection reset while
+the body is still streaming on the legacy `PUT /upload` path. Android
+attestation size is device-dependent (it is the `X509Certificate.toString()`
+dump of the whole chain), so an uncapped client fails on some devices and not
+others.
 
 Any future proof payload that can exceed the budget must travel in the
 `complete` request body, not in a header.

--- a/docs/protocol/blossom/2026-03-26-divine-resumable-upload-sessions-bud.md
+++ b/docs/protocol/blossom/2026-03-26-divine-resumable-upload-sessions-bud.md
@@ -116,6 +116,28 @@ When present, these headers carry the same ProofMode metadata that legacy
 uploads preserve the same server-side ProofMode handling without forcing the
 video bytes back onto the legacy single-request upload path.
 
+These headers are **supplementary and size-capped**. Servers must not treat
+them as the delivery mechanism for the proof: the canonical manifest is the
+`proofmode` tag on the kind 34236 event, and the C2PA manifest is embedded in
+the uploaded bytes. No Divine Blossom server reads them today.
+
+Clients must keep the combined `X-ProofMode-*` header size within a
+conservative budget — the mobile client uses 8 KiB
+(`BlossomUploadService.maxProofModeHeaderBytes`) — and drop headers that do
+not fit, cheapest-and-most-identifying first.
+
+Measured against `media.divine.video`, combined request headers must stay
+under **128 KiB over HTTP/1.1** (past it the edge answers 502) and under
+**64 KiB over HTTP/2** (past it the connection is closed mid-request). An
+Android hardware attestation chain base64-encodes to ~75 KB in
+`X-ProofMode-Manifest` and another ~72 KB in `X-ProofMode-Attestation`, so an
+uncapped client sends ~147 KB and fails every upload with an opaque 502 — or,
+on the legacy `PUT /upload` path, a connection reset while the body is still
+streaming.
+
+Any future proof payload that can exceed the budget must travel in the
+`complete` request body, not in a header.
+
 Example successful response:
 
 ```json

--- a/mobile/docs/PROOFMODE_ARCHITECTURE.md
+++ b/mobile/docs/PROOFMODE_ARCHITECTURE.md
@@ -320,6 +320,23 @@ class VineRecordingController {
 
 ProofMode manifest is uploaded alongside video to Blossom server:
 
+> **The `X-ProofMode-*` headers are best-effort supplementary metadata, not the
+> delivery mechanism for the manifest.** The canonical copy is the `proofmode`
+> tag on the kind 34236 event, and the C2PA manifest is embedded in the video
+> bytes themselves. No Blossom server currently reads these headers.
+>
+> They are also hard-capped: `BlossomUploadService.maxProofModeHeaderBytes`
+> (8 KiB combined) governs what actually goes on the wire, cheapest-and-most-
+> identifying first (`X-ProofMode-C2PA`, then `-Signature`, `-Attestation`,
+> `-Manifest`). An Android hardware attestation chain is ~54 KB and used to
+> travel twice — ~75 KB base64-encoded in `X-ProofMode-Manifest` plus ~72 KB
+> again in `X-ProofMode-Attestation`. Measured against `media.divine.video`,
+> combined request headers must stay under **128 KiB over HTTP/1.1** (past it
+> the edge answers 502) and under **64 KiB over HTTP/2** (past it the
+> connection is closed mid-request). At ~147 KB every publish from such a
+> device failed. Do not reintroduce an uncapped header here; put new proof
+> payloads in a request body.
+
 ```dart
 class BlossomUploadService {
   Future<UploadResult> uploadVideo({

--- a/mobile/docs/PROOFMODE_ARCHITECTURE.md
+++ b/mobile/docs/PROOFMODE_ARCHITECTURE.md
@@ -330,14 +330,20 @@ ProofMode manifest is uploaded alongside video to Blossom server:
 > identifying first (`X-ProofMode-C2PA`, then `-Signature`, `-PublicKey`,
 > `-Attestation`, `-Manifest`). `-Signature` and `-PublicKey` sit above the
 > bulk headers because a signature without its key cannot be verified from
-> headers alone. An Android hardware attestation chain is ~54 KB and used to
-> travel twice — ~75 KB base64-encoded in `X-ProofMode-Manifest` plus ~72 KB
-> again in `X-ProofMode-Attestation`. Measured against `media.divine.video`,
-> combined request headers must stay under **128 KiB over HTTP/1.1** (past it
-> the edge answers 502) and under **64 KiB over HTTP/2** (past it the
-> connection is closed mid-request). At ~147 KB every publish from such a
-> device failed. Do not reintroduce an uncapped header here; put new proof
-> payloads in a request body.
+> headers alone. Measured against `media.divine.video`, combined request
+> headers must stay under **128 KiB over HTTP/1.1** (past it the edge answers
+> 502) and under **64 KiB over HTTP/2** (past it the connection is closed
+> mid-request).
+>
+> An Android device attestation is the `X509Certificate.toString()` dump of
+> the whole cert chain, so its size varies per device, and it used to travel
+> twice — base64 in `X-ProofMode-Manifest` and again in
+> `X-ProofMode-Attestation`. Past roughly **47.5 KB of raw attestation** the
+> request crosses 128 KiB and every publish from that device fails. That is
+> why the bug looked sporadic: a Pixel 8 Pro produced 53,826 bytes and always
+> failed, shorter chains stayed under the line and uploaded fine, and iOS
+> ships a compact integrity token that never came close. Do not reintroduce an
+> uncapped header here; put new proof payloads in a request body.
 
 ```dart
 class BlossomUploadService {

--- a/mobile/docs/PROOFMODE_ARCHITECTURE.md
+++ b/mobile/docs/PROOFMODE_ARCHITECTURE.md
@@ -327,8 +327,10 @@ ProofMode manifest is uploaded alongside video to Blossom server:
 >
 > They are also hard-capped: `BlossomUploadService.maxProofModeHeaderBytes`
 > (8 KiB combined) governs what actually goes on the wire, cheapest-and-most-
-> identifying first (`X-ProofMode-C2PA`, then `-Signature`, `-Attestation`,
-> `-Manifest`). An Android hardware attestation chain is ~54 KB and used to
+> identifying first (`X-ProofMode-C2PA`, then `-Signature`, `-PublicKey`,
+> `-Attestation`, `-Manifest`). `-Signature` and `-PublicKey` sit above the
+> bulk headers because a signature without its key cannot be verified from
+> headers alone. An Android hardware attestation chain is ~54 KB and used to
 > travel twice — ~75 KB base64-encoded in `X-ProofMode-Manifest` plus ~72 KB
 > again in `X-ProofMode-Attestation`. Measured against `media.divine.video`,
 > combined request headers must stay under **128 KiB over HTTP/1.1** (past it

--- a/mobile/docs/PROOFMODE_ARCHITECTURE.md
+++ b/mobile/docs/PROOFMODE_ARCHITECTURE.md
@@ -339,11 +339,19 @@ ProofMode manifest is uploaded alongside video to Blossom server:
 > the whole cert chain, so its size varies per device, and it used to travel
 > twice — base64 in `X-ProofMode-Manifest` and again in
 > `X-ProofMode-Attestation`. Past roughly **47.5 KB of raw attestation** the
-> request crosses 128 KiB and every publish from that device fails. That is
-> why the bug looked sporadic: a Pixel 8 Pro produced 53,826 bytes and always
-> failed, shorter chains stayed under the line and uploaded fine, and iOS
-> ships a compact integrity token that never came close. Do not reintroduce an
-> uncapped header here; put new proof payloads in a request body.
+> request crosses 128 KiB and the publish carrying it fails. A Pixel 8 Pro
+> produced 53,826 bytes, shorter chains stayed under the line and uploaded
+> fine, and iOS ships a compact integrity token that never came close.
+>
+> The attestation is a **per-capture** artifact, not a device constant:
+> `readProofMetadata` reads `<proofDir>/<fileHash>.attest` for the file being
+> proofed, and that file only exists for captures where attestation actually
+> succeeded. One handset can therefore hold a clip with no attestation that
+> publishes fine and a 53,826-byte one that does not — a device failing *some*
+> publishes is the expected shape, not evidence against this diagnosis.
+>
+> Do not reintroduce an uncapped header here; put new proof payloads in a
+> request body.
 
 ```dart
 class BlossomUploadService {

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -2928,8 +2928,8 @@ class BlossomUploadService {
   /// Add ProofMode headers to upload request.
   ///
   /// Generates X-ProofMode-Manifest, X-ProofMode-Signature,
-  /// and X-ProofMode-Attestation headers from the provided
-  /// ProofManifest JSON.
+  /// X-ProofMode-PublicKey, X-ProofMode-Attestation and X-ProofMode-C2PA
+  /// headers from the provided ProofManifest JSON.
   ///
   /// Headers are attached best-effort within [maxProofModeHeaderBytes]. See
   /// that constant for why an oversized proof is dropped instead of sent.
@@ -2941,13 +2941,17 @@ class BlossomUploadService {
       final manifestMap = jsonDecode(proofManifestJson) as Map<String, dynamic>;
 
       // Ordered cheapest-and-most-identifying first, so a proof that busts the
-      // budget still carries the C2PA id and the signature.
+      // budget still carries the C2PA id and a verifiable signature/key pair.
       final candidates = <String, String>{
         if (manifestMap['c2paManifestId'] ?? manifestMap['c2pa_manifest_id']
             case final c2paManifestId?)
           'X-ProofMode-C2PA': _encodeHeaderValue(c2paManifestId),
         if (manifestMap['pgpSignature'] case final pgpSignature?)
           'X-ProofMode-Signature': _encodeHeaderValue(pgpSignature),
+        // Paired with the signature: without the key the signature cannot be
+        // verified from headers alone.
+        if (manifestMap['publicKey'] case final publicKey?)
+          'X-ProofMode-PublicKey': _encodeHeaderValue(publicKey),
         if (manifestMap['deviceAttestation'] case final deviceAttestation?)
           'X-ProofMode-Attestation': _encodeHeaderValue(deviceAttestation),
         'X-ProofMode-Manifest': base64.encode(utf8.encode(proofManifestJson)),

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -537,6 +537,25 @@ class BlossomUploadService {
   /// The default Divine Blossom media server.
   static const String defaultBlossomServer = 'https://media.divine.video';
 
+  /// Combined wire budget for the `X-ProofMode-*` request headers.
+  ///
+  /// An Android hardware attestation chain is ~54 KB, and it used to travel
+  /// twice: ~75 KB base64-encoded inside `X-ProofMode-Manifest` plus ~72 KB
+  /// again in `X-ProofMode-Attestation`. Measured against
+  /// `media.divine.video`, combined request headers must stay under 128 KiB
+  /// over HTTP/1.1 (past it the edge answers 502) and under 64 KiB over
+  /// HTTP/2 (past it the connection is closed mid-request). At ~147 KB every
+  /// publish from such a device failed.
+  ///
+  /// 8 KiB leaves headroom for the auth header and keeps the request inside
+  /// the stricter 8 KB-per-header budget common to nginx-fronted Blossom
+  /// deployments too.
+  ///
+  /// Dropping an oversized header loses nothing: no Blossom server reads
+  /// these, and the canonical copy of the manifest is the `proofmode` tag on
+  /// the kind 34236 event.
+  static const int maxProofModeHeaderBytes = 8192;
+
   /// Maximum retries for a single chunk PUT before bubbling to the caller.
   static const int _maxChunkRetries = 2;
   static const Duration _chunkRetryDelay = Duration(seconds: 1);
@@ -2911,6 +2930,9 @@ class BlossomUploadService {
   /// Generates X-ProofMode-Manifest, X-ProofMode-Signature,
   /// and X-ProofMode-Attestation headers from the provided
   /// ProofManifest JSON.
+  ///
+  /// Headers are attached best-effort within [maxProofModeHeaderBytes]. See
+  /// that constant for why an oversized proof is dropped instead of sent.
   void _addProofModeHeaders(
     Map<String, dynamic> headers,
     String proofManifestJson,
@@ -2918,33 +2940,45 @@ class BlossomUploadService {
     try {
       final manifestMap = jsonDecode(proofManifestJson) as Map<String, dynamic>;
 
-      // Base64 encode the full manifest
-      headers['X-ProofMode-Manifest'] = base64.encode(
-        utf8.encode(proofManifestJson),
-      );
+      // Ordered cheapest-and-most-identifying first, so a proof that busts the
+      // budget still carries the C2PA id and the signature.
+      final candidates = <String, String>{
+        if (manifestMap['c2paManifestId'] ?? manifestMap['c2pa_manifest_id']
+            case final c2paManifestId?)
+          'X-ProofMode-C2PA': _encodeHeaderValue(c2paManifestId),
+        if (manifestMap['pgpSignature'] case final pgpSignature?)
+          'X-ProofMode-Signature': _encodeHeaderValue(pgpSignature),
+        if (manifestMap['deviceAttestation'] case final deviceAttestation?)
+          'X-ProofMode-Attestation': _encodeHeaderValue(deviceAttestation),
+        'X-ProofMode-Manifest': base64.encode(utf8.encode(proofManifestJson)),
+      };
 
-      // Extract and encode signature if present
-      if (manifestMap['pgpSignature'] != null) {
-        headers['X-ProofMode-Signature'] = _encodeHeaderValue(
-          manifestMap['pgpSignature'],
+      var usedBytes = 0;
+      final dropped = <String>[];
+      for (final candidate in candidates.entries) {
+        // `name: value\r\n` is what actually counts against a proxy's budget.
+        final wireBytes = candidate.key.length + candidate.value.length + 4;
+        if (usedBytes + wireBytes > maxProofModeHeaderBytes) {
+          dropped.add('${candidate.key} (${candidate.value.length}B)');
+          continue;
+        }
+        usedBytes += wireBytes;
+        headers[candidate.key] = candidate.value;
+      }
+
+      if (dropped.isEmpty) {
+        Log.info(
+          'Added ProofMode headers to upload ($usedBytes bytes)',
+          name: 'BlossomUploadService',
+          category: LogCategory.video,
         );
+        return;
       }
 
-      // Extract and encode attestation if present
-      if (manifestMap['deviceAttestation'] != null) {
-        headers['X-ProofMode-Attestation'] = _encodeHeaderValue(
-          manifestMap['deviceAttestation'],
-        );
-      }
-
-      final c2paManifestId =
-          manifestMap['c2paManifestId'] ?? manifestMap['c2pa_manifest_id'];
-      if (c2paManifestId != null) {
-        headers['X-ProofMode-C2PA'] = _encodeHeaderValue(c2paManifestId);
-      }
-
-      Log.info(
-        'Added ProofMode headers to upload',
+      Log.warning(
+        'ProofMode headers over the $maxProofModeHeaderBytes byte budget; '
+        'sent $usedBytes bytes and dropped ${dropped.join(', ')}. '
+        'The full manifest still ships in the video event proofmode tag.',
         name: 'BlossomUploadService',
         category: LogCategory.video,
       );

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -539,13 +539,18 @@ class BlossomUploadService {
 
   /// Combined wire budget for the `X-ProofMode-*` request headers.
   ///
-  /// An Android hardware attestation chain is ~54 KB, and it used to travel
-  /// twice: ~75 KB base64-encoded inside `X-ProofMode-Manifest` plus ~72 KB
-  /// again in `X-ProofMode-Attestation`. Measured against
-  /// `media.divine.video`, combined request headers must stay under 128 KiB
-  /// over HTTP/1.1 (past it the edge answers 502) and under 64 KiB over
-  /// HTTP/2 (past it the connection is closed mid-request). At ~147 KB every
-  /// publish from such a device failed.
+  /// Measured against `media.divine.video`, combined request headers must
+  /// stay under 128 KiB over HTTP/1.1 (past it the edge answers 502) and
+  /// under 64 KiB over HTTP/2 (past it the connection is closed mid-request).
+  ///
+  /// An Android device attestation is the `X509Certificate.toString()` dump
+  /// of the whole cert chain, so its size varies per device, and it used to
+  /// travel twice — base64 inside `X-ProofMode-Manifest` and again in
+  /// `X-ProofMode-Attestation`. Past roughly 47.5 KB of raw attestation the
+  /// request crosses 128 KiB and every publish from that device fails, which
+  /// is why the failure looked sporadic rather than universal: a Pixel 8 Pro
+  /// produced 53,826 bytes and always failed, while shorter chains stayed
+  /// under the line and uploaded fine.
   ///
   /// 8 KiB leaves headroom for the auth header and keeps the request inside
   /// the stricter 8 KB-per-header budget common to nginx-fronted Blossom

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_proofmode_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_proofmode_test.dart
@@ -432,6 +432,78 @@ void main() {
           expect(headers, contains('X-ProofMode-C2PA'));
         },
       );
+
+      test(
+        'drops the bulk headers when an Android attestation busts the budget',
+        () async {
+          arrangeUploadMocks();
+          final mockFile = createMockFile();
+
+          // Real Android hardware attestation chains run ~54 KB, and used to
+          // ship twice (base64 in the manifest and again in its own header):
+          // ~147 KB combined, past the 128 KiB that media.divine.video
+          // accepts over HTTP/1.1 before answering 502.
+          final manifest = jsonEncode({
+            'videoHash': 'abc123',
+            'pgpSignature': _pgpSignatureString,
+            'deviceAttestation': 'A' * 54000,
+            'c2pa_manifest_id': 'c2pa-test-id',
+          });
+
+          await service.uploadVideo(
+            description: 'test',
+            videoFile: mockFile,
+            nostrPubkey: _testPubkey,
+            title: 'test',
+            hashtags: const [],
+            proofManifestJson: manifest,
+          );
+
+          final headers = capturedOptions!.headers!;
+          // The identifying headers survive...
+          expect(headers, contains('X-ProofMode-C2PA'));
+          expect(headers, contains('X-ProofMode-Signature'));
+          // ...the two that blow the budget do not.
+          expect(headers, isNot(contains('X-ProofMode-Attestation')));
+          expect(headers, isNot(contains('X-ProofMode-Manifest')));
+        },
+      );
+
+      test(
+        'keeps every proof header inside the wire budget',
+        () async {
+          arrangeUploadMocks();
+          final mockFile = createMockFile();
+
+          final manifest = jsonEncode({
+            'videoHash': 'abc123',
+            'pgpSignature': _pgpSignatureString,
+            'deviceAttestation': 'A' * 54000,
+            'c2pa_manifest_id': 'c2pa-test-id',
+          });
+
+          await service.uploadVideo(
+            description: 'test',
+            videoFile: mockFile,
+            nostrPubkey: _testPubkey,
+            title: 'test',
+            hashtags: const [],
+            proofManifestJson: manifest,
+          );
+
+          final proofBytes = capturedOptions!.headers!.entries
+              .where((e) => e.key.startsWith('X-ProofMode-'))
+              .fold<int>(
+                0,
+                (sum, e) => sum + e.key.length + '${e.value}'.length + 4,
+              );
+
+          expect(
+            proofBytes,
+            lessThanOrEqualTo(BlossomUploadService.maxProofModeHeaderBytes),
+          );
+        },
+      );
     });
   });
 }

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_proofmode_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_proofmode_test.dart
@@ -445,9 +445,11 @@ void main() {
           // header) for ~147 KB combined, past the 128 KiB that
           // media.divine.video accepts over HTTP/1.1 before answering 502.
           final realWorldSignature = 'S' * 821;
+          final realWorldPublicKey = 'K' * 2048;
           final manifest = jsonEncode({
             'videoHash': 'abc123',
             'pgpSignature': realWorldSignature,
+            'publicKey': realWorldPublicKey,
             'deviceAttestation': 'A' * 53826,
             'c2pa_manifest_id': 'urn:c2pa:7ae319b2-8641-4eea-8203-a1faf72e31e4',
           });
@@ -465,18 +467,52 @@ void main() {
           // The identifying headers survive...
           expect(headers, contains('X-ProofMode-C2PA'));
           expect(headers, contains('X-ProofMode-Signature'));
+          expect(headers, contains('X-ProofMode-PublicKey'));
           // ...the two that blow the budget do not.
           expect(headers, isNot(contains('X-ProofMode-Attestation')));
           expect(headers, isNot(contains('X-ProofMode-Manifest')));
 
-          // A real-world PGP signature survives the budget intact, not merely
-          // present: truncating it would make the proof unverifiable.
+          // The signature and the key that verifies it both survive the budget
+          // intact, not merely present: truncating either one leaves a proof
+          // that cannot be checked from headers alone.
           expect(
             utf8.decode(
               base64.decode(headers['X-ProofMode-Signature'] as String),
             ),
             equals(realWorldSignature),
           );
+          expect(
+            utf8.decode(
+              base64.decode(headers['X-ProofMode-PublicKey'] as String),
+            ),
+            equals(realWorldPublicKey),
+          );
+        },
+      );
+
+      test(
+        'omits the public key header when the manifest has no publicKey',
+        () async {
+          arrangeUploadMocks();
+          final mockFile = createMockFile();
+
+          final manifest = jsonEncode({
+            'videoHash': 'abc123',
+            'pgpSignature': _pgpSignatureString,
+          });
+
+          await service.uploadVideo(
+            description: 'test',
+            videoFile: mockFile,
+            nostrPubkey: _testPubkey,
+            title: 'test',
+            hashtags: const [],
+            proofManifestJson: manifest,
+          );
+
+          final headers = capturedOptions!.headers!;
+          expect(headers, contains('X-ProofMode-Signature'));
+          expect(headers, isNot(contains('X-ProofMode-PublicKey')));
         },
       );
 

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_proofmode_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_proofmode_test.dart
@@ -439,15 +439,17 @@ void main() {
           arrangeUploadMocks();
           final mockFile = createMockFile();
 
-          // Real Android hardware attestation chains run ~54 KB, and used to
-          // ship twice (base64 in the manifest and again in its own header):
-          // ~147 KB combined, past the 128 KiB that media.divine.video
-          // accepts over HTTP/1.1 before answering 502.
+          // Field sizes taken from a real Android capture: an 821-byte PGP
+          // signature and a ~54 KB hardware attestation chain. The attestation
+          // used to ship twice (base64 in the manifest and again in its own
+          // header) for ~147 KB combined, past the 128 KiB that
+          // media.divine.video accepts over HTTP/1.1 before answering 502.
+          final realWorldSignature = 'S' * 821;
           final manifest = jsonEncode({
             'videoHash': 'abc123',
-            'pgpSignature': _pgpSignatureString,
-            'deviceAttestation': 'A' * 54000,
-            'c2pa_manifest_id': 'c2pa-test-id',
+            'pgpSignature': realWorldSignature,
+            'deviceAttestation': 'A' * 53826,
+            'c2pa_manifest_id': 'urn:c2pa:7ae319b2-8641-4eea-8203-a1faf72e31e4',
           });
 
           await service.uploadVideo(
@@ -466,6 +468,15 @@ void main() {
           // ...the two that blow the budget do not.
           expect(headers, isNot(contains('X-ProofMode-Attestation')));
           expect(headers, isNot(contains('X-ProofMode-Manifest')));
+
+          // A real-world PGP signature survives the budget intact, not merely
+          // present: truncating it would make the proof unverifiable.
+          expect(
+            utf8.decode(
+              base64.decode(headers['X-ProofMode-Signature'] as String),
+            ),
+            equals(realWorldSignature),
+          );
         },
       );
 


### PR DESCRIPTION
Closes #6529

## Description

On some Android devices every video publish fails, and the retry loop hides why. It is not all of them, which is what made this hard to see.

The client base64-encodes the full ProofMode manifest into `X-ProofMode-Manifest` and then the device attestation *a second time* into `X-ProofMode-Attestation`. Android's attestation is the `X509Certificate.toString()` dump of the whole cert chain, so its size is device-dependent — and it goes on the wire twice.

**Blast radius:** publishing breaks once the raw attestation passes roughly **47.5 KB**, because that is where the doubled payload crosses what `media.divine.video` accepts. Probed with the pre-fix header shape:

| Raw attestation | Combined headers | Result |
|---|---|---|
| 46,500 B | 126 KB | `401` (reaches the handler) |
| 47,500 B | 128 KB | `401` |
| 48,000 B | 131 KB | `502` |
| 53,826 B (Pixel 8 Pro) | 147 KB | `502` |

So: a capture whose attestation dumps over ~47.5 KB fails to publish, one under it does not, iOS ships a compact integrity token and is unaffected, and captures without ProofMode send no such headers at all. Same root cause either way — the doubled, uncapped payload — but the failure is a long tail rather than an Android-wide outage.

**The threshold is per capture, not per device.** The client reads the attestation from `<proofDir>/<fileHash>.attest` for the file being proofed, and that file only exists for captures where attestation actually succeeded. Chain size is device-dependent, so a big-attestation handset is the precondition — but on such a handset some clips carry 53,826 bytes and others carry none, and only the former fail. A user reporting "new videos post, older clips don't" is the expected shape of this bug, not a counter-example to it.

Measured against production, combined request headers must stay under:

| Protocol | Limit | Behaviour past it |
|---|---|---|
| HTTP/1.1 (what the Dart client uses) | **128 KiB** | edge answers `502` |
| HTTP/2 | **64 KiB** | connection closed mid-request |

The boundary is sharp: over HTTP/1.1, 130,800 bytes of headers still reaches the handler (`401`), 131,000 returns `502`. Reproducing the app's exact header shape — `X-ProofMode-Manifest` at 74,788 bytes plus `X-ProofMode-Attestation` at 71,768 — returns `502`, the same status the client logged on all six attempts.

That explains the whole failure pattern in the session log:

| Request | ProofMode headers | Result |
|---|---|---|
| Chunk PUT (6.45 MB body) | no | ✅ 1.53 MB/s |
| `POST /upload/*/complete` | yes | ❌ 502, 6/6 attempts |
| Legacy `PUT /upload` | yes | ❌ reset while streaming the body |
| OS-first background PUT | yes | ❌ "network" |

The one request type that succeeds is the one carrying no ProofMode headers. On the legacy `PUT` the server answers 502 early and closes while the client is still writing 6.45 MB, which surfaces as `SocketException: Write failed (Connection reset by peer)`.

Nothing consumed these headers. `divine-blossom` (which serves `media.divine.video`, including `PUT /upload` and `/upload/*/complete`) contains no reference to `proofmode` outside a debug script and docs, and `divine-upload-server` has none at all. The canonical manifest is already the `proofmode` tag on the kind 34236 event, and the C2PA manifest is embedded in the uploaded bytes — which is what `cloud-functions/process-blob` actually reads.

### Where the proof actually travels

Worth being explicit, because "we drop the manifest header" reads alarming: the ProofMode payload never depended on these headers. Two separate channels carry the same data, and only one of them is read.

| Channel | Carries | Read by anyone? |
|---|---|---|
| `X-ProofMode-*` HTTP headers on the Blossom upload | manifest + attestation | **no** — and never stored either; Blossom keeps blobs, not request headers |
| `proofmode` / `device_attestation` tags on the kind 34236 event | manifest + attestation | **yes** — this is what the ProofMode badge and verification level read from |

Unread headers on their own would have been waste, not a bug. What broke uploads was the combination: a payload nothing consumes, sent twice, uncapped, large enough to cross the request-header limit.

The event route is verified to carry the full payload with room to spare. Probing `wss://relay.divine.video` with an intentionally invalid signature (so nothing can be stored), the relay rejects on content rather than size all the way up:

| Event size | Relay response |
|---|---|
| 56 KB | `invalid: video missing required 'title' tag` |
| 110 KB (what a big-attestation capture actually needs) | `invalid: video missing required 'title' tag` |
| 500 KB | `invalid: video missing required 'title' tag` |
| 1 MB | connection reset |

So the ~110 KB of proof tags sit at roughly a fifth of what the relay accepts. Dropping the header copies loses nothing.

(Noted in passing, not changed here: the event carries the attestation twice as well — the `proofmode` tag already embeds it, and `device_attestation` repeats it. Harmless at this headroom, but it is the same redundancy.)

**The fix:** attach the headers best-effort inside an 8 KiB budget, ordered cheapest-and-most-identifying first (`X-ProofMode-C2PA` → `-Signature` → `-PublicKey` → `-Attestation` → `-Manifest`), dropping whatever does not fit and logging what was dropped.

**New header — `X-ProofMode-PublicKey`.** The PGP signature survives the budget, but the key that verifies it previously only lived inside `X-ProofMode-Manifest`, which is exactly the header dropped for an oversized proof. That left a header-only consumer with a signature it could not check. The key now ships as its own header ranked directly after the signature, so the pair stays together above the bulk headers. With real field sizes the result is:

| Header | Size | |
|---|---|---|
| `X-ProofMode-C2PA` | 60 B | kept |
| `X-ProofMode-Signature` | 1,096 B | kept |
| `X-ProofMode-PublicKey` | 2,732 B | kept |
| `X-ProofMode-Attestation` | 71,768 B | dropped |
| `X-ProofMode-Manifest` | 75,856 B | dropped |

3,958 bytes of the 8,192 budget. The key comes from the ProofMode `<hash>-pubkey.asc` file the client already reads; captures where libProofMode does not emit that file simply omit the header.

**Backward compatibility:** the change is additive — every header that ships today keeps its exact value. Real captures do gain one header: `NativeProofData` emits `publicKey`, so any manifest carrying it now also sends `X-ProofMode-PublicKey` (2,732 B, well inside the budget). All ten pre-existing ProofMode tests pass unchanged, and their headers are byte-identical, because their fixtures carry no `publicKey`. Oversized proofs degrade from "upload always fails" to "upload succeeds, carrying the C2PA id and a verifiable signature/key pair". A mid-size proof that would have fit whole can now spend 2,732 B on the key and drop the manifest copy instead — the better trade for a header-only consumer, since the manifest embeds the key but not the reverse. No server or protocol change is required, and no shipped client is affected by this change.

8 KiB is deliberately far below both measured limits, so nginx-fronted Blossom deployments with an 8 KB per-header budget stay safe too, and splitting the payload across several headers would not help — the limit applies to the sum.

Both docs that presented "whole manifest in a header" as the design are corrected, so this does not get reintroduced.

**Related Issue:** 

### What the user actually sees

Worth pinning down, because support triages off the sentence in the sheet and neither variant says "proof" or "header". Which one appears depends on which request in the chain surfaces last:

| Failing request | Classified as | Sheet copy |
|---|---|---|
| `POST /upload/*/complete` answered `502` | `502` → `SERVER_UNAVAILABLE` → `serverDown` | "The media server (media.divine.video) is temporarily down. Try again shortly or choose another in your settings." |
| Legacy `PUT /upload` reset mid-body | `SocketException` (no status) → `NETWORK_ERROR` → `serverUnreachable` | "Could not reach the server. Please try again in a moment." |

`categorizeError` branches on the HTTP status before any string matching, so a clean 502 never reaches the network bucket; the reset does, because it carries no status. Both then re-localize through `PublishErrorKind`, so the raw English sentences in `UploadProgressReporter` are log text, not what the user reads.

## Out of Scope

- **Retry behaviour.** After attempt 1 the bytes are fully uploaded (`resuming from offset 6760190`, `0 chunks this session`), so attempts 2–6 spent 90 seconds replaying the same deterministic failure and then logged "Network error on WiFi. Check your connection and try again." (surfacing as the `serverUnreachable` copy above). Pre-existing, unrelated to this diff.
- **Shipped clients.** ≤1.0.17 keeps sending the doubled payload, so affected devices stay broken until they update. The rejection happens at the edge, before any handler runs, so no server-side mitigation can rescue them.
- Separately visible in the same session log and untouched here: `ERROR_CODE_PARSING_CONTAINER_MALFORMED` when the editor previews a C2PA-signed recording, and `VerifierApiException: verifier returned 400 "Invalid identity"` from `MyProfileBloc`.

## Verification

- `flutter test` in `mobile/packages/blossom_upload_service` — 230 tests pass
- `flutter test --coverage` — 859/859 lines covered in `blossom_upload_service.dart`, package stays at the 100% gate
- `flutter test test/services/blossom_resumable_upload_integration_test.dart` — 7 pass
- `flutter analyze lib test integration_test` — no issues
- `dart format` — clean
- Production probes of `media.divine.video` establishing both protocol limits, the sharp 131,072-byte HTTP/1.1 boundary, the `401` baseline with small headers, and a `502` reproduction using the app's exact header sizes

- Real Samsung Galaxy run: recorded and published with ProofMode on. The budget logic fired as designed — `sent 1121 bytes and dropped X-ProofMode-Attestation (11956B), X-ProofMode-Manifest (13512B)` — the upload completed and the kind 34236 event got its ProofMode tags.

Two limits on what that device run establishes. Its attestation is 8,967 raw bytes, roughly five times under the ~47.5 KB failure threshold, so the pre-fix request would have been about 26 KB of headers and published fine anyway: the run proves the new path is regression-free, not that the 502 is gone. Observing the fix itself still needs a big-attestation handset of the Pixel 8 Pro class. Separately, libProofMode emitted no `<hash>-pubkey.asc` for that capture, so `X-ProofMode-PublicKey` was omitted and the signature shipped alone — the signature/key pairing holds only for captures that produce the key file.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation



