### PR TITLE
fix(test): wait for the save result before asserting the stop-motion cleanup

### DIFF
--- a/mobile/test/blocs/clips_library/clips_library_bloc_test.dart
+++ b/mobile/test/blocs/clips_library/clips_library_bloc_test.dart
@@ -1096,7 +1096,18 @@ void main() {
           selectedDuration: const Duration(seconds: 1),
         ),
         build: createBloc,
-        act: (bloc) => bloc.add(const ClipsLibrarySaveToGallery()),
+        // Wait for the save-result state before asserting on disk. The cleanup
+        // runs in the save loop's `finally`, which the handler awaits before
+        // emitting that state — but `blocTest` closes the bloc without waiting
+        // for an in-flight handler, so a bare `add` would race the real (async)
+        // file delete and see the mp4 still there.
+        act: (bloc) async {
+          final saved = bloc.stream.firstWhere(
+            (s) => s.lastGallerySaveResult is GallerySaveResultSuccess,
+          );
+          bloc.add(const ClipsLibrarySaveToGallery());
+          await saved;
+        },
         verify: (_) {
           final captured =
               verify(


### PR DESCRIPTION
## Description

Fixes the intermittent failure of `ClipsLibraryBloc ClipsLibrarySaveToGallery cleans up the transient mp4 after saving a stop-motion clip`.

**Root cause is in the test harness, not the bloc.** `blocTest` runs `act`, waits a single `Duration.zero` turn, then calls `bloc.close()`. `Bloc.close()` calls `emitter.cancel()`, and `_Emitter.cancel()` completes the emitter's future *immediately* — it never awaits the handler body. Everything past the handler's current `await` keeps running detached, and `verify` can run before it lands.

That one turn is plenty for a chain of microtasks (the mocked gallery service, the `async` render overrides), which is why the test usually passes. It is not enough for `File.delete()`: that goes to the I/O thread pool, and whether its completion beats the zero-duration timer depends on machine load. Hence green locally, green on a re-run at the *same* ordering seed, red under CI's `--concurrency=4`.

The fix waits for the state the handler emits after the cleanup. `cleanupMaterializedOutput` runs in the save loop's `finally`, which the handler awaits before emitting `lastGallerySaveResult` — so that state is a real barrier for the delete, not a timing bet. `bloc.stream.firstWhere` inside `act` is already the idiom used in `clip_editor_bloc_test.dart`, `conversation_list_bloc_test.dart` and others.

Deliberately **not** `wait:` or a longer `pumpEventQueue` — both are the same race with a bigger number attached.

The two hypotheses in the issue were checked and ruled out:

- **Leaking statics.** All four test files that set `StopMotionRenderService.assembleOverride` / `probeDurationOverride` reset them in a `tearDown`. Leakage would also be ordering-dependent, and the issue reports the same seed producing both outcomes.
- **Deletion not awaited in the bloc's `finally`.** It is awaited; no production change is needed.

**Related Issue:** Closes #6557

## Out of Scope

`video_recorder_bloc_test.dart` has four assertions of the same shape (filesystem state in `verify`), but they use `await pumpEventQueue()` in `act`, which yields real event-loop turns and is far more robust. None have been reported flaky, so they are left alone.

## Verification

Confirmed the mechanism with a throwaway repro reproducing exactly this shape — a handler with `finally { await file.delete(); }` and the assertion in `verify`:

| Repro | Result |
|---|---|
| Bare `bloc.add` in `act`, 300 iterations | **1 failure** |
| Awaiting the terminal state in `act`, 300 iterations | 300/300 pass |

On the real suite:

- `flutter test test/blocs/clips_library/clips_library_bloc_test.dart` — 12 consecutive runs, 12/12 green (41 tests)
- `flutter analyze lib test integration_test` — no issues
- `dart format` — no changes

Not run: the full shard-3 reproduction from the issue. Its hit rate is roughly one failure per several 14k-test runs, which is weaker evidence than the 300-iteration measurement against the isolated mechanism.

No device testing — the diff is one test file, with no runtime behaviour change.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)