### PR TITLE
feat(notifications): notify me when a creator I follow posts

### DIFF
--- a/docs/plans/2026-07-29-bell-notifications-design.md
+++ b/docs/plans/2026-07-29-bell-notifications-design.md
@@ -1,0 +1,339 @@
+# Design: bell notifications (subscribe to a creator's new posts)
+
+Status: design, not yet approved
+Date: 2026-07-29
+Companion work: `divine-push-service` PR #34 / issue #33, `divine-funnelcake` (in-app row)
+
+## Problem
+
+Every notification Divine sends today is *"someone acted on your content"* —
+like, comment, repost, mention. Users have asked for the inverse: **tell me
+when a creator I care about posts**. That is a subscription to someone else's
+output, and nothing in the current model supports it.
+
+This doc covers the mobile half: the bell UI, the subscription list we publish,
+the preference change that makes delivery possible, and how a new-post push is
+parsed and routed on tap. It also states the contract `divine-funnelcake` needs
+to honor for the in-app row.
+
+The service half is specified in `divine-push-service`
+`docs/plans/new-post-notifications.md`. Read it first; this doc assumes it.
+
+## Protocol shape (agreed with the service)
+
+The subscription list is a NIP-51 people list with a reserved `d` tag,
+published by this client and read by the push service:
+
+```
+kind 30000
+["d", "notify"]
+["title", "Notify"]
+["p", "<creator-pubkey-hex>"]   × N
+```
+
+Replaceable, public, portable. The service maintains a `creator → [subscribers]`
+reverse index from it.
+
+---
+
+## Three findings that block the plan as written
+
+I verified the service plan's mobile-side assumptions against `origin/main`
+(`9e16e73a2`). Three of them do not hold. Each is a silent failure — nothing
+crashes, the feature just does nothing.
+
+### 1. `d=notify` collides with the user-facing People Lists UI — bells are user-deletable
+
+`Nip51PeopleListCodec.decode`
+(`mobile/packages/people_lists_repository/lib/src/nip51_people_list_codec.dart:95`)
+turns any kind 30000 event into a user-editable `UserList`. It excludes exactly
+one reserved identifier:
+
+```dart
+static const String blockedDTag = 'block';        // :51
+...
+if (dTag == null || dTag == blockedDTag) {        // :101
+  return null;
+}
+```
+
+A `d=notify` list is not excluded. It would decode into a `UserList` named
+"Notify" and appear in the People Lists UI alongside the user's own lists —
+renameable, editable, deletable. A user tidying their lists silently wipes every
+bell they have set, and the app gives no indication that is what happened.
+
+**Fix:** replace the single constant with a reserved set, and exclude on
+membership:
+
+```dart
+/// Reserved `d` tag values for app-managed kind 30000 lists.
+///
+/// These are excluded from the user-facing list collection so app-managed
+/// lists cannot be edited, renamed, or deleted as ordinary people lists.
+static const Set<String> reservedDTags = {blockedDTag, notifyDTag};
+
+static const String blockedDTag = 'block';
+static const String notifyDTag = 'notify';
+```
+
+`blockedDTag` stays as a named constant — it is referenced elsewhere and in the
+package's public docs (`people_lists_repository.dart:81`). The docs on `decode`
+and the codec's ABOUTME line both need updating; they name `d=block` specifically.
+
+This is the load-bearing fix. Without it the feature is actively destructive.
+
+### 2. `NotificationPreferences` structurally cannot express kind 34236
+
+The service gates delivery on the kind list published in the kind-3083
+preferences event. `NotificationPreferences`
+(`mobile/lib/models/notification_preferences.dart`) is five fixed booleans, and
+`toKindsList()` can only ever emit a subset of `{1, 3, 7, 16}`:
+
+```dart
+List<int> toKindsList() {
+  final kinds = <int>{};
+  if (likesEnabled) kinds.add(7);
+  if (commentsEnabled || mentionsEnabled) kinds.add(1);
+  if (followsEnabled) kinds.add(3);
+  if (repostsEnabled) kinds.add(16);
+  return kinds.toList()..sort();
+}
+```
+
+`push_notification_service.dart:254` publishes exactly this list. So **34236 is
+never published today**, and the service's `is_enabled` check gates every
+new-post push off.
+
+The service plan (task 4) treats this as a soft ordering dependency — "confirm
+the mobile PR publishes preferences alongside the first bell." It is not a
+timing risk. It is a guaranteed failure until this model changes. The plan's
+statement that *"the client publishes kind 3083 including 34236 at the same
+moment it publishes the notify list"* describes work that does not exist yet.
+
+**Fix:** add a sixth flag.
+
+```dart
+const NotificationPreferences({
+  ...
+  this.newPostsEnabled = true,
+});
+```
+
+- `toKindsList()`: `if (newPostsEnabled) kinds.add(34236);`
+- `fromKindsList()`: `newPostsEnabled: kinds.contains(34236)`
+- `fromJson`/`toJson`/`copyWith`/`props`: mirror the existing five
+- `notification_settings_screen.dart`: a sixth toggle following the existing
+  five (`:110`–`:156`)
+
+Note `fromKindsList` defaults every flag from list membership, so a user whose
+stored preferences predate this change reads back `newPostsEnabled: false`. That
+is correct and self-healing: the first time they touch the settings screen or
+set a bell we republish with 34236 included. See [Ordering](#ordering-and-rollout).
+
+The existing "comments and mentions both map to kind 1" limitation is documented
+in the model and is unaffected — 34236 is distinct from kind 1, so new-post
+pushes toggle independently of video mentions. That part of the service plan
+does hold.
+
+### 3. `newPost` is not a routable wire type
+
+`notificationKindFromWire`
+(`mobile/lib/notifications/routing/notification_tap_target.dart:92`) switches on
+the FCM `type` string and returns `null` for anything unrecognized. The service
+will send `type: "newPost"` (the service's `display_name()`), which falls through
+to `null` and degrades the tap route.
+
+`parseFcmPayload` itself is type-agnostic and will *not* drop the push — it only
+returns null when nothing routable is present, and a new-post push always carries
+`referencedAddress`. So the notification displays; only the tap target is wrong.
+
+**Fix:** add `NotificationKind.newPost` to the enum
+(`mobile/packages/models/lib/src/notification_item.dart:12`) and a `case
+'newPost'` to the wire switch. A new-post notification is video-anchored, so it
+routes through the existing `videoAddressableTarget(referencedAddress)` path —
+the same one "Inspired by" mentions already use. No new routing logic.
+
+Adding an enum value breaks the exhaustive switch in
+`notification_type_icon_spec.dart:40`, which is the desired behavior — the
+compiler will demand an icon spec. Use a Phosphor icon per the visual identity
+rules; `bell` is the obvious choice and matches the affordance.
+
+`NotificationKind` is described in its own doc comment as "matching the Figma
+design spec," so the new value wants a design sign-off, not just a code change.
+
+---
+
+## Bell UI
+
+**Placement.** On the creator's profile, next to Follow. The bell is
+follow-gated: visible and tappable only when the viewer already follows the
+creator. Unfollowing removes the bell and the subscription together.
+
+**States.** Off (outline bell) / on (filled bell). No third "all posts vs.
+highlights" state — we have one notification tier, and inventing a second
+control implies a filtering feature that does not exist.
+
+**Feedback.** The toggle is optimistic: flip immediately, publish in the
+background, revert with a snackbar on publish failure. Follow the existing
+snackbar precedent for failed kind-30000 publishes (there is one already for
+block-list publish failure, `app_localizations.dart:13767`).
+
+**Copy** (provisional — needs brand sign-off per `brand-guidelines/TONE_OF_VOICE.md`):
+
+| Surface | String |
+|---|---|
+| Bell on, confirmation | "You'll hear about new vines from {name}." |
+| Bell off, confirmation | "Bell off. No more new-vine pings from {name}." |
+| Publish failed | "Couldn't save that. Try again?" |
+| Settings toggle label | "New vines from creators you've belled" |
+
+All four are new `app_en.arb` keys and must be mirrored into every other
+`app_*.arb` locale or added to `_knownUntranslatedDebt`, per AGENTS.md.
+
+## Publishing the notify list
+
+New repository method rather than routing through `PeopleListsRepository`'s
+user-list surface — the reserved list is app-managed and must not be reachable
+by list-editing UI (finding 1).
+
+Read-modify-write on the current list:
+
+1. Read the current `d=notify` event. `NostrListServiceMixin.filterMyParameterizedEvents`
+   (`nostr_list_service_mixin.dart:107`) already returns the latest event per
+   `(kind, d-tag)` and is the right helper — it handles the replaceable-event
+   "most recent wins" rule we would otherwise reimplement.
+2. Add or remove the creator's pubkey.
+3. Re-encode all `p` tags and publish.
+
+Three rules the implementation has to get right:
+
+- **Never truncate pubkeys.** Full 64-char hex on every `p` tag, per repo policy
+  and because the service parses them as `PublicKey`.
+- **Publish the full list every time.** It is a replaceable event; a partial
+  list is a destructive write.
+- **Serialize concurrent toggles.** Two fast bell taps racing produces two
+  read-modify-write cycles against the same base event, and the loser silently
+  drops the other's change. Queue mutations per-list. `PeopleListsRepository`
+  already has a mutation-sequencing concept (`people_lists_mutation.dart`) worth
+  reusing rather than reinventing.
+
+Unfollow must remove the creator from the list. If that publish fails, the local
+state and the relay disagree and the user keeps getting pushes for someone they
+unfollowed — retry on next app start rather than dropping it.
+
+## Ordering and rollout
+
+The dangerous rollout is a build that publishes notify lists **without** the
+preference change. The service finds watchers, builds targets, then gates every
+one of them off at the `is_enabled` check. No error, no push, and it looks like
+a service bug — exactly the failure the service plan warns about.
+
+Findings 1–3 and the notify-list publishing must therefore ship in **one mobile
+release**. Do not split the preference change into a follow-up PR.
+
+Given that, ordering between the repos is safe in both directions:
+
+- Service first: no notify lists exist, no watchers found, nothing happens.
+- Mobile first: bells accumulate, pushes start flowing when the service deploys.
+
+Republish kind 3083 on first launch after upgrade, not only when the settings
+screen is opened. Existing users have stored preferences without 34236
+(finding 2); waiting for them to visit settings means their first bell silently
+does nothing.
+
+## FunnelCake contract for the in-app row
+
+The push is rate-limited to one per (subscriber, creator) per hour. The in-app
+feed is **not** — a user who gets one push for a six-post burst opens the app and
+sees all six. That is the intended split, and it means FunnelCake needs its own
+fan-out rather than mirroring what the push service sent.
+
+FunnelCake already materializes kind 34236 into the notification inbox, but only
+when the event carries a `p` tag
+(`database/migrations/000188_curated_list_notification_sources.up.sql:23-30`) —
+that is the mention path. New-post rows are the case with **no** `p` tag, and
+the recipient set cannot be read off the event at all. It has to come from a
+join against the `d=notify` subscription lists.
+
+What FunnelCake needs from us:
+
+- The list is public kind 30000, `d=notify`, `p`-tagged. It is on the relay
+  already; no new API surface from mobile.
+- A `newPost` notification type on the inbox row, matching the push service's
+  `display_name()` string exactly. Mobile switches on one string across both
+  transports.
+- Dedup against the mention path: if a video both mentions the user and comes
+  from a creator they have belled, that is **one** row, typed `mention`. Same
+  rule the push service applies.
+
+Open question for that team, and the reason this section is a contract and not a
+design: this is the inbox's first subscription-driven fan-out. Every existing
+source resolves recipients from tags on the event itself. A join against a
+subscription table is a different write shape, and the
+`notification_list_add_seen` table
+(`000188_curated_list_notification_sources.up.sql:59`) is the closest existing
+precedent. I have not verified whether the materialization path can express that
+join, and I should not design another team's schema. **This needs a FunnelCake
+owner before the mobile row is built.**
+
+Mobile can ship bells + push without the in-app row. The row is additive.
+
+## Test plan
+
+Unit:
+
+- `Nip51PeopleListCodec.decode` returns `null` for `d=notify` and for `d=block`;
+  still decodes ordinary lists. Regression test for finding 1.
+- `toKindsList()` includes 34236 when `newPostsEnabled`, omits it when not.
+- `fromKindsList([7, 1, 3, 16])` yields `newPostsEnabled: false` — the
+  pre-upgrade shape.
+- `notificationKindFromWire('newPost')` returns `NotificationKind.newPost`.
+- Notify-list publish: add to empty, add to existing, remove down to empty,
+  pubkeys never truncated.
+- Concurrent toggles resolve to one list containing both changes.
+
+Widget:
+
+- Bell hidden when not following; visible and toggleable when following.
+- Optimistic flip reverts with a snackbar on publish failure.
+- Settings screen shows the sixth toggle and republishes on change.
+
+Integration / manual, once the service branch is deployed:
+
+1. Bell creator B from account A. Confirm the kind 30000 `d=notify` event on the
+   relay carries B's full `p` tag.
+2. Confirm the list does **not** appear in A's People Lists UI.
+3. Post as B, confirm A gets a push titled "New vine", and that tapping it opens
+   the video rather than falling back to a profile or the inbox.
+4. Post again within the hour, confirm no second push.
+5. Unbell, confirm the `p` tag is gone from the republished list and pushes stop.
+6. Unfollow B while belled, confirm the bell and the subscription both clear.
+
+Per AGENTS.md: run the affected package tests plus `flutter analyze` before any
+push, and `dart run build_runner build --delete-conflicting-outputs` if the
+`NotificationPreferences` change touches generated code.
+
+## Risks
+
+**Public subscription lists.** `d=notify` is world-readable, so who you have
+belled is public. This is a deliberate product tradeoff for portability, decided
+on the service side. Worth confirming it survives contact with the bell UI — a
+user tapping a bell on a profile has no reason to expect they just published
+that fact. If we want it, it needs to be said in the UI, not buried here. **I
+think this deserves an explicit product call before the bell ships**, separately
+from the protocol decision already made.
+
+**Reserved-tag squatting.** Any user could already have a list with `d=notify`
+from another Nostr client. After finding 1's fix it vanishes from their Divine
+list UI, and we would overwrite it on their first bell. Rare, but it is data
+loss on a replaceable event we do not own. Cheapest mitigation is to check for a
+pre-existing `d=notify` list with a `title` we did not write before the first
+publish, and leave it alone if so.
+
+**`d=block` is called legacy.** `moderation_providers.dart:220` describes the
+kind-30000 block list as legacy, superseded by the kind-10000 mute list. The
+service plan cites `d=block` as the precedent to mirror. The *mechanism*
+(reserved `d` tag, hidden from list UI) is sound and still live in the codec, so
+mirroring it is fine — but we are extending a pattern the moderation code is
+moving away from. Not a blocker; worth a sentence of agreement so nobody
+deprecates the codec exclusion out from under bells.

--- a/mobile/lib/blocs/notify_bell/notify_bell_cubit.dart
+++ b/mobile/lib/blocs/notify_bell/notify_bell_cubit.dart
@@ -1,0 +1,145 @@
+// ABOUTME: Cubit backing the profile bell — subscribe to a creator's posts.
+// ABOUTME: Optimistic toggle that reverts when the list publish fails.
+
+import 'dart:async';
+
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/notify_bell/reportable_sites.dart';
+import 'package:openvine/observability/reportable_error.dart';
+import 'package:people_lists_repository/people_lists_repository.dart';
+
+part 'notify_bell_state.dart';
+
+/// Drives the bell on a creator's profile.
+///
+/// One cubit per (viewer, creator) pair. Reads the viewer's `d=notify`
+/// subscription list and toggles this creator in or out of it.
+///
+/// The repository serializes concurrent publishes, so this cubit does not
+/// need its own guard against rapid taps — but it does flip state
+/// optimistically and revert on failure, so the bell tracks the finger
+/// rather than the relay round-trip.
+class NotifyBellCubit extends Cubit<NotifyBellState> {
+  NotifyBellCubit({
+    required NotifySubscriptionsRepository repository,
+    required String viewerPubkey,
+    required String creatorPubkey,
+  }) : _repository = repository,
+       _viewerPubkey = viewerPubkey,
+       _creatorPubkey = creatorPubkey,
+       super(const NotifyBellState());
+
+  final NotifySubscriptionsRepository _repository;
+  final String _viewerPubkey;
+  final String _creatorPubkey;
+
+  StreamSubscription<Set<String>>? _subscription;
+
+  /// Loads the current subscription state and tracks later changes.
+  ///
+  /// Watching (rather than a one-shot read) keeps two bells for the same
+  /// creator in sync — e.g. the profile bell and a bell reached from a
+  /// different route — and picks up an unfollow teardown published while
+  /// this bell is mounted.
+  Future<void> load() async {
+    _subscription ??= _repository
+        .watchSubscriptions(ownerPubkey: _viewerPubkey)
+        .listen(_onSubscriptionsChanged);
+  }
+
+  void _onSubscriptionsChanged(Set<String> creators) {
+    if (isClosed) return;
+    emit(
+      state.copyWith(
+        status: NotifyBellStatus.ready,
+        isSubscribed: creators.contains(_creatorPubkey),
+      ),
+    );
+  }
+
+  /// Flips the bell, publishing the updated list.
+  ///
+  /// Reverts and emits [NotifyBellStatus.failure] when the publish fails, so
+  /// the bell never claims a subscription the relays never received.
+  Future<void> toggle() async {
+    if (!state.isInteractive) return;
+
+    final wasSubscribed = state.isSubscribed;
+    emit(
+      state.copyWith(
+        status: NotifyBellStatus.ready,
+        isSubscribed: !wasSubscribed,
+      ),
+    );
+
+    try {
+      final result = wasSubscribed
+          ? await _repository.unsubscribe(
+              ownerPubkey: _viewerPubkey,
+              creatorPubkey: _creatorPubkey,
+            )
+          : await _repository.subscribe(
+              ownerPubkey: _viewerPubkey,
+              creatorPubkey: _creatorPubkey,
+            );
+      if (isClosed) return;
+
+      if (result.status == PeopleListPublishStatus.failed) {
+        emit(
+          state.copyWith(
+            status: NotifyBellStatus.failure,
+            isSubscribed: wasSubscribed,
+          ),
+        );
+      }
+      // submitted and noop both leave the optimistic state standing: the
+      // stream emission from the repository confirms it, and a noop means
+      // the desired state already held.
+    } on Object catch (error, stackTrace) {
+      if (isClosed) return;
+      addError(
+        Reportable(error, context: NotifyBellReportableSites.toggle),
+        stackTrace,
+      );
+      emit(
+        state.copyWith(
+          status: NotifyBellStatus.failure,
+          isSubscribed: wasSubscribed,
+        ),
+      );
+    }
+  }
+
+  /// Drops the subscription because the viewer unfollowed this creator.
+  ///
+  /// The bell is follow-gated, so leaving the subscription behind would keep
+  /// pushing videos from someone the viewer no longer follows, with no UI
+  /// left to turn it off.
+  ///
+  /// Safe to call unconditionally — the repository treats removing a
+  /// non-member as a no-op.
+  Future<void> clearForUnfollow() async {
+    try {
+      await _repository.unsubscribe(
+        ownerPubkey: _viewerPubkey,
+        creatorPubkey: _creatorPubkey,
+      );
+    } on Object catch (error, stackTrace) {
+      if (isClosed) return;
+      // Deliberately not surfaced: the user asked to unfollow, and that
+      // succeeded. A failed teardown is retried on the next profile visit
+      // because load() re-reads the list.
+      addError(
+        Reportable(error, context: NotifyBellReportableSites.clearForUnfollow),
+        stackTrace,
+      );
+    }
+  }
+
+  @override
+  Future<void> close() async {
+    await _subscription?.cancel();
+    return super.close();
+  }
+}

--- a/mobile/lib/blocs/notify_bell/notify_bell_cubit.dart
+++ b/mobile/lib/blocs/notify_bell/notify_bell_cubit.dart
@@ -8,8 +8,11 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/notify_bell/reportable_sites.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:people_lists_repository/people_lists_repository.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 part 'notify_bell_state.dart';
+
+const String _logName = 'NotifyBellCubit';
 
 /// Drives the bell on a creator's profile.
 ///
@@ -42,10 +45,33 @@ class NotifyBellCubit extends Cubit<NotifyBellState> {
   /// creator in sync — e.g. the profile bell and a bell reached from a
   /// different route — and picks up an unfollow teardown published while
   /// this bell is mounted.
+  ///
+  /// The stream stays silent until the list has actually been read, so the
+  /// bell holds [NotifyBellStatus.initial] — and stays untappable — while the
+  /// relays are unreachable. Tapping an unverified "off" would publish a
+  /// replacement list containing only this creator.
   Future<void> load() async {
     _subscription ??= _repository
         .watchSubscriptions(ownerPubkey: _viewerPubkey)
         .listen(_onSubscriptionsChanged);
+    await _retryOutstandingTeardown();
+  }
+
+  /// Republishes an unfollow teardown whose earlier publish failed.
+  ///
+  /// The bell is follow-gated, so once the viewer unfollows there is no bell
+  /// left to retry from. Every bell mount therefore drains whatever removal
+  /// is still outstanding for this viewer, whichever creator it belonged to.
+  Future<void> _retryOutstandingTeardown() async {
+    try {
+      await _repository.reconcile(ownerPubkey: _viewerPubkey);
+    } on Object catch (error, stackTrace) {
+      if (isClosed) return;
+      addError(
+        Reportable(error, context: NotifyBellReportableSites.reconcile),
+        stackTrace,
+      );
+    }
   }
 
   void _onSubscriptionsChanged(Set<String> creators) {
@@ -121,15 +147,24 @@ class NotifyBellCubit extends Cubit<NotifyBellState> {
   /// non-member as a no-op.
   Future<void> clearForUnfollow() async {
     try {
-      await _repository.unsubscribe(
+      final result = await _repository.unsubscribe(
         ownerPubkey: _viewerPubkey,
         creatorPubkey: _creatorPubkey,
       );
+      if (result.status == PeopleListPublishStatus.failed) {
+        // Deliberately not surfaced: the user asked to unfollow, and that
+        // succeeded. The repository retains the removal and reapplies it on
+        // its next publish for this viewer, or on the next bell mount via
+        // load(), so an abandoned subscription cannot keep pushing unseen.
+        Log.warning(
+          'Notify teardown publish failed; retained for retry: '
+          '${result.error}',
+          name: _logName,
+          category: LogCategory.relay,
+        );
+      }
     } on Object catch (error, stackTrace) {
       if (isClosed) return;
-      // Deliberately not surfaced: the user asked to unfollow, and that
-      // succeeded. A failed teardown is retried on the next profile visit
-      // because load() re-reads the list.
       addError(
         Reportable(error, context: NotifyBellReportableSites.clearForUnfollow),
         stackTrace,

--- a/mobile/lib/blocs/notify_bell/notify_bell_state.dart
+++ b/mobile/lib/blocs/notify_bell/notify_bell_state.dart
@@ -1,0 +1,42 @@
+// ABOUTME: State for the profile bell that subscribes to a creator's posts.
+// ABOUTME: Status enum only — error text is composed in the UI layer.
+
+part of 'notify_bell_cubit.dart';
+
+enum NotifyBellStatus {
+  /// Not loaded yet; the bell renders in its off state but is not tappable.
+  initial,
+
+  /// Subscription state is known and the bell is interactive.
+  ready,
+
+  /// A publish failed. The optimistic flip has already been reverted, so
+  /// [NotifyBellState.isSubscribed] again reflects the last known truth; the
+  /// UI shows a transient message off this status.
+  failure,
+}
+
+class NotifyBellState extends Equatable {
+  const NotifyBellState({
+    this.status = NotifyBellStatus.initial,
+    this.isSubscribed = false,
+  });
+
+  final NotifyBellStatus status;
+
+  /// Whether the viewer receives new-post notifications for this creator.
+  final bool isSubscribed;
+
+  /// Whether the bell may be tapped.
+  bool get isInteractive => status != NotifyBellStatus.initial;
+
+  NotifyBellState copyWith({NotifyBellStatus? status, bool? isSubscribed}) {
+    return NotifyBellState(
+      status: status ?? this.status,
+      isSubscribed: isSubscribed ?? this.isSubscribed,
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, isSubscribed];
+}

--- a/mobile/lib/blocs/notify_bell/reportable_sites.dart
+++ b/mobile/lib/blocs/notify_bell/reportable_sites.dart
@@ -1,0 +1,17 @@
+// ABOUTME: Per-feature Reportable `context:` constants for NotifyBellCubit.
+// ABOUTME: See .claude/rules/error_handling.md — 2+ wrapped sites lift here.
+
+/// Stable `context:` identifiers for `Reportable(...)` wraps inside
+/// `NotifyBellCubit`.
+abstract class NotifyBellReportableSites {
+  /// `toggle` generic-catch arm. `NotifySubscriptionsRepository` reports
+  /// publish failures as a `failed` status rather than throwing, so anything
+  /// reaching this arm is an invariant violation — realistically a `TypeError`
+  /// from a malformed relay event, not a network fault.
+  static const String toggle = 'toggle';
+
+  /// `clearForUnfollow` generic-catch arm. Same coverage as [toggle], kept
+  /// distinct because the failure is invisible to the user (the unfollow
+  /// itself succeeded) and so only shows up here.
+  static const String clearForUnfollow = 'clearForUnfollow';
+}

--- a/mobile/lib/blocs/notify_bell/reportable_sites.dart
+++ b/mobile/lib/blocs/notify_bell/reportable_sites.dart
@@ -14,4 +14,9 @@ abstract class NotifyBellReportableSites {
   /// distinct because the failure is invisible to the user (the unfollow
   /// itself succeeded) and so only shows up here.
   static const String clearForUnfollow = 'clearForUnfollow';
+
+  /// `load` generic-catch arm around the outstanding-teardown retry. Same
+  /// coverage as [toggle]; a publish failure here is reported as a `failed`
+  /// status, not a throw.
+  static const String reconcile = 'reconcile';
 }

--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -80,6 +80,13 @@ enum FeatureFlag {
     'Divine Supporters',
     'Optional monthly supporter subscription via in-app purchase. '
         'Nothing is gated — it keeps Divine running and recognizes supporters.',
+  ),
+  newPostNotifications(
+    'New Post Notifications',
+    'Turn on a bell for creators you follow to get notified when they post. '
+        'Off by default until the push service fans out kind 34236 to '
+        'subscribers — with it off, the bell would publish a subscription '
+        'that nothing ever delivers.',
   );
 
   const FeatureFlag(

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -56,6 +56,11 @@ class BuildConfiguration {
         // Default OFF: MVP exploration behind the flag until store products
         // are configured in App Store Connect and Google Play Console.
         return const bool.fromEnvironment('FF_DIVINE_SUPPORTERS');
+      case FeatureFlag.newPostNotifications:
+        // Default OFF until divine-push-service fans kind 34236 out to
+        // d=notify subscribers. On without it, the bell publishes a
+        // subscription no service reads.
+        return const bool.fromEnvironment('FF_NEW_POST_NOTIFICATIONS');
     }
   }
 
@@ -102,6 +107,8 @@ class BuildConfiguration {
         return 'FF_EMAIL_VERIFICATION_PIN_FALLBACK';
       case FeatureFlag.divineSupporters:
         return 'FF_DIVINE_SUPPORTERS';
+      case FeatureFlag.newPostNotifications:
+        return 'FF_NEW_POST_NOTIFICATIONS';
     }
   }
 }

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4839,5 +4839,8 @@
     "videoEditorStopMotionFrameSemanticLabel": "የስቶፕ-ሞሽን ፍሬም {position} ከ{total}",
     "videoEditorStopMotionFramesCount": "{count, plural, other{{count} ፍሬሞች}}",
     "videoEditorStopMotionFramesPerImageButtonLabel": "ፍሬሞች",
-    "libraryStopMotionClipLabel": "የስቶፕ-ሞሽን ክሊፕ"
+    "libraryStopMotionClipLabel": "የስቶፕ-ሞሽን ክሊፕ",
+  "profileNotifyBellOff": "ስለ አዲስ ቫይኖች አሳውቀኝ",
+  "profileNotifyBellOn": "ስለ አዲስ ቫይኖች አታሳውቀኝ",
+  "profileNotifyUpdateFailed": "ማስቀመጥ አልተቻለም። እንደገና ይሞክሩ?"
 }

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -1200,6 +1200,8 @@
     "notificationSettingsMentionsSubtitle": "እርስዎ ሲጠቀሱ",
     "notificationSettingsReposts": "ድጋሚ ልጥፎች",
     "notificationSettingsRepostsSubtitle": "አንድ ሰው ቪዲዮዎችህን በድጋሚ ሲለጥፍ",
+    "notificationSettingsNewPosts": "አዲስ ቫይኖች",
+    "notificationSettingsNewPostsSubtitle": "የምትከታተለው ሰው ሲለጥፍ",
     "notificationSettingsActions": "ድርጊቶች",
     "notificationSettingsMarkAllAsRead": "ሁሉንም እንደተነበቡ ምልክት ያድርጉበት",
     "notificationSettingsMarkAllAsReadSubtitle": "ሁሉንም ማሳወቂያዎች እንደተነበቡ ምልክት ያድርጉባቸው",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3292,6 +3292,7 @@
         }
     },
     "notificationRepostedYourVideo": "{actorName} ቪዲዮህን በድጋሚ ለጥፏል",
+    "notificationPostedNewVine": "{actorName} አዲስ ቫይን ለጠፈ",
     "@notificationRepostedYourVideo": {
         "placeholders": {
             "actorName": {

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2613,6 +2613,7 @@
         }
     },
     "notificationRepostedYourVideo": "{actorName} أعاد نشر فيديوك",
+    "notificationPostedNewVine": "{actorName} نشر مقطعًا جديدًا",
     "@notificationRepostedYourVideo": {
         "placeholders": {
             "actorName": {

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -990,6 +990,8 @@
     "notificationSettingsMentionsSubtitle": "عندما تتم الإشارة إليك",
     "notificationSettingsReposts": "إعادات النشر",
     "notificationSettingsRepostsSubtitle": "عندما يعيد أحدهم نشر فيديوهاتك",
+    "notificationSettingsNewPosts": "مقاطع جديدة",
+    "notificationSettingsNewPostsSubtitle": "عندما ينشر شخص تتابعه",
     "notificationSettingsActions": "الإجراءات",
     "notificationSettingsMarkAllAsRead": "وسم الكل كمقروء",
     "notificationSettingsMarkAllAsReadSubtitle": "وسم جميع الإشعارات كمقروءة",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4714,5 +4714,8 @@
     "videoEditorStopMotionFrameSemanticLabel": "إطار الحركة الإيقافية {position} من {total}",
     "videoEditorStopMotionFramesCount": "{count, plural, one{إطار واحد} two{إطاران} few{{count} إطارات} other{{count} إطار}}",
     "videoEditorStopMotionFramesPerImageButtonLabel": "إطارات",
-    "libraryStopMotionClipLabel": "مقطع الحركة الإيقافية"
+    "libraryStopMotionClipLabel": "مقطع الحركة الإيقافية",
+  "profileNotifyBellOff": "أبلغني عن المقاطع الجديدة",
+  "profileNotifyBellOn": "أوقف إشعارات المقاطع الجديدة",
+  "profileNotifyUpdateFailed": "لم نتمكن من الحفظ. أعد المحاولة؟"
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4845,5 +4845,8 @@
     "videoEditorStopMotionFrameSemanticLabel": "Стоп-моушън кадър {position} от {total}",
     "videoEditorStopMotionFramesCount": "{count, plural, =1{1 кадър} other{{count} кадъра}}",
     "videoEditorStopMotionFramesPerImageButtonLabel": "Кадри",
-    "libraryStopMotionClipLabel": "Стоп-моушън клип"
+    "libraryStopMotionClipLabel": "Стоп-моушън клип",
+  "profileNotifyBellOff": "Получавай известия за нови видеа",
+  "profileNotifyBellOn": "Спри известията за нови видеа",
+  "profileNotifyUpdateFailed": "Не се запази. Опитай пак?"
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2962,6 +2962,7 @@
         }
     },
     "notificationRepostedYourVideo": "{actorName} сподели видеото ти пак",
+    "notificationPostedNewVine": "{actorName} публикува ново видео",
     "@notificationRepostedYourVideo": {
         "placeholders": {
             "actorName": {

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -1069,6 +1069,8 @@
     "notificationSettingsMentionsSubtitle": "Когато те споменат",
     "notificationSettingsReposts": "Репостове",
     "notificationSettingsRepostsSubtitle": "Когато някой препубликува видеата ти",
+    "notificationSettingsNewPosts": "Нови видеа",
+    "notificationSettingsNewPostsSubtitle": "Когато някой, когото следиш, публикува",
     "notificationSettingsActions": "Действия",
     "notificationSettingsMarkAllAsRead": "Маркирай всички като прочетени",
     "notificationSettingsMarkAllAsReadSubtitle": "Маркирай всички известия като прочетени",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4714,5 +4714,8 @@
     "videoEditorStopMotionFrameSemanticLabel": "Stop-Motion-Bild {position} von {total}",
     "videoEditorStopMotionFramesCount": "{count, plural, =1{1 Frame} other{{count} Frames}}",
     "videoEditorStopMotionFramesPerImageButtonLabel": "Frames",
-    "libraryStopMotionClipLabel": "Stop-Motion-Clip"
+    "libraryStopMotionClipLabel": "Stop-Motion-Clip",
+  "profileNotifyBellOff": "Über neue Vines benachrichtigen",
+  "profileNotifyBellOn": "Keine Benachrichtigungen über neue Vines",
+  "profileNotifyUpdateFailed": "Konnte nicht gespeichert werden. Nochmal?"
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2621,6 +2621,7 @@
         }
     },
     "notificationRepostedYourVideo": "{actorName} hat dein Video geteilt",
+    "notificationPostedNewVine": "{actorName} hat einen neuen Vine gepostet",
     "@notificationRepostedYourVideo": {
         "placeholders": {
             "actorName": {

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -993,6 +993,8 @@
     "notificationSettingsMentionsSubtitle": "Wenn du erwähnt wirst",
     "notificationSettingsReposts": "Reposts",
     "notificationSettingsRepostsSubtitle": "Wenn jemand deine Videos repostet",
+    "notificationSettingsNewPosts": "Neue Vines",
+    "notificationSettingsNewPostsSubtitle": "Wenn jemand, den du beobachtest, postet",
     "notificationSettingsActions": "Aktionen",
     "notificationSettingsMarkAllAsRead": "Alle als gelesen markieren",
     "notificationSettingsMarkAllAsReadSubtitle": "Alle Benachrichtigungen als gelesen markieren",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1446,6 +1446,8 @@
   "notificationSettingsMentionsSubtitle": "When you are mentioned",
   "notificationSettingsReposts": "Reposts",
   "notificationSettingsRepostsSubtitle": "When someone reposts your videos",
+  "notificationSettingsNewPosts": "New vines",
+  "notificationSettingsNewPostsSubtitle": "When someone you're watching posts",
   "notificationSettingsSystem": "System",
   "notificationSettingsSystemSubtitle": "App updates and system messages",
   "notificationSettingsPushNotificationsSection": "Push Notifications",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4600,6 +4600,15 @@
       }
     }
   },
+  "notificationPostedNewVine": "{actorName} posted a new vine",
+  "@notificationPostedNewVine": {
+    "description": "Shown when a creator the user subscribed to (belled) publishes a new video. Unlike the other notification verbs this is not a reaction to the user's own content.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      }
+    }
+  },
   "notificationRepliedToYourComment": "{actorName} replied to your comment",
   "@notificationRepliedToYourComment": {
     "description": "Full sentence shown for a reply notification.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -6337,5 +6337,17 @@
   "supporterErrorUnknown": "Something went wrong. Please try again.",
   "@supporterErrorUnknown": {"description": "Generic supporter flow error shown when no more specific message applies."},
   "supporterDisclaimer": "Divine confirms supporter status after the store verifies your purchase. Recognition is optional, and the halo is not verification.",
-  "@supporterDisclaimer": {"description": "Footnote on the supporter screen explaining server-side confirmation and that recognition is optional."}
+  "@supporterDisclaimer": {"description": "Footnote on the supporter screen explaining server-side confirmation and that recognition is optional."},
+  "profileNotifyBellOff": "Get notified about new vines",
+  "@profileNotifyBellOff": {
+    "description": "Accessibility label on the profile bell when the viewer is not subscribed. Describes the action the tap performs, not the current state."
+  },
+  "profileNotifyBellOn": "Stop notifying me about new vines",
+  "@profileNotifyBellOn": {
+    "description": "Accessibility label on the profile bell when the viewer is subscribed. Describes the action the tap performs."
+  },
+  "profileNotifyUpdateFailed": "Couldn't save that. Try again?",
+  "@profileNotifyUpdateFailed": {
+    "description": "Transient message when publishing the notification-subscription list fails. The bell has already reverted to its previous state."
+  }
 }

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2629,6 +2629,7 @@
         }
     },
     "notificationRepostedYourVideo": "{actorName} compartió tu video",
+    "notificationPostedNewVine": "{actorName} publicó un nuevo vine",
     "@notificationRepostedYourVideo": {
         "placeholders": {
             "actorName": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -997,6 +997,8 @@
     "notificationSettingsMentionsSubtitle": "Cuando te mencionan",
     "notificationSettingsReposts": "Reposts",
     "notificationSettingsRepostsSubtitle": "Cuando alguien repostea tus videos",
+    "notificationSettingsNewPosts": "Nuevos vines",
+    "notificationSettingsNewPostsSubtitle": "Cuando alguien que sigues publica",
     "notificationSettingsActions": "Acciones",
     "notificationSettingsMarkAllAsRead": "Marcar todas como leídas",
     "notificationSettingsMarkAllAsReadSubtitle": "Marcá todas las notificaciones como leídas",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4714,5 +4714,8 @@
     "videoEditorStopMotionFrameSemanticLabel": "Fotograma de stop motion {position} de {total}",
     "videoEditorStopMotionFramesCount": "{count, plural, =1{1 fotograma} other{{count} fotogramas}}",
     "videoEditorStopMotionFramesPerImageButtonLabel": "Fotogramas",
-    "libraryStopMotionClipLabel": "Clip de stop motion"
+    "libraryStopMotionClipLabel": "Clip de stop motion",
+  "profileNotifyBellOff": "Avisarme de nuevos vines",
+  "profileNotifyBellOn": "Dejar de avisarme de nuevos vines",
+  "profileNotifyUpdateFailed": "No se pudo guardar. ¿Reintentar?"
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1692,6 +1692,7 @@
     "notificationStartedFollowing": "Sinimulan kang i-follow ni {actorName}",
     "notificationMentionedYou": "Binanggit ka ni {actorName}",
     "notificationRepostedYourVideo": "Na-repost ni {actorName} ang video mo",
+    "notificationPostedNewVine": "Nag-post si {actorName} ng bagong vine",
     "notificationSystemUpdate": "May bago kang update",
     "notificationSomeoneLikedYourVideo": "May nag-like sa video mo",
     "commentReplyToPrefix": "Re:",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -3290,5 +3290,8 @@
     "videoEditorStopMotionFrameSemanticLabel": "Stop-motion frame {position} ng {total}",
     "videoEditorStopMotionFramesCount": "{count, plural, other{{count} frame}}",
     "videoEditorStopMotionFramesPerImageButtonLabel": "Mga frame",
-    "libraryStopMotionClipLabel": "Stop-motion na clip"
+    "libraryStopMotionClipLabel": "Stop-motion na clip",
+  "profileNotifyBellOff": "Ipaalam ang mga bagong vine",
+  "profileNotifyBellOn": "Itigil ang pagpaalam sa mga bagong vine",
+  "profileNotifyUpdateFailed": "Hindi nai-save. Subukan muli?"
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -646,6 +646,8 @@
     "notificationSettingsMentionsSubtitle": "Kapag na-mention ka",
     "notificationSettingsReposts": "Mga Repost",
     "notificationSettingsRepostsSubtitle": "Kapag may nag-repost ng iyong mga video",
+    "notificationSettingsNewPosts": "Mga Bagong Vine",
+    "notificationSettingsNewPostsSubtitle": "Kapag nag-post ang taong binabantayan mo",
     "notificationSettingsActions": "Mga Aksyon",
     "notificationSettingsMarkAllAsRead": "Markahang Lahat Bilang Nabasa",
     "notificationSettingsMarkAllAsReadSubtitle": "Markahan lahat ng notification bilang nabasa na",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -993,6 +993,8 @@
     "notificationSettingsMentionsSubtitle": "Quand tu es mentionné",
     "notificationSettingsReposts": "Reposts",
     "notificationSettingsRepostsSubtitle": "Quand quelqu'un reposte tes vidéos",
+    "notificationSettingsNewPosts": "Nouvelles vines",
+    "notificationSettingsNewPostsSubtitle": "Quand quelqu'un que tu suis publie",
     "notificationSettingsActions": "Actions",
     "notificationSettingsMarkAllAsRead": "Tout marquer comme lu",
     "notificationSettingsMarkAllAsReadSubtitle": "Marquer toutes les notifications comme lues",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2621,6 +2621,7 @@
         }
     },
     "notificationRepostedYourVideo": "{actorName} a repartagé ta vidéo",
+    "notificationPostedNewVine": "{actorName} a publié une nouvelle vine",
     "@notificationRepostedYourVideo": {
         "placeholders": {
             "actorName": {

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4714,5 +4714,8 @@
     "videoEditorStopMotionFrameSemanticLabel": "Image stop-motion {position} sur {total}",
     "videoEditorStopMotionFramesCount": "{count, plural, =1{1 image} other{{count} images}}",
     "videoEditorStopMotionFramesPerImageButtonLabel": "Images",
-    "libraryStopMotionClipLabel": "Clip stop-motion"
+    "libraryStopMotionClipLabel": "Clip stop-motion",
+  "profileNotifyBellOff": "M'avertir des nouvelles vines",
+  "profileNotifyBellOn": "Ne plus m'avertir des nouvelles vines",
+  "profileNotifyUpdateFailed": "Échec de l'enregistrement. Réessayer ?"
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -990,6 +990,8 @@
     "notificationSettingsMentionsSubtitle": "Saat kamu disebut",
     "notificationSettingsReposts": "Repost",
     "notificationSettingsRepostsSubtitle": "Saat ada yang me-repost videomu",
+    "notificationSettingsNewPosts": "Vine Baru",
+    "notificationSettingsNewPostsSubtitle": "Saat orang yang kamu pantau memposting",
     "notificationSettingsActions": "Aksi",
     "notificationSettingsMarkAllAsRead": "Tandai Semua Sudah Dibaca",
     "notificationSettingsMarkAllAsReadSubtitle": "Tandai semua notifikasi sudah dibaca",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4714,5 +4714,8 @@
     "videoEditorStopMotionFrameSemanticLabel": "Bingkai stop-motion {position} dari {total}",
     "videoEditorStopMotionFramesCount": "{count, plural, other{{count} bingkai}}",
     "videoEditorStopMotionFramesPerImageButtonLabel": "Bingkai",
-    "libraryStopMotionClipLabel": "Klip stop-motion"
+    "libraryStopMotionClipLabel": "Klip stop-motion",
+  "profileNotifyBellOff": "Beri tahu tentang vine baru",
+  "profileNotifyBellOn": "Hentikan pemberitahuan vine baru",
+  "profileNotifyUpdateFailed": "Gagal menyimpan. Coba lagi?"
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2620,6 +2620,7 @@
         }
     },
     "notificationRepostedYourVideo": "{actorName} membagikan ulang videomu",
+    "notificationPostedNewVine": "{actorName} memposting vine baru",
     "@notificationRepostedYourVideo": {
         "placeholders": {
             "actorName": {

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2621,6 +2621,7 @@
         }
     },
     "notificationRepostedYourVideo": "{actorName} ha ricondiviso il tuo video",
+    "notificationPostedNewVine": "{actorName} ha pubblicato un nuovo vine",
     "@notificationRepostedYourVideo": {
         "placeholders": {
             "actorName": {

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -993,6 +993,8 @@
     "notificationSettingsMentionsSubtitle": "Quando vieni menzionato",
     "notificationSettingsReposts": "Repost",
     "notificationSettingsRepostsSubtitle": "Quando qualcuno ripubblica i tuoi video",
+    "notificationSettingsNewPosts": "Nuovi vine",
+    "notificationSettingsNewPostsSubtitle": "Quando qualcuno che segui pubblica",
     "notificationSettingsActions": "Azioni",
     "notificationSettingsMarkAllAsRead": "Segna tutto come letto",
     "notificationSettingsMarkAllAsReadSubtitle": "Segna tutte le notifiche come lette",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4714,5 +4714,8 @@
     "videoEditorStopMotionFrameSemanticLabel": "Fotogramma stop-motion {position} di {total}",
     "videoEditorStopMotionFramesCount": "{count, plural, =1{1 fotogramma} other{{count} fotogrammi}}",
     "videoEditorStopMotionFramesPerImageButtonLabel": "Fotogrammi",
-    "libraryStopMotionClipLabel": "Clip stop-motion"
+    "libraryStopMotionClipLabel": "Clip stop-motion",
+  "profileNotifyBellOff": "Avvisami dei nuovi vine",
+  "profileNotifyBellOn": "Non avvisarmi più dei nuovi vine",
+  "profileNotifyUpdateFailed": "Salvataggio non riuscito. Riprovare?"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4714,5 +4714,8 @@
     "videoEditorStopMotionFrameSemanticLabel": "ストップモーションのフレーム {total}枚中{position}枚目",
     "videoEditorStopMotionFramesCount": "{count, plural, other{{count}フレーム}}",
     "videoEditorStopMotionFramesPerImageButtonLabel": "フレーム",
-    "libraryStopMotionClipLabel": "ストップモーションクリップ"
+    "libraryStopMotionClipLabel": "ストップモーションクリップ",
+  "profileNotifyBellOff": "新しい動画を通知する",
+  "profileNotifyBellOn": "新しい動画の通知を停止",
+  "profileNotifyUpdateFailed": "保存できませんでした。もう一度試しますか？"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2613,6 +2613,7 @@
         }
     },
     "notificationRepostedYourVideo": "{actorName}さんがあなたの動画をリポストしました",
+    "notificationPostedNewVine": "{actorName}が新しい動画を投稿しました",
     "@notificationRepostedYourVideo": {
         "placeholders": {
             "actorName": {

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -990,6 +990,8 @@
     "notificationSettingsMentionsSubtitle": "あなたがメンションされた時",
     "notificationSettingsReposts": "リポスト",
     "notificationSettingsRepostsSubtitle": "誰かがあなたの動画をリポストした時",
+    "notificationSettingsNewPosts": "新しい動画",
+    "notificationSettingsNewPostsSubtitle": "フォロー中の人が投稿した時",
     "notificationSettingsActions": "アクション",
     "notificationSettingsMarkAllAsRead": "すべて既読にする",
     "notificationSettingsMarkAllAsReadSubtitle": "すべての通知を既読にするよ",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -583,6 +583,8 @@
     "notificationSettingsMentionsSubtitle": "멘션될 때",
     "notificationSettingsReposts": "리포스트",
     "notificationSettingsRepostsSubtitle": "누군가 내 영상을 리포스트할 때",
+    "notificationSettingsNewPosts": "새 영상",
+    "notificationSettingsNewPostsSubtitle": "지켜보는 사람이 게시할 때",
     "notificationSettingsActions": "작업",
     "notificationSettingsMarkAllAsRead": "모두 읽음으로 표시",
     "notificationSettingsMarkAllAsReadSubtitle": "모든 알림을 읽음으로 표시",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1944,6 +1944,7 @@
         }
     },
     "notificationRepostedYourVideo": "{actorName}님이 회원님의 동영상을 리포스트했어요",
+    "notificationPostedNewVine": "{actorName}님이 새 영상을 게시했습니다",
     "@notificationRepostedYourVideo": {
         "placeholders": {
             "actorName": {

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -4038,5 +4038,8 @@
     "videoEditorStopMotionFrameSemanticLabel": "스톱모션 프레임 {total}개 중 {position}개",
     "videoEditorStopMotionFramesCount": "{count, plural, other{{count}프레임}}",
     "videoEditorStopMotionFramesPerImageButtonLabel": "프레임",
-    "libraryStopMotionClipLabel": "스톱모션 클립"
+    "libraryStopMotionClipLabel": "스톱모션 클립",
+  "profileNotifyBellOff": "새 영상 알림 받기",
+  "profileNotifyBellOn": "새 영상 알림 끄기",
+  "profileNotifyUpdateFailed": "저장하지 못했습니다. 다시 시도할까요?"
 }

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -1438,6 +1438,8 @@
   "notificationSettingsMentionsSubtitle": "Apabila anda disebut",
   "notificationSettingsReposts": "Siaran Semula",
   "notificationSettingsRepostsSubtitle": "Apabila seseorang menyiarkan semula video anda",
+  "notificationSettingsNewPosts": "Vine baharu",
+  "notificationSettingsNewPostsSubtitle": "Apabila seseorang yang anda ikuti menyiarkan",
   "notificationSettingsSystem": "Sistem",
   "notificationSettingsSystemSubtitle": "Kemas kini apl dan mesej sistem",
   "notificationSettingsPushNotificationsSection": "Pemberitahuan Tolak",
@@ -4788,6 +4790,7 @@
       }
     }
   },
+  "notificationPostedNewVine": "{actorName} menyiarkan vine baharu",
   "notificationRepliedToYourComment": "{actorName} membalas komen anda",
   "@notificationRepliedToYourComment": {
     "description": "Full sentence shown for a reply notification.",
@@ -6664,5 +6667,8 @@
   "supporterDisclaimer": "Divine mengesahkan status penyokong selepas kedai mengesahkan pembelian anda. Pengiktirafan adalah pilihan, dan halo itu bukan pengesahan.",
   "@supporterDisclaimer": {
     "description": "Footnote on the supporter screen explaining server-side confirmation and that recognition is optional."
-  }
+  },
+  "profileNotifyBellOff": "Beritahu saya tentang vine baharu",
+  "profileNotifyBellOn": "Berhenti beritahu saya tentang vine baharu",
+  "profileNotifyUpdateFailed": "Tidak dapat disimpan. Cuba lagi?"
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4714,5 +4714,8 @@
     "videoEditorStopMotionFrameSemanticLabel": "Stop-motion-beeld {position} van {total}",
     "videoEditorStopMotionFramesCount": "{count, plural, =1{1 frame} other{{count} frames}}",
     "videoEditorStopMotionFramesPerImageButtonLabel": "Frames",
-    "libraryStopMotionClipLabel": "Stop-motion-clip"
+    "libraryStopMotionClipLabel": "Stop-motion-clip",
+  "profileNotifyBellOff": "Melden bij nieuwe vines",
+  "profileNotifyBellOn": "Niet meer melden bij nieuwe vines",
+  "profileNotifyUpdateFailed": "Kon niet opslaan. Opnieuw proberen?"
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -993,6 +993,8 @@
     "notificationSettingsMentionsSubtitle": "Wanneer je wordt genoemd",
     "notificationSettingsReposts": "Reposts",
     "notificationSettingsRepostsSubtitle": "Wanneer iemand je video's repost",
+    "notificationSettingsNewPosts": "Nieuwe vines",
+    "notificationSettingsNewPostsSubtitle": "Wanneer iemand die je volgt post",
     "notificationSettingsActions": "Acties",
     "notificationSettingsMarkAllAsRead": "Alles als gelezen markeren",
     "notificationSettingsMarkAllAsReadSubtitle": "Markeer alle meldingen als gelezen",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2621,6 +2621,7 @@
         }
     },
     "notificationRepostedYourVideo": "{actorName} heeft je video gedeeld",
+    "notificationPostedNewVine": "{actorName} heeft een nieuwe vine gepost",
     "@notificationRepostedYourVideo": {
         "placeholders": {
             "actorName": {

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4714,5 +4714,8 @@
     "videoEditorStopMotionFrameSemanticLabel": "Klatka poklatkowa {position} z {total}",
     "videoEditorStopMotionFramesCount": "{count, plural, =1{1 klatka} few{{count} klatki} many{{count} klatek} other{{count} klatki}}",
     "videoEditorStopMotionFramesPerImageButtonLabel": "Klatki",
-    "libraryStopMotionClipLabel": "Klip poklatkowy"
+    "libraryStopMotionClipLabel": "Klip poklatkowy",
+  "profileNotifyBellOff": "Powiadamiaj o nowych vine'ach",
+  "profileNotifyBellOn": "Nie powiadamiaj o nowych vine'ach",
+  "profileNotifyUpdateFailed": "Nie udało się zapisać. Spróbować ponownie?"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2621,6 +2621,7 @@
         }
     },
     "notificationRepostedYourVideo": "{actorName} udostępnił(a) Twoje wideo",
+    "notificationPostedNewVine": "{actorName} opublikował nowy vine",
     "@notificationRepostedYourVideo": {
         "placeholders": {
             "actorName": {

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -993,6 +993,8 @@
     "notificationSettingsMentionsSubtitle": "Gdy zostaniesz wspomniany",
     "notificationSettingsReposts": "Reposty",
     "notificationSettingsRepostsSubtitle": "Gdy ktoś repostuje twoje filmy",
+    "notificationSettingsNewPosts": "Nowe vine'y",
+    "notificationSettingsNewPostsSubtitle": "Gdy ktoś, kogo obserwujesz, publikuje",
     "notificationSettingsActions": "Akcje",
     "notificationSettingsMarkAllAsRead": "Oznacz wszystkie jako przeczytane",
     "notificationSettingsMarkAllAsReadSubtitle": "Oznacz wszystkie powiadomienia jako przeczytane",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -993,6 +993,8 @@
     "notificationSettingsMentionsSubtitle": "Quando você é mencionado",
     "notificationSettingsReposts": "Reposts",
     "notificationSettingsRepostsSubtitle": "Quando alguém reposta seus vídeos",
+    "notificationSettingsNewPosts": "Novos vines",
+    "notificationSettingsNewPostsSubtitle": "Quando alguém que você acompanha posta",
     "notificationSettingsActions": "Ações",
     "notificationSettingsMarkAllAsRead": "Marcar tudo como lido",
     "notificationSettingsMarkAllAsReadSubtitle": "Marcar todas as notificações como lidas",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4714,5 +4714,8 @@
     "videoEditorStopMotionFrameSemanticLabel": "Quadro de stop motion {position} de {total}",
     "videoEditorStopMotionFramesCount": "{count, plural, =1{1 quadro} other{{count} quadros}}",
     "videoEditorStopMotionFramesPerImageButtonLabel": "Quadros",
-    "libraryStopMotionClipLabel": "Clipe de stop motion"
+    "libraryStopMotionClipLabel": "Clipe de stop motion",
+  "profileNotifyBellOff": "Avisar sobre novos vines",
+  "profileNotifyBellOn": "Parar de avisar sobre novos vines",
+  "profileNotifyUpdateFailed": "Não foi possível salvar. Tentar de novo?"
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2621,6 +2621,7 @@
         }
     },
     "notificationRepostedYourVideo": "{actorName} repostou seu vídeo",
+    "notificationPostedNewVine": "{actorName} postou um novo vine",
     "@notificationRepostedYourVideo": {
         "placeholders": {
             "actorName": {

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2621,6 +2621,7 @@
         }
     },
     "notificationRepostedYourVideo": "{actorName} a redistribuit videoclipul tău",
+    "notificationPostedNewVine": "{actorName} a postat un videoclip nou",
     "@notificationRepostedYourVideo": {
         "placeholders": {
             "actorName": {

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -993,6 +993,8 @@
     "notificationSettingsMentionsSubtitle": "Când ești menționat",
     "notificationSettingsReposts": "Redistribuiri",
     "notificationSettingsRepostsSubtitle": "Când cineva âți redistribuie videoclipurile",
+    "notificationSettingsNewPosts": "Videoclipuri noi",
+    "notificationSettingsNewPostsSubtitle": "Când cineva pe care îl urmărești postează",
     "notificationSettingsActions": "Acțiuni",
     "notificationSettingsMarkAllAsRead": "Marchează toate ca citite",
     "notificationSettingsMarkAllAsReadSubtitle": "Marchează toate notificările ca citite",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4714,5 +4714,8 @@
     "videoEditorStopMotionFrameSemanticLabel": "Cadru stop-motion {position} din {total}",
     "videoEditorStopMotionFramesCount": "{count, plural, =1{1 cadru} other{{count} cadre}}",
     "videoEditorStopMotionFramesPerImageButtonLabel": "Cadre",
-    "libraryStopMotionClipLabel": "Clip stop-motion"
+    "libraryStopMotionClipLabel": "Clip stop-motion",
+  "profileNotifyBellOff": "Anunță-mă despre videoclipuri noi",
+  "profileNotifyBellOn": "Nu mă mai anunța despre videoclipuri noi",
+  "profileNotifyUpdateFailed": "Nu s-a salvat. Reîncerci?"
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -993,6 +993,8 @@
     "notificationSettingsMentionsSubtitle": "När du omnämns",
     "notificationSettingsReposts": "Återpubliceringar",
     "notificationSettingsRepostsSubtitle": "När någon återpublicerar dina videor",
+    "notificationSettingsNewPosts": "Nya vines",
+    "notificationSettingsNewPostsSubtitle": "När någon du bevakar publicerar",
     "notificationSettingsActions": "Åtgärder",
     "notificationSettingsMarkAllAsRead": "Markera alla som lästa",
     "notificationSettingsMarkAllAsReadSubtitle": "Markera alla aviseringar som lästa",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2621,6 +2621,7 @@
         }
     },
     "notificationRepostedYourVideo": "{actorName} delade din video",
+    "notificationPostedNewVine": "{actorName} publicerade en ny vine",
     "@notificationRepostedYourVideo": {
         "placeholders": {
             "actorName": {

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4714,5 +4714,8 @@
     "videoEditorStopMotionFrameSemanticLabel": "Stop motion-bild {position} av {total}",
     "videoEditorStopMotionFramesCount": "{count, plural, =1{1 bildruta} other{{count} bildrutor}}",
     "videoEditorStopMotionFramesPerImageButtonLabel": "Bildrutor",
-    "libraryStopMotionClipLabel": "Stop motion-klipp"
+    "libraryStopMotionClipLabel": "Stop motion-klipp",
+  "profileNotifyBellOff": "Meddela om nya vines",
+  "profileNotifyBellOn": "Sluta meddela om nya vines",
+  "profileNotifyUpdateFailed": "Kunde inte sparas. Försök igen?"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2620,6 +2620,7 @@
         }
     },
     "notificationRepostedYourVideo": "{actorName} videonu paylaştı",
+    "notificationPostedNewVine": "{actorName} yeni bir vine paylaştı",
     "@notificationRepostedYourVideo": {
         "placeholders": {
             "actorName": {

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4714,5 +4714,8 @@
     "videoEditorStopMotionFrameSemanticLabel": "Stop motion karesi {position}/{total}",
     "videoEditorStopMotionFramesCount": "{count, plural, other{{count} kare}}",
     "videoEditorStopMotionFramesPerImageButtonLabel": "Kare",
-    "libraryStopMotionClipLabel": "Stop motion klibi"
+    "libraryStopMotionClipLabel": "Stop motion klibi",
+  "profileNotifyBellOff": "Yeni vine'lardan haberdar et",
+  "profileNotifyBellOn": "Yeni vine bildirimlerini kapat",
+  "profileNotifyUpdateFailed": "Kaydedilemedi. Tekrar denensin mi?"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -990,6 +990,8 @@
     "notificationSettingsMentionsSubtitle": "Senden bahsedildiğinde",
     "notificationSettingsReposts": "Yeniden Paylaşımlar",
     "notificationSettingsRepostsSubtitle": "Biri videolarını yeniden paylaştığında",
+    "notificationSettingsNewPosts": "Yeni vine'lar",
+    "notificationSettingsNewPostsSubtitle": "İzlediğin biri paylaştığında",
     "notificationSettingsActions": "İşlemler",
     "notificationSettingsMarkAllAsRead": "Tümünü Okundu Olarak İşaretle",
     "notificationSettingsMarkAllAsReadSubtitle": "Tüm bildirimleri okundu olarak işaretle",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -1438,6 +1438,8 @@
   "notificationSettingsMentionsSubtitle": "جب آپ کا ذکر ہو",
   "notificationSettingsReposts": "ریپوسٹس",
   "notificationSettingsRepostsSubtitle": "جب کوئی آپ کی ویڈیوز ریپوسٹ کرے",
+  "notificationSettingsNewPosts": "نئی ویڈیوز",
+  "notificationSettingsNewPostsSubtitle": "جب آپ کا فالو کردہ کوئی شخص پوسٹ کرے",
   "notificationSettingsSystem": "سسٹم",
   "notificationSettingsSystemSubtitle": "ایپ اپڈیٹس اور سسٹم پیغامات",
   "notificationSettingsPushNotificationsSection": "پش اطلاعات",
@@ -4788,6 +4790,7 @@
       }
     }
   },
+  "notificationPostedNewVine": "{actorName} نے نئی ویڈیو پوسٹ کی",
   "notificationRepliedToYourComment": "{actorName} نے آپ کے تبصرے کا جواب دیا",
   "@notificationRepliedToYourComment": {
     "description": "Full sentence shown for a reply notification.",
@@ -6664,5 +6667,8 @@
   "supporterDisclaimer": "اسٹور آپ کی خریداری کی تصدیق کرنے کے بعد Divine سپورٹر اسٹیٹس کی تصدیق کرتا ہے۔ پہچان اختیاری ہے، اور ہالہ تصدیق نہیں ہے۔",
   "@supporterDisclaimer": {
     "description": "Footnote on the supporter screen explaining server-side confirmation and that recognition is optional."
-  }
+  },
+  "profileNotifyBellOff": "نئی ویڈیوز کی اطلاع دیں",
+  "profileNotifyBellOn": "نئی ویڈیوز کی اطلاعات بند کریں",
+  "profileNotifyUpdateFailed": "محفوظ نہیں ہو سکا۔ دوبارہ کوشش کریں؟"
 }

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -1438,6 +1438,8 @@
   "notificationSettingsMentionsSubtitle": "Khi bạn được nhắc đến",
   "notificationSettingsReposts": "Bài đăng lại",
   "notificationSettingsRepostsSubtitle": "Khi có người đăng lại video của bạn",
+  "notificationSettingsNewPosts": "Vine mới",
+  "notificationSettingsNewPostsSubtitle": "Khi người bạn theo dõi đăng bài",
   "notificationSettingsSystem": "Hệ thống",
   "notificationSettingsSystemSubtitle": "Cập nhật ứng dụng và thông điệp hệ thống",
   "notificationSettingsPushNotificationsSection": "Thông báo đẩy",
@@ -4788,6 +4790,7 @@
       }
     }
   },
+  "notificationPostedNewVine": "{actorName} đã đăng một vine mới",
   "notificationRepliedToYourComment": "{actorName} đã trả lời bình luận của bạn",
   "@notificationRepliedToYourComment": {
     "description": "Full sentence shown for a reply notification.",
@@ -6664,5 +6667,8 @@
   "supporterDisclaimer": "Divine xác nhận trạng thái người ủng hộ sau khi cửa hàng xác minh giao dịch mua của bạn. Việc ghi nhận là tùy chọn, và vòng hào quang không phải là xác minh danh tính.",
   "@supporterDisclaimer": {
     "description": "Footnote on the supporter screen explaining server-side confirmation and that recognition is optional."
-  }
+  },
+  "profileNotifyBellOff": "Nhận thông báo về vine mới",
+  "profileNotifyBellOn": "Ngừng thông báo về vine mới",
+  "profileNotifyUpdateFailed": "Không lưu được. Thử lại nhé?"
 }

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -1438,6 +1438,8 @@
   "notificationSettingsMentionsSubtitle": "当有人提到你时",
   "notificationSettingsReposts": "转发",
   "notificationSettingsRepostsSubtitle": "当有人转发你的视频时",
+  "notificationSettingsNewPosts": "新视频",
+  "notificationSettingsNewPostsSubtitle": "当你关注的人发布内容时",
   "notificationSettingsSystem": "系统",
   "notificationSettingsSystemSubtitle": "应用更新和系统消息",
   "notificationSettingsPushNotificationsSection": "推送通知",
@@ -4788,6 +4790,7 @@
       }
     }
   },
+  "notificationPostedNewVine": "{actorName} 发布了新视频",
   "notificationRepliedToYourComment": "{actorName} 回复了你的评论",
   "@notificationRepliedToYourComment": {
     "description": "Full sentence shown for a reply notification.",
@@ -6664,5 +6667,8 @@
   "supporterDisclaimer": "Divine 会在商店验证你的购买后确认支持者状态。展示与否完全自愿，光环标识不代表认证。",
   "@supporterDisclaimer": {
     "description": "Footnote on the supporter screen explaining server-side confirmation and that recognition is optional."
-  }
+  },
+  "profileNotifyBellOff": "接收新视频通知",
+  "profileNotifyBellOn": "停止新视频通知",
+  "profileNotifyUpdateFailed": "没能保存，再试一次？"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -13796,6 +13796,12 @@ abstract class AppLocalizations {
   /// **'{actorName} reposted your video'**
   String notificationRepostedYourVideo(String actorName);
 
+  /// Shown when a creator the user subscribed to (belled) publishes a new video. Unlike the other notification verbs this is not a reaction to the user's own content.
+  ///
+  /// In en, this message translates to:
+  /// **'{actorName} posted a new vine'**
+  String notificationPostedNewVine(String actorName);
+
   /// Full sentence shown for a reply notification.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -18599,6 +18599,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Divine confirms supporter status after the store verifies your purchase. Recognition is optional, and the halo is not verification.'**
   String get supporterDisclaimer;
+
+  /// Accessibility label on the profile bell when the viewer is not subscribed. Describes the action the tap performs, not the current state.
+  ///
+  /// In en, this message translates to:
+  /// **'Get notified about new vines'**
+  String get profileNotifyBellOff;
+
+  /// Accessibility label on the profile bell when the viewer is subscribed. Describes the action the tap performs.
+  ///
+  /// In en, this message translates to:
+  /// **'Stop notifying me about new vines'**
+  String get profileNotifyBellOn;
+
+  /// Transient message when publishing the notification-subscription list fails. The bell has already reverted to its previous state.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t save that. Try again?'**
+  String get profileNotifyUpdateFailed;
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -4286,6 +4286,18 @@ abstract class AppLocalizations {
   /// **'When someone reposts your videos'**
   String get notificationSettingsRepostsSubtitle;
 
+  /// No description provided for @notificationSettingsNewPosts.
+  ///
+  /// In en, this message translates to:
+  /// **'New vines'**
+  String get notificationSettingsNewPosts;
+
+  /// No description provided for @notificationSettingsNewPostsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'When someone you\'re watching posts'**
+  String get notificationSettingsNewPostsSubtitle;
+
   /// No description provided for @notificationSettingsSystem.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -10574,4 +10574,13 @@ class AppLocalizationsAm extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'Divine confirms supporter status after the store verifies your purchase. Recognition is optional, and the halo is not verification.';
+
+  @override
+  String get profileNotifyBellOff => 'ስለ አዲስ ቫይኖች አሳውቀኝ';
+
+  @override
+  String get profileNotifyBellOn => 'ስለ አዲስ ቫይኖች አታሳውቀኝ';
+
+  @override
+  String get profileNotifyUpdateFailed => 'ማስቀመጥ አልተቻለም። እንደገና ይሞክሩ?';
 }

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7829,6 +7829,11 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return '$actorName አዲስ ቫይን ለጠፈ';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName ለአስተያየትዎ ምላሽ ሰጥተዋል';
   }

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -2422,6 +2422,12 @@ class AppLocalizationsAm extends AppLocalizations {
   String get notificationSettingsRepostsSubtitle => 'አንድ ሰው ቪዲዮዎችህን በድጋሚ ሲለጥፍ';
 
   @override
+  String get notificationSettingsNewPosts => 'አዲስ ቫይኖች';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle => 'የምትከታተለው ሰው ሲለጥፍ';
+
+  @override
   String get notificationSettingsSystem => 'System';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -10721,4 +10721,13 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'Divine confirms supporter status after the store verifies your purchase. Recognition is optional, and the halo is not verification.';
+
+  @override
+  String get profileNotifyBellOff => 'أبلغني عن المقاطع الجديدة';
+
+  @override
+  String get profileNotifyBellOn => 'أوقف إشعارات المقاطع الجديدة';
+
+  @override
+  String get profileNotifyUpdateFailed => 'لم نتمكن من الحفظ. أعد المحاولة؟';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -2444,6 +2444,12 @@ class AppLocalizationsAr extends AppLocalizations {
       'عندما يعيد أحدهم نشر فيديوهاتك';
 
   @override
+  String get notificationSettingsNewPosts => 'مقاطع جديدة';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle => 'عندما ينشر شخص تتابعه';
+
+  @override
   String get notificationSettingsSystem => 'System';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -7935,6 +7935,11 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return '$actorName نشر مقطعًا جديدًا';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName ردّ على تعليقك';
   }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -8059,6 +8059,11 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return '$actorName публикува ново видео';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName Отговори на коментара ти';
   }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -2500,6 +2500,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Когато някой препубликува видеата ти';
 
   @override
+  String get notificationSettingsNewPosts => 'Нови видеа';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle =>
+      'Когато някой, когото следиш, публикува';
+
+  @override
   String get notificationSettingsSystem => 'System';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -10899,4 +10899,13 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'Divine confirms supporter status after the store verifies your purchase. Recognition is optional, and the halo is not verification.';
+
+  @override
+  String get profileNotifyBellOff => 'Получавай известия за нови видеа';
+
+  @override
+  String get profileNotifyBellOn => 'Спри известията за нови видеа';
+
+  @override
+  String get profileNotifyUpdateFailed => 'Не се запази. Опитай пак?';
 }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -10914,4 +10914,14 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'Divine confirms supporter status after the store verifies your purchase. Recognition is optional, and the halo is not verification.';
+
+  @override
+  String get profileNotifyBellOff => 'Über neue Vines benachrichtigen';
+
+  @override
+  String get profileNotifyBellOn => 'Keine Benachrichtigungen über neue Vines';
+
+  @override
+  String get profileNotifyUpdateFailed =>
+      'Konnte nicht gespeichert werden. Nochmal?';
 }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -8081,6 +8081,11 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return '$actorName hat einen neuen Vine gepostet';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName hat auf deinen Kommentar geantwortet';
   }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -2488,6 +2488,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Wenn jemand deine Videos repostet';
 
   @override
