### PR TITLE
fix(nostr): make publishEventAwaitOk success semantics explicit

### DIFF
--- a/mobile/lib/blocs/owner_video_actions/owner_video_actions_cubit.dart
+++ b/mobile/lib/blocs/owner_video_actions/owner_video_actions_cubit.dart
@@ -24,6 +24,7 @@ class OwnerVideoActionsState extends Equatable {
     deleteStatus,
     deleteResult?.success,
     deleteResult?.failureKind,
+    deleteResult?.acceptance,
     deleteResult?.deleteEventId,
     deleteResult?.error,
   ];

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -1842,6 +1842,7 @@
     "shareMenuDeleteFailedCouldNotSign": "የመሰረዝ ጥያቄውን መፈረም አልተቻለም። እንደገና ይሞክሩ።",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "ቅብብሎሹን መድረስ አልተቻለም። ግንኙነትዎን ይፈትሹ እና እንደገና ይሞክሩ።",
+    "shareMenuDeleteFailedRelayPartial": "ይህ ቪዲዮ አሁንም በአንዳንድ ሪሌዎች ላይ አለ። እንደገና ለመሰረዝ ይሞክሩ።",
     "shareMenuDeleteFailedGeneric": "ይህን ቪዲዮ መሰረዝ አልተቻለም። እንደገና ይሞክሩ።",
     "shareMenuFollowSetName": "የቅንብር ስም ተከተል",
     "shareMenuFollowSetNameHint": "ለምሳሌ፣ የይዘት ፈጣሪዎች፣ ሙዚቀኞች፣ ወዘተ",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -1842,7 +1842,7 @@
     "shareMenuDeleteFailedCouldNotSign": "የመሰረዝ ጥያቄውን መፈረም አልተቻለም። እንደገና ይሞክሩ።",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "ቅብብሎሹን መድረስ አልተቻለም። ግንኙነትዎን ይፈትሹ እና እንደገና ይሞክሩ።",
-    "shareMenuDeleteFailedRelayPartial": "ይህ ቪዲዮ አሁንም በአንዳንድ ሪሌዎች ላይ አለ። እንደገና ለመሰረዝ ይሞክሩ።",
+    "shareMenuDeletePartiallyConfirmed": "ተሰርዟል። ሁሉም ሪሌዎች አላረጋገጡም፣ ስለዚህ በሌሎች መተግበሪያዎች ላይ አሁንም ሊታይ ይችላል።",
     "shareMenuDeleteFailedGeneric": "ይህን ቪዲዮ መሰረዝ አልተቻለም። እንደገና ይሞክሩ።",
     "shareMenuFollowSetName": "የቅንብር ስም ተከተል",
     "shareMenuFollowSetNameHint": "ለምሳሌ፣ የይዘት ፈጣሪዎች፣ ሙዚቀኞች፣ ወዘተ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3221,7 +3221,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{تكرار} other{تكرارات}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
-    "shareMenuDeleteFailedRelayPartial": "لا يزال هذا الفيديو موجودًا على بعض المرحّلات. حاول حذفه مرة أخرى.",
+    "shareMenuDeletePartiallyConfirmed": "تم الحذف. لم تؤكّد كل المرحّلات، لذا قد يظل ظاهرًا في تطبيقات أخرى.",
     "videoEditorAudioSegmentInstruction": "حدّد مقطع الصوت لفيديوك",
     "videoEditorClipGalleryInstruction": "اضغط للتعديل. اضغط مطولاً واسحب لإعادة الترتيب.",
     "fullscreenFeedRemovedMessage": "تمت إزالة الفيديو",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3221,6 +3221,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{تكرار} other{تكرارات}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
+    "shareMenuDeleteFailedRelayPartial": "لا يزال هذا الفيديو موجودًا على بعض المرحّلات. حاول حذفه مرة أخرى.",
     "videoEditorAudioSegmentInstruction": "حدّد مقطع الصوت لفيديوك",
     "videoEditorClipGalleryInstruction": "اضغط للتعديل. اضغط مطولاً واسحب لإعادة الترتيب.",
     "fullscreenFeedRemovedMessage": "تمت إزالة الفيديو",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -1716,6 +1716,7 @@
     "shareMenuDeleteFailedCouldNotSign": "Не успяхме да подпишем заявката за изтриване. Опитай пак.",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Не можем да достигнем релето. Провери връзката си и опитай пак.",
+    "shareMenuDeleteFailedRelayPartial": "Това видео още го има на някои релета. Опитай да го изтриеш пак.",
     "shareMenuDeleteFailedGeneric": "Не успяхме да изтрием това видео. Опитай пак.",
     "shareMenuFollowSetName": "Име на списъка за следване",
     "shareMenuFollowSetNameHint": "Например създатели на съдържание, музиканти и др.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -1716,7 +1716,7 @@
     "shareMenuDeleteFailedCouldNotSign": "Не успяхме да подпишем заявката за изтриване. Опитай пак.",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Не можем да достигнем релето. Провери връзката си и опитай пак.",
-    "shareMenuDeleteFailedRelayPartial": "Това видео още го има на някои релета. Опитай да го изтриеш пак.",
+    "shareMenuDeletePartiallyConfirmed": "Изтрито. Не всички релета потвърдиха, така че може още да се вижда в други приложения.",
     "shareMenuDeleteFailedGeneric": "Не успяхме да изтрием това видео. Опитай пак.",
     "shareMenuFollowSetName": "Име на списъка за следване",
     "shareMenuFollowSetNameHint": "Например създатели на съдържание, музиканти и др.",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3226,6 +3226,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{Loop} other{Loops}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
+    "shareMenuDeleteFailedRelayPartial": "Dieses Video ist noch auf einigen Relays. Versuch es noch mal zu löschen.",
     "videoEditorAudioSegmentInstruction": "Wähle den Audiobereich für dein Video aus",
     "videoEditorClipGalleryInstruction": "Tippen zum Bearbeiten. Halten und ziehen zum Neuordnen.",
     "navSearch": "Suche",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3226,7 +3226,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{Loop} other{Loops}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
-    "shareMenuDeleteFailedRelayPartial": "Dieses Video ist noch auf einigen Relays. Versuch es noch mal zu löschen.",
+    "shareMenuDeletePartiallyConfirmed": "Gelöscht. Nicht alle Relays haben bestätigt, es kann also noch in anderen Apps auftauchen.",
     "videoEditorAudioSegmentInstruction": "Wähle den Audiobereich für dein Video aus",
     "videoEditorClipGalleryInstruction": "Tippen zum Bearbeiten. Halten und ziehen zum Neuordnen.",
     "navSearch": "Suche",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2228,6 +2228,7 @@
   "shareMenuDeleteFailedCouldNotSign": "Couldn't sign the delete request. Try again.",
   "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
   "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
+  "shareMenuDeleteFailedRelayPartial": "This video is still live on some relays. Try deleting it again.",
   "shareMenuDeleteFailedGeneric": "Couldn't delete this video. Try again.",
   "shareMenuFollowSetName": "Follow Set Name",
   "shareMenuFollowSetNameHint": "e.g., Content Creators, Musicians, etc.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2228,7 +2228,7 @@
   "shareMenuDeleteFailedCouldNotSign": "Couldn't sign the delete request. Try again.",
   "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
   "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
-  "shareMenuDeleteFailedRelayPartial": "This video is still live on some relays. Try deleting it again.",
+  "shareMenuDeletePartiallyConfirmed": "Deleted. Not every relay confirmed, so it may still show up in other apps.",
   "shareMenuDeleteFailedGeneric": "Couldn't delete this video. Try again.",
   "shareMenuFollowSetName": "Follow Set Name",
   "shareMenuFollowSetNameHint": "e.g., Content Creators, Musicians, etc.",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3234,6 +3234,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{bucle} other{bucles}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
+    "shareMenuDeleteFailedRelayPartial": "Este video sigue en algunos relays. Intenta borrarlo de nuevo.",
     "videoEditorAudioSegmentInstruction": "Selecciona el segmento de audio para tu video",
     "videoEditorClipGalleryInstruction": "Toca para editar. Mantén presionado y arrastra para reordenar.",
     "navSearch": "Buscar",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3234,7 +3234,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{bucle} other{bucles}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
-    "shareMenuDeleteFailedRelayPartial": "Este video sigue en algunos relays. Intenta borrarlo de nuevo.",
+    "shareMenuDeletePartiallyConfirmed": "Borrado. No todos los relays lo confirmaron, así que puede seguir apareciendo en otras apps.",
     "videoEditorAudioSegmentInstruction": "Selecciona el segmento de audio para tu video",
     "videoEditorClipGalleryInstruction": "Toca para editar. Mantén presionado y arrastra para reordenar.",
     "navSearch": "Buscar",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -986,7 +986,7 @@
     "shareMenuDeleteFailedCouldNotSign": "Hindi na-sign ang delete request. Subukan ulit.",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Hindi maabot ang relay. Tingnan ang iyong koneksyon at subukan ulit.",
-    "shareMenuDeleteFailedRelayPartial": "Nasa ilang relay pa rin ang video na ito. Subukan ulit itong burahin.",
+    "shareMenuDeletePartiallyConfirmed": "Nabura na. Hindi lahat ng relay ang nakumpirma, kaya baka lumabas pa rin ito sa ibang app.",
     "shareMenuDeleteFailedGeneric": "Hindi nabura ang video na ito. Subukan ulit.",
     "shareMenuFollowSetName": "Pangalan ng Follow Set",
     "shareMenuFollowSetNameHint": "hal., Content Creators, Musicians, atbp.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -986,6 +986,7 @@
     "shareMenuDeleteFailedCouldNotSign": "Hindi na-sign ang delete request. Subukan ulit.",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Hindi maabot ang relay. Tingnan ang iyong koneksyon at subukan ulit.",
+    "shareMenuDeleteFailedRelayPartial": "Nasa ilang relay pa rin ang video na ito. Subukan ulit itong burahin.",
     "shareMenuDeleteFailedGeneric": "Hindi nabura ang video na ito. Subukan ulit.",
     "shareMenuFollowSetName": "Pangalan ng Follow Set",
     "shareMenuFollowSetNameHint": "hal., Content Creators, Musicians, atbp.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3226,6 +3226,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{boucle} other{boucles}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
+    "shareMenuDeleteFailedRelayPartial": "Cette vidéo est encore sur certains relais. Réessaie de la supprimer.",
     "videoEditorAudioSegmentInstruction": "Sélectionne le segment audio de ta vidéo",
     "videoEditorClipGalleryInstruction": "Appuie pour modifier. Maintiens appuyé et fais glisser pour réorganiser.",
     "navSearch": "Recherche",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3226,7 +3226,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{boucle} other{boucles}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
-    "shareMenuDeleteFailedRelayPartial": "Cette vidéo est encore sur certains relais. Réessaie de la supprimer.",
+    "shareMenuDeletePartiallyConfirmed": "Supprimée. Tous les relais n'ont pas confirmé, elle peut donc encore apparaître dans d'autres apps.",
     "videoEditorAudioSegmentInstruction": "Sélectionne le segment audio de ta vidéo",
     "videoEditorClipGalleryInstruction": "Appuie pour modifier. Maintiens appuyé et fais glisser pour réorganiser.",
     "navSearch": "Recherche",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3228,6 +3228,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loop}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
+    "shareMenuDeleteFailedRelayPartial": "Video ini masih ada di beberapa relay. Coba hapus lagi.",
     "videoEditorAudioSegmentInstruction": "Pilih segmen audio untuk videomu",
     "videoEditorClipGalleryInstruction": "Ketuk untuk mengedit. Tekan lama dan seret untuk mengurutkan ulang.",
     "fullscreenFeedRemovedMessage": "Video dihapus",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3228,7 +3228,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loop}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
-    "shareMenuDeleteFailedRelayPartial": "Video ini masih ada di beberapa relay. Coba hapus lagi.",
+    "shareMenuDeletePartiallyConfirmed": "Terhapus. Tidak semua relay mengonfirmasi, jadi ini mungkin masih muncul di aplikasi lain.",
     "videoEditorAudioSegmentInstruction": "Pilih segmen audio untuk videomu",
     "videoEditorClipGalleryInstruction": "Ketuk untuk mengedit. Tekan lama dan seret untuk mengurutkan ulang.",
     "fullscreenFeedRemovedMessage": "Video dihapus",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3226,7 +3226,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loop}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
-    "shareMenuDeleteFailedRelayPartial": "Questo video è ancora su alcuni relay. Prova a eliminarlo di nuovo.",
+    "shareMenuDeletePartiallyConfirmed": "Eliminato. Non tutti i relay hanno confermato, quindi potrebbe comparire ancora in altre app.",
     "videoEditorAudioSegmentInstruction": "Seleziona il segmento audio per il tuo video",
     "videoEditorClipGalleryInstruction": "Tocca per modificare. Tieni premuto e trascina per riordinare.",
     "navSearch": "Cerca",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3226,6 +3226,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loop}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
+    "shareMenuDeleteFailedRelayPartial": "Questo video è ancora su alcuni relay. Prova a eliminarlo di nuovo.",
     "videoEditorAudioSegmentInstruction": "Seleziona il segmento audio per il tuo video",
     "videoEditorClipGalleryInstruction": "Tocca per modificare. Tieni premuto e trascina per riordinare.",
     "navSearch": "Cerca",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3221,7 +3221,7 @@
     "videoFeedLoopCountLine": "{compactCount}{count, plural, other{ループ}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
-    "shareMenuDeleteFailedRelayPartial": "この動画は一部のリレーにまだ残っています。もう一度削除してみてください。",
+    "shareMenuDeletePartiallyConfirmed": "削除しました。すべてのリレーが確認したわけではないので、他のアプリではまだ表示されることがあります。",
     "videoEditorAudioSegmentInstruction": "動画に使うオーディオ範囲を選択",
     "videoEditorClipGalleryInstruction": "タップして編集。長押ししてドラッグで並べ替え。",
     "fullscreenFeedRemovedMessage": "動画を削除しました",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3221,6 +3221,7 @@
     "videoFeedLoopCountLine": "{compactCount}{count, plural, other{ループ}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
+    "shareMenuDeleteFailedRelayPartial": "この動画は一部のリレーにまだ残っています。もう一度削除してみてください。",
     "videoEditorAudioSegmentInstruction": "動画に使うオーディオ範囲を選択",
     "videoEditorClipGalleryInstruction": "タップして編集。長押ししてドラッグで並べ替え。",
     "fullscreenFeedRemovedMessage": "動画を削除しました",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2552,7 +2552,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, other{루프}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
-    "shareMenuDeleteFailedRelayPartial": "이 영상이 일부 릴레이에 아직 남아 있어요. 다시 삭제해 보세요.",
+    "shareMenuDeletePartiallyConfirmed": "삭제했어요. 모든 릴레이가 확인한 건 아니라서 다른 앱에는 아직 보일 수 있어요.",
     "videoEditorAudioSegmentInstruction": "동영상에 사용할 오디오 구간을 선택하세요",
     "videoEditorClipGalleryInstruction": "탭해서 편집하세요. 길게 누르고 드래그해 순서를 바꾸세요.",
     "fullscreenFeedRemovedMessage": "동영상이 삭제됐어요",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2552,6 +2552,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, other{루프}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
+    "shareMenuDeleteFailedRelayPartial": "이 영상이 일부 릴레이에 아직 남아 있어요. 다시 삭제해 보세요.",
     "videoEditorAudioSegmentInstruction": "동영상에 사용할 오디오 구간을 선택하세요",
     "videoEditorClipGalleryInstruction": "탭해서 편집하세요. 길게 누르고 드래그해 순서를 바꾸세요.",
     "fullscreenFeedRemovedMessage": "동영상이 삭제됐어요",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -2226,7 +2226,7 @@
   "shareMenuDeleteFailedCouldNotSign": "Tidak dapat menandatangani permintaan pemadaman. Cuba lagi.",
   "shareMenuDeleteFailedRelayRejected": "Relay tidak menerima permintaan pemadaman ini. Cuba lagi sebentar nanti.",
   "shareMenuDeleteFailedRelayNoResponse": "Tidak dapat mencapai relay. Semak sambungan anda dan cuba lagi.",
-  "shareMenuDeleteFailedRelayPartial": "Video ini masih ada pada sesetengah relay. Cuba padam sekali lagi.",
+  "shareMenuDeletePartiallyConfirmed": "Dipadam. Bukan semua relay mengesahkan, jadi ia mungkin masih muncul dalam apl lain.",
   "shareMenuDeleteFailedGeneric": "Tidak dapat memadam video ini. Cuba lagi.",
   "shareMenuFollowSetName": "Nama Set Ikutan",
   "shareMenuFollowSetNameHint": "cth. Pencipta Kandungan, Pemuzik, dsb.",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -2226,6 +2226,7 @@
   "shareMenuDeleteFailedCouldNotSign": "Tidak dapat menandatangani permintaan pemadaman. Cuba lagi.",
   "shareMenuDeleteFailedRelayRejected": "Relay tidak menerima permintaan pemadaman ini. Cuba lagi sebentar nanti.",
   "shareMenuDeleteFailedRelayNoResponse": "Tidak dapat mencapai relay. Semak sambungan anda dan cuba lagi.",
+  "shareMenuDeleteFailedRelayPartial": "Video ini masih ada pada sesetengah relay. Cuba padam sekali lagi.",
   "shareMenuDeleteFailedGeneric": "Tidak dapat memadam video ini. Cuba lagi.",
   "shareMenuFollowSetName": "Nama Set Ikutan",
   "shareMenuFollowSetNameHint": "cth. Pencipta Kandungan, Pemuzik, dsb.",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3226,6 +3226,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loops}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
+    "shareMenuDeleteFailedRelayPartial": "Deze video staat nog op sommige relays. Probeer 'm opnieuw te verwijderen.",
     "videoEditorAudioSegmentInstruction": "Selecteer het audiofragment voor je video",
     "videoEditorClipGalleryInstruction": "Tik om te bewerken. Houd vast en sleep om te herordenen.",
     "navSearch": "Zoeken",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3226,7 +3226,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loops}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
-    "shareMenuDeleteFailedRelayPartial": "Deze video staat nog op sommige relays. Probeer 'm opnieuw te verwijderen.",
+    "shareMenuDeletePartiallyConfirmed": "Verwijderd. Niet elke relay heeft bevestigd, dus hij kan nog in andere apps opduiken.",
     "videoEditorAudioSegmentInstruction": "Selecteer het audiofragment voor je video",
     "videoEditorClipGalleryInstruction": "Tik om te bewerken. Houd vast en sleep om te herordenen.",
     "navSearch": "Zoeken",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3226,6 +3226,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{pętla} few{pętle} many{pętli} other{pętli}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
