### PR TITLE
perf(publish): reclaim published drafts off the publish critical path

### DIFF
--- a/mobile/lib/blocs/background_publish/background_publish_bloc.dart
+++ b/mobile/lib/blocs/background_publish/background_publish_bloc.dart
@@ -94,6 +94,9 @@ class BackgroundPublishBloc
         ),
       );
 
+      // Deliberately after the emit above: the video is already live, so the
+      // draft row and its unreferenced media are reclaimed off the publish
+      // critical path rather than in front of the success state (#6548).
       await _deletePublishedDrafts(event.draft);
     } else {
       // Update the upload with the result
@@ -313,6 +316,10 @@ class BackgroundPublishBloc
     emit(state.copyWith(uploads: [...state.uploads, failedUpload]));
   }
 
+  /// Reclaims a published draft: the publish copy, plus the draft it was
+  /// copied from. Sole owner of post-publish draft deletion — the publish
+  /// service intentionally leaves the draft in place (see
+  /// [VideoPublishService.publishVideo]).
   Future<void> _deletePublishedDrafts(DivineVideoDraft publishedDraft) async {
     await _deleteDraft(publishedDraft.id);
 

--- a/mobile/lib/blocs/background_publish/background_publish_bloc.dart
+++ b/mobile/lib/blocs/background_publish/background_publish_bloc.dart
@@ -44,7 +44,8 @@ class BackgroundPublishBloc
 
   /// Keeps the process foregrounded for the whole publish so the in-process
   /// steps after the OS-backed upload (signing, relay broadcast) survive app
-  /// suspension. Null disables the behaviour (e.g. in tests).
+  /// suspension, and so do the durable writes that record how the publish
+  /// ended. Null disables the behaviour (e.g. in tests).
   final PublishForegroundSession? _foregroundSession;
 
   Future<void> _onBackgroundPublishRequested(
@@ -64,10 +65,65 @@ class BackgroundPublishBloc
       emit(state.copyWith(uploads: [...state.uploads, newUpload]));
     }
 
-    PublishResult result;
     await _beginForegroundSession(event.draft.id);
     try {
-      result = await event.publishmentProcess;
+      final result = await _awaitPublishResult(event.publishmentProcess);
+
+      // Remove the upload if it was successful
+      if (result is PublishSuccess) {
+        final updatedUploads = state.uploads
+            .where((upload) => upload.draft.id != event.draft.id)
+            .toList();
+
+        emit(
+          state.copyWith(
+            uploads: updatedUploads,
+            recentlySucceededIds: {event.draft.id},
+          ),
+        );
+
+        // After the emit — the video is already live, so the draft row and its
+        // unreferenced media are reclaimed off the publish critical path
+        // rather than in front of the success state (#6548). Still inside the
+        // foreground session: deleting the row is the only record that this
+        // publish finished, so losing the process first makes resume offer a
+        // retry for an already-published video.
+        await _deletePublishedDrafts(event.draft);
+      } else {
+        // Update the upload with the result
+        final updatedUploads = state.uploads.map((upload) {
+          if (upload.draft.id == event.draft.id) {
+            return upload.copyWith(result: result, progress: 1.0);
+          }
+          return upload;
+        }).toList();
+
+        emit(state.copyWith(uploads: updatedUploads));
+
+        // Persist the classified kind (same encoding the service writes), so
+        // the service/bloc writes are idempotent and resume re-localizes
+        // correctly.
+        final publishError = result is PublishError
+            ? result.toPersistedString()
+            : null;
+        await _persistPublishStatus(
+          draftId: event.draft.id,
+          status: PublishStatus.failed,
+          publishError: publishError,
+        );
+      }
+    } finally {
+      await _endForegroundSession(event.draft.id);
+    }
+  }
+
+  /// Awaits the publish, turning a thrown error into a [PublishError] so the
+  /// caller always has a result to record.
+  Future<PublishResult> _awaitPublishResult(
+    Future<PublishResult> publishmentProcess,
+  ) async {
+    try {
+      return await publishmentProcess;
     } catch (e, stackTrace) {
       Log.error(
         'Publish process threw an exception: $e',
@@ -76,49 +132,7 @@ class BackgroundPublishBloc
         stackTrace: stackTrace,
       );
       addError(e, stackTrace);
-      result = const PublishError(PublishErrorKind.generic);
-    } finally {
-      await _endForegroundSession(event.draft.id);
-    }
-
-    // Remove the upload if it was successful
-    if (result is PublishSuccess) {
-      final updatedUploads = state.uploads
-          .where((upload) => upload.draft.id != event.draft.id)
-          .toList();
-
-      emit(
-        state.copyWith(
-          uploads: updatedUploads,
-          recentlySucceededIds: {event.draft.id},
-        ),
-      );
-
-      // Deliberately after the emit above: the video is already live, so the
-      // draft row and its unreferenced media are reclaimed off the publish
-      // critical path rather than in front of the success state (#6548).
-      await _deletePublishedDrafts(event.draft);
-    } else {
-      // Update the upload with the result
-      final updatedUploads = state.uploads.map((upload) {
-        if (upload.draft.id == event.draft.id) {
-          return upload.copyWith(result: result, progress: 1.0);
-        }
-        return upload;
-      }).toList();
-
-      emit(state.copyWith(uploads: updatedUploads));
-
-      // Persist the classified kind (same encoding the service writes), so the
-      // service/bloc writes are idempotent and resume re-localizes correctly.
-      final publishError = result is PublishError
-          ? result.toPersistedString()
-          : null;
-      await _persistPublishStatus(
-        draftId: event.draft.id,
-        status: PublishStatus.failed,
-        publishError: publishError,
-      );
+      return const PublishError(PublishErrorKind.generic);
     }
   }
 

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -703,14 +703,18 @@ class DraftStorageService {
   /// the last referencing clip is gone. Never throws: a corrupt blob is logged
   /// and skipped.
   ///
-  /// Trashed clips are included (`includeTrashed: true`): a soft-deleted clip
-  /// can still be restored, so a ghost frame it shares with the draft being
-  /// deleted must survive. This mirrors [ClipsDao.isFileReferenced], which
-  /// already protects the indexed video/thumbnail files of trashed clips.
+  /// Trashed clips are included: a soft-deleted clip can still be restored, so
+  /// a ghost frame it shares with the draft being deleted must survive. This
+  /// mirrors [ClipsDao.isFileReferenced], which already protects the indexed
+  /// video/thumbnail files of trashed clips.
+  ///
+  /// Uses [ClipsDao.getClipsWithGhostFrames] rather than reading the whole clip
+  /// table: this scan runs on every draft deletion, and decoding every blob in
+  /// the database made it grow with the size of the clip library (#6548).
   Future<Set<String>> _referencedGhostFrameFilenames({
     String? excludeDraftId,
   }) async {
-    final clipRows = await _clipsDao.getAllClips(includeTrashed: true);
+    final clipRows = await _clipsDao.getClipsWithGhostFrames();
     final filenames = <String>{};
 
     for (final row in clipRows) {

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -198,9 +198,10 @@ class VideoPublishService {
   /// Share of the publish bar owned by the upload.
   ///
   /// Everything after it — resolving mentions, signing and broadcasting the
-  /// Nostr event, reclaiming the draft — measured ~2s on device, and the bar
-  /// used to reach 100% before any of it ran. The remainder is handed out at
-  /// the boundaries below so the bar never claims to be done while it isn't.
+  /// Nostr event, sending collaborator invites — measured ~2s on device, and
+  /// the bar used to reach 100% before any of it ran. The remainder is handed
+  /// out at the boundaries below so the bar never claims to be done while it
+  /// isn't.
   static const double _uploadProgressShare = 0.85;
 
   /// Reached once mentions and subtitle assets are resolved.
@@ -229,6 +230,13 @@ class VideoPublishService {
   ///
   /// Wraps the publish in a [PublishTimeline] so every run emits per-phase
   /// timing plus a summary line, whichever way it ends.
+  ///
+  /// A successful publish does *not* delete the draft. Reclaiming the draft
+  /// row and its unreferenced media is `BackgroundPublishBloc`'s job
+  /// (`_deletePublishedDrafts`), which runs after the success state is emitted
+  /// — the video is already live at that point, so making the caller wait on
+  /// garbage collection only delays the UI (#6548). The bloc also deletes the
+  /// source draft this publish copy came from, which this service never saw.
   Future<PublishResult> publishVideo({required DivineVideoDraft draft}) async {
     final timeline = PublishTimeline(draft.id);
     PublishResult? result;
@@ -412,10 +420,6 @@ class VideoPublishService {
           creatorPubkey: pubkey,
         ),
       );
-
-      // Success: delete draft
-      await draftService.deleteDraft(draft.id);
-      Log.debug('🗑️ Deleted publish draft: ${draft.id}', category: .video);
 
       onProgressChanged(draftId: draft.id, progress: 1);
 

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -198,10 +198,11 @@ class VideoPublishService {
   /// Share of the publish bar owned by the upload.
   ///
   /// Everything after it — resolving mentions, signing and broadcasting the
-  /// Nostr event, sending collaborator invites — measured ~2s on device, and
-  /// the bar used to reach 100% before any of it ran. The remainder is handed
-  /// out at the boundaries below so the bar never claims to be done while it
-  /// isn't.
+  /// Nostr event, sending collaborator invites — measured ~2s on device back
+  /// when draft reclamation was still part of that tail (#6548 moved it to
+  /// the bloc), and the bar used to reach 100% before any of it ran. The
+  /// remainder is handed out at the boundaries below so the bar never claims
+  /// to be done while it isn't.
   static const double _uploadProgressShare = 0.85;
 
   /// Reached once mentions and subtitle assets are resolved.

--- a/mobile/lib/widgets/library/drafts_tab.dart
+++ b/mobile/lib/widgets/library/drafts_tab.dart
@@ -221,7 +221,9 @@ class DraftsTab extends ConsumerWidget {
     );
     await ref.read(videoPublishProvider.notifier).publishVideo(context, draft);
 
-    // Reload drafts to reflect deletion (handled by publishVideo)
+    // Reload so a published draft leaves the list. BackgroundPublishBloc owns
+    // that deletion and runs it after its success state, so a reload racing it
+    // can still show the draft until the next one.
     if (context.mounted) {
       context.read<DraftsLibraryBloc>().add(const DraftsLibraryLoadRequested());
     }

--- a/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
@@ -82,9 +82,9 @@ class ClipsDao extends DatabaseAccessor<AppDatabase> with _$ClipsDaoMixin {
   /// provided, returns only clips owned by that account **plus** legacy
   /// clips with no owner.
   ///
-  /// [includeTrashed] is for file-reference scans that must keep a
-  /// trashed (restorable) clip's files alive — active-clip listings should
-  /// leave it at its default.
+  /// [includeTrashed] keeps trashed (restorable) clips in the result — useful
+  /// when the caller must account for a clip that can come back. Active-clip
+  /// listings should leave it at its default.
   Future<List<ClipRow>> getAllClips({
     int? limit,
     String? ownerPubkey,
@@ -106,7 +106,9 @@ class ClipsDao extends DatabaseAccessor<AppDatabase> with _$ClipsDaoMixin {
   }
 
   /// Every clip row that carries a non-null `ghostFramePath`, projected to the
-  /// two fields a ghost-frame reference scan needs.
+  /// fields a ghost-frame reference scan needs: `draftId` to skip the draft
+  /// being deleted, `data` to read the frame out of, and `id` to name the row
+  /// if its blob turns out to be corrupt.
   ///
   /// Ghost frames have no indexed column — they exist only inside the `data`
   /// blob — so the alternative is loading and JSON-decoding *every* clip row in

--- a/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
@@ -105,6 +105,45 @@ class ClipsDao extends DatabaseAccessor<AppDatabase> with _$ClipsDaoMixin {
     return query.get();
   }
 
+  /// Every clip row that carries a non-null `ghostFramePath`, projected to the
+  /// two fields a ghost-frame reference scan needs.
+  ///
+  /// Ghost frames have no indexed column — they exist only inside the `data`
+  /// blob — so the alternative is loading and JSON-decoding *every* clip row in
+  /// the database, which grows with the whole clip library. The `LIKE` still
+  /// scans the table, but SQLite discards the non-matching rows before they
+  /// cross into Dart, and clips carrying a ghost frame are a small minority of
+  /// a typical library.
+  ///
+  /// Trashed clips are included: a soft-deleted clip can still be restored, so
+  /// a ghost frame it references must survive a sharing draft's deletion.
+  ///
+  /// The predicate matches the encoding `DivineVideoClip.toJson` produces for
+  /// a set ghost frame. A clip whose `ghostFramePath` is null serializes to
+  /// `"ghostFramePath":null` and is correctly skipped. Because the filter
+  /// depends on that encoding, the app layer pins it end-to-end against the
+  /// real model in `draft_storage_service_test.dart`.
+  Future<List<({String id, String? draftId, String data})>>
+  getClipsWithGhostFrames() async {
+    final rows = await customSelect(
+      'SELECT id, draft_id, data FROM clips WHERE data LIKE ?',
+      variables: [Variable.withString('%$_ghostFramePathJsonPrefix%')],
+      readsFrom: {clips},
+    ).get();
+
+    return [
+      for (final row in rows)
+        (
+          id: row.read<String>('id'),
+          draftId: row.read<String?>('draft_id'),
+          data: row.read<String>('data'),
+        ),
+    ];
+  }
+
+  /// Serialized prefix of a set `ghostFramePath` inside a clip's `data` blob.
+  static const _ghostFramePathJsonPrefix = '"ghostFramePath":"';
+
   /// Update the order index of a clip
   Future<bool> updateOrderIndex({
     required String id,

--- a/mobile/packages/db_client/test/src/database/daos/clips_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/clips_dao_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: operations. Tests upsertClip, getClipsByDraftId, deleteClip,
 // ABOUTME: deleteClipsByDraftId, watchClipsByDraftId.
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:db_client/db_client.dart';
@@ -439,6 +440,90 @@ void main() {
           results.map((c) => c.id),
           containsAll(<String>['clip_active', 'clip_trashed']),
         );
+      });
+    });
+
+    group('getClipsWithGhostFrames', () {
+      Future<void> insertClip({
+        required String id,
+        required String data,
+        String? draftId,
+      }) => dao.upsertClip(
+        id: id,
+        draftId: draftId,
+        orderIndex: 0,
+        durationMs: 3000,
+        recordedAt: DateTime(2023, 11, 14, 10),
+        filePath: null,
+        thumbnailPath: null,
+        data: data,
+      );
+
+      test('returns only clips carrying a ghost frame', () async {
+        await insertClip(
+          id: 'clip_ghost',
+          draftId: testDraftId,
+          data: json.encode({
+            'filePath': 'video.mp4',
+            'ghostFramePath': 'ghost.jpg',
+          }),
+        );
+        await insertClip(
+          id: 'clip_null_ghost',
+          draftId: testDraftId,
+          data: json.encode({'filePath': 'video.mp4', 'ghostFramePath': null}),
+        );
+        await insertClip(
+          id: 'clip_no_key',
+          draftId: testDraftId,
+          data: json.encode({'filePath': 'video.mp4'}),
+        );
+
+        final results = await dao.getClipsWithGhostFrames();
+
+        expect(results, hasLength(1));
+        expect(results.single.id, equals('clip_ghost'));
+        expect(results.single.draftId, equals(testDraftId));
+        expect(results.single.data, contains('ghost.jpg'));
+      });
+
+      test('includes trashed and library clips', () async {
+        // A trashed clip can be restored and a library clip has no draft, so
+        // both still hold their ghost frame alive.
+        await insertClip(
+          id: 'clip_trashed',
+          draftId: testDraftId,
+          data: json.encode({'ghostFramePath': 'trashed_ghost.jpg'}),
+        );
+        await dao.softDeleteClip(
+          id: 'clip_trashed',
+          deletedAt: DateTime(2023, 11, 15),
+        );
+        await insertClip(
+          id: 'clip_library',
+          data: json.encode({'ghostFramePath': 'library_ghost.jpg'}),
+        );
+
+        final results = await dao.getClipsWithGhostFrames();
+
+        expect(
+          results.map((row) => row.id),
+          containsAll(<String>['clip_trashed', 'clip_library']),
+        );
+        expect(
+          results.firstWhere((row) => row.id == 'clip_library').draftId,
+          isNull,
+        );
+      });
+
+      test('returns empty list when no clip has a ghost frame', () async {
+        await insertClip(
+          id: 'clip_plain',
+          draftId: testDraftId,
+          data: json.encode({'filePath': 'video.mp4'}),
+        );
+
+        expect(await dao.getClipsWithGhostFrames(), isEmpty);
       });
     });
 

--- a/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
+++ b/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
@@ -173,6 +173,51 @@ void main() {
             ).called(1);
           },
         );
+
+        test('emits success before the draft cleanup completes', () async {
+          // Draft deletion reclaims files and rescans the clip table, so it
+          // must never sit in front of the success state — the video is
+          // already live by then (#6548).
+          final cleanupGate = Completer<void>();
+          var cleanupStarted = false;
+          var cleanupFinished = false;
+          when(() => mockDraftStorageService.deleteDraft(draftId)).thenAnswer((
+            _,
+          ) {
+            cleanupStarted = true;
+            return cleanupGate.future.then((_) => cleanupFinished = true);
+          });
+
+          final bloc = BackgroundPublishBloc(
+            videoPublishServiceFactory: defaultVieoPublishServiceFactory,
+            draftStorageService: mockDraftStorageService,
+          );
+          addTearDown(bloc.close);
+
+          final states = <BackgroundPublishState>[];
+          final subscription = bloc.stream.listen(states.add);
+          addTearDown(subscription.cancel);
+
+          bloc.add(
+            BackgroundPublishRequested(
+              draft: draft,
+              publishmentProcess: Future.value(const PublishSuccess()),
+            ),
+          );
+          await pumpEventQueue();
+
+          // The deletion is still gated, yet the UI already sees the publish
+          // land: it is not waiting on garbage collection.
+          expect(states.last.recentlySucceededIds, contains(draftId));
+          expect(states.last.uploads, isEmpty);
+          expect(cleanupStarted, isTrue);
+          expect(cleanupFinished, isFalse);
+
+          // ...and the cleanup still runs to completion afterwards.
+          cleanupGate.complete();
+          await pumpEventQueue();
+          expect(cleanupFinished, isTrue);
+        });
       });
 
       group('when the upload is a failure', () {

--- a/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
+++ b/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
@@ -193,6 +193,13 @@ void main() {
             draftStorageService: mockDraftStorageService,
           );
           addTearDown(bloc.close);
+          // Registered after `bloc.close` so it runs before it — tear-downs
+          // are LIFO. Without it, an expectation failing below would skip the
+          // `complete()` at the end and park `close()` on a gate that never
+          // opens, turning a clear failure into a suite-wide timeout.
+          addTearDown(() {
+            if (!cleanupGate.isCompleted) cleanupGate.complete();
+          });
 
           final states = <BackgroundPublishState>[];
           final subscription = bloc.stream.listen(states.add);
@@ -991,6 +998,45 @@ void main() {
         ),
         verify: (_) {
           expect(session.beginCalls, [draftId]);
+          expect(session.endCalls, [draftId]);
+        },
+      );
+
+      test(
+        'holds the session open until the draft cleanup completes',
+        () async {
+          // Deleting the draft row is the only record that this publish
+          // finished, so it must stay inside the keep-alive window: losing the
+          // process first makes resume offer a retry for an already-live video.
+          final cleanupGate = Completer<void>();
+          when(
+            () => mockDraftStorageService.deleteDraft(draftId),
+          ).thenAnswer((_) => cleanupGate.future);
+
+          final bloc = BackgroundPublishBloc(
+            videoPublishServiceFactory: defaultVieoPublishServiceFactory,
+            draftStorageService: mockDraftStorageService,
+            foregroundSession: session,
+          );
+          addTearDown(bloc.close);
+          addTearDown(() {
+            if (!cleanupGate.isCompleted) cleanupGate.complete();
+          });
+
+          bloc.add(
+            BackgroundPublishRequested(
+              draft: draft,
+              publishmentProcess: Future.value(const PublishSuccess()),
+            ),
+          );
+          await pumpEventQueue();
+
+          expect(session.beginCalls, [draftId]);
+          expect(session.endCalls, isEmpty);
+
+          cleanupGate.complete();
+          await pumpEventQueue();
+
           expect(session.endCalls, [draftId]);
         },
       );

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -2054,7 +2054,7 @@ void main() {
 
       DivineVideoDraft draftWithGhost({
         required String id,
-        required String ghostPath,
+        required String? ghostPath,
       }) => DivineVideoDraft.create(
         id: id,
         clips: [
@@ -2214,6 +2214,54 @@ void main() {
           isFalse,
           reason: 'a corrupt sibling clip must not block ghost-frame cleanup',
         );
+      });
+
+      // [ClipsDao.getClipsWithGhostFrames] pre-filters clip blobs on a literal
+      // serialized key instead of an indexed column, so it is only correct for
+      // as long as it agrees with what [DivineVideoClip.toJson] writes. The
+      // deletion tests above cannot catch a drift between the two: when the
+      // filter matches nothing, `FileCleanupService.deleteGhostFrameFiles`
+      // falls back to `deleteFileIfUnreferenced`, whose JSON scan already
+      // covers `ghostFramePath` via `ClipsDao` and keeps the file alive
+      // anyway. These two go straight at the filter, through the real save
+      // path, so either half drifting turns them red instead of silently
+      // emptying the scan.
+      group('ghost-frame filter encoding', () {
+        test('matches a clip persisted with a ghost frame', () async {
+          final draft = draftWithGhost(
+            id: 'draft_encoding_match',
+            ghostPath: writeGhost('ghost_encoding_match.jpg').path,
+          );
+          await service.saveDraft(draft);
+
+          final rows = await database.clipsDao.getClipsWithGhostFrames();
+
+          expect(
+            rows.map((row) => row.draftId),
+            contains(draft.id),
+            reason:
+                'the SQL pre-filter must still match the encoding '
+                'DivineVideoClip.toJson produces for a set ghost frame',
+          );
+        });
+
+        test('skips a clip persisted without a ghost frame', () async {
+          final draft = draftWithGhost(
+            id: 'draft_encoding_skip',
+            ghostPath: null,
+          );
+          await service.saveDraft(draft);
+
+          final rows = await database.clipsDao.getClipsWithGhostFrames();
+
+          expect(
+            rows,
+            isEmpty,
+            reason:
+                'a null ghost frame serializes to "ghostFramePath":null, so a '
+                'filter that matched it would keep every ghost file forever',
+          );
+        });
       });
     });
   });

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -2194,12 +2194,15 @@ void main() {
         // A sibling clip row whose data blob can't be parsed. The ghost-frame
         // reference scan runs after the target draft's rows are deleted, so an
         // unguarded throw here would leak the deleted draft's ghost file.
+        // The blob is truncated rather than arbitrary text so it still reaches
+        // the decode step — the scan pre-filters on the serialized
+        // `ghostFramePath` key.
         await database.clipsDao.upsertClip(
           id: 'corrupt_sibling_clip',
           orderIndex: 0,
           durationMs: 6000,
           recordedAt: DateTime(2025),
-          data: 'not-json',
+          data: '{"ghostFramePath":"ghost_target.jpg"',
           filePath: null,
           thumbnailPath: null,
         );

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -1281,9 +1281,6 @@ void main() {
           () => mockAuthService.currentPublicKeyHex,
         ).thenReturn('test_pubkey');
         when(() => mockDraftService.saveDraft(any())).thenAnswer((_) async {});
-        when(
-          () => mockDraftService.deleteDraft(any()),
-        ).thenAnswer((_) async {});
         when(() => mockUploadManager.isInitialized).thenReturn(false);
         when(() => mockUploadManager.initialize()).thenAnswer((_) async {});
         when(
@@ -1414,9 +1411,6 @@ void main() {
           () => mockAuthService.currentPublicKeyHex,
         ).thenReturn('test_pubkey');
         when(() => mockDraftService.saveDraft(any())).thenAnswer((_) async {});
-        when(
-          () => mockDraftService.deleteDraft(any()),
-        ).thenAnswer((_) async {});
         when(() => mockUploadManager.isInitialized).thenReturn(true);
 
         final readyUpload = _createPendingUpload(
@@ -1489,9 +1483,6 @@ void main() {
           () => mockAuthService.currentPublicKeyHex,
         ).thenReturn('test_pubkey');
         when(() => mockDraftService.saveDraft(any())).thenAnswer((_) async {});
-        when(
-          () => mockDraftService.deleteDraft(any()),
-        ).thenAnswer((_) async {});
         when(() => mockUploadManager.isInitialized).thenReturn(true);
 
         final uploadingUpload = _createPendingUpload(
@@ -2143,7 +2134,6 @@ void _setupSuccessfulPublish({
   when(() => mockAuthService.isAuthenticated).thenReturn(true);
   when(() => mockAuthService.currentPublicKeyHex).thenReturn('test_pubkey');
   when(() => mockDraftService.saveDraft(any())).thenAnswer((_) async {});
-  when(() => mockDraftService.deleteDraft(any())).thenAnswer((_) async {});
   when(() => mockUploadManager.isInitialized).thenReturn(true);
   when(
     () => mockUploadManager.startUploadFromDraft(

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -123,24 +123,27 @@ void main() {
         expect((result as PublishError).kind, PublishErrorKind.notSignedIn);
       });
 
-      test('returns success when publish completes successfully', () async {
-        // Arrange
-        _setupSuccessfulPublish(
-          mockAuthService: mockAuthService,
-          mockUploadManager: mockUploadManager,
-          mockDraftService: mockDraftService,
-          mockVideoEventPublisher: mockVideoEventPublisher,
-        );
+      test(
+        'returns success and leaves the draft for the bloc to reclaim',
+        () async {
+          // Draft deletion and its file cleanup are BackgroundPublishBloc's job
+          // and run after the success state is emitted — the video is already
+          // live, so the caller must not wait on garbage collection (#6548).
+          _setupSuccessfulPublish(
+            mockAuthService: mockAuthService,
+            mockUploadManager: mockUploadManager,
+            mockDraftService: mockDraftService,
+            mockVideoEventPublisher: mockVideoEventPublisher,
+          );
 
-        final draft = _createTestDraft();
+          final draft = _createTestDraft();
 
-        // Act
-        final result = await service.publishVideo(draft: draft);
+          final result = await service.publishVideo(draft: draft);
 
-        // Assert
-        expect(result, isA<PublishSuccess>());
-        verify(() => mockDraftService.deleteDraft(draft.id)).called(1);
-      });
+          expect(result, isA<PublishSuccess>());
+          verifyNever(() => mockDraftService.deleteDraft(any()));
+        },
+      );
 
       test('holds the bar below 100% until the event lands', () async {
         // Arrange
@@ -613,7 +616,6 @@ void main() {
           final result = await service.publishVideo(draft: draft);
 
           expect(result, isA<PublishSuccess>());
-          verify(() => mockDraftService.deleteDraft(draft.id)).called(1);
         },
       );
 
@@ -1140,7 +1142,6 @@ void main() {
           final result = await service.publishVideo(draft: draft);
 
           expect(result, isA<PublishSuccess>());
-          verify(() => mockDraftService.deleteDraft(draft.id)).called(1);
         },
       );
 


### PR DESCRIPTION
## Description

`VideoPublishService.publishVideo` deleted the draft and reclaimed its files *before* returning `PublishSuccess` — the video was already live at that point, so the user was waiting on garbage collection.

**Ownership is settled on the bloc.** `BackgroundPublishBloc._deletePublishedDrafts` already deletes the publish copy *and* the source draft it was copied from (which the service never saw), after emitting the success state. Every publish result flows through that handler — the provider path and the retry path both hand their future to `BackgroundPublishRequested` — so the service-side deletion was redundant rather than merely mistimed. It is removed, and both sides now document the bloc as the sole owner. A failed reclaim is still surfaced: `_deleteDraft` logs and calls `addError`.

**The full-table clip scan is narrowed.** `deleteDraft` → `_referencedGhostFrameFilenames` loaded *every* clip row in the database and JSON-decoded each `data` blob to find ghost frames a surviving draft still references. That is O(all clips), grows as the clip library grows, and ran twice per publish (publish copy + source draft). New `ClipsDao.getClipsWithGhostFrames()` filters in SQL on the serialized `ghostFramePath` key, so only the few rows that actually carry one cross into Dart and get decoded. The decode and corrupt-blob handling stay where they were.

The SQL pre-filter depends on `DivineVideoClip.toJson`'s encoding, which is why it is pinned end-to-end (real model → real DAO) by the existing shared-ghost-frame tests in `draft_storage_service_test.dart` rather than only by a string-level unit test — if serialization ever drifts, those go red instead of silently deleting a shared ghost frame.

**Related Issue:** Closes #6548

## Out of Scope

- `saveDraft(publishing)` at the start of `publishVideo`, mentioned in the issue as "a smaller version of the same shape". Its orphan diff is O(1) in stored drafts (one row read, and for a status-only flip the orphan list is empty), so it is not part of the growth this issue targets.
- Separately noticed, not fixed here: `video_publish_provider` saves `publishDraft` immediately before handing it to `publishVideo`, which then saves the same draft again with the same status — a redundant full draft+clips upsert on every publish. Left alone because it touches publish-resume semantics; happy to file a follow-up.
- The PUBTIME `other` measurement in the issue's acceptance criteria cannot be reproduced on `main` — that instrumentation lives on `feat/publish-phase-timing`.

## Verification

- `flutter analyze lib test` — clean, in `mobile/` and in `mobile/packages/db_client/`
- `dart format` — clean on all changed files
- `flutter test test/services/video_publish/` (72)
- `flutter test test/blocs/background_publish_bloc/background_publish_bloc_test.dart` (34)
- `flutter test test/services/draft_storage_service_test.dart`, `test/providers/video_publish_provider_test.dart`, `test/providers/video_editor_provider_test.dart`, `test/services/clip_library_service_test.dart` (173 combined)
- `flutter test` in `mobile/packages/db_client` (213)
- Mutation-checked the new ordering test: moving `_deletePublishedDrafts` back in front of the `emit` fails it with `Expected: contains '1' / Actual: Set:[]`, so it is not a test that passes either way.

### Test plan

- [ ] Manual verification on a real Samsung Galaxy: publish a video with a populated draft library, confirm the success state lands promptly, the draft (and its source draft) disappear from the library afterwards, and a stop-motion draft sharing a ghost frame with a duplicate keeps its frames.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