+  String get notificationSettingsNewPosts => 'Neue Vines';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle =>
+      'Wenn jemand, den du beobachtest, postet';
+
+  @override
   String get notificationSettingsSystem => 'System';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -7977,6 +7977,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return '$actorName posted a new vine';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName replied to your comment';
   }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -10768,4 +10768,13 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'Divine confirms supporter status after the store verifies your purchase. Recognition is optional, and the halo is not verification.';
+
+  @override
+  String get profileNotifyBellOff => 'Get notified about new vines';
+
+  @override
+  String get profileNotifyBellOn => 'Stop notifying me about new vines';
+
+  @override
+  String get profileNotifyUpdateFailed => 'Couldn\'t save that. Try again?';
 }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -2463,6 +2463,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'When someone reposts your videos';
 
   @override
+  String get notificationSettingsNewPosts => 'New vines';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle =>
+      'When someone you\'re watching posts';
+
+  @override
   String get notificationSettingsSystem => 'System';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -8060,6 +8060,11 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return '$actorName publicó un nuevo vine';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName respondió a tu comentario';
   }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -2487,6 +2487,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Cuando alguien repostea tus videos';
 
   @override
+  String get notificationSettingsNewPosts => 'Nuevos vines';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle =>
+      'Cuando alguien que sigues publica';
+
+  @override
   String get notificationSettingsSystem => 'System';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -10901,4 +10901,13 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'Divine confirms supporter status after the store verifies your purchase. Recognition is optional, and the halo is not verification.';