+    "shareMenuDeleteFailedRelayPartial": "Ten film wciąż jest na części przekaźników. Spróbuj usunąć go ponownie.",
     "videoEditorAudioSegmentInstruction": "Wybierz fragment audio dla swojego filmu",
     "videoEditorClipGalleryInstruction": "Dotknij, aby edytować. Przytrzymaj i przeciągnij, aby zmienić kolejność.",
     "navSearch": "Szukaj",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3226,7 +3226,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{pętla} few{pętle} many{pętli} other{pętli}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
-    "shareMenuDeleteFailedRelayPartial": "Ten film wciąż jest na części przekaźników. Spróbuj usunąć go ponownie.",
+    "shareMenuDeletePartiallyConfirmed": "Usunięto. Nie wszystkie przekaźniki potwierdziły, więc może się jeszcze pojawiać w innych aplikacjach.",
     "videoEditorAudioSegmentInstruction": "Wybierz fragment audio dla swojego filmu",
     "videoEditorClipGalleryInstruction": "Dotknij, aby edytować. Przytrzymaj i przeciągnij, aby zmienić kolejność.",
     "navSearch": "Szukaj",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3226,6 +3226,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loops}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
+    "shareMenuDeleteFailedRelayPartial": "Este vídeo ainda está em alguns relays. Tenta apagar de novo.",
     "videoEditorAudioSegmentInstruction": "Selecione o trecho de áudio para seu vídeo",
     "videoEditorClipGalleryInstruction": "Toque para editar. Pressione e arraste para reordenar.",
     "navSearch": "Pesquisar",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3226,7 +3226,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loops}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
-    "shareMenuDeleteFailedRelayPartial": "Este vídeo ainda está em alguns relays. Tenta apagar de novo.",
+    "shareMenuDeletePartiallyConfirmed": "Apagado. Nem todos os relays confirmaram, por isso ainda pode aparecer noutras apps.",
     "videoEditorAudioSegmentInstruction": "Selecione o trecho de áudio para seu vídeo",
     "videoEditorClipGalleryInstruction": "Toque para editar. Pressione e arraste para reordenar.",
     "navSearch": "Pesquisar",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3226,7 +3226,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{buclă} other{bucle}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
-    "shareMenuDeleteFailedRelayPartial": "Videoclipul e încă pe unele relee. Încearcă să-l ștergi din nou.",
+    "shareMenuDeletePartiallyConfirmed": "Șters. Nu toate releele au confirmat, așa că poate apărea în continuare în alte aplicații.",
     "videoEditorAudioSegmentInstruction": "Alege segmentul audio pentru videoclipul tău",
     "videoEditorClipGalleryInstruction": "Atinge pentru editare. Ține apăsat și trage pentru reordonare.",
     "navSearch": "Caută",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3226,6 +3226,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{buclă} other{bucle}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
+    "shareMenuDeleteFailedRelayPartial": "Videoclipul e încă pe unele relee. Încearcă să-l ștergi din nou.",
     "videoEditorAudioSegmentInstruction": "Alege segmentul audio pentru videoclipul tău",
     "videoEditorClipGalleryInstruction": "Atinge pentru editare. Ține apăsat și trage pentru reordonare.",
     "navSearch": "Caută",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3226,6 +3226,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loopar}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
+    "shareMenuDeleteFailedRelayPartial": "Den här videon finns kvar på vissa reläer. Försök radera den igen.",
     "videoEditorAudioSegmentInstruction": "Välj ljudsegmentet för din video",
     "videoEditorClipGalleryInstruction": "Tryck för att redigera. Håll ned och dra för att ändra ordning.",
     "navSearch": "Sök",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3226,7 +3226,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loopar}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
-    "shareMenuDeleteFailedRelayPartial": "Den här videon finns kvar på vissa reläer. Försök radera den igen.",
+    "shareMenuDeletePartiallyConfirmed": "Raderad. Alla reläer bekräftade inte, så den kan fortfarande dyka upp i andra appar.",
     "videoEditorAudioSegmentInstruction": "Välj ljudsegmentet för din video",
     "videoEditorClipGalleryInstruction": "Tryck för att redigera. Håll ned och dra för att ändra ordning.",
     "navSearch": "Sök",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3228,7 +3228,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{döngü} other{döngüler}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
-    "shareMenuDeleteFailedRelayPartial": "Bu video hâlâ bazı relay'lerde duruyor. Tekrar silmeyi dene.",
+    "shareMenuDeletePartiallyConfirmed": "Silindi. Tüm relay'ler onaylamadı, bu yüzden başka uygulamalarda hâlâ görünebilir.",
     "videoEditorAudioSegmentInstruction": "Videon için ses bölümünü seç",
     "videoEditorClipGalleryInstruction": "Düzenlemek için dokun. Yeniden sıralamak için basılı tutup sürükle.",
     "fullscreenFeedRemovedMessage": "Video kaldırıldı",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3228,6 +3228,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{döngü} other{döngüler}}",
     "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
     "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
+    "shareMenuDeleteFailedRelayPartial": "Bu video hâlâ bazı relay'lerde duruyor. Tekrar silmeyi dene.",
     "videoEditorAudioSegmentInstruction": "Videon için ses bölümünü seç",
     "videoEditorClipGalleryInstruction": "Düzenlemek için dokun. Yeniden sıralamak için basılı tutup sürükle.",
     "fullscreenFeedRemovedMessage": "Video kaldırıldı",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -2226,6 +2226,7 @@
   "shareMenuDeleteFailedCouldNotSign": "حذف کی درخواست پر دستخط نہیں ہو سکے۔ دوبارہ کوشش کریں۔",
   "shareMenuDeleteFailedRelayRejected": "ریلے نے حذف کی یہ درخواست قبول نہیں کی۔ تھوڑی دیر میں دوبارہ کوشش کریں۔",
   "shareMenuDeleteFailedRelayNoResponse": "ریلے تک رسائی نہیں ہو سکی۔ اپنا کنکشن چیک کر کے دوبارہ کوشش کریں۔",
+  "shareMenuDeleteFailedRelayPartial": "یہ ویڈیو اب بھی کچھ ریلے پر موجود ہے۔ دوبارہ حذف کرنے کی کوشش کریں۔",
   "shareMenuDeleteFailedGeneric": "یہ ویڈیو حذف نہیں ہو سکی۔ دوبارہ کوشش کریں۔",
   "shareMenuFollowSetName": "فالو سیٹ کا نام",
   "shareMenuFollowSetNameHint": "مثلاً مواد تخلیق کار، موسیقار وغیرہ",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -2226,7 +2226,7 @@
   "shareMenuDeleteFailedCouldNotSign": "حذف کی درخواست پر دستخط نہیں ہو سکے۔ دوبارہ کوشش کریں۔",
   "shareMenuDeleteFailedRelayRejected": "ریلے نے حذف کی یہ درخواست قبول نہیں کی۔ تھوڑی دیر میں دوبارہ کوشش کریں۔",
   "shareMenuDeleteFailedRelayNoResponse": "ریلے تک رسائی نہیں ہو سکی۔ اپنا کنکشن چیک کر کے دوبارہ کوشش کریں۔",
-  "shareMenuDeleteFailedRelayPartial": "یہ ویڈیو اب بھی کچھ ریلے پر موجود ہے۔ دوبارہ حذف کرنے کی کوشش کریں۔",
+  "shareMenuDeletePartiallyConfirmed": "حذف ہو گیا۔ سب ریلے نے تصدیق نہیں کی، اس لیے یہ اب بھی دوسری ایپس میں دکھائی دے سکتا ہے۔",
   "shareMenuDeleteFailedGeneric": "یہ ویڈیو حذف نہیں ہو سکی۔ دوبارہ کوشش کریں۔",
   "shareMenuFollowSetName": "فالو سیٹ کا نام",
   "shareMenuFollowSetNameHint": "مثلاً مواد تخلیق کار، موسیقار وغیرہ",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -2226,7 +2226,7 @@
   "shareMenuDeleteFailedCouldNotSign": "Không ký được yêu cầu xóa. Thử lại nhé.",
   "shareMenuDeleteFailedRelayRejected": "Relay không chấp nhận yêu cầu xóa này. Thử lại sau ít phút.",
   "shareMenuDeleteFailedRelayNoResponse": "Không kết nối được với relay. Kiểm tra kết nối của bạn rồi thử lại.",
-  "shareMenuDeleteFailedRelayPartial": "Video này vẫn còn trên một số relay. Thử xoá lại nhé.",
+  "shareMenuDeletePartiallyConfirmed": "Đã xoá. Không phải relay nào cũng xác nhận, nên nó có thể vẫn hiện ở app khác.",
   "shareMenuDeleteFailedGeneric": "Không xóa được video này. Thử lại nhé.",
   "shareMenuFollowSetName": "Tên nhóm theo dõi",
   "shareMenuFollowSetNameHint": "VD: Nhà sáng tạo nội dung, Nhạc sĩ...",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -2226,6 +2226,7 @@
   "shareMenuDeleteFailedCouldNotSign": "Không ký được yêu cầu xóa. Thử lại nhé.",
   "shareMenuDeleteFailedRelayRejected": "Relay không chấp nhận yêu cầu xóa này. Thử lại sau ít phút.",
   "shareMenuDeleteFailedRelayNoResponse": "Không kết nối được với relay. Kiểm tra kết nối của bạn rồi thử lại.",
+  "shareMenuDeleteFailedRelayPartial": "Video này vẫn còn trên một số relay. Thử xoá lại nhé.",
   "shareMenuDeleteFailedGeneric": "Không xóa được video này. Thử lại nhé.",
   "shareMenuFollowSetName": "Tên nhóm theo dõi",
   "shareMenuFollowSetNameHint": "VD: Nhà sáng tạo nội dung, Nhạc sĩ...",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -2226,7 +2226,7 @@
   "shareMenuDeleteFailedCouldNotSign": "无法为删除请求签名，请重试。",
   "shareMenuDeleteFailedRelayRejected": "中继拒绝了该删除请求，请稍后再试。",
   "shareMenuDeleteFailedRelayNoResponse": "连不上中继。请检查网络连接后重试。",
-  "shareMenuDeleteFailedRelayPartial": "这个视频还留在部分中继上。再删一次试试。",
+  "shareMenuDeletePartiallyConfirmed": "已删除。不是所有中继都确认了，所以它可能还会出现在其他应用里。",
   "shareMenuDeleteFailedGeneric": "无法删除此视频，请重试。",
   "shareMenuFollowSetName": "关注集合名称",
   "shareMenuFollowSetNameHint": "例如：内容创作者、音乐人等",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -2226,6 +2226,7 @@
   "shareMenuDeleteFailedCouldNotSign": "无法为删除请求签名，请重试。",
   "shareMenuDeleteFailedRelayRejected": "中继拒绝了该删除请求，请稍后再试。",
   "shareMenuDeleteFailedRelayNoResponse": "连不上中继。请检查网络连接后重试。",
