### PR TITLE
fix(account): prove key control when deleting the server account

### DIFF
--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -28,6 +28,7 @@ import 'package:openvine/services/auth/signer_secure_store.dart';
 import 'package:openvine/services/background_activity_manager.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/nip07_service.dart';
+import 'package:openvine/services/nip98_auth_service.dart';
 import 'package:openvine/services/relay_discovery_service.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:openvine/utils/divine_login_banner_dismissal.dart';
@@ -3133,7 +3134,18 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         );
       }
 
-      final result = await _oauthClient.deleteAccount(accessToken);
+      // Prefer a NIP-98 proof-of-key over the bearer token.
+      // [activeAccountKeycastToken] above may have just minted a refreshed
+      // token, and a refreshed token no longer carries the server's first-party
+      // fact — so the bearer path is exactly the one that gets refused, after
+      // the irreversible NIP-62 vanish has already been published. Signing
+      // proves key control instead. Falls back to the bearer token when signing
+      // is unavailable, so this can ship before the server accepts proofs.
+      // See #5756 / #4881 / keycast#323.
+      final result = await _oauthClient.deleteAccount(
+        accessToken,
+        nip98Signer: _signAccountDeletionProof,
+      );
 
       if (result.success) {
         Log.info(
@@ -3165,6 +3177,54 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         error: 'Failed to delete Keycast account: $e',
         requiresReauthentication: false,
       );
+    }
+  }
+
+  /// NIP-98 signer, built on first use against this instance.
+  ///
+  /// Reuses the audited token construction in [Nip98AuthService] rather than
+  /// hand-rolling a second kind-27235 code path for one call site. Deliberately
+  /// nullable rather than `late final`, so [dispose] does not construct one (and
+  /// start its cache-cleanup timer) purely in order to tear it down.
+  Nip98AuthService? _nip98AuthService;
+
+  Nip98AuthService get _nip98Auth =>
+      _nip98AuthService ??= Nip98AuthService(authService: this);
+
+  /// Sign a NIP-98 proof-of-key for the account-deletion request at [url].
+  ///
+  /// Returns the base64 event body, or null when a proof cannot be produced —
+  /// in which case the caller falls back to the bearer token. Never throws:
+  /// failing to sign must not abort a deletion that the bearer path could still
+  /// complete.
+  ///
+  /// The signer must still be alive here. It is: the flow signs and publishes
+  /// the kind-62 vanish moments earlier, so a working signer is a precondition
+  /// of reaching this point at all. If that ordering ever changes, this returns
+  /// null and the call silently degrades to the bearer token — which is the
+  /// behavior this exists to avoid, so keep the ordering.
+  Future<String?> _signAccountDeletionProof(String url) async {
+    try {
+      final token = await _nip98Auth.createAuthToken(
+        url: url,
+        method: HttpMethod.delete,
+      );
+      if (token == null) {
+        Log.warning(
+          'Could not sign NIP-98 proof for account deletion; '
+          'falling back to bearer token',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+      }
+      return token?.token;
+    } catch (e) {
+      Log.warning(
+        'NIP-98 proof signing threw for account deletion: $e',
+        name: 'AuthService',
+        category: LogCategory.auth,
+      );
+      return null;
     }
   }
 
@@ -4632,6 +4692,10 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     // Close bunker signer if active
     _bunkerSigner?.close();
     _bunkerSigner = null;
+
+    // Cancels the NIP-98 token cache's periodic cleanup timer, if one was built.
+    _nip98AuthService?.dispose();
+    _nip98AuthService = null;
 
     // Close Amber signer if active
     _amberSigner?.close();

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -971,17 +971,35 @@ class KeycastOAuth {
 
   /// Delete the user's account permanently from Keycast
   ///
-  /// Requires an active bearer token from headless login/register flow.
   /// This is a destructive action that cannot be undone.
   ///
+  /// Authorization prefers a **NIP-98 proof-of-key** when [nip98Signer] is
+  /// supplied and succeeds, falling back to the bearer [token] otherwise.
+  /// The proof matters because a bearer token minted by a *refresh* no longer
+  /// carries the server's first-party fact, so it is refused — while a
+  /// signature proves key control regardless of how old the session is.
+  ///
+  /// [nip98Signer] receives the exact request URL and returns the base64 event
+  /// body (without the `Nostr ` scheme), or null if it cannot sign. The URL is
+  /// passed in rather than rebuilt by the caller because NIP-98 binds the
+  /// signature to it: any divergence makes the server reject the proof.
+  ///
   /// Returns [DeleteAccountResult] with success status.
-  Future<DeleteAccountResult> deleteAccount(String token) async {
+  Future<DeleteAccountResult> deleteAccount(
+    String token, {
+    Future<String?> Function(String url)? nip98Signer,
+  }) async {
     try {
+      final url = '${config.serverUrl}/api/user/account';
+      final nip98Token = nip98Signer == null ? null : await nip98Signer(url);
+
       final response = await _client
           .delete(
-            Uri.parse('${config.serverUrl}/api/user/account'),
+            Uri.parse(url),
             headers: {
-              'Authorization': 'Bearer $token',
+              'Authorization': nip98Token != null
+                  ? 'Nostr $nip98Token'
+                  : 'Bearer $token',
               'Content-Type': 'application/json',
             },
           )

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -1488,6 +1488,100 @@ void main() {
         expect(result.requiresReauthentication, isTrue);
       });
 
+      test(
+        'sends a NIP-98 proof instead of the bearer token when signed',
+        () async {
+          // The bearer token is exactly the credential that gets refused once it
+          // has been refreshed, so a proof must take precedence over it.
+          String? sentAuthorization;
+          final mockClient = MockClient((request) async {
+            sentAuthorization = request.headers['Authorization'];
+            return http.Response(
+              jsonEncode({'success': true, 'message': 'Account deleted'}),
+              200,
+            );
+          });
+
+          final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+          final result = await oauth.deleteAccount(
+            'refreshed_token',
+            nip98Signer: (_) async => 'BASE64EVENT',
+          );
+
+          expect(result.success, isTrue);
+          expect(sentAuthorization, 'Nostr BASE64EVENT');
+          expect(sentAuthorization, isNot(contains('Bearer')));
+        },
+      );
+
+      test('signs the proof over the exact URL the request is sent to', () async {
+        // NIP-98 binds the signature to the `u` tag; if the signer is handed a
+        // different URL than the request uses, the server rejects every proof.
+        String? signedUrl;
+        Uri? requestedUri;
+        final mockClient = MockClient((request) async {
+          requestedUri = request.url;
+          return http.Response(
+            jsonEncode({'success': true, 'message': 'Account deleted'}),
+            200,
+          );
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        await oauth.deleteAccount(
+          'token',
+          nip98Signer: (url) async {
+            signedUrl = url;
+            return 'PROOF';
+          },
+        );
+
+        expect(signedUrl, isNotNull);
+        expect(signedUrl, requestedUri.toString());
+      });
+
+      test(
+        'falls back to the bearer token when the signer returns null',
+        () async {
+          // Lets the client ship before the server accepts proofs, and keeps
+          // deletion working for anyone whose signer is unavailable.
+          String? sentAuthorization;
+          final mockClient = MockClient((request) async {
+            sentAuthorization = request.headers['Authorization'];
+            return http.Response(
+              jsonEncode({'success': true, 'message': 'Account deleted'}),
+              200,
+            );
+          });
+
+          final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+          final result = await oauth.deleteAccount(
+            'test_token',
+            nip98Signer: (_) async => null,
+          );
+
+          expect(result.success, isTrue);
+          expect(sentAuthorization, 'Bearer test_token');
+        },
+      );
+
+      test('uses the bearer token when no signer is supplied', () async {
+        // Pins the default: existing callers keep their current behavior.
+        String? sentAuthorization;
+        final mockClient = MockClient((request) async {
+          sentAuthorization = request.headers['Authorization'];
+          return http.Response(
+            jsonEncode({'success': true, 'message': 'Account deleted'}),
+            200,
+          );
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        await oauth.deleteAccount('test_token');
+
+        expect(sentAuthorization, 'Bearer test_token');
+      });
+
       test('returns error on 404 not found', () async {
         final mockClient = MockClient((request) async {
           return http.Response('Not Found', 404);

--- a/mobile/test/services/auth_service_delete_keycast_account_test.dart
+++ b/mobile/test/services/auth_service_delete_keycast_account_test.dart
@@ -109,7 +109,12 @@ void main() {
       expect(result.success, isFalse);
       expect(result.error, contains('No usable session'));
       expect(result.requiresReauthentication, isTrue);
-      verifyNever(() => mockOAuthClient.deleteAccount(any()));
+      verifyNever(
+        () => mockOAuthClient.deleteAccount(
+          any(),
+          nip98Signer: any(named: 'nip98Signer'),
+        ),
+      );
     });
 
     test(
@@ -124,7 +129,12 @@ void main() {
 
         expect(result.success, isFalse);
         expect(result.error, contains('No usable session'));
-        verifyNever(() => mockOAuthClient.deleteAccount(any()));
+        verifyNever(
+          () => mockOAuthClient.deleteAccount(
+            any(),
+            nip98Signer: any(named: 'nip98Signer'),
+          ),
+        );
       },
     );
 
@@ -141,7 +151,12 @@ void main() {
 
       expect(result.success, isFalse);
       expect(result.requiresReauthentication, isTrue);
-      verifyNever(() => mockOAuthClient.deleteAccount(any()));
+      verifyNever(
+        () => mockOAuthClient.deleteAccount(
+          any(),
+          nip98Signer: any(named: 'nip98Signer'),
+        ),
+      );
     });
 
     test('refuses a session bound to a different account', () async {
@@ -154,7 +169,12 @@ void main() {
 
       expect(result.success, isFalse);
       expect(result.requiresReauthentication, isTrue);
-      verifyNever(() => mockOAuthClient.deleteAccount(any()));
+      verifyNever(
+        () => mockOAuthClient.deleteAccount(
+          any(),
+          nip98Signer: any(named: 'nip98Signer'),
+        ),
+      );
     });
 
     // A refresh that does not name its owner persists a session no account can
@@ -170,7 +190,12 @@ void main() {
         ).thenAnswer(
           (_) async => session(owner: pubkeyHex, token: testAccessToken),
         );
-        when(() => mockOAuthClient.deleteAccount(testAccessToken)).thenAnswer(
+        when(
+          () => mockOAuthClient.deleteAccount(
+            testAccessToken,
+            nip98Signer: any(named: 'nip98Signer'),
+          ),
+        ).thenAnswer(
           (_) async => DeleteAccountResult(
             success: true,
             message: 'Account permanently deleted',
@@ -188,7 +213,12 @@ void main() {
 
     test('returns success when account deletion succeeds', () async {
       final authService = await withUsableSession();
-      when(() => mockOAuthClient.deleteAccount(testAccessToken)).thenAnswer(
+      when(
+        () => mockOAuthClient.deleteAccount(
+          testAccessToken,
+          nip98Signer: any(named: 'nip98Signer'),
+        ),
+      ).thenAnswer(
         (_) async => DeleteAccountResult(
           success: true,
           message: 'Account permanently deleted',
@@ -199,21 +229,34 @@ void main() {
 
       expect(result.success, isTrue);
       expect(result.error, isNull);
-      verify(() => mockOAuthClient.deleteAccount(testAccessToken)).called(1);
+      verify(
+        () => mockOAuthClient.deleteAccount(
+          testAccessToken,
+          nip98Signer: any(named: 'nip98Signer'),
+        ),
+      ).called(1);
     });
 
     test('returns failure with error message when deletion fails', () async {
       final authService = await withUsableSession();
       const errorMessage = 'Unauthorized: invalid or expired token';
       when(
-        () => mockOAuthClient.deleteAccount(testAccessToken),
+        () => mockOAuthClient.deleteAccount(
+          testAccessToken,
+          nip98Signer: any(named: 'nip98Signer'),
+        ),
       ).thenAnswer((_) async => DeleteAccountResult.error(errorMessage));
 
       final result = await authService.deleteKeycastAccount();
 
       expect(result.success, isFalse);
       expect(result.error, equals(errorMessage));
-      verify(() => mockOAuthClient.deleteAccount(testAccessToken)).called(1);
+      verify(
+        () => mockOAuthClient.deleteAccount(
+          testAccessToken,
+          nip98Signer: any(named: 'nip98Signer'),
+        ),
+      ).called(1);
     });
 
     // The caller decides between "retry" and "sign in again" copy from this
@@ -224,7 +267,12 @@ void main() {
       'propagates requiresReauthentication from a refused deletion',
       () async {
         final authService = await withUsableSession();
-        when(() => mockOAuthClient.deleteAccount(testAccessToken)).thenAnswer(
+        when(
+          () => mockOAuthClient.deleteAccount(
+            testAccessToken,
+            nip98Signer: any(named: 'nip98Signer'),
+          ),
+        ).thenAnswer(
           (_) async => DeleteAccountResult.error(
             'Account deletion requires the Divine app or web login with your '
             'private key',
@@ -239,10 +287,52 @@ void main() {
       },
     );
 
+    // Without a proof-of-key the request falls back to the bearer token, and a
+    // refreshed bearer token is exactly what keycast refuses (#4881) — after
+    // the irreversible NIP-62 vanish has already been published. If this
+    // regresses, deletion silently goes back to failing for every returning
+    // user.
+    test(
+      'supplies a NIP-98 signer so a refreshed session can still delete',
+      () async {
+        final (authService, pubkeyHex) = await signedInAuthService();
+        when(() => mockOAuthClient.getSession()).thenAnswer((_) async => null);
+        when(
+          () => mockOAuthClient.refreshSession(userPubkey: pubkeyHex),
+        ).thenAnswer(
+          (_) async => session(owner: pubkeyHex, token: testAccessToken),
+        );
+
+        Future<String?> Function(String)? capturedSigner;
+        when(
+          () => mockOAuthClient.deleteAccount(
+            testAccessToken,
+            nip98Signer: any(named: 'nip98Signer'),
+          ),
+        ).thenAnswer((invocation) async {
+          capturedSigner =
+              invocation.namedArguments[#nip98Signer]
+                  as Future<String?> Function(String)?;
+          return DeleteAccountResult(success: true, message: 'deleted');
+        });
+
+        await authService.deleteKeycastAccount();
+
+        expect(
+          capturedSigner,
+          isNotNull,
+          reason: 'deleteKeycastAccount must offer a proof-of-key signer',
+        );
+      },
+    );
+
     test('returns failure when exception is thrown', () async {
       final authService = await withUsableSession();
       when(
-        () => mockOAuthClient.deleteAccount(testAccessToken),
+        () => mockOAuthClient.deleteAccount(
+          testAccessToken,
+          nip98Signer: any(named: 'nip98Signer'),
+        ),
       ).thenThrow(Exception('Network error'));
 
       final result = await authService.deleteKeycastAccount();


### PR DESCRIPTION
## Description

Account deletion sends a **NIP-98 proof-of-key** to Keycast instead of relying on the bearer token.

`AuthService.deleteKeycastAccount()` calls `getSessionOrRefresh()` immediately before `DELETE /user/account`, and a refreshed access token no longer carries Keycast's first-party fact — so the request is refused. Because that call runs *after* the irreversible NIP-62 vanish and kind-5 sweep, the user is left with their content broadcast for deletion, their account still alive, and a message telling them to check their connection. Retrying reproduces it exactly.

A kind-27235 event signed by the account's own key, bound to the exact request URL and method, proves the request comes from the key holder regardless of how the session was obtained or how old it is.

Notes for review:

- `KeycastOAuth.deleteAccount` takes an optional `nip98Signer` and **passes it the URL it is about to call** rather than letting the caller rebuild it. NIP-98 binds the signature to the `u` tag, so any divergence between signed URL and requested URL makes the server reject every proof.
- **Falls back to the bearer token** whenever a proof cannot be produced. That keeps this safe to ship before the server accepts proofs, and means it cannot make anything worse for anyone.
- The readiness gate from #6417 is **deliberately untouched**. It should only be relaxed once the server side is confirmed live, or users regress straight back to the stranded state.
- The signer must be alive at this point, and is — the flow signs and publishes the kind-62 vanish moments earlier. That ordering is now load-bearing and is called out in the code.
- `Nip98AuthService` is built on first use and is nullable rather than `late final`, so `dispose()` does not construct one (starting its cache-cleanup timer) purely to tear it down.

**Related Issue:** Relates to #5756, Relates to #4881

Server-side counterpart: divinevideo/keycast#331 — that PR is what actually makes deletion succeed. This one is the client half and is inert until it ships.

## Out of Scope

- Relaxing the `checkAccountDeletionReadiness()` gate — intentionally deferred until keycast#331 is deployed.
- #6450 (successful deletion throws `GoError: There is nothing to pop` and shows no confirmation) — still live on main, separate fix.
- #6215 — already fixed on main; both publishes now await a relay OK.
- The shipped build emits kind-5 requests with no `a` tags for addressable kinds; fixed on main, unrelated to this diff.
- divinevideo/divine-funnelcake#746 — a vanish never erases media blobs. Independent workstream.

## Verification

- `flutter analyze lib test packages/keycast_flutter` — No issues found
- `flutter test packages/keycast_flutter/test/oauth_client_test.dart` — 116 pass (4 new)
- `flutter test test/services/auth_service_delete_keycast_account_test.dart` — 9 pass (1 new)
- `flutter test test/services/auth_service_*.dart` — 239 pass
- `flutter test test/widgets/delete_account_dialog_test.dart test/widgets/delete_account_confirmation_test.dart` — 53 pass
- `flutter test test/services/account_deletion_service_test.dart` — 25 pass
- Pre-commit and pre-push hooks passed (format, analyze, codegen, changed-file tests)

New coverage:

- proof is sent as `Nostr <token>` and takes precedence over the bearer token
- the signer is handed the exact URL the request goes to
- falls back to `Bearer` when the signer returns null, and when no signer is supplied
- `deleteKeycastAccount` actually supplies a signer — this is the one that fails if the fix regresses

Four existing stubs in `auth_service_delete_keycast_account_test.dart` needed the new named argument added; that was my diff's doing, not a pre-existing failure.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
