### PR TITLE
fix(upload): stop duplicating the device attestation into its own header

### DIFF
--- a/docs/protocol/blossom/2026-03-26-divine-resumable-upload-sessions-bud.md
+++ b/docs/protocol/blossom/2026-03-26-divine-resumable-upload-sessions-bud.md
@@ -108,13 +108,19 @@ Optional request headers:
 
 - `X-ProofMode-Manifest`
 - `X-ProofMode-Signature`
-- `X-ProofMode-Attestation`
 - `X-ProofMode-C2PA`
 
 When present, these headers carry the same ProofMode metadata that legacy
 `PUT /upload` accepts. Clients should send them on `complete` so resumable
-uploads preserve the same server-side ProofMode handling without forcing the
-video bytes back onto the legacy single-request upload path.
+uploads preserve the same ProofMode metadata without forcing the video bytes
+back onto the legacy single-request upload path.
+
+There is deliberately no `X-ProofMode-Attestation` header. The device
+attestation is already carried inside `X-ProofMode-Manifest`, and sending it
+a second time took total request headers past the 128 KiB HTTP/1.1 limit at
+the edge on handsets with a large KeyMint chain — the edge then answered 502
+before any handler ran (#6529). Keep the combined header set well under
+128 KiB; the ceiling is enforced at the edge, not by any handler.
 
 Example successful response:
 

--- a/mobile/docs/PROOFMODE_ARCHITECTURE.md
+++ b/mobile/docs/PROOFMODE_ARCHITECTURE.md
@@ -346,10 +346,11 @@ class BlossomUploadService {
         headers['X-ProofMode-Signature'] = manifest['pgpSignature']['signature'];
       }
 
-      // Add attestation header
-      if (manifest['deviceAttestation'] != null) {
-        headers['X-ProofMode-Attestation'] = manifest['deviceAttestation']['token'];
-      }
+      // The device attestation is NOT sent as its own header. It already
+      // ships inside X-ProofMode-Manifest above, and duplicating it took
+      // total request headers past the 128 KiB edge limit on handsets with
+      // a large KeyMint chain, which returned 502 before any handler ran
+      // (#6529).
     }
 
     // Upload video with headers

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -2908,9 +2908,15 @@ class BlossomUploadService {
 
   /// Add ProofMode headers to upload request.
   ///
-  /// Generates X-ProofMode-Manifest, X-ProofMode-Signature,
-  /// and X-ProofMode-Attestation headers from the provided
-  /// ProofManifest JSON.
+  /// Generates X-ProofMode-Manifest, X-ProofMode-Signature and
+  /// X-ProofMode-C2PA headers from the provided ProofManifest JSON.
+  ///
+  /// The device attestation is carried inside X-ProofMode-Manifest and is
+  /// deliberately not repeated in a standalone X-ProofMode-Attestation
+  /// header: on handsets whose KeyMint chain dumps large (~53 KB on a Pixel
+  /// 8 Pro) the duplicate pushed total request headers past the 128 KiB
+  /// HTTP/1.1 limit at the media.divine.video edge, which answered 502
+  /// before any handler ran and made every publish fail. See #6529.
   void _addProofModeHeaders(
     Map<String, dynamic> headers,
     String proofManifestJson,
@@ -2927,13 +2933,6 @@ class BlossomUploadService {
       if (manifestMap['pgpSignature'] != null) {
         headers['X-ProofMode-Signature'] = _encodeHeaderValue(
           manifestMap['pgpSignature'],
-        );
-      }
-
-      // Extract and encode attestation if present
-      if (manifestMap['deviceAttestation'] != null) {
-        headers['X-ProofMode-Attestation'] = _encodeHeaderValue(
-          manifestMap['deviceAttestation'],
         );
       }
 

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_proofmode_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_proofmode_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for BlossomUploadService ProofMode header integration
 // ABOUTME: Verifies _addProofModeHeaders correctly handles String and Map
-//          values for pgpSignature, deviceAttestation, and c2pa_manifest_id
+//          values for pgpSignature and c2pa_manifest_id, keeps the device
+//          attestation to the manifest header only, and stays under the
+//          128 KiB edge request-header limit
 
 import 'dart:convert';
 import 'dart:io';
@@ -35,6 +37,11 @@ const _pgpSignatureString =
 const _sha256Of123 =
     '039058c6f2c0cb492c533b0a4d14ef77'
     'cc0f78abccced5287d84a1a2011cfb81';
+
+/// The HTTP/1.1 request-header ceiling at the media.divine.video edge.
+///
+/// Requests over this are answered 502 before any handler runs (#6529).
+const int _edgeRequestHeaderLimitBytes = 128 * 1024;
 
 const _deviceAttestationString =
     'Certificate:\n'
@@ -220,7 +227,8 @@ void main() {
       );
 
       test(
-        'encodes String deviceAttestation as base64 without double-encoding',
+        'never sends a standalone attestation header, but keeps the '
+        'attestation reachable inside the manifest',
         () async {
           arrangeUploadMocks();
           final mockFile = createMockFile();
@@ -240,12 +248,23 @@ void main() {
           );
 
           final headers = capturedOptions!.headers!;
-          expect(headers, contains('X-ProofMode-Attestation'));
+          expect(headers, isNot(contains('X-ProofMode-Attestation')));
 
-          final decoded = utf8.decode(
-            base64.decode(headers['X-ProofMode-Attestation'] as String),
+          // No data is lost: the attestation still ships, once, inside the
+          // manifest header a consumer already has to decode.
+          final decodedManifest =
+              jsonDecode(
+                    utf8.decode(
+                      base64.decode(
+                        headers['X-ProofMode-Manifest'] as String,
+                      ),
+                    ),
+                  )
+                  as Map<String, dynamic>;
+          expect(
+            decodedManifest['deviceAttestation'],
+            equals(_deviceAttestationString),
           );
-          expect(decoded, equals(_deviceAttestationString));
         },
       );
 
@@ -331,30 +350,7 @@ void main() {
 
         final headers = capturedOptions!.headers!;
         expect(headers, isNot(contains('X-ProofMode-Signature')));
-        expect(headers, contains('X-ProofMode-Attestation'));
-      });
-
-      test('omits attestation header when deviceAttestation is null', () async {
-        arrangeUploadMocks();
-        final mockFile = createMockFile();
-
-        final manifest = jsonEncode({
-          'videoHash': 'abc123',
-          'pgpSignature': _pgpSignatureString,
-        });
-
-        await service.uploadVideo(
-          description: 'test',
-          videoFile: mockFile,
-          nostrPubkey: _testPubkey,
-          title: 'test',
-          hashtags: const [],
-          proofManifestJson: manifest,
-        );
-
-        final headers = capturedOptions!.headers!;
-        expect(headers, contains('X-ProofMode-Signature'));
-        expect(headers, isNot(contains('X-ProofMode-Attestation')));
+        expect(headers, contains('X-ProofMode-Manifest'));
       });
 
       test('does not add ProofMode headers when manifest is null', () async {
@@ -428,8 +424,53 @@ void main() {
           final headers = capturedOptions!.headers!;
           expect(headers, contains('X-ProofMode-Manifest'));
           expect(headers, contains('X-ProofMode-Signature'));
-          expect(headers, contains('X-ProofMode-Attestation'));
           expect(headers, contains('X-ProofMode-C2PA'));
+          expect(headers, isNot(contains('X-ProofMode-Attestation')));
+        },
+      );
+
+      test(
+        'a Pixel-8-Pro-sized attestation stays under the edge header limit',
+        () async {
+          arrangeUploadMocks();
+          final mockFile = createMockFile();
+
+          // A KeyMint chain dumped via X509Certificate.toString() measured
+          // 53,826 B on a Pixel 8 Pro (#6529). Duplicating it into a
+          // standalone header took total request headers to ~147 KB, past
+          // the 128 KiB HTTP/1.1 limit at the media.divine.video edge, and
+          // the edge answered 502 before any handler ran.
+          final hugeAttestation = 'A' * 53826;
+          final manifest = jsonEncode({
+            'videoHash': 'abc123',
+            'pgpSignature': _pgpSignatureString,
+            'deviceAttestation': hugeAttestation,
+            'c2pa_manifest_id': 'c2pa-test-id',
+          });
+
+          await service.uploadVideo(
+            description: 'test',
+            videoFile: mockFile,
+            nostrPubkey: _testPubkey,
+            title: 'test',
+            hashtags: const [],
+            proofManifestJson: manifest,
+          );
+
+          final headers = capturedOptions!.headers!;
+          final totalBytes = headers.entries.fold<int>(
+            0,
+            // +4 for the ": " and CRLF that frame each header line.
+            (sum, e) => sum + e.key.length + '${e.value}'.length + 4,
+          );
+
+          expect(
+            totalBytes,
+            lessThan(_edgeRequestHeaderLimitBytes),
+            reason:
+                'Total request headers must stay under the 128 KiB edge '
+                'limit; exceeding it returns 502 before any handler runs.',
+          );
         },
       );
     });


### PR DESCRIPTION
Closes #6552

## What

`_addProofModeHeaders` base64-encodes the whole ProofMode manifest into
`X-ProofMode-Manifest`, then pulls `deviceAttestation` back out of that same
JSON and sends it a second time as a standalone `X-ProofMode-Attestation`
header. This drops the duplicate.

## Why

On handsets whose KeyMint chain dumps large — 53,826 B measured on a Pixel
8 Pro — the duplicate took total request headers to roughly 147 KB, past the
128 KiB HTTP/1.1 request-header limit at the media.divine.video edge. The edge
answers 502 before any handler runs, which is why the tiny
`POST /upload/{id}/complete` failed while the multi-megabyte chunk `PUT` (which
carries no ProofMode headers) succeeded. Every publish on an affected device
died.

Dropping the duplicate takes the combined headers to roughly 75 KB, under the
limit, with no data loss — the attestation still ships, once, inside the
manifest header a consumer already has to decode.

## Relationship to #6507

Same root cause, different remedy, and the two are alternatives rather than
dependencies.

#6507 keeps both headers and adds a byte budget, which means the attestation is
silently dropped once it exceeds the budget. This change removes the
redundancy instead, so nothing is ever dropped and no budget is needed. If
#6507 lands first this becomes a simplification on top of it; if this lands
first, #6507's budget may be unnecessary.

Worth noting for whichever lands: no server currently reads any `X-ProofMode-*`
header. `handle_upload_service_proxy` and `handle_upload_complete` in
divine-blossom (`src/main.rs:3782-3803` and `:3608-3643`) build a fresh request
carrying only Host, Authorization, Content-Type and Content-Length, so all four
headers are dropped at the Fastly Compute edge before any backend sees them.
`git log --all -S"X-ProofMode"` over divine-blossom's `src/`, `blossom-core/`,
`cloud-run-upload/`, `cloud-functions/`, `cloud-run-transcoder/` and `vcl/`
returns no commits. The attestation that does reach the backend arrives via
Nostr event tags, not HTTP headers. That is context for reviewers, not a
justification for this change — the change is safe regardless of whether a
consumer appears later, because the data is still on the wire.

## Testing

- Rewrote the three assertions in
  `mobile/packages/blossom_upload_service/test/src/blossom_upload_proofmode_test.dart`
  that pinned the standalone header. The attestation test now asserts the
  header is absent **and** that the value is still recoverable by decoding
  `X-ProofMode-Manifest`, so the no-data-loss property is what is guarded.
- Removed `omits attestation header when deviceAttestation is null`, which
  became a tautology once the header is never sent.
- Added `a Pixel-8-Pro-sized attestation stays under the edge header limit`: it
  builds a 53,826 B attestation and asserts total request-header bytes stay
  under 128 KiB. Verified this fails without the production change
  (`is not a value less than <131072>`) and passes with it.

`flutter analyze lib test` clean; all 227 tests in `blossom_upload_service`
pass.

## Not covered here

This fixes the header size. It does not address why an affected device can
publish some captures and not others — the attestation is a per-file artifact
(`<proofDir>/<fileHash>.attest`, written once at first proof and gated on the
device being online at that moment), so clips on one handset can legitimately
carry 0 B or 53,826 B. Details in #6529.

Covers #6529.