### PR TITLE
fix(video-player): clamp an over-long audio track to the video end

### DIFF
--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -958,6 +958,13 @@ internal class DivineVideoPlayerInstance(
         val trimMs = playbackEndMs - commonEndMs
         if (commonEndMs <= startMs || trimMs <= 0) return null
 
+        // The bound only exists to stop a stub audio track collapsing a real
+        // video into a tiny loop, and that risk only runs one way. Where the
+        // audio track is the longer one the clamp lands on the video's own
+        // end, and everything past it is audio over a frozen frame — which is
+        // the seam itself, whatever its length.
+        if (audioEndMs > videoEndMs) return commonEndMs
+
         val playableDurationMs = playbackEndMs - startMs
         if (playableDurationMs <= 0) return null
 
@@ -1772,7 +1779,12 @@ internal class DivineVideoPlayerInstance(
          */
         private const val MIN_PLAYBACK_SPEED = 0.001f
 
-        /** Maximum tail considered an encoder/export track-end mismatch. */
+        /**
+         * Maximum tail considered an encoder/export track-end mismatch, for
+         * the direction where clamping discards video the viewer can see —
+         * an audio track shorter than the video. The other direction is
+         * unbounded; see [boundedCommonTrackEndMs].
+         */
         private const val MAX_COMMON_TRACK_END_TRIM_MS = 500L
         private const val MAX_COMMON_TRACK_END_TRIM_RATIO = 0.10
 

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -899,6 +899,47 @@ class DivineVideoPlayerInstanceTest {
     }
 
     @Test
+    fun `an audio track longer than the video is clamped past the trim bound`() {
+        every { mockPlayer.mediaItemCount } returns 1
+        every { mockPlayer.getMediaItemAt(0) } returns MediaItem.Builder().build()
+
+        // An archived Vine: 6.533 s of video against a 7.287 s audio track,
+        // whose own last packet is at 6.525 s. The 754 ms the mux claims past
+        // the video are a frozen last frame over silence, and they are over
+        // the 500 ms bound that guards the opposite mismatch.
+        withTrackDurations(videoUs = 6_533_000L, audioUs = 7_287_000L) {
+            instance.onMethodCall(
+                trimmingSetClipsCall("https://cdn.example/long-audio.mp4"),
+                mockk(relaxed = true),
+            )
+            capturePostedRunnables().forEach { it.run() }
+        }
+
+        val replaced = slot<MediaItem>()
+        verify { mockPlayer.replaceMediaItem(0, capture(replaced)) }
+        assertEquals(6_533L, replaced.captured.clippingConfiguration.endPositionMs)
+    }
+
+    @Test
+    fun `a video track longer than the audio keeps the trim bound`() {
+        every { mockPlayer.mediaItemCount } returns 1
+        every { mockPlayer.getMediaItemAt(0) } returns MediaItem.Builder().build()
+
+        // The same 754 ms mismatch the other way round. Clamping here would
+        // discard video the viewer can see, so a stub audio track must not be
+        // allowed to cut the clip short.
+        withTrackDurations(videoUs = 7_287_000L, audioUs = 6_533_000L) {
+            instance.onMethodCall(
+                trimmingSetClipsCall("https://cdn.example/short-audio.mp4"),
+                mockk(relaxed = true),
+            )
+            capturePostedRunnables().forEach { it.run() }
+        }
+
+        verify(exactly = 0) { mockPlayer.replaceMediaItem(any(), any()) }
+    }
+
+    @Test
     fun `a resolved clamp is not applied over a playlist already playing`() {
         every { mockPlayer.mediaItemCount } returns 1
         every { mockPlayer.getMediaItemAt(0) } returns MediaItem.Builder().build()

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -33,6 +33,9 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
 
     private static let setClipsTimeoutMs = 10_000
     private static let bufferingStallMs = 8_000
+    /// Bounds on the loop-seam clamp, for the direction where clamping
+    /// discards video the viewer can see — an audio track shorter than the
+    /// video. The other direction is unbounded; see `boundedCommonTrackEnd`.
     private static let maxCommonTrackEndTrimMs = 500.0
     private static let maxCommonTrackEndTrimRatio = 0.10
     /// Length of the fade applied to each outer edge of the composition.
@@ -880,6 +883,15 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
               CMTimeCompare(playbackEnd, commonEnd) > 0
         else {
             return nil
+        }
+
+        // The bound only exists to stop a stub audio track collapsing a real
+        // video into a tiny loop, and that risk only runs one way. Where the
+        // audio track is the longer one the clamp lands on the video's own
+        // end, and everything past it is audio over a frozen frame — which is
+        // the seam itself, whatever its length.
+        if CMTimeCompare(audioEnd, videoEnd) > 0 {
+            return commonEnd
         }
 
         let trimMs = CMTimeSubtract(playbackEnd, commonEnd).seconds * 1000

--- a/mobile/packages/divine_video_player/test/src/loop_seam_trim_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/loop_seam_trim_contract_test.dart
@@ -49,6 +49,14 @@ void main() {
             'The clamp must also be relative to playable duration so short '
             'clips cannot lose an excessive fraction of content.',
       );
+      expect(
+        source,
+        contains('if CMTimeCompare(audioEnd, videoEnd) > 0 {'),
+        reason:
+            'The bound only guards against discarding visible video, so it '
+            'must not apply when the audio track is the longer one — that '
+            'excess is a frozen frame at every loop restart.',
+      );
     });
 
     test('Android clamps the clipping configuration, not just endMs', () {
@@ -88,6 +96,14 @@ void main() {
         reason:
             'The clamp must also be relative to playable duration so short '
             'clips cannot lose an excessive fraction of content.',
+      );
+      expect(
+        source,
+        contains('if (audioEndMs > videoEndMs) return commonEndMs'),
+        reason:
+            'The bound only guards against discarding visible video, so it '
+            'must not apply when the audio track is the longer one — that '
+            'excess is a frozen frame at every loop restart.',
       );
     });
 


### PR DESCRIPTION
## Description

`boundedCommonTrackEndMs` clamps a looping clip to the point where both tracks still have content, but only while the trim stays under `min(500 ms, 10% of playable duration)`. Past that it returns `null` and the loop runs to the container duration.

That bound protects one direction only. An audio track much *shorter* than the video must not collapse a real video into a tiny loop, because clamping there discards frames the viewer can see. Where the **audio** is the longer track there is nothing to lose: the excess plays over a frozen last frame, which is the seam itself whatever its length.

So the bound becomes asymmetric — unchanged when the video track is the longer one, skipped entirely when the audio track is.

The relaxed direction deliberately carries no lower floor. Feed clips are Vine-length — every video track in the seed corpus runs 6.47–6.53 s — so clamping to the video end can never discard a meaningful stretch, and a frozen last frame is not the better outcome at any length. A floor would only guard against a mux declaring a wrongly *short* video track, which is the opposite of what the corpus shows: all eight seed videos are audio ≥ video.

The archived Vine measured in #6486 (`0189ef5a…mp4`, `Lavf56.36`) declares 6.533 s of video against 7.287 s of audio, while the audio's own last packet sits at 6.525 s and `ffmpeg` extracts no frame past 6.6 s. The 762 ms the mux claims beyond that last packet are a wrong length, so clamping to the video end discards zero audio. The trim needed is 754 ms — over the bound, so neither platform clamped it, and every loop restart replayed 754 ms of frozen frame and silence on iOS and Android alike.

Both platforms share the constants, so the early return lands in `DivineVideoPlayerInstance.kt` and `DivineVideoPlayerInstance.swift` together, and the cross-platform contract test pins the asymmetry for both source files.

Scope note from the issue: no video in a 59-video live feed sample exceeds the bound (worst case 69 ms), so this is archive-corpus material rather than fresh uploads. #6469 fixed the in-bound cases; this is the remainder.

**Related Issue:** Closes #6486

## Out of Scope

The editor-side `commonTrackEnd` in `mobile/lib/services/video_editor/clip_media_duration.dart` has its own `minCommonTrackEnd` floor and is unrelated to loop seams — left untouched.

## Verification

- `gradle :divine_video_player:testDebugUnitTest` — green. Two new Kotlin tests use the issue's numbers: 6.533 s video / 7.287 s audio clamps to 6 533 ms, and the same 754 ms mismatch the other way round stays unclamped. Red/green verified — with the early return removed the first one fails.
- `flutter test` in `mobile/packages/divine_video_player` — 278 passed, including the extended contract test.
- `flutter analyze`, `dart format`, `swiftc -parse` on the Swift file — clean.
- Device pass on a real Samsung Galaxy (SM-S942B, Android 16): debug build installed from this branch, feed plays through loop restarts, no regression in playback.
- Also run on macOS, which builds and executes the same `DivineVideoPlayerInstance.swift` the iOS player uses: app launches, feed plays, no new player errors.
- iOS itself is parse-checked only, not built on a device.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

