### PR TITLE
chore(feed): delete the dead _LoadingIndicator

### DIFF
--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -964,47 +964,6 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
   }
 }
 
-class _LoadingIndicator extends StatefulWidget {
-  const _LoadingIndicator();
-
-  @override
-  State<_LoadingIndicator> createState() => _LoadingIndicatorState();
-}
-
-class _LoadingIndicatorState extends State<_LoadingIndicator> {
-  // Delay before the indicator becomes visible. Suppresses sub-threshold
-  // flashes that occur during play/pause and loop-enforcement seeks without
-  // hiding the indicator during genuine long loads.
-  static const _delay = Duration(milliseconds: 100);
-  static const _fadeDuration = Duration(milliseconds: 150);
-
-  bool _visible = false;
-  Timer? _timer;
-
-  @override
-  void initState() {
-    super.initState();
-    _timer = Timer(_delay, () {
-      if (mounted) setState(() => _visible = true);
-    });
-  }
-
-  @override
-  void dispose() {
-    _timer?.cancel();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return AnimatedOpacity(
-      duration: _fadeDuration,
-      opacity: _visible ? 1.0 : 0.0,
-      child: const Center(child: BrandedLoadingIndicator(size: 60)),
-    );
-  }
-}
-
 /// Wraps the fullscreen video feed in a [NavRoundedShell] when the
 /// inline comment composer bar is on screen, so the bottom of the
 /// video carries the same rounded-corner treatment as the home feed.


### PR DESCRIPTION
## Description

Deletes the private `_LoadingIndicator` / `_LoadingIndicatorState` pair in `mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart`. It is never instantiated — the only four references in the repo were its own class declaration, constructor, `createState`, and the State class. It is file-private and the file has no `part` directive, so nothing outside could reach it either.

The other `_LoadingIndicator`s that grep turns up (`add_to_list_dialog.dart`, `camera_permission_gate.dart`, `video_loading_placeholder.dart`) are separate file-scoped classes and all in use.

Why delete rather than polish: the widget carried the last non-doc reference to the seek-based loop enforcement removed in #6489 — its `_delay` constant was justified with "flashes that occur during play/pause and loop-enforcement seeks". Trimming that comment was suggested during review of #6489, but touching up a widget that never builds is the wrong fix.

**Related Issue:** Closes #6492

## Out of Scope

None. Pure deletion, no behaviour change.

## Verification

- Confirmed no imports go stale: `dart:async` is still needed for `unawaited`/`Future`, and `BrandedLoadingIndicator` is still used at two other call sites in the same file.
- `flutter analyze` on the changed file — no issues.
- `flutter test test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart test/screens/feed/pooled_fullscreen_video_feed_args_test.dart test/screens/feed/video_tap_shield_test.dart test/screens/feed/keyboard_aware_top_fade_test.dart` — 47/47 pass.
- No device verification: the deleted widget never built, so there is nothing observable to check on a real device.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore