### PR TITLE
fix(profile): sanitize display text against malformed UTF-16

### DIFF
--- a/mobile/lib/blocs/comments/comment_composer/mention_search.dart
+++ b/mobile/lib/blocs/comments/comment_composer/mention_search.dart
@@ -1,3 +1,4 @@
+import 'package:models/models.dart' show UserProfile;
 import 'package:profile_repository/profile_repository.dart';
 
 /// A single mention match, as a record so this helper has no dependency on
@@ -37,7 +38,10 @@ Future<({List<MentionMatch> matches, Set<String> seen})> mentionSearchLocal({
         displayName.toLowerCase().contains(lowercaseQuery)) {
       matches.add((
         pubkey: pubkey,
-        displayName: displayName,
+        // Matched on the raw value so query behaviour is unchanged, but
+        // carried sanitized: this string is rendered in the suggestion list
+        // and inserted into the composer on select.
+        displayName: UserProfile.sanitizeDisplayName(displayName),
         picture: profile?.picture,
         nip05: profile?.nip05,
       ));
@@ -73,7 +77,7 @@ Future<List<MentionMatch>> mentionSearchRemote({
     if (name == null) continue;
     merged.add((
       pubkey: profile.pubkey,
-      displayName: name,
+      displayName: UserProfile.sanitizeDisplayName(name),
       picture: profile.picture,
       nip05: profile.nip05,
     ));

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -741,8 +741,7 @@ class _MainCommentInputState extends ConsumerState<MainCommentInput> {
                 .watch(userProfileReactiveProvider(replyToAuthorPubkey))
                 .value;
             replyToDisplayName =
-                profile?.displayName ??
-                profile?.name ??
+                profile?.bestDisplayName ??
                 UserProfile.generatedNameFor(replyToAuthorPubkey);
           }
         }

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -662,10 +662,11 @@ class _ReplyIndicator extends ConsumerWidget {
         .watch(userProfileReactiveProvider(parentAuthorPubkey))
         .value;
 
-    // Get display name with fallback chain
+    // bestDisplayName is the same displayName -> name chain, but sanitized:
+    // a lone UTF-16 surrogate in either field crashes the paragraph builder
+    // when this renders.
     final displayName =
-        profile?.displayName ??
-        profile?.name ??
+        profile?.bestDisplayName ??
         UserProfile.generatedNameFor(parentAuthorPubkey);
 
     return Row(

--- a/mobile/lib/screens/comments/widgets/mention_overlay.dart
+++ b/mobile/lib/screens/comments/widgets/mention_overlay.dart
@@ -4,6 +4,7 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:models/models.dart' show UserProfile;
 import 'package:openvine/blocs/comments/comment_composer/comment_composer_bloc.dart';
 import 'package:openvine/providers/nip05_verification_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
@@ -88,11 +89,16 @@ class MentionOverlay extends ConsumerWidget {
                 final cachedProfile = ref
                     .read(userProfileReactiveProvider(suggestion.pubkey))
                     .value;
-                final displayName =
+                // Sanitized rather than swapped for bestDisplayName: that
+                // getter substitutes a generated name for a profile with no
+                // name at all, which would shadow the npub fallback below.
+                final resolvedName =
                     suggestion.displayName ??
                     cachedProfile?.displayName ??
-                    cachedProfile?.name ??
-                    npub;
+                    cachedProfile?.name;
+                final displayName = resolvedName == null
+                    ? npub
+                    : UserProfile.sanitizeDisplayName(resolvedName);
                 onSelect(suggestion.pubkey, displayName);
               },
             );
@@ -115,8 +121,11 @@ class _MentionSuggestionItem extends ConsumerWidget {
         .watch(userProfileReactiveProvider(suggestion.pubkey))
         .value;
 
-    final displayName =
+    final rawDisplayName =
         suggestion.displayName ?? profile?.displayName ?? profile?.name;
+    final displayName = rawDisplayName == null
+        ? null
+        : UserProfile.sanitizeDisplayName(rawDisplayName);
     final picture = suggestion.picture ?? profile?.picture;
     final rawNip05 = suggestion.nip05 ?? profile?.nip05;
     final displayNip05 = _displayNip05(rawNip05);
@@ -180,6 +189,8 @@ class _MentionSuggestionItem extends ConsumerWidget {
   }
 }
 
+/// Mirrors [UserProfile.shortDisplayNip05], including its sanitization: the
+/// result is rendered directly, and `nip05` is an unverified kind-0 field.
 String? _displayNip05(String? nip05) {
   if (nip05 == null || nip05.isEmpty) return null;
   if (nip05.startsWith('_@')) {
@@ -187,12 +198,14 @@ String? _displayNip05(String? nip05) {
     final match = RegExp(
       r'^@([a-z0-9\-_.]+)\.divine\.video$',
     ).firstMatch(stripped);
-    return match != null ? '@${match.group(1)}' : stripped;
+    return UserProfile.sanitizeDisplayName(
+      match != null ? '@${match.group(1)}' : stripped,
+    );
   }
 
   if (nip05.endsWith('@divine.video') || nip05.endsWith('@openvine.co')) {
-    return '@${nip05.split('@')[0]}';
+    return '@${UserProfile.sanitizeDisplayName(nip05.split('@')[0])}';
   }
 
-  return nip05;
+  return UserProfile.sanitizeDisplayName(nip05);
 }

--- a/mobile/lib/screens/inbox/widgets/conversation_tile.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_tile.dart
@@ -12,6 +12,7 @@ import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/utils/divine_video_url.dart';
+import 'package:openvine/utils/string_utils.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -245,7 +246,14 @@ class _PreviewPayload {
   final bool isDivineVideoShare;
 }
 
-_PreviewPayload _previewPayload(BuildContext context, String content) {
+_PreviewPayload _previewPayload(BuildContext context, String rawContent) {
+  // Sender-controlled text straight from a rumor body, so it can carry
+  // unpaired UTF-16 surrogates that crash the paragraph builder during
+  // layout. This preview renders through plain `Text`/`Text.rich` rather than
+  // `LinkifiedText`, so it does not inherit the span builder's guard and
+  // sanitizes once here, ahead of every split and both output paths.
+  final content = StringUtils.sanitizeUtf16(rawContent);
+
   // The structured collaborator-invite card carries a deterministic
   // plaintext fallback ("...Open diVine to review and accept.") so old
   // clients can still see something. Inside diVine that copy is misleading

--- a/mobile/lib/services/video_sharing_service.dart
+++ b/mobile/lib/services/video_sharing_service.dart
@@ -21,6 +21,10 @@ class ShareableUser {
     this.isFollower = false,
   });
   final String pubkey;
+
+  /// Populate from `UserProfile.bestDisplayName`, never the raw kind-0
+  /// fields: this renders directly in the share sheet and find-people list,
+  /// where a lone UTF-16 surrogate crashes the paragraph builder.
   final String? displayName;
   final String? picture;
   final bool isFollowing;
@@ -302,7 +306,7 @@ class VideoSharingService {
         return [
           ShareableUser(
             pubkey: query,
-            displayName: profile?.displayName,
+            displayName: profile?.bestDisplayName,
             picture: profile?.picture,
           ),
         ];
@@ -415,7 +419,7 @@ class VideoSharingService {
         0,
         ShareableUser(
           pubkey: pubkey,
-          displayName: profile?.displayName,
+          displayName: profile?.bestDisplayName,
           picture: profile?.picture,
         ),
       );

--- a/mobile/lib/widgets/linkified_text/linkified_text_span_builder.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text_span_builder.dart
@@ -5,6 +5,7 @@ import 'package:flutter/painting.dart';
 import 'package:nostr_sdk/nip19/nip19.dart';
 import 'package:nostr_sdk/nip19/nip19_tlv.dart';
 import 'package:openvine/utils/npub_hex.dart';
+import 'package:text_sanitizer/text_sanitizer.dart';
 
 /// Called when a profile reference is tapped.
 typedef LinkifiedProfileTap = void Function(String hexPubkey);
@@ -84,13 +85,22 @@ class LinkifiedTextSpanBuilder {
   final String? videoLabel;
 
   /// Builds spans preserving the token precedence from [LinkifiedText].
+  ///
+  /// Unpaired UTF-16 surrogates are normalized here rather than at each
+  /// caller. Flutter's paragraph builder throws on them during layout — a
+  /// crash, not a rendering glitch — and they reach spans from two independent
+  /// directions: [text] itself, and the labels injected for profile
+  /// references. This is the one point every span passes through, so guarding
+  /// it covers both. Sanitizing is code-unit-for-code-unit, so match offsets
+  /// stay valid.
   List<TextSpan> build() {
+    final safeText = sanitizeUtf16(text);
     final spans = <TextSpan>[];
     var lastEnd = 0;
 
-    for (final match in _combinedRegex.allMatches(text)) {
+    for (final match in _combinedRegex.allMatches(safeText)) {
       if (match.start > lastEnd) {
-        spans.add(_plainSpan(text.substring(lastEnd, match.start)));
+        spans.add(_plainSpan(safeText.substring(lastEnd, match.start)));
       }
 
       final matchedUrl = match.group(1);
@@ -114,11 +124,11 @@ class LinkifiedTextSpanBuilder {
       lastEnd = match.end;
     }
 
-    if (lastEnd < text.length) {
-      spans.add(_plainSpan(text.substring(lastEnd)));
+    if (lastEnd < safeText.length) {
+      spans.add(_plainSpan(safeText.substring(lastEnd)));
     }
 
-    if (spans.isEmpty) return [_plainSpan(text)];
+    if (spans.isEmpty) return [_plainSpan(safeText)];
     return spans;
   }
 
@@ -189,7 +199,11 @@ class LinkifiedTextSpanBuilder {
   }
 
   TextSpan _buildProfileReferenceSpan(String hexPubkey, TextStyle style) {
-    final label = profileLabelForHex?.call(hexPubkey) ?? hexPubkey;
+    // Resolved from profile metadata, so it does not come through the
+    // sanitized source text and needs its own pass (see [build]).
+    final label = sanitizeUtf16(
+      profileLabelForHex?.call(hexPubkey) ?? hexPubkey,
+    );
     final displayText = label.startsWith('@') ? label : '@$label';
     return TextSpan(
       text: displayText,

--- a/mobile/lib/widgets/linkified_text/linkified_text_support.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text_support.dart
@@ -10,9 +10,16 @@ final class LinkifiedTextSupport {
   const LinkifiedTextSupport._();
 
   /// Resolves the display label used for profile references.
+  ///
+  /// The candidates are raw metadata fields, not the sanitizing accessors
+  /// ([UserProfile.bestDisplayName] and friends), because this label keeps its
+  /// own precedence — display name, then name, then NIP-05. So it sanitizes
+  /// the winner itself: an unpaired UTF-16 surrogate in someone's profile name
+  /// otherwise reaches the paragraph builder through every mention of them and
+  /// crashes the render.
   static String profileDisplayText(WidgetRef ref, String hexPubkey) {
     final profile = ref.watch(userProfileReactiveProvider(hexPubkey)).value;
-    final profileText = switch (profile) {
+    final profileText = UserProfile.sanitizeDisplayName(switch (profile) {
       UserProfile(:final displayName?) when displayName.isNotEmpty =>
         displayName,
       UserProfile(:final name?) when name.isNotEmpty => name,
@@ -20,7 +27,7 @@ final class LinkifiedTextSupport {
           when shortDisplayNip05.isNotEmpty =>
         shortDisplayNip05,
       _ => UserProfile.defaultDisplayNameFor(hexPubkey),
-    };
+    });
     return profileText.startsWith('@') ? profileText : '@$profileText';
   }
 

--- a/mobile/packages/models/lib/src/user_profile.dart
+++ b/mobile/packages/models/lib/src/user_profile.dart
@@ -245,12 +245,19 @@ class UserProfile {
   /// Prefers NIP-05 identifier, falls back to [name]. Returns an empty
   /// string when neither is available. Uses [shortDisplayNip05] so
   /// divine.video users render as `@rabble`, not `@rabble.divine.video`.
+  ///
+  /// Sanitized like [bestDisplayName]: both candidates are raw kind-0 fields,
+  /// and an unpaired UTF-16 surrogate in either crashes the paragraph builder
+  /// wherever this renders — the DM conversation header, the new-message
+  /// sheet, and people-list rows all pass it straight to a plain `Text`.
   String get handle {
     if (nip05 != null && nip05!.isNotEmpty) {
       final dn = shortDisplayNip05!;
       return dn.startsWith('@') ? dn : '@$dn';
     }
-    if (name != null && name!.isNotEmpty) return '@$name';
+    if (name != null && name!.isNotEmpty) {
+      return '@${sanitizeForDisplay(name!)}';
+    }
     return '';
   }
 
@@ -263,15 +270,23 @@ class UserProfile {
   /// Use this when the domain is meaningful to the user — settings screens,
   /// the share-video watermark, the NIP-05 editor — so people understand
   /// what they own. For general UI rendering prefer [shortDisplayNip05].
+  ///
+  /// Sanitized: `nip05` is an unverified kind-0 field, and every consumer of
+  /// this getter renders it. Verification compares by pubkey, not by this
+  /// string, so normalizing it cannot affect a verified badge.
   String? get displayNip05 {
     if (nip05 == null || nip05!.isEmpty) return null;
     // New subdomain format: _@username.divine.video → @username.divine.video
-    if (nip05!.startsWith('_@')) return nip05!.substring(1);
+    if (nip05!.startsWith('_@')) {
+      return sanitizeForDisplay(nip05!.substring(1));
+    }
     // Legacy divine.video/openvine.co → @username.divine.video
     final username = divineUsername;
-    if (username != null) return '@$username.divine.video';
+    if (username != null) {
+      return '@${sanitizeForDisplay(username)}.divine.video';
+    }
     // External domain: keep as-is
-    return nip05;
+    return sanitizeForDisplay(nip05!);
   }
 
   /// NIP-05 formatted for display, short form.
@@ -280,11 +295,13 @@ class UserProfile {
   /// user shows up as `@rabble` instead of `@rabble.divine.video`. External
   /// identifiers (e.g. `alice@example.com`) are returned unchanged because
   /// the domain is the user's own and meaningful.
+  ///
+  /// Sanitized for the same reason as [displayNip05].
   String? get shortDisplayNip05 {
     if (nip05 == null || nip05!.isEmpty) return null;
     final username = divineUsername;
-    if (username != null) return '@$username';
-    return nip05;
+    if (username != null) return '@${sanitizeForDisplay(username)}';
+    return sanitizeForDisplay(nip05!);
   }
 
   /// Whether the banner field contains a hex color (Vine import).

--- a/mobile/packages/models/test/src/user_profile_test.dart
+++ b/mobile/packages/models/test/src/user_profile_test.dart
@@ -716,6 +716,45 @@ void main() {
 
         expect(profile.handle, equals('@rabble'));
       });
+
+      // An unpaired surrogate reaches the paragraph builder through every
+      // surface that renders a handle and throws during layout, so the
+      // getter sanitizes like its [bestDisplayName] sibling.
+      test('replaces an unpaired UTF-16 surrogate in name', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          name: 'ca${String.fromCharCode(0xD83D)}sey',
+        );
+
+        expect(profile.handle, equals('@ca�sey'));
+      });
+
+      test('replaces an unpaired UTF-16 surrogate in nip05', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          nip05: 'ca${String.fromCharCode(0xDE00)}sey@example.com',
+        );
+
+        expect(profile.handle, equals('@ca�sey@example.com'));
+      });
+
+      test('keeps a valid surrogate pair intact', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          name: 'casey 😀',
+        );
+
+        expect(profile.handle, equals('@casey 😀'));
+      });
     });
 
     group('computed properties', () {
@@ -1135,6 +1174,18 @@ void main() {
 
         expect(profile.displayNip05, isNull);
       });
+
+      test('replaces an unpaired UTF-16 surrogate in an external nip05', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          nip05: 'al${String.fromCharCode(0xDE00)}ice@example.com',
+        );
+
+        expect(profile.displayNip05, equals('al�ice@example.com'));
+      });
     });
 
     group('shortDisplayNip05', () {
@@ -1207,6 +1258,18 @@ void main() {
         );
 
         expect(profile.shortDisplayNip05, isNull);
+      });
+
+      test('replaces an unpaired UTF-16 surrogate in an external nip05', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          nip05: 'al${String.fromCharCode(0xD83D)}ice@example.com',
+        );
+
+        expect(profile.shortDisplayNip05, equals('al�ice@example.com'));
       });
     });
 

--- a/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
+++ b/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
@@ -151,6 +151,44 @@ void main() {
       });
 
       testWidgets(
+        'renders without crashing when the last message contains an '
+        'unpaired UTF-16 surrogate',
+        (tester) async {
+          // The preview renders through plain Text rather than
+          // LinkifiedText, so it does not inherit the span builder's
+          // guard and has to sanitize the rumor body itself. Without it
+          // the paragraph builder throws during layout.
+          // See https://github.com/divinevideo/divine-mobile/issues/6516.
+          final testProfile = createTestProfile(displayName: 'Alice');
+          final testConversation = createTestConversation(
+            lastMessageContent: 'before${String.fromCharCode(0xD83D)}after',
+            lastMessageTimestamp: nowUnix,
+          );
+
+          await tester.pumpWidget(
+            testMaterialApp(
+              additionalOverrides: [
+                fetchUserProfileProvider(
+                  otherPubkey,
+                ).overrideWith((ref) async => testProfile),
+              ],
+              home: Scaffold(
+                body: ConversationTile(
+                  conversation: testConversation,
+                  currentUserPubkey: currentPubkey,
+                  onTap: () {},
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(tester.takeException(), isNull);
+          expect(find.text('before�after'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
         'last message preview uses VineTheme.onSurfaceVariant',
         (tester) async {
           // PR #3548 picked onSurfaceVariant for the preview; a later

--- a/mobile/test/widgets/linkified_text/linkified_text_span_builder_test.dart
+++ b/mobile/test/widgets/linkified_text/linkified_text_span_builder_test.dart
@@ -276,6 +276,51 @@ void main() {
       expect(spans.single.style, equals(linkStyle));
       expect(spans.single.recognizer, isNull);
     });
+
+    // Unpaired UTF-16 surrogates make Flutter's paragraph builder throw
+    // "string is not well-formed UTF-16" during layout, which is a crash
+    // rather than a rendering glitch. They reach spans from two independent
+    // directions, so both are pinned here.
+    group('malformed UTF-16', () {
+      // A lone high surrogate, e.g. an emoji cut in half in transit or a
+      // half-escaped `\uD83D` in event JSON.
+      final loneSurrogate = String.fromCharCode(0xD83D);
+
+      test('replaces an unpaired surrogate in the source text', () {
+        final spans = LinkifiedTextSpanBuilder(
+          text: 'hi ${loneSurrogate}there',
+          defaultStyle: defaultStyle,
+          linkStyle: linkStyle,
+        ).build();
+
+        expect(spans.map((span) => span.text).join(), equals('hi �there'));
+      });
+
+      test('replaces an unpaired surrogate in a resolved profile label', () {
+        const profileHex =
+            'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+        final spans = LinkifiedTextSpanBuilder(
+          text: 'author: $profileHex',
+          defaultStyle: defaultStyle,
+          linkStyle: linkStyle,
+          mentionStyle: mentionStyle,
+          profileLabelForHex: (_) => 'ca${loneSurrogate}sey',
+        ).build();
+
+        expect(spans.tappableSpans.single.text, equals('@ca�sey'));
+      });
+
+      test('keeps a valid surrogate pair intact', () {
+        final spans = const LinkifiedTextSpanBuilder(
+          text: 'hi 😀 there',
+          defaultStyle: defaultStyle,
+          linkStyle: linkStyle,
+        ).build();
+
+        expect(spans.map((span) => span.text).join(), equals('hi 😀 there'));
+      });
+    });
   });
 }
 


### PR DESCRIPTION
Closes #6516

## Description

An unpaired UTF-16 surrogate makes Flutter's paragraph builder throw `Invalid argument(s): string is not well-formed UTF-16` during layout. That is a crash, not a rendering glitch — it is the top FATAL issue in Crashlytics, 76 events across 11 users, flagged `SIGNAL_REPETITIVE` at ~10 crashes per affected user.

#6288 sanitized the text handed to `LinkifiedText`, but the crash survived it, because the span builder also injects text that never came from there: the label for a `nostr:npub…` mention, resolved from profile metadata. So a single profile whose name carries a lone surrogate crashes every viewer who sees a caption or comment mentioning them — and keeps crashing them, because that profile keeps reappearing in the feed.

The stack pins the surface exactly. Three nested `TextSpan.build` frames (298 → 316 → 316) only occur for `Text.rich` with a span that has children, which is the shape `LinkifiedText` builds — a plain `Text` produces one frame, a flat `Text.rich` two. Sample events confirm it: all of them crash on `pooled_video_feed` or with the comments sheet open, none on a notifications screen.

Fixed at both ends:

- `profileDisplayText` sanitizes the name it picks. It reads the raw metadata fields rather than the sanitizing accessors (`bestDisplayName` and friends) because it keeps its own precedence — display name, then name, then NIP-05 — so it has to sanitize the winner itself rather than delegate.
- `LinkifiedTextSpanBuilder.build()` sanitizes too. That is the one point every span passes through, so no future caller has to remember, and it covers the injected label as well as the source text. Replacement is code-unit-for-code-unit, so match offsets stay valid. The constructor stays `const` (existing tests depend on it), which is why this lives in `build()` rather than the initializer.

This also closes `notification_comment_quote.dart`, which called the builder directly and was the only consumer without its own sanitizing wrapper.

The DM conversation preview is fixed separately: it renders through plain `Text`/`Text.rich` rather than the span builder, so it does not inherit that guard and sanitizes its own sender-controlled content once, ahead of every split.

### Closing the rest of the same crash class

Review turned up that the mention label was not the last hole — the same fatal reaches a plain `Text` through several sibling paths that never touch the span builder. Rather than patch each render site, this fixes it where the data is shaped.

**The model rule (`fix(profile)`).** `UserProfile` exposes raw kind-0 fields (`name`, `displayName`, `nip05`) and a set of *display* getters. `bestDisplayName` and `betterDisplayName` already sanitized; `handle`, `displayNip05` and `shortDisplayNip05` did not, despite existing only to be rendered. `handle` alone reaches the DM conversation header, the new-message sheet and people-list rows — so the inbox row survived this PR's first commit while opening the thread still crashed. Fixing the three getters covers every consumer at once. NIP-05 verification compares by pubkey rather than by these strings, and mention matching normalizes to `[a-z0-9]`, so neither is affected. The raw fields stay raw for editors, matching, and serialization; that split is now the rule.

**The remaining render sites (`fix(comments)`).** `comment_item` and `comments_screen` built a chain character-for-character identical to `bestDisplayName`, so they swap to it directly. `mention_overlay` and `mention_search` sanitize in place instead — `bestDisplayName` substitutes a generated name for a profile that has none, which would have shadowed the npub fallback and made `mention_search`'s null guard always true, matching generated names against the query. `ShareableUser.displayName` had two of five construction sites still on raw fields; both move to `bestDisplayName`, covering find-people, share-with, and the recipient announcement in one place.

Profile editors are deliberately untouched. `profile_editor_bloc`, `monetization_links_settings_cubit` and `profile_setup_listeners` seed a `TextField` with the user's *own* name, where sanitizing would silently rewrite it on the next publish.

**Related Issue:** 

## Out of Scope

Two other issues from the same Crashlytics pass are left for their own PRs: the `hashmap.cc` SIGABRT (23 users — a `cupertino_http` FFI callback firing after isolate teardown in the background) and `SqliteException(26): file is not a database` (12 users — the encrypted Drift DB failing to open).

`UserProfile.sanitizeDisplayName` is `stripZalgo`, so it also caps combining characters at two per base character. For mention labels that matches how display names are treated everywhere else and keeps a Zalgo name from blowing up feed layout. If we ever want the narrower behaviour for mentions specifically, `StringUtils.sanitizeUtf16` is the surgical alternative.

The call-site swaps in `fix(comments)` are covered by the existing suites rather than by pinning tests of their own; the model getters and the DM preview are pinned directly.

## Verification

- Three new tests in `linkified_text_span_builder_test.dart`. The two regression tests **fail without the fix** — verified by stashing the builder change and re-running (`+11 -2`). The third pins that valid surrogate pairs (emoji) survive untouched, so the guard cannot regress into over-sanitizing.
- One new test in `conversation_tile_test.dart` for the DM preview, and six in `user_profile_test.dart` for `handle` / `displayNip05` / `shortDisplayNip05`. Both were mutation-tested: reverting the DM preview sanitize fails exactly that one test (`+30 -1`), reverting the `handle` sanitize fails exactly its two (`+12 -2`), and nothing else moves.
- `models` 834/834; comments + composer 208/208; sharing, find-people, settings, search, watermark 262/262; inbox, linkified text, people-lists, mention resolution, delete-account 561/561.
- `flutter analyze lib test integration_test` — No issues found
- `dart format` — no changes

Manual reproduction is impractical: it needs a real profile whose name contains an unpaired surrogate. The pinned tests are the gate here; the field confirmation is the `_NativeParagraphBuilder.addText` signature disappearing from Crashlytics after release.

What device testing should cover is the *absence* of regression for well-formed input, since the sweep touches display names on a lot of surfaces at once: feed, comments sheet, DM inbox and conversation header, share sheet, find-people, and people-lists.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
