### PR TITLE
fix(report): pin the report sheet's submit action and finish the profile snackbar sweep

### DIFF
--- a/mobile/lib/blocs/profile_feed/profile_feed_scope.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_scope.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Riverpod->BLoC bridge that provides a keyed ProfileFeedCubit.
 // ABOUTME: Reused at every profile-feed entry point (in-shell and off-shell).
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -71,7 +72,10 @@ class ProfileFeedScope extends ConsumerWidget {
             !previous.hasLoadMoreError && current.hasLoadMoreError,
         listener: (context, state) {
           ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(context.l10n.profileFeedLoadMoreError)),
+            DivineSnackbarContainer.snackBar(
+              context.l10n.profileFeedLoadMoreError,
+              error: true,
+            ),
           );
         },
         child: _BlocklistVersionForwarder(

--- a/mobile/lib/screens/other_profile_screen.dart
+++ b/mobile/lib/screens/other_profile_screen.dart
@@ -237,7 +237,10 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
 
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(context.l10n.profileShareFailed(e))),
+          DivineSnackbarContainer.snackBar(
+            context.l10n.profileShareFailed(e),
+            error: true,
+          ),
         );
       }
     }
@@ -336,9 +339,8 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
               profile?.bestDisplayName ??
               widget.displayNameHint ??
               fallbackName;
-          // TODO(SofiaRey): revisit when designs are ready
           ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(l10n.profileBlockedUser(name))),
+            DivineSnackbarContainer.snackBar(l10n.profileBlockedUser(name)),
           );
           context.pop();
         }
@@ -354,9 +356,8 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
               profile?.bestDisplayName ??
               widget.displayNameHint ??
               fallbackName;
-          // TODO(SofiaRey): revisit when designs are ready
           ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(l10n.profileUnblockedUser(name))),
+            DivineSnackbarContainer.snackBar(l10n.profileUnblockedUser(name)),
           );
         }
     }
@@ -373,8 +374,8 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
 
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(context.l10n.profileUnfollowedUser(displayName)),
+        DivineSnackbarContainer.snackBar(
+          context.l10n.profileUnfollowedUser(displayName),
         ),
       );
     }

--- a/mobile/lib/screens/profile_screen_router.dart
+++ b/mobile/lib/screens/profile_screen_router.dart
@@ -202,7 +202,10 @@ class _ProfileScreenRouterState extends ConsumerState<ProfileScreenRouter>
 
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(context.l10n.profileShareFailed(e))),
+          DivineSnackbarContainer.snackBar(
+            context.l10n.profileShareFailed(e),
+            error: true,
+          ),
         );
       }
     }
@@ -283,7 +286,7 @@ class _ProfileScreenRouterState extends ConsumerState<ProfileScreenRouter>
 
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(context.l10n.profilePublicKeyCopied)),
+        DivineSnackbarContainer.snackBar(context.l10n.profilePublicKeyCopied),
       );
     }
   }
@@ -302,7 +305,7 @@ class _ProfileScreenRouterState extends ConsumerState<ProfileScreenRouter>
 
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(context.l10n.profileEmbedCodeCopied)),
+        DivineSnackbarContainer.snackBar(context.l10n.profileEmbedCodeCopied),
       );
     }
   }

--- a/mobile/lib/widgets/profile/follow_from_profile_button.dart
+++ b/mobile/lib/widgets/profile/follow_from_profile_button.dart
@@ -153,7 +153,10 @@ class FollowFromProfileButtonView extends StatelessWidget {
           previous.status != MyFollowingStatus.toggleFailure,
       listener: (context, state) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(context.l10n.followersUpdateFollowFailed)),
+          DivineSnackbarContainer.snackBar(
+            context.l10n.followersUpdateFollowFailed,
+            error: true,
+          ),
         );
       },
       child: BlocSelector<MyFollowingBloc, MyFollowingState, bool>(

--- a/mobile/lib/widgets/profile/profile_notify_bell_button.dart
+++ b/mobile/lib/widgets/profile/profile_notify_bell_button.dart
@@ -23,7 +23,10 @@ class ProfileNotifyBellButton extends StatelessWidget {
           previous.status != NotifyBellStatus.failure,
       listener: (context, state) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(context.l10n.profileNotifyUpdateFailed)),
+          DivineSnackbarContainer.snackBar(
+            context.l10n.profileNotifyUpdateFailed,
+            error: true,
+          ),
         );
       },
       builder: (context, state) {

--- a/mobile/lib/widgets/report_content_confirmation.dart
+++ b/mobile/lib/widgets/report_content_confirmation.dart
@@ -1,0 +1,175 @@
+// ABOUTME: Post-submission confirmation state of the report bottom sheet.
+// ABOUTME: Split into a scrollable body and the actions that ride the footer.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Scrollable content shown after a report is accepted.
+class ReportConfirmationBody extends StatelessWidget {
+  /// Creates a [ReportConfirmationBody].
+  const ReportConfirmationBody({required this.moderationDmFailed, super.key});
+
+  /// Whether the secondary NIP-17 DM to the moderation team failed to
+  /// send. The report itself still succeeded; this only drives a calm
+  /// informational notice so the user isn't misled.
+  final bool moderationDmFailed;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 8),
+        Row(
+          spacing: 12,
+          children: [
+            const DivineIcon(
+              icon: DivineIconName.checkCircle,
+              color: VineTheme.vineGreen,
+              size: 28,
+            ),
+            Expanded(
+              child: Text(
+                l10n.reportReceivedTitle,
+                style: VineTheme.titleMediumFont(
+                  color: context.vineColors.primaryText,
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        Text(
+          l10n.reportReceivedThankYou,
+          style: VineTheme.bodyLargeFont(color: context.vineColors.primaryText),
+        ),
+        const SizedBox(height: 16),
+        Text(
+          l10n.reportReceivedReviewNotice,
+          style: VineTheme.bodyMediumFont(
+            color: context.vineColors.onSurfaceMuted,
+          ),
+        ),
+        if (moderationDmFailed) ...[
+          const SizedBox(height: 12),
+          Text(
+            l10n.reportModerationDmDelayed,
+            style: VineTheme.bodySmallFont(
+              color: context.vineColors.onSurfaceMuted,
+            ),
+          ),
+        ],
+        const SizedBox(height: 8),
+        const _SafetyPolicyLink(),
+      ],
+    );
+  }
+}
+
+class _SafetyPolicyLink extends StatelessWidget {
+  const _SafetyPolicyLink();
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Semantics(
+      button: true,
+      label: l10n.reportSafetyUrl,
+      child: GestureDetector(
+        onTap: () async {
+          final uri = Uri.parse('https://divine.video/safety');
+          if (await canLaunchUrl(uri)) {
+            await launchUrl(uri, mode: LaunchMode.externalApplication);
+          }
+        },
+        child: Text.rich(
+          TextSpan(
+            children: [
+              TextSpan(
+                text: '${l10n.reportLearnMoreAt} ',
+                style: VineTheme.bodyMediumFont(
+                  color: context.vineColors.onSurfaceMuted,
+                ),
+              ),
+              TextSpan(
+                text: l10n.reportSafetyUrl,
+                style: VineTheme.bodyMediumFont(color: VineTheme.vineGreen),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Footer actions for the post-submission confirmation.
+class ReportConfirmationActions extends ConsumerWidget {
+  /// Creates a [ReportConfirmationActions].
+  const ReportConfirmationActions({required this.isFromShareMenu, super.key});
+
+  /// Whether the sheet was opened from the share menu, which needs a second
+  /// pop to also dismiss the menu underneath.
+  final bool isFromShareMenu;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    final currentPubkey = ref.read(authServiceProvider).currentPublicKeyHex;
+    final moderationPubkey = ref
+        .read(moderationLabelServiceProvider)
+        .divineModerationPubkeyHex;
+    // The moderation conversation is an ordinary NIP-17 thread; deep-link
+    // straight to it so the user can follow up about their report. Null
+    // when we have no current pubkey (signed out) — the button hides.
+    final moderationConversationId =
+        (currentPubkey != null && currentPubkey.isNotEmpty)
+        ? DmRepository.computeConversationId([currentPubkey, moderationPubkey])
+        : null;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      spacing: 8,
+      children: [
+        if (moderationConversationId case final conversationId?)
+          DivineButton(
+            label: l10n.reportContactModeration,
+            type: DivineButtonType.secondary,
+            expanded: true,
+            onPressed: () {
+              // Capture the router before popping the sheet so the push
+              // doesn't run against a defunct context.
+              final router = GoRouter.of(context);
+              final navigator = Navigator.of(context);
+              navigator.pop();
+              if (isFromShareMenu) {
+                navigator.pop();
+              }
+              router.push(
+                ConversationPage.pathForId(conversationId),
+                extra: [moderationPubkey],
+              );
+            },
+          ),
+        DivineButton(
+          label: l10n.reportClose,
+          expanded: true,
+          onPressed: () {
+            Navigator.of(context).pop();
+            if (isFromShareMenu) {
+              Navigator.of(context).pop();
+            }
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/widgets/report_content_confirmation.dart
+++ b/mobile/lib/widgets/report_content_confirmation.dart
@@ -80,9 +80,11 @@ class _SafetyPolicyLink extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
+    // No `label:` here — the Text.rich below already supplies one, and a
+    // label on the annotation is prepended to it rather than replacing it,
+    // so the URL would be announced twice.
     return Semantics(
       button: true,
-      label: l10n.reportSafetyUrl,
       child: GestureDetector(
         onTap: () async {
           final uri = Uri.parse('https://divine.video/safety');

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -42,6 +42,7 @@ class ReportContentDialog extends ConsumerStatefulWidget {
     this.moderationEventLabel = 'Event',
     this.isFromShareMenu = false,
     this.draggableController,
+    this.scrollController,
   }) {
     final hasVideo = video != null;
     final hasContent = eventId != null && authorPubkey != null;
@@ -87,6 +88,15 @@ class ReportContentDialog extends ConsumerStatefulWidget {
   /// field is reachable above the keyboard).
   final DraggableScrollableController? draggableController;
 
+  /// Scroll controller handed down by the enclosing [VineBottomSheet].
+  ///
+  /// The sheet's [DraggableScrollableSheet] only reacts to a downward drag
+  /// when its own controller drives the scroll view inside it — with a
+  /// foreign controller the drag is swallowed by the content and the sheet
+  /// can no longer be pulled closed. Null when the dialog is shown outside a
+  /// draggable sheet, where an internal controller stands in.
+  final ScrollController? scrollController;
+
   static Future<void> show(
     BuildContext context, {
     required VideoEvent video,
@@ -99,10 +109,11 @@ class ReportContentDialog extends ConsumerStatefulWidget {
           maxChildSize: 0.95,
           minChildSize: 0.5,
           draggableController: controller,
-          body: ReportContentDialog(
+          buildScrollBody: (scrollController) => ReportContentDialog(
             video: video,
             isFromShareMenu: isFromShareMenu,
             draggableController: controller,
+            scrollController: scrollController,
           ),
         )
         .whenComplete(controller.dispose);
@@ -122,12 +133,13 @@ class ReportContentDialog extends ConsumerStatefulWidget {
           maxChildSize: 0.95,
           minChildSize: 0.5,
           draggableController: controller,
-          body: ReportContentDialog(
+          buildScrollBody: (scrollController) => ReportContentDialog(
             eventId: messageId,
             authorPubkey: senderPubkey,
             moderationKindLabel: 'DM Message Report',
             moderationEventLabel: 'Message ID',
             draggableController: controller,
+            scrollController: scrollController,
           ),
         )
         .whenComplete(controller.dispose);
@@ -149,11 +161,12 @@ class ReportContentDialog extends ConsumerStatefulWidget {
           maxChildSize: 0.95,
           minChildSize: 0.5,
           draggableController: controller,
-          body: ReportContentDialog(
+          buildScrollBody: (scrollController) => ReportContentDialog(
             userPubkey: userPubkey,
             moderationKindLabel: 'User Report',
             moderationEventLabel: 'User Pubkey',
             draggableController: controller,
+            scrollController: scrollController,
           ),
         )
         .whenComplete(controller.dispose);
@@ -170,7 +183,7 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
   final FocusNode _detailsFocusNode = FocusNode();
   final GlobalKey _detailsFieldKey = GlobalKey();
   final GlobalKey _otherCardKey = GlobalKey();
-  final ScrollController _scrollController = ScrollController();
+  final ScrollController _fallbackScrollController = ScrollController();
   bool _isSubmitting = false;
   bool _submitted = false;
   bool _moderationDmFailed = false;
@@ -179,6 +192,13 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
   double _previousViewInsetsBottom = 0;
 
   bool get _isUserReport => widget.userPubkey != null;
+
+  ScrollController get _scrollController =>
+      widget.scrollController ?? _fallbackScrollController;
+
+  /// Submission needs a reason; "Other" additionally needs details, but that
+  /// stays a tap-time inline error so the reason for the block is explained.
+  bool get _canSubmit => _selectedReason != null && !_isSubmitting;
 
   String get _eventId {
     final userPubkey = widget.userPubkey;
@@ -237,169 +257,54 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
 
   @override
   Widget build(BuildContext context) {
-    if (_submitted) {
-      final currentPubkey = ref.read(authServiceProvider).currentPublicKeyHex;
-      final moderationPubkey = ref
-          .read(moderationLabelServiceProvider)
-          .divineModerationPubkeyHex;
-      // The moderation conversation is an ordinary NIP-17 thread; deep-link
-      // straight to it so the user can follow up about their report. Null
-      // when we have no current pubkey (signed out) — the button hides.
-      final moderationConversationId =
-          (currentPubkey != null && currentPubkey.isNotEmpty)
-          ? DmRepository.computeConversationId([
-              currentPubkey,
-              moderationPubkey,
-            ])
-          : null;
-      return _ReportConfirmationView(
-        isFromShareMenu: widget.isFromShareMenu,
-        moderationDmFailed: _moderationDmFailed,
-        moderationPubkey: moderationPubkey,
-        moderationConversationId: moderationConversationId,
-      );
-    }
-
-    final l10n = context.l10n;
-    final keyboardInset = MediaQuery.viewInsetsOf(context).bottom;
-    final safeAreaBottom = MediaQuery.viewPaddingOf(context).bottom;
-    return SingleChildScrollView(
-      controller: _scrollController,
-      padding: EdgeInsetsDirectional.fromSTEB(
-        16,
-        8,
-        16,
-        24 + keyboardInset + safeAreaBottom,
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const SizedBox(height: 8),
-          Text(
-            l10n.reportWhyReporting,
-            style: VineTheme.titleMediumFont(
-              color: context.vineColors.primaryText,
-            ),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            l10n.reportPolicyNotice,
-            style: VineTheme.bodyMediumFont(
-              color: context.vineColors.onSurfaceMuted,
-            ),
-          ),
-          const SizedBox(height: 16),
-          ...ContentFilterReason.values.map(
-            (reason) => Padding(
-              key: reason == ContentFilterReason.other ? _otherCardKey : null,
-              padding: const EdgeInsets.only(bottom: 8),
-              child: _ReasonCard(
-                title: l10n.reportReasonTitle(reason),
-                subtitle: l10n.reportReasonSubtitle(reason),
-                isSelected: _selectedReason == reason,
-                onTap: () => _onReasonSelected(reason),
-              ),
-            ),
-          ),
-          if (_selectedReason == ContentFilterReason.other) ...[
-            const SizedBox(height: 4),
-            DecoratedBox(
-              decoration: BoxDecoration(
-                color: context.vineColors.surfaceContainer,
-                borderRadius: BorderRadius.circular(24),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  spacing: 4,
-                  children: [
-                    Text(
-                      l10n.reportDetailsRequired,
-                      style: VineTheme.labelSmallFont(
-                        color: VineTheme.vineGreen,
-                      ),
-                    ),
-                    TextField(
-                      key: _detailsFieldKey,
-                      controller: _detailsController,
-                      focusNode: _detailsFocusNode,
-                      enableInteractiveSelection: true,
-                      onChanged: (_) {
-                        if (_errorMessage == null) return;
-                        setState(() => _errorMessage = null);
-                      },
-                      style: VineTheme.bodyLargeFont(
-                        color: context.vineColors.primaryText,
-                      ),
-                      minLines: 3,
-                      maxLines: 5,
-                      decoration: const InputDecoration(
-                        border: InputBorder.none,
-                        isCollapsed: true,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ],
-          if (_errorMessage case final errorMessage?) ...[
-            const SizedBox(height: 16),
-            Semantics(
-              container: true,
-              liveRegion: true,
-              label: errorMessage,
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  color: VineTheme.error.withValues(alpha: 0.1),
-                  border: Border.all(color: VineTheme.error),
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.all(12),
-                  child: Row(
-                    children: [
-                      const DivineIcon(
-                        icon: DivineIconName.warningCircle,
-                        color: VineTheme.error,
-                        size: 20,
-                      ),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: Text(
-                          errorMessage,
-                          style: VineTheme.bodySmallFont(
-                            color: VineTheme.error,
-                          ),
-                        ),
-                      ),
-                    ],
+    // One scroll view across both states so the sheet's scroll controller
+    // stays attached to a single position when the form is swapped for the
+    // confirmation — the actions ride in the pinned footer instead.
+    return Column(
+      children: [
+        Expanded(
+          child: SingleChildScrollView(
+            controller: _scrollController,
+            padding: const EdgeInsetsDirectional.fromSTEB(16, 8, 16, 16),
+            child: _submitted
+                ? _ReportConfirmationBody(
+                    moderationDmFailed: _moderationDmFailed,
+                  )
+                : _ReportFormBody(
+                    selectedReason: _selectedReason,
+                    onReasonSelected: _onReasonSelected,
+                    detailsController: _detailsController,
+                    detailsFocusNode: _detailsFocusNode,
+                    detailsFieldKey: _detailsFieldKey,
+                    otherCardKey: _otherCardKey,
+                    errorMessage: _errorMessage,
+                    onDetailsChanged: _clearErrorMessage,
                   ),
-                ),
-              ),
-            ),
-          ],
-          const SizedBox(height: 24),
-          DivineButton(
-            label: l10n.reportSubmit,
-            expanded: true,
-            onPressed: _isSubmitting ? null : _handleSubmitReport,
-            isLoading: _isSubmitting,
           ),
-        ],
-      ),
+        ),
+        _SheetFooter(
+          child: _submitted
+              ? _ReportConfirmationActions(
+                  isFromShareMenu: widget.isFromShareMenu,
+                )
+              : DivineButton(
+                  label: context.l10n.reportSubmit,
+                  expanded: true,
+                  onPressed: _canSubmit ? _handleSubmitReport : null,
+                  isLoading: _isSubmitting,
+                ),
+        ),
+      ],
     );
+  }
+
+  void _clearErrorMessage() {
+    if (_errorMessage == null) return;
+    setState(() => _errorMessage = null);
   }
 
   void _handleSubmitReport() {
     if (_isSubmitting) return;
-    if (_selectedReason == null) {
-      setState(() {
-        _errorMessage = context.l10n.reportSelectReason;
-      });
-      return;
-    }
     if (_selectedReason == ContentFilterReason.other &&
         _detailsController.text.trim().isEmpty) {
       setState(() {
@@ -530,8 +435,191 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
   void dispose() {
     _detailsController.dispose();
     _detailsFocusNode.dispose();
-    _scrollController.dispose();
+    _fallbackScrollController.dispose();
     super.dispose();
+  }
+}
+
+/// Action area pinned below the sheet's scrollable content.
+///
+/// Rides above the keyboard the same way [VineBottomSheet]'s `bottomInput`
+/// slot does — the report form's details field lives in the scroll area
+/// above, and a footer flush with the keyboard would put the button under it.
+class _SheetFooter extends StatelessWidget {
+  const _SheetFooter({required this.child});
+
+  /// Gap kept between a raised keyboard and the footer.
+  static const double _keyboardClearance = 12;
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final keyboardInset = MediaQuery.viewInsetsOf(context).bottom;
+    return SafeArea(
+      top: false,
+      child: AnimatedPadding(
+        duration: const Duration(milliseconds: 180),
+        curve: Curves.easeOutCubic,
+        padding: EdgeInsets.only(
+          bottom: keyboardInset > 0 ? keyboardInset + _keyboardClearance : 0,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+          child: child,
+        ),
+      ),
+    );
+  }
+}
+
+// =============================================================================
+// Report form
+// =============================================================================
+
+class _ReportFormBody extends StatelessWidget {
+  const _ReportFormBody({
+    required this.selectedReason,
+    required this.onReasonSelected,
+    required this.detailsController,
+    required this.detailsFocusNode,
+    required this.detailsFieldKey,
+    required this.otherCardKey,
+    required this.errorMessage,
+    required this.onDetailsChanged,
+  });
+
+  final ContentFilterReason? selectedReason;
+  final ValueChanged<ContentFilterReason> onReasonSelected;
+  final TextEditingController detailsController;
+  final FocusNode detailsFocusNode;
+  final GlobalKey detailsFieldKey;
+
+  /// Anchors the "Other" card so it can be scrolled back into view once the
+  /// keyboard pushes the details field up.
+  final GlobalKey otherCardKey;
+
+  final String? errorMessage;
+  final VoidCallback onDetailsChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 8),
+        Text(
+          l10n.reportWhyReporting,
+          style: VineTheme.titleMediumFont(
+            color: context.vineColors.primaryText,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          l10n.reportPolicyNotice,
+          style: VineTheme.bodyMediumFont(
+            color: context.vineColors.onSurfaceMuted,
+          ),
+        ),
+        const SizedBox(height: 16),
+        ...ContentFilterReason.values.map(
+          (reason) => Padding(
+            key: reason == ContentFilterReason.other ? otherCardKey : null,
+            padding: const EdgeInsets.only(bottom: 8),
+            child: _ReasonCard(
+              title: l10n.reportReasonTitle(reason),
+              subtitle: l10n.reportReasonSubtitle(reason),
+              isSelected: selectedReason == reason,
+              onTap: () => onReasonSelected(reason),
+            ),
+          ),
+        ),
+        if (selectedReason == ContentFilterReason.other) ...[
+          const SizedBox(height: 4),
+          DecoratedBox(
+            decoration: BoxDecoration(
+              color: context.vineColors.surfaceContainer,
+              borderRadius: BorderRadius.circular(24),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                spacing: 4,
+                children: [
+                  Text(
+                    l10n.reportDetailsRequired,
+                    style: VineTheme.labelSmallFont(color: VineTheme.vineGreen),
+                  ),
+                  TextField(
+                    key: detailsFieldKey,
+                    controller: detailsController,
+                    focusNode: detailsFocusNode,
+                    enableInteractiveSelection: true,
+                    onChanged: (_) => onDetailsChanged(),
+                    style: VineTheme.bodyLargeFont(
+                      color: context.vineColors.primaryText,
+                    ),
+                    minLines: 3,
+                    maxLines: 5,
+                    decoration: const InputDecoration(
+                      border: InputBorder.none,
+                      isCollapsed: true,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+        if (errorMessage case final message?) ...[
+          const SizedBox(height: 16),
+          _InlineError(message: message),
+        ],
+      ],
+    );
+  }
+}
+
+class _InlineError extends StatelessWidget {
+  const _InlineError({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      container: true,
+      liveRegion: true,
+      label: message,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: VineTheme.error.withValues(alpha: 0.1),
+          border: Border.all(color: VineTheme.error),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Row(
+            children: [
+              const DivineIcon(
+                icon: DivineIconName.warningCircle,
+                color: VineTheme.error,
+                size: 20,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  message,
+                  style: VineTheme.bodySmallFont(color: VineTheme.error),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }
 
@@ -539,140 +627,160 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
 // Confirmation view (shown inside the sheet after successful submission)
 // =============================================================================
 
-class _ReportConfirmationView extends StatelessWidget {
-  const _ReportConfirmationView({
-    required this.isFromShareMenu,
-    required this.moderationDmFailed,
-    required this.moderationPubkey,
-    required this.moderationConversationId,
-  });
-
-  final bool isFromShareMenu;
+class _ReportConfirmationBody extends StatelessWidget {
+  const _ReportConfirmationBody({required this.moderationDmFailed});
 
   /// Whether the secondary NIP-17 DM to the moderation team failed to
   /// send. The report itself still succeeded; this only drives a calm
   /// informational notice so the user isn't misled.
   final bool moderationDmFailed;
 
-  /// The Divine moderation account pubkey, passed to the conversation
-  /// route so it can render the thread.
-  final String moderationPubkey;
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 8),
+        Row(
+          spacing: 12,
+          children: [
+            const DivineIcon(
+              icon: DivineIconName.checkCircle,
+              color: VineTheme.vineGreen,
+              size: 28,
+            ),
+            Expanded(
+              child: Text(
+                l10n.reportReceivedTitle,
+                style: VineTheme.titleMediumFont(
+                  color: context.vineColors.primaryText,
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        Text(
+          l10n.reportReceivedThankYou,
+          style: VineTheme.bodyLargeFont(color: context.vineColors.primaryText),
+        ),
+        const SizedBox(height: 16),
+        Text(
+          l10n.reportReceivedReviewNotice,
+          style: VineTheme.bodyMediumFont(
+            color: context.vineColors.onSurfaceMuted,
+          ),
+        ),
+        if (moderationDmFailed) ...[
+          const SizedBox(height: 12),
+          Text(
+            l10n.reportModerationDmDelayed,
+            style: VineTheme.bodySmallFont(
+              color: context.vineColors.onSurfaceMuted,
+            ),
+          ),
+        ],
+        const SizedBox(height: 8),
+        const _SafetyPolicyLink(),
+      ],
+    );
+  }
+}
 
-  /// The 1:1 conversation id between the current user and the moderation
-  /// account. Null when signed out — the "Message the moderation team"
-  /// affordance is hidden in that case.
-  final String? moderationConversationId;
+class _SafetyPolicyLink extends StatelessWidget {
+  const _SafetyPolicyLink();
 
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
-    return SingleChildScrollView(
-      padding: const EdgeInsetsDirectional.fromSTEB(16, 8, 16, 24),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const SizedBox(height: 8),
-          Row(
-            spacing: 12,
+    return Semantics(
+      button: true,
+      label: l10n.reportSafetyUrl,
+      child: GestureDetector(
+        onTap: () async {
+          final uri = Uri.parse('https://divine.video/safety');
+          if (await canLaunchUrl(uri)) {
+            await launchUrl(uri, mode: LaunchMode.externalApplication);
+          }
+        },
+        child: Text.rich(
+          TextSpan(
             children: [
-              const DivineIcon(
-                icon: DivineIconName.checkCircle,
-                color: VineTheme.vineGreen,
-                size: 28,
-              ),
-              Expanded(
-                child: Text(
-                  l10n.reportReceivedTitle,
-                  style: VineTheme.titleMediumFont(
-                    color: context.vineColors.primaryText,
-                  ),
+              TextSpan(
+                text: '${l10n.reportLearnMoreAt} ',
+                style: VineTheme.bodyMediumFont(
+                  color: context.vineColors.onSurfaceMuted,
                 ),
+              ),
+              TextSpan(
+                text: l10n.reportSafetyUrl,
+                style: VineTheme.bodyMediumFont(color: VineTheme.vineGreen),
               ),
             ],
           ),
-          const SizedBox(height: 16),
-          Text(
-            l10n.reportReceivedThankYou,
-            style: VineTheme.bodyLargeFont(
-              color: context.vineColors.primaryText,
-            ),
-          ),
-          const SizedBox(height: 16),
-          Text(
-            l10n.reportReceivedReviewNotice,
-            style: VineTheme.bodyMediumFont(
-              color: context.vineColors.onSurfaceMuted,
-            ),
-          ),
-          if (moderationDmFailed) ...[
-            const SizedBox(height: 12),
-            Text(
-              l10n.reportModerationDmDelayed,
-              style: VineTheme.bodySmallFont(
-                color: context.vineColors.onSurfaceMuted,
-              ),
-            ),
-          ],
-          const SizedBox(height: 8),
-          GestureDetector(
-            onTap: () async {
-              final uri = Uri.parse('https://divine.video/safety');
-              if (await canLaunchUrl(uri)) {
-                await launchUrl(uri, mode: LaunchMode.externalApplication);
-              }
-            },
-            child: Text.rich(
-              TextSpan(
-                children: [
-                  TextSpan(
-                    text: '${l10n.reportLearnMoreAt} ',
-                    style: VineTheme.bodyMediumFont(
-                      color: context.vineColors.onSurfaceMuted,
-                    ),
-                  ),
-                  TextSpan(
-                    text: l10n.reportSafetyUrl,
-                    style: VineTheme.bodyMediumFont(color: VineTheme.vineGreen),
-                  ),
-                ],
-              ),
-            ),
-          ),
-          const SizedBox(height: 24),
-          if (moderationConversationId case final conversationId?) ...[
-            DivineButton(
-              label: l10n.reportContactModeration,
-              type: DivineButtonType.secondary,
-              expanded: true,
-              onPressed: () {
-                // Capture the router before popping the sheet so the push
-                // doesn't run against a defunct context.
-                final router = GoRouter.of(context);
-                final navigator = Navigator.of(context);
-                navigator.pop();
-                if (isFromShareMenu) {
-                  navigator.pop();
-                }
-                router.push(
-                  ConversationPage.pathForId(conversationId),
-                  extra: [moderationPubkey],
-                );
-              },
-            ),
-            const SizedBox(height: 8),
-          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Footer actions for the post-submission confirmation.
+class _ReportConfirmationActions extends ConsumerWidget {
+  const _ReportConfirmationActions({required this.isFromShareMenu});
+
+  final bool isFromShareMenu;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    final currentPubkey = ref.read(authServiceProvider).currentPublicKeyHex;
+    final moderationPubkey = ref
+        .read(moderationLabelServiceProvider)
+        .divineModerationPubkeyHex;
+    // The moderation conversation is an ordinary NIP-17 thread; deep-link
+    // straight to it so the user can follow up about their report. Null
+    // when we have no current pubkey (signed out) — the button hides.
+    final moderationConversationId =
+        (currentPubkey != null && currentPubkey.isNotEmpty)
+        ? DmRepository.computeConversationId([currentPubkey, moderationPubkey])
+        : null;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      spacing: 8,
+      children: [
+        if (moderationConversationId case final conversationId?)
           DivineButton(
-            label: l10n.reportClose,
+            label: l10n.reportContactModeration,
+            type: DivineButtonType.secondary,
             expanded: true,
             onPressed: () {
-              Navigator.of(context).pop();
+              // Capture the router before popping the sheet so the push
+              // doesn't run against a defunct context.
+              final router = GoRouter.of(context);
+              final navigator = Navigator.of(context);
+              navigator.pop();
               if (isFromShareMenu) {
-                Navigator.of(context).pop();
+                navigator.pop();
               }
+              router.push(
+                ConversationPage.pathForId(conversationId),
+                extra: [moderationPubkey],
+              );
             },
           ),
-        ],
-      ),
+        DivineButton(
+          label: l10n.reportClose,
+          expanded: true,
+          onPressed: () {
+            Navigator.of(context).pop();
+            if (isFromShareMenu) {
+              Navigator.of(context).pop();
+            }
+          },
+        ),
+      ],
     );
   }
 }

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -2,19 +2,16 @@
 // ABOUTME: Replaces the legacy AlertDialog with a VineBottomSheet-based flow.
 
 import 'package:divine_ui/divine_ui.dart';
-import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/l10n/content_filter_reason_localizations.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
 import 'package:openvine/services/content_moderation_types.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
+import 'package:openvine/widgets/report_content_confirmation.dart';
 import 'package:unified_logger/unified_logger.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 /// Shows a [VineBottomSheet] for reporting content or a user.
 ///
@@ -267,7 +264,7 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
             controller: _scrollController,
             padding: const EdgeInsetsDirectional.fromSTEB(16, 8, 16, 16),
             child: _submitted
-                ? _ReportConfirmationBody(
+                ? ReportConfirmationBody(
                     moderationDmFailed: _moderationDmFailed,
                   )
                 : _ReportFormBody(
@@ -277,22 +274,38 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
                     detailsFocusNode: _detailsFocusNode,
                     detailsFieldKey: _detailsFieldKey,
                     otherCardKey: _otherCardKey,
-                    errorMessage: _errorMessage,
                     onDetailsChanged: _clearErrorMessage,
                   ),
           ),
         ),
-        _SheetFooter(
-          child: _submitted
-              ? _ReportConfirmationActions(
-                  isFromShareMenu: widget.isFromShareMenu,
-                )
-              : DivineButton(
-                  label: context.l10n.reportSubmit,
-                  expanded: true,
-                  onPressed: _canSubmit ? _handleSubmitReport : null,
-                  isLoading: _isSubmitting,
-                ),
+        // The error rides the footer rather than the end of the scroll
+        // content: with the submit action pinned, the user can submit from
+        // any scroll offset, and an error appended below eleven reason cards
+        // lands off-screen — the tap would look like it did nothing.
+        VineKeyboardAwareFooter(
+          includeSafeArea: true,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+            child: _submitted
+                ? ReportConfirmationActions(
+                    isFromShareMenu: widget.isFromShareMenu,
+                  )
+                : Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    spacing: 12,
+                    children: [
+                      if (_errorMessage case final message?)
+                        _InlineError(message: message),
+                      DivineButton(
+                        label: context.l10n.reportSubmit,
+                        expanded: true,
+                        onPressed: _canSubmit ? _handleSubmitReport : null,
+                        isLoading: _isSubmitting,
+                      ),
+                    ],
+                  ),
+          ),
         ),
       ],
     );
@@ -440,39 +453,6 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
   }
 }
 
-/// Action area pinned below the sheet's scrollable content.
-///
-/// Rides above the keyboard the same way [VineBottomSheet]'s `bottomInput`
-/// slot does — the report form's details field lives in the scroll area
-/// above, and a footer flush with the keyboard would put the button under it.
-class _SheetFooter extends StatelessWidget {
-  const _SheetFooter({required this.child});
-
-  /// Gap kept between a raised keyboard and the footer.
-  static const double _keyboardClearance = 12;
-
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    final keyboardInset = MediaQuery.viewInsetsOf(context).bottom;
-    return SafeArea(
-      top: false,
-      child: AnimatedPadding(
-        duration: const Duration(milliseconds: 180),
-        curve: Curves.easeOutCubic,
-        padding: EdgeInsets.only(
-          bottom: keyboardInset > 0 ? keyboardInset + _keyboardClearance : 0,
-        ),
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
-          child: child,
-        ),
-      ),
-    );
-  }
-}
-
 // =============================================================================
 // Report form
 // =============================================================================
@@ -485,7 +465,6 @@ class _ReportFormBody extends StatelessWidget {
     required this.detailsFocusNode,
     required this.detailsFieldKey,
     required this.otherCardKey,
-    required this.errorMessage,
     required this.onDetailsChanged,
   });
 
@@ -499,7 +478,7 @@ class _ReportFormBody extends StatelessWidget {
   /// keyboard pushes the details field up.
   final GlobalKey otherCardKey;
 
-  final String? errorMessage;
+  /// Clears a pending validation error as soon as the user edits the details.
   final VoidCallback onDetailsChanged;
 
   @override
@@ -573,10 +552,6 @@ class _ReportFormBody extends StatelessWidget {
             ),
           ),
         ],
-        if (errorMessage case final message?) ...[
-          const SizedBox(height: 16),
-          _InlineError(message: message),
-        ],
       ],
     );
   }
@@ -619,168 +594,6 @@ class _InlineError extends StatelessWidget {
           ),
         ),
       ),
-    );
-  }
-}
-
-// =============================================================================
-// Confirmation view (shown inside the sheet after successful submission)
-// =============================================================================
-
-class _ReportConfirmationBody extends StatelessWidget {
-  const _ReportConfirmationBody({required this.moderationDmFailed});
-
-  /// Whether the secondary NIP-17 DM to the moderation team failed to
-  /// send. The report itself still succeeded; this only drives a calm
-  /// informational notice so the user isn't misled.
-  final bool moderationDmFailed;
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = context.l10n;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const SizedBox(height: 8),
-        Row(
-          spacing: 12,
-          children: [
-            const DivineIcon(
-              icon: DivineIconName.checkCircle,
-              color: VineTheme.vineGreen,
-              size: 28,
-            ),
-            Expanded(
-              child: Text(
-                l10n.reportReceivedTitle,
-                style: VineTheme.titleMediumFont(
-                  color: context.vineColors.primaryText,
-                ),
-              ),
-            ),
-          ],
-        ),
-        const SizedBox(height: 16),
-        Text(
-          l10n.reportReceivedThankYou,
-          style: VineTheme.bodyLargeFont(color: context.vineColors.primaryText),
-        ),
-        const SizedBox(height: 16),
-        Text(
-          l10n.reportReceivedReviewNotice,
-          style: VineTheme.bodyMediumFont(
-            color: context.vineColors.onSurfaceMuted,
-          ),
-        ),
-        if (moderationDmFailed) ...[
-          const SizedBox(height: 12),
-          Text(
-            l10n.reportModerationDmDelayed,
-            style: VineTheme.bodySmallFont(
-              color: context.vineColors.onSurfaceMuted,
-            ),
-          ),
-        ],
-        const SizedBox(height: 8),
-        const _SafetyPolicyLink(),
-      ],
-    );
-  }
-}
-
-class _SafetyPolicyLink extends StatelessWidget {
-  const _SafetyPolicyLink();
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = context.l10n;
-    return Semantics(
-      button: true,
-      label: l10n.reportSafetyUrl,
-      child: GestureDetector(
-        onTap: () async {
-          final uri = Uri.parse('https://divine.video/safety');
-          if (await canLaunchUrl(uri)) {
-            await launchUrl(uri, mode: LaunchMode.externalApplication);
-          }
-        },
-        child: Text.rich(
-          TextSpan(
-            children: [
-              TextSpan(
-                text: '${l10n.reportLearnMoreAt} ',
-                style: VineTheme.bodyMediumFont(
-                  color: context.vineColors.onSurfaceMuted,
-                ),
-              ),
-              TextSpan(
-                text: l10n.reportSafetyUrl,
-                style: VineTheme.bodyMediumFont(color: VineTheme.vineGreen),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// Footer actions for the post-submission confirmation.
-class _ReportConfirmationActions extends ConsumerWidget {
-  const _ReportConfirmationActions({required this.isFromShareMenu});
-
-  final bool isFromShareMenu;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = context.l10n;
-    final currentPubkey = ref.read(authServiceProvider).currentPublicKeyHex;
-    final moderationPubkey = ref
-        .read(moderationLabelServiceProvider)
-        .divineModerationPubkeyHex;
-    // The moderation conversation is an ordinary NIP-17 thread; deep-link
-    // straight to it so the user can follow up about their report. Null
-    // when we have no current pubkey (signed out) — the button hides.
-    final moderationConversationId =
-        (currentPubkey != null && currentPubkey.isNotEmpty)
-        ? DmRepository.computeConversationId([currentPubkey, moderationPubkey])
-        : null;
-
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      spacing: 8,
-      children: [
-        if (moderationConversationId case final conversationId?)
-          DivineButton(
-            label: l10n.reportContactModeration,
-            type: DivineButtonType.secondary,
-            expanded: true,
-            onPressed: () {
-              // Capture the router before popping the sheet so the push
-              // doesn't run against a defunct context.
-              final router = GoRouter.of(context);
-              final navigator = Navigator.of(context);
-              navigator.pop();
-              if (isFromShareMenu) {
-                navigator.pop();
-              }
-              router.push(
-                ConversationPage.pathForId(conversationId),
-                extra: [moderationPubkey],
-              );
-            },
-          ),
-        DivineButton(
-          label: l10n.reportClose,
-          expanded: true,
-          onPressed: () {
-            Navigator.of(context).pop();
-            if (isFromShareMenu) {
-              Navigator.of(context).pop();
-            }
-          },
-        ),
-      ],
     );
   }
 }

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -564,10 +564,12 @@ class _InlineError extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // `container` makes this its own node and absorbs the Text below, so the
+    // live region already reads [message]. Repeating it as a `label:` here
+    // would prepend a second copy.
     return Semantics(
       container: true,
       liveRegion: true,
-      label: message,
       child: DecoratedBox(
         decoration: BoxDecoration(
           color: VineTheme.error.withValues(alpha: 0.1),

--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/bottom_sheet.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/bottom_sheet.dart
@@ -6,3 +6,4 @@ export 'vine_bottom_sheet_drag_handle.dart';
 export 'vine_bottom_sheet_header.dart';
 export 'vine_bottom_sheet_prompt.dart';
 export 'vine_bottom_sheet_selection_menu.dart';
+export 'vine_keyboard_aware_footer.dart';

--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet.dart
@@ -526,7 +526,7 @@ class _ScrollableContent extends StatelessWidget {
 
         // Optional bottom input
         if (bottomInput != null)
-          _KeyboardAwareBottomInput(includeSafeArea: true, child: bottomInput!),
+          VineKeyboardAwareFooter(includeSafeArea: true, child: bottomInput!),
       ],
     );
   }
@@ -632,55 +632,13 @@ class _FixedContent extends StatelessWidget {
 
           // Optional bottom input
           if (bottomInput != null)
-            _KeyboardAwareBottomInput(
+            VineKeyboardAwareFooter(
               includeSafeArea: false,
               child: bottomInput!,
             ),
         ],
       ),
     );
-  }
-}
-
-class _KeyboardAwareBottomInput extends StatelessWidget {
-  const _KeyboardAwareBottomInput({
-    required this.child,
-    required this.includeSafeArea,
-  });
-
-  /// Gap kept between a raised keyboard and the bottom input so
-  /// keyboard-height variance cannot swallow the input's bottom edge.
-  static const double _keyboardClearance = 12;
-
-  final Widget child;
-  final bool includeSafeArea;
-
-  @override
-  Widget build(BuildContext context) {
-    // Let the bottom input ride the keyboard in both scrollable and fixed
-    // sheet layouts so composers stay visible while typing.
-    //
-    // The clearance keeps the input from sitting flush against the keyboard
-    // top. Real keyboards vary in reported height while typing (predictive
-    // bar appearing, inset animation lag), and a flush composer puts its
-    // bottom-anchored action buttons (send, dismiss) under the keyboard.
-    final keyboardInset = MediaQuery.viewInsetsOf(context).bottom;
-    final paddedInput = AnimatedPadding(
-      duration: const Duration(milliseconds: 180),
-      curve: Curves.easeOutCubic,
-      padding: EdgeInsets.only(
-        bottom: keyboardInset > 0
-            ? keyboardInset + _keyboardClearance
-            : keyboardInset,
-      ),
-      child: child,
-    );
-
-    // Scrollable sheets still need the platform bottom inset once the keyboard
-    // is gone. Fixed sheets are already wrapped in SafeArea higher up.
-    if (!includeSafeArea) return paddedInput;
-
-    return SafeArea(top: false, child: paddedInput);
   }
 }
 

--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_keyboard_aware_footer.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_keyboard_aware_footer.dart
@@ -1,0 +1,55 @@
+// ABOUTME: Bottom-anchored sheet slot that rides above the software keyboard.
+// ABOUTME: Backs VineBottomSheet's bottomInput and custom sheet footers.
+
+import 'package:flutter/material.dart';
+
+/// Bottom-anchored slot that stays above the software keyboard.
+///
+/// Let the slot ride the keyboard in both scrollable and fixed sheet layouts
+/// so composers and actions stay visible while typing.
+///
+/// The clearance keeps the slot from sitting flush against the keyboard top.
+/// Real keyboards vary in reported height while typing (predictive bar
+/// appearing, inset animation lag), and a flush composer puts its
+/// bottom-anchored action buttons (send, dismiss) under the keyboard.
+///
+/// Set [includeSafeArea] to true when nothing above already applies the
+/// platform bottom inset — scrollable sheets need it once the keyboard is
+/// gone, fixed sheets are already wrapped in a `SafeArea` higher up.
+class VineKeyboardAwareFooter extends StatelessWidget {
+  /// Creates a [VineKeyboardAwareFooter].
+  const VineKeyboardAwareFooter({
+    required this.child,
+    required this.includeSafeArea,
+    super.key,
+  });
+
+  /// Gap kept between a raised keyboard and the slot so keyboard-height
+  /// variance cannot swallow the slot's bottom edge.
+  static const double keyboardClearance = 12;
+
+  /// The bottom-anchored content.
+  final Widget child;
+
+  /// Whether to apply the platform bottom inset around [child].
+  final bool includeSafeArea;
+
+  @override
+  Widget build(BuildContext context) {
+    final keyboardInset = MediaQuery.viewInsetsOf(context).bottom;
+    final paddedChild = AnimatedPadding(
+      duration: const Duration(milliseconds: 180),
+      curve: Curves.easeOutCubic,
+      padding: EdgeInsets.only(
+        bottom: keyboardInset > 0
+            ? keyboardInset + keyboardClearance
+            : keyboardInset,
+      ),
+      child: child,
+    );
+
+    if (!includeSafeArea) return paddedChild;
+
+    return SafeArea(top: false, child: paddedChild);
+  }
+}

--- a/mobile/scripts/baseline/file_sizes.txt
+++ b/mobile/scripts/baseline/file_sizes.txt
@@ -29,7 +29,6 @@ lib/services/video_event_publisher.dart	1709
 lib/services/video_event_service.dart	6034
 lib/services/video_publish/video_publish_service.dart	843
 lib/services/zendesk_support_service.dart	1168
-lib/widgets/report_content_dialog.dart	857
 lib/widgets/user_picker_sheet.dart	1009
 lib/widgets/video_editor/main_editor/video_editor_canvas.dart	1962
 lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart	859

--- a/mobile/test/widgets/report_content_confirmation_test.dart
+++ b/mobile/test/widgets/report_content_confirmation_test.dart
@@ -1,0 +1,62 @@
+// ABOUTME: Tests for the report sheet's post-submission confirmation state.
+// ABOUTME: Pins the safety-link semantics so the URL is announced once.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/report_content_confirmation.dart';
+
+void main() {
+  final l10n = lookupAppLocalizations(const Locale('en'));
+
+  Widget buildSubject({bool moderationDmFailed = false}) => MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: ReportConfirmationBody(moderationDmFailed: moderationDmFailed),
+    ),
+  );
+
+  group(ReportConfirmationBody, () {
+    testWidgets('renders the thank-you copy', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n.reportReceivedTitle), findsOneWidget);
+      expect(find.text(l10n.reportReceivedThankYou), findsOneWidget);
+      expect(find.text(l10n.reportModerationDmDelayed), findsNothing);
+    });
+
+    testWidgets('surfaces the delayed-DM notice when the DM failed', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject(moderationDmFailed: true));
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n.reportModerationDmDelayed), findsOneWidget);
+    });
+
+    testWidgets('safety link is a button that announces its label once', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      final link = tester.getSemantics(
+        find.textContaining(l10n.reportSafetyUrl),
+      );
+
+      // A `label:` on the Semantics annotation is prepended to the child
+      // Text's own label rather than replacing it, so a redundant one makes
+      // a screen reader read the URL twice.
+      expect(link.label, '${l10n.reportLearnMoreAt} ${l10n.reportSafetyUrl}');
+      expect(link.getSemanticsData().flagsCollection.isButton, isTrue);
+      expect(link.getSemanticsData().hasAction(SemanticsAction.tap), isTrue);
+
+      handle.dispose();
+    });
+  });
+}

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -593,6 +593,37 @@ void main() {
       },
     );
 
+    testWidgets('the inline error announces its message once', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await setLargeSurface(tester);
+      await openBottomSheetReport(tester);
+
+      await tester.ensureVisible(find.text(l10n.reportReasonOther));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(l10n.reportReasonOther));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
+      await tester.pumpAndSettle();
+
+      final error = tester.getSemantics(
+        find.text(l10n.reportOtherRequiresDetails),
+      );
+
+      // `container: true` already absorbs the Text, so a `label:` on the
+      // annotation would prepend a second copy and a screen reader would
+      // read the whole error twice.
+      expect(error.label, l10n.reportOtherRequiresDetails);
+      expect(
+        error.getSemanticsData().flagsCollection.isLiveRegion,
+        isTrue,
+        reason: 'The error appears without focus moving, so it must announce',
+      );
+
+      handle.dispose();
+    });
+
     testWidgets(
       'bottom sheet path surfaces validation errors inline without snackbars',
       (tester) async {

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -539,14 +539,57 @@ void main() {
         await tester.tap(find.text(l10n.reportReasonSpam));
         await tester.pumpAndSettle();
 
-        await tester.ensureVisible(
-          find.widgetWithText(DivineButton, l10n.reportSubmit),
-        );
         await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
         await tester.pumpAndSettle();
 
         expect(find.textContaining('Failed to report content'), findsOneWidget);
         expect(find.byType(SnackBar), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'submit failure surfaces the error on screen without scrolling',
+      (tester) async {
+        when(
+          () => mockReportingService.reportContent(
+            eventId: any(named: 'eventId'),
+            authorPubkey: any(named: 'authorPubkey'),
+            reason: any(named: 'reason'),
+            details: any(named: 'details'),
+            sourceRelay: any(named: 'sourceRelay'),
+            additionalContext: any(named: 'additionalContext'),
+            hashtags: any(named: 'hashtags'),
+          ),
+        ).thenAnswer((_) async => ReportResult.failure('Server error'));
+
+        // A real phone, not the roomy default surface: the eleven reason
+        // cards overflow here the way they do on device.
+        const screen = Size(412, 915);
+        await tester.binding.setSurfaceSize(screen);
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await openBottomSheetReport(tester);
+
+        // Pick the first reason so the user never has to scroll — the pinned
+        // submit action is reachable from offset zero.
+        await tester.tap(find.text(l10n.reportReasonSpam));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
+        await tester.pumpAndSettle();
+
+        final errorRect = tester.getRect(
+          find.textContaining('Failed to report content'),
+        );
+        expect(
+          errorRect.bottom,
+          lessThanOrEqualTo(screen.height),
+          reason:
+              'The error must be visible where the user tapped. Rendered at '
+              'the end of the scroll content it lands far below the fold and '
+              'the failed submit looks like it did nothing.',
+        );
+        expect(errorRect.top, greaterThanOrEqualTo(0));
       },
     );
 

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -178,7 +178,8 @@ void main() {
     });
 
     testWidgets(
-      'Submit button is visible even before selecting a reason (Apple requirement)',
+      'Submit button is visible before selecting a reason (Apple requirement) '
+      'but stays disabled until one is picked',
       (tester) async {
         await setLargeSurface(tester);
 
@@ -189,34 +190,26 @@ void main() {
           DivineButton,
           l10n.reportSubmit,
         );
-        expect(submitButton, findsOneWidget);
-
-        final DivineButton button = tester.widget(submitButton);
         expect(
-          button.onPressed,
-          isNotNull,
+          submitButton,
+          findsOneWidget,
           reason:
-              'Submit button must be visible/enabled before selecting reason '
+              'Submit button must be visible before selecting a reason '
               '(Apple requirement)',
         );
-      },
-    );
+        expect(
+          tester.widget<DivineButton>(submitButton).onPressed,
+          isNull,
+          reason: 'Nothing to submit until a reason is picked',
+        );
 
-    testWidgets(
-      'Submit button shows error when tapped without selecting reason',
-      (tester) async {
-        await setLargeSurface(tester);
-
-        await tester.pumpWidget(buildSubject());
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
+        await tester.tap(find.text(l10n.reportReasonSpam));
         await tester.pumpAndSettle();
 
         expect(
-          find.text(l10n.reportSelectReason),
-          findsOneWidget,
-          reason: 'Should show error when no reason selected',
+          tester.widget<DivineButton>(submitButton).onPressed,
+          isNotNull,
+          reason: 'Picking a reason enables submission',
         );
       },
     );
@@ -563,16 +556,38 @@ void main() {
         await setLargeSurface(tester);
         await openBottomSheetReport(tester);
 
-        await tester.ensureVisible(
-          find.widgetWithText(DivineButton, l10n.reportSubmit),
-        );
+        await tester.ensureVisible(find.text(l10n.reportReasonOther));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(l10n.reportReasonOther));
+        await tester.pumpAndSettle();
+
         await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
         await tester.pumpAndSettle();
 
-        expect(find.text(l10n.reportSelectReason), findsOneWidget);
+        expect(find.text(l10n.reportOtherRequiresDetails), findsOneWidget);
         expect(find.byType(SnackBar), findsNothing);
       },
     );
+
+    testWidgets('dragging the sheet content down dismisses the sheet', (
+      tester,
+    ) async {
+      await setLargeSurface(tester);
+      await openBottomSheetReport(tester);
+
+      expect(find.text(l10n.reportWhyReporting), findsOneWidget);
+
+      // The sheet's scroll view must run on the DraggableScrollableSheet's
+      // own controller — with a private one the drag never reaches the sheet
+      // and the report form traps the user.
+      await tester.drag(
+        find.text(l10n.reportWhyReporting),
+        const Offset(0, 600),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n.reportWhyReporting), findsNothing);
+    });
 
     testWidgets('Other reason with details submits successfully', (
       tester,


### PR DESCRIPTION
Closes #6619

## Description

Two report-sheet defects plus the last raw snackbars on the profile surfaces.

**The report sheet could not be dragged closed.** It was handed to `VineBottomSheet` as `body:`, and only the `buildScrollBody:` slot receives the `DraggableScrollableSheet`'s `ScrollController`. The content therefore scrolled on a private controller, the sheet's own controller had no attached scrollable, and a downward drag was swallowed by the content instead of shrinking the sheet — so `DraggableScrollableNotification` never reached min extent and `showModalBottomSheet` never closed. All three entry points (`show`, `showForMessage`, `showForUser`) now use `buildScrollBody:` and thread the controller into the scroll view.

**Submit scrolled away with the form and was tappable on an empty form.** It now rides in a pinned footer and stays disabled until a reason is picked. The footer is keyboard-aware the same way `VineBottomSheet`'s `bottomInput` slot is — the "Other" details field sits in the scroll area above it, and a footer flush with the screen bottom would end up under the keyboard.

The confirmation view's actions moved into that same footer. That is what allows a single `SingleChildScrollView` to span both states: swapping one scroll view for another would briefly attach two positions to the sheet's controller during the rebuild. The oversized `build` was split into `_ReportFormBody`, `_InlineError` and the confirmation widgets along the way. The confirmation state (`ReportConfirmationBody`, `ReportConfirmationActions`) lives in its own `report_content_confirmation.dart`, which takes the dialog file from 886 back to 703 lines — under the advisory 800-line ceiling, so its baseline entry is dropped rather than raised.

**The inline error follows the pinned action.** Pinning submit let the user submit from any scroll offset, but the error still rendered at the end of the scroll content — below eleven reason cards. On a 412x915 device, submitting from the top with "Spam" selected put the error at y=1692, roughly 780px past the fold: the spinner stopped and nothing else appeared to happen. The pre-pinning layout hid this because the in-flow button forced the user to the bottom, so the error was always next to it. The error now rides the footer directly above the button. The regression test asserts the error's rect falls inside the viewport at phone size; it fails at 1708.25 > 915.0 without the fix.

The footer itself is no longer bespoke: `VineBottomSheet`'s private `_KeyboardAwareBottomInput` is promoted to a shared `VineKeyboardAwareFooter` in `divine_ui` rather than keeping a second copy of the same clearance and animation constants here.

**Profile snackbars.** Block, unblock, unfollow, copy, embed-code, share failures, follow-toggle failures, notify-bell failures and profile-feed load-more errors were still raw Material `SnackBar`s rendering in default dark grey. They now go through `DivineSnackbarContainer`, with `error: true` on the failure cases. Two `// TODO(SofiaRey): revisit when designs are ready` comments on the block/unblock banners are dropped — the design-system banner is what they were waiting for.

One behavioural change worth calling out: the test `Submit button is visible even before selecting a reason (Apple requirement)` also asserted the button was *enabled*. Apple's requirement is that the reporting affordance is present and reachable, which it still is; the test now pins visible-but-disabled instead.

**Related Issue:** 

## Out of Scope

- The l10n key `reportSelectReason` is now unused in code (the "no reason picked" path is unreachable with the button disabled). Left in the ARBs rather than deleting it from 18 locales in a fix PR.
- On Android 13+ the system shows its own clipboard confirmation on top of our "copied" snackbar. Android's own guidance is to drop the app-side confirmation at API 33+, but `minSdk` is 28 and iOS never shows one, so suppressing it needs a cached `sdkInt` check — separate change.
- ~20 raw `SnackBar` call sites remain elsewhere in `mobile/lib` (comments, inbox, video editor, curated lists). Not touched here to keep the diff reviewable.

## Verification

- `flutter analyze lib test` — clean
- `flutter test` on `report_content_dialog_test.dart`, `other_profile_screen_test.dart`, `profile_screen_router_test.dart`, `follow_from_profile_button_test.dart`, `profile_action_buttons_widget_test.dart`, `conversation_view_test.dart` — 99 passed
- New regression test: dragging the sheet content down dismisses the sheet. Red before this change, green after.
- Both defects were reproduced on a real Samsung Galaxy before the fix. Manual re-verification of the fixed sheet on device is still pending — hence draft.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor
