### PR TITLE
chore(local_stack): actionable diagnostics for port conflicts and partial stacks

### DIFF
--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -39,8 +39,8 @@ lose the timeline and the diagnostics.
 | Service | Port | Purpose |
 |---|---|---|
 | Keycast | 43000 | OAuth + NIP-46 signer |
-| FunnelCake Relay | 47777 | Nostr relay |
-| FunnelCake API | 43001 | REST API |
+| FunnelCake Relay | 47777 | Nostr relay (WebSocket) |
+| FunnelCake API | 47777 | REST API, under `/api/` on the same proxy |
 | Blossom | 43003 | Media server |
 | Postgres | 15432 | Keycast DB |
 | Invite | 43004 | divine-invite-darshan (Viceroy) |
@@ -98,13 +98,22 @@ are routine. The check names the service, the port, and the holder:
 
   port 45173  wanted by service "keycast"
             held by a host process (not a container), listening on: 127.0.0.1:45173
-            find it: ss -ltnp "sport = :45173"   (or: sudo lsof -iTCP:45173 -sTCP:LISTEN)
+            find it: sudo lsof -nP -iTCP:45173 -sTCP:LISTEN
 ```
 
 Ports already published by our own containers are not conflicts —
 `up.sh` is idempotent. The raw daemon error it replaces (`Bind for
 0.0.0.0:16380 failed: port is already allocated`) named neither the
 service nor the holder.
+
+Listening sockets come from `ss` on Linux and `lsof` on macOS, and
+the `find it:` line names whichever of the two the machine has. With
+neither installed the run says so and falls back to container-held
+ports alone, which `docker ps` reports without either tool — and a
+stale container is the usual culprit anyway.
+
+`bash local_stack/test_stack_scripts.sh` covers these paths against a
+stubbed docker/ss/lsof, so it needs no daemon and no free ports.
 
 ### Startup races
 

--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -5,7 +5,7 @@ description: |
   app against a local Docker backend (no mocks). Use when running
   E2E tests, debugging failures, or working on the local harness.
 author: Claude Code
-version: 1.1.0
+version: 1.2.0
 ---
 
 # E2E Integration Testing
@@ -43,6 +43,22 @@ lose the timeline and the diagnostics.
 | FunnelCake API | 43001 | REST API |
 | Blossom | 43003 | Media server |
 | Postgres | 15432 | Keycast DB |
+| Invite | 43004 | divine-invite-darshan (Viceroy) |
+
+The app reaches these at `10.0.2.2` from the emulator. Cleartext to
+loopback hosts is permitted in every build type on both platforms.
+
+### Only start what your flow needs
+
+Most services are irrelevant to any given test, and `local_up`
+failing on one does not mean you are blocked. An invite-only flow
+needs `invite` alone: a locally-generated nsec signs on-device, so
+no Keycast, and `onboarding_mode=open` means no invite gate. Check
+what is actually healthy before debugging a service you never call:
+
+```bash
+docker compose -f local_stack/docker-compose.yml ps
+```
 
 ```bash
 mise run local_up         # Start (auto-runs local_setup on fresh worktrees)
@@ -58,6 +74,73 @@ bypass the seed:
 
 ```bash
 bash ../local_stack/profile.sh integration_test/<your_test>.dart
+```
+
+Any `local_up` failure prints the per-service status, the logs of
+whatever is down, and that same bypass command. Set `E2E_TEST_PATH`
+before the run and it prints the command for *your* test:
+
+```bash
+E2E_TEST_PATH=integration_test/auth/auth_journey_test.dart mise run local_up
+```
+
+### Port conflicts
+
+`up.sh` pre-flights every host port in `docker-compose.yml` before
+starting anything. This machine runs several compose projects, and
+stale test containers days old are the normal case, so collisions
+are routine. The check names the service, the port, and the holder:
+
+```
+  port 43000  wanted by service "keycast"
+            held by container "funnelcake-test-clickhouse-sim" — compose project "funnelcake-test"
+            remedy: docker rm -f funnelcake-test-clickhouse-sim
+
+  port 45173  wanted by service "keycast"
+            held by a host process (not a container), listening on: 127.0.0.1:45173
+            find it: ss -ltnp "sport = :45173"   (or: sudo lsof -iTCP:45173 -sTCP:LISTEN)
+```
+
+Ports already published by our own containers are not conflicts —
+`up.sh` is idempotent. The raw daemon error it replaces (`Bind for
+0.0.0.0:16380 failed: port is already allocated`) named neither the
+service nor the holder.
+
+### Startup races
+
+Containers sometimes start before Docker's embedded DNS knows a
+dependency's alias: `funnelcake-migrate` dies with `dial tcp: lookup
+funnelcake-clickhouse on 127.0.0.11:53: no such host`, or `keycast`
+burns its DB connection attempts on `Temporary failure in name
+resolution`. Both succeed on an unchanged retry. `up.sh` re-runs the
+whole `up` (idempotent — it restarts whatever died) up to 3 attempts,
+5s apart, **only** when it sees a name-resolution signature in the
+compose output or in the failed containers' logs. A port clash or a
+bad image fails straight through rather than retrying pointlessly.
+
+### Running a locally built backend
+
+Compose pulls `ghcr.io/divinevideo/divine-invite-darshan:e2e`. To
+test an unmerged backend branch, build it and tag it as that name so
+compose uses the local image without pulling:
+
+```bash
+docker build -f Dockerfile.local -t divine-invite-darshan:local .
+docker tag divine-invite-darshan:local ghcr.io/divinevideo/divine-invite-darshan:e2e
+```
+
+`invite` is one of the few services without `pull_policy: always`, so
+a plain `mise run local_up` keeps your tag. Use `local_up_cached` if
+you have overridden a service that *does* pull on every start.
+
+### Cross-repo gotcha: `kv-store-data.json`
+
+The invite service (`divine-invite-darshan`) reads a gitignored
+`kv-store-data.json`. A **fresh worktree of that repo does not have
+it**, and without it the entire invite-service suite fails. Seed it:
+
+```bash
+printf '{}' > kv-store-data.json
 ```
 
 ## Emulator
@@ -77,6 +160,19 @@ Stale-state debugging cost is yours.
 
 Buffer auth-flow logs: `adb logcat -G 16M` (default 256 KB rotates
 mid-flow).
+
+### Storage exhaustion
+
+Not just a Patrol problem — `flutter run` hits it too, and the error
+is on the install, not the build:
+
+```
+java.io.IOException: Requested internal only, but not enough space
+```
+
+A debug APK is ~289 MB and needs real headroom on top of that.
+`adb shell pm trim-caches 1G` often does not free enough; `mise run
+emulator_wipe` (`emulator.sh --wipe`) is usually the faster fix.
 
 ## Patterns
 
@@ -134,6 +230,16 @@ Patrol bundles every file in a target dir into one APK. When file B
 runs, file A shows up as "not requested" `[E]` markers in logcat.
 Trust only the final `✅`/`❌` lines.
 
+### NIP-98 URL binding
+
+The invite service rejects a signed request whose `u` tag does not
+match the URL the server saw: `auth_invalid_binding`, HTTP 401. The
+client must sign the **same base URL it calls**. Signing
+`http://10.0.2.2:43004` while calling `http://localhost:43004` fails;
+signing and calling the same host works. If you switch the emulator
+between `10.0.2.2` and a forwarded `localhost`, switch the signing
+base URL with it.
+
 ### Provider error caching
 
 Providers using `requireIdentity` (or similar non-nullable getters)
