### PR TITLE
fix(drafts): keep library clips in the ghost-frame scan

### DIFF
--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -718,7 +718,9 @@ class DraftStorageService {
     final filenames = <String>{};
 
     for (final row in clipRows) {
-      if (row.draftId == excludeDraftId) continue;
+      // Guard the null: library clips carry a NULL draftId, so an unguarded
+      // comparison would drop exactly them when no draft is excluded.
+      if (excludeDraftId != null && row.draftId == excludeDraftId) continue;
       try {
         final data = json.decode(row.data) as Map<String, dynamic>;
         final ghostFramePath = data['ghostFramePath'] as String?;

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -603,13 +603,10 @@ class DraftStorageService {
 
     // Ghost frames live only in the clip `data` blob, so — like draft-local
     // audio — the indexed-column check can't tell that a surviving draft (e.g.
-    // a duplicate sharing this draft's clips) still references them. Scan the
-    // other drafts' clips for shared ghost frames and keep those alive.
-    // Exclude this draft's own clips so its ghost frames aren't kept alive by
-    // rows that haven't cascade-deleted yet.
-    final referencedGhostFrames = await _referencedGhostFrameFilenames(
-      excludeDraftId: id,
-    );
+    // a duplicate sharing this draft's clips) still references them. This
+    // draft's own rows are already gone, so every clip the scan sees is a
+    // legitimate survivor whose ghost frame must stay alive.
+    final referencedGhostFrames = await _referencedGhostFrameFilenames();
 
     // Delete clip files only if not referenced by clip library
     await FileCleanupService.deleteRecordingClipsFiles(
@@ -645,15 +642,13 @@ class DraftStorageService {
         audioPaths,
         draftsDao: _draftsDao,
         clipsDao: _clipsDao,
-        referencedAudioFilenames: await _referencedLocalAudioFilenames(
-          excludeDraftId: id,
-        ),
+        referencedAudioFilenames: await _referencedLocalAudioFilenames(),
       );
     }
   }
 
-  /// Basenames of draft-local audio files referenced by any draft other than
-  /// [excludeDraftId], across all accounts.
+  /// Basenames of draft-local audio files referenced by any surviving draft,
+  /// across all accounts.
   ///
   /// The same local audio file can be shared by a draft and its publish copy —
   /// `copyWith` carries [DivineVideoDraft.editorStateHistory] and
@@ -662,17 +657,14 @@ class DraftStorageService {
   /// directly (audio paths live there, not in an indexed column) and never
   /// throws: a corrupt blob is logged and skipped.
   ///
-  /// [excludeDraftId] is required: the sole caller always excludes a draft,
-  /// and a nullable parameter would silently mean "scan everything".
-  Future<Set<String>> _referencedLocalAudioFilenames({
-    required String excludeDraftId,
-  }) async {
+  /// Callers run this *after* deleting the draft they are cleaning up, so
+  /// every row it sees is a survivor and there is nothing to exclude.
+  Future<Set<String>> _referencedLocalAudioFilenames() async {
     final rows = await _draftsDao.getAllDrafts();
     final documentsPath = await getDocumentsPath();
     final filenames = <String>{};
 
     for (final row in rows) {
-      if (row.id == excludeDraftId) continue;
       final DivineVideoDraft draft;
       try {
         draft = DivineVideoDraft.fromJson(
@@ -695,8 +687,8 @@ class DraftStorageService {
     return filenames;
   }
 
-  /// Basenames of clip ghost-frame files referenced by any clip other than
-  /// those belonging to [excludeDraftId], across all accounts.
+  /// Basenames of clip ghost-frame files referenced by any surviving clip,
+  /// across all accounts — library clips, whose `draftId` is NULL, included.
   ///
   /// A clip's ghost frame is persisted only inside the clip `data` blob (no
   /// indexed column), so a draft that shares clips with another draft — a
@@ -715,16 +707,13 @@ class DraftStorageService {
   /// table: this scan runs on every draft deletion, and decoding every blob in
   /// the database made it grow with the size of the clip library (#6548).
   ///
-  /// A null [excludeDraftId] excludes nothing: every clip is scanned, including
-  /// library clips, whose `draftId` is NULL. `clearAllDrafts` relies on that.
-  Future<Set<String>> _referencedGhostFrameFilenames({
-    String? excludeDraftId,
-  }) async {
+  /// Callers run this *after* deleting the draft they are cleaning up, so
+  /// every clip it sees is a survivor and there is nothing to exclude.
+  Future<Set<String>> _referencedGhostFrameFilenames() async {
     final clipRows = await _clipsDao.getClipsWithGhostFrames();
     final filenames = <String>{};
 
     for (final row in clipRows) {
-      if (excludeDraftId != null && row.draftId == excludeDraftId) continue;
       try {
         final data = json.decode(row.data) as Map<String, dynamic>;
         final ghostFramePath = data['ghostFramePath'] as String?;
@@ -770,8 +759,7 @@ class DraftStorageService {
 
     // Every draft and its clips are gone; the clips that survive are library
     // clips (active or trashed). Ghost frames live only in the clip `data`
-    // blob, so protect any a surviving library clip still references. No
-    // excludeDraftId — all remaining clips are legitimate survivors.
+    // blob, so protect any a surviving library clip still references.
     final referencedGhostFrames = await _referencedGhostFrameFilenames();
 
     // Delete clip files only if not referenced by clip library

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -661,8 +661,12 @@ class DraftStorageService {
   /// the last referencing draft is deleted. Scans the draft `data` blobs
   /// directly (audio paths live there, not in an indexed column) and never
   /// throws: a corrupt blob is logged and skipped.
+  ///
+  /// [excludeDraftId] is required: unlike the ghost-frame scan there is no
+  /// scan-everything caller, so leaving it nullable would only invite the
+  /// `null == null` skip that #6581 fixed there.
   Future<Set<String>> _referencedLocalAudioFilenames({
-    String? excludeDraftId,
+    required String excludeDraftId,
   }) async {
     final rows = await _draftsDao.getAllDrafts();
     final documentsPath = await getDocumentsPath();

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -662,9 +662,8 @@ class DraftStorageService {
   /// directly (audio paths live there, not in an indexed column) and never
   /// throws: a corrupt blob is logged and skipped.
   ///
-  /// [excludeDraftId] is required: unlike the ghost-frame scan there is no
-  /// scan-everything caller, so leaving it nullable would only invite the
-  /// `null == null` skip that #6581 fixed there.
+  /// [excludeDraftId] is required: the sole caller always excludes a draft,
+  /// and a nullable parameter would silently mean "scan everything".
   Future<Set<String>> _referencedLocalAudioFilenames({
     required String excludeDraftId,
   }) async {
@@ -715,6 +714,9 @@ class DraftStorageService {
   /// Uses [ClipsDao.getClipsWithGhostFrames] rather than reading the whole clip
   /// table: this scan runs on every draft deletion, and decoding every blob in
   /// the database made it grow with the size of the clip library (#6548).
+  ///
+  /// A null [excludeDraftId] excludes nothing: every clip is scanned, including
+  /// library clips, whose `draftId` is NULL. `clearAllDrafts` relies on that.
   Future<Set<String>> _referencedGhostFrameFilenames({
     String? excludeDraftId,
   }) async {
@@ -722,8 +724,6 @@ class DraftStorageService {
     final filenames = <String>{};
 
     for (final row in clipRows) {
-      // Guard the null: library clips carry a NULL draftId, so an unguarded
-      // comparison would drop exactly them when no draft is excluded.
       if (excludeDraftId != null && row.draftId == excludeDraftId) continue;
       try {
         final data = json.decode(row.data) as Map<String, dynamic>;

--- a/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
@@ -106,9 +106,12 @@ class ClipsDao extends DatabaseAccessor<AppDatabase> with _$ClipsDaoMixin {
   }
 
   /// Every clip row that carries a non-null `ghostFramePath`, projected to the
-  /// fields a ghost-frame reference scan needs: `draftId` to skip the draft
-  /// being deleted, `data` to read the frame out of, and `id` to name the row
-  /// if its blob turns out to be corrupt.
+  /// fields a ghost-frame reference scan needs: `data` to read the frame out
+  /// of, and `id` to name the row if its blob turns out to be corrupt.
+  /// `draftId` is returned too and is NULL for library clips; no caller
+  /// filters on it, and none should — the scan runs after the draft being
+  /// cleaned up has lost its own rows, so every row here is a survivor whose
+  /// ghost frame must stay alive (#6581).
   ///
   /// Ghost frames have no indexed column — they exist only inside the `data`
   /// blob — so the alternative is loading and JSON-decoding *every* clip row in

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -2313,10 +2313,18 @@ void main() {
 /// `FileCleanupService` treats that check as a defensive backstop behind the
 /// caller-supplied ghost-frame set; removing it leaves that set as the only
 /// thing keeping a shared ghost file alive.
+///
+/// Both query entry points are overridden. `ClipsDao.isFileReferenced` happens
+/// to delegate to [referencedFilenames] today, but nothing pins that: if it
+/// ever queried directly, a single override would quietly restore the backstop
+/// and the test would pass for the wrong reason.
 class _BackstopBlindClipsDao extends ClipsDao {
   _BackstopBlindClipsDao(super.attachedDatabase);
 
   @override
   Future<Set<String>> referencedFilenames(Set<String> filenames) async =>
       const {};
+
+  @override
+  Future<bool> isFileReferenced(String filename) async => false;
 }

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -2185,6 +2185,46 @@ void main() {
         );
       });
 
+      // The case above survives even a ghost-frame scan that returns nothing:
+      // `deleteGhostFrameFiles` then falls back to `deleteFileIfUnreferenced`,
+      // whose clip JSON scan also covers `ghostFramePath` and keeps the file.
+      // This one takes that backstop away, leaving the scan as the only
+      // protection — so a scan that drops library clips deletes the frame
+      // (#6581).
+      test('keeps a surviving library clip ghost frame when the indexed '
+          'reference backstop misses it', () async {
+        final ghost = writeGhost('ghost_backstop_blind.jpg');
+        final blindService = DraftStorageService(
+          draftsDao: database.draftsDao,
+          clipsDao: _BackstopBlindClipsDao(database),
+        );
+        final draft = draftWithGhost(
+          id: 'draft_backstop_blind',
+          ghostPath: ghost.path,
+        );
+        await blindService.saveDraft(draft);
+
+        await database.clipsDao.upsertClip(
+          id: 'library_clip_backstop_blind',
+          orderIndex: 0,
+          durationMs: 6000,
+          recordedAt: DateTime(2025),
+          data: json.encode({'ghostFramePath': 'ghost_backstop_blind.jpg'}),
+          filePath: null,
+          thumbnailPath: null,
+        );
+
+        await blindService.clearAllDrafts();
+
+        expect(
+          ghost.existsSync(),
+          isTrue,
+          reason:
+              'the ghost-frame scan must include library clips, whose draftId '
+              'is NULL, when no draft is excluded',
+        );
+      });
+
       test('still deletes the target ghost frame when a sibling clip row has a '
           'corrupt data blob', () async {
         final ghost = writeGhost('ghost_target.jpg');
@@ -2265,4 +2305,18 @@ void main() {
       });
     });
   });
+}
+
+/// A [ClipsDao] that never reports a filename as referenced, standing in for a
+/// clip-side reference check that no longer covers `ghostFramePath`.
+///
+/// `FileCleanupService` treats that check as a defensive backstop behind the
+/// caller-supplied ghost-frame set; removing it leaves that set as the only
+/// thing keeping a shared ghost file alive.
+class _BackstopBlindClipsDao extends ClipsDao {
+  _BackstopBlindClipsDao(super.attachedDatabase);
+
+  @override
+  Future<Set<String>> referencedFilenames(Set<String> filenames) async =>
+      const {};
 }


### PR DESCRIPTION
## Description

`DraftStorageService._referencedGhostFrameFilenames` skipped every clip row whose `draftId` equalled `excludeDraftId`. `clearAllDrafts()` calls it with no argument, so `excludeDraftId` is `null` — and library clips are exactly the rows with a `NULL` `draft_id`, so `null == null` was true and **every library clip was skipped**: the rows the call exists to protect. The `deleteDraft` path was never affected, since there `excludeDraftId` is a real draft id.

The first fix guarded the null explicitly. Review then established that the exclusion is dead in both directions: both scans run *after* `DraftsDao.deleteDraft` has removed the draft **and** its clip rows in one transaction (`drafts_dao.dart:161-166`, awaited at `:602` before the scans at `:610`/`:645`), so no row the exclusion could skip ever reaches them. Deleting either guard line leaves all 77 tests in the two affected suites green.

So `excludeDraftId` is dropped from both scans instead. Library clips reach the ghost-frame scan by construction rather than by guard, and the nullable-exclude hazard class that caused this bug is gone with the parameter that carried it. The tradeoff is the lost safety net if someone later moves a scan ahead of the delete — that failure mode leaks a file rather than deleting one, and the delete-first ordering is deliberate and commented at `:599-601`.

Nothing is broken for users today. `FileCleanupService.deleteGhostFrameFiles` falls back to `deleteFileIfUnreferenced`, whose JSON scan runs `ClipsDao.referencedFilenames` — and `_jsonFilePathKeys` still contains `ghostFramePath`, so the backstop finds the reference and keeps the file. It becomes a real ghost-frame deletion the moment that backstop stops covering the key, e.g. if `_jsonFilePathKeys` is trimmed or the fallback is skipped as an optimisation.

That same backstop is why the existing `keeps a ghost frame referenced by a surviving library clip when all drafts are cleared` test passes with **or** without the fix — it asserts the file outcome, which the fallback rescues either way. The regression test added here runs `clearAllDrafts` against a `ClipsDao` whose `referencedFilenames` and `isFileReferenced` both return nothing, leaving the ghost-frame set as the only thing that can protect the file.

It also stops paying for that rescue. With the set always empty, every shared ghost frame in `clearAllDrafts` fell through to `deleteFileIfUnreferenced`, and `ClipsDao.referencedFilenames` resolves an unindexed name with a full `SELECT data FROM clips` plus a JSON decode of every row — once per frame. Those short-circuit on the set now, which is the same scan cost #6548 took off this path.

**Related Issue:** Closes #6581

## Sibling Scan

`_referencedLocalAudioFilenames` carried the same comparison shape, but it compares against `row.id`, a non-null primary key, so `null` could never match and it was never broken. Its `excludeDraftId` is dead for the same reason as the ghost-frame one — `deleteDraft` removes the draft row at `:602` before `getAllDrafts()` runs — so it is dropped too, and both functions read the same way again.

## Verification

- Reproduced first, per the issue's evidence recipe: with `'ghostFramePath'` removed from `ClipsDao._jsonFilePathKeys` (backstop disabled, everything else intact), exactly one test failed — the library-clip case. The duplicate and trashed-clip siblings stayed green, confirming the null comparison drops library clips and nothing else. Re-running with the fix applied and the backstop still disabled turned it green.
- Dead-branch check: deleting **both** exclusion guards from the shipped code leaves all 77 tests in `draft_storage_service_test.dart` + `file_cleanup_service_test.dart` green. That is the evidence the branch is unreachable through the real DAO, not just an argument that it should be.
- The regression test still bites after the parameter removal: mutating the scan to `if (row.draftId == null) continue;` fails exactly one test out of 69, and it is the new one. It guards the behaviour directly rather than guarding the guard.
- Swept `mobile/lib` and `mobile/packages` for the same shape — an identity skip whose *exclude* operand is nullable. Exactly two other sites qualify: `video_editor_timeline_overlay_strips.dart:116` (`String? selectedItemId`) and `timeline_snap_controller.dart:243` (`int? _releasedSnapMs`). Both are safe because the left operand is non-null — `TimelineOverlayItem.id` is a `String`, and `snapPoints` is a `Set<int>` — so `null == null` can never fire. This was the only broken instance.
- All 17 suites touching `DraftStorageService`: 464 passing, 2 pre-existing skips.
- `flutter analyze lib test integration_test` — clean.
- `dart format` — clean.
- No device pass: the bug is latent behind the backstop and has no user-visible surface on a build, so a Samsung Galaxy run would show the same thing before and after. The disabled-backstop reproduction above is what actually distinguishes them.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
