### PR TITLE
fix(settings): use the renamed text-style helpers in the crossposting row

### DIFF
--- a/mobile/lib/screens/settings/general_settings_screen.dart
+++ b/mobile/lib/screens/settings/general_settings_screen.dart
@@ -82,11 +82,11 @@ class GeneralSettingsScreen extends ConsumerWidget {
                   ),
                   title: Text(
                     context.l10n.settingsCrosspostingTitle,
-                    style: _titleStyle,
+                    style: _titleStyleOf(context),
                   ),
                   subtitle: Text(
                     context.l10n.settingsCrosspostingSubtitle,
-                    style: _subtitleStyle,
+                    style: _subtitleStyleOf(context),
                   ),
                   trailing: const DivineIcon(
                     icon: DivineIconName.caretRight,


### PR DESCRIPTION
Closes #6542

## Description

`main` does not compile.

`#6467` renamed the file-local `_titleStyle` / `_subtitleStyle` getters to `_titleStyleOf(context)` / `_subtitleStyleOf(context)`. `#6350` added the crossposting `ListTile` written against the old names and merged afterwards. The two never conflicted textually, so both stayed green on their own branches and the breakage only surfaced once they were combined on `main`.

```
lib/screens/settings/general_settings_screen.dart:85:28: Error: The getter '_titleStyle' isn't defined for the type 'GeneralSettingsScreen'.
lib/screens/settings/general_settings_screen.dart:89:28: Error: The getter '_subtitleStyle' isn't defined for the type 'GeneralSettingsScreen'.
```

Every test that imports `package:openvine/main.dart` currently fails to compile, so this blocks app-layer work until it lands. Two call sites, switched to the helpers every other row in the file already uses.

**Related Issue:** 

## Out of Scope

Only the two broken call sites. The crossposting feature itself and the semantic-token migration are both untouched.

## Verification

- `flutter analyze lib test integration_test` — No issues found
- Pre-push hook ran the affected suites — all passed
- Confirmed the same two call sites are the only references to the removed getters (`grep _titleStyle\|_subtitleStyle`)

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore