### PR TITLE
fix(theme): finish the light-mode contrast pass #6467 left open

### DIFF
--- a/mobile/lib/screens/comments/widgets/comment_options_modal.dart
+++ b/mobile/lib/screens/comments/widgets/comment_options_modal.dart
@@ -168,7 +168,10 @@ class _OptionTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final color = isDestructive
-        ? VineTheme.likeRed
+        // The sheet surface follows the palette now, and fixed `likeRed` only
+        // holds 4.13:1 on the light one. The palette token is `likeRed`
+        // verbatim on dark, so that rendering is unchanged.
+        ? context.vineColors.onErrorContainer
         : context.vineColors.onSurface;
 
     return Semantics(
@@ -291,7 +294,10 @@ class _FlagContentSheetState extends State<_FlagContentSheet> {
                     ? VineTheme.vineGreen
                     : context.vineColors.containerLow,
                 foregroundColor: _selectedReason != null
-                    ? context.vineColors.background
+                    // The fill above is the fixed brand green, so its label
+                    // has to be fixed too — the palette `background` token
+                    // goes near-white on light and drops to 2.08:1.
+                    ? VineTheme.onPrimary
                     : context.vineColors.onSurfaceMuted,
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(24),
@@ -302,7 +308,7 @@ class _FlagContentSheetState extends State<_FlagContentSheet> {
                 context.l10n.commentOptionsFlagSubmit,
                 style: VineTheme.labelLargeFont(
                   color: _selectedReason != null
-                      ? context.vineColors.background
+                      ? VineTheme.onPrimary
                       : context.vineColors.onSurfaceMuted,
                 ),
               ),
@@ -313,6 +319,16 @@ class _FlagContentSheetState extends State<_FlagContentSheet> {
     );
   }
 }
