### PR TITLE
fix(lists): stop the delete-list dialog reporting a fatal on a dead route

### DIFF
--- a/mobile/lib/screens/curated_list_feed_screen.dart
+++ b/mobile/lib/screens/curated_list_feed_screen.dart
@@ -23,6 +23,18 @@ import 'package:unified_logger/unified_logger.dart';
 
 enum _CuratedListAction { delete, unfollow }
 
+/// Pops the delete-confirmation dialog with [confirmed].
+///
+/// The route can be gone by the time a tap on one of its buttons is
+/// delivered. `Navigator.of` then walks a defunct element and throws, which
+/// `FlutterError.onError` records as a fatal even though the pop is moot.
+void _popConfirmation(BuildContext dialogContext, {required bool confirmed}) {
+  if (!dialogContext.mounted) {
+    return;
+  }
+  Navigator.of(dialogContext).pop(confirmed);
+}
+
 class CuratedListFeedScreen extends ConsumerStatefulWidget {
   /// Route name for this screen.
   static const routeName = 'list';
@@ -416,14 +428,14 @@ class _CuratedListFeedScreenState extends ConsumerState<CuratedListFeedScreen> {
         ),
         actions: [
           TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(false),
+            onPressed: () => _popConfirmation(dialogContext, confirmed: false),
             child: Text(
               l10n.commonCancel,
               style: VineTheme.labelMediumFont(color: VineTheme.secondaryText),
             ),
           ),
           TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(true),
+            onPressed: () => _popConfirmation(dialogContext, confirmed: true),
             child: Text(
               l10n.commonDelete,
               style: VineTheme.labelMediumFont(color: VineTheme.error),

--- a/mobile/test/screens/curated_list_feed_screen_test.dart
+++ b/mobile/test/screens/curated_list_feed_screen_test.dart
@@ -245,6 +245,32 @@ void main() {
       expect(find.text(l10n.curatedListUnfollowAction), findsNothing);
     });
 
+    testWidgets('delete cancel dismisses without deleting', (tester) async {
+      when(() => mockService.isSubscribedToList('owned-list')).thenReturn(true);
+      when(() => mockService.isOwnedList('owned-list')).thenReturn(true);
+
+      await tester.pumpWidget(
+        buildSubject(
+          listId: 'owned-list',
+          listName: 'Owned List',
+          authorPubkey: 'owned-pubkey',
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.byTooltip(l10n.curatedListActionsTooltip));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(l10n.listDeleteAction));
+      await tester.pumpAndSettle();
+      expect(find.text(l10n.curatedListDeleteConfirmTitle), findsOneWidget);
+
+      await tester.tap(find.text(l10n.commonCancel));
+      await tester.pumpAndSettle();
+
+      verifyNever(() => mockService.deleteOwnedList('owned-list'));
+      expect(find.text(l10n.curatedListDeleteConfirmTitle), findsNothing);
+    });
+
     testWidgets(
       'delete confirmation buttons no-op once their route is torn down',
       (tester) async {
@@ -287,7 +313,6 @@ void main() {
 
         expect(cancel, returnsNormally);
         expect(confirm, returnsNormally);
-        verifyNever(() => mockService.deleteOwnedList('owned-list'));
       },
     );
 

--- a/mobile/test/screens/curated_list_feed_screen_test.dart
+++ b/mobile/test/screens/curated_list_feed_screen_test.dart
@@ -245,6 +245,52 @@ void main() {
       expect(find.text(l10n.curatedListUnfollowAction), findsNothing);
     });
 
+    testWidgets(
+      'delete confirmation buttons no-op once their route is torn down',
+      (tester) async {
+        when(
+          () => mockService.isSubscribedToList('owned-list'),
+        ).thenReturn(true);
+        when(() => mockService.isOwnedList('owned-list')).thenReturn(true);
+
+        await tester.pumpWidget(
+          buildSubject(
+            listId: 'owned-list',
+            listName: 'Owned List',
+            authorPubkey: 'owned-pubkey',
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(find.byTooltip(l10n.curatedListActionsTooltip));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(l10n.listDeleteAction));
+        await tester.pumpAndSettle();
+
+        VoidCallback actionFor(String label) => tester
+            .widget<TextButton>(
+              find.ancestor(
+                of: find.text(label),
+                matching: find.byType(TextButton),
+              ),
+            )
+            .onPressed!;
+
+        final cancel = actionFor(l10n.commonCancel);
+        final confirm = actionFor(l10n.commonDelete);
+
+        // Stands in for anything that drops the dialog's route while the tap
+        // is in flight — a feature-flag flip re-inflating the app shell, a
+        // redirect, a deep link.
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pumpAndSettle();
+
+        expect(cancel, returnsNormally);
+        expect(confirm, returnsNormally);
+        verifyNever(() => mockService.deleteOwnedList('owned-list'));
+      },
+    );
+
     testWidgets('unfollow calls service and updates action state', (
       tester,
     ) async {


### PR DESCRIPTION
## Description

The **Cancel** and **Delete** buttons of the delete-curated-list confirmation dialog called `Navigator.of(dialogContext)` unguarded. When the dialog's route is already torn down by the time the tap is delivered, that ancestor walk hits a defunct element and throws — the pop never happens and the tap does nothing.

Nothing crashes: `GestureRecognizer.invokeCallback` catches it and hands it to `FlutterError.reportError`, which `crash_reporting_service.dart` forwards to `recordFlutterFatalError`. So a no-op tap is filed in Crashlytics as a fatal, competing with real crashes in triage.

Both actions now go through `_popConfirmation`, which returns early when `dialogContext.mounted` is false. Behaviour is unchanged while the route is alive; when it is gone the pop was moot anyway, and `showDialog` already completes with `null`, which `_confirmDeleteList` treats as "not confirmed".

Frame-by-frame resolution of the stack against the pinned Flutter 3.44.0, and why the teardown trigger itself is still open, are in the issue.

**Related Issue:** Closes #6512
**Follow-up:** #6526 tracks the sibling modal/sheet call sites and the shared-helper decision.

## Out of Scope

- **What tore the route down.** Not determined from a single session export. The leading candidate — the app-shell `if (peopleListsEnabled)` provider entry that re-inflates everything below it — was already removed by #6476, which lands in 1.0.19; the crashing 1.0.17 and 1.0.18 builds both still carry it. #6476's own commit message records that the step from re-inflation to route loss is not pinned. The guard here is correct for any teardown, so it does not wait on that.
- **Sibling modal/sheet call sites.** Nine sibling sites use the same unguarded `Navigator.of(dialogContext)` / `Navigator.of(sheetContext)` shape. None has a report against it. Whether this should become a shared helper across all of them is a call worth making deliberately rather than as a side effect of this fix, so the inventory now lives in #6526.

## Verification

- `flutter analyze lib test integration_test` — no issues.
- `dart format --set-exit-if-changed` on both changed files — clean.
- `flutter test test/screens/curated_list_feed_screen_test.dart` — 12/12.
- Neighbouring suites that touch this screen: `main_list_deep_link_nav_action_test.dart`, `l10n/hardcoded_visible_strings_test.dart`, `screens/curated_list_by_author_screen_test.dart`, `router/route_coverage_test.dart` — 119/119.
- The new regression test was confirmed red with the guard removed: it fails with `Looking up a deactivated widget's ancestor is unsafe`, which is the debug-build form of the same ancestor walk that produces the `_state!` null check in release AOT.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
