### PR TITLE
fix(video): purge NIP-09 deleted videos from the local event store

### DIFF
--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -176,9 +176,11 @@ VideoEventService videoEventService(Ref ref) {
   }
   service.seedKnownDeletionTombstones(
     eventIds: persistedDeletions.map((deletion) => deletion.originalEventId),
-    addressableIds: persistedDeletions
-        .map((deletion) => deletion.addressableId)
-        .whereType<String>(),
+    addressableDeletedAt: {
+      for (final deletion in persistedDeletions)
+        ?deletion.addressableId:
+            deletion.deletedAt.millisecondsSinceEpoch ~/ 1000,
+    },
   );
   service.setBlocklistRepository(blocklistRepository);
   service.setLikesRepository(likesRepository);

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -269,7 +269,7 @@ final class VideoEventServiceProvider
   }
 }
 
-String _$videoEventServiceHash() => r'7507831fe85efacc79d4b974a06fd19a0bb8dec7';
+String _$videoEventServiceHash() => r'e2aabe88e273a2b1748f596b7b32fa920122911d';
 
 /// Video event publisher for publishing video events to Nostr relays
 

--- a/mobile/lib/services/event_router.dart
+++ b/mobile/lib/services/event_router.dart
@@ -140,6 +140,29 @@ class EventRouter {
   /// lifetime.
   int get droppedEventCount => _droppedEventCount;
 
+  /// Drops every queued event whose id is in [eventIds], across all
+  /// priorities. Returns the number of events removed.
+  ///
+  /// Callers use this when an event has just been tombstoned: a write queued
+  /// before the tombstone existed would otherwise flush *after* the row was
+  /// deleted and put it straight back. Only pending writes are affected —
+  /// rows already flushed must be deleted through the DAO.
+  int dropQueuedEvents(Set<String> eventIds) {
+    if (_disposed || eventIds.isEmpty) return 0;
+
+    var dropped = 0;
+    for (final queue in [_visibleQueue, _normalQueue, _backgroundQueue]) {
+      final survivors = queue
+          .where((event) => !eventIds.contains(event.id))
+          .toList();
+      dropped += queue.length - survivors.length;
+      queue
+        ..clear()
+        ..addAll(survivors);
+    }
+    return dropped;
+  }
+
   /// Drops all queued background- and normal-priority events, preserving the
   /// visible queue so the on-screen feed still persists.
   ///

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -231,7 +231,14 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   // Track known deleted videos to prevent resurrection from pagination.
   // Includes local user deletions and observed remote NIP-09 deletes.
   final Set<String> _knownDeletedVideoIds = {};
-  final Set<String> _knownDeletedVideoCoordinateKeys = {};
+
+  /// `pubkey:stable-id` coordinate to the `created_at` of the deletion that
+  /// removed it.
+  ///
+  /// NIP-09 scopes an `a` deletion to versions up to the deletion request's
+  /// own timestamp, so a version the author republishes afterwards is not
+  /// covered and must stay visible.
+  final Map<String, int> _knownDeletedVideoCoordinates = {};
 
   // Broadcasts video ids the moment they are removed (deletion / future
   // block / mute). Subscribers — fullscreen feed bloc, profile feed
@@ -1103,7 +1110,12 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     _knownDeletedVideoIds.add(primaryEventId);
     _knownDeletedVideoIds.addAll(removedVideoIds);
     if (coordinateKey != null) {
-      _knownDeletedVideoCoordinateKeys.add(coordinateKey);
+      // The NIP-09 request the caller just published carries "now", so every
+      // version up to this moment is covered while a later republish is not.
+      _rememberDeletedCoordinate(
+        coordinateKey,
+        DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      );
     }
 
     _purgeEventsFromLocalCache({primaryEventId, ...removedVideoIds});
@@ -1157,28 +1169,30 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   /// Hydrate known deletion tombstones from persisted delete history or
   /// observed remote deletes.
   ///
-  /// [addressableIds] must use the NIP-33 `kind:pubkey:d-tag` format. The
-  /// service keeps its own compact lookup key private so callers do not couple
-  /// to the in-memory implementation.
+  /// Keys of [addressableDeletedAt] must use the NIP-33 `kind:pubkey:d-tag`
+  /// format; each value is the `created_at` of the deletion request that
+  /// removed it, in seconds. The service keeps its own compact lookup key
+  /// private so callers do not couple to the in-memory implementation.
   void seedKnownDeletionTombstones({
     Iterable<String> eventIds = const [],
-    Iterable<String> addressableIds = const [],
+    Map<String, int> addressableDeletedAt = const {},
   }) {
     _knownDeletedVideoIds.addAll(eventIds.where((id) => id.isNotEmpty));
 
-    for (final addressableId in addressableIds) {
-      final parsed = AId.fromString(addressableId);
+    for (final entry in addressableDeletedAt.entries) {
+      final parsed = AId.fromString(entry.key);
       if (parsed == null ||
           parsed.kind != NIP71VideoKinds.addressableShortVideo ||
           parsed.pubkey.isEmpty ||
           parsed.dTag.isEmpty) {
         continue;
       }
-      _knownDeletedVideoCoordinateKeys.add(
+      _rememberDeletedCoordinate(
         _knownDeletionCoordinateKeyFromParts(
           pubkey: parsed.pubkey,
           stableId: parsed.dTag,
         ),
+        entry.value,
       );
     }
   }
@@ -1186,20 +1200,36 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   /// Backwards-compatible alias for local delete-history hydration.
   void seedLocalDeletionTombstones({
     Iterable<String> eventIds = const [],
-    Iterable<String> addressableIds = const [],
+    Map<String, int> addressableDeletedAt = const {},
   }) {
     seedKnownDeletionTombstones(
       eventIds: eventIds,
-      addressableIds: addressableIds,
+      addressableDeletedAt: addressableDeletedAt,
     );
+  }
+
+  /// Records a coordinate tombstone, keeping the newest deletion when the
+  /// same coordinate is deleted more than once.
+  void _rememberDeletedCoordinate(String coordinateKey, int deletedAt) {
+    final known = _knownDeletedVideoCoordinates[coordinateKey];
+    if (known != null && known >= deletedAt) return;
+    _knownDeletedVideoCoordinates[coordinateKey] = deletedAt;
+  }
+
+  /// Whether [coordinateKey] was deleted by a request at or after
+  /// [createdAt] — a version published later is not covered by it.
+  bool _isCoordinateDeleted(String coordinateKey, int createdAt) {
+    final deletedUpTo = _knownDeletedVideoCoordinates[coordinateKey];
+    return deletedUpTo != null && createdAt <= deletedUpTo;
   }
 
   /// Check whether this concrete video or its addressable identity has been
   /// deleted by a known local or remote NIP-09 delete.
   bool isVideoEventKnownDeleted(VideoEvent video) {
     return _knownDeletedVideoIds.contains(video.id) ||
-        _knownDeletedVideoCoordinateKeys.contains(
+        _isCoordinateDeleted(
           _knownDeletionCoordinateKey(video),
+          video.createdAt,
         );
   }
 
@@ -1230,11 +1260,12 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     final stableId = _rawStableId(event);
     if (stableId == null) return false;
 
-    return _knownDeletedVideoCoordinateKeys.contains(
+    return _isCoordinateDeleted(
       _knownDeletionCoordinateKeyFromParts(
         pubkey: event.pubkey,
         stableId: stableId,
       ),
+      event.createdAt,
     );
   }
 
@@ -1295,9 +1326,9 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       final matchesRequestedId = requestedEventIds.contains(
         video.id.toLowerCase(),
       );
-      final matchesCoordinate = coordinateKeys.contains(
-        _knownDeletionCoordinateKey(video),
-      );
+      final matchesCoordinate =
+          coordinateKeys.contains(_knownDeletionCoordinateKey(video)) &&
+          video.createdAt <= deletionEvent.createdAt;
 
       if (matchesRequestedId || matchesCoordinate) {
         validatedEventIds.add(video.id);
@@ -1310,6 +1341,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     // against the stored row instead of against memory.
     _purgeDeletedVideosFromStore(
       deletionPubkey: deletionPubkey,
+      deletionCreatedAt: deletionEvent.createdAt,
       requestedEventIds: requestedEventIds,
       addressableIds: addressableIds,
     );
@@ -1318,12 +1350,16 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
     seedKnownDeletionTombstones(
       eventIds: validatedEventIds,
-      addressableIds: addressableIds,
+      addressableDeletedAt: {
+        for (final addressableId in addressableIds)
+          addressableId: deletionEvent.createdAt,
+      },
     );
 
     _removeKnownDeletedVideos(
       eventIds: validatedEventIds,
       coordinateKeys: coordinateKeys,
+      deletionCreatedAt: deletionEvent.createdAt,
       logIdentity: deletionEvent.id,
     );
   }
@@ -1343,14 +1379,18 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   void _removeKnownDeletedVideos({
     required Set<String> eventIds,
     required Set<String> coordinateKeys,
+    required int deletionCreatedAt,
     required String logIdentity,
   }) {
     var removedCount = 0;
     final removedVideoIds = <String>{};
 
+    // A coordinate match only counts up to the deletion's own timestamp; a
+    // version the author republished afterwards is not covered by it.
     bool shouldRemove(VideoEvent video) =>
         eventIds.contains(video.id) ||
-        coordinateKeys.contains(_knownDeletionCoordinateKey(video));
+        (coordinateKeys.contains(_knownDeletionCoordinateKey(video)) &&
+            video.createdAt <= deletionCreatedAt);
 
     for (final entry in _eventLists.entries) {
       final initialLength = entry.value.length;
@@ -1445,6 +1485,12 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     );
   }
 
+  /// Upper bound on rows a single `a`-tag coordinate can contribute to one
+  /// purge. Addressable writes upsert per coordinate, so a handful is the
+  /// realistic ceiling; this only stops the DAO's implicit default from
+  /// silently truncating a pathological set.
+  static const int _maxCoordinateRowsPerPurge = 500;
+
   /// Purges the rows an observed NIP-09 deletion targets, including rows no
   /// feed has loaded — the ones that survive a restart and flash on the next
   /// launch.
@@ -1454,6 +1500,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   /// Addressable `a` tags were already author-matched by the caller.
   void _purgeDeletedVideosFromStore({
     required String deletionPubkey,
+    required int deletionCreatedAt,
     required Set<String> requestedEventIds,
     required Set<String> addressableIds,
   }) {
@@ -1465,6 +1512,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       _resolveAndPurgeDeletedRows(
         router: router,
         deletionPubkey: deletionPubkey,
+        deletionCreatedAt: deletionCreatedAt,
         requestedEventIds: requestedEventIds,
         addressableIds: addressableIds,
       ).catchError((Object error) {
@@ -1480,6 +1528,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   Future<void> _resolveAndPurgeDeletedRows({
     required EventRouter router,
     required String deletionPubkey,
+    required int deletionCreatedAt,
     required Set<String> requestedEventIds,
     required Set<String> addressableIds,
   }) async {
@@ -1510,12 +1559,22 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           kinds: [parsed.kind],
           authors: [parsed.pubkey],
           d: [parsed.dTag],
+          // NIP-09 scopes an `a` deletion to versions up to the request's
+          // own timestamp. Without this, an old Kind 5 that a relay
+          // redelivers on launch wipes a version republished after it.
+          until: deletionCreatedAt,
+          limit: _maxCoordinateRowsPerPurge,
         ),
       );
       idsToPurge.addAll(matches.map((event) => event.id));
     }
 
     if (idsToPurge.isEmpty) return;
+
+    // Record the tombstone for rows no feed had loaded. Without it the
+    // ingestion guard stays false for these ids and the next relay delivery
+    // writes the row straight back, undoing the purge above.
+    seedKnownDeletionTombstones(eventIds: idsToPurge);
 
     router.dropQueuedEvents(idsToPurge);
     final purged = await dao.deleteEventsByIds(idsToPurge.toList());

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -1342,6 +1342,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     _purgeDeletedVideosFromStore(
       deletionPubkey: deletionPubkey,
       deletionCreatedAt: deletionEvent.createdAt,
+      deletionEventId: deletionEvent.id,
       requestedEventIds: requestedEventIds,
       addressableIds: addressableIds,
     );
@@ -1376,11 +1377,16 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     }
   }
 
+  /// Drops tombstoned videos from every in-memory surface.
+  ///
+  /// Pass `purgeStore: false` when the caller has already deleted these rows;
+  /// without it the store purge runs a second time for the same ids.
   void _removeKnownDeletedVideos({
     required Set<String> eventIds,
     required Set<String> coordinateKeys,
     required int deletionCreatedAt,
     required String logIdentity,
+    bool purgeStore = true,
   }) {
     var removedCount = 0;
     final removedVideoIds = <String>{};
@@ -1428,7 +1434,9 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       }
     }
 
-    _purgeEventsFromLocalCache({...eventIds, ...removedVideoIds});
+    if (purgeStore) {
+      _purgeEventsFromLocalCache({...eventIds, ...removedVideoIds});
+    }
 
     Log.info(
       removedCount > 0
@@ -1501,6 +1509,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   void _purgeDeletedVideosFromStore({
     required String deletionPubkey,
     required int deletionCreatedAt,
+    required String deletionEventId,
     required Set<String> requestedEventIds,
     required Set<String> addressableIds,
   }) {
@@ -1513,6 +1522,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         router: router,
         deletionPubkey: deletionPubkey,
         deletionCreatedAt: deletionCreatedAt,
+        deletionEventId: deletionEventId,
         requestedEventIds: requestedEventIds,
         addressableIds: addressableIds,
       ).catchError((Object error) {
@@ -1529,6 +1539,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     required EventRouter router,
     required String deletionPubkey,
     required int deletionCreatedAt,
+    required String deletionEventId,
     required Set<String> requestedEventIds,
     required Set<String> addressableIds,
   }) async {
@@ -1581,6 +1592,21 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
     router.dropQueuedEvents(idsToPurge);
     final purged = await dao.deleteEventsByIds(idsToPurge.toList());
+
+    // A copy can arrive between the Kind 5 and the awaits above: it cleared
+    // the ingestion guard before the tombstone existed, so a feed may be
+    // holding it even though the row is gone. Sweep those ids out of memory
+    // and announce them; the store was already purged a line ago.
+    if (_allCachedVideos().any((video) => idsToPurge.contains(video.id))) {
+      _removeKnownDeletedVideos(
+        eventIds: idsToPurge,
+        coordinateKeys: const {},
+        deletionCreatedAt: deletionCreatedAt,
+        logIdentity: deletionEventId,
+        purgeStore: false,
+      );
+    }
+
     if (purged == 0) return;
     Log.debug(
       'Purged $purged deleted event(s) from the local cache',

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -1106,6 +1106,8 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       _knownDeletedVideoCoordinateKeys.add(coordinateKey);
     }
 
+    _purgeEventsFromLocalCache({primaryEventId, ...removedVideoIds});
+
     // Emit on the side-channel BEFORE notifyListeners so that subscribers
     // who react via the stream (e.g. FullscreenFeedBloc) update their
     // state in the same frame as ChangeNotifier consumers. Emit
@@ -1344,6 +1346,8 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       }
     }
 
+    _purgeEventsFromLocalCache({...eventIds, ...removedVideoIds});
+
     Log.info(
       removedCount > 0
           ? 'Applied observed video deletion $logIdentity to $removedCount cached location(s)'
@@ -1352,6 +1356,41 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       category: LogCategory.video,
     );
     notifyListeners();
+  }
+
+  /// Deletes tombstoned events from the local event store.
+  ///
+  /// The in-memory removal above only lasts for this service's lifetime, but
+  /// the rows survive it. The cache-first startup query ([_loadCachedEvents])
+  /// reads straight from those rows, so without this purge every launch
+  /// re-serves deleted videos until the relay redelivers the Kind 5 event —
+  /// roughly 700ms of deleted clips on the profile grid, once per app start.
+  ///
+  /// Fire-and-forget: deletion handling has already succeeded in memory, so a
+  /// failed purge must not break it. The next observed deletion retries.
+  void _purgeEventsFromLocalCache(Set<String> eventIds) {
+    final router = _eventRouter;
+    if (router == null || eventIds.isEmpty) return;
+
+    unawaited(
+      Future.wait(eventIds.map(router.db.nostrEventsDao.deleteEventById))
+          .then((results) {
+            final purged = results.where((deleted) => deleted).length;
+            if (purged == 0) return;
+            Log.debug(
+              'Purged $purged deleted event(s) from the local cache',
+              name: 'VideoEventService',
+              category: LogCategory.video,
+            );
+          })
+          .catchError((Object error) {
+            Log.warning(
+              'Failed to purge deleted events from local cache: $error',
+              name: 'VideoEventService',
+              category: LogCategory.video,
+            );
+          }),
+    );
   }
 
   /// Emits a video id whenever the service has marked it removed —

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -1222,23 +1222,34 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
   /// Whether a raw relay event is already tombstoned, by id or — for
   /// addressable videos, where an edit mints a new id for the same clip — by
-  /// its `pubkey:d-tag` coordinate.
+  /// its `pubkey:stable-id` coordinate.
   bool _isKnownDeletedRawEvent(Event event) {
     if (_knownDeletedVideoIds.contains(event.id)) return true;
     if (!NIP71VideoKinds.isVideoKind(event.kind)) return false;
 
+    final stableId = _rawStableId(event);
+    if (stableId == null) return false;
+
+    return _knownDeletedVideoCoordinateKeys.contains(
+      _knownDeletionCoordinateKeyFromParts(
+        pubkey: event.pubkey,
+        stableId: stableId,
+      ),
+    );
+  }
+
+  /// The stable id a raw event will parse into, mirroring
+  /// [VideoEvent.stableId]: the `d` tag, else the `vine_id` tag some clients
+  /// send instead. Returns null when neither is present, where the event id
+  /// is the identity and the id check above already covers it.
+  String? _rawStableId(Event event) {
+    String? vineId;
     for (final tag in event.tags) {
-      if (tag.length < 2 || tag[0] != 'd') continue;
-      final dTag = tag[1];
-      if (dTag.isEmpty) return false;
-      return _knownDeletedVideoCoordinateKeys.contains(
-        _knownDeletionCoordinateKeyFromParts(
-          pubkey: event.pubkey,
-          stableId: dTag,
-        ),
-      );
+      if (tag.length < 2 || tag[1].isEmpty) continue;
+      if (tag[0] == 'd') return tag[1];
+      if (tag[0] == 'vine_id') vineId ??= tag[1];
     }
-    return false;
+    return vineId;
   }
 
   void _handleObservedDeletionEvent(Event deletionEvent) {
@@ -1292,6 +1303,16 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         validatedEventIds.add(video.id);
       }
     }
