### PR TITLE
fix(library): render draft overlays instead of hiding the post action

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -26,6 +26,7 @@
     "publishErrorUploadSessionExpired": "የስቀላ ክፍለ ጊዜዎ አብቅቷል። እባክዎ እንደገና ይሞክሩ።",
     "publishErrorPermissionDenied": "Divine ለመስቀል ፈቃድ የለውም። በቅንብሮችዎ ውስጥ የመተግበሪያ ፈቃዶችን ይፈትሹ እና እንደገና ይሞክሩ።",
     "publishErrorOutOfMemory": "የመሣሪያዎ ማህደረ ትውስታ እያለቀ ነው። አንዳንድ መተግበሪያዎችን ይዝጉ እና እንደገና ይሞክሩ።",
+    "publishErrorOverlaysUnavailable": "የዚህ ረቂቅ ጽሑፍና ተለጣፊዎች ሊዘጋጁ አልቻሉም። በአራሚው ውስጥ ይክፈቱት፣ ከዚያ እንደገና ይለጥፉ።",
     "publishErrorUnknownServer": "ያልታወቀ አገልጋይ",
     "dmReactionsSheetTitle": "ምላሾች",
     "dmReactionsViewA11yLabel": "ማን ምላሽ እንደሰጠ ይመልከቱ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -26,6 +26,7 @@
     "publishErrorUploadSessionExpired": "انتهت صلاحية جلسة الرفع. يرجى المحاولة مرّة أخرى.",
     "publishErrorPermissionDenied": "ليست لدى Divine صلاحية الرفع. تحقّق من أذونات التطبيق في إعدادات جهازك وحاول مرّة أخرى.",
     "publishErrorOutOfMemory": "ذاكرة جهازك منخفضة. أغلق بعض التطبيقات وحاول مرّة أخرى.",
+    "publishErrorOverlaysUnavailable": "تعذّر تجهيز النص والملصقات في هذه المسودة. افتحها في المحرّر ثم انشر مرّة أخرى.",
     "publishErrorUnknownServer": "خادم غير معروف",
     "dmReactionsSheetTitle": "التفاعلات",
     "dmReactionsViewA11yLabel": "اعرف من تفاعل",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -26,6 +26,7 @@
     "publishErrorUploadSessionExpired": "Сесията ти за качване изтече. Опитай пак.",
     "publishErrorPermissionDenied": "Divine няма разрешение да качва. Провери разрешенията на приложението в настройките и опитай пак.",
     "publishErrorOutOfMemory": "Устройството ти е с малко свободна памет. Затвори няколко приложения и опитай пак.",
+    "publishErrorOverlaysUnavailable": "Текстът и стикерите в тази чернова не можаха да се подготвят. Отвори я в редактора и публикувай пак.",
     "publishErrorUnknownServer": "Неизвестен сървър",
     "dmReactionsSheetTitle": "Реакции",
     "dmReactionsViewA11yLabel": "Вижте кой реагира",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -26,6 +26,7 @@
     "publishErrorUploadSessionExpired": "Deine Upload-Sitzung ist abgelaufen. Bitte versuch es erneut.",
     "publishErrorPermissionDenied": "Divine hat keine Berechtigung zum Hochladen. Prüfe die App-Berechtigungen in den Einstellungen und versuch es erneut.",
     "publishErrorOutOfMemory": "Dein Gerät hat wenig Arbeitsspeicher. Schließe ein paar Apps und versuch es erneut.",
+    "publishErrorOverlaysUnavailable": "Text und Sticker dieses Entwurfs konnten nicht vorbereitet werden. Öffne ihn im Editor und poste dann erneut.",
     "publishErrorUnknownServer": "Unbekannter Server",
     "dmReactionsSheetTitle": "Reaktionen",
     "dmReactionsViewA11yLabel": "Sehen, wer reagiert hat",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4104,6 +4104,7 @@
   "publishErrorUploadSessionExpired": "Your upload session expired. Please try again.",
   "publishErrorPermissionDenied": "Divine doesn’t have permission to upload. Check app permissions in your settings and try again.",
   "publishErrorOutOfMemory": "Your device is low on memory. Close some apps and try again.",
+  "publishErrorOverlaysUnavailable": "The text and stickers on this draft couldn’t be prepared. Open it in the editor, then post again.",
   "publishErrorUnknownServer": "Unknown server",
   "searchFilterPillSemanticLabel": "Filter: {filter}",
   "@searchFilterPillSemanticLabel": {"placeholders": {"filter": {"type": "String"}}},

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -26,6 +26,7 @@
     "publishErrorUploadSessionExpired": "Tu sesión de subida expiró. Intentá de nuevo.",
     "publishErrorPermissionDenied": "Divine no tiene permiso para subir. Revisá los permisos de la app en tus ajustes e intentá de nuevo.",
     "publishErrorOutOfMemory": "Tu dispositivo se está quedando sin memoria. Cerrá algunas apps e intentá de nuevo.",
+    "publishErrorOverlaysUnavailable": "No se pudieron preparar el texto y los stickers de este borrador. Abrilo en el editor y publicá de nuevo.",
     "publishErrorUnknownServer": "Servidor desconocido",
     "dmReactionsSheetTitle": "Reacciones",
     "dmReactionsViewA11yLabel": "Ver quién reaccionó",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -26,6 +26,7 @@
     "publishErrorUploadSessionExpired": "Nag-expire ang iyong upload session. Pakisubukan ulit.",
     "publishErrorPermissionDenied": "Walang permission ang Divine para mag-upload. Tingnan ang app permissions sa iyong settings at subukan ulit.",
     "publishErrorOutOfMemory": "Kulang ang memory sa device mo. Magsara ng ilang app at subukan ulit.",
+    "publishErrorOverlaysUnavailable": "Hindi na-prepare ang text at stickers sa draft na ito. Buksan mo sa editor, tapos i-post ulit.",
     "publishErrorUnknownServer": "Hindi kilalang server",
     "dmReactionsSheetTitle": "Mga reaksyon",
     "dmReactionsViewA11yLabel": "Tingnan kung sino ang nag-react",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -26,6 +26,7 @@
     "publishErrorUploadSessionExpired": "Ta session d'envoi a expiré. Réessaie.",
     "publishErrorPermissionDenied": "Divine n'a pas l'autorisation d'envoyer. Vérifie les autorisations de l'application dans tes réglages et réessaie.",
     "publishErrorOutOfMemory": "Ton appareil manque de mémoire. Ferme quelques applications et réessaie.",
+    "publishErrorOverlaysUnavailable": "Le texte et les stickers de ce brouillon n’ont pas pu être préparés. Ouvre-le dans l’éditeur, puis publie à nouveau.",
     "publishErrorUnknownServer": "Serveur inconnu",
     "dmReactionsSheetTitle": "Réactions",
     "dmReactionsViewA11yLabel": "Voir qui a réagi",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -26,6 +26,7 @@
     "publishErrorUploadSessionExpired": "Sesi unggahanmu sudah berakhir. Silakan coba lagi.",
     "publishErrorPermissionDenied": "Divine tidak punya izin untuk mengunggah. Periksa izin aplikasi di pengaturanmu dan coba lagi.",
     "publishErrorOutOfMemory": "Memori perangkatmu menipis. Tutup beberapa aplikasi lalu coba lagi.",
+    "publishErrorOverlaysUnavailable": "Teks dan stiker di draf ini tidak bisa disiapkan. Buka di editor, lalu posting lagi.",
     "publishErrorUnknownServer": "Server tidak dikenal",
     "dmReactionsSheetTitle": "Reaksi",
     "dmReactionsViewA11yLabel": "Lihat siapa yang bereaksi",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -26,6 +26,7 @@
   "publishErrorUploadSessionExpired": "La sessione di caricamento è scaduta. Riprova.",
   "publishErrorPermissionDenied": "Divine non ha il permesso di caricare. Controlla i permessi dell'app nelle impostazioni e riprova.",
   "publishErrorOutOfMemory": "Memoria insufficiente sul dispositivo. Chiudi alcune app e riprova.",
+  "publishErrorOverlaysUnavailable": "Non è stato possibile preparare testo e sticker di questa bozza. Aprila nell’editor e ripubblica.",
   "publishErrorUnknownServer": "Server sconosciuto",
     "dmReactionsSheetTitle": "Reazioni",
     "dmReactionsViewA11yLabel": "Vedi chi ha reagito",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -26,6 +26,7 @@
     "publishErrorUploadSessionExpired": "アップロードのセッションが切れちゃったよ。もう一回試してみて。",
     "publishErrorPermissionDenied": "Divine にアップロードの権限がないよ。設定でアプリの権限を確認して、もう一回試してみて。",
     "publishErrorOutOfMemory": "端末のメモリが足りないよ。アプリをいくつか閉じて、もう一回試してみて。",
+    "publishErrorOverlaysUnavailable": "この下書きのテキストとステッカーを準備できなかったよ。エディタで開いてから、もう一回投稿してみて。",
     "publishErrorUnknownServer": "不明なサーバー",
     "dmReactionsSheetTitle": "リアクション",
     "dmReactionsViewA11yLabel": "リアクションした人を見る",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -26,6 +26,7 @@
     "publishErrorUploadSessionExpired": "업로드 세션이 만료됐어요. 다시 시도해주세요.",
     "publishErrorPermissionDenied": "Divine에 업로드 권한이 없어요. 설정에서 앱 권한을 확인하고 다시 시도해주세요.",
     "publishErrorOutOfMemory": "기기 메모리가 부족해요. 앱을 몇 개 닫고 다시 시도해주세요.",
+    "publishErrorOverlaysUnavailable": "이 초안의 텍스트와 스티커를 준비하지 못했어요. 편집기에서 연 다음 다시 게시해주세요.",
     "publishErrorUnknownServer": "알 수 없는 서버",
     "dmReactionsSheetTitle": "반응",
     "dmReactionsViewA11yLabel": "반응한 사람 보기",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -26,6 +26,7 @@
     "publishErrorUploadSessionExpired": "Je uploadsessie is verlopen. Probeer het opnieuw.",
     "publishErrorPermissionDenied": "Divine heeft geen toestemming om te uploaden. Controleer de app-rechten in je instellingen en probeer het opnieuw.",
     "publishErrorOutOfMemory": "Je apparaat heeft weinig werkgeheugen. Sluit een paar apps en probeer het opnieuw.",
+    "publishErrorOverlaysUnavailable": "De tekst en stickers van dit concept konden niet worden voorbereid. Open het in de editor en post opnieuw.",
     "publishErrorUnknownServer": "Onbekende server",
     "dmReactionsSheetTitle": "Reacties",
     "dmReactionsViewA11yLabel": "Bekijk wie heeft gereageerd",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -26,6 +26,7 @@
     "publishErrorUploadSessionExpired": "Sesja przesyłania wygasła. Spróbuj ponownie.",
     "publishErrorPermissionDenied": "Divine nie ma uprawnień do przesyłania. Sprawdź uprawnienia aplikacji w ustawieniach i spróbuj ponownie.",
     "publishErrorOutOfMemory": "Za mało pamięci operacyjnej urządzenia. Zamknij kilka aplikacji i spróbuj ponownie.",
+    "publishErrorOverlaysUnavailable": "Nie udało się przygotować tekstu i naklejek z tej wersji roboczej. Otwórz ją w edytorze i opublikuj ponownie.",
     "publishErrorUnknownServer": "Nieznany serwer",
     "dmReactionsSheetTitle": "Reakcje",
     "dmReactionsViewA11yLabel": "Zobacz, kto zareagował",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -26,6 +26,7 @@
     "publishErrorUploadSessionExpired": "Sua sessão de envio expirou. Tente novamente.",
     "publishErrorPermissionDenied": "O Divine não tem permissão para enviar. Verifique as permissões do app nas suas configurações e tente novamente.",
     "publishErrorOutOfMemory": "Seu dispositivo está com pouca memória. Feche alguns apps e tente novamente.",
