### PR TITLE
fix(l10n): regenerate vi/ur/zh/ms localizations

### DIFF
--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -122,6 +122,26 @@ class AppLocalizationsMs extends AppLocalizations {
   String get settingsUnsavedDraftsTitle => 'Draf Belum Disimpan';
 
   @override
+  String get settingsUploadInProgressTitle => 'Upload in progress';
+
+  @override
+  String settingsUploadInProgressMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'videos',
+      one: 'video',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'videos stay as drafts',
+      one: 'video stays as a draft',
+    );
+    return 'You still have $count $_temp0 uploading. Switching accounts stops the upload — your $_temp1 in this account.';
+  }
+
+  @override
   String settingsUnsavedDraftsMessage(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -7249,6 +7269,10 @@ class AppLocalizationsMs extends AppLocalizations {
       'Muat naik ini terganggu. Adakah anda mahu cuba lagi?';
 
   @override
+  String get publishErrorAccountChanged =>
+      'This video belongs to a different account. Switch back to that account to post it.';
+
+  @override
   String get publishErrorGeneric => 'Sesuatu telah berlaku. Sila cuba lagi.';
 
   @override
@@ -7266,6 +7290,10 @@ class AppLocalizationsMs extends AppLocalizations {
   @override
   String get publishErrorOutOfMemory =>
       'Peranti anda kekurangan memori. Tutup beberapa apl dan cuba lagi.';
+
+  @override
+  String get publishErrorOverlaysUnavailable =>
+      'The text and stickers on this draft couldn’t be prepared. Open it in the editor, then post again.';
 
   @override
   String get publishErrorUnknownServer => 'Pelayan tidak diketahui';
@@ -8772,6 +8800,108 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get videoEditorTimelineSlideToAdjust => 'Luncur untuk melaras';
+
+  @override
+  String get videoEditorChromaKeyLabel => 'Green screen';
+
+  @override
+  String get videoEditorChromaKeyTitle => 'Green screen';
+
+  @override
+  String get videoEditorChromaKeySemanticLabel =>
+      'Set up the green screen for this clip';
+
+  @override
+  String get videoEditorChromaKeyCloseSemanticLabel =>
+      'Discard green screen changes';
+
+  @override
+  String get videoEditorChromaKeyDoneSemanticLabel => 'Apply the green screen';
+
+  @override
+  String get videoEditorChromaKeyAutoDetect => 'Auto-detect';
+
+  @override
+  String get videoEditorChromaKeyPresetGreen => 'Green';
+
+  @override
+  String get videoEditorChromaKeyPresetBlue => 'Blue';
+
+  @override
+  String get videoEditorChromaKeyScreenColorLabel => 'Screen color';
+
+  @override
+  String get videoEditorChromaKeyAmountLabel => 'Amount';
+
+  @override
+  String get videoEditorChromaKeyAmountHint =>
+      'How much of the screen color disappears';
+
+  @override
+  String get videoEditorChromaKeyEdgeLabel => 'Edge';
+
+  @override
+  String get videoEditorChromaKeyEdgeHint =>
+      'Softens the cutout so hair doesn\'t turn jagged';
+
+  @override
+  String get videoEditorChromaKeySpillLabel => 'Spill';
+
+  @override
+  String get videoEditorChromaKeySpillHint =>
+      'Pulls the screen\'s color back off your subject';
+
+  @override
+  String get videoEditorChromaKeyBackgroundLabel => 'Replace with';
+
+  @override
+  String get videoEditorChromaKeyBackgroundNone => 'Nothing';
+
+  @override
+  String get videoEditorChromaKeyBackgroundColor => 'Color';
+
+  @override
+  String get videoEditorChromaKeyBackgroundImage => 'Image';
+
+  @override
+  String get videoEditorChromaKeyBackgroundVideo => 'Clip';
+
+  @override
+  String get videoEditorChromaKeyTransparentHint =>
+      'Video can\'t hold transparency, so this exports as black.';
+
+  @override
+  String get videoEditorChromaKeyDetectFailed =>
+      'Couldn\'t find a screen. It has to reach the edges of the frame — pick the color by hand instead.';
+
+  @override
+  String get videoEditorChromaKeyPickClipTitle => 'Pick a clip';
+
+  @override
+  String get videoEditorChromaKeyNoLibraryClips =>
+      'Your library is empty. Save a clip first, then use it as a background.';
+
+  @override
+  String get videoEditorChromaKeyImagePickFailed =>
+      'Couldn\'t load that image.';
+
+  @override
+  String get videoEditorChromaKeyRemove => 'Remove green screen';
+
+  @override
+  String get videoEditorChromaKeyFailed =>
+      'Couldn\'t apply the green screen. Your clip is unchanged.';
+
+  @override
+  String get videoEditorChromaKeyRemoveFailed =>
+      'Couldn\'t remove the green screen. Your clip is unchanged.';
+
+  @override
+  String get videoEditorChromaKeyApplying => 'Applying the green screen…';
+
+  @override
+  String get videoEditorChromaKeyPreviewUnavailable =>
+      'This device can\'t show the live preview. Your settings still apply when you export.';
 
   @override
   String get videoEditorOriginalAudioLabel => 'Audio asal';
@@ -10523,6 +10653,88 @@ class AppLocalizationsMs extends AppLocalizations {
   @override
   String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
       'Percayai relay Divine, sahkan yang lain.';
+
+  @override
+  String get settingsCrosspostingTitle => 'Crossposting';
+
+  @override
+  String get settingsCrosspostingSubtitle =>
+      'Share your videos to other platforms';
+
+  @override
+  String get crosspostingSignInRequired =>
+      'Sign in with Divine to manage crossposting';
+
+  @override
+  String get crosspostingLoadFailed =>
+      'Couldn\'t load your crossposting settings';
+
+  @override
+  String get crosspostingNoPlatforms =>
+      'No crossposting platforms are available right now';
+
+  @override
+  String get crosspostingRetry => 'Retry';
+
+  @override
+  String get crosspostingNotConnected => 'Not connected';
+
+  @override
+  String get crosspostingConnected => 'Connected';
+
+  @override
+  String get crosspostingNeedsReconnect => 'Needs reconnecting';
+
+  @override
+  String get crosspostingConnect => 'Connect';
+
+  @override
+  String get crosspostingReconnect => 'Reconnect';
+
+  @override
+  String get crosspostingDisconnect => 'Disconnect';
+
+  @override
+  String get crosspostingModeOff => 'Off';
+
+  @override
+  String get crosspostingModeManual => 'Manual';
+
+  @override
+  String get crosspostingModeManualSubtitle => 'You choose per video';
+
+  @override
+  String get crosspostingModeAutomatic => 'Automatic';
+
+  @override
+  String get crosspostingModeAutomaticSubtitle =>
+      'Future videos post automatically — only videos published after you turn this on';
+
+  @override
+  String get crosspostingNotConnectedError =>
+      'Connect this platform first to change how it posts.';
+
+  @override
+  String get crosspostingGenericError => 'Something went wrong. Try again.';
+
+  @override
+  String get crosspostingCallbackTimeoutError =>
+      'We never heard back from the sign-in page. If you finished connecting there, refresh — your account may already be linked.';
+
+  @override
+  String crosspostingConnectionSuccess(String platform) {
+    return '$platform connected';
+  }
+
+  @override
+  String crosspostingConnectionFailed(String platform) {
+    return 'Couldn\'t connect $platform';
+  }
+
+  @override
+  String crosspostingConnectionDenied(String platform) {
+    return 'Connection was canceled on $platform';
+  }
 
   @override
   String get supporterTitle => 'Penyokong Divine';

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -122,6 +122,26 @@ class AppLocalizationsUr extends AppLocalizations {
   String get settingsUnsavedDraftsTitle => 'غیر محفوظ مسودے';
 
   @override
+  String get settingsUploadInProgressTitle => 'Upload in progress';
+
+  @override
+  String settingsUploadInProgressMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'videos',
+      one: 'video',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'videos stay as drafts',
+      one: 'video stays as a draft',
+    );
+    return 'You still have $count $_temp0 uploading. Switching accounts stops the upload — your $_temp1 in this account.';
+  }
+
+  @override
   String settingsUnsavedDraftsMessage(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -7201,6 +7221,10 @@ class AppLocalizationsUr extends AppLocalizations {
       'یہ اپلوڈ رک گیا۔ کیا آپ دوبارہ کوشش کرنا چاہیں گے؟';
 
   @override
+  String get publishErrorAccountChanged =>
+      'This video belongs to a different account. Switch back to that account to post it.';
+
+  @override
   String get publishErrorGeneric =>
       'کچھ غلط ہو گیا۔ براہ کرم دوبارہ کوشش کریں۔';
 
@@ -7219,6 +7243,10 @@ class AppLocalizationsUr extends AppLocalizations {
   @override
   String get publishErrorOutOfMemory =>
       'آپ کی ڈیوائس کی میموری کم ہے۔ کچھ ایپس بند کر کے دوبارہ کوشش کریں۔';
+
+  @override
+  String get publishErrorOverlaysUnavailable =>
+      'The text and stickers on this draft couldn’t be prepared. Open it in the editor, then post again.';
 
   @override
   String get publishErrorUnknownServer => 'نامعلوم سرور';
@@ -8716,6 +8744,108 @@ class AppLocalizationsUr extends AppLocalizations {
   @override
   String get videoEditorTimelineSlideToAdjust =>
       'ایڈجسٹ کرنے کے لیے سلائیڈ کریں';
+
+  @override
+  String get videoEditorChromaKeyLabel => 'Green screen';
+
+  @override
+  String get videoEditorChromaKeyTitle => 'Green screen';
+
+  @override
+  String get videoEditorChromaKeySemanticLabel =>
+      'Set up the green screen for this clip';
+
+  @override
+  String get videoEditorChromaKeyCloseSemanticLabel =>
+      'Discard green screen changes';
+
+  @override
+  String get videoEditorChromaKeyDoneSemanticLabel => 'Apply the green screen';
+
+  @override
+  String get videoEditorChromaKeyAutoDetect => 'Auto-detect';
+
+  @override
+  String get videoEditorChromaKeyPresetGreen => 'Green';
+
+  @override
+  String get videoEditorChromaKeyPresetBlue => 'Blue';
+
+  @override
+  String get videoEditorChromaKeyScreenColorLabel => 'Screen color';
+
+  @override
+  String get videoEditorChromaKeyAmountLabel => 'Amount';
+
+  @override
+  String get videoEditorChromaKeyAmountHint =>
+      'How much of the screen color disappears';
+
+  @override
+  String get videoEditorChromaKeyEdgeLabel => 'Edge';
+
+  @override
+  String get videoEditorChromaKeyEdgeHint =>
+      'Softens the cutout so hair doesn\'t turn jagged';
+
+  @override
+  String get videoEditorChromaKeySpillLabel => 'Spill';
+
+  @override
+  String get videoEditorChromaKeySpillHint =>
+      'Pulls the screen\'s color back off your subject';
+
+  @override
+  String get videoEditorChromaKeyBackgroundLabel => 'Replace with';
+
+  @override
+  String get videoEditorChromaKeyBackgroundNone => 'Nothing';
+
+  @override
+  String get videoEditorChromaKeyBackgroundColor => 'Color';
+
+  @override
+  String get videoEditorChromaKeyBackgroundImage => 'Image';
+
+  @override
+  String get videoEditorChromaKeyBackgroundVideo => 'Clip';
+
+  @override
+  String get videoEditorChromaKeyTransparentHint =>
+      'Video can\'t hold transparency, so this exports as black.';
+
+  @override
+  String get videoEditorChromaKeyDetectFailed =>
+      'Couldn\'t find a screen. It has to reach the edges of the frame — pick the color by hand instead.';
+
+  @override
+  String get videoEditorChromaKeyPickClipTitle => 'Pick a clip';
+
+  @override
+  String get videoEditorChromaKeyNoLibraryClips =>
+      'Your library is empty. Save a clip first, then use it as a background.';
+
+  @override
+  String get videoEditorChromaKeyImagePickFailed =>
+      'Couldn\'t load that image.';
+
+  @override
+  String get videoEditorChromaKeyRemove => 'Remove green screen';
+
+  @override
+  String get videoEditorChromaKeyFailed =>
+      'Couldn\'t apply the green screen. Your clip is unchanged.';
+
+  @override
+  String get videoEditorChromaKeyRemoveFailed =>
+      'Couldn\'t remove the green screen. Your clip is unchanged.';
+
+  @override
+  String get videoEditorChromaKeyApplying => 'Applying the green screen…';
+
+  @override
+  String get videoEditorChromaKeyPreviewUnavailable =>
+      'This device can\'t show the live preview. Your settings still apply when you export.';
 
   @override
   String get videoEditorOriginalAudioLabel => 'اصل آڈیو';
@@ -10461,6 +10591,88 @@ class AppLocalizationsUr extends AppLocalizations {
   @override
   String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
       'Divine ریلے پر بھروسہ کریں، باقی کی تصدیق کریں۔';
+
+  @override
+  String get settingsCrosspostingTitle => 'Crossposting';
+
+  @override
+  String get settingsCrosspostingSubtitle =>
+      'Share your videos to other platforms';
+
+  @override
+  String get crosspostingSignInRequired =>
+      'Sign in with Divine to manage crossposting';
+
+  @override
+  String get crosspostingLoadFailed =>
+      'Couldn\'t load your crossposting settings';
+
+  @override
+  String get crosspostingNoPlatforms =>
+      'No crossposting platforms are available right now';
+
+  @override
+  String get crosspostingRetry => 'Retry';
+
+  @override
+  String get crosspostingNotConnected => 'Not connected';
+
+  @override
+  String get crosspostingConnected => 'Connected';
+
+  @override
+  String get crosspostingNeedsReconnect => 'Needs reconnecting';
+
+  @override
+  String get crosspostingConnect => 'Connect';
+
+  @override
+  String get crosspostingReconnect => 'Reconnect';
+
+  @override
+  String get crosspostingDisconnect => 'Disconnect';
+
+  @override
+  String get crosspostingModeOff => 'Off';
+
+  @override
+  String get crosspostingModeManual => 'Manual';
+
+  @override
+  String get crosspostingModeManualSubtitle => 'You choose per video';
+
+  @override
+  String get crosspostingModeAutomatic => 'Automatic';
+
+  @override
+  String get crosspostingModeAutomaticSubtitle =>
+      'Future videos post automatically — only videos published after you turn this on';
+
+  @override
+  String get crosspostingNotConnectedError =>
+      'Connect this platform first to change how it posts.';
+
+  @override
+  String get crosspostingGenericError => 'Something went wrong. Try again.';
+
+  @override
+  String get crosspostingCallbackTimeoutError =>
+      'We never heard back from the sign-in page. If you finished connecting there, refresh — your account may already be linked.';
+
+  @override
+  String crosspostingConnectionSuccess(String platform) {
+    return '$platform connected';
+  }
+
+  @override
+  String crosspostingConnectionFailed(String platform) {
+    return 'Couldn\'t connect $platform';
+  }
+
+  @override
+  String crosspostingConnectionDenied(String platform) {
+    return 'Connection was canceled on $platform';
+  }
 
   @override
   String get supporterTitle => 'Divine سپورٹرز';

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -122,6 +122,26 @@ class AppLocalizationsVi extends AppLocalizations {
   String get settingsUnsavedDraftsTitle => 'Bản nháp chưa lưu';
 
   @override
+  String get settingsUploadInProgressTitle => 'Upload in progress';
+
+  @override
+  String settingsUploadInProgressMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'videos',
+      one: 'video',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'videos stay as drafts',
+      one: 'video stays as a draft',
+    );
+    return 'You still have $count $_temp0 uploading. Switching accounts stops the upload — your $_temp1 in this account.';
+  }
+
+  @override
   String settingsUnsavedDraftsMessage(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -7207,6 +7227,10 @@ class AppLocalizationsVi extends AppLocalizations {
       'Lần tải lên này đã bị gián đoạn. Bạn có muốn thử lại không?';
 
   @override
+  String get publishErrorAccountChanged =>
+      'This video belongs to a different account. Switch back to that account to post it.';
+
+  @override
   String get publishErrorGeneric => 'Có gì đó không ổn. Vui lòng thử lại.';
 
   @override
@@ -7224,6 +7248,10 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get publishErrorOutOfMemory =>
       'Thiết bị của bạn sắp hết bộ nhớ. Đóng bớt ứng dụng rồi thử lại nhé.';
+
+  @override
+  String get publishErrorOverlaysUnavailable =>
+      'The text and stickers on this draft couldn’t be prepared. Open it in the editor, then post again.';
 
   @override
   String get publishErrorUnknownServer => 'Máy chủ không xác định';
@@ -8724,6 +8752,108 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get videoEditorTimelineSlideToAdjust => 'Trượt để điều chỉnh';
+
+  @override
+  String get videoEditorChromaKeyLabel => 'Green screen';
+
+  @override
+  String get videoEditorChromaKeyTitle => 'Green screen';
+
+  @override
+  String get videoEditorChromaKeySemanticLabel =>
+      'Set up the green screen for this clip';
+
+  @override
+  String get videoEditorChromaKeyCloseSemanticLabel =>
+      'Discard green screen changes';
+
+  @override
+  String get videoEditorChromaKeyDoneSemanticLabel => 'Apply the green screen';
+
+  @override
+  String get videoEditorChromaKeyAutoDetect => 'Auto-detect';
+
+  @override
+  String get videoEditorChromaKeyPresetGreen => 'Green';
+
+  @override
+  String get videoEditorChromaKeyPresetBlue => 'Blue';
+
+  @override
+  String get videoEditorChromaKeyScreenColorLabel => 'Screen color';
+
+  @override
+  String get videoEditorChromaKeyAmountLabel => 'Amount';
+
+  @override
+  String get videoEditorChromaKeyAmountHint =>
+      'How much of the screen color disappears';
+
+  @override
+  String get videoEditorChromaKeyEdgeLabel => 'Edge';
+
+  @override
+  String get videoEditorChromaKeyEdgeHint =>
+      'Softens the cutout so hair doesn\'t turn jagged';
+
+  @override
+  String get videoEditorChromaKeySpillLabel => 'Spill';
+
+  @override
+  String get videoEditorChromaKeySpillHint =>
+      'Pulls the screen\'s color back off your subject';
+
+  @override
+  String get videoEditorChromaKeyBackgroundLabel => 'Replace with';
+
+  @override
+  String get videoEditorChromaKeyBackgroundNone => 'Nothing';
+
+  @override
+  String get videoEditorChromaKeyBackgroundColor => 'Color';
+
+  @override
+  String get videoEditorChromaKeyBackgroundImage => 'Image';
+
+  @override
+  String get videoEditorChromaKeyBackgroundVideo => 'Clip';
+
+  @override
+  String get videoEditorChromaKeyTransparentHint =>
+      'Video can\'t hold transparency, so this exports as black.';
+
+  @override
+  String get videoEditorChromaKeyDetectFailed =>
+      'Couldn\'t find a screen. It has to reach the edges of the frame — pick the color by hand instead.';
+
+  @override
+  String get videoEditorChromaKeyPickClipTitle => 'Pick a clip';
+
+  @override
+  String get videoEditorChromaKeyNoLibraryClips =>
+      'Your library is empty. Save a clip first, then use it as a background.';
+
+  @override
+  String get videoEditorChromaKeyImagePickFailed =>
+      'Couldn\'t load that image.';
+
+  @override
+  String get videoEditorChromaKeyRemove => 'Remove green screen';
+
+  @override
+  String get videoEditorChromaKeyFailed =>
+      'Couldn\'t apply the green screen. Your clip is unchanged.';
+
+  @override
+  String get videoEditorChromaKeyRemoveFailed =>
+      'Couldn\'t remove the green screen. Your clip is unchanged.';
+
+  @override
+  String get videoEditorChromaKeyApplying => 'Applying the green screen…';
+
+  @override
+  String get videoEditorChromaKeyPreviewUnavailable =>
+      'This device can\'t show the live preview. Your settings still apply when you export.';
 
   @override
   String get videoEditorOriginalAudioLabel => 'Âm thanh gốc';
@@ -10472,6 +10602,88 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
       'Tin tưởng relay Divine, xác minh phần còn lại.';
+
+  @override
+  String get settingsCrosspostingTitle => 'Crossposting';
+
+  @override
+  String get settingsCrosspostingSubtitle =>
+      'Share your videos to other platforms';
+
+  @override
+  String get crosspostingSignInRequired =>
+      'Sign in with Divine to manage crossposting';
+
+  @override
+  String get crosspostingLoadFailed =>
+      'Couldn\'t load your crossposting settings';
+
+  @override
+  String get crosspostingNoPlatforms =>
+      'No crossposting platforms are available right now';
+
+  @override
+  String get crosspostingRetry => 'Retry';
+
+  @override
+  String get crosspostingNotConnected => 'Not connected';
+
+  @override
+  String get crosspostingConnected => 'Connected';
+
+  @override
+  String get crosspostingNeedsReconnect => 'Needs reconnecting';
+
+  @override
+  String get crosspostingConnect => 'Connect';
+
+  @override
+  String get crosspostingReconnect => 'Reconnect';
+
+  @override
+  String get crosspostingDisconnect => 'Disconnect';
+
+  @override
+  String get crosspostingModeOff => 'Off';
+
+  @override
+  String get crosspostingModeManual => 'Manual';
+
+  @override
+  String get crosspostingModeManualSubtitle => 'You choose per video';
+
+  @override
+  String get crosspostingModeAutomatic => 'Automatic';
+
+  @override
+  String get crosspostingModeAutomaticSubtitle =>
+      'Future videos post automatically — only videos published after you turn this on';
+
+  @override
+  String get crosspostingNotConnectedError =>
+      'Connect this platform first to change how it posts.';
+
+  @override
+  String get crosspostingGenericError => 'Something went wrong. Try again.';
+
+  @override
+  String get crosspostingCallbackTimeoutError =>
+      'We never heard back from the sign-in page. If you finished connecting there, refresh — your account may already be linked.';
+
+  @override
+  String crosspostingConnectionSuccess(String platform) {
+    return '$platform connected';
+  }
+
+  @override
+  String crosspostingConnectionFailed(String platform) {
+    return 'Couldn\'t connect $platform';
+  }
+
+  @override
+  String crosspostingConnectionDenied(String platform) {
+    return 'Connection was canceled on $platform';
+  }
 
   @override
   String get supporterTitle => 'Người ủng hộ Divine';

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -115,6 +115,26 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settingsUnsavedDraftsTitle => '未保存的草稿';
 
   @override
+  String get settingsUploadInProgressTitle => 'Upload in progress';
+
+  @override
+  String settingsUploadInProgressMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'videos',
+      one: 'video',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'videos stay as drafts',
+      one: 'video stays as a draft',
+    );
+    return 'You still have $count $_temp0 uploading. Switching accounts stops the upload — your $_temp1 in this account.';
+  }
+
+  @override
   String settingsUnsavedDraftsMessage(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -6839,6 +6859,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get publishErrorInterrupted => '上传被中断。要重试吗？';
 
   @override
+  String get publishErrorAccountChanged =>
+      'This video belongs to a different account. Switch back to that account to post it.';
+
+  @override
   String get publishErrorGeneric => '出了点问题，请重试。';
 
   @override
@@ -6852,6 +6876,10 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get publishErrorOutOfMemory => '设备内存不足。关掉一些应用后再试。';
+
+  @override
+  String get publishErrorOverlaysUnavailable =>
+      'The text and stickers on this draft couldn’t be prepared. Open it in the editor, then post again.';
 
   @override
   String get publishErrorUnknownServer => '未知服务器';
@@ -8296,6 +8324,108 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get videoEditorTimelineSlideToAdjust => '滑动调节';
+
+  @override
+  String get videoEditorChromaKeyLabel => 'Green screen';
+
+  @override
+  String get videoEditorChromaKeyTitle => 'Green screen';
+
+  @override
+  String get videoEditorChromaKeySemanticLabel =>
+      'Set up the green screen for this clip';
+
+  @override
+  String get videoEditorChromaKeyCloseSemanticLabel =>
+      'Discard green screen changes';
+
+  @override
+  String get videoEditorChromaKeyDoneSemanticLabel => 'Apply the green screen';
+
+  @override
+  String get videoEditorChromaKeyAutoDetect => 'Auto-detect';
+
+  @override
+  String get videoEditorChromaKeyPresetGreen => 'Green';
+
+  @override
+  String get videoEditorChromaKeyPresetBlue => 'Blue';
+
+  @override
+  String get videoEditorChromaKeyScreenColorLabel => 'Screen color';
+
+  @override
+  String get videoEditorChromaKeyAmountLabel => 'Amount';
+
+  @override
+  String get videoEditorChromaKeyAmountHint =>
+      'How much of the screen color disappears';
+
+  @override
+  String get videoEditorChromaKeyEdgeLabel => 'Edge';
+
+  @override
+  String get videoEditorChromaKeyEdgeHint =>
+      'Softens the cutout so hair doesn\'t turn jagged';
+
+  @override
+  String get videoEditorChromaKeySpillLabel => 'Spill';
+
+  @override
+  String get videoEditorChromaKeySpillHint =>
+      'Pulls the screen\'s color back off your subject';
+
+  @override
+  String get videoEditorChromaKeyBackgroundLabel => 'Replace with';
+
+  @override
+  String get videoEditorChromaKeyBackgroundNone => 'Nothing';
+
+  @override
+  String get videoEditorChromaKeyBackgroundColor => 'Color';
+
+  @override
+  String get videoEditorChromaKeyBackgroundImage => 'Image';
+
+  @override
+  String get videoEditorChromaKeyBackgroundVideo => 'Clip';
+
+  @override
+  String get videoEditorChromaKeyTransparentHint =>
+      'Video can\'t hold transparency, so this exports as black.';
+
+  @override
+  String get videoEditorChromaKeyDetectFailed =>
+      'Couldn\'t find a screen. It has to reach the edges of the frame — pick the color by hand instead.';
+
+  @override
+  String get videoEditorChromaKeyPickClipTitle => 'Pick a clip';
+
+  @override
+  String get videoEditorChromaKeyNoLibraryClips =>
+      'Your library is empty. Save a clip first, then use it as a background.';
+
+  @override
+  String get videoEditorChromaKeyImagePickFailed =>
+      'Couldn\'t load that image.';
+
+  @override
+  String get videoEditorChromaKeyRemove => 'Remove green screen';
+
+  @override
+  String get videoEditorChromaKeyFailed =>
+      'Couldn\'t apply the green screen. Your clip is unchanged.';
+
+  @override
+  String get videoEditorChromaKeyRemoveFailed =>
+      'Couldn\'t remove the green screen. Your clip is unchanged.';
+
+  @override
+  String get videoEditorChromaKeyApplying => 'Applying the green screen…';
+
+  @override
+  String get videoEditorChromaKeyPreviewUnavailable =>
+      'This device can\'t show the live preview. Your settings still apply when you export.';
 
   @override
   String get videoEditorOriginalAudioLabel => '原始音频';
@@ -9914,6 +10044,88 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
       '信任 Divine 中继，验证其余中继。';
+
+  @override
+  String get settingsCrosspostingTitle => 'Crossposting';
+
+  @override
+  String get settingsCrosspostingSubtitle =>
+      'Share your videos to other platforms';
+
+  @override
+  String get crosspostingSignInRequired =>
+      'Sign in with Divine to manage crossposting';
+
+  @override
+  String get crosspostingLoadFailed =>
+      'Couldn\'t load your crossposting settings';
+
+  @override
+  String get crosspostingNoPlatforms =>
+      'No crossposting platforms are available right now';
+
+  @override
+  String get crosspostingRetry => 'Retry';
+
+  @override
+  String get crosspostingNotConnected => 'Not connected';
+
+  @override
+  String get crosspostingConnected => 'Connected';
+
+  @override
+  String get crosspostingNeedsReconnect => 'Needs reconnecting';
+
+  @override
+  String get crosspostingConnect => 'Connect';
+
+  @override
+  String get crosspostingReconnect => 'Reconnect';
+
+  @override
+  String get crosspostingDisconnect => 'Disconnect';
+
+  @override
+  String get crosspostingModeOff => 'Off';
+
+  @override
+  String get crosspostingModeManual => 'Manual';
+
+  @override
+  String get crosspostingModeManualSubtitle => 'You choose per video';
+
+  @override
+  String get crosspostingModeAutomatic => 'Automatic';
+
+  @override
+  String get crosspostingModeAutomaticSubtitle =>
+      'Future videos post automatically — only videos published after you turn this on';
+
+  @override
+  String get crosspostingNotConnectedError =>
+      'Connect this platform first to change how it posts.';
+
+  @override
+  String get crosspostingGenericError => 'Something went wrong. Try again.';
+
+  @override
+  String get crosspostingCallbackTimeoutError =>
+      'We never heard back from the sign-in page. If you finished connecting there, refresh — your account may already be linked.';
+
+  @override
+  String crosspostingConnectionSuccess(String platform) {
+    return '$platform connected';
+  }
+
+  @override
+  String crosspostingConnectionFailed(String platform) {
+    return 'Couldn\'t connect $platform';
+  }
+
+  @override
+  String crosspostingConnectionDenied(String platform) {
+    return 'Connection was canceled on $platform';
+  }
 
   @override
   String get supporterTitle => 'Divine 支持者';


### PR DESCRIPTION
Closes #6565

## What

Regenerates the four locale classes added by #6495 (Vietnamese, Urdu, Chinese, Malay). Generated files only — no ARB edits, no source changes.

## Why

`main` is currently red. #6495 was approved and CI-green at the time, but its generated localization classes were produced before other PRs added new ARB keys. `gen-l10n` backfills untranslated keys with the English template value, so once both merged, `app_localizations_{vi,ur,zh,ms}.dart` were left missing overrides for 57 abstract getters:

```
Missing implementations for these members:
 - AppLocalizations.videoEditorChromaKeyTitle
 - AppLocalizations.videoEditorChromaKeyTransparentHint
 ...
```

The 17 pre-existing locales are unaffected — their generated files were regenerated on a later base.

## How

```bash
cd mobile && flutter gen-l10n
```

## Verification

- `flutter analyze lib test` → `No issues found!` (red before this commit)
- Diff is 4 generated files, additions only

🤖 Generated with [Claude Code](https://claude.com/claude-code)