### PR TITLE
fix(ios): add NSSpeechRecognitionUsageDescription to Info.plist

### DIFF
--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -91,6 +91,13 @@
 	<string>Photo library access is needed to save exported videos to your library.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Photo library access is needed to pick and share your videos.</string>
+	<!-- Required by ITMS-90683: a linked third-party SDK references
+	     Apple's speech recognition APIs. Divine itself never starts a
+	     speech recognition request, so this prompt is not expected to
+	     appear, but the purpose string is mandatory for App Store
+	     submission whenever the binary references those APIs. -->
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Divine does not use speech recognition. This permission is only requested if a feature you start needs to turn speech in your recording into text.</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
Closes #6590

## What

Adds the `NSSpeechRecognitionUsageDescription` purpose string to `mobile/ios/Runner/Info.plist`.

## Why

App Store Connect rejected the 1.0.19 (821) delivery:

> ITMS-90683: Missing purpose string in Info.plist — The Info.plist file for the "Runner.app" bundle should contain a NSSpeechRecognitionUsageDescription key with a user-facing purpose string.

Divine's own code never starts a speech recognition request (no `SFSpeechRecognizer` usage in `lib/`, `packages/`, or `ios/Runner/`) — a linked third-party SDK references the API. Apple requires the purpose string regardless of whether the app calls it, so this unblocks upload.

## Notes

- Copy is honest about the app not driving speech recognition itself, per Apple's requirement that the string explain the access clearly.
- `plutil -lint mobile/ios/Runner/Info.plist` → OK.
- No Dart/CI-guarded surface touched; no test changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)