### PR TITLE
fix(feed): randomize the home Classics feed like Discover

### DIFF
--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -925,16 +925,12 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       _videosRepository
           .getNewVideos(until: until, skipCache: skipCache)
           .then((videos) => HomeFeedResult(videos: videos)),
-    VideoFeedSourceType.classic =>
-      paginationCursor == null
-          ? _videosRepository.getClassicVideos(
-              until: until,
-              skipCache: skipCache,
-            )
-          : _videosRepository.getClassicVideos(
-              cursor: paginationCursor,
-              skipCache: skipCache,
-            ),
+    // Classics is offset-paginated behind an opaque cursor and has no
+    // time-window pagination, so `until` does not apply.
+    VideoFeedSourceType.classic => _videosRepository.getClassicVideos(
+      cursor: paginationCursor,
+      skipCache: skipCache,
+    ),
   };
 
   void _scheduleNostrEnrichment({

--- a/mobile/lib/providers/classic_vines_provider.dart
+++ b/mobile/lib/providers/classic_vines_provider.dart
@@ -15,6 +15,7 @@ import 'package:openvine/providers/video_providers.dart';
 import 'package:openvine/state/video_feed_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:unified_logger/unified_logger.dart';
+import 'package:videos_repository/videos_repository.dart';
 
 part 'classic_vines_provider.g.dart';
 
@@ -30,7 +31,10 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
   static const int _pageSize = 50;
   static const int _totalClassicVines = 10000; // Approximate total
   static const int _initialRequestAttempts = 2;
-  static const int _maxRandomStartOffset = 400;
+
+  /// Shared with the home feed's Classics mode so both surfaces open on the
+  /// same slice of the archive.
+  static const int _maxRandomStartOffset = classicsMaxRandomStartOffset;
 
   final Random _random = Random();
 

--- a/mobile/lib/providers/classic_vines_provider.g.dart
+++ b/mobile/lib/providers/classic_vines_provider.g.dart
@@ -54,7 +54,7 @@ final class ClassicVinesFeedProvider
   ClassicVinesFeed create() => ClassicVinesFeed();
 }
 
-String _$classicVinesFeedHash() => r'081600c9119922b6177b9d06f744c4f13346dcef';
+String _$classicVinesFeedHash() => r'0de34401a1012fa881eaade7880dcd8a62767569';
 
 /// ClassicVines feed provider - shows pre-2017 Vine archive sorted by loops
 ///

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -4,6 +4,8 @@
 // ABOUTME: Returns Future<List<VideoEvent>>, not streams -
 // ABOUTME: loading is pagination-based.
 
+import 'dart:math';
+
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
@@ -74,6 +76,16 @@ const Duration _recentRelayRefreshTimeout = Duration(seconds: 3);
 const Duration _routeRelayTimeout = Duration(seconds: 3);
 const String _popularCacheKey = 'popular';
 const String _popularLegacyBeforeCursorPrefix = 'before:';
+const String _classicsCacheKey = 'classics';
+const String _classicsOffsetCursorPrefix = 'classic-offset:';
+
+/// Highest archive offset the Classics feed may open a session on.
+///
+/// The loops-sorted archive holds roughly 10k videos; starting anywhere in
+/// the most-looped few hundred keeps the feed varied between sessions without
+/// dropping the user into the unwatched long tail. Mirrors the Explore →
+/// Classics tab so both surfaces draw from the same window.
+const int _classicsMaxRandomStartOffset = 400;
 
 /// Result of a hashtag REST feed fetch.
 class HashtagFeedVideosResult {
@@ -107,6 +119,17 @@ int? _decodePopularLegacyBeforeCursor(String? cursor) {
   return int.tryParse(
     cursor.substring(_popularLegacyBeforeCursorPrefix.length),
   );
+}
+
+String _encodeClassicsOffsetCursor(int offset) =>
+    '$_classicsOffsetCursorPrefix$offset';
+
+int? _decodeClassicsOffsetCursor(String? cursor) {
+  if (cursor == null || !cursor.startsWith(_classicsOffsetCursorPrefix)) {
+    return null;
+  }
+
+  return int.tryParse(cursor.substring(_classicsOffsetCursorPrefix.length));
 }
 
 String _popularPreferenceCacheSuffix({
@@ -153,6 +176,7 @@ class VideosRepository {
     FunnelcakeApiClient? funnelcakeApiClient,
     InMemoryFeedCache? inMemoryFeedCache,
     SeenVideoLookup? seenVideoLookup,
+    Random? random,
   }) : _nostrClient = nostrClient,
        _localStorage = localStorage,
        _blockFilter = blockFilter,
@@ -160,7 +184,8 @@ class VideosRepository {
        _warningLabelsResolver = warningLabelsResolver,
        _funnelcakeApiClient = funnelcakeApiClient,
        _inMemoryFeedCache = inMemoryFeedCache,
-       _seenVideoLookup = seenVideoLookup;
+       _seenVideoLookup = seenVideoLookup,
+       _random = random ?? Random();
 
   final NostrClient _nostrClient;
   final VideoLocalStorage? _localStorage;
@@ -170,6 +195,11 @@ class VideosRepository {
   final FunnelcakeApiClient? _funnelcakeApiClient;
   final InMemoryFeedCache? _inMemoryFeedCache;
   final SeenVideoLookup? _seenVideoLookup;
+
+  /// Randomness behind the Classics feed's per-session slice and shuffle.
+  /// Injectable so tests can pin an order.
+  final Random _random;
+
   String _recommendationSessionSeed = generateRecommendationSessionSeed();
 
   /// Clears the in-memory feed cache.
@@ -777,37 +807,83 @@ class VideosRepository {
     return visible.take(limit).toList();
   }
 
-  /// Fetches popular classic Vine archive videos for the home feed's
-  /// Classics mode.
+  /// Fetches classic Vine archive videos for the home feed's Classics mode.
   ///
-  /// Delegates to [getPopularVideosPage] with [PopularVideosVariant.classic],
-  /// so the source is identical to Explore → Popular's "Classic" toggle
-  /// (v2 popular feed, `sort=popular&period=month&platform=vine`,
-  /// cursor-paged, server-ordered) — not the standalone Explore → Classics
-  /// tab, which is offset-based and client-side shuffled. Mapped into a
-  /// [HomeFeedResult] so the home feed paginates it via
-  /// [HomeFeedResult.paginationCursor] like the For You feed. Funnelcake-only:
-  /// returns an empty result when no
-  /// Funnelcake relay is connected (relays do not expose the server-side
-  /// `platform` filter).
+  /// Reads the same offset-paginated, loops-sorted archive as the standalone
+  /// Explore → Classics tab — not Explore → Popular's "Classic" toggle, which
+  /// is server-ordered and therefore opens on the same videos in the same
+  /// order every time. Each fetch that misses the cache starts at a random
+  /// offset within [_classicsMaxRandomStartOffset] and shuffles the page, so
+  /// two sessions do not see the same opening run. The next offset rides in
+  /// [HomeFeedResult.paginationCursor], so the home feed paginates this like
+  /// the For You feed.
+  ///
+  /// Caching keeps the slice stable within a session: leaving and re-entering
+  /// the feed preserves the current ordering, while pull-to-refresh
+  /// ([skipCache] `true`) draws a fresh slice.
+  ///
+  /// Funnelcake-only: returns an empty result when no Funnelcake relay is
+  /// connected (relays do not expose the server-side `platform` filter).
   Future<HomeFeedResult> getClassicVideos({
     int limit = _defaultLimit,
-    int? until,
     String? cursor,
     bool skipCache = false,
   }) async {
-    final page = await getPopularVideosPage(
-      variant: PopularVideosVariant.classic,
-      limit: limit,
-      until: until,
-      cursor: cursor,
-      skipCache: skipCache,
-    );
-    return HomeFeedResult(
-      videos: page.videos,
-      paginationCursor: page.nextCursor,
-      hasMore: page.hasMore,
-    );
+    final isFirstPage = cursor == null;
+    if (!skipCache && isFirstPage) {
+      final cached = _inMemoryFeedCache?.get(_classicsCacheKey);
+      if (cached != null) return cached;
+    }
+
+    if (_funnelcakeApiClient == null || !_funnelcakeApiClient.isAvailable) {
+      return const HomeFeedResult(videos: [], hasMore: false);
+    }
+
+    final offset =
+        _decodeClassicsOffsetCursor(cursor) ?? _classicsOffset(limit);
+
+    try {
+      final stats = await _funnelcakeApiClient.getClassicVines(
+        limit: limit,
+        offset: offset,
+      );
+
+      final videos = _filterPopularVideosForVariant(
+        await _hydrateVideosWithBulkStats(
+          _transformVideoStats(stats, sortByCreatedAt: false),
+          replaceInteractionCounts: true,
+        ),
+        PopularVideosVariant.classic,
+      );
+
+      final deduped = <VideoEvent>[];
+      _appendUniqueVideos(deduped, videos, seenVideoKeys: <String>{});
+      deduped.shuffle(_random);
+
+      // A short page means the archive ran out at this offset. Length is read
+      // from the raw stats, not the filtered list, so a page that filters down
+      // to nothing still advances instead of ending the feed.
+      final exhausted = stats.length < limit;
+      final result = HomeFeedResult(
+        videos: deduped,
+        paginationCursor: exhausted
+            ? null
+            : _encodeClassicsOffsetCursor(offset + limit),
+        hasMore: !exhausted,
+      );
+
+      if (isFirstPage) _inMemoryFeedCache?.set(_classicsCacheKey, result);
+      return result;
+    } on FunnelcakeException {
+      return const HomeFeedResult(videos: [], hasMore: false);
+    }
+  }
+
+  /// A random archive offset for a Classics session, aligned to [limit]-sized
+  /// pages so successive cursors stay on page boundaries.
+  int _classicsOffset(int limit) {
+    final pageCount = (_classicsMaxRandomStartOffset ~/ limit) + 1;
+    return _random.nextInt(pageCount) * limit;
   }
 
   /// Fetches new divine videos from the popular leaderboard.

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -83,9 +83,17 @@ const String _classicsOffsetCursorPrefix = 'classic-offset:';
 ///
 /// The loops-sorted archive holds roughly 10k videos; starting anywhere in
 /// the most-looped few hundred keeps the feed varied between sessions without
-/// dropping the user into the unwatched long tail. Mirrors the Explore →
+/// dropping the user into the unwatched long tail. Shared with the Explore →
 /// Classics tab so both surfaces draw from the same window.
-const int _classicsMaxRandomStartOffset = 400;
+const int classicsMaxRandomStartOffset = 400;
+
+/// Archive pages one Classics fetch may read while trying to fill its page.
+///
+/// Filtering — blocked authors, content preferences, transport scheme — can
+/// empty an otherwise full archive page, and a feed that opens on an empty
+/// page cannot paginate its way out. Reading a couple of extra pages covers
+/// that without turning a single fetch into a crawl through the archive.
+const int _classicsMaxPageFetches = 3;
 
 /// Result of a hashtag REST feed fetch.
 class HashtagFeedVideosResult {
@@ -813,14 +821,17 @@ class VideosRepository {
   /// Explore → Classics tab — not Explore → Popular's "Classic" toggle, which
   /// is server-ordered and therefore opens on the same videos in the same
   /// order every time. Each fetch that misses the cache starts at a random
-  /// offset within [_classicsMaxRandomStartOffset] and shuffles the page, so
+  /// offset within [classicsMaxRandomStartOffset] and shuffles the page, so
   /// two sessions do not see the same opening run. The next offset rides in
   /// [HomeFeedResult.paginationCursor], so the home feed paginates this like
-  /// the For You feed.
+  /// the For You feed. Filtering can empty an archive page, so up to
+  /// [_classicsMaxPageFetches] pages are read to fill [limit] rather than
+  /// handing back a page a feed cannot paginate out of.
   ///
-  /// Caching keeps the slice stable within a session: leaving and re-entering
-  /// the feed preserves the current ordering, while pull-to-refresh
-  /// ([skipCache] `true`) draws a fresh slice.
+  /// The in-memory cache keeps the slice stable while the process lives:
+  /// leaving and re-entering the feed preserves the current ordering, while
+  /// pull-to-refresh ([skipCache] `true`) draws a fresh slice. A cold start
+  /// starts from an empty cache and therefore draws a fresh slice too.
   ///
   /// Funnelcake-only: returns an empty result when no Funnelcake relay is
   /// connected (relays do not expose the server-side `platform` filter).
@@ -839,50 +850,68 @@ class VideosRepository {
       return const HomeFeedResult(videos: [], hasMore: false);
     }
 
-    final offset =
-        _decodeClassicsOffsetCursor(cursor) ?? _classicsOffset(limit);
+    var offset = _decodeClassicsOffsetCursor(cursor) ?? _classicsOffset(limit);
+
+    final collected = <VideoEvent>[];
+    final seenVideoKeys = <String>{};
+    var exhausted = false;
+    var failed = false;
 
     try {
-      final stats = await _funnelcakeApiClient.getClassicVines(
-        limit: limit,
-        offset: offset,
-      );
+      for (
+        var fetch = 0;
+        fetch < _classicsMaxPageFetches &&
+            collected.length < limit &&
+            !exhausted;
+        fetch++
+      ) {
+        final stats = await _funnelcakeApiClient.getClassicVines(
+          limit: limit,
+          offset: offset,
+        );
 
-      final videos = _filterPopularVideosForVariant(
-        await _hydrateVideosWithBulkStats(
-          _transformVideoStats(stats, sortByCreatedAt: false),
-          replaceInteractionCounts: true,
-        ),
-        PopularVideosVariant.classic,
-      );
+        _appendUniqueVideos(
+          collected,
+          _filterPopularVideosForVariant(
+            await _hydrateVideosWithBulkStats(
+              _transformVideoStats(stats, sortByCreatedAt: false),
+              replaceInteractionCounts: true,
+            ),
+            PopularVideosVariant.classic,
+          ),
+          seenVideoKeys: seenVideoKeys,
+        );
 
-      final deduped = <VideoEvent>[];
-      _appendUniqueVideos(deduped, videos, seenVideoKeys: <String>{});
-      deduped.shuffle(_random);
-
-      // A short page means the archive ran out at this offset. Length is read
-      // from the raw stats, not the filtered list, so a page that filters down
-      // to nothing still advances instead of ending the feed.
-      final exhausted = stats.length < limit;
-      final result = HomeFeedResult(
-        videos: deduped,
-        paginationCursor: exhausted
-            ? null
-            : _encodeClassicsOffsetCursor(offset + limit),
-        hasMore: !exhausted,
-      );
-
-      if (isFirstPage) _inMemoryFeedCache?.set(_classicsCacheKey, result);
-      return result;
+        // A short page means the archive ran out at this offset. Length is
+        // read from the raw stats, not the filtered list, so a page that
+        // filters down to nothing tops up instead of ending the feed.
+        exhausted = stats.length < limit;
+        offset += limit;
+      }
     } on FunnelcakeException {
-      return const HomeFeedResult(videos: [], hasMore: false);
+      failed = true;
     }
+
+    collected.shuffle(_random);
+
+    final hasMore = !exhausted && !failed;
+    final result = HomeFeedResult(
+      videos: collected,
+      paginationCursor: hasMore ? _encodeClassicsOffsetCursor(offset) : null,
+      hasMore: hasMore,
+    );
+
+    // A failed page is not worth pinning for the rest of the session.
+    if (!failed && isFirstPage) {
+      _inMemoryFeedCache?.set(_classicsCacheKey, result);
+    }
+    return result;
   }
 
   /// A random archive offset for a Classics session, aligned to [limit]-sized
   /// pages so successive cursors stay on page boundaries.
   int _classicsOffset(int limit) {
-    final pageCount = (_classicsMaxRandomStartOffset ~/ limit) + 1;
+    final pageCount = (classicsMaxRandomStartOffset ~/ limit) + 1;
     return _random.nextInt(pageCount) * limit;
   }
 

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -81,10 +81,13 @@ const String _classicsOffsetCursorPrefix = 'classic-offset:';
 
 /// Highest archive offset the Classics feed may open a session on.
 ///
-/// The loops-sorted archive holds roughly 10k videos; starting anywhere in
-/// the most-looped few hundred keeps the feed varied between sessions without
-/// dropping the user into the unwatched long tail. Shared with the Explore →
-/// Classics tab so both surfaces draw from the same window.
+/// The archive holds roughly 10k videos; starting anywhere in the most-viewed
+/// few hundred keeps the feed varied between sessions without dropping the
+/// user into the unwatched long tail. (`sort=loops` orders by views first and
+/// loops as the tiebreak on this path, because the request carries a
+/// `platform` filter and so misses Funnelcake's rank-ordered classic
+/// snapshot.) Shared with the Explore → Classics tab so both surfaces draw
+/// from the same window.
 const int classicsMaxRandomStartOffset = 400;
 
 /// Archive pages one Classics fetch may read while trying to fill its page.
@@ -817,21 +820,27 @@ class VideosRepository {
 
   /// Fetches classic Vine archive videos for the home feed's Classics mode.
   ///
-  /// Reads the same offset-paginated, loops-sorted archive as the standalone
-  /// Explore → Classics tab — not Explore → Popular's "Classic" toggle, which
-  /// is server-ordered and therefore opens on the same videos in the same
-  /// order every time. Each fetch that misses the cache starts at a random
-  /// offset within [classicsMaxRandomStartOffset] and shuffles the page, so
-  /// two sessions do not see the same opening run. The next offset rides in
+  /// Reads the same offset-paginated archive as the standalone Explore →
+  /// Classics tab — not Explore → Popular's "Classic" toggle, which is
+  /// server-ordered and therefore opens on the same videos in the same order
+  /// every time. Each fetch that misses the cache starts at a random offset
+  /// within [classicsMaxRandomStartOffset] and shuffles the page, so two
+  /// sessions do not see the same opening run. The next offset rides in
   /// [HomeFeedResult.paginationCursor], so the home feed paginates this like
   /// the For You feed. Filtering can empty an archive page, so up to
   /// [_classicsMaxPageFetches] pages are read to fill [limit] rather than
-  /// handing back a page a feed cannot paginate out of.
+  /// handing back a page a feed cannot paginate out of. A topped-up page can
+  /// therefore exceed [limit]; the cursor advances past every page actually
+  /// read, so trimming to [limit] would drop those videos rather than defer
+  /// them.
   ///
-  /// The in-memory cache keeps the slice stable while the process lives:
-  /// leaving and re-entering the feed preserves the current ordering, while
-  /// pull-to-refresh ([skipCache] `true`) draws a fresh slice. A cold start
-  /// starts from an empty cache and therefore draws a fresh slice too.
+  /// The in-memory cache keeps the *first* page stable while the process
+  /// lives, so leaving and re-entering the feed resumes on the same opening
+  /// run instead of reshuffling under the user; later pages are re-drawn and
+  /// re-shuffled on re-entry. Pull-to-refresh ([skipCache] `true`) draws a
+  /// fresh slice, and a cold start begins from an empty cache. An empty page
+  /// is never cached, so a slice that filters down to nothing is redrawn on
+  /// the next entry rather than pinned for the session.
   ///
   /// Funnelcake-only: returns an empty result when no Funnelcake relay is
   /// connected (relays do not expose the server-side `platform` filter).
@@ -882,10 +891,12 @@ class VideosRepository {
           seenVideoKeys: seenVideoKeys,
         );
 
-        // A short page means the archive ran out at this offset. Length is
-        // read from the raw stats, not the filtered list, so a page that
+        // Exhaustion is "the archive returned nothing here", not "the page
+        // came back short": the client drops rows with a missing id or URL
+        // before this sees them, so a short page is not an end-of-archive
+        // signal. Reading the count before filtering also means a page that
         // filters down to nothing tops up instead of ending the feed.
-        exhausted = stats.length < limit;
+        exhausted = stats.isEmpty;
         offset += limit;
       }
     } on FunnelcakeException {
@@ -901,8 +912,10 @@ class VideosRepository {
       hasMore: hasMore,
     );
 
-    // A failed page is not worth pinning for the rest of the session.
-    if (!failed && isFirstPage) {
+    // A failed page is not worth pinning for the rest of the session, and an
+    // empty one would be a trap: the feed cannot paginate out of an empty
+    // list, so pinning it would keep serving nothing until a manual refresh.
+    if (!failed && isFirstPage && collected.isNotEmpty) {
       _inMemoryFeedCache?.set(_classicsCacheKey, result);
     }
     return result;

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -17,27 +17,42 @@ class MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
 
 class MockVideoLocalStorage extends Mock implements VideoLocalStorage {}
 
-/// [Random] that pins the very first `nextInt` result and records the bounds
-/// it was asked for.
+/// [Random] that scripts the Classics archive-offset draws and records the
+/// bounds it was asked for.
 ///
-/// The Classics feed draws its archive offset before it shuffles the page, so
-/// pinning the first draw fixes which page it lands on while the shuffle's
-/// draws fall through to a seeded [Random] and stay deterministic.
+/// The offset draw is the only call bounded by the reachable page count
+/// ([offsetDrawMax]); the page shuffle's draws are bounded by the page length,
+/// so the two are distinguishable. Scripted draws are handed out in order and
+/// every other call falls through to a seeded [Random] so shuffles stay
+/// deterministic. Asking for an unscripted offset throws rather than silently
+/// drawing, so a test that fetches more pages than it planned for fails loudly.
 class _StubRandom implements Random {
-  _StubRandom({this.firstDraw = 0});
+  _StubRandom({this.offsetDraws = const [0]});
 
-  /// Result handed to the offset draw.
-  final int firstDraw;
+  /// Results handed to successive offset draws, in call order.
+  final List<int> offsetDraws;
+
+  /// The `max` that identifies an offset draw: the reachable page count for
+  /// the `limit: 20` pages these tests use.
+  static const int offsetDrawMax = (classicsMaxRandomStartOffset ~/ 20) + 1;
 
   final Random _shuffleRandom = Random(0);
 
   /// Every `max` passed to [nextInt], in call order.
   final List<int> recordedMaxima = [];
 
+  int _offsetDrawCount = 0;
+
   @override
   int nextInt(int max) {
     recordedMaxima.add(max);
-    return recordedMaxima.length == 1 ? firstDraw : _shuffleRandom.nextInt(max);
+    if (max != offsetDrawMax) return _shuffleRandom.nextInt(max);
+
+    final index = _offsetDrawCount++;
+    if (index >= offsetDraws.length) {
+      throw StateError('Unscripted Classics offset draw #${index + 1}');
+    }
+    return offsetDraws[index];
   }
 
   @override
@@ -4222,6 +4237,18 @@ void main() {
           ),
       ];
 
+      /// Full-length archive page whose rows are all filtered out of Classics
+      /// because they are not original vines.
+      List<VideoStats> nonVinePage(int count) => [
+        for (var i = 0; i < count; i++)
+          _createVideoStats(
+            id: 'divine-$i',
+            pubkey: 'pubkey-$i',
+            dTag: 'divine-$i',
+            videoUrl: 'https://example.com/divine-$i.mp4',
+          ),
+      ];
+
       void stubArchive(List<VideoStats> page) {
         when(
           () => mockFunnelcakeClient.getClassicVines(
@@ -4231,6 +4258,24 @@ void main() {
             before: any(named: 'before'),
           ),
         ).thenAnswer((_) async => page);
+      }
+
+      /// Serves a different page per archive offset, so top-up behaviour can
+      /// be driven page by page.
+      void stubArchiveByOffset(
+        List<VideoStats> Function(int offset) pageForOffset,
+      ) {
+        when(
+          () => mockFunnelcakeClient.getClassicVines(
+            sort: any(named: 'sort'),
+            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
+            before: any(named: 'before'),
+          ),
+        ).thenAnswer(
+          (invocation) async =>
+              pageForOffset(invocation.namedArguments[#offset] as int),
+        );
       }
 
       VideosRepository buildRepository({Random? random}) => VideosRepository(
@@ -4251,7 +4296,7 @@ void main() {
         stubArchive(archivePage(20));
 
         // Random.nextInt is called once, over the number of reachable pages.
-        final random = _StubRandom(firstDraw: 7);
+        final random = _StubRandom(offsetDraws: [7]);
         await buildRepository(random: random).getClassicVideos(limit: 20);
 
         // The offset is drawn over the reachable page count, not a raw index.
@@ -4264,6 +4309,64 @@ void main() {
             before: any(named: 'before'),
           ),
         ).called(1);
+      });
+
+      test('reads the loops-sorted archive, like Explore → Classics', () async {
+        stubArchive(archivePage(20));
+
+        await buildRepository(
+          random: _StubRandom(),
+        ).getClassicVideos(limit: 20);
+
+        // The shared window only lines up with the Explore tab while both
+        // read the same sort; 'trending' or 'recent' would be a different
+        // feed wearing the same name.
+        final captured = verify(
+          () => mockFunnelcakeClient.getClassicVines(
+            sort: captureAny(named: 'sort'),
+            limit: captureAny(named: 'limit'),
+            offset: any(named: 'offset'),
+            before: any(named: 'before'),
+          ),
+        ).captured;
+        expect(captured, ['loops', 20]);
+      });
+
+      test('tops up when a page filters down to nothing', () async {
+        // The archive answers at full length, but nothing on the first page
+        // survives the Classics filter.
+        stubArchiveByOffset(
+          (offset) => offset == 0 ? nonVinePage(20) : archivePage(20),
+        );
+
+        final result = await buildRepository(
+          random: _StubRandom(),
+        ).getClassicVideos(limit: 20);
+
+        expect(result.videos, hasLength(20));
+        expect(result.paginationCursor, 'classic-offset:40');
+        expect(result.hasMore, isTrue);
+      });
+
+      test('stops topping up after a bounded number of pages', () async {
+        stubArchive(nonVinePage(20));
+
+        final result = await buildRepository(
+          random: _StubRandom(),
+        ).getClassicVideos(limit: 20);
+
+        expect(result.videos, isEmpty);
+        // The cursor still advances past every page that was read, so a
+        // retry resumes beyond the filtered-out run instead of repeating it.
+        expect(result.paginationCursor, 'classic-offset:60');
+        verify(
+          () => mockFunnelcakeClient.getClassicVines(
+            sort: any(named: 'sort'),
+            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
+            before: any(named: 'before'),
+          ),
+        ).called(3);
       });
 
       test('shuffles the page rather than preserving archive order', () async {
@@ -4281,7 +4384,9 @@ void main() {
       test('draws a different slice on each cache-missing fetch', () async {
         stubArchive(archivePage(20));
 
-        final repository = buildRepository(random: Random(7));
+        final repository = buildRepository(
+          random: _StubRandom(offsetDraws: [7, 3]),
+        );
         await repository.getClassicVideos(limit: 20);
         await repository.getClassicVideos(limit: 20, skipCache: true);
 
@@ -4293,8 +4398,7 @@ void main() {
             before: any(named: 'before'),
           ),
         ).captured;
-        expect(offsets, hasLength(2));
-        expect(offsets.first, isNot(offsets.last));
+        expect(offsets, [140, 60]); // 7 * 20, then 3 * 20
       });
 
       test('advances the cursor by a page and resumes from it', () async {

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -15,6 +16,36 @@ class MockNostrClient extends Mock implements NostrClient {}
 class MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
 
 class MockVideoLocalStorage extends Mock implements VideoLocalStorage {}
+
+/// [Random] that pins the very first `nextInt` result and records the bounds
+/// it was asked for.
+///
+/// The Classics feed draws its archive offset before it shuffles the page, so
+/// pinning the first draw fixes which page it lands on while the shuffle's
+/// draws fall through to a seeded [Random] and stay deterministic.
+class _StubRandom implements Random {
+  _StubRandom({this.firstDraw = 0});
+
+  /// Result handed to the offset draw.
+  final int firstDraw;
+
+  final Random _shuffleRandom = Random(0);
+
+  /// Every `max` passed to [nextInt], in call order.
+  final List<int> recordedMaxima = [];
+
+  @override
+  int nextInt(int max) {
+    recordedMaxima.add(max);
+    return recordedMaxima.length == 1 ? firstDraw : _shuffleRandom.nextInt(max);
+  }
+
+  @override
+  bool nextBool() => _shuffleRandom.nextBool();
+
+  @override
+  double nextDouble() => _shuffleRandom.nextDouble();
+}
 
 /// Test helper that tracks content filter calls.
 class TestContentFilter {
@@ -4179,125 +4210,197 @@ void main() {
     group('getClassicVideos', () {
       late MockFunnelcakeApiClient mockFunnelcakeClient;
 
+      /// Archive page large enough that a shuffle is observable.
+      List<VideoStats> archivePage(int count) => [
+        for (var i = 0; i < count; i++)
+          _createVideoStats(
+            id: 'vine-$i',
+            pubkey: 'pubkey-$i',
+            dTag: 'vine-$i',
+            videoUrl: 'https://example.com/vine-$i.mp4',
+            rawTags: const {'platform': 'vine'},
+          ),
+      ];
+
+      void stubArchive(List<VideoStats> page) {
+        when(
+          () => mockFunnelcakeClient.getClassicVines(
+            sort: any(named: 'sort'),
+            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
+            before: any(named: 'before'),
+          ),
+        ).thenAnswer((_) async => page);
+      }
+
+      VideosRepository buildRepository({Random? random}) => VideosRepository(
+        nostrClient: mockNostrClient,
+        funnelcakeApiClient: mockFunnelcakeClient,
+        random: random,
+      );
+
       setUp(() {
         mockFunnelcakeClient = MockFunnelcakeApiClient();
+        when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
         when(
           () => mockFunnelcakeClient.getBulkVideoStats(any()),
         ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
-        when(
-          () => mockFunnelcakeClient.getV2PopularVideosPage(
-            variant: any(named: 'variant'),
-            limit: any(named: 'limit'),
-            cursor: any(named: 'cursor'),
-            before: any(named: 'before'),
-            preferredLanguages: any(named: 'preferredLanguages'),
-            viewerCountry: any(named: 'viewerCountry'),
-          ),
-        ).thenAnswer((invocation) async {
-          final stats = await mockFunnelcakeClient.getV2PopularVideos(
-            variant:
-                invocation.namedArguments[#variant] as PopularVideosVariant,
-            limit: invocation.namedArguments[#limit] as int? ?? 25,
-            before: invocation.namedArguments[#before] as int?,
-          );
-          return V2PopularVideosResponse(videos: stats);
-        });
       });
 
-      test(
-        'delegates to the classic popular feed and maps it to a HomeFeedResult',
-        () async {
-          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
-          when(
-            () => mockFunnelcakeClient.getV2PopularVideos(
-              variant: any(named: 'variant'),
-              limit: any(named: 'limit'),
-              before: any(named: 'before'),
-            ),
-          ).thenAnswer(
-            (_) async => [
-              _createVideoStats(
-                id: 'vine-1',
-                pubkey: 'pubkey-1',
-                dTag: 'vine-1',
-                videoUrl: 'https://example.com/vine-1.mp4',
-                rawTags: const {'platform': 'vine'},
-              ),
-            ],
-          );
+      test('reads the archive at a page-aligned random start offset', () async {
+        stubArchive(archivePage(20));
 
-          final repositoryWithApi = VideosRepository(
-            nostrClient: mockNostrClient,
-            funnelcakeApiClient: mockFunnelcakeClient,
-          );
+        // Random.nextInt is called once, over the number of reachable pages.
+        final random = _StubRandom(firstDraw: 7);
+        await buildRepository(random: random).getClassicVideos(limit: 20);
 
-          final result = await repositoryWithApi.getClassicVideos();
+        // The offset is drawn over the reachable page count, not a raw index.
+        expect(random.recordedMaxima.first, 21); // (400 ~/ 20) + 1
+        verify(
+          () => mockFunnelcakeClient.getClassicVines(
+            sort: any(named: 'sort'),
+            limit: 20,
+            offset: 140, // 7 * 20
+            before: any(named: 'before'),
+          ),
+        ).called(1);
+      });
 
-          expect(result.videos.map((v) => v.id), ['vine-1']);
-          verify(
-            () => mockFunnelcakeClient.getV2PopularVideosPage(
-              variant: PopularVideosVariant.classic,
-              limit: any(named: 'limit'),
-              cursor: any(named: 'cursor'),
-              before: any(named: 'before'),
-              preferredLanguages: any(named: 'preferredLanguages'),
-              viewerCountry: any(named: 'viewerCountry'),
-            ),
-          ).called(1);
-        },
-      );
+      test('shuffles the page rather than preserving archive order', () async {
+        stubArchive(archivePage(20));
 
-      test(
-        'maps a non-null page cursor to paginationCursor with hasMore',
-        () async {
-          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
-          when(
-            () => mockFunnelcakeClient.getV2PopularVideosPage(
-              variant: any(named: 'variant'),
-              limit: any(named: 'limit'),
-              cursor: any(named: 'cursor'),
-              before: any(named: 'before'),
-              preferredLanguages: any(named: 'preferredLanguages'),
-              viewerCountry: any(named: 'viewerCountry'),
-            ),
-          ).thenAnswer(
-            (_) async => V2PopularVideosResponse(
-              videos: [
-                _createVideoStats(
-                  id: 'vine-1',
-                  pubkey: 'pubkey-1',
-                  dTag: 'vine-1',
-                  videoUrl: 'https://example.com/vine-1.mp4',
-                  rawTags: const {'platform': 'vine'},
-                ),
-              ],
-              nextCursor: 'page-2',
-              hasMore: true,
-            ),
-          );
+        final result = await buildRepository(
+          random: Random(7),
+        ).getClassicVideos(limit: 20);
 
-          final repositoryWithApi = VideosRepository(
-            nostrClient: mockNostrClient,
-            funnelcakeApiClient: mockFunnelcakeClient,
-          );
+        final archiveOrder = [for (var i = 0; i < 20; i++) 'vine-$i'];
+        expect(result.videos.map((v) => v.id), isNot(archiveOrder));
+        expect(result.videos.map((v) => v.id), unorderedEquals(archiveOrder));
+      });
 
-          final result = await repositoryWithApi.getClassicVideos(limit: 1);
+      test('draws a different slice on each cache-missing fetch', () async {
+        stubArchive(archivePage(20));
 
-          expect(result.videos.map((v) => v.id), ['vine-1']);
-          expect(result.paginationCursor, 'page-2');
-          expect(result.hasMore, isTrue);
-        },
-      );
+        final repository = buildRepository(random: Random(7));
+        await repository.getClassicVideos(limit: 20);
+        await repository.getClassicVideos(limit: 20, skipCache: true);
+
+        final offsets = verify(
+          () => mockFunnelcakeClient.getClassicVines(
+            sort: any(named: 'sort'),
+            limit: any(named: 'limit'),
+            offset: captureAny(named: 'offset'),
+            before: any(named: 'before'),
+          ),
+        ).captured;
+        expect(offsets, hasLength(2));
+        expect(offsets.first, isNot(offsets.last));
+      });
+
+      test('advances the cursor by a page and resumes from it', () async {
+        stubArchive(archivePage(20));
+
+        final repository = buildRepository(random: _StubRandom());
+        final first = await repository.getClassicVideos(limit: 20);
+        expect(first.paginationCursor, 'classic-offset:20');
+        expect(first.hasMore, isTrue);
+
+        await repository.getClassicVideos(
+          limit: 20,
+          cursor: first.paginationCursor,
+        );
+
+        verify(
+          () => mockFunnelcakeClient.getClassicVines(
+            sort: any(named: 'sort'),
+            limit: any(named: 'limit'),
+            offset: 20,
+            before: any(named: 'before'),
+          ),
+        ).called(1);
+      });
+
+      test('ends pagination when the archive returns a short page', () async {
+        stubArchive(archivePage(3));
+
+        final result = await buildRepository(
+          random: _StubRandom(),
+        ).getClassicVideos(limit: 20);
+
+        expect(result.paginationCursor, isNull);
+        expect(result.hasMore, isFalse);
+      });
+
+      test('keeps the slice stable across cache-eligible fetches', () async {
+        stubArchive(archivePage(20));
+
+        final repository = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcakeClient,
+          inMemoryFeedCache: InMemoryFeedCache(),
+          random: _StubRandom(),
+        );
+
+        final first = await repository.getClassicVideos(limit: 20);
+        final second = await repository.getClassicVideos(limit: 20);
+
+        expect(second.videos.map((v) => v.id), first.videos.map((v) => v.id));
+        verify(
+          () => mockFunnelcakeClient.getClassicVines(
+            sort: any(named: 'sort'),
+            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
+            before: any(named: 'before'),
+          ),
+        ).called(1);
+      });
+
+      test('drops archive rows that are not original vines', () async {
+        stubArchive([
+          _createVideoStats(
+            id: 'vine-1',
+            pubkey: 'pubkey-1',
+            dTag: 'vine-1',
+            videoUrl: 'https://example.com/vine-1.mp4',
+            rawTags: const {'platform': 'vine'},
+          ),
+          _createVideoStats(
+            id: 'divine-1',
+            pubkey: 'pubkey-2',
+            dTag: 'divine-1',
+            videoUrl: 'https://example.com/divine-1.mp4',
+          ),
+        ]);
+
+        final result = await buildRepository(
+          random: _StubRandom(),
+        ).getClassicVideos(limit: 20);
+
+        expect(result.videos.map((v) => v.id), ['vine-1']);
+      });
 
       test('returns an empty result when Funnelcake is unavailable', () async {
         when(() => mockFunnelcakeClient.isAvailable).thenReturn(false);
 
-        final repositoryWithApi = VideosRepository(
-          nostrClient: mockNostrClient,
-          funnelcakeApiClient: mockFunnelcakeClient,
-        );
+        final result = await buildRepository().getClassicVideos();
 
-        final result = await repositoryWithApi.getClassicVideos();
+        expect(result.videos, isEmpty);
+        expect(result.hasMore, isFalse);
+      });
+
+      test('returns an empty result when the archive request fails', () async {
+        when(
+          () => mockFunnelcakeClient.getClassicVines(
+            sort: any(named: 'sort'),
+            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
+            before: any(named: 'before'),
+          ),
+        ).thenThrow(const FunnelcakeNotConfiguredException());
+
+        final result = await buildRepository(
+          random: _StubRandom(),
+        ).getClassicVideos();
 
         expect(result.videos, isEmpty);
         expect(result.hasMore, isFalse);

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -20,39 +20,48 @@ class MockVideoLocalStorage extends Mock implements VideoLocalStorage {}
 /// [Random] that scripts the Classics archive-offset draws and records the
 /// bounds it was asked for.
 ///
-/// The offset draw is the only call bounded by the reachable page count
-/// ([offsetDrawMax]); the page shuffle's draws are bounded by the page length,
-/// so the two are distinguishable. Scripted draws are handed out in order and
-/// every other call falls through to a seeded [Random] so shuffles stay
-/// deterministic. Asking for an unscripted offset throws rather than silently
-/// drawing, so a test that fetches more pages than it planned for fails loudly.
+/// A fetch draws its offset first and shuffles its page last, so the armed
+/// draw ([expectOffsetDraw]) identifies the offset by position; every other
+/// call falls through to a seeded [Random] so shuffles stay deterministic.
+/// [recordedMaxima] exposes the bounds, so tests can pin the page count the
+/// offset was drawn over.
 class _StubRandom implements Random {
-  _StubRandom({this.offsetDraws = const [0]});
-
-  /// Results handed to successive offset draws, in call order.
-  final List<int> offsetDraws;
-
-  /// The `max` that identifies an offset draw: the reachable page count for
-  /// the `limit: 20` pages these tests use.
-  static const int offsetDrawMax = (classicsMaxRandomStartOffset ~/ 20) + 1;
+  _StubRandom({int firstOffsetDraw = 0}) : _pendingOffsetDraw = firstOffsetDraw;
 
   final Random _shuffleRandom = Random(0);
 
   /// Every `max` passed to [nextInt], in call order.
   final List<int> recordedMaxima = [];
 
-  int _offsetDrawCount = 0;
+  int? _pendingOffsetDraw;
+
+  /// Scripts the archive page the next offset draw lands on.
+  ///
+  /// A Classics fetch draws its offset before its first archive read, so the
+  /// armed draw is consumed by the next `nextInt`. Everything after it — the
+  /// page shuffle — falls through to [_shuffleRandom]. Position rather than
+  /// `max` identifies the draw, because a shuffle of N items walks
+  /// `nextInt(N)` down to `nextInt(2)` and would otherwise collide with the
+  /// reachable-page count.
+  /// Throws when the previously armed draw was never consumed, so a test that
+  /// scripts an offset for a fetch that never draws one fails loudly instead
+  /// of leaking the value into a later shuffle.
+  void expectOffsetDraw(int page) {
+    if (_pendingOffsetDraw != null) {
+      throw StateError('Scripted Classics offset draw was never consumed');
+    }
+    _pendingOffsetDraw = page;
+  }
 
   @override
   int nextInt(int max) {
     recordedMaxima.add(max);
-    if (max != offsetDrawMax) return _shuffleRandom.nextInt(max);
 
-    final index = _offsetDrawCount++;
-    if (index >= offsetDraws.length) {
-      throw StateError('Unscripted Classics offset draw #${index + 1}');
-    }
-    return offsetDraws[index];
+    final offsetDraw = _pendingOffsetDraw;
+    if (offsetDraw == null) return _shuffleRandom.nextInt(max);
+
+    _pendingOffsetDraw = null;
+    return offsetDraw;
   }
 
   @override
@@ -4226,8 +4235,11 @@ void main() {
       late MockFunnelcakeApiClient mockFunnelcakeClient;
 
       /// Archive page large enough that a shuffle is observable.
-      List<VideoStats> archivePage(int count) => [
-        for (var i = 0; i < count; i++)
+      ///
+      /// [startIndex] keeps successive pages distinct, so a topped-up fetch
+      /// is not silently deduplicated down to one page's worth of rows.
+      List<VideoStats> archivePage(int count, {int startIndex = 0}) => [
+        for (var i = startIndex; i < startIndex + count; i++)
           _createVideoStats(
             id: 'vine-$i',
             pubkey: 'pubkey-$i',
@@ -4278,9 +4290,12 @@ void main() {
         );
       }
 
+      /// Repository wired to a live cache, so the cache guards are load-bearing
+      /// in every test rather than only in the ones that name the cache.
       VideosRepository buildRepository({Random? random}) => VideosRepository(
         nostrClient: mockNostrClient,
         funnelcakeApiClient: mockFunnelcakeClient,
+        inMemoryFeedCache: InMemoryFeedCache(),
         random: random,
       );
 
@@ -4296,7 +4311,7 @@ void main() {
         stubArchive(archivePage(20));
 
         // Random.nextInt is called once, over the number of reachable pages.
-        final random = _StubRandom(offsetDraws: [7]);
+        final random = _StubRandom(firstOffsetDraw: 7);
         await buildRepository(random: random).getClassicVideos(limit: 20);
 
         // The offset is drawn over the reachable page count, not a raw index.
@@ -4310,6 +4325,28 @@ void main() {
           ),
         ).called(1);
       });
+
+      test(
+        'aligns the offset grid to the page size the feed asks for',
+        () async {
+          // The home feed passes no limit, so the grid is the default page size
+          // rather than the 20 the rest of this group uses.
+          stubArchive(archivePage(25));
+
+          final random = _StubRandom(firstOffsetDraw: 7);
+          await buildRepository(random: random).getClassicVideos();
+
+          expect(random.recordedMaxima.first, 17); // (400 ~/ 25) + 1
+          verify(
+            () => mockFunnelcakeClient.getClassicVines(
+              sort: any(named: 'sort'),
+              limit: 25,
+              offset: 175, // 7 * 25
+              before: any(named: 'before'),
+            ),
+          ).called(1);
+        },
+      );
 
       test('reads the loops-sorted archive, like Explore → Classics', () async {
         stubArchive(archivePage(20));
@@ -4384,10 +4421,13 @@ void main() {
       test('draws a different slice on each cache-missing fetch', () async {
         stubArchive(archivePage(20));
 
-        final repository = buildRepository(
-          random: _StubRandom(offsetDraws: [7, 3]),
-        );
+        final random = _StubRandom(firstOffsetDraw: 7);
+        final repository = buildRepository(random: random);
         await repository.getClassicVideos(limit: 20);
+
+        // skipCache is what makes the second fetch redraw: without it the
+        // repository serves the slice it just pinned.
+        random.expectOffsetDraw(3);
         await repository.getClassicVideos(limit: 20, skipCache: true);
 
         final offsets = verify(
@@ -4424,26 +4464,48 @@ void main() {
         ).called(1);
       });
 
-      test('ends pagination when the archive returns a short page', () async {
-        stubArchive(archivePage(3));
+      test('ends pagination when the archive runs out', () async {
+        stubArchiveByOffset(
+          (offset) => offset == 0 ? archivePage(3) : const [],
+        );
 
         final result = await buildRepository(
           random: _StubRandom(),
         ).getClassicVideos(limit: 20);
 
+        expect(result.videos, hasLength(3));
         expect(result.paginationCursor, isNull);
         expect(result.hasMore, isFalse);
       });
 
+      test(
+        'keeps paginating when a short page is not the archive end',
+        () async {
+          // The client drops rows with a missing id or URL before the
+          // repository sees them, so a short page cannot be read as exhaustion:
+          // one dropped row would end the feed mid-archive.
+          stubArchiveByOffset(
+            (offset) =>
+                offset == 0 ? archivePage(19) : archivePage(20, startIndex: 19),
+          );
+
+          final result = await buildRepository(
+            random: _StubRandom(),
+          ).getClassicVideos(limit: 20);
+
+          expect(result.hasMore, isTrue);
+          expect(result.paginationCursor, 'classic-offset:40');
+          // Both pages are handed back rather than trimmed to `limit`: the
+          // cursor has already advanced past them, so trimming would drop
+          // those videos instead of deferring them to the next page.
+          expect(result.videos, hasLength(39));
+        },
+      );
+
       test('keeps the slice stable across cache-eligible fetches', () async {
         stubArchive(archivePage(20));
 
-        final repository = VideosRepository(
-          nostrClient: mockNostrClient,
-          funnelcakeApiClient: mockFunnelcakeClient,
-          inMemoryFeedCache: InMemoryFeedCache(),
-          random: _StubRandom(),
-        );
+        final repository = buildRepository(random: _StubRandom());
 
         final first = await repository.getClassicVideos(limit: 20);
         final second = await repository.getClassicVideos(limit: 20);
@@ -4457,6 +4519,51 @@ void main() {
             before: any(named: 'before'),
           ),
         ).called(1);
+      });
+
+      test(
+        'does not let a later page overwrite the cached first page',
+        () async {
+          stubArchiveByOffset(
+            (offset) =>
+                offset == 0 ? archivePage(20) : archivePage(20, startIndex: 20),
+          );
+
+          final random = _StubRandom();
+          final repository = buildRepository(random: random);
+
+          final first = await repository.getClassicVideos(limit: 20);
+          await repository.getClassicVideos(
+            limit: 20,
+            cursor: first.paginationCursor,
+          );
+          final reentry = await repository.getClassicVideos(limit: 20);
+
+          expect(
+            reentry.videos.map((v) => v.id),
+            first.videos.map((v) => v.id),
+          );
+        },
+      );
+
+      test('does not pin an empty page for the rest of the session', () async {
+        // Three full pages that filter down to nothing: the feed cannot
+        // paginate out of an empty list, so caching this would keep serving
+        // nothing until a manual refresh.
+        stubArchiveByOffset(
+          (offset) => offset < 200 ? nonVinePage(20) : archivePage(20),
+        );
+
+        final random = _StubRandom();
+        final repository = buildRepository(random: random);
+
+        final empty = await repository.getClassicVideos(limit: 20);
+        expect(empty.videos, isEmpty);
+
+        random.expectOffsetDraw(10); // 10 * 20 = offset 200
+        final reentry = await repository.getClassicVideos(limit: 20);
+
+        expect(reentry.videos, hasLength(20));
       });
 
       test('drops archive rows that are not original vines', () async {
@@ -4508,6 +4615,34 @@ void main() {
 
         expect(result.videos, isEmpty);
         expect(result.hasMore, isFalse);
+      });
+
+      test('serves the pages that succeeded when a top-up fails', () async {
+        // The first page filters short, so the fetch tops up — and the
+        // top-up is what fails.
+        stubArchiveByOffset((offset) {
+          if (offset == 0) {
+            return [...archivePage(12), ...nonVinePage(8)];
+          }
+          throw const FunnelcakeNotConfiguredException();
+        });
+
+        final random = _StubRandom();
+        final repository = buildRepository(random: random);
+
+        final result = await repository.getClassicVideos(limit: 20);
+
+        expect(result.videos, hasLength(12));
+        expect(result.hasMore, isFalse);
+        expect(result.paginationCursor, isNull);
+
+        // A partial page is not worth pinning: the next entry redraws
+        // instead of replaying what the failure left behind.
+        stubArchive(archivePage(20));
+        random.expectOffsetDraw(2);
+        final reentry = await repository.getClassicVideos(limit: 20);
+
+        expect(reentry.videos, hasLength(20));
       });
     });
 
@@ -11248,81 +11383,77 @@ void main() {
         ).called(2);
       });
 
-      test(
-        'reorders cached recommendations when seen state changes',
-        () async {
-          final first = _createVideoStats(
-            id: 'first-video',
-            pubkey: 'first-pubkey',
-            dTag: 'first-dtag',
-            videoUrl: 'https://example.com/first.mp4',
-          );
-          final second = _createVideoStats(
-            id: 'second-video',
-            pubkey: 'second-pubkey',
-            dTag: 'second-dtag',
-            videoUrl: 'https://example.com/second.mp4',
-          );
-          when(
-            () => mockFunnelcakeClient.getRecommendations(
-              seed: any(named: 'seed'),
-              pubkey: any(named: 'pubkey'),
-              limit: any(named: 'limit'),
-              fallback: any(named: 'fallback'),
-              category: any(named: 'category'),
-              preferredLanguages: any(named: 'preferredLanguages'),
-              viewerCountry: any(named: 'viewerCountry'),
-            ),
-          ).thenAnswer(
-            (_) async => RecommendationsResponse(
-              videos: [first, second],
-              source: 'personalized',
-              nextCursor: 'page-2',
-              hasMore: true,
-            ),
-          );
+      test('reorders cached recommendations when seen state changes', () async {
+        final first = _createVideoStats(
+          id: 'first-video',
+          pubkey: 'first-pubkey',
+          dTag: 'first-dtag',
+          videoUrl: 'https://example.com/first.mp4',
+        );
+        final second = _createVideoStats(
+          id: 'second-video',
+          pubkey: 'second-pubkey',
+          dTag: 'second-dtag',
+          videoUrl: 'https://example.com/second.mp4',
+        );
+        when(
+          () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
+            pubkey: any(named: 'pubkey'),
+            limit: any(named: 'limit'),
+            fallback: any(named: 'fallback'),
+            category: any(named: 'category'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
+          ),
+        ).thenAnswer(
+          (_) async => RecommendationsResponse(
+            videos: [first, second],
+            source: 'personalized',
+            nextCursor: 'page-2',
+            hasMore: true,
+          ),
+        );
 
-          final recentlySeenIds = <String>{};
-          final repo = VideosRepository(
-            nostrClient: mockNostrClient,
-            funnelcakeApiClient: mockFunnelcakeClient,
-            inMemoryFeedCache: InMemoryFeedCache(),
-            seenVideoLookup: SeenVideoLookup(
-              wasSeenRecently:
-                  (videoId, {within = const Duration(hours: 24)}) =>
-                      recentlySeenIds.contains(videoId),
-            ),
-          );
+        final recentlySeenIds = <String>{};
+        final repo = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcakeClient,
+          inMemoryFeedCache: InMemoryFeedCache(),
+          seenVideoLookup: SeenVideoLookup(
+            wasSeenRecently: (videoId, {within = const Duration(hours: 24)}) =>
+                recentlySeenIds.contains(videoId),
+          ),
+        );
 
-          final fresh = await repo.getRecommendedVideos(
-            userPubkey: 'user-pubkey',
+        final fresh = await repo.getRecommendedVideos(
+          userPubkey: 'user-pubkey',
+          limit: 10,
+        );
+        recentlySeenIds.add('first-video');
+        final cached = await repo.getRecommendedVideos(
+          userPubkey: 'user-pubkey',
+          limit: 10,
+        );
+
+        expect(fresh.videos.map((video) => video.id), [
+          'first-video',
+          'second-video',
+        ]);
+        expect(cached.videos.map((video) => video.id), [
+          'second-video',
+          'first-video',
+        ]);
+        expect(cached.paginationCursor, equals('page-2'));
+        expect(cached.hasMore, isTrue);
+        verify(
+          () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
+            pubkey: 'user-pubkey',
             limit: 10,
-          );
-          recentlySeenIds.add('first-video');
-          final cached = await repo.getRecommendedVideos(
-            userPubkey: 'user-pubkey',
-            limit: 10,
-          );
-
-          expect(fresh.videos.map((video) => video.id), [
-            'first-video',
-            'second-video',
-          ]);
-          expect(cached.videos.map((video) => video.id), [
-            'second-video',
-            'first-video',
-          ]);
-          expect(cached.paginationCursor, equals('page-2'));
-          expect(cached.hasMore, isTrue);
-          verify(
-            () => mockFunnelcakeClient.getRecommendations(
-              seed: any(named: 'seed'),
-              pubkey: 'user-pubkey',
-              limit: 10,
-            ),
-          ).called(1);
-        },
-      );
+          ),
+        ).called(1);
+      });
 
       test('keeps the same session seed across cursor pagination', () async {
         final requestedSeeds = <String?>[];

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -962,7 +962,6 @@ void main() {
           when(
             () => mockVideosRepository.getClassicVideos(
               limit: any(named: 'limit'),
-              until: any(named: 'until'),
               cursor: any(named: 'cursor'),
               skipCache: any(named: 'skipCache'),
             ),
@@ -998,7 +997,6 @@ void main() {
           verify(
             () => mockVideosRepository.getClassicVideos(
               limit: any(named: 'limit'),
-              until: any(named: 'until'),
               cursor: any(named: 'cursor'),
               skipCache: any(named: 'skipCache'),
             ),
@@ -1575,7 +1573,6 @@ void main() {
           when(
             () => mockVideosRepository.getClassicVideos(
               limit: any(named: 'limit'),
-              until: any(named: 'until'),
               cursor: any(named: 'cursor'),
               skipCache: any(named: 'skipCache'),
             ),
@@ -1609,7 +1606,6 @@ void main() {
           verify(
             () => mockVideosRepository.getClassicVideos(
               limit: any(named: 'limit'),
-              until: any(named: 'until'),
               cursor: any(named: 'cursor'),
               skipCache: any(named: 'skipCache'),
             ),
@@ -1630,7 +1626,6 @@ void main() {
           when(
             () => mockVideosRepository.getClassicVideos(
               limit: any(named: 'limit'),
-              until: any(named: 'until'),
               cursor: any(named: 'cursor'),
               skipCache: any(named: 'skipCache'),
             ),
@@ -2799,7 +2794,6 @@ void main() {
           verifyNever(
             () => mockVideosRepository.getClassicVideos(
               limit: any(named: 'limit'),
-              until: any(named: 'until'),
               cursor: any(named: 'cursor'),
               skipCache: any(named: 'skipCache'),
             ),


### PR DESCRIPTION
Closes #6538

## Description

The home feed's Classics mode and Discover's Classics tab read two different sources, and only one of them varied. Home Classics went through `getClassicVideos`, which delegated to the v2 popular feed with the classic variant — server-ranked and cursor-paged, so every user opened on the same top-of-month vines in the same order on every session. Discover's Classics tab reads the offset-paginated archive (`sort=loops`, which the server serves views-first on this path) with a random start offset plus a per-page shuffle. The split was deliberate when Classics was added to the home picker (#5564) and is documented in the old doc comment, but the two surfaces ended up feeling like different features.

This points `getClassicVideos` at the same archive Discover uses: draw a page-aligned random offset within the top 400 on every fetch that misses the cache, shuffle the resolved page, and carry the next offset in `paginationCursor` (`classic-offset:<n>`) so the home feed keeps paginating through the existing cursor plumbing rather than needing a new pagination shape. Classics already opts out of the `createdAt` re-sort on page merge (`_usesCursorPagination`), so the shuffled order reaches the feed intact instead of being undone. Both surfaces now draw their random start from one exported constant (`classicsMaxRandomStartOffset`) so the window cannot desync between them.

**Why the fetch tops up:** filtering — blocked authors, content preferences, transport scheme, non-vine rows — can empty an otherwise full archive page, and `VideoFeedBloc` stops paginating once the feed list is empty, so an empty first page would dead-end Classics until a manual refresh. The delegating implementation this replaces looped until it had a full page of *visible* videos; the archive read does the same, bounded at three pages so a systematically filtered slice cannot turn one fetch into a crawl through the archive. Exhaustion is read from the page the client returned rather than the filtered list, so a fully-filtered page advances the cursor instead of ending the feed. It means "the archive returned nothing at this offset", not "the page came back short": the client drops rows with a missing id or URL before the repository sees them, so a short page is not an end-of-archive signal — one dropped row would otherwise end the feed mid-archive. The cost is one extra request at the true end of the archive. A topped-up page is handed back whole rather than trimmed to `limit`, because the offset cursor has already advanced past every page read: trimming would drop those videos rather than defer them to the next page. A request that fails partway serves the pages that already succeeded and is not pinned in the session cache.

**Why the cache still matters:** only pull-to-refresh passes `skipCache: true`, and that is what draws a fresh slice. Picking Classics from the home picker goes through `_loadVideos` with the default `skipCache: false` and so resumes the pinned first page — deliberately, so navigating away and back does not reshuffle the feed out from under the user's resume position. (Auto-refresh never applies here; `_onAutoRefreshRequested` returns early for anything other than Following and For You.) The cache holds the *first* page only, so pages 2+ come back re-drawn and re-shuffled on re-entry, and it is in-memory, so a cold start begins empty and draws a fresh slice. That mirrors the Discover tab, where `refresh()` picks a new offset but an ordinary rebuild does not. An empty page is never cached: a slice that filters down to nothing would otherwise be pinned as `videos: []` + `hasMore: true`, which the feed can neither paginate out of nor re-fetch.

**Why `until` was dropped from the signature:** the archive has no time-window pagination — the funnelcake client only honours `before` when `sort == 'recent'`. The parameter was silently ignored on this path, so removing it makes that explicit rather than leaving a dead pass-through in the bloc's call site.

Explore → Popular's "Classic" toggle is deliberately left on the ranked leaderboard via `getPopularVideosPage`; that surface is meant to be ordered, so home and Discover now match while Popular-Classic intentionally does not.

**Related Issue:** 

## Out of Scope

Explore → Popular's "Classic" toggle keeps its server-ranked ordering — it is a leaderboard, not a discovery feed.

Classics remains Funnelcake-only and returns an empty result when no Funnelcake relay is connected, unchanged from before. Relays do not expose the server-side `platform` filter.

`ClassicVinesFeed` still calls the funnelcake client directly rather than going through the repository. Only the shared window constant is unified here; moving that provider behind the repository is a larger migration than this fix.

If all three archive pages in one fetch filter down to nothing, the feed still lands empty and cannot self-advance within that entry, because `VideoFeedBloc` gates load-more on a non-empty list. Relaxing that guard also changes For You, so it is left alone here; since the empty page is not cached, refresh or the next entry redraws.

## Verification

- `flutter test --coverage` in `mobile/packages/videos_repository` — 456 passing, **100% line coverage** held (the VGV gate default; this package sets no `min_coverage`)
- `flutter test mobile/test/blocs/video_feed` — 116 passing; `mobile/test/providers/classic_vines_refresh_test.dart` + `mobile/test/screens/feed` — 155 passing
- `flutter analyze` clean on `mobile/lib` and `mobile/packages/videos_repository`
- `dart format` clean on all changed files; `build_runner` re-run after the provider edit (regenerated provider hash committed)

Seventeen cases in the `getClassicVideos` group cover the page-aligned random offset draw at both the group's `limit: 20` and the production default of 25, the sort the shared window depends on, the shuffle, slice variation across successive cache-missing fetches, cursor advance and resume, archive exhaustion, a short page that is *not* the archive end, top-up over a fully-filtered page, the top-up bound, the un-trimmed page size a top-up produces, all three cache-write guards (first-page-only, non-empty, not-after-a-failure), cache stability across cache-eligible fetches, partial results surviving a failed top-up, non-vine filtering, and both empty-result paths. Randomness is injected via an optional `Random` constructor parameter, and the tests script the offset draws by position so an assertion cannot pass by chance. Each guard was mutation-checked: removing it turns exactly one test red.

Manually verified on a real Samsung Galaxy (SM-S942B).

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