+
+    // The store is purged from the *requested* ids, not the validated ones:
+    // a row that no feed has loaded is exactly the case that survives a
+    // restart and flashes on the next launch. Authorship is re-checked
+    // against the stored row instead of against memory.
+    _purgeDeletedVideosFromStore(
+      deletionPubkey: deletionPubkey,
+      requestedEventIds: requestedEventIds,
+      addressableIds: addressableIds,
+    );
 
     if (validatedEventIds.isEmpty && coordinateKeys.isEmpty) return;
 
@@ -1385,13 +1406,23 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   /// the rows survive it. The cache-first startup query ([_loadCachedEvents])
   /// reads straight from those rows, so without this purge every launch
   /// re-serves deleted videos until the relay redelivers the Kind 5 event —
-  /// roughly 700ms of deleted clips on the profile grid, once per app start.
+  /// several hundred milliseconds of deleted clips on the profile grid, once
+  /// per app start.
+  ///
+  /// `NostrClient` purges the same rows when it sees or publishes a Kind 5,
+  /// but only when it was given a database; this keeps the service correct on
+  /// its own and adds the authorship check that the client-side purge lacks.
   ///
   /// Fire-and-forget: deletion handling has already succeeded in memory, so a
-  /// failed purge must not break it. The next observed deletion retries.
+  /// failed purge must not break it.
   void _purgeEventsFromLocalCache(Set<String> eventIds) {
     final router = _eventRouter;
     if (router == null || eventIds.isEmpty) return;
+
+    // Evict pending writes first. A row queued before the tombstone existed
+    // passed the ingestion guard, and its flush would land after the DELETE
+    // below and re-create exactly what was just removed.
+    router.dropQueuedEvents(eventIds);
 
     unawaited(
       router.db.nostrEventsDao
@@ -1411,6 +1442,88 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
               category: LogCategory.video,
             );
           }),
+    );
+  }
+
+  /// Purges the rows an observed NIP-09 deletion targets, including rows no
+  /// feed has loaded — the ones that survive a restart and flash on the next
+  /// launch.
+  ///
+  /// Every id is re-checked against the stored row's own pubkey, so a relay
+  /// cannot use a forged `e` tag to delete another author's cached videos.
+  /// Addressable `a` tags were already author-matched by the caller.
+  void _purgeDeletedVideosFromStore({
+    required String deletionPubkey,
+    required Set<String> requestedEventIds,
+    required Set<String> addressableIds,
+  }) {
+    final router = _eventRouter;
+    if (router == null) return;
+    if (requestedEventIds.isEmpty && addressableIds.isEmpty) return;
+
+    unawaited(
+      _resolveAndPurgeDeletedRows(
+        router: router,
+        deletionPubkey: deletionPubkey,
+        requestedEventIds: requestedEventIds,
+        addressableIds: addressableIds,
+      ).catchError((Object error) {
+        Log.warning(
+          'Failed to purge deleted events from local cache: $error',
+          name: 'VideoEventService',
+          category: LogCategory.video,
+        );
+      }),
+    );
+  }
+
+  Future<void> _resolveAndPurgeDeletedRows({
+    required EventRouter router,
+    required String deletionPubkey,
+    required Set<String> requestedEventIds,
+    required Set<String> addressableIds,
+  }) async {
+    final dao = router.db.nostrEventsDao;
+    final idsToPurge = <String>{};
+
+    if (requestedEventIds.isNotEmpty) {
+      // One query for the whole `e` tag set — a Kind 5 may name many ids.
+      // The author check stays in Dart so it tolerates pubkey casing the way
+      // the rest of this class does; `pubkey IN (...)` would not.
+      final stored = await dao.getEventsByFilter(
+        Filter(
+          ids: requestedEventIds.toList(),
+          limit: requestedEventIds.length,
+        ),
+      );
+      for (final event in stored) {
+        if (event.pubkey.toLowerCase() != deletionPubkey) continue;
+        idsToPurge.add(event.id);
+      }
+    }
+
+    for (final addressableId in addressableIds) {
+      final parsed = AId.fromString(addressableId);
+      if (parsed == null) continue;
+      final matches = await dao.getEventsByFilter(
+        Filter(
+          kinds: [parsed.kind],
+          authors: [parsed.pubkey],
+          d: [parsed.dTag],
+        ),
+      );
+      idsToPurge.addAll(matches.map((event) => event.id));
+    }
+
+    if (idsToPurge.isEmpty) return;
+
+    router.dropQueuedEvents(idsToPurge);
+    final purged = await dao.deleteEventsByIds(idsToPurge.toList());
+    if (purged == 0) return;
+    Log.debug(
+      'Purged $purged deleted event(s) from the local cache',
+      name: 'VideoEventService',
+      category: LogCategory.video,
     );
   }
 
