### PR TITLE
feat(db): name the bootstrap failure and offer a guarded local reset

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1419,6 +1419,15 @@ Future<void> _startOpenVineApp() async {
     ),
     shouldRepairLocalDatabaseCache:
         shouldRepairLocalDatabaseCacheAfterBootstrapError,
+    // Manual escape hatch behind a confirmation, offered only for diagnoses
+    // where the database is already unusable. It clears the DB and its cipher
+    // key but not the signing key, so it costs local-only drafts and clips
+    // while an uninstall — the alternative a stuck user is left with — takes
+    // the whole Android keystore and the account with it.
+    resetLocalDatabase: () => resetEncryptedDatabaseCache(
+      secureStorage: dbCipherSecureStorage,
+      onDatabaseReset: () => DmSyncState(sharedPreferences).clearAll(),
+    ),
     runApp: runApp,
     removeNativeSplash: FlutterNativeSplash.remove,
   );

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1382,6 +1382,20 @@ Future<void> _startOpenVineApp() async {
     ),
   );
 
+  // Both the automatic repair and the manual escape hatch below mean the same
+  // operation, so they share one definition and cannot drift apart. They differ
+  // only in whether the cipher key goes with the database.
+  Future<void> resetLocalDatabaseCache({required bool deleteCipherKey}) =>
+      resetEncryptedDatabaseCache(
+        secureStorage: dbCipherSecureStorage,
+        deleteCipherKey: deleteCipherKey,
+        // On the recreate the Drift DB is wiped but SharedPreferences survives;
+        // clear the DM sync state so the next inbox open runs a full re-drain
+        // instead of skipping it as "already complete" (which had left
+        // recovered chats stranded under "Message requests"). See #5304.
+        onDatabaseReset: () => DmSyncState(sharedPreferences).clearAll(),
+      );
+
   final dbCipherKeyResult = await resolveDatabaseBootstrapForAppStart(
     resolveCipherKey: () => resolveStartupDatabaseCipherKey(
       // resetOnError MUST stay false here: the cipher key is the one secret
@@ -1413,21 +1427,34 @@ Future<void> _startOpenVineApp() async {
       // would open an existing encrypted DB as plaintext and spam SQLITE_NOTADB.
       recordError: recordDatabaseBootstrapFailure,
     ),
-    repairLocalDatabaseCache: (error, stack) => resetEncryptedDatabaseCache(
-      secureStorage: dbCipherSecureStorage,
-      onDatabaseReset: () => DmSyncState(sharedPreferences).clearAll(),
-    ),
+    repairLocalDatabaseCache: (error, stack) =>
+        resetLocalDatabaseCache(deleteCipherKey: true),
     shouldRepairLocalDatabaseCache:
         shouldRepairLocalDatabaseCacheAfterBootstrapError,
     // Manual escape hatch behind a confirmation, offered only for diagnoses
-    // where the database is already unusable. It clears the DB and its cipher
-    // key but not the signing key, so it costs local-only drafts and clips
-    // while an uninstall — the alternative a stuck user is left with — takes
-    // the whole Android keystore and the account with it.
-    resetLocalDatabase: () => resetEncryptedDatabaseCache(
-      secureStorage: dbCipherSecureStorage,
-      onDatabaseReset: () => DmSyncState(sharedPreferences).clearAll(),
-    ),
+    // where the database is unusable. It clears the DB but not the signing key,
+    // so it costs local-only drafts and clips while an uninstall — the
+    // alternative a stuck user is left with — takes the whole Android keystore
+    // and the account with it.
+    //
+    // The cipher key stays: the diagnoses that reach this button cannot prove
+    // it is stale, and it is the only thing that can still read the backup this
+    // reset leaves behind. Keeping it also means the reset never touches the
+    // keystore, which may itself be why the user is on that screen.
+    resetLocalDatabase: () async {
+      try {
+        await resetLocalDatabaseCache(deleteCipherKey: false);
+      } catch (error, stack) {
+        // The screen keeps the user on it and says the reset failed; without
+        // this the only report of a failed recovery would be that sentence.
+        await CrashReportingService.instance.recordError(
+          error,
+          stack,
+          reason: 'Manual local database reset from the bootstrap failure app',
+        );
+        rethrow;
+      }
+    },
     runApp: runApp,
     removeNativeSplash: FlutterNativeSplash.remove,
   );

--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -115,9 +115,14 @@ class DatabaseEncryptionBootstrap {
   /// populated plaintext database could not be migrated this launch (the
   /// migration left it intact and retries on the next launch).
   ///
-  /// Throws [StateError] when SQLite3MultipleCiphers is not the active SQLite
-  /// build — a build misconfiguration that must fail loudly rather than
-  /// silently ship an unencrypted database.
+  /// Throws:
+  ///
+  /// * [DatabaseCipherUnavailableError] when SQLite3MultipleCiphers is not the
+  ///   active SQLite build — a build misconfiguration that must fail loudly
+  ///   rather than silently ship an unencrypted database.
+  /// * [DatabaseCipherStorageUnavailableException] when the keystore holding
+  ///   the cipher key cannot be read or written, most often a launch before
+  ///   the device's first unlock.
   ///
   /// Must run before the first `AppDatabase` open.
   Future<String?> resolveCipherKey() async {
@@ -203,10 +208,7 @@ class DatabaseEncryptionBootstrap {
           );
         }
         final replacementKey = generateCipherKeyHex();
-        await _secureStorage.write(
-          key: dbCipherKeyStorageKey,
-          value: replacementKey,
-        );
+        await _writeCipherKey(replacementKey);
         return (
           await _recoverUnusableEncryptedDatabase(
             replacementKey,
@@ -230,14 +232,42 @@ class DatabaseEncryptionBootstrap {
   }
 
   Future<(String, bool)> _readOrCreateKey() async {
-    final existing = await _secureStorage.read(key: dbCipherKeyStorageKey);
+    final existing = await _readCipherKey();
     if (existing != null && _isValidCipherKey(existing)) {
       return (existing, false);
     }
 
     final key = generateCipherKeyHex();
-    await _secureStorage.write(key: dbCipherKeyStorageKey, value: key);
+    await _writeCipherKey(key);
     return (key, true);
+  }
+
+  /// Reads the stored cipher key, translating a platform secure-storage
+  /// failure into [DatabaseCipherStorageUnavailableException].
+  ///
+  /// Rethrows rather than degrading a failed read into "no key stored": the
+  /// caller would generate a replacement and overwrite the only key that can
+  /// open the existing database.
+  Future<String?> _readCipherKey() async {
+    try {
+      return await _secureStorage.read(key: dbCipherKeyStorageKey);
+    } on Object catch (error, stack) {
+      Error.throwWithStackTrace(
+        DatabaseCipherStorageUnavailableException(error),
+        stack,
+      );
+    }
+  }
+
+  Future<void> _writeCipherKey(String key) async {
+    try {
+      await _secureStorage.write(key: dbCipherKeyStorageKey, value: key);
+    } on Object catch (error, stack) {
+      Error.throwWithStackTrace(
+        DatabaseCipherStorageUnavailableException(error),
+        stack,
+      );
+    }
   }
 
   Future<String> _recoverUnusableEncryptedDatabase(
@@ -285,6 +315,30 @@ class DatabaseRecoveryEvent implements Exception {
 
   @override
   String toString() => 'DatabaseRecoveryEvent: $reason';
+}
+
+/// Thrown when the platform secure storage holding the DB cipher key cannot be
+/// read or written during startup.
+///
+/// The key material is intact and only unreachable right now. The common cause
+/// is a launch while the device is still locked — a push or background fetch
+/// before the first unlock after boot — where the Keychain refuses the read.
+///
+/// Distinct from a corrupt or key-mismatched database, and deliberately NOT
+/// repairable by clearing the local cache: that path deletes the cipher key
+/// this error merely failed to reach, turning a transient lock into permanent
+/// data loss. See [shouldRepairLocalDatabaseCacheAfterBootstrapError].
+class DatabaseCipherStorageUnavailableException implements Exception {
+  DatabaseCipherStorageUnavailableException(this.cause);
+
+  /// The underlying platform failure, typically a `PlatformException` raised by
+  /// `flutter_secure_storage`.
+  final Object cause;
+
+  @override
+  String toString() =>
+      'DatabaseCipherStorageUnavailableException: '
+      'secure storage is unavailable ($cause)';
 }
 
 class DatabaseCipherUnavailableError extends StateError {
@@ -335,6 +389,9 @@ const _sqliteNotADb = 26;
 /// unusable.
 bool shouldRepairLocalDatabaseCacheAfterBootstrapError(Object error) {
   if (error is DatabaseCipherUnavailableError) return false;
+  // The database is fine; only the keystore holding its key was unreachable.
+  // Repairing would delete that key and strand a recoverable database.
+  if (error is DatabaseCipherStorageUnavailableException) return false;
 
   final message = error.toString();
   return message.contains('SqliteException($_sqliteNotADb)') ||

--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -122,7 +122,8 @@ class DatabaseEncryptionBootstrap {
   ///   rather than silently ship an unencrypted database.
   /// * [DatabaseCipherStorageUnavailableException] when the keystore holding
   ///   the cipher key cannot be read or written, most often a launch before
-  ///   the device's first unlock.
+  ///   the device's first unlock. Raised by the Keychain backends only — see
+  ///   the platform note on that class.
   ///
   /// Must run before the first `AppDatabase` open.
   Future<String?> resolveCipherKey() async {
@@ -247,7 +248,9 @@ class DatabaseEncryptionBootstrap {
   ///
   /// Rethrows rather than degrading a failed read into "no key stored": the
   /// caller would generate a replacement and overwrite the only key that can
-  /// open the existing database.
+  /// open the existing database. Covers failures that surface as a thrown
+  /// platform error — see the platform note on
+  /// [DatabaseCipherStorageUnavailableException].
   Future<String?> _readCipherKey() async {
     try {
       return await _secureStorage.read(key: dbCipherKeyStorageKey);
@@ -328,6 +331,12 @@ class DatabaseRecoveryEvent implements Exception {
 /// repairable by clearing the local cache: that path deletes the cipher key
 /// this error merely failed to reach, turning a transient lock into permanent
 /// data loss. See [shouldRepairLocalDatabaseCacheAfterBootstrapError].
+///
+/// Platform note: only the Keychain backends (iOS, macOS) surface the failure
+/// as a throw and therefore reach this type. Android's
+/// `encryptedSharedPreferences` backend falls back to plaintext preferences
+/// when the keystore cannot be initialised and reads back `null`, which this
+/// bootstrap cannot tell apart from a fresh install.
 class DatabaseCipherStorageUnavailableException implements Exception {
   DatabaseCipherStorageUnavailableException(this.cause);
 
@@ -402,15 +411,24 @@ bool shouldRepairLocalDatabaseCacheAfterBootstrapError(Object error) {
       message.contains('file is not a database');
 }
 
-/// Backs up the encrypted local database cache and removes only its DB cipher
-/// key so the next bootstrap creates a fresh encrypted cache.
+/// Backs up the encrypted local database cache so the next bootstrap creates a
+/// fresh one.
+///
+/// [deleteCipherKey] additionally removes the DB cipher key (and nothing else
+/// from the keystore). Pass `false` when the caller cannot prove the stored key
+/// is stale: the backup this call leaves behind is encrypted under that key, so
+/// deleting it makes the backup permanently unreadable — while a retained key
+/// opens a fresh database just as well as a rotated one.
 Future<void> resetEncryptedDatabaseCache({
   required FlutterSecureStorage secureStorage,
+  bool deleteCipherKey = true,
   Future<void> Function()? deleteDatabase,
   Future<void> Function()? onDatabaseReset,
 }) async {
   await (deleteDatabase ?? backUpAndRemoveSharedDatabase)();
-  await secureStorage.delete(key: dbCipherKeyStorageKey);
+  if (deleteCipherKey) {
+    await secureStorage.delete(key: dbCipherKeyStorageKey);
+  }
   await _runPostDatabaseReset(onDatabaseReset);
 }
 

--- a/mobile/lib/startup/database_bootstrap_failure_app.dart
+++ b/mobile/lib/startup/database_bootstrap_failure_app.dart
@@ -1,6 +1,7 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart' show SemanticsService;
 import 'package:flutter/services.dart';
 import 'package:openvine/services/database_encryption_bootstrap.dart';
 
@@ -82,6 +83,22 @@ const _diagnosticStyle = TextStyle(
   decoration: TextDecoration.none,
 );
 
+/// Titles are reused as screen-reader announcements when a step replaces the
+/// one before it, so they live next to each other rather than inline.
+const _failureTitle = "couldn't unlock your local database";
+const _confirmTitle = 'reset your local database?';
+const _resetDoneTitle = 'local database reset';
+const _resetFailedMessage = "That didn't work. Close Divine and try again.";
+
+/// Ceiling on the manual reset. It renames a few files and clears
+/// SharedPreferences, so anything approaching this means a platform channel is
+/// wedged — better to report a failure the user can act on than to leave the
+/// screen spinning behind two disabled buttons.
+const _resetTimeout = Duration(seconds: 15);
+
+/// Which step of the failure screen is currently on screen.
+enum _Step { failure, confirm, done }
+
 class DatabaseBootstrapFailureApp extends StatelessWidget {
   const DatabaseBootstrapFailureApp({
     required this.error,
@@ -134,7 +151,7 @@ class _FailureScreen extends StatefulWidget {
 }
 
 class _FailureScreenState extends State<_FailureScreen> {
-  bool _confirmingReset = false;
+  _Step _step = _Step.failure;
   bool _resetting = false;
   bool _resetFailed = false;
 
@@ -144,28 +161,54 @@ class _FailureScreenState extends State<_FailureScreen> {
         widget.error,
       ).allowsLocalDatabaseReset;
 
+  /// Swaps the step in place and announces it: nothing is pushed, so assistive
+  /// tech gets no route change and the focused node just disappears.
+  void _goTo(_Step step, String announcement) {
+    setState(() {
+      _step = step;
+      // A previous attempt's failure banner must not greet the user on a step
+      // they re-entered before trying again.
+      _resetFailed = false;
+    });
+    _announce(announcement);
+  }
+
   Future<void> _resetLocalDatabase() async {
     setState(() {
       _resetting = true;
       _resetFailed = false;
     });
     try {
-      await widget.onResetLocalDatabase!();
+      await widget.onResetLocalDatabase!().timeout(_resetTimeout);
     } on Object {
-      // The reset itself can fail — clearing the keystore entry needs the same
-      // keystore that may be the reason we are on this screen. Stay put and
-      // say so rather than closing on a reset that did not happen.
+      // The reset can fail outright, and a wedged platform channel can hang it
+      // past the timeout. Stay put and say so rather than closing on a reset
+      // that did not happen — or spinning behind two disabled buttons forever.
       if (!mounted) return;
       setState(() {
         _resetting = false;
         _resetFailed = true;
       });
+      _announce(_resetFailedMessage);
       return;
     }
-    // Startup already bailed out, so there is nothing to resume into. The next
-    // launch rebuilds the database from scratch.
+    if (mounted) {
+      setState(() {
+        _step = _Step.done;
+        _resetting = false;
+      });
+      _announce(_resetDoneTitle);
+    }
+    // Finishes the activity on Android. On iOS the process stays alive, which
+    // is what the done step renders for.
     widget.onCloseApp();
   }
+
+  void _announce(String message) => SemanticsService.sendAnnouncement(
+    View.of(context),
+    message,
+    Directionality.of(context),
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -177,21 +220,23 @@ class _FailureScreenState extends State<_FailureScreen> {
             padding: const EdgeInsets.symmetric(horizontal: 28, vertical: 32),
             child: ConstrainedBox(
               constraints: const BoxConstraints(maxWidth: 420),
-              child: _confirmingReset
-                  ? _ResetConfirmView(
-                      isResetting: _resetting,
-                      didFail: _resetFailed,
-                      onConfirm: _resetLocalDatabase,
-                      onCancel: () => setState(() => _confirmingReset = false),
-                    )
-                  : _FailureView(
-                      error: widget.error,
-                      stack: widget.stack,
-                      onCloseApp: widget.onCloseApp,
-                      onResetRequested: _canReset
-                          ? () => setState(() => _confirmingReset = true)
-                          : null,
-                    ),
+              child: switch (_step) {
+                _Step.failure => _FailureView(
+                  error: widget.error,
+                  stack: widget.stack,
+                  onCloseApp: widget.onCloseApp,
+                  onResetRequested: _canReset
+                      ? () => _goTo(_Step.confirm, _confirmTitle)
+                      : null,
+                ),
+                _Step.confirm => _ResetConfirmView(
+                  isResetting: _resetting,
+                  didFail: _resetFailed,
+                  onConfirm: _resetLocalDatabase,
+                  onCancel: () => _goTo(_Step.failure, _failureTitle),
+                ),
+                _Step.done => _ResetDoneView(onCloseApp: widget.onCloseApp),
+              },
             ),
           ),
         ),
@@ -213,6 +258,15 @@ class _FailureView extends StatelessWidget {
   final VoidCallback onCloseApp;
   final VoidCallback? onResetRequested;
 
+  /// The advice and the reset offer answer the same question, so one condition
+  /// decides both: unlocking and restarting is the fix for the transient
+  /// keystore case, and misleading for the diagnoses a reset is offered for.
+  String get _advice => onResetRequested != null
+      ? "A restart won't fix this one. Resetting the local database below "
+            'gives Divine a clean start — your account stays.'
+      : 'Restart Divine after unlocking your device. If this '
+            'keeps happening, update the app or contact support.';
+
   @override
   Widget build(BuildContext context) {
     return Column(
@@ -225,17 +279,12 @@ class _FailureView extends StatelessWidget {
         ),
         const SizedBox(height: 20),
         const Text(
-          "couldn't unlock your local database",
+          _failureTitle,
           textAlign: TextAlign.center,
           style: _titleStyle,
         ),
         const SizedBox(height: 12),
-        const Text(
-          'Restart Divine after unlocking your device. If this '
-          'keeps happening, update the app or contact support.',
-          textAlign: TextAlign.center,
-          style: _bodyStyle,
-        ),
+        Text(_advice, textAlign: TextAlign.center, style: _bodyStyle),
         const SizedBox(height: 12),
         Text(
           'Diagnostic: ${databaseBootstrapDiagnosticCode(error)}',
@@ -290,7 +339,7 @@ class _ResetConfirmView extends StatelessWidget {
         ),
         const SizedBox(height: 20),
         const Text(
-          'reset your local database?',
+          _confirmTitle,
           textAlign: TextAlign.center,
           style: _titleStyle,
         ),
@@ -304,7 +353,7 @@ class _ResetConfirmView extends StatelessWidget {
         if (didFail) ...[
           const SizedBox(height: 12),
           Text(
-            "That didn't work. Close Divine and try again.",
+            _resetFailedMessage,
             textAlign: TextAlign.center,
             style: _diagnosticStyle.copyWith(color: VineTheme.error),
           ),
@@ -320,6 +369,51 @@ class _ResetConfirmView extends StatelessWidget {
         DivineButton(
           label: 'cancel',
           onPressed: isResetting ? null : onCancel,
+          type: DivineButtonType.secondary,
+        ),
+      ],
+    );
+  }
+}
+
+/// Terminal step after a successful reset.
+///
+/// Only ever seen where [DatabaseBootstrapFailureApp.onCloseApp] did not end
+/// the process — on iOS `SystemNavigator.pop` cannot close the app, so without
+/// this step the confirmation would sit there spinning behind two disabled
+/// buttons with nothing left to happen.
+class _ResetDoneView extends StatelessWidget {
+  const _ResetDoneView({required this.onCloseApp});
+
+  final VoidCallback onCloseApp;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const DivineIcon(
+          icon: DivineIconName.checkCircle,
+          color: VineTheme.success,
+          size: 48,
+        ),
+        const SizedBox(height: 20),
+        const Text(
+          _resetDoneTitle,
+          textAlign: TextAlign.center,
+          style: _titleStyle,
+        ),
+        const SizedBox(height: 12),
+        const Text(
+          'Close Divine and open it again — the next launch builds a fresh '
+          'local database.',
+          textAlign: TextAlign.center,
+          style: _bodyStyle,
+        ),
+        const SizedBox(height: 24),
+        DivineButton(
+          label: 'close Divine',
+          onPressed: onCloseApp,
           type: DivineButtonType.secondary,
         ),
       ],
@@ -350,13 +444,17 @@ enum DatabaseBootstrapDiagnosis {
 
   /// Whether the screen may offer the destructive local-database reset.
   ///
-  /// Only where the database is already unusable, so the reset costs nothing
-  /// that is not lost anyway. [secureStorage] must never reach it: the
-  /// database is intact and only its keystore was unreachable, so clearing it
-  /// would trade a restart-and-retry for permanent loss of every local-only
-  /// draft and clip. [cipherUnavailable] cannot be helped either — without a
-  /// cipher, a fresh database could not be created any more than the old one
-  /// could be opened.
+  /// [cipherMismatch] is provably unusable — the key no longer opens the file.
+  /// [bootstrapFailed] is only presumed unusable: the cause is unknown, though
+  /// startup did fail on it. The reset keeps the cipher key for exactly that
+  /// reason, so the backup it leaves behind stays readable if the presumption
+  /// was wrong.
+  ///
+  /// [secureStorage] must never reach it: the database is intact and only its
+  /// keystore was unreachable, so clearing it would trade a restart-and-retry
+  /// for permanent loss of every local-only draft and clip.
+  /// [cipherUnavailable] cannot be helped either — without a cipher, a fresh
+  /// database could not be created any more than the old one could be opened.
   ///
   /// Switched exhaustively on purpose: a future diagnosis has to make this
   /// choice deliberately instead of defaulting into a destructive offer.

--- a/mobile/lib/startup/database_bootstrap_failure_app.dart
+++ b/mobile/lib/startup/database_bootstrap_failure_app.dart
@@ -141,18 +141,26 @@ class DatabaseBootstrapFailureApp extends StatelessWidget {
   }
 }
 
+/// Classifies a bootstrap failure into the short code shown on the screen, so
+/// a support report identifies the cause without a stack trace.
+///
+/// Match on error TYPE wherever the bootstrap owns the throw. The
+/// secure-storage case used to be detected by looking for `secure storage` in
+/// the message, which no error ever contains: `flutter_secure_storage` raises
+/// a `PlatformException` carrying a platform status code. Every locked-keychain
+/// failure was therefore reported as the `db-bootstrap-failed` catch-all —
+/// the one code that tells a reader nothing.
 String databaseBootstrapDiagnosticCode(Object error) {
   if (error is DatabaseCipherUnavailableError) {
     return 'db-cipher-unavailable';
   }
+  if (error is DatabaseCipherStorageUnavailableException) {
+    return 'db-secure-storage';
+  }
 
   final message = error.toString();
-  if (message.contains('SQLCipher is not linked') ||
-      message.contains('SQLite3MultipleCiphers is not active')) {
+  if (message.contains('SQLite3MultipleCiphers is not active')) {
     return 'db-cipher-unavailable';
-  }
-  if (message.contains('secure storage')) {
-    return 'db-secure-storage';
   }
   if (message.contains('SQLITE_NOTADB') || message.contains('not a database')) {
     return 'db-cipher-mismatch';

--- a/mobile/lib/startup/database_bootstrap_failure_app.dart
+++ b/mobile/lib/startup/database_bootstrap_failure_app.dart
@@ -30,6 +30,7 @@ Future<DatabaseBootstrapStartupResult> resolveDatabaseBootstrapForAppStart({
   Future<void> Function(Object error, StackTrace stack)?
   repairLocalDatabaseCache,
   bool Function(Object error)? shouldRepairLocalDatabaseCache,
+  Future<void> Function()? resetLocalDatabase,
 }) async {
   try {
     return DatabaseBootstrapStartupResult.ready(await resolveCipherKey());
@@ -45,16 +46,48 @@ Future<DatabaseBootstrapStartupResult> resolveDatabaseBootstrapForAppStart({
       }
     }
     removeNativeSplash();
-    runApp(DatabaseBootstrapFailureApp(error: error, stack: stack));
+    runApp(
+      DatabaseBootstrapFailureApp(
+        error: error,
+        stack: stack,
+        onResetLocalDatabase: resetLocalDatabase,
+      ),
+    );
     return const DatabaseBootstrapStartupResult.failure();
   }
 }
+
+// Fixed dark colors in both appearance modes. This screen replaces the whole
+// app when the database cannot be unlocked, so it runs before the appearance
+// setting is readable. Shared by both steps so the reset confirmation cannot
+// drift away from the screen it interrupts.
+const _titleStyle = TextStyle(
+  color: VineTheme.primaryText,
+  fontSize: 22,
+  fontWeight: FontWeight.w700,
+  decoration: TextDecoration.none,
+);
+
+const _bodyStyle = TextStyle(
+  color: VineTheme.onSurfaceVariant,
+  fontSize: 14,
+  height: 1.45,
+  decoration: TextDecoration.none,
+);
+
+const _diagnosticStyle = TextStyle(
+  color: VineTheme.onSurfaceVariant,
+  fontSize: 12,
+  height: 1.35,
+  decoration: TextDecoration.none,
+);
 
 class DatabaseBootstrapFailureApp extends StatelessWidget {
   const DatabaseBootstrapFailureApp({
     required this.error,
     required this.stack,
     this.onCloseApp = SystemNavigator.pop,
+    this.onResetLocalDatabase,
     super.key,
   });
 
@@ -62,77 +95,103 @@ class DatabaseBootstrapFailureApp extends StatelessWidget {
   final StackTrace stack;
   final VoidCallback onCloseApp;
 
+  /// Backs up and clears the local database so the next launch rebuilds it.
+  ///
+  /// `null` hides the affordance. Even when provided it is only offered for
+  /// diagnoses where the database is already unusable — see
+  /// [DatabaseBootstrapDiagnosis.allowsLocalDatabaseReset].
+  final Future<void> Function()? onResetLocalDatabase;
+
   @override
   Widget build(BuildContext context) {
-    // Fixed dark colors in both appearance modes. This screen replaces the
-    // whole app when the database cannot be unlocked, so it runs before the
-    // appearance setting is readable — and `context` here sits above its own
-    // `MaterialApp`, where no palette exists to resolve.
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      home: Scaffold(
-        backgroundColor: VineTheme.backgroundColor,
-        body: SafeArea(
-          child: Center(
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.symmetric(horizontal: 28, vertical: 32),
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 420),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    const DivineIcon(
-                      icon: DivineIconName.warningCircle,
-                      color: VineTheme.accentOrange,
-                      size: 48,
+      home: _FailureScreen(
+        error: error,
+        stack: stack,
+        onCloseApp: onCloseApp,
+        onResetLocalDatabase: onResetLocalDatabase,
+      ),
+    );
+  }
+}
+
+class _FailureScreen extends StatefulWidget {
+  const _FailureScreen({
+    required this.error,
+    required this.stack,
+    required this.onCloseApp,
+    required this.onResetLocalDatabase,
+  });
+
+  final Object error;
+  final StackTrace stack;
+  final VoidCallback onCloseApp;
+  final Future<void> Function()? onResetLocalDatabase;
+
+  @override
+  State<_FailureScreen> createState() => _FailureScreenState();
+}
+
+class _FailureScreenState extends State<_FailureScreen> {
+  bool _confirmingReset = false;
+  bool _resetting = false;
+  bool _resetFailed = false;
+
+  bool get _canReset =>
+      widget.onResetLocalDatabase != null &&
+      databaseBootstrapDiagnosis(
+        widget.error,
+      ).allowsLocalDatabaseReset;
+
+  Future<void> _resetLocalDatabase() async {
+    setState(() {
+      _resetting = true;
+      _resetFailed = false;
+    });
+    try {
+      await widget.onResetLocalDatabase!();
+    } on Object {
+      // The reset itself can fail — clearing the keystore entry needs the same
+      // keystore that may be the reason we are on this screen. Stay put and
+      // say so rather than closing on a reset that did not happen.
+      if (!mounted) return;
+      setState(() {
+        _resetting = false;
+        _resetFailed = true;
+      });
+      return;
+    }
+    // Startup already bailed out, so there is nothing to resume into. The next
+    // launch rebuilds the database from scratch.
+    widget.onCloseApp();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: VineTheme.backgroundColor,
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.symmetric(horizontal: 28, vertical: 32),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 420),
+              child: _confirmingReset
+                  ? _ResetConfirmView(
+                      isResetting: _resetting,
+                      didFail: _resetFailed,
+                      onConfirm: _resetLocalDatabase,
+                      onCancel: () => setState(() => _confirmingReset = false),
+                    )
+                  : _FailureView(
+                      error: widget.error,
+                      stack: widget.stack,
+                      onCloseApp: widget.onCloseApp,
+                      onResetRequested: _canReset
+                          ? () => setState(() => _confirmingReset = true)
+                          : null,
                     ),
-                    const SizedBox(height: 20),
-                    const Text(
-                      "couldn't unlock your local database",
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        color: VineTheme.primaryText,
-                        fontSize: 22,
-                        fontWeight: FontWeight.w700,
-                        decoration: TextDecoration.none,
-                      ),
-                    ),
-                    const SizedBox(height: 12),
-                    const Text(
-                      'Restart Divine after unlocking your device. If this '
-                      'keeps happening, update the app or contact support.',
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        color: VineTheme.onSurfaceVariant,
-                        fontSize: 14,
-                        height: 1.45,
-                        decoration: TextDecoration.none,
-                      ),
-                    ),
-                    const SizedBox(height: 12),
-                    Text(
-                      'Diagnostic: ${databaseBootstrapDiagnosticCode(error)}',
-                      textAlign: TextAlign.center,
-                      style: const TextStyle(
-                        color: VineTheme.onSurfaceVariant,
-                        fontSize: 12,
-                        height: 1.35,
-                        decoration: TextDecoration.none,
-                      ),
-                    ),
-                    const SizedBox(height: 24),
-                    DivineButton(
-                      label: 'close Divine',
-                      onPressed: onCloseApp,
-                      type: DivineButtonType.secondary,
-                    ),
-                    if (kDebugMode) ...[
-                      const SizedBox(height: 24),
-                      _DebugErrorDetails(error: error, stack: stack),
-                    ],
-                  ],
-                ),
-              ),
             ),
           ),
         ),
@@ -141,8 +200,174 @@ class DatabaseBootstrapFailureApp extends StatelessWidget {
   }
 }
 
-/// Classifies a bootstrap failure into the short code shown on the screen, so
-/// a support report identifies the cause without a stack trace.
+class _FailureView extends StatelessWidget {
+  const _FailureView({
+    required this.error,
+    required this.stack,
+    required this.onCloseApp,
+    required this.onResetRequested,
+  });
+
+  final Object error;
+  final StackTrace stack;
+  final VoidCallback onCloseApp;
+  final VoidCallback? onResetRequested;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const DivineIcon(
+          icon: DivineIconName.warningCircle,
+          color: VineTheme.accentOrange,
+          size: 48,
+        ),
+        const SizedBox(height: 20),
+        const Text(
+          "couldn't unlock your local database",
+          textAlign: TextAlign.center,
+          style: _titleStyle,
+        ),
+        const SizedBox(height: 12),
+        const Text(
+          'Restart Divine after unlocking your device. If this '
+          'keeps happening, update the app or contact support.',
+          textAlign: TextAlign.center,
+          style: _bodyStyle,
+        ),
+        const SizedBox(height: 12),
+        Text(
+          'Diagnostic: ${databaseBootstrapDiagnosticCode(error)}',
+          textAlign: TextAlign.center,
+          style: _diagnosticStyle,
+        ),
+        const SizedBox(height: 24),
+        DivineButton(
+          label: 'close Divine',
+          onPressed: onCloseApp,
+          type: DivineButtonType.secondary,
+        ),
+        if (onResetRequested != null) ...[
+          const SizedBox(height: 12),
+          DivineButton(
+            label: 'reset local database',
+            onPressed: onResetRequested,
+            type: DivineButtonType.link,
+          ),
+        ],
+        if (kDebugMode) ...[
+          const SizedBox(height: 24),
+          _DebugErrorDetails(error: error, stack: stack),
+        ],
+      ],
+    );
+  }
+}
+
+class _ResetConfirmView extends StatelessWidget {
+  const _ResetConfirmView({
+    required this.isResetting,
+    required this.didFail,
+    required this.onConfirm,
+    required this.onCancel,
+  });
+
+  final bool isResetting;
+  final bool didFail;
+  final VoidCallback onConfirm;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const DivineIcon(
+          icon: DivineIconName.warningCircle,
+          color: VineTheme.accentOrange,
+          size: 48,
+        ),
+        const SizedBox(height: 20),
+        const Text(
+          'reset your local database?',
+          textAlign: TextAlign.center,
+          style: _titleStyle,
+        ),
+        const SizedBox(height: 12),
+        const Text(
+          'Your account stays. Drafts and clips saved on this device are '
+          'deleted — messages and feeds come back from the network.',
+          textAlign: TextAlign.center,
+          style: _bodyStyle,
+        ),
+        if (didFail) ...[
+          const SizedBox(height: 12),
+          Text(
+            "That didn't work. Close Divine and try again.",
+            textAlign: TextAlign.center,
+            style: _diagnosticStyle.copyWith(color: VineTheme.error),
+          ),
+        ],
+        const SizedBox(height: 24),
+        DivineButton(
+          label: 'reset and close',
+          onPressed: isResetting ? null : onConfirm,
+          isLoading: isResetting,
+          type: DivineButtonType.error,
+        ),
+        const SizedBox(height: 12),
+        DivineButton(
+          label: 'cancel',
+          onPressed: isResetting ? null : onCancel,
+          type: DivineButtonType.secondary,
+        ),
+      ],
+    );
+  }
+}
+
+/// Why the startup database bootstrap failed, as shown on the failure screen.
+enum DatabaseBootstrapDiagnosis {
+  /// The active SQLite build has no cipher — a build misconfiguration.
+  cipherUnavailable('db-cipher-unavailable'),
+
+  /// The keystore holding the cipher key was unreachable, most often a launch
+  /// before the device's first unlock.
+  secureStorage('db-secure-storage'),
+
+  /// The key no longer opens the database file.
+  cipherMismatch('db-cipher-mismatch'),
+
+  /// Anything else. Read the exception from Crashlytics for this one.
+  bootstrapFailed('db-bootstrap-failed');
+
+  const DatabaseBootstrapDiagnosis(this.code);
+
+  /// Short identifier rendered on the screen, so a support report names the
+  /// cause without a stack trace.
+  final String code;
+
+  /// Whether the screen may offer the destructive local-database reset.
+  ///
+  /// Only where the database is already unusable, so the reset costs nothing
+  /// that is not lost anyway. [secureStorage] must never reach it: the
+  /// database is intact and only its keystore was unreachable, so clearing it
+  /// would trade a restart-and-retry for permanent loss of every local-only
+  /// draft and clip. [cipherUnavailable] cannot be helped either — without a
+  /// cipher, a fresh database could not be created any more than the old one
+  /// could be opened.
+  ///
+  /// Switched exhaustively on purpose: a future diagnosis has to make this
+  /// choice deliberately instead of defaulting into a destructive offer.
+  bool get allowsLocalDatabaseReset => switch (this) {
+    cipherMismatch || bootstrapFailed => true,
+    cipherUnavailable || secureStorage => false,
+  };
+}
+
+/// Classifies a bootstrap failure so the screen can name the cause and decide
+/// whether a reset is safe to offer.
 ///
 /// Match on error TYPE wherever the bootstrap owns the throw. The
 /// secure-storage case used to be detected by looking for `secure storage` in
@@ -150,23 +375,27 @@ class DatabaseBootstrapFailureApp extends StatelessWidget {
 /// a `PlatformException` carrying a platform status code. Every locked-keychain
 /// failure was therefore reported as the `db-bootstrap-failed` catch-all —
 /// the one code that tells a reader nothing.
-String databaseBootstrapDiagnosticCode(Object error) {
+DatabaseBootstrapDiagnosis databaseBootstrapDiagnosis(Object error) {
   if (error is DatabaseCipherUnavailableError) {
-    return 'db-cipher-unavailable';
+    return DatabaseBootstrapDiagnosis.cipherUnavailable;
   }
   if (error is DatabaseCipherStorageUnavailableException) {
-    return 'db-secure-storage';
+    return DatabaseBootstrapDiagnosis.secureStorage;
   }
 
   final message = error.toString();
   if (message.contains('SQLite3MultipleCiphers is not active')) {
-    return 'db-cipher-unavailable';
+    return DatabaseBootstrapDiagnosis.cipherUnavailable;
   }
   if (message.contains('SQLITE_NOTADB') || message.contains('not a database')) {
-    return 'db-cipher-mismatch';
+    return DatabaseBootstrapDiagnosis.cipherMismatch;
   }
-  return 'db-bootstrap-failed';
+  return DatabaseBootstrapDiagnosis.bootstrapFailed;
 }
+
+/// The short diagnostic code for [error], as rendered on the failure screen.
+String databaseBootstrapDiagnosticCode(Object error) =>
+    databaseBootstrapDiagnosis(error).code;
 
 class _DebugErrorDetails extends StatelessWidget {
   const _DebugErrorDetails({required this.error, required this.stack});

--- a/mobile/test/services/database_encryption_bootstrap_test.dart
+++ b/mobile/test/services/database_encryption_bootstrap_test.dart
@@ -1,4 +1,5 @@
 import 'package:db_client/db_client.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -96,6 +97,50 @@ void main() {
         throwsA(isA<DatabaseCipherUnavailableError>()),
       );
     });
+
+    test(
+      'surfaces an unreachable keystore as '
+      'DatabaseCipherStorageUnavailableException without rotating the key',
+      () async {
+        // What flutter_secure_storage raises when the Keychain refuses a read
+        // because the device is still locked: a status code, no prose.
+        final platformFailure = PlatformException(
+          code: 'Unexpected security result code',
+          message: 'Code: -25308, Message: User interaction is not allowed.',
+        );
+        when(
+          () => storage.read(key: any(named: 'key')),
+        ).thenThrow(platformFailure);
+        final bootstrap = buildBootstrap(
+          outcome: CipherMigrationOutcome.noDatabase,
+          onDelete: () {},
+        );
+
+        await expectLater(
+          bootstrap.resolveCipherKey(),
+          throwsA(
+            isA<DatabaseCipherStorageUnavailableException>().having(
+              (e) => e.cause,
+              'cause',
+              same(platformFailure),
+            ),
+          ),
+        );
+        verifyNever(
+          () => storage.write(
+            key: any(named: 'key'),
+            value: any(named: 'value'),
+          ),
+        );
+        expect(
+          store,
+          isEmpty,
+          reason:
+              'a failed read must not be read as "no key stored" — that '
+              'would overwrite the only key that opens the existing database',
+        );
+      },
+    );
 
     test(
       'generates and persists a key on fresh install (noDatabase)',

--- a/mobile/test/services/database_encryption_bootstrap_test.dart
+++ b/mobile/test/services/database_encryption_bootstrap_test.dart
@@ -143,6 +143,40 @@ void main() {
     );
 
     test(
+      'surfaces an unwritable keystore as '
+      'DatabaseCipherStorageUnavailableException',
+      () async {
+        // Same locked-keystore shape as the read above, on the other half of
+        // the contract: a launch that has to persist a key cannot either.
+        final platformFailure = PlatformException(
+          code: 'Unexpected security result code',
+          message: 'Code: -25308, Message: User interaction is not allowed.',
+        );
+        when(
+          () => storage.write(
+            key: any(named: 'key'),
+            value: any(named: 'value'),
+          ),
+        ).thenThrow(platformFailure);
+        final bootstrap = buildBootstrap(
+          outcome: CipherMigrationOutcome.noDatabase,
+          onDelete: () {},
+        );
+
+        await expectLater(
+          bootstrap.resolveCipherKey(),
+          throwsA(
+            isA<DatabaseCipherStorageUnavailableException>().having(
+              (e) => e.cause,
+              'cause',
+              same(platformFailure),
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
       'generates and persists a key on fresh install (noDatabase)',
       () async {
         var deleted = false;
@@ -598,6 +632,29 @@ void main() {
         expect(store, isNot(contains(dbCipherKeyStorageKey)));
         expect(store['auth_key'], equals('must-stay'));
         expect(reset, isTrue);
+      },
+    );
+
+    test(
+      'keeps the cipher key when the caller opts out of deleting it',
+      () async {
+        var deleted = false;
+
+        await resetEncryptedDatabaseCache(
+          secureStorage: storage,
+          deleteCipherKey: false,
+          deleteDatabase: () async => deleted = true,
+        );
+
+        expect(deleted, isTrue);
+        expect(
+          store[dbCipherKeyStorageKey],
+          isNotNull,
+          reason:
+              'the backup this leaves behind is encrypted under that key, so '
+              'deleting it would make the backup permanently unreadable',
+        );
+        verifyNever(() => storage.delete(key: any(named: 'key')));
       },
     );
   });

--- a/mobile/test/startup/database_bootstrap_failure_app_test.dart
+++ b/mobile/test/startup/database_bootstrap_failure_app_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -354,6 +356,29 @@ void main() {
       expect(find.text('reset local database'), findsNothing);
     });
 
+    testWidgets('drops the unlock-and-restart advice when a reset is offered', (
+      tester,
+    ) async {
+      // Telling the user to restart after unlocking is the fix for the
+      // keystore case only, and misleading next to a reset button.
+      await tester.pumpWidget(
+        DatabaseBootstrapFailureApp(
+          error: StateError('something else entirely'),
+          stack: StackTrace.current,
+          onResetLocalDatabase: () async {},
+        ),
+      );
+
+      expect(
+        find.textContaining('Restart Divine after unlocking'),
+        findsNothing,
+      );
+      expect(
+        find.textContaining("A restart won't fix this one"),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('resets and closes once the user confirms', (tester) async {
       var resets = 0;
       var closed = false;
@@ -426,6 +451,95 @@ void main() {
         closed,
         isFalse,
         reason: 'closing would claim a reset that never happened',
+      );
+    });
+
+    testWidgets('lands on a terminal step when the app cannot close itself', (
+      tester,
+    ) async {
+      // SystemNavigator.pop cannot end the process on iOS, so without this
+      // step a successful reset leaves a spinner behind two disabled buttons.
+      var closes = 0;
+
+      await tester.pumpWidget(
+        DatabaseBootstrapFailureApp(
+          error: StateError('something else entirely'),
+          stack: StackTrace.current,
+          onCloseApp: () => closes++,
+          onResetLocalDatabase: () async {},
+        ),
+      );
+
+      await tester.tap(find.text('reset local database'));
+      await tester.pump();
+      await tester.tap(find.text('reset and close'));
+      await tester.pump();
+
+      expect(find.text('local database reset'), findsOneWidget);
+      expect(find.text('reset and close'), findsNothing);
+      expect(closes, equals(1));
+
+      await tester.tap(find.text('close Divine'));
+      expect(
+        closes,
+        equals(2),
+        reason: 'the terminal step still needs a live way out',
+      );
+    });
+
+    testWidgets('reports a reset that hangs instead of spinning forever', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        DatabaseBootstrapFailureApp(
+          error: StateError('something else entirely'),
+          stack: StackTrace.current,
+          onResetLocalDatabase: () => Completer<void>().future,
+        ),
+      );
+
+      await tester.tap(find.text('reset local database'));
+      await tester.pump();
+      await tester.tap(find.text('reset and close'));
+      await tester.pump(const Duration(seconds: 16));
+
+      expect(find.textContaining("That didn't work"), findsOneWidget);
+
+      await tester.tap(find.text('cancel'));
+      await tester.pump();
+      expect(
+        find.text("couldn't unlock your local database"),
+        findsOneWidget,
+        reason: 'a wedged platform call must not disable the way back',
+      );
+    });
+
+    testWidgets('drops a stale failure banner when the step is re-entered', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        DatabaseBootstrapFailureApp(
+          error: StateError('something else entirely'),
+          stack: StackTrace.current,
+          onResetLocalDatabase: () async => throw StateError('nope'),
+        ),
+      );
+
+      await tester.tap(find.text('reset local database'));
+      await tester.pump();
+      await tester.tap(find.text('reset and close'));
+      await tester.pump();
+      expect(find.textContaining("That didn't work"), findsOneWidget);
+
+      await tester.tap(find.text('cancel'));
+      await tester.pump();
+      await tester.tap(find.text('reset local database'));
+      await tester.pump();
+
+      expect(
+        find.textContaining("That didn't work"),
+        findsNothing,
+        reason: 'the banner belongs to an attempt, not to the step',
       );
     });
   });

--- a/mobile/test/startup/database_bootstrap_failure_app_test.dart
+++ b/mobile/test/startup/database_bootstrap_failure_app_test.dart
@@ -239,6 +239,25 @@ void main() {
     );
   });
 
+  group('resolveDatabaseBootstrapForAppStart reset wiring', () {
+    test('hands the reset hook to the failure app', () async {
+      Widget? renderedApp;
+      Future<void> reset() async {}
+
+      await resolveDatabaseBootstrapForAppStart(
+        resolveCipherKey: () async => throw StateError('bootstrap failed'),
+        resetLocalDatabase: reset,
+        removeNativeSplash: () {},
+        runApp: (app) => renderedApp = app,
+      );
+
+      expect(
+        (renderedApp! as DatabaseBootstrapFailureApp).onResetLocalDatabase,
+        same(reset),
+      );
+    });
+  });
+
   group(DatabaseBootstrapFailureApp, () {
     testWidgets('shows a visible database startup failure screen', (
       tester,
@@ -302,6 +321,125 @@ void main() {
       expect(
         databaseBootstrapDiagnosticCode(StateError('something else entirely')),
         equals('db-bootstrap-failed'),
+      );
+    });
+
+    testWidgets('offers no reset when the caller supplies no hook', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        DatabaseBootstrapFailureApp(
+          error: StateError('something else entirely'),
+          stack: StackTrace.current,
+        ),
+      );
+
+      expect(find.text('reset local database'), findsNothing);
+    });
+
+    testWidgets('offers no reset for a locked keystore', (tester) async {
+      // The database is intact here and the reset would delete the key that
+      // opens it. Offering the button would be worse than offering nothing.
+      await tester.pumpWidget(
+        DatabaseBootstrapFailureApp(
+          error: DatabaseCipherStorageUnavailableException(
+            _lockedKeychainFailure(),
+          ),
+          stack: StackTrace.current,
+          onResetLocalDatabase: () async {},
+        ),
+      );
+
+      expect(find.text('Diagnostic: db-secure-storage'), findsOneWidget);
+      expect(find.text('reset local database'), findsNothing);
+    });
+
+    testWidgets('resets and closes once the user confirms', (tester) async {
+      var resets = 0;
+      var closed = false;
+
+      await tester.pumpWidget(
+        DatabaseBootstrapFailureApp(
+          error: StateError('something else entirely'),
+          stack: StackTrace.current,
+          onCloseApp: () => closed = true,
+          onResetLocalDatabase: () async => resets++,
+        ),
+      );
+
+      await tester.tap(find.text('reset local database'));
+      await tester.pump();
+
+      expect(find.text('reset your local database?'), findsOneWidget);
+      expect(find.textContaining('Your account stays'), findsOneWidget);
+      expect(resets, isZero, reason: 'confirmation must gate the wipe');
+
+      await tester.tap(find.text('reset and close'));
+      await tester.pump();
+
+      expect(resets, equals(1));
+      expect(closed, isTrue);
+    });
+
+    testWidgets('returns to the failure screen on cancel', (tester) async {
+      var resets = 0;
+
+      await tester.pumpWidget(
+        DatabaseBootstrapFailureApp(
+          error: StateError('something else entirely'),
+          stack: StackTrace.current,
+          onResetLocalDatabase: () async => resets++,
+        ),
+      );
+
+      await tester.tap(find.text('reset local database'));
+      await tester.pump();
+      await tester.tap(find.text('cancel'));
+      await tester.pump();
+
+      expect(find.text("couldn't unlock your local database"), findsOneWidget);
+      expect(resets, isZero);
+    });
+
+    testWidgets('stays put and reports when the reset itself fails', (
+      tester,
+    ) async {
+      var closed = false;
+
+      await tester.pumpWidget(
+        DatabaseBootstrapFailureApp(
+          error: StateError('something else entirely'),
+          stack: StackTrace.current,
+          onCloseApp: () => closed = true,
+          onResetLocalDatabase: () async =>
+              throw StateError('keystore delete failed'),
+        ),
+      );
+
+      await tester.tap(find.text('reset local database'));
+      await tester.pump();
+      await tester.tap(find.text('reset and close'));
+      await tester.pump();
+
+      expect(find.textContaining("That didn't work"), findsOneWidget);
+      expect(
+        closed,
+        isFalse,
+        reason: 'closing would claim a reset that never happened',
+      );
+    });
+  });
+
+  group(DatabaseBootstrapDiagnosis, () {
+    test('allows a reset only where the database is already unusable', () {
+      expect(
+        DatabaseBootstrapDiagnosis.values
+            .where((d) => d.allowsLocalDatabaseReset)
+            .toSet(),
+        equals({
+          DatabaseBootstrapDiagnosis.cipherMismatch,
+          DatabaseBootstrapDiagnosis.bootstrapFailed,
+        }),
       );
     });
   });

--- a/mobile/test/startup/database_bootstrap_failure_app_test.dart
+++ b/mobile/test/startup/database_bootstrap_failure_app_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/database_encryption_bootstrap.dart';
 import 'package:openvine/startup/database_bootstrap_failure_app.dart';
@@ -174,7 +175,9 @@ void main() {
         Widget? renderedApp;
         var attempts = 0;
         var repaired = false;
-        final error = StateError('secure storage unavailable before unlock');
+        final error = DatabaseCipherStorageUnavailableException(
+          _lockedKeychainFailure(),
+        );
 
         final result = await resolveDatabaseBootstrapForAppStart(
           resolveCipherKey: () async {
@@ -244,7 +247,9 @@ void main() {
 
       await tester.pumpWidget(
         DatabaseBootstrapFailureApp(
-          error: StateError('secure storage unavailable'),
+          error: DatabaseCipherStorageUnavailableException(
+            _lockedKeychainFailure(),
+          ),
           stack: StackTrace.current,
           onCloseApp: () => closed = true,
         ),
@@ -255,7 +260,9 @@ void main() {
         findsOneWidget,
       );
       expect(find.textContaining('Restart Divine'), findsOneWidget);
-      expect(find.textContaining('Diagnostic:'), findsOneWidget);
+      // The rendered code is what a support report is triaged from, so pin the
+      // value rather than just the label.
+      expect(find.text('Diagnostic: db-secure-storage'), findsOneWidget);
 
       await tester.tap(find.text('close Divine'));
       expect(closed, isTrue);
@@ -267,6 +274,34 @@ void main() {
           DatabaseCipherUnavailableError(),
         ),
         equals('db-cipher-unavailable'),
+      );
+    });
+
+    test('classifies an unreachable keystore as a secure-storage failure', () {
+      expect(
+        databaseBootstrapDiagnosticCode(
+          DatabaseCipherStorageUnavailableException(_lockedKeychainFailure()),
+        ),
+        equals('db-secure-storage'),
+      );
+    });
+
+    test('classifies a key that no longer opens the database', () {
+      expect(
+        databaseBootstrapDiagnosticCode(
+          SqliteException(
+            extendedResultCode: 26,
+            message: 'file is not a database',
+          ),
+        ),
+        equals('db-cipher-mismatch'),
+      );
+    });
+
+    test('falls back to the catch-all for unrecognized failures', () {
+      expect(
+        databaseBootstrapDiagnosticCode(StateError('something else entirely')),
+        equals('db-bootstrap-failed'),
       );
     });
   });
@@ -300,12 +335,23 @@ void main() {
         ),
         isFalse,
       );
+      // Repairing deletes the cipher key. The database behind a locked keychain
+      // is intact, so clearing it would turn a restart-and-retry into
+      // permanent loss of every local-only draft and clip.
       expect(
         shouldRepairLocalDatabaseCacheAfterBootstrapError(
-          StateError('secure storage unavailable before unlock'),
+          DatabaseCipherStorageUnavailableException(_lockedKeychainFailure()),
         ),
         isFalse,
       );
     });
   });
 }
+
+/// What `flutter_secure_storage` raises when the Keychain refuses a read on a
+/// still-locked device: a platform status code and no prose, which is why
+/// classifying this case by message never matched.
+PlatformException _lockedKeychainFailure() => PlatformException(
+  code: 'Unexpected security result code',
+  message: 'Code: -25308, Message: User interaction is not allowed.',
+);


### PR DESCRIPTION
Closes #6580

## Description

A user reported the "couldn't unlock your local database" fail-closed screen showing `db-bootstrap-failed`, with one button on it: close Divine. Two problems, plus a review pass that made the fix for the second one safe to complete.

### 1. The diagnosis was unreachable for a whole class of failures

`databaseBootstrapDiagnosticCode` detected the secure-storage case by looking for the literal `secure storage` in the error message. Nothing in the codebase produces that text: `flutter_secure_storage` raises a `PlatformException` carrying a platform status code and no prose (iOS `Code: -25308, User interaction is not allowed`). So every locked-keychain launch was filed under the `db-bootstrap-failed` catch-all — and that is exactly the case the screen's own copy, "Restart Divine after unlocking your device", is written for. The one variant a user can fix in ten seconds was indistinguishable from the ones they can't.

The bootstrap's keystore access is now wrapped in a typed `DatabaseCipherStorageUnavailableException` and classification matches on the type. The original stack is preserved with `Error.throwWithStackTrace`, so Crashlytics grouping is unchanged.

The repair allowlist now excludes that type explicitly. Repair deletes the cipher key, and behind a locked keychain the database is intact — clearing it would turn a restart-and-retry into permanent loss. That was already the behaviour, but only by accident (no marker matched); now it can't regress when the allowlist widens.

Also drops the `SQLCipher is not linked` check — a 1.0.15 message no code has produced since the SQLite3MultipleCiphers migration in #5331.

Note the guarantee is platform-scoped, and the docs now say so: only the Keychain backends surface the failure as a throw. Android's `encryptedSharedPreferences` backend falls back to plaintext preferences when the keystore cannot be initialised and reads back `null`, which the bootstrap cannot tell apart from a fresh install. Closing that gap needs a written-a-key-before marker and belongs with the accessibility migration below.

### 2. A stuck user had no way out except reinstalling

Reinstalling is the worst available option on Android: the signing key lives in app data and `backup_rules.xml` excludes it from cloud backup and device transfer, so the account is gone unless the nsec was written down. An in-app reset clears the database but *not* the signing key — the same recovery, costing local-only drafts and clips instead of the account.

It is gated on the diagnosis rather than offered unconditionally:

| Diagnosis | Reset offered | Why |
|---|---|---|
| `db-secure-storage` | no | Database is intact, only its keystore was unreachable. Resetting would delete data a restart recovers for free. |
| `db-cipher-unavailable` | no | No cipher available, so a fresh database could not be created any more than the old one could be opened. |
| `db-cipher-mismatch` | yes | The key already doesn't open the file; nothing left to lose. |
| `db-bootstrap-failed` | yes, confirmed | Cause unknown, database presumed unusable. The cipher key is kept in case that presumption is wrong — see below. |

That table is why the commits belong together: the gate is only safe because the first commit made the diagnosis trustworthy. The diagnosis is now an enum and the gate an exhaustive switch, so a future code has to make this choice deliberately instead of defaulting into a destructive offer.

The reset sits below "close Divine" so the non-destructive action stays primary, and is behind a confirmation naming what is lost.

Naming note: the new exception ends in `Exception` while its sibling `DatabaseCipherUnavailableError` ends in `Error`. Deliberate — the sibling is a build misconfiguration (a genuine `StateError`, reportable per `.claude/rules/error_handling.md`), this one is an expected environmental condition that must not be treated as a programming invariant violation.

### 3. The reset was safe to offer, but not yet safe to complete

A review pass over the two commits above found three ways the flow broke *after* the user confirmed. All three are in the third commit.

**A successful reset had nowhere to land.** `SystemNavigator.pop` cannot end the process on iOS, and the success path never cleared the loading flag, so the confirmation sat there spinning behind two disabled buttons with nothing left to happen — on the very platform the locked-Keychain diagnosis is written for, and on the one flow that exists to unstick a stuck user. The screen now moves to a terminal step that says to close and reopen Divine, and still closes the app from there so Android finishes the activity exactly as before.

**The reset deleted the DB cipher key.** For `db-bootstrap-failed` the cause is unknown and the key may be perfectly valid, so deleting it made the backup the reset had just created permanently unreadable — the same invariant the bootstrap defends when it refuses to rotate a still-valid key before a wipe. `resetEncryptedDatabaseCache` now takes `deleteCipherKey`, defaulting to the old behaviour so the automatic repair is untouched, and the manual path keeps the key. A fresh database opens just as well under a retained key. Keeping it also drops the reset's last keystore dependency — which may itself be why the user is on this screen — so the "a reset that throws keeps the screen and says so" path is now a genuine edge rather than the likely one.

**A failing reset was swallowed whole.** The catch did not even bind the error, so the only report of a failed recovery was one sentence on screen. It now records to Crashlytics before rethrowing.

Smaller fixes from the same pass: the failure banner is cleared when the confirmation is re-entered rather than greeting the user with a previous attempt; each step swap and the failure are announced to screen readers, since nothing is pushed and the focused node just disappears; the reset times out so a wedged platform channel cannot hang it forever; the screen stops advising a restart on the diagnoses where restarting cannot help, which previously sat directly above the reset button; and one closure is shared between the automatic repair and the manual reset so the two cannot drift apart.

**Related Issue:** 

## Out of Scope

**The root cause of the keychain variant.** The DB cipher key is written with the `flutter_secure_storage` default `KeychainAccessibility.unlocked`, while the nsec uses `first_unlock` (`packages/nostr_key_manager/lib/src/platform_secure_storage.dart`). The key is therefore unreadable whenever the device is locked, including a background launch before the first unlock after boot — which matches the `processState: BACKGROUND` on the historical Crashlytics events. Aligning it needs the legacy-read-and-rewrite migration that `platform_secure_storage.dart` already implements, because an existing keychain item keeps its accessibility when overwritten. Own PR: a mistake there costs the key, and with it the database.

**Android's silent keystore fallback.** Detecting it needs a persisted "a key was written once" marker so a `null` read can be told apart from a fresh install. That is a storage-format change with its own migration, not a docs fix.

**Screen copy stays hardcoded English.** This screen builds its own `MaterialApp` without localization delegates, since it runs after startup has already bailed out. The confirmation, terminal, and diagnosis-dependent steps follow the existing convention on this screen rather than introducing a partial l10n setup here.

## Verification

- `dart format` on all changed files — clean
- `flutter analyze lib test integration_test` — No issues found
- All four design-system ceiling ratchets (`raw_textstyle`, `raw_colors`, `material_button`, `raw_dialog`) — OK. The screen's existing inline styles were extracted into shared constants and reused by every step, so the raw-`TextStyle` count stays at its baseline of 4 rather than growing.
- `flutter test test/services/database_encryption_bootstrap_test.dart test/startup/database_bootstrap_failure_app_test.dart test/main_background_launch_downloads_test.dart test/main_video_cache_startup_test.dart` — 63/63 passing
- Manual verification on a real Samsung Galaxy — pending, this is a draft
- Screenshots of the reset flow — pending

The load-bearing test on the fix is in the bootstrap suite: when the keystore read throws, `resolveCipherKey` must raise the typed exception *and* write no replacement key. A failed read must never be read as "no key stored", or the bootstrap overwrites the only key that opens the existing database. The write half of that contract is pinned too — a regression there would re-open the original misclassification and, through it, flip the reset gate.

The load-bearing test on the feature is `offers no reset for a locked keystore` — the case where showing the button would cause the data loss it appears to prevent. `lands on a terminal step when the app cannot close itself` covers the iOS failure above: it drives the reset with an `onCloseApp` that does not terminate, which is what iOS actually does.

Existing tests for this path asserted against hand-built `StateError('secure storage unavailable')` values — a string no production code emits, which is why the dead branch looked covered. Those now use the real type.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