+    "publishErrorOverlaysUnavailable": "Não foi possível preparar o texto e os stickers deste rascunho. Abra no editor e poste de novo.",
     "publishErrorUnknownServer": "Servidor desconhecido",
     "dmReactionsSheetTitle": "Reações",
     "dmReactionsViewA11yLabel": "Ver quem reagiu",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -26,6 +26,7 @@
     "publishErrorUploadSessionExpired": "Sesiunea de încărcare a expirat. Încearcă din nou.",
     "publishErrorPermissionDenied": "Divine nu are permisiunea de a încărca. Verifică permisiunile aplicației în setări și încearcă din nou.",
     "publishErrorOutOfMemory": "Dispozitivul are puțină memorie disponibilă. Închide câteva aplicații și încearcă din nou.",
+    "publishErrorOverlaysUnavailable": "Textul și stickerele din această schiță nu au putut fi pregătite. Deschide-o în editor, apoi postează din nou.",
     "publishErrorUnknownServer": "Server necunoscut",
     "dmReactionsSheetTitle": "Reacții",
     "dmReactionsViewA11yLabel": "Vezi cine a reacționat",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -26,6 +26,7 @@
     "publishErrorUploadSessionExpired": "Din uppladdningssession har gått ut. Försök igen.",
     "publishErrorPermissionDenied": "Divine har inte behörighet att ladda upp. Kontrollera appens behörigheter i dina inställningar och försök igen.",
     "publishErrorOutOfMemory": "Enheten har ont om minne. Stäng några appar och försök igen.",
+    "publishErrorOverlaysUnavailable": "Texten och dekalerna i det här utkastet kunde inte förberedas. Öppna det i redigeraren och posta igen.",
     "publishErrorUnknownServer": "Okänd server",
     "dmReactionsSheetTitle": "Reaktioner",
     "dmReactionsViewA11yLabel": "Se vilka som reagerat",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -26,6 +26,7 @@
     "publishErrorUploadSessionExpired": "Yükleme oturumun sona erdi. Lütfen tekrar dene.",
     "publishErrorPermissionDenied": "Divine'in yükleme izni yok. Ayarlarından uygulama izinlerini kontrol edip tekrar dene.",
     "publishErrorOutOfMemory": "Cihazının belleği azaldı. Bazı uygulamaları kapatıp tekrar dene.",
+    "publishErrorOverlaysUnavailable": "Bu taslaktaki yazı ve çıkartmalar hazırlanamadı. Düzenleyicide aç ve tekrar paylaş.",
     "publishErrorUnknownServer": "Bilinmeyen sunucu",
     "dmReactionsSheetTitle": "Tepkiler",
     "dmReactionsViewA11yLabel": "Kimlerin tepki verdiğini gör",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -12573,6 +12573,12 @@ abstract class AppLocalizations {
   /// **'Your device is low on memory. Close some apps and try again.'**
   String get publishErrorOutOfMemory;
 
+  /// No description provided for @publishErrorOverlaysUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'The text and stickers on this draft couldn’t be prepared. Open it in the editor, then post again.'**
+  String get publishErrorOverlaysUnavailable;
+
   /// No description provided for @publishErrorUnknownServer.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7101,6 +7101,10 @@ class AppLocalizationsAm extends AppLocalizations {
       'የመሣሪያዎ ማህደረ ትውስታ እያለቀ ነው። አንዳንድ መተግበሪያዎችን ይዝጉ እና እንደገና ይሞክሩ።';
 
   @override
+  String get publishErrorOverlaysUnavailable =>
+      'የዚህ ረቂቅ ጽሑፍና ተለጣፊዎች ሊዘጋጁ አልቻሉም። በአራሚው ውስጥ ይክፈቱት፣ ከዚያ እንደገና ይለጥፉ።';
+
+  @override
   String get publishErrorUnknownServer => 'ያልታወቀ አገልጋይ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -7194,6 +7194,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'ذاكرة جهازك منخفضة. أغلق بعض التطبيقات وحاول مرّة أخرى.';
 
   @override
+  String get publishErrorOverlaysUnavailable =>
+      'تعذّر تجهيز النص والملصقات في هذه المسودة. افتحها في المحرّر ثم انشر مرّة أخرى.';
+
+  @override
   String get publishErrorUnknownServer => 'خادم غير معروف';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -7312,6 +7312,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Устройството ти е с малко свободна памет. Затвори няколко приложения и опитай пак.';
 
   @override
+  String get publishErrorOverlaysUnavailable =>
+      'Текстът и стикерите в тази чернова не можаха да се подготвят. Отвори я в редактора и публикувай пак.';
+
+  @override
   String get publishErrorUnknownServer => 'Неизвестен сървър';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -7329,6 +7329,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Dein Gerät hat wenig Arbeitsspeicher. Schließe ein paar Apps und versuch es erneut.';
 
   @override
+  String get publishErrorOverlaysUnavailable =>
+      'Text und Sticker dieses Entwurfs konnten nicht vorbereitet werden. Öffne ihn im Editor und poste dann erneut.';
+
+  @override
   String get publishErrorUnknownServer => 'Unbekannter Server';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -7232,6 +7232,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Your device is low on memory. Close some apps and try again.';
 
   @override
+  String get publishErrorOverlaysUnavailable =>
+      'The text and stickers on this draft couldn’t be prepared. Open it in the editor, then post again.';
+
+  @override
   String get publishErrorUnknownServer => 'Unknown server';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -7308,6 +7308,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Tu dispositivo se está quedando sin memoria. Cerrá algunas apps e intentá de nuevo.';
 
   @override
+  String get publishErrorOverlaysUnavailable =>
+      'No se pudieron preparar el texto y los stickers de este borrador. Abrilo en el editor y publicá de nuevo.';
+
+  @override
   String get publishErrorUnknownServer => 'Servidor desconocido';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -7323,6 +7323,10 @@ class AppLocalizationsFil extends AppLocalizations {
       'Kulang ang memory sa device mo. Magsara ng ilang app at subukan ulit.';
 
   @override
+  String get publishErrorOverlaysUnavailable =>
+      'Hindi na-prepare ang text at stickers sa draft na ito. Buksan mo sa editor, tapos i-post ulit.';
+
+  @override
   String get publishErrorUnknownServer => 'Hindi kilalang server';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -7332,6 +7332,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Ton appareil manque de mémoire. Ferme quelques applications et réessaie.';
 
   @override
+  String get publishErrorOverlaysUnavailable =>
+      'Le texte et les stickers de ce brouillon n’ont pas pu être préparés. Ouvre-le dans l’éditeur, puis publie à nouveau.';
+
+  @override
   String get publishErrorUnknownServer => 'Serveur inconnu';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -7203,6 +7203,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Memori perangkatmu menipis. Tutup beberapa aplikasi lalu coba lagi.';
 
   @override
+  String get publishErrorOverlaysUnavailable =>
+      'Teks dan stiker di draf ini tidak bisa disiapkan. Buka di editor, lalu posting lagi.';
+
+  @override
   String get publishErrorUnknownServer => 'Server tidak dikenal';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -7307,6 +7307,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Memoria insufficiente sul dispositivo. Chiudi alcune app e riprova.';
 
   @override
+  String get publishErrorOverlaysUnavailable =>
+      'Non è stato possibile preparare testo e sticker di questa bozza. Aprila nell’editor e ripubblica.';
+
+  @override
   String get publishErrorUnknownServer => 'Server sconosciuto';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -6933,6 +6933,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get publishErrorOutOfMemory => '端末のメモリが足りないよ。アプリをいくつか閉じて、もう一回試してみて。';
 
   @override
+  String get publishErrorOverlaysUnavailable =>
+      'この下書きのテキストとステッカーを準備できなかったよ。エディタで開いてから、もう一回投稿してみて。';
+
+  @override
   String get publishErrorUnknownServer => '不明なサーバー';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -6957,6 +6957,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get publishErrorOutOfMemory => '기기 메모리가 부족해요. 앱을 몇 개 닫고 다시 시도해주세요.';
 
   @override
+  String get publishErrorOverlaysUnavailable =>
+      '이 초안의 텍스트와 스티커를 준비하지 못했어요. 편집기에서 연 다음 다시 게시해주세요.';
+
+  @override
   String get publishErrorUnknownServer => '알 수 없는 서버';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -7273,6 +7273,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Je apparaat heeft weinig werkgeheugen. Sluit een paar apps en probeer het opnieuw.';
 
   @override
+  String get publishErrorOverlaysUnavailable =>
+      'De tekst en stickers van dit concept konden niet worden voorbereid. Open het in de editor en post opnieuw.';
+
+  @override
   String get publishErrorUnknownServer => 'Onbekende server';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -7409,6 +7409,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Za mało pamięci operacyjnej urządzenia. Zamknij kilka aplikacji i spróbuj ponownie.';
 
   @override
+  String get publishErrorOverlaysUnavailable =>
+      'Nie udało się przygotować tekstu i naklejek z tej wersji roboczej. Otwórz ją w edytorze i opublikuj ponownie.';
+
+  @override
   String get publishErrorUnknownServer => 'Nieznany serwer';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -7288,6 +7288,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Seu dispositivo está com pouca memória. Feche alguns apps e tente novamente.';
 
   @override
+  String get publishErrorOverlaysUnavailable =>
+      'Não foi possível preparar o texto e os stickers deste rascunho. Abra no editor e poste de novo.';
+
+  @override
   String get publishErrorUnknownServer => 'Servidor desconhecido';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -7407,6 +7407,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Dispozitivul are puțină memorie disponibilă. Închide câteva aplicații și încearcă din nou.';
 
   @override
+  String get publishErrorOverlaysUnavailable =>
+      'Textul și stickerele din această schiță nu au putut fi pregătite. Deschide-o în editor, apoi postează din nou.';
+
+  @override
   String get publishErrorUnknownServer => 'Server necunoscut';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -7237,6 +7237,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Enheten har ont om minne. Stäng några appar och försök igen.';
 
   @override
+  String get publishErrorOverlaysUnavailable =>
+      'Texten och dekalerna i det här utkastet kunde inte förberedas. Öppna det i redigeraren och posta igen.';
+
+  @override
   String get publishErrorUnknownServer => 'Okänd server';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -7204,6 +7204,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Cihazının belleği azaldı. Bazı uygulamaları kapatıp tekrar dene.';
 
   @override
+  String get publishErrorOverlaysUnavailable =>
+      'Bu taslaktaki yazı ve çıkartmalar hazırlanamadı. Düzenleyicide aç ve tekrar paylaş.';
+
+  @override
   String get publishErrorUnknownServer => 'Bilinmeyen sunucu';
 
   @override

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -69,6 +69,7 @@ import 'package:openvine/providers/device_scope.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/foreground_idle_warmup_provider.dart';
 import 'package:openvine/providers/install_source_provider.dart';
+import 'package:openvine/providers/layer_rasterizer_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
@@ -133,6 +134,8 @@ import 'package:openvine/widgets/upload_failure_sheet.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:permissions_service/permissions_service.dart';
+import 'package:pro_image_editor/pro_image_editor.dart'
+    show LayerRasterizerHost;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:window_manager/window_manager.dart';
@@ -2578,6 +2581,24 @@ class _DivineAppState extends ConsumerState<DivineApp>
       return false; // Not handled - let PopScope handle it (may exit app)
     }
 
+    // One gate above every route: once the local database reports corruption
+    // there is no screen left that can work, so ask for the restart that
+    // repairs it instead of failing route by route. The review coordinator
+    // lives inside that gate so the recovery screen cannot be interrupted by
+    // an OS-native review card.
+    //
+    // The rasterizer host sits above both: baking a draft's editor layers
+    // needs them mounted somewhere, and that has to keep working while the
+    // corruption gate swaps out everything below it.
+    Widget buildAppShell(BuildContext context, Widget? child) {
+      return LayerRasterizerHost(
+        rasterizer: ref.read(layerRasterizerProvider),
+        child: DatabaseCorruptionGate(
+          child: AppReviewCoordinator(child: child ?? const SizedBox.shrink()),
+        ),
+      );
+    }
+
     // Build MaterialApp with locale from LocaleCubit.
     // The BlocBuilder is used because the cubit is provided further down
     // in the widget tree by MultiBlocProvider.
@@ -2614,16 +2635,7 @@ class _DivineAppState extends ConsumerState<DivineApp>
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             localeListResolutionCallback: resolveAppUiLocale,
-            // One gate above every route: once the local database reports
-            // corruption there is no screen left that can work, so ask for the
-            // restart that repairs it instead of failing route by route. The
-            // review coordinator lives inside that gate so the recovery screen
-            // cannot be interrupted by an OS-native review card.
-            builder: (context, child) => DatabaseCorruptionGate(
-              child: AppReviewCoordinator(
-                child: child ?? const SizedBox.shrink(),
-              ),
-            ),
+            builder: buildAppShell,
           ),
         );
       }
@@ -2646,16 +2658,7 @@ class _DivineAppState extends ConsumerState<DivineApp>
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             localeListResolutionCallback: resolveAppUiLocale,
-            // One gate above every route: once the local database reports
-            // corruption there is no screen left that can work, so ask for the
-            // restart that repairs it instead of failing route by route. The
-            // review coordinator lives inside that gate so the recovery screen
-            // cannot be interrupted by an OS-native review card.
-            builder: (context, child) => DatabaseCorruptionGate(
-              child: AppReviewCoordinator(
-                child: child ?? const SizedBox.shrink(),
-              ),
-            ),
+            builder: buildAppShell,
           ),
         ),
       );

--- a/mobile/lib/models/divine_video_draft.dart
+++ b/mobile/lib/models/divine_video_draft.dart
@@ -509,12 +509,12 @@ class DivineVideoDraft {
 
   /// Whether the draft can be posted directly from the library.
   ///
-  /// Single-clip drafts require [finalRenderedClip] so the published video
-  /// includes all editor layers (text, stickers, filters). Without a render,
-  /// the single-clip publish path falls back to the raw recording and silently
-  /// drops those layers. Multi-clip drafts can still be posted because the
-  /// publish path renders them before upload.
-  bool get canPost => finalRenderedClip != null || clips.length > 1;
+  /// Only requires something to publish. A draft without [finalRenderedClip]
+  /// is rendered on demand during publish, with its editor layers, timed
+  /// filters, tune adjustments and audio restored from [editorStateHistory]
+  /// and [editorEditingParameters] first — so posting no longer depends on a
+  /// render happening to be cached.
+  bool get canPost => clips.isNotEmpty;
 
   bool get hasEditorStateEdits {
     if (editorStateHistory.isEmpty) return false;

--- a/mobile/lib/providers/layer_rasterizer_provider.dart
+++ b/mobile/lib/providers/layer_rasterizer_provider.dart
@@ -1,0 +1,17 @@
+// ABOUTME: Provides the app-wide LayerRasterizer used to bake draft layers
+// ABOUTME: Its host is mounted once in main.dart above every route
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pro_image_editor/pro_image_editor.dart';
+
+/// The single [LayerRasterizer] for the app.
+///
+/// Layers can only be captured while mounted, so this is paired with exactly
+/// one `LayerRasterizerHost` in `main.dart`. Keep it app-scoped: a rasterizer
+/// whose host is gone throws on capture, which is why it must not be tied to
+/// the lifetime of any screen.
+final layerRasterizerProvider = Provider<LayerRasterizer>((ref) {
+  final rasterizer = LayerRasterizer();
+  ref.onDispose(rasterizer.dispose);
+  return rasterizer;
+});

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -1487,15 +1487,10 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         state.editorEditingParameters ?? CompleteParameters.fromMap({});
 
     final audioEvents = baseParams.audioTracksFromMeta;
-    final audioTracks = <AudioTrack>[
-      for (final track in audioEvents) ?audioTrackFromMetaForRender(track),
-      // selectedSound is legacy single-sound state from the recorder flow.
-      // When the timeline already carries audio (meta tracks) it is the same
-      // sound, so adding it again duplicates the audio. Only fall back to it
-      // when the timeline has no audio of its own.
-      if (audioEvents.isEmpty && soundTrack != null)
-        ?audioTrackFromSoundForRender(soundTrack),
-    ];
+    final audioTracks = buildRenderAudioTracks(
+      metaTracks: audioEvents,
+      selectedSound: soundTrack,
+    );
 
     // Surface the resolution result so a silent export (no audio) is
     // diagnosable from logs instead of failing quietly — the common cause is

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -15,7 +15,6 @@ import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' show NativeProofData;
 import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
-import 'package:openvine/extensions/complete_parameters_extensions.dart';
 import 'package:openvine/l10n/current_app_l10n.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/publish_error_kind_l10n.dart';
@@ -25,6 +24,7 @@ import 'package:openvine/models/video_publish/video_publish_provider_state.dart'
 import 'package:openvine/models/video_reply_context.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/layer_rasterizer_provider.dart';
 import 'package:openvine/providers/preferences_providers.dart';
 import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
@@ -42,10 +42,12 @@ import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/mention_resolution_service.dart';
 import 'package:openvine/services/native_proofmode_service.dart';
 import 'package:openvine/services/nostr_creator_binding_service.dart';
+import 'package:openvine/services/video_editor/draft_render_parameters_service.dart';
 import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/services/video_publish/publish_error_kind.dart';
 import 'package:openvine/services/video_publish/video_publish_service.dart';
+import 'package:pro_image_editor/pro_image_editor.dart' show CompleteParameters;
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -386,13 +388,9 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
       // BuildContext-across-async-gap) but only when a stop-motion render is
       // actually needed — a normal publish never depends on l10n being wired
       // up, and materialize is a no-op passthrough for a clip that already
-      // has a video.
-      final needsStopMotionRender =
-          (finalRenderedClip?.isStopMotion ?? false) ||
-          (finalRenderedClip == null &&
-              draft.clips.length == 1 &&
-              draft.clips.first.isStopMotion);
-      final stopMotionFailedMessage = needsStopMotionRender
+      // has a video. A draft with no render of its own goes through
+      // renderVideoToClip below, which materializes its own stop-motion clips.
+      final stopMotionFailedMessage = finalRenderedClip?.isStopMotion ?? false
           ? context.l10n.videoRecorderStopMotionAssembleFailed
           : null;
 
@@ -408,54 +406,72 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
       }
 
       if (finalRenderedClip == null) {
-        if (draft.clips.length == 1) {
-          final singleClip = draft.clips.first;
-          if (singleClip.isStopMotion) {
-            final materialized = await StopMotionRenderService.materialize(
-              singleClip,
-            );
-            if (materialized == null) {
-              setError(stopMotionFailedMessage!);
-              return;
-            }
-            finalRenderedClip = materialized;
-          } else {
-            finalRenderedClip = singleClip;
-          }
-        } else {
-          // Multiple clips without rendered output - render now
-          Log.info(
-            '🎬 Rendering ${draft.clips.length} clips for publish',
+        // Always render, never publish a source clip as-is. A draft persists
+        // its editing parameters through `CompleteParameters.toMap`, which
+        // drops the captured layers, timed filters, tune adjustments and audio
+        // tracks — so the parameters restored from storage describe far less
+        // than the user authored. `buildForDraft` rebuilds them (re-baking the
+        // layers offscreen) before the render.
+        //
+        // The old shortcut of publishing a lone clip directly skipped the
+        // render entirely and shipped the raw recording: no overlays, and no
+        // trim, speed or volume either. That is what #5203 papered over by
+        // hiding the Post action; rendering here is the actual fix.
+        Log.info(
+          '🎬 Rendering ${draft.clips.length} clip(s) for publish',
+          name: 'VideoPublishNotifier',
+          category: LogCategory.video,
+        );
+
+        final CompleteParameters? parameters;
+        try {
+          parameters = await DraftRenderParametersService(
+            rasterizer: ref.read(layerRasterizerProvider),
+          ).buildForDraft(draft);
+        } on DraftOverlayRestoreException catch (error) {
+          // The draft has overlays we cannot reproduce. Publishing anyway would
+          // ship a video silently missing text/stickers the user can still see
+          // in the draft — the #5203 failure — and a Nostr event cannot be
+          // quietly corrected. Point them at the editor, which re-renders and
+          // repopulates whatever went missing.
+          Log.warning(
+            '⚠️ Blocking publish: $error',
             name: 'VideoPublishNotifier',
             category: LogCategory.video,
           );
-
-          final parameters = draft.editorEditingParameters.isNotEmpty
-              ? completeParametersFromDraftMap(draft.editorEditingParameters)
-              : null;
-
-          final result = await VideoEditorRenderService.renderVideoToClip(
-            clips: draft.clips,
-            parameters: parameters,
-            editorStateHistory: draft.editorStateHistory,
-            taskId: draft.id,
-          );
-
-          if (result == null) {
-            setError('Video rendering failed');
-            return;
-          }
-
-          final (clip, proofJson) = result;
-          finalRenderedClip = clip;
-          proofManifestJson = proofJson;
-
-          Log.info(
-            '✅ Video rendered successfully for publish',
-            name: 'VideoPublishNotifier',
-            category: LogCategory.video,
-          );
+          final message = currentAppL10n(
+            ref.read(sharedPreferencesProvider),
+          ).publishErrorOverlaysUnavailable;
+          setError(message);
+          _showPublishError(message);
+          return;
         }
+
+        final result = await VideoEditorRenderService.renderVideoToClip(
+          clips: draft.clips,
+          parameters: parameters,
+          editorStateHistory: draft.editorStateHistory,
+          taskId: draft.id,
+        );
+
+        if (result == null) {
+          setError(
+            currentAppL10n(
+              ref.read(sharedPreferencesProvider),
+            ).publishErrorMessage(PublishErrorKind.generic),
+          );
+          return;
+        }
+
+        final (clip, proofJson) = result;
+        finalRenderedClip = clip;
+        proofManifestJson = proofJson;
+
+        Log.info(
+          '✅ Video rendered successfully for publish',
+          name: 'VideoPublishNotifier',
+          category: LogCategory.video,
+        );
       }
 
       if (shouldAttachCreatorIdentityProof(proofManifestJson)) {

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -389,8 +389,14 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
       // actually needed — a normal publish never depends on l10n being wired
       // up, and materialize is a no-op passthrough for a clip that already
       // has a video. A draft with no render of its own goes through
-      // renderVideoToClip below, which materializes its own stop-motion clips.
-      final stopMotionFailedMessage = finalRenderedClip?.isStopMotion ?? false
+      // renderVideoToClip below, which materializes its own stop-motion clips
+      // and reports an assembly failure the same way as any other render
+      // failure — so that path needs the copy too.
+      final needsStopMotionRender =
+          (finalRenderedClip?.isStopMotion ?? false) ||
+          (finalRenderedClip == null &&
+              draft.clips.any((clip) => clip.isStopMotion));
+      final stopMotionFailedMessage = needsStopMotionRender
           ? context.l10n.videoRecorderStopMotionAssembleFailed
           : null;
 
@@ -455,11 +461,17 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
         );
 
         if (result == null) {
-          setError(
-            currentAppL10n(
-              ref.read(sharedPreferencesProvider),
-            ).publishErrorMessage(PublishErrorKind.generic),
-          );
+          // `setError` alone is invisible here: nothing on screen reads the
+          // error state, so the `.preparing` scrim would just vanish (#6058).
+          // A frames-only draft that got this far failed its stop-motion
+          // assembly, which has its own copy.
+          final message =
+              stopMotionFailedMessage ??
+              currentAppL10n(
+                ref.read(sharedPreferencesProvider),
+              ).publishErrorMessage(PublishErrorKind.generic);
+          setError(message);
+          _showPublishError(message);
           return;
         }
 

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -8,7 +8,6 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/clips_library/clips_library_bloc.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
@@ -42,6 +41,7 @@ import 'package:openvine/screens/video_editor/voice_over_take_commit.dart';
 import 'package:openvine/screens/video_editor/voice_over_take_placement.dart';
 import 'package:openvine/screens/video_recorder_screen.dart';
 import 'package:openvine/utils/await_push_transition.dart';
+import 'package:openvine/utils/editor_text_fonts.dart';
 import 'package:openvine/utils/mounted_post_frame.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
@@ -229,7 +229,7 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
       // default font (see #5181).
       if (mounted &&
           ref.read(videoEditorProvider).editorStateHistory.isNotEmpty) {
-        await _preloadEditorTextFonts();
+        await preloadEditorTextFonts();
       }
 
       if (mounted) {
@@ -267,24 +267,6 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
     _zoomMatrixNotifier.dispose();
     _playTimeNotifier.dispose();
     super.dispose();
-  }
-
-  /// Registers every text-overlay Google Font so a restored draft resolves
-  /// the font family stored on its text layers.
-  ///
-  /// Calling a `GoogleFonts.*` getter registers its [FontLoader] as a side
-  /// effect; the serialized [TextLayer] only keeps the family string, so the
-  /// loader must be re-registered each session before the overlays render.
-  /// Already-loaded fonts resolve instantly, so the timeout only guards the
-  /// first, uncached load.
-  Future<void> _preloadEditorTextFonts() async {
-    for (final font in VideoEditorConstants.textFonts) {
-      font();
-    }
-    await GoogleFonts.pendingFonts().timeout(
-      VideoEditorConstants.textFontLoadTimeout,
-      onTimeout: () => const [],
-    );
   }
 
   /// Precaches stickers for faster display.

--- a/mobile/lib/services/video_editor/draft_render_parameters_service.dart
+++ b/mobile/lib/services/video_editor/draft_render_parameters_service.dart
@@ -14,25 +14,12 @@ import 'package:openvine/extensions/aspect_ratio_extensions.dart';
 import 'package:openvine/extensions/complete_parameters_extensions.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/services/video_editor/video_editor_audio_render.dart';
+import 'package:openvine/utils/editor_text_fonts.dart';
 import 'package:openvine/utils/open_vine_image_cache.dart';
 import 'package:openvine/widgets/video_editor/sticker_editor/video_editor_sticker.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:unified_logger/unified_logger.dart';
 
-/// Rebuilds the [CompleteParameters] needed to render a draft when no editor
-/// session is open — posting straight from the library, most importantly.
-///
-/// A draft persists its editing parameters via `CompleteParameters.toMap`,
-/// which drops `capturedLayers`, `filterStates`, `tuneAdjustments` and
-/// `audioTracks`. Rendering from the restored map alone therefore produces a
-/// video with none of the overlays the user authored: no text, stickers or
-/// drawings, no timed filters or tune adjustments, and no added music.
-///
-/// Everything needed to rebuild them survives elsewhere in the draft —
-/// `editorStateHistory` keeps the layers, filters and tune, and the audio
-/// timeline lives in the parameters' own `meta`. Only the *rasterized* layer
-/// bytes are unrecoverable from storage, which is what [LayerRasterizer]
-/// regenerates by briefly mounting the layers offscreen.
 /// Thrown when a draft's authored overlays cannot be reproduced for a render.
 ///
 /// Publishing is blocked rather than degraded. A video that silently lacks the
@@ -50,6 +37,21 @@ class DraftOverlayRestoreException implements Exception {
   String toString() => 'DraftOverlayRestoreException: $message';
 }
 
+/// Rebuilds the [CompleteParameters] needed to render a draft when no editor
+/// session is open — posting straight from the library, most importantly.
+///
+/// A draft persists its editing parameters via `CompleteParameters.toMap`,
+/// which drops `capturedLayers`, `filterStates`, `tuneAdjustments` and
+/// `audioTracks`. Rendering from the restored map alone therefore produces a
+/// video with none of the overlays the user authored: no text, stickers or
+/// drawings, no timed filters or tune adjustments, and no added music.
+///
+/// Everything needed to rebuild them survives elsewhere in the draft —
+/// `editorStateHistory` keeps the layers, filters and tune, the audio timeline
+/// lives in the parameters' own `meta`, and a recorder-picked sound sits on the
+/// draft itself. Only the *rasterized* layer bytes are unrecoverable from
+/// storage, which is what [LayerRasterizer] regenerates by briefly mounting the
+/// layers offscreen.
 class DraftRenderParametersService {
   /// Creates a service that rasterizes through [rasterizer].
   const DraftRenderParametersService({required LayerRasterizer rasterizer})
@@ -60,23 +62,28 @@ class DraftRenderParametersService {
   static const _logName = 'DraftRenderParametersService';
 
   /// Returns render parameters for [draft] with its overlays restored, or
-  /// `null` when the draft carries no editor state at all (a plain recording
-  /// with no edits, which renders fine without parameters).
+  /// `null` when the draft carries nothing to restore (a plain recording with
+  /// no edits and no sound, which renders fine without parameters).
   ///
   /// Rasterization needs a mounted `LayerRasterizerHost`, which `main.dart`
   /// installs above every route.
   ///
   /// Throws [DraftOverlayRestoreException] when the draft has overlays that
   /// cannot be reproduced — an unreadable state history, layers with no body
-  /// size to place them against, or a rasterization that failed. The caller
-  /// must not publish in that case; the video would be missing them.
+  /// size to place them against, or a rasterization that failed or came back
+  /// short. The caller must not publish in that case; the video would be
+  /// missing them.
   ///
   /// A draft with no overlays to begin with is not an error, and neither is a
   /// single sticker image that fails to load — that one costs its own sticker
   /// and is logged.
   Future<CompleteParameters?> buildForDraft(DivineVideoDraft draft) async {
+    // `selectedSound` counts: a sound picked in the recorder is stored on the
+    // draft alone, so a draft that never entered the editor still has audio to
+    // carry into the render.
     if (draft.editorEditingParameters.isEmpty &&
-        draft.editorStateHistory.isEmpty) {
+        draft.editorStateHistory.isEmpty &&
+        draft.selectedSound == null) {
       return null;
     }
 
@@ -84,20 +91,36 @@ class DraftRenderParametersService {
         ? completeParametersFromDraftMap(draft.editorEditingParameters)
         : CompleteParameters.fromMap(const {});
 
-    final audioTracks = <AudioTrack>[
-      for (final track in base.audioTracksFromMeta)
-        ?audioTrackFromMetaForRender(track),
-    ];
+    final audioTracks = buildRenderAudioTracks(
+      metaTracks: base.audioTracksFromMeta,
+      // Mirrors the in-editor export: a recorder-picked sound never becomes a
+      // timeline track, so without this the same draft publishes with music
+      // from the editor and silent from the library.
+      selectedSound: draft.selectedSound,
+    );
 
     final stickers = <StickerData>[];
-    final entry = _activeHistoryEntry(draft.editorStateHistory, stickers);
+    final history = _importHistory(draft.editorStateHistory, stickers);
+    final entry = _activeEntry(history);
+
+    // `bodySize` only reaches storage through the editor's complete callback,
+    // which fires on Done — a draft saved by backing out has its layers but no
+    // parameters at all. The exported history carries the size those layers
+    // were laid out against, so it is the fallback; both the capture and the
+    // render read whichever one we settle on, so they stay consistent either
+    // way. `safeParseSize` yields `Size.zero` for a history that carries no
+    // size, which is no more usable than none at all.
+    final historySize = history?.lastRenderedImgSize;
+    final bodySize =
+        base.bodySize ??
+        (historySize != null && !historySize.isEmpty ? historySize : null);
 
     final capturedLayers = entry == null
         ? const <ExportedLayer>[]
         : await _rasterizeLayers(
             layers: entry.layers,
             stickers: stickers,
-            bodySize: base.bodySize,
+            bodySize: bodySize,
             aspectRatio: draft.clips.isNotEmpty
                 ? draft.clips.first.targetAspectRatio
                 : AspectRatio.square,
@@ -118,26 +141,29 @@ class DraftRenderParametersService {
       tuneAdjustments: entry?.tuneAdjustments ?? const [],
       audioTracks: audioTracks,
       blur: entry?.blur ?? base.blur,
+      // The render scales and centres the captured layers against this, so it
+      // has to be the size they were captured at — otherwise a fallback size
+      // would place them correctly in the raster and wrongly in the video.
+      bodySize: bodySize,
     );
   }
 
-  /// Deserializes [stateHistory] and returns the entry the user last had
-  /// active, recording every sticker it rehydrates into [stickers].
+  /// Deserializes [stateHistory], recording every sticker it rehydrates into
+  /// [stickers].
   ///
-  /// Returns `null` for an empty history or an editor position outside it —
-  /// `editorPosition` is `-1` for a session that was never edited.
+  /// Returns `null` for an empty history.
   ///
   /// Throws [DraftOverlayRestoreException] when a non-empty history cannot be
   /// read: it may well describe layers, and there is no way to tell from a map
   /// that failed to parse, so it counts as overlays we cannot reproduce.
-  EditorStateHistory? _activeHistoryEntry(
+  ImportStateHistory? _importHistory(
     Map<String, dynamic> stateHistory,
     List<StickerData> stickers,
   ) {
     if (stateHistory.isEmpty) return null;
 
     try {
-      final history = ImportStateHistory.fromMap(
+      return ImportStateHistory.fromMap(
         stateHistory,
         configs: ImportEditorConfigs(
           widgetLoader: (id, {meta}) {
@@ -151,10 +177,6 @@ class DraftRenderParametersService {
           },
         ),
       );
-
-      final position = history.editorPosition;
-      if (position < 0 || position >= history.stateHistory.length) return null;
-      return history.stateHistory[position];
     } catch (error, stackTrace) {
       Log.error(
         'Failed to restore editor state history for render',
@@ -169,13 +191,24 @@ class DraftRenderParametersService {
     }
   }
 
+  /// Returns the entry the user last had active, or `null` for an editor
+  /// position outside the history — `editorPosition` is `-1` for a session
+  /// that was never edited.
+  EditorStateHistory? _activeEntry(ImportStateHistory? history) {
+    if (history == null) return null;
+    final position = history.editorPosition;
+    if (position < 0 || position >= history.stateHistory.length) return null;
+    return history.stateHistory[position];
+  }
+
   /// Bakes [layers] into images the render can composite over the video.
   ///
   /// Returns an empty list when there is nothing to bake. Throws
   /// [DraftOverlayRestoreException] when there are layers but they cannot be
-  /// baked — a missing [bodySize] leaves their offsets unresolvable, and a
-  /// failed capture leaves them unrendered. Both would otherwise publish a
-  /// video without overlays the user can see in the draft.
+  /// baked — a missing [bodySize] leaves their offsets unresolvable, a failed
+  /// capture leaves them unrendered, and a capture that comes back short
+  /// dropped some of them. All three would otherwise publish a video without
+  /// overlays the user can see in the draft.
   Future<List<ExportedLayer>> _rasterizeLayers({
     required List<Layer> layers,
     required List<StickerData> stickers,
@@ -204,15 +237,28 @@ class DraftRenderParametersService {
       // editor canvas overrides none of them. Both sides reading the same
       // defaults is what keeps a re-render identical to what the user saw; if
       // the canvas ever overrides one, mirror it here.
-      return await _rasterizer.capture(
+      final captured = await _rasterizer.capture(
         layers: layers,
         editorBodySize: bodySize,
         // The render scales each layer by `videoSize.width / bodySize.width`
         // (see VideoEditorRenderService.buildImageLayers), so capturing at
         // that ratio lands one raster pixel per output pixel.
         basePixelRatio: (videoSize.width / bodySize.width).clamp(1.0, 10.0),
-        awaitContentReady: () => _precacheStickers(stickers),
+        awaitContentReady: () => _prepareLayerContent(layers, stickers),
       );
+
+      // `captureAllLayers` drops a layer whose repaint boundary produced no
+      // image rather than reporting it, so a short result is a silent partial
+      // bake — the exact degrade this service exists to prevent.
+      if (captured.length != layers.length) {
+        throw DraftOverlayRestoreException(
+          'Only ${captured.length} of ${layers.length} layer(s) could be '
+          'rasterized',
+        );
+      }
+      return captured;
+    } on DraftOverlayRestoreException {
+      rethrow;
     } catch (error, stackTrace) {
       Log.error(
         'Failed to rasterize ${layers.length} draft layer(s) for render',
@@ -226,6 +272,20 @@ class DraftRenderParametersService {
       );
     }
   }
+
+  /// Resolves everything the mounted layers need before they are captured.
+  ///
+  /// Runs while the layers are mounted but before the capture frame, so both
+  /// halves land in the first build the rasterizer measures: fonts for text
+  /// and emoji layers, images for stickers.
+  Future<void> _prepareLayerContent(
+    List<Layer> layers,
+    List<StickerData> stickers,
+  ) => Future.wait([
+    if (layers.any((layer) => layer is TextLayer || layer is EmojiLayer))
+      preloadEditorTextFonts(),
+    _precacheStickers(stickers),
+  ]);
 
   /// Loads every sticker's image into the cache the sticker widget reads from.
   ///

--- a/mobile/lib/services/video_editor/draft_render_parameters_service.dart
+++ b/mobile/lib/services/video_editor/draft_render_parameters_service.dart
@@ -1,0 +1,304 @@
+// ABOUTME: Rebuilds a draft's full render parameters outside the editor
+// ABOUTME: Restores overlay layers, timed filters, tune and audio from storage
+
+import 'dart:async';
+
+// The models AspectRatio is the one this file means; the Flutter widget of the
+// same name is unused here.
+import 'package:flutter/widgets.dart' hide AspectRatio;
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:media_cache/media_cache.dart';
+import 'package:models/models.dart' show AspectRatio, StickerData;
+import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/extensions/aspect_ratio_extensions.dart';
+import 'package:openvine/extensions/complete_parameters_extensions.dart';
+import 'package:openvine/models/divine_video_draft.dart';
+import 'package:openvine/services/video_editor/video_editor_audio_render.dart';
+import 'package:openvine/utils/open_vine_image_cache.dart';
+import 'package:openvine/widgets/video_editor/sticker_editor/video_editor_sticker.dart';
+import 'package:pro_image_editor/pro_image_editor.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Rebuilds the [CompleteParameters] needed to render a draft when no editor
+/// session is open — posting straight from the library, most importantly.
+///
+/// A draft persists its editing parameters via `CompleteParameters.toMap`,
+/// which drops `capturedLayers`, `filterStates`, `tuneAdjustments` and
+/// `audioTracks`. Rendering from the restored map alone therefore produces a
+/// video with none of the overlays the user authored: no text, stickers or
+/// drawings, no timed filters or tune adjustments, and no added music.
+///
+/// Everything needed to rebuild them survives elsewhere in the draft —
+/// `editorStateHistory` keeps the layers, filters and tune, and the audio
+/// timeline lives in the parameters' own `meta`. Only the *rasterized* layer
+/// bytes are unrecoverable from storage, which is what [LayerRasterizer]
+/// regenerates by briefly mounting the layers offscreen.
+/// Thrown when a draft's authored overlays cannot be reproduced for a render.
+///
+/// Publishing is blocked rather than degraded. A video that silently lacks the
+/// text, stickers or drawings the user placed is the exact failure #5203 was
+/// filed for, and a published Nostr event cannot be quietly corrected —
+/// so a failure the user can retry beats a wrong post they cannot take back.
+class DraftOverlayRestoreException implements Exception {
+  /// Creates an exception explaining which overlays could not be restored.
+  const DraftOverlayRestoreException(this.message);
+
+  /// Why the overlays could not be reproduced.
+  final String message;
+
+  @override
+  String toString() => 'DraftOverlayRestoreException: $message';
+}
+
+class DraftRenderParametersService {
+  /// Creates a service that rasterizes through [rasterizer].
+  const DraftRenderParametersService({required LayerRasterizer rasterizer})
+    : _rasterizer = rasterizer;
+
+  final LayerRasterizer _rasterizer;
+
+  static const _logName = 'DraftRenderParametersService';
+
+  /// Returns render parameters for [draft] with its overlays restored, or
+  /// `null` when the draft carries no editor state at all (a plain recording
+  /// with no edits, which renders fine without parameters).
+  ///
+  /// Rasterization needs a mounted `LayerRasterizerHost`, which `main.dart`
+  /// installs above every route.
+  ///
+  /// Throws [DraftOverlayRestoreException] when the draft has overlays that
+  /// cannot be reproduced — an unreadable state history, layers with no body
+  /// size to place them against, or a rasterization that failed. The caller
+  /// must not publish in that case; the video would be missing them.
+  ///
+  /// A draft with no overlays to begin with is not an error, and neither is a
+  /// single sticker image that fails to load — that one costs its own sticker
+  /// and is logged.
+  Future<CompleteParameters?> buildForDraft(DivineVideoDraft draft) async {
+    if (draft.editorEditingParameters.isEmpty &&
+        draft.editorStateHistory.isEmpty) {
+      return null;
+    }
+
+    final base = draft.editorEditingParameters.isNotEmpty
+        ? completeParametersFromDraftMap(draft.editorEditingParameters)
+        : CompleteParameters.fromMap(const {});
+
+    final audioTracks = <AudioTrack>[
+      for (final track in base.audioTracksFromMeta)
+        ?audioTrackFromMetaForRender(track),
+    ];
+
+    final stickers = <StickerData>[];
+    final entry = _activeHistoryEntry(draft.editorStateHistory, stickers);
+
+    final capturedLayers = entry == null
+        ? const <ExportedLayer>[]
+        : await _rasterizeLayers(
+            layers: entry.layers,
+            stickers: stickers,
+            bodySize: base.bodySize,
+            aspectRatio: draft.clips.isNotEmpty
+                ? draft.clips.first.targetAspectRatio
+                : AspectRatio.square,
+          );
+
+    Log.info(
+      'Restored draft render parameters: ${capturedLayers.length} layer(s), '
+      '${entry?.filters.length ?? 0} filter(s), '
+      '${entry?.tuneAdjustments.length ?? 0} tune adjustment(s), '
+      '${audioTracks.length} audio track(s)',
+      name: _logName,
+      category: LogCategory.video,
+    );
+
+    return base.copyWith(
+      capturedLayers: capturedLayers,
+      filterStates: entry?.filters ?? const [],
+      tuneAdjustments: entry?.tuneAdjustments ?? const [],
+      audioTracks: audioTracks,
+      blur: entry?.blur ?? base.blur,
+    );
+  }
+
+  /// Deserializes [stateHistory] and returns the entry the user last had
+  /// active, recording every sticker it rehydrates into [stickers].
+  ///
+  /// Returns `null` for an empty history or an editor position outside it —
+  /// `editorPosition` is `-1` for a session that was never edited.
+  ///
+  /// Throws [DraftOverlayRestoreException] when a non-empty history cannot be
+  /// read: it may well describe layers, and there is no way to tell from a map
+  /// that failed to parse, so it counts as overlays we cannot reproduce.
+  EditorStateHistory? _activeHistoryEntry(
+    Map<String, dynamic> stateHistory,
+    List<StickerData> stickers,
+  ) {
+    if (stateHistory.isEmpty) return null;
+
+    try {
+      final history = ImportStateHistory.fromMap(
+        stateHistory,
+        configs: ImportEditorConfigs(
+          widgetLoader: (id, {meta}) {
+            if (meta == null) return const SizedBox.shrink();
+            final sticker = StickerData.fromJson(meta);
+            stickers.add(sticker);
+            return VideoEditorSticker(
+              sticker: sticker,
+              enableLimitCacheSize: false,
+            );
+          },
+        ),
+      );
+
+      final position = history.editorPosition;
+      if (position < 0 || position >= history.stateHistory.length) return null;
+      return history.stateHistory[position];
+    } catch (error, stackTrace) {
+      Log.error(
+        'Failed to restore editor state history for render',
+        name: _logName,
+        category: LogCategory.video,
+        error: error,
+        stackTrace: stackTrace,
+      );
+      throw DraftOverlayRestoreException(
+        'The editor state history could not be read: $error',
+      );
+    }
+  }
+
+  /// Bakes [layers] into images the render can composite over the video.
+  ///
+  /// Returns an empty list when there is nothing to bake. Throws
+  /// [DraftOverlayRestoreException] when there are layers but they cannot be
+  /// baked — a missing [bodySize] leaves their offsets unresolvable, and a
+  /// failed capture leaves them unrendered. Both would otherwise publish a
+  /// video without overlays the user can see in the draft.
+  Future<List<ExportedLayer>> _rasterizeLayers({
+    required List<Layer> layers,
+    required List<StickerData> stickers,
+    required Size? bodySize,
+    required AspectRatio aspectRatio,
+  }) async {
+    if (layers.isEmpty) return const [];
+
+    if (bodySize == null || bodySize.isEmpty) {
+      throw DraftOverlayRestoreException(
+        'The draft has ${layers.length} layer(s) but no editor body size, so '
+        'their positions cannot be resolved',
+      );
+    }
+
+    final videoSize = VideoEditorConstants.quality.resolutionForAspectRatio(
+      aspectRatio,
+    );
+
+    try {
+      // `configs` is deliberately left at the package default. Only a few
+      // values change how a layer *renders* rather than how it is edited —
+      // `textEditor.initFontSize` (which scales text and emoji layers),
+      // `textEditor.style.leadingDistribution`, `emojiEditor.style.textStyle`,
+      // `stickerEditor.initWidth` and `paintEditor.censorConfigs` — and the
+      // editor canvas overrides none of them. Both sides reading the same
+      // defaults is what keeps a re-render identical to what the user saw; if
+      // the canvas ever overrides one, mirror it here.
+      return await _rasterizer.capture(
+        layers: layers,
+        editorBodySize: bodySize,
+        // The render scales each layer by `videoSize.width / bodySize.width`
+        // (see VideoEditorRenderService.buildImageLayers), so capturing at
+        // that ratio lands one raster pixel per output pixel.
+        basePixelRatio: (videoSize.width / bodySize.width).clamp(1.0, 10.0),
+        awaitContentReady: () => _precacheStickers(stickers),
+      );
+    } catch (error, stackTrace) {
+      Log.error(
+        'Failed to rasterize ${layers.length} draft layer(s) for render',
+        name: _logName,
+        category: LogCategory.video,
+        error: error,
+        stackTrace: stackTrace,
+      );
+      throw DraftOverlayRestoreException(
+        'Rasterizing ${layers.length} layer(s) failed: $error',
+      );
+    }
+  }
+
+  /// Loads every sticker's image into the cache the sticker widget reads from.
+  ///
+  /// Sticker layers paint nothing until their image resolves, and network
+  /// stickers additionally fade in from fully transparent — capturing before
+  /// either finishes yields a blank layer. Warming the cache first makes the
+  /// mounted widget resolve on its first build, which also skips the fade
+  /// (`AnimatedOpacity` does not animate into its initial value).
+  ///
+  /// Failures are logged and swallowed: one unreachable sticker should cost
+  /// that sticker, not the whole publish.
+  Future<void> _precacheStickers(List<StickerData> stickers) async {
+    if (stickers.isEmpty) return;
+
+    await Future.wait(
+      stickers.map((sticker) async {
+        try {
+          final networkUrl = sticker.networkUrl;
+          final assetPath = sticker.assetPath;
+          if (networkUrl != null) {
+            await _resolveImage(
+              MediaCacheImageProvider(
+                networkUrl,
+                cacheManager: openVineImageCache,
+              ),
+            );
+          } else if (assetPath != null) {
+            // Populates flutter_svg's own cache, which SvgPicture.asset reads.
+            await SvgAssetLoader(assetPath).loadBytes(null);
+          }
+        } catch (error) {
+          Log.warning(
+            'Could not preload sticker for render: $error',
+            name: _logName,
+            category: LogCategory.video,
+          );
+        }
+      }),
+    );
+  }
+
+  /// Resolves [provider] into the image cache and completes once it settled.
+  ///
+  /// This is `precacheImage` without the [BuildContext] — the service has no
+  /// business holding one, and the sticker providers ignore the configuration
+  /// a context would supply. Errors complete normally so a broken sticker
+  /// image cannot stall the render.
+  Future<void> _resolveImage(ImageProvider<Object> provider) {
+    final completer = Completer<void>();
+    final stream = provider.resolve(ImageConfiguration.empty);
+
+    late final ImageStreamListener listener;
+    void finish() {
+      stream.removeListener(listener);
+      if (!completer.isCompleted) completer.complete();
+    }
+
+    listener = ImageStreamListener(
+      (image, _) {
+        image.dispose();
+        finish();
+      },
+      onError: (error, stackTrace) {
+        Log.warning(
+          'Could not preload sticker image for render: $error',
+          name: _logName,
+          category: LogCategory.video,
+        );
+        finish();
+      },
+    );
+    stream.addListener(listener);
+
+    return completer.future;
+  }
+}

--- a/mobile/lib/services/video_editor/video_editor_audio_render.dart
+++ b/mobile/lib/services/video_editor/video_editor_audio_render.dart
@@ -103,6 +103,28 @@ AudioTrack? audioTrackFromMetaForRender(AudioEvent track) {
   );
 }
 
+/// Builds the render audio tracks for a session from its timeline
+/// [metaTracks], falling back to the recorder's [selectedSound].
+///
+/// [selectedSound] is legacy single-sound state from the recorder flow. When
+/// the timeline already carries audio it is the same sound, so adding it again
+/// duplicates the audio — hence the fallback only applies to an empty
+/// timeline. Tracks that resolve to no usable source are dropped by the
+/// mappers and logged there.
+///
+/// Both render entry points go through this: the in-editor export and the
+/// headless draft render used when publishing from the library. Keeping it in
+/// one place is what stops the two from disagreeing about whether a
+/// recorder-picked sound survives.
+List<AudioTrack> buildRenderAudioTracks({
+  required List<AudioEvent> metaTracks,
+  required AudioEvent? selectedSound,
+}) => [
+  for (final track in metaTracks) ?audioTrackFromMetaForRender(track),
+  if (metaTracks.isEmpty && selectedSound != null)
+    ?audioTrackFromSoundForRender(selectedSound),
+];
+
 /// Clamps an audio composition window so it cannot extend past [videoDuration],
 /// or returns `null` when the window lies entirely past the video and the track
 /// should be dropped.

--- a/mobile/lib/utils/editor_text_fonts.dart
+++ b/mobile/lib/utils/editor_text_fonts.dart
@@ -1,0 +1,28 @@
+// ABOUTME: Registers the editor's Google Fonts before restored text renders
+// ABOUTME: Shared by the editor screen and the headless draft rasterizer
+
+import 'package:google_fonts/google_fonts.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
+
+/// Registers every text-overlay font so a restored [TextLayer] paints in the
+/// typeface the user picked.
+///
+/// A persisted text layer carries only the serialized font family name, and
+/// Google Fonts register lazily per process. Anything that renders imported
+/// overlays — the editor canvas importing a state history, or the headless
+/// rasterizer baking them for a publish — has to register them first, or the
+/// text falls back to the platform default: wrong typeface, and wrong metrics,
+/// which also moves the layer (#5181).
+///
+/// Already-cached fonts resolve instantly; the timeout only bounds the first,
+/// uncached load. Timing out is not an error — the render proceeds with
+/// whatever resolved.
+Future<void> preloadEditorTextFonts() async {
+  for (final font in VideoEditorConstants.textFonts) {
+    font();
+  }
+  await GoogleFonts.pendingFonts().timeout(
+    VideoEditorConstants.textFontLoadTimeout,
+    onTimeout: () => const [],
+  );
+}

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1831,10 +1831,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_image_editor
-      sha256: "80f3677566c29eec012ce3aafa7c06bc009c838fd733c72fa909579bf56b17df"
+      sha256: b75e82792ff9d3c51d6627558b4d916e5da7bc1dfaeb59d17b296fc5ae03d773
       url: "https://pub.dev"
     source: hosted
-    version: "13.2.3"
+    version: "13.3.0"
   pro_video_editor:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -331,7 +331,7 @@ dependencies:
   firebase_messaging: ^16.1.1
   audio_session: ^0.2.2
   pro_video_editor: ^2.11.1
-  pro_image_editor: ^13.2.3
+  pro_image_editor: ^13.3.0
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7
   sensors_plus: ^7.0.0

--- a/mobile/test/models/divine_video_draft_can_post_test.dart
+++ b/mobile/test/models/divine_video_draft_can_post_test.dart
@@ -35,11 +35,15 @@ DivineVideoDraft _draft({
 void main() {
   group(DivineVideoDraft, () {
     group('canPost', () {
-      test('returns false for single-clip draft without final render', () {
-        expect(_draft().canPost, isFalse);
+      // #5203 hid Post for these drafts because the publish path shipped the
+      // raw recording, dropping every editor layer. Publish now renders them
+      // with their layers restored, so gating on a cached render would only
+      // hide a working action.
+      test('allows posting a single-clip draft with no final render', () {
+        expect(_draft().canPost, isTrue);
       });
 
-      test('returns true for multi-clip draft without final render', () {
+      test('allows posting a multi-clip draft with no final render', () {
         expect(
           _draft(
             clips: [_createTestClip(), _createTestClip('clip_2')],
@@ -48,8 +52,8 @@ void main() {
         );
       });
 
-      test('returns true when finalRenderedClip is present', () {
-        expect(_draft(finalRenderedClip: _createTestClip()).canPost, isTrue);
+      test('refuses a draft with nothing to publish', () {
+        expect(_draft(clips: const []).canPost, isFalse);
       });
     });
   });

--- a/mobile/test/providers/video_publish_provider_test.dart
+++ b/mobile/test/providers/video_publish_provider_test.dart
@@ -15,8 +15,10 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/l10n/publish_error_kind_l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/models/video_publish/video_publish_state.dart';
 import 'package:openvine/models/video_reply_context.dart';
+import 'package:openvine/providers/layer_rasterizer_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
@@ -25,7 +27,10 @@ import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/services/cawg_verifier_client.dart';
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/mention_resolution_service.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/services/video_publish/publish_error_kind.dart';
+import 'package:pro_image_editor/pro_image_editor.dart'
+    show LayerRasterizer, TextLayer;
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -457,4 +462,257 @@ void main() {
       },
     );
   });
+
+  // #5203 hid Post for drafts with no cached render because publishing one
+  // shipped the raw recording without its editor layers. Publish now renders
+  // on demand instead, so these tests pin that the render actually happens and
+  // that its failures reach the user.
+  group(
+    'VideoPublishNotifier publishVideo renders drafts without a render',
+    () {
+      setUpAll(() {
+        registerFallbackValue(_FakeDivineVideoDraft());
+      });
+
+      tearDown(() {
+        VideoEditorRenderService.renderVideoToClipOverride = null;
+      });
+
+      DivineVideoClip clip({List<StopMotionClipFrame>? stopMotionFrames}) =>
+          DivineVideoClip(
+            id: 'clip_1',
+            video: stopMotionFrames == null
+                ? EditorVideo.file('/tmp/test.mp4')
+                : null,
+            stopMotionFrames: stopMotionFrames,
+            duration: const Duration(seconds: 6),
+            recordedAt: DateTime(2025),
+            originalAspectRatio: 9 / 16,
+            targetAspectRatio: .vertical,
+          );
+
+      DivineVideoDraft draft({List<DivineVideoClip>? clips}) =>
+          DivineVideoDraft(
+            id: 'draft_1',
+            clips: clips ?? [clip()],
+            title: 'Plants',
+            description: '',
+            hashtags: const {},
+            selectedApproach: 'camera',
+            createdAt: DateTime(2025),
+            lastModified: DateTime(2025),
+            publishStatus: PublishStatus.draft,
+            publishAttempts: 0,
+            // No finalRenderedClip: this is the branch under test.
+          );
+
+      /// Pumps the app shell the notifier needs: mocked draft storage, real
+      /// prefs for the l10n lookup, and a navigator the snackbars land in.
+      ///
+      /// [rasterizer] defaults to one with no mounted host, which is what a
+      /// draft whose layers cannot be baked looks like — capture throws.
+      Future<ProviderContainer> pumpHarness(
+        WidgetTester tester, {
+        LayerRasterizer? rasterizer,
+      }) async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+
+        final mockDraftStorage = _MockDraftStorageService();
+        when(() => mockDraftStorage.saveDraft(any())).thenAnswer((_) async {});
+
+        final container = ProviderContainer(
+          overrides: [
+            draftStorageServiceProvider.overrideWithValue(mockDraftStorage),
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            if (rasterizer != null)
+              layerRasterizerProvider.overrideWithValue(rasterizer),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: MaterialApp(
+              navigatorKey: NavigatorKeys.root,
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: const Scaffold(body: SizedBox()),
+            ),
+          ),
+        );
+        return container;
+      }
+
+      testWidgets('renders a single-clip draft instead of publishing it raw', (
+        tester,
+      ) async {
+        final container = await pumpHarness(tester);
+        var renderCalls = 0;
+        VideoEditorRenderService.renderVideoToClipOverride =
+            ({
+              required clips,
+              required editorStateHistory,
+              parameters,
+              taskId,
+            }) async {
+              renderCalls++;
+              return null; // stop the publish here; the render is the assertion
+            };
+
+        final context = tester.element(find.byType(SizedBox));
+        await container
+            .read(videoPublishProvider.notifier)
+            .publishVideo(context, draft());
+
+        expect(
+          renderCalls,
+          equals(1),
+          reason:
+              'a lone clip used to skip the render and ship the raw recording, '
+              'losing every layer plus trim, speed and volume',
+        );
+      });
+
+      testWidgets('surfaces a snackbar when the render fails', (tester) async {
+        final container = await pumpHarness(tester);
+        VideoEditorRenderService.renderVideoToClipOverride =
+            ({
+              required clips,
+              required editorStateHistory,
+              parameters,
+              taskId,
+            }) async => null;
+
+        final context = tester.element(find.byType(SizedBox));
+        await container
+            .read(videoPublishProvider.notifier)
+            .publishVideo(context, draft());
+        await tester.pump();
+
+        expect(
+          find.widgetWithText(
+            SnackBar,
+            lookupAppLocalizations(
+              const Locale('en'),
+            ).publishErrorMessage(PublishErrorKind.generic),
+          ),
+          findsOneWidget,
+          reason:
+              'nothing on screen reads the error state, so setError alone just '
+              'makes the preparing scrim vanish (#6058)',
+        );
+      });
+
+      testWidgets('reports a failed stop-motion assembly in its own words', (
+        tester,
+      ) async {
+        final container = await pumpHarness(tester);
+        VideoEditorRenderService.renderVideoToClipOverride =
+            ({
+              required clips,
+              required editorStateHistory,
+              parameters,
+              taskId,
+            }) async => null;
+
+        final context = tester.element(find.byType(SizedBox));
+        await container
+            .read(videoPublishProvider.notifier)
+            .publishVideo(
+              context,
+              draft(
+                clips: [
+                  clip(
+                    stopMotionFrames: const [
+                      StopMotionClipFrame(
+                        path: '/tmp/frame_1.jpg',
+                        duration: Duration(milliseconds: 100),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            );
+        await tester.pump();
+
+        expect(
+          find.widgetWithText(
+            SnackBar,
+            lookupAppLocalizations(
+              const Locale('en'),
+            ).videoRecorderStopMotionAssembleFailed,
+          ),
+          findsOneWidget,
+          reason:
+              'a frames-only draft that reaches here failed its assembly pass, '
+              'which the generic render copy does not describe',
+        );
+      });
+
+      testWidgets('blocks the publish when the overlays cannot be restored', (
+        tester,
+      ) async {
+        final rasterizer = LayerRasterizer();
+        addTearDown(rasterizer.dispose);
+        final container = await pumpHarness(tester, rasterizer: rasterizer);
+        var renderCalls = 0;
+        VideoEditorRenderService.renderVideoToClipOverride =
+            ({
+              required clips,
+              required editorStateHistory,
+              parameters,
+              taskId,
+            }) async {
+              renderCalls++;
+              return null;
+            };
+
+        final context = tester.element(find.byType(SizedBox));
+        await container
+            .read(videoPublishProvider.notifier)
+            .publishVideo(
+              context,
+              draft().copyWith(
+                editorEditingParameters: const {
+                  'bodySize': {'width': 300.0, 'height': 500.0},
+                },
+                editorStateHistory: {
+                  'position': 0,
+                  'references': {
+                    'text-1': TextLayer(id: 'text-1', text: 'hello').toMap(),
+                  },
+                  'history': [
+                    {
+                      'layers': [
+                        {'id': 'text-1'},
+                      ],
+                    },
+                  ],
+                },
+              ),
+            );
+        await tester.pump();
+
+        expect(
+          renderCalls,
+          isZero,
+          reason:
+              'a video published without the text the user still sees on the '
+              'draft is the #5203 failure, and a Nostr event cannot be quietly '
+              'corrected',
+        );
+        expect(
+          find.widgetWithText(
+            SnackBar,
+            lookupAppLocalizations(
+              const Locale('en'),
+            ).publishErrorOverlaysUnavailable,
+          ),
+          findsOneWidget,
+        );
+      });
+    },
+  );
 }

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -429,7 +429,9 @@ void main() {
         final drafts = await service.getAllDrafts();
         expect(drafts, hasLength(1));
         expect(drafts.single.finalRenderedClip, isNull);
-        expect(drafts.single.canPost, isFalse);
+        // Dropping the dangling render does not take the draft out of play:
+        // publish re-renders it from its clips and editor state.
+        expect(drafts.single.canPost, isTrue);
       });
     });
 

--- a/mobile/test/services/video_editor/draft_render_parameters_service_test.dart
+++ b/mobile/test/services/video_editor/draft_render_parameters_service_test.dart
@@ -6,7 +6,7 @@ import 'dart:ui' show ImageByteFormat;
 
 import 'package:flutter/material.dart' hide AspectRatio;
 import 'package:flutter_test/flutter_test.dart';
-import 'package:models/models.dart' show AspectRatio;
+import 'package:models/models.dart' show AspectRatio, AudioEvent;
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/extensions/aspect_ratio_extensions.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -27,6 +27,7 @@ DivineVideoClip _clip() => DivineVideoClip(
 DivineVideoDraft _draft({
   Map<String, dynamic> editorStateHistory = const {},
   Map<String, dynamic> editorEditingParameters = const {},
+  AudioEvent? selectedSound,
 }) => DivineVideoDraft(
   id: 'draft_1',
   clips: [_clip()],
@@ -40,6 +41,7 @@ DivineVideoDraft _draft({
   publishAttempts: 0,
   editorStateHistory: editorStateHistory,
   editorEditingParameters: editorEditingParameters,
+  selectedSound: selectedSound,
 );
 
 /// The persisted shape of a session laid out against [bodySize].
@@ -121,19 +123,107 @@ void main() {
       },
     );
 
-    // The three cases below all mean "this draft has overlays we cannot
+    test(
+      'restores the recorder-picked sound the timeline never carries',
+      () async {
+        // `selectSound` writes no timeline track, so without the fallback the
+        // same draft publishes with music from the editor and silent from the
+        // library.
+        final draft = _draft(
+          editorEditingParameters: _persistedParameters(),
+          selectedSound: const AudioEvent(
+            id: 'sound-1',
+            pubkey: 'pubkey-1',
+            createdAt: 1735689600,
+            url: 'https://example.com/track.mp3',
+            duration: 6,
+          ),
+        );
+
+        final parameters = await service.buildForDraft(draft);
+
+        expect(parameters!.audioTracks, hasLength(1));
+        expect(parameters.audioTracks.single.id, equals('sound-1'));
+      },
+    );
+
+    test('falls back to the size the state history was laid out at', () async {
+      // `bodySize` only reaches storage through the editor's Done callback, so
+      // a draft saved by backing out has layers and no parameters at all.
+      // Blocking those would hide Post behind an error for the most ordinary
+      // way to end up with overlays.
+      final stub = _StubLayerRasterizer();
+      addTearDown(stub.dispose);
+
+      final draft = _draft(
+        editorStateHistory: {
+          ..._historyWithTextLayer(),
+          'lastRenderedImgSize': {'width': 390.0, 'height': 694.0},
+        },
+      );
+
+      final parameters = await DraftRenderParametersService(
+        rasterizer: stub,
+      ).buildForDraft(draft);
+
+      expect(stub.editorBodySize, equals(const Size(390, 694)));
+      expect(
+        parameters!.bodySize,
+        equals(const Size(390, 694)),
+        reason:
+            'the render scales the captured layers against this, so it has '
+            'to match the size they were captured at',
+      );
+    });
+
+    // The four cases below all mean "this draft has overlays we cannot
     // reproduce". Returning parameters without them would publish a video
     // silently missing text/stickers the user still sees on the draft — the
     // #5203 failure — so the publish is blocked instead.
-    test('refuses to build when the draft has no editor body size', () async {
+    test('refuses to build when no body size can be resolved', () async {
+      final stub = _StubLayerRasterizer();
+      addTearDown(stub.dispose);
+
+      // No `lastRenderedImgSize` either — `safeParseSize` yields `Size.zero`.
       final draft = _draft(
         editorEditingParameters: _persistedParameters(),
         editorStateHistory: _historyWithTextLayer(),
       );
 
       await expectLater(
-        service.buildForDraft(draft),
-        throwsA(isA<DraftOverlayRestoreException>()),
+        DraftRenderParametersService(rasterizer: stub).buildForDraft(draft),
+        throwsA(
+          isA<DraftOverlayRestoreException>().having(
+            (e) => e.message,
+            'message',
+            contains('no editor body size'),
+          ),
+        ),
+      );
+    });
+
+    test('refuses to build when only some layers rasterize', () async {
+      // `captureAllLayers` drops a layer that produced no image instead of
+      // reporting it, so a short result is a silent partial bake.
+      final stub = _StubLayerRasterizer(dropLayers: true);
+      addTearDown(stub.dispose);
+
+      final draft = _draft(
+        editorEditingParameters: _persistedParameters(
+          bodySize: const Size(300, 500),
+        ),
+        editorStateHistory: _historyWithTextLayer(),
+      );
+
+      await expectLater(
+        DraftRenderParametersService(rasterizer: stub).buildForDraft(draft),
+        throwsA(
+          isA<DraftOverlayRestoreException>().having(
+            (e) => e.message,
+            'message',
+            contains('Only 0 of 1 layer(s)'),
+          ),
+        ),
       );
     });
 
@@ -220,7 +310,14 @@ void main() {
 
 /// Stands in for the real rasterizer so the service can be exercised without
 /// a widget tree, recording what it was asked to bake.
+///
+/// [dropLayers] reproduces `captureAllLayers` returning fewer layers than it
+/// was given, which is how the package reports a layer that produced no image.
 class _StubLayerRasterizer extends LayerRasterizer {
+  _StubLayerRasterizer({this.dropLayers = false});
+
+  final bool dropLayers;
+
   int? capturedLayerCount;
   Size? editorBodySize;
   double? basePixelRatio;
@@ -240,6 +337,7 @@ class _StubLayerRasterizer extends LayerRasterizer {
     this.editorBodySize = editorBodySize;
     this.basePixelRatio = basePixelRatio;
     await awaitContentReady?.call();
+    if (dropLayers) return const [];
     return [
       for (final layer in layers)
         ExportedLayer(

--- a/mobile/test/services/video_editor/draft_render_parameters_service_test.dart
+++ b/mobile/test/services/video_editor/draft_render_parameters_service_test.dart
@@ -1,0 +1,252 @@
+// ABOUTME: Tests DraftRenderParametersService restoring a draft's overlays
+// ABOUTME: Covers layers, timed filters, tune and the graceful degrade paths
+
+import 'dart:typed_data';
+import 'dart:ui' show ImageByteFormat;
+
+import 'package:flutter/material.dart' hide AspectRatio;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' show AspectRatio;
+import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/extensions/aspect_ratio_extensions.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/divine_video_draft.dart';
+import 'package:openvine/services/video_editor/draft_render_parameters_service.dart';
+import 'package:pro_image_editor/pro_image_editor.dart';
+import 'package:pro_video_editor/pro_video_editor.dart' show EditorVideo;
+
+DivineVideoClip _clip() => DivineVideoClip(
+  id: 'clip_1',
+  video: EditorVideo.file('/tmp/test.mp4'),
+  duration: const Duration(seconds: 6),
+  recordedAt: DateTime(2025),
+  originalAspectRatio: 9 / 16,
+  targetAspectRatio: .vertical,
+);
+
+DivineVideoDraft _draft({
+  Map<String, dynamic> editorStateHistory = const {},
+  Map<String, dynamic> editorEditingParameters = const {},
+}) => DivineVideoDraft(
+  id: 'draft_1',
+  clips: [_clip()],
+  title: '',
+  description: '',
+  hashtags: const {},
+  selectedApproach: 'camera',
+  createdAt: DateTime(2025),
+  lastModified: DateTime(2025),
+  publishStatus: PublishStatus.draft,
+  publishAttempts: 0,
+  editorStateHistory: editorStateHistory,
+  editorEditingParameters: editorEditingParameters,
+);
+
+/// The persisted shape of a session laid out against [bodySize].
+///
+/// This is what `CompleteParameters.toMap` writes into a draft — note it has
+/// no `capturedLayers`, `filterStates`, `tuneAdjustments` or `audioTracks`,
+/// which is the gap the service exists to close.
+Map<String, dynamic> _persistedParameters({Size? bodySize}) => {
+  if (bodySize != null)
+    'bodySize': {'width': bodySize.width, 'height': bodySize.height},
+};
+
+Map<String, dynamic> _historyWithTextLayer() => {
+  'position': 0,
+  'references': {
+    'text-1': TextLayer(id: 'text-1', text: 'hello').toMap(),
+  },
+  'history': [
+    {
+      'layers': [
+        {'id': 'text-1'},
+      ],
+    },
+  ],
+};
+
+void main() {
+  group(DraftRenderParametersService, () {
+    late LayerRasterizer rasterizer;
+    late DraftRenderParametersService service;
+
+    setUp(() {
+      rasterizer = LayerRasterizer();
+      service = DraftRenderParametersService(rasterizer: rasterizer);
+    });
+
+    tearDown(() => rasterizer.dispose());
+
+    test('returns null when the draft carries no editor state', () async {
+      expect(await service.buildForDraft(_draft()), isNull);
+    });
+
+    test(
+      'restores timed filters and tune the persisted parameters drop',
+      () async {
+        final draft = _draft(
+          editorEditingParameters: _persistedParameters(),
+          editorStateHistory: {
+            'position': 0,
+            'history': [
+              {
+                'filters': [
+                  {
+                    'matrices': [
+                      List<double>.filled(20, 0.5),
+                    ],
+                    'startTime': 1000,
+                    'endTime': 3000,
+                  },
+                ],
+                'tune': [
+                  {'id': 'brightness', 'value': 0.4, 'matrix': <double>[]},
+                ],
+              },
+            ],
+          },
+        );
+
+        final parameters = await service.buildForDraft(draft);
+
+        expect(parameters, isNotNull);
+        expect(parameters!.filterStates, hasLength(1));
+        expect(
+          parameters.filterStates.single.startTime,
+          equals(const Duration(milliseconds: 1000)),
+          reason: 'the timeline window is what the raw matrix list loses',
+        );
+        expect(parameters.tuneAdjustments, hasLength(1));
+      },
+    );
+
+    // The three cases below all mean "this draft has overlays we cannot
+    // reproduce". Returning parameters without them would publish a video
+    // silently missing text/stickers the user still sees on the draft — the
+    // #5203 failure — so the publish is blocked instead.
+    test('refuses to build when the draft has no editor body size', () async {
+      final draft = _draft(
+        editorEditingParameters: _persistedParameters(),
+        editorStateHistory: _historyWithTextLayer(),
+      );
+
+      await expectLater(
+        service.buildForDraft(draft),
+        throwsA(isA<DraftOverlayRestoreException>()),
+      );
+    });
+
+    test('refuses to build when the state history is malformed', () async {
+      // A history that will not parse may well describe layers, and there is
+      // no way to tell from the outside.
+      final draft = _draft(
+        editorEditingParameters: _persistedParameters(
+          bodySize: const Size(300, 500),
+        ),
+        editorStateHistory: const {'position': 0, 'history': 'not-a-list'},
+      );
+
+      await expectLater(
+        service.buildForDraft(draft),
+        throwsA(isA<DraftOverlayRestoreException>()),
+      );
+    });
+
+    test('refuses to build when rasterizing the layers fails', () async {
+      final draft = _draft(
+        editorEditingParameters: _persistedParameters(
+          bodySize: const Size(300, 500),
+        ),
+        editorStateHistory: _historyWithTextLayer(),
+      );
+
+      // No host is mounted, so the real rasterizer throws a StateError.
+      await expectLater(
+        service.buildForDraft(draft),
+        throwsA(isA<DraftOverlayRestoreException>()),
+      );
+    });
+
+    test('rasterizes the restored layers into capturedLayers', () async {
+      // The rasterizer is stubbed here: producing real bytes means PNG
+      // encoding through the isolate-backed recorder, which a widget test
+      // cannot drive. pro_image_editor's own LayerRasterizer tests cover that
+      // mount-paint-capture mechanism end to end; what matters here is that
+      // the service hands it the layers it recovered from storage and puts
+      // the result where the render reads it.
+      final stub = _StubLayerRasterizer();
+      addTearDown(stub.dispose);
+
+      final draft = _draft(
+        editorEditingParameters: _persistedParameters(
+          bodySize: const Size(300, 500),
+        ),
+        editorStateHistory: _historyWithTextLayer(),
+      );
+
+      final parameters = await DraftRenderParametersService(
+        rasterizer: stub,
+      ).buildForDraft(draft);
+
+      expect(
+        stub.capturedLayerCount,
+        equals(1),
+        reason:
+            'a layer restored from storage has never been rasterized, so '
+            'without this the render would drop it entirely',
+      );
+      expect(
+        stub.editorBodySize,
+        equals(const Size(300, 500)),
+        reason: 'layer offsets are relative to the editor body size',
+      );
+      expect(
+        stub.basePixelRatio,
+        equals(
+          VideoEditorConstants.quality
+                  .resolutionForAspectRatio(AspectRatio.vertical)
+                  .width /
+              300,
+        ),
+        reason:
+            'capturing at the render scale gives one raster pixel per '
+            'output pixel',
+      );
+      expect(parameters!.capturedLayers, hasLength(1));
+    });
+  });
+}
+
+/// Stands in for the real rasterizer so the service can be exercised without
+/// a widget tree, recording what it was asked to bake.
+class _StubLayerRasterizer extends LayerRasterizer {
+  int? capturedLayerCount;
+  Size? editorBodySize;
+  double? basePixelRatio;
+
+  @override
+  Future<List<ExportedLayer>> capture({
+    required List<Layer> layers,
+    required Size editorBodySize,
+    ProImageEditorConfigs configs = const ProImageEditorConfigs(),
+    double? pixelRatio,
+    double? basePixelRatio,
+    bool applyTransforms = true,
+    ImageByteFormat format = ImageByteFormat.png,
+    Future<void> Function()? awaitContentReady,
+  }) async {
+    capturedLayerCount = layers.length;
+    this.editorBodySize = editorBodySize;
+    this.basePixelRatio = basePixelRatio;
+    await awaitContentReady?.call();
+    return [
+      for (final layer in layers)
+        ExportedLayer(
+          layer: layer,
+          bytes: Uint8List.fromList(const [1, 2, 3]),
+          logicalSize: const Size(10, 10),
+        ),
+    ];
+  }
+}

--- a/mobile/test/widgets/library/drafts_tab_test.dart
+++ b/mobile/test/widgets/library/drafts_tab_test.dart
@@ -40,12 +40,15 @@ void main() {
     DivineVideoDraft createDraft({
       String? id,
       String title = 'Test Draft',
-      List<DivineVideoClip> clips = const [],
+      // Defaults to one clip because a draft without any is not a state the
+      // library can produce — and post eligibility keys off having something
+      // to publish.
+      List<DivineVideoClip>? clips,
       DivineVideoClip? finalRenderedClip,
     }) {
       return DivineVideoDraft(
         id: id ?? 'draft-${DateTime.now().millisecondsSinceEpoch}',
-        clips: clips,
+        clips: clips ?? [_createTestClip()],
         title: title,
         description: 'Test Description',
         hashtags: const {},
@@ -201,7 +204,11 @@ void main() {
     });
 
     group('post action', () {
-      testWidgets('hides post action when draft has no final render', (
+      // #5203 hid this action for drafts with no cached render, because
+      // publishing one shipped the raw recording without its editor layers.
+      // Publish now renders on demand with those layers restored, so the
+      // action stays available.
+      testWidgets('shows post action when draft has no final render', (
         tester,
       ) async {
         when(
@@ -212,7 +219,7 @@ void main() {
         await tester.tap(find.byType(IconButton));
         await tester.pumpAndSettle();
 
-        expect(find.text(en.libraryDraftActionPost), findsNothing);
+        expect(find.text(en.libraryDraftActionPost), findsOneWidget);
         expect(find.text(en.libraryDraftActionEdit), findsOneWidget);
         expect(find.text(en.libraryDraftActionDelete), findsOneWidget);
       });
@@ -234,28 +241,6 @@ void main() {
 
         expect(find.text(en.libraryDraftActionPost), findsOneWidget);
       });
-
-      testWidgets(
-        'shows post action for multi-clip draft without final render',
-        (tester) async {
-          when(() => mockBloc.state).thenReturn(
-            DraftsLibraryLoaded(
-              drafts: [
-                createDraft(
-                  id: 'draft1',
-                  clips: [_createTestClip(), _createTestClip('clip_2')],
-                ),
-              ],
-            ),
-          );
-
-          await tester.pumpWidget(buildWidget());
-          await tester.tap(find.byType(IconButton));
-          await tester.pumpAndSettle();
-
-          expect(find.text(en.libraryDraftActionPost), findsOneWidget);
-        },
-      );
     });
 
     group('duplicate action', () {


### PR DESCRIPTION
Closes #6550

## Description

Posting a draft from the library shipped a video without the overlays the user authored.

`CompleteParameters.toMap` — how a draft persists its editing parameters — does not serialize `capturedLayers`, `filterStates`, `tuneAdjustments` or `audioTracks`. Parameters restored from storage therefore describe far less than the editor session did: no text, stickers or drawings, no timed filters or tune, no added music. On top of that, a single-clip draft skipped the render entirely and uploaded the raw recording, losing trim, speed and volume too.

#5203 worked around this by hiding the Post action until a render happened to be cached. That left the multi-clip path — which the gate allowed through — still shipping broken videos.

Publish now always renders, and rebuilds what storage dropped before it does. Layers, timed filters and tune come back from `editorStateHistory`; audio comes from the parameters' own `meta` plus the draft's own recorder-picked sound. Only the *rasterized* layer bytes are unrecoverable, because `Layer.captureAsPng` returns `null` for a layer that was never mounted — so they are re-baked offscreen via `LayerRasterizer`, added in pro_image_editor 13.3.0 for exactly this case and hosted once above every route.

Three further inputs the render needs do not survive in the parameters either, and each one silently changed what got published:

- **The editor body size.** It only reaches storage through the editor's complete callback, which fires on Done — a draft saved by backing out keeps its layers but no parameters at all. It now falls back to the size the exported state history was laid out against, and that size is handed back on the returned parameters so the capture and the render share one reference frame.
- **The overlay fonts.** A text layer persists only its font family, and Google Fonts register lazily per process, so a publish after a cold start baked every non-default preset in the platform default — wrong typeface, and wrong position through the changed metrics (#5181). The editor screen already guarded this before importing a history; that preload moved into a shared helper the headless rasterizer calls too.
- **The recorder-picked sound.** It lives on the draft and never becomes a timeline track, so the same draft published with music from the editor and silent from the library.

### Why some non-obvious calls were made

**Blocking rather than degrading.** When the overlays cannot be reproduced (unreadable state history, no body size from either source, a failed rasterization, or a capture that comes back short) the publish fails with an actionable message instead of posting a video without them. Silently dropping overlays is the original bug, and a published Nostr event cannot be quietly corrected — a retry the user can act on beats a wrong post they cannot take back. A single sticker image that fails to load is treated differently: it costs that sticker and is logged.

**Always rendering, even for one clip.** The old pass-through was faster but only correct for a completely unedited recording, and getting that condition right means enumerating every field that affects output. Rendering unconditionally is both simpler and strictly more faithful — it is what fixes the trim/speed/volume loss.

**Package defaults for the rasterizer configs.** Only a few config values change how a layer *renders* (`textEditor.initFontSize`, `textEditor.style.leadingDistribution`, `emojiEditor.style.textStyle`, `stickerEditor.initWidth`, `paintEditor.censorConfigs`) and the editor canvas overrides none of them. Both sides reading the same defaults is what keeps a re-render identical to what the user saw, so the argument is deliberately omitted rather than pinned to a copy.

**Warming sticker images before capture.** A sticker paints nothing until its image resolves, and a network sticker additionally fades in from fully transparent — capturing before either finishes yields a blank layer. Priming the cache makes the mounted widget resolve on its first build, which also skips the fade. The font registration rides along on the same hook, so both land in the first build the rasterizer measures.

**One helper per shared decision.** The audio list and the font preload are now single functions the in-editor export and the headless draft render both call, rather than parallel implementations. Both had already drifted once — that is how the recorder sound went missing from one path and not the other.

**Checking the capture length.** `Layer.captureAllLayers` drops a layer whose repaint boundary produced no image rather than reporting it, so a short result is a silent partial bake. Comparing the count is what makes that reach the same block as an outright failure.

## Out of Scope

- Removing `DivineVideoDraft.canPost` entirely. It is now just `clips.isNotEmpty`, which still carries meaning at the call site.
- The remaining `PublishErrorKind.generic` message on a plain render failure. A frames-only draft gets the stop-motion assembly copy; everything else stays generic.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test` over the affected suites (draft render params, publish provider, editor provider, drafts tab, draft storage, models, l10n) — 515 passing
- `flutter test test/l10n/arb_consistency_test.dart` — the new key is translated in all 18 locales, no English fallbacks
- `check_untested_services_floor.sh`, `check_test_unit_structure.sh` and all four design-system ceilings — OK
- Pre-push hook (analyze + codegen + changed-file tests) — 243 passing
- Mutation-checked all seven new and reworked tests: removing each production change fails exactly its own test, including the body-size guard, whose earlier test could not fail because an unmounted rasterizer threw either way
- Manually verified on a real Samsung Galaxy: the layers never flash visible while a publish rasterizes them, and stickers land fully in the exported video

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
