### PR TITLE
fix(crash): downgrade hero flight layout failures to non-fatal

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1311,8 +1311,7 @@ Future<void> _startOpenVineApp() async {
     final recoverableReason = classifyRecoverableFlutterError(details);
     if (recoverableReason != null) {
       Log.warning(
-        'Recoverable Flutter resource load error (non-fatal): '
-        '${details.exception}',
+        '$recoverableReason (non-fatal): ${details.exception}',
         name: 'Main',
       );
       unawaited(

--- a/mobile/lib/utils/recoverable_flutter_error.dart
+++ b/mobile/lib/utils/recoverable_flutter_error.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:media_cache/media_cache.dart';
 
 const _recoverableMediaLoadReason = 'Recoverable media load failure';
+const _recoverableHeroFlightReason = 'Recoverable hero flight layout failure';
 const _recoverableMediaHosts = <String>{
   'media.divine.video',
   'cdn.divine.video',
@@ -10,14 +11,18 @@ const _recoverableMediaHosts = <String>{
   'cdn.vine.co',
 };
 
-/// Returns a non-fatal reporting reason when a Flutter error represents a
-/// recoverable media or image loading failure.
+/// Returns a non-fatal reporting reason when a Flutter error is one the app
+/// recovers from on its own, or `null` when it must stay fatal.
 ///
-/// The signature checks below match against Flutter/Dart SDK-internal library
-/// paths and context descriptions (for example `_network_image_io` and
-/// `image codec`). Those strings are not part of Flutter's public API and may
-/// change silently on a major SDK upgrade — re-verify them when bumping
-/// Flutter to a new major version.
+/// The signature checks below match against Flutter/Dart SDK internals:
+/// library paths, context descriptions (for example `_network_image_io` and
+/// `image codec`), and stack frame symbols (`HeroController`). None are part
+/// of Flutter's public API and they may change silently on a major SDK
+/// upgrade — re-verify them when bumping Flutter to a new major version. The
+/// stack frame match additionally assumes release builds keep Dart symbols in
+/// `StackTrace.toString()`: building with `--obfuscate` *or*
+/// `--split-debug-info` (which implies `--dwarf-stack-traces`) strips them and
+/// silently sends those errors back to the fatal path.
 String? classifyRecoverableFlutterError(FlutterErrorDetails details) {
   final error = details.exception.toString();
   final library = details.library ?? '';
@@ -69,6 +74,21 @@ String? classifyRecoverableFlutterError(FlutterErrorDetails details) {
       isInvalidImageData ||
       isMediaCacheLoadFailure) {
     return _recoverableMediaLoadReason;
+  }
+
+  // A hero flight measures its destination hero in a post-frame callback, and
+  // a route added to the pages stack under an opaque cover was never laid out
+  // — release's RenderBox.size throws where debug would assert. The scheduler
+  // catches it and skips the flight, so nothing actually crashes
+  // (flutter/flutter#136356, closed unfixed; only the swipe-back variant is
+  // guarded upstream). The stack gate is what keeps a genuine app layout bug
+  // fatal, and is read lazily so the common path never stringifies a stack.
+  final isHeroFlightLayoutFailure =
+      error.contains('RenderBox was not laid out') &&
+      (details.stack?.toString().contains('HeroController') ?? false);
+
+  if (isHeroFlightLayoutFailure) {
+    return _recoverableHeroFlightReason;
   }
 
   return null;

--- a/mobile/test/utils/recoverable_flutter_error_test.dart
+++ b/mobile/test/utils/recoverable_flutter_error_test.dart
@@ -119,6 +119,124 @@ void main() {
       );
     });
 
+    test('classifies hero flight layout failures as recoverable', () {
+      // A destination route added to the go_router pages stack under an opaque
+      // cover is never laid out (_RenderTheatre lays out on-stage children
+      // only), so measuring its hero throws. The scheduler catches it and
+      // skips the flight, but Crashlytics filed
+      // 7743fddabc5ad680dcedf319b70f4f60 as fatal. Frames are verbatim from
+      // that report — flutter/flutter#136356 is the unfixed upstream bug.
+      final details = FlutterErrorDetails(
+        exception: StateError(
+          'RenderBox was not laid out: RenderRepaintBoundary#5a1b2',
+        ),
+        library: 'scheduler library',
+        context: ErrorDescription('during a scheduler callback'),
+        stack: StackTrace.fromString(
+          '#0      RenderBox.size '
+          '(package:flutter/src/rendering/box.dart:2304:7)\n'
+          '#1      _HeroFlightManifest._boundingBoxFor '
+          '(package:flutter/src/widgets/heroes.dart:507:26)\n'
+          '#2      _HeroFlightManifest.toHeroLocation '
+          '(package:flutter/src/widgets/heroes.dart:520:41)\n'
+          '#3      _HeroFlightManifest.isValid '
+          '(package:flutter/src/widgets/heroes.dart:529:29)\n'
+          '#4      HeroController._startHeroTransition '
+          '(package:flutter/src/widgets/heroes.dart:1049:35)\n'
+          '#5      HeroController._maybeStartHeroTransition.<anonymous '
+          'closure> (package:flutter/src/widgets/heroes.dart:972:9)\n'
+          '#6      SchedulerBinding._invokeFrameCallback '
+          '(package:flutter/src/scheduler/binding.dart:1430:15)\n',
+        ),
+      );
+
+      expect(
+        classifyRecoverableFlutterError(details),
+        'Recoverable hero flight layout failure',
+      );
+    });
+
+    test('classifies hero placeholder measurement failures as recoverable', () {
+      // Same root cause, second of the three throw sites: _HeroState
+      // .startFlight reads box.size for the flight placeholder rather than
+      // _boundingBoxFor.
+      final details = FlutterErrorDetails(
+        exception: StateError(
+          'RenderBox was not laid out: RenderSemanticsAnnotations#3f8c9',
+        ),
+        library: 'scheduler library',
+        context: ErrorDescription('during a scheduler callback'),
+        stack: StackTrace.fromString(
+          '#0      RenderBox.size '
+          '(package:flutter/src/rendering/box.dart:2304:7)\n'
+          '#1      _HeroState.startFlight '
+          '(package:flutter/src/widgets/heroes.dart:387:26)\n'
+          '#2      _HeroFlight.start '
+          '(package:flutter/src/widgets/heroes.dart:734:22)\n'
+          '#3      HeroController._startHeroTransition '
+          '(package:flutter/src/widgets/heroes.dart:1054:56)\n'
+          '#4      SchedulerBinding._invokeFrameCallback '
+          '(package:flutter/src/scheduler/binding.dart:1430:15)\n',
+        ),
+      );
+
+      expect(
+        classifyRecoverableFlutterError(details),
+        'Recoverable hero flight layout failure',
+      );
+    });
+
+    test(
+      'does not classify non-hero RenderBox layout failures as recoverable',
+      () {
+        // Exception, library and context are identical to the hero flight
+        // failure: any post-frame callback that measures a widget which is
+        // mounted but unlaid out produces this. ScrollToHideMixin
+        // (scroll_to_hide_mixin.dart:38-45) guards on `box != null`, which does
+        // not imply hasSize. Only the stack tells the two apart, and this one is
+        // a real app bug that must stay fatal.
+        final details = FlutterErrorDetails(
+          exception: StateError(
+            'RenderBox was not laid out: RenderPadding#7c3d1',
+          ),
+          library: 'scheduler library',
+          context: ErrorDescription('during a scheduler callback'),
+          stack: StackTrace.fromString(
+            '#0      RenderBox.size '
+            '(package:flutter/src/rendering/box.dart:2304:7)\n'
+            '#1      ScrollToHideMixin.measureHeaderHeight.<anonymous closure> '
+            '(package:openvine/widgets/scroll_to_hide_mixin.dart:42:26)\n'
+            '#2      SchedulerBinding._invokeFrameCallback '
+            '(package:flutter/src/scheduler/binding.dart:1430:15)\n',
+          ),
+        );
+
+        expect(classifyRecoverableFlutterError(details), isNull);
+      },
+    );
+
+    test('does not classify debug hero layout assertions as recoverable', () {
+      // heroes.dart:504 asserts `box.hasSize && box.size.isFinite`, which
+      // short-circuits before RenderBox.size is read, so the debug message
+      // never mentions the size. Debug and test runs stay loud; only the
+      // release StateError is downgraded.
+      final details = FlutterErrorDetails(
+        exception: AssertionError(
+          "'package:flutter/src/widgets/heroes.dart': Failed assertion: "
+          "line 504 pos 12: 'box.hasSize && box.size.isFinite': is not true.",
+        ),
+        library: 'scheduler library',
+        stack: StackTrace.fromString(
+          '#0      _HeroFlightManifest._boundingBoxFor '
+          '(package:flutter/src/widgets/heroes.dart:504:12)\n'
+          '#1      HeroController._startHeroTransition '
+          '(package:flutter/src/widgets/heroes.dart:1049:35)\n',
+        ),
+      );
+
+      expect(classifyRecoverableFlutterError(details), isNull);
+    });
+
     test('does not classify unrelated gesture errors as recoverable', () {
       final details = FlutterErrorDetails(
         exception: Exception('GoError: There is nothing to pop.'),


### PR DESCRIPTION
## Description

Crashlytics `7743fddabc5ad680dcedf319b70f4f60` (1.0.17/813, iOS) is filed as `Fatal Exception: FlutterError`, but nothing crashed. The real error is `StateError: RenderBox was not laid out` from `box.dart:2304` — the release-mode throw in the `RenderBox.size` getter — reached through Flutter's hero machinery:

```
RenderBox.size                                    box.dart:2304
_HeroFlightManifest._boundingBoxFor               heroes.dart:507
_HeroFlightManifest.toHeroLocation                heroes.dart:520
_HeroFlightManifest.isValid                       heroes.dart
HeroController._startHeroTransition               heroes.dart
HeroController._maybeStartHeroTransition.<fn>     heroes.dart:972
SchedulerBinding._invokeFrameCallback             binding.dart:1430
```

`SchedulerBinding._invokeFrameCallback` catches the throw, so the app keeps running and the hero transition is simply skipped. It is recorded as fatal only because `crash_reporting_service.dart:37-46` wires `FlutterError.onError` to `recordFlutterFatalError` and nothing in `main.dart`'s handler matched the signature.

**Why it happens:** `_RenderTheatre.performLayout` lays out only the overlay children from `_firstOnstageChild`, so entries below the topmost opaque route are never laid out. A route that enters the go_router pages stack while already covered can therefore reach a hero flight with no size, and every size read on that path is guarded by a release-stripped `assert`. There are three such throw sites, all under `HeroController._startHeroTransition`: `heroes.dart:507`, `:387` (`_HeroState.startFlight`) and `:1033` (`navigatorSize`).

Unfixed upstream: [flutter/flutter#136356](https://github.com/flutter/flutter/issues/136356) carries the identical stack under `Navigator.pages` and was auto-closed for lack of a reproduction; [#168267](https://github.com/flutter/flutter/issues/168267) guards only the user-gesture swipe-back path, which our SDK already has.

**What this does:** adds a second signature to `classifyRecoverableFlutterError` so the report records as a non-fatal with its own reason (`Recoverable hero flight layout failure`) instead of counting against crash-free users, while keeping its frequency measurable.

The stack gate carries the precision. `scroll_to_hide_mixin.dart:38-45` reads `box.size.height` from a post-frame callback behind a `box != null` check that does not imply `hasSize`, on three screens — that produces a byte-identically framed error (same message, same `library: 'scheduler library'`, same context) which must stay fatal. Only the stack separates them, and a regression test pins that. Matching `HeroController` rather than `_HeroFlightManifest` is also what covers all three throw sites without reaching a `flightShuttleBuilder`, which runs during the build phase outside the controller.

The predicate reads Dart symbols out of `StackTrace.toString()`. Those survive only because shipped builds pass neither `--obfuscate` nor `--split-debug-info`; either flag sends these errors back to the fatal path (fail-safe, and it would make every Crashlytics report unsymbolized at the same time). The doc comment says so.

**This is reporting hygiene, not a fix.** The flight still fails, and the empty-placeholder artifact it can leave behind when the aborted cleanup loop doesn't run is untouched — the stack carries no app frames, so there is no way yet to say which of the ~15 hero sites is involved.

**Related Issue:** Closes #6615

## Out of Scope

Two adjacent findings, deliberately not changed here:

- `main.dart:1289-1290` runs before the classifier and matches `errorStr.contains('Bad state') && errorStr.contains('player')`. `StateError.toString()` starts with `Bad state:`, so this error already satisfies half of it and is spared only because render-object type names carry no lowercase `player`. Anyone who lowercases that check, or adds `.toLowerCase()`, silently reroutes hero errors into the video-player reason and this signature goes dark.
- `global_error_widget.dart:47` calls `recordFlutterFatalError` unconditionally, bypassing the classifier. It has no production caller today (`main.dart:1195` installs a different `ErrorWidget.builder`) and cannot affect this change, since `ErrorWidget.builder` only fires for build-phase errors while this throw is in a post-frame callback. If it is ever wired, build-phase recoverable errors would be reported twice — worth its own issue rather than doubling the blast radius of a crash-reporting change.

## Verification

- `flutter test test/utils/recoverable_flutter_error_test.dart` — 16 pass (12 existing + 4 new).
- `flutter analyze lib test integration_test` — no issues.
- `dart format --set-exit-if-changed` on all three files — no changes.
- Mutation check that the new guard is load-bearing: dropping the `HeroController` condition from the predicate turns "does not classify non-hero RenderBox layout failures as recoverable" red, and only that test. Restored before commit.

The stack fixtures are the verbatim production frames. There is no end-to-end runtime check available — the framework bug has no known reproduction, and an asserts-enabled build trips `heroes.dart:504` first, whose message deliberately does not match (it short-circuits on `box.hasSize` before reading `box.size`), so debug and test runs stay loud. What validates the predicate instead is the production artifact: firebase_crashlytics 5.0.7 builds its frames from `Trace.parseVM(stackTrace.toString())`, so the console rendering `_HeroFlightManifest._boundingBoxFor (heroes.dart:507)` is direct evidence that `details.stack.toString()` carried those symbols in the shipped build.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
