### PR TITLE
fix(snackbar): stop actions that outlive their screen reading a dead context

### DIFF
--- a/mobile/lib/screens/settings/bluesky_settings_screen.dart
+++ b/mobile/lib/screens/settings/bluesky_settings_screen.dart
@@ -123,6 +123,7 @@ class _BlueskySettingsView extends StatelessWidget {
     // defunct element, whose inherited-widget map the framework has already
     // cleared.
     final cubit = context.read<CrosspostSettingsCubit>();
+    final router = GoRouter.of(context);
     switch (state.error) {
       case CrosspostSettingsError.usernameNotClaimed:
         messenger.showSnackBar(
@@ -137,7 +138,7 @@ class _BlueskySettingsView extends StatelessWidget {
                 // tracks whether the screen the action refers to still exists.
                 if (cubit.isClosed) return;
                 cubit.acknowledgeError();
-                unawaited(_openClaimFlowAndRefresh(context, cubit));
+                unawaited(_openClaimFlowAndRefresh(router, cubit));
               },
             ),
           ),
@@ -217,7 +218,7 @@ class _UsernameRequiredNotice extends StatelessWidget {
       trailing: TextButton(
         onPressed: () => unawaited(
           _openClaimFlowAndRefresh(
-            context,
+            GoRouter.of(context),
             context.read<CrosspostSettingsCubit>(),
           ),
         ),
@@ -231,14 +232,11 @@ class _UsernameRequiredNotice extends StatelessWidget {
 }
 
 Future<void> _openClaimFlowAndRefresh(
-  BuildContext context,
+  GoRouter router,
   CrosspostSettingsCubit cubit,
 ) async {
-  await context.push(Nip05SettingsScreen.path);
-  // `context.mounted` only goes false once the element is unmounted, and the
-  // framework clears the inherited-widget map one step earlier — so pair it
-  // with the cubit's own liveness rather than trusting it alone.
-  if (!context.mounted || cubit.isClosed) return;
+  await router.push(Nip05SettingsScreen.path);
+  if (cubit.isClosed) return;
   await cubit.loadStatus();
 }
 

--- a/mobile/lib/screens/settings/bluesky_settings_screen.dart
+++ b/mobile/lib/screens/settings/bluesky_settings_screen.dart
@@ -117,6 +117,12 @@ class _BlueskySettingsView extends StatelessWidget {
     if (state.status != CrosspostSettingsStatus.failure) return;
 
     final messenger = ScaffoldMessenger.of(context);
+    // Captured here, while the route is still mounted. The root
+    // ScaffoldMessenger lives above the Navigator, so this snackbar outlives a
+    // pop — reading the cubit off [context] inside the action would then hit a
+    // defunct element, whose inherited-widget map the framework has already
+    // cleared.
+    final cubit = context.read<CrosspostSettingsCubit>();
     switch (state.error) {
       case CrosspostSettingsError.usernameNotClaimed:
         messenger.showSnackBar(
@@ -127,8 +133,11 @@ class _BlueskySettingsView extends StatelessWidget {
               label: context.l10n.blueskySetUpHandle,
               textColor: context.vineColors.primaryText,
               onPressed: () {
-                context.read<CrosspostSettingsCubit>().acknowledgeError();
-                unawaited(_openClaimFlowAndRefresh(context));
+                // BlocProvider closes the cubit when the route pops, so this
+                // tracks whether the screen the action refers to still exists.
+                if (cubit.isClosed) return;
+                cubit.acknowledgeError();
+                unawaited(_openClaimFlowAndRefresh(context, cubit));
               },
             ),
           ),
@@ -206,7 +215,12 @@ class _UsernameRequiredNotice extends StatelessWidget {
         style: TextStyle(color: context.vineColors.mutedText, fontSize: 14),
       ),
       trailing: TextButton(
-        onPressed: () => unawaited(_openClaimFlowAndRefresh(context)),
+        onPressed: () => unawaited(
+          _openClaimFlowAndRefresh(
+            context,
+            context.read<CrosspostSettingsCubit>(),
+          ),
+        ),
         child: Text(
           context.l10n.blueskySetUpHandle,
           style: const TextStyle(color: VineTheme.vineGreen),
@@ -216,10 +230,15 @@ class _UsernameRequiredNotice extends StatelessWidget {
   }
 }
 
-Future<void> _openClaimFlowAndRefresh(BuildContext context) async {
-  final cubit = context.read<CrosspostSettingsCubit>();
+Future<void> _openClaimFlowAndRefresh(
+  BuildContext context,
+  CrosspostSettingsCubit cubit,
+) async {
   await context.push(Nip05SettingsScreen.path);
-  if (!context.mounted) return;
+  // `context.mounted` only goes false once the element is unmounted, and the
+  // framework clears the inherited-widget map one step earlier — so pair it
+  // with the cubit's own liveness rather than trusting it alone.
+  if (!context.mounted || cubit.isClosed) return;
   await cubit.loadStatus();
 }
 

--- a/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
+++ b/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
@@ -163,6 +163,16 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
   ScaffoldFeatureController<SnackBar, SnackBarClosedReason>?
   _retrySnackBarController;
 
+  /// Whether the retry snackbar reached the front of the messenger's queue.
+  ///
+  /// `close()` asserts the controller it belongs to is that front entry, so one
+  /// still waiting behind another snackbar must be left alone.
+  bool _retrySnackBarVisible = false;
+
+  /// Captured while mounted so the deferred close in [dispose] can check the
+  /// messenger is still alive without a lookup on a defunct element.
+  ScaffoldMessengerState? _messenger;
+
   DmReplyContext get _ctx => widget.dmReplyContext;
 
   @override
@@ -178,9 +188,15 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _messenger = ScaffoldMessenger.of(context);
+  }
+
+  @override
   void dispose() {
     _throttleTimer?.cancel();
-    _retrySnackBarController?.close();
+    _closeRetrySnackBar(deferred: true);
     _controller
       ..removeListener(_handleTextChanged)
       ..dispose();
@@ -331,9 +347,10 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
       }
       _announce(context.l10n.dmReelReplyFailed);
       _showRetrySnackBar(
-        SnackBar(
+        (markVisible) => SnackBar(
           content: Text(context.l10n.dmReelReplyFailed),
           behavior: SnackBarBehavior.floating,
+          onVisible: markVisible,
           action: SnackBarAction(
             label: context.l10n.dmSendFailedRetry,
             onPressed: () {
@@ -357,7 +374,7 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
         'dm_reel_reply_sent',
         params: {'is_group': _ctx.isGroup ? 1 : 0},
       );
-      _retrySnackBarController?.close();
+      _closeRetrySnackBar();
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(context.l10n.shareSent),
@@ -378,17 +395,53 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
     cubit.acknowledge();
   }
 
-  void _showRetrySnackBar(SnackBar snackBar) {
-    _retrySnackBarController?.close();
-    final controller = ScaffoldMessenger.of(context).showSnackBar(snackBar);
+  void _showRetrySnackBar(
+    SnackBar Function(VoidCallback markVisible) buildSnackBar,
+  ) {
+    _closeRetrySnackBar();
+    late ScaffoldFeatureController<SnackBar, SnackBarClosedReason> controller;
+    controller = ScaffoldMessenger.of(context).showSnackBar(
+      buildSnackBar(() {
+        if (_retrySnackBarController == controller) {
+          _retrySnackBarVisible = true;
+        }
+      }),
+    );
     _retrySnackBarController = controller;
+    _retrySnackBarVisible = false;
     unawaited(
       controller.closed.then((_) {
         if (_retrySnackBarController == controller) {
           _retrySnackBarController = null;
+          _retrySnackBarVisible = false;
         }
       }),
     );
+  }
+
+  /// Dismisses the retry snackbar so its now-inert CTA leaves with the bar.
+  ///
+  /// Left alone while it is still queued behind another snackbar: `close()`
+  /// asserts it is the front of the messenger's queue, and without the assert
+  /// it dismisses whichever snackbar *is* in front. The action is harmless
+  /// either way — it checks `mounted` before touching anything.
+  ///
+  /// From [dispose] the close must be [deferred]. Under `accessibleNavigation`
+  /// the messenger skips the exit animation and rebuilds synchronously, which
+  /// the framework forbids while it holds the state lock to unmount us.
+  void _closeRetrySnackBar({bool deferred = false}) {
+    final controller = _retrySnackBarController;
+    if (controller == null || !_retrySnackBarVisible) return;
+    _retrySnackBarController = null;
+    _retrySnackBarVisible = false;
+    if (!deferred) {
+      controller.close();
+      return;
+    }
+    final messenger = _messenger;
+    scheduleMicrotask(() {
+      if (messenger?.mounted ?? false) controller.close();
+    });
   }
 
   void _announce(String message) {

--- a/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
+++ b/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
@@ -160,6 +160,9 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
   /// Optimistically-selected emoji, highlighted immediately on tap.
   String? _optimisticEmoji;
 
+  ScaffoldFeatureController<SnackBar, SnackBarClosedReason>?
+  _retrySnackBarController;
+
   DmReplyContext get _ctx => widget.dmReplyContext;
 
   @override
@@ -177,6 +180,7 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
   @override
   void dispose() {
     _throttleTimer?.cancel();
+    _retrySnackBarController?.close();
     _controller
       ..removeListener(_handleTextChanged)
       ..dispose();
@@ -302,14 +306,12 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
     }
   }
 
-  void _openChat() {
-    // Reachable from a snackbar action that outlives the player route, where
-    // the lookup would fail with "No GoRouter found in context".
-    if (!mounted) return;
-    context.push(
-      ConversationPage.pathForId(_ctx.conversationId),
-      extra: _ctx.participantPubkeys,
-    );
+  void _openChat(
+    GoRouter router, {
+    required String conversationPath,
+    required List<String> participantPubkeys,
+  }) {
+    router.push(conversationPath, extra: participantPubkeys);
   }
 
   void _onReplyOutcome(InlineReelReplyState state) {
@@ -328,46 +330,65 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
         _controller.selection = TextSelection.collapsed(offset: draft.length);
       }
       _announce(context.l10n.dmReelReplyFailed);
-      ScaffoldMessenger.of(context)
-        ..hideCurrentSnackBar()
-        ..showSnackBar(
-          SnackBar(
-            content: Text(context.l10n.dmReelReplyFailed),
-            behavior: SnackBarBehavior.floating,
-            action: SnackBarAction(
-              label: context.l10n.dmSendFailedRetry,
-              onPressed: () {
-                // `mounted` also guards `_controller`, which dispose() tears
-                // down along with the rest of this State.
-                if (draft.isEmpty || !mounted || cubit.isClosed) return;
-                _pendingDraft = draft;
-                cubit.submit(draft);
-                _controller.clear();
-              },
-            ),
+      _showRetrySnackBar(
+        SnackBar(
+          content: Text(context.l10n.dmReelReplyFailed),
+          behavior: SnackBarBehavior.floating,
+          action: SnackBarAction(
+            label: context.l10n.dmSendFailedRetry,
+            onPressed: () {
+              // `mounted` also guards `_controller`, which dispose() tears
+              // down along with the rest of this State.
+              if (draft.isEmpty || !mounted || cubit.isClosed) return;
+              _pendingDraft = draft;
+              cubit.submit(draft);
+              _controller.clear();
+            },
           ),
-        );
+        ),
+      );
     } else {
+      final router = GoRouter.maybeOf(context);
+      final conversationPath = ConversationPage.pathForId(_ctx.conversationId);
+      final participantPubkeys = List<String>.of(_ctx.participantPubkeys);
       _announce(context.l10n.dmReelReplySentAnnouncement);
       ScreenAnalyticsService().trackInteraction(
         ReelReplyConstants.analyticsScreen,
         'dm_reel_reply_sent',
         params: {'is_group': _ctx.isGroup ? 1 : 0},
       );
-      ScaffoldMessenger.of(context)
-        ..hideCurrentSnackBar()
-        ..showSnackBar(
-          SnackBar(
-            content: Text(context.l10n.shareSent),
-            behavior: SnackBarBehavior.floating,
-            action: SnackBarAction(
-              label: context.l10n.dmReelReplyViewChat,
-              onPressed: _openChat,
-            ),
-          ),
-        );
+      _retrySnackBarController?.close();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(context.l10n.shareSent),
+          behavior: SnackBarBehavior.floating,
+          action: router == null
+              ? null
+              : SnackBarAction(
+                  label: context.l10n.dmReelReplyViewChat,
+                  onPressed: () => _openChat(
+                    router,
+                    conversationPath: conversationPath,
+                    participantPubkeys: participantPubkeys,
+                  ),
+                ),
+        ),
+      );
     }
     cubit.acknowledge();
+  }
+
+  void _showRetrySnackBar(SnackBar snackBar) {
+    _retrySnackBarController?.close();
+    final controller = ScaffoldMessenger.of(context).showSnackBar(snackBar);
+    _retrySnackBarController = controller;
+    unawaited(
+      controller.closed.then((_) {
+        if (_retrySnackBarController == controller) {
+          _retrySnackBarController = null;
+        }
+      }),
+    );
   }
 
   void _announce(String message) {

--- a/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
+++ b/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
@@ -303,6 +303,9 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
   }
 
   void _openChat() {
+    // Reachable from a snackbar action that outlives the player route, where
+    // the lookup would fail with "No GoRouter found in context".
+    if (!mounted) return;
     context.push(
       ConversationPage.pathForId(_ctx.conversationId),
       extra: _ctx.participantPubkeys,
@@ -312,6 +315,11 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
   void _onReplyOutcome(InlineReelReplyState state) {
     final draft = _pendingDraft;
     _pendingDraft = '';
+
+    // Captured while the bar is still mounted. Snackbars are hosted by the root
+    // ScaffoldMessenger, above the Navigator, so their actions can fire after
+    // the player route is gone and this element is defunct.
+    final cubit = context.read<InlineReelReplyCubit>();
 
     if (state.status == InlineReelReplyStatus.failure) {
       // Restore the draft so the user can retry without retyping.
@@ -329,11 +337,12 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
             action: SnackBarAction(
               label: context.l10n.dmSendFailedRetry,
               onPressed: () {
-                if (draft.isNotEmpty) {
-                  _pendingDraft = draft;
-                  context.read<InlineReelReplyCubit>().submit(draft);
-                  _controller.clear();
-                }
+                // `mounted` also guards `_controller`, which dispose() tears
+                // down along with the rest of this State.
+                if (draft.isEmpty || !mounted || cubit.isClosed) return;
+                _pendingDraft = draft;
+                cubit.submit(draft);
+                _controller.clear();
               },
             ),
           ),
@@ -358,7 +367,7 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
           ),
         );
     }
-    context.read<InlineReelReplyCubit>().acknowledge();
+    cubit.acknowledge();
   }
 
   void _announce(String message) {

--- a/mobile/test/screens/settings/bluesky_settings_screen_test.dart
+++ b/mobile/test/screens/settings/bluesky_settings_screen_test.dart
@@ -26,6 +26,9 @@ void main() {
 
     const claimRouteMarker = 'NIP05 CLAIM ROUTE';
     const returnFromClaimFlow = 'Return from claim flow';
+    const homePath = '/';
+    const openSettings = 'Open Bluesky settings';
+    late GoRouter router;
 
     setUp(() {
       authService = _MockAuthService();
@@ -43,10 +46,19 @@ void main() {
       );
     });
 
-    Widget buildApp() {
-      final router = GoRouter(
-        initialLocation: BlueskySettingsScreen.path,
+    Widget buildApp({bool startAtHome = false}) {
+      router = GoRouter(
+        initialLocation: startAtHome ? homePath : BlueskySettingsScreen.path,
         routes: [
+          GoRoute(
+            path: homePath,
+            builder: (context, _) => Scaffold(
+              body: TextButton(
+                onPressed: () => context.push(BlueskySettingsScreen.path),
+                child: const Text(openSettings),
+              ),
+            ),
+          ),
           GoRoute(
             path: BlueskySettingsScreen.path,
             builder: (_, _) => const BlueskySettingsScreen(),
@@ -300,6 +312,44 @@ void main() {
           find.widgetWithText(TextButton, l10n.blueskySetUpHandle),
           findsNothing,
         );
+      },
+    );
+
+    testWidgets(
+      'snackbar claim action survives the settings route being popped',
+      (tester) async {
+        when(
+          () => profileRepository.lookupUsernameByPubkey(
+            pubkeyHex: any(named: 'pubkeyHex'),
+          ),
+        ).thenAnswer((_) async => const DivineUsernameNotFound());
+        when(() => apiClient.getStatus()).thenAnswer(
+          (_) async => const CrosspostStatus(crosspostEnabled: false),
+        );
+
+        await tester.pumpWidget(buildApp(startAtHome: true));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text(openSettings));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byType(Switch));
+        await tester.pumpAndSettle();
+        expect(find.byType(SnackBarAction), findsOneWidget);
+
+        // The root ScaffoldMessenger sits above the Navigator, so the snackbar
+        // migrates to the previous route's Scaffold instead of going away.
+        router.pop();
+        await tester.pumpAndSettle();
+        expect(find.text(openSettings), findsOneWidget);
+        expect(find.byType(SnackBarAction), findsOneWidget);
+
+        await tester.tap(find.text(l10n.blueskySetUpHandle).last);
+        await tester.pumpAndSettle();
+
+        // The action is inert rather than throwing on the defunct context.
+        expect(tester.takeException(), isNull);
+        expect(find.text(claimRouteMarker), findsNothing);
       },
     );
 

--- a/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
+++ b/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
@@ -96,6 +96,34 @@ void main() {
     ),
   );
 
+  /// The bar under a switch, so a test can take it out of the tree the way
+  /// scrolling to the next reel does.
+  Widget toggleableBarApp(ValueNotifier<bool> barVisible, DmReplyContext ctx) =>
+      ProviderScope(
+        overrides: [
+          dmRepositoryProvider.overrideWithValue(dmRepo),
+          dmReactionsRepositoryProvider.overrideWithValue(reactionsRepo),
+          authServiceProvider.overrideWithValue(auth),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Builder(
+              builder: (inner) => MediaQuery(
+                data: MediaQuery.of(inner).copyWith(disableAnimations: true),
+                child: ValueListenableBuilder<bool>(
+                  valueListenable: barVisible,
+                  builder: (_, visible, _) => visible
+                      ? ReelDmReplyBarHost(dmReplyContext: ctx)
+                      : const SizedBox.shrink(),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
   testWidgets('renders composer + the 6 quick emojis + picker button', (
     tester,
   ) async {
@@ -454,32 +482,7 @@ void main() {
     final barVisible = ValueNotifier(true);
     addTearDown(barVisible.dispose);
 
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          dmRepositoryProvider.overrideWithValue(dmRepo),
-          dmReactionsRepositoryProvider.overrideWithValue(reactionsRepo),
-          authServiceProvider.overrideWithValue(auth),
-        ],
-        child: MaterialApp(
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: Scaffold(
-            body: Builder(
-              builder: (inner) => MediaQuery(
-                data: MediaQuery.of(inner).copyWith(disableAnimations: true),
-                child: ValueListenableBuilder<bool>(
-                  valueListenable: barVisible,
-                  builder: (_, visible, _) => visible
-                      ? ReelDmReplyBarHost(dmReplyContext: context())
-                      : const SizedBox.shrink(),
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
+    await tester.pumpWidget(toggleableBarApp(barVisible, context()));
     await tester.pump();
 
     await tester.enterText(find.byType(TextField), 'hello');
@@ -503,6 +506,87 @@ void main() {
         replyToId: _reelId,
       ),
     ).called(1);
+  });
+
+  testWidgets('leaves a queued retry snackbar for whatever is on screen', (
+    tester,
+  ) async {
+    when(
+      () => dmRepo.sendMessage(
+        recipientPubkey: any(named: 'recipientPubkey'),
+        content: any(named: 'content'),
+        replyToId: any(named: 'replyToId'),
+      ),
+    ).thenThrow(Exception('send failed'));
+
+    final barVisible = ValueNotifier(true);
+    addTearDown(barVisible.dispose);
+
+    await tester.pumpWidget(toggleableBarApp(barVisible, context()));
+    await tester.pump();
+
+    // Something else on the reel route got to the messenger first, so the
+    // retry snackbar queues behind it instead of showing.
+    tester
+        .state<ScaffoldMessengerState>(find.byType(ScaffoldMessenger).first)
+        .showSnackBar(
+          const SnackBar(
+            content: Text('unrelated'),
+            duration: Duration(seconds: 30),
+          ),
+        );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'hello');
+    await tester.pump();
+    await tester.tap(find.byType(IconButton));
+    await tester.pumpAndSettle();
+
+    barVisible.value = false;
+    await tester.pumpAndSettle();
+
+    // Closing a queued snackbar would have dismissed this one instead.
+    expect(tester.takeException(), isNull);
+    expect(find.text('unrelated'), findsOneWidget);
+  });
+
+  testWidgets('closes the retry snackbar when navigation is accessible', (
+    tester,
+  ) async {
+    // The messenger skips the exit animation in this mode and rebuilds
+    // synchronously, which the framework rejects while it is unmounting the
+    // bar unless the close is deferred past the state lock.
+    tester.platformDispatcher.accessibilityFeaturesTestValue =
+        const FakeAccessibilityFeatures(accessibleNavigation: true);
+    addTearDown(tester.platformDispatcher.clearAccessibilityFeaturesTestValue);
+
+    when(
+      () => dmRepo.sendMessage(
+        recipientPubkey: any(named: 'recipientPubkey'),
+        content: any(named: 'content'),
+        replyToId: any(named: 'replyToId'),
+      ),
+    ).thenThrow(Exception('send failed'));
+
+    final barVisible = ValueNotifier(true);
+    addTearDown(barVisible.dispose);
+
+    await tester.pumpWidget(toggleableBarApp(barVisible, context()));
+    await tester.pump();
+
+    await tester.enterText(find.byType(TextField), 'hello');
+    await tester.pump();
+    await tester.tap(find.byType(IconButton));
+    await tester.pumpAndSettle();
+
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    expect(find.text(l10n.dmSendFailedRetry), findsOneWidget);
+
+    barVisible.value = false;
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text(l10n.dmSendFailedRetry), findsNothing);
   });
 
   testWidgets('view chat action navigates after the bar leaves the tree', (

--- a/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
+++ b/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
@@ -6,11 +6,13 @@ import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/dm_reply_context.dart';
+import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/widgets/video_feed_item/reel_dm_reply_bar.dart';
 
@@ -438,7 +440,9 @@ void main() {
     expect(reacted, isNull);
   });
 
-  testWidgets('retry action survives the bar leaving the tree', (tester) async {
+  testWidgets('retry action closes when the bar leaves the tree', (
+    tester,
+  ) async {
     when(
       () => dmRepo.sendMessage(
         recipientPubkey: any(named: 'recipientPubkey'),
@@ -486,17 +490,11 @@ void main() {
     final l10n = lookupAppLocalizations(const Locale('en'));
     expect(find.text(l10n.dmSendFailedRetry), findsOneWidget);
 
-    // The player route goes away; the app-level ScaffoldMessenger keeps the
-    // snackbar — and its action — on screen.
     barVisible.value = false;
     await tester.pumpAndSettle();
     expect(find.byType(TextField), findsNothing);
-    expect(find.text(l10n.dmSendFailedRetry), findsOneWidget);
+    expect(find.text(l10n.dmSendFailedRetry), findsNothing);
 
-    await tester.tap(find.text(l10n.dmSendFailedRetry));
-    await tester.pumpAndSettle();
-
-    // Inert rather than throwing on the defunct context: no second send.
     expect(tester.takeException(), isNull);
     verify(
       () => dmRepo.sendMessage(
@@ -505,5 +503,90 @@ void main() {
         replyToId: _reelId,
       ),
     ).called(1);
+  });
+
+  testWidgets('view chat action navigates after the bar leaves the tree', (
+    tester,
+  ) async {
+    when(
+      () => dmRepo.sendMessage(
+        recipientPubkey: any(named: 'recipientPubkey'),
+        content: any(named: 'content'),
+        replyToId: any(named: 'replyToId'),
+      ),
+    ).thenAnswer(
+      (_) async => NIP17SendResult.success(
+        rumorEventId: 'rumor-id',
+        messageEventId: 'message-id',
+        recipientPubkey: _peer,
+      ),
+    );
+
+    final barVisible = ValueNotifier(true);
+    addTearDown(barVisible.dispose);
+    final dmContext = context();
+
+    final router = GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, _) => Scaffold(
+            body: Builder(
+              builder: (inner) => MediaQuery(
+                data: MediaQuery.of(inner).copyWith(disableAnimations: true),
+                child: ValueListenableBuilder<bool>(
+                  valueListenable: barVisible,
+                  builder: (_, visible, _) => visible
+                      ? ReelDmReplyBarHost(dmReplyContext: dmContext)
+                      : const SizedBox.shrink(),
+                ),
+              ),
+            ),
+          ),
+        ),
+        GoRoute(
+          path: ConversationPage.pathPattern,
+          builder: (_, state) => Scaffold(
+            body: Text('conversation ${state.pathParameters['id']}'),
+          ),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          dmRepositoryProvider.overrideWithValue(dmRepo),
+          dmReactionsRepositoryProvider.overrideWithValue(reactionsRepo),
+          authServiceProvider.overrideWithValue(auth),
+        ],
+        child: MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.enterText(find.byType(TextField), 'hello');
+    await tester.pump();
+    await tester.tap(find.byType(IconButton));
+    await tester.pumpAndSettle();
+
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    expect(find.text(l10n.dmReelReplyViewChat), findsOneWidget);
+
+    barVisible.value = false;
+    await tester.pumpAndSettle();
+    expect(find.byType(TextField), findsNothing);
+    expect(find.text(l10n.dmReelReplyViewChat), findsOneWidget);
+
+    await tester.tap(find.text(l10n.dmReelReplyViewChat));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('conversation convo-id'), findsOneWidget);
   });
 }

--- a/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
+++ b/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
@@ -437,4 +437,73 @@ void main() {
     ).called(1);
     expect(reacted, isNull);
   });
+
+  testWidgets('retry action survives the bar leaving the tree', (tester) async {
+    when(
+      () => dmRepo.sendMessage(
+        recipientPubkey: any(named: 'recipientPubkey'),
+        content: any(named: 'content'),
+        replyToId: any(named: 'replyToId'),
+      ),
+    ).thenThrow(Exception('send failed'));
+
+    final barVisible = ValueNotifier(true);
+    addTearDown(barVisible.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          dmRepositoryProvider.overrideWithValue(dmRepo),
+          dmReactionsRepositoryProvider.overrideWithValue(reactionsRepo),
+          authServiceProvider.overrideWithValue(auth),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Builder(
+              builder: (inner) => MediaQuery(
+                data: MediaQuery.of(inner).copyWith(disableAnimations: true),
+                child: ValueListenableBuilder<bool>(
+                  valueListenable: barVisible,
+                  builder: (_, visible, _) => visible
+                      ? ReelDmReplyBarHost(dmReplyContext: context())
+                      : const SizedBox.shrink(),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.enterText(find.byType(TextField), 'hello');
+    await tester.pump();
+    await tester.tap(find.byType(IconButton));
+    await tester.pumpAndSettle();
+
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    expect(find.text(l10n.dmSendFailedRetry), findsOneWidget);
+
+    // The player route goes away; the app-level ScaffoldMessenger keeps the
+    // snackbar — and its action — on screen.
+    barVisible.value = false;
+    await tester.pumpAndSettle();
+    expect(find.byType(TextField), findsNothing);
+    expect(find.text(l10n.dmSendFailedRetry), findsOneWidget);
+
+    await tester.tap(find.text(l10n.dmSendFailedRetry));
+    await tester.pumpAndSettle();
+
+    // Inert rather than throwing on the defunct context: no second send.
+    expect(tester.takeException(), isNull);
+    verify(
+      () => dmRepo.sendMessage(
+        recipientPubkey: _peer,
+        content: 'hello',
+        replyToId: _reelId,
+      ),
+    ).called(1);
+  });
 }


### PR DESCRIPTION
## Description

Snackbar actions that call `context.read<T>()` throw when tapped after their screen is gone. `MaterialApp`'s root `ScaffoldMessenger` sits above the `Navigator` — the repo sets no `scaffoldMessengerKey` and installs no app-level messenger — so a snackbar migrates to the next route's `Scaffold` on a pop and stays tappable long after the widget that created it is defunct.

Traced from Crashlytics issue `a8c821212ea690bd4ecf96e4a9d696c9` on 1.0.17 (813), whose sampled session lands on `bluesky_settings_screen.dart:109`.

### Root cause

`provider.dart:377` (provider 6.1.5+1) is `throw ProviderNotFoundException(T, context.widget.runtimeType);`. Reaching it means `_inheritedElements?[T]` was null — and `Element._ensureDeactivated()` (framework.dart:4820), which always runs right after `Element.deactivate()`, sets `_inheritedElements = null`. Every provider lookup on a deactivated element therefore returns null regardless of what is in the tree.

That produces two different Crashlytics messages from one defect, which is why they were merged into a single issue:

- **deactivated, still mounted** → the real `ProviderNotFoundException`
- **unmounted** → `context.widget` throws first (`Widget get widget => _widget!`, framework.dart:3653) → `Null check operator used on a null value`, masking it

The app never crashed: `GestureRecognizer.invokeCallback` caught the error and `crash_reporting_service.dart:45` forwarded it via `recordFlutterFatalError`. The visible symptom was a CTA that silently did nothing.

`context.mounted` is **not** a sufficient guard here — `Element.mounted => _widget != null`, and `_widget` is nulled in `unmount()`, one step *after* the inherited-widget map is cleared. The fix captures dependencies while the route is mounted, gates bloc work on `isClosed` / `State.mounted`, and captures router/path data for navigation actions that can still be honored after the original widget is gone.

### Commits

1. **`fix(bluesky)`** — the crosspost failure snackbar's **Set up handle** action, plus `_openClaimFlowAndRefresh`, which did a second `context.read` and a `context.push` on the same tap.
2. **`fix(dm)`** — the reel reply bar's **Retry** action (same `context.read` shape) and **View chat**, which would have thrown `No GoRouter found in context`. Both reachable after scrolling to the next reel disposes the bar.
3. **`fix(snackbar)`** — follow-up takeover cleanup: captures `GoRouter` for claim routing, closes the retry snackbar when its reply bar is disposed, and keeps **View chat** functional after the bar is gone by capturing router/path data.
4. **`fix(dm)`** — hardens that dispose-time close against two framework asserts it could trip. `ScaffoldFeatureController.close()` asserts it owns the front of the messenger's queue, so a retry snackbar queued behind one of the six other snackbars on the reel route threw `'_snackBars.first == controller'` — and without the assert it would have dismissed that other snackbar instead; the close is now gated on `SnackBar.onVisible`, the only public signal that ours reached the front. Under `accessibleNavigation` the messenger skips the exit animation and rebuilds synchronously, so the close reached `setState` while `BuildOwner.lockState` was unmounting the bar (`setState() or markNeedsBuild() called when widget tree was locked.`); that one call is now deferred to a microtask past the lock, and dropped if the captured messenger is gone by then.

A sweep of all 6 `SnackBarAction` sites in `mobile/lib` found the other four already correct — `user_list_people_screen.dart:723`, `video_publish_provider.dart:630`, `support_center_screen.dart:192` and `profile_avatar_section.dart:284` each capture their dependency before building the action, which is the pattern these two were missing.

No behaviour change while the screen is alive.

**Related Issue:** Closes #6520

## Out of Scope

- The same Crashlytics issue carries a sample reading `Provider<OthersFollowersBloc> not found for BlocBuilder<OthersFollowersBloc, OthersFollowersState>`. That sample's stack is not in the export, so its call path is unconfirmed. The only live such `BlocBuilder` is `others_followers_screen.dart:106`, whose `MultiBlocProvider` is created directly above it in the same route widget, so a genuinely-missing provider is not reachable there — tracked in #6527 pending a sample with frames.
- `mobile/lib/widgets/profile/profile_followers_stat.dart` holds a second `BlocBuilder<OthersFollowersBloc, …>` that *would* hit a genuinely-missing provider, but the widget has had zero call sites since at least 1.0.13. Dead code, tracked in #6528.

## Verification

Regression tests were confirmed to fail without their fix, with the debug-mode counterpart of the release crash:

- `bluesky_settings_screen_test.dart` → `Looking up a deactivated widget's ancestor is unsafe.`
- `reel_dm_reply_bar_test.dart` → `This widget has been unmounted, so the State no longer has a context (and should be considered defunct).`
- `leaves a queued retry snackbar for whatever is on screen` → `'_snackBars.first == controller': is not true.`
- `closes the retry snackbar when navigation is accessible` → `setState() or markNeedsBuild() called when widget tree was locked.`

Run from `mobile/`:

- `flutter test test/screens/settings/bluesky_settings_screen_test.dart test/widgets/video_feed_item/reel_dm_reply_bar_test.dart` — passed
- `flutter test test/blocs/crosspost_settings/ test/blocs/dm/inline_reel_reply/ test/screens/settings/ test/widgets/video_feed_item/` — 450 passed (rebased onto current main)
- `flutter analyze lib test integration_test` — No issues found
- `mise exec -- dart format lib test integration_test` — 2814 files checked, 0 changed

No screenshots: there is no visual change.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