+
+/// Accent for the selected reason's ring and dot.
+///
+/// The ring is the only thing that marks which of the eleven reasons is
+/// chosen, and the brand green reaches just 2.22:1 on the light sheet
+/// surface. [VineTheme.primaryAccessible] is the same hue at 3.17:1, which
+/// clears the 3:1 floor a non-text indicator has to meet.
+Color _selectedIndicatorOf(BuildContext context) => context.vineColors.isLight
+    ? VineTheme.primaryAccessible
+    : VineTheme.vineGreen;
 
 class _ReasonRadioTile extends StatelessWidget {
   const _ReasonRadioTile({
@@ -351,7 +367,7 @@ class _ReasonRadioTile extends StatelessWidget {
                   shape: BoxShape.circle,
                   border: Border.all(
                     color: isSelected
-                        ? VineTheme.vineGreen
+                        ? _selectedIndicatorOf(context)
                         : context.vineColors.onSurfaceMuted,
                     width: 2,
                   ),
@@ -361,9 +377,9 @@ class _ReasonRadioTile extends StatelessWidget {
                         child: Container(
                           width: 10,
                           height: 10,
-                          decoration: const BoxDecoration(
+                          decoration: BoxDecoration(
                             shape: BoxShape.circle,
-                            color: VineTheme.vineGreen,
+                            color: _selectedIndicatorOf(context),
                           ),
                         ),
                       )

--- a/mobile/lib/screens/comments/widgets/video_comment_player.dart
+++ b/mobile/lib/screens/comments/widgets/video_comment_player.dart
@@ -233,7 +233,7 @@ class _OpenVideoButton extends StatelessWidget {
       icon: DivineIconName.arrowUpRight,
       semanticLabel: context.l10n.commentsOpenVideoLabel,
       size: DivineIconButtonSize.small,
-      type: DivineIconButtonType.ghostSecondary,
+      type: DivineIconButtonType.ghostOverMedia,
       onPressed: onTap,
     );
   }
@@ -280,7 +280,7 @@ class _MuteButton extends StatelessWidget {
           ? context.l10n.commentsUnmuteVideoReplyLabel
           : context.l10n.commentsMuteVideoReplyLabel,
       size: DivineIconButtonSize.small,
-      type: DivineIconButtonType.ghostSecondary,
+      type: DivineIconButtonType.ghostOverMedia,
       onPressed: onTap,
     );
   }

--- a/mobile/lib/screens/feed/feed_settings_menu.dart
+++ b/mobile/lib/screens/feed/feed_settings_menu.dart
@@ -155,7 +155,7 @@ class _FeedSettingsMenuState extends ConsumerState<FeedSettingsMenu> {
           builder: (context, isShowing, _) => DivineIconButton(
             icon: isShowing ? DivineIconName.x : DivineIconName.dotsThree,
             size: DivineIconButtonSize.small,
-            type: DivineIconButtonType.ghostSecondary,
+            type: DivineIconButtonType.ghostOverMedia,
             semanticLabel: isShowing
                 ? context.l10n.videoSettingsMenuClose
                 : context.l10n.videoSettingsMenuOpen,

--- a/mobile/lib/screens/image_crop_editor/widgets/image_crop_editor_toolbar.dart
+++ b/mobile/lib/screens/image_crop_editor/widgets/image_crop_editor_toolbar.dart
@@ -40,7 +40,7 @@ class ImageCropEditorToolbar extends StatelessWidget
         padding: const EdgeInsets.only(left: 16),
         child: DivineIconButton(
           icon: DivineIconName.x,
-          type: DivineIconButtonType.ghostSecondary,
+          type: DivineIconButtonType.ghostOverMedia,
           size: DivineIconButtonSize.small,
           semanticLabel: l10n.imageCropEditorCloseSemanticLabel,
           onPressed: onClose,

--- a/mobile/lib/screens/image_crop_editor/widgets/image_crop_editor_toolbar.dart
+++ b/mobile/lib/screens/image_crop_editor/widgets/image_crop_editor_toolbar.dart
@@ -40,7 +40,10 @@ class ImageCropEditorToolbar extends StatelessWidget
         padding: const EdgeInsets.only(left: 16),
         child: DivineIconButton(
           icon: DivineIconName.x,
-          type: DivineIconButtonType.ghostOverMedia,
+          // `CropRotateEditor` hands this to a plain `Scaffold.appBar` with no
+          // `extendBodyBehindAppBar`, so the bar sits above the image on the
+          // scaffold's own `colors.surface` — a themed surface, not media.
+          type: DivineIconButtonType.ghostSecondary,
           size: DivineIconButtonSize.small,
           semanticLabel: l10n.imageCropEditorCloseSemanticLabel,
           onPressed: onClose,

--- a/mobile/lib/screens/profile_setup/widgets/profile_setup_field_decorations.dart
+++ b/mobile/lib/screens/profile_setup/widgets/profile_setup_field_decorations.dart
@@ -2,12 +2,16 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 
 /// Shared underline border for the profile-setup form fields.
+/// The fields carry no fill, so the underline sits straight on the screen's
+/// `surfaceContainerHigh` background. `outlineMuted` there is #DCE7E2 on
+/// #E7E4E1 — 1.00:1, an underline with no edge at all — where the dark value
+/// keeps 1.18:1. `outline` restores it.
 UnderlineInputBorder profileFieldBorderOf(BuildContext context) {
   final colors = context.vineColors;
   return UnderlineInputBorder(
     borderRadius: BorderRadius.zero,
     borderSide: BorderSide(
-      color: colors.isLight ? colors.outlineMuted : VineTheme.neutral10,
+      color: colors.isLight ? colors.outline : VineTheme.neutral10,
     ),
   );
 }

--- a/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
+++ b/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
@@ -235,7 +235,7 @@ class _VideoAudioEditorTimingScreenState
                       closeIcon: widget.enableDeleteButton ? .trash : .x,
                       closeType: widget.enableDeleteButton
                           ? .error
-                          : .ghostSecondary,
+                          : .ghostOverMedia,
                       closeSemanticLabel: widget.enableDeleteButton
                           ? 'Remove audio'
                           : 'Close',

--- a/mobile/lib/screens/video_editor/video_clip_chroma_key_screen.dart
+++ b/mobile/lib/screens/video_editor/video_clip_chroma_key_screen.dart
@@ -299,7 +299,7 @@ class _VideoClipChromaKeyScreenState extends State<VideoClipChromaKeyScreen> {
         // system back gesture waits with everything else.
         canPop: !isBaking,
         child: Scaffold(
-          backgroundColor: VineTheme.surfaceBackground,
+          backgroundColor: context.vineColors.surfaceContainerHigh,
           body: SafeArea(
             child: MultiBlocListener(
               listeners: [
@@ -347,7 +347,7 @@ class _VideoClipChromaKeyScreenState extends State<VideoClipChromaKeyScreen> {
                         center: Text(
                           context.l10n.videoEditorChromaKeyTitle,
                           style: VineTheme.titleMediumFont(
-                            color: VineTheme.onSurface,
+                            color: context.vineColors.onSurface,
                           ),
                         ),
                       ),

--- a/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
@@ -514,7 +514,7 @@ class _TopBar extends StatelessWidget {
                 button: true,
                 child: DivineIconButton(
                   icon: .x,
-                  type: .ghostSecondary,
+                  type: .ghostOverMedia,
                   size: .small,
                   onPressed: onClose,
                 ),

--- a/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
@@ -261,7 +261,7 @@ class _CloseButton extends StatelessWidget {
           tag: VideoEditorConstants.heroBackButtonId,
           child: DivineIconButton(
             icon: .x,
-            type: .ghostSecondary,
+            type: .ghostOverMedia,
             size: .small,
             semanticLabel: context.l10n.videoMetadataClosePreviewSemanticLabel,
             onPressed: () => context.pop(),

--- a/mobile/lib/widgets/profile/profile_header_media.dart
+++ b/mobile/lib/widgets/profile/profile_header_media.dart
@@ -567,7 +567,7 @@ class _AvatarLightbox extends StatelessWidget {
                     left: 12,
                     child: DivineIconButton(
                       icon: DivineIconName.x,
-                      type: DivineIconButtonType.ghostSecondary,
+                      type: DivineIconButtonType.ghostOverMedia,
                       size: DivineIconButtonSize.small,
                       onPressed: () => Navigator.of(context).pop(),
                     ),

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -312,6 +312,12 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
         mainAxisSize: .min,
         children: [
           // Navigation buttons — always visible immediately.
+          //
+          // These are not reliably over media: a profile with no banner image
+          // and no `profileColor` — the default — gets the palette gradient
+          // `containerLow` -> `surface` from [ProfileBanner], and the banner's
+          // own scrim is fully transparent at this height. A fixed light glyph
+          // would sit at ~1.5:1 there on light, so they follow the palette.
           Padding(
             padding: const EdgeInsets.all(12),
             child: Row(
@@ -320,21 +326,21 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
                 if (widget.isOwnProfile)
                   DivineIconButton(
                     icon: DivineIconName.gear,
-                    type: DivineIconButtonType.ghostOverMedia,
+                    type: DivineIconButtonType.ghostSecondary,
                     size: DivineIconButtonSize.small,
                     onPressed: () => context.push(SettingsScreen.path),
                   )
                 else if (widget.onBack != null)
                   DivineIconButton(
                     icon: DivineIconName.caretLeft,
-                    type: DivineIconButtonType.ghostOverMedia,
+                    type: DivineIconButtonType.ghostSecondary,
                     size: DivineIconButtonSize.small,
                     onPressed: widget.onBack,
                   ),
                 if (widget.onMore != null)
                   DivineIconButton(
                     icon: DivineIconName.dotsThree,
-                    type: DivineIconButtonType.ghostOverMedia,
+                    type: DivineIconButtonType.ghostSecondary,
                     size: DivineIconButtonSize.small,
                     onPressed: widget.onMore,
                   ),

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -320,21 +320,21 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
                 if (widget.isOwnProfile)
                   DivineIconButton(
                     icon: DivineIconName.gear,
-                    type: DivineIconButtonType.ghostSecondary,
+                    type: DivineIconButtonType.ghostOverMedia,
                     size: DivineIconButtonSize.small,
                     onPressed: () => context.push(SettingsScreen.path),
                   )
                 else if (widget.onBack != null)
                   DivineIconButton(
                     icon: DivineIconName.caretLeft,
-                    type: DivineIconButtonType.ghostSecondary,
+                    type: DivineIconButtonType.ghostOverMedia,
                     size: DivineIconButtonSize.small,
                     onPressed: widget.onBack,
                   ),
                 if (widget.onMore != null)
                   DivineIconButton(
                     icon: DivineIconName.dotsThree,
-                    type: DivineIconButtonType.ghostSecondary,
+                    type: DivineIconButtonType.ghostOverMedia,
                     size: DivineIconButtonSize.small,
                     onPressed: widget.onMore,
                   ),

--- a/mobile/lib/widgets/video_editor/chroma_key/chroma_key_clip_picker_sheet.dart
+++ b/mobile/lib/widgets/video_editor/chroma_key/chroma_key_clip_picker_sheet.dart
@@ -75,7 +75,9 @@ class _ClipPickerGrid extends StatelessWidget {
         child: Text(
           context.l10n.videoEditorChromaKeyNoLibraryClips,
           textAlign: TextAlign.center,
-          style: VineTheme.bodyMediumFont(color: VineTheme.onSurfaceVariant),
+          style: VineTheme.bodyMediumFont(
+            color: context.vineColors.onSurfaceVariant,
+          ),
         ),
       );
     }
@@ -123,7 +125,7 @@ class _ClipTile extends StatelessWidget {
         child: ClipRRect(
           borderRadius: BorderRadius.circular(12),
           child: ColoredBox(
-            color: VineTheme.surfaceContainer,
+            color: context.vineColors.surfaceContainer,
             child: thumbnailPath == null
                 ? const SizedBox.expand()
                 : Image.file(

--- a/mobile/lib/widgets/video_editor/chroma_key/chroma_key_controls.dart
+++ b/mobile/lib/widgets/video_editor/chroma_key/chroma_key_controls.dart
@@ -97,11 +97,13 @@ class _PreviewUnavailableNoticeState extends State<_PreviewUnavailableNotice> {
       spacing: 8,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const DivineIcon(icon: .info, color: VineTheme.onSurfaceVariant),
+        DivineIcon(icon: .info, color: context.vineColors.onSurfaceVariant),
         Expanded(
           child: Text(
             context.l10n.videoEditorChromaKeyPreviewUnavailable,
-            style: VineTheme.bodySmallFont(color: VineTheme.onSurfaceVariant),
+            style: VineTheme.bodySmallFont(
+              color: context.vineColors.onSurfaceVariant,
+            ),
           ),
         ),
       ],
@@ -165,7 +167,9 @@ class _ScreenColorRow extends StatelessWidget {
         Expanded(
           child: Text(
             context.l10n.videoEditorChromaKeyScreenColorLabel,
-            style: VineTheme.titleSmallFont(color: VineTheme.onSurface),
+            style: VineTheme.titleSmallFont(
+              color: context.vineColors.onSurface,
+            ),
           ),
         ),
         _ColorSwatchButton(
@@ -287,13 +291,15 @@ class _LabeledSlider extends StatelessWidget {
             Expanded(
               child: Text(
                 label,
-                style: VineTheme.bodyMediumFont(color: VineTheme.onSurface),
+                style: VineTheme.bodyMediumFont(
+                  color: context.vineColors.onSurface,
+                ),
               ),
             ),
             Text(
               '${(value * 100).round()}',
               style: VineTheme.bodyMediumFont(
-                color: VineTheme.onSurfaceVariant,
+                color: context.vineColors.onSurfaceVariant,
               ),
             ),
           ],
@@ -328,7 +334,9 @@ class _BackgroundSection extends StatelessWidget {
         _Gutter(
           child: Text(
             context.l10n.videoEditorChromaKeyBackgroundLabel,
-            style: VineTheme.titleSmallFont(color: VineTheme.onSurface),
+            style: VineTheme.titleSmallFont(
+              color: context.vineColors.onSurface,
+            ),
           ),
         ),
         // Each chip takes the width its label needs rather than an equal
@@ -356,7 +364,11 @@ class _BackgroundSection extends StatelessWidget {
           _Gutter(
             child: Text(
               context.l10n.videoEditorChromaKeyTransparentHint,
-              style: VineTheme.bodySmallFont(color: VineTheme.onSurfaceMuted),
+              // `onSurfaceMuted` is only 3.05:1 on the light canvas, so this
+              // hint takes the variant token instead of the muted one.
+              style: VineTheme.bodySmallFont(
+                color: context.vineColors.onSurfaceVariant,
+              ),
             ),
           ),
       ],

--- a/mobile/lib/widgets/video_editor/text_editor/video_editor_text_overlay_controls.dart
+++ b/mobile/lib/widgets/video_editor/text_editor/video_editor_text_overlay_controls.dart
@@ -39,6 +39,10 @@ class VideoEditorTextOverlayControls extends StatelessWidget {
         Align(
           alignment: .topCenter,
           child: VideoEditorToolbar(
+            // This screen paints a fixed 61 % black scrim over everything
+            // (`VideoEditorConstants.textEditorBackground`), so the close
+            // button cannot follow the palette into light mode.
+            closeType: .ghostOverMedia,
             onClose: () => VideoTextEditorScope.of(context).editor.close(),
             onDone: () => VideoTextEditorScope.of(context).editor.done(),
           ),

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/animation_picker_components.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/animation_picker_components.dart
@@ -82,9 +82,15 @@ class AnimationPickerChip extends StatelessWidget {
                   : VineTheme.lightText.withValues(alpha: 0.08),
               borderRadius: BorderRadius.circular(8),
               border: Border.all(
+                // Light mode cannot lean on the accent the way dark does:
+                // `primaryContainer` and `containerLow` are 1.001:1 apart, so
+                // the border is the only thing left to carry the selected
+                // state. `outline` against `outlineMuted` is 1.37:1 — this
+                // pairing puts it at 10.10:1, matching the glyph and label
+                // that already resolve `onSurface` here.
                 color: selected
                     ? isLight
-                          ? colors.outline
+                          ? colors.onSurface
                           : VineTheme.primary
                     : isLight
                     ? colors.outlineMuted

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_layer_animation_sheet.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_layer_animation_sheet.dart
@@ -618,9 +618,11 @@ class _PhaseSegment extends StatelessWidget {
                   : null,
               borderRadius: BorderRadius.circular(10),
               border: Border.all(
+                // See `AnimationPickerChip`: the light fills are 1.001:1
+                // apart, so the border carries the selected state alone.
                 color: selected
                     ? isLight
-                          ? colors.outline
+                          ? colors.onSurface
                           : VineTheme.primary
                     : VineTheme.transparent,
               ),
@@ -671,6 +673,7 @@ class _LayerTypeTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = context.vineColors;
     // Merge the explicit button node with the GestureDetector's tap action into
     // one node, and exclude the visible Text below from semantics so its label
     // isn't concatenated onto the explicit one — otherwise the screen reader
@@ -691,7 +694,14 @@ class _LayerTypeTile extends StatelessWidget {
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.circular(10),
                   border: Border.all(
-                    color: selected ? VineTheme.primary : VineTheme.transparent,
+                    // Same reasoning as the phase segments — and `primary`
+                    // only reaches 2.22:1 on a light tile, so it cannot mark
+                    // the selection there either.
+                    color: selected
+                        ? colors.isLight
+                              ? colors.onSurface
+                              : VineTheme.primary
+                        : VineTheme.transparent,
                     width: 2,
                   ),
                 ),

--- a/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
@@ -877,8 +877,16 @@ class _AddElementFabContent extends StatelessWidget {
               borderRadius: .circular(24),
             ),
           ),
-          child: const Center(
-            child: DivineIcon(icon: .plus, color: VineTheme.primary),
+          child: Center(
+            // Hand-rolled twin of `DivineIconButtonType.secondary`, so it
+            // takes that variant's icon rule: the brand green only reaches
+            // 1.92:1 on the light `surfaceContainer` fill.
+            child: DivineIcon(
+              icon: .plus,
+              color: context.vineColors.isLight
+                  ? context.vineColors.onSurface
+                  : VineTheme.primary,
+            ),
           ),
         ),
       ),

--- a/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview.dart
+++ b/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview.dart
@@ -124,7 +124,7 @@ class VideoMetadataCaptureClipPreview extends ConsumerWidget {
                             excludeSemantics: true,
                             child: DivineIconButton(
                               icon: .pencilSimpleLine,
-                              type: .ghostSecondary,
+                              type: .ghostOverMedia,
                               size: .small,
                               onPressed: () => _openCoverEditor(
                                 context,

--- a/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_stack.dart
+++ b/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_stack.dart
@@ -244,7 +244,7 @@ class _EditClipPreview extends StatelessWidget {
                       excludeSemantics: true,
                       child: DivineIconButton(
                         icon: .pencilSimpleLine,
-                        type: .ghostSecondary,
+                        type: .ghostOverMedia,
                         size: .small,
                         onPressed: onEditCover,
                       ),

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart
@@ -137,7 +137,7 @@ class VideoRecorderCaptureStack extends ConsumerWidget {
                         icon: .trash,
                         semanticLabel:
                             context.l10n.videoRecorderDeleteLastClipLabel,
-                        type: .ghostSecondary,
+                        type: .ghostOverMedia,
                         size: .small,
                         onPressed: recorderMode.capturesStills
                             ? () => context.read<VideoRecorderBloc>().add(
@@ -156,7 +156,7 @@ class VideoRecorderCaptureStack extends ConsumerWidget {
                     child: IgnorePointer(
                       child: DivineIconButton(
                         icon: .trash,
-                        type: .ghostSecondary,
+                        type: .ghostOverMedia,
                         size: .small,
                         onPressed: null,
                       ),

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_top_bar.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_top_bar.dart
@@ -67,7 +67,7 @@ class VideoRecorderCaptureTopBar extends ConsumerWidget {
                       semanticLabel:
                           context.l10n.videoRecorderCaptureCloseLabel,
                       size: .small,
-                      type: .ghostSecondary,
+                      type: .ghostOverMedia,
                       onPressed: () => fromEditor
                           ? context.pop(false)
                           : closeVideoRecorder(context),
@@ -81,7 +81,7 @@ class VideoRecorderCaptureTopBar extends ConsumerWidget {
                         semanticLabel:
                             context.l10n.videoRecorderCaptureNextLabel,
                         size: .small,
-                        type: .ghostSecondary,
+                        type: .ghostOverMedia,
                         onPressed: capturesStills
                             ? () => context.read<VideoRecorderBloc>().add(
                                 const VideoRecorderStopMotionAssembleRequested(),

--- a/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
@@ -9,8 +9,12 @@ import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
 /// Horizontal picker-wheel mode selector.
 ///
 /// Items scroll horizontally. A fixed pill is always centered — its width
-/// animates to fit the selected label. The centered item shows
-/// semantic `onSurface` text; all others show `mediaChromeForeground`.
+/// animates to fit the selected label.
+///
+/// In dark mode the centered item shows `VineTheme.primary` text and the rest
+/// show semantic `onSurface`. In light mode the accent only reaches 1.92:1 on
+/// the pill, so the centered item takes `onSurface` and the rest step down to
+/// `mutedText`, with an `outline` edge on the pill to keep it legible.
 class VideoRecorderModeSelectorWheel extends StatefulWidget {
   const VideoRecorderModeSelectorWheel({
     required this.selectedMode,
@@ -203,6 +207,8 @@ class _VideoRecorderModeSelectorWheelState
         _jumpTo(pendingJumpIndex);
       });
     }
+    final colors = context.vineColors;
+    final isLight = colors.isLight;
     return LayoutBuilder(
       builder: (context, constraints) {
         final leadingPadding = (constraints.maxWidth - itemWidths.first) / 2;
@@ -220,8 +226,12 @@ class _VideoRecorderModeSelectorWheelState
                   height: _pillHeight,
                   width: _pillWidth(modes[_selectedIndex].label, textScaler),
                   decoration: BoxDecoration(
-                    color: context.vineColors.surfaceContainer,
+                    color: colors.surfaceContainer,
                     borderRadius: .circular(_pillHeight / 2),
+                    // The light pill is only 1.09:1 against the bar behind
+                    // it, so without an edge the wheel loses the one thing
+                    // that shows which mode is armed.
+                    border: isLight ? Border.all(color: colors.outline) : null,
                   ),
                 ),
               ),
@@ -282,8 +292,12 @@ class _VideoRecorderModeSelectorWheelState
                                 duration: const Duration(milliseconds: 200),
                                 style: VineTheme.titleSmallFont(
                                   color: isSelected
-                                      ? VineTheme.primary
-                                      : context.vineColors.onSurface,
+                                      ? isLight
+                                            ? colors.onSurface
+                                            : VineTheme.primary
+                                      : isLight
+                                      ? colors.mutedText
+                                      : colors.onSurface,
                                 ),
                                 child: Text(
                                   modes[i].label,

--- a/mobile/packages/divine_ui/lib/src/button/divine_icon_button.dart
+++ b/mobile/packages/divine_ui/lib/src/button/divine_icon_button.dart
@@ -19,8 +19,22 @@ enum DivineIconButtonType {
   /// and white icon.
   ghost,
 
-  /// Ghost secondary button with lighter scrim (15% black) and white icon.
+  /// Ghost secondary button with lighter scrim (15% black), carrying a
+  /// palette-derived icon.
+  ///
+  /// For chrome that sits on a themed surface. Use [ghostOverMedia] when the
+  /// scrim is painted over a video frame or an image instead — there the
+  /// backdrop is content-driven, so a palette-derived icon can land on
+  /// anything.
   ghostSecondary,
+
+  /// Same 15% black scrim as [ghostSecondary], with a fixed light icon in
+  /// both appearance modes.
+  ///
+  /// The button-level counterpart of `DiVineAppBarStyle.overMediaStyle`: what
+  /// shows through a scrim over media is a video frame rather than a palette
+  /// surface, so the icon cannot follow the palette.
+  ghostOverMedia,
 
   /// Error/destructive button with red background and light icon.
   error,
@@ -251,7 +265,8 @@ class _DivineIconButtonContent extends StatelessWidget {
         DivineIconButtonType.secondary => colors.surfaceContainer,
         DivineIconButtonType.tertiary => colors.inverseSurface,
         DivineIconButtonType.ghost => VineTheme.scrim65,
-        DivineIconButtonType.ghostSecondary => VineTheme.scrim15,
+        DivineIconButtonType.ghostSecondary ||
+        DivineIconButtonType.ghostOverMedia => VineTheme.scrim15,
         DivineIconButtonType.error => VineTheme.error,
       };
 
@@ -262,8 +277,10 @@ class _DivineIconButtonContent extends StatelessWidget {
         DivineIconButtonType.secondary =>
           colors.isLight ? colors.onSurface : VineTheme.primary,
         DivineIconButtonType.tertiary => colors.inverseOnSurface,
-        // The stronger ghost scrim can carry fixed light content in both modes.
-        DivineIconButtonType.ghost => VineTheme.onSurface,
+        // The stronger ghost scrim, and any scrim over media, carry fixed
+        // light content in both modes.
+        DivineIconButtonType.ghost ||
+        DivineIconButtonType.ghostOverMedia => VineTheme.onSurface,
         DivineIconButtonType.ghostSecondary =>
           colors.isLight ? colors.onSurface : VineTheme.onSurface,
         DivineIconButtonType.error => VineTheme.onErrorContainer,
@@ -284,7 +301,8 @@ class _DivineIconButtonContent extends StatelessWidget {
     // Disabled buttons have no shadow (except for some types).
     if ((!_isEnabled && type == .primary) ||
         type == .ghost ||
-        type == .ghostSecondary) {
+        type == .ghostSecondary ||
+        type == .ghostOverMedia) {
       return null;
     }
 

--- a/mobile/packages/divine_ui/test/src/button/divine_icon_button_test.dart
+++ b/mobile/packages/divine_ui/test/src/button/divine_icon_button_test.dart
@@ -383,6 +383,25 @@ void main() {
         expect(divineIcon.color, VineTheme.lightColors.onSurface);
       });
 
+      testWidgets('ghostOverMedia type keeps the fixed light icon in light '
+          'mode', (tester) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            theme: VineTheme.lightTheme,
+            type: DivineIconButtonType.ghostOverMedia,
+            onPressed: () {},
+          ),
+        );
+
+        final divineIcon = tester.widget<DivineIcon>(
+          find.byType(DivineIcon),
+        );
+        // A 15 % scrim over a video frame stays dark whatever the palette
+        // says, so this variant must not follow it into the light palette.
+        expect(divineIcon.color, VineTheme.onSurface);
+        expect(divineIcon.color, isNot(VineTheme.lightColors.onSurface));
+      });
+
       testWidgets('error type uses onErrorContainer color', (tester) async {
         await tester.pumpWidget(
           buildTestWidget(

--- a/mobile/test/screens/comments/widgets/comment_options_modal_test.dart
+++ b/mobile/test/screens/comments/widgets/comment_options_modal_test.dart
@@ -1,0 +1,69 @@
+// ABOUTME: Pins the comment options sheet's destructive row to a colour that
+// ABOUTME: survives the light sheet surface once light mode is on.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/screens/comments/widgets/comment_options_modal.dart';
+
+void main() {
+  group(CommentOptionsModal, () {
+    Future<void> openOwnCommentSheet(
+      WidgetTester tester,
+      ThemeData theme,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: theme,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => TextButton(
+                onPressed: () => CommentOptionsModal.showForOwnComment(
+                  context,
+                  commentId: 'c1',
+                  commentContent: 'hi',
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+    }
+
+    /// The Delete row's resolved colour. The row paints its glyph and its
+    /// label from one `color`, so the label pins both.
+    Color? deleteLabelColor(WidgetTester tester) {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      return tester.widget<Text>(find.text(l10n.commonDelete)).style?.color;
+    }
+
+    testWidgets('destructive row leaves fixed likeRed behind on light', (
+      tester,
+    ) async {
+      await openOwnCommentSheet(tester, VineTheme.lightTheme);
+
+      // The sheet body is `ColoredBox(color: colors.surface)` = #FFFFFF on
+      // light, where fixed `likeRed` holds only 4.13:1. The palette token is
+      // #8C1D18 there — 9.11:1.
+      final color = deleteLabelColor(tester);
+      expect(color, VineTheme.lightColors.onErrorContainer);
+      expect(color, isNot(VineTheme.likeRed));
+    });
+
+    testWidgets('destructive row is byte-identical on dark', (tester) async {
+      await openOwnCommentSheet(tester, VineTheme.theme);
+
+      // The dark palette defines onErrorContainer as likeRed itself, so dark
+      // rendering must not move.
+      final color = deleteLabelColor(tester);
+      expect(color, VineTheme.likeRed);
+      expect(color, VineTheme.darkColors.onErrorContainer);
+    });
+  });
+}

--- a/mobile/test/screens/image_crop_editor/widgets/image_crop_editor_toolbar_test.dart
+++ b/mobile/test/screens/image_crop_editor/widgets/image_crop_editor_toolbar_test.dart
@@ -19,18 +19,28 @@ void main() {
       WidgetTester tester, {
       required VoidCallback onClose,
       VoidCallback? onDone,
+      ThemeData? theme,
     }) {
       return tester.pumpWidget(
         MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          theme: VineTheme.theme,
+          theme: theme ?? VineTheme.theme,
           home: Scaffold(
             appBar: ImageCropEditorToolbar(onClose: onClose, onDone: onDone),
           ),
         ),
       );
     }
+
+    Color? glyphColor(WidgetTester tester, DivineIconName icon) => tester
+        .widget<DivineIcon>(
+          find.descendant(
+            of: buttonWithIcon(icon),
+            matching: find.byType(DivineIcon),
+          ),
+        )
+        .color;
 
     testWidgets('renders close and done buttons', (tester) async {
       await pump(tester, onClose: () {}, onDone: () {});
@@ -70,6 +80,26 @@ void main() {
         buttonWithIcon(DivineIconName.check),
       );
       expect(doneButton.onPressed, isNull);
+    });
+
+    testWidgets('close glyph follows the palette on light', (tester) async {
+      await pump(tester, onClose: () {}, theme: VineTheme.lightTheme);
+
+      // `CropRotateEditor` puts this bar in a plain `Scaffold.appBar` over
+      // `CropRotateEditorStyle.background`, which the screen sets to
+      // `colors.surface` — #FFFFFF on light. A fixed light glyph on the 15%
+      // scrim over that is 1.39:1; the palette token is 9.07:1.
+      expect(
+        glyphColor(tester, DivineIconName.x),
+        VineTheme.lightColors.onSurface,
+      );
+      expect(glyphColor(tester, DivineIconName.x), isNot(VineTheme.onSurface));
+    });
+
+    testWidgets('close glyph stays light on dark', (tester) async {
+      await pump(tester, onClose: () {}, theme: VineTheme.theme);
+
+      expect(glyphColor(tester, DivineIconName.x), VineTheme.onSurface);
     });
 
     testWidgets('labels the buttons for screen readers', (tester) async {

--- a/mobile/test/screens/profile_setup/profile_setup_field_decorations_test.dart
+++ b/mobile/test/screens/profile_setup/profile_setup_field_decorations_test.dart
@@ -1,0 +1,52 @@
+// ABOUTME: Tests the shared profile-setup field border and hint resolvers
+// ABOUTME: against both appearance palettes.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/screens/profile_setup/widgets/profile_setup_field_decorations.dart';
+
+void main() {
+  group('profileFieldBorderOf', () {
+    Future<UnderlineInputBorder> resolve(
+      WidgetTester tester, {
+      ThemeData? theme,
+    }) async {
+      late UnderlineInputBorder border;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: theme,
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                border = profileFieldBorderOf(context);
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        ),
+      );
+      return border;
+    }
+
+    testWidgets('uses an edge that survives the light background', (
+      tester,
+    ) async {
+      final border = await resolve(tester, theme: VineTheme.lightTheme);
+
+      // The fields have no fill, so the underline sits on the screen's
+      // `surfaceContainerHigh`. `outlineMuted` is 1.00:1 against it.
+      expect(border.borderSide.color, VineTheme.lightColors.outline);
+      expect(
+        border.borderSide.color,
+        isNot(VineTheme.lightColors.outlineMuted),
+      );
+    });
+
+    testWidgets('keeps the dark neutral edge in dark mode', (tester) async {
+      final border = await resolve(tester, theme: VineTheme.theme);
+
+      expect(border.borderSide.color, VineTheme.neutral10);
+    });
+  });
+}

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -303,6 +303,7 @@ void main() {
       List<ProfileBadgeViewData> acceptedProfileBadges = const [],
       MockGoRouter? goRouter,
       bool monetizationLinksEnabled = false,
+      ThemeData? theme,
     }) {
       final authService = MockAuthService(
         isAnonymousValue: isAnonymous,
@@ -414,6 +415,7 @@ void main() {
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
+          theme: theme,
           home: Scaffold(body: SingleChildScrollView(child: header)),
         ),
       );
@@ -623,6 +625,33 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(UserAvatar), findsOneWidget);
+    });
+
+    testWidgets('nav glyphs follow the palette on light', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          userIdHex: testUserHex,
+          isOwnProfile: true,
+          profile: createTestProfile(displayName: 'Test User'),
+          theme: VineTheme.lightTheme,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // A profile with no banner image and no profileColor — the default —
+      // gets ProfileBanner's palette gradient (containerLow -> surface), and
+      // the banner scrim is fully transparent at this height. A fixed light
+      // glyph on the 15% scrim over #EDF3EF is ~1.5:1.
+      final gear = tester.widget<DivineIcon>(
+        find.descendant(
+          of: find.byWidgetPredicate(
+            (w) => w is DivineIconButton && w.icon == DivineIconName.gear,
+          ),
+          matching: find.byType(DivineIcon),
+        ),
+      );
+      expect(gear.color, VineTheme.lightColors.onSurface);
+      expect(gear.color, isNot(VineTheme.onSurface));
     });
 
     testWidgets('avatar lightbox seeds placeholder with the pubkey so the '

--- a/mobile/test/widgets/video_editor/chroma_key/chroma_key_controls_test.dart
+++ b/mobile/test/widgets/video_editor/chroma_key/chroma_key_controls_test.dart
@@ -1,0 +1,95 @@
+// ABOUTME: Pins the chroma-key controls to the active palette so the panel
+// ABOUTME: stays readable once light mode reaches the video editor.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/blocs/video_editor/chroma_key/chroma_key_editor_cubit.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/video_editor/clip_chroma_key.dart';
+import 'package:openvine/widgets/video_editor/chroma_key/chroma_key_controls.dart';
+import 'package:pro_video_editor/pro_video_editor.dart' show ChromaKey;
+
+class _MockChromaKeyEditorCubit extends MockCubit<ChromaKeyEditorState>
+    implements ChromaKeyEditorCubit {}
+
+void main() {
+  group(ChromaKeyControls, () {
+    late ChromaKeyEditorCubit cubit;
+
+    setUp(() {
+      cubit = _MockChromaKeyEditorCubit();
+      whenListen(
+        cubit,
+        const Stream<ChromaKeyEditorState>.empty(),
+        initialState: const ChromaKeyEditorState(
+          chromaKey: ClipChromaKey(key: ChromaKey.greenScreen()),
+        ),
+      );
+    });
+
+    Future<void> pump(WidgetTester tester, ThemeData theme) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: theme,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: BlocProvider<ChromaKeyEditorCubit>.value(
+            value: cubit,
+            child: Scaffold(
+              backgroundColor: theme
+                  .extension<VineThemeColors>()!
+                  .surfaceContainerHigh,
+              body: ChromaKeyControls(onPickBackground: (_) {}),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    /// Every colour the panel resolves for its own text.
+    Set<Color?> textColors(WidgetTester tester) => tester
+        .widgetList<Text>(find.byType(Text))
+        .map((t) => t.style?.color)
+        .toSet();
+
+    testWidgets('takes its text from the light palette, not fixed dark', (
+      tester,
+    ) async {
+      await pump(tester, VineTheme.lightTheme);
+
+      final colors = textColors(tester);
+      expect(colors, contains(VineTheme.lightColors.onSurface));
+
+      // The fixed dark constants are what made this panel unreadable on a
+      // light canvas — `onSurface` is 95% white, which is 1.1:1 on it.
+      expect(colors, isNot(contains(VineTheme.onSurface)));
+      expect(colors, isNot(contains(VineTheme.onSurfaceVariant)));
+      expect(colors, isNot(contains(VineTheme.onSurfaceMuted)));
+    });
+
+    testWidgets('is unchanged on the dark palette', (tester) async {
+      await pump(tester, VineTheme.theme);
+
+      // The dark palette aliases the same constants, so dark rendering must
+      // not move — that is what keeps the dark goldens valid.
+      expect(textColors(tester), contains(VineTheme.darkColors.onSurface));
+    });
+
+    testWidgets('never uses onSurfaceMuted on the light canvas', (
+      tester,
+    ) async {
+      await pump(tester, VineTheme.lightTheme);
+
+      // `onSurfaceMuted` is only 3.05:1 against `surfaceContainerHigh`, under
+      // the 4.5:1 this 12px hint needs.
+      expect(
+        textColors(tester),
+        isNot(contains(VineTheme.lightColors.onSurfaceMuted)),
+      );
+    });
+  });
+}

--- a/mobile/test/widgets/video_editor/chroma_key/chroma_key_controls_test.dart
+++ b/mobile/test/widgets/video_editor/chroma_key/chroma_key_controls_test.dart
@@ -71,12 +71,34 @@ void main() {
       expect(colors, isNot(contains(VineTheme.onSurfaceMuted)));
     });
 
-    testWidgets('is unchanged on the dark palette', (tester) async {
+    testWidgets('keeps every label on its dark constant', (tester) async {
       await pump(tester, VineTheme.theme);
 
-      // The dark palette aliases the same constants, so dark rendering must
-      // not move — that is what keeps the dark goldens valid.
-      expect(textColors(tester), contains(VineTheme.darkColors.onSurface));
+      // The dark palette aliases the same constants, so the labels and the
+      // slider readouts resolve exactly what they resolved before.
+      final colors = textColors(tester);
+      expect(colors, contains(VineTheme.darkColors.onSurface));
+      expect(colors, contains(VineTheme.darkColors.onSurfaceVariant));
+    });
+
+    testWidgets('lifts the transparent hint off the muted register on dark', (
+      tester,
+    ) async {
+      await pump(tester, VineTheme.theme);
+
+      // The one value this migration moves on dark. `onSurfaceMuted` is 50%
+      // white — 5.30:1 on the canvas this screen used to paint — and the hint
+      // now takes the same `onSurfaceVariant` as the panel's other secondary
+      // text, 11.19:1 on the canvas it paints today.
+      final hint = tester.widget<Text>(
+        find.text(
+          lookupAppLocalizations(
+            const Locale('en'),
+          ).videoEditorChromaKeyTransparentHint,
+        ),
+      );
+      expect(hint.style?.color, VineTheme.darkColors.onSurfaceVariant);
+      expect(hint.style?.color, isNot(VineTheme.onSurfaceMuted));
     });
 
     testWidgets('never uses onSurfaceMuted on the light canvas', (

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/animation_picker_components_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/animation_picker_components_test.dart
@@ -1,0 +1,77 @@
+// ABOUTME: Tests that the shared animation-picker chip marks its selected
+// ABOUTME: state visibly in both appearance modes.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/controls/animation_picker_components.dart';
+
+void main() {
+  group(AnimationPickerChip, () {
+    Future<void> pumpChip(
+      WidgetTester tester, {
+      required bool selected,
+      ThemeData? theme,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: theme,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: AnimationPickerChip(
+              selected: selected,
+              onTap: () {},
+              semanticLabel: 'Curve 1',
+              child: const SizedBox(width: 28, height: 18),
+            ),
+          ),
+        ),
+      );
+    }
+
+    BoxDecoration decorationOf(WidgetTester tester) =>
+        tester.widget<DecoratedBox>(find.byType(DecoratedBox).first).decoration
+            as BoxDecoration;
+
+    testWidgets('marks the selected chip with a readable border in light '
+        'mode', (tester) async {
+      await pumpChip(tester, selected: true, theme: VineTheme.lightTheme);
+
+      final decoration = decorationOf(tester);
+      expect(decoration.color, VineTheme.lightColors.primaryContainer);
+      // `outline` would sit at 1.37:1 against the unselected chip's border,
+      // and the two fills are 1.001:1 apart, so nothing else marks the state.
+      expect(
+        (decoration.border! as Border).top.color,
+        VineTheme.lightColors.onSurface,
+      );
+    });
+
+    testWidgets(
+      'leaves the unselected chip on the muted border in light mode',
+      (
+        tester,
+      ) async {
+        await pumpChip(tester, selected: false, theme: VineTheme.lightTheme);
+
+        final decoration = decorationOf(tester);
+        expect(decoration.color, VineTheme.lightColors.containerLow);
+        expect(
+          (decoration.border! as Border).top.color,
+          VineTheme.lightColors.outlineMuted,
+        );
+      },
+    );
+
+    testWidgets('keeps the accent border in dark mode', (tester) async {
+      await pumpChip(tester, selected: true, theme: VineTheme.theme);
+
+      expect(
+        (decorationOf(tester).border! as Border).top.color,
+        VineTheme.primary,
+      );
+    });
+  });
+}

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_layer_animation_sheet_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_layer_animation_sheet_test.dart
@@ -94,28 +94,38 @@ void main() {
     testWidgets('picker chrome follows the light palette', (tester) async {
       await openPicker(tester, theme: VineTheme.lightTheme);
 
-      expect(
-        find.byWidgetPredicate((w) {
-          if (w is! DecoratedBox) return false;
-          final decoration = w.decoration;
-          return decoration is BoxDecoration &&
-              decoration.color == VineTheme.lightColors.containerLow;
-        }),
-        findsWidgets,
-      );
+      const colors = VineTheme.lightColors;
 
+      // Anchored on the two phase segments rather than "any box carrying this
+      // token" — the sheet paints a dozen boxes in `containerLow`, so a
+      // predicate over all of them stays green when a single site regresses.
+      // Enter is the initially selected phase.
+      final enter = _segmentDecoration(
+        tester,
+        l10n.videoEditorLayerAnimationEnter,
+      );
+      expect(enter.color, colors.primaryContainer);
+      expect((enter.border! as Border).top.color, colors.outline);
+
+      final leave = _segmentDecoration(
+        tester,
+        l10n.videoEditorLayerAnimationLeave,
+      );
+      expect(leave.color, isNull);
+      expect((leave.border! as Border).top.color, VineTheme.transparent);
+
+      // The toggle these two segments sit in is the `containerLow` surface.
+      final toggle = tester.widget<DecoratedBox>(
+        find
+            .ancestor(
+              of: find.text(l10n.videoEditorLayerAnimationEnter),
+              matching: find.byType(DecoratedBox),
+            )
+            .last,
+      );
       expect(
-        find.byWidgetPredicate((w) {
-          if (w is! DecoratedBox && w is! Container) return false;
-          final decoration = switch (w) {
-            DecoratedBox(:final decoration) => decoration,
-            Container(:final decoration) => decoration,
-            _ => null,
-          };
-          return decoration is BoxDecoration &&
-              decoration.color == VineTheme.lightColors.primaryContainer;
-        }),
-        findsWidgets,
+        (toggle.decoration as BoxDecoration).color,
+        colors.containerLow,
       );
     });
 
@@ -603,3 +613,11 @@ typedef _LayerAnimationResult = ({
   List<editor.LayerAnimation> enter,
   List<editor.LayerAnimation> leave,
 });
+
+/// The decoration of the phase segment labelled [label].
+BoxDecoration _segmentDecoration(WidgetTester tester, String label) {
+  final container = tester.widget<Container>(
+    find.ancestor(of: find.text(label), matching: find.byType(Container)).first,
+  );
+  return container.decoration! as BoxDecoration;
+}

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_layer_animation_sheet_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_layer_animation_sheet_test.dart
@@ -105,7 +105,9 @@ void main() {
         l10n.videoEditorLayerAnimationEnter,
       );
       expect(enter.color, colors.primaryContainer);
-      expect((enter.border! as Border).top.color, colors.outline);
+      // The two light fills are 1.001:1 apart, so the border is what marks
+      // the selection — it has to be the readable token, not `outline`.
+      expect((enter.border! as Border).top.color, colors.onSurface);
 
       final leave = _segmentDecoration(
         tester,

--- a/mobile/test/widgets/video_editor/video_editor_scaffold_test.dart
+++ b/mobile/test/widgets/video_editor/video_editor_scaffold_test.dart
@@ -64,6 +64,7 @@ void main() {
       required bool isLoading,
       ClipEditorBloc? clipBlocOverride,
       ProImageEditorState? editorOverride,
+      ThemeData? theme,
     }) {
       final editorKey = GlobalKey<ProImageEditorState>();
       final removeAreaKey = GlobalKey();
@@ -96,6 +97,7 @@ void main() {
               BlocProvider<VideoEditorFilterBloc>.value(value: filterBloc),
             ],
             child: MaterialApp(
+              theme: theme,
               localizationsDelegates: AppLocalizations.localizationsDelegates,
               supportedLocales: AppLocalizations.supportedLocales,
               home: VideoEditorScaffold(isLoading: isLoading),
@@ -112,6 +114,46 @@ void main() {
 
       expect(find.byType(BrandedLoadingScaffold), findsOneWidget);
       expect(find.bySemanticsLabel('Add element'), findsOneWidget);
+    });
+
+    testWidgets('add-element glyph follows the palette on light', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildWidget(isLoading: true, theme: VineTheme.lightTheme),
+      );
+      // Not pumpAndSettle: the loading scaffold animates forever. A fresh
+      // tree resolves its theme on the first frame anyway.
+      await tester.pump();
+
+      final icon = tester.widget<DivineIcon>(
+        find.descendant(
+          of: find.bySemanticsLabel('Add element'),
+          matching: find.byType(DivineIcon),
+        ),
+      );
+
+      // This FAB is a hand-rolled twin of `DivineIconButtonType.secondary`,
+      // so it takes that variant's icon rule. The brand green only reaches
+      // 1.92:1 on the light `surfaceContainer` fill; `onSurface` is 11.06:1.
+      expect(icon.color, VineTheme.lightColors.onSurface);
+      expect(icon.color, isNot(VineTheme.primary));
+    });
+
+    testWidgets('add-element glyph stays brand green on dark', (tester) async {
+      await tester.pumpWidget(
+        buildWidget(isLoading: true, theme: VineTheme.theme),
+      );
+      await tester.pump();
+
+      final icon = tester.widget<DivineIcon>(
+        find.descendant(
+          of: find.bySemanticsLabel('Add element'),
+          matching: find.byType(DivineIcon),
+        ),
+      );
+
+      expect(icon.color, VineTheme.primary);
     });
 
     testWidgets('hides FAB while a sub-editor is open', (tester) async {

--- a/mobile/test/widgets/video_recorder/video_recorder_mode_selector_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_mode_selector_test.dart
@@ -1,3 +1,4 @@
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -22,8 +23,9 @@ void main() {
       modeChanges = [];
     });
 
-    Widget buildWidget({VideoRecorderMode? mode}) {
+    Widget buildWidget({VideoRecorderMode? mode, ThemeData? theme}) {
       return MaterialApp(
+        theme: theme,
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
@@ -43,14 +45,29 @@ void main() {
     Future<void> pumpSelector(
       WidgetTester tester, {
       VideoRecorderMode? mode,
+      ThemeData? theme,
     }) async {
       tester.view.physicalSize = const Size(surfaceWidth, 400);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
       addTearDown(tester.view.resetDevicePixelRatio);
-      await tester.pumpWidget(buildWidget(mode: mode));
+      await tester.pumpWidget(buildWidget(mode: mode, theme: theme));
       await tester.pumpAndSettle();
     }
+
+    // `Material` also inserts an `AnimatedDefaultTextStyle`, so take the
+    // closest ancestor — the wheel's own.
+    Color labelColor(WidgetTester tester, String label) => tester
+        .widget<AnimatedDefaultTextStyle>(
+          find
+              .ancestor(
+                of: find.text(label),
+                matching: find.byType(AnimatedDefaultTextStyle),
+              )
+              .first,
+        )
+        .style
+        .color!;
 
     group('renders', () {
       testWidgets('renders all mode labels', (tester) async {
@@ -77,6 +94,51 @@ void main() {
         await pumpSelector(tester);
 
         expect(find.byType(AnimatedContainer), findsOneWidget);
+      });
+
+      testWidgets('keeps the armed mode readable in light mode', (
+        tester,
+      ) async {
+        await pumpSelector(
+          tester,
+          mode: VideoRecorderMode.capture,
+          theme: VineTheme.lightTheme,
+        );
+
+        // The accent only reaches 1.92:1 on the `surfaceContainer` pill.
+        expect(
+          labelColor(tester, VideoRecorderMode.capture.label),
+          VineTheme.lightColors.onSurface,
+        );
+        expect(
+          labelColor(tester, VideoRecorderMode.classic.label),
+          VineTheme.lightColors.mutedText,
+        );
+
+        final pill = tester.widget<AnimatedContainer>(
+          find.byType(AnimatedContainer),
+        );
+        final decoration = pill.decoration! as BoxDecoration;
+        expect(decoration.color, VineTheme.lightColors.surfaceContainer);
+        expect(
+          (decoration.border! as Border).top.color,
+          VineTheme.lightColors.outline,
+        );
+      });
+
+      testWidgets('keeps the accent on the armed mode in dark mode', (
+        tester,
+      ) async {
+        await pumpSelector(
+          tester,
+          mode: VideoRecorderMode.capture,
+          theme: VineTheme.theme,
+        );
+
+        expect(
+          labelColor(tester, VideoRecorderMode.capture.label),
+          VineTheme.primary,
+        );
       });
     });
 


### PR DESCRIPTION
Closes #6531

## What

#6467 turned light mode on for every user. Eight contrast pairs it left behind are fixed here, one commit each so any can be reverted alone.

Five of these were reviewed and approved on #6467 on 2026-07-30 (`34d54fbb2`..`d59d4daae`) but were dropped by a force-push shortly before it merged, so they never reached `main`. The other three come from the chroma-key feature (#6483) and the flag sheet (#6312), which landed on `main` after #6467's base was cut — the sweep never saw them, and they regress because #6467 moved shared `divine_ui` defaults from fixed constants to palette tokens.

Every ratio below was measured by pumping the widget under `VineTheme.lightTheme` and reading the resolved colors, not derived from the token table.

## Fixes

| Commit | Light before → after | Dark |
| --- | --- | --- |
| `ghostOverMedia` variant + 14 over-media sites | 1.31–2.47:1 → 17.31:1 | unchanged |
| Animation-picker selected chip | fills 1.001:1, borders 1.37:1 → visible | unchanged |
| Recorder mode wheel label + pill edge | 1.92:1 → readable | unchanged |
| Profile-setup field underline | 1.00:1 → 1.37:1 | unchanged |
| Chroma-key screen canvas (close button + 3 slider thumbs + panel text + picker sheet) | 1.00–1.50:1 → 5.78–10.11:1 | canvas and hint move, see below |
| Flag sheet Submit label | 2.08:1 → 8.49:1 | 9.45 → 8.49:1 |
| Flag sheet selected reason indicator | 2.22:1 → 3.17:1 | unchanged |
| Comment Delete row | 4.13:1 → 9.11:1 | 4.57:1, byte-identical |
| Editor add-element FAB glyph | 1.92:1 → 11.06:1 | unchanged |

`ghostSecondary`'s fill is a fixed `scrim15` while its icon follows the palette, so `colors.isLight` cannot tell whether the caller put the button over media or over a themed surface. `ghostOverMedia` keeps the same scrim with a fixed light icon and serves the over-media sites; `ghostSecondary` now serves themed surfaces only. @hm21 caught two of the migrated sites that are **not** over media — the profile nav buttons (no banner and no `profileColor` is the default, and the backdrop is then `ProfileBanner`'s palette gradient) and the crop editor's close button (`CropRotateEditor` puts the bar in a plain `Scaffold.appBar`, no `extendBodyBehindAppBar`, over the scaffold's own `colors.surface`) — and pushed the revert in `af1d72a0e`. Both verified here: the package has no `extendBodyBehindAppBar` anywhere, and `profile_header_media.dart:134-141` is the gradient. That takes the migration from 18 buttons to 14.

## Chroma-key screen: what moves on dark

The chroma-key screen painted a fixed near-black canvas while hosting palette-following chrome. It now takes `surfaceContainerHigh`, matching `video_editor_scaffold.dart:50` — the editor this screen is launched from. Two things do change on dark, so the row above is not "unchanged":

- **Canvas** `surfaceBackground` #00150D → `surfaceContainerHigh` #000A06. Every light-on-dark pair on the screen gains a little: the title goes 16.97:1 → 18.05:1, the slider readouts 10.68:1 → 11.19:1.
- **Transparent-background hint** `onSurfaceMuted` (50% white, 5.30:1) → `onSurfaceVariant` (75% white, 11.19:1). It was the only piece of secondary text in the panel still on the muted register; the preview-unavailable notice and the slider readouts already used the variant on both palettes.

Neither is a regression, but both were described as no-ops in an earlier revision of this table. `chroma_key_controls_test.dart` now pins the hint on dark, so the claim cannot drift again — reverting it to `onSurfaceMuted` turns that test red.

Left fixed on purpose, and verified as such: the chroma baking overlay's own 85% scrim (still 13.26:1 over the lighter canvas), the transparency checkerboard inside the video frame, the swatch border on a user-chosen colour, and the editor canvases that deliberately stay fixed dark.

## Known issues, not fixed here

`BrandedLoadingIndicator` draws a pure-white sprite and exposes no `color` parameter at all, across 41 call sites in 33 files. On any palette `surface` that is 1.00:1 — an invisible spinner, so the chroma clip-picker looks hung while it loads. Tinting the brand loading animation app-wide is a design call, so it is left for design rather than decided in this PR.

The profile-setup field underline lands at 1.37:1, not the 3:1 a non-text boundary should meet — @hm21's second note. `outline` #B7C9C1 is the *strongest* of the three light outline tokens (`outlineMuted` #DCE7E2 is the 1.00:1 this commit replaces, `outlineDisabled` #EBF1EE is weaker still), so no call-site swap reaches 3:1 without borrowing a text token and mispairing its role. Dark has shipped the same underline at 1.18:1 since before light mode existed, so 1.37:1 leaves light marginally ahead of the treatment already in production rather than behind it. Closing the gap properly means raising `lightColors.outline` for every outline in the app, or adding a stronger token — a palette change design owns, not a review round.

## Verification

Re-run at `af1d72a0e` + the test commit, not carried over from an earlier revision:

- `flutter analyze lib test integration_test` — clean
- 1908 tests over `test/screens/{comments,image_crop_editor,profile_setup,video_editor,feed}`, the three `video_metadata_*_screen` suites, and `test/widgets/{profile,video_editor,video_metadata,video_recorder}` — pass, 4 pre-existing skips
- `divine_ui` — 723 tests, 100.00% lines (1771/1771)
- All 7 design-system ratchets — pass
- `mobile/scripts/golden.sh verify` — unchanged

New tests are falsifiable, each confirmed by running it against the pre-fix code: reverting the chroma-key migration turns `chroma_key_controls_test.dart` red on both palettes, and the two `ghostSecondary` reverts in `af1d72a0e` are pinned by `profile_header_widget_test.dart` and `image_crop_editor_toolbar_test.dart`.