+
+  @override
+  String get profileNotifyBellOff => 'Avisarme de nuevos vines';
+
+  @override
+  String get profileNotifyBellOn => 'Dejar de avisarme de nuevos vines';
+
+  @override
+  String get profileNotifyUpdateFailed => 'No se pudo guardar. ¿Reintentar?';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -10909,4 +10909,13 @@ class AppLocalizationsFil extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'Divine confirms supporter status after the store verifies your purchase. Recognition is optional, and the halo is not verification.';
+
+  @override
+  String get profileNotifyBellOff => 'Ipaalam ang mga bagong vine';
+
+  @override
+  String get profileNotifyBellOn => 'Itigil ang pagpaalam sa mga bagong vine';
+
+  @override
+  String get profileNotifyUpdateFailed => 'Hindi nai-save. Subukan muli?';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -8077,6 +8077,11 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return 'Nag-post si $actorName ng bagong vine';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return 'nag-reply si $actorName sa comment mo';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -2498,6 +2498,13 @@ class AppLocalizationsFil extends AppLocalizations {
       'Kapag may nag-repost ng iyong mga video';
 
   @override
+  String get notificationSettingsNewPosts => 'Mga Bagong Vine';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle =>
+      'Kapag nag-post ang taong binabantayan mo';
+
+  @override
   String get notificationSettingsSystem => 'System';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -2493,6 +2493,13 @@ class AppLocalizationsFr extends AppLocalizations {
       'Quand quelqu\'un reposte tes vidéos';
 
   @override
+  String get notificationSettingsNewPosts => 'Nouvelles vines';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle =>
+      'Quand quelqu\'un que tu suis publie';
+
+  @override
   String get notificationSettingsSystem => 'System';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -10939,4 +10939,14 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'Divine confirms supporter status after the store verifies your purchase. Recognition is optional, and the halo is not verification.';
+
+  @override
+  String get profileNotifyBellOff => 'M\'avertir des nouvelles vines';
+
+  @override
+  String get profileNotifyBellOn => 'Ne plus m\'avertir des nouvelles vines';
+
+  @override
+  String get profileNotifyUpdateFailed =>
+      'Échec de l\'enregistrement. Réessayer ?';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -8088,6 +8088,11 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return '$actorName a publié une nouvelle vine';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName a répondu à ton commentaire';
   }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -2423,6 +2423,13 @@ class AppLocalizationsId extends AppLocalizations {
       'Saat ada yang me-repost videomu';
 
   @override
+  String get notificationSettingsNewPosts => 'Vine Baru';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle =>
+      'Saat orang yang kamu pantau memposting';
+
+  @override
   String get notificationSettingsSystem => 'System';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -7948,6 +7948,11 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return '$actorName memposting vine baru';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName membalas komentar Anda';
   }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -10754,4 +10754,13 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'Divine confirms supporter status after the store verifies your purchase. Recognition is optional, and the halo is not verification.';
+
+  @override
+  String get profileNotifyBellOff => 'Beri tahu tentang vine baru';
+
+  @override
+  String get profileNotifyBellOn => 'Hentikan pemberitahuan vine baru';
+
+  @override
+  String get profileNotifyUpdateFailed => 'Gagal menyimpan. Coba lagi?';
 }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -10897,4 +10897,14 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'Divine confirms supporter status after the store verifies your purchase. Recognition is optional, and the halo is not verification.';
+
+  @override
+  String get profileNotifyBellOff => 'Avvisami dei nuovi vine';
+
+  @override
+  String get profileNotifyBellOn => 'Non avvisarmi più dei nuovi vine';
+
+  @override
+  String get profileNotifyUpdateFailed =>
+      'Salvataggio non riuscito. Riprovare?';
 }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -2487,6 +2487,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'Quando qualcuno ripubblica i tuoi video';
 
   @override
+  String get notificationSettingsNewPosts => 'Nuovi vine';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle =>
+      'Quando qualcuno che segui pubblica';
+
+  @override
   String get notificationSettingsSystem => 'System';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -8061,6 +8061,11 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return '$actorName ha pubblicato un nuovo vine';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName ha risposto al tuo commento';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -2329,6 +2329,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get notificationSettingsRepostsSubtitle => '誰かがあなたの動画をリポストした時';
 
   @override
+  String get notificationSettingsNewPosts => '新しい動画';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle => 'フォロー中の人が投稿した時';
+
+  @override
   String get notificationSettingsSystem => 'System';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -10374,4 +10374,13 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'Divine confirms supporter status after the store verifies your purchase. Recognition is optional, and the halo is not verification.';
+
+  @override
+  String get profileNotifyBellOff => '新しい動画を通知する';
+
+  @override
+  String get profileNotifyBellOn => '新しい動画の通知を停止';
+
+  @override
+  String get profileNotifyUpdateFailed => '保存できませんでした。もう一度試しますか？';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7656,6 +7656,11 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return '$actorNameが新しい動画を投稿しました';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorNameさんがあなたのコメントに返信しました';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -2340,6 +2340,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get notificationSettingsRepostsSubtitle => '누군가 내 영상을 리포스트할 때';
 
   @override
+  String get notificationSettingsNewPosts => '새 영상';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle => '지켜보는 사람이 게시할 때';
+
+  @override
   String get notificationSettingsSystem => 'System';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -10398,4 +10398,13 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'Divine confirms supporter status after the store verifies your purchase. Recognition is optional, and the halo is not verification.';
+
+  @override
+  String get profileNotifyBellOff => '새 영상 알림 받기';
+
+  @override
+  String get profileNotifyBellOn => '새 영상 알림 끄기';
+
+  @override
+  String get profileNotifyUpdateFailed => '저장하지 못했습니다. 다시 시도할까요?';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -7678,6 +7678,11 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return '$actorName님이 새 영상을 게시했습니다';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName님이 회원님의 댓글에 답글을 남겼습니다';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -2482,6 +2482,13 @@ class AppLocalizationsMs extends AppLocalizations {
       'Apabila seseorang menyiarkan semula video anda';
 
   @override
+  String get notificationSettingsNewPosts => 'Vine baharu';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle =>
+      'Apabila seseorang yang anda ikuti menyiarkan';
+
+  @override
   String get notificationSettingsSystem => 'Sistem';
 
   @override
@@ -8031,6 +8038,11 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return '$actorName menyiarkan vine baharu';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName membalas komen anda';
   }
@@ -10847,4 +10859,14 @@ class AppLocalizationsMs extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'Divine mengesahkan status penyokong selepas kedai mengesahkan pembelian anda. Pengiktirafan adalah pilihan, dan halo itu bukan pengesahan.';
+
+  @override
+  String get profileNotifyBellOff => 'Beritahu saya tentang vine baharu';
+
+  @override
+  String get profileNotifyBellOn =>
+      'Berhenti beritahu saya tentang vine baharu';
+
+  @override
+  String get profileNotifyUpdateFailed => 'Tidak dapat disimpan. Cuba lagi?';
 }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -8022,6 +8022,11 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return '$actorName heeft een nieuwe vine gepost';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName heeft op je reactie gereageerd';
   }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -2472,6 +2472,13 @@ class AppLocalizationsNl extends AppLocalizations {
       'Wanneer iemand je video\'s repost';
 
   @override
+  String get notificationSettingsNewPosts => 'Nieuwe vines';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle =>
+      'Wanneer iemand die je volgt post';
+
+  @override
   String get notificationSettingsSystem => 'System';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -10845,4 +10845,13 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'Divine confirms supporter status after the store verifies your purchase. Recognition is optional, and the halo is not verification.';
+
+  @override
+  String get profileNotifyBellOff => 'Melden bij nieuwe vines';
+
+  @override
+  String get profileNotifyBellOn => 'Niet meer melden bij nieuwe vines';
+
+  @override
+  String get profileNotifyUpdateFailed => 'Kon niet opslaan. Opnieuw proberen?';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -8162,6 +8162,11 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return '$actorName opublikował nowy vine';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName odpowiedział(a) na Twój komentarz';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -2541,6 +2541,13 @@ class AppLocalizationsPl extends AppLocalizations {
       'Gdy ktoś repostuje twoje filmy';
 
   @override
+  String get notificationSettingsNewPosts => 'Nowe vine\'y';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle =>
+      'Gdy ktoś, kogo obserwujesz, publikuje';
+
+  @override
   String get notificationSettingsSystem => 'System';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -10988,4 +10988,14 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'Divine confirms supporter status after the store verifies your purchase. Recognition is optional, and the halo is not verification.';
+
+  @override
+  String get profileNotifyBellOff => 'Powiadamiaj o nowych vine\'ach';
+
+  @override
+  String get profileNotifyBellOn => 'Nie powiadamiaj o nowych vine\'ach';
+
+  @override
+  String get profileNotifyUpdateFailed =>
+      'Nie udało się zapisać. Spróbować ponownie?';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -2482,6 +2482,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Quando alguém reposta seus vídeos';
 
   @override
+  String get notificationSettingsNewPosts => 'Novos vines';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle =>
+      'Quando alguém que você acompanha posta';
+
+  @override
   String get notificationSettingsSystem => 'System';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -10866,4 +10866,14 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'Divine confirms supporter status after the store verifies your purchase. Recognition is optional, and the halo is not verification.';
+
+  @override
+  String get profileNotifyBellOff => 'Avisar sobre novos vines';
+
+  @override
+  String get profileNotifyBellOn => 'Parar de avisar sobre novos vines';
+
+  @override
+  String get profileNotifyUpdateFailed =>
+      'Não foi possível salvar. Tentar de novo?';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -8040,6 +8040,11 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return '$actorName postou um novo vine';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName respondeu ao teu comentário';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -8161,6 +8161,11 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return '$actorName a postat un videoclip nou';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName a răspuns la comentariul tău';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -11005,4 +11005,13 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'Divine confirms supporter status after the store verifies your purchase. Recognition is optional, and the halo is not verification.';
+
+  @override
+  String get profileNotifyBellOff => 'Anunță-mă despre videoclipuri noi';
+
+  @override
+  String get profileNotifyBellOn => 'Nu mă mai anunța despre videoclipuri noi';
+
+  @override
+  String get profileNotifyUpdateFailed => 'Nu s-a salvat. Reîncerci?';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -2551,6 +2551,13 @@ class AppLocalizationsRo extends AppLocalizations {
       'Când cineva âți redistribuie videoclipurile';
 
   @override
+  String get notificationSettingsNewPosts => 'Videoclipuri noi';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle =>
+      'Când cineva pe care îl urmărești postează';
+
+  @override
   String get notificationSettingsSystem => 'System';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -7983,6 +7983,11 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return '$actorName publicerade en ny vine';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName svarade på din kommentar';
   }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -2456,6 +2456,13 @@ class AppLocalizationsSv extends AppLocalizations {
       'När någon återpublicerar dina videor';
 
   @override
+  String get notificationSettingsNewPosts => 'Nya vines';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle =>
+      'När någon du bevakar publicerar';
+
+  @override
   String get notificationSettingsSystem => 'System';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -10799,4 +10799,13 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'Divine confirms supporter status after the store verifies your purchase. Recognition is optional, and the halo is not verification.';
+
+  @override
+  String get profileNotifyBellOff => 'Meddela om nya vines';
+
+  @override
+  String get profileNotifyBellOn => 'Sluta meddela om nya vines';
+
+  @override
+  String get profileNotifyUpdateFailed => 'Kunde inte sparas. Försök igen?';
 }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -7947,6 +7947,11 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return '$actorName yeni bir vine paylaştı';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName yorumuna yanıt verdi';
   }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -2429,6 +2429,13 @@ class AppLocalizationsTr extends AppLocalizations {
       'Biri videolarını yeniden paylaştığında';
 
   @override
+  String get notificationSettingsNewPosts => 'Yeni vine\'lar';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle =>
+      'İzlediğin biri paylaştığında';
+
+  @override
   String get notificationSettingsSystem => 'System';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -10755,4 +10755,13 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'Divine confirms supporter status after the store verifies your purchase. Recognition is optional, and the halo is not verification.';
+
+  @override
+  String get profileNotifyBellOff => 'Yeni vine\'lardan haberdar et';
+
+  @override
+  String get profileNotifyBellOn => 'Yeni vine bildirimlerini kapat';
+
+  @override
+  String get profileNotifyUpdateFailed => 'Kaydedilemedi. Tekrar denensin mi?';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -2464,6 +2464,13 @@ class AppLocalizationsUr extends AppLocalizations {
       'جب کوئی آپ کی ویڈیوز ریپوسٹ کرے';
 
   @override
+  String get notificationSettingsNewPosts => 'نئی ویڈیوز';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle =>
+      'جب آپ کا فالو کردہ کوئی شخص پوسٹ کرے';
+
+  @override
   String get notificationSettingsSystem => 'سسٹم';
 
   @override
@@ -7983,6 +7990,11 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return '$actorName نے نئی ویڈیو پوسٹ کی';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName نے آپ کے تبصرے کا جواب دیا';
   }
@@ -10783,4 +10795,14 @@ class AppLocalizationsUr extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'اسٹور آپ کی خریداری کی تصدیق کرنے کے بعد Divine سپورٹر اسٹیٹس کی تصدیق کرتا ہے۔ پہچان اختیاری ہے، اور ہالہ تصدیق نہیں ہے۔';
+
+  @override
+  String get profileNotifyBellOff => 'نئی ویڈیوز کی اطلاع دیں';
+
+  @override
+  String get profileNotifyBellOn => 'نئی ویڈیوز کی اطلاعات بند کریں';
+
+  @override
+  String get profileNotifyUpdateFailed =>
+      'محفوظ نہیں ہو سکا۔ دوبارہ کوشش کریں؟';
 }

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -2471,6 +2471,13 @@ class AppLocalizationsVi extends AppLocalizations {
       'Khi có người đăng lại video của bạn';
 
   @override
+  String get notificationSettingsNewPosts => 'Vine mới';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle =>
+      'Khi người bạn theo dõi đăng bài';
+
+  @override
   String get notificationSettingsSystem => 'Hệ thống';
 
   @override
@@ -7986,6 +7993,11 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return '$actorName đã đăng một vine mới';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName đã trả lời bình luận của bạn';
   }
@@ -10794,4 +10806,13 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'Divine xác nhận trạng thái người ủng hộ sau khi cửa hàng xác minh giao dịch mua của bạn. Việc ghi nhận là tùy chọn, và vòng hào quang không phải là xác minh danh tính.';
+
+  @override
+  String get profileNotifyBellOff => 'Nhận thông báo về vine mới';
+
+  @override
+  String get profileNotifyBellOn => 'Ngừng thông báo về vine mới';
+
+  @override
+  String get profileNotifyUpdateFailed => 'Không lưu được. Thử lại nhé?';
 }

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -2344,6 +2344,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get notificationSettingsRepostsSubtitle => '当有人转发你的视频时';
 
   @override
