### PR TITLE
fix(ci): derive the iOS build number from App Store Connect

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -231,8 +231,33 @@ definitions:
     - &build_ios
       name: Build and sign iOS
       script: |
-        # Offset to continue from existing manual builds
+        # App Store Connect is the source of truth, mirroring the Play lookup in
+        # the AAB step. Apple rejects any upload whose build number does not
+        # exceed the last one accepted for the version train, and it does so
+        # *after* the upload succeeds — so a stale number costs a full build and
+        # an emailed rejection rather than a fast failure.
+        #
+        # PROJECT_BUILD_NUMBER + 142 stays as a floor for when the lookup fails.
+        # It cannot be the primary source: it tracks Codemagic's own counter, so
+        # any build uploaded from elsewhere leaves it behind permanently. That is
+        # how it ended up at 531 against a shipped 819 (#6587).
+        APP_STORE_APP_ID=6747959501 # co.openvine.app
+        LATEST_IOS_BUILD_NUMBER=$(app-store-connect get-latest-build-number "$APP_STORE_APP_ID" 2>/dev/null || true)
         BUILD_NUMBER=$((PROJECT_BUILD_NUMBER + 142))
+        case "$LATEST_IOS_BUILD_NUMBER" in
+          ''|*[!0-9]*)
+            echo "WARNING: could not read the latest App Store Connect build number."
+            echo "         Falling back to PROJECT_BUILD_NUMBER + 142 = $BUILD_NUMBER,"
+            echo "         which Apple will reject if it is not above the last upload."
+            ;;
+          *)
+            NEXT_IOS_BUILD_NUMBER=$((LATEST_IOS_BUILD_NUMBER + 1))
+            if [ "$NEXT_IOS_BUILD_NUMBER" -gt "$BUILD_NUMBER" ]; then
+              BUILD_NUMBER=$NEXT_IOS_BUILD_NUMBER
+            fi
+            ;;
+        esac
+        echo "iOS build number: $BUILD_NUMBER (App Store Connect latest: ${LATEST_IOS_BUILD_NUMBER:-unknown})"
         flutter build ipa --release --build-number=$BUILD_NUMBER \
           --dart-define=ZENDESK_APP_ID=$ZENDESK_APP_ID \
           --dart-define=ZENDESK_CLIENT_ID=$ZENDESK_CLIENT_ID \


### PR DESCRIPTION
Closes #6587

## Summary

iOS build 389 uploaded to App Store Connect and then vanished — a 15-minute wait, *"the corresponding build is not available in App Store Connect"*, and `post-processing failed`. The binary was fine; Apple rejected it during processing because its build number did not exceed the last one accepted for the version train.

The number is derived from Codemagic's own counter plus a fixed offset, which reads neither `pubspec.yaml` nor App Store Connect. This makes it read the store instead, exactly as the Android path in the same file already does.

## What Changed

The offset tracks a counter that no other uploader increments, so a single build shipped from anywhere else leaves it behind permanently — and nothing brings it back. It reached **531** against a shipped **819**.

```
marketing 1.0.19: builds ['819']    ← uploaded 2026-07-27
marketing 1.0.18: builds ['818']
marketing 1.0.17: builds ['815', '813', '812', '809', '808']
```

The offset cannot have produced 819 (that needs `PROJECT_BUILD_NUMBER` = 677, and the counter only increases), which is what the *"continue from existing manual builds"* comment was always describing.

- `app-store-connect get-latest-build-number` is now the primary source; the build takes whichever of that+1 and the old formula is higher.
- The offset stays as a floor for a failed lookup, with a warning that says plainly that Apple will reject it if it is not above the last upload. There is nothing better to fall back to, and failing the build outright on a transient API blip is worse than the Android path's behaviour, which this mirrors.
- The resolved number is echoed alongside what App Store Connect reported, so the next person debugging this does not have to infer it.

No new credentials: the CLI ships in the codemagic-cli-tools already on the builder (0.69.0 in the failing log), and `ios-build` already declares the `app_store_connect` integration.

This is the second time the number has drifted. #6470 resynced `pubspec.yaml` and the Xcode project from 508 → 819 three weeks ago; that corrected the recorded numbers but not the mechanism producing them, so it resumed immediately.

## Testing

The lookup returns a bare integer (verified live against the app: `819`), so the existing Android `case` guard works unchanged.

The build-number block was extracted from the parsed YAML and exercised against a stubbed `app-store-connect` across every branch:

| scenario | latest | counter | build number |
|---|---|---|---|
| today's real case | 819 | 389 | **820** |
| lookup fails | — | 389 | 531 + warning |
| store behind the offset | 100 | 389 | 531 |
| garbage output | `error: nope` | 389 | 531 + warning |
| counter ahead of store | 819 | 900 | 1042 |

`codemagic.yaml` also confirmed to parse.

Not covered: no CI runs this file, so the real proof is the next iOS build. It should report `iOS build number: 820 (App Store Connect latest: 819)`.

## Risks

Low, and contained to iOS release automation. The number can only move upward relative to today's behaviour — the offset is a floor, never a ceiling — so the failure mode this replaces cannot recur while the lookup works. If the lookup breaks, behaviour is exactly what it is today, plus a warning.

## Follow-ups

CI still never writes the resolved number back to the repo, so `pubspec.yaml` and `project.pbxproj` will drift from TestFlight again. Cosmetic for iOS since nothing reads them, but it is what made #6470 necessary, and worth a separate decision rather than a silent third resync.
