### PR TITLE
perf(upload): ~32% faster publishing by taking the thumbnail off the critical path

### DIFF
--- a/mobile/lib/models/pending_upload.dart
+++ b/mobile/lib/models/pending_upload.dart
@@ -70,6 +70,7 @@ class PendingUpload {
     this.streamingHlsUrl,
     this.fallbackUrl,
     this.resumableSession,
+    this.blurhash,
   });
 
   /// Create a new pending upload
@@ -179,6 +180,15 @@ class PendingUpload {
   @HiveField(25)
   final int? thumbnailTimestampMillis; // Store as milliseconds for Hive
 
+  /// Blurhash of the upload's thumbnail frame.
+  ///
+  /// Computed in the thumbnail leg, which already holds the decoded frame and
+  /// runs beside the video transfer. Publishing reads it from here instead of
+  /// decoding the video a second time on the critical path. Null on records
+  /// written before this field existed — publishing falls back to computing it.
+  @HiveField(26)
+  final String? blurhash;
+
   /// Get video duration as Duration object
   Duration? get videoDuration => videoDurationMillis != null
       ? Duration(milliseconds: videoDurationMillis!)
@@ -241,6 +251,7 @@ class PendingUpload {
     Object? streamingHlsUrl = _pendingUploadUnset,
     Object? fallbackUrl = _pendingUploadUnset,
     Object? resumableSession = _pendingUploadUnset,
+    String? blurhash,
   }) => PendingUpload(
     id: id ?? this.id,
     localVideoPath: localVideoPath ?? this.localVideoPath,
@@ -281,6 +292,7 @@ class PendingUpload {
     resumableSession: identical(resumableSession, _pendingUploadUnset)
         ? this.resumableSession
         : resumableSession as BlossomResumableUploadSession?,
+    blurhash: blurhash ?? this.blurhash,
   );
 
   /// Check if the upload is in a terminal state

--- a/mobile/lib/models/pending_upload.g.dart
+++ b/mobile/lib/models/pending_upload.g.dart
@@ -43,13 +43,14 @@ class PendingUploadAdapter extends TypeAdapter<PendingUpload> {
       streamingHlsUrl: fields[22] as String?,
       fallbackUrl: fields[23] as String?,
       resumableSession: fields[24] as BlossomResumableUploadSession?,
+      blurhash: fields[26] as String?,
     );
   }
 
   @override
   void write(BinaryWriter writer, PendingUpload obj) {
     writer
-      ..writeByte(26)
+      ..writeByte(27)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -101,7 +102,9 @@ class PendingUploadAdapter extends TypeAdapter<PendingUpload> {
       ..writeByte(24)
       ..write(obj.resumableSession)
       ..writeByte(25)
-      ..write(obj.thumbnailTimestampMillis);
+      ..write(obj.thumbnailTimestampMillis)
+      ..writeByte(26)
+      ..write(obj.blurhash);
   }
 
   @override

--- a/mobile/lib/services/upload/upload_retry_policy.dart
+++ b/mobile/lib/services/upload/upload_retry_policy.dart
@@ -407,9 +407,18 @@ class UploadRetryPolicy {
     final upload = _store.getUpload(uploadId);
     if (upload == null) return;
 
-    final persistedProgress = fileSizeBytes <= 0
+    // The live transfer callback persists progress on every tick and owns the
+    // bar; this checkpoint exists so a restart resumes from a sane mark. The
+    // two run on different curves, so the checkpoint may only ever raise the
+    // stored value — otherwise it drags the publish bar backwards mid-upload.
+    final checkpoint = fileSizeBytes <= 0
         ? upload.uploadProgress
-        : ((session.nextOffset / fileSizeBytes) * 0.8).clamp(0.0, 0.8);
+        : ((session.nextOffset / fileSizeBytes) *
+                  UploadManager.videoProgressShare)
+              .clamp(0.0, UploadManager.videoProgressShare);
+    final persistedProgress = checkpoint == null
+        ? upload.uploadProgress
+        : math.max(checkpoint, upload.uploadProgress ?? 0.0);
 
     await _store.update(
       upload.copyWith(

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -25,6 +25,7 @@ import 'package:openvine/services/upload/upload_session_errors.dart';
 import 'package:openvine/services/upload_initialization_helper.dart';
 import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
+import 'package:openvine/services/video_publish/publish_timeline.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
@@ -120,6 +121,17 @@ class CrashReportingUploadReporter implements UploadCrashReporter {
       CrashReportingService.instance.recordError(error, stack, reason: reason);
 }
 
+/// Pulls a thumbnail frame out of a local video file.
+///
+/// Mirrors [VideoThumbnailService.extractThumbnail]; exists so [UploadManager]
+/// can be handed a stand-in that does not need a decodable video.
+typedef ThumbnailExtractor =
+    Future<ThumbnailFileResult?> Function({
+      required String videoPath,
+      required Duration targetTimestamp,
+      required int quality,
+    });
+
 /// Manages video uploads and their persistent state with enhanced reliability
 /// REFACTORED: Removed ChangeNotifier - now uses pure state management via Riverpod
 class UploadManager implements BackgroundAwareService {
@@ -133,7 +145,9 @@ class UploadManager implements BackgroundAwareService {
     UploadCrashReporter? crashReporter,
     this.useBackgroundUpload = false,
     BackgroundActivityManager? backgroundActivityManager,
+    ThumbnailExtractor? thumbnailExtractor,
   }) : _blossomService = blossomService,
+       _extractThumbnail = thumbnailExtractor ?? _defaultThumbnailExtractor,
        _defaultBlossomUrl =
            defaultBlossomUrl ?? BlossomUploadService.defaultBlossomServer,
        _circuitBreaker = circuitBreaker ?? VideoCircuitBreaker(),
@@ -169,6 +183,22 @@ class UploadManager implements BackgroundAwareService {
   // Core services
   final PendingUploadStore _store;
   final BlossomUploadService _blossomService;
+
+  /// Pulls the thumbnail frame out of the local video. Injectable so the
+  /// thumbnail leg can be exercised without a decodable video and the native
+  /// plugin behind [VideoThumbnailService].
+  final ThumbnailExtractor _extractThumbnail;
+
+  static Future<ThumbnailFileResult?> _defaultThumbnailExtractor({
+    required String videoPath,
+    required Duration targetTimestamp,
+    required int quality,
+  }) => VideoThumbnailService.extractThumbnail(
+    videoPath: videoPath,
+    targetTimestamp: targetTimestamp,
+    quality: quality,
+  );
+
   final String _defaultBlossomUrl;
   final VideoCircuitBreaker _circuitBreaker;
   final UploadRetryConfig _retryConfig;
@@ -1007,6 +1037,11 @@ class UploadManager implements BackgroundAwareService {
       // (passed as resumableTimeout), so a stalled socket does not hang
       // forever. `useBackgroundUpload` is the kill-switch for the OS-first
       // attempt: flip it to false to go straight to chunked resumable.
+      // Bytes are read before the transfer so the timing line can report
+      // throughput even if the file is gone by the time the phase ends.
+      final videoBytes = videoFile.existsSync() ? videoFile.lengthSync() : null;
+      final transferWatch = Stopwatch()..start();
+
       BlossomUploadResult result;
       try {
         result = await _blossomService.uploadVideoWithResume(
@@ -1050,6 +1085,13 @@ class UploadManager implements BackgroundAwareService {
         });
 
         rethrow;
+      } finally {
+        transferWatch.stop();
+        logPublishPhase(
+          'upload.transfer',
+          transferWatch.elapsed,
+          detail: formatTransferDetail(videoBytes, transferWatch.elapsed),
+        );
       }
 
       if (_userStoppedUploadIds.contains(upload.id)) {
@@ -1072,11 +1114,18 @@ class UploadManager implements BackgroundAwareService {
         );
 
         // Generate and upload thumbnail to Blossom CDN
-        thumbnailCdnUrl = await _generateAndUploadThumbnail(
-          videoFile: videoFile,
-          nostrPubkey: upload.nostrPubkey,
-          upload: upload,
-        );
+        final thumbnailWatch = Stopwatch()..start();
+        try {
+          thumbnailCdnUrl = await _generateAndUploadThumbnail(
+            videoFile: videoFile,
+            nostrPubkey: upload.nostrPubkey,
+            upload: upload,
+            onProgress: onProgress,
+          );
+        } finally {
+          thumbnailWatch.stop();
+          logPublishPhase('upload.thumbnail', thumbnailWatch.elapsed);
+        }
 
         if (thumbnailCdnUrl != null) {
           Log.info(
@@ -1810,11 +1859,23 @@ class UploadManager implements BackgroundAwareService {
   }
 
   /// Generate and upload thumbnail to Blossom CDN
+  /// Extracts a thumbnail from [videoFile] and uploads it to Blossom.
+  ///
+  /// [onProgress] receives the same absolute values written to the store, so
+  /// publish-facing listeners keep moving through the thumbnail leg instead of
+  /// freezing at the end of the video transfer (#6086 follow-up: the leg can
+  /// take seconds, and the bar sat still for all of it).
   Future<String?> _generateAndUploadThumbnail({
     required File videoFile,
     required String nostrPubkey,
     required PendingUpload upload,
+    ValueChanged<double>? onProgress,
   }) async {
+    void reportThumbnailProgress(double value) {
+      _reporter.updateProgress(upload.id, value);
+      onProgress?.call(value);
+    }
+
     try {
       Log.info(
         '📸 Extracting thumbnail from video: ${videoFile.path}',
@@ -1823,13 +1884,16 @@ class UploadManager implements BackgroundAwareService {
       );
 
       // Generate thumbnail at optimal timestamp
-      final thumbnailExtraction = await VideoThumbnailService.extractThumbnail(
+      final extractWatch = Stopwatch()..start();
+      final thumbnailExtraction = await _extractThumbnail(
         videoPath: videoFile.path,
         quality: 85,
         targetTimestamp:
             upload.thumbnailTimestamp ??
             VideoEditorConstants.defaultThumbnailExtractTime,
       );
+      extractWatch.stop();
+      logPublishPhase('upload.thumbnail.extract', extractWatch.elapsed);
 
       if (thumbnailExtraction == null) {
         Log.warning(
@@ -1856,12 +1920,14 @@ class UploadManager implements BackgroundAwareService {
         category: LogCategory.video,
       );
 
-      _reporter.updateProgress(upload.id, 0.85);
+      reportThumbnailProgress(0.85);
 
       // Upload thumbnail to Blossom server. Divine relay publishing requires
       // a CDN thumbnail, so keep the image upload's own retry enabled here.
       // If no HTTP thumbnail URL is available after that, the outer video
       // pipeline treats it as terminal to avoid re-uploading the whole video.
+      final thumbnailBytes = thumbnailFile.lengthSync();
+      final putWatch = Stopwatch()..start();
       final uploadResult = await _blossomService.uploadImage(
         imageFile: thumbnailFile,
         nostrPubkey: nostrPubkey,
@@ -1871,8 +1937,14 @@ class UploadManager implements BackgroundAwareService {
         allowResumable: false,
         onProgress: (progress) {
           // Map thumbnail progress to 85%-100% of total upload
-          _reporter.updateProgress(upload.id, 0.85 + (progress * 0.15));
+          reportThumbnailProgress(0.85 + (progress * 0.15));
         },
+      );
+      putWatch.stop();
+      logPublishPhase(
+        'upload.thumbnail.put',
+        putWatch.elapsed,
+        detail: formatTransferDetail(thumbnailBytes, putWatch.elapsed),
       );
 
       // Clean up local thumbnail file

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -1173,17 +1173,6 @@ class UploadManager implements BackgroundAwareService {
         onProgress?.call(1.0);
       }
 
-      // Store the thumbnail URL and blurhash so publishing can read both
-      // instead of deriving them again.
-      if (thumbnailCdnUrl != null || thumbnailResult.blurhash != null) {
-        await _store.update(
-          upload.copyWith(
-            thumbnailPath: thumbnailCdnUrl ?? upload.thumbnailPath,
-            blurhash: thumbnailResult.blurhash,
-          ),
-        );
-      }
-
       Log.info(
         '✅ Upload execution completed',
         name: 'UploadManager',
@@ -1906,11 +1895,28 @@ class UploadManager implements BackgroundAwareService {
 
     final watch = Stopwatch()..start();
     try {
-      return await _generateAndUploadThumbnail(
+      final result = await _generateAndUploadThumbnail(
         videoFile: videoFile,
         nostrPubkey: upload.nostrPubkey,
         upload: upload,
       );
+
+      // Persist as soon as the leg lands, not once the whole attempt
+      // succeeds. A failing video transfer aborts this method's caller before
+      // its own store write, so deferring would make every retry re-extract
+      // and re-upload a thumbnail that is already on the CDN — and the
+      // short-circuit above would never fire.
+      if (result.cdnUrl != null || result.blurhash != null) {
+        final current = _store.getUpload(upload.id) ?? upload;
+        await _store.update(
+          current.copyWith(
+            thumbnailPath: result.cdnUrl ?? current.thumbnailPath,
+            blurhash: result.blurhash,
+          ),
+        );
+      }
+
+      return result;
     } finally {
       watch.stop();
       logPublishPhase('upload.thumbnail', watch.elapsed);

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:blurhash_service/blurhash_service.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
@@ -127,6 +128,10 @@ class CrashReportingUploadReporter implements UploadCrashReporter {
 /// is virtually always finished first — so the bar reaches this mark and then
 /// completes, rather than sitting at 100% while the publish is still working.
 const double _videoProgressShare = 0.95;
+
+/// What the thumbnail leg produces: the CDN URL of the uploaded frame, and the
+/// blurhash derived from that same frame.
+typedef ThumbnailLegResult = ({String? cdnUrl, String? blurhash});
 
 /// Pulls a thumbnail frame out of a local video file.
 ///
@@ -1119,7 +1124,8 @@ class UploadManager implements BackgroundAwareService {
 
       // Join the parallel leg before any early return below, so it can never
       // outlive this call.
-      final thumbnailCdnUrl = await thumbnailFuture;
+      final thumbnailResult = await thumbnailFuture;
+      final thumbnailCdnUrl = thumbnailResult.cdnUrl;
 
       if (_userStoppedUploadIds.contains(upload.id)) {
         Log.info(
@@ -1167,9 +1173,15 @@ class UploadManager implements BackgroundAwareService {
         onProgress?.call(1.0);
       }
 
-      // Store thumbnail URL in upload for later use
-      if (thumbnailCdnUrl != null) {
-        await _store.update(upload.copyWith(thumbnailPath: thumbnailCdnUrl));
+      // Store the thumbnail URL and blurhash so publishing can read both
+      // instead of deriving them again.
+      if (thumbnailCdnUrl != null || thumbnailResult.blurhash != null) {
+        await _store.update(
+          upload.copyWith(
+            thumbnailPath: thumbnailCdnUrl ?? upload.thumbnailPath,
+            blurhash: thumbnailResult.blurhash,
+          ),
+        );
       }
 
       Log.info(
@@ -1881,7 +1893,7 @@ class UploadManager implements BackgroundAwareService {
   /// the caller turns a missing thumbnail into the publish-level error. That
   /// matters here because this future is started before the video transfer and
   /// awaited after it.
-  Future<String?> _startThumbnailUpload({
+  Future<ThumbnailLegResult> _startThumbnailUpload({
     required File videoFile,
     required PendingUpload upload,
   }) async {
@@ -1889,7 +1901,7 @@ class UploadManager implements BackgroundAwareService {
     if (existing != null && existing.startsWith('http')) {
       // A prior attempt in this retry chain already uploaded it. The blob is
       // content-addressed, so re-uploading would land on the same hash.
-      return existing;
+      return (cdnUrl: existing, blurhash: upload.blurhash);
     }
 
     final watch = Stopwatch()..start();
@@ -1905,11 +1917,12 @@ class UploadManager implements BackgroundAwareService {
     }
   }
 
-  /// Extracts a thumbnail from [videoFile] and uploads it to Blossom.
+  /// Extracts a thumbnail from [videoFile], uploads it to Blossom, and derives
+  /// the blurhash from the same decoded frame.
   ///
   /// Reports no progress: it runs in parallel with the video transfer, which
   /// owns the bar alone. See [_videoProgressShare].
-  Future<String?> _generateAndUploadThumbnail({
+  Future<ThumbnailLegResult> _generateAndUploadThumbnail({
     required File videoFile,
     required String nostrPubkey,
     required PendingUpload upload,
@@ -1939,7 +1952,7 @@ class UploadManager implements BackgroundAwareService {
           name: 'UploadManager',
           category: LogCategory.video,
         );
-        return null;
+        return (cdnUrl: null, blurhash: null);
       }
 
       final thumbnailFile = File(thumbnailExtraction.path);
@@ -1949,7 +1962,7 @@ class UploadManager implements BackgroundAwareService {
           name: 'UploadManager',
           category: LogCategory.video,
         );
-        return null;
+        return (cdnUrl: null, blurhash: null);
       }
 
       Log.info(
@@ -1957,6 +1970,15 @@ class UploadManager implements BackgroundAwareService {
         name: 'UploadManager',
         category: LogCategory.video,
       );
+
+      // Derive the blurhash from the frame we just decoded. Publishing used to
+      // decode the video a second time for this, on the critical path.
+      final blurhashWatch = Stopwatch()..start();
+      final blurhash = await BlurhashService.generateBlurhash(
+        thumbnailFile.readAsBytesSync(),
+      );
+      blurhashWatch.stop();
+      logPublishPhase('upload.thumbnail.blurhash', blurhashWatch.elapsed);
 
       // Upload thumbnail to Blossom server. Divine relay publishing requires
       // a CDN thumbnail, so keep the image upload's own retry enabled here.
@@ -1996,17 +2018,17 @@ class UploadManager implements BackgroundAwareService {
       }
 
       if (uploadResult.success && uploadResult.cdnUrl != null) {
-        return uploadResult.cdnUrl;
+        return (cdnUrl: uploadResult.cdnUrl, blurhash: blurhash);
       }
 
-      return null;
+      return (cdnUrl: null, blurhash: blurhash);
     } catch (e) {
       Log.error(
         'Error generating/uploading thumbnail: $e',
         name: 'UploadManager',
         category: LogCategory.video,
       );
-      return null;
+      return (cdnUrl: null, blurhash: null);
     }
   }
 

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -121,6 +121,13 @@ class CrashReportingUploadReporter implements UploadCrashReporter {
       CrashReportingService.instance.recordError(error, stack, reason: reason);
 }
 
+/// Share of the progress bar driven by the video transfer.
+///
+/// The remainder covers joining the thumbnail leg, which runs in parallel and
+/// is virtually always finished first — so the bar reaches this mark and then
+/// completes, rather than sitting at 100% while the publish is still working.
+const double _videoProgressShare = 0.95;
+
 /// Pulls a thumbnail frame out of a local video file.
 ///
 /// Mirrors [VideoThumbnailService.extractThumbnail]; exists so [UploadManager]
@@ -983,6 +990,17 @@ class UploadManager implements BackgroundAwareService {
       category: LogCategory.video,
     );
 
+    // Start the thumbnail beside the video transfer rather than after it. It
+    // only needs the local file, never the transfer's result, and running it
+    // sequentially put 3.2-4.1s of extract + sign + PUT on the critical path
+    // for a 16KB payload — a fifth to a quarter of the whole publish. It is
+    // reliably the shorter leg (measured against 6.8-16.8s for the video), so
+    // it lands before the transfer does and costs nothing extra.
+    final thumbnailFuture = _startThumbnailUpload(
+      videoFile: videoFile,
+      upload: upload,
+    );
+
     try {
       // Use Blossom upload service exclusively
       Log.info(
@@ -1017,8 +1035,13 @@ class UploadManager implements BackgroundAwareService {
         );
       }
 
+      // The video transfer owns the bar on its own. The thumbnail runs beside
+      // it and deliberately reports nothing: two legs writing progress
+      // concurrently would make the bar jump backwards. The reserved top slice
+      // covers joining the thumbnail, so the bar never claims 100% while work
+      // is still outstanding.
       void reportProgress(double value) {
-        final progress = value * 0.8; // Reserve 20% for thumbnail
+        final progress = value * _videoProgressShare;
         _reporter.updateProgress(upload.id, progress);
         onProgress?.call(progress);
       }
@@ -1094,38 +1117,26 @@ class UploadManager implements BackgroundAwareService {
         );
       }
 
+      // Join the parallel leg before any early return below, so it can never
+      // outlive this call.
+      final thumbnailCdnUrl = await thumbnailFuture;
+
       if (_userStoppedUploadIds.contains(upload.id)) {
         Log.info(
           'Upload ${upload.id} stopped by user after video transfer; '
-          'skipping thumbnail and success handling',
+          'skipping success handling',
           name: 'UploadManager',
           category: LogCategory.video,
         );
         return result;
       }
 
-      // Generate and upload thumbnail after video upload succeeds
-      String? thumbnailCdnUrl;
       if (result.success && result.cdnUrl != null) {
         Log.info(
           '✅ Video uploaded successfully',
           name: 'UploadManager',
           category: LogCategory.video,
         );
-
-        // Generate and upload thumbnail to Blossom CDN
-        final thumbnailWatch = Stopwatch()..start();
-        try {
-          thumbnailCdnUrl = await _generateAndUploadThumbnail(
-            videoFile: videoFile,
-            nostrPubkey: upload.nostrPubkey,
-            upload: upload,
-            onProgress: onProgress,
-          );
-        } finally {
-          thumbnailWatch.stop();
-          logPublishPhase('upload.thumbnail', thumbnailWatch.elapsed);
-        }
 
         if (thumbnailCdnUrl != null) {
           Log.info(
@@ -1168,6 +1179,11 @@ class UploadManager implements BackgroundAwareService {
       );
       return result;
     } catch (e) {
+      // A transfer failure must not strand the parallel thumbnail leg: settle
+      // it before propagating so it cannot still be running when the retry
+      // policy starts the next attempt. It never throws, so this cannot mask
+      // the original error.
+      await thumbnailFuture;
       Log.error(
         '❌ Upload execution failed: $e',
         name: 'UploadManager',
@@ -1858,24 +1874,46 @@ class UploadManager implements BackgroundAwareService {
         _isHttpUrl(existingThumbnailUrl);
   }
 
-  /// Generate and upload thumbnail to Blossom CDN
+  /// Runs the thumbnail leg for [upload], or short-circuits when a previous
+  /// attempt already landed one on the CDN.
+  ///
+  /// Never throws: [_generateAndUploadThumbnail] reports failure as `null`, and
+  /// the caller turns a missing thumbnail into the publish-level error. That
+  /// matters here because this future is started before the video transfer and
+  /// awaited after it.
+  Future<String?> _startThumbnailUpload({
+    required File videoFile,
+    required PendingUpload upload,
+  }) async {
+    final existing = upload.thumbnailPath;
+    if (existing != null && existing.startsWith('http')) {
+      // A prior attempt in this retry chain already uploaded it. The blob is
+      // content-addressed, so re-uploading would land on the same hash.
+      return existing;
+    }
+
+    final watch = Stopwatch()..start();
+    try {
+      return await _generateAndUploadThumbnail(
+        videoFile: videoFile,
+        nostrPubkey: upload.nostrPubkey,
+        upload: upload,
+      );
+    } finally {
+      watch.stop();
+      logPublishPhase('upload.thumbnail', watch.elapsed);
+    }
+  }
+
   /// Extracts a thumbnail from [videoFile] and uploads it to Blossom.
   ///
-  /// [onProgress] receives the same absolute values written to the store, so
-  /// publish-facing listeners keep moving through the thumbnail leg instead of
-  /// freezing at the end of the video transfer (#6086 follow-up: the leg can
-  /// take seconds, and the bar sat still for all of it).
+  /// Reports no progress: it runs in parallel with the video transfer, which
+  /// owns the bar alone. See [_videoProgressShare].
   Future<String?> _generateAndUploadThumbnail({
     required File videoFile,
     required String nostrPubkey,
     required PendingUpload upload,
-    ValueChanged<double>? onProgress,
   }) async {
-    void reportThumbnailProgress(double value) {
-      _reporter.updateProgress(upload.id, value);
-      onProgress?.call(value);
-    }
-
     try {
       Log.info(
         '📸 Extracting thumbnail from video: ${videoFile.path}',
@@ -1920,8 +1958,6 @@ class UploadManager implements BackgroundAwareService {
         category: LogCategory.video,
       );
 
-      reportThumbnailProgress(0.85);
-
       // Upload thumbnail to Blossom server. Divine relay publishing requires
       // a CDN thumbnail, so keep the image upload's own retry enabled here.
       // If no HTTP thumbnail URL is available after that, the outer video
@@ -1935,10 +1971,6 @@ class UploadManager implements BackgroundAwareService {
         // init/chunk/complete handshake (two extra round-trips plus extra auth
         // signings) that otherwise dominated short-clip publish time.
         allowResumable: false,
-        onProgress: (progress) {
-          // Map thumbnail progress to 85%-100% of total upload
-          reportThumbnailProgress(0.85 + (progress * 0.15));
-        },
       );
       putWatch.stop();
       logPublishPhase(

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -122,13 +122,6 @@ class CrashReportingUploadReporter implements UploadCrashReporter {
       CrashReportingService.instance.recordError(error, stack, reason: reason);
 }
 
-/// Share of the progress bar driven by the video transfer.
-///
-/// The remainder covers joining the thumbnail leg, which runs in parallel and
-/// is virtually always finished first — so the bar reaches this mark and then
-/// completes, rather than sitting at 100% while the publish is still working.
-const double _videoProgressShare = 0.95;
-
 /// What the thumbnail leg produces: the CDN URL of the uploaded frame, and the
 /// blurhash derived from that same frame.
 typedef ThumbnailLegResult = ({String? cdnUrl, String? blurhash});
@@ -181,6 +174,16 @@ class UploadManager implements BackgroundAwareService {
       crashReporter: crashReporter ?? const CrashReportingUploadReporter(),
     );
   }
+
+  /// Share of the progress bar driven by the video transfer.
+  ///
+  /// The remainder covers joining the thumbnail leg, which runs in parallel and
+  /// is virtually always finished first — so the bar reaches this mark and then
+  /// completes, rather than sitting at 100% while the publish is still working.
+  ///
+  /// [UploadRetryPolicy] persists its resumable checkpoint on the same scale,
+  /// so the two writers of `uploadProgress` cannot disagree on the ceiling.
+  static const double videoProgressShare = 0.95;
 
   /// Attempts the OS background uploader
   /// ([BlossomUploadService.uploadVideoInBackground]) *first* for a fresh
@@ -1046,7 +1049,7 @@ class UploadManager implements BackgroundAwareService {
       // covers joining the thumbnail, so the bar never claims 100% while work
       // is still outstanding.
       void reportProgress(double value) {
-        final progress = value * _videoProgressShare;
+        final progress = value * videoProgressShare;
         _reporter.updateProgress(upload.id, progress);
         onProgress?.call(progress);
       }
@@ -1942,7 +1945,7 @@ class UploadManager implements BackgroundAwareService {
   /// the blurhash from the same decoded frame.
   ///
   /// Reports no progress: it runs in parallel with the video transfer, which
-  /// owns the bar alone. See [_videoProgressShare].
+  /// owns the bar alone. See [videoProgressShare].
   Future<ThumbnailLegResult> _generateAndUploadThumbnail({
     required File videoFile,
     required String nostrPubkey,

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -1182,8 +1182,8 @@ class UploadManager implements BackgroundAwareService {
     } catch (e) {
       // A transfer failure must not strand the parallel thumbnail leg: settle
       // it before propagating so it cannot still be running when the retry
-      // policy starts the next attempt. It never throws, so this cannot mask
-      // the original error.
+      // policy starts the next attempt. [_startThumbnailUpload] guarantees it
+      // never throws, so this cannot mask the original error.
       await thumbnailFuture;
       Log.error(
         '❌ Upload execution failed: $e',
@@ -1878,10 +1878,12 @@ class UploadManager implements BackgroundAwareService {
   /// Runs the thumbnail leg for [upload], or short-circuits when a previous
   /// attempt already landed one on the CDN.
   ///
-  /// Never throws: [_generateAndUploadThumbnail] reports failure as `null`, and
-  /// the caller turns a missing thumbnail into the publish-level error. That
-  /// matters here because this future is started before the video transfer and
-  /// awaited after it.
+  /// Never throws: [_generateAndUploadThumbnail] reports failure as `null` and
+  /// the persist swallows its own errors, so the caller turns a missing
+  /// thumbnail into the publish-level error. That matters here because this
+  /// future is started before the video transfer and awaited after it — an
+  /// escaping error would spend the whole transfer with no listener, and would
+  /// then replace the transfer's own failure at the join.
   Future<ThumbnailLegResult> _startThumbnailUpload({
     required File videoFile,
     required PendingUpload upload,
@@ -1907,13 +1909,26 @@ class UploadManager implements BackgroundAwareService {
       // and re-upload a thumbnail that is already on the CDN — and the
       // short-circuit above would never fire.
       if (result.cdnUrl != null || result.blurhash != null) {
-        final current = _store.getUpload(upload.id) ?? upload;
-        await _store.update(
-          current.copyWith(
-            thumbnailPath: result.cdnUrl ?? current.thumbnailPath,
-            blurhash: result.blurhash,
-          ),
-        );
+        try {
+          final current = _store.getUpload(upload.id) ?? upload;
+          await _store.update(
+            current.copyWith(
+              thumbnailPath: result.cdnUrl ?? current.thumbnailPath,
+              blurhash: result.blurhash,
+            ),
+          );
+        } catch (e) {
+          // The persist is an optimization — without it the next attempt just
+          // re-extracts. A closed box or a full disk must not escape: this
+          // future is unlistened for the length of the transfer, so it would
+          // surface as an uncaught error, and at the join it would replace the
+          // transfer's real failure with a storage one.
+          Log.error(
+            'Failed to persist thumbnail result for ${upload.id}: $e',
+            name: 'UploadManager',
+            category: LogCategory.video,
+          );
+        }
       }
 
       return result;

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -1894,7 +1894,10 @@ class UploadManager implements BackgroundAwareService {
     final existing = upload.thumbnailPath;
     if (existing != null && existing.startsWith('http')) {
       // A prior attempt in this retry chain already uploaded it. The blob is
-      // content-addressed, so re-uploading would land on the same hash.
+      // content-addressed, so re-uploading would land on the same hash. The
+      // zero-duration line keeps the PUBTIME timeline honest on retries —
+      // without it an export reads as "the leg never ran".
+      logPublishPhase('upload.thumbnail', Duration.zero, detail: 'reused');
       return (cdnUrl: existing, blurhash: upload.blurhash);
     }
 

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -1172,8 +1172,21 @@ class VideoEventPublisher {
         }
       }
 
-      // Generate blurhash for progressive image loading
-      if (upload.localVideoPath.isNotEmpty) {
+      // Blurhash for progressive image loading. The upload's thumbnail leg
+      // already decoded the frame and derived it there, beside the video
+      // transfer; deriving it again here meant a second video decode on the
+      // critical path (measured at 568ms). Records written before the field
+      // existed, and uploads whose thumbnail was reused from an earlier
+      // attempt, still fall through to computing it.
+      final storedBlurhash = upload.blurhash;
+      if (storedBlurhash != null && storedBlurhash.isNotEmpty) {
+        imetaComponents.add('blurhash $storedBlurhash');
+        Log.info(
+          '✅ Reused blurhash from upload: $storedBlurhash',
+          name: 'VideoEventPublisher',
+          category: LogCategory.video,
+        );
+      } else if (upload.localVideoPath.isNotEmpty) {
         final blurhashWatch = Stopwatch()..start();
         try {
           Log.debug(

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -1633,9 +1633,6 @@ class VideoEventPublisher {
         signWatch.elapsed,
         detail: reusedEvent != null ? 'reused' : 'signed',
       );
-      // Signing is a remote Keycast round-trip (~0.3-1.4s measured), so the
-      // caller gets a step here rather than waiting out the whole phase.
-      onEventSigned?.call();
 
       if (event == null) {
         Log.error(
@@ -1645,6 +1642,11 @@ class VideoEventPublisher {
         );
         return false;
       }
+
+      // Signing is a remote Keycast round-trip (~0.3-1.4s measured), so the
+      // caller gets a step here rather than waiting out the whole phase. Kept
+      // below the null check so a failed signing cannot advance the bar.
+      onEventSigned?.call();
 
       if (upload.nostrEventId != event.id) {
         await _persistRetryableSignedEvent(upload, event);

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -1142,25 +1142,27 @@ class VideoEventPublisher {
         imetaComponents.add('dim ${upload.videoWidth}x${upload.videoHeight}');
       }
 
-      // Add file size and SHA256 if available from local video file
+      // x: the digest is the upload's videoId, which every upload path sets
+      // from the locally streamed HashUtil.sha256File over this same file —
+      // _parseUploadResponse takes fileHash as a parameter and never reads a
+      // hash off the response body, so this is value-identical to re-hashing
+      // the file (which used to cost a measurable slice of the publish and
+      // pulled the whole video into memory). Deliberately independent of the
+      // local file still existing: funnelcake materializes events_local.sha256
+      // from this sub-field and joins moderation labels on it, so a publish
+      // landing after local cleanup must still carry it.
+      final hash = upload.videoId;
+      if (hash != null && hash.isNotEmpty) {
+        imetaComponents.add('x $hash');
+      }
+
+      // size genuinely needs the file on disk.
       if (upload.localVideoPath.isNotEmpty) {
         try {
           final videoFile = File(upload.localVideoPath);
           if (videoFile.existsSync()) {
-            // Add file size
             final fileSize = videoFile.lengthSync();
             imetaComponents.add('size $fileSize');
-
-            // Blossom is content-addressed, so the upload already streamed
-            // this exact digest and handed it back as the videoId — which
-            // publishDirectUpload has already required to be present. Hashing
-            // the file again here cost a measurable slice of the publish and
-            // pulled the whole video into memory, which is exactly what the
-            // upload path streams to avoid.
-            final hash = upload.videoId;
-            if (hash != null && hash.isNotEmpty) {
-              imetaComponents.add('x $hash');
-            }
 
             Log.verbose(
               'Added file metadata - size: $fileSize bytes, hash: $hash',

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -830,6 +830,7 @@ class VideoEventPublisher {
     bool addReplyToFeed = false,
     List<String> textTrackRefs = const [],
     String textTrackLang = 'en',
+    void Function()? onEventSigned,
   }) async {
     // Create a temporary upload with updated metadata
     final updatedUpload = upload.copyWith(
@@ -857,6 +858,7 @@ class VideoEventPublisher {
       addReplyToFeed: addReplyToFeed,
       textTrackRefs: textTrackRefs,
       textTrackLang: textTrackLang,
+      onEventSigned: onEventSigned,
     );
   }
 
@@ -887,6 +889,7 @@ class VideoEventPublisher {
     bool addReplyToFeed = false,
     List<String> textTrackRefs = const [],
     String textTrackLang = 'en',
+    void Function()? onEventSigned,
   }) async {
     final videoId = upload.videoId;
     if (videoId == null || upload.cdnUrl == null) {
@@ -928,6 +931,7 @@ class VideoEventPublisher {
       addReplyToFeed: addReplyToFeed,
       textTrackRefs: textTrackRefs,
       textTrackLang: textTrackLang,
+      onEventSigned: onEventSigned,
     );
     _inFlightDirectPublishes[videoId] = publish;
     try {
@@ -962,6 +966,7 @@ class VideoEventPublisher {
     bool addReplyToFeed = false,
     List<String> textTrackRefs = const [],
     String textTrackLang = 'en',
+    void Function()? onEventSigned,
   }) async {
     // Validate that at least one video URL is a proper HTTP/HTTPS URL
     // This prevents local file paths from being published to Nostr
@@ -1628,6 +1633,9 @@ class VideoEventPublisher {
         signWatch.elapsed,
         detail: reusedEvent != null ? 'reused' : 'signed',
       );
+      // Signing is a remote Keycast round-trip (~0.3-1.4s measured), so the
+      // caller gets a step here rather than waiting out the whole phase.
+      onEventSigned?.call();
 
       if (event == null) {
         Log.error(

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:blurhash_service/blurhash_service.dart';
-import 'package:crypto/crypto.dart';
 //adding c2pa support for publishing c2pa manifest data into nostr
 import 'package:db_client/db_client.dart' hide Filter;
 import 'package:meta/meta.dart';
@@ -1147,10 +1146,16 @@ class VideoEventPublisher {
             final fileSize = videoFile.lengthSync();
             imetaComponents.add('size $fileSize');
 
-            // Calculate SHA256 hash
-            final bytes = await videoFile.readAsBytes();
-            final hash = sha256.convert(bytes);
-            imetaComponents.add('x $hash');
+            // Blossom is content-addressed, so the upload already streamed
+            // this exact digest and handed it back as the videoId — which
+            // publishDirectUpload has already required to be present. Hashing
+            // the file again here cost a measurable slice of the publish and
+            // pulled the whole video into memory, which is exactly what the
+            // upload path streams to avoid.
+            final hash = upload.videoId;
+            if (hash != null && hash.isNotEmpty) {
+              imetaComponents.add('x $hash');
+            }
 
             Log.verbose(
               'Added file metadata - size: $fileSize bytes, hash: $hash',
@@ -1169,6 +1174,7 @@ class VideoEventPublisher {
 
       // Generate blurhash for progressive image loading
       if (upload.localVideoPath.isNotEmpty) {
+        final blurhashWatch = Stopwatch()..start();
         try {
           Log.debug(
             '🎨 Generating blurhash from video thumbnail',
@@ -1240,6 +1246,9 @@ class VideoEventPublisher {
             category: LogCategory.video,
           );
           // Continue publishing without blurhash - it's optional metadata
+        } finally {
+          blurhashWatch.stop();
+          logPublishPhase('nostr.blurhash', blurhashWatch.elapsed);
         }
       }
 

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -31,6 +31,7 @@ import 'package:openvine/services/personal_event_cache_service.dart';
 import 'package:openvine/services/saved_sounds_service.dart';
 import 'package:openvine/services/upload_manager.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/services/video_publish/publish_timeline.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:openvine/utils/collaborator_tags.dart';
 import 'package:openvine/utils/inspired_by_tags.dart';
@@ -1590,6 +1591,7 @@ class VideoEventPublisher {
       );
 
       final reusedEvent = _loadRetryableSignedEvent(upload);
+      final signWatch = Stopwatch()..start();
       final event =
           reusedEvent ??
           await _authService.createAndSignEvent(
@@ -1598,6 +1600,12 @@ class VideoEventPublisher {
             content: content,
             tags: tags,
           );
+      signWatch.stop();
+      logPublishPhase(
+        'nostr.sign',
+        signWatch.elapsed,
+        detail: reusedEvent != null ? 'reused' : 'signed',
+      );
 
       if (event == null) {
         Log.error(
@@ -1625,11 +1633,14 @@ class VideoEventPublisher {
         category: LogCategory.video,
       );
 
+      final publishWatch = Stopwatch()..start();
       final publishResult = await publishSignedVideoEvent(
         upload: upload,
         event: event,
         isRetry: reusedEvent != null,
       );
+      publishWatch.stop();
+      logPublishPhase('nostr.publish', publishWatch.elapsed);
 
       if (publishResult) {
         final shouldAddToDiscoveryCache =

--- a/mobile/lib/services/video_publish/publish_timeline.dart
+++ b/mobile/lib/services/video_publish/publish_timeline.dart
@@ -1,0 +1,109 @@
+// ABOUTME: Phase-level timing for a single video publish, emitted as
+// ABOUTME: greppable PUBTIME log lines so a slow publish can be attributed.
+
+import 'package:unified_logger/unified_logger.dart';
+
+/// Token every timing line carries, so a log export can be reduced to the
+/// publish timeline with a single `grep PUBTIME`.
+const String publishTimingToken = 'PUBTIME';
+
+/// Logger name every timing line is tagged with. Exported log lines render it
+/// as `[PublishTiming]`, which is the second way to filter for these entries.
+const String publishTimingLogName = 'PublishTiming';
+
+/// One finished phase of a publish.
+typedef PublishPhase = ({String name, Duration elapsed});
+
+/// Emits a single timing line for a phase that has just finished.
+///
+/// Free function so layers that do not own the [PublishTimeline] (the upload
+/// pipeline) can contribute lines to the same filterable stream.
+void logPublishPhase(String phase, Duration elapsed, {String? detail}) {
+  final suffix = (detail == null || detail.isEmpty) ? '' : ' $detail';
+  Log.info(
+    '⏱️ $publishTimingToken $phase ${elapsed.inMilliseconds}ms$suffix',
+    name: publishTimingLogName,
+    category: LogCategory.video,
+  );
+}
+
+/// Formats a transferred payload as `8.20MB 1.63MB/s` for a timing line.
+///
+/// Returns an empty string when the size is unknown or zero, and omits the
+/// rate when [elapsed] rounds to zero seconds.
+String formatTransferDetail(int? bytes, Duration elapsed) {
+  if (bytes == null || bytes <= 0) return '';
+  final megabytes = bytes / (1024 * 1024);
+  final seconds = elapsed.inMicroseconds / Duration.microsecondsPerSecond;
+  if (seconds <= 0) return '${megabytes.toStringAsFixed(2)}MB';
+  final rate = megabytes / seconds;
+  return '${megabytes.toStringAsFixed(2)}MB ${rate.toStringAsFixed(2)}MB/s';
+}
+
+/// Collects the phase durations of one publish and emits a summary line.
+///
+/// Phases are logged as they finish, so a publish that hangs still leaves the
+/// completed phases in the log; the summary adds the total plus an `other`
+/// bucket for everything not covered by a measured phase.
+class PublishTimeline {
+  PublishTimeline(this.draftId);
+
+  /// Draft this publish belongs to — the join key between the timing lines and
+  /// the surrounding upload logs.
+  final String draftId;
+
+  final Stopwatch _total = Stopwatch()..start();
+  final List<PublishPhase> _phases = <PublishPhase>[];
+
+  /// Phases recorded so far, in completion order.
+  List<PublishPhase> get phases => List.unmodifiable(_phases);
+
+  /// Wall-clock time since this timeline was created.
+  Duration get total => _total.elapsed;
+
+  /// Runs [action], recording its duration under [phase].
+  ///
+  /// The phase is recorded even when [action] throws, so a failed publish is
+  /// still attributable; the error propagates unchanged.
+  Future<T> measure<T>(String phase, Future<T> Function() action) async {
+    final watch = Stopwatch()..start();
+    try {
+      return await action();
+    } finally {
+      watch.stop();
+      record(phase, watch.elapsed);
+    }
+  }
+
+  /// Records an already-measured [phase] and logs its line.
+  void record(String phase, Duration elapsed) {
+    _phases.add((name: phase, elapsed: elapsed));
+    logPublishPhase(phase, elapsed);
+  }
+
+  /// Builds the one-line summary for a publish that ended with [outcome].
+  String summaryLine({required String outcome}) {
+    final measured = _phases.fold(
+      Duration.zero,
+      (sum, phase) => sum + phase.elapsed,
+    );
+    final elapsed = _total.elapsed;
+    final buffer = StringBuffer()
+      ..write('⏱️ $publishTimingToken summary draft=$draftId ')
+      ..write('outcome=$outcome total=${elapsed.inMilliseconds}ms');
+    for (final phase in _phases) {
+      buffer.write(' ${phase.name}=${phase.elapsed.inMilliseconds}ms');
+    }
+    buffer.write(' other=${(elapsed - measured).inMilliseconds}ms');
+    return buffer.toString();
+  }
+
+  /// Logs [summaryLine] for a publish that ended with [outcome].
+  void logSummary({required String outcome}) {
+    Log.info(
+      summaryLine(outcome: outcome),
+      name: publishTimingLogName,
+      category: LogCategory.video,
+    );
+  }
+}

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -206,6 +206,10 @@ class VideoPublishService {
   /// Reached once mentions and subtitle assets are resolved.
   static const double _progressAfterMetadata = 0.88;
 
+  /// Reached once the Nostr event is signed. Signing is a remote Keycast
+  /// round-trip, so it is worth its own step inside the publish phase.
+  static const double _progressAfterSigning = 0.92;
+
   /// Reached once the Nostr event is accepted.
   static const double _progressAfterNostr = 0.97;
 
@@ -382,6 +386,10 @@ class VideoPublishService {
           textTrackLang: captionTrack != null
               ? _languageCode(captionTrack.languageTag)
               : 'en',
+          onEventSigned: () => onProgressChanged(
+            draftId: draft.id,
+            progress: _progressAfterSigning,
+          ),
         ),
       );
 

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -195,6 +195,28 @@ class VideoPublishService {
 
   static const Duration _defaultSubtitlePublishTimeout = Duration(seconds: 30);
 
+  /// Share of the publish bar owned by the upload.
+  ///
+  /// Everything after it — resolving mentions, signing and broadcasting the
+  /// Nostr event, reclaiming the draft — measured ~2s on device, and the bar
+  /// used to reach 100% before any of it ran. The remainder is handed out at
+  /// the boundaries below so the bar never claims to be done while it isn't.
+  static const double _uploadProgressShare = 0.85;
+
+  /// Reached once mentions and subtitle assets are resolved.
+  static const double _progressAfterMetadata = 0.88;
+
+  /// Reached once the Nostr event is accepted.
+  static const double _progressAfterNostr = 0.97;
+
+  /// Maps an upload's own 0..1 progress onto the share of the bar it owns.
+  void _reportUploadProgress(String draftId, double uploadProgress) {
+    onProgressChanged(
+      draftId: draftId,
+      progress: uploadProgress.clamp(0.0, 1.0) * _uploadProgressShare,
+    );
+  }
+
   /// Tracks the current background upload ID.
   String? _backgroundUploadId;
 
@@ -326,6 +348,11 @@ class VideoPublishService {
             )
           : const <String>[];
 
+      onProgressChanged(
+        draftId: draft.id,
+        progress: _progressAfterMetadata,
+      );
+
       final published = await timeline.measure(
         'nostr',
         () => videoEventPublisher.publishVideoEvent(
@@ -367,6 +394,8 @@ class VideoPublishService {
         );
       }
 
+      onProgressChanged(draftId: draft.id, progress: _progressAfterNostr);
+
       final inviteWarnings = await timeline.measure(
         'invites',
         () => _sendCollaboratorInvites(
@@ -379,6 +408,8 @@ class VideoPublishService {
       // Success: delete draft
       await draftService.deleteDraft(draft.id);
       Log.debug('🗑️ Deleted publish draft: ${draft.id}', category: .video);
+
+      onProgressChanged(draftId: draft.id, progress: 1);
 
       Log.info('📝 Published successfully', category: .video);
       return PublishSuccess(inviteWarnings: inviteWarnings);
@@ -737,7 +768,7 @@ class VideoPublishService {
     final upload = uploadManager.getUpload(uploadId);
     if (upload == null) return false;
 
-    onProgressChanged(draftId: draftId, progress: upload.uploadProgress ?? 0.0);
+    _reportUploadProgress(draftId, upload.uploadProgress ?? 0.0);
 
     switch (upload.status) {
       case .readyToPublish:
@@ -773,8 +804,7 @@ class VideoPublishService {
     final pendingUpload = await uploadManager.startUploadFromDraft(
       draft: draft,
       nostrPubkey: pubkey,
-      onProgress: (value) =>
-          onProgressChanged(draftId: draft.id, progress: value),
+      onProgress: (value) => _reportUploadProgress(draft.id, value),
     );
     _backgroundUploadId = pendingUpload.id;
 

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -24,6 +24,7 @@ import 'package:openvine/services/subtitle_service.dart';
 import 'package:openvine/services/upload_manager.dart';
 import 'package:openvine/services/video_event_publisher.dart';
 import 'package:openvine/services/video_publish/publish_error_kind.dart';
+import 'package:openvine/services/video_publish/publish_timeline.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/public_identifier_normalizer.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -199,7 +200,30 @@ class VideoPublishService {
 
   /// Publishes a video draft.
   /// Returns [PublishSuccess] on success, [PublishError] on failure.
+  ///
+  /// Wraps the publish in a [PublishTimeline] so every run emits per-phase
+  /// timing plus a summary line, whichever way it ends.
   Future<PublishResult> publishVideo({required DivineVideoDraft draft}) async {
+    final timeline = PublishTimeline(draft.id);
+    PublishResult? result;
+    try {
+      result = await _publishVideo(draft: draft, timeline: timeline);
+      return result;
+    } finally {
+      timeline.logSummary(
+        outcome: switch (result) {
+          PublishSuccess() => 'success',
+          PublishError(:final kind) => 'error:${kind.name}',
+          null => 'threw',
+        },
+      );
+    }
+  }
+
+  Future<PublishResult> _publishVideo({
+    required DivineVideoDraft draft,
+    required PublishTimeline timeline,
+  }) async {
     // An account switch while the upload was in flight leaves the previous
     // account's draft reachable from this session. Publishing it would sign the
     // video with the wrong identity, and the `publishing` save below would
@@ -245,7 +269,10 @@ class VideoPublishService {
       final pubkey = authService.currentPublicKeyHex!;
 
       // Use existing upload if available, otherwise start new upload
-      final pendingUpload = await _getOrCreateUpload(pubkey, draft);
+      final pendingUpload = await timeline.measure(
+        'upload',
+        () => _getOrCreateUpload(pubkey, draft),
+      );
       if (pendingUpload == null) {
         Log.error('❌ Upload creation failed', category: .video);
         final failedUpload = _backgroundUploadId != null
@@ -286,43 +313,49 @@ class VideoPublishService {
       // Publish Nostr event
       Log.info('📝 Publishing Nostr event...', category: .video);
 
-      final mentionedPubkeys = await _resolveMentionedPubkeys(
-        draft,
-        currentUserPubkey: pubkey,
+      final mentionedPubkeys = await timeline.measure(
+        'mentions',
+        () => _resolveMentionedPubkeys(draft, currentUserPubkey: pubkey),
       );
 
       final captionTrack = _captionTrackForPublish(draft);
       final textTrackRefs = captionTrack != null
-          ? await _publishSubtitleAssets(captionTrack, pendingUpload)
+          ? await timeline.measure(
+              'subtitles',
+              () => _publishSubtitleAssets(captionTrack, pendingUpload),
+            )
           : const <String>[];
 
-      final published = await videoEventPublisher.publishVideoEvent(
-        upload: pendingUpload,
-        title: draft.title,
-        description: draft.description,
-        hashtags: draft.hashtags.toList(),
-        expirationTimestamp: draft.expireTime != null
-            ? DateTime.now().millisecondsSinceEpoch ~/ 1000 +
-                  draft.expireTime!.inSeconds
-            : null,
-        allowAudioReuse: draft.allowAudioReuse,
-        collaboratorPubkeys: draft.collaboratorPubkeys.toList(),
-        mentionedPubkeys: mentionedPubkeys,
-        inspiredByAddressableId: draft.inspiredByVideo?.addressableId,
-        inspiredByRelayUrl: draft.inspiredByVideo?.relayUrl,
-        inspiredByNpub: draft.inspiredByNpub,
-        selectedAudio: draft.selectedSound,
-        selectedAudioEventId: draft.selectedSound?.id,
-        selectedAudioRelay: draft.selectedSound?.sourceVideoRelay,
-        language: languagePreferenceService?.contentLanguage,
-        contentWarning: draft.contentWarning,
-        thumbnailTimestamp: draft.thumbnailTimestamp,
-        replyContext: draft.videoReplyContext,
-        addReplyToFeed: draft.shareReplyToFeed,
-        textTrackRefs: textTrackRefs,
-        textTrackLang: captionTrack != null
-            ? _languageCode(captionTrack.languageTag)
-            : 'en',
+      final published = await timeline.measure(
+        'nostr',
+        () => videoEventPublisher.publishVideoEvent(
+          upload: pendingUpload,
+          title: draft.title,
+          description: draft.description,
+          hashtags: draft.hashtags.toList(),
+          expirationTimestamp: draft.expireTime != null
+              ? DateTime.now().millisecondsSinceEpoch ~/ 1000 +
+                    draft.expireTime!.inSeconds
+              : null,
+          allowAudioReuse: draft.allowAudioReuse,
+          collaboratorPubkeys: draft.collaboratorPubkeys.toList(),
+          mentionedPubkeys: mentionedPubkeys,
+          inspiredByAddressableId: draft.inspiredByVideo?.addressableId,
+          inspiredByRelayUrl: draft.inspiredByVideo?.relayUrl,
+          inspiredByNpub: draft.inspiredByNpub,
+          selectedAudio: draft.selectedSound,
+          selectedAudioEventId: draft.selectedSound?.id,
+          selectedAudioRelay: draft.selectedSound?.sourceVideoRelay,
+          language: languagePreferenceService?.contentLanguage,
+          contentWarning: draft.contentWarning,
+          thumbnailTimestamp: draft.thumbnailTimestamp,
+          replyContext: draft.videoReplyContext,
+          addReplyToFeed: draft.shareReplyToFeed,
+          textTrackRefs: textTrackRefs,
+          textTrackLang: captionTrack != null
+              ? _languageCode(captionTrack.languageTag)
+              : 'en',
+        ),
       );
 
       if (!published) {
@@ -334,10 +367,13 @@ class VideoPublishService {
         );
       }
 
-      final inviteWarnings = await _sendCollaboratorInvites(
-        draft: draft,
-        upload: pendingUpload,
-        creatorPubkey: pubkey,
+      final inviteWarnings = await timeline.measure(
+        'invites',
+        () => _sendCollaboratorInvites(
+          draft: draft,
+          upload: pendingUpload,
+          creatorPubkey: pubkey,
+        ),
       );
 
       // Success: delete draft

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -19,6 +19,21 @@ import 'package:image_metadata_stripper/image_metadata_stripper.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+/// Emits an upload-phase timing line.
+///
+/// Deliberately mirrors the format of the app layer's `logPublishPhase`
+/// (token `PUBTIME`, logger name `PublishTiming`) so one `grep PUBTIME` spans
+/// both layers in order. The format is duplicated rather than shared because
+/// the helper lives above this package and the dependency only runs one way.
+void _logUploadPhase(String phase, Duration elapsed, {String? detail}) {
+  final suffix = (detail == null || detail.isEmpty) ? '' : ' $detail';
+  Log.info(
+    '⏱️ PUBTIME $phase ${elapsed.inMilliseconds}ms$suffix',
+    name: 'PublishTiming',
+    category: LogCategory.video,
+  );
+}
+
 bool _hasTransientDioSignal(DioException error) {
   final statusCode = error.response?.statusCode;
   if (statusCode != null && statusCode >= 500) return true;
@@ -769,6 +784,7 @@ class BlossomUploadService {
     required String contentDescription,
     Duration authTtl = _defaultAuthTtl,
   }) async {
+    final signWatch = Stopwatch()..start();
     final authEvent = await _createBlossomAuthEvent(
       url: url,
       method: method,
@@ -777,6 +793,13 @@ class BlossomUploadService {
       contentDescription: contentDescription,
       authTtl: authTtl,
     );
+    signWatch.stop();
+    _logUploadPhase(
+      'auth.sign',
+      signWatch.elapsed,
+      detail: '$method ${Uri.tryParse(url)?.path ?? url}',
+    );
+
     if (authEvent == null) {
       return null;
     }
@@ -1713,6 +1736,7 @@ class BlossomUploadService {
       // for file-backed sources (constant-memory upload, used for video and
       // audio) or the raw `Uint8List` for byte-backed sources (used by the
       // web image-upload path where there is no filesystem to stream from).
+      final putWatch = Stopwatch()..start();
       final response = await dio.put<dynamic>(
         '$serverUrl/upload',
         data: source.getStreamingBody(),
@@ -1732,6 +1756,13 @@ class BlossomUploadService {
           }
         },
         // coverage:ignore-end
+      );
+
+      putWatch.stop();
+      _logUploadPhase(
+        'net.put',
+        putWatch.elapsed,
+        detail: '$fileSize bytes -> ${response.statusCode}',
       );
 
       Log.debug(
@@ -2677,11 +2708,19 @@ class BlossomUploadService {
           category: LogCategory.video,
         );
 
-        final capability = await _fetchDivineUploadCapability(serverUrl);
+        // The capability probe only picks between the resumable flow and the
+        // single PUT. A caller that already opted out of resumable cannot be
+        // routed by the answer, so the HEAD is dead weight — and an expensive
+        // one: the OS-first video upload never warms the capability cache, so
+        // the thumbnail leg pays a cold round-trip on the publish critical
+        // path (measured at ~3.7s for a 20KB thumbnail).
+        final capability = allowResumable
+            ? await _fetchDivineUploadCapability(serverUrl)
+            : null;
 
         final result = await _uploadWithRetry(
           attempt: () {
-            if (capability.supportsResumable && allowResumable) {
+            if (capability != null && capability.supportsResumable) {
               return _uploadWithSingleLegacyFallback(
                 serverUrl: serverUrl,
                 uploadResumable: () => _uploadToServerResumable(

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -2708,12 +2708,13 @@ class BlossomUploadService {
           category: LogCategory.video,
         );
 
-        // The capability probe only picks between the resumable flow and the
-        // single PUT. A caller that already opted out of resumable cannot be
-        // routed by the answer, so the HEAD is dead weight — and an expensive
-        // one: the OS-first video upload never warms the capability cache, so
-        // the thumbnail leg pays a cold round-trip on the publish critical
-        // path (measured at ~3.7s for a 20KB thumbnail).
+        // The capability probe only feeds supportsResumable, so a caller that
+        // already opted out of resumable cannot be routed by the answer — the
+        // HEAD would be a provably inert round-trip (and always a cold one on
+        // the publish path: the OS-first video upload never warms this cache).
+        // Skipped because it is inert, not because it was measured as the
+        // cost; on-device timing showed the thumbnail PUT dominates with or
+        // without it.
         final capability = allowResumable
             ? await _fetchDivineUploadCapability(serverUrl)
             : null;

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
@@ -5762,6 +5762,74 @@ void main() {
       );
 
       test(
+        'skips the capability probe entirely when allowResumable is false',
+        () async {
+          when(() => mockAuthProvider.isAuthenticated).thenReturn(true);
+          when(
+            () => mockAuthProvider.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async =>
+                _signedEvent(_testPublicKey, 24242, const [], 'upload'),
+          );
+
+          final tempDir = await Directory.systemTemp.createTemp(
+            'image_no_capability_probe_test_',
+          );
+          final imageFile = File('${tempDir.path}/image.jpg')
+            ..writeAsBytesSync([0xFF, 0xD8, 0xFF]);
+
+          // Stubbed so a stray probe would surface as a verify failure rather
+          // than a null-return crash.
+          when(
+            () => mockDio.head<dynamic>(any(), options: any(named: 'options')),
+          ).thenAnswer(
+            (_) async => Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 200,
+              headers: Headers(),
+            ),
+          );
+
+          when(
+            () => mockDio.put<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+              onSendProgress: any(named: 'onSendProgress'),
+            ),
+          ).thenAnswer(
+            (_) async => Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 200,
+              data: {
+                'url': 'https://media.divine.video/hash',
+                'fallbackUrl': 'https://media.divine.video/hash',
+              },
+            ),
+          );
+
+          final result = await service.uploadImage(
+            imageFile: imageFile,
+            nostrPubkey: _testPublicKey,
+            allowResumable: false,
+          );
+
+          expect(result.success, isTrue);
+          // The probe only picks resumable vs single PUT, so with resumable
+          // off it is a pure round-trip tax on the publish critical path.
+          verifyNever(
+            () => mockDio.head<dynamic>(any(), options: any(named: 'options')),
+          );
+
+          await tempDir.delete(recursive: true);
+        },
+      );
+
+      test(
         'falls back to legacy upload when Divine image resumable init fails',
         () async {
           when(() => mockAuthProvider.isAuthenticated).thenReturn(true);

--- a/mobile/test/services/upload/upload_retry_policy_test.dart
+++ b/mobile/test/services/upload/upload_retry_policy_test.dart
@@ -555,11 +555,37 @@ void main() {
       expect(captured, hasLength(1));
       final updated = captured.first as PendingUpload;
       expect(updated.resumableSession, equals(session));
-      // progress = (512000 / 1024000) * 0.8 = 0.4
-      expect(updated.uploadProgress, closeTo(0.4, 0.001));
+      // progress = (512000 / 1024000) * videoProgressShare = 0.475
+      expect(updated.uploadProgress, closeTo(0.475, 0.001));
     });
 
-    test('clamps progress to [0.0, 0.8]', () async {
+    test(
+      'never lowers progress already reported by the live transfer',
+      () async {
+        final upload = _makeUpload().copyWith(uploadProgress: 0.7);
+        when(() => store.getUpload('upload-1')).thenReturn(upload);
+        when(() => store.update(any())).thenAnswer((_) async {});
+
+        // The live callback and this checkpoint run on different curves, so a
+        // checkpoint computed below the reported value must not drag it back.
+        const session = BlossomResumableUploadSession(
+          uploadId: 'session-1',
+          uploadUrl: 'https://example.com/upload',
+          chunkSize: 1024 * 1024,
+          nextOffset: 512000,
+        );
+
+        policy.enqueueSessionPersist('upload-1', session, 1024000);
+        await Future<void>.delayed(Duration.zero);
+
+        final captured = verify(() => store.update(captureAny())).captured;
+        final updated = captured.first as PendingUpload;
+        expect(updated.resumableSession, equals(session));
+        expect(updated.uploadProgress, closeTo(0.7, 0.001));
+      },
+    );
+
+    test('clamps progress to the video share', () async {
       final upload = _makeUpload();
       when(() => store.getUpload('upload-1')).thenReturn(upload);
       when(() => store.update(any())).thenAnswer((_) async {});
@@ -577,7 +603,10 @@ void main() {
 
       final captured = verify(() => store.update(captureAny())).captured;
       final updated = captured.first as PendingUpload;
-      expect(updated.uploadProgress, lessThanOrEqualTo(0.8));
+      expect(
+        updated.uploadProgress,
+        lessThanOrEqualTo(UploadManager.videoProgressShare),
+      );
     });
 
     test('no-op when upload not found in store', () async {

--- a/mobile/test/services/upload_manager_resumable_upload_test.dart
+++ b/mobile/test/services/upload_manager_resumable_upload_test.dart
@@ -568,10 +568,9 @@ void main() {
         final persisted = uploadManager.getUpload(uploadId)!;
         expect(persisted.resumableSession?.nextOffset, equals(chunkSize * 5));
 
-        final expectedProgress = ((chunkSize * 5) / fileSize * 0.8).clamp(
-          0.0,
-          0.8,
-        );
+        final expectedProgress =
+            ((chunkSize * 5) / fileSize * UploadManager.videoProgressShare)
+                .clamp(0.0, UploadManager.videoProgressShare);
         expect(persisted.uploadProgress, closeTo(expectedProgress, 0.001));
 
         // Complete the upload future and await the full startUpload so

--- a/mobile/test/services/upload_manager_thumbnail_progress_test.dart
+++ b/mobile/test/services/upload_manager_thumbnail_progress_test.dart
@@ -1,0 +1,146 @@
+// ABOUTME: Pins that the thumbnail leg reports progress to the publish-facing
+// ABOUTME: callback, not only to the store, so the bar keeps moving past 80%.
+
+import 'dart:io';
+
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/services/upload_manager.dart';
+import 'package:openvine/services/video_thumbnail_service.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+import '../mocks/mock_path_provider_platform.dart';
+
+class _MockBlossomUploadService extends Mock implements BlossomUploadService {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('UploadManager thumbnail progress', () {
+    late _MockBlossomUploadService mockBlossom;
+    late UploadManager uploadManager;
+    late Directory testDir;
+    late PathProviderPlatform originalPathProvider;
+
+    setUpAll(() {
+      registerFallbackValue(File(''));
+    });
+
+    setUp(() async {
+      testDir = await Directory.systemTemp.createTemp(
+        'upload_thumbnail_progress_test_',
+      );
+      originalPathProvider = PathProviderPlatform.instance;
+      PathProviderPlatform.instance = MockPathProviderPlatform()
+        ..setTemporaryPath(testDir.path)
+        ..setApplicationDocumentsPath('${testDir.path}/documents')
+        ..setApplicationSupportPath('${testDir.path}/support');
+      await Directory('${testDir.path}/support').create(recursive: true);
+
+      const channel = MethodChannel('dev.fluttercommunity.plus/connectivity');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            if (call.method == 'check') return ['wifi'];
+            return null;
+          });
+
+      mockBlossom = _MockBlossomUploadService();
+
+      // Stands in for the native extractor: writes a real file so the
+      // thumbnail leg proceeds to the upload step.
+      final thumbnailPath = '${testDir.path}/thumb.jpg';
+      uploadManager = UploadManager(
+        blossomService: mockBlossom,
+        thumbnailExtractor:
+            ({
+              required String videoPath,
+              required Duration targetTimestamp,
+              required int quality,
+            }) async {
+              File(thumbnailPath).writeAsBytesSync([0xFF, 0xD8, 0xFF]);
+              return ThumbnailFileResult(
+                path: thumbnailPath,
+                timestamp: targetTimestamp,
+              );
+            },
+      );
+      await uploadManager.initialize();
+    });
+
+    tearDown(() async {
+      uploadManager.dispose();
+      PathProviderPlatform.instance = originalPathProvider;
+      try {
+        await Hive.close();
+      } catch (_) {}
+      try {
+        await testDir.delete(recursive: true);
+      } catch (_) {}
+    });
+
+    test('forwards the thumbnail leg to the publish-facing callback', () async {
+      when(() => mockBlossom.isBlossomEnabled()).thenAnswer((_) async => false);
+      when(
+        () => mockBlossom.uploadVideoWithResume(
+          videoFile: any(named: 'videoFile'),
+          nostrPubkey: any(named: 'nostrPubkey'),
+          taskId: any(named: 'taskId'),
+          title: any(named: 'title'),
+          description: any(named: 'description'),
+          hashtags: any(named: 'hashtags'),
+          proofManifestJson: any(named: 'proofManifestJson'),
+          useBackgroundFirst: any(named: 'useBackgroundFirst'),
+          resumableTimeout: any(named: 'resumableTimeout'),
+          resumableSession: any(named: 'resumableSession'),
+          onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).thenAnswer(
+        (_) async => const BlossomUploadResult(
+          success: true,
+          videoId: 'vid-1',
+          url: 'https://media.divine.video/vid-1',
+          fallbackUrl: 'https://media.divine.video/vid-1',
+        ),
+      );
+
+      // Report a mid-transfer tick so the 85%-100% mapping is observable.
+      when(
+        () => mockBlossom.uploadImage(
+          imageFile: any(named: 'imageFile'),
+          nostrPubkey: any(named: 'nostrPubkey'),
+          allowResumable: any(named: 'allowResumable'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).thenAnswer((invocation) async {
+        (invocation.namedArguments[#onProgress] as void Function(double)?)
+            ?.call(0.5);
+        return const BlossomUploadResult(
+          success: true,
+          videoId: 'thumb-1',
+          url: 'https://media.divine.video/thumb-1.jpg',
+          fallbackUrl: 'https://media.divine.video/thumb-1.jpg',
+        );
+      });
+
+      final videoFile = File('${testDir.path}/video.mp4')
+        ..writeAsBytesSync([0, 1, 2, 3]);
+
+      final reported = <double>[];
+      await uploadManager.startUpload(
+        videoFile: videoFile,
+        nostrPubkey: 'pubkey-1',
+        onProgress: reported.add,
+      );
+
+      // Before the fix the callback jumped straight from the end of the video
+      // transfer to 1.0, leaving the publish bar frozen for the whole leg.
+      expect(reported, contains(0.85));
+      expect(reported.any((value) => (value - 0.925).abs() < 0.0001), isTrue);
+      expect(reported.last, equals(1.0));
+    });
+  });
+}

--- a/mobile/test/services/upload_manager_thumbnail_progress_test.dart
+++ b/mobile/test/services/upload_manager_thumbnail_progress_test.dart
@@ -60,6 +60,12 @@ void main() {
       final thumbnailPath = '${testDir.path}/thumb.jpg';
       uploadManager = UploadManager(
         blossomService: mockBlossom,
+        // Zero delays so the retry test does not sleep the default 2s backoff.
+        retryConfig: const UploadRetryConfig(
+          initialDelay: Duration.zero,
+          maxDelay: Duration.zero,
+          networkTimeout: Duration(seconds: 30),
+        ),
         thumbnailExtractor:
             ({
               required String videoPath,

--- a/mobile/test/services/upload_manager_thumbnail_progress_test.dart
+++ b/mobile/test/services/upload_manager_thumbnail_progress_test.dart
@@ -172,6 +172,73 @@ void main() {
       },
     );
 
+    test('does not re-upload the thumbnail after a failed transfer', () async {
+      var thumbnailUploads = 0;
+      when(
+        () => mockBlossom.uploadImage(
+          imageFile: any(named: 'imageFile'),
+          nostrPubkey: any(named: 'nostrPubkey'),
+          allowResumable: any(named: 'allowResumable'),
+        ),
+      ).thenAnswer((_) async {
+        thumbnailUploads++;
+        if (!thumbnailStarted.isCompleted) thumbnailStarted.complete();
+        return const BlossomUploadResult(
+          success: true,
+          videoId: 'thumb-1',
+          url: 'https://media.divine.video/thumb-1.jpg',
+          fallbackUrl: 'https://media.divine.video/thumb-1.jpg',
+        );
+      });
+
+      // Fail the transfer once, then succeed — the retry policy re-enters the
+      // whole execute step, thumbnail leg included.
+      var transferAttempts = 0;
+      when(() => mockBlossom.isBlossomEnabled()).thenAnswer((_) async => false);
+      when(
+        () => mockBlossom.uploadVideoWithResume(
+          videoFile: any(named: 'videoFile'),
+          nostrPubkey: any(named: 'nostrPubkey'),
+          taskId: any(named: 'taskId'),
+          title: any(named: 'title'),
+          description: any(named: 'description'),
+          hashtags: any(named: 'hashtags'),
+          proofManifestJson: any(named: 'proofManifestJson'),
+          useBackgroundFirst: any(named: 'useBackgroundFirst'),
+          resumableTimeout: any(named: 'resumableTimeout'),
+          resumableSession: any(named: 'resumableSession'),
+          onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).thenAnswer((_) async {
+        transferAttempts++;
+        if (transferAttempts == 1) {
+          throw const BlossomUploadFailureException('connection refused');
+        }
+        return const BlossomUploadResult(
+          success: true,
+          videoId: 'vid-1',
+          url: 'https://media.divine.video/vid-1',
+          fallbackUrl: 'https://media.divine.video/vid-1',
+        );
+      });
+
+      final videoFile = File('${testDir.path}/video.mp4')
+        ..writeAsBytesSync([0, 1, 2, 3]);
+
+      await uploadManager.startUpload(
+        videoFile: videoFile,
+        nostrPubkey: 'pubkey-1',
+      );
+
+      expect(transferAttempts, equals(2));
+      expect(
+        thumbnailUploads,
+        equals(1),
+        reason: 'the retry must reuse the thumbnail already on the CDN',
+      );
+    });
+
     test('lets the video alone drive a monotonic bar up to 1.0', () async {
       stubThumbnailUpload();
       stubVideoUpload(

--- a/mobile/test/services/upload_manager_thumbnail_progress_test.dart
+++ b/mobile/test/services/upload_manager_thumbnail_progress_test.dart
@@ -1,6 +1,7 @@
-// ABOUTME: Pins that the thumbnail leg reports progress to the publish-facing
-// ABOUTME: callback, not only to the store, so the bar keeps moving past 80%.
+// ABOUTME: Pins that the thumbnail leg runs beside the video transfer and
+// ABOUTME: that the video alone drives a monotonic progress bar.
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:blossom_upload_service/blossom_upload_service.dart';
@@ -19,11 +20,15 @@ class _MockBlossomUploadService extends Mock implements BlossomUploadService {}
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  group('UploadManager thumbnail progress', () {
+  group('UploadManager thumbnail leg', () {
     late _MockBlossomUploadService mockBlossom;
     late UploadManager uploadManager;
     late Directory testDir;
     late PathProviderPlatform originalPathProvider;
+
+    /// Completes as soon as the thumbnail upload starts, so the video stub can
+    /// prove the two legs overlap.
+    late Completer<void> thumbnailStarted;
 
     setUpAll(() {
       registerFallbackValue(File(''));
@@ -31,7 +36,7 @@ void main() {
 
     setUp(() async {
       testDir = await Directory.systemTemp.createTemp(
-        'upload_thumbnail_progress_test_',
+        'upload_thumbnail_parallel_test_',
       );
       originalPathProvider = PathProviderPlatform.instance;
       PathProviderPlatform.instance = MockPathProviderPlatform()
@@ -47,6 +52,7 @@ void main() {
             return null;
           });
 
+      thumbnailStarted = Completer<void>();
       mockBlossom = _MockBlossomUploadService();
 
       // Stands in for the native extractor: writes a real file so the
@@ -81,7 +87,30 @@ void main() {
       } catch (_) {}
     });
 
-    test('forwards the thumbnail leg to the publish-facing callback', () async {
+    /// Stubs the image upload to announce its start via [thumbnailStarted].
+    void stubThumbnailUpload() {
+      when(
+        () => mockBlossom.uploadImage(
+          imageFile: any(named: 'imageFile'),
+          nostrPubkey: any(named: 'nostrPubkey'),
+          allowResumable: any(named: 'allowResumable'),
+        ),
+      ).thenAnswer((_) async {
+        if (!thumbnailStarted.isCompleted) thumbnailStarted.complete();
+        return const BlossomUploadResult(
+          success: true,
+          videoId: 'thumb-1',
+          url: 'https://media.divine.video/thumb-1.jpg',
+          fallbackUrl: 'https://media.divine.video/thumb-1.jpg',
+        );
+      });
+    }
+
+    /// Stubs the video transfer, running [duringTransfer] before it resolves.
+    void stubVideoUpload({
+      Future<void> Function(void Function(double) reportProgress)?
+      duringTransfer,
+    }) {
       when(() => mockBlossom.isBlossomEnabled()).thenAnswer((_) async => false);
       when(
         () => mockBlossom.uploadVideoWithResume(
@@ -98,33 +127,65 @@ void main() {
           onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
           onProgress: any(named: 'onProgress'),
         ),
-      ).thenAnswer(
-        (_) async => const BlossomUploadResult(
+      ).thenAnswer((invocation) async {
+        final report =
+            invocation.namedArguments[#onProgress] as void Function(double)?;
+        await duringTransfer?.call(report ?? (_) {});
+        return const BlossomUploadResult(
           success: true,
           videoId: 'vid-1',
           url: 'https://media.divine.video/vid-1',
           fallbackUrl: 'https://media.divine.video/vid-1',
-        ),
-      );
-
-      // Report a mid-transfer tick so the 85%-100% mapping is observable.
-      when(
-        () => mockBlossom.uploadImage(
-          imageFile: any(named: 'imageFile'),
-          nostrPubkey: any(named: 'nostrPubkey'),
-          allowResumable: any(named: 'allowResumable'),
-          onProgress: any(named: 'onProgress'),
-        ),
-      ).thenAnswer((invocation) async {
-        (invocation.namedArguments[#onProgress] as void Function(double)?)
-            ?.call(0.5);
-        return const BlossomUploadResult(
-          success: true,
-          videoId: 'thumb-1',
-          url: 'https://media.divine.video/thumb-1.jpg',
-          fallbackUrl: 'https://media.divine.video/thumb-1.jpg',
         );
       });
+    }
+
+    test(
+      'uploads the thumbnail while the video transfer is still open',
+      () async {
+        stubThumbnailUpload();
+
+        var overlapped = false;
+        stubVideoUpload(
+          duringTransfer: (_) async {
+            // Resolves only if the thumbnail leg was started before the transfer
+            // finished. Sequential execution would leave it pending.
+            overlapped = await thumbnailStarted.future
+                .timeout(const Duration(seconds: 2))
+                .then((_) => true, onError: (_) => false);
+          },
+        );
+
+        final videoFile = File('${testDir.path}/video.mp4')
+          ..writeAsBytesSync([0, 1, 2, 3]);
+
+        await uploadManager.startUpload(
+          videoFile: videoFile,
+          nostrPubkey: 'pubkey-1',
+        );
+
+        expect(
+          overlapped,
+          isTrue,
+          reason: 'the thumbnail must not wait for the video transfer',
+        );
+      },
+    );
+
+    test('lets the video alone drive a monotonic bar up to 1.0', () async {
+      stubThumbnailUpload();
+      stubVideoUpload(
+        duringTransfer: (reportProgress) async {
+          // Report once the thumbnail leg is underway (parallelism is the
+          // other test's job, so a miss here must not hang this one): if that
+          // leg also wrote progress, these would arrive out of order.
+          await thumbnailStarted.future
+              .timeout(const Duration(seconds: 2))
+              .then((_) => true, onError: (_) => false);
+          reportProgress(0.5);
+          reportProgress(1);
+        },
+      );
 
       final videoFile = File('${testDir.path}/video.mp4')
         ..writeAsBytesSync([0, 1, 2, 3]);
@@ -136,10 +197,17 @@ void main() {
         onProgress: reported.add,
       );
 
-      // Before the fix the callback jumped straight from the end of the video
-      // transfer to 1.0, leaving the publish bar frozen for the whole leg.
-      expect(reported, contains(0.85));
-      expect(reported.any((value) => (value - 0.925).abs() < 0.0001), isTrue);
+      expect(reported, isNotEmpty);
+      for (var i = 1; i < reported.length; i++) {
+        expect(
+          reported[i],
+          greaterThanOrEqualTo(reported[i - 1]),
+          reason: 'progress went backwards: $reported',
+        );
+      }
+      // The transfer tops out at the video's share, and only the join to the
+      // thumbnail completes the bar.
+      expect(reported, contains(0.95));
       expect(reported.last, equals(1.0));
     });
   });

--- a/mobile/test/services/upload_manager_thumbnail_progress_test.dart
+++ b/mobile/test/services/upload_manager_thumbnail_progress_test.dart
@@ -12,6 +12,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:openvine/services/upload_manager.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 import '../mocks/mock_path_provider_platform.dart';
 
@@ -242,6 +243,15 @@ void main() {
         thumbnailUploads,
         equals(1),
         reason: 'the retry must reuse the thumbnail already on the CDN',
+      );
+      // The reused leg still emits a timeline line, so a log export reads
+      // "reused" rather than "the leg never ran".
+      expect(
+        LogCaptureService().getRecentLogs().any(
+          (entry) => entry.message.contains('upload.thumbnail 0ms reused'),
+        ),
+        isTrue,
+        reason: 'retry must log the reused thumbnail leg',
       );
     });
 

--- a/mobile/test/services/video_event_publisher_imeta_hash_test.dart
+++ b/mobile/test/services/video_event_publisher_imeta_hash_test.dart
@@ -1,0 +1,193 @@
+// ABOUTME: Pins that the imeta `x` digest is reused from the content-addressed
+// ABOUTME: upload instead of re-hashing the whole video file at publish time.
+
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:nostr_sdk/relay/publish_outcome.dart';
+import 'package:openvine/constants/nip71_migration.dart';
+import 'package:openvine/models/pending_upload.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/upload_manager.dart';
+import 'package:openvine/services/video_event_publisher.dart';
+import 'package:openvine/services/video_event_service.dart';
+
+class _MockUploadManager extends Mock implements UploadManager {}
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _FakeEvent extends Fake implements Event {}
+
+class _FakeFilter extends Fake implements Filter {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _MockUploadManager uploadManager;
+  late _MockNostrClient nostrClient;
+  late _MockAuthService authService;
+  late _MockVideoEventService videoEventService;
+  late VideoEventPublisher publisher;
+  late List<List<String>> capturedTags;
+  late Directory testDir;
+  late File videoFile;
+
+  const testPubkey =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const videoBytes = [1, 2, 3, 4, 5];
+
+  /// The digest the upload would have streamed and stored as `videoId`.
+  const uploadedDigest =
+      '1111111111111111111111111111111111111111111111111111111111111111';
+
+  setUpAll(() {
+    registerFallbackValue(_FakeEvent());
+    registerFallbackValue(_FakeFilter());
+    registerFallbackValue(<Filter>[]);
+    registerFallbackValue(UploadStatus.pending);
+    registerFallbackValue(Duration.zero);
+  });
+
+  setUp(() async {
+    testDir = await Directory.systemTemp.createTemp('imeta_hash_test_');
+    videoFile = File('${testDir.path}/video.mp4')..writeAsBytesSync(videoBytes);
+
+    uploadManager = _MockUploadManager();
+    nostrClient = _MockNostrClient();
+    authService = _MockAuthService();
+    videoEventService = _MockVideoEventService();
+    capturedTags = [];
+
+    publisher = VideoEventPublisher(
+      uploadManager: uploadManager,
+      nostrService: nostrClient,
+      authService: authService,
+      videoEventService: videoEventService,
+    );
+
+    when(() => nostrClient.isInitialized).thenReturn(true);
+    when(() => nostrClient.configuredRelayCount).thenReturn(1);
+    when(() => nostrClient.connectedRelayCount).thenReturn(1);
+    when(
+      () => nostrClient.configuredRelays,
+    ).thenReturn(['wss://relay.divine.video']);
+    when(
+      () => nostrClient.connectedRelays,
+    ).thenReturn(['wss://relay.divine.video']);
+    when(() => nostrClient.publicKey).thenReturn('');
+
+    when(() => authService.isAuthenticated).thenReturn(true);
+    when(() => authService.currentPublicKeyHex).thenReturn(testPubkey);
+
+    when(
+      () => uploadManager.updateUploadStatus(
+        any(),
+        any(),
+        nostrEventId: any(named: 'nostrEventId'),
+      ),
+    ).thenAnswer((_) async {});
+  });
+
+  tearDown(() async {
+    try {
+      await testDir.delete(recursive: true);
+    } catch (_) {}
+  });
+
+  PendingUpload createUpload({required String? videoId}) {
+    return PendingUpload(
+      id: 'upload-id',
+      localVideoPath: videoFile.path,
+      nostrPubkey: testPubkey,
+      status: UploadStatus.readyToPublish,
+      createdAt: DateTime.now(),
+      videoId: videoId,
+      cdnUrl: 'https://cdn.example.com/video.mp4',
+      fallbackUrl: 'https://cdn.example.com/video.mp4',
+      thumbnailPath: 'https://cdn.example.com/thumb.jpg',
+    );
+  }
+
+  void stubSignAndPublish() {
+    late Event publishedEvent;
+
+    when(
+      () => authService.createAndSignEvent(
+        kind: any(named: 'kind'),
+        content: any(named: 'content'),
+        tags: any(named: 'tags'),
+      ),
+    ).thenAnswer((invocation) async {
+      capturedTags = invocation.namedArguments[#tags] as List<List<String>>;
+      publishedEvent = Event(
+        testPubkey,
+        NIP71VideoKinds.getPreferredAddressableKind(),
+        capturedTags,
+        'test content',
+      );
+      return publishedEvent;
+    });
+
+    when(
+      () => nostrClient.publishEventAwaitOk(
+        any(),
+        timeout: any(named: 'timeout'),
+      ),
+    ).thenAnswer(
+      (_) async => PublishOutcome(
+        eventId: publishedEvent.id,
+        acceptedBy: const ['wss://relay.divine.video'],
+        rejectedBy: const {},
+        noResponseFrom: const [],
+      ),
+    );
+    when(
+      () => nostrClient.queryEvents(
+        any(),
+        subscriptionId: any(named: 'subscriptionId'),
+        tempRelays: any(named: 'tempRelays'),
+        relayTypes: any(named: 'relayTypes'),
+        sendAfterAuth: any(named: 'sendAfterAuth'),
+        useCache: any(named: 'useCache'),
+      ),
+    ).thenAnswer((_) async => <Event>[publishedEvent]);
+  }
+
+  /// The `x <digest>` component of the emitted imeta tag.
+  String? capturedDigest() {
+    final imeta = capturedTags.firstWhere(
+      (tag) => tag.isNotEmpty && tag.first == 'imeta',
+      orElse: () => const <String>[],
+    );
+    for (final component in imeta) {
+      if (component.startsWith('x ')) return component.substring(2);
+    }
+    return null;
+  }
+
+  test('reuses the digest the upload already computed', () async {
+    stubSignAndPublish();
+
+    final result = await publisher.publishDirectUpload(
+      createUpload(videoId: uploadedDigest),
+    );
+
+    expect(result, isTrue);
+    expect(capturedDigest(), equals(uploadedDigest));
+    // Re-hashing the file would produce this instead — the whole point is that
+    // the video is never read back at publish time.
+    expect(
+      capturedDigest(),
+      isNot(equals(sha256.convert(videoBytes).toString())),
+    );
+  });
+}

--- a/mobile/test/services/video_event_publisher_imeta_hash_test.dart
+++ b/mobile/test/services/video_event_publisher_imeta_hash_test.dart
@@ -197,6 +197,22 @@ void main() {
     );
   });
 
+  test('emits the digest even when the local file is already gone', () async {
+    stubSignAndPublish();
+
+    // Funnelcake materializes events_local.sha256 from this sub-field and
+    // joins moderation labels on it — a publish landing after local cleanup
+    // must still carry x, even though size (which needs the file) cannot.
+    await videoFile.delete();
+
+    final result = await publisher.publishDirectUpload(
+      createUpload(videoId: uploadedDigest),
+    );
+
+    expect(result, isTrue);
+    expect(capturedDigest(), equals(uploadedDigest));
+  });
+
   test('reuses the blurhash the thumbnail leg already derived', () async {
     stubSignAndPublish();
 

--- a/mobile/test/services/video_event_publisher_imeta_hash_test.dart
+++ b/mobile/test/services/video_event_publisher_imeta_hash_test.dart
@@ -103,7 +103,7 @@ void main() {
     } catch (_) {}
   });
 
-  PendingUpload createUpload({required String? videoId}) {
+  PendingUpload createUpload({required String? videoId, String? blurhash}) {
     return PendingUpload(
       id: 'upload-id',
       localVideoPath: videoFile.path,
@@ -114,6 +114,7 @@ void main() {
       cdnUrl: 'https://cdn.example.com/video.mp4',
       fallbackUrl: 'https://cdn.example.com/video.mp4',
       thumbnailPath: 'https://cdn.example.com/thumb.jpg',
+      blurhash: blurhash,
     );
   }
 
@@ -162,17 +163,22 @@ void main() {
     ).thenAnswer((_) async => <Event>[publishedEvent]);
   }
 
-  /// The `x <digest>` component of the emitted imeta tag.
-  String? capturedDigest() {
+  /// The value of the imeta component introduced by [prefix].
+  String? capturedImeta(String prefix) {
     final imeta = capturedTags.firstWhere(
       (tag) => tag.isNotEmpty && tag.first == 'imeta',
       orElse: () => const <String>[],
     );
     for (final component in imeta) {
-      if (component.startsWith('x ')) return component.substring(2);
+      if (component.startsWith('$prefix ')) {
+        return component.substring(prefix.length + 1);
+      }
     }
     return null;
   }
+
+  /// The `x <digest>` component of the emitted imeta tag.
+  String? capturedDigest() => capturedImeta('x');
 
   test('reuses the digest the upload already computed', () async {
     stubSignAndPublish();
@@ -189,5 +195,18 @@ void main() {
       capturedDigest(),
       isNot(equals(sha256.convert(videoBytes).toString())),
     );
+  });
+
+  test('reuses the blurhash the thumbnail leg already derived', () async {
+    stubSignAndPublish();
+
+    final result = await publisher.publishDirectUpload(
+      createUpload(videoId: uploadedDigest, blurhash: 'LEHV6nWB2yk8pyoJadR*'),
+    );
+
+    expect(result, isTrue);
+    // Decoding the video again here would yield nothing for these bytes, so a
+    // present value proves it came from the record.
+    expect(capturedImeta('blurhash'), equals('LEHV6nWB2yk8pyoJadR*'));
   });
 }

--- a/mobile/test/services/video_event_publisher_signed_callback_test.dart
+++ b/mobile/test/services/video_event_publisher_signed_callback_test.dart
@@ -1,0 +1,192 @@
+// ABOUTME: Pins that the onEventSigned progress step only fires once an event
+// ABOUTME: actually exists, so a failed signing cannot advance the publish bar.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:nostr_sdk/relay/publish_outcome.dart';
+import 'package:openvine/constants/nip71_migration.dart';
+import 'package:openvine/models/pending_upload.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/upload_manager.dart';
+import 'package:openvine/services/video_event_publisher.dart';
+import 'package:openvine/services/video_event_service.dart';
+
+class _MockUploadManager extends Mock implements UploadManager {}
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _FakeEvent extends Fake implements Event {}
+
+class _FakeFilter extends Fake implements Filter {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group(VideoEventPublisher, () {
+    late _MockUploadManager uploadManager;
+    late _MockNostrClient nostrClient;
+    late _MockAuthService authService;
+    late _MockVideoEventService videoEventService;
+    late VideoEventPublisher publisher;
+    late Directory testDir;
+    late File videoFile;
+    late int signedSteps;
+
+    const testPubkey =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const uploadedDigest =
+        '1111111111111111111111111111111111111111111111111111111111111111';
+
+    setUpAll(() {
+      registerFallbackValue(_FakeEvent());
+      registerFallbackValue(_FakeFilter());
+      registerFallbackValue(<Filter>[]);
+      registerFallbackValue(UploadStatus.pending);
+      registerFallbackValue(Duration.zero);
+    });
+
+    setUp(() async {
+      testDir = await Directory.systemTemp.createTemp('signed_callback_test_');
+      videoFile = File('${testDir.path}/video.mp4')
+        ..writeAsBytesSync([1, 2, 3]);
+
+      uploadManager = _MockUploadManager();
+      nostrClient = _MockNostrClient();
+      authService = _MockAuthService();
+      videoEventService = _MockVideoEventService();
+      signedSteps = 0;
+
+      publisher = VideoEventPublisher(
+        uploadManager: uploadManager,
+        nostrService: nostrClient,
+        authService: authService,
+        videoEventService: videoEventService,
+      );
+
+      when(() => nostrClient.isInitialized).thenReturn(true);
+      when(() => nostrClient.configuredRelayCount).thenReturn(1);
+      when(() => nostrClient.connectedRelayCount).thenReturn(1);
+      when(
+        () => nostrClient.configuredRelays,
+      ).thenReturn(['wss://relay.divine.video']);
+      when(
+        () => nostrClient.connectedRelays,
+      ).thenReturn(['wss://relay.divine.video']);
+      when(() => nostrClient.publicKey).thenReturn('');
+
+      when(() => authService.isAuthenticated).thenReturn(true);
+      when(() => authService.currentPublicKeyHex).thenReturn(testPubkey);
+
+      when(
+        () => uploadManager.updateUploadStatus(
+          any(),
+          any(),
+          nostrEventId: any(named: 'nostrEventId'),
+        ),
+      ).thenAnswer((_) async {});
+    });
+
+    tearDown(() async {
+      try {
+        await testDir.delete(recursive: true);
+      } catch (_) {}
+    });
+
+    PendingUpload createUpload() => PendingUpload(
+      id: 'upload-id',
+      localVideoPath: videoFile.path,
+      nostrPubkey: testPubkey,
+      status: UploadStatus.readyToPublish,
+      createdAt: DateTime.now(),
+      videoId: uploadedDigest,
+      cdnUrl: 'https://cdn.example.com/video.mp4',
+      fallbackUrl: 'https://cdn.example.com/video.mp4',
+      thumbnailPath: 'https://cdn.example.com/thumb.jpg',
+    );
+
+    group('onEventSigned', () {
+      test('does not report the signing step when signing fails', () async {
+        when(
+          () => authService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((_) async => null);
+
+        final result = await publisher.publishDirectUpload(
+          createUpload(),
+          onEventSigned: () => signedSteps++,
+        );
+
+        expect(result, isFalse);
+        expect(
+          signedSteps,
+          isZero,
+          reason:
+              'the bar advanced to the signing step for an event that '
+              'was never signed',
+        );
+      });
+
+      test('reports the signing step once the event is signed', () async {
+        late Event signedEvent;
+        when(
+          () => authService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((invocation) async {
+          signedEvent = Event(
+            testPubkey,
+            NIP71VideoKinds.getPreferredAddressableKind(),
+            invocation.namedArguments[#tags] as List<List<String>>,
+            'test content',
+          );
+          return signedEvent;
+        });
+        when(
+          () => nostrClient.publishEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: signedEvent.id,
+            acceptedBy: const ['wss://relay.divine.video'],
+            rejectedBy: const {},
+            noResponseFrom: const [],
+          ),
+        );
+        when(
+          () => nostrClient.queryEvents(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            tempRelays: any(named: 'tempRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            sendAfterAuth: any(named: 'sendAfterAuth'),
+            useCache: any(named: 'useCache'),
+          ),
+        ).thenAnswer((_) async => <Event>[signedEvent]);
+
+        final result = await publisher.publishDirectUpload(
+          createUpload(),
+          onEventSigned: () => signedSteps++,
+        );
+
+        expect(result, isTrue);
+        expect(signedSteps, equals(1));
+      });
+    });
+  });
+}

--- a/mobile/test/services/video_publish/publish_timeline_test.dart
+++ b/mobile/test/services/video_publish/publish_timeline_test.dart
@@ -1,0 +1,109 @@
+// ABOUTME: Tests for PublishTimeline — phase capture, summary shape, and the
+// ABOUTME: PUBTIME token contract the log-filtering workflow depends on.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/video_publish/publish_timeline.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+void main() {
+  group(PublishTimeline, () {
+    late PublishTimeline timeline;
+
+    setUp(() {
+      timeline = PublishTimeline('draft-1');
+    });
+
+    group('measure', () {
+      test('returns the action result and records the phase', () async {
+        final result = await timeline.measure('nostr', () async => 42);
+
+        expect(result, equals(42));
+        expect(timeline.phases.map((phase) => phase.name), equals(['nostr']));
+      });
+
+      test('records the phase and rethrows when the action throws', () async {
+        await expectLater(
+          timeline.measure<void>('nostr', () async => throw StateError('boom')),
+          throwsA(isA<StateError>()),
+        );
+
+        expect(timeline.phases.map((phase) => phase.name), equals(['nostr']));
+      });
+
+      test('keeps phases in completion order', () async {
+        await timeline.measure('upload', () async {});
+        await timeline.measure('nostr', () async {});
+
+        expect(
+          timeline.phases.map((phase) => phase.name),
+          equals(['upload', 'nostr']),
+        );
+      });
+    });
+
+    group('summaryLine', () {
+      test('carries the filter token, draft, outcome and every phase', () {
+        timeline
+          ..record('upload', const Duration(milliseconds: 900))
+          ..record('nostr', const Duration(milliseconds: 120));
+
+        final summary = timeline.summaryLine(outcome: 'success');
+
+        expect(summary, contains(publishTimingToken));
+        expect(summary, contains('draft=draft-1'));
+        expect(summary, contains('outcome=success'));
+        expect(summary, contains('upload=900ms'));
+        expect(summary, contains('nostr=120ms'));
+        expect(summary, contains('other='));
+      });
+
+      test('reports a total even when no phase was recorded', () {
+        final summary = timeline.summaryLine(outcome: 'threw');
+
+        expect(summary, contains('outcome=threw'));
+        expect(summary, contains('total='));
+      });
+    });
+  });
+
+  group('logPublishPhase', () {
+    test('emits one filterable line carrying phase, duration and detail', () {
+      logPublishPhase(
+        'upload.transfer',
+        const Duration(milliseconds: 5231),
+        detail: '8.00MB 1.53MB/s',
+      );
+
+      final captured = LogCaptureService().getRecentLogs(limit: 1).single;
+
+      expect(captured.name, equals(publishTimingLogName));
+      expect(captured.category, equals(LogCategory.video));
+      expect(captured.message, contains(publishTimingToken));
+      expect(captured.message, contains('upload.transfer'));
+      expect(captured.message, contains('5231ms'));
+      expect(captured.message, contains('8.00MB 1.53MB/s'));
+    });
+  });
+
+  group('formatTransferDetail', () {
+    test('reports size and rate for a measured transfer', () {
+      final detail = formatTransferDetail(
+        8 * 1024 * 1024,
+        const Duration(seconds: 4),
+      );
+
+      expect(detail, equals('8.00MB 2.00MB/s'));
+    });
+
+    test('omits the rate when the transfer took no measurable time', () {
+      final detail = formatTransferDetail(2 * 1024 * 1024, Duration.zero);
+
+      expect(detail, equals('2.00MB'));
+    });
+
+    test('returns nothing when the size is unknown or empty', () {
+      expect(formatTransferDetail(null, const Duration(seconds: 1)), isEmpty);
+      expect(formatTransferDetail(0, const Duration(seconds: 1)), isEmpty);
+    });
+  });
+}

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -142,6 +142,71 @@ void main() {
         verify(() => mockDraftService.deleteDraft(draft.id)).called(1);
       });
 
+      test('holds the bar below 100% until the event lands', () async {
+        // Arrange
+        _setupSuccessfulPublish(
+          mockAuthService: mockAuthService,
+          mockUploadManager: mockUploadManager,
+          mockDraftService: mockDraftService,
+          mockVideoEventPublisher: mockVideoEventPublisher,
+        );
+
+        // Snapshot the bar at the moment the Nostr publish begins — signing
+        // and broadcasting took ~2s on device, and the bar used to sit at
+        // 100% for all of it.
+        late List<double> beforeEvent;
+        when(
+          () => mockVideoEventPublisher.publishVideoEvent(
+            upload: any(named: 'upload'),
+            title: any(named: 'title'),
+            description: any(named: 'description'),
+            hashtags: any(named: 'hashtags'),
+            expirationTimestamp: any(named: 'expirationTimestamp'),
+            allowAudioReuse: any(named: 'allowAudioReuse'),
+            collaboratorPubkeys: any(named: 'collaboratorPubkeys'),
+            mentionedPubkeys: any(named: 'mentionedPubkeys'),
+            inspiredByAddressableId: any(named: 'inspiredByAddressableId'),
+            inspiredByRelayUrl: any(named: 'inspiredByRelayUrl'),
+            inspiredByNpub: any(named: 'inspiredByNpub'),
+            selectedAudio: any(named: 'selectedAudio'),
+            selectedAudioEventId: any(named: 'selectedAudioEventId'),
+            selectedAudioRelay: any(named: 'selectedAudioRelay'),
+            language: any(named: 'language'),
+            contentWarning: any(named: 'contentWarning'),
+            thumbnailTimestamp: any(named: 'thumbnailTimestamp'),
+            replyContext: any(named: 'replyContext'),
+            addReplyToFeed: any(named: 'addReplyToFeed'),
+            textTrackRefs: any(named: 'textTrackRefs'),
+            textTrackLang: any(named: 'textTrackLang'),
+          ),
+        ).thenAnswer((_) async {
+          beforeEvent = List<double>.of(progressChanges);
+          return true;
+        });
+
+        // Act
+        final result = await service.publishVideo(draft: _createTestDraft());
+
+        // Assert
+        expect(result, isA<PublishSuccess>());
+        expect(beforeEvent, isNotEmpty);
+        for (final value in beforeEvent) {
+          expect(
+            value,
+            lessThan(1.0),
+            reason: 'bar reported done while the event was still unpublished',
+          );
+        }
+        expect(progressChanges.last, equals(1.0));
+        for (var i = 1; i < progressChanges.length; i++) {
+          expect(
+            progressChanges[i],
+            greaterThanOrEqualTo(progressChanges[i - 1]),
+            reason: 'progress went backwards: $progressChanges',
+          );
+        }
+      });
+
       group('caption publishing', () {
         const overlayTrack = CaptionTrack(
           presetId: 'classic',

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -184,8 +184,9 @@ void main() {
           beforeEvent = List<double>.of(progressChanges);
           // Standing in for the publisher: it reports back once the event is
           // signed, part-way through a phase that measured ~1.5s on device.
-          // If the callback ever stops being forwarded down the publisher's
-          // three-deep call chain, the step assertion below fails.
+          // This pins the service's end of the contract — that it passes a
+          // callback which moves the bar to the signing step. The publisher's
+          // own forwarding is mocked out here.
           (invocation.namedArguments[#onEventSigned] as void Function()?)
               ?.call();
           return true;

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -178,9 +178,16 @@ void main() {
             addReplyToFeed: any(named: 'addReplyToFeed'),
             textTrackRefs: any(named: 'textTrackRefs'),
             textTrackLang: any(named: 'textTrackLang'),
+            onEventSigned: any(named: 'onEventSigned'),
           ),
-        ).thenAnswer((_) async {
+        ).thenAnswer((invocation) async {
           beforeEvent = List<double>.of(progressChanges);
+          // Standing in for the publisher: it reports back once the event is
+          // signed, part-way through a phase that measured ~1.5s on device.
+          // If the callback ever stops being forwarded down the publisher's
+          // three-deep call chain, the step assertion below fails.
+          (invocation.namedArguments[#onEventSigned] as void Function()?)
+              ?.call();
           return true;
         });
 
@@ -198,6 +205,11 @@ void main() {
           );
         }
         expect(progressChanges.last, equals(1.0));
+        expect(
+          progressChanges,
+          contains(0.92),
+          reason: 'the signing step never reached the bar',
+        );
         for (var i = 1; i < progressChanges.length; i++) {
           expect(
             progressChanges[i],
@@ -651,6 +663,7 @@ void main() {
               thumbnailTimestamp: any(named: 'thumbnailTimestamp'),
               replyContext: any(named: 'replyContext'),
               addReplyToFeed: any(named: 'addReplyToFeed'),
+              onEventSigned: any(named: 'onEventSigned'),
             ),
           );
         },
@@ -734,6 +747,7 @@ void main() {
               thumbnailTimestamp: any(named: 'thumbnailTimestamp'),
               replyContext: any(named: 'replyContext'),
               addReplyToFeed: any(named: 'addReplyToFeed'),
+              onEventSigned: any(named: 'onEventSigned'),
             ),
           ).called(1);
         },
@@ -818,6 +832,7 @@ void main() {
               thumbnailTimestamp: any(named: 'thumbnailTimestamp'),
               replyContext: any(named: 'replyContext'),
               addReplyToFeed: any(named: 'addReplyToFeed'),
+              onEventSigned: any(named: 'onEventSigned'),
             ),
           ).called(1);
         },
@@ -863,6 +878,7 @@ void main() {
             thumbnailTimestamp: any(named: 'thumbnailTimestamp'),
             replyContext: any(named: 'replyContext'),
             addReplyToFeed: any(named: 'addReplyToFeed'),
+            onEventSigned: any(named: 'onEventSigned'),
           ),
         )..called(1);
         expect(captured.captured.single, isEmpty);
@@ -1008,6 +1024,7 @@ void main() {
               thumbnailTimestamp: any(named: 'thumbnailTimestamp'),
               replyContext: any(named: 'replyContext'),
               addReplyToFeed: any(named: 'addReplyToFeed'),
+              onEventSigned: any(named: 'onEventSigned'),
             ),
             () => mockCollaboratorInviteService.sendInvites(
               collaboratorPubkeys: any(named: 'collaboratorPubkeys'),
@@ -1054,6 +1071,7 @@ void main() {
               expirationTimestamp: any(named: 'expirationTimestamp'),
               allowAudioReuse: any(named: 'allowAudioReuse'),
               selectedAudio: any(named: 'selectedAudio'),
+              onEventSigned: any(named: 'onEventSigned'),
             ),
           ).thenAnswer((_) async => false);
           when(
@@ -1220,6 +1238,7 @@ void main() {
             expirationTimestamp: any(named: 'expirationTimestamp'),
             allowAudioReuse: any(named: 'allowAudioReuse'),
             selectedAudio: any(named: 'selectedAudio'),
+            onEventSigned: any(named: 'onEventSigned'),
           ),
         ).thenAnswer((_) async => false);
         when(
@@ -1287,6 +1306,7 @@ void main() {
             expirationTimestamp: any(named: 'expirationTimestamp'),
             allowAudioReuse: any(named: 'allowAudioReuse'),
             selectedAudio: any(named: 'selectedAudio'),
+            onEventSigned: any(named: 'onEventSigned'),
           ),
         ).thenAnswer((_) async => true);
 
@@ -1379,6 +1399,7 @@ void main() {
             title: any(named: 'title'),
             description: any(named: 'description'),
             hashtags: any(named: 'hashtags'),
+            onEventSigned: any(named: 'onEventSigned'),
           ),
         );
       });
@@ -1412,6 +1433,7 @@ void main() {
             expirationTimestamp: any(named: 'expirationTimestamp'),
             allowAudioReuse: any(named: 'allowAudioReuse'),
             selectedAudio: any(named: 'selectedAudio'),
+            onEventSigned: any(named: 'onEventSigned'),
           ),
         ).thenAnswer((_) async => true);
 
@@ -1500,6 +1522,7 @@ void main() {
             expirationTimestamp: any(named: 'expirationTimestamp'),
             allowAudioReuse: any(named: 'allowAudioReuse'),
             selectedAudio: any(named: 'selectedAudio'),
+            onEventSigned: any(named: 'onEventSigned'),
           ),
         ).thenAnswer((_) async => true);
 
@@ -2063,6 +2086,7 @@ Future<bool> _verifyPublishVideoEvent(
   addReplyToFeed: any(named: 'addReplyToFeed'),
   textTrackRefs: textTrackRefs,
   textTrackLang: textTrackLang,
+  onEventSigned: any(named: 'onEventSigned'),
 );
 
 DivineVideoDraft _createTestDraft({
@@ -2150,6 +2174,7 @@ void _setupSuccessfulPublish({
       addReplyToFeed: any(named: 'addReplyToFeed'),
       textTrackRefs: any(named: 'textTrackRefs'),
       textTrackLang: any(named: 'textTrackLang'),
+      onEventSigned: any(named: 'onEventSigned'),
     ),
   ).thenAnswer((_) async => true);
 }


### PR DESCRIPTION
Closes #6555

## Description

Publishing a video felt like it stalled around 75%. It had no timing anywhere — the only duration in the logs was one aggregate upload figure — so the stall could not be attributed to a phase. This adds phase timing, then fixes what the measurements exposed.

Every phase now emits a line carrying a `PUBTIME` token, so one `grep PUBTIME` over a log export reconstructs a publish in order, across both the app and the `blossom_upload_service` package:

```
⏱️ PUBTIME upload.thumbnail.extract 220ms
⏱️ PUBTIME upload.thumbnail.blurhash 587ms
⏱️ PUBTIME auth.sign 279ms PUT /upload
⏱️ PUBTIME net.put 5274ms 16572 bytes -> 200
⏱️ PUBTIME upload.thumbnail 6403ms
⏱️ PUBTIME upload.transfer 8856ms 4.92MB 0.56MB/s
⏱️ PUBTIME nostr.sign 331ms signed
⏱️ PUBTIME nostr.publish 1160ms
⏱️ PUBTIME summary draft=… outcome=success total=11303ms upload=8965ms nostr=1525ms other=809ms
```

### What the measurements showed

Nine publishes on a real Samsung Galaxy. The 16 KB thumbnail cost 3.2–4.1 s and sat entirely behind the video transfer — a fifth to a quarter of the whole publish — and almost none of it was bandwidth. Splitting it further: ~0.3–1.4 s signing a Blossom auth event, and 2.3–7.2 s in a single PUT round-trip for 16 KB.

Two hypotheses were measured and disproved along the way, rather than shipped as fixes: a capability probe that turned out to be noise, and a suspected upload retry that never happened.

### What changed

**The thumbnail leg runs beside the video transfer.** It only reads the local file and never touches the transfer's result, so it no longer waits. It was the shorter leg in all nine runs, so it lands first and leaves the critical path entirely.

**The blurhash moved into that leg.** Publishing used to decode the video a second time to extract a frame for it — 568 ms measured — 220 ms after the upload leg had decoded the very same frame at the very same timestamp. The leg now derives it from the frame it already holds and persists it on the upload record (`PendingUpload.blurhash`, Hive index 26).

**The video is no longer hashed twice.** The publisher read the whole video back into memory to compute its SHA-256, which the upload had already streamed and returned as `videoId` — Blossom is content-addressed. The second pass also defeated the streaming the upload path does specifically to keep large files out of memory on iOS.

**The progress bar stopped lying.** It reached 100% when the upload finished and then sat there for the ~2 s the tail actually takes. The upload now owns 0–85%, and the tail hands out the rest at real boundaries: 88% once mentions resolve, 92% once the Nostr event is signed (a remote Keycast round-trip, 0.3–1.4 s), 97% once it is accepted, 100% when the draft is gone.

**A failed transfer no longer discards a finished thumbnail.** The reuse guard read a record that was only written once the whole attempt succeeded, so every retry re-extracted, re-signed and re-uploaded a blob already on the CDN.

## Measured effect

Comparable network conditions, before and after, on the same device:

| | before | after |
|---|---|---|
| network | 0.73 MB/s | 0.75 MB/s |
| total publish | 14 387 ms | **9 736 ms** |

**−32% at equal bandwidth.** The gain grows as conditions worsen: on a 0.22 MB/s run the same publish would have cost ~37 s sequentially and took 27 s.

Structurally, the thumbnail is now fully absorbed. `upload` equals the transfer plus ~110–140 ms in every run since, where it used to be transfer + thumbnail. In the run quoted above the thumbnail took 6 403 ms and cost nothing.

The unexplained gap inside the Nostr phase closed too: 734 ms before, 34 ms now.

## Out of Scope

Everything still on the clock is outside this app:

- `net.put` — 2 273 to 7 216 ms for a constant 16 572 bytes, with no relation to bandwidth. On a 50 Mbit/s line that is ~3 ms of transfer; the rest is latency or server-side work. Scoping note from review: the thumbnail PUT is served in-process at the Fastly edge (`media.divine.video` only proxies to `cloud-run-upload` above 500 KB or for video MIME types), so this cost lives at the edge, not in the upload service.
- The Keycast signatures. The account signs via `KeycastNostrIdentity` with `authSource=divineOAuth`, which has no local key, so every signature is an RPC round-trip. Two of the three now overlap the transfer; only the event signature is left on the critical path.
- Draft deletion and file cleanup, still ~0.4–1.3 s after the event is published — divinevideo/divine-mobile#6548.
- Orphaned blobs from publishes that never completed — divinevideo/divine-blossom#163.

Worth noting for whoever picks up the backend side: the **video** PUT (proxied to `cloud-run-upload` by MIME type) runs an ffmpeg thumbnail extraction **and** a dimension probe synchronously before responding, for every video — divinevideo/divine-blossom#164. The client extracts and uploads its own thumbnail anyway, so that work is duplicated and sits on the response path of the client's upload.

## Verification

- `flutter analyze lib test` — clean
- `flutter test test/services/ test/models/ test/repositories/ test/blocs/… test/providers/…` — 4 288 passing
- `blossom_upload_service` package suite — 228 passing, coverage 100.00% (958/958), gate held
- `dart format` clean; Hive adapter regenerated and committed
- Manually verified on a real Samsung Galaxy across nine publishes; every commit was measured on device before the next one was written

Each behavioural change is pinned by a test that was confirmed to fail without it:

- thumbnail parallelism — the video stub only resolves once the thumbnail leg has started
- progress — never moves backwards, never reports 100% before the event lands, and carries the signing step
- digest reuse — the emitted `x` component is the upload's `videoId` and explicitly not the SHA-256 of the file contents
- retry — one failed transfer, thumbnail uploaded exactly once (it uploaded twice before)

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor

