### PR TITLE
fix(settings): restore crossposting tile after the token rename

### DIFF
--- a/mobile/lib/screens/settings/crossposting_settings_screen.dart
+++ b/mobile/lib/screens/settings/crossposting_settings_screen.dart
@@ -317,7 +317,9 @@ class _PlatformSection extends StatelessWidget {
                   children: [
                     Text(
                       entry.platform.displayName,
-                      style: VineTheme.titleMediumFont(),
+                      style: VineTheme.titleMediumFont(
+                        color: context.vineColors.primaryText,
+                      ),
                     ),
                     if (identity != null)
                       Text(

--- a/mobile/lib/screens/settings/general_settings_screen.dart
+++ b/mobile/lib/screens/settings/general_settings_screen.dart
@@ -82,15 +82,15 @@ class GeneralSettingsScreen extends ConsumerWidget {
                   ),
                   title: Text(
                     context.l10n.settingsCrosspostingTitle,
-                    style: _titleStyle,
+                    style: _titleStyleOf(context),
                   ),
                   subtitle: Text(
                     context.l10n.settingsCrosspostingSubtitle,
-                    style: _subtitleStyle,
+                    style: _subtitleStyleOf(context),
                   ),
-                  trailing: const DivineIcon(
+                  trailing: DivineIcon(
                     icon: DivineIconName.caretRight,
-                    color: VineTheme.lightText,
+                    color: context.vineColors.mutedText,
                   ),
                   onTap: () => context.push(CrosspostingSettingsScreen.path),
                 ),


### PR DESCRIPTION
Closes #6536

## Description

`main` is currently red on two separate counts, both from the same collision. #6467 (`refactor(theme): semantic color tokens for light mode`) reshaped how settings screens get their colors; #6350 (`feat(settings): crossposting connections and modes`) branched before that and was merged after. Neither PR touched the other's lines, so git reported no conflict and both symptoms only surfaced on `main`.

**1. It does not compile.** #6467 renamed the file-private `_titleStyle` / `_subtitleStyle` constants in `general_settings_screen.dart` into `_titleStyleOf(context)` / `_subtitleStyleOf(context)` helpers, and #6350's new crossposting `ListTile` still used the old names:

```
lib/screens/settings/general_settings_screen.dart:85 • Undefined name '_titleStyle'
lib/screens/settings/general_settings_screen.dart:89 • Undefined name '_subtitleStyle'
```

**2. The light-mode ratchet fails.** #6404 freezes implicit-color `VineTheme.*Font(` calls at zero, and #6350's `crossposting_settings_screen.dart` has a platform title that inherits the ambient text style — the exact shape that rendered call sites white-on-white when light mode landed. This is what turned the `Generated Files` job red.

Beyond restoring the two call sites, the trailing caret in the crossposting tile moves from the fixed `VineTheme.lightText` to `context.vineColors.mutedText`, for the same reason its neighbouring tiles were migrated — a hardcoded light caret is unreadable once the light appearance flag is on. Dropping the constant color means that `DivineIcon` can no longer be `const`, matching the Bluesky, appearance, and storage tiles directly above and below it. The platform title gets `context.vineColors.primaryText`, which is what the ambient style already resolved to under the dark theme, so both color changes are no-ops today and correct under light mode.

**Related Issue:** 

## Out of Scope

The remaining `VineTheme.lightText` call sites in `crossposting_settings_screen.dart` are untouched. The ratchet only forbids *omitting* a color, not using a fixed one, so they do not block CI — migrating them belongs with the rest of the light-mode pass, not in a hotfix.

## Verification

- `flutter analyze lib test integration_test` — clean (it reported the two errors above before this change)
- All 27 guard scripts from the `Generated Files` job run locally — all pass, including `check_implicit_font_color_ceiling.sh`, which fails on `main`
- `flutter test test/screens/settings/` — 112 tests pass, including `settings_screens_light_mode_test.dart` and `general_settings_screen_test.dart`
- `dart format --output=none --set-exit-if-changed lib test integration_test` — clean
- pre-push hook passed

Not yet checked on a real Samsung Galaxy — this is a compile fix plus two color-token swaps that are no-ops under the dark theme, and `main` is red until it lands.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore