### PR TITLE
fix(nostr): stop offline relays from making every publish look partial

### DIFF
--- a/mobile/lib/services/content_deletion_service.dart
+++ b/mobile/lib/services/content_deletion_service.dart
@@ -265,10 +265,10 @@ class ContentDeletionService {
 
       // One acceptance is the bar, not all of them. NIP-09 deletion is a
       // request relays SHOULD honour, so no acknowledgement proves the video
-      // is gone — requiring every relay buys a guarantee that does not exist
-      // and costs the user the feature, because the target set includes pool
-      // members the client never connected to and nothing here republishes.
-      // Breadth is reported on [DeleteResult.acceptance] instead.
+      // is gone. Requiring every targeted relay buys a guarantee that does not
+      // exist and costs the user the feature when a relay rejects, times out, or
+      // cannot be reached. Breadth is reported on [DeleteResult.acceptance]
+      // instead.
       if (publishOutcome.failed) {
         Log.error(
           'Delete publish not confirmed by any relay: '
@@ -321,10 +321,7 @@ class ContentDeletionService {
         name: 'ContentDeletionService',
         category: LogCategory.system,
       );
-      return DeleteResult.createSuccess(
-        deleteEvent.id,
-        acceptance: acceptance,
-      );
+      return DeleteResult.createSuccess(deleteEvent.id, acceptance: acceptance);
     } catch (e) {
       Log.error(
         'Failed to delete content: $e',

--- a/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
@@ -22,7 +22,10 @@ import 'dart:async';
 ///
 /// Every relay the publish targeted appears in exactly one of [acceptedBy],
 /// [rejectedBy], [noResponseFrom] or [unreachableTargets], and no other relay
-/// appears at all.
+/// appears at all. "Targeted" means every relay the fan-out reached, plus the
+/// ones it was supposed to reach and could not — a configured relay whose
+/// socket was down when the publish started was never asked, and does not
+/// appear (see [PublishTracker.countedTargets]).
 class PublishOutcome {
   const PublishOutcome({
     required this.eventId,
@@ -149,8 +152,9 @@ class PublishTracker {
     this.deadline,
     required this.expectedRelays,
     required Duration timeout,
+    Set<String>? countedTargets,
     this.settleWindow = defaultSettleWindow,
-  }) {
+  }) : countedTargets = countedTargets ?? expectedRelays {
     _timer = Timer(timeout, _onTimeout);
   }
 
@@ -185,12 +189,23 @@ class PublishTracker {
   /// Hard publish deadline shared with SDK-internal retry paths.
   final DateTime? deadline;
 
-  /// Every relay this publish intends to reach.
+  /// Every relay this publish may write to, and therefore every relay allowed
+  /// to answer it — see [isTarget].
   ///
   /// Computed before the fan-out starts, so it covers relays the pool later
-  /// fails to write to. Those are reported in
-  /// [PublishOutcome.unreachableTargets] instead of vanishing from the result.
+  /// fails to write to. Deliberately wider than [countedTargets]: a relay that
+  /// looks unwritable up front can still be reached (`send` waits out a
+  /// handshake in progress), and its `OK` must not be discarded.
   final Set<String> expectedRelays;
+
+  /// The relays an unwritten target is reported against.
+  ///
+  /// Defaults to [expectedRelays]. A caller narrows it to exclude relays that
+  /// were never going to be reached — a configured relay whose socket is down
+  /// was never asked, so counting it would make every publish read as partial.
+  /// Only [PublishOutcome.unreachableTargets] consults this; anything the
+  /// fan-out actually reached counts through [setReachable] regardless.
+  final Set<String> countedTargets;
 
   /// Grace period granted to the remaining relays after the first answer.
   final Duration settleWindow;
@@ -364,7 +379,7 @@ class PublishTracker {
         .toList(growable: false);
     // A relay that answered is never unreachable, even if the fan-out reported
     // its write as failed — the answer proves it got the frame.
-    final unreachable = expectedRelays
+    final unreachable = countedTargets
         .where((r) => !awaitable.contains(r) && !answered(r))
         .toList(growable: false);
     _completer.complete(

--- a/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
@@ -23,9 +23,10 @@ import 'dart:async';
 /// Every relay the publish targeted appears in exactly one of [acceptedBy],
 /// [rejectedBy], [noResponseFrom] or [unreachableTargets], and no other relay
 /// appears at all. "Targeted" means every relay the fan-out reached, plus the
-/// ones it was supposed to reach and could not — a configured relay whose
-/// socket was down when the publish started was never asked, and does not
-/// appear (see [PublishTracker.countedTargets]).
+/// relays it meant to count if a write failed. Configured relays that were
+/// plainly disconnected and never attempted do not appear, while relays whose
+/// in-flight connection was actually attempted can still be reported as
+/// unreachable (see [PublishTracker.countedTargets]).
 class PublishOutcome {
   const PublishOutcome({
     required this.eventId,
@@ -154,7 +155,7 @@ class PublishTracker {
     required Duration timeout,
     Set<String>? countedTargets,
     this.settleWindow = defaultSettleWindow,
-  }) : countedTargets = countedTargets ?? expectedRelays {
+  }) : _countedTargets = countedTargets ?? expectedRelays {
     _timer = Timer(timeout, _onTimeout);
   }
 
@@ -200,12 +201,13 @@ class PublishTracker {
 
   /// The relays an unwritten target is reported against.
   ///
-  /// Defaults to [expectedRelays]. A caller narrows it to exclude relays that
-  /// were never going to be reached — a configured relay whose socket is down
-  /// was never asked, so counting it would make every publish read as partial.
-  /// Only [PublishOutcome.unreachableTargets] consults this; anything the
-  /// fan-out actually reached counts through [setReachable] regardless.
-  final Set<String> countedTargets;
+  /// Defaults to [expectedRelays]. A caller narrows it up front to exclude
+  /// relays that were never going to be reached, then may add back relays the
+  /// fan-out actually attempted. Only [PublishOutcome.unreachableTargets]
+  /// consults this; anything the fan-out wrote to counts through [setReachable]
+  /// regardless.
+  Set<String> get countedTargets => _countedTargets;
+  Set<String> _countedTargets;
 
   /// Grace period granted to the remaining relays after the first answer.
   final Duration settleWindow;
@@ -261,9 +263,15 @@ class PublishTracker {
   ///
   /// Relays that were targeted but not reached stop being awaited and are
   /// reported as unreachable.
-  void setReachable(Iterable<String> reachable) {
+  void setReachable(
+    Iterable<String> reachable, {
+    Iterable<String>? countedTargets,
+  }) {
     if (_closed) return;
     _reachable = reachable.toSet();
+    if (countedTargets != null) {
+      _countedTargets = countedTargets.toSet();
+    }
     _fanOutReported = true;
     if (_timedOutBeforeFanOut) {
       _complete();
@@ -379,7 +387,7 @@ class PublishTracker {
         .toList(growable: false);
     // A relay that answered is never unreachable, even if the fan-out reported
     // its write as failed — the answer proves it got the frame.
-    final unreachable = countedTargets
+    final unreachable = _countedTargets
         .where((r) => !awaitable.contains(r) && !answered(r))
         .toList(growable: false);
     _completer.complete(

--- a/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
@@ -155,7 +155,7 @@ class PublishTracker {
     required Duration timeout,
     Set<String>? countedTargets,
     this.settleWindow = defaultSettleWindow,
-  }) : _countedTargets = countedTargets ?? expectedRelays {
+  }) : _countedTargets = countedTargets?.toSet() ?? expectedRelays.toSet() {
     _timer = Timer(timeout, _onTimeout);
   }
 
@@ -206,7 +206,7 @@ class PublishTracker {
   /// fan-out actually attempted. Only [PublishOutcome.unreachableTargets]
   /// consults this; anything the fan-out wrote to counts through [setReachable]
   /// regardless.
-  Set<String> get countedTargets => _countedTargets;
+  Set<String> get countedTargets => Set.unmodifiable(_countedTargets);
   Set<String> _countedTargets;
 
   /// Grace period granted to the remaining relays after the first answer.

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1722,7 +1722,8 @@ class RelayPool {
     );
   }
 
-  /// Every relay a publish with these parameters intends to reach.
+  /// Every relay a publish with these parameters intends to reach, split into
+  /// who may answer it and who counts towards its denominator.
   ///
   /// Mirrors the iteration [_sendCollect] performs, but resolves it *before*
   /// the fan-out starts so the set is complete even for relays the fan-out
@@ -1731,41 +1732,56 @@ class RelayPool {
   /// written to would be absent from the outcome entirely, and a publish could
   /// settle while later relays had not been attempted yet.
   ///
-  /// For an *unfiltered* `EVENT` fan-out a target must be connected as well as
-  /// write-enabled, matching [writable]. `writeAccess` is a config flag that
-  /// defaults to true, so counting on it alone made every configured-but-
+  /// `expected` is every write-enabled relay the fan-out may write to, and is
+  /// what [PublishTracker.isTarget] admits. It deliberately ignores connection
+  /// state: `relayStatus.connected` lags the socket it describes — it starts
+  /// at [ClientConnected.disconnect] and only advances when the state stream
+  /// delivers, and a relay retrying a dead host is [ClientConnected.connecting]
+  /// exactly like one whose first handshake is still in flight. Gating who may
+  /// answer on it would discard a real `OK true` from a healthy relay that
+  /// replied before the fan-out reported, since `send` waits out the
+  /// `connecting` state and writes anyway.
+  ///
+  /// `counted` narrows that to the relays a *failed* write should be reported
+  /// against, dropping the configured-but-offline ones. `writeAccess` is a
+  /// config flag that defaults to true, so counting on it alone made every
   /// offline relay a target that could only ever land in
   /// [PublishOutcome.unreachableTargets] — which on mobile, where some relay
   /// is nearly always down, left [PublishOutcome.acceptedByAll] permanently
-  /// false and reported every successful publish as partial. A relay the
-  /// fan-out *does* reach despite being disconnected is still counted:
-  /// [PublishTracker.setReachable] adds whatever was actually written to.
+  /// false and reported every successful publish as partial. Nothing the
+  /// fan-out actually reached drops out: [PublishTracker.setReachable] adds
+  /// whatever was written to, and those relays count however they answer.
   ///
-  /// [targetRelays] and [tempRelays] are exempt. Naming a relay is the caller
-  /// asserting intent for that specific relay, and "we never reached the one
-  /// you asked for" is the answer it wants — the kind:10002 bootstrap publish
-  /// names its indexers precisely so it can tell an unreached indexer from a
-  /// refusing one.
-  Set<String> _intendedPublishTargets(
+  /// [targetRelays] and [tempRelays] are exempt from the narrowing. Naming a
+  /// relay is the caller asserting intent for that specific relay, and "we
+  /// never reached the one you asked for" is the answer it wants — the
+  /// kind:10002 bootstrap publish names its indexers precisely so it can tell
+  /// an unreached indexer from a refusing one.
+  ({Set<String> expected, Set<String> counted}) _intendedPublishTargets(
     List<dynamic> message, {
     List<String>? tempRelays,
     List<String>? targetRelays,
   }) {
-    final targets = <String>{};
+    final expected = <String>{};
+    final counted = <String>{};
     final isEvent = message.isNotEmpty && message[0] == "EVENT";
     final hasFilter = targetRelays != null && targetRelays.isNotEmpty;
     for (final relay in _relaysSnapshot()) {
       if (isEvent && !relay.relayStatus.writeAccess) continue;
+      if (hasFilter && !targetRelays.contains(relay.url)) continue;
+      expected.add(relay.url);
       if (isEvent &&
           !hasFilter &&
           relay.relayStatus.connected != ClientConnected.connected) {
         continue;
       }
-      if (hasFilter && !targetRelays.contains(relay.url)) continue;
-      targets.add(relay.url);
+      counted.add(relay.url);
     }
-    if (tempRelays != null) targets.addAll(tempRelays);
-    return targets;
+    if (tempRelays != null) {
+      expected.addAll(tempRelays);
+      counted.addAll(tempRelays);
+    }
+    return (expected: expected, counted: counted);
   }
 
   /// Send an `EVENT` message and wait for `OK` confirmations from relays.
@@ -1802,17 +1818,19 @@ class RelayPool {
     }
     final sentAt = DateTime.now();
     final deadline = sentAt.add(timeout);
+    final targets = _intendedPublishTargets(
+      message,
+      tempRelays: tempRelays,
+      targetRelays: targetRelays,
+    );
     final tracker = PublishTracker(
       eventId: eventId,
       eventKind: eventKind ?? _eventKindFromMessage(message),
       diagnosticTag: diagnosticTag,
       message: message,
       deadline: deadline,
-      expectedRelays: _intendedPublishTargets(
-        message,
-        tempRelays: tempRelays,
-        targetRelays: targetRelays,
-      ),
+      expectedRelays: targets.expected,
+      countedTargets: targets.counted,
       timeout: timeout,
     );
     _pendingPublishes[eventId] = tracker;

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1455,12 +1455,12 @@ class RelayPool {
     List<String>? tempRelays,
     List<String>? targetRelays,
   }) async {
-    final sentTo = await _sendCollect(
+    final result = await _sendCollect(
       message,
       tempRelays: tempRelays,
       targetRelays: targetRelays,
     );
-    return sentTo.isNotEmpty;
+    return result.sentTo.isNotEmpty;
   }
 
   /// Same as [send] but returns the list of relay URLs the message reached.
@@ -1487,7 +1487,7 @@ class RelayPool {
   /// the publish call in their own outer guard should size that guard
   /// against `perRelaySendTimeout * configuredRelays.length` plus a small
   /// scheduling buffer.
-  Future<List<String>> _sendCollect(
+  Future<({List<String> sentTo, Set<String> attemptedRelayUrls})> _sendCollect(
     List<dynamic> message, {
     List<String>? tempRelays,
     List<String>? targetRelays,
@@ -1702,7 +1702,7 @@ class RelayPool {
       'send complete kind=$eventKind eventId=$eventId sentTo=$sentTo',
     );
 
-    return sentTo;
+    return (sentTo: sentTo, attemptedRelayUrls: attemptedRelayUrls);
   }
 
   /// Record how broadly a publish was accepted.
@@ -1742,15 +1742,17 @@ class RelayPool {
   /// replied before the fan-out reported, since `send` waits out the
   /// `connecting` state and writes anyway.
   ///
-  /// `counted` narrows that to the relays a *failed* write should be reported
-  /// against, dropping the configured-but-offline ones. `writeAccess` is a
-  /// config flag that defaults to true, so counting on it alone made every
+  /// `counted` starts as the relays a failed write should be reported against,
+  /// dropping configured relays that were plainly offline before the fan-out.
+  /// The fan-out then adds back relays it actually attempted, including ones
+  /// whose in-flight connection waited until the publish deadline. `writeAccess`
+  /// is a config flag that defaults to true, so counting on it alone made every
   /// offline relay a target that could only ever land in
   /// [PublishOutcome.unreachableTargets] — which on mobile, where some relay
   /// is nearly always down, left [PublishOutcome.acceptedByAll] permanently
   /// false and reported every successful publish as partial. Nothing the
-  /// fan-out actually reached drops out: [PublishTracker.setReachable] adds
-  /// whatever was written to, and those relays count however they answer.
+  /// fan-out actually reached or exhausted drops out: [PublishTracker.setReachable]
+  /// receives both the written relays and the attempted denominator.
   ///
   /// [targetRelays] and [tempRelays] are exempt from the narrowing. Naming a
   /// relay is the caller asserting intent for that specific relay, and "we
@@ -1843,16 +1845,19 @@ class RelayPool {
     // until this call arrives: a fan-out that threw would otherwise leave the
     // publish hanging.
     var sentTo = const <String>[];
+    var countedTargets = targets.counted;
     try {
-      sentTo = await _sendCollect(
+      final result = await _sendCollect(
         message,
         tempRelays: tempRelays,
         targetRelays: targetRelays,
         deadline: deadline,
         diagnosticTag: diagnosticTag,
       );
+      sentTo = result.sentTo;
+      countedTargets = {...targets.counted, ...result.attemptedRelayUrls};
     } finally {
-      tracker.setReachable(sentTo);
+      tracker.setReachable(sentTo, countedTargets: countedTargets);
     }
 
     unawaited(

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1551,6 +1551,8 @@ class RelayPool {
         }
       }
 
+      final sendStartedWhileConnecting =
+          relay.relayStatus.connected == ClientConnected.connecting;
       try {
         // Check if relay requires authentication
         if (relay.relayStatus.alwaysAuth && !relay.relayStatus.authed) {
@@ -1586,7 +1588,10 @@ class RelayPool {
                     return false;
                   },
                 );
-            if (result || timedOut || deadlineExpired()) {
+            if (result ||
+                timedOut ||
+                sendStartedWhileConnecting ||
+                deadlineExpired()) {
               attemptedRelayUrls.add(relay.url);
             }
             if (result) {
@@ -1636,7 +1641,10 @@ class RelayPool {
                   return false;
                 },
               );
-          if (result || timedOut || deadlineExpired()) {
+          if (result ||
+              timedOut ||
+              sendStartedWhileConnecting ||
+              deadlineExpired()) {
             attemptedRelayUrls.add(relay.url);
           }
           if (result) {
@@ -1647,6 +1655,9 @@ class RelayPool {
           );
         }
       } catch (err) {
+        if (sendStartedWhileConnecting) {
+          attemptedRelayUrls.add(relay.url);
+        }
         logDiagnostic(
           'send error kind=$eventKind eventId=$eventId relay=${relay.url} error=$err',
         );

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1730,6 +1730,16 @@ class RelayPool {
   /// instead would silently shrink the denominator: a relay that could not be
   /// written to would be absent from the outcome entirely, and a publish could
   /// settle while later relays had not been attempted yet.
+  ///
+  /// An `EVENT` target must be *connected* as well as write-enabled, matching
+  /// [writable]. `writeAccess` is a config flag that defaults to true, so
+  /// counting on it alone made every configured-but-offline relay a target
+  /// that could only ever land in [PublishOutcome.unreachableTargets] — which
+  /// on mobile, where some relay is nearly always down, left
+  /// [PublishOutcome.acceptedByAll] permanently false and reported every
+  /// successful publish as partial. A relay the fan-out *does* reach despite
+  /// being disconnected is still counted: [PublishTracker.setReachable] adds
+  /// whatever was actually written to.
   Set<String> _intendedPublishTargets(
     List<dynamic> message, {
     List<String>? tempRelays,
@@ -1740,6 +1750,9 @@ class RelayPool {
     final hasFilter = targetRelays != null && targetRelays.isNotEmpty;
     for (final relay in _relaysSnapshot()) {
       if (isEvent && !relay.relayStatus.writeAccess) continue;
+      if (isEvent && relay.relayStatus.connected != ClientConnected.connected) {
+        continue;
+      }
       if (hasFilter && !targetRelays.contains(relay.url)) continue;
       targets.add(relay.url);
     }

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1731,15 +1731,21 @@ class RelayPool {
   /// written to would be absent from the outcome entirely, and a publish could
   /// settle while later relays had not been attempted yet.
   ///
-  /// An `EVENT` target must be *connected* as well as write-enabled, matching
-  /// [writable]. `writeAccess` is a config flag that defaults to true, so
-  /// counting on it alone made every configured-but-offline relay a target
-  /// that could only ever land in [PublishOutcome.unreachableTargets] — which
-  /// on mobile, where some relay is nearly always down, left
-  /// [PublishOutcome.acceptedByAll] permanently false and reported every
-  /// successful publish as partial. A relay the fan-out *does* reach despite
-  /// being disconnected is still counted: [PublishTracker.setReachable] adds
-  /// whatever was actually written to.
+  /// For an *unfiltered* `EVENT` fan-out a target must be connected as well as
+  /// write-enabled, matching [writable]. `writeAccess` is a config flag that
+  /// defaults to true, so counting on it alone made every configured-but-
+  /// offline relay a target that could only ever land in
+  /// [PublishOutcome.unreachableTargets] — which on mobile, where some relay
+  /// is nearly always down, left [PublishOutcome.acceptedByAll] permanently
+  /// false and reported every successful publish as partial. A relay the
+  /// fan-out *does* reach despite being disconnected is still counted:
+  /// [PublishTracker.setReachable] adds whatever was actually written to.
+  ///
+  /// [targetRelays] and [tempRelays] are exempt. Naming a relay is the caller
+  /// asserting intent for that specific relay, and "we never reached the one
+  /// you asked for" is the answer it wants — the kind:10002 bootstrap publish
+  /// names its indexers precisely so it can tell an unreached indexer from a
+  /// refusing one.
   Set<String> _intendedPublishTargets(
     List<dynamic> message, {
     List<String>? tempRelays,
@@ -1750,7 +1756,9 @@ class RelayPool {
     final hasFilter = targetRelays != null && targetRelays.isNotEmpty;
     for (final relay in _relaysSnapshot()) {
       if (isEvent && !relay.relayStatus.writeAccess) continue;
-      if (isEvent && relay.relayStatus.connected != ClientConnected.connected) {
+      if (isEvent &&
+          !hasFilter &&
+          relay.relayStatus.connected != ClientConnected.connected) {
         continue;
       }
       if (hasFilter && !targetRelays.contains(relay.url)) continue;

--- a/mobile/packages/nostr_sdk/test/support/fake_web_socket.dart
+++ b/mobile/packages/nostr_sdk/test/support/fake_web_socket.dart
@@ -1,0 +1,109 @@
+// ABOUTME: Shared fake WebSocket channel primitives for nostr_sdk tests.
+// ABOUTME: Keeps relay and connection-manager tests from duplicating sockets.
+
+import 'dart:async';
+
+import 'package:nostr_sdk/relay/web_socket_connection_manager.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+class FakeWebSocketSink implements WebSocketSink {
+  final List<dynamic> messages = [];
+  bool closed = false;
+  final Completer<void> _doneCompleter = Completer<void>();
+
+  @override
+  void add(dynamic data) {
+    if (closed) throw StateError('Sink is closed');
+    messages.add(data);
+  }
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {}
+
+  @override
+  Future<dynamic> addStream(Stream<dynamic> stream) async {
+    await for (final data in stream) {
+      add(data);
+    }
+  }
+
+  @override
+  Future<dynamic> close([int? closeCode, String? closeReason]) async {
+    closed = true;
+    if (!_doneCompleter.isCompleted) {
+      _doneCompleter.complete();
+    }
+  }
+
+  @override
+  Future<dynamic> get done => _doneCompleter.future;
+}
+
+class FakeWebSocketChannel implements WebSocketChannel {
+  FakeWebSocketChannel({Future<void>? readyFuture})
+    : _readyFuture = readyFuture ?? Future.value();
+
+  final FakeWebSocketSink _sink = FakeWebSocketSink();
+  final StreamController<dynamic> _streamController =
+      StreamController<dynamic>.broadcast();
+  final Future<void> _readyFuture;
+
+  @override
+  WebSocketSink get sink => _sink;
+
+  @override
+  Stream<dynamic> get stream => _streamController.stream;
+
+  @override
+  int? get closeCode => null;
+
+  @override
+  String? get closeReason => null;
+
+  @override
+  String? get protocol => null;
+
+  @override
+  Future<void> get ready => _readyFuture;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnimplementedError('${invocation.memberName} not used in this test');
+  }
+
+  void simulateMessage(dynamic message) => _streamController.add(message);
+
+  List<dynamic> get sentMessages => _sink.messages;
+}
+
+class FakeWebSocketChannelFactory implements WebSocketChannelFactory {
+  FakeWebSocketChannelFactory({
+    this.readyDelay,
+    this.readyError,
+    this.readyFutureFactory,
+  });
+
+  Duration? readyDelay;
+  Object? readyError;
+  Future<void> Function()? readyFutureFactory;
+  final List<FakeWebSocketChannel> createdChannels = [];
+
+  @override
+  WebSocketChannel create(Uri uri) {
+    final channel = FakeWebSocketChannel(readyFuture: _readyFuture());
+    createdChannels.add(channel);
+    return channel;
+  }
+
+  FakeWebSocketChannel? get lastChannel =>
+      createdChannels.isEmpty ? null : createdChannels.last;
+
+  Future<void> _readyFuture() {
+    final factory = readyFutureFactory;
+    if (factory != null) return factory();
+    final error = readyError;
+    if (error != null) return Future<void>.error(error);
+    final delay = readyDelay;
+    return delay == null ? Future.value() : Future<void>.delayed(delay);
+  }
+}

--- a/mobile/packages/nostr_sdk/test/unit/publish_outcome_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/publish_outcome_test.dart
@@ -437,6 +437,27 @@ void main() {
     });
 
     group('publish diagnostics metadata', () {
+      test('does not expose mutable counted target state', () {
+        final expectedRelays = {'wss://a.example', 'wss://b.example'};
+        final tracker = PublishTracker(
+          eventId: 'note-1',
+          expectedRelays: expectedRelays,
+          timeout: const Duration(seconds: 30),
+        );
+
+        expectedRelays.add('wss://outside.example');
+
+        expect(
+          tracker.countedTargets,
+          equals({'wss://a.example', 'wss://b.example'}),
+        );
+        expect(
+          () => tracker.countedTargets.add('wss://mutated.example'),
+          throwsUnsupportedError,
+        );
+        tracker.cancel();
+      });
+
       test('keeps diagnostic tag caller-supplied and domain-neutral', () {
         final tracker = PublishTracker(
           eventId: 'note-1',

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_publish_targets_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_publish_targets_test.dart
@@ -177,6 +177,33 @@ void main() {
       },
     );
 
+    test(
+      'an explicitly targeted relay is reported unreachable, not dropped',
+      () async {
+        acceptFromLiveRelay();
+
+        // Naming relays is the caller asserting intent — the kind:10002
+        // bootstrap does this so it can tell an unreached indexer from a
+        // refusing one. Silently shrinking the denominator would destroy
+        // exactly the signal it publishes for.
+        final outcome = await nostr.relayPool.sendEventAwaitOk(
+          [
+            'EVENT',
+            {'id': eventId, 'kind': 10002},
+          ],
+          eventId: eventId,
+          eventKind: 10002,
+          targetRelays: const [liveUrl, downUrl],
+          timeout: const Duration(milliseconds: 400),
+        );
+
+        expect(outcome.acceptedBy, equals([liveUrl]));
+        expect(outcome.unreachableTargets, equals([downUrl]));
+        expect(outcome.targetCount, equals(2));
+        expect(outcome.acceptedByAll, isFalse);
+      },
+    );
+
     test('the disconnected relay still cannot speak for the publish', () async {
       acceptFromLiveRelay();
 

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_publish_targets_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_publish_targets_test.dart
@@ -1,0 +1,198 @@
+// ABOUTME: Regression tests for which relays count as publish targets.
+// ABOUTME: A configured-but-disconnected relay must not inflate the denominator.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+class _BufferingSink implements WebSocketSink {
+  final List<dynamic> messages = [];
+  bool closed = false;
+  final Completer<void> _doneCompleter = Completer<void>();
+
+  @override
+  void add(dynamic data) {
+    if (closed) throw StateError('Sink is closed');
+    messages.add(data);
+  }
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {}
+
+  @override
+  Future<dynamic> addStream(Stream<dynamic> stream) async {
+    await for (final data in stream) {
+      add(data);
+    }
+  }
+
+  @override
+  Future<dynamic> close([int? closeCode, String? closeReason]) async {
+    closed = true;
+    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
+  }
+
+  @override
+  Future<dynamic> get done => _doneCompleter.future;
+}
+
+class _FakeWebSocketChannel implements WebSocketChannel {
+  _FakeWebSocketChannel({this.failReady = false});
+
+  /// When true, `ready` rejects — the shape of a relay that is configured but
+  /// currently unreachable, which is what `RelayBase.connect()` reports as a
+  /// failed connect.
+  final bool failReady;
+
+  final _BufferingSink _sink = _BufferingSink();
+  final StreamController<dynamic> _streamController =
+      StreamController<dynamic>.broadcast();
+
+  @override
+  WebSocketSink get sink => _sink;
+
+  @override
+  Stream<dynamic> get stream => _streamController.stream;
+
+  @override
+  int? get closeCode => null;
+
+  @override
+  String? get closeReason => null;
+
+  @override
+  String? get protocol => null;
+
+  @override
+  Future<void> get ready => failReady
+      ? Future<void>.error(StateError('unreachable'))
+      : Future.value();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnimplementedError('${invocation.memberName} not used in this test');
+  }
+
+  void simulateMessage(String message) => _streamController.add(message);
+
+  List<dynamic> get sentMessages => _sink.messages;
+}
+
+class _FakeChannelFactory implements WebSocketChannelFactory {
+  _FakeChannelFactory({this.failReady = false});
+
+  final bool failReady;
+  final List<_FakeWebSocketChannel> createdChannels = [];
+
+  @override
+  WebSocketChannel create(Uri uri) {
+    final channel = _FakeWebSocketChannel(failReady: failReady);
+    createdChannels.add(channel);
+    return channel;
+  }
+}
+
+void main() {
+  group('RelayPool publish targets', () {
+    const liveUrl = 'wss://relay.divine.video';
+    const downUrl = 'wss://relay.offline.example';
+    const eventId = 'target-denominator-event-id';
+
+    late LocalNostrSigner signer;
+    late Nostr nostr;
+    late _FakeChannelFactory liveFactory;
+
+    setUp(() async {
+      signer = LocalNostrSigner(
+        '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+      );
+      nostr = Nostr(signer, [], (url) => RelayBase(url, RelayStatus(url)));
+      await nostr.refreshPublicKey();
+
+      liveFactory = _FakeChannelFactory();
+      await nostr.relayPool.add(
+        RelayBase(liveUrl, RelayStatus(liveUrl), channelFactory: liveFactory),
+      );
+
+      // Configured, write-enabled, but the socket never comes up. `add()`
+      // keeps it in the pool even when connect() fails, which is exactly the
+      // steady state on mobile when one of the user's relays is down.
+      await nostr.relayPool.add(
+        RelayBase(
+          downUrl,
+          RelayStatus(downUrl),
+          channelFactory: _FakeChannelFactory(failReady: true),
+        ),
+      );
+    });
+
+    /// Answers `OK true` from the live relay as soon as its EVENT lands.
+    void acceptFromLiveRelay() {
+      final channel = liveFactory.createdChannels.single;
+      Timer.run(() {
+        final sawEvent = channel.sentMessages.any((m) {
+          final frame = jsonDecode(m as String) as List<dynamic>;
+          return frame.first == 'EVENT';
+        });
+        if (sawEvent) {
+          channel.simulateMessage(jsonEncode(['OK', eventId, true, '']));
+        }
+      });
+    }
+
+    test(
+      'a configured relay that never connected is not a publish target',
+      () async {
+        acceptFromLiveRelay();
+
+        final outcome = await nostr.relayPool.sendEventAwaitOk(
+          [
+            'EVENT',
+            {'id': eventId, 'kind': 5},
+          ],
+          eventId: eventId,
+          eventKind: 5,
+          timeout: const Duration(milliseconds: 400),
+        );
+
+        expect(outcome.acceptedBy, equals([liveUrl]));
+        expect(
+          outcome.unreachableTargets,
+          isEmpty,
+          reason:
+              'a relay that was never connected was never a target, so it '
+              'cannot be an unreachable one',
+        );
+        expect(outcome.targetCount, equals(1));
+        expect(
+          outcome.acceptedByAll,
+          isTrue,
+          reason:
+              'every relay this publish could reach accepted it, so the '
+              'outcome must not read as partial',
+        );
+      },
+    );
+
+    test('the disconnected relay still cannot speak for the publish', () async {
+      acceptFromLiveRelay();
+
+      final outcome = await nostr.relayPool.sendEventAwaitOk(
+        [
+          'EVENT',
+          {'id': eventId, 'kind': 5},
+        ],
+        eventId: eventId,
+        eventKind: 5,
+        timeout: const Duration(milliseconds: 400),
+      );
+
+      expect(outcome.acceptedBy, isNot(contains(downUrl)));
+      expect(outcome.rejectedBy.keys, isNot(contains(downUrl)));
+      expect(outcome.noResponseFrom, isNot(contains(downUrl)));
+    });
+  });
+}

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_publish_targets_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_publish_targets_test.dart
@@ -106,6 +106,23 @@ class _FakeChannelFactory implements WebSocketChannelFactory {
   }
 }
 
+/// Answers `OK true` from [factory]'s channel as soon as its EVENT lands.
+void _acceptEventWhenSent(_FakeChannelFactory factory, String eventId) {
+  Timer? timer;
+  timer = Timer.periodic(const Duration(milliseconds: 5), (_) {
+    if (factory.createdChannels.isEmpty) return;
+    final channel = factory.createdChannels.single;
+    final sawEvent = channel.sentMessages.any((m) {
+      final frame = jsonDecode(m as String) as List<dynamic>;
+      return frame.first == 'EVENT';
+    });
+    if (!sawEvent) return;
+    timer?.cancel();
+    channel.simulateMessage(jsonEncode(['OK', eventId, true, '']));
+  });
+  addTearDown(() => timer?.cancel());
+}
+
 void main() {
   group('RelayPool publish targets', () {
     const liveUrl = 'wss://relay.divine.video';
@@ -142,16 +159,7 @@ void main() {
 
     /// Answers `OK true` from the live relay as soon as its EVENT lands.
     void acceptFromLiveRelay() {
-      final channel = liveFactory.createdChannels.single;
-      Timer.run(() {
-        final sawEvent = channel.sentMessages.any((m) {
-          final frame = jsonDecode(m as String) as List<dynamic>;
-          return frame.first == 'EVENT';
-        });
-        if (sawEvent) {
-          channel.simulateMessage(jsonEncode(['OK', eventId, true, '']));
-        }
-      });
+      _acceptEventWhenSent(liveFactory, eventId);
     }
 
     test(
@@ -282,17 +290,7 @@ void main() {
           ),
         );
 
-        Timer.periodic(const Duration(milliseconds: 5), (timer) {
-          if (fastFactory.createdChannels.isEmpty) return;
-          final channel = fastFactory.createdChannels.single;
-          final sawEvent = channel.sentMessages.any((m) {
-            final frame = jsonDecode(m as String) as List<dynamic>;
-            return frame.first == 'EVENT';
-          });
-          if (!sawEvent) return;
-          timer.cancel();
-          channel.simulateMessage(jsonEncode(['OK', eventId, true, '']));
-        });
+        _acceptEventWhenSent(fastFactory, eventId);
 
         final outcome = await nostr.relayPool.sendEventAwaitOk(
           [
@@ -314,6 +312,61 @@ void main() {
               'a failed one',
         );
         expect(outcome.failed, isFalse);
+      },
+    );
+
+    test(
+      'reports an attempted connecting relay as unreachable when write times out',
+      () async {
+        final signer = LocalNostrSigner(
+          '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+        );
+        final nostr = Nostr(
+          signer,
+          [],
+          (url) => RelayBase(url, RelayStatus(url)),
+        );
+        await nostr.refreshPublicKey();
+
+        final fastFactory = _FakeChannelFactory();
+        await nostr.relayPool.add(
+          RelayBase(fastUrl, RelayStatus(fastUrl), channelFactory: fastFactory),
+        );
+
+        final slowAdd = nostr.relayPool.add(
+          RelayBase(
+            slowUrl,
+            RelayStatus(slowUrl),
+            channelFactory: _FakeChannelFactory(
+              readyDelay: const Duration(milliseconds: 800),
+            ),
+          ),
+        );
+
+        _acceptEventWhenSent(fastFactory, eventId);
+
+        final outcome = await nostr.relayPool.sendEventAwaitOk(
+          [
+            'EVENT',
+            {'id': eventId, 'kind': 5},
+          ],
+          eventId: eventId,
+          eventKind: 5,
+          timeout: const Duration(milliseconds: 250),
+        );
+        await slowAdd;
+
+        expect(outcome.acceptedBy, equals([fastUrl]));
+        expect(outcome.unreachableTargets, equals([slowUrl]));
+        expect(outcome.noResponseFrom, isNot(contains(slowUrl)));
+        expect(outcome.targetCount, equals(2));
+        expect(
+          outcome.acceptedByAll,
+          isFalse,
+          reason:
+              'a relay whose connecting socket was actually attempted and '
+              'timed out must still count as unreachable',
+        );
       },
     );
   });

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_publish_targets_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_publish_targets_test.dart
@@ -40,12 +40,17 @@ class _BufferingSink implements WebSocketSink {
 }
 
 class _FakeWebSocketChannel implements WebSocketChannel {
-  _FakeWebSocketChannel({this.failReady = false});
+  _FakeWebSocketChannel({this.failReady = false, this.readyDelay});
 
   /// When true, `ready` rejects — the shape of a relay that is configured but
   /// currently unreachable, which is what `RelayBase.connect()` reports as a
   /// failed connect.
   final bool failReady;
+
+  /// How long the handshake takes. While it is outstanding the relay is not
+  /// yet connected, so it is not a *counted* target — but `send` still waits
+  /// it out and writes, so it can still answer.
+  final Duration? readyDelay;
 
   final _BufferingSink _sink = _BufferingSink();
   final StreamController<dynamic> _streamController =
@@ -67,9 +72,11 @@ class _FakeWebSocketChannel implements WebSocketChannel {
   String? get protocol => null;
 
   @override
-  Future<void> get ready => failReady
-      ? Future<void>.error(StateError('unreachable'))
-      : Future.value();
+  Future<void> get ready {
+    if (failReady) return Future<void>.error(StateError('unreachable'));
+    final delay = readyDelay;
+    return delay == null ? Future.value() : Future<void>.delayed(delay);
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) {
@@ -82,14 +89,18 @@ class _FakeWebSocketChannel implements WebSocketChannel {
 }
 
 class _FakeChannelFactory implements WebSocketChannelFactory {
-  _FakeChannelFactory({this.failReady = false});
+  _FakeChannelFactory({this.failReady = false, this.readyDelay});
 
   final bool failReady;
+  final Duration? readyDelay;
   final List<_FakeWebSocketChannel> createdChannels = [];
 
   @override
   WebSocketChannel create(Uri uri) {
-    final channel = _FakeWebSocketChannel(failReady: failReady);
+    final channel = _FakeWebSocketChannel(
+      failReady: failReady,
+      readyDelay: readyDelay,
+    );
     createdChannels.add(channel);
     return channel;
   }
@@ -221,5 +232,89 @@ void main() {
       expect(outcome.rejectedBy.keys, isNot(contains(downUrl)));
       expect(outcome.noResponseFrom, isNot(contains(downUrl)));
     });
+  });
+
+  group('RelayPool publish targets while relays are still connecting', () {
+    const fastUrl = 'wss://relay.fast.example';
+    const slowUrl = 'wss://relay.slow.example';
+    const eventId = 'still-connecting-event-id';
+
+    test(
+      'counts an OK from a relay whose handshake was still in flight',
+      () async {
+        final signer = LocalNostrSigner(
+          '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+        );
+        final nostr = Nostr(
+          signer,
+          [],
+          (url) => RelayBase(url, RelayStatus(url)),
+        );
+        await nostr.refreshPublicKey();
+
+        // Both relays are healthy; both handshakes are simply still in flight
+        // when the publish starts — the ordinary shape right after launch or a
+        // connectivity flap, where `relayStatus.connected` has not caught up
+        // with the socket yet. The fast one lands and answers while the
+        // sequential fan-out is still waiting on the slow one, so its OK
+        // arrives before the fan-out reports which relays it wrote to.
+        final fastFactory = _FakeChannelFactory(
+          readyDelay: const Duration(milliseconds: 30),
+        );
+        unawaited(
+          nostr.relayPool.add(
+            RelayBase(
+              fastUrl,
+              RelayStatus(fastUrl),
+              channelFactory: fastFactory,
+            ),
+          ),
+        );
+        unawaited(
+          nostr.relayPool.add(
+            RelayBase(
+              slowUrl,
+              RelayStatus(slowUrl),
+              channelFactory: _FakeChannelFactory(
+                readyDelay: const Duration(milliseconds: 800),
+              ),
+            ),
+          ),
+        );
+
+        Timer.periodic(const Duration(milliseconds: 5), (timer) {
+          if (fastFactory.createdChannels.isEmpty) return;
+          final channel = fastFactory.createdChannels.single;
+          final sawEvent = channel.sentMessages.any((m) {
+            final frame = jsonDecode(m as String) as List<dynamic>;
+            return frame.first == 'EVENT';
+          });
+          if (!sawEvent) return;
+          timer.cancel();
+          channel.simulateMessage(jsonEncode(['OK', eventId, true, '']));
+        });
+
+        final outcome = await nostr.relayPool.sendEventAwaitOk(
+          [
+            'EVENT',
+            {'id': eventId, 'kind': 5},
+          ],
+          eventId: eventId,
+          eventKind: 5,
+          timeout: const Duration(seconds: 3),
+        );
+
+        expect(
+          outcome.acceptedBy,
+          contains(fastUrl),
+          reason:
+              'the relay answered OK true, so it must be allowed to speak for '
+              'the publish however unconnected it looked when targets were '
+              'resolved — discarding the answer turns a confirmed publish into '
+              'a failed one',
+        );
+        expect(outcome.failed, isFalse);
+      },
+    );
   });
 }

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_publish_targets_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_publish_targets_test.dart
@@ -6,112 +6,16 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
-import 'package:web_socket_channel/web_socket_channel.dart';
+import 'package:nostr_sdk/relay/client_connected.dart';
 
-class _BufferingSink implements WebSocketSink {
-  final List<dynamic> messages = [];
-  bool closed = false;
-  final Completer<void> _doneCompleter = Completer<void>();
-
-  @override
-  void add(dynamic data) {
-    if (closed) throw StateError('Sink is closed');
-    messages.add(data);
-  }
-
-  @override
-  void addError(Object error, [StackTrace? stackTrace]) {}
-
-  @override
-  Future<dynamic> addStream(Stream<dynamic> stream) async {
-    await for (final data in stream) {
-      add(data);
-    }
-  }
-
-  @override
-  Future<dynamic> close([int? closeCode, String? closeReason]) async {
-    closed = true;
-    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
-  }
-
-  @override
-  Future<dynamic> get done => _doneCompleter.future;
-}
-
-class _FakeWebSocketChannel implements WebSocketChannel {
-  _FakeWebSocketChannel({this.failReady = false, this.readyDelay});
-
-  /// When true, `ready` rejects — the shape of a relay that is configured but
-  /// currently unreachable, which is what `RelayBase.connect()` reports as a
-  /// failed connect.
-  final bool failReady;
-
-  /// How long the handshake takes. While it is outstanding the relay is not
-  /// yet connected, so it is not a *counted* target — but `send` still waits
-  /// it out and writes, so it can still answer.
-  final Duration? readyDelay;
-
-  final _BufferingSink _sink = _BufferingSink();
-  final StreamController<dynamic> _streamController =
-      StreamController<dynamic>.broadcast();
-
-  @override
-  WebSocketSink get sink => _sink;
-
-  @override
-  Stream<dynamic> get stream => _streamController.stream;
-
-  @override
-  int? get closeCode => null;
-
-  @override
-  String? get closeReason => null;
-
-  @override
-  String? get protocol => null;
-
-  @override
-  Future<void> get ready {
-    if (failReady) return Future<void>.error(StateError('unreachable'));
-    final delay = readyDelay;
-    return delay == null ? Future.value() : Future<void>.delayed(delay);
-  }
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) {
-    throw UnimplementedError('${invocation.memberName} not used in this test');
-  }
-
-  void simulateMessage(String message) => _streamController.add(message);
-
-  List<dynamic> get sentMessages => _sink.messages;
-}
-
-class _FakeChannelFactory implements WebSocketChannelFactory {
-  _FakeChannelFactory({this.failReady = false, this.readyDelay});
-
-  final bool failReady;
-  final Duration? readyDelay;
-  final List<_FakeWebSocketChannel> createdChannels = [];
-
-  @override
-  WebSocketChannel create(Uri uri) {
-    final channel = _FakeWebSocketChannel(
-      failReady: failReady,
-      readyDelay: readyDelay,
-    );
-    createdChannels.add(channel);
-    return channel;
-  }
-}
+import '../support/fake_web_socket.dart';
 
 /// Answers `OK true` from [factory]'s channel as soon as its EVENT lands.
-void _acceptEventWhenSent(_FakeChannelFactory factory, String eventId) {
+void _acceptEventWhenSent(FakeWebSocketChannelFactory factory, String eventId) {
   Timer? timer;
   timer = Timer.periodic(const Duration(milliseconds: 5), (_) {
     if (factory.createdChannels.isEmpty) return;
-    final channel = factory.createdChannels.single;
+    final channel = factory.createdChannels.last;
     final sawEvent = channel.sentMessages.any((m) {
       final frame = jsonDecode(m as String) as List<dynamic>;
       return frame.first == 'EVENT';
@@ -123,6 +27,14 @@ void _acceptEventWhenSent(_FakeChannelFactory factory, String eventId) {
   addTearDown(() => timer?.cancel());
 }
 
+Future<void> _waitForRelayState(RelayBase relay, int state) async {
+  for (var i = 0; i < 50; i++) {
+    if (relay.relayStatus.connected == state) return;
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+  }
+  fail('relay ${relay.url} did not reach state $state');
+}
+
 void main() {
   group('RelayPool publish targets', () {
     const liveUrl = 'wss://relay.divine.video';
@@ -131,7 +43,7 @@ void main() {
 
     late LocalNostrSigner signer;
     late Nostr nostr;
-    late _FakeChannelFactory liveFactory;
+    late FakeWebSocketChannelFactory liveFactory;
 
     setUp(() async {
       signer = LocalNostrSigner(
@@ -140,7 +52,7 @@ void main() {
       nostr = Nostr(signer, [], (url) => RelayBase(url, RelayStatus(url)));
       await nostr.refreshPublicKey();
 
-      liveFactory = _FakeChannelFactory();
+      liveFactory = FakeWebSocketChannelFactory();
       await nostr.relayPool.add(
         RelayBase(liveUrl, RelayStatus(liveUrl), channelFactory: liveFactory),
       );
@@ -152,7 +64,9 @@ void main() {
         RelayBase(
           downUrl,
           RelayStatus(downUrl),
-          channelFactory: _FakeChannelFactory(failReady: true),
+          channelFactory: FakeWebSocketChannelFactory(
+            readyError: StateError('unreachable'),
+          ),
         ),
       );
     });
@@ -245,6 +159,7 @@ void main() {
   group('RelayPool publish targets while relays are still connecting', () {
     const fastUrl = 'wss://relay.fast.example';
     const slowUrl = 'wss://relay.slow.example';
+    const failedUrl = 'wss://relay.failed.example';
     const eventId = 'still-connecting-event-id';
 
     test(
@@ -266,7 +181,7 @@ void main() {
         // with the socket yet. The fast one lands and answers while the
         // sequential fan-out is still waiting on the slow one, so its OK
         // arrives before the fan-out reports which relays it wrote to.
-        final fastFactory = _FakeChannelFactory(
+        final fastFactory = FakeWebSocketChannelFactory(
           readyDelay: const Duration(milliseconds: 30),
         );
         unawaited(
@@ -283,7 +198,7 @@ void main() {
             RelayBase(
               slowUrl,
               RelayStatus(slowUrl),
-              channelFactory: _FakeChannelFactory(
+              channelFactory: FakeWebSocketChannelFactory(
                 readyDelay: const Duration(milliseconds: 800),
               ),
             ),
@@ -328,7 +243,7 @@ void main() {
         );
         await nostr.refreshPublicKey();
 
-        final fastFactory = _FakeChannelFactory();
+        final fastFactory = FakeWebSocketChannelFactory();
         await nostr.relayPool.add(
           RelayBase(fastUrl, RelayStatus(fastUrl), channelFactory: fastFactory),
         );
@@ -337,7 +252,7 @@ void main() {
           RelayBase(
             slowUrl,
             RelayStatus(slowUrl),
-            channelFactory: _FakeChannelFactory(
+            channelFactory: FakeWebSocketChannelFactory(
               readyDelay: const Duration(milliseconds: 800),
             ),
           ),
@@ -367,6 +282,60 @@ void main() {
               'a relay whose connecting socket was actually attempted and '
               'timed out must still count as unreachable',
         );
+      },
+    );
+
+    test(
+      'reports an attempted connecting relay as unreachable when connect fails',
+      () async {
+        final signer = LocalNostrSigner(
+          '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+        );
+        final nostr = Nostr(
+          signer,
+          [],
+          (url) => RelayBase(url, RelayStatus(url)),
+        );
+        await nostr.refreshPublicKey();
+
+        final fastFactory = FakeWebSocketChannelFactory();
+        await nostr.relayPool.add(
+          RelayBase(fastUrl, RelayStatus(fastUrl), channelFactory: fastFactory),
+        );
+
+        final failedReady = Completer<void>();
+        final failedRelay = RelayBase(
+          failedUrl,
+          RelayStatus(failedUrl),
+          channelFactory: FakeWebSocketChannelFactory(
+            readyFutureFactory: () => failedReady.future,
+          ),
+        );
+        final failedAdd = nostr.relayPool.add(failedRelay);
+        await _waitForRelayState(failedRelay, ClientConnected.connecting);
+
+        _acceptEventWhenSent(fastFactory, eventId);
+        final failTimer = Timer(const Duration(milliseconds: 20), () {
+          failedReady.completeError(StateError('connect failed'));
+        });
+        addTearDown(failTimer.cancel);
+
+        final outcome = await nostr.relayPool.sendEventAwaitOk(
+          [
+            'EVENT',
+            {'id': eventId, 'kind': 5},
+          ],
+          eventId: eventId,
+          eventKind: 5,
+          timeout: const Duration(seconds: 1),
+        );
+        await failedAdd;
+
+        expect(outcome.acceptedBy, equals([fastUrl]));
+        expect(outcome.unreachableTargets, equals([failedUrl]));
+        expect(outcome.noResponseFrom, isNot(contains(failedUrl)));
+        expect(outcome.targetCount, equals(2));
+        expect(outcome.acceptedByAll, isFalse);
       },
     );
   });

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_zombie_remediation_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_zombie_remediation_test.dart
@@ -6,95 +6,15 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
-import 'package:web_socket_channel/web_socket_channel.dart';
 
-/// Sink that accepts every frame without erroring — the zombie-socket
-/// behaviour: a half-open TCP connection buffers outbound bytes and
-/// `sink.add` never throws.
-class _BufferingSink implements WebSocketSink {
-  final List<dynamic> messages = [];
-  bool closed = false;
-  final Completer<void> _doneCompleter = Completer<void>();
-
-  @override
-  void add(dynamic data) {
-    if (closed) throw StateError('Sink is closed');
-    messages.add(data);
-  }
-
-  @override
-  void addError(Object error, [StackTrace? stackTrace]) {}
-
-  @override
-  Future<dynamic> addStream(Stream<dynamic> stream) async {
-    await for (final data in stream) {
-      add(data);
-    }
-  }
-
-  @override
-  Future<dynamic> close([int? closeCode, String? closeReason]) async {
-    closed = true;
-    if (!_doneCompleter.isCompleted) {
-      _doneCompleter.complete();
-    }
-  }
-
-  @override
-  Future<dynamic> get done => _doneCompleter.future;
-}
-
-class _FakeWebSocketChannel implements WebSocketChannel {
-  final _BufferingSink _sink = _BufferingSink();
-  final StreamController<dynamic> _streamController =
-      StreamController<dynamic>.broadcast();
-
-  @override
-  WebSocketSink get sink => _sink;
-
-  @override
-  Stream<dynamic> get stream => _streamController.stream;
-
-  @override
-  int? get closeCode => null;
-
-  @override
-  String? get closeReason => null;
-
-  @override
-  String? get protocol => null;
-
-  @override
-  Future<void> get ready => Future.value();
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) {
-    throw UnimplementedError('${invocation.memberName} not used in this test');
-  }
-
-  /// Simulate an inbound frame from the relay.
-  void simulateMessage(String message) => _streamController.add(message);
-
-  List<dynamic> get sentMessages => _sink.messages;
-}
-
-class _FakeChannelFactory implements WebSocketChannelFactory {
-  final List<_FakeWebSocketChannel> createdChannels = [];
-
-  @override
-  WebSocketChannel create(Uri uri) {
-    final channel = _FakeWebSocketChannel();
-    createdChannels.add(channel);
-    return channel;
-  }
-}
+import '../support/fake_web_socket.dart';
 
 void main() {
   group('RelayPool zombie-socket remediation on OK timeout', () {
     const relayUrl = 'wss://relay.divine.video';
     late LocalNostrSigner signer;
     late Nostr nostr;
-    late _FakeChannelFactory factory;
+    late FakeWebSocketChannelFactory factory;
     late RelayBase relay;
 
     setUp(() async {
@@ -103,7 +23,7 @@ void main() {
       );
       nostr = Nostr(signer, [], (url) => RelayBase(url, RelayStatus(url)));
       await nostr.refreshPublicKey();
-      factory = _FakeChannelFactory();
+      factory = FakeWebSocketChannelFactory();
       relay = RelayBase(
         relayUrl,
         RelayStatus(relayUrl),
@@ -214,7 +134,7 @@ void main() {
       // and said nothing. That is the wedged-socket signal repair exists for,
       // and a confirmed publish no longer hides it.
       const siblingUrl = 'wss://inbox.example.com';
-      final siblingFactory = _FakeChannelFactory();
+      final siblingFactory = FakeWebSocketChannelFactory();
       final sibling = RelayBase(
         siblingUrl,
         RelayStatus(siblingUrl),
@@ -260,7 +180,7 @@ void main() {
       // churning healthy connections: any inbound frame since the publish
       // proves the socket is alive, so the relay is left alone.
       const siblingUrl = 'wss://busy.example.com';
-      final siblingFactory = _FakeChannelFactory();
+      final siblingFactory = FakeWebSocketChannelFactory();
       final sibling = RelayBase(
         siblingUrl,
         RelayStatus(siblingUrl),


### PR DESCRIPTION
## What

`RelayPool._intendedPublishTargets` used `relay.relayStatus.writeAccess` alone to decide which relays counted in a publish outcome. That flag is configuration and defaults to `true`, so configured relays the client had never connected to inflated the denominator.

A relay that was never connected can only land in `PublishOutcome.unreachableTargets`, and `acceptedByAll` requires that list to be empty. On mobile, where some configured relay is often down, that made `acceptedByAll` effectively unreachable and made successful publishes look partial.

## Fix

Publishing now separates three relay sets:

- `expectedRelays`: every write-enabled relay the fan-out may write to. This remains wide so relays whose connection state is stale or still in flight can answer their own publish.
- `countedTargets`: the denominator used for `unreachableTargets`. This starts narrower for unfiltered whole-pool `EVENT` publishes so plainly disconnected, never-attempted relays do not make every publish partial.
- attempted relays: `_sendCollect` now reports relays the fan-out genuinely attempted but did not write to, such as a relay whose `connecting` socket waited until the publish deadline or failed before the deadline. Those relays are added back to `countedTargets` and can be reported as unreachable.

`targetRelays` and `tempRelays` remain exempt from the narrowing. Naming a relay is the caller asserting intent for that specific relay, so an unreached named relay should still appear in the outcome.

This preserves the original fix without dropping healthy-but-still-connecting relays from `acceptedBy`, and without letting attempted-but-failed relays disappear from the denominator.

## Tests

`relay_pool_publish_targets_test.dart` covers:

- configured relay that never connected is not a publish target
- explicitly targeted relay is reported unreachable, not dropped
- disconnected relay cannot speak for an unfiltered publish
- still-connecting relay can answer its own publish
- attempted still-connecting relay is reported unreachable when the write times out
- attempted still-connecting relay is reported unreachable when the connect fails before the deadline

This also extracts the duplicated fake WebSocket test support and verifies `PublishTracker.countedTargets` does not expose mutable internal state.

## Verification

- `flutter test test/unit/relay_pool_publish_targets_test.dart` in `mobile/packages/nostr_sdk`
- `flutter test test/unit/publish_outcome_test.dart` in `mobile/packages/nostr_sdk`
- `flutter test test/unit/relay_pool_zombie_remediation_test.dart` in `mobile/packages/nostr_sdk`
- `flutter analyze lib test` in `mobile/packages/nostr_sdk`
- `flutter test` in `mobile/packages/nostr_sdk` - 422 passing
- `flutter test test/services/content_deletion_service_test.dart` in `mobile`
- pre-push hook: merge-conflict check, analyzer, changed-file tests

Closes #6634

🤖 Generated with [Claude Code](https://claude.com/claude-code)