+  String get notificationSettingsNewPosts => '新视频';
+
+  @override
+  String get notificationSettingsNewPostsSubtitle => '当你关注的人发布内容时';
+
+  @override
   String get notificationSettingsSystem => '系统';
 
   @override
@@ -7580,6 +7586,11 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String notificationPostedNewVine(String actorName) {
+    return '$actorName 发布了新视频';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName 回复了你的评论';
   }
@@ -10207,4 +10218,13 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get supporterDisclaimer =>
       'Divine 会在商店验证你的购买后确认支持者状态。展示与否完全自愿，光环标识不代表认证。';
+
+  @override
+  String get profileNotifyBellOff => '接收新视频通知';
+
+  @override
+  String get profileNotifyBellOn => '停止新视频通知';
+
+  @override
+  String get profileNotifyUpdateFailed => '没能保存，再试一次？';
 }

--- a/mobile/lib/models/notification_preferences.dart
+++ b/mobile/lib/models/notification_preferences.dart
@@ -12,6 +12,7 @@ class NotificationPreferences extends Equatable {
     this.followsEnabled = true,
     this.mentionsEnabled = true,
     this.repostsEnabled = true,
+    this.newPostsEnabled = true,
   });
 
   /// Create preferences from a list of enabled Nostr event kinds.
@@ -21,11 +22,17 @@ class NotificationPreferences extends Equatable {
   /// - 1: text notes (comments and mentions)
   /// - 3: contact list (follows)
   /// - 16: reposts
+  /// - 34236: videos from creators the user subscribed to ("bells")
   ///
   /// Comments and mentions both use kind 1. When kind 1 is present,
   /// both are enabled. When absent, both are disabled.
   /// Known limitation: the push service filters by kind number only,
   /// so comments and mentions cannot be toggled independently.
+  ///
+  /// Preferences published before bells shipped carry no 34236, so
+  /// [newPostsEnabled] reads back `false` for them. That is self-healing:
+  /// opening the settings screen or setting the first bell republishes with
+  /// 34236 included.
   factory NotificationPreferences.fromKindsList(List<int> kinds) {
     return NotificationPreferences(
       likesEnabled: kinds.contains(7),
@@ -33,6 +40,7 @@ class NotificationPreferences extends Equatable {
       followsEnabled: kinds.contains(3),
       mentionsEnabled: kinds.contains(1),
       repostsEnabled: kinds.contains(16),
+      newPostsEnabled: kinds.contains(newPostKind),
     );
   }
 
@@ -43,14 +51,24 @@ class NotificationPreferences extends Equatable {
       followsEnabled: json['followsEnabled'] as bool? ?? true,
       mentionsEnabled: json['mentionsEnabled'] as bool? ?? true,
       repostsEnabled: json['repostsEnabled'] as bool? ?? true,
+      newPostsEnabled: json['newPostsEnabled'] as bool? ?? true,
     );
   }
+
+  /// Nostr kind for Divine video events, used to gate new-post pushes.
+  ///
+  /// Distinct from kind 1, so muting mentions does not mute new-post pushes
+  /// even though video mentions also arrive on kind 34236 events.
+  static const int newPostKind = 34236;
 
   final bool likesEnabled;
   final bool commentsEnabled;
   final bool followsEnabled;
   final bool mentionsEnabled;
   final bool repostsEnabled;
+
+  /// Whether to receive a push when a subscribed creator posts a new video.
+  final bool newPostsEnabled;
 
   /// Convert to the kinds list format expected by the push service.
   ///
@@ -61,6 +79,7 @@ class NotificationPreferences extends Equatable {
     if (commentsEnabled || mentionsEnabled) kinds.add(1);
     if (followsEnabled) kinds.add(3);
     if (repostsEnabled) kinds.add(16);
+    if (newPostsEnabled) kinds.add(newPostKind);
     return kinds.toList()..sort();
   }
 
@@ -71,6 +90,7 @@ class NotificationPreferences extends Equatable {
       'followsEnabled': followsEnabled,
       'mentionsEnabled': mentionsEnabled,
       'repostsEnabled': repostsEnabled,
+      'newPostsEnabled': newPostsEnabled,
     };
   }
 
@@ -80,6 +100,7 @@ class NotificationPreferences extends Equatable {
     bool? followsEnabled,
     bool? mentionsEnabled,
     bool? repostsEnabled,
+    bool? newPostsEnabled,
   }) {
     return NotificationPreferences(
       likesEnabled: likesEnabled ?? this.likesEnabled,
@@ -87,6 +108,7 @@ class NotificationPreferences extends Equatable {
       followsEnabled: followsEnabled ?? this.followsEnabled,
       mentionsEnabled: mentionsEnabled ?? this.mentionsEnabled,
       repostsEnabled: repostsEnabled ?? this.repostsEnabled,
+      newPostsEnabled: newPostsEnabled ?? this.newPostsEnabled,
     );
   }
 
@@ -97,5 +119,6 @@ class NotificationPreferences extends Equatable {
     followsEnabled,
     mentionsEnabled,
     repostsEnabled,
+    newPostsEnabled,
   ];
 }