@@ -161,6 +267,18 @@ Material(color: Colors.transparent, child: TextField(...))
 
 ## Debugging
 
+### Never pipe a long-running command through `tail`/`head`
+
+```bash
+flutter run ... | tail -40      # WRONG
+flutter run ... > /tmp/run.log 2>&1   # then read/grep the file
+```
+
+Two separate failures. The pipe buffers until the command exits, so
+you watch a blank screen and lose everything if you kill it. And the
+pipeline's exit status is `tail`'s, so a failed run reports success.
+Redirect to a file and read that instead.
+
 ```bash
 # Service logs
 docker compose -f local_stack/docker-compose.yml logs keycast --tail=50
@@ -171,6 +289,16 @@ adb logcat -d | grep 'flutter.*\[AUTH\]' | grep -v 'Router redirect'
 
 # Last merged timeline
 ls mobile/test_reports/*.jsonl
+```
+
+The timeline is where cross-service failures actually show up. A test
+can fail in **teardown** from an unhandled async error against a service
+that is down — Patrol's summary only says the test failed, while the
+timeline names the URL that was refused. Read it before writing a
+failure off as flaky.
+
+```bash
+rg -o '.{0,60}logout.{0,50}' mobile/test_reports/<run>.jsonl
 ```
 
 If patrol reports `Total: 0` with Gradle exit 1, the runner

--- a/local_stack/preflight.sh
+++ b/local_stack/preflight.sh
@@ -45,6 +45,37 @@ _stack_project_name() {
     python3 -c 'import json, sys; print(json.load(sys.stdin).get("name", ""))'
 }
 
+# --- Host listeners ---------------------------------------------------------
+
+# stdout: one "<address>:<port>" per listening TCP socket.
+# `ss` is iproute2, so it does not exist on macOS; `lsof` is there instead.
+# Returns 1 when neither is installed, so the caller can say so rather than
+# read "no listeners found" as "every port is free".
+_stack_listen_addrs() {
+    if command -v ss >/dev/null 2>&1; then
+        ss -Hltn 2>/dev/null | awk '{ print $4 }'
+    elif command -v lsof >/dev/null 2>&1; then
+        # -Fn emits one "n<address>:<port>" record per socket, which spares us
+        # the header line and the space-separated NAME column. Without sudo it
+        # only sees our own processes — enough for Docker Desktop's proxy.
+        lsof -nP -iTCP -sTCP:LISTEN -Fn 2>/dev/null | sed -n 's/^n//p'
+    else
+        return 1
+    fi
+    return 0
+}
+
+# stdout: the command that names what holds <port>, for whichever of ss/lsof
+# this machine actually has.
+_stack_port_finder_cmd() {
+    local port="$1"
+    if command -v ss >/dev/null 2>&1; then
+        printf 'ss -ltnp "sport = :%s"' "$port"
+    else
+        printf 'sudo lsof -nP -iTCP:%s -sTCP:LISTEN' "$port"
+    fi
+}
+
 # --- Pre-flight -------------------------------------------------------------
 
 # preflight_ports <compose_file>