@@ -2263,10 +2376,6 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           (event) {
             eventCount++;
 
-            // Route events to normal-priority persistence without blocking
-            // visible feed updates.
-            _eventRouter?.handleEvent(event);
-
             // Track first event arrival time
             if (firstEventTime == null) {
               firstEventTime = DateTime.now();
@@ -2309,7 +2418,13 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
               } catch (_) {}
             }
 
-            _handleNewVideoEvent(event, subscriptionType);
+            // Normal priority: the live feed is on screen, so these rows
+            // should reach the store ahead of background ingestion.
+            _handleNewVideoEvent(
+              event,
+              subscriptionType,
+              priority: EventIngestionPriority.normal,
+            );
           },
           onError: (error) {
             feedLoadingTimeout?.cancel();
@@ -2503,15 +2618,21 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
   /// Handle new video event from subscription.
   ///
+  /// This is the service's single persistence entry point: every ingestion
+  /// path routes through here so the tombstone guard below cannot be bypassed.
+  ///
   /// [persist] must be false for events that were just read back out of the
   /// local store. They are already persisted, and re-queueing them is not
   /// merely redundant: the router drains the background queue last, so under
   /// the startup relay burst those writes land *after* an observed deletion
   /// has purged the same rows — resurrecting deleted videos on every launch.
+  ///
+  /// [priority] lets an on-screen feed jump the background ingestion backlog.
   void _handleNewVideoEvent(
     dynamic eventData,
     SubscriptionType subscriptionType, {
     bool persist = true,
+    EventIngestionPriority priority = EventIngestionPriority.background,
   }) {
     try {
       // The event should already be an Event object from NostrService
@@ -2531,10 +2652,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       // Tombstoned events are never re-persisted — a queued write that lands
       // after the purge would put the row straight back.
       if (persist && !_isKnownDeletedRawEvent(event)) {
-        _eventRouter?.handleEvent(
-          event,
-          priority: EventIngestionPriority.background,
-        );
+        _eventRouter?.handleEvent(event, priority: priority);
       }
 
       // Fast-path de-duplication before logging and processing

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -1229,7 +1229,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     return _knownDeletedVideoIds.contains(video.id) ||
         _isCoordinateDeleted(
           _knownDeletionCoordinateKey(video),
-          video.createdAt,
+          video.nostrCreatedAt,
         );
   }
 
@@ -1328,7 +1328,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       );
       final matchesCoordinate =
           coordinateKeys.contains(_knownDeletionCoordinateKey(video)) &&
-          video.createdAt <= deletionEvent.createdAt;
+          video.nostrCreatedAt <= deletionEvent.createdAt;
 
       if (matchesRequestedId || matchesCoordinate) {
         validatedEventIds.add(video.id);
@@ -1390,7 +1390,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     bool shouldRemove(VideoEvent video) =>
         eventIds.contains(video.id) ||
         (coordinateKeys.contains(_knownDeletionCoordinateKey(video)) &&
-            video.createdAt <= deletionCreatedAt);
+            video.nostrCreatedAt <= deletionCreatedAt);
 
     for (final entry in _eventLists.entries) {
       final initialLength = entry.value.length;

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -1220,6 +1220,27 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     required String stableId,
   }) => '${pubkey.toLowerCase()}:$stableId';
 