+  "shareMenuDeleteFailedRelayPartial": "这个视频还留在部分中继上。再删一次试试。",
   "shareMenuDeleteFailedGeneric": "无法删除此视频，请重试。",
   "shareMenuFollowSetName": "关注集合名称",
   "shareMenuFollowSetNameHint": "例如：内容创作者、音乐人等",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -6890,6 +6890,12 @@ abstract class AppLocalizations {
   /// **'Couldn\'t reach the relay. Check your connection and try again.'**
   String get shareMenuDeleteFailedRelayNoResponse;
 
+  /// No description provided for @shareMenuDeleteFailedRelayPartial.
+  ///
+  /// In en, this message translates to:
+  /// **'This video is still live on some relays. Try deleting it again.'**
+  String get shareMenuDeleteFailedRelayPartial;
+
   /// No description provided for @shareMenuDeleteFailedGeneric.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -6890,11 +6890,11 @@ abstract class AppLocalizations {
   /// **'Couldn\'t reach the relay. Check your connection and try again.'**
   String get shareMenuDeleteFailedRelayNoResponse;
 
-  /// No description provided for @shareMenuDeleteFailedRelayPartial.
+  /// No description provided for @shareMenuDeletePartiallyConfirmed.
   ///
   /// In en, this message translates to:
-  /// **'This video is still live on some relays. Try deleting it again.'**
-  String get shareMenuDeleteFailedRelayPartial;
+  /// **'Deleted. Not every relay confirmed, so it may still show up in other apps.'**
+  String get shareMenuDeletePartiallyConfirmed;
 
   /// No description provided for @shareMenuDeleteFailedGeneric.
   ///

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -3897,6 +3897,10 @@ class AppLocalizationsAm extends AppLocalizations {
       'ቅብብሎሹን መድረስ አልተቻለም። ግንኙነትዎን ይፈትሹ እና እንደገና ይሞክሩ።';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial =>
+      'ይህ ቪዲዮ አሁንም በአንዳንድ ሪሌዎች ላይ አለ። እንደገና ለመሰረዝ ይሞክሩ።';
+
+  @override
   String get shareMenuDeleteFailedGeneric => 'ይህን ቪዲዮ መሰረዝ አልተቻለም። እንደገና ይሞክሩ።';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -3897,8 +3897,8 @@ class AppLocalizationsAm extends AppLocalizations {
       'ቅብብሎሹን መድረስ አልተቻለም። ግንኙነትዎን ይፈትሹ እና እንደገና ይሞክሩ።';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial =>
-      'ይህ ቪዲዮ አሁንም በአንዳንድ ሪሌዎች ላይ አለ። እንደገና ለመሰረዝ ይሞክሩ።';
+  String get shareMenuDeletePartiallyConfirmed =>
+      'ተሰርዟል። ሁሉም ሪሌዎች አላረጋገጡም፣ ስለዚህ በሌሎች መተግበሪያዎች ላይ አሁንም ሊታይ ይችላል።';
 
   @override
   String get shareMenuDeleteFailedGeneric => 'ይህን ቪዲዮ መሰረዝ አልተቻለም። እንደገና ይሞክሩ።';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3938,6 +3938,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial =>
+      'لا يزال هذا الفيديو موجودًا على بعض المرحّلات. حاول حذفه مرة أخرى.';
+
+  @override
   String get shareMenuDeleteFailedGeneric =>
       'تعذّر حذف هذا الفيديو. حاول مرة أخرى.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3938,8 +3938,8 @@ class AppLocalizationsAr extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial =>
-      'لا يزال هذا الفيديو موجودًا على بعض المرحّلات. حاول حذفه مرة أخرى.';
+  String get shareMenuDeletePartiallyConfirmed =>
+      'تم الحذف. لم تؤكّد كل المرحّلات، لذا قد يظل ظاهرًا في تطبيقات أخرى.';
 
   @override
   String get shareMenuDeleteFailedGeneric =>

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4014,8 +4014,8 @@ class AppLocalizationsBg extends AppLocalizations {
       'Не можем да достигнем релето. Провери връзката си и опитай пак.';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial =>
-      'Това видео още го има на някои релета. Опитай да го изтриеш пак.';
+  String get shareMenuDeletePartiallyConfirmed =>
+      'Изтрито. Не всички релета потвърдиха, така че може още да се вижда в други приложения.';
 
   @override
   String get shareMenuDeleteFailedGeneric =>

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4014,6 +4014,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Не можем да достигнем релето. Провери връзката си и опитай пак.';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial =>
+      'Това видео още го има на някои релета. Опитай да го изтриеш пак.';
+
+  @override
   String get shareMenuDeleteFailedGeneric =>
       'Не успяхме да изтрием това видео. Опитай пак.';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4016,8 +4016,8 @@ class AppLocalizationsDe extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial =>
-      'Dieses Video ist noch auf einigen Relays. Versuch es noch mal zu löschen.';
+  String get shareMenuDeletePartiallyConfirmed =>
+      'Gelöscht. Nicht alle Relays haben bestätigt, es kann also noch in anderen Apps auftauchen.';
 
   @override
   String get shareMenuDeleteFailedGeneric =>

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4016,6 +4016,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial =>
+      'Dieses Video ist noch auf einigen Relays. Versuch es noch mal zu löschen.';
+
+  @override
   String get shareMenuDeleteFailedGeneric =>
       'Dieses Video konnte nicht gelöscht werden. Versuch es nochmal.';
 

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3967,8 +3967,8 @@ class AppLocalizationsEn extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial =>
-      'This video is still live on some relays. Try deleting it again.';
+  String get shareMenuDeletePartiallyConfirmed =>
+      'Deleted. Not every relay confirmed, so it may still show up in other apps.';
 
   @override
   String get shareMenuDeleteFailedGeneric =>

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3967,6 +3967,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial =>
+      'This video is still live on some relays. Try deleting it again.';
+
+  @override
   String get shareMenuDeleteFailedGeneric =>
       'Couldn\'t delete this video. Try again.';
 

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4009,8 +4009,8 @@ class AppLocalizationsEs extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial =>
-      'Este video sigue en algunos relays. Intenta borrarlo de nuevo.';
+  String get shareMenuDeletePartiallyConfirmed =>
+      'Borrado. No todos los relays lo confirmaron, así que puede seguir apareciendo en otras apps.';
 
   @override
   String get shareMenuDeleteFailedGeneric =>

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4009,6 +4009,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial =>
+      'Este video sigue en algunos relays. Intenta borrarlo de nuevo.';
+
+  @override
   String get shareMenuDeleteFailedGeneric =>
       'No pudimos borrar este video. Probá de nuevo.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4024,8 +4024,8 @@ class AppLocalizationsFil extends AppLocalizations {
       'Hindi maabot ang relay. Tingnan ang iyong koneksyon at subukan ulit.';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial =>
-      'Nasa ilang relay pa rin ang video na ito. Subukan ulit itong burahin.';
+  String get shareMenuDeletePartiallyConfirmed =>
+      'Nabura na. Hindi lahat ng relay ang nakumpirma, kaya baka lumabas pa rin ito sa ibang app.';
 
   @override
   String get shareMenuDeleteFailedGeneric =>

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4024,6 +4024,10 @@ class AppLocalizationsFil extends AppLocalizations {
       'Hindi maabot ang relay. Tingnan ang iyong koneksyon at subukan ulit.';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial =>
+      'Nasa ilang relay pa rin ang video na ito. Subukan ulit itong burahin.';
+
+  @override
   String get shareMenuDeleteFailedGeneric =>
       'Hindi nabura ang video na ito. Subukan ulit.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4023,8 +4023,8 @@ class AppLocalizationsFr extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial =>
-      'Cette vidéo est encore sur certains relais. Réessaie de la supprimer.';
+  String get shareMenuDeletePartiallyConfirmed =>
+      'Supprimée. Tous les relais n\'ont pas confirmé, elle peut donc encore apparaître dans d\'autres apps.';
 
   @override
   String get shareMenuDeleteFailedGeneric =>

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4023,6 +4023,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial =>
+      'Cette vidéo est encore sur certains relais. Réessaie de la supprimer.';
+
+  @override
   String get shareMenuDeleteFailedGeneric =>
       'Impossible de supprimer cette vidéo. Réessaie.';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3928,6 +3928,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial =>
+      'Video ini masih ada di beberapa relay. Coba hapus lagi.';
+
+  @override
   String get shareMenuDeleteFailedGeneric =>
       'Tidak bisa menghapus video ini. Coba lagi.';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3928,8 +3928,8 @@ class AppLocalizationsId extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial =>
-      'Video ini masih ada di beberapa relay. Coba hapus lagi.';
+  String get shareMenuDeletePartiallyConfirmed =>
+      'Terhapus. Tidak semua relay mengonfirmasi, jadi ini mungkin masih muncul di aplikasi lain.';
 
   @override
   String get shareMenuDeleteFailedGeneric =>

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4009,8 +4009,8 @@ class AppLocalizationsIt extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial =>
-      'Questo video è ancora su alcuni relay. Prova a eliminarlo di nuovo.';
+  String get shareMenuDeletePartiallyConfirmed =>
+      'Eliminato. Non tutti i relay hanno confermato, quindi potrebbe comparire ancora in altre app.';
 
   @override
   String get shareMenuDeleteFailedGeneric =>

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4009,6 +4009,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial =>
+      'Questo video è ancora su alcuni relay. Prova a eliminarlo di nuovo.';
+
+  @override
   String get shareMenuDeleteFailedGeneric =>
       'Non è stato possibile eliminare questo video. Riprova.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3769,8 +3769,8 @@ class AppLocalizationsJa extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial =>
-      'この動画は一部のリレーにまだ残っています。もう一度削除してみてください。';
+  String get shareMenuDeletePartiallyConfirmed =>
+      '削除しました。すべてのリレーが確認したわけではないので、他のアプリではまだ表示されることがあります。';
 
   @override
   String get shareMenuDeleteFailedGeneric => 'この動画を削除できなかったよ。もう一度試してね。';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3769,6 +3769,10 @@ class AppLocalizationsJa extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial =>
+      'この動画は一部のリレーにまだ残っています。もう一度削除してみてください。';
+
+  @override
   String get shareMenuDeleteFailedGeneric => 'この動画を削除できなかったよ。もう一度試してね。';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3786,6 +3786,10 @@ class AppLocalizationsKo extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial =>
+      '이 영상이 일부 릴레이에 아직 남아 있어요. 다시 삭제해 보세요.';
+
+  @override
   String get shareMenuDeleteFailedGeneric => '이 영상을 삭제하지 못했어요. 다시 시도해요.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3786,8 +3786,8 @@ class AppLocalizationsKo extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial =>
-      '이 영상이 일부 릴레이에 아직 남아 있어요. 다시 삭제해 보세요.';
+  String get shareMenuDeletePartiallyConfirmed =>
+      '삭제했어요. 모든 릴레이가 확인한 건 아니라서 다른 앱에는 아직 보일 수 있어요.';
 
   @override
   String get shareMenuDeleteFailedGeneric => '이 영상을 삭제하지 못했어요. 다시 시도해요.';

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -4001,6 +4001,10 @@ class AppLocalizationsMs extends AppLocalizations {
       'Tidak dapat mencapai relay. Semak sambungan anda dan cuba lagi.';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial =>
+      'Video ini masih ada pada sesetengah relay. Cuba padam sekali lagi.';
+
+  @override
   String get shareMenuDeleteFailedGeneric =>
       'Tidak dapat memadam video ini. Cuba lagi.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -4001,8 +4001,8 @@ class AppLocalizationsMs extends AppLocalizations {
       'Tidak dapat mencapai relay. Semak sambungan anda dan cuba lagi.';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial =>
-      'Video ini masih ada pada sesetengah relay. Cuba padam sekali lagi.';
+  String get shareMenuDeletePartiallyConfirmed =>
+      'Dipadam. Bukan semua relay mengesahkan, jadi ia mungkin masih muncul dalam apl lain.';
 
   @override
   String get shareMenuDeleteFailedGeneric =>

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3986,6 +3986,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial =>
+      'Deze video staat nog op sommige relays. Probeer \'m opnieuw te verwijderen.';
+
+  @override
   String get shareMenuDeleteFailedGeneric =>
       'Kon deze video niet verwijderen. Probeer opnieuw.';
 

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3986,8 +3986,8 @@ class AppLocalizationsNl extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial =>
-      'Deze video staat nog op sommige relays. Probeer \'m opnieuw te verwijderen.';
+  String get shareMenuDeletePartiallyConfirmed =>
+      'Verwijderd. Niet elke relay heeft bevestigd, dus hij kan nog in andere apps opduiken.';
 
   @override
   String get shareMenuDeleteFailedGeneric =>

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4077,8 +4077,8 @@ class AppLocalizationsPl extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial =>
-      'Ten film wciąż jest na części przekaźników. Spróbuj usunąć go ponownie.';
+  String get shareMenuDeletePartiallyConfirmed =>
+      'Usunięto. Nie wszystkie przekaźniki potwierdziły, więc może się jeszcze pojawiać w innych aplikacjach.';
 
   @override
   String get shareMenuDeleteFailedGeneric =>

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4077,6 +4077,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial =>
+      'Ten film wciąż jest na części przekaźników. Spróbuj usunąć go ponownie.';
+
+  @override
   String get shareMenuDeleteFailedGeneric =>
       'Nie udało się usunąć tego filmu. Spróbuj ponownie.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3996,8 +3996,8 @@ class AppLocalizationsPt extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial =>
-      'Este vídeo ainda está em alguns relays. Tenta apagar de novo.';
+  String get shareMenuDeletePartiallyConfirmed =>
+      'Apagado. Nem todos os relays confirmaram, por isso ainda pode aparecer noutras apps.';
 
   @override
   String get shareMenuDeleteFailedGeneric =>

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3996,6 +3996,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial =>
+      'Este vídeo ainda está em alguns relays. Tenta apagar de novo.';
+
+  @override
   String get shareMenuDeleteFailedGeneric =>
       'Não foi possível apagar este vídeo. Tenta de novo.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4085,8 +4085,8 @@ class AppLocalizationsRo extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial =>
-      'Videoclipul e încă pe unele relee. Încearcă să-l ștergi din nou.';
+  String get shareMenuDeletePartiallyConfirmed =>
+      'Șters. Nu toate releele au confirmat, așa că poate apărea în continuare în alte aplicații.';
 
   @override
   String get shareMenuDeleteFailedGeneric =>

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4085,6 +4085,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial =>
+      'Videoclipul e încă pe unele relee. Încearcă să-l ștergi din nou.';
+
+  @override
   String get shareMenuDeleteFailedGeneric =>
       'Nu am putut șterge acest videoclip. Încearcă din nou.';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3967,8 +3967,8 @@ class AppLocalizationsSv extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial =>
-      'Den här videon finns kvar på vissa reläer. Försök radera den igen.';
+  String get shareMenuDeletePartiallyConfirmed =>
+      'Raderad. Alla reläer bekräftade inte, så den kan fortfarande dyka upp i andra appar.';
 
   @override
   String get shareMenuDeleteFailedGeneric =>

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3967,6 +3967,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial =>
+      'Den här videon finns kvar på vissa reläer. Försök radera den igen.';
+
+  @override
   String get shareMenuDeleteFailedGeneric =>
       'Kunde inte ta bort den här videon. Försök igen.';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3937,6 +3937,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial =>
+      'Bu video hâlâ bazı relay\'lerde duruyor. Tekrar silmeyi dene.';
+
+  @override
   String get shareMenuDeleteFailedGeneric =>
       'Bu video silinemedi. Tekrar dene.';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3937,8 +3937,8 @@ class AppLocalizationsTr extends AppLocalizations {
       'Couldn\'t reach the relay. Check your connection and try again.';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial =>
-      'Bu video hâlâ bazı relay\'lerde duruyor. Tekrar silmeyi dene.';
+  String get shareMenuDeletePartiallyConfirmed =>
+      'Silindi. Tüm relay\'ler onaylamadı, bu yüzden başka uygulamalarda hâlâ görünebilir.';
 
   @override
   String get shareMenuDeleteFailedGeneric =>

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -3972,8 +3972,8 @@ class AppLocalizationsUr extends AppLocalizations {
       'ریلے تک رسائی نہیں ہو سکی۔ اپنا کنکشن چیک کر کے دوبارہ کوشش کریں۔';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial =>
-      'یہ ویڈیو اب بھی کچھ ریلے پر موجود ہے۔ دوبارہ حذف کرنے کی کوشش کریں۔';
+  String get shareMenuDeletePartiallyConfirmed =>
+      'حذف ہو گیا۔ سب ریلے نے تصدیق نہیں کی، اس لیے یہ اب بھی دوسری ایپس میں دکھائی دے سکتا ہے۔';
 
   @override
   String get shareMenuDeleteFailedGeneric =>

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -3972,6 +3972,10 @@ class AppLocalizationsUr extends AppLocalizations {
       'ریلے تک رسائی نہیں ہو سکی۔ اپنا کنکشن چیک کر کے دوبارہ کوشش کریں۔';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial =>
+      'یہ ویڈیو اب بھی کچھ ریلے پر موجود ہے۔ دوبارہ حذف کرنے کی کوشش کریں۔';
+
+  @override
   String get shareMenuDeleteFailedGeneric =>
       'یہ ویڈیو حذف نہیں ہو سکی۔ دوبارہ کوشش کریں۔';
 

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -3974,6 +3974,10 @@ class AppLocalizationsVi extends AppLocalizations {
       'Không kết nối được với relay. Kiểm tra kết nối của bạn rồi thử lại.';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial =>
+      'Video này vẫn còn trên một số relay. Thử xoá lại nhé.';
+
+  @override
   String get shareMenuDeleteFailedGeneric =>
       'Không xóa được video này. Thử lại nhé.';
 

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -3974,8 +3974,8 @@ class AppLocalizationsVi extends AppLocalizations {
       'Không kết nối được với relay. Kiểm tra kết nối của bạn rồi thử lại.';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial =>
-      'Video này vẫn còn trên một số relay. Thử xoá lại nhé.';
+  String get shareMenuDeletePartiallyConfirmed =>
+      'Đã xoá. Không phải relay nào cũng xác nhận, nên nó có thể vẫn hiện ở app khác.';
 
   @override
   String get shareMenuDeleteFailedGeneric =>

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -3748,6 +3748,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get shareMenuDeleteFailedRelayNoResponse => '连不上中继。请检查网络连接后重试。';
 
   @override
+  String get shareMenuDeleteFailedRelayPartial => '这个视频还留在部分中继上。再删一次试试。';
+
+  @override
   String get shareMenuDeleteFailedGeneric => '无法删除此视频，请重试。';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -3748,7 +3748,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get shareMenuDeleteFailedRelayNoResponse => '连不上中继。请检查网络连接后重试。';
 
   @override
-  String get shareMenuDeleteFailedRelayPartial => '这个视频还留在部分中继上。再删一次试试。';
+  String get shareMenuDeletePartiallyConfirmed =>
+      '已删除。不是所有中继都确认了，所以它可能还会出现在其他应用里。';
 
   @override
   String get shareMenuDeleteFailedGeneric => '无法删除此视频，请重试。';

--- a/mobile/lib/providers/nostr_client_provider.dart
+++ b/mobile/lib/providers/nostr_client_provider.dart
@@ -755,13 +755,31 @@ class NostrService extends _$NostrService {
   /// so we self-publish a minimal relay list on the user's behalf. Used at
   /// both initial-build and account-switch sites so the publish path stays
   /// in one place. See divine-mobile#3174 / keycast#94.
+  /// Awaits a real relay acceptance rather than a socket write.
+  ///
+  /// The caller records a one-shot "already bootstrapped" flag when this
+  /// returns true and otherwise retries on the next login, so reporting a
+  /// frame-accept as published permanently strands a user whose relay list
+  /// every indexer silently dropped: discovery keeps missing, and the device
+  /// stays pinned to the fallback relay set forever.
+  ///
+  /// One indexer is enough — discovery queries them all and merges the
+  /// results, so the list only has to be findable somewhere.
   static BootstrapRelayListCallback _bootstrapCallbackFor(NostrClient client) {
     return (event, targetRelays) async {
-      final published = await client.publishEvent(
+      final outcome = await client.publishEventAwaitOk(
         event,
         targetRelays: targetRelays,
       );
-      return published is PublishSuccess;
+      if (!outcome.acceptedByAny) {
+        Log.warning(
+          '[NostrService] Bootstrap kind:10002 not accepted: '
+          '${outcome.summary}',
+          name: 'NostrService',
+          category: LogCategory.system,
+        );
+      }
+      return outcome.acceptedByAny;
     };
   }
 }

--- a/mobile/lib/providers/nostr_client_provider.dart
+++ b/mobile/lib/providers/nostr_client_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:db_client/db_client.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:meta/meta.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/models/environment_config.dart';
@@ -13,6 +14,7 @@ import 'package:openvine/providers/relay_providers.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/nostr_service_factory.dart';
 import 'package:openvine/services/nostr_signature_verification_preference_service.dart';
+import 'package:openvine/services/relay_discovery_service.dart';
 import 'package:openvine/services/relay_statistics_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -323,7 +325,7 @@ class NostrService extends _$NostrService {
       _userRelaysDiscoveredCallbackFor(client, pubkey, clientGeneration),
     );
     authService.registerBootstrapRelayListCallback(
-      _bootstrapCallbackFor(client),
+      bootstrapCallbackFor(client),
     );
   }
 
@@ -764,22 +766,29 @@ class NostrService extends _$NostrService {
   /// stays pinned to the fallback relay set forever.
   ///
   /// One indexer is enough — discovery queries them all and merges the
-  /// results, so the list only has to be findable somewhere.
-  static BootstrapRelayListCallback _bootstrapCallbackFor(NostrClient client) {
+  /// results, so the list only has to be findable somewhere. It does have to
+  /// be an *indexer*: the Divine relay is in the target set but
+  /// [RelayDiscoveryService] never queries it, so its acceptance says nothing
+  /// about whether the user became discoverable.
+  @visibleForTesting
+  static BootstrapRelayListCallback bootstrapCallbackFor(NostrClient client) {
     return (event, targetRelays) async {
       final outcome = await client.publishEventAwaitOk(
         event,
         targetRelays: targetRelays,
       );
-      if (!outcome.acceptedByAny) {
+      final acceptedByIndexer = outcome.acceptedBy.any(
+        IndexerRelayConfig.defaultIndexers.contains,
+      );
+      if (!acceptedByIndexer) {
         Log.warning(
-          '[NostrService] Bootstrap kind:10002 not accepted: '
+          '[NostrService] Bootstrap kind:10002 accepted by no indexer: '
           '${outcome.summary}',
           name: 'NostrService',
           category: LogCategory.system,
         );
       }
-      return outcome.acceptedByAny;
+      return acceptedByIndexer;
     };
   }
 }

--- a/mobile/lib/providers/nostr_client_provider.g.dart
+++ b/mobile/lib/providers/nostr_client_provider.g.dart
@@ -109,7 +109,7 @@ final class NostrServiceProvider
   }
 }
 
-String _$nostrServiceHash() => r'f51f89033b372d819a1a5de7f9f8662d60f7ad6f';
+String _$nostrServiceHash() => r'b376725f85bbca6720898b91e19ea75d5f82a646';
 
 /// Core Nostr service via NostrClient for relay communication
 /// Uses a Notifier to react to auth state changes and recreate the client

--- a/mobile/lib/providers/nostr_client_provider.g.dart
+++ b/mobile/lib/providers/nostr_client_provider.g.dart
@@ -109,7 +109,7 @@ final class NostrServiceProvider
   }
 }
 
-String _$nostrServiceHash() => r'25763f4f11d5562473bb22fceaaeaadedd7b4344';
+String _$nostrServiceHash() => r'f51f89033b372d819a1a5de7f9f8662d60f7ad6f';
 
 /// Core Nostr service via NostrClient for relay communication
 /// Uses a Notifier to react to auth state changes and recreate the client

--- a/mobile/lib/screens/feed/feed_settings_menu.dart
+++ b/mobile/lib/screens/feed/feed_settings_menu.dart
@@ -13,7 +13,7 @@ import 'package:openvine/blocs/owner_video_actions/owner_video_actions_cubit.dar
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart';
-import 'package:openvine/utils/delete_failure_localization.dart';
+import 'package:openvine/utils/delete_result_localization.dart';
 import 'package:openvine/widgets/owner_video_delete_confirmation_dialog.dart';
 import 'package:openvine/widgets/video_feed_item/feed_playback_toggles_pill.dart';
 
@@ -119,7 +119,8 @@ class _FeedSettingsMenuState extends ConsumerState<FeedSettingsMenu> {
     if (state.deleteStatus == OwnerVideoDeleteStatus.success) {
       final messenger = ScaffoldMessenger.of(context);
       final snackBar = DivineSnackbarContainer.snackBar(
-        context.l10n.shareMenuVideoDeletionRequested,
+        localizedPartialDeleteMessage(context, state.deleteResult) ??
+            context.l10n.shareMenuVideoDeletionRequested,
       );
       _close();
       messenger.showSnackBar(snackBar);

--- a/mobile/lib/services/content_deletion_service.dart
+++ b/mobile/lib/services/content_deletion_service.dart
@@ -34,6 +34,15 @@ enum DeleteFailureKind {
   /// timeout. The delete is NOT persisted locally so the user can retry.
   relayNoResponse,
 
+  /// Some relays accepted the delete event and some did not, so the video is
+  /// gone from part of the network and still live on the rest.
+  ///
+  /// Nothing republishes to the relays that did not accept, so this does not
+  /// resolve itself. The delete is NOT persisted locally, which keeps the
+  /// video visible and the retry available; republishing the same kind 5 is
+  /// safe because a relay that already has it answers `OK true` again.
+  relayPartial,
+
   /// Unexpected error (including outer [deleteContent] catch).
   unknown,
 }
@@ -222,16 +231,39 @@ class ContentDeletionService {
         deleteEvent,
       );
 
-      if (publishOutcome.failed) {
-        Log.error(
-          'Delete publish not confirmed by any relay: '
-          '${publishOutcome.summary}',
-          name: 'ContentDeletionService',
-          category: LogCategory.system,
-        );
-        final failureKind = publishOutcome.rejectedBy.isNotEmpty
-            ? DeleteFailureKind.relayRejected
-            : DeleteFailureKind.relayNoResponse;
+      // Counts only — never relay URLs — so this is safe to keep on in every
+      // build and still answers "how often is a delete only partly accepted?".
+      final breadth =
+          'accepted=${publishOutcome.acceptedBy.length}/'
+          '${publishOutcome.targetCount} '
+          'rejected=${publishOutcome.rejectedBy.length} '
+          'silent=${publishOutcome.noResponseFrom.length} '
+          'unreachable=${publishOutcome.unreachableTargets.length}';
+
+      // A delete is only done when every relay we reached took it. Anything
+      // less leaves the video live somewhere, and nothing in this client
+      // republishes to the relays that refused.
+      if (!publishOutcome.acceptedByAll) {
+        final failureKind = switch (publishOutcome) {
+          final o when o.acceptedByPartial => DeleteFailureKind.relayPartial,
+          final o when o.rejectedBy.isNotEmpty =>
+            DeleteFailureKind.relayRejected,
+          _ => DeleteFailureKind.relayNoResponse,
+        };
+        if (publishOutcome.acceptedByPartial) {
+          Log.warning(
+            'Delete only partly accepted: $breadth',
+            name: 'ContentDeletionService',
+            category: LogCategory.system,
+          );
+        } else {
+          Log.error(
+            'Delete publish not confirmed by any relay: '
+            '${publishOutcome.summary}',
+            name: 'ContentDeletionService',
+            category: LogCategory.system,
+          );
+        }
         return DeleteResult.failure(
           'Relay did not confirm deletion: ${publishOutcome.summary}',
           failureKind,
@@ -239,7 +271,7 @@ class ContentDeletionService {
       }
 
       Log.info(
-        'Delete request confirmed by relay(s): ${publishOutcome.acceptedBy}',
+        'Delete request confirmed by every relay: $breadth',
         name: 'ContentDeletionService',
         category: LogCategory.system,
       );
@@ -314,6 +346,8 @@ class ContentDeletionService {
         return 'Relay rejected deletion';
       case DeleteFailureKind.relayNoResponse:
         return 'Relay did not confirm deletion';
+      case DeleteFailureKind.relayPartial:
+        return 'Only some relays accepted the deletion';
       case DeleteFailureKind.unknown:
         return 'Failed to delete content';
     }

--- a/mobile/lib/services/content_deletion_service.dart
+++ b/mobile/lib/services/content_deletion_service.dart
@@ -184,10 +184,11 @@ class ContentDeletionService {
 
   /// Delete user's own content using NIP-09.
   ///
-  /// The deletion is only considered successful when at least one relay
-  /// returns an `OK true` acknowledgement (NIP-20). If every relay rejects
-  /// the event, or none respond before the publish timeout, the operation
-  /// fails and is NOT added to local deletion history — the caller can retry.
+  /// The deletion is only considered successful when every relay the publish
+  /// reached returns an `OK true` acknowledgement (NIP-20). A rejection,
+  /// silence, or a target the publish could not write to all fail the
+  /// operation, and a failed deletion is NOT added to local deletion history
+  /// — the video stays visible and the caller can retry.
   Future<DeleteResult> deleteContent({
     required VideoEvent video,
     required String reason,

--- a/mobile/lib/services/content_deletion_service.dart
+++ b/mobile/lib/services/content_deletion_service.dart
@@ -34,17 +34,26 @@ enum DeleteFailureKind {
   /// timeout. The delete is NOT persisted locally so the user can retry.
   relayNoResponse,
 
-  /// Some relays accepted the delete event and some did not, so the video is
-  /// gone from part of the network and still live on the rest.
-  ///
-  /// Nothing republishes to the relays that did not accept, so this does not
-  /// resolve itself. The delete is NOT persisted locally, which keeps the
-  /// video visible and the retry available; republishing the same kind 5 is
-  /// safe because a relay that already has it answers `OK true` again.
-  relayPartial,
-
   /// Unexpected error (including outer [deleteContent] catch).
   unknown,
+}
+
+/// How broadly the relay network took a delete request that succeeded.
+///
+/// Set on every successful [DeleteResult] so callers can tell the user what
+/// actually happened. Deletion under NIP-09 is a *request* relays SHOULD
+/// honour, so neither value is a promise the video is gone from the network.
+enum DeleteAcceptance {
+  /// Every relay the publish targeted answered `OK true`.
+  everyRelay,
+
+  /// At least one relay accepted, and at least one rejected the request,
+  /// stayed silent, or was never reached.
+  ///
+  /// The video is out of this device's library and the tombstone is recorded,
+  /// but the relays that did not accept can still serve it. Nothing here
+  /// republishes to them.
+  someRelays,
 }
 
 /// Delete request result
@@ -56,6 +65,7 @@ class DeleteResult {
     this.error,
     this.deleteEventId,
     this.failureKind,
+    this.acceptance,
   });
   final bool success;
   final String? error;
@@ -65,9 +75,16 @@ class DeleteResult {
   /// Set when [success] is false; use for localized UI messages.
   final DeleteFailureKind? failureKind;
 
-  static DeleteResult createSuccess(String deleteEventId) => DeleteResult(
+  /// Set when [success] is true; how broadly the relays took the request.
+  final DeleteAcceptance? acceptance;
+
+  static DeleteResult createSuccess(
+    String deleteEventId, {
+    required DeleteAcceptance acceptance,
+  }) => DeleteResult(
     success: true,
     deleteEventId: deleteEventId,
+    acceptance: acceptance,
     timestamp: DateTime.now(),
   );
 
@@ -184,11 +201,16 @@ class ContentDeletionService {
 
   /// Delete user's own content using NIP-09.
   ///
-  /// The deletion is only considered successful when every relay the publish
-  /// reached returns an `OK true` acknowledgement (NIP-20). A rejection,
-  /// silence, or a target the publish could not write to all fail the
-  /// operation, and a failed deletion is NOT added to local deletion history
-  /// — the video stays visible and the caller can retry.
+  /// Succeeds once **any** targeted relay returns `OK true`, which is the
+  /// point at which the tombstone exists somewhere other than this device.
+  /// The deletion is then recorded locally and the video leaves the user's
+  /// library. When only part of the relay set accepted, the result carries
+  /// [DeleteAcceptance.someRelays] so the caller can say so rather than
+  /// claiming the video is gone everywhere.
+  ///
+  /// When no relay accepted, nothing was recorded anywhere: the deletion is
+  /// NOT added to local deletion history, the video stays visible, and the
+  /// caller can retry.
   Future<DeleteResult> deleteContent({
     required VideoEvent video,
     required String reason,
@@ -241,43 +263,46 @@ class ContentDeletionService {
           'silent=${publishOutcome.noResponseFrom.length} '
           'unreachable=${publishOutcome.unreachableTargets.length}';
 
-      // A delete is only done when every relay we reached took it. Anything
-      // less leaves the video live somewhere, and nothing in this client
-      // republishes to the relays that refused.
-      if (!publishOutcome.acceptedByAll) {
-        final failureKind = switch (publishOutcome) {
-          final o when o.acceptedByPartial => DeleteFailureKind.relayPartial,
-          final o when o.rejectedBy.isNotEmpty =>
-            DeleteFailureKind.relayRejected,
-          _ => DeleteFailureKind.relayNoResponse,
-        };
-        if (publishOutcome.acceptedByPartial) {
-          Log.warning(
-            'Delete only partly accepted: $breadth',
-            name: 'ContentDeletionService',
-            category: LogCategory.system,
-          );
-        } else {
-          Log.error(
-            'Delete publish not confirmed by any relay: '
-            '${publishOutcome.summary}',
-            name: 'ContentDeletionService',
-            category: LogCategory.system,
-          );
-        }
+      // One acceptance is the bar, not all of them. NIP-09 deletion is a
+      // request relays SHOULD honour, so no acknowledgement proves the video
+      // is gone — requiring every relay buys a guarantee that does not exist
+      // and costs the user the feature, because the target set includes pool
+      // members the client never connected to and nothing here republishes.
+      // Breadth is reported on [DeleteResult.acceptance] instead.
+      if (publishOutcome.failed) {
+        Log.error(
+          'Delete publish not confirmed by any relay: '
+          '${publishOutcome.summary}',
+          name: 'ContentDeletionService',
+          category: LogCategory.system,
+        );
         return DeleteResult.failure(
           'Relay did not confirm deletion: ${publishOutcome.summary}',
-          failureKind,
+          publishOutcome.rejectedBy.isNotEmpty
+              ? DeleteFailureKind.relayRejected
+              : DeleteFailureKind.relayNoResponse,
         );
       }
 
-      Log.info(
-        'Delete request confirmed by every relay: $breadth',
-        name: 'ContentDeletionService',
-        category: LogCategory.system,
-      );
+      final acceptance = publishOutcome.acceptedByAll
+          ? DeleteAcceptance.everyRelay
+          : DeleteAcceptance.someRelays;
 
-      // Relay accepted — now it is safe to persist the deletion locally.
+      if (acceptance == DeleteAcceptance.someRelays) {
+        Log.warning(
+          'Delete only partly accepted: $breadth',
+          name: 'ContentDeletionService',
+          category: LogCategory.system,
+        );
+      } else {
+        Log.info(
+          'Delete request confirmed by every relay: $breadth',
+          name: 'ContentDeletionService',
+          category: LogCategory.system,
+        );
+      }
+
+      // A relay took the tombstone — now it is safe to persist the deletion.
       final deletion = ContentDeletion(
         deleteEventId: deleteEvent.id,
         originalEventId: video.id,
@@ -296,7 +321,10 @@ class ContentDeletionService {
         name: 'ContentDeletionService',
         category: LogCategory.system,
       );
-      return DeleteResult.createSuccess(deleteEvent.id);
+      return DeleteResult.createSuccess(
+        deleteEvent.id,
+        acceptance: acceptance,
+      );
     } catch (e) {
       Log.error(
         'Failed to delete content: $e',
@@ -347,8 +375,6 @@ class ContentDeletionService {
         return 'Relay rejected deletion';
       case DeleteFailureKind.relayNoResponse:
         return 'Relay did not confirm deletion';
-      case DeleteFailureKind.relayPartial:
-        return 'Only some relays accepted the deletion';
       case DeleteFailureKind.unknown:
         return 'Failed to delete content';
     }

--- a/mobile/lib/utils/delete_failure_localization.dart
+++ b/mobile/lib/utils/delete_failure_localization.dart
@@ -25,6 +25,8 @@ String localizedDeleteFailureMessage(
       return l10n.shareMenuDeleteFailedRelayRejected;
     case DeleteFailureKind.relayNoResponse:
       return l10n.shareMenuDeleteFailedRelayNoResponse;
+    case DeleteFailureKind.relayPartial:
+      return l10n.shareMenuDeleteFailedRelayPartial;
     case DeleteFailureKind.unknown:
       return l10n.shareMenuDeleteFailedGeneric;
   }

--- a/mobile/lib/utils/delete_result_localization.dart
+++ b/mobile/lib/utils/delete_result_localization.dart
@@ -25,9 +25,19 @@ String localizedDeleteFailureMessage(
       return l10n.shareMenuDeleteFailedRelayRejected;
     case DeleteFailureKind.relayNoResponse:
       return l10n.shareMenuDeleteFailedRelayNoResponse;
-    case DeleteFailureKind.relayPartial:
-      return l10n.shareMenuDeleteFailedRelayPartial;
     case DeleteFailureKind.unknown:
       return l10n.shareMenuDeleteFailedGeneric;
   }
 }
+
+/// Message for a delete that succeeded but that only part of the relay set
+/// accepted, or `null` when every targeted relay confirmed.
+///
+/// Returning `null` lets each screen keep its own confirmation copy and only
+/// swap it out when there is a caveat to report.
+String? localizedPartialDeleteMessage(
+  BuildContext context,
+  DeleteResult? result,
+) => result != null && result.acceptance == DeleteAcceptance.someRelays
+    ? context.l10n.shareMenuDeletePartiallyConfirmed
+    : null;

--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -15,7 +15,7 @@ import 'package:openvine/mixins/scroll_pagination_mixin.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/services/content_deletion_service.dart';
-import 'package:openvine/utils/delete_failure_localization.dart';
+import 'package:openvine/utils/delete_result_localization.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/feed_refresh_control.dart';
 import 'package:openvine/widgets/show_edit_dialog_for_video.dart';
@@ -475,7 +475,8 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
                 Expanded(
                   child: Text(
                     result.success
-                        ? context.l10n.videoGridDeleteSuccess
+                        ? localizedPartialDeleteMessage(context, result) ??
+                              context.l10n.videoGridDeleteSuccess
                         : localizedDeleteFailureMessage(context, result),
                   ),
                 ),

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -20,7 +20,7 @@ import 'package:openvine/mixins/scroll_pagination_mixin.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart';
-import 'package:openvine/utils/delete_failure_localization.dart';
+import 'package:openvine/utils/delete_result_localization.dart';
 import 'package:openvine/utils/video_identity.dart';
 import 'package:openvine/widgets/owner_video_delete_confirmation_dialog.dart';
 import 'package:openvine/widgets/profile/pending_collaborator_invite_banner_cubit.dart';
@@ -225,7 +225,8 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
       context.read<ProfileFeedCubit>().add(const ProfileFeedRefreshRequested());
       messenger.showSnackBar(
         DivineSnackbarContainer.snackBar(
-          context.l10n.shareMenuVideoDeletionRequested,
+          localizedPartialDeleteMessage(context, state.deleteResult) ??
+              context.l10n.shareMenuVideoDeletionRequested,
         ),
       );
     } else {

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -26,7 +26,7 @@ import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart';
 import 'package:openvine/services/video_clip_import_service.dart';
 import 'package:openvine/services/video_sharing_service.dart';
-import 'package:openvine/utils/delete_failure_localization.dart';
+import 'package:openvine/utils/delete_result_localization.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:openvine/utils/watermark_text_resolver.dart';
 import 'package:openvine/widgets/add_to_list_dialog.dart';
@@ -429,7 +429,8 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
     if (state.deleteStatus == OwnerVideoDeleteStatus.success) {
       final messenger = ScaffoldMessenger.of(context);
       final snackBar = DivineSnackbarContainer.snackBar(
-        context.l10n.shareMenuVideoDeletionRequested,
+        localizedPartialDeleteMessage(context, state.deleteResult) ??
+            context.l10n.shareMenuVideoDeletionRequested,
       );
       _safePop(context);
       messenger.showSnackBar(snackBar);

--- a/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar.dart
+++ b/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar.dart
@@ -14,7 +14,7 @@ import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/screens/subtitle_editor/subtitle_editor_screen.dart';
 import 'package:openvine/services/content_deletion_service.dart';
 import 'package:openvine/services/video_metadata_update_service.dart';
-import 'package:openvine/utils/delete_failure_localization.dart';
+import 'package:openvine/utils/delete_result_localization.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Bottom action bar for the video metadata edit screen.
@@ -153,7 +153,8 @@ class _VideoMetadataEditBottomBarState
         if (mounted) {
           final messenger = ScaffoldMessenger.of(context);
           final snackBar = DivineSnackbarContainer.snackBar(
-            context.l10n.shareMenuVideoDeletionRequested,
+            localizedPartialDeleteMessage(context, result) ??
+                context.l10n.shareMenuVideoDeletionRequested,
           );
           context.pop();
           messenger.showSnackBar(snackBar);

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -568,11 +568,13 @@ class NostrClient {
   /// acceptance, never a durability guarantee. Do not surface it to a user as
   /// "saved".
   ///
-  /// Callers should pick the predicate that matches what they need:
-  /// [PublishOutcome.acceptedByAll] when the event must land everywhere it
-  /// was sent (deletions, moderation), or [PublishOutcome.acceptedByAny] when
-  /// one relay is enough. Nothing in this client republishes to relays that
-  /// did not accept, so a partial publish stays partial.
+  /// Nothing in this client republishes to relays that did not accept, so a
+  /// partial publish stays partial. That makes
+  /// [PublishOutcome.acceptedByAll] a poor gate for anything the user is
+  /// waiting on: one pool member that is down, wedged, or refusing blocks it
+  /// on every attempt, and the pool keeps relays it never managed to connect
+  /// to. Gate progress on [PublishOutcome.acceptedByAny] and report
+  /// [PublishOutcome.acceptedByAll] as breadth — which is what it measures.
   ///
   /// Cache writes follow the same rules as [publishEvent], except that the
   /// optimistic cache is rolled back when no relay accepted, and

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -541,25 +541,45 @@ class NostrClient {
     return PublishSuccess(event: sentEvent);
   }
 
-  /// Publishes an event and waits for an `OK` confirmation from at least one
-  /// relay.
+  /// Publishes an event and waits for the targeted relays to answer with
+  /// NIP-01 `OK` frames.
   ///
-  /// Unlike [publishEvent], this method does NOT consider the publish
-  /// successful just because the WebSocket accepted the frame. It waits for
-  /// the relay to respond with an `OK true` message (NIP-20), and treats the
-  /// publish as failed if:
-  ///  * no relay is connected, or
-  ///  * every relay rejects the event, or
-  ///  * no relay responds before [timeout].
+  /// Unlike [publishEvent], this does NOT treat the publish as successful
+  /// just because the WebSocket accepted the frame.
+  ///
+  /// ## When the future completes
+  ///
+  /// Whichever of these happens first:
+  ///  * every relay the fan-out reached has answered, or
+  ///  * a short settle window elapses after the first answer, or
+  ///  * [timeout] elapses.
+  ///
+  /// It does **not** complete on the first acceptance. A publish that one
+  /// relay accepts and another rejects reports both, and relays that were
+  /// targeted but never reached are reported in
+  /// [PublishOutcome.unreachableTargets].
+  ///
+  /// ## What acceptance means
+  ///
+  /// `OK true` means a relay accepted the event for writing — NIP-01 defines
+  /// the flag as "accepted by the relay", and Divine's relay acknowledges
+  /// from an in-memory queue and commits to storage afterwards. Even
+  /// [PublishOutcome.acceptedByAll] is therefore a statement about breadth of
+  /// acceptance, never a durability guarantee. Do not surface it to a user as
+  /// "saved".
+  ///
+  /// Callers should pick the predicate that matches what they need:
+  /// [PublishOutcome.acceptedByAll] when the event must land everywhere it
+  /// was sent (deletions, moderation), or [PublishOutcome.acceptedByAny] when
+  /// one relay is enough. Nothing in this client republishes to relays that
+  /// did not accept, so a partial publish stays partial.
   ///
   /// Cache writes follow the same rules as [publishEvent], except that the
-  /// optimistic cache is rolled back on rejection/timeout, and deletion-event
-  /// cache cleanup only runs after confirmation.
+  /// optimistic cache is rolled back when no relay accepted, and
+  /// deletion-event cache cleanup only runs once something accepted.
   ///
-  /// Use this for operations where the caller needs to know the event is
-  /// actually persisted on at least one relay — deletions, critical profile
-  /// updates, etc. Ephemeral events (20000–29999) should use [publishEvent]
-  /// because relays are not required to respond with `OK` to them.
+  /// Ephemeral events (20000–29999) should use [publishEvent] because relays
+  /// are not required to answer them with `OK`.
   Future<PublishOutcome> publishEventAwaitOk(
     Event event, {
     List<String>? targetRelays,

--- a/mobile/packages/nostr_sdk/lib/nostr.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr.dart
@@ -210,12 +210,18 @@ class Nostr {
     return null;
   }
 
-  /// Sends an event and awaits `OK` confirmation from at least one relay.
+  /// Sends an event and awaits `OK` confirmations from the targeted relays.
   ///
   /// Signs the event if needed, dispatches to relays, and returns a
-  /// [PublishOutcome] describing per-relay acceptance and rejection. The
-  /// future completes early once one relay confirms, but no later than
-  /// [timeout].
+  /// [PublishOutcome] describing per-relay acceptance, rejection and silence.
+  ///
+  /// The future completes once every relay the fan-out reached has answered,
+  /// or a short settle window after the first answer, or at [timeout] —
+  /// whichever comes first. It does **not** complete on the first acceptance,
+  /// so an accepted publish that another relay refused reports both.
+  ///
+  /// Note that [timeout] bounds only the publish: signing happens first and
+  /// its latency is additive.
   ///
   /// Returns `null` if signing failed.
   Future<PublishOutcome?> sendEventAwaitOk(

--- a/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
@@ -133,7 +133,9 @@ class PublishOutcome {
 ///  * every reached relay has answered, or
 ///  * [settleWindow] elapses after the first answer, counted no earlier than
 ///    the [setReachable] call that reports the fan-out's target set, or
-///  * [timeout] elapses.
+///  * [timeout] elapses — deferred until [setReachable] arrives, and by at
+///    most [fanOutReportGrace], so a publish that times out mid-fan-out can
+///    still tell an unreached target from a silent one.
 ///
 /// The settle window bounds the cost of one wedged relay: healthy relays
 /// answer in single-digit milliseconds, so waiting the full [timeout] for a
@@ -159,6 +161,14 @@ class PublishTracker {
   /// while still capping a wedged relay far below the publish timeout. Revisit
   /// once publish telemetry gives a real latency distribution.
   static const defaultSettleWindow = Duration(seconds: 1);
+
+  /// How long [timeout] may overrun while waiting for the fan-out's report.
+  ///
+  /// The report is the statement of which relays were written to, and without
+  /// it a timed-out publish cannot tell "we asked and got silence" from "we
+  /// never asked". `RelayPool` makes the call in a `finally` immediately after
+  /// the fan-out, so this only bounds the pathological case.
+  static const fanOutReportGrace = Duration(milliseconds: 250);
 
   /// The event id we are waiting on.
   final String eventId;
@@ -189,22 +199,26 @@ class PublishTracker {
   ///
   /// `null` until [setReachable] is called, which means "assume every target
   /// can answer". The fan-out narrows it, which is what lets an unreachable
-  /// target stop blocking completion.
+  /// target stop blocking completion. [setReachable] is its only writer, so
+  /// the set always means exactly "what the fan-out wrote".
   Set<String>? _reachable;
 
   /// Whether the fan-out has reported which relays it wrote to.
   ///
-  /// Gates the settle window. The tracker is registered *before* the
-  /// sequential fan-out starts, so a connected relay can answer while a later
-  /// target has not been written to yet. Arming on that answer would let the
-  /// window expire mid-fan-out: [setReachable] would find the tracker closed,
-  /// and targets the publish never reached would be reported as silent
-  /// instead of unreachable.
-  ///
-  /// Tracked separately from [_reachable] because [onRelayUnavailable] also
-  /// narrows that set, and a relay dropping mid-fan-out is not the fan-out
-  /// reporting.
+  /// Gates the settle window and the hard timeout. The tracker is registered
+  /// *before* the sequential fan-out starts, so a connected relay can answer
+  /// while a later target has not been written to yet. Settling on that
+  /// answer would let the window expire mid-fan-out: [setReachable] would
+  /// find the tracker closed, and targets the publish never reached would be
+  /// reported as silent instead of unreachable.
   bool _fanOutReported = false;
+
+  /// Whether the hard timeout fired before the fan-out reported.
+  ///
+  /// The fan-out is bounded by the same deadline as this tracker, so the two
+  /// finish together and either can win. [setReachable] settles the publish
+  /// when this is set — see [_onTimeout].
+  bool _timedOutBeforeFanOut = false;
 
   final Map<String, String> _rejected = {};
   final Map<String, String> _deferredRejections = {};
@@ -212,6 +226,7 @@ class PublishTracker {
   final Completer<PublishOutcome> _completer = Completer<PublishOutcome>();
   late final Timer _timer;
   Timer? _settleTimer;
+  Timer? _fanOutGraceTimer;
   bool _closed = false;
 
   Future<PublishOutcome> get future => _completer.future;
@@ -235,6 +250,10 @@ class PublishTracker {
     if (_closed) return;
     _reachable = reachable.toSet();
     _fanOutReported = true;
+    if (_timedOutBeforeFanOut) {
+      _complete();
+      return;
+    }
     // Answers that landed during the fan-out could not start the settle
     // window; now that the target set is final, they can.
     _armSettleWindow();
@@ -275,14 +294,6 @@ class PublishTracker {
     _deferredRejections.remove(relayUrl);
   }
 
-  /// Call when a relay disconnected or otherwise cannot be awaited further.
-  void onRelayUnavailable(String relayUrl) {
-    if (_closed) return;
-    _deferredRejections.remove(relayUrl);
-    _reachable = _awaitable.where((r) => r != relayUrl).toSet();
-    _maybeComplete();
-  }
-
   /// Start the settle window on the first answer, then re-test completion.
   void _onAnswered() {
     _armSettleWindow();
@@ -320,6 +331,18 @@ class PublishTracker {
 
   void _onTimeout() {
     if (_closed) return;
+    if (!_fanOutReported) {
+      // The fan-out shares this tracker's deadline, so when it consumes the
+      // whole budget both fire together and the timer wins the tie. Settling
+      // here would close the tracker before [setReachable] lands, and every
+      // target the fan-out never got to would be reported as silent — which
+      // is what makes the pool force-reconnect relays the publish never
+      // wrote to. Hand over to [setReachable], but keep the resolution
+      // bounded: a driver that never reports must not hang the publish.
+      _timedOutBeforeFanOut = true;
+      _fanOutGraceTimer ??= Timer(fanOutReportGrace, _complete);
+      return;
+    }
     _complete();
   }
 
@@ -328,6 +351,7 @@ class PublishTracker {
     _closed = true;
     _timer.cancel();
     _settleTimer?.cancel();
+    _fanOutGraceTimer?.cancel();
     final effectiveRejected = Map<String, String>.from(_rejected);
     if (_accepted.isEmpty) {
       effectiveRejected.addAll(_deferredRejections);

--- a/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
@@ -1,12 +1,28 @@
 // ABOUTME: Result type for publishing an event with relay OK confirmation.
-// ABOUTME: Tracks per-relay acceptance, rejection, and timeout outcomes.
+// ABOUTME: Tracks per-relay acceptance, rejection, unreachability and silence.
 
 import 'dart:async';
 
 /// Outcome of a publish operation that awaits relay OK confirmations.
 ///
-/// Per NIP-20, relays respond to `EVENT` messages with `OK` frames indicating
+/// Per NIP-01, relays respond to `EVENT` messages with `OK` frames indicating
 /// acceptance (`true`) or rejection (`false`) with an optional reason.
+///
+/// ## What acceptance means
+///
+/// `OK true` means the relay *accepted the event for writing*. It does not
+/// mean the event is stored: NIP-01 defines the flag as "accepted by the
+/// relay", and its own example of a valid `OK true` carries the reason
+/// `duplicate: already have this event` — an acceptance that wrote nothing.
+/// Divine's own relay acknowledges from an in-memory queue and commits to
+/// storage on a batch interval afterwards. Treat this type as a record of
+/// **how broadly a publish was accepted**, never as a durability guarantee.
+///
+/// ## Partition invariant
+///
+/// Every relay the publish targeted appears in exactly one of [acceptedBy],
+/// [rejectedBy], [noResponseFrom] or [unreachableTargets], and no other relay
+/// appears at all.
 class PublishOutcome {
   const PublishOutcome({
     required this.eventId,
@@ -14,6 +30,7 @@ class PublishOutcome {
     required this.acceptedBy,
     required this.rejectedBy,
     required this.noResponseFrom,
+    this.unreachableTargets = const [],
   });
 
   /// The id of the event that was published.
@@ -32,22 +49,60 @@ class PublishOutcome {
   /// Relay URLs that returned `OK false`, mapped to the reason returned.
   final Map<String, String> rejectedBy;
 
-  /// Relays the event was sent to that did not respond before timeout or
-  /// disconnected without answering.
+  /// Relays the event reached that did not answer before the publish settled.
   final List<String> noResponseFrom;
 
-  /// `true` when at least one relay confirmed acceptance.
-  bool get confirmed => acceptedBy.isNotEmpty;
+  /// Relays the publish targeted but could not write to at all.
+  ///
+  /// These never received the `EVENT` frame — the socket was down, the send
+  /// timed out, or the relay dropped out mid-publish. They are reported
+  /// separately from [noResponseFrom] because "we never asked" and "we asked
+  /// and got silence" call for different recovery.
+  final List<String> unreachableTargets;
 
-  /// `true` when every targeted relay either rejected the event or failed to
-  /// respond. Callers should treat this as a hard failure.
+  /// Every relay this publish targeted.
+  int get targetCount =>
+      acceptedBy.length +
+      rejectedBy.length +
+      noResponseFrom.length +
+      unreachableTargets.length;
+
+  /// `true` when at least one relay confirmed acceptance.
+  bool get acceptedByAny => acceptedBy.isNotEmpty;
+
+  /// `true` when every targeted relay confirmed acceptance.
+  ///
+  /// Returns `false` when the publish had no targets at all — "all of zero" is
+  /// a surprising success, so an empty publish is never treated as accepted.
+  bool get acceptedByAll =>
+      acceptedBy.isNotEmpty &&
+      rejectedBy.isEmpty &&
+      noResponseFrom.isEmpty &&
+      unreachableTargets.isEmpty;
+
+  /// `true` when some but not all targeted relays accepted the event.
+  ///
+  /// Nothing in the client republishes to the relays that did not accept, so a
+  /// partial publish stays partial until the caller acts on it.
+  bool get acceptedByPartial => acceptedByAny && !acceptedByAll;
+
+  /// `true` when at least one relay confirmed acceptance.
+  ///
+  /// Prefer [acceptedByAny] or [acceptedByAll], which say which one they mean.
+  bool get confirmed => acceptedByAny;
+
+  /// `true` when no targeted relay accepted the event. Callers should treat
+  /// this as a hard failure.
   bool get failed => acceptedBy.isEmpty;
 
   /// A short, human-readable summary for logs and error messages.
   String get summary {
-    if (confirmed) {
-      return 'accepted by ${acceptedBy.length} relay'
+    if (acceptedByAll) {
+      return 'accepted by all ${acceptedBy.length} relay'
           '${acceptedBy.length == 1 ? '' : 's'}';
+    }
+    if (acceptedByAny) {
+      return 'accepted by ${acceptedBy.length} of $targetCount relays';
     }
     if (rejectedBy.isNotEmpty) {
       final first = rejectedBy.entries.first;
@@ -56,17 +111,32 @@ class PublishOutcome {
     if (noResponseFrom.isNotEmpty) {
       return 'no relay responded (${noResponseFrom.length} timed out)';
     }
+    if (unreachableTargets.isNotEmpty) {
+      return 'no relay reachable (${unreachableTargets.length} unreachable)';
+    }
     return 'no relay reached';
   }
 
   @override
   String toString() =>
       'PublishOutcome(eventId: $eventId, accepted: $acceptedBy, '
-      'rejected: $rejectedBy, noResponse: $noResponseFrom)';
+      'rejected: $rejectedBy, noResponse: $noResponseFrom, '
+      'unreachable: $unreachableTargets)';
 }
 
 /// Internal tracker used by [RelayPool] to correlate OK frames with the
 /// original publish call.
+///
+/// Completion waits for **every** relay the publish reached, so the outcome
+/// describes what the relays actually said rather than whichever answered
+/// first. It resolves when:
+///  * every reached relay has answered, or
+///  * [settleWindow] elapses after the first answer, or
+///  * [timeout] elapses.
+///
+/// The settle window bounds the cost of one wedged relay: healthy relays
+/// answer in single-digit milliseconds, so waiting the full [timeout] for a
+/// silent sibling would stall every publish behind the slowest connection.
 class PublishTracker {
   PublishTracker({
     required this.eventId,
@@ -76,9 +146,18 @@ class PublishTracker {
     this.deadline,
     required this.expectedRelays,
     required Duration timeout,
+    this.settleWindow = defaultSettleWindow,
   }) {
     _timer = Timer(timeout, _onTimeout);
   }
+
+  /// Grace period granted to the remaining relays after the first answer.
+  ///
+  /// Sized against measured relay behaviour: a healthy relay returns `OK`
+  /// within a few milliseconds, so this is orders of magnitude of headroom
+  /// while still capping a wedged relay far below the publish timeout. Revisit
+  /// once publish telemetry gives a real latency distribution.
+  static const defaultSettleWindow = Duration(seconds: 1);
 
   /// The event id we are waiting on.
   final String eventId;
@@ -95,26 +174,60 @@ class PublishTracker {
   /// Hard publish deadline shared with SDK-internal retry paths.
   final DateTime? deadline;
 
-  /// Relay URLs we expect responses from.
+  /// Every relay this publish intends to reach.
+  ///
+  /// Computed before the fan-out starts, so it covers relays the pool later
+  /// fails to write to. Those are reported in
+  /// [PublishOutcome.unreachableTargets] instead of vanishing from the result.
   final Set<String> expectedRelays;
+
+  /// Grace period granted to the remaining relays after the first answer.
+  final Duration settleWindow;
+
+  /// Relays the fan-out actually wrote to, once it has reported.
+  ///
+  /// `null` until [setReachable] is called, which means "assume every target
+  /// can answer". The fan-out narrows it, which is what lets an unreachable
+  /// target stop blocking completion.
+  Set<String>? _reachable;
 
   final Map<String, String> _rejected = {};
   final Map<String, String> _deferredRejections = {};
   final Set<String> _accepted = {};
   final Completer<PublishOutcome> _completer = Completer<PublishOutcome>();
   late final Timer _timer;
+  Timer? _settleTimer;
   bool _closed = false;
 
   Future<PublishOutcome> get future => _completer.future;
+
+  /// Relays that may still answer this publish.
+  Set<String> get _awaitable => _reachable ?? expectedRelays;
+
+  /// Whether [relayUrl] is allowed to speak for this publish.
+  ///
+  /// Frames are routed by event id alone, so without this check any connected
+  /// relay could accept or reject a publish it was never sent.
+  bool isTarget(String relayUrl) =>
+      expectedRelays.contains(relayUrl) ||
+      (_reachable?.contains(relayUrl) ?? false);
+
+  /// Record which relays the fan-out managed to write to.
+  ///
+  /// Relays that were targeted but not reached stop being awaited and are
+  /// reported as unreachable.
+  void setReachable(Iterable<String> reachable) {
+    if (_closed) return;
+    _reachable = reachable.toSet();
+    _maybeComplete();
+  }
 
   /// Call when the relay returned `OK true`.
   void onAccepted(String relayUrl) {
     if (_closed) return;
     _deferredRejections.remove(relayUrl);
     _accepted.add(relayUrl);
-    // First confirmation is enough for deletion-style operations; we still
-    // collect the remaining responses but complete immediately.
-    _complete();
+    _onAnswered();
   }
 
   /// Call when the relay returned `OK false` with a reason.
@@ -122,7 +235,7 @@ class PublishTracker {
     if (_closed) return;
     _deferredRejections.remove(relayUrl);
     _rejected[relayUrl] = reason;
-    _maybeCompleteIfAllAnswered();
+    _onAnswered();
   }
 
   /// Record a relay rejection that should be reported if the publish times out,
@@ -147,15 +260,26 @@ class PublishTracker {
   void onRelayUnavailable(String relayUrl) {
     if (_closed) return;
     _deferredRejections.remove(relayUrl);
-    expectedRelays.remove(relayUrl);
-    _maybeCompleteIfAllAnswered();
+    _reachable = _awaitable.where((r) => r != relayUrl).toSet();
+    _maybeComplete();
   }
 
-  void _maybeCompleteIfAllAnswered() {
-    final responded = _accepted.length + _rejected.length;
-    if (responded >= expectedRelays.length) {
+  /// Start the settle window on the first answer, then re-test completion.
+  void _onAnswered() {
+    _settleTimer ??= Timer(settleWindow, _onSettleWindowElapsed);
+    _maybeComplete();
+  }
+
+  void _maybeComplete() {
+    final answered = _accepted.length + _rejected.length;
+    if (answered >= _awaitable.length) {
       _complete();
     }
+  }
+
+  void _onSettleWindowElapsed() {
+    if (_closed) return;
+    _complete();
   }
 
   void _onTimeout() {
@@ -167,14 +291,21 @@ class PublishTracker {
     if (_closed) return;
     _closed = true;
     _timer.cancel();
+    _settleTimer?.cancel();
     final effectiveRejected = Map<String, String>.from(_rejected);
     if (_accepted.isEmpty) {
       effectiveRejected.addAll(_deferredRejections);
     }
-    final noResponse = expectedRelays
-        .where(
-          (r) => !_accepted.contains(r) && !effectiveRejected.containsKey(r),
-        )
+    final awaitable = _awaitable;
+    bool answered(String relay) =>
+        _accepted.contains(relay) || effectiveRejected.containsKey(relay);
+    final noResponse = awaitable
+        .where((r) => !answered(r))
+        .toList(growable: false);
+    // A relay that answered is never unreachable, even if the fan-out reported
+    // its write as failed — the answer proves it got the frame.
+    final unreachable = expectedRelays
+        .where((r) => !awaitable.contains(r) && !answered(r))
         .toList(growable: false);
     _completer.complete(
       PublishOutcome(
@@ -183,25 +314,14 @@ class PublishTracker {
         acceptedBy: _accepted.toList(growable: false),
         rejectedBy: Map<String, String>.unmodifiable(effectiveRejected),
         noResponseFrom: noResponse,
+        unreachableTargets: unreachable,
       ),
     );
   }
 
   /// Cancel the tracker without waiting. Used when the pool is shut down.
-  void cancel() {
-    if (_closed) return;
-    _closed = true;
-    _timer.cancel();
-    if (!_completer.isCompleted) {
-      _completer.complete(
-        PublishOutcome(
-          eventId: eventId,
-          eventKind: eventKind,
-          acceptedBy: _accepted.toList(growable: false),
-          rejectedBy: Map<String, String>.unmodifiable(_rejected),
-          noResponseFrom: expectedRelays.toList(growable: false),
-        ),
-      );
-    }
-  }
+  ///
+  /// Reports whatever has arrived so far, using the same partitioning as a
+  /// normal completion so a relay can never appear in two buckets.
+  void cancel() => _complete();
 }

--- a/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
@@ -300,8 +300,15 @@ class PublishTracker {
   }
 
   void _maybeComplete() {
-    final answered = _accepted.length + _rejected.length;
-    if (answered >= _awaitable.length) {
+    // Tested over the awaitable set rather than as a total, because a relay
+    // the fan-out reported as unwritten can still answer — its frame may have
+    // gone out just before the per-relay send timeout fired. Comparing totals
+    // let that answer fill an awaited relay's quota and settle the publish
+    // while that relay was still silent.
+    final allAnswered = _awaitable.every(
+      (relay) => _accepted.contains(relay) || _rejected.containsKey(relay),
+    );
+    if (allAnswered) {
       _complete();
     }
   }

--- a/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
@@ -131,7 +131,8 @@ class PublishOutcome {
 /// describes what the relays actually said rather than whichever answered
 /// first. It resolves when:
 ///  * every reached relay has answered, or
-///  * [settleWindow] elapses after the first answer, or
+///  * [settleWindow] elapses after the first answer, counted no earlier than
+///    the [setReachable] call that reports the fan-out's target set, or
 ///  * [timeout] elapses.
 ///
 /// The settle window bounds the cost of one wedged relay: healthy relays
@@ -191,6 +192,20 @@ class PublishTracker {
   /// target stop blocking completion.
   Set<String>? _reachable;
 
+  /// Whether the fan-out has reported which relays it wrote to.
+  ///
+  /// Gates the settle window. The tracker is registered *before* the
+  /// sequential fan-out starts, so a connected relay can answer while a later
+  /// target has not been written to yet. Arming on that answer would let the
+  /// window expire mid-fan-out: [setReachable] would find the tracker closed,
+  /// and targets the publish never reached would be reported as silent
+  /// instead of unreachable.
+  ///
+  /// Tracked separately from [_reachable] because [onRelayUnavailable] also
+  /// narrows that set, and a relay dropping mid-fan-out is not the fan-out
+  /// reporting.
+  bool _fanOutReported = false;
+
   final Map<String, String> _rejected = {};
   final Map<String, String> _deferredRejections = {};
   final Set<String> _accepted = {};
@@ -219,6 +234,10 @@ class PublishTracker {
   void setReachable(Iterable<String> reachable) {
     if (_closed) return;
     _reachable = reachable.toSet();
+    _fanOutReported = true;
+    // Answers that landed during the fan-out could not start the settle
+    // window; now that the target set is final, they can.
+    _armSettleWindow();
     _maybeComplete();
   }
 
@@ -266,8 +285,18 @@ class PublishTracker {
 
   /// Start the settle window on the first answer, then re-test completion.
   void _onAnswered() {
-    _settleTimer ??= Timer(settleWindow, _onSettleWindowElapsed);
+    _armSettleWindow();
     _maybeComplete();
+  }
+
+  /// Start the grace period for the relays that have not answered yet.
+  ///
+  /// No-op until the fan-out has reported its target set — see
+  /// [_fanOutReported].
+  void _armSettleWindow() {
+    if (!_fanOutReported) return;
+    if (_accepted.isEmpty && _rejected.isEmpty) return;
+    _settleTimer ??= Timer(settleWindow, _onSettleWindowElapsed);
   }
 
   void _maybeComplete() {

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -307,7 +307,12 @@ class RelayPool {
           )
           .timeout(timeout, onTimeout: () => false);
       if (!sent) {
-        retry.tracker.onRelayUnavailable(relay.url);
+        // The relay answered — `auth-required` is why we are here — so it is
+        // not an unreachable target, whatever happened to the resend. Report
+        // what it said, the same as the expired-deadline branch above; a
+        // caller told "could not reach this relay" would retry the network
+        // instead of the authentication.
+        retry.tracker.onRejected(relay.url, retry.reason);
         _removeAuthRequiredPublish(eventId, relay.url);
       }
     }
@@ -1791,18 +1796,25 @@ class RelayPool {
     );
     _pendingPublishes[eventId] = tracker;
 
-    final sentTo = await _sendCollect(
-      message,
-      tempRelays: tempRelays,
-      targetRelays: targetRelays,
-      deadline: deadline,
-      diagnosticTag: diagnosticTag,
-    );
-
     // Narrow the awaited set to the relays the fan-out actually wrote to. The
     // rest become unreachable targets rather than blocking the publish until
     // the timeout. When nothing was written this settles the tracker at once.
-    tracker.setReachable(sentTo);
+    //
+    // Reported in a `finally` because the tracker defers its hard timeout
+    // until this call arrives: a fan-out that threw would otherwise leave the
+    // publish hanging.
+    var sentTo = const <String>[];
+    try {
+      sentTo = await _sendCollect(
+        message,
+        tempRelays: tempRelays,
+        targetRelays: targetRelays,
+        deadline: deadline,
+        diagnosticTag: diagnosticTag,
+      );
+    } finally {
+      tracker.setReachable(sentTo);
+    }
 
     unawaited(
       tracker.future

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -894,7 +894,21 @@ class RelayPool {
       if (message == null) return;
 
       // Check if this OK is for a publish we are awaiting.
-      final publishTracker = _pendingPublishes[eventId];
+      //
+      // Trackers are keyed on event id alone, so without the membership check
+      // any connected relay could accept or reject a publish it was never
+      // sent — deciding the outcome of, say, a narrowly targeted direct
+      // message it has no part in.
+      final pendingPublish = _pendingPublishes[eventId];
+      final publishTracker =
+          pendingPublish != null && pendingPublish.isTarget(relay.url)
+          ? pendingPublish
+          : null;
+      if (pendingPublish != null && publishTracker == null) {
+        log(
+          '📡 Ignoring OK for $eventId from ${relay.url}: not a publish target',
+        );
+      }
       if (publishTracker != null) {
         if (success) {
           _removeAuthRequiredPublish(eventId, relay.url);
@@ -1474,7 +1488,6 @@ class RelayPool {
     List<String>? targetRelays,
     DateTime? deadline,
     String? diagnosticTag,
-    void Function(String relayUrl)? onSent,
   }) async {
     final sentTo = <String>[];
     final attemptedRelayUrls = <String>{};
@@ -1573,7 +1586,6 @@ class RelayPool {
             }
             if (result) {
               sentTo.add(relay.url);
-              onSent?.call(relay.url);
             }
             logDiagnostic(
               'auth-trigger send kind=$eventKind eventId=$eventId '
@@ -1584,7 +1596,6 @@ class RelayPool {
             relay.pendingAuthedMessages.add(message);
             sentTo.add(relay.url);
             attemptedRelayUrls.add(relay.url);
-            onSent?.call(relay.url);
             logDiagnostic(
               'queued for auth kind=$eventKind eventId=$eventId relay=${relay.url}',
             );
@@ -1625,7 +1636,6 @@ class RelayPool {
           }
           if (result) {
             sentTo.add(relay.url);
-            onSent?.call(relay.url);
           }
           logDiagnostic(
             'send kind=$eventKind eventId=$eventId relay=${relay.url} sent=$result',
@@ -1676,7 +1686,6 @@ class RelayPool {
         }
         if (result) {
           sentTo.add(tempRelay.url);
-          onSent?.call(tempRelay.url);
         }
         logDiagnostic(
           'temp send kind=$eventKind eventId=$eventId relay=${tempRelay.url} sent=$result',
@@ -1691,18 +1700,65 @@ class RelayPool {
     return sentTo;
   }
 
+  /// Record how broadly a publish was accepted.
+  ///
+  /// Counts only — never relay URLs or event ids, so the line is safe to keep
+  /// on in any build and carries nothing that identifies a user. Until this
+  /// existed there was no signal at all about how often a publish is accepted
+  /// by some relays and refused by others.
+  void _recordPublishBreadth(PublishOutcome outcome) {
+    if (outcome.acceptedByAll) return;
+    log(
+      '📡 Publish accepted by ${outcome.acceptedBy.length}/'
+      '${outcome.targetCount} relays '
+      '(rejected=${outcome.rejectedBy.length} '
+      'silent=${outcome.noResponseFrom.length} '
+      'unreachable=${outcome.unreachableTargets.length})',
+    );
+  }
+
+  /// Every relay a publish with these parameters intends to reach.
+  ///
+  /// Mirrors the iteration [_sendCollect] performs, but resolves it *before*
+  /// the fan-out starts so the set is complete even for relays the fan-out
+  /// later fails to write to. Deriving the target set from send results
+  /// instead would silently shrink the denominator: a relay that could not be
+  /// written to would be absent from the outcome entirely, and a publish could
+  /// settle while later relays had not been attempted yet.
+  Set<String> _intendedPublishTargets(
+    List<dynamic> message, {
+    List<String>? tempRelays,
+    List<String>? targetRelays,
+  }) {
+    final targets = <String>{};
+    final isEvent = message.isNotEmpty && message[0] == "EVENT";
+    final hasFilter = targetRelays != null && targetRelays.isNotEmpty;
+    for (final relay in _relaysSnapshot()) {
+      if (isEvent && !relay.relayStatus.writeAccess) continue;
+      if (hasFilter && !targetRelays.contains(relay.url)) continue;
+      targets.add(relay.url);
+    }
+    if (tempRelays != null) targets.addAll(tempRelays);
+    return targets;
+  }
+
   /// Send an `EVENT` message and wait for `OK` confirmations from relays.
   ///
   /// Registers a [PublishTracker] keyed on the event id. The returned future
   /// completes when either:
-  ///  * at least one relay has confirmed acceptance (`OK true`), OR
-  ///  * every targeted relay has responded (accept or reject), OR
+  ///  * every relay the fan-out reached has responded (accept or reject), OR
+  ///  * [PublishTracker.settleWindow] elapses after the first response, OR
   ///  * [timeout] elapses.
   ///
-  /// If no relay received the message at the WebSocket level, the tracker
-  /// completes immediately with an empty [PublishOutcome] (all in
-  /// `noResponseFrom`). Callers must inspect [PublishOutcome.confirmed] to
-  /// decide whether the publish succeeded.
+  /// It does **not** complete on the first acceptance. A publish that one
+  /// relay accepts and another rejects must report both, and nothing in this
+  /// client republishes to the relays that did not accept.
+  ///
+  /// Relays that were targeted but could not be written to are reported in
+  /// [PublishOutcome.unreachableTargets]. Callers should inspect
+  /// [PublishOutcome.acceptedByAll] or [PublishOutcome.acceptedByAny]
+  /// depending on the breadth of acceptance they require — note that relay
+  /// acceptance is not a durability guarantee.
   Future<PublishOutcome> sendEventAwaitOk(
     List<dynamic> message, {
     required String eventId,
@@ -1726,7 +1782,11 @@ class RelayPool {
       diagnosticTag: diagnosticTag,
       message: message,
       deadline: deadline,
-      expectedRelays: <String>{},
+      expectedRelays: _intendedPublishTargets(
+        message,
+        tempRelays: tempRelays,
+        targetRelays: targetRelays,
+      ),
       timeout: timeout,
     );
     _pendingPublishes[eventId] = tracker;
@@ -1737,12 +1797,12 @@ class RelayPool {
       targetRelays: targetRelays,
       deadline: deadline,
       diagnosticTag: diagnosticTag,
-      onSent: (relayUrl) => tracker.expectedRelays.add(relayUrl),
     );
 
-    if (sentTo.isEmpty) {
-      tracker.cancel();
-    }
+    // Narrow the awaited set to the relays the fan-out actually wrote to. The
+    // rest become unreachable targets rather than blocking the publish until
+    // the timeout. When nothing was written this settles the tracker at once.
+    tracker.setReachable(sentTo);
 
     unawaited(
       tracker.future
@@ -1753,19 +1813,21 @@ class RelayPool {
                 diagnosticTag,
                 'OK outcome kind=${tracker.eventKind} eventId=$eventId '
                 'acceptedBy=${outcome.acceptedBy} rejectedBy=${outcome.rejectedBy} '
-                'noResponseFrom=${outcome.noResponseFrom}',
+                'noResponseFrom=${outcome.noResponseFrom} '
+                'unreachableTargets=${outcome.unreachableTargets}',
               );
             }
-            // Repair only when the publish went UNCONFIRMED. The tracker
-            // resolves on the FIRST OK-true, so on a multi-relay publish the
-            // slower healthy siblings land in `noResponseFrom` while
-            // `isSilentSince(sentAt)` passes trivially over the few-hundred-ms
-            // race window — cycling them on every send churns connections and
-            // fails concurrent `skipReconnect` publishes. A genuinely zombie
-            // sibling is repaired by the next publish that needs it (its own
-            // OK window then times out) or by the connectivity-transition
-            // forceReconnectAll.
-            if (!outcome.confirmed) {
+            _recordPublishBreadth(outcome);
+            // Repair every relay that stayed silent, whether or not a sibling
+            // accepted. `noResponseFrom` now means "reached this relay and it
+            // never answered", not "lost the OK race", so a confirmed publish
+            // can still be hiding a zombie socket. The existing filters keep
+            // this from churning healthy connections: `isSilentSince` requires
+            // no inbound frame of ANY kind since the publish (so a relay
+            // serving subscriptions is excluded), `silentRepairCooldown`
+            // rate-limits per relay, and `_silentRelayRepairsInFlight`
+            // collapses concurrent repairs of the same URL.
+            if (outcome.noResponseFrom.isNotEmpty) {
               _repairSilentRelays(outcome.noResponseFrom, sentAt);
             }
           })

--- a/mobile/packages/nostr_sdk/test/unit/publish_outcome_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/publish_outcome_test.dart
@@ -1,27 +1,230 @@
 // ABOUTME: Unit tests for PublishTracker and PublishOutcome used to await
 // ABOUTME: OK responses from relays when publishing events.
 
+import 'dart:async';
+
 import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:test/test.dart';
+
+/// Every targeted relay must appear in exactly one bucket, and no relay may
+/// appear that was never targeted.
+///
+/// This single invariant is what the pre-fix code violated three different
+/// ways: a target the pool could not write to appeared in no bucket, a relay
+/// that answered after the first OK appeared in the wrong bucket, and a relay
+/// that was never a target could appear in `acceptedBy`.
+void expectPartitions(PublishOutcome outcome, Set<String> targets) {
+  final buckets = <String>[
+    ...outcome.acceptedBy,
+    ...outcome.rejectedBy.keys,
+    ...outcome.noResponseFrom,
+    ...outcome.unreachableTargets,
+  ];
+  expect(
+    buckets.toSet(),
+    equals(targets),
+    reason: 'every target must appear in exactly one bucket',
+  );
+  expect(
+    buckets.length,
+    equals(targets.length),
+    reason: 'no relay may appear in two buckets',
+  );
+}
+
+PublishTracker trackerFor(
+  Set<String> targets, {
+  String eventId = 'event-1',
+  int? eventKind,
+  Duration timeout = const Duration(seconds: 30),
+  Duration settleWindow = const Duration(milliseconds: 50),
+}) {
+  return PublishTracker(
+    eventId: eventId,
+    eventKind: eventKind,
+    expectedRelays: targets,
+    timeout: timeout,
+    settleWindow: settleWindow,
+  );
+}
 
 void main() {
   group(PublishTracker, () {
     group('onAccepted', () {
-      test('completes immediately once any relay confirms, leaving the rest in '
-          'noResponseFrom', () async {
-        final tracker = PublishTracker(
-          eventId: 'event-1',
-          expectedRelays: {'wss://a.example', 'wss://b.example'},
-          timeout: const Duration(seconds: 30),
-        );
+      test('waits for the other relays instead of completing on the first '
+          'acceptance', () async {
+        final tracker = trackerFor({'wss://a.example', 'wss://b.example'});
 
         tracker.onAccepted('wss://a.example');
+        var resolved = false;
+        unawaited(tracker.future.then((_) => resolved = true));
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        expect(
+          resolved,
+          isFalse,
+          reason: 'a second relay had not answered yet',
+        );
+
+        tracker.onAccepted('wss://b.example');
         final outcome = await tracker.future;
 
-        expect(outcome.eventId, equals('event-1'));
-        expect(outcome.confirmed, isTrue);
-        expect(outcome.acceptedBy, equals(['wss://a.example']));
-        expect(outcome.noResponseFrom, equals(['wss://b.example']));
+        expect(outcome.acceptedByAll, isTrue);
+        expect(
+          outcome.acceptedBy,
+          unorderedEquals(['wss://a.example', 'wss://b.example']),
+        );
+        expectPartitions(outcome, {'wss://a.example', 'wss://b.example'});
+      });
+
+      test('completes at once when the only target accepts', () async {
+        final tracker = trackerFor({'wss://only.example'});
+
+        tracker.onAccepted('wss://only.example');
+        final outcome = await tracker.future;
+
+        expect(outcome.acceptedByAll, isTrue);
+        expect(outcome.acceptedByPartial, isFalse);
+        expectPartitions(outcome, {'wss://only.example'});
+      });
+    });
+
+    // The behaviour issue #3366 was filed for: an acceptance and a later
+    // rejection must both survive into the outcome, in either arrival order.
+    group('one accept plus a later reject', () {
+      test('records the rejection that arrives after an acceptance', () async {
+        final tracker = trackerFor({
+          'wss://fast.example',
+          'wss://slow.example',
+        });
+
+        tracker.onAccepted('wss://fast.example');
+        tracker.onRejected('wss://slow.example', 'blocked: policy');
+        final outcome = await tracker.future;
+
+        expect(outcome.acceptedBy, equals(['wss://fast.example']));
+        expect(
+          outcome.rejectedBy,
+          equals({'wss://slow.example': 'blocked: policy'}),
+          reason: 'the rejection must not be discarded as a non-response',
+        );
+        expect(outcome.acceptedByAll, isFalse);
+        expect(outcome.acceptedByAny, isTrue);
+        expect(outcome.acceptedByPartial, isTrue);
+        expectPartitions(outcome, {'wss://fast.example', 'wss://slow.example'});
+      });
+
+      test(
+        'produces the same outcome when the rejection arrives first',
+        () async {
+          final tracker = trackerFor({
+            'wss://fast.example',
+            'wss://slow.example',
+          });
+
+          tracker.onRejected('wss://slow.example', 'blocked: policy');
+          tracker.onAccepted('wss://fast.example');
+          final outcome = await tracker.future;
+
+          expect(outcome.acceptedBy, equals(['wss://fast.example']));
+          expect(
+            outcome.rejectedBy,
+            equals({'wss://slow.example': 'blocked: policy'}),
+            reason: 'the outcome must not depend on arrival order',
+          );
+          expect(outcome.acceptedByPartial, isTrue);
+          expectPartitions(outcome, {
+            'wss://fast.example',
+            'wss://slow.example',
+          });
+        },
+      );
+
+      test(
+        'reports a relay that never answers as silent, not as accepting',
+        () async {
+          final tracker = trackerFor({
+            'wss://fast.example',
+            'wss://mute.example',
+          });
+
+          tracker.onAccepted('wss://fast.example');
+          final outcome = await tracker.future;
+
+          expect(outcome.acceptedBy, equals(['wss://fast.example']));
+          expect(outcome.noResponseFrom, equals(['wss://mute.example']));
+          expect(outcome.acceptedByAll, isFalse);
+          expectPartitions(outcome, {
+            'wss://fast.example',
+            'wss://mute.example',
+          });
+        },
+      );
+    });
+
+    group('settle window', () {
+      test(
+        'bounds the wait for a silent relay well below the timeout',
+        () async {
+          final tracker = trackerFor(
+            {'wss://fast.example', 'wss://mute.example'},
+            timeout: const Duration(seconds: 30),
+            settleWindow: const Duration(milliseconds: 40),
+          );
+
+          final stopwatch = Stopwatch()..start();
+          tracker.onAccepted('wss://fast.example');
+          await tracker.future;
+          stopwatch.stop();
+
+          expect(stopwatch.elapsed, lessThan(const Duration(seconds: 5)));
+        },
+      );
+    });
+
+    group('unreachable targets', () {
+      test('reports a target the fan-out could not write to', () async {
+        final tracker = trackerFor({'wss://up.example', 'wss://down.example'});
+
+        tracker.setReachable(['wss://up.example']);
+        tracker.onAccepted('wss://up.example');
+        final outcome = await tracker.future;
+
+        expect(outcome.acceptedBy, equals(['wss://up.example']));
+        expect(outcome.unreachableTargets, equals(['wss://down.example']));
+        expect(
+          outcome.acceptedByAll,
+          isFalse,
+          reason: 'a target we never reached is not an acceptance',
+        );
+        expect(outcome.targetCount, equals(2));
+        expectPartitions(outcome, {'wss://up.example', 'wss://down.example'});
+      });
+
+      test('settles immediately when the fan-out reached nothing', () async {
+        final tracker = trackerFor({'wss://a.example', 'wss://b.example'});
+
+        tracker.setReachable(const <String>[]);
+        final outcome = await tracker.future;
+
+        expect(outcome.failed, isTrue);
+        expect(
+          outcome.unreachableTargets,
+          unorderedEquals(['wss://a.example', 'wss://b.example']),
+        );
+        expect(outcome.summary, contains('unreachable'));
+        expectPartitions(outcome, {'wss://a.example', 'wss://b.example'});
+      });
+    });
+
+    group('isTarget', () {
+      test('rejects a relay that was never a publish target', () {
+        final tracker = trackerFor({'wss://target.example'});
+
+        expect(tracker.isTarget('wss://target.example'), isTrue);
+        expect(tracker.isTarget('wss://intruder.example'), isFalse);
+
+        tracker.cancel();
       });
     });
 
@@ -29,11 +232,9 @@ void main() {
       test(
         'reports rejection reason and does not consider the publish confirmed',
         () async {
-          final tracker = PublishTracker(
-            eventId: 'event-2',
-            expectedRelays: {'wss://only.example'},
-            timeout: const Duration(seconds: 30),
-          );
+          final tracker = trackerFor({
+            'wss://only.example',
+          }, eventId: 'event-2');
 
           tracker.onRejected('wss://only.example', 'blocked: policy');
           final outcome = await tracker.future;
@@ -52,9 +253,9 @@ void main() {
       test(
         'completes with every relay in noResponseFrom when no response arrives',
         () async {
-          final tracker = PublishTracker(
+          final tracker = trackerFor(
+            {'wss://a.example', 'wss://b.example'},
             eventId: 'event-3',
-            expectedRelays: {'wss://a.example', 'wss://b.example'},
             timeout: const Duration(milliseconds: 20),
           );
 
@@ -73,11 +274,7 @@ void main() {
 
     group('cancel', () {
       test('completes the tracker synchronously for pool shutdown', () async {
-        final tracker = PublishTracker(
-          eventId: 'event-4',
-          expectedRelays: {'wss://only.example'},
-          timeout: const Duration(seconds: 30),
-        );
+        final tracker = trackerFor({'wss://only.example'}, eventId: 'event-4');
 
         tracker.cancel();
         final outcome = await tracker.future;
@@ -85,6 +282,35 @@ void main() {
         expect(outcome.failed, isTrue);
         expect(outcome.noResponseFrom, equals(['wss://only.example']));
       });
+
+      test('never lists an accepting relay as unanswered', () async {
+        final tracker = trackerFor({'wss://a.example', 'wss://b.example'});
+
+        tracker.onAccepted('wss://a.example');
+        tracker.cancel();
+        final outcome = await tracker.future;
+
+        expect(outcome.acceptedBy, equals(['wss://a.example']));
+        expect(outcome.noResponseFrom, equals(['wss://b.example']));
+        expectPartitions(outcome, {'wss://a.example', 'wss://b.example'});
+      });
+
+      test(
+        'keeps a deferred rejection reason when nothing was accepted',
+        () async {
+          final tracker = trackerFor({'wss://a.example'});
+
+          tracker.deferRejection('wss://a.example', 'auth-required: sign in');
+          tracker.cancel();
+          final outcome = await tracker.future;
+
+          expect(
+            outcome.rejectedBy,
+            equals({'wss://a.example': 'auth-required: sign in'}),
+            reason: 'shutdown must report the same reasons a timeout would',
+          );
+        },
+      );
     });
 
     group('publish diagnostics metadata', () {
@@ -102,11 +328,10 @@ void main() {
       });
 
       test('propagates event kind to publish outcome', () async {
-        final tracker = PublishTracker(
+        final tracker = trackerFor(
+          {'wss://relay.divine.video'},
           eventId: 'accepted-event',
           eventKind: 1,
-          expectedRelays: {'wss://relay.divine.video'},
-          timeout: const Duration(seconds: 30),
         );
 
         tracker.onAccepted('wss://relay.divine.video');
@@ -114,6 +339,25 @@ void main() {
 
         expect(outcome.eventKind, equals(1));
       });
+    });
+  });
+
+  group(PublishOutcome, () {
+    test('treats a publish with no targets as not accepted', () {
+      const outcome = PublishOutcome(
+        eventId: 'empty',
+        acceptedBy: [],
+        rejectedBy: {},
+        noResponseFrom: [],
+      );
+
+      expect(
+        outcome.acceptedByAll,
+        isFalse,
+        reason: '"all of zero" must not read as success',
+      );
+      expect(outcome.acceptedByAny, isFalse);
+      expect(outcome.failed, isTrue);
     });
   });
 }

--- a/mobile/packages/nostr_sdk/test/unit/publish_outcome_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/publish_outcome_test.dart
@@ -148,6 +148,7 @@ void main() {
             'wss://mute.example',
           });
 
+          tracker.setReachable(['wss://fast.example', 'wss://mute.example']);
           tracker.onAccepted('wss://fast.example');
           final outcome = await tracker.future;
 
@@ -173,11 +174,54 @@ void main() {
           );
 
           final stopwatch = Stopwatch()..start();
+          tracker.setReachable(['wss://fast.example', 'wss://mute.example']);
           tracker.onAccepted('wss://fast.example');
           await tracker.future;
           stopwatch.stop();
 
           expect(stopwatch.elapsed, lessThan(const Duration(seconds: 5)));
+        },
+      );
+
+      // `RelayPool.sendEventAwaitOk` registers the tracker before it awaits
+      // the sequential fan-out, and only calls `setReachable` once that
+      // fan-out returns. A connected relay therefore answers while a later
+      // target may not have been written to yet — and the fan-out can outlast
+      // the settle window, since it waits out a relay's `connecting` state and
+      // caps each one at `perRelaySendTimeout`.
+      test(
+        'does not start before the fan-out has reported its targets',
+        () async {
+          final tracker = trackerFor({
+            'wss://fast.example',
+            'wss://slow.example',
+          }, settleWindow: const Duration(milliseconds: 20));
+
+          tracker.onAccepted('wss://fast.example');
+          await Future<void>.delayed(const Duration(milliseconds: 60));
+
+          var resolved = false;
+          unawaited(tracker.future.then((_) => resolved = true));
+          await Future<void>.delayed(Duration.zero);
+          expect(
+            resolved,
+            isFalse,
+            reason: 'the fan-out was still writing to wss://slow.example',
+          );
+
+          tracker.setReachable(['wss://fast.example', 'wss://slow.example']);
+          tracker.onAccepted('wss://slow.example');
+          final outcome = await tracker.future;
+
+          expect(
+            outcome.acceptedByAll,
+            isTrue,
+            reason: 'both relays accepted, so this is not a partial publish',
+          );
+          expectPartitions(outcome, {
+            'wss://fast.example',
+            'wss://slow.example',
+          });
         },
       );
     });

--- a/mobile/packages/nostr_sdk/test/unit/publish_outcome_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/publish_outcome_test.dart
@@ -259,6 +259,44 @@ void main() {
         expect(outcome.summary, contains('unreachable'));
         expectPartitions(outcome, {'wss://a.example', 'wss://b.example'});
       });
+
+      // A relay outside `sentTo` can still answer: `_sendCollect` reports the
+      // write as failed when its per-relay timeout fires, which can happen
+      // after the frame already went out. That answer must not settle the
+      // publish on behalf of a relay that is still silent.
+      test(
+        'does not let an unreached relay answer for a reached one',
+        () async {
+          final tracker = trackerFor({
+            'wss://late.example',
+            'wss://b.example',
+            'wss://c.example',
+          }, settleWindow: const Duration(seconds: 10));
+
+          tracker.onAccepted('wss://late.example');
+          tracker.setReachable(['wss://b.example', 'wss://c.example']);
+          tracker.onAccepted('wss://b.example');
+
+          var resolved = false;
+          unawaited(tracker.future.then((_) => resolved = true));
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+          expect(
+            resolved,
+            isFalse,
+            reason: 'wss://c.example had not answered yet',
+          );
+
+          tracker.onAccepted('wss://c.example');
+          final outcome = await tracker.future;
+
+          expect(outcome.acceptedByAll, isTrue);
+          expectPartitions(outcome, {
+            'wss://late.example',
+            'wss://b.example',
+            'wss://c.example',
+          });
+        },
+      );
     });
 
     group('isTarget', () {

--- a/mobile/packages/nostr_sdk/test/unit/publish_outcome_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/publish_outcome_test.dart
@@ -260,6 +260,47 @@ void main() {
         expectPartitions(outcome, {'wss://a.example', 'wss://b.example'});
       });
 
+      // `RelayPool` bounds the fan-out by the same deadline as this tracker,
+      // so a fan-out that spends the whole budget racing the hard timeout is
+      // the normal case rather than an exotic one. Completing first would
+      // report every target the fan-out never got to as silent, and the pool
+      // force-reconnects silent relays — cycling connections the publish
+      // never wrote to.
+      test(
+        'waits for the fan-out report when the timeout wins the race',
+        () async {
+          final tracker = trackerFor({
+            'wss://written.example',
+            'wss://untouched.example',
+          }, timeout: const Duration(milliseconds: 20));
+
+          await Future<void>.delayed(const Duration(milliseconds: 60));
+
+          var resolved = false;
+          unawaited(tracker.future.then((_) => resolved = true));
+          await Future<void>.delayed(Duration.zero);
+          expect(
+            resolved,
+            isFalse,
+            reason: 'the fan-out had not said what it wrote to yet',
+          );
+
+          tracker.setReachable(['wss://written.example']);
+          final outcome = await tracker.future;
+
+          expect(outcome.noResponseFrom, equals(['wss://written.example']));
+          expect(
+            outcome.unreachableTargets,
+            equals(['wss://untouched.example']),
+            reason: 'the fan-out never wrote to it, so it was not silent',
+          );
+          expectPartitions(outcome, {
+            'wss://written.example',
+            'wss://untouched.example',
+          });
+        },
+      );
+
       // A relay outside `sentTo` can still answer: `_sendCollect` reports the
       // write as failed when its per-relay timeout fires, which can happen
       // after the frame already went out. That answer must not settle the

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
@@ -43,7 +43,7 @@ class _AuthFakeRelay extends Relay {
   final List<List<dynamic>> sentMessages = [];
 
   /// When true, [send] records the frame but reports transport failure, so the
-  /// post-auth resend path (`onRelayUnavailable`) can be exercised.
+  /// failing post-auth resend path can be exercised.
   bool failSends = false;
 
   @override
@@ -497,7 +497,7 @@ void main() {
     });
 
     test(
-      'marks the relay unavailable when the post-auth resend fails',
+      'reports what the relay said when the post-auth resend fails',
       () async {
         const eventId =
             '6666666666666666666666666666666666666666666666666666666666666666';
@@ -527,7 +527,16 @@ void main() {
 
         expect(outcome.failed, isTrue);
         expect(outcome.acceptedBy, isEmpty);
-        expect(outcome.rejectedBy, isEmpty);
+        // The relay answered — `auth-required` is why the retry existed — so
+        // it must not be reported as a target we never reached, and its
+        // reason is the only thing that tells the caller to fix the auth
+        // rather than the network.
+        expect(
+          outcome.rejectedBy,
+          equals({relay.url: 'auth-required: you must auth'}),
+        );
+        expect(outcome.unreachableTargets, isEmpty);
+        expect(outcome.noResponseFrom, isEmpty);
         expect(
           sentMessagesOfType(relay, 'EVENT'),
           hasLength(2),

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_zombie_remediation_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_zombie_remediation_test.dart
@@ -207,12 +207,12 @@ void main() {
       expect(factory.createdChannels, hasLength(1));
     });
 
-    test('on a multi-relay publish, a healthy sibling that merely lost the '
-        'OK race to a faster relay is not force-cycled', () async {
-      // The tracker resolves on the FIRST OK-true, so the sibling relay
-      // lands in noResponseFrom after only the few-ms race window — far too
-      // short for its silence to mean anything. Cycling it would tear down
-      // a healthy inbox relay on every send.
+    test('on a multi-relay publish, a sibling that stayed silent for the whole '
+        'window is force-cycled even though another relay accepted', () async {
+      // The tracker no longer resolves on the first OK-true, so a sibling in
+      // noResponseFrom has genuinely had the full publish window to answer
+      // and said nothing. That is the wedged-socket signal repair exists for,
+      // and a confirmed publish no longer hides it.
       const siblingUrl = 'wss://inbox.example.com';
       final siblingFactory = _FakeChannelFactory();
       final sibling = RelayBase(
@@ -246,12 +246,57 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 50));
       expect(
         siblingFactory.createdChannels,
-        hasLength(1),
+        hasLength(2),
         reason:
-            'a confirmed publish must not cycle the slower sibling relay '
-            'that never got a chance to respond',
+            'a relay that received the frame and never answered is a zombie '
+            'socket, whether or not a sibling accepted',
       );
       expect(factory.createdChannels, hasLength(1));
+    });
+
+    test('a sibling that is still receiving traffic is not force-cycled, even '
+        'when it does not answer the publish', () async {
+      // `isSilentSince` is the guard that keeps the broadened repair from
+      // churning healthy connections: any inbound frame since the publish
+      // proves the socket is alive, so the relay is left alone.
+      const siblingUrl = 'wss://busy.example.com';
+      final siblingFactory = _FakeChannelFactory();
+      final sibling = RelayBase(
+        siblingUrl,
+        RelayStatus(siblingUrl),
+        channelFactory: siblingFactory,
+      );
+      await nostr.relayPool.add(sibling);
+      expect(siblingFactory.createdChannels, hasLength(1));
+
+      final fastChannel = factory.createdChannels.single;
+      final siblingChannel = siblingFactory.createdChannels.single;
+      final outcomeFuture = nostr.relayPool.sendEventAwaitOk(
+        [
+          'EVENT',
+          {'id': 'busy-event-id', 'kind': 14},
+        ],
+        eventId: 'busy-event-id',
+        eventKind: 14,
+        targetRelays: [relayUrl, siblingUrl],
+        timeout: const Duration(milliseconds: 100),
+      );
+      await Future<void>.delayed(Duration.zero);
+      // The sibling stays quiet about this publish but is plainly alive.
+      siblingChannel.simulateMessage(jsonEncode(['NOTICE', 'still here']));
+      fastChannel.simulateMessage(
+        jsonEncode(['OK', 'busy-event-id', true, '']),
+      );
+
+      final outcome = await outcomeFuture;
+      expect(outcome.noResponseFrom, contains(siblingUrl));
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(
+        siblingFactory.createdChannels,
+        hasLength(1),
+        reason: 'inbound traffic proves the socket is not wedged',
+      );
     });
 
     Future<PublishOutcome> publishWithId(String id) {

--- a/mobile/test/blocs/owner_video_actions/owner_video_actions_cubit_test.dart
+++ b/mobile/test/blocs/owner_video_actions/owner_video_actions_cubit_test.dart
@@ -49,7 +49,10 @@ void main() {
             reason: DeleteReason.personalChoice,
           ),
         ).thenAnswer(
-          (_) async => DeleteResult.createSuccess('delete-event-id'),
+          (_) async => DeleteResult.createSuccess(
+            'delete-event-id',
+            acceptance: DeleteAcceptance.everyRelay,
+          ),
         );
       },
       act: (cubit) => cubit.deleteVideo(video),

--- a/mobile/test/providers/nostr_client_provider_bootstrap_test.dart
+++ b/mobile/test/providers/nostr_client_provider_bootstrap_test.dart
@@ -1,0 +1,100 @@
+// ABOUTME: Tests the bootstrap kind:10002 publish gate in NostrService.
+// ABOUTME: Only an indexer acceptance may report the relay list as published.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/relay/publish_outcome.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/services/relay_discovery_service.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _FakeEvent extends Fake implements Event {}
+
+void main() {
+  const primaryRelay = 'wss://relay.divine.video';
+  final indexer = IndexerRelayConfig.defaultIndexers.first;
+
+  setUpAll(() {
+    registerFallbackValue(_FakeEvent());
+  });
+
+  group('NostrService.bootstrapCallbackFor', () {
+    late _MockNostrClient client;
+    late Event event;
+    late List<String> targets;
+
+    setUp(() {
+      client = _MockNostrClient();
+      event = _FakeEvent();
+      targets = [primaryRelay, ...IndexerRelayConfig.defaultIndexers];
+    });
+
+    void stubOutcome(PublishOutcome outcome) {
+      when(
+        () => client.publishEventAwaitOk(
+          any(),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((_) async => outcome);
+    }
+
+    test('reports not-published when only the Divine relay accepted', () async {
+      // The caller records a permanent "already bootstrapped" flag on true,
+      // and discovery never queries the Divine relay — so accepting this
+      // would strand the user on the fallback relay set forever.
+      stubOutcome(
+        const PublishOutcome(
+          eventId: 'bootstrap-event',
+          acceptedBy: [primaryRelay],
+          rejectedBy: {},
+          noResponseFrom: [],
+          unreachableTargets: IndexerRelayConfig.defaultIndexers,
+        ),
+      );
+
+      expect(
+        await NostrService.bootstrapCallbackFor(client)(event, targets),
+        isFalse,
+      );
+    });
+
+    test('reports published when one indexer accepted', () async {
+      stubOutcome(
+        PublishOutcome(
+          eventId: 'bootstrap-event',
+          acceptedBy: [primaryRelay, indexer],
+          rejectedBy: const {},
+          noResponseFrom: const [],
+          unreachableTargets: IndexerRelayConfig.defaultIndexers
+              .where((relay) => relay != indexer)
+              .toList(),
+        ),
+      );
+
+      expect(
+        await NostrService.bootstrapCallbackFor(client)(event, targets),
+        isTrue,
+      );
+    });
+
+    test('reports not-published when nothing accepted', () async {
+      stubOutcome(
+        PublishOutcome(
+          eventId: 'bootstrap-event',
+          acceptedBy: const [],
+          rejectedBy: const {},
+          noResponseFrom: const [],
+          unreachableTargets: targets,
+        ),
+      );
+
+      expect(
+        await NostrService.bootstrapCallbackFor(client)(event, targets),
+        isFalse,
+      );
+    });
+  });
+}

--- a/mobile/test/services/account_deletion_service_test.dart
+++ b/mobile/test/services/account_deletion_service_test.dart
@@ -59,12 +59,15 @@ const _rejected = PublishOutcome(
   noResponseFrom: <String>[],
 );
 
-/// No relay answered before the timeout.
+/// The relay received the event and never answered before the timeout.
+///
+/// A targeted relay always lands in one of the outcome's buckets, so leaving
+/// all of them empty would describe a publish with no targets at all.
 const _noRelayResponse = PublishOutcome(
   eventId: 'unreachable',
   acceptedBy: <String>[],
   rejectedBy: <String, String>{},
-  noResponseFrom: <String>[],
+  noResponseFrom: <String>['wss://relay.example.com'],
 );
 
 void main() {

--- a/mobile/test/services/content_deletion_service_test.dart
+++ b/mobile/test/services/content_deletion_service_test.dart
@@ -84,6 +84,25 @@ void main() {
       noResponseFrom: const ['wss://backup-relay.test'],
     );
 
+    /// One relay took the deletion and another refused it, so the video is
+    /// gone from part of the network and still live on the rest.
+    PublishOutcome partiallyAccepted(String eventId) => PublishOutcome(
+      eventId: eventId,
+      acceptedBy: const ['wss://relay.test'],
+      rejectedBy: const {'wss://backup-relay.test': 'blocked: policy'},
+      noResponseFrom: const [],
+    );
+
+    /// One relay took the deletion and a second target was never reached.
+    PublishOutcome acceptedWithUnreachableTarget(String eventId) =>
+        PublishOutcome(
+          eventId: eventId,
+          acceptedBy: const ['wss://relay.test'],
+          rejectedBy: const {},
+          noResponseFrom: const [],
+          unreachableTargets: const ['wss://offline-relay.test'],
+        );
+
     test('parseDeletionHistory reads persisted deletion records', () {
       final deletedAt = DateTime.utc(2026);
       final historyJson = jsonEncode([
@@ -417,6 +436,95 @@ void main() {
           expect(result.error, contains('blocked: policy'));
           expect(service.hasBeenDeleted(video.id), isFalse);
           expect(service.deletionHistory, isEmpty);
+        },
+      );
+
+      test(
+        'fails with relayPartial and does NOT save locally when one relay '
+        'accepts and another rejects',
+        () async {
+          final video = createTestVideoEvent(testPublicKey);
+          final deleteEvent = createTestEvent(
+            pubkey: testPublicKey,
+            kind: 5,
+            tags: [
+              ['e', video.id],
+              ['a', video.addressableId!],
+              ['k', '34236'],
+            ],
+            content: 'CONTENT DELETION',
+          );
+
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => deleteEvent);
+
+          when(
+            () => mockNostrService.publishEventAwaitOk(
+              any(),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => partiallyAccepted(deleteEvent.id));
+
+          final result = await service.deleteContent(
+            video: video,
+            reason: 'Personal choice',
+          );
+
+          expect(result.success, isFalse);
+          expect(result.failureKind, equals(DeleteFailureKind.relayPartial));
+          // Keeping the video locally is what leaves the retry available;
+          // nothing else republishes to the relay that refused.
+          expect(service.hasBeenDeleted(video.id), isFalse);
+          expect(service.deletionHistory, isEmpty);
+          verifyNever(() => mockProfileStatsDao.deleteStats(any()));
+        },
+      );
+
+      test(
+        'fails with relayPartial when a targeted relay was never reached',
+        () async {
+          final video = createTestVideoEvent(testPublicKey);
+          final deleteEvent = createTestEvent(
+            pubkey: testPublicKey,
+            kind: 5,
+            tags: [
+              ['e', video.id],
+              ['a', video.addressableId!],
+              ['k', '34236'],
+            ],
+            content: 'CONTENT DELETION',
+          );
+
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => deleteEvent);
+
+          when(
+            () => mockNostrService.publishEventAwaitOk(
+              any(),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer(
+            (_) async => acceptedWithUnreachableTarget(deleteEvent.id),
+          );
+
+          final result = await service.deleteContent(
+            video: video,
+            reason: 'Personal choice',
+          );
+
+          expect(result.success, isFalse);
+          expect(result.failureKind, equals(DeleteFailureKind.relayPartial));
+          expect(service.hasBeenDeleted(video.id), isFalse);
         },
       );
 

--- a/mobile/test/services/content_deletion_service_test.dart
+++ b/mobile/test/services/content_deletion_service_test.dart
@@ -242,6 +242,7 @@ void main() {
           );
 
           expect(result.success, isTrue);
+          expect(result.acceptance, equals(DeleteAcceptance.everyRelay));
           expect(result.deleteEventId, equals(deleteEvent.id));
           expect(service.hasBeenDeleted(video.id), isTrue);
           expect(
@@ -440,8 +441,8 @@ void main() {
       );
 
       test(
-        'fails with relayPartial and does NOT save locally when one relay '
-        'accepts and another rejects',
+        'saves locally and reports someRelays when one relay accepts and '
+        'another rejects',
         () async {
           final video = createTestVideoEvent(testPublicKey);
           final deleteEvent = createTestEvent(
@@ -475,18 +476,22 @@ void main() {
             reason: 'Personal choice',
           );
 
-          expect(result.success, isFalse);
-          expect(result.failureKind, equals(DeleteFailureKind.relayPartial));
-          // Keeping the video locally is what leaves the retry available;
-          // nothing else republishes to the relay that refused.
-          expect(service.hasBeenDeleted(video.id), isFalse);
-          expect(service.deletionHistory, isEmpty);
-          verifyNever(() => mockProfileStatsDao.deleteStats(any()));
+          // The tombstone exists on a relay, so the video leaves this device's
+          // library. Retrying would only re-ask the relay that refused, which
+          // answers the same way.
+          expect(result.success, isTrue);
+          expect(result.acceptance, equals(DeleteAcceptance.someRelays));
+          expect(service.hasBeenDeleted(video.id), isTrue);
+          expect(service.deletionHistory, hasLength(1));
+          verify(
+            () => mockProfileStatsDao.deleteStats(testPublicKey),
+          ).called(1);
         },
       );
 
       test(
-        'fails with relayPartial when a targeted relay was never reached',
+        'saves locally and reports someRelays when a targeted relay was never '
+        'reached',
         () async {
           final video = createTestVideoEvent(testPublicKey);
           final deleteEvent = createTestEvent(
@@ -522,9 +527,13 @@ void main() {
             reason: 'Personal choice',
           );
 
-          expect(result.success, isFalse);
-          expect(result.failureKind, equals(DeleteFailureKind.relayPartial));
-          expect(service.hasBeenDeleted(video.id), isFalse);
+          // The unreachable relay is the case that used to strand the user:
+          // a pool member the client never connected to stays in the target
+          // set on every retry, so gating on all-of-them made the video
+          // permanently undeletable.
+          expect(result.success, isTrue);
+          expect(result.acceptance, equals(DeleteAcceptance.someRelays));
+          expect(service.hasBeenDeleted(video.id), isTrue);
         },
       );
 

--- a/mobile/test/utils/delete_result_localization_test.dart
+++ b/mobile/test/utils/delete_result_localization_test.dart
@@ -1,0 +1,143 @@
+// ABOUTME: Tests the DeleteResult -> localized-string mapping for deletes.
+// ABOUTME: Pins that only a partly-accepted delete gets the caveat copy.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/services/content_deletion_service.dart';
+import 'package:openvine/utils/delete_result_localization.dart';
+
+void main() {
+  Future<BuildContext> pumpContext(
+    WidgetTester tester, {
+    Locale locale = const Locale('en'),
+  }) async {
+    late BuildContext captured;
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: locale,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) {
+            captured = context;
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+    return captured;
+  }
+
+  group('localizedPartialDeleteMessage', () {
+    testWidgets('returns the caveat copy when only some relays accepted', (
+      tester,
+    ) async {
+      final context = await pumpContext(tester);
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      expect(
+        localizedPartialDeleteMessage(
+          context,
+          DeleteResult.createSuccess(
+            'delete-event-id',
+            acceptance: DeleteAcceptance.someRelays,
+          ),
+        ),
+        equals(l10n.shareMenuDeletePartiallyConfirmed),
+      );
+    });
+
+    testWidgets('returns null when every relay accepted', (tester) async {
+      final context = await pumpContext(tester);
+
+      expect(
+        localizedPartialDeleteMessage(
+          context,
+          DeleteResult.createSuccess(
+            'delete-event-id',
+            acceptance: DeleteAcceptance.everyRelay,
+          ),
+        ),
+        isNull,
+      );
+    });
+
+    testWidgets('returns null for a failed delete and for no result at all', (
+      tester,
+    ) async {
+      final context = await pumpContext(tester);
+
+      expect(
+        localizedPartialDeleteMessage(
+          context,
+          DeleteResult.failure('nope', DeleteFailureKind.relayRejected),
+        ),
+        isNull,
+      );
+      expect(localizedPartialDeleteMessage(context, null), isNull);
+    });
+
+    testWidgets('reads the caveat from l10n rather than a hardcoded string', (
+      tester,
+    ) async {
+      final context = await pumpContext(tester, locale: const Locale('de'));
+
+      expect(
+        localizedPartialDeleteMessage(
+          context,
+          DeleteResult.createSuccess(
+            'delete-event-id',
+            acceptance: DeleteAcceptance.someRelays,
+          ),
+        ),
+        equals(
+          lookupAppLocalizations(
+            const Locale('de'),
+          ).shareMenuDeletePartiallyConfirmed,
+        ),
+      );
+    });
+  });
+
+  group('localizedDeleteFailureMessage', () {
+    testWidgets('maps every failure kind to distinct, non-empty copy', (
+      tester,
+    ) async {
+      final context = await pumpContext(tester);
+
+      final messages = DeleteFailureKind.values
+          .map(
+            (kind) => localizedDeleteFailureMessage(
+              context,
+              DeleteResult.failure('diagnostic', kind),
+            ),
+          )
+          .toList();
+
+      expect(messages.every((m) => m.isNotEmpty), isTrue);
+      expect(
+        messages.toSet(),
+        hasLength(messages.length),
+        reason: 'two failure kinds resolve to the same copy',
+      );
+    });
+
+    testWidgets('returns an empty string for a successful delete', (
+      tester,
+    ) async {
+      final context = await pumpContext(tester);
+
+      expect(
+        localizedDeleteFailureMessage(
+          context,
+          DeleteResult.createSuccess(
+            'delete-event-id',
+            acceptance: DeleteAcceptance.someRelays,
+          ),
+        ),
+        isEmpty,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description

`publishEventAwaitOk` is documented as the primitive for "deletions, critical profile updates", but its tracker completed on the **first** relay response and then hard-closed, discarding everything after. A caller could not tell *"1 of 5 relays accepted, 4 refused"* from *"5 of 5 accepted"* — and the relay that refused was recorded as **silent** rather than **rejecting**.

This is not a corner case. Divine accounts are provisioned without a published relay list, so NIP-65 discovery misses, the four third-party fallback relays (`damus.io`, `nos.lol`, `primal.net`, `nos.social`) are added through the *persisting* path, and nothing ever removes them. Deletions publish with no `targetRelays`, so a normal user's delete fans out to ~5 relays and whichever answers first decides what they are told.

Reproduced against the live relay before the fix — one permissive relay and one real `funnelcake-relay`, same kind-5 deletion:

```
B permissive          OK=true                                              (+10.1ms)
A funnelcake (real)   OK=false  "blocked: delete targets non-existent events"  (+15.0ms)
```

The permissive relay won by 5ms, so the user was told "deleted" while the relay the app actually reads from had explicitly refused. And because `ContentDeletionService` picks its failure message by whether `rejectedBy` is empty, that branch could never observe the refusal.

Same scenario on this branch:

```
accepted:  [ws://127.0.0.1:47811]
rejected:  {ws://localhost:47777: blocked: delete targets non-existent events}
acceptedByAll=false  acceptedByPartial=true  summary="accepted by 1 of 2 relays"
```

### What changed

Four defects sat at one site:

* **First-accept hard close.** `onAccepted` called `_complete()`, which set `_closed` and made every later frame a no-op. Completion now waits for every relay the fan-out reached, bounded by a one-second settle window after the first answer so a single wedged relay cannot stall a publish for the full timeout. Healthy relays answer in single-digit milliseconds, so the window costs effectively nothing — and the caller already blocked on the full sequential fan-out anyway, so first-accept was never actually buying latency.
* **The denominator was built backwards.** The tracker was constructed with an *empty* `expectedRelays`, filled incrementally from send results during a sequential fan-out. `0 >= 0` let any early signal close an un-armed tracker, and a target the pool failed to write to vanished from the outcome entirely. The target set is now resolved *before* the fan-out starts, and unreachable targets are reported instead of disappearing.
* **No membership check.** OK frames were routed by event id alone, so any connected relay could accept or reject a publish it was never sent. For a full-pool delete a hostile relay holds the event id anyway, so this is primarily a correctness fix; it matters for narrowly targeted publishes such as DMs.
* **`cancel()` snapshotted differently** from a normal completion, so a partial-accept shutdown could list the same relay as both accepted and unanswered. It now shares one code path.

Deleting a video now requires every relay it reached to accept, and reports the new `relayPartial` state when only some do — true and actionable, since republishing the same kind 5 is safe (a relay that already has it answers `OK true` again). A delete that is not fully confirmed is still not persisted locally, which keeps the video visible and the retry available.

Also fixes the relay-list bootstrap, which set its one-shot "already published" flag on a **WebSocket write** rather than a relay acceptance. That is *why* users end up pinned to the 5-relay fallback: if the indexers silently drop the kind 10002, the flag is set anyway and the bootstrap never retries on that device.

### What this does NOT give you

**Acceptance is not durability, and nothing here changes that.** NIP-01 defines `OK true` as "accepted by the relay" — its own example of a valid `OK true` carries the reason `duplicate: already have this event`. Divine's relay acknowledges from an in-memory queue and commits to ClickHouse on a batch interval afterwards; a failed insert produces no negative acknowledgement of any kind. Even `acceptedByAll` is a statement about **breadth of acceptance**. The docs now say so, and nothing should present it to a user as "saved".

There is also no repair path: no federation, no deployed relay-sync, NIP-77 off in production, and no client outbox. A relay that did not accept never gets the event. That is exactly why a partial publish is surfaced rather than smoothed over.

**Related Issue:** Closes #3366, Closes #3178

## Out of Scope

- **#6215** (account deletion) and **#6436** (blocklist) — this PR gives them the primitive they need but does not migrate them. Both still report success on a socket write.
- The 34 fire-and-forget `publishEvent` call sites, of which at least 11 turn a frame-accept into user-visible or persisted success. The correctly fire-and-forget set (view events, feed tuning, NIP-17 self-wrap) stays as-is.
- `video_event_publisher` keeps its deliberate opt-out from OK-confirmation; that decision was made on purpose with a stated rationale and is not reversed here as a side effect.
- `retry_policy.dart` from the old #3177 branch ports cleanly but has no consumer, so it is deliberately not brought over as unused foundation.
- Four adjacent defects found while investigating are filed separately rather than folded in.

## Verification

- `flutter analyze lib test integration_test` — clean
- `nostr_sdk` 412 tests, `nostr_client` 297, `dm_repository` 551 — all green
- All 16 app test files touching `PublishOutcome` / `publishEventAwaitOk` — 197 tests green
- `test/l10n/arb_consistency_test.dart` green; new key translated into all 22 locales
- `check_untested_services_floor.sh` and `check_test_unit_structure.sh` — no new entries
- End-to-end against a live local `funnelcake-relay` plus a permissive stand-in, output quoted above

Tests are anchored on a **partition invariant** — every targeted relay appears in exactly one of `acceptedBy` / `rejectedBy` / `noResponseFrom` / `unreachableTargets`, and no other relay appears at all. That single assertion catches all three outcome-shaping defects, and is the test that would have caught this in April 2026.

Note `publish_outcome_test.dart`'s old first test was **deleted rather than rewritten**: it asserted "completes immediately once any relay confirms, leaving the rest in noResponseFrom" — it pinned the bug as intended behaviour.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