@@ -95,12 +126,17 @@ preflight_ports() {
 
     # port -> space-separated local addresses currently listening on it
     local listen_addrs=()
-    local local_addr port
-    while read -r _ _ _ local_addr _; do
-        port="${local_addr##*:}"
-        [[ "$port" =~ ^[0-9]+$ ]] || continue
-        listen_addrs["$port"]+="${local_addr} "
-    done < <(ss -Hltn 2>/dev/null || true)
+    local listeners_known=1
+    local listener_lines local_addr port
+    if listener_lines="$(_stack_listen_addrs)"; then
+        while read -r local_addr; do
+            port="${local_addr##*:}"
+            [[ "$port" =~ ^[0-9]+$ ]] || continue
+            listen_addrs["$port"]+="${local_addr} "
+        done <<<"$listener_lines"
+    else
+        listeners_known=0
+    fi
 
     # port -> container name / owning compose project (empty if standalone)
     local port_container=() port_project=()
@@ -119,12 +155,25 @@ preflight_ports() {
         done < <(grep -oE ':[0-9]+->' <<<"$portspec" | tr -d ':>-')
     done < <(docker ps --format '{{.Names}}|{{.Label "com.docker.compose.project"}}|{{.Ports}}' 2>/dev/null)
 
-    local service conflicts=0 holder holder_project
-    while read -r service port; do
-        [[ -n "${listen_addrs[$port]:-}" ]] || continue
+    if ((listeners_known == 0)); then
+        {
+            echo ""
+            echo "WARNING: neither 'ss' nor 'lsof' is installed, so a port held by a"
+            echo "         plain host process cannot be detected. Ports held by"
+            echo "         containers are still checked below."
+        } >&2
+    fi
 
+    local service conflicts=0 holder holder_project addrs
+    while read -r service port; do
         holder="${port_container[$port]:-}"
         holder_project="${port_project[$port]:-}"
+        addrs="${listen_addrs[$port]:-}"
+
+        # A container that published the port clashes even when the listener
+        # enumeration cannot see the socket — no ss/lsof, or a listener owned
+        # by another user.
+        [[ -n "$addrs" || -n "$holder" ]] || continue
 
         # Already published by our own stack — `up` is idempotent, not a clash.
         if [[ -n "$holder" && "$holder_project" == "$project" ]]; then
@@ -156,9 +205,8 @@ preflight_ports() {
             {
                 printf '  port %-6s wanted by service "%s"\n' "$port" "$service"
                 printf '            held by a host process (not a container), listening on: %s\n' \
-                    "${listen_addrs[$port]% }"
-                printf '            find it: ss -ltnp "sport = :%s"   (or: sudo lsof -iTCP:%s -sTCP:LISTEN)\n' \
-                    "$port" "$port"
+                    "${addrs% }"
+                printf '            find it: %s\n' "$(_stack_port_finder_cmd "$port")"
             } >&2
         fi
         echo "" >&2

--- a/local_stack/preflight.sh
+++ b/local_stack/preflight.sh
@@ -69,8 +69,26 @@ preflight_ports() {
         return 1
     fi
 
-    project="$(printf '%s' "$config_json" | _stack_project_name)"
-    ports="$(printf '%s' "$config_json" | _stack_published_ports)"
+    # Fail closed. An unreadable port list is indistinguishable from "the stack
+    # publishes no ports", and passing on it hands the operator back the
+    # anonymous daemon error this whole check exists to replace.
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "ERROR: the port pre-flight needs python3 on PATH, and it is missing." >&2
+        return 1
+    fi
+
+    if ! project="$(printf '%s' "$config_json" | _stack_project_name)" ||
+        ! ports="$(printf '%s' "$config_json" | _stack_published_ports)"; then
+        echo "ERROR: could not read the published ports out of ${compose_file}." >&2
+        return 1
+    fi
+
+    if [[ -z "$project" ]]; then
+        echo "ERROR: ${compose_file} resolved to an empty compose project name," >&2
+        echo "       so this stack's own containers cannot be told apart from others." >&2
+        return 1
+    fi
+
     if [[ -z "$ports" ]]; then
         return 0
     fi

--- a/local_stack/preflight.sh
+++ b/local_stack/preflight.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# Pre-flight and post-mortem diagnostics for the local E2E stack.
+#
+# Sourced by up.sh. Two jobs:
+#   1. preflight_ports  — before starting anything, prove every host port the
+#      stack publishes is free (or already ours). The raw daemon error
+#      ("Bind for 0.0.0.0:16380 failed: port is already allocated") names
+#      neither the service that wanted the port nor what is holding it.
+#   2. stack_failure_is_transient / stack_failure_report — after a failed
+#      `up`, tell the operator which services are down and what to do next.
+#
+# The port list is read from docker-compose.yml via `docker compose config`,
+# so it cannot drift from the stack definition.
+
+# --- Port list, straight from the compose file ------------------------------
+
+# stdout: "<service> <host_port>" per published TCP port.
+_stack_published_ports() {
+    python3 -c '
+import json, sys
+
+doc = json.load(sys.stdin)
+for service, config in sorted((doc.get("services") or {}).items()):
+    for port in config.get("ports") or []:
+        if port.get("protocol", "tcp") != "tcp":
+            continue
+        published = str(port.get("published") or "")
+        if not published:
+            continue
+        low, _, high = published.partition("-")
+        try:
+            span = range(int(low), int(high or low) + 1)
+        except ValueError:
+            continue
+        for host_port in span:
+            print(service, host_port)
+'
+}
+
+_stack_project_name() {
+    python3 -c 'import json, sys; print(json.load(sys.stdin).get("name", ""))'
+}
+
+# --- Pre-flight -------------------------------------------------------------
+
+# preflight_ports <compose_file>
+# Returns 0 if every published host port is free or held by this project's own
+# containers; 1 (with an actionable report on stderr) otherwise.
+preflight_ports() {
+    local compose_file="$1"
+    local config_json project ports
+
+    if ! docker ps --format '{{.Names}}' >/dev/null 2>&1; then
+        echo "ERROR: cannot talk to the Docker daemon. Is it running? (systemctl status docker)" >&2
+        return 1
+    fi
+
+    if ! config_json="$(docker compose -f "$compose_file" config --format json 2>&1)"; then
+        echo "ERROR: could not parse ${compose_file}:" >&2
+        echo "$config_json" >&2
+        return 1
+    fi
+
+    project="$(printf '%s' "$config_json" | _stack_project_name)"
+    ports="$(printf '%s' "$config_json" | _stack_published_ports)"
+    if [[ -z "$ports" ]]; then
+        return 0
+    fi
+
+    # port -> space-separated local addresses currently listening on it
+    local -A listen_addrs=()
+    local local_addr port
+    while read -r _ _ _ local_addr _; do
+        port="${local_addr##*:}"
+        [[ "$port" =~ ^[0-9]+$ ]] || continue
+        listen_addrs["$port"]+="${local_addr} "
+    done < <(ss -Hltn 2>/dev/null || true)
+
+    # port -> container name / owning compose project (empty if standalone)
+    local -A port_container=() port_project=()
+    local name proj portspec host_port
+    while IFS=$'\t' read -r name proj portspec; do
+        [[ -n "$name" ]] || continue
+        while read -r host_port; do
+            [[ -n "$host_port" ]] || continue
+            port_container["$host_port"]="$name"
+            port_project["$host_port"]="$proj"
+        done < <(grep -oE ':[0-9]+->' <<<"$portspec" | tr -d ':>-')
+    done < <(docker ps --format '{{.Names}}	{{.Label "com.docker.compose.project"}}	{{.Ports}}' 2>/dev/null)
+
+    local service conflicts=0 holder holder_project
+    while read -r service port; do
+        [[ -n "${listen_addrs[$port]:-}" ]] || continue
+
+        holder="${port_container[$port]:-}"
+        holder_project="${port_project[$port]:-}"
+
+        # Already published by our own stack — `up` is idempotent, not a clash.
+        if [[ -n "$holder" && "$holder_project" == "$project" ]]; then
+            continue
+        fi
+
+        if ((conflicts == 0)); then
+            {
+                echo ""
+                echo "ERROR: host ports the local stack needs are already in use."
+                echo ""
+            } >&2
+        fi
+        conflicts=$((conflicts + 1))
+
+        if [[ -n "$holder" ]]; then
+            local owner_desc
+            if [[ -n "$holder_project" ]]; then
+                owner_desc="compose project \"${holder_project}\""
+            else
+                owner_desc="standalone container (no compose project)"
+            fi
+            {
+                printf '  port %-6s wanted by service "%s"\n' "$port" "$service"
+                printf '            held by container "%s" — %s\n' "$holder" "$owner_desc"
+                printf '            remedy: docker rm -f %s\n' "$holder"
+            } >&2
+        else
+            {
+                printf '  port %-6s wanted by service "%s"\n' "$port" "$service"
+                printf '            held by a host process (not a container), listening on: %s\n' \
+                    "${listen_addrs[$port]% }"
+                printf '            find it: ss -ltnp "sport = :%s"   (or: sudo lsof -iTCP:%s -sTCP:LISTEN)\n' \
+                    "$port" "$port"
+            } >&2
+        fi
+        echo "" >&2
+    done <<<"$ports"
+
+    if ((conflicts > 0)); then
+        {
+            echo "${conflicts} port conflict(s). Nothing was started."
+            echo "Stale containers from earlier test runs are the usual cause:"
+            printf '    docker ps --format %s\n' "'{{.Names}}\t{{.Status}}\t{{.Ports}}'"
+            echo ""
+        } >&2
+        return 1
+    fi
+
+    return 0
+}
+
+# --- Post-mortem ------------------------------------------------------------
+
+# Startup races that a plain retry fixes: the container came up before Docker's
+# embedded DNS had the dependency's alias, so the name did not resolve.
+_STACK_TRANSIENT_RE='no such host|Temporary failure in name resolution|Name or service not known|i/o timeout'
+
+# stack_failure_is_transient <compose_file> <up_log> <service>...
+# True when the failure looks like a DNS/startup race rather than a real break.
+stack_failure_is_transient() {
+    local compose_file="$1" up_log="$2"
+    shift 2
+
+    if grep -qE "$_STACK_TRANSIENT_RE" "$up_log" 2>/dev/null; then
+        return 0
+    fi
+
+    # The daemon error is usually generic ("dependency failed to start"); the
+    # real signature is in the failed container's own log.
+    local logs
+    logs="$(docker compose -f "$compose_file" logs --tail=50 "$@" 2>/dev/null || true)"
+    grep -qE "$_STACK_TRANSIENT_RE" <<<"$logs"
+}
+
+# stack_failure_report <compose_file> <script_dir> <service>...
+# Says which services are healthy vs down, and how to run tests anyway.
+stack_failure_report() {
+    local compose_file="$1" script_dir="$2"
+    shift 2
+
+    {
+        echo ""
+        echo "=== Local stack failed to come up ==="
+        echo ""
+        echo "Service status:"
+        docker compose -f "$compose_file" ps -a --format '{{.Service}}	{{.State}}	{{.Status}}' \
+            "$@" 2>/dev/null | sed 's/^/  /' || true
+        echo ""
+
+        local service state exit_code
+        while IFS=$'\t' read -r service state exit_code; do
+            [[ -n "$service" ]] || continue
+            [[ "$state" == "running" ]] && continue
+            # One-shot services (migrations, seeding) legitimately exit 0.
+            [[ "$state" == "exited" && "$exit_code" == "0" ]] && continue
+            local service_logs
+            service_logs="$(docker compose -f "$compose_file" logs --tail=20 --no-log-prefix "$service" 2>&1 || true)"
+            echo "--- last 20 log lines: ${service} (${state}) ---"
+            if [[ -n "$service_logs" ]]; then
+                # shellcheck disable=SC2001  # indenting every line, not a substring swap
+                sed 's/^/    /' <<<"$service_logs"
+            else
+                echo "    (no output — the container never started)"
+            fi
+            echo ""
+        done < <(docker compose -f "$compose_file" ps -a --format '{{.Service}}	{{.State}}	{{.ExitCode}}' "$@" 2>/dev/null)
+
+        echo "A service being down does NOT block tests that never call it."
+        echo "profile.sh skips the local_up gate and runs patrol directly:"
+        echo ""
+        if [[ -n "${E2E_TEST_PATH:-}" ]]; then
+            echo "    bash ${script_dir}/profile.sh ${E2E_TEST_PATH}"
+        else
+            echo "    bash ${script_dir}/profile.sh <test_path>"
+            echo ""
+            echo "e.g. bash ${script_dir}/profile.sh integration_test/auth/auth_journey_test.dart"
+        fi
+        echo ""
+    } >&2
+}

--- a/local_stack/preflight.sh
+++ b/local_stack/preflight.sh
@@ -276,36 +276,27 @@ stack_failure_is_transient() {
     grep -qE "$_STACK_TRANSIENT_RE" <<<"$logs"
 }
 
-# stack_failure_report <compose_file> <script_dir> <service>...
-# Says which services are healthy vs down, and how to run tests anyway.
-stack_failure_report() {
-    local compose_file="$1" script_dir="$2"
-    shift 2
+# stack_service_status <compose_file> <service>...
+# The per-service state table, on stderr.
+stack_service_status() {
+    local compose_file="$1"
+    shift
 
     {
-        echo ""
-        echo "=== Local stack failed to come up ==="
-        echo ""
         echo "Service status:"
         docker compose -f "$compose_file" ps -a --format '{{.Service}}	{{.State}}	{{.Status}}' \
             "$@" 2>/dev/null | sed 's/^/  /' || true
         echo ""
+    } >&2
+}
 
-        local service state service_logs
-        while IFS='|' read -r service state; do
-            [[ -n "$service" ]] || continue
-            service_logs="$(docker compose -f "$compose_file" logs --tail=20 --no-log-prefix "$service" 2>&1 || true)"
-            echo "--- last 20 log lines: ${service} (${state}) ---"
-            if [[ -n "$service_logs" ]]; then
-                # shellcheck disable=SC2001  # indenting every line, not a substring swap
-                sed 's/^/    /' <<<"$service_logs"
-            else
-                echo "    (no output — the container never started)"
-            fi
-            echo ""
-        done < <(_stack_down_services "$compose_file" "$@")
+# stack_bypass_hint <script_dir> <lead_in>
+# How to run tests anyway, on stderr.
+stack_bypass_hint() {
+    local script_dir="$1" lead_in="$2"
 
-        echo "A service being down does NOT block tests that never call it."
+    {
+        echo "$lead_in"
         echo "profile.sh skips the local_up gate and runs patrol directly:"
         echo ""
         if [[ -n "${E2E_TEST_PATH:-}" ]]; then
@@ -317,4 +308,38 @@ stack_failure_report() {
         fi
         echo ""
     } >&2
+}
+
+# stack_failure_report <compose_file> <script_dir> <service>...
+# Says which services are healthy vs down, and how to run tests anyway.
+stack_failure_report() {
+    local compose_file="$1" script_dir="$2"
+    shift 2
+
+    {
+        echo ""
+        echo "=== Local stack failed to come up ==="
+        echo ""
+    } >&2
+
+    stack_service_status "$compose_file" "$@"
+
+    local service state service_logs
+    while IFS='|' read -r service state; do
+        [[ -n "$service" ]] || continue
+        service_logs="$(docker compose -f "$compose_file" logs --tail=20 --no-log-prefix "$service" 2>&1 || true)"
+        {
+            echo "--- last 20 log lines: ${service} (${state}) ---"
+            if [[ -n "$service_logs" ]]; then
+                # shellcheck disable=SC2001  # indenting every line, not a substring swap
+                sed 's/^/    /' <<<"$service_logs"
+            else
+                echo "    (no output — the container never started)"
+            fi
+            echo ""
+        } >&2
+    done < <(_stack_down_services "$compose_file" "$@")
+
+    stack_bypass_hint "$script_dir" \
+        "A service being down does NOT block tests that never call it."
 }

--- a/local_stack/preflight.sh
+++ b/local_stack/preflight.sh
@@ -55,7 +55,11 @@ preflight_ports() {
     local config_json project ports
 
     if ! docker ps --format '{{.Names}}' >/dev/null 2>&1; then
-        echo "ERROR: cannot talk to the Docker daemon. Is it running? (systemctl status docker)" >&2
+        local daemon_hint="systemctl status docker"
+        if [[ "$(uname -s)" == "Darwin" ]]; then
+            daemon_hint="open -a Docker"
+        fi
+        echo "ERROR: cannot talk to the Docker daemon. Is it running? (${daemon_hint})" >&2
         return 1
     fi
 

--- a/local_stack/preflight.sh
+++ b/local_stack/preflight.sh
@@ -231,6 +231,23 @@ preflight_ports() {
 # embedded DNS had the dependency's alias, so the name did not resolve.
 _STACK_TRANSIENT_RE='no such host|Temporary failure in name resolution|Name or service not known|i/o timeout'
 
+# _stack_down_services <compose_file> <service>...
+# stdout: "<service>|<state>" per service that is not up. One-shot jobs
+# (migrations, seeding) that exited 0 did their work and are not failures.
+_stack_down_services() {
+    local compose_file="$1"
+    shift
+
+    local service state exit_code
+    # `|` for the same reason as above: an empty middle field survives.
+    while IFS='|' read -r service state exit_code; do
+        [[ -n "$service" ]] || continue
+        [[ "$state" == "running" ]] && continue
+        [[ "$state" == "exited" && "$exit_code" == "0" ]] && continue
+        echo "${service}|${state}"
+    done < <(docker compose -f "$compose_file" ps -a --format '{{.Service}}|{{.State}}|{{.ExitCode}}' "$@" 2>/dev/null)
+}
+
 # stack_failure_is_transient <compose_file> <up_log> <service>...
 # True when the failure looks like a DNS/startup race rather than a real break.
 stack_failure_is_transient() {
@@ -242,9 +259,20 @@ stack_failure_is_transient() {
     fi
 
     # The daemon error is usually generic ("dependency failed to start"); the
-    # real signature is in the failed container's own log.
+    # real signature is in the failed containers' own logs. Only theirs — an
+    # `i/o timeout` in the recent output of a service that came up fine would
+    # otherwise buy two more pointless `up --wait` cycles before the real
+    # report prints.
+    local down_services=() service
+    while IFS='|' read -r service _; do
+        [[ -n "$service" ]] || continue
+        down_services+=("$service")
+    done < <(_stack_down_services "$compose_file" "$@")
+
+    ((${#down_services[@]} > 0)) || return 1
+
     local logs
-    logs="$(docker compose -f "$compose_file" logs --tail=50 "$@" 2>/dev/null || true)"
+    logs="$(docker compose -f "$compose_file" logs --tail=50 "${down_services[@]}" 2>/dev/null || true)"
     grep -qE "$_STACK_TRANSIENT_RE" <<<"$logs"
 }
 
@@ -263,14 +291,9 @@ stack_failure_report() {
             "$@" 2>/dev/null | sed 's/^/  /' || true
         echo ""
 
-        local service state exit_code
-        # `|` for the same reason as above: an empty middle field survives.
-        while IFS='|' read -r service state exit_code; do
+        local service state service_logs
+        while IFS='|' read -r service state; do
             [[ -n "$service" ]] || continue
-            [[ "$state" == "running" ]] && continue
-            # One-shot services (migrations, seeding) legitimately exit 0.
-            [[ "$state" == "exited" && "$exit_code" == "0" ]] && continue
-            local service_logs
             service_logs="$(docker compose -f "$compose_file" logs --tail=20 --no-log-prefix "$service" 2>&1 || true)"
             echo "--- last 20 log lines: ${service} (${state}) ---"
             if [[ -n "$service_logs" ]]; then
@@ -280,7 +303,7 @@ stack_failure_report() {
                 echo "    (no output — the container never started)"
             fi
             echo ""
-        done < <(docker compose -f "$compose_file" ps -a --format '{{.Service}}|{{.State}}|{{.ExitCode}}' "$@" 2>/dev/null)
+        done < <(_stack_down_services "$compose_file" "$@")
 
         echo "A service being down does NOT block tests that never call it."
         echo "profile.sh skips the local_up gate and runs patrol directly:"

--- a/local_stack/preflight.sh
+++ b/local_stack/preflight.sh
@@ -11,6 +11,10 @@
 #
 # The port list is read from docker-compose.yml via `docker compose config`,
 # so it cannot drift from the stack definition.
+#
+# `mise run local_up` calls plain `bash`, which on macOS is 3.2. No
+# associative arrays: every port map below is an indexed array subscripted by
+# the port number, which behaves identically on 3.2 and 4+.
 
 # --- Port list, straight from the compose file ------------------------------
 
@@ -68,7 +72,7 @@ preflight_ports() {
     fi
 
     # port -> space-separated local addresses currently listening on it
-    local -A listen_addrs=()
+    local listen_addrs=()
     local local_addr port
     while read -r _ _ _ local_addr _; do
         port="${local_addr##*:}"
@@ -77,7 +81,7 @@ preflight_ports() {
     done < <(ss -Hltn 2>/dev/null || true)
 
     # port -> container name / owning compose project (empty if standalone)
-    local -A port_container=() port_project=()
+    local port_container=() port_project=()
     local name proj portspec host_port
     # `|` rather than tab: tab is IFS whitespace, so bash collapses a run of
     # them and an empty middle field disappears. A standalone container has no

--- a/local_stack/preflight.sh
+++ b/local_stack/preflight.sh
@@ -79,14 +79,19 @@ preflight_ports() {
     # port -> container name / owning compose project (empty if standalone)
     local -A port_container=() port_project=()
     local name proj portspec host_port
-    while IFS=$'\t' read -r name proj portspec; do
+    # `|` rather than tab: tab is IFS whitespace, so bash collapses a run of
+    # them and an empty middle field disappears. A standalone container has no
+    # compose-project label, which is exactly the stale-container case this
+    # check exists to catch — with tabs its ports column shifts into `proj`
+    # and the container is misreported as an anonymous host process.
+    while IFS='|' read -r name proj portspec; do
         [[ -n "$name" ]] || continue
         while read -r host_port; do
             [[ -n "$host_port" ]] || continue
             port_container["$host_port"]="$name"
             port_project["$host_port"]="$proj"
         done < <(grep -oE ':[0-9]+->' <<<"$portspec" | tr -d ':>-')
-    done < <(docker ps --format '{{.Names}}	{{.Label "com.docker.compose.project"}}	{{.Ports}}' 2>/dev/null)
+    done < <(docker ps --format '{{.Names}}|{{.Label "com.docker.compose.project"}}|{{.Ports}}' 2>/dev/null)
 
     local service conflicts=0 holder holder_project
     while read -r service port; do
@@ -185,7 +190,8 @@ stack_failure_report() {
         echo ""
 
         local service state exit_code
-        while IFS=$'\t' read -r service state exit_code; do
+        # `|` for the same reason as above: an empty middle field survives.
+        while IFS='|' read -r service state exit_code; do
             [[ -n "$service" ]] || continue
             [[ "$state" == "running" ]] && continue
             # One-shot services (migrations, seeding) legitimately exit 0.
@@ -200,7 +206,7 @@ stack_failure_report() {
                 echo "    (no output — the container never started)"
             fi
             echo ""
-        done < <(docker compose -f "$compose_file" ps -a --format '{{.Service}}	{{.State}}	{{.ExitCode}}' "$@" 2>/dev/null)
+        done < <(docker compose -f "$compose_file" ps -a --format '{{.Service}}|{{.State}}|{{.ExitCode}}' "$@" 2>/dev/null)
 
         echo "A service being down does NOT block tests that never call it."
         echo "profile.sh skips the local_up gate and runs patrol directly:"

--- a/local_stack/test_stack_scripts.sh
+++ b/local_stack/test_stack_scripts.sh
@@ -1,0 +1,403 @@
+#!/usr/bin/env bash
+# Behavioural checks for preflight.sh and up.sh.
+#
+# Every case runs the real code against a sandboxed PATH holding a stubbed
+# `docker` (plus whichever of `ss`/`lsof` the case wants to exist), so the
+# outcome depends only on the fixtures — no daemon, no listening sockets, same
+# result on macOS and Linux.
+#
+#   bash local_stack/test_stack_scripts.sh
+#
+# shellcheck disable=SC2016  # snippets expand inside the sandboxed shell, not here
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PREFLIGHT="${SCRIPT_DIR}/preflight.sh"
+COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yml"
+BASH_BIN="$(command -v bash)"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+BIN="${tmp_dir}/bin"
+FIXTURES="${tmp_dir}/fixtures"
+mkdir -p "$BIN" "$FIXTURES"
+
+failures=0
+
+fail() {
+    echo "FAIL: $1" >&2
+    shift
+    local line
+    for line in "$@"; do
+        echo "  ${line}" >&2
+    done
+    failures=$((failures + 1))
+}
+
+assert_status() {
+    local expected="$1" actual="$2" message="$3"
+
+    if [[ "$actual" != "$expected" ]]; then
+        fail "$message" "expected exit ${expected}, got ${actual}" \
+            "stderr:" "$(sed 's/^/    /' "${tmp_dir}/err")"
+    fi
+}
+
+assert_stderr_contains() {
+    local needle="$1" message="$2"
+
+    if ! grep -qF -- "$needle" "${tmp_dir}/err"; then
+        fail "$message" "missing from stderr: ${needle}" \
+            "stderr:" "$(sed 's/^/    /' "${tmp_dir}/err")"
+    fi
+}
+
+assert_stderr_lacks() {
+    local needle="$1" message="$2"
+
+    if grep -qF -- "$needle" "${tmp_dir}/err"; then
+        fail "$message" "unexpected in stderr: ${needle}" \
+            "stderr:" "$(sed 's/^/    /' "${tmp_dir}/err")"
+    fi
+}
+
+# --- Sandbox ----------------------------------------------------------------
+
+# Only what these scripts and the stubs actually shell out to. `ss` and `lsof`
+# are left out on purpose: each case links in the ones it wants to exist.
+link_core_tools() {
+    local tool path
+    for tool in bash cat awk sed grep tr uname python3 dirname mktemp tee tail rm; do
+        path="$(command -v "$tool" || true)"
+        if [[ -z "$path" ]]; then
+            echo "ERROR: ${tool} is required to run these checks" >&2
+            exit 1
+        fi
+        ln -sf "$path" "${BIN}/${tool}"
+    done
+}
+
+cat >"${BIN}/docker" <<'STUB'
+#!/usr/bin/env bash
+# Serves canned output and exit codes from $STUB_FIXTURES. Unknown invocations
+# succeed silently, which is close enough to the real client for the paths
+# under test.
+set -u
+
+emit() { [[ -f "$1" ]] && cat "$1"; return 0; }
+
+# Exit code for a stubbed subcommand, 0 unless the case asked otherwise.
+stub_rc() {
+    local rc_file="${STUB_FIXTURES}/rc_$1"
+    if [[ -f "$rc_file" ]]; then
+        cat "$rc_file"
+    else
+        echo 0
+    fi
+}
+
+case "${1:-}" in
+  ps)
+    # The daemon liveness probe: `docker ps --format '{{.Names}}'`.
+    if [[ "${3:-}" == '{{.Names}}' ]]; then
+      exit "$(stub_rc daemon)"
+    fi
+    emit "${STUB_FIXTURES}/docker_ps.txt"
+    ;;
+  compose)
+    shift
+    while (($# > 0)); do
+      case "$1" in
+        config)
+          emit "${STUB_FIXTURES}/compose_config.json"
+          exit 0
+          ;;
+        up)
+          emit "${STUB_FIXTURES}/up_output.txt"
+          exit "$(stub_rc up)"
+          ;;
+        run)
+          emit "${STUB_FIXTURES}/seed_output.txt"
+          exit "$(stub_rc run)"
+          ;;
+        ps)
+          # Two different --format strings; ExitCode marks the pipe-delimited one.
+          if printf '%s\n' "$@" | grep -q 'ExitCode'; then
+            emit "${STUB_FIXTURES}/compose_ps_pipe.txt"
+          else
+            emit "${STUB_FIXTURES}/compose_ps_table.txt"
+          fi
+          exit 0
+          ;;
+        logs)
+          shift
+          for arg in "$@"; do
+            [[ "$arg" == --* ]] && continue
+            emit "${STUB_FIXTURES}/logs_${arg}.txt"
+          done
+          exit 0
+          ;;
+      esac
+      shift
+    done
+    ;;
+esac
+exit 0
+STUB
+chmod +x "${BIN}/docker"
+
+cat >"${BIN}/ss.stub" <<'STUB'
+#!/usr/bin/env bash
+# `ss -Hltn`: State Recv-Q Send-Q Local Peer
+cat "${STUB_FIXTURES}/ss.txt" 2>/dev/null
+exit 0
+STUB
+
+cat >"${BIN}/lsof.stub" <<'STUB'
+#!/usr/bin/env bash
+# `lsof -nP -iTCP -sTCP:LISTEN -Fn`: one n<address>:<port> record per socket.
+cat "${STUB_FIXTURES}/lsof.txt" 2>/dev/null
+exit 0
+STUB
+
+link_core_tools
+
+# with_tools <tool>... — exactly these of ss/lsof exist for the next run.
+with_tools() {
+    rm -f "${BIN}/ss" "${BIN}/lsof"
+    local tool
+    for tool in "$@"; do
+        cp "${BIN}/${tool}.stub" "${BIN}/${tool}"
+        chmod +x "${BIN}/${tool}"
+    done
+}
+
+# drop_python — the next run has no python3 on PATH.
+drop_python() { rm -f "${BIN}/python3"; }
+
+reset_fixtures() {
+    rm -f "${FIXTURES}"/*
+    cat >"${FIXTURES}/compose_config.json" <<'JSON'
+{
+  "name": "local_stack",
+  "services": {
+    "funnelcake-redis": {
+      "ports": [{"published": "16380", "target": 6379, "protocol": "tcp"}]
+    },
+    "keycast": {
+      "ports": [{"published": "45173", "target": 5173, "protocol": "tcp"}]
+    }
+  }
+}
+JSON
+}
+
+sandbox_env() {
+    env -i PATH="$BIN" HOME="$tmp_dir" STUB_FIXTURES="$FIXTURES" "$@"
+}
+
+# run_in_sandbox <snippet> [arg]...
+# The snippet runs in a fresh shell with preflight.sh sourced; $1 is the script
+# itself, $2 the compose file, $3.. whatever the caller passes. Errexit is the
+# caller's business, so the exit status survives.
+run_in_sandbox() {
+    local snippet="$1"
+    shift
+
+    sandbox_env "$BASH_BIN" -c "source \"\$1\"; ${snippet}" \
+        _ "$PREFLIGHT" "$COMPOSE_FILE" "$@" \
+        >"${tmp_dir}/out" 2>"${tmp_dir}/err"
+}
+
+run_preflight() {
+    set +e
+    run_in_sandbox 'preflight_ports "$2"'
+    last_status=$?
+    set -e
+}
+
+run_transient() {
+    set +e
+    run_in_sandbox 'stack_failure_is_transient "$2" "$3" "${@:4}"' "$@"
+    last_status=$?
+    set -e
+}
+
+run_up_sh() {
+    set +e
+    sandbox_env "$BASH_BIN" "${SCRIPT_DIR}/up.sh" \
+        >"${tmp_dir}/out" 2>"${tmp_dir}/err"
+    last_status=$?
+    set -e
+}
+
+# --- A stale container holding a stack port is a conflict -------------------
+# The bug this replaces: with no `ss` on the box the listener map stayed empty,
+# every port was skipped, and pre-flight returned 0 into a doomed `up`.
+
+reset_fixtures
+with_tools lsof
+echo 'stale-redis||0.0.0.0:16380->6379/tcp, [::]:16380->6379/tcp' >"${FIXTURES}/docker_ps.txt"
+echo 'n*:16380' >"${FIXTURES}/lsof.txt"
+run_preflight
+
+assert_status 1 "$last_status" "a container on a stack port should fail pre-flight without ss"
+assert_stderr_contains 'port 16380' "the conflicting port should be named"
+assert_stderr_contains 'wanted by service "funnelcake-redis"' "the service that wanted the port should be named"
+assert_stderr_contains 'held by container "stale-redis"' "the holding container should be named"
+assert_stderr_contains 'standalone container (no compose project)' "a container with no compose label should be called standalone"
+assert_stderr_contains 'docker rm -f stale-redis' "the remedy should be printed"
+# bash 3.2 is the only bash on macOS, and `mise run local_up` runs plain `bash`.
+assert_stderr_lacks 'invalid option' "no bash-4-only syntax should reach stderr"
+
+# --- Same conflict, no ss and no lsof ---------------------------------------
+# Container-held ports come from `docker ps`, so they are still caught; the
+# host-process blind spot is stated rather than passed over.
+
+reset_fixtures
+with_tools
+echo 'stale-redis||0.0.0.0:16380->6379/tcp' >"${FIXTURES}/docker_ps.txt"
+run_preflight
+
+assert_status 1 "$last_status" "a container conflict should be caught with neither ss nor lsof"
+assert_stderr_contains 'held by container "stale-redis"' "the holding container should still be named"
+assert_stderr_contains "neither 'ss' nor 'lsof' is installed" "the blind spot should be stated out loud"
+
+# --- A host process holding a stack port ------------------------------------
+
+reset_fixtures
+with_tools lsof
+: >"${FIXTURES}/docker_ps.txt"
+echo 'n127.0.0.1:45173' >"${FIXTURES}/lsof.txt"
+run_preflight
+
+assert_status 1 "$last_status" "a host process on a stack port should fail pre-flight"
+assert_stderr_contains 'held by a host process (not a container)' "a non-container holder should be described as one"
+assert_stderr_contains '127.0.0.1:45173' "the listening address should be shown"
+assert_stderr_contains 'sudo lsof -nP -iTCP:45173 -sTCP:LISTEN' "the remedy should use lsof where ss is absent"
+
+# --- ...and the remedy follows the tool the machine has ---------------------
+
+reset_fixtures
+with_tools ss
+: >"${FIXTURES}/docker_ps.txt"
+echo 'LISTEN 0 4096 127.0.0.1:45173 0.0.0.0:*' >"${FIXTURES}/ss.txt"
+run_preflight
+
+assert_status 1 "$last_status" "ss output should drive the same conflict report"
+assert_stderr_contains 'ss -ltnp "sport = :45173"' "the remedy should use ss where it exists"
+
+# --- Our own stack is not a conflict ----------------------------------------
+
+reset_fixtures
+with_tools lsof
+echo 'local_stack-funnelcake-redis-1|local_stack|0.0.0.0:16380->6379/tcp' >"${FIXTURES}/docker_ps.txt"
+echo 'n*:16380' >"${FIXTURES}/lsof.txt"
+run_preflight
+
+assert_status 0 "$last_status" "a port already published by this project should not be a conflict"
+
+# --- Nothing holding anything -----------------------------------------------
+
+reset_fixtures
+with_tools lsof
+: >"${FIXTURES}/docker_ps.txt"
+: >"${FIXTURES}/lsof.txt"
+run_preflight
+
+assert_status 0 "$last_status" "a clean machine should pass pre-flight"
+
+# --- An unreadable port list fails closed -----------------------------------
+# Empty output from a broken extractor reads exactly like "publishes no ports".
+
+reset_fixtures
+with_tools lsof
+echo 'stale-redis||0.0.0.0:16380->6379/tcp' >"${FIXTURES}/docker_ps.txt"
+drop_python
+run_preflight
+link_core_tools
+
+assert_status 1 "$last_status" "pre-flight should fail closed when it cannot read the port list"
+assert_stderr_contains 'needs python3' "the missing dependency should be named"
+
+# --- An unreachable daemon fails closed -------------------------------------
+
+reset_fixtures
+with_tools lsof
+echo 1 >"${FIXTURES}/rc_daemon"
+run_preflight
+
+assert_status 1 "$last_status" "pre-flight should fail closed when the daemon is unreachable"
+assert_stderr_contains 'cannot talk to the Docker daemon' "the daemon should be named as the problem"
+
+# --- Transience is judged on the failed service's own log -------------------
+# A retry-worthy signature in a service that came up fine is not evidence, and
+# acting on it costs two more `up --wait` cycles before the real report prints.
+
+reset_fixtures
+with_tools lsof
+cat >"${FIXTURES}/compose_ps_pipe.txt" <<'PS'
+keycast|running|0
+funnelcake-migrate|exited|1
+minio-init|exited|0
+PS
+echo 'dial tcp: i/o timeout' >"${FIXTURES}/logs_keycast.txt"
+echo 'migration failed: permission denied' >"${FIXTURES}/logs_funnelcake-migrate.txt"
+echo 'dependency failed to start' >"${tmp_dir}/up.log"
+
+run_transient "${tmp_dir}/up.log" keycast funnelcake-migrate minio-init
+assert_status 1 "$last_status" "a healthy service's log should not make a hard failure look transient"
+
+echo 'lookup funnelcake-clickhouse on 127.0.0.11:53: no such host' >"${FIXTURES}/logs_funnelcake-migrate.txt"
+
+run_transient "${tmp_dir}/up.log" keycast funnelcake-migrate minio-init
+assert_status 0 "$last_status" "a name-resolution failure in the down service should be transient"
+
+# --- Nothing down means nothing to retry ------------------------------------
+
+reset_fixtures
+with_tools lsof
+cat >"${FIXTURES}/compose_ps_pipe.txt" <<'PS'
+keycast|running|0
+minio-init|exited|0
+PS
+echo 'dial tcp: i/o timeout' >"${FIXTURES}/logs_keycast.txt"
+
+run_transient "${tmp_dir}/up.log" keycast minio-init
+assert_status 1 "$last_status" "with every service up there is no failed log to call transient"
+
+# --- A failed seed reports the seed, not the healthy services ---------------
+# The services came up; saying "Local stack failed to come up" over a list of
+# 15 healthy ones buries the one log that explains the failure.
+
+reset_fixtures
+with_tools lsof
+: >"${FIXTURES}/docker_ps.txt"
+: >"${FIXTURES}/lsof.txt"
+echo 'Container local_stack-keycast-1  Healthy' >"${FIXTURES}/up_output.txt"
+cat >"${FIXTURES}/seed_output.txt" <<'SEED'
+seeding 100 videos
+error: blossom upload failed: connection refused
+SEED
+echo 3 >"${FIXTURES}/rc_run"
+cat >"${FIXTURES}/compose_ps_table.txt" <<'PS'
+keycast	running	Up 2 minutes (healthy)
+PS
+run_up_sh
+
+assert_status 3 "$last_status" "up.sh should exit with the seed's own status"
+assert_stderr_contains '=== e2e-seed failed ===' "the seed should be named as what failed"
+assert_stderr_contains 'blossom upload failed: connection refused' "the seed's own error should be shown"
+assert_stderr_lacks '=== Local stack failed to come up ===' "the stack came up, so it should not claim otherwise"
+assert_stderr_contains 'Service status:' "the service table still helps explain a seed failure"
+assert_stderr_contains 'profile.sh' "the bypass command should still be offered"
+
+# ----------------------------------------------------------------------------
+
+if ((failures > 0)); then
+    echo "${failures} local stack check(s) failed" >&2
+    exit 1
+fi
+
+echo "local stack script checks passed"

--- a/local_stack/up.sh
+++ b/local_stack/up.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yml"
 
+# shellcheck source=preflight.sh
+source "${SCRIPT_DIR}/preflight.sh"
+
 PULL_ARGS=()
 case "${1:-}" in
   --pull=missing)
@@ -24,9 +27,60 @@ SERVICES=(
   minio blossom blossom-proxy invite
 )
 
-if ((${#PULL_ARGS[@]} > 0)); then
-  docker compose -f "$COMPOSE_FILE" up -d --wait "${PULL_ARGS[@]}" "${SERVICES[@]}"
-else
-  docker compose -f "$COMPOSE_FILE" up -d --wait "${SERVICES[@]}"
+# SERVICES plus the one-shot jobs compose pulls in as dependencies. Failures
+# often land in those, so the post-mortem has to be able to see them.
+REPORT_SERVICES=("${SERVICES[@]}" keycast-migrate funnelcake-migrate minio-init)
+
+# Fail early and by name on port clashes, instead of letting the daemon report
+# an anonymous "port is already allocated" partway through startup.
+if ! preflight_ports "$COMPOSE_FILE"; then
+  exit 1
 fi
-docker compose -f "$COMPOSE_FILE" run --rm e2e-seed
+
+UP_CMD=(docker compose -f "$COMPOSE_FILE" up -d --wait)
+if ((${#PULL_ARGS[@]} > 0)); then
+  UP_CMD+=("${PULL_ARGS[@]}")
+fi
+UP_CMD+=("${SERVICES[@]}")
+
+UP_LOG="$(mktemp)"
+trap 'rm -f "$UP_LOG"' EXIT
+
+# Containers occasionally start before Docker's embedded DNS knows their
+# dependency's alias ("no such host" / "Temporary failure in name resolution").
+# `up` is idempotent and restarts whatever died, so a bounded retry clears it.
+MAX_ATTEMPTS=3
+RETRY_DELAY=5
+
+attempt=1
+while true; do
+  set +e
+  "${UP_CMD[@]}" 2>&1 | tee "$UP_LOG"
+  UP_RC="${PIPESTATUS[0]}"
+  set -e
+
+  if [[ "$UP_RC" -eq 0 ]]; then
+    break
+  fi
+
+  if ((attempt < MAX_ATTEMPTS)) &&
+    stack_failure_is_transient "$COMPOSE_FILE" "$UP_LOG" "${REPORT_SERVICES[@]}"; then
+    echo "" >&2
+    echo "Name resolution failed during startup — a known race. Retrying in ${RETRY_DELAY}s (attempt $((attempt + 1)) of ${MAX_ATTEMPTS})." >&2
+    echo "" >&2
+    sleep "$RETRY_DELAY"
+    attempt=$((attempt + 1))
+    continue
+  fi
+
+  stack_failure_report "$COMPOSE_FILE" "$SCRIPT_DIR" "${REPORT_SERVICES[@]}"
+  exit "$UP_RC"
+done
+
+if ! docker compose -f "$COMPOSE_FILE" run --rm e2e-seed; then
+  echo "" >&2
+  echo "ERROR: e2e-seed failed. The services themselves may still be healthy —" >&2
+  echo "only tests that read seeded relay/blossom data need it." >&2
+  stack_failure_report "$COMPOSE_FILE" "$SCRIPT_DIR" "${REPORT_SERVICES[@]}"
+  exit 1
+fi

--- a/local_stack/up.sh
+++ b/local_stack/up.sh
@@ -44,7 +44,8 @@ fi
 UP_CMD+=("${SERVICES[@]}")
 
 UP_LOG="$(mktemp)"
-trap 'rm -f "$UP_LOG"' EXIT
+SEED_LOG="$(mktemp)"
+trap 'rm -f "$UP_LOG" "$SEED_LOG"' EXIT
 
 # Containers occasionally start before Docker's embedded DNS knows their
 # dependency's alias ("no such host" / "Temporary failure in name resolution").
@@ -77,10 +78,27 @@ while true; do
   exit "$UP_RC"
 done
 
-if ! docker compose -f "$COMPOSE_FILE" run --rm e2e-seed; then
-  echo "" >&2
-  echo "ERROR: e2e-seed failed. The services themselves may still be healthy —" >&2
-  echo "only tests that read seeded relay/blossom data need it." >&2
-  stack_failure_report "$COMPOSE_FILE" "$SCRIPT_DIR" "${REPORT_SERVICES[@]}"
-  exit 1
+# `--rm` takes the seed container away with it, so its logs are gone by the
+# time a post-mortem could ask for them. Keep a copy.
+set +e
+docker compose -f "$COMPOSE_FILE" run --rm e2e-seed 2>&1 | tee "$SEED_LOG"
+SEED_RC="${PIPESTATUS[0]}"
+set -e
+
+if [[ "$SEED_RC" -ne 0 ]]; then
+  {
+    echo ""
+    echo "=== e2e-seed failed ==="
+    echo ""
+    echo "The services themselves may still be healthy — the seed only loads"
+    echo "relay/blossom fixtures."
+    echo ""
+    echo "--- last 20 log lines: e2e-seed ---"
+    tail -n 20 "$SEED_LOG" | sed 's/^/    /'
+    echo ""
+  } >&2
+  stack_service_status "$COMPOSE_FILE" "${REPORT_SERVICES[@]}"
+  stack_bypass_hint "$SCRIPT_DIR" \
+    "Only tests that read seeded relay/blossom data need it."
+  exit "$SEED_RC"
 fi


### PR DESCRIPTION
Closes #6577

## Summary

When the local stack failed to start, it did not tell you why or what to do about it.
Now it checks ports before starting, survives transient startup races, and reports which parts of the stack came up.
When a port is taken it names the container holding it and prints the command to remove it.

## What Changed

The second commit fixes a real parsing bug found while using the tool. Splitting `docker ps` output on tabs collapsed the empty compose-project field, so standalone containers were misreported as host processes — which sends you hunting for a process that does not exist.

- Port pre-flight checks before startup.
- Transient startup races are retried instead of failing the run.
- Partial-stack reporting, so you can see what came up and what did not.
- Skill documentation for the workflow.
- Fixed the tab-delimited `docker ps` parse.

## Testing

Verified by causing the actual failures rather than by reasoning about them.

- Triggered a real port conflict held by a container: the tool names the container and prints the `docker rm -f` command.
- Triggered a conflict held by a non-container host process: correctly identified as a host process.

## Risks

Low. Developer tooling only, with no effect on app or production behaviour.
