### PR TITLE
fix(media-cache): suspend downloads on a background launch

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1760,6 +1760,26 @@ class DivineApp extends ConsumerStatefulWidget {
   ConsumerState<DivineApp> createState() => _DivineAppState();
 }
 
+/// Whether a launch that observes [state] as its first lifecycle reading must
+/// start with media downloads suspended.
+///
+/// #6222 tears in-flight downloads down on the `paused` transition, because on
+/// Apple platforms a live NSURLSession callback trampolining into a suspended
+/// isolate aborts the process in the `cupertino_http` FFI layer. A process
+/// launched straight into the background — silent push, background upload
+/// completion — never gets that transition, because it was never resumed. Its
+/// downloads therefore ran until iOS suspended it mid-request, which is the
+/// remaining crash. Reading the state we start in covers what a transition
+/// cannot.
+///
+/// `null` means the engine has not reported a state yet, which is the normal
+/// case on a foreground launch. Suspending there would risk latching downloads
+/// off with no `resumed` transition arriving to lift them again, so it is
+/// treated as "not background".
+@visibleForTesting
+bool shouldSuspendDownloadsAtLaunch(AppLifecycleState? state) =>
+    state != null && state != AppLifecycleState.resumed;
+
 class _DivineAppState extends ConsumerState<DivineApp>
     with WidgetsBindingObserver {
   bool _backgroundInitDone = false;
@@ -1774,6 +1794,14 @@ class _DivineAppState extends ConsumerState<DivineApp>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    // Transitions alone do not cover a process launched straight into the
+    // background, so latch the suspension from the state we start in.
+    if (shouldSuspendDownloadsAtLaunch(
+      WidgetsBinding.instance.lifecycleState,
+    )) {
+      openVineMediaCache.cancelInFlightDownloads();
+      openVineImageCache.cancelInFlightDownloads();
+    }
     _memoryPressureHandler = MemoryPressureHandler(
       clearImageCache: () {
         PaintingBinding.instance.imageCache

--- a/mobile/test/main_background_launch_downloads_test.dart
+++ b/mobile/test/main_background_launch_downloads_test.dart
@@ -1,0 +1,41 @@
+// ABOUTME: Pins the launch-time media-download suspension policy from main.dart.
+// ABOUTME: Guards the background-launch case that lifecycle transitions miss.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/main.dart';
+
+void main() {
+  group('shouldSuspendDownloadsAtLaunch', () {
+    test('suspends when the app starts in a background state', () {
+      // A silent push or a background upload completion launches the process
+      // without ever resuming it, so no `paused` transition follows to tear
+      // in-flight NSURLSession requests down before iOS suspends the isolate.
+      for (final state in [
+        AppLifecycleState.paused,
+        AppLifecycleState.hidden,
+        AppLifecycleState.detached,
+        AppLifecycleState.inactive,
+      ]) {
+        expect(
+          shouldSuspendDownloadsAtLaunch(state),
+          isTrue,
+          reason: '$state must start suspended',
+        );
+      }
+    });
+
+    test('does not suspend a foreground launch', () {
+      expect(
+        shouldSuspendDownloadsAtLaunch(AppLifecycleState.resumed),
+        isFalse,
+      );
+    });
+
+    test('does not suspend when the engine has not reported a state yet', () {
+      // Latching here would leave downloads off for a foreground launch that
+      // never sends a `resumed` transition to lift them.
+      expect(shouldSuspendDownloadsAtLaunch(null), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Closes #6544


## Description

On Apple platforms a live NSURLSession callback trampolining into a suspended isolate aborts the process inside the `cupertino_http` FFI layer. It is the second-biggest FATAL issue in Crashlytics: 25 events across 23 users.

#6222 already tears in-flight downloads down on the `paused` transition. The crash survived it, because the observer only reacts to *transitions*: a process launched straight into the background — silent push, background upload completion — never receives `paused`, since it was never `resumed`. `didChangeAppLifecycleState` therefore never fires, the teardown never runs, and the downloads keep going until iOS suspends the process mid-request.

The sampled events back that up rather than the cancellation theory I started with:

- All four are `processState: BACKGROUND`.
- Two are on build 813, which already contains #6222.
- The blamed callbacks are `dataTask:didReceiveData:` and `dataTask:didReceiveResponse:` — active streams, not the `didCompleteWithError` a cancellation would produce. One is inside `CFHostCreateCopy`, i.e. still resolving DNS.
- Their logs show a full app init seconds before the crash, at 02:16 and 04:46 local time.

So the fix reads the lifecycle state the process *starts* in, which is what a transition cannot cover, and latches the same suspension #6222 already implements.

A `null` reading is deliberately treated as foreground. It is the normal case early in a foreground launch, and latching there would risk leaving downloads suspended for good on a launch that never sends a `resumed` transition to lift them — a worse failure than the crash being fixed.

**Related Issue:** 

## Out of Scope

Only the launch-time gap. The transition handling from #6222 is untouched, and no `cupertino_http` or `media_cache` internals change — `cancelInFlightDownloads()` is the existing entry point.

The remaining Crashlytics finding from the same pass, `SqliteException(26): file is not a database` (12 users), is a separate root cause and gets its own PR.

## Verification

- Three tests on the extracted predicate, covering the background states, `resumed`, and the `null` reading.
- `flutter analyze lib test integration_test` — clean once the upstream `main` breakage is patched locally; the only remaining errors are the two inherited ones quoted above.

The crash needs a real background launch followed by an OS suspension, so it is not reproducible by hand in a debug session. Field confirmation is the `hashmap.cc` / `DLRT_GetFfiCallbackMetadata` signature dropping after release.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore