### PR TITLE
fix(profile): stop ID-list grids locking into a sub-page window

### DIFF
--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
@@ -253,7 +253,9 @@ class ProfileLikedVideosBloc
   /// window: when the ID list is unchanged (the common reopen) this is just a
   /// flag flip; when it changed, [_reconcile] drops unliked videos and fetches
   /// only the newly-liked IDs in the window, so the UI thread never does bulk
-  /// video work here.
+  /// video work here. The one exception is an underfilled window
+  /// ([_isWindowUnderfilled]), which reconciles even on an unchanged ID list
+  /// because it can never recover otherwise.
   Future<void> _warmRevalidate(Emitter<ProfileLikedVideosState> emit) async {
     final List<String> freshIds;
     if (_isOtherUserProfile) {
@@ -263,7 +265,8 @@ class ProfileLikedVideosBloc
     }
     if (isClosed) return;
 
-    if (listEquals(freshIds, state.likedEventIds)) {
+    if (listEquals(freshIds, state.likedEventIds) &&
+        !_isWindowUnderfilled(freshIds)) {
       // Nothing changed — just hide the bar. No re-fetch, no re-serialize.
       emit(state.copyWith(isRefreshing: false));
       return;
@@ -297,7 +300,8 @@ class ProfileLikedVideosBloc
   /// Keeps videos still liked (in fresh order), drops unliked ones, and
   /// fetches only the liked IDs in the loaded window that have no video yet —
   /// typically just the clip the user (or another device) liked at the top.
-  /// Bounded to the loaded window so it never bulk-fetches.
+  /// Bounded to the loaded window (but never below one page) so it never
+  /// bulk-fetches.
   Future<({List<VideoEvent> videos, int nextPageOffset, bool hasMoreContent})>
   _reconcile(List<String> freshIds) async {
     final byId = {for (final video in state.videos) video.id: video};
@@ -307,11 +311,15 @@ class ProfileLikedVideosBloc
     // previous total), which would otherwise balloon the window to a full
     // re-fetch on reopen. Falls back to 0 (no growth) if the old top is gone.
     final newAtTop = _newItemsAtTop(freshIds);
-    final windowSize =
-        (max(state.nextPageOffset, state.videos.length) + newAtTop).clamp(
-          0,
-          freshIds.length,
-        );
+    // Floored at one page. The window is otherwise bounded by what is already
+    // loaded, so a first load that resolved fewer than a page — e.g. the cold
+    // path ran against a local liked-ID list that had not finished syncing —
+    // stays that size permanently: every reconcile re-derives the same short
+    // window and persists it, and a grid shorter than the viewport never
+    // scrolls, so scroll-driven pagination can never grow it either.
+    final loadedWindow =
+        max(state.nextPageOffset, state.videos.length) + newAtTop;
+    final windowSize = max(loadedWindow, _pageSize).clamp(0, freshIds.length);
     final windowIds = freshIds.take(windowSize).toList();
 
     final missingIds = windowIds.where((id) => !byId.containsKey(id)).toList();
@@ -341,6 +349,16 @@ class ProfileLikedVideosBloc
     final index = freshIds.indexOf(state.likedEventIds.first);
     return index < 0 ? 0 : index;
   }
+
+  /// Whether the loaded window holds less than a page while [ids] still has
+  /// unconsumed entries.
+  ///
+  /// This is the state a short first load leaves behind, and it must be
+  /// topped up even when the ID list itself is unchanged — otherwise the
+  /// unchanged-IDs fast path in [_warmRevalidate] would keep the short window
+  /// alive on every reopen for anyone whose ID list has settled.
+  bool _isWindowUnderfilled(List<String> ids) =>
+      state.nextPageOffset < _pageSize && state.nextPageOffset < ids.length;
 
   static const ProfileVideoListSnapshot _emptySnapshot =
       ProfileVideoListSnapshot(

--- a/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
@@ -219,7 +219,8 @@ class ProfileRepostedVideosBloc
     }
     if (isClosed) return;
 
-    if (listEquals(freshIds, state.repostedAddressableIds)) {
+    if (listEquals(freshIds, state.repostedAddressableIds) &&
+        !_isWindowUnderfilled(freshIds)) {
       emit(state.copyWith(isRefreshing: false));
       return;
     }
@@ -261,11 +262,11 @@ class ProfileRepostedVideosBloc
     // persisted ID list can't balloon the reconcile window into a full
     // re-fetch on reopen (see ProfileLikedVideosBloc for the rationale).
     final newAtTop = _newItemsAtTop(freshIds);
-    final windowSize =
-        (max(state.nextPageOffset, state.videos.length) + newAtTop).clamp(
-          0,
-          freshIds.length,
-        );
+    // Floored at one page so a window that was once shorter than a page can
+    // recover; see ProfileLikedVideosBloc for the lock-in it prevents.
+    final loadedWindow =
+        max(state.nextPageOffset, state.videos.length) + newAtTop;
+    final windowSize = max(loadedWindow, _pageSize).clamp(0, freshIds.length);
     final windowIds = freshIds.take(windowSize).toList();
 
     final missingIds = windowIds.where((id) => !byId.containsKey(id)).toList();
@@ -296,6 +297,13 @@ class ProfileRepostedVideosBloc
     final index = freshIds.indexOf(state.repostedAddressableIds.first);
     return index < 0 ? 0 : index;
   }
+
+  /// Whether the loaded window holds less than a page while [ids] still has
+  /// unconsumed entries — the state a short first load leaves behind, which
+  /// must be topped up even when the ID list itself is unchanged. See
+  /// ProfileLikedVideosBloc for the lock-in this prevents.
+  bool _isWindowUnderfilled(List<String> ids) =>
+      state.nextPageOffset < _pageSize && state.nextPageOffset < ids.length;
 
   static const ProfileVideoListSnapshot _emptySnapshot =
       ProfileVideoListSnapshot(

--- a/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
@@ -183,7 +183,8 @@ class ProfileSavedVideosBloc
     List<String> freshIds,
     Emitter<ProfileSavedVideosState> emit,
   ) async {
-    if (listEquals(freshIds, state.savedEventIds)) {
+    if (listEquals(freshIds, state.savedEventIds) &&
+        !_isWindowUnderfilled(freshIds)) {
       emit(state.copyWith(isRefreshing: false));
       return;
     }
@@ -221,11 +222,11 @@ class ProfileSavedVideosBloc
     // persisted ID list can't balloon the reconcile window into a full
     // re-fetch on reopen (see ProfileLikedVideosBloc for the rationale).
     final newAtTop = _newItemsAtTop(freshIds);
-    final windowSize =
-        (max(state.nextPageOffset, state.videos.length) + newAtTop).clamp(
-          0,
-          freshIds.length,
-        );
+    // Floored at one page so a window that was once shorter than a page can
+    // recover; see ProfileLikedVideosBloc for the lock-in it prevents.
+    final loadedWindow =
+        max(state.nextPageOffset, state.videos.length) + newAtTop;
+    final windowSize = max(loadedWindow, _pageSize).clamp(0, freshIds.length);
     final windowIds = freshIds.take(windowSize).toList();
 
     final missingIds = windowIds.where((id) => !byId.containsKey(id)).toList();
@@ -255,6 +256,13 @@ class ProfileSavedVideosBloc
     final index = freshIds.indexOf(state.savedEventIds.first);
     return index < 0 ? 0 : index;
   }
+
+  /// Whether the loaded window holds less than a page while [ids] still has
+  /// unconsumed entries — the state a short first load leaves behind, which
+  /// must be topped up even when the ID list itself is unchanged. See
+  /// ProfileLikedVideosBloc for the lock-in this prevents.
+  bool _isWindowUnderfilled(List<String> ids) =>
+      state.nextPageOffset < _pageSize && state.nextPageOffset < ids.length;
 
   static const ProfileVideoListSnapshot _emptySnapshot =
       ProfileVideoListSnapshot(

--- a/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
@@ -344,6 +344,110 @@ void main() {
       );
 
       blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
+        'grows a persisted window shorter than a page even when the liked-ID '
+        'list is unchanged',
+        setUp: () async {
+          final ids = List.generate(50, (i) => 'like$i');
+          // A previous run persisted a 6-item window: its cold load resolved
+          // the local liked-ID list before the relay sync had filled it in.
+          await cacheDao.write(
+            key: '$currentUserPubkey:$currentUserPubkey:profile_liked_videos',
+            payload: ProfileVideoListSnapshot(
+              videos: ids.take(6).map(createTestVideo).toList(),
+              itemIds: ids,
+              nextPageOffset: 6,
+              hasMoreContent: true,
+            ).toJson(),
+          );
+          // Relay agrees with the persisted ID list, so the unchanged-IDs
+          // fast path would otherwise leave the short window in place.
+          when(() => mockLikesRepository.syncUserReactions()).thenAnswer(
+            (_) async => LikesSyncResult(
+              orderedEventIds: ids,
+              eventIdToReactionId: const {},
+            ),
+          );
+          when(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).thenAnswer(
+            (invocation) async =>
+                (invocation.positionalArguments[0] as List<String>)
+                    .map(createTestVideo)
+                    .toList(),
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ProfileLikedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileLikedVideosState>().having(
+            (s) => s.videos.length,
+            'short cached window served first',
+            6,
+          ),
+          isA<ProfileLikedVideosState>()
+              .having((s) => s.videos.length, 'grown to a full page', 18)
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 18)
+              .having((s) => s.hasMoreContent, 'hasMoreContent', true)
+              .having((s) => s.isRefreshing, 'isRefreshing', false),
+        ],
+      );
+
+      blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
+        'reconciling a short window against a longer ID list refills it to a '
+        'page',
+        setUp: () async {
+          // The persisted ID list is capped, so it differs from the relay's —
+          // reconciliation runs, and must not inherit the 6-item window.
+          final cachedIds = List.generate(30, (i) => 'like$i');
+          final freshIds = List.generate(40, (i) => 'like$i');
+          await cacheDao.write(
+            key: '$currentUserPubkey:$currentUserPubkey:profile_liked_videos',
+            payload: ProfileVideoListSnapshot(
+              videos: cachedIds.take(6).map(createTestVideo).toList(),
+              itemIds: cachedIds,
+              nextPageOffset: 6,
+              hasMoreContent: true,
+            ).toJson(),
+          );
+          when(() => mockLikesRepository.syncUserReactions()).thenAnswer(
+            (_) async => LikesSyncResult(
+              orderedEventIds: freshIds,
+              eventIdToReactionId: const {},
+            ),
+          );
+          when(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).thenAnswer(
+            (invocation) async =>
+                (invocation.positionalArguments[0] as List<String>)
+                    .map(createTestVideo)
+                    .toList(),
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ProfileLikedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileLikedVideosState>().having(
+            (s) => s.videos.length,
+            'short cached window served first',
+            6,
+          ),
+          isA<ProfileLikedVideosState>()
+              .having((s) => s.videos.length, 'refilled to a page', 18)
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 18)
+              .having((s) => s.hasMoreContent, 'hasMoreContent', true),
+        ],
+      );
+
+      blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
         'warm revalidation drops unliked videos without re-fetching',
         setUp: () async {
           await cacheDao.write(

--- a/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
@@ -448,6 +448,71 @@ void main() {
       );
 
       blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
+        'stays on the fast path for a sub-page window whose IDs are all '
+        'consumed',
+        setUp: () async {
+          // Sparse likes: 6 IDs consumed, only 5 resolved to a video. The
+          // window is under a page, but there is nothing left to top it up
+          // with, so revalidation must not re-enter reconcile. Counting
+          // resolved videos rather than consumed IDs would loop here — a
+          // fetch, a re-serialize and a cache write on every single reopen.
+          final ids = List.generate(6, (i) => 'like$i');
+          await cacheDao.write(
+            key: '$currentUserPubkey:$currentUserPubkey:profile_liked_videos',
+            payload: ProfileVideoListSnapshot(
+              videos: ids
+                  .where((id) => id != 'like3')
+                  .map(createTestVideo)
+                  .toList(),
+              itemIds: ids,
+              nextPageOffset: 6,
+              hasMoreContent: false,
+            ).toJson(),
+          );
+          when(() => mockLikesRepository.syncUserReactions()).thenAnswer(
+            (_) async => LikesSyncResult(
+              orderedEventIds: ids,
+              eventIdToReactionId: const {},
+            ),
+          );
+          // `like3` stays unresolvable, so a reconcile would keep asking for
+          // it forever.
+          when(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).thenAnswer(
+            (invocation) async =>
+                (invocation.positionalArguments[0] as List<String>)
+                    .where((id) => id != 'like3')
+                    .map(createTestVideo)
+                    .toList(),
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ProfileLikedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileLikedVideosState>()
+              .having((s) => s.videos.length, 'cached videos', 5)
+              .having((s) => s.isRefreshing, 'isRefreshing', true),
+          isA<ProfileLikedVideosState>()
+              .having((s) => s.videos.length, 'unchanged videos', 5)
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 6)
+              .having((s) => s.isRefreshing, 'isRefreshing', false),
+        ],
+        verify: (_) {
+          verifyNever(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          );
+        },
+      );
+
+      blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
         'warm revalidation drops unliked videos without re-fetching',
         setUp: () async {
           await cacheDao.write(

--- a/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
@@ -424,6 +424,81 @@ void main() {
       );
 
       blocTest<ProfileRepostedVideosBloc, ProfileRepostedVideosState>(
+        'stays on the fast path for a sub-page window whose IDs are all '
+        'consumed',
+        setUp: () async {
+          // 6 addressable IDs consumed, only 5 resolved to a video. The
+          // window is under a page with nothing left to top it up with, so
+          // revalidation must not re-enter reconcile. See
+          // ProfileLikedVideosBloc's sibling test for the loop this pins.
+          final ids = List.generate(
+            6,
+            (i) => createAddressableId(currentUserPubkey, 'd$i'),
+          );
+          await cacheDao.write(
+            key: '$currentUserPubkey:profile_reposted_videos',
+            payload: ProfileVideoListSnapshot(
+              videos: [
+                for (var i = 0; i < 6; i++)
+                  if (i != 3)
+                    createTestVideo(
+                      id: 'e$i',
+                      pubkey: currentUserPubkey,
+                      vineId: 'd$i',
+                    ),
+              ],
+              itemIds: ids,
+              nextPageOffset: 6,
+              hasMoreContent: false,
+            ).toJson(),
+          );
+          when(() => mockRepostsRepository.syncUserReposts()).thenAnswer(
+            (_) async => RepostsSyncResult(
+              orderedAddressableIds: ids,
+              addressableIdToRepostId: const {},
+            ),
+          );
+          when(
+            () => mockVideosRepository.getVideosByAddressableIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).thenAnswer((invocation) async {
+            final requested = invocation.positionalArguments[0] as List<String>;
+            return [
+              for (final id in requested)
+                if (id.split(':').last != 'd3')
+                  createTestVideo(
+                    id: 'e${id.split(':').last.substring(1)}',
+                    pubkey: currentUserPubkey,
+                    vineId: id.split(':').last,
+                  ),
+            ];
+          });
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ProfileRepostedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileRepostedVideosState>()
+              .having((s) => s.videos.length, 'cached videos', 5)
+              .having((s) => s.isRefreshing, 'isRefreshing', true),
+          isA<ProfileRepostedVideosState>()
+              .having((s) => s.videos.length, 'unchanged videos', 5)
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 6)
+              .having((s) => s.isRefreshing, 'isRefreshing', false),
+        ],
+        verify: (_) {
+          verifyNever(
+            () => mockVideosRepository.getVideosByAddressableIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          );
+        },
+      );
+
+      blocTest<ProfileRepostedVideosBloc, ProfileRepostedVideosState>(
         'reopen restores the full scrolled-through list from cache',
         setUp: () async {
           final ids = List.generate(

--- a/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
@@ -361,6 +361,69 @@ void main() {
       );
 
       blocTest<ProfileRepostedVideosBloc, ProfileRepostedVideosState>(
+        'grows a persisted window shorter than a page even when the reposted '
+        'ID list is unchanged',
+        setUp: () async {
+          final ids = List.generate(
+            50,
+            (i) => createAddressableId(currentUserPubkey, 'd$i'),
+          );
+          await cacheDao.write(
+            key: '$currentUserPubkey:profile_reposted_videos',
+            payload: ProfileVideoListSnapshot(
+              videos: List.generate(
+                6,
+                (i) => createTestVideo(
+                  id: 'e$i',
+                  pubkey: currentUserPubkey,
+                  vineId: 'd$i',
+                ),
+              ),
+              itemIds: ids,
+              nextPageOffset: 6,
+              hasMoreContent: true,
+            ).toJson(),
+          );
+          when(() => mockRepostsRepository.syncUserReposts()).thenAnswer(
+            (_) async => RepostsSyncResult(
+              orderedAddressableIds: ids,
+              addressableIdToRepostId: const {},
+            ),
+          );
+          when(
+            () => mockVideosRepository.getVideosByAddressableIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).thenAnswer((invocation) async {
+            final requested = invocation.positionalArguments[0] as List<String>;
+            return [
+              for (final id in requested)
+                createTestVideo(
+                  id: 'e${id.split(':').last.substring(1)}',
+                  pubkey: currentUserPubkey,
+                  vineId: id.split(':').last,
+                ),
+            ];
+          });
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ProfileRepostedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileRepostedVideosState>().having(
+            (s) => s.videos.length,
+            'short cached window served first',
+            6,
+          ),
+          isA<ProfileRepostedVideosState>()
+              .having((s) => s.videos.length, 'grown to a full page', 18)
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 18)
+              .having((s) => s.hasMoreContent, 'hasMoreContent', true),
+        ],
+      );
+
+      blocTest<ProfileRepostedVideosBloc, ProfileRepostedVideosState>(
         'reopen restores the full scrolled-through list from cache',
         setUp: () async {
           final ids = List.generate(

--- a/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
@@ -222,6 +222,65 @@ void main() {
       );
 
       blocTest<ProfileSavedVideosBloc, ProfileSavedVideosState>(
+        'stays on the fast path for a sub-page window whose IDs are all '
+        'consumed',
+        setUp: () async {
+          // 6 bookmark IDs consumed, only 5 resolved to a video. The window
+          // is under a page with nothing left to top it up with, so
+          // revalidation must not re-enter reconcile. See
+          // ProfileLikedVideosBloc's sibling test for the loop this pins.
+          final ids = List.generate(6, (i) => 'video-$i');
+          await cacheDao.write(
+            key: '$currentUserPubkey:profile_saved_videos',
+            payload: ProfileVideoListSnapshot(
+              videos: ids
+                  .where((id) => id != 'video-3')
+                  .map(createTestVideo)
+                  .toList(),
+              itemIds: ids,
+              nextPageOffset: 6,
+              hasMoreContent: false,
+            ).toJson(),
+          );
+          when(() => mockBookmarkService.globalBookmarks).thenReturn([
+            for (final id in ids) BookmarkItem(type: 'e', id: id),
+          ]);
+          when(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).thenAnswer(
+            (invocation) async =>
+                (invocation.positionalArguments[0] as List<String>)
+                    .where((id) => id != 'video-3')
+                    .map(createTestVideo)
+                    .toList(),
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ProfileSavedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileSavedVideosState>()
+              .having((s) => s.videos.length, 'cached videos', 5)
+              .having((s) => s.isRefreshing, 'isRefreshing', true),
+          isA<ProfileSavedVideosState>()
+              .having((s) => s.videos.length, 'unchanged videos', 5)
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 6)
+              .having((s) => s.isRefreshing, 'isRefreshing', false),
+        ],
+        verify: (_) {
+          verifyNever(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          );
+        },
+      );
+
+      blocTest<ProfileSavedVideosBloc, ProfileSavedVideosState>(
         'filters non-event bookmarks (hashtags, urls) and loads videos for '
         'event bookmarks',
         setUp: () {

--- a/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
@@ -177,6 +177,51 @@ void main() {
       );
 
       blocTest<ProfileSavedVideosBloc, ProfileSavedVideosState>(
+        'grows a persisted window shorter than a page even when the bookmark '
+        'list is unchanged',
+        setUp: () async {
+          final ids = List.generate(50, (i) => 'video-$i');
+          await cacheDao.write(
+            key: '$currentUserPubkey:profile_saved_videos',
+            payload: ProfileVideoListSnapshot(
+              videos: ids.take(6).map(createTestVideo).toList(),
+              itemIds: ids,
+              nextPageOffset: 6,
+              hasMoreContent: true,
+            ).toJson(),
+          );
+          when(() => mockBookmarkService.globalBookmarks).thenReturn([
+            for (final id in ids) BookmarkItem(type: 'e', id: id),
+          ]);
+          when(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).thenAnswer(
+            (invocation) async =>
+                (invocation.positionalArguments[0] as List<String>)
+                    .map(createTestVideo)
+                    .toList(),
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ProfileSavedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileSavedVideosState>().having(
+            (s) => s.videos.length,
+            'short cached window served first',
+            6,
+          ),
+          isA<ProfileSavedVideosState>()
+              .having((s) => s.videos.length, 'grown to a full page', 18)
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 18)
+              .having((s) => s.hasMoreContent, 'hasMoreContent', true),
+        ],
+      );
+
+      blocTest<ProfileSavedVideosBloc, ProfileSavedVideosState>(
         'filters non-event bookmarks (hashtags, urls) and loads videos for '
         'event bookmarks',
         setUp: () {


### PR DESCRIPTION
Closes #6622

## Description

The profile Liked tab could get permanently stuck showing a handful of videos. Reproduced on a real account with 254 likes on the relay that rendered only 6 tiles, across restarts.

**Root cause.** `_reconcile` sized its window as `max(nextPageOffset, videos.length) + newAtTop` — bounded by what was already loaded, with no lower bound. Once a window ended up shorter than a page it could never grow again:

- The cold path prefers the local liked-ID list and syncs the relay only in the background. If that local list has not finished syncing, the first load resolves whatever few IDs it has and persists `nextPageOffset: 6`.
- The background sync then delivers the full list, but reconciliation inherits the 6-item window and writes it straight back to `CacheSync`.
- Every restart repeats that: the snapshot is served, revalidation reconciles, the window stays 6, the snapshot is re-persisted.
- The only escape would be pagination, but `ScrollPaginationMixin` fires on scroll events only. Six tiles are two rows — profile header plus two rows fits the viewport, nothing scrolls, `onLoadMore` never runs. `hasMoreContent` sat at `true` the whole time and was never redeemable.

Evidence from the affected device's `cache_sync.db`:

```
videos: 6   itemIds: 200   nextPageOffset: 6   hasMoreContent: true
```

...with the 6 videos being exactly the 6 most recent likes. Relay-side the data was fine: 228 of 250 liked IDs survive the full parse and filter chain, so nothing was actually missing.

**Fix.** Two changes, applied to all three ID-list-backed tabs (Liked, Saved, Reposts) since they share the same reconcile shape:

1. Floor the reconcile window at one page, so a window that was once short can recover.
2. Bypass the unchanged-IDs fast path in `_warmRevalidate` when the window is underfilled. Without this the fix would only reach users whose ID list is still changing — with ≤200 items the cached and fresh lists are identical, `listEquals` short-circuits, and the short window survives forever.

The underfill predicate counts consumed **IDs**, not resolved videos. Liked IDs are sparse (roughly 8% never resolve to a playable video), so a video-count predicate would stay true after the top-up and re-reconcile on every reopen. Counting IDs makes it fire exactly once and then stay on the cheap path.

Affected installs heal themselves on next launch — the window widens from 6 to 18 and pagination takes over from there. No cache migration needed.

**Related Issue:** 

Same user-visible symptom as #5210 and #5325, both of which were different mechanisms (pagination not continuing, and a SQLite/​cache drift in `watchLikedEventIds`).

## Out of Scope

`ScrollPaginationMixin` still keys purely off scroll events, so a list shorter than the viewport with `hasMoreContent: true` cannot request more on its own. Fixing it properly touches all 11 call sites and belongs in its own PR.

That weakness leaves one residual case this PR does not close. The floor is one page of **IDs**: `_reconcile` sets `nextPageOffset` to the IDs it consumed, while the grid renders only the subset that resolves — and `_fetchVideos` drops unsupported formats and blocklist-filtered authors on top of dead events. A window whose 18 IDs resolve to a handful of tiles therefore lands on `nextPageOffset: 18`, `hasMoreContent: true`, and an underfill predicate that is now false: the same non-scrolling dead end, one offset further out. Note the asymmetry — `_coldLoad` fills a page of *videos* via `_fetchVideoPage`, `_reconcile` does not. Closing that here by making `_reconcile` fill a page of videos would reintroduce exactly the unbounded re-fetch it was written to avoid (pinned by the capped-snapshot test), so it belongs with the mixin fix, which closes it generically for every tab regardless of cause. At the ~8% sparsity measured on the affected account this needs roughly 90% of a window to be unresolvable, so it is a narrow tail, not the reported bug.

## Verification

- 4 new regression tests: the unchanged-ID growth case on each of the three tabs, plus the changed-ID refill case on Liked. Each was checked individually against a stashed `lib/` fix and fails without it.
- `flutter test test/blocs test/widgets/profile` → 3072 passed
- `flutter analyze lib test` → clean
- Manually verified on a real Samsung Galaxy (SM-S942B): the Liked tab recovered from 6 tiles to the full list on the next launch, and scrolling continues to paginate.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
