### PR TITLE
fix(auth): stop anonymous signup emitting after close

### DIFF
--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -359,6 +359,11 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
         category: LogCategory.auth,
       );
 
+      // Same close-mid-flight race as skipWithAnonymousAccount: the sign-in
+      // above flips AuthService to `authenticated` before returning, which
+      // can reroute off the auth screen and close this cubit.
+      if (isClosed) return;
+
       emit(const DivineAuthSuccess());
     } on InviteApiException catch (e, stackTrace) {
       await _authService.clearPendingDivineOAuthSession();
@@ -372,7 +377,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       addError(e, stackTrace);
 
       final current = state;
-      if (current is DivineAuthFormState) {
+      if (!isClosed && current is DivineAuthFormState) {
         emit(
           current.copyWith(
             isSubmitting: false,
@@ -393,7 +398,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       addError(e, stackTrace);
 
       final current = state;
-      if (current is DivineAuthFormState) {
+      if (!isClosed && current is DivineAuthFormState) {
         emit(current.copyWith(isSubmitting: false, generalError: e.message));
       }
     } catch (e, stackTrace) {
@@ -407,7 +412,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       addError(e, stackTrace);
 
       final current = state;
-      if (current is DivineAuthFormState) {
+      if (!isClosed && current is DivineAuthFormState) {
         emit(
           current.copyWith(
             isSubmitting: false,

--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -194,7 +194,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       addError(e, stackTrace);
 
       final currentState = state;
-      if (currentState is DivineAuthFormState) {
+      if (!isClosed && currentState is DivineAuthFormState) {
         emit(
           currentState.copyWith(
             isSubmitting: false,
@@ -228,7 +228,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       );
 
       final current = state;
-      if (current is DivineAuthFormState) {
+      if (!isClosed && current is DivineAuthFormState) {
         emit(
           current.copyWith(isSubmitting: false, signInFailureReason: reason),
         );
@@ -286,7 +286,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       );
 
       final current = state;
-      if (current is DivineAuthFormState) {
+      if (!isClosed && current is DivineAuthFormState) {
         emit(
           current.copyWith(
             isSubmitting: false,
@@ -313,6 +313,8 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
         inviteCode: _inviteCode,
       );
 
+      if (isClosed) return;
+
       // Emit email verification state
       emit(
         DivineAuthEmailVerification(
@@ -323,7 +325,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       );
     } else {
       final current = state;
-      if (current is DivineAuthFormState) {
+      if (!isClosed && current is DivineAuthFormState) {
         emit(
           current.copyWith(
             isSubmitting: false,

--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -487,6 +487,13 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
         category: LogCategory.auth,
       );
 
+      // The account creation above flips AuthService to `authenticated`
+      // before it returns, which reroutes off the create-account screen and
+      // closes this cubit. Emitting the success state is then both
+      // impossible and unnecessary — the navigation it would trigger has
+      // already happened.
+      if (isClosed) return;
+
       emit(const DivineAuthSuccess());
     } on InviteApiException catch (e, stackTrace) {
       Log.error(
@@ -499,7 +506,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       addError(e, stackTrace);
 
       final currentState = state;
-      if (currentState is DivineAuthFormState) {
+      if (!isClosed && currentState is DivineAuthFormState) {
         emit(
           currentState.copyWith(
             isSkipping: false,
@@ -521,7 +528,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       addError(e, stackTrace);
 
       final currentState = state;
-      if (currentState is DivineAuthFormState) {
+      if (!isClosed && currentState is DivineAuthFormState) {
         emit(
           currentState.copyWith(
             isSkipping: false,

--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -126,6 +126,11 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
     emit(current.copyWith(obscurePassword: !current.obscurePassword));
   }
 
+  void _emitIfOpen(DivineAuthState nextState) {
+    if (isClosed) return;
+    emit(nextState);
+  }
+
   /// Validate and submit the form
   Future<void> submit() async {
     final current = state;
@@ -194,8 +199,8 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       addError(e, stackTrace);
 
       final currentState = state;
-      if (!isClosed && currentState is DivineAuthFormState) {
-        emit(
+      if (currentState is DivineAuthFormState) {
+        _emitIfOpen(
           currentState.copyWith(
             isSubmitting: false,
             generalError: 'An unexpected error occurred. Please try again.',
@@ -228,8 +233,8 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       );
 
       final current = state;
-      if (!isClosed && current is DivineAuthFormState) {
-        emit(
+      if (current is DivineAuthFormState) {
+        _emitIfOpen(
           current.copyWith(isSubmitting: false, signInFailureReason: reason),
         );
       }
@@ -286,8 +291,8 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       );
 
       final current = state;
-      if (!isClosed && current is DivineAuthFormState) {
-        emit(
+      if (current is DivineAuthFormState) {
+        _emitIfOpen(
           current.copyWith(
             isSubmitting: false,
             generalError: errorMsg,
@@ -313,10 +318,8 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
         inviteCode: _inviteCode,
       );
 
-      if (isClosed) return;
-
       // Emit email verification state
-      emit(
+      _emitIfOpen(
         DivineAuthEmailVerification(
           email: email,
           deviceCode: result.deviceCode!,
@@ -325,8 +328,8 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       );
     } else {
       final current = state;
-      if (!isClosed && current is DivineAuthFormState) {
-        emit(
+      if (current is DivineAuthFormState) {
+        _emitIfOpen(
           current.copyWith(
             isSubmitting: false,
             generalError: 'Registration complete. Please check your email.',
@@ -364,9 +367,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       // Same close-mid-flight race as skipWithAnonymousAccount: the sign-in
       // above flips AuthService to `authenticated` before returning, which
       // can reroute off the auth screen and close this cubit.
-      if (isClosed) return;
-
-      emit(const DivineAuthSuccess());
+      _emitIfOpen(const DivineAuthSuccess());
     } on InviteApiException catch (e, stackTrace) {
       await _authService.clearPendingDivineOAuthSession();
       Log.error(
@@ -379,8 +380,8 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       addError(e, stackTrace);
 
       final current = state;
-      if (!isClosed && current is DivineAuthFormState) {
-        emit(
+      if (current is DivineAuthFormState) {
+        _emitIfOpen(
           current.copyWith(
             isSubmitting: false,
             generalError: InviteErrorUtils.activationFailureMessage(e),
@@ -400,8 +401,10 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       addError(e, stackTrace);
 
       final current = state;
-      if (!isClosed && current is DivineAuthFormState) {
-        emit(current.copyWith(isSubmitting: false, generalError: e.message));
+      if (current is DivineAuthFormState) {
+        _emitIfOpen(
+          current.copyWith(isSubmitting: false, generalError: e.message),
+        );
       }
     } catch (e, stackTrace) {
       Log.error(
@@ -414,8 +417,8 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       addError(e, stackTrace);
 
       final current = state;
-      if (!isClosed && current is DivineAuthFormState) {
-        emit(
+      if (current is DivineAuthFormState) {
+        _emitIfOpen(
           current.copyWith(
             isSubmitting: false,
             generalError: 'Failed to complete authentication',
@@ -498,9 +501,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       // returns, which reroutes off the create-account screen and closes
       // this cubit. Nothing is lost: the redirect runs off auth state, and
       // no listener acts on DivineAuthSuccess here.
-      if (isClosed) return;
-
-      emit(const DivineAuthSuccess());
+      _emitIfOpen(const DivineAuthSuccess());
     } on InviteApiException catch (e, stackTrace) {
       Log.error(
         'Anonymous account invite activation failed: '
@@ -512,8 +513,8 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       addError(e, stackTrace);
 
       final currentState = state;
-      if (!isClosed && currentState is DivineAuthFormState) {
-        emit(
+      if (currentState is DivineAuthFormState) {
+        _emitIfOpen(
           currentState.copyWith(
             isSkipping: false,
             generalError: InviteErrorUtils.activationFailureMessage(e),
@@ -534,8 +535,8 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       addError(e, stackTrace);
 
       final currentState = state;
-      if (!isClosed && currentState is DivineAuthFormState) {
-        emit(
+      if (currentState is DivineAuthFormState) {
+        _emitIfOpen(
           currentState.copyWith(
             isSkipping: false,
             generalError: 'Failed to create account. Please try again.',

--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -494,11 +494,10 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
         category: LogCategory.auth,
       );
 
-      // The account creation above flips AuthService to `authenticated`
-      // before it returns, which reroutes off the create-account screen and
-      // closes this cubit. Emitting the success state is then both
-      // impossible and unnecessary — the navigation it would trigger has
-      // already happened.
+      // Account creation flips AuthService to `authenticated` before it
+      // returns, which reroutes off the create-account screen and closes
+      // this cubit. Nothing is lost: the redirect runs off auth state, and
+      // no listener acts on DivineAuthSuccess here.
       if (isClosed) return;
 
       emit(const DivineAuthSuccess());

--- a/mobile/lib/screens/auth/create_account_screen.dart
+++ b/mobile/lib/screens/auth/create_account_screen.dart
@@ -70,7 +70,6 @@ class _CreateAccountView extends StatelessWidget {
     return BlocListener<DivineAuthCubit, DivineAuthState>(
       listenWhen: (prev, next) =>
           next is DivineAuthEmailVerification ||
-          next is DivineAuthSuccess ||
           next is DivineAuthFormState && next.showLoginOptionsRecovery,
       listener: (context, state) {
         if (state is DivineAuthFormState && state.showLoginOptionsRecovery) {

--- a/mobile/lib/screens/auth/login_options_screen.dart
+++ b/mobile/lib/screens/auth/login_options_screen.dart
@@ -19,7 +19,6 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/auth/email_verification_screen.dart';
 import 'package:openvine/screens/auth/nostr_connect_screen.dart';
 import 'package:openvine/screens/key_import_screen.dart';
-import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/utils/validators.dart';
 import 'package:openvine/widgets/auth/auth_error_box.dart';
 import 'package:openvine/widgets/auth/forgot_password_dialog.dart';
@@ -64,7 +63,12 @@ class LoginOptionsScreen extends ConsumerWidget {
             initialGeneralError: initialError,
           ),
       child: _CommitAutofillOnAuthenticated(
-        authStates: authService.authStateStream,
+        // Re-sample the flag on each auth event rather than passing the
+        // service's own state enum through, so this screen stays clear of
+        // service-layer types (scripts/check_ui_service_boundary.sh).
+        authenticated: authService.authStateStream.map(
+          (_) => authService.isAuthenticated,
+        ),
         child: const _LoginOptionsView(),
       ),
     );
@@ -82,11 +86,12 @@ class LoginOptionsScreen extends ConsumerWidget {
 /// the frame that disposes this subtree.
 class _CommitAutofillOnAuthenticated extends StatefulWidget {
   const _CommitAutofillOnAuthenticated({
-    required this.authStates,
+    required this.authenticated,
     required this.child,
   });
 
-  final Stream<AuthState> authStates;
+  /// Emits the session's authenticated flag on every auth-state change.
+  final Stream<bool> authenticated;
   final Widget child;
 
   @override
@@ -96,16 +101,16 @@ class _CommitAutofillOnAuthenticated extends StatefulWidget {
 
 class _CommitAutofillOnAuthenticatedState
     extends State<_CommitAutofillOnAuthenticated> {
-  StreamSubscription<AuthState>? _subscription;
+  StreamSubscription<bool>? _subscription;
 
   @override
   void initState() {
     super.initState();
-    _subscription = widget.authStates.listen(_onAuthState);
+    _subscription = widget.authenticated.listen(_onAuthenticatedChanged);
   }
 
-  void _onAuthState(AuthState state) {
-    if (state != AuthState.authenticated) return;
+  void _onAuthenticatedChanged(bool isAuthenticated) {
+    if (!isAuthenticated) return;
     // Only the email/password form has credentials worth saving; the other
     // sign-in methods on this screen leave the autofill context empty.
     if (!_hasSubmittedCredentials) return;

--- a/mobile/lib/screens/auth/login_options_screen.dart
+++ b/mobile/lib/screens/auth/login_options_screen.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Options: Email sign-in, Import Nostr Key, Signer App, or Amber
 // DESIGN: https://www.figma.com/design/rp1DsDEUuCaicW0lk6I2aZ/UI-Design?node-id=5061-65986
 
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -17,6 +19,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/auth/email_verification_screen.dart';
 import 'package:openvine/screens/auth/nostr_connect_screen.dart';
 import 'package:openvine/screens/key_import_screen.dart';
+import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/utils/validators.dart';
 import 'package:openvine/widgets/auth/auth_error_box.dart';
 import 'package:openvine/widgets/auth/forgot_password_dialog.dart';
@@ -60,9 +63,69 @@ class LoginOptionsScreen extends ConsumerWidget {
             initialEmail: initialEmail,
             initialGeneralError: initialError,
           ),
-      child: const _LoginOptionsView(),
+      child: _CommitAutofillOnAuthenticated(
+        authStates: authService.authStateStream,
+        child: const _LoginOptionsView(),
+      ),
     );
   }
+}
+
+/// Commits the autofill context off the auth-state signal rather than off
+/// [DivineAuthSuccess].
+///
+/// A successful sign-in flips `AuthService` to authenticated, which refreshes
+/// the router and closes [DivineAuthCubit] before `_handleSignIn` reaches its
+/// emit. Listening for [DivineAuthSuccess] therefore misses the password-manager
+/// save prompt whenever the redirect wins that race. This listens to the same
+/// stream `RouterRefreshListenable` uses, and stream events are delivered before
+/// the frame that disposes this subtree.
+class _CommitAutofillOnAuthenticated extends StatefulWidget {
+  const _CommitAutofillOnAuthenticated({
+    required this.authStates,
+    required this.child,
+  });
+
+  final Stream<AuthState> authStates;
+  final Widget child;
+
+  @override
+  State<_CommitAutofillOnAuthenticated> createState() =>
+      _CommitAutofillOnAuthenticatedState();
+}
+
+class _CommitAutofillOnAuthenticatedState
+    extends State<_CommitAutofillOnAuthenticated> {
+  StreamSubscription<AuthState>? _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _subscription = widget.authStates.listen(_onAuthState);
+  }
+
+  void _onAuthState(AuthState state) {
+    if (state != AuthState.authenticated) return;
+    // Only the email/password form has credentials worth saving; the other
+    // sign-in methods on this screen leave the autofill context empty.
+    if (!_hasSubmittedCredentials) return;
+    TextInput.finishAutofillContext();
+  }
+
+  bool get _hasSubmittedCredentials {
+    final state = context.read<DivineAuthCubit>().state;
+    return state is DivineAuthFormState && state.isSubmitting;
+  }
+
+  @override
+  void dispose() {
+    unawaited(_subscription?.cancel());
+    _subscription = null;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
 }
 
 /// Sign-in screen — View that consumes [DivineAuthCubit] state.
@@ -74,7 +137,6 @@ class _LoginOptionsView extends StatelessWidget {
     return BlocListener<DivineAuthCubit, DivineAuthState>(
       listenWhen: (prev, next) =>
           next is DivineAuthEmailVerification ||
-          next is DivineAuthSuccess ||
           (prev is DivineAuthFormState &&
               next is DivineAuthFormState &&
               next.signInFailureReason != null &&
@@ -88,10 +150,6 @@ class _LoginOptionsView extends StatelessWidget {
             Directionality.of(context),
           );
           return;
-        }
-        if (state is DivineAuthSuccess) {
-          // Signal password managers to save credentials.
-          TextInput.finishAutofillContext();
         }
         if (state is DivineAuthEmailVerification) {
           final encodedEmail = Uri.encodeComponent(state.email);

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -108,11 +108,14 @@ class KeycastOAuth {
     return _storage.read(_storageKeyHandle);
   }
 
-  /// Clear local session and POST to server logout (keeps authorization_handle)
+  /// Clear the local session, keeping the authorization handle.
   ///
-  /// Server-side logout has a 2-second timeout - if it fails or times out,
-  /// we still complete the local logout. The server will eventually expire
-  /// the token anyway.
+  /// Also pings the server's logout endpoint, which revokes nothing: keycast's
+  /// handler takes no extractors and only returns a cookie-clearing header this
+  /// client has no use for, and by this point the tokens it would need to
+  /// identify the session are already deleted. The call is kept because the
+  /// endpoint may grow a real revocation later; tokens expire on their own
+  /// until then. Local logout is complete either way.
   Future<void> logout() async {
     _storageEpoch++;
     await _storage.delete(_storageKeySession);

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -122,19 +122,13 @@ class KeycastOAuth {
     // Local logout is complete, server notification is best-effort
     //
     // The error handler must be attached to the future itself. A surrounding
-    // try/catch cannot see the failure, because `unawaited` returns before
-    // the request completes and the rejection would surface later as an
-    // unhandled async error.
-    unawaited(
-      _client
-          .post(Uri.parse('${config.serverUrl}/api/auth/logout'))
-          .timeout(const Duration(seconds: 2))
-          .then<void>(
-            (_) {},
-            // Ignore timeout or network errors - local logout is complete
-            onError: (Object _) {},
-          ),
-    );
+    // try/catch cannot see the failure, because the rejection would surface
+    // after logout() has already returned, as an unhandled async error.
+    // `ignore()` discards both the result and any error.
+    _client
+        .post(Uri.parse('${config.serverUrl}/api/auth/logout'))
+        .timeout(const Duration(seconds: 2))
+        .ignore();
   }
 
   Future<void> _saveSession(KeycastSession session) async {

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -120,15 +120,21 @@ class KeycastOAuth {
     await _storage.delete(_storageKeyRefreshToken);
     // Fire-and-forget server logout with short timeout
     // Local logout is complete, server notification is best-effort
-    try {
-      unawaited(
-        _client
-            .post(Uri.parse('${config.serverUrl}/api/auth/logout'))
-            .timeout(const Duration(seconds: 2)),
-      );
-    } catch (_) {
-      // Ignore timeout or network errors - local logout is complete
-    }
+    //
+    // The error handler must be attached to the future itself. A surrounding
+    // try/catch cannot see the failure, because `unawaited` returns before
+    // the request completes and the rejection would surface later as an
+    // unhandled async error.
+    unawaited(
+      _client
+          .post(Uri.parse('${config.serverUrl}/api/auth/logout'))
+          .timeout(const Duration(seconds: 2))
+          .then<void>(
+            (_) {},
+            // Ignore timeout or network errors - local logout is complete
+            onError: (Object _) {},
+          ),
+    );
   }
 
   Future<void> _saveSession(KeycastSession session) async {

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -118,13 +118,9 @@ class KeycastOAuth {
     await _storage.delete(_storageKeySession);
     await _storage.delete(_storageKeyHandle);
     await _storage.delete(_storageKeyRefreshToken);
-    // Fire-and-forget server logout with short timeout
-    // Local logout is complete, server notification is best-effort
-    //
-    // The error handler must be attached to the future itself. A surrounding
-    // try/catch cannot see the failure, because the rejection would surface
-    // after logout() has already returned, as an unhandled async error.
-    // `ignore()` discards both the result and any error.
+    // Best-effort server logout; the local one is already complete. The
+    // handler has to be on the future itself — a surrounding try/catch
+    // cannot see a rejection that surfaces after logout() has returned.
     _client
         .post(Uri.parse('${config.serverUrl}/api/auth/logout'))
         .timeout(const Duration(seconds: 2))

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -282,6 +282,33 @@ void main() {
 
         expect(logoutCalled, isTrue);
       });
+
+      test('does not leak an unhandled error when the server is '
+          'unreachable', () async {
+        final mockClient = MockClient((request) async {
+          throw http.ClientException('Connection refused', request.url);
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+
+        final escaped = <Object>[];
+        await runZonedGuarded(
+          () async {
+            await oauth.logout();
+            // Let the fire-and-forget POST reject.
+            await Future<void>.delayed(Duration.zero);
+          },
+          (error, _) => escaped.add(error),
+        );
+
+        expect(
+          escaped,
+          isEmpty,
+          reason:
+              'Local logout is complete; a failed best-effort server '
+              'notification must not surface as an unhandled async error',
+        );
+      });
     });
 
     group('getAuthorizationUrl - additional', () {

--- a/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
+++ b/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
@@ -1725,29 +1725,12 @@ void main() {
         expect: () => <DivineAuthState>[],
       );
 
-      test('does not throw when the cubit closes mid-creation', () async {
-        // Account creation flips AuthService to `authenticated` before it
-        // returns. The router then leaves the create-account screen, which
-        // closes this cubit while the await is still in flight.
-        final accountCreated = Completer<void>();
-        when(
-          () => mockAuthService.createAnonymousAccount(),
-        ).thenAnswer((_) => accountCreated.future);
-
-        final cubit = buildCubit();
-        cubit.initialize();
-
-        final skip = cubit.skipWithAnonymousAccount();
-        await cubit.close();
-        accountCreated.complete();
-
-        await expectLater(skip, completes);
-        expect(cubit.state, isA<DivineAuthFormState>());
-      });
-
       test(
         'closing mid-creation reports no error to the bloc observer',
         () async {
+          // Account creation flips AuthService to `authenticated` before it
+          // returns. The router then leaves the create-account screen, which
+          // closes this cubit while the await is still in flight.
           final accountCreated = Completer<void>();
           when(
             () => mockAuthService.createAnonymousAccount(),

--- a/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
+++ b/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
@@ -355,48 +355,60 @@ void main() {
           },
         );
 
-        test('does not throw when the cubit closes mid-sign-in', () async {
-          // Same close-mid-flight race as skipWithAnonymousAccount: the
-          // sign-in flips AuthService to `authenticated` before returning,
-          // which reroutes off the auth screen and closes this cubit while
-          // the await is still in flight.
-          final signedIn = Completer<void>();
-          when(
-            () => mockOAuth.headlessLogin(
-              email: any(named: 'email'),
-              password: any(named: 'password'),
-              scope: any(named: 'scope'),
-            ),
-          ).thenAnswer(
-            (_) async => (
-              HeadlessLoginResult(success: true, code: testCode),
-              testVerifier,
-            ),
-          );
-          when(
-            () => mockOAuth.exchangeCode(
-              code: any(named: 'code'),
-              verifier: any(named: 'verifier'),
-            ),
-          ).thenAnswer(
-            (_) async => const TokenResponse(bunkerUrl: 'bunker://test'),
-          );
-          when(
-            () => mockAuthService.signInWithDivineOAuth(any()),
-          ).thenAnswer((_) => signedIn.future);
+        test(
+          'closing mid-sign-in reports no error to the bloc observer',
+          () async {
+            // Same close-mid-flight race as skipWithAnonymousAccount: the
+            // sign-in flips AuthService to `authenticated` before returning,
+            // which reroutes off the auth screen and closes this cubit while
+            // the await is still in flight.
+            //
+            // Assert via the observer, not on completion: emit-after-close is
+            // swallowed by the generic catch, so `completes` alone stays green
+            // even with the guard removed.
+            final signedIn = Completer<void>();
+            when(
+              () => mockOAuth.headlessLogin(
+                email: any(named: 'email'),
+                password: any(named: 'password'),
+                scope: any(named: 'scope'),
+              ),
+            ).thenAnswer(
+              (_) async => (
+                HeadlessLoginResult(success: true, code: testCode),
+                testVerifier,
+              ),
+            );
+            when(
+              () => mockOAuth.exchangeCode(
+                code: any(named: 'code'),
+                verifier: any(named: 'verifier'),
+              ),
+            ).thenAnswer(
+              (_) async => const TokenResponse(bunkerUrl: 'bunker://test'),
+            );
+            when(
+              () => mockAuthService.signInWithDivineOAuth(any()),
+            ).thenAnswer((_) => signedIn.future);
 
-          final cubit = buildCubit()
-            ..initialize(isSignIn: true)
-            ..updateEmail(testEmail)
-            ..updatePassword(testPassword);
+            final observed = <Object>[];
+            final previousObserver = Bloc.observer;
+            Bloc.observer = _RecordingBlocObserver(observed);
+            addTearDown(() => Bloc.observer = previousObserver);
 
-          final submit = cubit.submit();
-          await cubit.close();
-          signedIn.complete();
+            final cubit = buildCubit()
+              ..initialize(isSignIn: true)
+              ..updateEmail(testEmail)
+              ..updatePassword(testPassword);
 
-          await expectLater(submit, completes);
-          expect(cubit.state, isA<DivineAuthFormState>());
-        });
+            final submit = cubit.submit();
+            await cubit.close();
+            signedIn.complete();
+
+            await expectLater(submit, completes);
+            expect(observed, isEmpty);
+          },
+        );
 
         blocTest<DivineAuthCubit, DivineAuthState>(
           'consumes invite with exchanged session before completing sign in',

--- a/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
+++ b/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
@@ -1,7 +1,10 @@
 // ABOUTME: Tests for DivineAuthCubit
 // ABOUTME: Verifies form state, validation, sign-in, sign-up, and error handling
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:invite_api_client/invite_api_client.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
@@ -25,6 +28,20 @@ class _MockInviteApiClient extends Mock implements InviteApiClient {}
 class _FakeKeycastSession extends Fake implements KeycastSession {}
 
 class _FakeSecureKeyContainer extends Fake implements SecureKeyContainer {}
+
+/// Captures errors routed through [Bloc.observer] so a test can assert that a
+/// flow reported none.
+class _RecordingBlocObserver extends BlocObserver {
+  _RecordingBlocObserver(this.errors);
+
+  final List<Object> errors;
+
+  @override
+  void onError(BlocBase<dynamic> bloc, Object error, StackTrace stackTrace) {
+    errors.add(error);
+    super.onError(bloc, error, stackTrace);
+  }
+}
 
 void main() {
   setUpAll(() {
@@ -1599,6 +1616,51 @@ void main() {
         seed: () => const DivineAuthFormState(isSubmitting: true),
         act: (cubit) => cubit.skipWithAnonymousAccount(),
         expect: () => <DivineAuthState>[],
+      );
+
+      test('does not throw when the cubit closes mid-creation', () async {
+        // Account creation flips AuthService to `authenticated` before it
+        // returns. The router then leaves the create-account screen, which
+        // closes this cubit while the await is still in flight.
+        final accountCreated = Completer<void>();
+        when(
+          () => mockAuthService.createAnonymousAccount(),
+        ).thenAnswer((_) => accountCreated.future);
+
+        final cubit = buildCubit();
+        cubit.initialize();
+
+        final skip = cubit.skipWithAnonymousAccount();
+        await cubit.close();
+        accountCreated.complete();
+
+        await expectLater(skip, completes);
+        expect(cubit.state, isA<DivineAuthFormState>());
+      });
+
+      test(
+        'closing mid-creation reports no error to the bloc observer',
+        () async {
+          final accountCreated = Completer<void>();
+          when(
+            () => mockAuthService.createAnonymousAccount(),
+          ).thenAnswer((_) => accountCreated.future);
+
+          final observed = <Object>[];
+          final previousObserver = Bloc.observer;
+          Bloc.observer = _RecordingBlocObserver(observed);
+          addTearDown(() => Bloc.observer = previousObserver);
+
+          final cubit = buildCubit();
+          cubit.initialize();
+
+          final skip = cubit.skipWithAnonymousAccount();
+          await cubit.close();
+          accountCreated.complete();
+          await skip;
+
+          expect(observed, isEmpty);
+        },
       );
     });
 

--- a/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
+++ b/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
@@ -1460,6 +1460,58 @@ void main() {
           ],
           errors: () => [isA<Exception>()],
         );
+
+        test(
+          'closing mid-sign-up reports no error to the bloc observer',
+          () async {
+            // The sign-up path emits DivineAuthEmailVerification after two
+            // awaits. Leaving the screen while headlessRegister is in flight
+            // closes the cubit, so that emit throws — and submit()'s own
+            // recovery emit then throws again with nothing left to catch it.
+            final registered = Completer<(HeadlessRegisterResult, String)>();
+            when(
+              () => mockOAuth.headlessRegister(
+                email: any(named: 'email'),
+                password: any(named: 'password'),
+                scope: any(named: 'scope'),
+              ),
+            ).thenAnswer((_) => registered.future);
+            when(
+              () => mockPendingVerification.save(
+                deviceCode: any(named: 'deviceCode'),
+                verifier: any(named: 'verifier'),
+                email: any(named: 'email'),
+                inviteCode: any(named: 'inviteCode'),
+              ),
+            ).thenAnswer((_) async {});
+
+            final observed = <Object>[];
+            final previousObserver = Bloc.observer;
+            Bloc.observer = _RecordingBlocObserver(observed);
+            addTearDown(() => Bloc.observer = previousObserver);
+
+            final cubit = buildCubit()
+              ..initialize()
+              ..updateEmail(testEmail)
+              ..updatePassword(testPassword);
+
+            final submit = cubit.submit();
+            await cubit.close();
+            registered.complete((
+              HeadlessRegisterResult(
+                success: true,
+                pubkey: 'test-pubkey',
+                verificationRequired: true,
+                deviceCode: testDeviceCode,
+                email: testEmail,
+              ),
+              testVerifier,
+            ));
+
+            await expectLater(submit, completes);
+            expect(observed, isEmpty);
+          },
+        );
       });
     });
 

--- a/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
+++ b/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
@@ -355,6 +355,49 @@ void main() {
           },
         );
 
+        test('does not throw when the cubit closes mid-sign-in', () async {
+          // Same close-mid-flight race as skipWithAnonymousAccount: the
+          // sign-in flips AuthService to `authenticated` before returning,
+          // which reroutes off the auth screen and closes this cubit while
+          // the await is still in flight.
+          final signedIn = Completer<void>();
+          when(
+            () => mockOAuth.headlessLogin(
+              email: any(named: 'email'),
+              password: any(named: 'password'),
+              scope: any(named: 'scope'),
+            ),
+          ).thenAnswer(
+            (_) async => (
+              HeadlessLoginResult(success: true, code: testCode),
+              testVerifier,
+            ),
+          );
+          when(
+            () => mockOAuth.exchangeCode(
+              code: any(named: 'code'),
+              verifier: any(named: 'verifier'),
+            ),
+          ).thenAnswer(
+            (_) async => const TokenResponse(bunkerUrl: 'bunker://test'),
+          );
+          when(
+            () => mockAuthService.signInWithDivineOAuth(any()),
+          ).thenAnswer((_) => signedIn.future);
+
+          final cubit = buildCubit()
+            ..initialize(isSignIn: true)
+            ..updateEmail(testEmail)
+            ..updatePassword(testPassword);
+
+          final submit = cubit.submit();
+          await cubit.close();
+          signedIn.complete();
+
+          await expectLater(submit, completes);
+          expect(cubit.state, isA<DivineAuthFormState>());
+        });
+
         blocTest<DivineAuthCubit, DivineAuthState>(
           'consumes invite with exchanged session before completing sign in',
           setUp: () {

--- a/mobile/test/screens/auth/login_options_screen_test.dart
+++ b/mobile/test/screens/auth/login_options_screen_test.dart
@@ -545,9 +545,17 @@ void main() {
       late StreamController<AuthState> authStates;
       late List<MethodCall> textInputCalls;
 
+      late bool isAuthenticated;
+
       setUp(() {
         authStates = StreamController<AuthState>.broadcast();
         textInputCalls = <MethodCall>[];
+        // The screen re-samples the flag on each auth event rather than
+        // reading the enum off the stream, so the stub is what decides.
+        isAuthenticated = false;
+        when(
+          () => mockAuthService.isAuthenticated,
+        ).thenAnswer((_) => isAuthenticated);
         addTearDown(authStates.close);
       });
 
@@ -619,6 +627,7 @@ void main() {
         (tester) async {
           await submitSignIn(tester);
 
+          isAuthenticated = true;
           authStates.add(AuthState.authenticated);
           await tester.pump();
 
@@ -657,6 +666,7 @@ void main() {
         recordTextInputCalls();
 
         // e.g. Amber or a browser extension authenticating from this screen.
+        isAuthenticated = true;
         authStates.add(AuthState.authenticated);
         await tester.pump();
 

--- a/mobile/test/screens/auth/login_options_screen_test.dart
+++ b/mobile/test/screens/auth/login_options_screen_test.dart
@@ -2,8 +2,11 @@
 // ABOUTME: Verifies form rendering, sign-in flow, forgot password,
 // ABOUTME: and alternative login method buttons
 
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -44,6 +47,9 @@ void main() {
     mockAuthService = _MockAuthService();
     mockPendingVerification = _MockPendingVerificationService();
     when(() => mockAuthService.isNip07Available).thenReturn(false);
+    when(
+      () => mockAuthService.authStateStream,
+    ).thenAnswer((_) => const Stream<AuthState>.empty());
   });
 
   Widget createTestWidget({String initialLocation = LoginOptionsScreen.path}) {
@@ -532,6 +538,129 @@ void main() {
             scope: any(named: 'scope'),
           ),
         );
+      });
+    });
+
+    group('autofill', () {
+      late StreamController<AuthState> authStates;
+      late List<MethodCall> textInputCalls;
+
+      setUp(() {
+        authStates = StreamController<AuthState>.broadcast();
+        textInputCalls = <MethodCall>[];
+        addTearDown(authStates.close);
+      });
+
+      /// Starts recording `flutter/textinput` traffic.
+      ///
+      /// Must run *after* `pumpWidget`: the test binding installs its own
+      /// [TestTextInput] handler on that channel while bringing the widget
+      /// tree up, which would otherwise replace this one.
+      void recordTextInputCalls() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.textInput, (call) async {
+              textInputCalls.add(call);
+              return null;
+            });
+        addTearDown(
+          () => TestDefaultBinaryMessengerBinding
+              .instance
+              .defaultBinaryMessenger
+              .setMockMethodCallHandler(SystemChannels.textInput, null),
+        );
+      }
+
+      bool committedAutofill() => textInputCalls.any(
+        (call) => call.method == 'TextInput.finishAutofillContext',
+      );
+
+      /// Pumps the screen with a controllable auth stream, then submits the
+      /// email/password form. [mockOAuth] is stubbed so `headlessLogin` never
+      /// completes, which holds the cubit mid-flight the way a real sign-in
+      /// does while `AuthService` flips underneath it.
+      Future<void> submitSignIn(WidgetTester tester) async {
+        when(
+          () => mockOAuth.headlessLogin(
+            email: any(named: 'email'),
+            password: any(named: 'password'),
+            scope: any(named: 'scope'),
+          ),
+        ).thenAnswer((_) => Completer<(HeadlessLoginResult, String)>().future);
+
+        final widget = createTestWidget();
+        when(
+          () => mockAuthService.authStateStream,
+        ).thenAnswer((_) => authStates.stream);
+        await tester.pumpWidget(widget);
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.descendant(
+            of: find.widgetWithText(DivineAuthTextField, 'Email'),
+            matching: find.byType(TextField),
+          ),
+          'test@example.com',
+        );
+        await tester.enterText(
+          find.descendant(
+            of: find.widgetWithText(DivineAuthTextField, 'Password'),
+            matching: find.byType(TextField),
+          ),
+          'SecurePass123!',
+        );
+        await tester.tap(find.widgetWithText(DivineButton, 'Sign in'));
+        await tester.pump();
+        recordTextInputCalls();
+      }
+
+      testWidgets(
+        'commits the autofill context when the session authenticates, even '
+        'though the redirect closes the cubit before it can emit success',
+        (tester) async {
+          await submitSignIn(tester);
+
+          authStates.add(AuthState.authenticated);
+          await tester.pump();
+
+          expect(
+            committedAutofill(),
+            isTrue,
+            reason:
+                'The password-manager save prompt must not depend on '
+                'DivineAuthSuccess, which the post-sign-in redirect races',
+          );
+        },
+      );
+
+      testWidgets(
+        'does not commit the autofill context while unauthenticated',
+        (
+          tester,
+        ) async {
+          await submitSignIn(tester);
+
+          authStates.add(AuthState.unauthenticated);
+          await tester.pump();
+
+          expect(committedAutofill(), isFalse);
+        },
+      );
+
+      testWidgets('does not commit the autofill context without a submitted '
+          'credential form', (tester) async {
+        final widget = createTestWidget();
+        when(
+          () => mockAuthService.authStateStream,
+        ).thenAnswer((_) => authStates.stream);
+        await tester.pumpWidget(widget);
+        await tester.pumpAndSettle();
+        recordTextInputCalls();
+
+        // e.g. Amber or a browser extension authenticating from this screen.
+        authStates.add(AuthState.authenticated);
+        await tester.pump();
+
+        expect(committedAutofill(), isFalse);
       });
     });
   });


### PR DESCRIPTION
Closes #6607

## Summary

Two unrelated emit/rejection bugs on the auth screens, plus the follow-on fixes from review. Both original bugs were observed firing on a real Android emulator, not inferred from reading the code.

## What Changed

### 1. Emit-after-close on the auth cubit

`DivineAuthCubit` awaits an auth call that flips `AuthService` to `authenticated` before it returns. That flip refreshes the router, which leaves the auth screen and closes the cubit — so the emit after the await throws `Bad state: Cannot emit new states after calling close`. Worse, `submit()`'s outer catch is the last-resort handler: when `_handleSignUp`'s email-verification emit throws into it, the catch's own recovery emit throws again with nothing left to catch it, and since `submit()` is fire-and-forget at all three call sites that second throw escapes as an unhandled async error.

`isClosed` guards now cover every emit reachable after an await: `skipWithAnonymousAccount`, `_handleSignIn`, `_handleSignUp`, both their failure paths, the email-verification emit, and `submit()`'s outer catch.

### 2. Unhandled rejection from the keycast logout

Wrapping `unawaited()` in a `try`/`catch` catches nothing — the rejection arrives after the wrapping call has already returned, so the handler has to be attached to the future itself. Replaced with `Future.ignore()`.

This one lives on the **sign-out** path, not anonymous signup: `logout()` has a single caller, `auth_service.dart:1939`, reachable only from `signOut()` and `_completeDestructiveSignOutAfterDeletedKeys()`. The two fixes share a branch, not a flow.

### 3. Autofill no longer rides on `DivineAuthSuccess`

Consequence of fix 1, raised in review: with the guard in place `DivineAuthSuccess` is never emitted when the redirect wins the race, so `login_options_screen`'s listener silently skipped `TextInput.finishAutofillContext()` and the user got no password-manager save prompt. The commit now hangs off `AuthService.authStateStream` — the same signal `RouterRefreshListenable` uses to drive that redirect, delivered before the frame that disposes the subtree, so the race cannot skip it. Gated on a submitted credential form so Amber / NIP-07 sign-ins from the same screen don't commit an empty context.

### 4. Doc correction on the keycast logout endpoint

The old comment implied a server-side logout. keycast's handler takes no extractors and only returns a cookie-clearing header, and the client sends it unauthenticated after the tokens are already deleted — it revokes nothing. The call is kept in case the endpoint grows real revocation; the comment no longer claims it already has.

## Testing

Every guard is pinned by a test that was mutation-checked to fail when that guard is removed. Emit-after-close is swallowed by the generic catch, so assertions on completion alone stay green either way — the tests assert through the bloc observer, which is the only place the difference is visible.

- 68 `DivineAuthCubit` tests, 236 `keycast_flutter` tests, 190 `test/screens/auth` + `test/blocs/divine_auth` tests.
- `flutter analyze lib test integration_test` clean; package-level analyze clean.
- The three new autofill tests fail against the pre-fix listener and pass with it.

## Risks

Low. Narrow guards that remove error paths without altering successful behaviour, plus one signal moved to a strictly more reliable source.

## Review history

This branch carries reviewer commits on top of the original two fixes, per `PR_REVIEW.md`:

- **@hm21** — `80ba816258` simplified the fire-and-forget logout to `Future.ignore()`; `8ec6f37b16` applied the same `isClosed` guards to `_exchangeCodeAndLogin`.
- **@mbradley** — `30f4c9db5` guarded the five remaining emit-after-close sites (the substantive one); `182d00978` made the sign-in guard detectable via the bloc observer, after finding the earlier test stayed green without the guard; `279514df1` dropped a test subsumed by its observer sibling; `bf304acdd` / `7d41fc207` corrected comments.
- **@rabble** — `4e70e0d6b` resolved the autofill question above; `9a37f6b49` corrected the logout doc comment.
