### PR TITLE
fix(local-stack): harden diagnostic preflight checks

### DIFF
--- a/local_stack/preflight.sh
+++ b/local_stack/preflight.sh
@@ -49,16 +49,35 @@ _stack_project_name() {
 
 # stdout: one "<address>:<port>" per listening TCP socket.
 # `ss` is iproute2, so it does not exist on macOS; `lsof` is there instead.
-# Returns 1 when neither is installed, so the caller can say so rather than
-# read "no listeners found" as "every port is free".
+# Returns 1 when neither is installed. Returns 2 when an available tool errors,
+# so the caller can fail closed instead of treating the result as port-free.
 _stack_listen_addrs() {
+    local tool_err tool_rc
     if command -v ss >/dev/null 2>&1; then
-        ss -Hltn 2>/dev/null | awk '{ print $4 }'
+        tool_err="$(mktemp)"
+        ss -Hltn 2>"$tool_err" | awk '{ print $4 }'
+        tool_rc="${PIPESTATUS[0]}"
+        if [[ "$tool_rc" -ne 0 ]]; then
+            [[ ! -s "$tool_err" ]] || sed 's/^/WARNING: ss failed while enumerating listeners: /' "$tool_err" >&2
+            rm -f "$tool_err"
+            return 2
+        fi
+        rm -f "$tool_err"
     elif command -v lsof >/dev/null 2>&1; then
         # -Fn emits one "n<address>:<port>" record per socket, which spares us
         # the header line and the space-separated NAME column. Without sudo it
         # only sees our own processes — enough for Docker Desktop's proxy.
-        lsof -nP -iTCP -sTCP:LISTEN -Fn 2>/dev/null | sed -n 's/^n//p'
+        tool_err="$(mktemp)"
+        lsof -nP -iTCP -sTCP:LISTEN -Fn 2>"$tool_err" | sed -n 's/^n//p'
+        tool_rc="${PIPESTATUS[0]}"
+        # lsof exits 1 when no sockets match. That is a clean empty listener
+        # list as long as stderr is empty; stderr means the check is blind.
+        if [[ "$tool_rc" -ne 0 && -s "$tool_err" ]]; then
+            sed 's/^/WARNING: lsof failed while enumerating listeners: /' "$tool_err" >&2
+            rm -f "$tool_err"
+            return 2
+        fi
+        rm -f "$tool_err"
     else
         return 1
     fi
@@ -83,7 +102,7 @@ _stack_port_finder_cmd() {
 # containers; 1 (with an actionable report on stderr) otherwise.
 preflight_ports() {
     local compose_file="$1"
-    local config_json project ports
+    local config_json config_err project ports
 
     if ! docker ps --format '{{.Names}}' >/dev/null 2>&1; then
         local daemon_hint="systemctl status docker"
@@ -94,11 +113,14 @@ preflight_ports() {
         return 1
     fi
 
-    if ! config_json="$(docker compose -f "$compose_file" config --format json 2>&1)"; then
+    config_err="$(mktemp)"
+    if ! config_json="$(docker compose -f "$compose_file" config --format json 2>"$config_err")"; then
         echo "ERROR: could not parse ${compose_file}:" >&2
-        echo "$config_json" >&2
+        cat "$config_err" >&2
+        rm -f "$config_err"
         return 1
     fi
+    rm -f "$config_err"
 
     # Fail closed. An unreadable port list is indistinguishable from "the stack
     # publishes no ports", and passing on it hands the operator back the
@@ -127,7 +149,7 @@ preflight_ports() {
     # port -> space-separated local addresses currently listening on it
     local listen_addrs=()
     local listeners_known=1
-    local listener_lines local_addr port
+    local listener_lines listener_rc local_addr port
     if listener_lines="$(_stack_listen_addrs)"; then
         while read -r local_addr; do
             port="${local_addr##*:}"
@@ -135,6 +157,11 @@ preflight_ports() {
             listen_addrs["$port"]+="${local_addr} "
         done <<<"$listener_lines"
     else
+        listener_rc=$?
+        if [[ "$listener_rc" -eq 2 ]]; then
+            echo "ERROR: could not enumerate host TCP listeners; port safety is unknown." >&2
+            return 1
+        fi
         listeners_known=0
     fi
 
@@ -158,8 +185,8 @@ preflight_ports() {
     if ((listeners_known == 0)); then
         {
             echo ""
-            echo "WARNING: neither 'ss' nor 'lsof' is installed, so a port held by a"
-            echo "         plain host process cannot be detected. Ports held by"
+            echo "WARNING: host listener enumeration is unavailable, so a port held by"
+            echo "         a plain host process cannot be detected. Ports held by"
             echo "         containers are still checked below."
         } >&2
     fi

--- a/local_stack/test_stack_scripts.sh
+++ b/local_stack/test_stack_scripts.sh
@@ -86,6 +86,7 @@ cat >"${BIN}/docker" <<'STUB'
 set -u
 
 emit() { [[ -f "$1" ]] && cat "$1"; return 0; }
+emit_err() { [[ -f "$1" ]] && cat "$1" >&2; return 0; }
 
 # Exit code for a stubbed subcommand, 0 unless the case asked otherwise.
 stub_rc() {
@@ -110,12 +111,27 @@ case "${1:-}" in
     while (($# > 0)); do
       case "$1" in
         config)
+          emit_err "${STUB_FIXTURES}/compose_config.stderr"
           emit "${STUB_FIXTURES}/compose_config.json"
-          exit 0
+          exit "$(stub_rc config)"
           ;;
         up)
+          up_count_file="${STUB_FIXTURES}/up_count"
+          if [[ -f "$up_count_file" ]]; then
+            up_count="$(cat "$up_count_file")"
+          else
+            up_count=0
+          fi
+          up_count=$((up_count + 1))
+          echo "$up_count" >"$up_count_file"
+          emit "${STUB_FIXTURES}/up_output_${up_count}.txt"
           emit "${STUB_FIXTURES}/up_output.txt"
-          exit "$(stub_rc up)"
+          if [[ -f "${STUB_FIXTURES}/rc_up_${up_count}" ]]; then
+            up_rc="$(cat "${STUB_FIXTURES}/rc_up_${up_count}")"
+          else
+            up_rc="$(stub_rc up)"
+          fi
+          exit "$up_rc"
           ;;
         run)
           emit "${STUB_FIXTURES}/seed_output.txt"
@@ -150,18 +166,32 @@ chmod +x "${BIN}/docker"
 cat >"${BIN}/ss.stub" <<'STUB'
 #!/usr/bin/env bash
 # `ss -Hltn`: State Recv-Q Send-Q Local Peer
-cat "${STUB_FIXTURES}/ss.txt" 2>/dev/null
+[[ -f "${STUB_FIXTURES}/ss.stderr" ]] && cat "${STUB_FIXTURES}/ss.stderr" >&2
+[[ -f "${STUB_FIXTURES}/ss.txt" ]] && cat "${STUB_FIXTURES}/ss.txt"
+if [[ -f "${STUB_FIXTURES}/rc_ss" ]]; then
+  exit "$(cat "${STUB_FIXTURES}/rc_ss")"
+fi
 exit 0
 STUB
 
 cat >"${BIN}/lsof.stub" <<'STUB'
 #!/usr/bin/env bash
 # `lsof -nP -iTCP -sTCP:LISTEN -Fn`: one n<address>:<port> record per socket.
-cat "${STUB_FIXTURES}/lsof.txt" 2>/dev/null
+[[ -f "${STUB_FIXTURES}/lsof.stderr" ]] && cat "${STUB_FIXTURES}/lsof.stderr" >&2
+[[ -f "${STUB_FIXTURES}/lsof.txt" ]] && cat "${STUB_FIXTURES}/lsof.txt"
+if [[ -f "${STUB_FIXTURES}/rc_lsof" ]]; then
+  exit "$(cat "${STUB_FIXTURES}/rc_lsof")"
+fi
 exit 0
 STUB
 
 link_core_tools
+
+cat >"${BIN}/sleep" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "${BIN}/sleep"
 
 # with_tools <tool>... — exactly these of ss/lsof exist for the next run.
 with_tools() {
@@ -262,7 +292,7 @@ run_preflight
 
 assert_status 1 "$last_status" "a container conflict should be caught with neither ss nor lsof"
 assert_stderr_contains 'held by container "stale-redis"' "the holding container should still be named"
-assert_stderr_contains "neither 'ss' nor 'lsof' is installed" "the blind spot should be stated out loud"
+assert_stderr_contains 'host listener enumeration is unavailable' "the blind spot should be stated out loud"
 
 # --- A host process holding a stack port ------------------------------------
 
@@ -307,6 +337,44 @@ with_tools lsof
 run_preflight
 
 assert_status 0 "$last_status" "a clean machine should pass pre-flight"
+
+# --- lsof's no-listeners status is not a tool failure -----------------------
+# lsof exits 1 with no stderr when no sockets match. That should stay a clean
+# empty listener list, not a blind-spot warning.
+
+reset_fixtures
+with_tools lsof
+: >"${FIXTURES}/docker_ps.txt"
+echo 1 >"${FIXTURES}/rc_lsof"
+run_preflight
+
+assert_status 0 "$last_status" "lsof exit 1 with empty stderr means no listeners"
+assert_stderr_lacks 'host listener enumeration is unavailable' "an empty lsof result should not warn"
+
+# --- A real listener-tool error is not an empty listener list ----------------
+
+reset_fixtures
+with_tools lsof
+: >"${FIXTURES}/docker_ps.txt"
+echo 1 >"${FIXTURES}/rc_lsof"
+echo 'lsof: unacceptable port specification' >"${FIXTURES}/lsof.stderr"
+run_preflight
+
+assert_status 1 "$last_status" "a real listener-tool error should fail pre-flight"
+assert_stderr_contains 'lsof failed while enumerating listeners' "the listener tool failure should be shown"
+assert_stderr_contains 'port safety is unknown' "the unknown host-port state should fail closed"
+
+# --- Compose config warnings are not JSON -----------------------------------
+
+reset_fixtures
+with_tools lsof
+: >"${FIXTURES}/docker_ps.txt"
+: >"${FIXTURES}/lsof.txt"
+echo 'WARN[0000] the attribute `version` is obsolete' >"${FIXTURES}/compose_config.stderr"
+run_preflight
+
+assert_status 0 "$last_status" "compose warnings on stderr should not corrupt the JSON config"
+assert_stderr_lacks 'could not read the published ports' "a compose warning should not become a JSON parse failure"
 
 # --- An unreadable port list fails closed -----------------------------------
 # Empty output from a broken extractor reads exactly like "publishes no ports".
@@ -366,6 +434,29 @@ echo 'dial tcp: i/o timeout' >"${FIXTURES}/logs_keycast.txt"
 
 run_transient "${tmp_dir}/up.log" keycast minio-init
 assert_status 1 "$last_status" "with every service up there is no failed log to call transient"
+
+# --- up.sh retries transient startup failures --------------------------------
+
+reset_fixtures
+with_tools lsof
+: >"${FIXTURES}/docker_ps.txt"
+: >"${FIXTURES}/lsof.txt"
+echo 1 >"${FIXTURES}/rc_up_1"
+echo 0 >"${FIXTURES}/rc_up_2"
+echo 'dependency failed to start' >"${FIXTURES}/up_output_1.txt"
+cat >"${FIXTURES}/compose_ps_pipe.txt" <<'PS'
+funnelcake-migrate|exited|1
+PS
+echo 'lookup funnelcake-clickhouse on 127.0.0.11:53: no such host' >"${FIXTURES}/logs_funnelcake-migrate.txt"
+echo 'seed ok' >"${FIXTURES}/seed_output.txt"
+run_up_sh
+
+assert_status 0 "$last_status" "up.sh should retry a transient startup failure and continue after success"
+if [[ "$(cat "${FIXTURES}/up_count")" != "2" ]]; then
+    fail "up.sh should stop retrying after a successful second attempt" \
+        "up attempts: $(cat "${FIXTURES}/up_count")"
+fi
+assert_stderr_contains 'Retrying in 5s (attempt 2 of 3).' "the retry should be announced"
 
 # --- A failed seed reports the seed, not the healthy services ---------------
 # The services came up; saying "Local stack failed to come up" over a list of

--- a/mobile/mise.toml
+++ b/mobile/mise.toml
@@ -52,6 +52,13 @@ bash ../local_stack/up.sh
 description = "First-time setup for local E2E"
 run = "bash ../local_stack/setup.sh"
 
+[tasks.test_local_stack_scripts]
+description = "Run local stack shell script checks"
+run = """
+bash ../local_stack/test_stack_scripts.sh
+bash ../local_stack/test_android_scripts.sh
+"""
+
 [tasks.local_token]
 description = "Get verification token for an email from local DB"
 run = """


### PR DESCRIPTION
## Summary

- keep docker compose config stderr out of the JSON parsed by local_stack/preflight.sh
- fail closed when ss/lsof listener enumeration errors, while preserving lsof's no-listeners exit behavior
- cover the up.sh transient retry loop and expose both local stack script suites through mise

Fixes #6608

## Verification

- bash local_stack/test_stack_scripts.sh
- bash local_stack/test_android_scripts.sh
- mise run test_local_stack_scripts

Note: the mise command passed but emitted a non-fatal sandbox warning while trying to track trusted config state outside the worktree.