--- a/mobile/lib/notifications/routing/notification_tap_target.dart
+++ b/mobile/lib/notifications/routing/notification_tap_target.dart
@@ -82,11 +82,13 @@ bool notificationKindOpensComments(
 
 /// Maps the push wire `type` to a [NotificationKind].
 ///
-/// `divine-push-service` sends a lowercase, five-value vocabulary
-/// (`like`/`comment`/`follow`/`mention`/`repost`). It never sends `reply`,
-/// `likeComment`, or `system`. Unknown / absent values return `null`, which
-/// [resolveNotificationTapTarget] treats as a best-effort video/profile/inbox
-/// tap.
+/// `divine-push-service` sends a lowercase vocabulary
+/// (`like`/`comment`/`follow`/`mention`/`repost`) plus the camelCase
+/// `newPost`, which matches that service's `NotificationType::display_name()`
+/// exactly — the string is a wire contract, not a display value. It never
+/// sends `reply`, `likeComment`, or `system`. Unknown / absent values return
+/// `null`, which [resolveNotificationTapTarget] treats as a best-effort
+/// video/profile/inbox tap.
 NotificationKind? notificationKindFromPushType(String? type) {
   switch (type) {
     case 'like':
@@ -99,6 +101,8 @@ NotificationKind? notificationKindFromPushType(String? type) {
       return NotificationKind.mention;
     case 'repost':
       return NotificationKind.repost;
+    case 'newPost':
+      return NotificationKind.newPost;
     default:
       // Keep unknown values non-fatal: a mistyped or legacy-cased payload
       // should still fall back to the best available target.

--- a/mobile/lib/notifications/widgets/actor_notification_row.dart
+++ b/mobile/lib/notifications/widgets/actor_notification_row.dart
@@ -241,9 +241,12 @@ String _messageFor(
       actorName,
     ),
     NotificationKind.reply => l10n.notificationRepliedToYourComment(actorName),
+    // newPost is video-anchored and never renders through the actor row;
+    // listed here for switch exhaustivity only.
     NotificationKind.system ||
     NotificationKind.like ||
     NotificationKind.comment ||
-    NotificationKind.repost => '',
+    NotificationKind.repost ||
+    NotificationKind.newPost => '',
   };
 }

--- a/mobile/lib/notifications/widgets/notification_type_icon_spec.dart
+++ b/mobile/lib/notifications/widgets/notification_type_icon_spec.dart
@@ -59,6 +59,11 @@ NotificationTypeIconSpec notificationTypeIconSpec(
       background: VineTheme.accentYellowBackground,
       foreground: VineTheme.accentYellow,
     ),
+    NotificationKind.newPost => const NotificationTypeIconSpec(
+      icon: DivineIconName.bellSimple,
+      background: VineTheme.accentBlueBackground,
+      foreground: VineTheme.accentBlue,
+    ),
     NotificationKind.system => const NotificationTypeIconSpec(
       icon: DivineIconName.logo,
       background: VineTheme.onPrimaryButton,

--- a/mobile/lib/notifications/widgets/video_notification_row.dart
+++ b/mobile/lib/notifications/widgets/video_notification_row.dart
@@ -297,8 +297,9 @@ String _verbFor(AppLocalizations l10n, NotificationKind type) {
     NotificationKind.repost =>
       l10n.notificationRepostedYourVideo('').trimLeft(),
     NotificationKind.mention => l10n.notificationMentionedYou('').trimLeft(),
+    NotificationKind.newPost => l10n.notificationPostedNewVine('').trimLeft(),
     // VideoNotification asserts type ∈ {like, likeComment, comment, mention,
-    // repost}; the remaining cases satisfy switch exhaustivity only.
+    // repost, newPost}; the remaining cases satisfy switch exhaustivity only.
     NotificationKind.reply ||
     NotificationKind.follow ||
     NotificationKind.system => '',
@@ -320,6 +321,7 @@ String _messageFor(
     ),
     NotificationKind.repost => l10n.notificationRepostedYourVideo(actorName),
     NotificationKind.mention => l10n.notificationMentionedYou(actorName),
+    NotificationKind.newPost => l10n.notificationPostedNewVine(actorName),
     NotificationKind.reply ||
     NotificationKind.follow ||
     NotificationKind.system => '',

--- a/mobile/lib/notifications/widgets/video_notification_row.dart
+++ b/mobile/lib/notifications/widgets/video_notification_row.dart
@@ -278,7 +278,8 @@ class _MessageText extends StatelessWidget {
 bool _typeShowsTitle(NotificationKind type) {
   return type == NotificationKind.like ||
       type == NotificationKind.comment ||
-      type == NotificationKind.repost;
+      type == NotificationKind.repost ||
+      type == NotificationKind.newPost;
 }
 
 /// Returns just the verb portion (no actor name) for inline composition.

--- a/mobile/lib/providers/notifications_providers.dart
+++ b/mobile/lib/providers/notifications_providers.dart
@@ -140,6 +140,11 @@ notificationPreferencesDirtySyncBridgeProvider =
             notificationPreferencesServiceProvider,
           );
           if (!isReadyForPubkey(pubkey)) return;
+          // Upgrades that changed the published kind list have nothing marked
+          // dirty, so without this the drain finds nothing and the push
+          // service keeps filtering on the pre-upgrade kinds.
+          await preferencesService.markDirtyIfSchemaOutdated(pubkey);
+          if (!isReadyForPubkey(pubkey)) return;
           final outcome = await preferencesService
               .syncDirtyPreferencesForPubkey(
                 pubkey,

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -482,6 +482,23 @@ PeopleListsRepository peopleListsRepository(Ref ref) {
 final Provider<Stream<PeopleListsRepository>>
 peopleListsRepositoryIdentityStreamProvider =
     identityStreamOf<PeopleListsRepository>(peopleListsRepositoryProvider);
+/// Repository for the reserved kind 30000 `d=notify` subscription list.
+///
+/// Owns which creators the signed-in user gets new-post notifications about
+/// ("bells"). Kept separate from [peopleListsRepository] so the app-managed
+/// list is never reachable from list-editing UI.
+///
+/// Long-lived so the in-memory subscription snapshot and its mutation queue
+/// survive navigation — a per-route instance would re-read the list on every
+/// profile visit and lose in-flight publishes.
+@Riverpod(keepAlive: true)
+NotifySubscriptionsRepository notifySubscriptionsRepository(Ref ref) {
+  final repository = NotifySubscriptionsRepositoryImpl(
+    nostrClient: ref.watch(nostrServiceProvider),
+  );
+  ref.onDispose(repository.dispose);
+  return repository;
+}
 
 /// Bookmark service for NIP-51 bookmarks
 @riverpod

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -482,6 +482,7 @@ PeopleListsRepository peopleListsRepository(Ref ref) {
 final Provider<Stream<PeopleListsRepository>>
 peopleListsRepositoryIdentityStreamProvider =
     identityStreamOf<PeopleListsRepository>(peopleListsRepositoryProvider);
+
 /// Repository for the reserved kind 30000 `d=notify` subscription list.
 ///
 /// Owns which creators the signed-in user gets new-post notifications about

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -667,6 +667,86 @@ final class PeopleListsRepositoryProvider
 String _$peopleListsRepositoryHash() =>
     r'd62acfadef10fcaab46ba5f74352e7feacf3a63d';
 
+/// Repository for the reserved kind 30000 `d=notify` subscription list.
+///
+/// Owns which creators the signed-in user gets new-post notifications about
+/// ("bells"). Kept separate from [peopleListsRepository] so the app-managed
+/// list is never reachable from list-editing UI.
+///
+/// Long-lived so the in-memory subscription snapshot and its mutation queue
+/// survive navigation — a per-route instance would re-read the list on every
+/// profile visit and lose in-flight publishes.
+
+@ProviderFor(notifySubscriptionsRepository)
+final notifySubscriptionsRepositoryProvider =
+    NotifySubscriptionsRepositoryProvider._();
+
+/// Repository for the reserved kind 30000 `d=notify` subscription list.
+///
+/// Owns which creators the signed-in user gets new-post notifications about
+/// ("bells"). Kept separate from [peopleListsRepository] so the app-managed
+/// list is never reachable from list-editing UI.
+///
+/// Long-lived so the in-memory subscription snapshot and its mutation queue
+/// survive navigation — a per-route instance would re-read the list on every
+/// profile visit and lose in-flight publishes.
+
+final class NotifySubscriptionsRepositoryProvider
+    extends
+        $FunctionalProvider<
+          NotifySubscriptionsRepository,
+          NotifySubscriptionsRepository,
+          NotifySubscriptionsRepository
+        >
+    with $Provider<NotifySubscriptionsRepository> {
+  /// Repository for the reserved kind 30000 `d=notify` subscription list.
+  ///
+  /// Owns which creators the signed-in user gets new-post notifications about
+  /// ("bells"). Kept separate from [peopleListsRepository] so the app-managed
+  /// list is never reachable from list-editing UI.
+  ///
+  /// Long-lived so the in-memory subscription snapshot and its mutation queue
+  /// survive navigation — a per-route instance would re-read the list on every
+  /// profile visit and lose in-flight publishes.
+  NotifySubscriptionsRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'notifySubscriptionsRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$notifySubscriptionsRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<NotifySubscriptionsRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  NotifySubscriptionsRepository create(Ref ref) {
+    return notifySubscriptionsRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(NotifySubscriptionsRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<NotifySubscriptionsRepository>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$notifySubscriptionsRepositoryHash() =>
+    r'54ed8c30c8819f524052ba4abaccb01dfaeaacce';
+
 /// Bookmark service for NIP-51 bookmarks
 
 @ProviderFor(bookmarkService)

--- a/mobile/lib/screens/notification_settings_screen.dart
+++ b/mobile/lib/screens/notification_settings_screen.dart
@@ -9,6 +9,8 @@ import 'package:go_router/go_router.dart';
 import 'package:notification_repository/notification_repository.dart';
 import 'package:openvine/blocs/notification_settings/notification_settings_cubit.dart';
 import 'package:openvine/blocs/notification_settings/notification_settings_state.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/notifications/providers/notification_repository_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -42,6 +44,9 @@ class NotificationSettingsScreen extends ConsumerWidget {
         onMarkAllAsRead: repository == null
             ? null
             : () => _markAllAsRead(repository),
+        showNewPosts: ref.watch(
+          isFeatureEnabledProvider(FeatureFlag.newPostNotifications),
+        ),
       ),
     );
   }
@@ -64,9 +69,18 @@ class NotificationSettingsScreen extends ConsumerWidget {
 /// notification repository (see #4744 scope decision).
 class NotificationSettingsView extends StatelessWidget {
   @visibleForTesting
-  const NotificationSettingsView({required this.onMarkAllAsRead, super.key});
+  const NotificationSettingsView({
+    required this.onMarkAllAsRead,
+    required this.showNewPosts,
+    super.key,
+  });
 
   final Future<bool> Function()? onMarkAllAsRead;
+
+  /// Whether to offer the new-post ("bell") toggle. Hidden until the push
+  /// service delivers kind 34236, since there is no bell to switch off and
+  /// the toggle would change nothing a user could observe.
+  final bool showNewPosts;
 
   @override
   Widget build(BuildContext context) => Scaffold(
@@ -156,17 +170,18 @@ class NotificationSettingsView extends StatelessWidget {
                         prefs.copyWith(repostsEnabled: value),
                       ),
                     ),
-                    _NotificationCard(
-                      icon: DivineIconName.bellSimple,
-                      iconColor: VineTheme.vineGreen,
-                      title: context.l10n.notificationSettingsNewPosts,
-                      subtitle:
-                          context.l10n.notificationSettingsNewPostsSubtitle,
-                      value: prefs.newPostsEnabled,
-                      onChanged: (value) => cubit.setPreferences(
-                        prefs.copyWith(newPostsEnabled: value),
+                    if (showNewPosts)
+                      _NotificationCard(
+                        icon: DivineIconName.bellSimple,
+                        iconColor: VineTheme.vineGreen,
+                        title: context.l10n.notificationSettingsNewPosts,
+                        subtitle:
+                            context.l10n.notificationSettingsNewPostsSubtitle,
+                        value: prefs.newPostsEnabled,
+                        onChanged: (value) => cubit.setPreferences(
+                          prefs.copyWith(newPostsEnabled: value),
+                        ),
                       ),
-                    ),
                     const SizedBox(height: 24),
                     _SectionHeader(context.l10n.notificationSettingsActions),
                     const SizedBox(height: 8),

--- a/mobile/lib/screens/notification_settings_screen.dart
+++ b/mobile/lib/screens/notification_settings_screen.dart
@@ -156,6 +156,17 @@ class NotificationSettingsView extends StatelessWidget {
                         prefs.copyWith(repostsEnabled: value),
                       ),
                     ),
+                    _NotificationCard(
+                      icon: DivineIconName.bellSimple,
+                      iconColor: VineTheme.vineGreen,
+                      title: context.l10n.notificationSettingsNewPosts,
+                      subtitle:
+                          context.l10n.notificationSettingsNewPostsSubtitle,
+                      value: prefs.newPostsEnabled,
+                      onChanged: (value) => cubit.setPreferences(
+                        prefs.copyWith(newPostsEnabled: value),
+                      ),
+                    ),
                     const SizedBox(height: 24),
                     _SectionHeader(context.l10n.notificationSettingsActions),
                     const SizedBox(height: 8),

--- a/mobile/lib/services/notification_preferences_service.dart
+++ b/mobile/lib/services/notification_preferences_service.dart
@@ -20,6 +20,12 @@ abstract interface class NotificationPreferencesStore {
     String pubkey,
     NotificationPreferences preferences,
   );
+
+  /// Schema version of the kinds list last published for [pubkey], or `null`
+  /// when nothing has been published since the marker was introduced.
+  Future<int?> loadPublishedSchemaVersion(String pubkey);
+
+  Future<void> savePublishedSchemaVersion(String pubkey, int version);
 }
 
 class HiveNotificationPreferencesStore implements NotificationPreferencesStore {
@@ -37,6 +43,7 @@ class HiveNotificationPreferencesStore implements NotificationPreferencesStore {
   static const _dirtyBoxName = 'push_notification_preferences_dirty';
   static const _prefsKey = 'push_preferences';
   static const _dirtyPrefix = 'push_preferences_dirty_';
+  static const _schemaVersionPrefix = 'push_preferences_schema_';
 
   @override
   Future<NotificationPreferences> loadPreferences() async {
@@ -154,11 +161,43 @@ class HiveNotificationPreferencesStore implements NotificationPreferencesStore {
     }
   }
 
+  @override
+  Future<int?> loadPublishedSchemaVersion(String pubkey) async {
+    try {
+      final box = await _openDirtyBox();
+      return box.get(_schemaVersionKey(pubkey)) as int?;
+    } on Object catch (error) {
+      Log.warning(
+        'Failed to load published preferences schema version: $error',
+        name: 'NotificationPreferencesService',
+        category: LogCategory.system,
+      );
+      return null;
+    }
+  }
+
+  @override
+  Future<void> savePublishedSchemaVersion(String pubkey, int version) async {
+    try {
+      final box = await _openDirtyBox();
+      await box.put(_schemaVersionKey(pubkey), version);
+    } on Object catch (error) {
+      Log.warning(
+        'Failed to persist published preferences schema version: $error',
+        name: 'NotificationPreferencesService',
+        category: LogCategory.system,
+      );
+    }
+  }
+
   static Future<Box<dynamic>> openBox() => Hive.openBox<dynamic>(_boxName);
   static Future<Box<dynamic>> openDirtyBox() =>
       Hive.openBox<dynamic>(_dirtyBoxName);
 
   static String _dirtyKey(String pubkey) => '$_dirtyPrefix$pubkey';
+
+  static String _schemaVersionKey(String pubkey) =>
+      '$_schemaVersionPrefix$pubkey';
 }
 
 enum NotificationPreferencesSyncOutcome {
@@ -202,6 +241,40 @@ class NotificationPreferencesService {
     }
   }
 
+  /// Schema version of the kind list [NotificationPreferences.toKindsList]
+  /// currently emits.
+  ///
+  /// Bump this whenever a kind is added or removed, so already-installed
+  /// clients republish instead of leaving the push service acting on a kind
+  /// list that predates the change.
+  ///
+  /// * 1 — added kind 34236 (new-post / "bell" notifications).
+  static const int publishedKindsSchemaVersion = 1;
+
+  /// Marks preferences dirty when the last published kind list predates
+  /// [publishedKindsSchemaVersion].
+  ///
+  /// Without this, an upgrading user's stored preferences read back with
+  /// new flags enabled locally while the push service still holds the old
+  /// kind list — the settings screen shows a notification type switched on
+  /// that the service is filtering out, and nothing ever republishes because
+  /// only an explicit user edit marks dirty.
+  ///
+  /// Marking dirty rather than publishing directly reuses the caller's
+  /// readiness gating and retry handling.
+  Future<bool> markDirtyIfSchemaOutdated(String pubkey) async {
+    final published = await _store.loadPublishedSchemaVersion(pubkey);
+    if (published == publishedKindsSchemaVersion) return false;
+
+    // A pending edit is already queued to publish and will record the marker
+    // on success. Overwriting it here would discard the user's change in
+    // favour of the last-saved snapshot.
+    if (await _store.loadDirty(pubkey) != null) return false;
+
+    await _store.markDirty(pubkey, await _store.loadPreferences());
+    return true;
+  }
+
   Future<NotificationPreferencesSyncOutcome> syncDirtyPreferencesForPubkey(
     String pubkey,
   ) async {
@@ -220,6 +293,12 @@ class NotificationPreferencesService {
       return NotificationPreferencesSyncOutcome.stillDirty;
     }
 
+    // Recorded only after the publish lands, so a failed publish leaves the
+    // marker behind and the next readiness pass retries.
+    await _store.savePublishedSchemaVersion(
+      pubkey,
+      publishedKindsSchemaVersion,
+    );
     await _store.clearDirtyIfMatches(pubkey, preferences);
     final dirty = await _store.loadDirty(pubkey);
     return dirty == null

--- a/mobile/lib/widgets/profile/profile_action_buttons_widget.dart
+++ b/mobile/lib/widgets/profile/profile_action_buttons_widget.dart
@@ -6,20 +6,24 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/my_following/my_following_bloc.dart';
+import 'package:openvine/blocs/notify_bell/notify_bell_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/widgets/profile/follow_from_profile_button.dart';
+import 'package:openvine/widgets/profile/profile_notify_bell_button.dart';
 
 /// Action buttons shown on profile page.
 ///
 /// Different buttons shown for own profile vs other user profiles.
 /// For other profiles, button order changes based on follow state:
 /// - Not following: [Follow] [Message] [Share]
-/// - Following:     [Message] [Following] [Share]
+/// - Following:     [Message] [Bell] [Following] [Share]
 ///
 /// Creates [MyFollowingBloc] for other profiles so both the follow button
-/// and the row ordering react to the same optimistic state change instantly.
+/// and the row ordering react to the same optimistic state change instantly,
+/// and [NotifyBellCubit] so the follow-gated bell has a host that outlives
+/// its own mount.
 class ProfileActionButtons extends ConsumerWidget {
   const ProfileActionButtons({
     required this.userIdHex,
@@ -58,7 +62,14 @@ class ProfileActionButtons extends ConsumerWidget {
     final contentBlocklistRepository = ref.watch(
       contentBlocklistRepositoryProvider,
     );
+    final notifySubscriptions = ref.watch(
+      notifySubscriptionsRepositoryProvider,
+    );
     final nostrClient = ref.watch(nostrServiceProvider);
+    // Empty rather than null when no signer is attached (the placeholder
+    // LocalKeySigner), so signed-out is an emptiness check.
+    final viewerPubkey = nostrClient.publicKey;
+    final hasViewer = viewerPubkey.isNotEmpty;
 
     // Watch blocklist version to trigger rebuilds when block/unblock occurs
     ref.watch(blocklistVersionProvider);
@@ -68,21 +79,45 @@ class ProfileActionButtons extends ConsumerWidget {
 
     // Create MyFollowingBloc at this level so both the follow button
     // and the row ordering share the same optimistic state.
-    return BlocProvider(
-      create: (_) => MyFollowingBloc(
-        followRepository: followRepository,
-        contentBlocklistRepository: contentBlocklistRepository,
-      )..add(const MyFollowingListLoadRequested()),
+    //
+    // NotifyBellCubit is provided here too, above the follow-gated bell, so
+    // it survives the bell unmounting on unfollow and can still publish the
+    // teardown. Both are keyed on their repositories' identity so an auth
+    // flip rebuilds them instead of leaving a stale capture.
+    return MultiBlocProvider(
+      key: ValueKey((
+        followRepository,
+        contentBlocklistRepository,
+        notifySubscriptions,
+        viewerPubkey,
+      )),
+      providers: [
+        BlocProvider(
+          create: (_) => MyFollowingBloc(
+            followRepository: followRepository,
+            contentBlocklistRepository: contentBlocklistRepository,
+          )..add(const MyFollowingListLoadRequested()),
+        ),
+        if (hasViewer)
+          BlocProvider(
+            create: (_) => NotifyBellCubit(
+              repository: notifySubscriptions,
+              viewerPubkey: viewerPubkey,
+              creatorPubkey: userIdHex,
+            )..load(),
+          ),
+      ],
       child: _OtherProfileButtons(
         userIdHex: userIdHex,
         displayName: displayName,
-        currentUserPubkey: nostrClient.publicKey,
+        currentUserPubkey: viewerPubkey,
         isBlocked: isBlocked,
         canTargetUser: canTargetUser,
         isMessageRestricted: isMessageRestricted,
         onMessageUser: onMessageUser,
         onShareProfile: onShareProfile,
         onBlockedTap: onBlockedTap,
+        canShowBell: hasViewer,
       ),
     );
   }
@@ -148,12 +183,16 @@ class _OtherProfileButtons extends StatelessWidget {
     required this.onMessageUser,
     required this.onShareProfile,
     required this.onBlockedTap,
+    required this.canShowBell,
   });
 
   final String userIdHex;
   final String? displayName;
   final String? currentUserPubkey;
   final bool isBlocked;
+
+  /// Whether a [NotifyBellCubit] was provided (requires a signed-in viewer).
+  final bool canShowBell;
 
   /// Whether the UI may offer interactions targeting this user. False
   /// hides the follow and message affordances entirely — absence, never
@@ -170,9 +209,22 @@ class _OtherProfileButtons extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
-    return BlocSelector<MyFollowingBloc, MyFollowingState, bool>(
-      selector: (state) => state.isFollowing(userIdHex),
-      builder: (context, isFollowing) {
+    return BlocConsumer<MyFollowingBloc, MyFollowingState>(
+      // The bell is follow-gated, so an abandoned subscription would keep
+      // pushing videos from someone the viewer no longer follows with no UI
+      // left to switch it off. Bridged here rather than inside the bell,
+      // which has already unmounted by the time this fires.
+      listenWhen: (previous, current) =>
+          canShowBell &&
+          previous.isFollowing(userIdHex) &&
+          !current.isFollowing(userIdHex),
+      listener: (context, state) {
+        context.read<NotifyBellCubit>().clearForUnfollow();
+      },
+      buildWhen: (previous, current) =>
+          previous.isFollowing(userIdHex) != current.isFollowing(userIdHex),
+      builder: (context, state) {
+        final isFollowing = state.isFollowing(userIdHex);
         final canShowMessage = canTargetUser && !isMessageRestricted;
         final followButton = FollowFromProfileButtonView(
           pubkey: userIdHex,
@@ -194,7 +246,7 @@ class _OtherProfileButtons extends StatelessWidget {
         final List<Widget> children;
 
         if (isFollowing) {
-          // Following: [Message (expanded)] [Following] [Share]
+          // Following: [Message (expanded)] [Bell] [Following] [Share]
           children = [
             if (canTargetUser) ...[
               if (canShowMessage)
@@ -209,6 +261,7 @@ class _OtherProfileButtons extends StatelessWidget {
                   ),
                 ),
               if (!canShowMessage) const Spacer(),
+              if (canShowBell) const ProfileNotifyBellButton(),
               followButton,
             ] else
               const Spacer(),

--- a/mobile/lib/widgets/profile/profile_action_buttons_widget.dart
+++ b/mobile/lib/widgets/profile/profile_action_buttons_widget.dart
@@ -7,6 +7,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/my_following/my_following_bloc.dart';
 import 'package:openvine/blocs/notify_bell/notify_bell_cubit.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -69,7 +71,12 @@ class ProfileActionButtons extends ConsumerWidget {
     // Empty rather than null when no signer is attached (the placeholder
     // LocalKeySigner), so signed-out is an emptiness check.
     final viewerPubkey = nostrClient.publicKey;
-    final hasViewer = viewerPubkey.isNotEmpty;
+    // Off until divine-push-service delivers kind 34236 to d=notify
+    // subscribers; until then the bell would publish a subscription that
+    // never produces a notification.
+    final canShowBell =
+        viewerPubkey.isNotEmpty &&
+        ref.watch(isFeatureEnabledProvider(FeatureFlag.newPostNotifications));
 
     // Watch blocklist version to trigger rebuilds when block/unblock occurs
     ref.watch(blocklistVersionProvider);
@@ -90,6 +97,7 @@ class ProfileActionButtons extends ConsumerWidget {
         contentBlocklistRepository,
         notifySubscriptions,
         viewerPubkey,
+        canShowBell,
       )),
       providers: [
         BlocProvider(
@@ -98,7 +106,7 @@ class ProfileActionButtons extends ConsumerWidget {
             contentBlocklistRepository: contentBlocklistRepository,
           )..add(const MyFollowingListLoadRequested()),
         ),
-        if (hasViewer)
+        if (canShowBell)
           BlocProvider(
             create: (_) => NotifyBellCubit(
               repository: notifySubscriptions,
@@ -117,7 +125,7 @@ class ProfileActionButtons extends ConsumerWidget {
         onMessageUser: onMessageUser,
         onShareProfile: onShareProfile,
         onBlockedTap: onBlockedTap,
-        canShowBell: hasViewer,
+        canShowBell: canShowBell,
       ),
     );
   }

--- a/mobile/lib/widgets/profile/profile_notify_bell_button.dart
+++ b/mobile/lib/widgets/profile/profile_notify_bell_button.dart
@@ -1,0 +1,52 @@
+// ABOUTME: Follow-gated bell on a creator's profile that subscribes the
+// ABOUTME: viewer to their new posts. Optimistic, reverts on publish failure.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/notify_bell/notify_bell_cubit.dart';
+import 'package:openvine/l10n/l10n.dart';
+
+/// Bell toggle shown next to Follow once the viewer follows the creator.
+///
+/// Expects a [NotifyBellCubit] above it — `ProfileActionButtons` provides one
+/// so the cubit outlives this widget's follow-gated mount and can still run
+/// unfollow teardown after the bell disappears.
+class ProfileNotifyBellButton extends StatelessWidget {
+  const ProfileNotifyBellButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<NotifyBellCubit, NotifyBellState>(
+      listenWhen: (previous, current) =>
+          current.status == NotifyBellStatus.failure &&
+          previous.status != NotifyBellStatus.failure,
+      listener: (context, state) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(context.l10n.profileNotifyUpdateFailed)),
+        );
+      },
+      builder: (context, state) {
+        final l10n = context.l10n;
+        return DivineIconButton(
+          icon: .bellSimple,
+          // Filled while subscribed so the on state reads at a glance in a row
+          // of otherwise-secondary buttons.
+          type: state.isSubscribed
+              ? DivineIconButtonType.primary
+              : DivineIconButtonType.secondary,
+          size: .small,
+          semanticLabel: state.isSubscribed
+              ? l10n.profileNotifyBellOn
+              : l10n.profileNotifyBellOff,
+          tooltip: state.isSubscribed
+              ? l10n.profileNotifyBellOn
+              : l10n.profileNotifyBellOff,
+          onPressed: state.isInteractive
+              ? () => context.read<NotifyBellCubit>().toggle()
+              : null,
+        );
+      },
+    );
+  }
+}

--- a/mobile/packages/models/lib/src/notification_item.dart
+++ b/mobile/packages/models/lib/src/notification_item.dart
@@ -18,6 +18,13 @@ enum NotificationKind {
   repost,
   mention,
   system,
+
+  /// A creator the user subscribed to ("belled") posted a new video.
+  ///
+  /// Video-anchored, but unlike the others it is not a reaction to the
+  /// user's own content — it comes from a subscription list the user
+  /// publishes. See `Nip51PeopleListCodec.notifyDTag`.
+  newPost,
 }
 
 /// Base for all displayable notifications.

--- a/mobile/packages/models/lib/src/video_notification.dart
+++ b/mobile/packages/models/lib/src/video_notification.dart
@@ -31,9 +31,10 @@ class VideoNotification extends NotificationItem {
              type == NotificationKind.likeComment ||
              type == NotificationKind.comment ||
              type == NotificationKind.mention ||
-             type == NotificationKind.repost,
+             type == NotificationKind.repost ||
+             type == NotificationKind.newPost,
          'VideoNotification only supports like, likeComment, comment, '
-         'mention, repost',
+         'mention, repost, newPost',
        ),
        assert(actors.length > 0, 'must have at least one actor'),
        assert(

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -763,6 +763,7 @@ class NotificationRepository {
         'comment' => NotificationKind.comment,
         'videoMention' => NotificationKind.mention,
         'repost' => NotificationKind.repost,
+        'newPost' => NotificationKind.newPost,
         _ => null,
       };
 
@@ -872,6 +873,7 @@ class NotificationRepository {
     NotificationKind.likeComment => 'likeComment',
     NotificationKind.reply => 'reply',
     NotificationKind.system => 'system',
+    NotificationKind.newPost => 'newPost',
   };
 
   static List<String>? _serverTypesForFilter(NotificationKind? filter) =>
@@ -885,6 +887,7 @@ class NotificationRepository {
         NotificationKind.likeComment => const ['reaction', 'zap'],
         NotificationKind.reply => const ['reply'],
         NotificationKind.system => const ['list_add'],
+        NotificationKind.newPost => const ['newPost'],
       };
 
   static final math.Random _jitter = math.Random();
@@ -1664,7 +1667,8 @@ class NotificationRepository {
   static bool _isVideoAnchoredKind(NotificationKind kind) =>
       kind == NotificationKind.like ||
       kind == NotificationKind.comment ||
-      kind == NotificationKind.repost;
+      kind == NotificationKind.repost ||
+      kind == NotificationKind.newPost;
 
   static bool _isVideoAnchoredNotification(
     NotificationKind kind,
@@ -1684,10 +1688,7 @@ class NotificationRepository {
     for (final n in raw) {
       final kind = _mapNotificationKind(n);
       // Skip kinds that became VideoNotifications.
-      if (kind == NotificationKind.like ||
-          kind == NotificationKind.comment ||
-          kind == NotificationKind.repost ||
-          _isVideoSourcedMention(n)) {
+      if (_isVideoAnchoredKind(kind) || _isVideoSourcedMention(n)) {
         continue;
       }
       // ActorNotification supports follow/mention/system/likeComment/reply;
@@ -2193,6 +2194,7 @@ class NotificationRepository {
       'comment' => NotificationKind.comment,
       'repost' => NotificationKind.repost,
       'mention' => NotificationKind.mention,
+      'newPost' => NotificationKind.newPost,
       'follow' || 'contact' => NotificationKind.follow,
       _ when n.sourceKind == 6 => NotificationKind.repost,
       _ when n.sourceKind == 16 => NotificationKind.repost,

--- a/mobile/packages/people_lists_repository/lib/people_lists_repository.dart
+++ b/mobile/packages/people_lists_repository/lib/people_lists_repository.dart
@@ -3,6 +3,8 @@ library;
 
 export 'src/local_people_lists_cache.dart';
 export 'src/nip51_people_list_codec.dart';
+export 'src/notify_subscriptions_repository.dart';
+export 'src/notify_subscriptions_repository_impl.dart';
 export 'src/people_list_publish_result.dart';
 export 'src/people_list_search_result.dart';
 export 'src/people_lists_repository.dart';

--- a/mobile/packages/people_lists_repository/lib/src/nip51_people_list_codec.dart
+++ b/mobile/packages/people_lists_repository/lib/src/nip51_people_list_codec.dart
@@ -90,6 +90,51 @@ abstract final class Nip51PeopleListCodec {
     return PeopleListEventPayload(kind: kind, tags: tags);
   }
 
+  /// Encodes an app-managed reserved list into a [PeopleListEventPayload].
+  ///
+  /// Reserved lists (see [reservedDTags]) never become a [UserList], so they
+  /// cannot go through [encode]. Emits one `p` tag per non-empty pubkey,
+  /// never truncated.
+  ///
+  /// An empty [pubkeys] is legitimate — it is how the user clears the list —
+  /// and produces an event with `d` and `title` but no `p` tags.
+  static PeopleListEventPayload encodeReserved({
+    required String dTag,
+    required String title,
+    required Iterable<String> pubkeys,
+  }) {
+    assert(
+      reservedDTags.contains(dTag),
+      'encodeReserved is only for app-managed lists in reservedDTags',
+    );
+    return PeopleListEventPayload(
+      kind: kind,
+      tags: [
+        ['d', dTag],
+        ['title', title],
+        for (final pubkey in pubkeys)
+          if (pubkey.isNotEmpty) ['p', pubkey],
+      ],
+    );
+  }
+
+  /// Decodes the member pubkeys of the app-managed reserved list [dTag].
+  ///
+  /// Returns `null` when [event] is not a kind [kind] event carrying that
+  /// exact `d` tag, so callers can filter a mixed relay response. An empty
+  /// list means the event exists and has no members — distinct from `null`.
+  ///
+  /// Full pubkeys are preserved; duplicates are collapsed while keeping first
+  /// occurrence order.
+  static List<String>? decodeReservedMembers(
+    Event event, {
+    required String dTag,
+  }) {
+    if (event.kind != kind) return null;
+    if (_firstTagValue(event.tags, 'd') != dTag) return null;
+    return _memberPubkeys(event.tags).toSet().toList(growable: false);
+  }
+
   /// Decodes [event] into a [UserList], or returns `null` when the event is
   /// not a user-facing people list.
   ///
@@ -111,12 +156,7 @@ abstract final class Nip51PeopleListCodec {
       return null;
     }
 
-    final pubkeys = event.tags
-        .where(
-          (tag) => tag.length >= 2 && tag[0] == 'p' && tag[1].isNotEmpty,
-        )
-        .map((tag) => tag[1])
-        .toList(growable: false);
+    final pubkeys = _memberPubkeys(event.tags).toList(growable: false);
 
     final timestamp = DateTime.fromMillisecondsSinceEpoch(
       event.createdAt * 1000,
@@ -134,6 +174,11 @@ abstract final class Nip51PeopleListCodec {
       nostrEventId: event.id.isEmpty ? null : event.id,
     );
   }
+
+  /// Member pubkeys from every non-empty `p` tag, in tag order.
+  static Iterable<String> _memberPubkeys(List<List<String>> tags) => tags
+      .where((tag) => tag.length >= 2 && tag[0] == 'p' && tag[1].isNotEmpty)
+      .map((tag) => tag[1]);
 
   static String? _firstTagValue(List<List<String>> tags, String name) {
     for (final tag in tags) {

--- a/mobile/packages/people_lists_repository/lib/src/nip51_people_list_codec.dart
+++ b/mobile/packages/people_lists_repository/lib/src/nip51_people_list_codec.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Encodes and decodes NIP-51 kind 30000 people (follow set) events.
-// ABOUTME: Preserves full Nostr pubkeys and skips the app block-list d=block.
+// ABOUTME: Preserves full Nostr pubkeys and skips app-managed reserved d tags.
 
 import 'package:equatable/equatable.dart';
 import 'package:models/models.dart';
@@ -39,16 +39,25 @@ class PeopleListEventPayload extends Equatable {
 /// * Encodes a [UserList] into a [PeopleListEventPayload].
 /// * Decodes a kind 30000 [Event] into a [UserList], or `null` when the event
 ///   does not describe a user-editable people list (missing `d`, wrong kind,
-///   or the reserved app block list).
+///   or one of the reserved app-managed lists in [reservedDTags]).
 abstract final class Nip51PeopleListCodec {
   /// NIP-51 kind for people / follow sets.
   static const int kind = 30000;
 
   /// Reserved `d` tag value used by the app's block list.
-  ///
-  /// Events with this identifier are filtered out of the user-facing list
-  /// collection so that the block list cannot be edited as a regular list.
   static const String blockedDTag = 'block';
+
+  /// Reserved `d` tag value used by the app's new-post notification
+  /// subscription list ("bells").
+  static const String notifyDTag = 'notify';
+
+  /// Reserved `d` tag values for app-managed kind 30000 lists.
+  ///
+  /// Events with these identifiers are filtered out of the user-facing list
+  /// collection so app-managed lists cannot be renamed, edited, or deleted as
+  /// ordinary people lists. Deleting the notify list would silently clear
+  /// every bell the user has set.
+  static const Set<String> reservedDTags = {blockedDTag, notifyDTag};
 
   /// Encodes [list] into a [PeopleListEventPayload].
   ///
@@ -87,7 +96,7 @@ abstract final class Nip51PeopleListCodec {
   /// Returns `null` when:
   /// * [Event.kind] is not [kind].
   /// * The event has no non-empty `d` tag.
-  /// * The `d` tag equals [blockedDTag] (the reserved block list).
+  /// * The `d` tag is one of [reservedDTags] (app-managed lists).
   ///
   /// The returned [UserList.name] prefers the `title` tag and falls back to
   /// the `d` tag when `title` is missing. Full 64-char pubkeys are preserved
@@ -98,7 +107,7 @@ abstract final class Nip51PeopleListCodec {
     }
 
     final dTag = _firstTagValue(event.tags, 'd');
-    if (dTag == null || dTag == blockedDTag) {
+    if (dTag == null || reservedDTags.contains(dTag)) {
       return null;
     }
 

--- a/mobile/packages/people_lists_repository/lib/src/notify_subscriptions_repository.dart
+++ b/mobile/packages/people_lists_repository/lib/src/notify_subscriptions_repository.dart
@@ -1,0 +1,59 @@
+// ABOUTME: Abstract interface for the app-managed d=notify subscription list.
+// ABOUTME: Owns which creators the user gets new-post notifications about.
+
+import 'package:people_lists_repository/src/people_list_publish_result.dart';
+
+/// Repository owning the reserved kind `30000` `d=notify` people list — the
+/// set of creators whose new videos the user wants to be notified about
+/// ("bells").
+///
+/// Deliberately separate from `PeopleListsRepository`: the notify list is
+/// app-managed and must never be reachable from list-editing UI, so it is
+/// excluded from the user-facing list collection by
+/// `Nip51PeopleListCodec.reservedDTags`.
+///
+/// The list is a single NIP-33 replaceable event, so **every** mutation is a
+/// full-list republish. Implementations must serialize mutations: two
+/// concurrent read-modify-write cycles against the same base event would
+/// otherwise let the loser silently drop the winner's change.
+///
+/// The list is public — anyone can read who the user has subscribed to.
+abstract interface class NotifySubscriptionsRepository {
+  /// Creators [ownerPubkey] is subscribed to, newest known state.
+  ///
+  /// Returns an empty set when the user has no notify list yet. Reads are
+  /// served from an in-memory snapshot once loaded; call [refresh] to
+  /// re-read from relays.
+  Future<Set<String>> readSubscriptions({required String ownerPubkey});
+
+  /// Emits the subscription set for [ownerPubkey] on every change.
+  ///
+  /// Emits the current set immediately on subscribe so a late listener (e.g.
+  /// a bell rebuilt after navigation) does not render a stale state.
+  Stream<Set<String>> watchSubscriptions({required String ownerPubkey});
+
+  /// Re-reads the notify list from relays, replacing the in-memory snapshot.
+  Future<void> refresh({required String ownerPubkey});
+
+  /// Adds [creatorPubkey] and publishes the replacement list.
+  ///
+  /// Returns [PeopleListPublishStatus.noop] when already subscribed. On
+  /// failure the snapshot is left untouched so the caller can revert
+  /// optimistic UI.
+  Future<PeopleListPublishResult> subscribe({
+    required String ownerPubkey,
+    required String creatorPubkey,
+  });
+
+  /// Removes [creatorPubkey] and publishes the replacement list.
+  ///
+  /// Returns [PeopleListPublishStatus.noop] when not subscribed, which makes
+  /// it safe to call unconditionally from unfollow teardown.
+  Future<PeopleListPublishResult> unsubscribe({
+    required String ownerPubkey,
+    required String creatorPubkey,
+  });
+
+  /// Releases stream resources.
+  Future<void> dispose();
+}

--- a/mobile/packages/people_lists_repository/lib/src/notify_subscriptions_repository.dart
+++ b/mobile/packages/people_lists_repository/lib/src/notify_subscriptions_repository.dart
@@ -3,6 +3,25 @@
 
 import 'package:people_lists_repository/src/people_list_publish_result.dart';
 
+/// Thrown when the subscription list could not be read from relays.
+///
+/// Distinct from "the user has no subscriptions": the list is a single
+/// replaceable event, so treating an unreadable list as empty and then
+/// publishing a replacement would delete every subscription that failed to
+/// load. Callers must keep their control disabled rather than assume empty.
+class NotifySubscriptionsUnavailableException implements Exception {
+  /// Creates an exception for an unreadable list belonging to [ownerPubkey].
+  const NotifySubscriptionsUnavailableException(this.ownerPubkey);
+
+  /// Owner whose list could not be read.
+  final String ownerPubkey;
+
+  @override
+  String toString() =>
+      'NotifySubscriptionsUnavailableException: could not read the notify '
+      'list for owner $ownerPubkey';
+}
+
 /// Repository owning the reserved kind `30000` `d=notify` people list — the
 /// set of creators whose new videos the user wants to be notified about
 /// ("bells").
@@ -17,6 +36,10 @@ import 'package:people_lists_repository/src/people_list_publish_result.dart';
 /// concurrent read-modify-write cycles against the same base event would
 /// otherwise let the loser silently drop the winner's change.
 ///
+/// Because a republish is destructive, implementations must also never
+/// publish against a base set they failed to read — see
+/// [NotifySubscriptionsUnavailableException].
+///
 /// The list is public — anyone can read who the user has subscribed to.
 abstract interface class NotifySubscriptionsRepository {
   /// Creators [ownerPubkey] is subscribed to, newest known state.
@@ -24,22 +47,34 @@ abstract interface class NotifySubscriptionsRepository {
   /// Returns an empty set when the user has no notify list yet. Reads are
   /// served from an in-memory snapshot once loaded; call [refresh] to
   /// re-read from relays.
+  ///
+  /// Throws [NotifySubscriptionsUnavailableException] when the list could
+  /// not be read — an unreachable relay pool is not an empty list.
   Future<Set<String>> readSubscriptions({required String ownerPubkey});
 
   /// Emits the subscription set for [ownerPubkey] on every change.
   ///
   /// Emits the current set immediately on subscribe so a late listener (e.g.
   /// a bell rebuilt after navigation) does not render a stale state.
+  ///
+  /// Emits **only** sets that were actually read or published. A failed read
+  /// emits nothing, so a listener can keep its control disabled instead of
+  /// rendering an unverified "off" that a tap would turn into a destructive
+  /// replacement.
   Stream<Set<String>> watchSubscriptions({required String ownerPubkey});
 
   /// Re-reads the notify list from relays, replacing the in-memory snapshot.
+  ///
+  /// A failed read leaves the previous snapshot in place rather than
+  /// clearing it.
   Future<void> refresh({required String ownerPubkey});
 
   /// Adds [creatorPubkey] and publishes the replacement list.
   ///
   /// Returns [PeopleListPublishStatus.noop] when already subscribed. On
   /// failure the snapshot is left untouched so the caller can revert
-  /// optimistic UI.
+  /// optimistic UI. Returns [PeopleListPublishStatus.failed] without
+  /// publishing anything when the current list could not be read.
   Future<PeopleListPublishResult> subscribe({
     required String ownerPubkey,
     required String creatorPubkey,

--- a/mobile/packages/people_lists_repository/lib/src/notify_subscriptions_repository.dart
+++ b/mobile/packages/people_lists_repository/lib/src/notify_subscriptions_repository.dart
@@ -84,10 +84,21 @@ abstract interface class NotifySubscriptionsRepository {
   ///
   /// Returns [PeopleListPublishStatus.noop] when not subscribed, which makes
   /// it safe to call unconditionally from unfollow teardown.
+  ///
+  /// A failed removal is retained and reapplied by the next mutation or
+  /// [reconcile] for the same owner, so an unfollow teardown cannot be
+  /// silently lost while the bell that would undo it is unmounted.
   Future<PeopleListPublishResult> unsubscribe({
     required String ownerPubkey,
     required String creatorPubkey,
   });
+
+  /// Republishes the list if any removal is still outstanding.
+  ///
+  /// Returns [PeopleListPublishStatus.noop] when nothing is pending. Call it
+  /// when a subscription surface mounts, so a teardown whose publish failed
+  /// is retried instead of waiting for an unrelated toggle.
+  Future<PeopleListPublishResult> reconcile({required String ownerPubkey});
 
   /// Releases stream resources.
   Future<void> dispose();

--- a/mobile/packages/people_lists_repository/lib/src/notify_subscriptions_repository_impl.dart
+++ b/mobile/packages/people_lists_repository/lib/src/notify_subscriptions_repository_impl.dart
@@ -1,0 +1,303 @@
+// ABOUTME: NostrClient-backed d=notify subscription list repository.
+// ABOUTME: Serializes mutations so concurrent bell toggles cannot clobber.
+
+import 'dart:async';
+
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:people_lists_repository/src/nip51_people_list_codec.dart';
+import 'package:people_lists_repository/src/notify_subscriptions_repository.dart';
+import 'package:people_lists_repository/src/people_list_publish_result.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+const String _logName = 'people_lists_repository.notify';
+
+/// Title tag written on the notify list.
+///
+/// Only shown if another client renders the list; Divine hides it from the
+/// user-facing list UI via `Nip51PeopleListCodec.reservedDTags`.
+const String _notifyListTitle = 'Notify';
+
+/// Concrete [NotifySubscriptionsRepository] backed by a [NostrClient].
+///
+/// Submission semantics match `PeopleListsRepositoryImpl`: a
+/// [PublishSuccess] means the event reached at least one relay socket, not
+/// that any relay persisted it.
+///
+/// ### Mutation serialization
+///
+/// Every bell toggle is a read-modify-write on one NIP-33 replaceable event.
+/// Two concurrent toggles would each read the same base set and the second
+/// publish would drop the first's change. Mutations are therefore chained
+/// per owner: each awaits the previous one's completion and reads the set
+/// that mutation produced, so a rapid on/off/on sequence converges instead
+/// of racing.
+///
+/// The chain is per owner rather than per creator on purpose — all bells live
+/// in a *single* event, so serializing per creator would still race.
+class NotifySubscriptionsRepositoryImpl
+    implements NotifySubscriptionsRepository {
+  /// Creates a repository bound to [nostrClient].
+  NotifySubscriptionsRepositoryImpl({required NostrClient nostrClient})
+    : _nostrClient = nostrClient;
+
+  final NostrClient _nostrClient;
+
+  final Map<String, _NotifyListSnapshot> _snapshots = {};
+  final Map<String, BehaviorSubject<Set<String>>> _subjects = {};
+
+  /// Tail of the per-owner mutation chain. Awaiting it serializes the next
+  /// read-modify-write behind every mutation already queued.
+  final Map<String, Future<void>> _mutationTails = {};
+
+  bool _disposed = false;
+
+  @override
+  Future<Set<String>> readSubscriptions({required String ownerPubkey}) async {
+    final snapshot = await _ensureSnapshot(ownerPubkey);
+    return snapshot.creators;
+  }
+
+  @override
+  Stream<Set<String>> watchSubscriptions({required String ownerPubkey}) {
+    final subject = _subjectFor(ownerPubkey);
+    // Seed asynchronously so a listener that subscribes before the first
+    // relay read still receives the loaded set rather than only future
+    // mutations.
+    if (!_snapshots.containsKey(ownerPubkey)) {
+      _ensureSnapshot(ownerPubkey).ignore();
+    }
+    return subject.stream;
+  }
+
+  @override
+  Future<void> refresh({required String ownerPubkey}) async {
+    final snapshot = await _readFromRelays(ownerPubkey);
+    _publishSnapshot(ownerPubkey, snapshot);
+  }
+
+  @override
+  Future<PeopleListPublishResult> subscribe({
+    required String ownerPubkey,
+    required String creatorPubkey,
+  }) {
+    return _mutate(
+      ownerPubkey: ownerPubkey,
+      creatorPubkey: creatorPubkey,
+      add: true,
+    );
+  }
+
+  @override
+  Future<PeopleListPublishResult> unsubscribe({
+    required String ownerPubkey,
+    required String creatorPubkey,
+  }) {
+    return _mutate(
+      ownerPubkey: ownerPubkey,
+      creatorPubkey: creatorPubkey,
+      add: false,
+    );
+  }
+
+  @override
+  Future<void> dispose() async {
+    _disposed = true;
+    for (final subject in _subjects.values) {
+      await subject.close();
+    }
+    _subjects.clear();
+    _snapshots.clear();
+    _mutationTails.clear();
+  }
+
+  /// Queues a mutation behind every mutation already pending for [ownerPubkey].
+  Future<PeopleListPublishResult> _mutate({
+    required String ownerPubkey,
+    required String creatorPubkey,
+    required bool add,
+  }) {
+    final previous = _mutationTails[ownerPubkey] ?? Future<void>.value();
+    final result = previous.then(
+      (_) => _applyMutation(
+        ownerPubkey: ownerPubkey,
+        creatorPubkey: creatorPubkey,
+        add: add,
+      ),
+    );
+    // The tail must never carry an error, or every later mutation in the
+    // chain would fail with the earlier one's error instead of running.
+    _mutationTails[ownerPubkey] = result.then((_) {}, onError: (_, _) {});
+    return result;
+  }
+
+  Future<PeopleListPublishResult> _applyMutation({
+    required String ownerPubkey,
+    required String creatorPubkey,
+    required bool add,
+  }) async {
+    if (_disposed) return const PeopleListPublishResult.failed();
+    if (creatorPubkey.isEmpty || creatorPubkey == ownerPubkey) {
+      // Subscribing to your own posts is meaningless; the push service drops
+      // self-references anyway, so never write one.
+      return const PeopleListPublishResult.noop();
+    }
+
+    final snapshot = await _ensureSnapshot(ownerPubkey);
+    final isSubscribed = snapshot.creators.contains(creatorPubkey);
+    if (add == isSubscribed) {
+      return const PeopleListPublishResult.noop();
+    }
+
+    final updated = <String>{...snapshot.creators};
+    if (add) {
+      updated.add(creatorPubkey);
+    } else {
+      updated.remove(creatorPubkey);
+    }
+
+    return _publishReplacement(
+      ownerPubkey: ownerPubkey,
+      creators: updated,
+      previousCreatedAt: snapshot.createdAt,
+    );
+  }
+
+  /// Publishes the full list. A partial list would be a destructive write:
+  /// the event is replaceable, so omitted members are removed.
+  Future<PeopleListPublishResult> _publishReplacement({
+    required String ownerPubkey,
+    required Set<String> creators,
+    required int previousCreatedAt,
+  }) async {
+    final payload = Nip51PeopleListCodec.encodeReserved(
+      dTag: Nip51PeopleListCodec.notifyDTag,
+      title: _notifyListTitle,
+      pubkeys: creators,
+    );
+
+    // NIP-33 replacement resolves by created_at, and relay behaviour for a
+    // tie is unspecified. Two toggles inside the same second would otherwise
+    // be a coin flip over which survives, so step past the previous event.
+    final nowSeconds = DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000;
+    final createdAt = nowSeconds > previousCreatedAt
+        ? nowSeconds
+        : previousCreatedAt + 1;
+
+    final event = Event(
+      ownerPubkey,
+      payload.kind,
+      payload.tags,
+      payload.content,
+      createdAt: createdAt,
+    );
+
+    try {
+      final sent = await _nostrClient.publishEvent(event);
+      if (sent is! PublishSuccess) {
+        Log.warning(
+          'Notify list publish returned no event for owner $ownerPubkey',
+          name: _logName,
+          category: LogCategory.relay,
+        );
+        return const PeopleListPublishResult.failed();
+      }
+      _publishSnapshot(
+        ownerPubkey,
+        _NotifyListSnapshot(creators: creators, createdAt: createdAt),
+      );
+      return PeopleListPublishResult.submitted(eventId: sent.event.id);
+    } on Object catch (error, stackTrace) {
+      Log.error(
+        'Failed to publish notify list for owner $ownerPubkey',
+        name: _logName,
+        category: LogCategory.relay,
+        error: error,
+        stackTrace: stackTrace,
+      );
+      // Snapshot intentionally untouched so the caller can revert optimistic
+      // UI and a retry re-reads the unchanged base set.
+      return PeopleListPublishResult.failed(error: error);
+    }
+  }
+
+  Future<_NotifyListSnapshot> _ensureSnapshot(String ownerPubkey) async {
+    final cached = _snapshots[ownerPubkey];
+    if (cached != null) return cached;
+    final loaded = await _readFromRelays(ownerPubkey);
+    // A mutation may have published while the relay read was in flight; that
+    // snapshot is newer than what the relay returned, so keep it.
+    final current = _snapshots[ownerPubkey];
+    if (current != null && current.createdAt >= loaded.createdAt) {
+      return current;
+    }
+    _publishSnapshot(ownerPubkey, loaded);
+    return loaded;
+  }
+
+  /// Reads the newest `d=notify` event for [ownerPubkey].
+  ///
+  /// Relays may return several replaceable generations; the highest
+  /// `created_at` wins. A read failure yields an empty snapshot so the bell
+  /// renders "off" rather than blocking, and a later [refresh] can correct it.
+  Future<_NotifyListSnapshot> _readFromRelays(String ownerPubkey) async {
+    final filter = Filter(
+      kinds: const [Nip51PeopleListCodec.kind],
+      authors: [ownerPubkey],
+      d: const [Nip51PeopleListCodec.notifyDTag],
+    );
+
+    try {
+      final events = await _nostrClient.queryEvents([filter]);
+      var newest = const _NotifyListSnapshot(creators: {}, createdAt: 0);
+      for (final event in events) {
+        final members = Nip51PeopleListCodec.decodeReservedMembers(
+          event,
+          dTag: Nip51PeopleListCodec.notifyDTag,
+        );
+        if (members == null) continue;
+        if (event.createdAt < newest.createdAt) continue;
+        newest = _NotifyListSnapshot(
+          creators: members.toSet(),
+          createdAt: event.createdAt,
+        );
+      }
+      return newest;
+    } on Object catch (error) {
+      Log.warning(
+        'Failed to read notify list for owner $ownerPubkey: $error',
+        name: _logName,
+        category: LogCategory.relay,
+      );
+      return const _NotifyListSnapshot(creators: {}, createdAt: 0);
+    }
+  }
+
+  void _publishSnapshot(String ownerPubkey, _NotifyListSnapshot snapshot) {
+    if (_disposed) return;
+    _snapshots[ownerPubkey] = snapshot;
+    final subject = _subjects[ownerPubkey];
+    if (subject != null && !subject.isClosed) {
+      subject.add(snapshot.creators);
+    }
+  }
+
+  BehaviorSubject<Set<String>> _subjectFor(String ownerPubkey) {
+    return _subjects.putIfAbsent(ownerPubkey, () {
+      final seed = _snapshots[ownerPubkey]?.creators ?? const <String>{};
+      return BehaviorSubject<Set<String>>.seeded(seed);
+    });
+  }
+}
+
+/// Immutable view of the notify list plus the `created_at` it was read at.
+///
+/// The timestamp is kept so the next publish can step past it — see
+/// `_publishReplacement`.
+class _NotifyListSnapshot {
+  const _NotifyListSnapshot({required this.creators, required this.createdAt});
+
+  final Set<String> creators;
+  final int createdAt;
+}

--- a/mobile/packages/people_lists_repository/lib/src/notify_subscriptions_repository_impl.dart
+++ b/mobile/packages/people_lists_repository/lib/src/notify_subscriptions_repository_impl.dart
@@ -63,6 +63,14 @@ class NotifySubscriptionsRepositoryImpl
   /// stampeding the pool with identical filters.
   final Map<String, Future<_NotifyListSnapshot?>> _inFlightReads = {};
 
+  /// Removals whose publish failed, per owner.
+  ///
+  /// The bell is follow-gated, so a failed unfollow teardown would otherwise
+  /// leave the creator in the public list with no UI left to remove them.
+  /// Pending removals are folded into the next publish for that owner and
+  /// drained by [reconcile].
+  final Map<String, Set<String>> _pendingRemovals = {};
+
   bool _disposed = false;
 
   @override
@@ -121,6 +129,14 @@ class NotifySubscriptionsRepositoryImpl
   }
 
   @override
+  Future<PeopleListPublishResult> reconcile({required String ownerPubkey}) {
+    if (_pendingRemovals[ownerPubkey]?.isNotEmpty != true) {
+      return Future.value(const PeopleListPublishResult.noop());
+    }
+    return _mutate(ownerPubkey: ownerPubkey, add: false);
+  }
+
+  @override
   Future<void> dispose() async {
     _disposed = true;
     for (final subject in _subjects.values) {
@@ -130,13 +146,17 @@ class NotifySubscriptionsRepositoryImpl
     _snapshots.clear();
     _mutationTails.clear();
     _inFlightReads.clear();
+    _pendingRemovals.clear();
   }
 
   /// Queues a mutation behind every mutation already pending for [ownerPubkey].
+  ///
+  /// A null [creatorPubkey] mutates nothing by itself and only republishes
+  /// outstanding removals — see [reconcile].
   Future<PeopleListPublishResult> _mutate({
     required String ownerPubkey,
-    required String creatorPubkey,
     required bool add,
+    String? creatorPubkey,
   }) {
     final previous = _mutationTails[ownerPubkey] ?? Future<void>.value();
     final result = previous.then(
@@ -154,11 +174,12 @@ class NotifySubscriptionsRepositoryImpl
 
   Future<PeopleListPublishResult> _applyMutation({
     required String ownerPubkey,
-    required String creatorPubkey,
+    required String? creatorPubkey,
     required bool add,
   }) async {
     if (_disposed) return const PeopleListPublishResult.failed();
-    if (creatorPubkey.isEmpty || creatorPubkey == ownerPubkey) {
+    if (creatorPubkey != null &&
+        (creatorPubkey.isEmpty || creatorPubkey == ownerPubkey)) {
       // Subscribing to your own posts is meaningless; the push service drops
       // self-references anyway, so never write one.
       return const PeopleListPublishResult.noop();
@@ -167,28 +188,47 @@ class NotifySubscriptionsRepositoryImpl
     final snapshot = await _ensureSnapshot(ownerPubkey);
     if (snapshot == null) {
       // Publishing against a base set we could not read would delete every
-      // subscription the read failed to load.
+      // subscription the read failed to load. Retain the removal so the next
+      // successful read reapplies it.
+      if (creatorPubkey != null && !add) {
+        _recordPendingRemoval(ownerPubkey, creatorPubkey);
+      }
       return PeopleListPublishResult.failed(
         error: NotifySubscriptionsUnavailableException(ownerPubkey),
       );
     }
 
-    final desired = <String>{...snapshot.creators};
-    if (add) {
-      desired.add(creatorPubkey);
-    } else {
-      desired.remove(creatorPubkey);
+    final desired = <String>{...snapshot.creators}
+      ..removeAll(_pendingRemovals[ownerPubkey] ?? const <String>{});
+    if (creatorPubkey != null) {
+      if (add) {
+        desired.add(creatorPubkey);
+      } else {
+        desired.remove(creatorPubkey);
+      }
     }
 
     if (_sameMembers(desired, snapshot.creators)) {
+      // The published list already matches what we want, so every pending
+      // removal is satisfied without a write.
+      _pendingRemovals.remove(ownerPubkey);
       return const PeopleListPublishResult.noop();
     }
 
-    return _publishReplacement(
+    final result = await _publishReplacement(
       ownerPubkey: ownerPubkey,
       creators: desired,
       previousCreatedAt: snapshot.createdAt,
     );
+
+    if (result.submitted) {
+      // `desired` excluded every pending removal, so a submitted publish
+      // clears all of them at once.
+      _pendingRemovals.remove(ownerPubkey);
+    } else if (creatorPubkey != null && !add) {
+      _recordPendingRemoval(ownerPubkey, creatorPubkey);
+    }
+    return result;
   }
 
   /// Publishes the full list. A partial list would be a destructive write:
@@ -334,6 +374,10 @@ class NotifySubscriptionsRepositoryImpl
       );
       return null;
     }
+  }
+
+  void _recordPendingRemoval(String ownerPubkey, String creatorPubkey) {
+    (_pendingRemovals[ownerPubkey] ??= <String>{}).add(creatorPubkey);
   }
 
   void _publishSnapshot(String ownerPubkey, _NotifyListSnapshot snapshot) {

--- a/mobile/packages/people_lists_repository/lib/src/notify_subscriptions_repository_impl.dart
+++ b/mobile/packages/people_lists_repository/lib/src/notify_subscriptions_repository_impl.dart
@@ -36,6 +36,14 @@ const String _notifyListTitle = 'Notify';
 ///
 /// The chain is per owner rather than per creator on purpose — all bells live
 /// in a *single* event, so serializing per creator would still race.
+///
+/// ### Unreadable lists are never a base for a publish
+///
+/// The event is replaceable, so a publish deletes every member it omits.
+/// An unreachable relay pool therefore cannot be treated as an empty list:
+/// reads that did not reach a relay produce no snapshot at all, mutations
+/// against a missing snapshot fail without publishing, and
+/// [watchSubscriptions] stays silent so the UI keeps its control disabled.
 class NotifySubscriptionsRepositoryImpl
     implements NotifySubscriptionsRepository {
   /// Creates a repository bound to [nostrClient].
@@ -51,11 +59,18 @@ class NotifySubscriptionsRepositoryImpl
   /// read-modify-write behind every mutation already queued.
   final Map<String, Future<void>> _mutationTails = {};
 
+  /// In-flight relay reads, so concurrent mounts share one query instead of
+  /// stampeding the pool with identical filters.
+  final Map<String, Future<_NotifyListSnapshot?>> _inFlightReads = {};
+
   bool _disposed = false;
 
   @override
   Future<Set<String>> readSubscriptions({required String ownerPubkey}) async {
     final snapshot = await _ensureSnapshot(ownerPubkey);
+    if (snapshot == null) {
+      throw NotifySubscriptionsUnavailableException(ownerPubkey);
+    }
     return snapshot.creators;
   }
 
@@ -64,7 +79,7 @@ class NotifySubscriptionsRepositoryImpl
     final subject = _subjectFor(ownerPubkey);
     // Seed asynchronously so a listener that subscribes before the first
     // relay read still receives the loaded set rather than only future
-    // mutations.
+    // mutations. A failed read stores nothing, so the next mount retries.
     if (!_snapshots.containsKey(ownerPubkey)) {
       _ensureSnapshot(ownerPubkey).ignore();
     }
@@ -74,6 +89,10 @@ class NotifySubscriptionsRepositoryImpl
   @override
   Future<void> refresh({required String ownerPubkey}) async {
     final snapshot = await _readFromRelays(ownerPubkey);
+    // A failed read must not clear a good snapshot: the empty set it would
+    // cache is exactly the base a later publish would delete the list down
+    // to.
+    if (snapshot == null) return;
     _publishSnapshot(ownerPubkey, snapshot);
   }
 
@@ -110,6 +129,7 @@ class NotifySubscriptionsRepositoryImpl
     _subjects.clear();
     _snapshots.clear();
     _mutationTails.clear();
+    _inFlightReads.clear();
   }
 
   /// Queues a mutation behind every mutation already pending for [ownerPubkey].
@@ -145,21 +165,28 @@ class NotifySubscriptionsRepositoryImpl
     }
 
     final snapshot = await _ensureSnapshot(ownerPubkey);
-    final isSubscribed = snapshot.creators.contains(creatorPubkey);
-    if (add == isSubscribed) {
-      return const PeopleListPublishResult.noop();
+    if (snapshot == null) {
+      // Publishing against a base set we could not read would delete every
+      // subscription the read failed to load.
+      return PeopleListPublishResult.failed(
+        error: NotifySubscriptionsUnavailableException(ownerPubkey),
+      );
     }
 
-    final updated = <String>{...snapshot.creators};
+    final desired = <String>{...snapshot.creators};
     if (add) {
-      updated.add(creatorPubkey);
+      desired.add(creatorPubkey);
     } else {
-      updated.remove(creatorPubkey);
+      desired.remove(creatorPubkey);
+    }
+
+    if (_sameMembers(desired, snapshot.creators)) {
+      return const PeopleListPublishResult.noop();
     }
 
     return _publishReplacement(
       ownerPubkey: ownerPubkey,
-      creators: updated,
+      creators: desired,
       previousCreatedAt: snapshot.createdAt,
     );
   }
@@ -222,10 +249,29 @@ class NotifySubscriptionsRepositoryImpl
     }
   }
 
-  Future<_NotifyListSnapshot> _ensureSnapshot(String ownerPubkey) async {
+  /// Returns the cached snapshot, reading from relays once when absent.
+  ///
+  /// Returns `null` when the list has never been read successfully. The
+  /// failure is deliberately not cached, so the next call retries.
+  Future<_NotifyListSnapshot?> _ensureSnapshot(String ownerPubkey) async {
     final cached = _snapshots[ownerPubkey];
     if (cached != null) return cached;
-    final loaded = await _readFromRelays(ownerPubkey);
+
+    final inFlight = _inFlightReads[ownerPubkey];
+    if (inFlight != null) return inFlight;
+
+    final read = _readFromRelays(ownerPubkey);
+    _inFlightReads[ownerPubkey] = read;
+    final _NotifyListSnapshot? loaded;
+    try {
+      loaded = await read;
+    } finally {
+      // The removed handle is the future awaited just above; `_readFromRelays`
+      // never completes with an error, so there is nothing left to observe.
+      _inFlightReads.remove(ownerPubkey)?.ignore();
+    }
+    if (loaded == null) return null;
+
     // A mutation may have published while the relay read was in flight; that
     // snapshot is newer than what the relay returned, so keep it.
     final current = _snapshots[ownerPubkey];
@@ -236,12 +282,18 @@ class NotifySubscriptionsRepositoryImpl
     return loaded;
   }
 
-  /// Reads the newest `d=notify` event for [ownerPubkey].
+  /// Reads the newest `d=notify` event for [ownerPubkey], or `null` when the
+  /// list could not be read.
   ///
   /// Relays may return several replaceable generations; the highest
-  /// `created_at` wins. A read failure yields an empty snapshot so the bell
-  /// renders "off" rather than blocking, and a later [refresh] can correct it.
-  Future<_NotifyListSnapshot> _readFromRelays(String ownerPubkey) async {
+  /// `created_at` wins.
+  ///
+  /// A query that reached no relay or timed out cannot distinguish "this user
+  /// has no subscriptions" from "we could not ask", and the difference is
+  /// destructive: the caller would publish a replacement built on an empty
+  /// base and delete the real list. Both cases therefore return `null`, as
+  /// does a thrown read.
+  Future<_NotifyListSnapshot?> _readFromRelays(String ownerPubkey) async {
     final filter = Filter(
       kinds: const [Nip51PeopleListCodec.kind],
       authors: [ownerPubkey],
@@ -249,9 +301,19 @@ class NotifySubscriptionsRepositoryImpl
     );
 
     try {
-      final events = await _nostrClient.queryEvents([filter]);
+      final result = await _nostrClient.queryEventsDetailed([filter]);
+      if (result.noRelays || result.timedOut) {
+        Log.warning(
+          'Notify list unreadable for owner $ownerPubkey '
+          '(noRelays: ${result.noRelays}, timedOut: ${result.timedOut})',
+          name: _logName,
+          category: LogCategory.relay,
+        );
+        return null;
+      }
+
       var newest = const _NotifyListSnapshot(creators: {}, createdAt: 0);
-      for (final event in events) {
+      for (final event in result.events) {
         final members = Nip51PeopleListCodec.decodeReservedMembers(
           event,
           dTag: Nip51PeopleListCodec.notifyDTag,
@@ -270,7 +332,7 @@ class NotifySubscriptionsRepositoryImpl
         name: _logName,
         category: LogCategory.relay,
       );
-      return const _NotifyListSnapshot(creators: {}, createdAt: 0);
+      return null;
     }
   }
 
@@ -285,10 +347,18 @@ class NotifySubscriptionsRepositoryImpl
 
   BehaviorSubject<Set<String>> _subjectFor(String ownerPubkey) {
     return _subjects.putIfAbsent(ownerPubkey, () {
-      final seed = _snapshots[ownerPubkey]?.creators ?? const <String>{};
-      return BehaviorSubject<Set<String>>.seeded(seed);
+      final seed = _snapshots[ownerPubkey]?.creators;
+      // Unseeded until something has actually been read or published: an
+      // unverified empty set would let a listener enable a control whose
+      // first tap replaces the real list with just that one member.
+      return seed == null
+          ? BehaviorSubject<Set<String>>()
+          : BehaviorSubject<Set<String>>.seeded(seed);
     });
   }
+
+  static bool _sameMembers(Set<String> a, Set<String> b) =>
+      a.length == b.length && a.containsAll(b);
 }
 
 /// Immutable view of the notify list plus the `created_at` it was read at.

--- a/mobile/packages/people_lists_repository/lib/src/people_lists_repository.dart
+++ b/mobile/packages/people_lists_repository/lib/src/people_lists_repository.dart
@@ -78,7 +78,7 @@ abstract interface class PeopleListsRepository {
   ///
   /// Results are filtered so that:
   /// * lists with no `p` tag members are excluded,
-  /// * the app block list (`d=block`) is excluded,
+  /// * app-managed lists (`d=block`, `d=notify`) are excluded,
   /// * duplicates sharing the addressable coordinate
   ///   (`kind:ownerPubkey:d-tag`) keep the newest by `updatedAt`.
   ///

--- a/mobile/packages/people_lists_repository/test/nip51_people_list_codec_test.dart
+++ b/mobile/packages/people_lists_repository/test/nip51_people_list_codec_test.dart
@@ -113,10 +113,7 @@ void main() {
         expect(
           decoded.createdAt,
           equals(
-            DateTime.fromMillisecondsSinceEpoch(
-              1710000000 * 1000,
-              isUtc: true,
-            ),
+            DateTime.fromMillisecondsSinceEpoch(1710000000 * 1000, isUtc: true),
           ),
         );
       });
@@ -179,6 +176,22 @@ void main() {
           30000,
           const [
             ['d', 'block'],
+            ['p', memberPubkeyA],
+          ],
+          '',
+          createdAt: 1710000000,
+        );
+
+        expect(Nip51PeopleListCodec.decode(event), isNull);
+      });
+
+      test('returns null for the app notify-list kind 30000 event', () {
+        final event = Event(
+          ownerPubkey,
+          30000,
+          const [
+            ['d', 'notify'],
+            ['title', 'Notify'],
             ['p', memberPubkeyA],
           ],
           '',
@@ -276,10 +289,7 @@ void main() {
         expect(
           decoded.updatedAt,
           equals(
-            DateTime.fromMillisecondsSinceEpoch(
-              1710000000 * 1000,
-              isUtc: true,
-            ),
+            DateTime.fromMillisecondsSinceEpoch(1710000000 * 1000, isUtc: true),
           ),
         );
       });

--- a/mobile/packages/people_lists_repository/test/nip51_people_list_codec_test.dart
+++ b/mobile/packages/people_lists_repository/test/nip51_people_list_codec_test.dart
@@ -201,6 +201,81 @@ void main() {
         expect(Nip51PeopleListCodec.decode(event), isNull);
       });
 
+      test('decodeReservedMembers reads members of the notify list', () {
+        final event = Event(
+          ownerPubkey,
+          30000,
+          const [
+            ['d', 'notify'],
+            ['p', memberPubkeyA],
+            ['p', memberPubkeyB],
+          ],
+          '',
+          createdAt: 1710000000,
+        );
+
+        expect(
+          Nip51PeopleListCodec.decodeReservedMembers(event, dTag: 'notify'),
+          equals([memberPubkeyA, memberPubkeyB]),
+        );
+      });
+
+      test('decodeReservedMembers distinguishes empty from absent', () {
+        final emptyList = Event(
+          ownerPubkey,
+          30000,
+          const [
+            ['d', 'notify'],
+          ],
+          '',
+          createdAt: 1710000000,
+        );
+        final otherList = Event(
+          ownerPubkey,
+          30000,
+          const [
+            ['d', 'block'],
+            ['p', memberPubkeyA],
+          ],
+          '',
+          createdAt: 1710000000,
+        );
+
+        expect(
+          Nip51PeopleListCodec.decodeReservedMembers(emptyList, dTag: 'notify'),
+          isEmpty,
+        );
+        expect(
+          Nip51PeopleListCodec.decodeReservedMembers(otherList, dTag: 'notify'),
+          isNull,
+        );
+      });
+
+      test('encodeReserved round-trips through decodeReservedMembers', () {
+        final payload = Nip51PeopleListCodec.encodeReserved(
+          dTag: Nip51PeopleListCodec.notifyDTag,
+          title: 'Notify',
+          pubkeys: [memberPubkeyA, memberPubkeyB],
+        );
+        final event = Event(
+          ownerPubkey,
+          payload.kind,
+          payload.tags,
+          payload.content,
+          createdAt: 1710000000,
+        );
+
+        expect(
+          Nip51PeopleListCodec.decodeReservedMembers(
+            event,
+            dTag: Nip51PeopleListCodec.notifyDTag,
+          ),
+          equals([memberPubkeyA, memberPubkeyB]),
+        );
+        // Must stay invisible to the user-facing list collection.
+        expect(Nip51PeopleListCodec.decode(event), isNull);
+      });
+
       test('returns null for non kind 30000 events', () {
         final event = Event(
           ownerPubkey,

--- a/mobile/packages/people_lists_repository/test/notify_subscriptions_repository_impl_test.dart
+++ b/mobile/packages/people_lists_repository/test/notify_subscriptions_repository_impl_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Covers d=notify list read/publish, mutation serialization, and
-// ABOUTME: that a failed publish leaves the snapshot revertible.
+// ABOUTME: that an unreadable list is never used as a base for a publish.
 
 import 'dart:async';
 
@@ -30,6 +30,13 @@ Event _notifyEvent(List<String> pubkeys, {int createdAt = 1710000000}) => Event(
   createdAt: createdAt,
 );
 
+/// Shapes a `queryEventsDetailed` answer.
+({List<Event> events, bool timedOut, bool noRelays}) _readResult(
+  List<Event> events, {
+  bool timedOut = false,
+  bool noRelays = false,
+}) => (events: events, timedOut: timedOut, noRelays: noRelays);
+
 /// Member pubkeys carried on the event handed to `publishEvent`.
 List<String> _publishedMembers(Event event) => event.tags
     .where((t) => t.length >= 2 && t[0] == 'p')
@@ -40,6 +47,15 @@ void main() {
   setUpAll(() {
     registerFallbackValue(_notifyEvent(const []));
     registerFallbackValue(<Filter>[]);
+  });
+
+  group(NotifySubscriptionsUnavailableException, () {
+    test('names the owner in full, never truncated', () {
+      const exception = NotifySubscriptionsUnavailableException(ownerPubkey);
+
+      expect(exception.ownerPubkey, equals(ownerPubkey));
+      expect(exception.toString(), contains(ownerPubkey));
+    });
   });
 
   group(NotifySubscriptionsRepositoryImpl, () {
@@ -63,9 +79,20 @@ void main() {
       );
     }
 
+    void stubRead(
+      List<Event> events, {
+      bool timedOut = false,
+      bool noRelays = false,
+    }) {
+      when(() => client.queryEventsDetailed(any())).thenAnswer(
+        (_) async =>
+            _readResult(events, timedOut: timedOut, noRelays: noRelays),
+      );
+    }
+
     group('readSubscriptions', () {
       test('returns an empty set when the user has no notify list', () async {
-        when(() => client.queryEvents(any())).thenAnswer((_) async => []);
+        stubRead(const []);
 
         expect(
           await repository.readSubscriptions(ownerPubkey: ownerPubkey),
@@ -74,13 +101,9 @@ void main() {
       });
 
       test('decodes members from the notify list event', () async {
-        when(
-          () => client.queryEvents(any()),
-        ).thenAnswer(
-          (_) async => [
-            _notifyEvent([creatorA, creatorB]),
-          ],
-        );
+        stubRead([
+          _notifyEvent([creatorA, creatorB]),
+        ]);
 
         expect(
           await repository.readSubscriptions(ownerPubkey: ownerPubkey),
@@ -89,14 +112,10 @@ void main() {
       });
 
       test('keeps the newest generation when relays return several', () async {
-        when(
-          () => client.queryEvents(any()),
-        ).thenAnswer(
-          (_) async => [
-            _notifyEvent([creatorA, creatorB]),
-            _notifyEvent([creatorA], createdAt: 1710000500),
-          ],
-        );
+        stubRead([
+          _notifyEvent([creatorA, creatorB]),
+          _notifyEvent([creatorA], createdAt: 1710000500),
+        ]);
 
         expect(
           await repository.readSubscriptions(ownerPubkey: ownerPubkey),
@@ -104,27 +123,144 @@ void main() {
         );
       });
 
-      test('returns empty rather than throwing when the read fails', () async {
+      test('throws rather than reporting empty when the read throws', () async {
         when(
-          () => client.queryEvents(any()),
+          () => client.queryEventsDetailed(any()),
         ).thenThrow(StateError('relay down'));
 
-        expect(
-          await repository.readSubscriptions(ownerPubkey: ownerPubkey),
-          isEmpty,
+        await expectLater(
+          repository.readSubscriptions(ownerPubkey: ownerPubkey),
+          throwsA(isA<NotifySubscriptionsUnavailableException>()),
         );
+      });
+
+      test('throws when the query reached no relay', () async {
+        stubRead(const [], noRelays: true);
+
+        await expectLater(
+          repository.readSubscriptions(ownerPubkey: ownerPubkey),
+          throwsA(isA<NotifySubscriptionsUnavailableException>()),
+        );
+      });
+
+      test('throws when the query timed out', () async {
+        stubRead(const [], timedOut: true);
+
+        await expectLater(
+          repository.readSubscriptions(ownerPubkey: ownerPubkey),
+          throwsA(isA<NotifySubscriptionsUnavailableException>()),
+        );
+      });
+    });
+
+    group('unreadable list', () {
+      test(
+        'subscribe publishes nothing when the list could not be read',
+        () async {
+          stubRead(const [], noRelays: true);
+          stubPublishSuccess();
+
+          final result = await repository.subscribe(
+            ownerPubkey: ownerPubkey,
+            creatorPubkey: creatorA,
+          );
+
+          expect(result.status, equals(PeopleListPublishStatus.failed));
+          verifyNever(() => client.publishEvent(any()));
+        },
+      );
+
+      test(
+        'unsubscribe publishes nothing when the list could not be read',
+        () async {
+          stubRead(const [], timedOut: true);
+          stubPublishSuccess();
+
+          final result = await repository.unsubscribe(
+            ownerPubkey: ownerPubkey,
+            creatorPubkey: creatorA,
+          );
+
+          expect(result.status, equals(PeopleListPublishStatus.failed));
+          verifyNever(() => client.publishEvent(any()));
+        },
+      );
+
+      test(
+        'watchSubscriptions stays silent so the UI cannot enable a bell',
+        () async {
+          stubRead(const [], noRelays: true);
+
+          final emitted = <Set<String>>[];
+          final subscription = repository
+              .watchSubscriptions(ownerPubkey: ownerPubkey)
+              .listen(emitted.add);
+          addTearDown(subscription.cancel);
+
+          await expectLater(
+            repository.readSubscriptions(ownerPubkey: ownerPubkey),
+            throwsA(isA<NotifySubscriptionsUnavailableException>()),
+          );
+          await Future<void>.delayed(Duration.zero);
+
+          expect(
+            emitted,
+            isEmpty,
+            reason:
+                'an unverified empty set would look like "no subscriptions"',
+          );
+        },
+      );
+
+      test(
+        're-reads on the next mount instead of caching the failure',
+        () async {
+          var attempts = 0;
+          when(() => client.queryEventsDetailed(any())).thenAnswer((_) async {
+            attempts++;
+            if (attempts == 1) return _readResult(const [], noRelays: true);
+            return _readResult([
+              _notifyEvent([creatorA]),
+            ]);
+          });
+
+          await expectLater(
+            repository.readSubscriptions(ownerPubkey: ownerPubkey),
+            throwsA(isA<NotifySubscriptionsUnavailableException>()),
+          );
+
+          expect(
+            await repository.readSubscriptions(ownerPubkey: ownerPubkey),
+            equals({creatorA}),
+          );
+          expect(attempts, equals(2));
+        },
+      );
+
+      test('shares one relay read across concurrent mounts', () async {
+        var attempts = 0;
+        when(() => client.queryEventsDetailed(any())).thenAnswer((_) async {
+          attempts++;
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          return _readResult([
+            _notifyEvent([creatorA]),
+          ]);
+        });
+
+        await Future.wait([
+          repository.readSubscriptions(ownerPubkey: ownerPubkey),
+          repository.readSubscriptions(ownerPubkey: ownerPubkey),
+        ]);
+
+        expect(attempts, equals(1));
       });
     });
 
     group('subscribe', () {
       test('publishes the full list including the new creator', () async {
-        when(
-          () => client.queryEvents(any()),
-        ).thenAnswer(
-          (_) async => [
-            _notifyEvent([creatorA]),
-          ],
-        );
+        stubRead([
+          _notifyEvent([creatorA]),
+        ]);
         stubPublishSuccess();
 
         final result = await repository.subscribe(
@@ -140,7 +276,7 @@ void main() {
       });
 
       test('never truncates the creator pubkey', () async {
-        when(() => client.queryEvents(any())).thenAnswer((_) async => []);
+        stubRead(const []);
         stubPublishSuccess();
 
         await repository.subscribe(
@@ -156,13 +292,9 @@ void main() {
       });
 
       test('is a no-op when already subscribed', () async {
-        when(
-          () => client.queryEvents(any()),
-        ).thenAnswer(
-          (_) async => [
-            _notifyEvent([creatorA]),
-          ],
-        );
+        stubRead([
+          _notifyEvent([creatorA]),
+        ]);
 
         final result = await repository.subscribe(
           ownerPubkey: ownerPubkey,
@@ -174,7 +306,7 @@ void main() {
       });
 
       test('refuses to subscribe the owner to themselves', () async {
-        when(() => client.queryEvents(any())).thenAnswer((_) async => []);
+        stubRead(const []);
 
         final result = await repository.subscribe(
           ownerPubkey: ownerPubkey,
@@ -186,13 +318,9 @@ void main() {
       });
 
       test('leaves the snapshot unchanged when the publish fails', () async {
-        when(
-          () => client.queryEvents(any()),
-        ).thenAnswer(
-          (_) async => [
-            _notifyEvent([creatorA]),
-          ],
-        );
+        stubRead([
+          _notifyEvent([creatorA]),
+        ]);
         when(
           () => client.publishEvent(any()),
         ).thenAnswer((_) async => const PublishFailed());
@@ -213,13 +341,9 @@ void main() {
 
     group('unsubscribe', () {
       test('publishes the list without the creator', () async {
-        when(
-          () => client.queryEvents(any()),
-        ).thenAnswer(
-          (_) async => [
-            _notifyEvent([creatorA, creatorB]),
-          ],
-        );
+        stubRead([
+          _notifyEvent([creatorA, creatorB]),
+        ]);
         stubPublishSuccess();
 
         final result = await repository.unsubscribe(
@@ -235,13 +359,9 @@ void main() {
       });
 
       test('publishes an empty list when the last bell is removed', () async {
-        when(
-          () => client.queryEvents(any()),
-        ).thenAnswer(
-          (_) async => [
-            _notifyEvent([creatorA]),
-          ],
-        );
+        stubRead([
+          _notifyEvent([creatorA]),
+        ]);
         stubPublishSuccess();
 
         await repository.unsubscribe(
@@ -262,7 +382,7 @@ void main() {
 
       test('is a no-op when not subscribed, so unfollow can call it '
           'unconditionally', () async {
-        when(() => client.queryEvents(any())).thenAnswer((_) async => []);
+        stubRead(const []);
 
         final result = await repository.unsubscribe(
           ownerPubkey: ownerPubkey,
@@ -276,7 +396,7 @@ void main() {
 
     group('mutation serialization', () {
       test('concurrent subscribes both survive in the final list', () async {
-        when(() => client.queryEvents(any())).thenAnswer((_) async => []);
+        stubRead(const []);
         // A slow publish widens the window a naive implementation would race
         // in: both mutations would read the same empty base set.
         when(() => client.publishEvent(any())).thenAnswer((invocation) async {
@@ -314,7 +434,7 @@ void main() {
       });
 
       test('a rapid on/off/on sequence converges to on', () async {
-        when(() => client.queryEvents(any())).thenAnswer((_) async => []);
+        stubRead(const []);
         when(() => client.publishEvent(any())).thenAnswer((invocation) async {
           await Future<void>.delayed(const Duration(milliseconds: 10));
           return PublishSuccess(
@@ -353,7 +473,7 @@ void main() {
       test(
         'a failed mutation does not abort the ones queued behind it',
         () async {
-          when(() => client.queryEvents(any())).thenAnswer((_) async => []);
+          stubRead(const []);
           var call = 0;
           when(() => client.publishEvent(any())).thenAnswer((invocation) async {
             call++;
@@ -387,12 +507,10 @@ void main() {
           'a coin flip', () async {
         final nowSeconds =
             DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000;
-        when(() => client.queryEvents(any())).thenAnswer(
-          // A list published "in the future" relative to this device's clock.
-          (_) async => [
-            _notifyEvent([creatorA], createdAt: nowSeconds + 500),
-          ],
-        );
+        // A list published "in the future" relative to this device's clock.
+        stubRead([
+          _notifyEvent([creatorA], createdAt: nowSeconds + 500),
+        ]);
         stubPublishSuccess();
 
         await repository.subscribe(
@@ -412,7 +530,9 @@ void main() {
         var events = [
           _notifyEvent([creatorA]),
         ];
-        when(() => client.queryEvents(any())).thenAnswer((_) async => events);
+        when(
+          () => client.queryEventsDetailed(any()),
+        ).thenAnswer((_) async => _readResult(events));
 
         expect(
           await repository.readSubscriptions(ownerPubkey: ownerPubkey),
@@ -439,17 +559,39 @@ void main() {
         );
         expect(emitted.last, equals({creatorB}));
       });
+
+      test('keeps the last good snapshot when the re-read fails', () async {
+        var reads = 0;
+        when(() => client.queryEventsDetailed(any())).thenAnswer((_) async {
+          reads++;
+          if (reads == 1) {
+            return _readResult([
+              _notifyEvent([creatorA]),
+            ]);
+          }
+          return _readResult(const [], noRelays: true);
+        });
+
+        expect(
+          await repository.readSubscriptions(ownerPubkey: ownerPubkey),
+          equals({creatorA}),
+        );
+
+        await repository.refresh(ownerPubkey: ownerPubkey);
+
+        expect(
+          await repository.readSubscriptions(ownerPubkey: ownerPubkey),
+          equals({creatorA}),
+          reason: 'a failed re-read must not clear the known subscriptions',
+        );
+      });
     });
 
     group('watchSubscriptions', () {
       test('emits the loaded set then each mutation', () async {
-        when(
-          () => client.queryEvents(any()),
-        ).thenAnswer(
-          (_) async => [
-            _notifyEvent([creatorA]),
-          ],
-        );
+        stubRead([
+          _notifyEvent([creatorA]),
+        ]);
         stubPublishSuccess();
 
         final emitted = <Set<String>>[];

--- a/mobile/packages/people_lists_repository/test/notify_subscriptions_repository_impl_test.dart
+++ b/mobile/packages/people_lists_repository/test/notify_subscriptions_repository_impl_test.dart
@@ -1,0 +1,477 @@
+// ABOUTME: Covers d=notify list read/publish, mutation serialization, and
+// ABOUTME: that a failed publish leaves the snapshot revertible.
+
+import 'dart:async';
+
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:people_lists_repository/people_lists_repository.dart';
+import 'package:test/test.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+const ownerPubkey =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const creatorA =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const creatorB =
+    'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+Event _notifyEvent(List<String> pubkeys, {int createdAt = 1710000000}) => Event(
+  ownerPubkey,
+  Nip51PeopleListCodec.kind,
+  [
+    ['d', Nip51PeopleListCodec.notifyDTag],
+    ['title', 'Notify'],
+    for (final p in pubkeys) ['p', p],
+  ],
+  '',
+  createdAt: createdAt,
+);
+
+/// Member pubkeys carried on the event handed to `publishEvent`.
+List<String> _publishedMembers(Event event) => event.tags
+    .where((t) => t.length >= 2 && t[0] == 'p')
+    .map((t) => t[1])
+    .toList();
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_notifyEvent(const []));
+    registerFallbackValue(<Filter>[]);
+  });
+
+  group(NotifySubscriptionsRepositoryImpl, () {
+    late _MockNostrClient client;
+    late NotifySubscriptionsRepositoryImpl repository;
+
+    setUp(() {
+      client = _MockNostrClient();
+      repository = NotifySubscriptionsRepositoryImpl(nostrClient: client);
+    });
+
+    tearDown(() async {
+      await repository.dispose();
+    });
+
+    void stubPublishSuccess() {
+      when(() => client.publishEvent(any())).thenAnswer(
+        (invocation) async => PublishSuccess(
+          event: invocation.positionalArguments.first as Event,
+        ),
+      );
+    }
+
+    group('readSubscriptions', () {
+      test('returns an empty set when the user has no notify list', () async {
+        when(() => client.queryEvents(any())).thenAnswer((_) async => []);
+
+        expect(
+          await repository.readSubscriptions(ownerPubkey: ownerPubkey),
+          isEmpty,
+        );
+      });
+
+      test('decodes members from the notify list event', () async {
+        when(
+          () => client.queryEvents(any()),
+        ).thenAnswer(
+          (_) async => [
+            _notifyEvent([creatorA, creatorB]),
+          ],
+        );
+
+        expect(
+          await repository.readSubscriptions(ownerPubkey: ownerPubkey),
+          equals({creatorA, creatorB}),
+        );
+      });
+
+      test('keeps the newest generation when relays return several', () async {
+        when(
+          () => client.queryEvents(any()),
+        ).thenAnswer(
+          (_) async => [
+            _notifyEvent([creatorA, creatorB]),
+            _notifyEvent([creatorA], createdAt: 1710000500),
+          ],
+        );
+
+        expect(
+          await repository.readSubscriptions(ownerPubkey: ownerPubkey),
+          equals({creatorA}),
+        );
+      });
+
+      test('returns empty rather than throwing when the read fails', () async {
+        when(
+          () => client.queryEvents(any()),
+        ).thenThrow(StateError('relay down'));
+
+        expect(
+          await repository.readSubscriptions(ownerPubkey: ownerPubkey),
+          isEmpty,
+        );
+      });
+    });
+
+    group('subscribe', () {
+      test('publishes the full list including the new creator', () async {
+        when(
+          () => client.queryEvents(any()),
+        ).thenAnswer(
+          (_) async => [
+            _notifyEvent([creatorA]),
+          ],
+        );
+        stubPublishSuccess();
+
+        final result = await repository.subscribe(
+          ownerPubkey: ownerPubkey,
+          creatorPubkey: creatorB,
+        );
+
+        expect(result.submitted, isTrue);
+        final published =
+            verify(() => client.publishEvent(captureAny())).captured.single
+                as Event;
+        expect(_publishedMembers(published), containsAll([creatorA, creatorB]));
+      });
+
+      test('never truncates the creator pubkey', () async {
+        when(() => client.queryEvents(any())).thenAnswer((_) async => []);
+        stubPublishSuccess();
+
+        await repository.subscribe(
+          ownerPubkey: ownerPubkey,
+          creatorPubkey: creatorA,
+        );
+
+        final published =
+            verify(() => client.publishEvent(captureAny())).captured.single
+                as Event;
+        expect(_publishedMembers(published), equals([creatorA]));
+        expect(creatorA, hasLength(64));
+      });
+
+      test('is a no-op when already subscribed', () async {
+        when(
+          () => client.queryEvents(any()),
+        ).thenAnswer(
+          (_) async => [
+            _notifyEvent([creatorA]),
+          ],
+        );
+
+        final result = await repository.subscribe(
+          ownerPubkey: ownerPubkey,
+          creatorPubkey: creatorA,
+        );
+
+        expect(result.status, equals(PeopleListPublishStatus.noop));
+        verifyNever(() => client.publishEvent(any()));
+      });
+
+      test('refuses to subscribe the owner to themselves', () async {
+        when(() => client.queryEvents(any())).thenAnswer((_) async => []);
+
+        final result = await repository.subscribe(
+          ownerPubkey: ownerPubkey,
+          creatorPubkey: ownerPubkey,
+        );
+
+        expect(result.status, equals(PeopleListPublishStatus.noop));
+        verifyNever(() => client.publishEvent(any()));
+      });
+
+      test('leaves the snapshot unchanged when the publish fails', () async {
+        when(
+          () => client.queryEvents(any()),
+        ).thenAnswer(
+          (_) async => [
+            _notifyEvent([creatorA]),
+          ],
+        );
+        when(
+          () => client.publishEvent(any()),
+        ).thenAnswer((_) async => const PublishFailed());
+
+        final result = await repository.subscribe(
+          ownerPubkey: ownerPubkey,
+          creatorPubkey: creatorB,
+        );
+
+        expect(result.status, equals(PeopleListPublishStatus.failed));
+        expect(
+          await repository.readSubscriptions(ownerPubkey: ownerPubkey),
+          equals({creatorA}),
+          reason: 'a failed publish must not leave optimistic state behind',
+        );
+      });
+    });
+
+    group('unsubscribe', () {
+      test('publishes the list without the creator', () async {
+        when(
+          () => client.queryEvents(any()),
+        ).thenAnswer(
+          (_) async => [
+            _notifyEvent([creatorA, creatorB]),
+          ],
+        );
+        stubPublishSuccess();
+
+        final result = await repository.unsubscribe(
+          ownerPubkey: ownerPubkey,
+          creatorPubkey: creatorA,
+        );
+
+        expect(result.submitted, isTrue);
+        final published =
+            verify(() => client.publishEvent(captureAny())).captured.single
+                as Event;
+        expect(_publishedMembers(published), equals([creatorB]));
+      });
+
+      test('publishes an empty list when the last bell is removed', () async {
+        when(
+          () => client.queryEvents(any()),
+        ).thenAnswer(
+          (_) async => [
+            _notifyEvent([creatorA]),
+          ],
+        );
+        stubPublishSuccess();
+
+        await repository.unsubscribe(
+          ownerPubkey: ownerPubkey,
+          creatorPubkey: creatorA,
+        );
+
+        final published =
+            verify(() => client.publishEvent(captureAny())).captured.single
+                as Event;
+        expect(_publishedMembers(published), isEmpty);
+        expect(
+          published.tags.any((t) => t.isNotEmpty && t[0] == 'd'),
+          isTrue,
+          reason: 'clearing the list must still be a valid d=notify event',
+        );
+      });
+
+      test('is a no-op when not subscribed, so unfollow can call it '
+          'unconditionally', () async {
+        when(() => client.queryEvents(any())).thenAnswer((_) async => []);
+
+        final result = await repository.unsubscribe(
+          ownerPubkey: ownerPubkey,
+          creatorPubkey: creatorA,
+        );
+
+        expect(result.status, equals(PeopleListPublishStatus.noop));
+        verifyNever(() => client.publishEvent(any()));
+      });
+    });
+
+    group('mutation serialization', () {
+      test('concurrent subscribes both survive in the final list', () async {
+        when(() => client.queryEvents(any())).thenAnswer((_) async => []);
+        // A slow publish widens the window a naive implementation would race
+        // in: both mutations would read the same empty base set.
+        when(() => client.publishEvent(any())).thenAnswer((invocation) async {
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+          return PublishSuccess(
+            event: invocation.positionalArguments.first as Event,
+          );
+        });
+
+        await Future.wait([
+          repository.subscribe(
+            ownerPubkey: ownerPubkey,
+            creatorPubkey: creatorA,
+          ),
+          repository.subscribe(
+            ownerPubkey: ownerPubkey,
+            creatorPubkey: creatorB,
+          ),
+        ]);
+
+        expect(
+          await repository.readSubscriptions(ownerPubkey: ownerPubkey),
+          equals({creatorA, creatorB}),
+        );
+
+        final published = verify(
+          () => client.publishEvent(captureAny()),
+        ).captured.cast<Event>();
+        expect(published, hasLength(2));
+        expect(
+          _publishedMembers(published.last),
+          containsAll([creatorA, creatorB]),
+          reason: 'the second publish must build on the first, not clobber it',
+        );
+      });
+
+      test('a rapid on/off/on sequence converges to on', () async {
+        when(() => client.queryEvents(any())).thenAnswer((_) async => []);
+        when(() => client.publishEvent(any())).thenAnswer((invocation) async {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          return PublishSuccess(
+            event: invocation.positionalArguments.first as Event,
+          );
+        });
+
+        await Future.wait([
+          repository.subscribe(
+            ownerPubkey: ownerPubkey,
+            creatorPubkey: creatorA,
+          ),
+          repository.unsubscribe(
+            ownerPubkey: ownerPubkey,
+            creatorPubkey: creatorA,
+          ),
+          repository.subscribe(
+            ownerPubkey: ownerPubkey,
+            creatorPubkey: creatorA,
+          ),
+        ]);
+
+        expect(
+          await repository.readSubscriptions(ownerPubkey: ownerPubkey),
+          equals({creatorA}),
+        );
+        // Each toggle must observe the previous one's result. Unserialized,
+        // all three read the same empty base set, so the unsubscribe collapses
+        // to a no-op and only two events are published.
+        expect(
+          verify(() => client.publishEvent(captureAny())).captured,
+          hasLength(3),
+        );
+      });
+
+      test(
+        'a failed mutation does not abort the ones queued behind it',
+        () async {
+          when(() => client.queryEvents(any())).thenAnswer((_) async => []);
+          var call = 0;
+          when(() => client.publishEvent(any())).thenAnswer((invocation) async {
+            call++;
+            if (call == 1) throw StateError('relay rejected');
+            return PublishSuccess(
+              event: invocation.positionalArguments.first as Event,
+            );
+          });
+
+          final results = await Future.wait([
+            repository.subscribe(
+              ownerPubkey: ownerPubkey,
+              creatorPubkey: creatorA,
+            ),
+            repository.subscribe(
+              ownerPubkey: ownerPubkey,
+              creatorPubkey: creatorB,
+            ),
+          ]);
+
+          expect(results.first.status, equals(PeopleListPublishStatus.failed));
+          expect(results.last.submitted, isTrue);
+          expect(
+            await repository.readSubscriptions(ownerPubkey: ownerPubkey),
+            equals({creatorB}),
+          );
+        },
+      );
+
+      test('steps created_at past the previous event so replacement is not '
+          'a coin flip', () async {
+        final nowSeconds =
+            DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000;
+        when(() => client.queryEvents(any())).thenAnswer(
+          // A list published "in the future" relative to this device's clock.
+          (_) async => [
+            _notifyEvent([creatorA], createdAt: nowSeconds + 500),
+          ],
+        );
+        stubPublishSuccess();
+
+        await repository.subscribe(
+          ownerPubkey: ownerPubkey,
+          creatorPubkey: creatorB,
+        );
+
+        final published =
+            verify(() => client.publishEvent(captureAny())).captured.single
+                as Event;
+        expect(published.createdAt, greaterThan(nowSeconds + 500));
+      });
+    });
+
+    group('refresh', () {
+      test('replaces a stale snapshot and emits the new set', () async {
+        var events = [
+          _notifyEvent([creatorA]),
+        ];
+        when(() => client.queryEvents(any())).thenAnswer((_) async => events);
+
+        expect(
+          await repository.readSubscriptions(ownerPubkey: ownerPubkey),
+          equals({creatorA}),
+        );
+
+        // The list changed elsewhere — another device, or another client.
+        events = [
+          _notifyEvent([creatorB], createdAt: 1710000900),
+        ];
+
+        final emitted = <Set<String>>[];
+        final subscription = repository
+            .watchSubscriptions(ownerPubkey: ownerPubkey)
+            .listen(emitted.add);
+        addTearDown(subscription.cancel);
+
+        await repository.refresh(ownerPubkey: ownerPubkey);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          await repository.readSubscriptions(ownerPubkey: ownerPubkey),
+          equals({creatorB}),
+        );
+        expect(emitted.last, equals({creatorB}));
+      });
+    });
+
+    group('watchSubscriptions', () {
+      test('emits the loaded set then each mutation', () async {
+        when(
+          () => client.queryEvents(any()),
+        ).thenAnswer(
+          (_) async => [
+            _notifyEvent([creatorA]),
+          ],
+        );
+        stubPublishSuccess();
+
+        final emitted = <Set<String>>[];
+        final subscription = repository
+            .watchSubscriptions(ownerPubkey: ownerPubkey)
+            .listen(emitted.add);
+        addTearDown(subscription.cancel);
+
+        await repository.readSubscriptions(ownerPubkey: ownerPubkey);
+        await repository.subscribe(
+          ownerPubkey: ownerPubkey,
+          creatorPubkey: creatorB,
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(emitted.last, equals({creatorA, creatorB}));
+        expect(
+          emitted,
+          contains(equals({creatorA})),
+          reason: 'a late listener must see the loaded set, not only changes',
+        );
+      });
+    });
+  });
+}

--- a/mobile/packages/people_lists_repository/test/notify_subscriptions_repository_impl_test.dart
+++ b/mobile/packages/people_lists_repository/test/notify_subscriptions_repository_impl_test.dart
@@ -17,6 +17,8 @@ const creatorA =
     'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 const creatorB =
     'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+const creatorC =
+    'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
 
 Event _notifyEvent(List<String> pubkeys, {int createdAt = 1710000000}) => Event(
   ownerPubkey,
@@ -392,6 +394,107 @@ void main() {
         expect(result.status, equals(PeopleListPublishStatus.noop));
         verifyNever(() => client.publishEvent(any()));
       });
+    });
+
+    group('outstanding removals', () {
+      test('a failed removal is reapplied by the next publish', () async {
+        stubRead([
+          _notifyEvent([creatorA, creatorB]),
+        ]);
+        when(
+          () => client.publishEvent(any()),
+        ).thenAnswer((_) async => const PublishFailed());
+
+        final teardown = await repository.unsubscribe(
+          ownerPubkey: ownerPubkey,
+          creatorPubkey: creatorA,
+        );
+        expect(teardown.status, equals(PeopleListPublishStatus.failed));
+
+        stubPublishSuccess();
+        await repository.subscribe(
+          ownerPubkey: ownerPubkey,
+          creatorPubkey: creatorC,
+        );
+
+        final published =
+            verify(() => client.publishEvent(captureAny())).captured.last
+                as Event;
+        expect(
+          _publishedMembers(published),
+          equals([creatorB, creatorC]),
+          reason: 'the abandoned bell must not survive the next publish',
+        );
+      });
+
+      test('reconcile republishes an outstanding removal', () async {
+        stubRead([
+          _notifyEvent([creatorA, creatorB]),
+        ]);
+        when(
+          () => client.publishEvent(any()),
+        ).thenAnswer((_) async => const PublishFailed());
+
+        await repository.unsubscribe(
+          ownerPubkey: ownerPubkey,
+          creatorPubkey: creatorA,
+        );
+
+        stubPublishSuccess();
+        final result = await repository.reconcile(ownerPubkey: ownerPubkey);
+
+        expect(result.submitted, isTrue);
+        final published =
+            verify(() => client.publishEvent(captureAny())).captured.last
+                as Event;
+        expect(_publishedMembers(published), equals([creatorB]));
+        expect(
+          await repository.readSubscriptions(ownerPubkey: ownerPubkey),
+          equals({creatorB}),
+        );
+      });
+
+      test('reconcile is a no-op when nothing is outstanding', () async {
+        stubRead([
+          _notifyEvent([creatorA]),
+        ]);
+        stubPublishSuccess();
+
+        final result = await repository.reconcile(ownerPubkey: ownerPubkey);
+
+        expect(result.status, equals(PeopleListPublishStatus.noop));
+        verifyNever(() => client.publishEvent(any()));
+      });
+
+      test(
+        'a removal that failed on an unreadable list is retried later',
+        () async {
+          var attempts = 0;
+          when(() => client.queryEventsDetailed(any())).thenAnswer((_) async {
+            attempts++;
+            if (attempts == 1) return _readResult(const [], noRelays: true);
+            return _readResult([
+              _notifyEvent([creatorA, creatorB]),
+            ]);
+          });
+          stubPublishSuccess();
+
+          final teardown = await repository.unsubscribe(
+            ownerPubkey: ownerPubkey,
+            creatorPubkey: creatorA,
+          );
+          expect(teardown.status, equals(PeopleListPublishStatus.failed));
+          verifyNever(() => client.publishEvent(any()));
+
+          final result = await repository.reconcile(ownerPubkey: ownerPubkey);
+
+          expect(result.submitted, isTrue);
+          final published =
+              verify(() => client.publishEvent(captureAny())).captured.last
+                  as Event;
+          expect(_publishedMembers(published), equals([creatorB]));
+        },
+      );
     });
 
     group('mutation serialization', () {

--- a/mobile/test/blocs/notify_bell/notify_bell_cubit_test.dart
+++ b/mobile/test/blocs/notify_bell/notify_bell_cubit_test.dart
@@ -1,0 +1,244 @@
+// ABOUTME: Covers the bell cubit's optimistic toggle, revert-on-failure, and
+// ABOUTME: unfollow teardown.
+
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/notify_bell/notify_bell_cubit.dart';
+import 'package:openvine/observability/reportable_error.dart';
+import 'package:people_lists_repository/people_lists_repository.dart';
+
+class _MockNotifySubscriptionsRepository extends Mock
+    implements NotifySubscriptionsRepository {}
+
+const _viewer = 'viewer_pubkey_hex';
+const _creator = 'creator_pubkey_hex';
+
+void main() {
+  group(NotifyBellCubit, () {
+    late _MockNotifySubscriptionsRepository repository;
+    late StreamController<Set<String>> subscriptions;
+
+    setUp(() {
+      repository = _MockNotifySubscriptionsRepository();
+      subscriptions = StreamController<Set<String>>.broadcast();
+      when(
+        () => repository.watchSubscriptions(
+          ownerPubkey: any(named: 'ownerPubkey'),
+        ),
+      ).thenAnswer((_) => subscriptions.stream);
+    });
+
+    tearDown(() async {
+      await subscriptions.close();
+    });
+
+    NotifyBellCubit build() => NotifyBellCubit(
+      repository: repository,
+      viewerPubkey: _viewer,
+      creatorPubkey: _creator,
+    );
+
+    blocTest<NotifyBellCubit, NotifyBellState>(
+      'is not interactive until the subscription list loads',
+      build: build,
+      verify: (cubit) {
+        expect(cubit.state.isInteractive, isFalse);
+        expect(cubit.state.isSubscribed, isFalse);
+      },
+    );
+
+    blocTest<NotifyBellCubit, NotifyBellState>(
+      'becomes subscribed when the list contains this creator',
+      build: build,
+      act: (cubit) async {
+        await cubit.load();
+        subscriptions.add({_creator});
+      },
+      expect: () => const [
+        NotifyBellState(status: NotifyBellStatus.ready, isSubscribed: true),
+      ],
+    );
+
+    blocTest<NotifyBellCubit, NotifyBellState>(
+      'ignores a list containing only other creators',
+      build: build,
+      act: (cubit) async {
+        await cubit.load();
+        subscriptions.add({'someone_else_pubkey_hex'});
+      },
+      expect: () => const [NotifyBellState(status: NotifyBellStatus.ready)],
+    );
+
+    group('toggle', () {
+      blocTest<NotifyBellCubit, NotifyBellState>(
+        'flips on optimistically before the publish resolves',
+        build: build,
+        setUp: () {
+          when(
+            () => repository.subscribe(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              creatorPubkey: any(named: 'creatorPubkey'),
+            ),
+          ).thenAnswer((_) async {
+            await Future<void>.delayed(const Duration(milliseconds: 20));
+            return const PeopleListPublishResult.submitted(eventId: 'e1');
+          });
+        },
+        act: (cubit) async {
+          await cubit.load();
+          subscriptions.add(const <String>{});
+          await Future<void>.delayed(Duration.zero);
+          await cubit.toggle();
+        },
+        expect: () => const [
+          NotifyBellState(status: NotifyBellStatus.ready),
+          NotifyBellState(status: NotifyBellStatus.ready, isSubscribed: true),
+        ],
+      );
+
+      blocTest<NotifyBellCubit, NotifyBellState>(
+        'reverts and reports failure when the publish fails',
+        build: build,
+        setUp: () {
+          when(
+            () => repository.subscribe(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              creatorPubkey: any(named: 'creatorPubkey'),
+            ),
+          ).thenAnswer((_) async => const PeopleListPublishResult.failed());
+        },
+        act: (cubit) async {
+          await cubit.load();
+          subscriptions.add(const <String>{});
+          await Future<void>.delayed(Duration.zero);
+          await cubit.toggle();
+        },
+        expect: () => const [
+          NotifyBellState(status: NotifyBellStatus.ready),
+          NotifyBellState(status: NotifyBellStatus.ready, isSubscribed: true),
+          NotifyBellState(status: NotifyBellStatus.failure),
+        ],
+      );
+
+      blocTest<NotifyBellCubit, NotifyBellState>(
+        'unsubscribes when already subscribed',
+        build: build,
+        setUp: () {
+          when(
+            () => repository.unsubscribe(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              creatorPubkey: any(named: 'creatorPubkey'),
+            ),
+          ).thenAnswer(
+            (_) async => const PeopleListPublishResult.submitted(eventId: 'e1'),
+          );
+        },
+        act: (cubit) async {
+          await cubit.load();
+          subscriptions.add({_creator});
+          await Future<void>.delayed(Duration.zero);
+          await cubit.toggle();
+        },
+        verify: (_) {
+          verify(
+            () => repository.unsubscribe(
+              ownerPubkey: _viewer,
+              creatorPubkey: _creator,
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<NotifyBellCubit, NotifyBellState>(
+        'does nothing before the list has loaded',
+        build: build,
+        act: (cubit) => cubit.toggle(),
+        expect: () => const <NotifyBellState>[],
+        verify: (_) {
+          verifyNever(
+            () => repository.subscribe(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              creatorPubkey: any(named: 'creatorPubkey'),
+            ),
+          );
+        },
+      );
+
+      blocTest<NotifyBellCubit, NotifyBellState>(
+        'reverts and reports when the repository throws',
+        build: build,
+        setUp: () {
+          when(
+            () => repository.subscribe(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              creatorPubkey: any(named: 'creatorPubkey'),
+            ),
+          ).thenThrow(StateError('no signer'));
+        },
+        act: (cubit) async {
+          await cubit.load();
+          subscriptions.add(const <String>{});
+          await Future<void>.delayed(Duration.zero);
+          await cubit.toggle();
+        },
+        expect: () => const [
+          NotifyBellState(status: NotifyBellStatus.ready),
+          NotifyBellState(status: NotifyBellStatus.ready, isSubscribed: true),
+          NotifyBellState(status: NotifyBellStatus.failure),
+        ],
+        errors: () => [
+          isA<Reportable<Object>>().having(
+            (r) => r.unwrap(),
+            'unwrap',
+            isA<StateError>(),
+          ),
+        ],
+      );
+    });
+
+    group('clearForUnfollow', () {
+      blocTest<NotifyBellCubit, NotifyBellState>(
+        'unsubscribes so an abandoned bell stops pushing',
+        build: build,
+        setUp: () {
+          when(
+            () => repository.unsubscribe(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              creatorPubkey: any(named: 'creatorPubkey'),
+            ),
+          ).thenAnswer(
+            (_) async => const PeopleListPublishResult.submitted(eventId: 'e1'),
+          );
+        },
+        act: (cubit) => cubit.clearForUnfollow(),
+        verify: (_) {
+          verify(
+            () => repository.unsubscribe(
+              ownerPubkey: _viewer,
+              creatorPubkey: _creator,
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<NotifyBellCubit, NotifyBellState>(
+        'stays silent when teardown fails — the unfollow itself succeeded',
+        build: build,
+        setUp: () {
+          when(
+            () => repository.unsubscribe(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              creatorPubkey: any(named: 'creatorPubkey'),
+            ),
+          ).thenThrow(StateError('relay down'));
+        },
+        act: (cubit) => cubit.clearForUnfollow(),
+        expect: () => const <NotifyBellState>[],
+        errors: () => [isA<Reportable<Object>>()],
+      );
+    });
+  });
+}

--- a/mobile/test/blocs/notify_bell/notify_bell_cubit_test.dart
+++ b/mobile/test/blocs/notify_bell/notify_bell_cubit_test.dart
@@ -29,6 +29,9 @@ void main() {
           ownerPubkey: any(named: 'ownerPubkey'),
         ),
       ).thenAnswer((_) => subscriptions.stream);
+      when(
+        () => repository.reconcile(ownerPubkey: any(named: 'ownerPubkey')),
+      ).thenAnswer((_) async => const PeopleListPublishResult.noop());
     });
 
     tearDown(() async {
@@ -60,6 +63,15 @@ void main() {
       expect: () => const [
         NotifyBellState(status: NotifyBellStatus.ready, isSubscribed: true),
       ],
+    );
+
+    blocTest<NotifyBellCubit, NotifyBellState>(
+      'drains an unfollow teardown that never reached the relays',
+      build: build,
+      act: (cubit) => cubit.load(),
+      verify: (_) {
+        verify(() => repository.reconcile(ownerPubkey: _viewer)).called(1);
+      },
     );
 
     blocTest<NotifyBellCubit, NotifyBellState>(
@@ -222,6 +234,23 @@ void main() {
             ),
           ).called(1);
         },
+      );
+
+      blocTest<NotifyBellCubit, NotifyBellState>(
+        'stays silent when the teardown publish fails, leaving the removal '
+        'for the repository to retry',
+        build: build,
+        setUp: () {
+          when(
+            () => repository.unsubscribe(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              creatorPubkey: any(named: 'creatorPubkey'),
+            ),
+          ).thenAnswer((_) async => const PeopleListPublishResult.failed());
+        },
+        act: (cubit) => cubit.clearForUnfollow(),
+        expect: () => const <NotifyBellState>[],
+        errors: () => const <Object>[],
       );
 
       blocTest<NotifyBellCubit, NotifyBellState>(

--- a/mobile/test/models/notification_preferences_test.dart
+++ b/mobile/test/models/notification_preferences_test.dart
@@ -10,17 +10,30 @@ void main() {
       expect(prefs.followsEnabled, isTrue);
       expect(prefs.mentionsEnabled, isTrue);
       expect(prefs.repostsEnabled, isTrue);
+      expect(prefs.newPostsEnabled, isTrue);
     });
 
     group('toKindsList', () {
       test('returns all kinds when all enabled', () {
         const prefs = NotificationPreferences();
-        expect(prefs.toKindsList(), equals([1, 3, 7, 16]));
+        expect(prefs.toKindsList(), equals([1, 3, 7, 16, 34236]));
       });
 
       test('excludes kind 7 when likes disabled', () {
         const prefs = NotificationPreferences(likesEnabled: false);
         expect(prefs.toKindsList(), isNot(contains(7)));
+      });
+
+      test('excludes kind 34236 when new posts disabled', () {
+        const prefs = NotificationPreferences(newPostsEnabled: false);
+        expect(prefs.toKindsList(), isNot(contains(34236)));
+      });
+
+      test('includes kind 34236 independently of mentions', () {
+        // Video mentions arrive on kind 34236 events but gate on kind 1, so
+        // muting mentions must not mute new-post pushes.
+        const prefs = NotificationPreferences(mentionsEnabled: false);
+        expect(prefs.toKindsList(), contains(34236));
       });
 
       test('returns empty when all disabled', () {
@@ -30,6 +43,7 @@ void main() {
           followsEnabled: false,
           mentionsEnabled: false,
           repostsEnabled: false,
+          newPostsEnabled: false,
         );
         expect(prefs.toKindsList(), isEmpty);
       });
@@ -51,12 +65,27 @@ void main() {
           3,
           7,
           16,
+          34236,
         ]);
         expect(prefs.likesEnabled, isTrue);
         expect(prefs.commentsEnabled, isTrue);
         expect(prefs.followsEnabled, isTrue);
         expect(prefs.mentionsEnabled, isTrue);
         expect(prefs.repostsEnabled, isTrue);
+        expect(prefs.newPostsEnabled, isTrue);
+      });
+
+      test('reads newPostsEnabled false from a pre-upgrade kinds list', () {
+        // Preferences published before bells shipped carry no 34236. Reading
+        // back false is correct — the settings screen and the first bell both
+        // republish with it included.
+        final prefs = NotificationPreferences.fromKindsList(const [
+          1,
+          3,
+          7,
+          16,
+        ]);
+        expect(prefs.newPostsEnabled, isFalse);
       });
     });
 

--- a/mobile/test/notifications/routing/notification_tap_target_test.dart
+++ b/mobile/test/notifications/routing/notification_tap_target_test.dart
@@ -53,6 +53,24 @@ void main() {
       expect(notificationKindFromPushType('repost'), NotificationKind.repost);
     });
 
+    test('maps the camelCase newPost type', () {
+      // Matches divine-push-service's NotificationType::display_name()
+      // exactly — the string is a wire contract, so a casing drift here
+      // silently degrades the tap target.
+      expect(notificationKindFromPushType('newPost'), NotificationKind.newPost);
+    });
+
+    test('routes a newPost tap to the video, not the profile', () {
+      expect(
+        resolveNotificationTapTarget(
+          kind: NotificationKind.newPost,
+          hasVideoTarget: true,
+          actorPubkey: 'creator_pubkey_hex',
+        ),
+        const OpenVideoTarget(autoOpenComments: false),
+      );
+    });
+
     test('returns null for values the push service never sends', () {
       // The backend emits lowercase only and has no reply/likeComment/system.
       expect(notificationKindFromPushType('Like'), isNull);

--- a/mobile/test/notifications/widgets/notification_type_icon_spec_test.dart
+++ b/mobile/test/notifications/widgets/notification_type_icon_spec_test.dart
@@ -67,6 +67,13 @@ void main() {
       expect(spec.foreground, equals(VineTheme.accentYellow));
     });
 
+    test('newPost uses bellSimple on accentBlue', () {
+      final spec = notificationTypeIconSpec(NotificationKind.newPost);
+      expect(spec.icon, equals(DivineIconName.bellSimple));
+      expect(spec.background, equals(VineTheme.accentBlueBackground));
+      expect(spec.foreground, equals(VineTheme.accentBlue));
+    });
+
     test('system uses logo on the primary accent', () {
       final spec = notificationTypeIconSpec(NotificationKind.system);
       expect(spec.icon, equals(DivineIconName.logo));

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -44,6 +44,17 @@ class _MockEvent extends Mock implements Event {}
 
 class _FakeNotificationPreferencesStore
     implements NotificationPreferencesStore {
+  final publishedSchemaVersions = <String, int>{};
+
+  @override
+  Future<int?> loadPublishedSchemaVersion(String pubkey) async =>
+      publishedSchemaVersions[pubkey];
+
+  @override
+  Future<void> savePublishedSchemaVersion(String pubkey, int version) async {
+    publishedSchemaVersions[pubkey] = version;
+  }
+
   NotificationPreferences? savedPreferences;
   final dirtyPreferencesByPubkey = <String, NotificationPreferences>{};
   final _clearWaitersByPubkey = <String, List<Completer<void>>>{};

--- a/mobile/test/screens/notification_settings_screen_test.dart
+++ b/mobile/test/screens/notification_settings_screen_test.dart
@@ -183,5 +183,34 @@ void main() {
         ).called(1);
       },
     );
+
+    testWidgets('toggling new vines off persists newPostsEnabled false', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject(repo: mockRepo));
+      await tester.pumpAndSettle();
+
+      final l10n = AppLocalizations.of(
+        tester.element(find.byType(NotificationSettingsScreen)),
+      );
+
+      final newPostsSwitch = find.descendant(
+        of: find.ancestor(
+          of: find.text(l10n.notificationSettingsNewPosts),
+          matching: find.byType(Card),
+        ),
+        matching: find.byType(Switch),
+      );
+      await tester.scrollUntilVisible(newPostsSwitch, 100);
+
+      await tester.tap(newPostsSwitch);
+      await tester.pump();
+
+      verify(
+        () => mockPrefsService.updatePreferences(
+          const NotificationPreferences(newPostsEnabled: false),
+        ),
+      ).called(1);
+    });
   });
 }

--- a/mobile/test/screens/notification_settings_screen_test.dart
+++ b/mobile/test/screens/notification_settings_screen_test.dart
@@ -8,6 +8,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:notification_repository/notification_repository.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/notification_preferences.dart';
 import 'package:openvine/notifications/providers/notification_repository_provider.dart';
@@ -43,13 +45,20 @@ void main() {
       ).thenAnswer((_) async {});
     });
 
-    Widget buildSubject({NotificationRepository? repo}) {
+    Widget buildSubject({
+      NotificationRepository? repo,
+      bool newPostNotifications = true,
+    }) {
       return testMaterialApp(
         additionalOverrides: [
           notificationRepositoryProvider.overrideWithValue(repo),
           notificationPreferencesServiceProvider.overrideWithValue(
             mockPrefsService,
           ),
+          // Ships default-off, so the new-posts row has to be asked for.
+          isFeatureEnabledProvider(
+            FeatureFlag.newPostNotifications,
+          ).overrideWithValue(newPostNotifications),
         ],
         home: const NotificationSettingsScreen(),
       );
@@ -211,6 +220,22 @@ void main() {
           const NotificationPreferences(newPostsEnabled: false),
         ),
       ).called(1);
+    });
+
+    testWidgets('hides the new vines row behind the flag', (tester) async {
+      await tester.pumpWidget(
+        buildSubject(repo: mockRepo, newPostNotifications: false),
+      );
+      await tester.pumpAndSettle();
+
+      final l10n = AppLocalizations.of(
+        tester.element(find.byType(NotificationSettingsScreen)),
+      );
+
+      expect(find.text(l10n.notificationSettingsNewPosts), findsNothing);
+      // The neighbouring rows still render, so this is the flag and not a
+      // failed build.
+      expect(find.text(l10n.notificationSettingsLikes), findsOneWidget);
     });
   });
 }

--- a/mobile/test/services/notification_preferences_service_test.dart
+++ b/mobile/test/services/notification_preferences_service_test.dart
@@ -110,10 +110,91 @@ void main() {
 
     expect(outcome, NotificationPreferencesSyncOutcome.nothingToDrain);
   });
+
+  group('published kind-list schema', () {
+    const pubkey =
+        '3333333333333333333333333333333333333333333333333333333333333333';
+
+    test('republishes for a user who upgraded across a kinds change', () async {
+      // The pre-upgrade state: preferences stored, nothing dirty, and no
+      // schema marker because the marker did not exist when they last
+      // published. The push service is still filtering on the old kind list.
+      final store = _MemoryNotificationPreferencesStore()
+        ..preferences = const NotificationPreferences();
+      final published = <NotificationPreferences>[];
+      final service = NotificationPreferencesService(
+        store: store,
+        currentPubkey: () => pubkey,
+        publishPreferences: (_, prefs) async {
+          published.add(prefs);
+          return true;
+        },
+      );
+
+      expect(await service.markDirtyIfSchemaOutdated(pubkey), isTrue);
+      final outcome = await service.syncDirtyPreferencesForPubkey(pubkey);
+
+      expect(outcome, NotificationPreferencesSyncOutcome.publishedAndCleared);
+      expect(published.single.toKindsList(), contains(34236));
+      expect(
+        store.publishedSchemaVersions[pubkey],
+        NotificationPreferencesService.publishedKindsSchemaVersion,
+      );
+    });
+
+    test('does not republish once the marker is current', () async {
+      final store = _MemoryNotificationPreferencesStore()
+        ..publishedSchemaVersions[pubkey] =
+            NotificationPreferencesService.publishedKindsSchemaVersion;
+      final service = NotificationPreferencesService(
+        store: store,
+        currentPubkey: () => pubkey,
+        publishPreferences: (_, _) async => true,
+      );
+
+      expect(await service.markDirtyIfSchemaOutdated(pubkey), isFalse);
+      expect(
+        await service.syncDirtyPreferencesForPubkey(pubkey),
+        NotificationPreferencesSyncOutcome.nothingToDrain,
+      );
+    });
+
+    test('leaves the marker behind when the publish fails, so the next '
+        'readiness pass retries', () async {
+      final store = _MemoryNotificationPreferencesStore()
+        ..preferences = const NotificationPreferences();
+      final service = NotificationPreferencesService(
+        store: store,
+        currentPubkey: () => pubkey,
+        publishPreferences: (_, _) async => false,
+      );
+
+      await service.markDirtyIfSchemaOutdated(pubkey);
+      final outcome = await service.syncDirtyPreferencesForPubkey(pubkey);
+
+      expect(outcome, NotificationPreferencesSyncOutcome.stillDirty);
+      expect(store.publishedSchemaVersions[pubkey], isNull);
+      // The retry rides the surviving dirty entry rather than a second
+      // schema-triggered mark, so the pending payload is never clobbered.
+      expect(store.dirty[pubkey], isNotNull);
+      expect(await service.markDirtyIfSchemaOutdated(pubkey), isFalse);
+    });
+  });
 }
 
 class _MemoryNotificationPreferencesStore
     implements NotificationPreferencesStore {
+  final publishedSchemaVersions = <String, int>{};
+
+  @override
+  Future<int?> loadPublishedSchemaVersion(String pubkey) async =>
+      publishedSchemaVersions[pubkey];
+
+  @override
+  Future<void> savePublishedSchemaVersion(String pubkey, int version) async {
+    publishedSchemaVersions[pubkey] = version;
+  }
+
   NotificationPreferences? preferences;
   final dirty = <String, NotificationPreferences>{};
 

--- a/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
@@ -61,6 +61,9 @@ void main() {
     ).thenAnswer(
       (_) async => const PeopleListPublishResult.submitted(eventId: 'e1'),
     );
+    when(
+      () => notifyRepository.reconcile(ownerPubkey: any(named: 'ownerPubkey')),
+    ).thenAnswer((_) async => const PeopleListPublishResult.noop());
     followRepository = MockFollowRepository();
     blocklistRepository = _MockContentBlocklistRepository();
     nostrClient = createMockNostrService();
@@ -273,8 +276,9 @@ void main() {
       await tester.pumpWidget(buildWidget());
       await tester.pumpAndSettle();
 
-      // The real repository hands out a seeded BehaviorSubject; the bell is
-      // deliberately inert until that first emission arrives.
+      // The real repository emits nothing until it has actually read the
+      // list, and the bell is deliberately inert until that first emission —
+      // tapping an unverified "off" would publish a replacement list.
       notifySubscriptions.add(const <String>{});
       await tester.pumpAndSettle();
 

--- a/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for profile action button row composition and target gating
 // ABOUTME: Verifies target-directed affordances are absent without explanation
 
+import 'dart:async';
+
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:content_policy/content_policy.dart';
 import 'package:divine_ui/divine_ui.dart';
@@ -10,11 +12,16 @@ import 'package:follow_repository/follow_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/widgets/profile/profile_action_buttons_widget.dart';
+import 'package:openvine/widgets/profile/profile_notify_bell_button.dart';
+import 'package:people_lists_repository/people_lists_repository.dart';
 
 import '../../helpers/test_provider_overrides.dart';
 
 class _MockContentBlocklistRepository extends Mock
     implements ContentBlocklistRepository {}
+
+class _MockNotifySubscriptionsRepository extends Mock
+    implements NotifySubscriptionsRepository {}
 
 void main() {
   const targetPubkey =
@@ -25,8 +32,33 @@ void main() {
   late MockFollowRepository followRepository;
   late _MockContentBlocklistRepository blocklistRepository;
   late MockNostrClient nostrClient;
+  late _MockNotifySubscriptionsRepository notifyRepository;
+  late StreamController<Set<String>> notifySubscriptions;
 
   setUp(() {
+    notifyRepository = _MockNotifySubscriptionsRepository();
+    notifySubscriptions = StreamController<Set<String>>.broadcast();
+    when(
+      () => notifyRepository.watchSubscriptions(
+        ownerPubkey: any(named: 'ownerPubkey'),
+      ),
+    ).thenAnswer((_) => notifySubscriptions.stream);
+    when(
+      () => notifyRepository.subscribe(
+        ownerPubkey: any(named: 'ownerPubkey'),
+        creatorPubkey: any(named: 'creatorPubkey'),
+      ),
+    ).thenAnswer(
+      (_) async => const PeopleListPublishResult.submitted(eventId: 'e1'),
+    );
+    when(
+      () => notifyRepository.unsubscribe(
+        ownerPubkey: any(named: 'ownerPubkey'),
+        creatorPubkey: any(named: 'creatorPubkey'),
+      ),
+    ).thenAnswer(
+      (_) async => const PeopleListPublishResult.submitted(eventId: 'e1'),
+    );
     followRepository = MockFollowRepository();
     blocklistRepository = _MockContentBlocklistRepository();
     nostrClient = createMockNostrService();
@@ -52,6 +84,10 @@ void main() {
     );
   });
 
+  tearDown(() async {
+    await notifySubscriptions.close();
+  });
+
   Widget buildWidget({bool isMessageRestricted = false}) {
     return testMaterialApp(
       home: Scaffold(
@@ -67,6 +103,9 @@ void main() {
       additionalOverrides: [
         contentBlocklistRepositoryProvider.overrideWithValue(
           blocklistRepository,
+        ),
+        notifySubscriptionsRepositoryProvider.overrideWithValue(
+          notifyRepository,
         ),
       ],
       mockFollowRepository: followRepository,
@@ -151,5 +190,97 @@ void main() {
     expect(find.text('Message'), findsNothing);
     expect(find.byType(DivineButton), findsOneWidget);
     expect(find.byType(DivineIconButton), findsOneWidget);
+  });
+
+  group('notification bell', () {
+    late StreamController<List<String>> followingStream;
+
+    setUp(() {
+      followingStream = StreamController<List<String>>.broadcast();
+      when(
+        () => followRepository.followingStream,
+      ).thenAnswer((_) => followingStream.stream);
+    });
+
+    tearDown(() async {
+      await followingStream.close();
+    });
+
+    void followingTarget() {
+      when(
+        () => followRepository.followingPubkeys,
+      ).thenReturn(const [targetPubkey]);
+      when(() => followRepository.watchMyFollowingCached()).thenAnswer(
+        (_) => Stream.value(
+          const CacheResult.live(
+            FollowingSnapshot(pubkeys: [targetPubkey], count: 1),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('is absent when the viewer does not follow the target', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ProfileNotifyBellButton), findsNothing);
+    });
+
+    testWidgets('appears once the viewer follows the target', (tester) async {
+      followingTarget();
+
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ProfileNotifyBellButton), findsOneWidget);
+    });
+
+    testWidgets('tapping it subscribes the viewer to the target', (
+      tester,
+    ) async {
+      followingTarget();
+
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpAndSettle();
+
+      // The real repository hands out a seeded BehaviorSubject; the bell is
+      // deliberately inert until that first emission arrives.
+      notifySubscriptions.add(const <String>{});
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(ProfileNotifyBellButton));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => notifyRepository.subscribe(
+          ownerPubkey: viewerPubkey,
+          creatorPubkey: targetPubkey,
+        ),
+      ).called(1);
+    });
+
+    testWidgets('unfollowing clears the subscription', (tester) async {
+      followingTarget();
+
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpAndSettle();
+      expect(find.byType(ProfileNotifyBellButton), findsOneWidget);
+
+      // The bell unmounts the moment the row flips to not-following, so the
+      // teardown has to be driven from a host above it.
+      when(() => followRepository.followingPubkeys).thenReturn(const []);
+      followingStream.add(const <String>[]);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ProfileNotifyBellButton), findsNothing);
+      verify(
+        () => notifyRepository.unsubscribe(
+          ownerPubkey: viewerPubkey,
+          creatorPubkey: targetPubkey,
+        ),
+      ).called(1);
+    });
   });
 }

--- a/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
@@ -10,6 +10,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/widgets/profile/profile_action_buttons_widget.dart';
 import 'package:openvine/widgets/profile/profile_notify_bell_button.dart';
@@ -88,7 +90,10 @@ void main() {
     await notifySubscriptions.close();
   });
 
-  Widget buildWidget({bool isMessageRestricted = false}) {
+  Widget buildWidget({
+    bool isMessageRestricted = false,
+    bool newPostNotifications = true,
+  }) {
     return testMaterialApp(
       home: Scaffold(
         body: ProfileActionButtons(
@@ -107,6 +112,10 @@ void main() {
         notifySubscriptionsRepositoryProvider.overrideWithValue(
           notifyRepository,
         ),
+        // Ships default-off, so the bell tests have to ask for it.
+        isFeatureEnabledProvider(
+          FeatureFlag.newPostNotifications,
+        ).overrideWithValue(newPostNotifications),
       ],
       mockFollowRepository: followRepository,
       mockNostrService: nostrClient,
@@ -236,6 +245,25 @@ void main() {
 
       expect(find.byType(ProfileNotifyBellButton), findsOneWidget);
     });
+
+    testWidgets(
+      'stays hidden behind the flag, and reads no subscriptions',
+      (tester) async {
+        followingTarget();
+
+        await tester.pumpWidget(buildWidget(newPostNotifications: false));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(ProfileNotifyBellButton), findsNothing);
+        // The cubit must not be constructed either — otherwise a flagged-off
+        // build still hits the relay for a list it can never show.
+        verifyNever(
+          () => notifyRepository.watchSubscriptions(
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+      },
+    );
 
     testWidgets('tapping it subscribes the viewer to the target', (
       tester,

--- a/mobile/test/widgets/settings_screen_scaffold_test.dart
+++ b/mobile/test/widgets/settings_screen_scaffold_test.dart
@@ -152,6 +152,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(sharedPreferences),
             authServiceProvider.overrideWithValue(mockAuthService),
             notificationRepositoryProvider.overrideWithValue(null),
           ],
@@ -178,6 +179,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(sharedPreferences),
             authServiceProvider.overrideWithValue(mockAuthService),
             notificationRepositoryProvider.overrideWithValue(null),
           ],


### PR DESCRIPTION
Closes #6518

## Description

Users asked to be notified when a creator they care about posts. This is the mobile half: a bell on the profiles of people you follow, backed by a NIP-51 people list, plus the notification plumbing to receive and route the resulting push.

**The whole feature ships behind `FF_NEW_POST_NOTIFICATIONS`, default off.** The delivery half lives in `divine-push-service` and has not landed ([divinevideo/divine-push-service#34](https://github.com/divinevideo/divine-push-service/pull/34) is the plan). Merging the UI live would put a bell on every profile that publishes a subscription nothing reads — a control that looks like it works and silently does nothing. Same pattern as `feedTuning` and `publishDmRelayList`.

Commits are separable and each stands alone:

**`fix(people-lists)`: reserve `d=notify`** — the load-bearing one. Kind 30000 lists are decoded into user-editable `UserList`s. Without reserving the `d` tag, a user's bell subscriptions would appear in the curated-lists UI as an ordinary list they could rename or delete, silently unsubscribing themselves from everyone. `d=block` was already reserved; this adds `notify` alongside it.

**`feat(notifications)`: publish kind 34236 in push preferences** — the preferences event enumerates which kinds the push service may deliver. Without 34236 in that list the feature is structurally undeliverable no matter what the service does.

**`feat(notifications)`: add the `newPost` kind** — the enum value, the icon, the cache/server type strings, and tap routing to the video. While wiring this I found and fixed a latent bug: `_mapActorAnchored` had a hand-copied duplicate of `_isVideoAnchoredKind`'s skip list, so every `newPost` row would have rendered twice. It now calls the predicate.

**`feat(people-lists)`: the `d=notify` repository** — reads and mutates the subscription list. Two things here are not obvious and are pinned by tests:

- All bells live in *one* replaceable event, so mutations are serialized through a single per-owner queue. Per-pubkey serialization would still race. The queue tail deliberately swallows errors — otherwise one failed publish poisons every mutation queued behind it.
- `created_at` steps past the previous event rather than using wall-clock seconds. NIP-33 leaves same-second tie-breaking unspecified, so two mutations inside one second can resolve to either.

**`feat(profile)`: the follow-gated bell** — optimistic toggle with revert on failure. Unfollow tears the subscription down, bridged from a host *above* the bell, because the bell has already unmounted by the time the follow state flips.

**`fix(notifications)`: republish preferences after a kinds-list change** — an upgrading user's stored preferences read back with `newPostsEnabled` on locally while the push service still holds the pre-upgrade kind list. Only an explicit user edit marked preferences dirty, so nothing ever republished. A persisted schema-version marker now triggers one republish on the first ready session after upgrade. I originally described this as self-healing in a commit message; it wasn't, and this commit is the fix.

**`feat(notifications)`: the feature flag** — gates the bell, the settings row, and `NotifyBellCubit` construction, so a flagged-off build never reads the subscription list from the relay.

**Related Issue:** Relates to divinevideo/divine-push-service#34

## Out of Scope

- **Delivery.** `divine-push-service` fans kind 34236 out to `d=notify` subscribers; tracked in that repo's PR #34, unimplemented.
- **The in-app notification row.** FunnelCake has the contract but no owner. It would be the inbox's first subscription-driven fan-out — every existing source reads recipients off tags on the event, whereas new-post rows have no `p` tag.
- **Reserved-tag squatting.** A pre-existing `d=notify` list this app didn't write is currently overwritten rather than detected. Noted in the design doc.
- **Copy and translations.** The 6 new ARB keys × 17 locales are mine and unreviewed — they need a brand pass and native-speaker review before the flag is flipped on.

## Verification

- `flutter analyze lib test integration_test` — clean
- 555 tests across `test/l10n`, `test/core/feature_flag_test.dart`, `test/features/feature_flags`, `test/screens/notification_settings_screen_test.dart`, `test/widgets/profile`, `test/blocs/notify_bell`, `test/blocs/notification_settings`, `test/services/notification_preferences_service_test.dart`, `test/providers/push_notification_sync_test.dart`, `test/notifications`
- `packages/people_lists_repository` — 76 tests, coverage 96.57% vs its 95 gate
- `packages/models` — 829 tests; `packages/notification_repository` — 160 tests
- Two tests were checked against the can-it-fail bar by breaking the code and confirming they go red: the flag gate, and the mutation-serialization test (which initially passed with the queue removed and was strengthened until it didn't)

Rebased onto fresh `origin/main`; the l10n and `repository_providers` conflicts against #6480 were resolved keeping both sides, and generated l10n was regenerated rather than hand-merged.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