+  /// Whether a raw relay event is already tombstoned, by id or — for
+  /// addressable videos, where an edit mints a new id for the same clip — by
+  /// its `pubkey:d-tag` coordinate.
+  bool _isKnownDeletedRawEvent(Event event) {
+    if (_knownDeletedVideoIds.contains(event.id)) return true;
+    if (!NIP71VideoKinds.isVideoKind(event.kind)) return false;
+
+    for (final tag in event.tags) {
+      if (tag.length < 2 || tag[0] != 'd') continue;
+      final dTag = tag[1];
+      if (dTag.isEmpty) return false;
+      return _knownDeletedVideoCoordinateKeys.contains(
+        _knownDeletionCoordinateKeyFromParts(
+          pubkey: event.pubkey,
+          stableId: dTag,
+        ),
+      );
+    }
+    return false;
+  }
+
   void _handleObservedDeletionEvent(Event deletionEvent) {
     if (deletionEvent.kind != _eventDeletionKind) return;
 
@@ -1373,9 +1394,9 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     if (router == null || eventIds.isEmpty) return;
 
     unawaited(
-      Future.wait(eventIds.map(router.db.nostrEventsDao.deleteEventById))
-          .then((results) {
-            final purged = results.where((deleted) => deleted).length;
+      router.db.nostrEventsDao
+          .deleteEventsByIds(eventIds.toList())
+          .then((purged) {
             if (purged == 0) return;
             Log.debug(
               'Purged $purged deleted event(s) from the local cache',
@@ -2124,9 +2145,10 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           }
         }
 
-        // Process cached events immediately (same flow as relay events)
+        // Process cached events immediately (same flow as relay events, minus
+        // the write-back — they were just read out of the store).
         for (final event in cachedEvents) {
-          _handleNewVideoEvent(event, subscriptionType);
+          _handleNewVideoEvent(event, subscriptionType, persist: false);
         }
 
         // Notify UI with cached results for instant display
@@ -2479,11 +2501,18 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     }
   }
 
-  /// Handle new video event from subscription
+  /// Handle new video event from subscription.
+  ///
+  /// [persist] must be false for events that were just read back out of the
+  /// local store. They are already persisted, and re-queueing them is not
+  /// merely redundant: the router drains the background queue last, so under
+  /// the startup relay burst those writes land *after* an observed deletion
+  /// has purged the same rows — resurrecting deleted videos on every launch.
   void _handleNewVideoEvent(
     dynamic eventData,
-    SubscriptionType subscriptionType,
-  ) {
+    SubscriptionType subscriptionType, {
+    bool persist = true,
+  }) {
     try {
       // The event should already be an Event object from NostrService
       if (eventData is! Event) {
@@ -2499,10 +2528,14 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
       // Route ALL events to database first (single source of truth)
       // Fire-and-forget: database writes shouldn't block event processing.
-      _eventRouter?.handleEvent(
-        event,
-        priority: EventIngestionPriority.background,
-      );
+      // Tombstoned events are never re-persisted — a queued write that lands
+      // after the purge would put the row straight back.
+      if (persist && !_isKnownDeletedRawEvent(event)) {
+        _eventRouter?.handleEvent(
+          event,
+          priority: EventIngestionPriority.background,
+        );
+      }
 
       // Fast-path de-duplication before logging and processing
       // Use case-insensitive ID comparison for consistent deduplication

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -1557,7 +1557,10 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       final matches = await dao.getEventsByFilter(
         Filter(
           kinds: [parsed.kind],
-          authors: [parsed.pubkey],
+          // `pubkey IN (...)` is case-sensitive, so bind the already-lowercased
+          // author the caller matched this coordinate against rather than the
+          // tag's own casing.
+          authors: [deletionPubkey],
           d: [parsed.dTag],
           // NIP-09 scopes an `a` deletion to versions up to the request's
           // own timestamp. Without this, an old Kind 5 that a relay

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -154,6 +154,7 @@ class VideoEvent {
     required this.createdAt,
     required this.content,
     required this.timestamp,
+    this.eventCreatedAt,
     this.title,
     this.videoUrl,
     this.thumbnailUrl,
@@ -245,6 +246,7 @@ class VideoEvent {
       fileSize: optInt(json['fileSize']),
       hashtags: stringList(json['hashtags']),
       categories: stringList(json['categories']),
+      eventCreatedAt: optInt(json['eventCreatedAt']),
       publishedAt: json['publishedAt'] as String?,
       rawTags:
           (json['rawTags'] as Map<String, dynamic>?)?.map(
@@ -700,6 +702,7 @@ class VideoEvent {
       sha256: sha256,
       fileSize: fileSize,
       hashtags: hashtags,
+      eventCreatedAt: createdAtTimestamp,
       publishedAt: publishedAt,
       rawTags: rawTags,
       vineId: vineId,
@@ -731,6 +734,13 @@ class VideoEvent {
   final String id;
   final String pubkey;
   final int createdAt;
+
+  /// The Nostr event's own `created_at`, in seconds.
+  ///
+  /// Null when this instance was not built from a relay event; prefer
+  /// [nostrCreatedAt], which falls back to [createdAt].
+  final int? eventCreatedAt;
+
   final String content;
   final String? title;
   final String? videoUrl;
@@ -949,6 +959,15 @@ class VideoEvent {
   /// For addressable events (Kind 34236), returns the vineId (d tag).
   /// Falls back to event id for non-addressable events.
   String get stableId => vineId ?? id;
+
+  /// The timestamp a NIP-09 deletion bound must be measured against:
+  /// [eventCreatedAt] when known, else [createdAt].
+  ///
+  /// [createdAt] prefers the `published_at` tag, and an edit re-emits the
+  /// original publication's value while minting a new event under the same
+  /// `d` tag. Comparing that against a deletion request would treat a
+  /// republished clip as older than the deletion and hide it for good.
+  int get nostrCreatedAt => eventCreatedAt ?? createdAt;
 
   /// Best-effort NIP-71 kind for citing this video.
   ///
@@ -1570,6 +1589,7 @@ class VideoEvent {
     List<String>? hashtags,
     List<String>? categories,
     DateTime? timestamp,
+    int? eventCreatedAt,
     String? publishedAt,
     Map<String, String>? rawTags,
     String? vineId,
@@ -1628,6 +1648,7 @@ class VideoEvent {
     hashtags: hashtags ?? this.hashtags,
     categories: categories ?? this.categories,
     timestamp: timestamp ?? this.timestamp,
+    eventCreatedAt: eventCreatedAt ?? this.eventCreatedAt,
     publishedAt: publishedAt ?? this.publishedAt,
     rawTags: rawTags ?? this.rawTags,
     vineId: vineId ?? this.vineId,
@@ -1718,6 +1739,7 @@ class VideoEvent {
     'hashtags': hashtags,
     'categories': categories,
     'timestamp': timestamp.toIso8601String(),
+    'eventCreatedAt': eventCreatedAt,
     'publishedAt': publishedAt,
     'rawTags': rawTags,
     'vineId': vineId,

--- a/mobile/packages/models/test/src/video_event_parsing_test.dart
+++ b/mobile/packages/models/test/src/video_event_parsing_test.dart
@@ -985,5 +985,41 @@ void main() {
 
       expect(video.imetaVideoUrls, isEmpty);
     });
+
+    group('nostrCreatedAt', () {
+      test('keeps the event created_at when published_at overrides '
+          'createdAt', () {
+        // An edit mints a new event under the same `d` tag but re-emits the
+        // original published_at, so createdAt reports the first publication.
+        final republishedEdit = Event(
+          '0f1e20e4f53b27b62a3eb4fe7eb454c6a4d1040abfa279e7bb4a5222723541c9',
+          34236,
+          [
+            ['d', 'clip-1'],
+            ['url', 'https://cdn.divine.video/clip.mp4'],
+            ['published_at', '1000'],
+          ],
+          'an edited clip',
+          createdAt: 3000,
+        );
+
+        final video = VideoEvent.fromNostrEvent(republishedEdit);
+
+        expect(video.createdAt, 1000, reason: 'display timestamp');
+        expect(video.nostrCreatedAt, 3000, reason: 'deletion-ordering');
+      });
+
+      test('falls back to createdAt when the raw timestamp is unknown', () {
+        final video = VideoEvent(
+          id: 'id',
+          pubkey: 'pubkey',
+          createdAt: 1000,
+          content: 'no raw timestamp',
+          timestamp: DateTime.fromMillisecondsSinceEpoch(1000 * 1000),
+        );
+
+        expect(video.nostrCreatedAt, 1000);
+      });
+    });
   });
 }

--- a/mobile/packages/models/test/src/video_event_to_json_test.dart
+++ b/mobile/packages/models/test/src/video_event_to_json_test.dart
@@ -24,6 +24,7 @@ VideoEvent _fullVideo() => VideoEvent(
   id: _id,
   pubkey: _pubkey,
   createdAt: 1704067200,
+  eventCreatedAt: 1704067300,
   content: 'hello vine',
   timestamp: DateTime.fromMillisecondsSinceEpoch(
     1704067200 * 1000,
@@ -104,6 +105,7 @@ const _expectedKeys = <String>{
   'id',
   'pubkey',
   'createdAt',
+  'eventCreatedAt',
   'content',
   'title',
   'videoUrl',
@@ -156,6 +158,7 @@ const _expectedKeys = <String>{
 
 const _excludedDerivedGetters = <String>{
   'hashCode',
+  'nostrCreatedAt',
   'isExpired',
   'shareKind',
   'isAddressableShareKind',

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -172,6 +172,14 @@ class NostrClient {
   /// Convenience getter for the NostrEventsDao
   NostrEventsDao? get _nostrEventsDao => _dbClient?.database.nostrEventsDao;
 
+  /// Upper bound on remembered NIP-09 tombstones, per set.
+  static const int _maxTrackedTombstones = 2000;
+
+  /// Event ids and `kind:pubkey:d-tag` coordinates removed by an observed or
+  /// published Kind 5. Insertion-ordered so eviction drops the oldest.
+  final Set<String> _tombstonedEventIds = <String>{};
+  final Set<String> _tombstonedCoordinates = <String>{};
+
   /// `"id:sig"` keys of events already persisted — and therefore already
   /// signature-verified — in a previous session. Seeded once at
   /// [initialize] so the relay pool can skip re-verifying events that relays
@@ -294,12 +302,84 @@ class NostrClient {
 
     if (targetEventIds.isEmpty && targetAddressableIds.isEmpty) return;
 
+    _rememberTombstones(
+      eventIds: targetEventIds,
+      addressableIds: targetAddressableIds,
+      deletionPubkey: deletionEvent.pubkey,
+    );
+
     await _deleteCachedEventsForDeletion(
       eventIds: targetEventIds,
       addressableIds: targetAddressableIds,
       deletionPubkey: deletionEvent.pubkey,
       deletionCreatedAt: deletionEvent.createdAt,
     );
+  }
+
+  /// Records what a Kind 5 tombstoned so [_shouldSkipAutoCache] can keep the
+  /// auto-cache from writing the row back when a relay redelivers it.
+  ///
+  /// Bounded: the oldest entries are evicted past [_maxTrackedTombstones], so
+  /// a long session cannot grow these sets without limit. Losing an old entry
+  /// only costs a redundant row that the next deletion purges again.
+  void _rememberTombstones({
+    required List<String> eventIds,
+    required List<AId> addressableIds,
+    required String deletionPubkey,
+  }) {
+    for (final eventId in eventIds) {
+      _tombstonedEventIds
+        ..remove(eventId)
+        ..add(eventId);
+    }
+    for (final addressableId in addressableIds) {
+      if (addressableId.pubkey != deletionPubkey) continue;
+      final key = _tombstoneCoordinateKey(
+        kind: addressableId.kind,
+        pubkey: addressableId.pubkey,
+        dTag: addressableId.dTag,
+      );
+      _tombstonedCoordinates
+        ..remove(key)
+        ..add(key);
+    }
+    _evictOldestTombstones(_tombstonedEventIds);
+    _evictOldestTombstones(_tombstonedCoordinates);
+  }
+
+  void _evictOldestTombstones(Set<String> tracked) {
+    while (tracked.length > _maxTrackedTombstones) {
+      tracked.remove(tracked.first);
+    }
+  }
+
+  static String _tombstoneCoordinateKey({
+    required int kind,
+    required String pubkey,
+    required String dTag,
+  }) => '$kind:${pubkey.toLowerCase()}:$dTag';
+
+  /// Whether the auto-cache must skip [event] because a Kind 5 already
+  /// removed it.
+  ///
+  /// Without this the subscription callback re-inserts a deleted event the
+  /// moment any relay redelivers it, undoing the purge and re-serving the
+  /// clip from the local store on the next launch.
+  bool _shouldSkipAutoCache(Event event) {
+    if (_tombstonedEventIds.contains(event.id)) return true;
+    if (!EventKind.isParameterizedReplaceable(event.kind)) return false;
+
+    for (final tag in event.tags) {
+      if (tag.length < 2 || tag[0] != 'd' || tag[1].isEmpty) continue;
+      return _tombstonedCoordinates.contains(
+        _tombstoneCoordinateKey(
+          kind: event.kind,
+          pubkey: event.pubkey,
+          dTag: tag[1],
+        ),
+      );
+    }
+    return false;
   }
 
   Future<void> _deleteCachedEventsForDeletion({
@@ -990,7 +1070,7 @@ class NostrClient {
         // Handle NIP-09 deletion events by removing target events from DB
         if (event.kind == EventKind.eventDeletion) {
           unawaited(_handleDeletionEvent(event).catchError((Object _) {}));
-        } else {
+        } else if (!_shouldSkipAutoCache(event)) {
           // Auto-cache non-deletion events (fire-and-forget)
           try {
             unawaited(_nostrEventsDao?.upsertEvent(event));

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -175,10 +175,21 @@ class NostrClient {
   /// Upper bound on remembered NIP-09 tombstones, per set.
   static const int _maxTrackedTombstones = 2000;
 
-  /// Event ids and `kind:pubkey:d-tag` coordinates removed by an observed or
-  /// published Kind 5. Insertion-ordered so eviction drops the oldest.
-  final Set<String> _tombstonedEventIds = <String>{};
-  final Set<String> _tombstonedCoordinates = <String>{};
+  /// `pubkey:event-id` pairs removed by an observed or published Kind 5.
+  ///
+  /// Keyed by the *deletion author* so a forged `e` tag cannot suppress
+  /// another author's event: NIP-09 requires a client to check that the
+  /// referenced event's pubkey matches the deletion request's, and the
+  /// referenced event is often not in the store to check against, so the
+  /// pubkey is carried in the key and compared when the event arrives.
+  final Set<String> _tombstonedEventKeys = <String>{};
+
+  /// `kind:pubkey:d-tag` coordinate to the `created_at` of the deletion that
+  /// removed it. NIP-09 scopes an `a` deletion to versions up to that
+  /// timestamp, so a coordinate republished afterwards must cache again.
+  ///
+  /// Insertion-ordered (`LinkedHashMap`) so eviction drops the oldest.
+  final Map<String, int> _tombstonedCoordinates = <String, int>{};
 
   /// `"id:sig"` keys of events already persisted — and therefore already
   /// signature-verified — in a previous session. Seeded once at
@@ -306,6 +317,7 @@ class NostrClient {
       eventIds: targetEventIds,
       addressableIds: targetAddressableIds,
       deletionPubkey: deletionEvent.pubkey,
+      deletionCreatedAt: deletionEvent.createdAt,
     );
 
     await _deleteCachedEventsForDeletion(
@@ -326,11 +338,13 @@ class NostrClient {
     required List<String> eventIds,
     required List<AId> addressableIds,
     required String deletionPubkey,
+    required int deletionCreatedAt,
   }) {
     for (final eventId in eventIds) {
-      _tombstonedEventIds
-        ..remove(eventId)
-        ..add(eventId);
+      final key = _tombstoneEventKey(pubkey: deletionPubkey, eventId: eventId);
+      _tombstonedEventKeys
+        ..remove(key)
+        ..add(key);
     }
     for (final addressableId in addressableIds) {
       if (addressableId.pubkey != deletionPubkey) continue;
@@ -339,19 +353,25 @@ class NostrClient {
         pubkey: addressableId.pubkey,
         dTag: addressableId.dTag,
       );
-      _tombstonedCoordinates
-        ..remove(key)
-        ..add(key);
+      // Keep the newest deletion for a coordinate, and re-insert so eviction
+      // still drops the least recently tombstoned.
+      final known = _tombstonedCoordinates.remove(key);
+      _tombstonedCoordinates[key] = known == null
+          ? deletionCreatedAt
+          : (known > deletionCreatedAt ? known : deletionCreatedAt);
     }
-    _evictOldestTombstones(_tombstonedEventIds);
-    _evictOldestTombstones(_tombstonedCoordinates);
+    while (_tombstonedEventKeys.length > _maxTrackedTombstones) {
+      _tombstonedEventKeys.remove(_tombstonedEventKeys.first);
+    }
+    while (_tombstonedCoordinates.length > _maxTrackedTombstones) {
+      _tombstonedCoordinates.remove(_tombstonedCoordinates.keys.first);
+    }
   }
 
-  void _evictOldestTombstones(Set<String> tracked) {
-    while (tracked.length > _maxTrackedTombstones) {
-      tracked.remove(tracked.first);
-    }
-  }
+  static String _tombstoneEventKey({
+    required String pubkey,
+    required String eventId,
+  }) => '${pubkey.toLowerCase()}:${eventId.toLowerCase()}';
 
   static String _tombstoneCoordinateKey({
     required int kind,
@@ -366,18 +386,25 @@ class NostrClient {
   /// moment any relay redelivers it, undoing the purge and re-serving the
   /// clip from the local store on the next launch.
   bool _shouldSkipAutoCache(Event event) {
-    if (_tombstonedEventIds.contains(event.id)) return true;
+    // The key carries the deletion author, so this only matches when the
+    // event's own pubkey signed the deletion that named it.
+    if (_tombstonedEventKeys.contains(
+      _tombstoneEventKey(pubkey: event.pubkey, eventId: event.id),
+    )) {
+      return true;
+    }
     if (!EventKind.isParameterizedReplaceable(event.kind)) return false;
 
     for (final tag in event.tags) {
       if (tag.length < 2 || tag[0] != 'd' || tag[1].isEmpty) continue;
-      return _tombstonedCoordinates.contains(
-        _tombstoneCoordinateKey(
-          kind: event.kind,
-          pubkey: event.pubkey,
-          dTag: tag[1],
-        ),
-      );
+      final deletedUpTo =
+          _tombstonedCoordinates[_tombstoneCoordinateKey(
+            kind: event.kind,
+            pubkey: event.pubkey,
+            dTag: tag[1],
+          )];
+      // A version published after the deletion request is not covered by it.
+      return deletedUpTo != null && event.createdAt <= deletedUpTo;
     }
     return false;
   }

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -1527,6 +1527,163 @@ void main() {
       });
     });
 
+    group('subscribe NIP-09 auto-cache suppression', () {
+      // NIP-71 addressable short video (parameterized replaceable).
+      const addressableShortVideoKind = 34236;
+
+      late _MockNostrEventsDao mockNostrEventsDao;
+      late NostrClient clientWithCache;
+
+      /// Subscribes and returns the relay callback the SDK was handed, so a
+      /// test can deliver events exactly as a relay would.
+      void Function(Event) subscribeAndCaptureRelayCallback() {
+        when(
+          () => mockNostr.subscribe(
+            any(),
+            any(),
+            id: any(named: 'id'),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            sendAfterAuth: any(named: 'sendAfterAuth'),
+            onEose: any(named: 'onEose'),
+          ),
+        ).thenReturn('test-sub-id');
+
+        clientWithCache.subscribe([
+          Filter(kinds: [addressableShortVideoKind], limit: 10),
+        ]);
+
+        final captured = verify(
+          () => mockNostr.subscribe(
+            any(),
+            captureAny(),
+            id: any(named: 'id'),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            sendAfterAuth: any(named: 'sendAfterAuth'),
+            onEose: any(named: 'onEose'),
+          ),
+        ).captured.single;
+        return captured as void Function(Event);
+      }
+
+      Event videoEvent({String? id, List<List<String>>? tags}) {
+        final event = Event(
+          testPublicKey,
+          addressableShortVideoKind,
+          tags ??
+              [
+                ['d', 'clip-1'],
+              ],
+          'a video',
+        );
+        if (id != null) event.id = id;
+        return event;
+      }
+
+      Event deletionEvent(List<List<String>> tags) => Event(
+        testPublicKey,
+        EventKind.eventDeletion,
+        tags,
+        'deleted',
+      );
+
+      setUp(() {
+        final mockDbClient = _MockAppDbClient();
+        final mockDatabase = _MockAppDatabase();
+        mockNostrEventsDao = _MockNostrEventsDao();
+        when(() => mockDbClient.database).thenReturn(mockDatabase);
+        when(() => mockDatabase.nostrEventsDao).thenReturn(mockNostrEventsDao);
+        when(
+          () => mockNostrEventsDao.upsertEvent(any()),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockNostrEventsDao.deleteEventsByIds(any()),
+        ).thenAnswer((_) async => 1);
+        when(
+          () => mockNostrEventsDao.getEventsByFilter(
+            any(),
+            sortBy: any(named: 'sortBy'),
+          ),
+        ).thenAnswer((_) async => <Event>[]);
+        when(() => mockRelayManager.connectedRelays).thenReturn([
+          'wss://relay.test',
+        ]);
+
+        clientWithCache = NostrClient.forTesting(
+          nostr: mockNostr,
+          relayManager: mockRelayManager,
+          dbClient: mockDbClient,
+        );
+      });
+
+      test(
+        'does not re-cache an event a Kind 5 already removed by id',
+        () async {
+          final onEvent = subscribeAndCaptureRelayCallback();
+          final video = videoEvent(id: 'a' * 64);
+
+          onEvent(
+            deletionEvent([
+              ['e', video.id],
+            ]),
+          );
+          await pumpEventQueue();
+
+          // A relay that never saw the deletion redelivers the same event.
+          onEvent(video);
+
+          verifyNever(() => mockNostrEventsDao.upsertEvent(video));
+        },
+      );
+
+      test(
+        'does not re-cache an edit of a coordinate a Kind 5 removed',
+        () async {
+          final onEvent = subscribeAndCaptureRelayCallback();
+
+          onEvent(
+            deletionEvent([
+              [
+                'a',
+                '$addressableShortVideoKind:$testPublicKey:clip-1',
+              ],
+            ]),
+          );
+          await pumpEventQueue();
+
+          // An edit carries a new event id but the same pubkey:d-tag identity.
+          final edited = videoEvent(id: 'b' * 64);
+          onEvent(edited);
+
+          verifyNever(() => mockNostrEventsDao.upsertEvent(edited));
+        },
+      );
+
+      test('still caches events that were never tombstoned', () async {
+        final onEvent = subscribeAndCaptureRelayCallback();
+
+        onEvent(
+          deletionEvent([
+            ['e', 'a' * 64],
+          ]),
+        );
+        await pumpEventQueue();
+
+        final other = videoEvent(
+          id: 'c' * 64,
+          tags: [
+            ['d', 'clip-2'],
+          ],
+        );
+        onEvent(other);
+
+        verify(() => mockNostrEventsDao.upsertEvent(other)).called(1);
+      });
+    });
+
     group('subscribe', () {
       test('creates subscription and returns stream', () {
         final filters = [

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -1786,9 +1786,9 @@ void main() {
         () async {
           final onEvent = subscribeAndCaptureRelayCallback();
 
-          // NIP-09 requires relays to serve deletion requests indefinitely, so a
-          // cold-start flood can deliver an old Kind 5 after a newer one for the
-          // same coordinate.
+          // NIP-09 has relays serve deletion requests indefinitely, so a
+          // cold-start flood can deliver an old Kind 5 after a newer one
+          // for the same coordinate.
           onEvent(
             deletionEvent([
               ['a', '$addressableShortVideoKind:$testPublicKey:clip-1'],

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -1569,25 +1569,36 @@ void main() {
         return captured as void Function(Event);
       }
 
-      Event videoEvent({String? id, List<List<String>>? tags}) {
+      Event videoEvent({
+        String? id,
+        List<List<String>>? tags,
+        String? pubkey,
+        int createdAt = 1000,
+      }) {
         final event = Event(
-          testPublicKey,
+          pubkey ?? testPublicKey,
           addressableShortVideoKind,
           tags ??
               [
                 ['d', 'clip-1'],
               ],
           'a video',
+          createdAt: createdAt,
         );
         if (id != null) event.id = id;
         return event;
       }
 
-      Event deletionEvent(List<List<String>> tags) => Event(
-        testPublicKey,
+      Event deletionEvent(
+        List<List<String>> tags, {
+        String? pubkey,
+        int createdAt = 2000,
+      }) => Event(
+        pubkey ?? testPublicKey,
         EventKind.eventDeletion,
         tags,
         'deleted',
+        createdAt: createdAt,
       );
 
       setUp(() {
@@ -1682,6 +1693,70 @@ void main() {
 
         verify(() => mockNostrEventsDao.upsertEvent(other)).called(1);
       });
+
+      test(
+        'ignores an `e` tag from someone other than the event author',
+        () async {
+          final onEvent = subscribeAndCaptureRelayCallback();
+          final video = videoEvent(id: 'a' * 64);
+
+          // NIP-09: a client MUST check the referenced event's pubkey against
+          // the deletion request's. Relays are not authoritative here, and
+          // inbound REQ filters are not enforced client-side, so any connected
+          // relay can land a forged deletion on an open subscription.
+          onEvent(
+            deletionEvent([
+              ['e', video.id],
+            ], pubkey: 'f' * 64),
+          );
+          await pumpEventQueue();
+
+          onEvent(video);
+
+          verify(() => mockNostrEventsDao.upsertEvent(video)).called(1);
+        },
+      );
+
+      test(
+        'caches a coordinate republished after the deletion request',
+        () async {
+          final onEvent = subscribeAndCaptureRelayCallback();
+
+          onEvent(
+            deletionEvent([
+              ['a', '$addressableShortVideoKind:$testPublicKey:clip-1'],
+            ], createdAt: 3000),
+          );
+          await pumpEventQueue();
+
+          // NIP-09 scopes an `a` deletion to versions up to its own created_at,
+          // so a later version under the same coordinate is not covered.
+          final republished = videoEvent(id: 'e' * 64, createdAt: 5000);
+          onEvent(republished);
+
+          verify(() => mockNostrEventsDao.upsertEvent(republished)).called(1);
+        },
+      );
+
+      test(
+        'still skips a coordinate version older than the deletion request',
+        () async {
+          final onEvent = subscribeAndCaptureRelayCallback();
+
+          onEvent(
+            deletionEvent([
+              ['a', '$addressableShortVideoKind:$testPublicKey:clip-1'],
+            ], createdAt: 3000),
+          );
+          await pumpEventQueue();
+
+          // Default created_at (1000) predates the deletion above (3000).
+          final older = videoEvent(id: 'f' * 64);
+          onEvent(older);
+
+          verifyNever(() => mockNostrEventsDao.upsertEvent(older));
+        },
+      );
     });
 
     group('subscribe', () {

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -1757,6 +1757,57 @@ void main() {
           verifyNever(() => mockNostrEventsDao.upsertEvent(older));
         },
       );
+
+      test(
+        'skips a coordinate version signed in the deletion second',
+        () async {
+          final onEvent = subscribeAndCaptureRelayCallback();
+
+          onEvent(
+            deletionEvent([
+              ['a', '$addressableShortVideoKind:$testPublicKey:clip-1'],
+            ], createdAt: 3000),
+          );
+          await pumpEventQueue();
+
+          // "up to created_at" is inclusive, and _deleteCachedEventsForDeletion
+          // passes the same value as `until`, which the DAO maps to
+          // `created_at <= ?`. If this side were exclusive the auto-cache would
+          // write back the very row that purge just deleted.
+          final boundary = videoEvent(id: '1' * 64, createdAt: 3000);
+          onEvent(boundary);
+
+          verifyNever(() => mockNostrEventsDao.upsertEvent(boundary));
+        },
+      );
+
+      test(
+        'keeps the newest bound when an older deletion arrives second',
+        () async {
+          final onEvent = subscribeAndCaptureRelayCallback();
+
+          // NIP-09 requires relays to serve deletion requests indefinitely, so a
+          // cold-start flood can deliver an old Kind 5 after a newer one for the
+          // same coordinate.
+          onEvent(
+            deletionEvent([
+              ['a', '$addressableShortVideoKind:$testPublicKey:clip-1'],
+            ], createdAt: 3000),
+          );
+          await pumpEventQueue();
+          onEvent(
+            deletionEvent([
+              ['a', '$addressableShortVideoKind:$testPublicKey:clip-1'],
+            ], createdAt: 1000),
+          );
+          await pumpEventQueue();
+
+          final covered = videoEvent(id: '2' * 64, createdAt: 2000);
+          onEvent(covered);
+
+          verifyNever(() => mockNostrEventsDao.upsertEvent(covered));
+        },
+      );
     });
 
     group('subscribe', () {

--- a/mobile/test/providers/video_event_service_tombstone_seed_test.dart
+++ b/mobile/test/providers/video_event_service_tombstone_seed_test.dart
@@ -1,0 +1,107 @@
+// ABOUTME: Pins the cold-start hydration of NIP-09 coordinate tombstones from
+// ABOUTME: persisted delete history, including the deletedAt unit conversion.
+
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:openvine/providers/video_providers.dart';
+import 'package:openvine/services/content_deletion_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/test_provider_overrides.dart';
+
+const _pubkey =
+    'c3dd74d68e414f0305db9f7dc96ec32e616502e6ccf5bbf5739de19a96b67f3e';
+const _dTag = 'clip-1';
+
+/// Seconds, so the stored ISO timestamp round-trips to a Nostr `created_at`.
+const _deletedAtSeconds = 2000;
+
+VideoEvent _video({required String id, required int createdAt}) =>
+    VideoEvent.fromNostrEvent(
+      Event(
+        _pubkey,
+        34236,
+        [
+          ['d', _dTag],
+          ['url', 'https://example.com/$id.mp4'],
+        ],
+        'a video',
+        createdAt: createdAt,
+      )..id = id,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('videoEventServiceProvider deletion-history hydration', () {
+    late ProviderContainer container;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({
+        ContentDeletionService.deletionsStorageKey: jsonEncode([
+          {
+            'deleteEventId': 'deletion-event-id',
+            'originalEventId': 'original-event-id',
+            'addressableId': '34236:$_pubkey:$_dTag',
+            'reason': 'personal choice',
+            'deletedAt': DateTime.fromMillisecondsSinceEpoch(
+              _deletedAtSeconds * 1000,
+              isUtc: true,
+            ).toIso8601String(),
+          },
+        ]),
+      });
+      final prefs = await SharedPreferences.getInstance();
+
+      container = ProviderContainer(
+        overrides: getStandardTestOverrides(
+          mockSharedPreferences: prefs,
+        ).cast(),
+      );
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test(
+      'covers versions up to the persisted deletedAt, and no later ones',
+      () {
+        final service = container.read(videoEventServiceProvider);
+
+        expect(
+          service.isVideoEventKnownDeleted(
+            _video(id: 'before', createdAt: _deletedAtSeconds - 1),
+          ),
+          isTrue,
+          reason: 'published before the deletion request',
+        );
+        expect(
+          service.isVideoEventKnownDeleted(
+            _video(id: 'after', createdAt: _deletedAtSeconds + 1),
+          ),
+          isFalse,
+          reason:
+              'republished after the deletion request; a wrong unit conversion '
+              'here silently makes every persisted tombstone cover nothing',
+        );
+      },
+    );
+
+    test('covers a version created at exactly the deletion timestamp', () {
+      final service = container.read(videoEventServiceProvider);
+
+      // NIP-09 deletes "up to the created_at timestamp" — inclusive.
+      expect(
+        service.isVideoEventKnownDeleted(
+          _video(id: 'exact', createdAt: _deletedAtSeconds),
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/mobile/test/services/event_router_test.dart
+++ b/mobile/test/services/event_router_test.dart
@@ -314,6 +314,53 @@ void main() {
       },
     );
 
+    group('dropQueuedEvents', () {
+      test('removes matching pending writes across every priority', () async {
+        final visible = videoEvent(6001);
+        final normal = videoEvent(6002);
+        final background = videoEvent(6003);
+        final keeper = videoEvent(6004);
+
+        router
+          ..handleEvent(visible, priority: EventIngestionPriority.visible)
+          ..handleEvent(normal)
+          ..handleEvent(background, priority: EventIngestionPriority.background)
+          ..handleEvent(keeper, priority: EventIngestionPriority.background);
+
+        final dropped = router.dropQueuedEvents({
+          visible.id,
+          normal.id,
+          background.id,
+        });
+
+        expect(dropped, equals(3));
+        expect(router.queuedLength, equals(1));
+
+        await router.drainForTesting();
+
+        expect(await db.nostrEventsDao.getEventById(visible.id), isNull);
+        expect(await db.nostrEventsDao.getEventById(normal.id), isNull);
+        expect(await db.nostrEventsDao.getEventById(background.id), isNull);
+        expect(await db.nostrEventsDao.getEventById(keeper.id), isNotNull);
+      });
+
+      test('ignores ids that are not queued', () {
+        router.handleEvent(videoEvent(6010));
+
+        expect(router.dropQueuedEvents({videoEvent(6011).id}), equals(0));
+        expect(router.queuedLength, equals(1));
+      });
+
+      test('is a no-op after dispose', () {
+        final event = videoEvent(6020);
+        router
+          ..handleEvent(event)
+          ..dispose();
+
+        expect(router.dropQueuedEvents({event.id}), equals(0));
+      });
+    });
+
     group('maxQueueDepth', () {
       test('bounds the queue and drops events once the cap is exceeded', () {
         router.dispose();

--- a/mobile/test/services/video_event_service_deleted_event_purge_test.dart
+++ b/mobile/test/services/video_event_service_deleted_event_purge_test.dart
@@ -151,6 +151,27 @@ void main() {
       expect(await cachedVideoRowCount(), 0);
     });
 
+    test('the cache-first read does not write the row back', () async {
+      // A row already in the store, as after a restart.
+      await db.nostrEventsDao.upsertEvent(_videoEvent());
+      expect(await cachedVideoRowCount(), 1);
+
+      // Cache-first picks it up and hands it to the same handler the relay
+      // path uses. Deliberately no drain here: that write-back is what used to
+      // land after the purge and resurrect the row on every single launch.
+      await service.subscribeToVideoFeed(
+        subscriptionType: SubscriptionType.discovery,
+        authors: const [_authorPubkey],
+      );
+
+      nostrService.emit(_deletionEvent());
+      await pumpEventQueue();
+      await pumpEventQueue();
+      await eventRouter.drainForTesting();
+
+      expect(await cachedVideoRowCount(), 0);
+    });
+
     test('deletes the row on a locally initiated delete too', () async {
       await service.subscribeToVideoFeed(
         subscriptionType: SubscriptionType.discovery,

--- a/mobile/test/services/video_event_service_deleted_event_purge_test.dart
+++ b/mobile/test/services/video_event_service_deleted_event_purge_test.dart
@@ -52,17 +52,21 @@ class _StreamingNostrService implements NostrClient {
 
 const _authorPubkey =
     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _otherPubkey =
+    'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
 const _videoId =
     'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const _editedVideoId =
+    'baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab';
 const _deletionId =
     'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
 const _sig =
     'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'
     'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
 
-Event _videoEvent() =>
+Event _videoEvent({String? id, String pubkey = _authorPubkey}) =>
     Event(
-        _authorPubkey,
+        pubkey,
         34236,
         [
           ['d', 'clip-1'],
@@ -72,15 +76,28 @@ Event _videoEvent() =>
         'a video that gets deleted',
         createdAt: 1000,
       )
-      ..id = _videoId
+      ..id = id ?? _videoId
       ..sig = _sig;
 
-Event _deletionEvent() =>
+Event _deletionEvent({String pubkey = _authorPubkey}) =>
+    Event(
+        pubkey,
+        5,
+        [
+          ['e', _videoId],
+        ],
+        'deleted by author',
+        createdAt: 2000,
+      )
+      ..id = _deletionId
+      ..sig = _sig;
+
+Event _addressableDeletionEvent() =>
     Event(
         _authorPubkey,
         5,
         [
-          ['e', _videoId],
+          ['a', '34236:$_authorPubkey:clip-1'],
         ],
         'deleted by author',
         createdAt: 2000,
@@ -184,6 +201,93 @@ void main() {
       await pumpEventQueue();
 
       expect(await cachedVideoRowCount(), 0);
+    });
+
+    test(
+      'does not re-persist a tombstoned video the relay redelivers',
+      () async {
+        await service.subscribeToVideoFeed(
+          subscriptionType: SubscriptionType.discovery,
+        );
+        nostrService.emit(_videoEvent());
+        await settle();
+        nostrService.emit(_deletionEvent());
+        await settle();
+        expect(await cachedVideoRowCount(), 0);
+
+        // A relay that never received the Kind 5 — or a second subscription —
+        // serves the deleted clip again.
+        nostrService.emit(_videoEvent());
+        await settle();
+
+        expect(await cachedVideoRowCount(), 0);
+      },
+    );
+
+    test(
+      'does not re-persist an edit of a tombstoned addressable video',
+      () async {
+        await service.subscribeToVideoFeed(
+          subscriptionType: SubscriptionType.discovery,
+        );
+        nostrService.emit(_videoEvent());
+        await settle();
+        nostrService.emit(_addressableDeletionEvent());
+        await settle();
+        expect(await cachedVideoRowCount(), 0);
+
+        // An edit mints a new event id for the same `pubkey:d-tag` clip, so only
+        // the coordinate half of the tombstone can catch it.
+        nostrService.emit(_videoEvent(id: _editedVideoId));
+        await settle();
+
+        expect(await cachedVideoRowCount(), 0);
+      },
+    );
+
+    test('a deletion arriving in the same burst still wins', () async {
+      await service.subscribeToVideoFeed(
+        subscriptionType: SubscriptionType.discovery,
+      );
+
+      // Video and its Kind 5 share one REQ, so the video is still queued in
+      // the router — unflushed — when the deletion is applied. The purge must
+      // evict that pending write, not just DELETE a row that isn't there yet.
+      nostrService.emit(_videoEvent());
+      await pumpEventQueue();
+      nostrService.emit(_deletionEvent());
+      await settle();
+
+      expect(await cachedVideoRowCount(), 0);
+    });
+
+    test('purges a stored row that no feed has loaded into memory', () async {
+      await db.nostrEventsDao.upsertEvent(_videoEvent());
+      expect(await cachedVideoRowCount(), 1);
+
+      // A feed for a different author: the row stays in the store, unloaded.
+      await service.subscribeToVideoFeed(
+        subscriptionType: SubscriptionType.homeFeed,
+        authors: const [_otherPubkey],
+      );
+      nostrService.emit(_deletionEvent());
+      await settle();
+
+      expect(await cachedVideoRowCount(), 0);
+    });
+
+    test('ignores a deletion that does not come from the row author', () async {
+      await db.nostrEventsDao.upsertEvent(_videoEvent());
+      expect(await cachedVideoRowCount(), 1);
+
+      await service.subscribeToVideoFeed(
+        subscriptionType: SubscriptionType.discovery,
+      );
+      // Forged `e` tag: a relay cannot delete another author's cached rows.
+      nostrService.emit(_deletionEvent(pubkey: _otherPubkey));
+      await settle();
+
+      expect(await cachedVideoRowCount(), 1);
     });
   });
 }

--- a/mobile/test/services/video_event_service_deleted_event_purge_test.dart
+++ b/mobile/test/services/video_event_service_deleted_event_purge_test.dart
@@ -98,18 +98,22 @@ Event _deletionEvent({String pubkey = _authorPubkey}) =>
       ..id = _deletionId
       ..sig = _sig;
 
-Event _addressableDeletionEvent() =>
-    Event(
-        _authorPubkey,
-        5,
-        [
-          ['a', '34236:$_authorPubkey:clip-1'],
-        ],
-        'deleted by author',
-        createdAt: 2000,
-      )
-      ..id = _deletionId
-      ..sig = _sig;
+Event _addressableDeletionEvent({bool uppercaseTagPubkey = false}) {
+  final tagPubkey = uppercaseTagPubkey
+      ? _authorPubkey.toUpperCase()
+      : _authorPubkey;
+  return Event(
+      _authorPubkey,
+      5,
+      [
+        ['a', '34236:$tagPubkey:clip-1'],
+      ],
+      'deleted by author',
+      createdAt: 2000,
+    )
+    ..id = _deletionId
+    ..sig = _sig;
+}
 
 void main() {
   group('VideoEventService NIP-09 local cache purge', () {
@@ -277,6 +281,23 @@ void main() {
         authors: const [_otherPubkey],
       );
       nostrService.emit(_deletionEvent());
+      await settle();
+
+      expect(await cachedVideoRowCount(), 0);
+    });
+
+    test('purges a stored row when the `a` tag uses uppercase hex', () async {
+      await db.nostrEventsDao.upsertEvent(_videoEvent());
+      expect(await cachedVideoRowCount(), 1);
+
+      // The author gate lowercases before comparing, so an uppercase tag is
+      // accepted; the SQL `pubkey IN (...)` behind the purge is case-sensitive
+      // and would match nothing if the tag's own casing were bound.
+      await service.subscribeToVideoFeed(
+        subscriptionType: SubscriptionType.homeFeed,
+        authors: const [_otherPubkey],
+      );
+      nostrService.emit(_addressableDeletionEvent(uppercaseTagPubkey: true));
       await settle();
 
       expect(await cachedVideoRowCount(), 0);

--- a/mobile/test/services/video_event_service_deleted_event_purge_test.dart
+++ b/mobile/test/services/video_event_service_deleted_event_purge_test.dart
@@ -64,7 +64,11 @@ const _sig =
     'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'
     'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
 
-Event _videoEvent({String? id, String pubkey = _authorPubkey}) =>
+Event _videoEvent({
+  String? id,
+  String pubkey = _authorPubkey,
+  int createdAt = 1000,
+}) =>
     Event(
         pubkey,
         34236,
@@ -74,7 +78,7 @@ Event _videoEvent({String? id, String pubkey = _authorPubkey}) =>
           ['title', 'Deleted clip'],
         ],
         'a video that gets deleted',
-        createdAt: 1000,
+        createdAt: createdAt,
       )
       ..id = id ?? _videoId
       ..sig = _sig;
@@ -288,6 +292,84 @@ void main() {
       await settle();
 
       expect(await cachedVideoRowCount(), 1);
+    });
+
+    test(
+      'keeps a coordinate version published after the deletion request',
+      () async {
+        // NIP-09 scopes an `a` deletion to versions up to its own created_at.
+        // Relays redeliver old Kind 5s on every launch, so an unbounded purge
+        // would wipe a clip the author has since republished.
+        await db.nostrEventsDao.upsertEvent(
+          _videoEvent(id: _editedVideoId, createdAt: 5000),
+        );
+        expect(await cachedVideoRowCount(), 1);
+
+        // Cache-first loads the row, so this covers the in-memory coordinate
+        // tombstone and the store purge together.
+        await service.subscribeToVideoFeed(
+          subscriptionType: SubscriptionType.discovery,
+        );
+        nostrService.emit(_addressableDeletionEvent());
+        await settle();
+
+        expect(await cachedVideoRowCount(), 1);
+      },
+    );
+
+    test('keeps the republished version visible in the feed', () async {
+      await service.subscribeToVideoFeed(
+        subscriptionType: SubscriptionType.discovery,
+      );
+      // Same coordinate, published after the deletion request below.
+      nostrService.emit(_videoEvent(id: _editedVideoId, createdAt: 5000));
+      await settle();
+
+      nostrService.emit(_addressableDeletionEvent());
+      await settle();
+
+      expect(
+        service.discoveryVideos.where((v) => v.id == _editedVideoId),
+        isNotEmpty,
+        reason: 'a version newer than the deletion is not covered by it',
+      );
+    });
+
+    test(
+      'caches a version the author republishes after the deletion',
+      () async {
+        await service.subscribeToVideoFeed(
+          subscriptionType: SubscriptionType.discovery,
+        );
+        nostrService.emit(_addressableDeletionEvent());
+        await settle();
+
+        // The tombstone now exists, so this arrival is what the ingestion guard
+        // inspects — and a version newer than the deletion is not covered.
+        nostrService.emit(_videoEvent(id: _editedVideoId, createdAt: 5000));
+        await settle();
+
+        expect(await cachedVideoRowCount(), 1);
+      },
+    );
+
+    test('tombstones a purged row so a relay cannot write it back', () async {
+      await db.nostrEventsDao.upsertEvent(_videoEvent());
+
+      // Never loaded into memory, so only the store purge sees it.
+      await service.subscribeToVideoFeed(
+        subscriptionType: SubscriptionType.homeFeed,
+        authors: const [_otherPubkey],
+      );
+      nostrService.emit(_deletionEvent());
+      await settle();
+      expect(await cachedVideoRowCount(), 0);
+
+      // Without a recorded tombstone the ingestion guard stays false here.
+      nostrService.emit(_videoEvent());
+      await settle();
+
+      expect(await cachedVideoRowCount(), 0);
     });
   });
 }

--- a/mobile/test/services/video_event_service_deleted_event_purge_test.dart
+++ b/mobile/test/services/video_event_service_deleted_event_purge_test.dart
@@ -68,6 +68,7 @@ Event _videoEvent({
   String? id,
   String pubkey = _authorPubkey,
   int createdAt = 1000,
+  String? publishedAt,
 }) =>
     Event(
         pubkey,
@@ -76,6 +77,7 @@ Event _videoEvent({
           ['d', 'clip-1'],
           ['url', 'https://example.com/video.mp4'],
           ['title', 'Deleted clip'],
+          if (publishedAt != null) ['published_at', publishedAt],
         ],
         'a video that gets deleted',
         createdAt: createdAt,
@@ -349,6 +351,33 @@ void main() {
         nostrService.emit(_videoEvent(id: _editedVideoId, createdAt: 5000));
         await settle();
 
+        expect(await cachedVideoRowCount(), 1);
+      },
+    );
+
+    test(
+      'keeps an edited clip whose published_at predates the deletion',
+      () async {
+        // An edit keeps the `d` tag and re-emits the original published_at, so
+        // VideoEvent.createdAt reports the first publication. Comparing that
+        // against the deletion would hide a clip republished after it — the row
+        // survives on disk while every feed drops it.
+        await service.subscribeToVideoFeed(
+          subscriptionType: SubscriptionType.discovery,
+        );
+        nostrService.emit(_addressableDeletionEvent());
+        await settle();
+
+        nostrService.emit(
+          _videoEvent(id: _editedVideoId, createdAt: 3000, publishedAt: '1000'),
+        );
+        await settle();
+
+        expect(
+          service.discoveryVideos.where((v) => v.id == _editedVideoId),
+          isNotEmpty,
+          reason: 'the edit was published after the deletion request',
+        );
         expect(await cachedVideoRowCount(), 1);
       },
     );

--- a/mobile/test/services/video_event_service_deleted_event_purge_test.dart
+++ b/mobile/test/services/video_event_service_deleted_event_purge_test.dart
@@ -286,6 +286,32 @@ void main() {
       expect(await cachedVideoRowCount(), 0);
     });
 
+    test(
+      'sweeps a copy admitted while the store purge was in flight',
+      () async {
+        await db.nostrEventsDao.upsertEvent(_videoEvent());
+
+        // A feed for a different author, so the row stays in the store and the
+        // deletion finds nothing in memory to validate against.
+        await service.subscribeToVideoFeed(
+          subscriptionType: SubscriptionType.homeFeed,
+          authors: const [_otherPubkey],
+        );
+        nostrService.emit(_deletionEvent());
+        // The copy lands while the purge is still suspended on its DAO round
+        // trip, so it clears the ingestion guard and a feed takes it.
+        nostrService.emit(_videoEvent());
+        await settle();
+
+        expect(await cachedVideoRowCount(), 0);
+        expect(
+          service.homeFeedVideos.where((v) => v.id == _videoId),
+          isEmpty,
+          reason: 'the tombstone must also evict what the window let in',
+        );
+      },
+    );
+
     test('purges a stored row when the `a` tag uses uppercase hex', () async {
       await db.nostrEventsDao.upsertEvent(_videoEvent());
       expect(await cachedVideoRowCount(), 1);

--- a/mobile/test/services/video_event_service_deleted_event_purge_test.dart
+++ b/mobile/test/services/video_event_service_deleted_event_purge_test.dart
@@ -312,6 +312,25 @@ void main() {
       },
     );
 
+    test('purges a stored row signed in the deletion second', () async {
+      // NIP-09 deletes "up to the created_at timestamp" — inclusive — and the
+      // DAO maps `until` to `created_at <= ?`. Off by one here strands the row
+      // on disk for the cache-first read to re-serve, while the in-memory
+      // guards would still treat the clip as deleted.
+      await db.nostrEventsDao.upsertEvent(
+        _videoEvent(id: _editedVideoId, createdAt: 2000),
+      );
+
+      await service.subscribeToVideoFeed(
+        subscriptionType: SubscriptionType.homeFeed,
+        authors: const [_otherPubkey],
+      );
+      nostrService.emit(_addressableDeletionEvent());
+      await settle();
+
+      expect(await cachedVideoRowCount(), 0);
+    });
+
     test('purges a stored row when the `a` tag uses uppercase hex', () async {
       await db.nostrEventsDao.upsertEvent(_videoEvent());
       expect(await cachedVideoRowCount(), 1);

--- a/mobile/test/services/video_event_service_deleted_event_purge_test.dart
+++ b/mobile/test/services/video_event_service_deleted_event_purge_test.dart
@@ -1,0 +1,168 @@
+// ABOUTME: Regression tests for purging NIP-09 deleted videos from the local
+// ABOUTME: event store, so a restart's cache-first load cannot resurface them.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:db_client/db_client.dart' hide Filter;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/services/event_router.dart';
+import 'package:openvine/services/subscription_manager.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:path/path.dart' as p;
+
+/// Emits events on demand so a deletion can be delivered after the video.
+class _StreamingNostrService implements NostrClient {
+  final StreamController<Event> _events = StreamController<Event>.broadcast();
+
+  @override
+  bool get isInitialized => true;
+
+  @override
+  int get connectedRelayCount => 1;
+
+  @override
+  Stream<Event> subscribe(
+    List<Filter> filters, {
+    String? subscriptionId,
+    List<String>? tempRelays,
+    List<String>? targetRelays,
+    List<int> relayTypes = const [],
+    bool sendAfterAuth = false,
+    void Function()? onEose,
+  }) {
+    if (onEose != null) {
+      Future.microtask(onEose);
+    }
+    return _events.stream;
+  }
+
+  void emit(Event event) => _events.add(event);
+
+  @override
+  Future<void> dispose() async => _events.close();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+const _authorPubkey =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _videoId =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const _deletionId =
+    'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+const _sig =
+    'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'
+    'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+
+Event _videoEvent() =>
+    Event(
+        _authorPubkey,
+        34236,
+        [
+          ['d', 'clip-1'],
+          ['url', 'https://example.com/video.mp4'],
+          ['title', 'Deleted clip'],
+        ],
+        'a video that gets deleted',
+        createdAt: 1000,
+      )
+      ..id = _videoId
+      ..sig = _sig;
+
+Event _deletionEvent() =>
+    Event(
+        _authorPubkey,
+        5,
+        [
+          ['e', _videoId],
+        ],
+        'deleted by author',
+        createdAt: 2000,
+      )
+      ..id = _deletionId
+      ..sig = _sig;
+
+void main() {
+  group('VideoEventService NIP-09 local cache purge', () {
+    late AppDatabase db;
+    late String dbPath;
+    late Directory tempDir;
+    late EventRouter eventRouter;
+    late _StreamingNostrService nostrService;
+    late VideoEventService service;
+
+    setUp(() async {
+      tempDir = Directory.systemTemp.createTempSync('openvine_purge_test_');
+      dbPath = p.join(tempDir.path, 'test.db');
+      db = AppDatabase.test(NativeDatabase(File(dbPath)));
+      eventRouter = EventRouter(
+        db,
+        config: const EventRouterConfig(autoStart: false),
+      );
+      nostrService = _StreamingNostrService();
+      service = VideoEventService(
+        nostrService,
+        subscriptionManager: SubscriptionManager(nostrService),
+        eventRouter: eventRouter,
+      );
+    });
+
+    tearDown(() async {
+      service.dispose();
+      await db.close();
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    /// Lets the broadcast stream forward pending events into the router, then
+    /// persists them. Replaces wall-clock waits.
+    Future<void> settle() async {
+      await pumpEventQueue();
+      await eventRouter.drainForTesting();
+    }
+
+    Future<int> cachedVideoRowCount() async {
+      final rows = await db.nostrEventsDao.getEventsByFilter(
+        Filter(kinds: const [34236], authors: const [_authorPubkey]),
+      );
+      return rows.length;
+    }
+
+    test('deletes the target event row from the local store', () async {
+      await service.subscribeToVideoFeed(
+        subscriptionType: SubscriptionType.discovery,
+      );
+      nostrService.emit(_videoEvent());
+      await settle();
+      expect(
+        await cachedVideoRowCount(),
+        1,
+        reason: 'the video should be cached before the deletion arrives',
+      );
+
+      nostrService.emit(_deletionEvent());
+      await settle();
+
+      expect(await cachedVideoRowCount(), 0);
+    });
+
+    test('deletes the row on a locally initiated delete too', () async {
+      await service.subscribeToVideoFeed(
+        subscriptionType: SubscriptionType.discovery,
+      );
+      nostrService.emit(_videoEvent());
+      await settle();
+      expect(await cachedVideoRowCount(), 1);
+
+      service.removeVideoCompletely(_videoId);
+      await pumpEventQueue();
+
+      expect(await cachedVideoRowCount(), 0);
+    });
+  });
+}

--- a/mobile/test/services/video_event_service_tombstone_deletion_test.dart
+++ b/mobile/test/services/video_event_service_tombstone_deletion_test.dart
@@ -278,5 +278,33 @@ void main() {
         reason: 'NIP-09 scopes an `a` deletion to its own created_at',
       );
     });
+
+    test('a second, older deletion does not lower the coordinate bound', () {
+      const pubkey =
+          'c3dd74d68e414f0305db9f7dc96ec32e616502e6ccf5bbf5739de19a96b67f3e';
+      const dTag = 'shared-vine-id';
+      final coveredVersion = _videoEvent(
+        id: 'version-between-deletions',
+        pubkey: pubkey,
+        dTag: dTag,
+        createdAt: 5000,
+      );
+
+      // Relays serve deletion requests indefinitely, so a cold-start flood can
+      // deliver an old Kind 5 after a newer one for the same coordinate. The
+      // newest bound has to win, or the version between them reappears.
+      videoEventService.seedLocalDeletionTombstones(
+        addressableDeletedAt: const {'34236:$pubkey:$dTag': 6000},
+      );
+      videoEventService.seedLocalDeletionTombstones(
+        addressableDeletedAt: const {'34236:$pubkey:$dTag': 2000},
+      );
+
+      expect(
+        videoEventService.isVideoEventKnownDeleted(coveredVersion),
+        isTrue,
+        reason: 'the older redelivery must not un-cover the 6000 deletion',
+      );
+    });
   });
 }

--- a/mobile/test/services/video_event_service_tombstone_deletion_test.dart
+++ b/mobile/test/services/video_event_service_tombstone_deletion_test.dart
@@ -215,7 +215,7 @@ void main() {
       );
 
       videoEventService.seedLocalDeletionTombstones(
-        addressableIds: const ['34236:$pubkey:$dTag'],
+        addressableDeletedAt: const {'34236:$pubkey:$dTag': 2000},
       );
 
       expect(
@@ -240,11 +240,43 @@ void main() {
         );
 
         videoEventService.seedLocalDeletionTombstones(
-          addressableIds: const ['30023:$pubkey:shared-vine-id'],
+          addressableDeletedAt: const {'30023:$pubkey:shared-vine-id': 2000},
         );
 
         expect(videoEventService.isVideoEventLocallyDeleted(video), isFalse);
       },
     );
+
+    test('a coordinate tombstone only covers versions up to its timestamp', () {
+      const pubkey =
+          'c3dd74d68e414f0305db9f7dc96ec32e616502e6ccf5bbf5739de19a96b67f3e';
+      const dTag = 'shared-vine-id';
+      // Default created_at (1000) predates the deletion seeded below (2000).
+      final deletedVersion = _videoEvent(
+        id: 'version-before-deletion',
+        pubkey: pubkey,
+        dTag: dTag,
+      );
+      final republishedVersion = _videoEvent(
+        id: 'version-after-deletion',
+        pubkey: pubkey,
+        dTag: dTag,
+        createdAt: 5000,
+      );
+
+      videoEventService.seedLocalDeletionTombstones(
+        addressableDeletedAt: const {'34236:$pubkey:$dTag': 2000},
+      );
+
+      expect(
+        videoEventService.isVideoEventKnownDeleted(deletedVersion),
+        isTrue,
+      );
+      expect(
+        videoEventService.isVideoEventKnownDeleted(republishedVersion),
+        isFalse,
+        reason: 'NIP-09 scopes an `a` deletion to its own created_at',
+      );
+    });
   });
 }


### PR DESCRIPTION
Closes #6625

## Description

Restarting the app and opening your own profile flashes already-deleted videos in the Videos tab for a few hundred milliseconds, on every launch.

**Root cause.** Applying a NIP-09 deletion only clears the in-memory feed caches — `_eventLists`, `_authorBuckets`, `_hashtagBuckets`. The comment on the local delete path says so outright: *"removal is permanent for the lifetime of this service."* The event rows in the local store survive it, and the cache-first startup query (`_loadCachedEvents`) reads straight from those rows, so every launch puts the deleted clips back into the author buckets. They only disappear once the relay redelivers the Kind 5 event and the handler re-applies the deletion in memory — which is the flash.

Captured from a device trace, restart → own profile:

```
12:02:42.248  Cache-first: UI updated with 3 cached events for instant display
12:02:42.557  SVC authorVideos: cached=3          <- grid renders the deleted clips
12:02:42.929  Applied observed video deletion c03f3e17… to 2 cached location(s)
12:02:42.930  Applied observed video deletion 63cbc380… to 2 cached location(s)
12:02:42.930  Applied observed video deletion 293201d8… to 2 cached location(s)
12:02:43.180  SVC authorVideos: cached=0          <- gone, ~680ms later
12:03:00.256  SVC authorVideos: cached=3          <- the real live videos
```

The three ids are that account's own Kind 5 events from June (the log line prints the deletion event id, not the target). Relay and backend were both clean at the time — 3 live videos, 63 tombstoned targets, none of them still fetchable — so the stale state was purely local.

The existing tombstone filter cannot cover this window: `_knownDeletedVideoIds` is seeded from `content_deletions_history` in SharedPreferences, which is empty on a cold start for anything this install did not delete itself.

### Purge the rows

Both removal paths now delete the rows as well, using `NostrEventsDao.deleteEventsByIds` — documented for exactly this (*"Used when processing NIP-09 deletion events (Kind 5)"*) and until now only reachable via `db_video_local_storage`.

The purge is fire-and-forget with a swallowed failure: the in-memory removal has already succeeded at that point, so a failed purge must not break deletion handling.

### Stop the cache-first read writing them back

Purging alone did not hold, and device testing caught it: the logs reported `Purged 1 deleted event(s) from the local cache` on every launch and the flash kept coming back. The cache-first read hands every row it loads to `_handleNewVideoEvent`, the same handler the relay path uses, which re-queues it for persistence at **background** priority — the queue `EventRouter` drains *last*. Under the startup relay burst (batches of 26/34/36/50 events in the trace above) that write-back lands *after* the deletion has purged the same rows. Every launch re-created exactly what it had just deleted, so no number of restarts converged.

So: skip the write-back for events that came out of the store — they are already persisted, and re-queueing them was pure write amplification on top of the correctness bug — and never re-persist an event that is already tombstoned, by id or by `pubkey:d-tag` coordinate (an addressable edit mints a new id for the same clip).

### Close the paths that bypassed that guard

Review found the guard could not actually do its job, and the review's own probe tests confirmed each gap on a real Drift database.

**The feed listener wrote the row back before the guard ran.** `subscribeToVideoFeed` queued every relay event unguarded at normal priority immediately before handing it to `_handleNewVideoEvent`, which queued it again at background priority. Since normal drains first, the guard only ever suppressed a redundant second write. Ingestion now goes through `_handleNewVideoEvent` alone, which takes the priority the caller wants, so the service has one persistence entry point that the guard genuinely covers — and one write per event instead of two.

**A write queued a moment before the deletion still landed after it.** The video filter and the Kind 5 filter share one REQ, so both arrive in the same burst. The video was queued while no tombstone existed, so it passed the guard; the purge then issued a DELETE that matched nothing, and the flush inserted the row afterwards. The purge now evicts pending router writes (`EventRouter.dropQueuedEvents`) before deleting.

**Rows no feed had loaded were never purged at all.** The purge only received ids validated against the in-memory caches, so a Kind 5 for a stored-but-unloaded video — the exact state that survives a restart — did nothing. It now resolves the deletion's requested ids and `a`-tag coordinates against the store, with the author re-checked per stored row so a forged `e` tag cannot reach another author's cache.

**Coordinate tombstones could not match.** They are keyed on `VideoEvent.stableId`, which falls back to a `vine_id` tag when there is no `d` tag, while the guard only scanned for `d`. Both now resolve the stable id the same way.

### Stop `NostrClient` re-caching deleted events

`NostrClient.subscribe` caches every non-deletion event straight to the DAO from its own callback, before the app layer sees the event. No guard in `VideoEventService` can reach that write, so any relay that redelivered a deleted video put the row straight back and the clip returned on the next launch.

`_handleDeletionEvent` now records what it removed — by event id and by `kind:pubkey:d-tag` coordinate, so an edit of the same clip is caught too — and the auto-cache skips those. The sets are bounded; losing an old entry only costs a redundant row that the next deletion purges again.

Installs that already hold stale rows flash **once** more on the next launch — that launch is what purges them — and are clean from the launch after.

**Related Issue:** 

## Out of Scope

- `NostrClient._deleteCachedEventsForDeletion` still deletes by `e` tag with no author validation, so a hostile relay can drop arbitrary rows from the local cache. Pre-existing and untouched. Both purge paths this PR adds do validate — the app-layer one against the stored row's pubkey, the client-side tombstone against the deletion author — so the gap is now limited to that one pre-existing delete.
- `content_deletions_history` was absent from the affected device's SharedPreferences despite 63 deletions on that account, so the tombstone seed had nothing to seed. This fix makes that irrelevant for the flash, but the persistence gap itself is untouched.
- Funnelcake's `/api/users/<pubkey>/videos` returned `[]` for an account with 3 live videos on the relay. Backend-side, not this PR.

## Verification

- Manually verified on a real Samsung Galaxy (SM-S942B). Reproducing needs two restarts: the first still flashes and purges, the second is clean. Re-verified on device after the review fixes.
- Review follow-up: NIP-09 `a` deletions are now scoped to the deletion request's own `created_at` on every path — the store purge, the in-memory coordinate tombstone, and the client-side auto-cache suppression — so a version republished after the request stays visible. Coordinate tombstones became a map to that timestamp, which changes `seedKnownDeletionTombstones` to take `addressableDeletedAt`. Client-side `e` tag tombstones are keyed on the deletion author, and rows the store purge resolves now seed the in-memory tombstone so a later relay delivery cannot write them back.
- 8 regression tests against a real Drift database, one per failure mode: both removal paths (observed Kind 5, locally initiated delete), the resurrection ordering, relay redelivery by id, redelivery of an addressable edit by coordinate, a deletion arriving in the same burst as its video, a stored row no feed has loaded, and a forged deletion from a non-author.
- Every fix is mutation-tested: reverting each one individually turns a specific test red. Removing the tombstone guard fails both redelivery tests, removing the queue eviction fails the same-burst test, removing the store purge fails the not-in-memory test, removing the author check fails the forged-deletion test, and removing the client-side suppression fails both `nostr_client` tests.
- 3 new `nostr_client` tests for the auto-cache suppression, including a negative control that a never-tombstoned event is still cached.
- `flutter test test/services/` → 3652 passed
- `flutter test` in `packages/nostr_client` → 300 passed, 86.79% line coverage (gate 82%)
- `flutter analyze lib test` → clean, both in the app and in `packages/nostr_client`

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

