### PR TITLE
fix(settings): rebuild the account danger-zone gates on Divine sheet components

### DIFF
--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4060,6 +4060,7 @@
   "deleteAccountConfirmUsernamePrompt": "To confirm, type your username:",
   "@deleteAccountConfirmUsernamePrompt": {"description": "Prompt above the confirmation field when the account has a username; the user re-types their username to confirm deletion."},
   "deleteAccountConfirmationHint": "Type DELETE",
+  "@deleteAccountConfirmationHint": {"description": "Label on the delete-confirmation field when the user must type the DELETE token. Shown inside the field when empty and floating above it once focused, so it stays visible while typing."},
   "deleteAccountConfirmationHintUsername": "Type your username",
   "@deleteAccountConfirmationHintUsername": {"description": "Label on the delete-confirmation field when the user must type their username. Shown inside the field when empty and floating above it once focused, so it stays visible while typing."},
   "deleteAccountContentDeletionFailed": "Failed to delete content from relays",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4061,7 +4061,7 @@
   "@deleteAccountConfirmUsernamePrompt": {"description": "Prompt above the confirmation field when the account has a username; the user re-types their username to confirm deletion."},
   "deleteAccountConfirmationHint": "Type DELETE",
   "deleteAccountConfirmationHintUsername": "Type your username",
-  "@deleteAccountConfirmationHintUsername": {"description": "Hint text in the delete-confirmation field when the user must type their username."},
+  "@deleteAccountConfirmationHintUsername": {"description": "Label on the delete-confirmation field when the user must type their username. Shown inside the field when empty and floating above it once focused, so it stays visible while typing."},
   "deleteAccountContentDeletionFailed": "Failed to delete content from relays",
   "deleteAccountDeleteAllContentButton": "Delete All Content",
   "deleteAccountDeletionIncomplete": "We couldn't finish deleting your account. Try again.",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -12131,7 +12131,7 @@ abstract class AppLocalizations {
   /// **'To confirm, type your username:'**
   String get deleteAccountConfirmUsernamePrompt;
 
-  /// No description provided for @deleteAccountConfirmationHint.
+  /// Label on the delete-confirmation field when the user must type the DELETE token. Shown inside the field when empty and floating above it once focused, so it stays visible while typing.
   ///
   /// In en, this message translates to:
   /// **'Type DELETE'**

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -12137,7 +12137,7 @@ abstract class AppLocalizations {
   /// **'Type DELETE'**
   String get deleteAccountConfirmationHint;
 
-  /// Hint text in the delete-confirmation field when the user must type their username.
+  /// Label on the delete-confirmation field when the user must type their username. Shown inside the field when empty and floating above it once focused, so it stays visible while typing.
   ///
   /// In en, this message translates to:
   /// **'Type your username'**

--- a/mobile/lib/screens/settings/nostr_settings_screen.dart
+++ b/mobile/lib/screens/settings/nostr_settings_screen.dart
@@ -166,50 +166,46 @@ class _RemoveKeysTile extends StatelessWidget {
         context.l10n.nostrSettingsCouldNotRemoveKeys;
     final failedToRemoveKeysFn = context.l10n.nostrSettingsFailedToRemoveKeys;
 
-    await showRemoveKeysWarningDialog(
-      context: context,
-      onConfirm: () async {
-        if (!context.mounted) return;
+    final confirmed = await showRemoveKeysWarningSheet(context);
+    if (!confirmed || !context.mounted) return;
 
-        // Resolved before the await: the spinner is an overlay entry, not a
-        // route, so a back press during sign-out pops this screen instead of
-        // the spinner. The app-level messenger outlives that pop; a
-        // post-await `ScaffoldMessenger.of(context)` would not, and the user
-        // would be left with no word on a key deletion that failed.
-        final messenger = ScaffoldMessenger.of(context);
-        final progressOverlay = ModalProgressOverlay.show(context);
+    // Resolved before the await: the spinner is an overlay entry, not a
+    // route, so a back press during sign-out pops this screen instead of
+    // the spinner. The app-level messenger outlives that pop; a
+    // post-await `ScaffoldMessenger.of(context)` would not, and the user
+    // would be left with no word on a key deletion that failed.
+    final messenger = ScaffoldMessenger.of(context);
+    final progressOverlay = ModalProgressOverlay.show(context);
 
-        try {
-          await authService.signOut(
-            deleteKeys: true,
-            abortOnKeyDeletionFailure: true,
-          );
-          progressOverlay.dismiss();
-          if (!context.mounted) return;
-          context.go(WelcomeScreen.path);
-        } on SecureKeyStorageException {
-          progressOverlay.dismiss();
-          // Platform key deletion failed — user stays signed in and can
-          // retry without having to log back in.
-          if (!messenger.mounted) return;
-          messenger.showSnackBar(
-            DivineSnackbarContainer.snackBar(
-              couldNotRemoveKeysMessage,
-              error: true,
-            ),
-          );
-        } catch (e) {
-          progressOverlay.dismiss();
-          if (!messenger.mounted) return;
-          messenger.showSnackBar(
-            DivineSnackbarContainer.snackBar(
-              failedToRemoveKeysFn('$e'),
-              error: true,
-            ),
-          );
-        }
-      },
-    );
+    try {
+      await authService.signOut(
+        deleteKeys: true,
+        abortOnKeyDeletionFailure: true,
+      );
+      progressOverlay.dismiss();
+      if (!context.mounted) return;
+      context.go(WelcomeScreen.path);
+    } on SecureKeyStorageException {
+      progressOverlay.dismiss();
+      // Platform key deletion failed — user stays signed in and can
+      // retry without having to log back in.
+      if (!messenger.mounted) return;
+      messenger.showSnackBar(
+        DivineSnackbarContainer.snackBar(
+          couldNotRemoveKeysMessage,
+          error: true,
+        ),
+      );
+    } catch (e) {
+      progressOverlay.dismiss();
+      if (!messenger.mounted) return;
+      messenger.showSnackBar(
+        DivineSnackbarContainer.snackBar(
+          failedToRemoveKeysFn('$e'),
+          error: true,
+        ),
+      );
+    }
   }
 }
 

--- a/mobile/lib/widgets/delete_account_action.dart
+++ b/mobile/lib/widgets/delete_account_action.dart
@@ -67,7 +67,7 @@ Future<void> startAccountDeletionFlow({
     handle: profile?.displayNip05,
   );
 
-  await showDeleteAllContentWarningDialog(
+  await showDeleteAllContentWarningSheet(
     context: context,
     confirmation: confirmation,
     ownedUsernameFuture: ownedUsernameFuture,

--- a/mobile/lib/widgets/delete_account_dialog.dart
+++ b/mobile/lib/widgets/delete_account_dialog.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Bottom sheets for the account deletion flow
+// ABOUTME: Account deletion flow: confirmation sheets, progress dialog, orchestration
 // ABOUTME: Warning sheets for key removal and content deletion with confirmation
 
 import 'dart:async';
@@ -283,7 +283,7 @@ class _DeleteAllContentFormState extends State<_DeleteAllContentForm> {
   }
 }
 
-/// Identity block (avatar + name + handle/npub) for the delete dialog.
+/// Identity block (avatar + name + handle/npub) for the delete sheet.
 class _DeleteIdentityHeader extends StatelessWidget {
   const _DeleteIdentityHeader({required this.confirmation});
 

--- a/mobile/lib/widgets/delete_account_dialog.dart
+++ b/mobile/lib/widgets/delete_account_dialog.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Account deletion flow: confirmation sheets, progress dialog, orchestration
+// ABOUTME: Account deletion flow: confirmation sheets, progress sheet, orchestration
 // ABOUTME: Warning sheets for key removal and content deletion with confirmation
 
 import 'dart:async';
@@ -339,77 +339,65 @@ class _DeleteIdentityHeader extends StatelessWidget {
   }
 }
 
-/// Progress dialog that shows deletion progress using BLoC pattern.
-class _DeletionProgressDialog extends StatelessWidget {
-  const _DeletionProgressDialog();
+/// Progress sheet content that shows deletion progress using BLoC pattern.
+class _DeletionProgressSheetContent extends StatelessWidget {
+  const _DeletionProgressSheetContent();
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Card(
-        color: context.vineColors.card,
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child:
-              BlocBuilder<
-                AccountDeletionProgressCubit,
-                AccountDeletionProgressState
-              >(
-                builder: (context, state) {
-                  return Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: switch (state) {
-                      AccountDeletionProgressUpdating(
-                        :final current,
-                        :final total,
-                      ) =>
-                        [
-                          CircularProgressIndicator(
-                            value: current / total,
-                            color: VineTheme.vineGreen,
-                            backgroundColor: context.vineColors.card,
-                          ),
-                          const SizedBox(height: 16),
-                          Text(
-                            context.l10n.videoGridDeletingContent,
-                            style: TextStyle(
-                              color: context.vineColors.primaryText,
-                              fontSize: 16,
-                              fontWeight: FontWeight.w500,
-                            ),
-                          ),
-                          const SizedBox(height: 8),
-                          Text(
-                            context.l10n.deleteAccountProgressEvents(
-                              current,
-                              total,
-                            ),
-                            style: TextStyle(
-                              color: context.vineColors.secondaryText,
-                              fontSize: 14,
-                            ),
-                          ),
-                        ],
-                      AccountDeletionProgressPreparing() => [
-                        const CircularProgressIndicator(
-                          color: VineTheme.vineGreen,
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 8, 24, 32),
+      child:
+          BlocBuilder<
+            AccountDeletionProgressCubit,
+            AccountDeletionProgressState
+          >(
+            builder: (context, state) {
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                children: switch (state) {
+                  AccountDeletionProgressUpdating(
+                    :final current,
+                    :final total,
+                  ) =>
+                    [
+                      CircularProgressIndicator(
+                        value: current / total,
+                        color: VineTheme.vineGreen,
+                        backgroundColor: context.vineColors.card,
+                      ),
+                      const SizedBox(height: 16),
+                      Text(
+                        context.l10n.videoGridDeletingContent,
+                        style: VineTheme.bodyLargeFont(
+                          color: context.vineColors.primaryText,
                         ),
-                        const SizedBox(height: 16),
-                        Text(
-                          context.l10n.deleteAccountPreparingDeletion,
-                          style: TextStyle(
-                            color: context.vineColors.primaryText,
-                            fontSize: 16,
-                            fontWeight: FontWeight.w500,
-                          ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        context.l10n.deleteAccountProgressEvents(
+                          current,
+                          total,
                         ),
-                      ],
-                    },
-                  );
+                        style: VineTheme.bodyMediumFont(
+                          color: context.vineColors.secondaryText,
+                        ),
+                      ),
+                    ],
+                  AccountDeletionProgressPreparing() => [
+                    const CircularProgressIndicator(color: VineTheme.vineGreen),
+                    const SizedBox(height: 16),
+                    Text(
+                      context.l10n.deleteAccountPreparingDeletion,
+                      style: VineTheme.bodyLargeFont(
+                        color: context.vineColors.primaryText,
+                      ),
+                    ),
+                  ],
                 },
-              ),
-        ),
-      ),
+              );
+            },
+          ),
     );
   }
 }
@@ -429,7 +417,7 @@ class _DeletionProgressDialog extends StatelessWidget {
 /// Aborts before any step (including the burn) when [confirmedPubkey] is set and
 /// no longer matches the signed-in account.
 ///
-/// [context] - BuildContext for showing dialogs
+/// [context] - BuildContext for showing sheets
 /// [deletionService] - Service to execute NIP-62 deletion
 /// [authService] - Service for Keycast deletion and sign out
 /// [profileRepository] - Burns the username / re-checks ownership when
@@ -452,25 +440,29 @@ Future<void> executeAccountDeletion({
   // Create cubit for tracking progress
   final cubit = AccountDeletionProgressCubit();
 
-  // Show progress dialog with BlocProvider
+  // Show progress sheet with BlocProvider
   if (!context.mounted) return;
   unawaited(
-    showDialog<void>(
+    VineBottomSheet.show<void>(
       context: context,
-      barrierDismissible: false,
-      builder: (dialogContext) => BlocProvider.value(
-        value: cubit,
-        child: const _DeletionProgressDialog(),
-      ),
+      scrollable: false,
+      showHeader: false,
+      showDragHandle: false,
+      isDismissible: false,
+      enableDrag: false,
+      tapOutsideToDismiss: false,
+      body: const _DeletionProgressSheetContent(),
+      contentWrapper: (_, child) =>
+          BlocProvider.value(value: cubit, child: child),
     ),
   );
 
-  // Track if dialog was dismissed to avoid double-popping
-  var dialogDismissed = false;
+  // Track if the progress sheet was dismissed to avoid double-popping.
+  var progressSheetDismissed = false;
 
-  void dismissDialog() {
-    if (!dialogDismissed && context.mounted) {
-      dialogDismissed = true;
+  void dismissProgressSheet() {
+    if (!progressSheetDismissed && context.mounted) {
+      progressSheetDismissed = true;
       context.pop();
     }
   }
@@ -516,7 +508,7 @@ Future<void> executeAccountDeletion({
         name: screenName,
         category: LogCategory.auth,
       );
-      dismissDialog();
+      dismissProgressSheet();
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           DivineSnackbarContainer.snackBar(accountChangedText, error: true),
@@ -543,7 +535,7 @@ Future<void> executeAccountDeletion({
         name: screenName,
         category: LogCategory.auth,
       );
-      dismissDialog();
+      dismissProgressSheet();
       if (context.mounted) {
         final text = context.l10n.deleteAccountReauthRequired;
         ScaffoldMessenger.of(
@@ -602,7 +594,7 @@ Future<void> executeAccountDeletion({
           name: screenName,
           category: LogCategory.auth,
         );
-        dismissDialog();
+        dismissProgressSheet();
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             DivineSnackbarContainer.snackBar(message, error: true),
@@ -621,7 +613,7 @@ Future<void> executeAccountDeletion({
         name: screenName,
         category: LogCategory.auth,
       );
-      dismissDialog();
+      dismissProgressSheet();
       if (context.mounted) {
         final text = (burnCommitted && burnReleasedText != null)
             ? burnReleasedText
@@ -655,7 +647,7 @@ Future<void> executeAccountDeletion({
           name: screenName,
           category: LogCategory.auth,
         );
-        dismissDialog();
+        dismissProgressSheet();
         if (context.mounted) {
           // The vanish and the kind-5 sweep have already been published and
           // confirmed by a relay at this point, so neither message may claim
@@ -709,7 +701,7 @@ Future<void> executeAccountDeletion({
 
       // Close loading indicator and show result snackbar
       // Router will automatically redirect to /welcome after sign out
-      dismissDialog();
+      dismissProgressSheet();
       if (context.mounted) {
         // When the relay query that enumerates existing content failed, no
         // per-item deletion request was sent for anything the user had already
@@ -740,7 +732,7 @@ Future<void> executeAccountDeletion({
           category: LogCategory.auth,
         );
       }
-      dismissDialog();
+      dismissProgressSheet();
       if (context.mounted) {
         final text = (burnCommitted && burnReleasedText != null)
             ? burnReleasedText
@@ -756,8 +748,8 @@ Future<void> executeAccountDeletion({
   } finally {
     await cubit.close();
 
-    // Ensure dialog is dismissed even if an exception occurred
-    dismissDialog();
+    // Ensure the progress sheet is dismissed even if an exception occurred.
+    dismissProgressSheet();
   }
 }
 

--- a/mobile/lib/widgets/delete_account_dialog.dart
+++ b/mobile/lib/widgets/delete_account_dialog.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Dialog widgets for account deletion flow
-// ABOUTME: Warning dialogs for key removal and content deletion with confirmation
+// ABOUTME: Bottom sheets for the account deletion flow
+// ABOUTME: Warning sheets for key removal and content deletion with confirmation
 
 import 'dart:async';
 
@@ -20,70 +20,39 @@ import 'package:openvine/widgets/user_avatar.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
 
-/// Show warning dialog for removing keys from device only
-Future<void> showRemoveKeysWarningDialog({
-  required BuildContext context,
-  required FutureOr<void> Function() onConfirm,
-}) {
-  return showDialog(
+/// Ask whether to remove this account's keys from the device only.
+///
+/// Returns true when the user confirmed. Dismissing the sheet — barrier tap
+/// or swipe — counts as cancelling, so backing out is never destructive.
+Future<bool> showRemoveKeysWarningSheet(BuildContext context) async {
+  final confirmed = await VineBottomSheetPrompt.show<bool>(
     context: context,
-    barrierDismissible: false,
-    builder: (context) => AlertDialog(
-      backgroundColor: context.vineColors.card,
-      title: Text(
-        context.l10n.deleteAccountRemoveKeysTitle,
-        style: TextStyle(
-          color: context.vineColors.primaryText,
-          fontSize: 20,
-          fontWeight: FontWeight.bold,
-        ),
-      ),
-      content: Text(
-        context.l10n.deleteAccountRemoveKeysBody,
-        style: TextStyle(
-          color: context.vineColors.primaryText,
-          fontSize: 16,
-          height: 1.5,
-        ),
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: Text(
-            context.l10n.commonCancel,
-            style: TextStyle(color: context.vineColors.mutedText, fontSize: 16),
-          ),
-        ),
-        ElevatedButton(
-          onPressed: () {
-            Navigator.of(context).pop();
-            unawaited(Future<void>.sync(onConfirm));
-          },
-          style: ElevatedButton.styleFrom(
-            backgroundColor: VineTheme.warning,
-            foregroundColor: VineTheme.whiteText,
-          ),
-          child: Text(
-            context.l10n.deleteAccountRemoveKeysConfirm,
-            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
-          ),
-        ),
-      ],
-    ),
+    sticker: DivineStickerName.skeletonKey,
+    title: context.l10n.deleteAccountRemoveKeysTitle,
+    subtitle: context.l10n.deleteAccountRemoveKeysBody,
+    primaryButtonText: context.l10n.deleteAccountRemoveKeysConfirm,
+    primaryButtonType: DivineButtonType.error,
+    onPrimaryPressed: () => Navigator.of(context).pop(true),
+    secondaryButtonText: context.l10n.commonCancel,
+    onSecondaryPressed: () => Navigator.of(context).pop(false),
   );
+  return confirmed ?? false;
 }
 
-/// Show confirmation dialog before deleting all content (requires typing
+/// Show the confirmation sheet before deleting all content (requires typing
 /// DELETE).
 ///
-/// This dialog ensures they understand the dangerous/irreversible nature of
-/// account deletion. The dialog opens immediately; [ownedUsernameFuture] is
+/// This sheet ensures they understand the dangerous/irreversible nature of
+/// account deletion. It opens immediately; [ownedUsernameFuture] is
 /// resolved in the background and the opt-in "burn my username" toggle is
 /// revealed only once it completes with a non-null handle — so a slow
 /// name-server lookup never blocks the tap or lets a second tap stack a
-/// duplicate dialog. [onConfirm] receives the handle the dialog actually
+/// duplicate sheet. [onConfirm] receives the handle the sheet actually
 /// displayed, so a burn only ever targets the name the user consented to.
-Future<void> showDeleteAllContentWarningDialog({
+///
+/// Dismissing the sheet cancels: nothing is deleted until the token is typed
+/// and the destructive button is tapped.
+Future<void> showDeleteAllContentWarningSheet({
   required BuildContext context,
   required DeleteAccountConfirmation confirmation,
   required void Function({
@@ -92,23 +61,92 @@ Future<void> showDeleteAllContentWarningDialog({
   })
   onConfirm,
   required Future<({String name, String canonical})?> ownedUsernameFuture,
-}) {
-  return showDialog<void>(
+}) async {
+  // The form and the pinned footer are sibling slots of the sheet rather than
+  // one subtree, so the footer learns about the typed token through this
+  // notifier and reaches the form's state through the key. The controllers
+  // themselves stay inside the form's State, which is what disposes them —
+  // the exit animation still rebuilds the field after this future completes.
+  final canConfirm = ValueNotifier<bool>(false);
+  final formKey = GlobalKey<_DeleteAllContentFormState>();
+
+  await VineBottomSheet.show<void>(
     context: context,
-    barrierDismissible: false,
-    builder: (context) => _DeleteAllContentDialog(
+    initialChildSize: 0.85,
+    minChildSize: 0.5,
+    maxChildSize: 0.95,
+    title: Text(context.l10n.deleteAccountFinalConfirmationTitle),
+    bottomInput: _DeleteAllContentActions(
+      canConfirm: canConfirm,
+      onConfirm: () => formKey.currentState?.confirm(),
+    ),
+    buildScrollBody: (scrollController) => _DeleteAllContentForm(
+      key: formKey,
       confirmation: confirmation,
       ownedUsernameFuture: ownedUsernameFuture,
       onConfirm: onConfirm,
+      canConfirm: canConfirm,
+      scrollController: scrollController,
     ),
   );
+
+  canConfirm.dispose();
 }
 
-class _DeleteAllContentDialog extends StatefulWidget {
-  const _DeleteAllContentDialog({
+/// Pinned footer of the delete sheet: cancel plus the destructive action.
+class _DeleteAllContentActions extends StatelessWidget {
+  const _DeleteAllContentActions({
+    required this.canConfirm,
+    required this.onConfirm,
+  });
+
+  final ValueNotifier<bool> canConfirm;
+  final VoidCallback onConfirm;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        spacing: 12,
+        children: [
+          Expanded(
+            child: DivineButton(
+              label: l10n.commonCancel,
+              type: DivineButtonType.secondary,
+              onPressed: context.pop,
+            ),
+          ),
+          Expanded(
+            child: ValueListenableBuilder<bool>(
+              valueListenable: canConfirm,
+              builder: (context, enabled, _) => DivineButton(
+                label: l10n.deleteAccountDeleteAllContentButton,
+                type: DivineButtonType.error,
+                onPressed: enabled ? onConfirm : null,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Scrollable body of the delete sheet.
+///
+/// [scrollController] comes from the sheet's `DraggableScrollableSheet`, so
+/// dragging the form down collapses and dismisses the sheet.
+class _DeleteAllContentForm extends StatefulWidget {
+  const _DeleteAllContentForm({
     required this.confirmation,
     required this.ownedUsernameFuture,
     required this.onConfirm,
+    required this.canConfirm,
+    required this.scrollController,
+    super.key,
   });
 
   final DeleteAccountConfirmation confirmation;
@@ -119,12 +157,15 @@ class _DeleteAllContentDialog extends StatefulWidget {
   })
   onConfirm;
 
+  /// Mirrors "the typed token matches" out to the pinned footer.
+  final ValueNotifier<bool> canConfirm;
+  final ScrollController scrollController;
+
   @override
-  State<_DeleteAllContentDialog> createState() =>
-      _DeleteAllContentDialogState();
+  State<_DeleteAllContentForm> createState() => _DeleteAllContentFormState();
 }
 
-class _DeleteAllContentDialogState extends State<_DeleteAllContentDialog> {
+class _DeleteAllContentFormState extends State<_DeleteAllContentForm> {
   final _confirmationController = TextEditingController();
   var _burnUsername = false;
   ({String name, String canonical})? _ownedUsername;
@@ -151,89 +192,84 @@ class _DeleteAllContentDialogState extends State<_DeleteAllContentDialog> {
     super.dispose();
   }
 
+  /// Closes the sheet and hands the consented values to the caller.
+  ///
+  /// Called by the footer through the form's key, since the two are sibling
+  /// slots of the sheet.
+  void confirm() {
+    if (!widget.confirmation.matches(_confirmationController.text)) return;
+    context.pop();
+    widget.onConfirm(
+      burnUsername: _burnUsername,
+      ownedUsername: _ownedUsername,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
     final owned = _ownedUsername;
     final c = widget.confirmation;
-    final canConfirm = c.matches(_confirmationController.text);
-    return AlertDialog(
-      backgroundColor: context.vineColors.card,
-      scrollable: true,
-      title: Text(
-        context.l10n.deleteAccountFinalConfirmationTitle,
-        style: const TextStyle(
-          color: VineTheme.error,
-          fontSize: 20,
-          fontWeight: FontWeight.bold,
-        ),
-      ),
-      content: Column(
+
+    return SingleChildScrollView(
+      controller: widget.scrollController,
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+      child: Column(
         mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        spacing: 16,
         children: [
           _DeleteIdentityHeader(confirmation: c),
-          const SizedBox(height: 16),
           Text(
-            context.l10n.deleteAccountWarningBody,
-            style: TextStyle(
-              color: context.vineColors.primaryText,
-              fontSize: 16,
-              height: 1.5,
-            ),
-          ),
-          const SizedBox(height: 12),
-          Text(
-            c.isUsernameConfirmation
-                ? context.l10n.deleteAccountConfirmUsernamePrompt
-                : context.l10n.deleteAccountConfirmDeletePrompt,
+            l10n.deleteAccountWarningBody,
             style: VineTheme.bodyLargeFont(
               color: context.vineColors.primaryText,
             ),
           ),
-          const SizedBox(height: 8),
-          Text(
-            c.requiredToken,
-            style: const TextStyle(
-              color: VineTheme.error,
-              fontSize: 18,
-              fontWeight: FontWeight.bold,
-              fontFamily: 'monospace',
-            ),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            spacing: 8,
+            children: [
+              Text(
+                c.isUsernameConfirmation
+                    ? l10n.deleteAccountConfirmUsernamePrompt
+                    : l10n.deleteAccountConfirmDeletePrompt,
+                style: VineTheme.bodyLargeFont(
+                  color: context.vineColors.primaryText,
+                ),
+              ),
+              // Monospaced so the token reads as something to copy verbatim.
+              Text(
+                c.requiredToken,
+                style: VineTheme.titleMediumFont(
+                  color: VineTheme.error,
+                ).copyWith(fontFamily: 'monospace'),
+              ),
+            ],
           ),
-          const SizedBox(height: 16),
-          TextField(
+          DivineTextField(
             controller: _confirmationController,
-            style: TextStyle(color: context.vineColors.primaryText),
+            labelText: c.isUsernameConfirmation
+                ? l10n.deleteAccountConfirmationHintUsername
+                : l10n.deleteAccountConfirmationHint,
+            filled: true,
             autocorrect: false,
             textCapitalization: c.isUsernameConfirmation
                 ? TextCapitalization.none
                 : TextCapitalization.characters,
-            decoration: InputDecoration(
-              hintText: c.isUsernameConfirmation
-                  ? context.l10n.deleteAccountConfirmationHintUsername
-                  : context.l10n.deleteAccountConfirmationHint,
-              hintStyle: TextStyle(color: context.vineColors.mutedText),
-              enabledBorder: OutlineInputBorder(
-                borderSide: BorderSide(color: context.vineColors.card),
-              ),
-              focusedBorder: const OutlineInputBorder(
-                borderSide: BorderSide(color: VineTheme.error),
-              ),
-            ),
-            onChanged: (_) => setState(() {}),
+            onChanged: (value) => widget.canConfirm.value = c.matches(value),
           ),
-          if (owned != null) ...[
-            const SizedBox(height: 16),
-            CheckboxListTile(
-              value: _burnUsername,
-              onChanged: (value) =>
-                  setState(() => _burnUsername = value ?? false),
-              controlAffinity: ListTileControlAffinity.leading,
-              contentPadding: EdgeInsets.zero,
-              activeColor: VineTheme.error,
-              checkColor: VineTheme.whiteText,
-              title: Text(
-                context.l10n.deleteAccountBurnUsernameToggle(
+          // Row rather than the ListTile-based DivineCheckboxTile: the sheet
+          // paints its surface with a ColoredBox, which a ListTile's ink and
+          // background cannot draw through.
+          if (owned != null)
+            DivineRowCheckbox(
+              state: _burnUsername
+                  ? DivineCheckboxState.selected
+                  : DivineCheckboxState.unselected,
+              onChanged: (value) => setState(() => _burnUsername = value),
+              label: Text(
+                l10n.deleteAccountBurnUsernameToggle(
                   '@${owned.name}.divine.video',
                 ),
                 style: VineTheme.bodyMediumFont(
@@ -241,40 +277,8 @@ class _DeleteAllContentDialogState extends State<_DeleteAllContentDialog> {
                 ),
               ),
             ),
-          ],
         ],
       ),
-      actionsAlignment: MainAxisAlignment.spaceBetween,
-      actions: [
-        TextButton(
-          onPressed: context.pop,
-          child: Text(
-            context.l10n.commonCancel,
-            style: TextStyle(color: context.vineColors.mutedText, fontSize: 16),
-          ),
-        ),
-        ElevatedButton(
-          onPressed: canConfirm
-              ? () {
-                  context.pop();
-                  widget.onConfirm(
-                    burnUsername: _burnUsername,
-                    ownedUsername: _ownedUsername,
-                  );
-                }
-              : null,
-          style: ElevatedButton.styleFrom(
-            backgroundColor: VineTheme.error,
-            foregroundColor: VineTheme.whiteText,
-            disabledBackgroundColor: context.vineColors.card,
-            disabledForegroundColor: context.vineColors.mutedText,
-          ),
-          child: Text(
-            context.l10n.deleteAccountDeleteAllContentButton,
-            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
-          ),
-        ),
-      ],
     );
   }
 }

--- a/mobile/lib/widgets/delete_account_dialog.dart
+++ b/mobile/lib/widgets/delete_account_dialog.dart
@@ -78,7 +78,14 @@ Future<void> showDeleteAllContentWarningSheet({
     initialChildSize: 0.85,
     minChildSize: 0.5,
     maxChildSize: 0.95,
-    title: Text(context.l10n.deleteAccountFinalConfirmationTitle),
+    // Error-coloured deliberately: this is the last gate before an
+    // irreversible delete, and the red title is the destructive-action signal
+    // the pre-sheet dialog carried. Reuses the header's own size and weight so
+    // only the colour differs from the sheet default.
+    title: Text(
+      context.l10n.deleteAccountFinalConfirmationTitle,
+      style: VineTheme.titleMediumFont(color: VineTheme.error),
+    ),
     bottomInput: _DeleteAllContentActions(
       canConfirm: canConfirm,
       onConfirm: () => formKey.currentState?.confirm(),

--- a/mobile/lib/widgets/delete_account_dialog.dart
+++ b/mobile/lib/widgets/delete_account_dialog.dart
@@ -67,6 +67,9 @@ Future<void> showDeleteAllContentWarningSheet({
   // notifier and reaches the form's state through the key. The controllers
   // themselves stay inside the form's State, which is what disposes them —
   // the exit animation still rebuilds the field after this future completes.
+  // The notifier is safe to dispose here despite that: its only writer is the
+  // field's onChanged, and the text input connection is already closed by the
+  // time the route pops.
   final canConfirm = ValueNotifier<bool>(false);
   final formKey = GlobalKey<_DeleteAllContentFormState>();
 
@@ -197,6 +200,8 @@ class _DeleteAllContentFormState extends State<_DeleteAllContentForm> {
   /// Called by the footer through the form's key, since the two are sibling
   /// slots of the sheet.
   void confirm() {
+    // Re-derived from the controller rather than trusting the footer's
+    // notifier, which only gates the button's enabled state.
     if (!widget.confirmation.matches(_confirmationController.text)) return;
     context.pop();
     widget.onConfirm(

--- a/mobile/lib/widgets/delete_account_dialog.dart
+++ b/mobile/lib/widgets/delete_account_dialog.dart
@@ -458,6 +458,12 @@ Future<void> executeAccountDeletion({
       isDismissible: false,
       enableDrag: false,
       tapOutsideToDismiss: false,
+      // Pinned rather than left at VineBottomSheet's local-navigator default:
+      // this blocks the UI through an irreversible delete, so it has to cover
+      // shell chrome too. Both callers are root-level routes today, so it
+      // changes nothing now — it keeps a future shell-nested caller from
+      // leaving the bottom nav tappable mid-deletion.
+      useRootNavigator: true,
       body: const _DeletionProgressSheetContent(),
       contentWrapper: (_, child) =>
           BlocProvider.value(value: cubit, child: child),
@@ -470,7 +476,10 @@ Future<void> executeAccountDeletion({
   void dismissProgressSheet() {
     if (!progressSheetDismissed && context.mounted) {
       progressSheetDismissed = true;
-      context.pop();
+      // Targets the navigator the sheet was pushed onto. `context.pop()` would
+      // resolve to the innermost navigator instead, which for a shell-nested
+      // caller is not the one holding this sheet.
+      Navigator.of(context, rootNavigator: true).pop();
     }
   }
 

--- a/mobile/scripts/baseline/material_buttons.txt
+++ b/mobile/scripts/baseline/material_buttons.txt
@@ -50,7 +50,6 @@ lib/widgets/categories_tab.dart	1
 lib/widgets/circular_icon_button.dart	1
 lib/widgets/composable_video_grid.dart	3
 lib/widgets/content_warning.dart	5
-lib/widgets/delete_account_dialog.dart	4
 lib/widgets/library/drafts_tab.dart	3
 lib/widgets/owner_video_delete_confirmation_dialog.dart	2
 lib/widgets/profile/follow_from_profile_button.dart	1

--- a/mobile/scripts/baseline/raw_dialogs.txt
+++ b/mobile/scripts/baseline/raw_dialogs.txt
@@ -25,7 +25,7 @@ lib/utils/pause_aware_modals.dart	2
 lib/widgets/add_to_list_dialog.dart	1
 lib/widgets/age_verification_dialog.dart	1
 lib/widgets/composable_video_grid.dart	2
-lib/widgets/delete_account_dialog.dart	3
+lib/widgets/delete_account_dialog.dart	1
 lib/widgets/find_people_sheet.dart	1
 lib/widgets/for_you_tab.dart	1
 lib/widgets/library/drafts_tab.dart	1

--- a/mobile/scripts/baseline/raw_dialogs.txt
+++ b/mobile/scripts/baseline/raw_dialogs.txt
@@ -25,7 +25,6 @@ lib/utils/pause_aware_modals.dart	2
 lib/widgets/add_to_list_dialog.dart	1
 lib/widgets/age_verification_dialog.dart	1
 lib/widgets/composable_video_grid.dart	2
-lib/widgets/delete_account_dialog.dart	1
 lib/widgets/find_people_sheet.dart	1
 lib/widgets/for_you_tab.dart	1
 lib/widgets/library/drafts_tab.dart	1

--- a/mobile/scripts/baseline/raw_textstyle.txt
+++ b/mobile/scripts/baseline/raw_textstyle.txt
@@ -63,7 +63,7 @@ lib/widgets/categories_tab.dart	2
 lib/widgets/classic_vines_tab.dart	7
 lib/widgets/composable_video_grid.dart	8
 lib/widgets/content_warning.dart	11
-lib/widgets/delete_account_dialog.dart	14
+lib/widgets/delete_account_dialog.dart	3
 lib/widgets/environment_indicator.dart	1
 lib/widgets/error_message.dart	1
 lib/widgets/find_people_sheet.dart	7

--- a/mobile/scripts/baseline/raw_textstyle.txt
+++ b/mobile/scripts/baseline/raw_textstyle.txt
@@ -63,7 +63,6 @@ lib/widgets/categories_tab.dart	2
 lib/widgets/classic_vines_tab.dart	7
 lib/widgets/composable_video_grid.dart	8
 lib/widgets/content_warning.dart	11
-lib/widgets/delete_account_dialog.dart	3
 lib/widgets/environment_indicator.dart	1
 lib/widgets/error_message.dart	1
 lib/widgets/find_people_sheet.dart	7

--- a/mobile/test/widgets/delete_account_dialog_test.dart
+++ b/mobile/test/widgets/delete_account_dialog_test.dart
@@ -151,6 +151,27 @@ void main() {
 
       expect(result, isFalse);
     });
+
+    // Dismissing is the only path that reaches the `?? false` default, and the
+    // dialog this replaced was barrierDismissible: false — so the path is new.
+    // If the default ever flips, a stray barrier tap deletes the keys.
+    testWidgets('returns false when dismissed without choosing', (
+      tester,
+    ) async {
+      await openSheet(tester);
+
+      // System back rather than a barrier tap: it dismisses without touching
+      // either button regardless of how tall the sheet renders, so the test
+      // pins the default instead of the sheet's layout.
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(_englishL10n().deleteAccountRemoveKeysTitle),
+        findsNothing,
+      );
+      expect(result, isFalse);
+    });
   });
 
   group('showDeleteAllContentWarningSheet – confirmation input', () {
@@ -193,6 +214,36 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(_deleteAllContentButton(), findsNothing);
+    });
+
+    // The sheet documents that dismissing cancels. Typing the token arms the
+    // destructive action, so the case worth pinning is dismissing *after* it
+    // is armed: nothing may reach the caller.
+    testWidgets('dismissing after typing the token does not confirm', (
+      tester,
+    ) async {
+      var confirmCalls = 0;
+      await _showSheet(
+        tester,
+        onConfirm:
+            ({
+              required bool burnUsername,
+              ({String name, String canonical})? ownedUsername,
+            }) => confirmCalls++,
+      );
+
+      await tester.enterText(find.byType(TextField), 'DELETE');
+      await tester.pump();
+      expect(
+        tester.widget<DivineButton>(_deleteAllContentButton()).onPressed,
+        isNotNull,
+      );
+
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      expect(_deleteAllContentButton(), findsNothing);
+      expect(confirmCalls, isZero);
     });
 
     testWidgets('wrong word keeps Delete button disabled', (tester) async {

--- a/mobile/test/widgets/delete_account_dialog_test.dart
+++ b/mobile/test/widgets/delete_account_dialog_test.dart
@@ -178,6 +178,20 @@ void main() {
   });
 
   group('showDeleteAllContentWarningSheet – confirmation input', () {
+    // The red title is the destructive-action signal the pre-sheet dialog
+    // carried; inheriting the sheet header's default style silently drops it.
+    testWidgets('renders the final-confirmation title in the error colour', (
+      tester,
+    ) async {
+      await _showSheet(tester);
+
+      final l10n = _englishL10n();
+      final title = tester.widget<Text>(
+        find.text(l10n.deleteAccountFinalConfirmationTitle),
+      );
+      expect(title.style?.color, equals(VineTheme.error));
+    });
+
     testWidgets('empty string keeps Delete button disabled', (tester) async {
       await _showSheet(tester);
 

--- a/mobile/test/widgets/delete_account_dialog_test.dart
+++ b/mobile/test/widgets/delete_account_dialog_test.dart
@@ -97,6 +97,9 @@ Finder _deleteAllContentButton() => find.widgetWithText(
   _englishL10n().deleteAccountDeleteAllContentButton,
 );
 
+Finder _deleteSheetCancelButton() =>
+    find.widgetWithText(DivineButton, _englishL10n().commonCancel);
+
 Future<void> _tapBurnUsernameCheckbox(WidgetTester tester) async {
   final tile = find.byType(DivineRowCheckbox);
   await tester.ensureVisible(tile);
@@ -247,6 +250,33 @@ void main() {
       );
 
       await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      expect(_deleteAllContentButton(), findsNothing);
+      expect(confirmCalls, isZero);
+    });
+
+    testWidgets('tapping Cancel after typing the token does not confirm', (
+      tester,
+    ) async {
+      var confirmCalls = 0;
+      await _showSheet(
+        tester,
+        onConfirm:
+            ({
+              required bool burnUsername,
+              ({String name, String canonical})? ownedUsername,
+            }) => confirmCalls++,
+      );
+
+      await tester.enterText(find.byType(TextField), 'DELETE');
+      await tester.pump();
+      expect(
+        tester.widget<DivineButton>(_deleteAllContentButton()).onPressed,
+        isNotNull,
+      );
+
+      await tester.tap(_deleteSheetCancelButton());
       await tester.pumpAndSettle();
 
       expect(_deleteAllContentButton(), findsNothing);
@@ -577,14 +607,9 @@ void main() {
           expectedPubkey: any(named: 'expectedPubkey'),
         ),
       ).thenAnswer((_) async => DeleteAccountResult.createSuccess('event-id'));
-      when(
-        authService.deleteKeycastAccount,
-      ).thenAnswer(
-        (_) async => (
-          success: true,
-          error: null,
-          requiresReauthentication: false,
-        ),
+      when(authService.deleteKeycastAccount).thenAnswer(
+        (_) async =>
+            (success: true, error: null, requiresReauthentication: false),
       );
       when(
         () => authService.signOut(deleteKeys: true, deleteLocalUserData: true),
@@ -692,14 +717,9 @@ void main() {
           expectedPubkey: any(named: 'expectedPubkey'),
         ),
       ).thenAnswer((_) async => DeleteAccountResult.createSuccess('event-id'));
-      when(
-        authService.deleteKeycastAccount,
-      ).thenAnswer(
-        (_) async => (
-          success: true,
-          error: null,
-          requiresReauthentication: false,
-        ),
+      when(authService.deleteKeycastAccount).thenAnswer(
+        (_) async =>
+            (success: true, error: null, requiresReauthentication: false),
       );
       when(
         () => authService.signOut(deleteKeys: true, deleteLocalUserData: true),
@@ -753,14 +773,9 @@ void main() {
           expectedPubkey: any(named: 'expectedPubkey'),
         ),
       ).thenAnswer((_) async => DeleteAccountResult.createSuccess('event-id'));
-      when(
-        authService.deleteKeycastAccount,
-      ).thenAnswer(
-        (_) async => (
-          success: true,
-          error: null,
-          requiresReauthentication: false,
-        ),
+      when(authService.deleteKeycastAccount).thenAnswer(
+        (_) async =>
+            (success: true, error: null, requiresReauthentication: false),
       );
       when(
         () => authService.signOut(deleteKeys: true, deleteLocalUserData: true),
@@ -933,9 +948,7 @@ void main() {
           (_) async => DeleteAccountResult.createSuccess('event-id'),
         );
         // Content deletion succeeded; the server-side account deletion did not.
-        when(
-          authService.deleteKeycastAccount,
-        ).thenAnswer(
+        when(authService.deleteKeycastAccount).thenAnswer(
           (_) async => (
             success: false,
             error: 'server refused',
@@ -1086,9 +1099,7 @@ void main() {
         );
         // Every non-OAuth user reaches this call and fails it: there is no
         // Keycast session to use, so a failure here is expected and benign.
-        when(
-          authService.deleteKeycastAccount,
-        ).thenAnswer(
+        when(authService.deleteKeycastAccount).thenAnswer(
           (_) async => (
             success: false,
             error: 'no keycast session',
@@ -1128,10 +1139,7 @@ void main() {
 
         final l10n = lookupAppLocalizations(const Locale('en'));
         expect(find.text(l10n.deleteAccountSuccess), findsOneWidget);
-        expect(
-          find.text(l10n.deleteAccountServerDeletionFailed),
-          findsNothing,
-        );
+        expect(find.text(l10n.deleteAccountServerDeletionFailed), findsNothing);
       },
     );
 
@@ -1156,9 +1164,7 @@ void main() {
         ).thenAnswer(
           (_) async => DeleteAccountResult.createSuccess('event-id'),
         );
-        when(
-          authService.deleteKeycastAccount,
-        ).thenAnswer(
+        when(authService.deleteKeycastAccount).thenAnswer(
           (_) async => (
             success: false,
             error: 'fk error',
@@ -1510,58 +1516,53 @@ void main() {
     // refreshed. 275 denials across 57 users in 30 days, 48 of whom never
     // completed: content broadcast for deletion, account still alive, still
     // signed in. Nothing destructive may run before the gate clears.
-    testWidgets(
-      'publishes nothing when the session cannot authorize deletion',
-      (tester) async {
-        final deletionService = _MockAccountDeletionService();
-        final authService = _MockAuthService();
-        when(authService.checkAccountDeletionReadiness).thenAnswer(
-          (_) async => AccountDeletionReadiness.requiresReauthentication,
-        );
-        when(() => authService.currentPublicKeyHex).thenReturn(_pubkeyHex);
+    testWidgets('publishes nothing when the session cannot authorize deletion', (
+      tester,
+    ) async {
+      final deletionService = _MockAccountDeletionService();
+      final authService = _MockAuthService();
+      when(authService.checkAccountDeletionReadiness).thenAnswer(
+        (_) async => AccountDeletionReadiness.requiresReauthentication,
+      );
+      when(() => authService.currentPublicKeyHex).thenReturn(_pubkeyHex);
 
-        late BuildContext capturedContext;
-        await tester.pumpWidget(
-          _wrapWithRouter(
-            Builder(
-              builder: (context) {
-                capturedContext = context;
-                return const Scaffold(body: SizedBox.shrink());
-              },
-            ),
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        _wrapWithRouter(
+          Builder(
+            builder: (context) {
+              capturedContext = context;
+              return const Scaffold(body: SizedBox.shrink());
+            },
           ),
-        );
+        ),
+      );
 
-        await executeAccountDeletion(
-          context: capturedContext,
-          deletionService: deletionService,
-          authService: authService,
-          confirmedPubkey: _pubkeyHex,
-        );
-        await tester.pumpAndSettle();
+      await executeAccountDeletion(
+        context: capturedContext,
+        deletionService: deletionService,
+        authService: authService,
+        confirmedPubkey: _pubkeyHex,
+      );
+      await tester.pumpAndSettle();
 
-        // Nothing irreversible was attempted.
-        verifyNever(
-          () => deletionService.deleteAccount(
-            onProgress: any(named: 'onProgress'),
-            expectedPubkey: any(named: 'expectedPubkey'),
-          ),
-        );
-        verifyNever(authService.deleteKeycastAccount);
-        verifyNever(
-          () =>
-              authService.signOut(deleteKeys: true, deleteLocalUserData: true),
-        );
+      // Nothing irreversible was attempted.
+      verifyNever(
+        () => deletionService.deleteAccount(
+          onProgress: any(named: 'onProgress'),
+          expectedPubkey: any(named: 'expectedPubkey'),
+        ),
+      );
+      verifyNever(authService.deleteKeycastAccount);
+      verifyNever(
+        () => authService.signOut(deleteKeys: true, deleteLocalUserData: true),
+      );
 
-        // The user is told to sign in again, not that their network is at fault.
-        final l10n = lookupAppLocalizations(const Locale('en'));
-        expect(find.text(l10n.deleteAccountReauthRequired), findsOneWidget);
-        expect(
-          find.text(l10n.deleteAccountServerDeletionFailed),
-          findsNothing,
-        );
-      },
-    );
+      // The user is told to sign in again, not that their network is at fault.
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.deleteAccountReauthRequired), findsOneWidget);
+      expect(find.text(l10n.deleteAccountServerDeletionFailed), findsNothing);
+    });
 
     testWidgets('proceeds when confirmedPubkey matches the current account', (
       tester,
@@ -1580,14 +1581,9 @@ void main() {
           expectedPubkey: any(named: 'expectedPubkey'),
         ),
       ).thenAnswer((_) async => DeleteAccountResult.createSuccess('event-id'));
-      when(
-        authService.deleteKeycastAccount,
-      ).thenAnswer(
-        (_) async => (
-          success: true,
-          error: null,
-          requiresReauthentication: false,
-        ),
+      when(authService.deleteKeycastAccount).thenAnswer(
+        (_) async =>
+            (success: true, error: null, requiresReauthentication: false),
       );
       when(
         () => authService.signOut(deleteKeys: true, deleteLocalUserData: true),

--- a/mobile/test/widgets/delete_account_dialog_test.dart
+++ b/mobile/test/widgets/delete_account_dialog_test.dart
@@ -1,8 +1,9 @@
-// ABOUTME: Tests for the delete account confirmation dialog
+// ABOUTME: Tests for the delete account confirmation sheet
 // ABOUTME: Verifies that the DELETE confirmation is case-insensitive and trims whitespace
 
 import 'dart:async';
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -68,7 +69,7 @@ Future<void> _showDialog(
         builder: (context) => Scaffold(
           body: ElevatedButton(
             key: const Key('open'),
-            onPressed: () => showDeleteAllContentWarningDialog(
+            onPressed: () => showDeleteAllContentWarningSheet(
               context: context,
               confirmation: confirmation ?? _deleteFallback(),
               ownedUsernameFuture: Future.value(ownedUsername),
@@ -92,21 +93,67 @@ Future<void> _showDialog(
 AppLocalizations _englishL10n() => lookupAppLocalizations(const Locale('en'));
 
 Finder _deleteAllContentButton() => find.widgetWithText(
-  ElevatedButton,
+  DivineButton,
   _englishL10n().deleteAccountDeleteAllContentButton,
 );
 
 Future<void> _tapBurnUsernameCheckbox(WidgetTester tester) async {
-  await tester.drag(
-    find.byType(SingleChildScrollView).first,
-    const Offset(0, -160),
-  );
+  final tile = find.byType(DivineRowCheckbox);
+  await tester.ensureVisible(tile);
   await tester.pumpAndSettle();
-  await tester.tap(find.byType(Checkbox));
+  await tester.tap(tile);
 }
 
 void main() {
-  group('showDeleteAllContentWarningDialog – confirmation input', () {
+  group('showRemoveKeysWarningSheet', () {
+    // Written by the sheet's future, which only completes after the sheet
+    // closes — so the tests read it once they have settled.
+    bool? result;
+
+    Future<void> openSheet(WidgetTester tester) async {
+      result = null;
+      await tester.pumpWidget(
+        _wrapWithRouter(
+          Builder(
+            builder: (context) => Scaffold(
+              body: ElevatedButton(
+                key: const Key('open'),
+                onPressed: () async {
+                  result = await showRemoveKeysWarningSheet(context);
+                },
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.byKey(const Key('open')));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('returns true after confirming', (tester) async {
+      await openSheet(tester);
+      final l10n = _englishL10n();
+
+      expect(find.text(l10n.deleteAccountRemoveKeysTitle), findsOneWidget);
+
+      await tester.tap(find.text(l10n.deleteAccountRemoveKeysConfirm));
+      await tester.pumpAndSettle();
+
+      expect(result, isTrue);
+    });
+
+    testWidgets('returns false after cancelling', (tester) async {
+      await openSheet(tester);
+
+      await tester.tap(find.text(_englishL10n().commonCancel));
+      await tester.pumpAndSettle();
+
+      expect(result, isFalse);
+    });
+  });
+
+  group('showDeleteAllContentWarningSheet – confirmation input', () {
     testWidgets('empty string keeps Delete button disabled', (tester) async {
       await _showDialog(tester);
 
@@ -114,8 +161,38 @@ void main() {
       expect(find.text(l10n.deleteAccountWarningBody), findsOneWidget);
       expect(find.text(l10n.deleteAccountConfirmDeletePrompt), findsOneWidget);
       // Button should be disabled (onPressed == null → tapping does nothing)
-      final button = tester.widget<ElevatedButton>(_deleteAllContentButton());
+      final button = tester.widget<DivineButton>(_deleteAllContentButton());
       expect(button.onPressed, isNull);
+    });
+
+    // The actions belong to the sheet's pinned footer, not to the scrolling
+    // form — otherwise they drift off screen while reading the warning.
+    testWidgets('keeps the actions out of the scrollable form', (tester) async {
+      await _showDialog(tester);
+
+      expect(
+        find.descendant(
+          of: find.byType(SingleChildScrollView).first,
+          matching: _deleteAllContentButton(),
+        ),
+        findsNothing,
+      );
+    });
+
+    // The form has to scroll through the sheet's own controller, otherwise
+    // dragging it down no longer collapses and dismisses the sheet.
+    testWidgets('dismisses the sheet when the form is dragged down', (
+      tester,
+    ) async {
+      await _showDialog(tester);
+
+      await tester.drag(
+        find.byType(SingleChildScrollView).first,
+        const Offset(0, 600),
+      );
+      await tester.pumpAndSettle();
+
+      expect(_deleteAllContentButton(), findsNothing);
     });
 
     testWidgets('wrong word keeps Delete button disabled', (tester) async {
@@ -124,7 +201,7 @@ void main() {
       await tester.enterText(find.byType(TextField), 'confirm');
       await tester.pump();
 
-      final button = tester.widget<ElevatedButton>(_deleteAllContentButton());
+      final button = tester.widget<DivineButton>(_deleteAllContentButton());
       expect(button.onPressed, isNull);
     });
 
@@ -134,7 +211,7 @@ void main() {
       await tester.enterText(find.byType(TextField), 'DELETE');
       await tester.pump();
 
-      final button = tester.widget<ElevatedButton>(_deleteAllContentButton());
+      final button = tester.widget<DivineButton>(_deleteAllContentButton());
       expect(button.onPressed, isNotNull);
     });
 
@@ -144,7 +221,7 @@ void main() {
       await tester.enterText(find.byType(TextField), 'delete');
       await tester.pump();
 
-      final button = tester.widget<ElevatedButton>(_deleteAllContentButton());
+      final button = tester.widget<DivineButton>(_deleteAllContentButton());
       expect(button.onPressed, isNotNull);
     });
 
@@ -154,7 +231,7 @@ void main() {
       await tester.enterText(find.byType(TextField), 'Delete');
       await tester.pump();
 
-      final button = tester.widget<ElevatedButton>(_deleteAllContentButton());
+      final button = tester.widget<DivineButton>(_deleteAllContentButton());
       expect(button.onPressed, isNotNull);
     });
 
@@ -166,7 +243,7 @@ void main() {
       await tester.enterText(find.byType(TextField), 'DELETE ');
       await tester.pump();
 
-      final button = tester.widget<ElevatedButton>(_deleteAllContentButton());
+      final button = tester.widget<DivineButton>(_deleteAllContentButton());
       expect(button.onPressed, isNotNull);
     });
 
@@ -178,7 +255,7 @@ void main() {
       await tester.enterText(find.byType(TextField), ' delete');
       await tester.pump();
 
-      final button = tester.widget<ElevatedButton>(_deleteAllContentButton());
+      final button = tester.widget<DivineButton>(_deleteAllContentButton());
       expect(button.onPressed, isNotNull);
     });
 
@@ -206,7 +283,7 @@ void main() {
       tester,
     ) async {
       await _showDialog(tester);
-      expect(find.byType(CheckboxListTile), findsNothing);
+      expect(find.byType(DivineRowCheckbox), findsNothing);
     });
 
     testWidgets('burn toggle is shown when a username is owned', (
@@ -216,7 +293,7 @@ void main() {
         tester,
         ownedUsername: (name: 'Alice', canonical: 'alice'),
       );
-      expect(find.byType(CheckboxListTile), findsOneWidget);
+      expect(find.byType(DivineRowCheckbox), findsOneWidget);
       // Pin the consent label naming the exact handle (display form, not
       // canonical) so swapping the interpolated variable can't slip through.
       expect(
@@ -284,7 +361,7 @@ void main() {
             builder: (context) => Scaffold(
               body: ElevatedButton(
                 key: const Key('open'),
-                onPressed: () => showDeleteAllContentWarningDialog(
+                onPressed: () => showDeleteAllContentWarningSheet(
                   context: context,
                   confirmation: _deleteFallback(),
                   ownedUsernameFuture: completer.future,
@@ -305,12 +382,12 @@ void main() {
 
       // Dialog is already open (lookup still pending) but no toggle yet.
       expect(_deleteAllContentButton(), findsOneWidget);
-      expect(find.byType(CheckboxListTile), findsNothing);
+      expect(find.byType(DivineRowCheckbox), findsNothing);
 
       completer.complete((name: 'Alice', canonical: 'alice'));
       await tester.pumpAndSettle();
 
-      expect(find.byType(CheckboxListTile), findsOneWidget);
+      expect(find.byType(DivineRowCheckbox), findsOneWidget);
     });
 
     testWidgets('a failed lookup leaves the toggle hidden without crashing', (
@@ -323,7 +400,7 @@ void main() {
             builder: (context) => Scaffold(
               body: ElevatedButton(
                 key: const Key('open'),
-                onPressed: () => showDeleteAllContentWarningDialog(
+                onPressed: () => showDeleteAllContentWarningSheet(
                   context: context,
                   confirmation: _deleteFallback(),
                   ownedUsernameFuture: completer.future,
@@ -347,7 +424,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(_deleteAllContentButton(), findsOneWidget);
-      expect(find.byType(CheckboxListTile), findsNothing);
+      expect(find.byType(DivineRowCheckbox), findsNothing);
       expect(tester.takeException(), isNull);
     });
 
@@ -402,7 +479,7 @@ void main() {
       await _showDialog(tester, confirmation: _divineUsername());
       await tester.enterText(find.byType(TextField), 'DELETE');
       await tester.pump();
-      final button = tester.widget<ElevatedButton>(_deleteAllContentButton());
+      final button = tester.widget<DivineButton>(_deleteAllContentButton());
       expect(button.onPressed, isNull);
     });
 
@@ -410,7 +487,7 @@ void main() {
       await _showDialog(tester, confirmation: _divineUsername());
       await tester.enterText(find.byType(TextField), '@rabble.divine.video');
       await tester.pump();
-      final button = tester.widget<ElevatedButton>(_deleteAllContentButton());
+      final button = tester.widget<DivineButton>(_deleteAllContentButton());
       expect(button.onPressed, isNotNull);
     });
 
@@ -420,7 +497,7 @@ void main() {
       await _showDialog(tester, confirmation: _divineUsername());
       await tester.enterText(find.byType(TextField), 'rabble.divine.video');
       await tester.pump();
-      final button = tester.widget<ElevatedButton>(_deleteAllContentButton());
+      final button = tester.widget<DivineButton>(_deleteAllContentButton());
       expect(button.onPressed, isNotNull);
     });
   });

--- a/mobile/test/widgets/delete_account_dialog_test.dart
+++ b/mobile/test/widgets/delete_account_dialog_test.dart
@@ -205,6 +205,13 @@ void main() {
     testWidgets('dismisses the sheet when the form is dragged down', (
       tester,
     ) async {
+      // Force the form to overflow the sheet regardless of font warm-up, so
+      // the inner scroll view always has extent to consume the drag.
+      tester.view.physicalSize = const Size(400, 400);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
       await _showSheet(tester);
 
       await tester.drag(

--- a/mobile/test/widgets/delete_account_dialog_test.dart
+++ b/mobile/test/widgets/delete_account_dialog_test.dart
@@ -41,7 +41,7 @@ DeleteAccountConfirmation _divineUsername() => DeleteAccountConfirmation(
   handle: '@rabble.divine.video',
 );
 
-/// Minimal router wrapper so [context.pop()] works inside the dialog.
+/// Minimal router wrapper so [context.pop()] works inside the sheet.
 Widget _wrapWithRouter(Widget child) {
   final router = GoRouter(
     routes: [GoRoute(path: '/', builder: (_, state) => child)],
@@ -53,7 +53,7 @@ Widget _wrapWithRouter(Widget child) {
   );
 }
 
-Future<void> _showDialog(
+Future<void> _showSheet(
   WidgetTester tester, {
   DeleteAccountConfirmation? confirmation,
   void Function({
@@ -155,7 +155,7 @@ void main() {
 
   group('showDeleteAllContentWarningSheet – confirmation input', () {
     testWidgets('empty string keeps Delete button disabled', (tester) async {
-      await _showDialog(tester);
+      await _showSheet(tester);
 
       final l10n = _englishL10n();
       expect(find.text(l10n.deleteAccountWarningBody), findsOneWidget);
@@ -168,7 +168,7 @@ void main() {
     // The actions belong to the sheet's pinned footer, not to the scrolling
     // form — otherwise they drift off screen while reading the warning.
     testWidgets('keeps the actions out of the scrollable form', (tester) async {
-      await _showDialog(tester);
+      await _showSheet(tester);
 
       expect(
         find.descendant(
@@ -184,7 +184,7 @@ void main() {
     testWidgets('dismisses the sheet when the form is dragged down', (
       tester,
     ) async {
-      await _showDialog(tester);
+      await _showSheet(tester);
 
       await tester.drag(
         find.byType(SingleChildScrollView).first,
@@ -196,7 +196,7 @@ void main() {
     });
 
     testWidgets('wrong word keeps Delete button disabled', (tester) async {
-      await _showDialog(tester);
+      await _showSheet(tester);
 
       await tester.enterText(find.byType(TextField), 'confirm');
       await tester.pump();
@@ -206,7 +206,7 @@ void main() {
     });
 
     testWidgets('exact uppercase DELETE enables the button', (tester) async {
-      await _showDialog(tester);
+      await _showSheet(tester);
 
       await tester.enterText(find.byType(TextField), 'DELETE');
       await tester.pump();
@@ -216,7 +216,7 @@ void main() {
     });
 
     testWidgets('lowercase delete enables the button', (tester) async {
-      await _showDialog(tester);
+      await _showSheet(tester);
 
       await tester.enterText(find.byType(TextField), 'delete');
       await tester.pump();
@@ -226,7 +226,7 @@ void main() {
     });
 
     testWidgets('mixed case Delete enables the button', (tester) async {
-      await _showDialog(tester);
+      await _showSheet(tester);
 
       await tester.enterText(find.byType(TextField), 'Delete');
       await tester.pump();
@@ -238,7 +238,7 @@ void main() {
     testWidgets('DELETE with trailing whitespace enables the button', (
       tester,
     ) async {
-      await _showDialog(tester);
+      await _showSheet(tester);
 
       await tester.enterText(find.byType(TextField), 'DELETE ');
       await tester.pump();
@@ -250,7 +250,7 @@ void main() {
     testWidgets('delete with leading whitespace enables the button', (
       tester,
     ) async {
-      await _showDialog(tester);
+      await _showSheet(tester);
 
       await tester.enterText(find.byType(TextField), ' delete');
       await tester.pump();
@@ -261,7 +261,7 @@ void main() {
 
     testWidgets('tapping enabled button calls onConfirm', (tester) async {
       var called = false;
-      await _showDialog(
+      await _showSheet(
         tester,
         onConfirm:
             ({
@@ -282,14 +282,14 @@ void main() {
     testWidgets('burn toggle is hidden when no username is owned', (
       tester,
     ) async {
-      await _showDialog(tester);
+      await _showSheet(tester);
       expect(find.byType(DivineRowCheckbox), findsNothing);
     });
 
     testWidgets('burn toggle is shown when a username is owned', (
       tester,
     ) async {
-      await _showDialog(
+      await _showSheet(
         tester,
         ownedUsername: (name: 'Alice', canonical: 'alice'),
       );
@@ -310,7 +310,7 @@ void main() {
       tester,
     ) async {
       bool? received;
-      await _showDialog(
+      await _showSheet(
         tester,
         ownedUsername: (name: 'alice', canonical: 'alice'),
         onConfirm:
@@ -334,7 +334,7 @@ void main() {
       tester,
     ) async {
       bool? received;
-      await _showDialog(
+      await _showSheet(
         tester,
         ownedUsername: (name: 'alice', canonical: 'alice'),
         onConfirm:
@@ -352,7 +352,7 @@ void main() {
       expect(received, isFalse);
     });
 
-    testWidgets('dialog opens before the lookup resolves and reveals the '
+    testWidgets('sheet opens before the lookup resolves and reveals the '
         'toggle only once it completes', (tester) async {
       final completer = Completer<({String name, String canonical})?>();
       await tester.pumpWidget(
@@ -380,7 +380,7 @@ void main() {
       await tester.tap(find.byKey(const Key('open')));
       await tester.pumpAndSettle();
 
-      // Dialog is already open (lookup still pending) but no toggle yet.
+      // Sheet is already open (lookup still pending) but no toggle yet.
       expect(_deleteAllContentButton(), findsOneWidget);
       expect(find.byType(DivineRowCheckbox), findsNothing);
 
@@ -419,7 +419,7 @@ void main() {
       await tester.tap(find.byKey(const Key('open')));
       await tester.pumpAndSettle();
 
-      // Dialog is open with the lookup still pending, then the lookup fails.
+      // Sheet is open with the lookup still pending, then the lookup fails.
       completer.completeError(Exception('lookup failed'));
       await tester.pumpAndSettle();
 
@@ -433,7 +433,7 @@ void main() {
     ) async {
       ({String name, String canonical})? receivedOwned;
       var receivedBurn = false;
-      await _showDialog(
+      await _showSheet(
         tester,
         ownedUsername: (name: 'Alice', canonical: 'alice'),
         onConfirm:
@@ -460,7 +460,7 @@ void main() {
     testWidgets('shows the identity (name + handle) and username prompt', (
       tester,
     ) async {
-      await _showDialog(tester, confirmation: _divineUsername());
+      await _showSheet(tester, confirmation: _divineUsername());
       expect(find.text('Rabble'), findsOneWidget);
       expect(find.text('@rabble.divine.video'), findsWidgets);
       expect(
@@ -476,7 +476,7 @@ void main() {
     testWidgets('typing DELETE does not enable the button for a username', (
       tester,
     ) async {
-      await _showDialog(tester, confirmation: _divineUsername());
+      await _showSheet(tester, confirmation: _divineUsername());
       await tester.enterText(find.byType(TextField), 'DELETE');
       await tester.pump();
       final button = tester.widget<DivineButton>(_deleteAllContentButton());
@@ -484,7 +484,7 @@ void main() {
     });
 
     testWidgets('typing the handle enables the button', (tester) async {
-      await _showDialog(tester, confirmation: _divineUsername());
+      await _showSheet(tester, confirmation: _divineUsername());
       await tester.enterText(find.byType(TextField), '@rabble.divine.video');
       await tester.pump();
       final button = tester.widget<DivineButton>(_deleteAllContentButton());
@@ -494,7 +494,7 @@ void main() {
     testWidgets('typing the handle without @ also enables the button', (
       tester,
     ) async {
-      await _showDialog(tester, confirmation: _divineUsername());
+      await _showSheet(tester, confirmation: _divineUsername());
       await tester.enterText(find.byType(TextField), 'rabble.divine.video');
       await tester.pump();
       final button = tester.widget<DivineButton>(_deleteAllContentButton());


### PR DESCRIPTION
Closes #6633

## Description

| Before | After |
| ------ | ------ |
|   <img width="322" alt="image" src="https://github.com/user-attachments/assets/e857810d-8f00-4642-86d5-f0906122e344" />   |   <img width="322" alt="image" src="https://github.com/user-attachments/assets/919f8442-4b92-494e-9997-9103e83ead94" /> |

Both entries in the Nostr settings danger zone were raw Material `AlertDialog`s with grey `OutlineInputBorder` fields, `TextButton`/`ElevatedButton` actions, a `CheckboxListTile`, and hand-rolled `TextStyle(fontSize: 20, fontWeight: bold)` headings -- none of which exists in `divine_ui` or in the Figma library. The two most destructive confirmations in the app were the ones that looked least like Divine. This rebuilds both on the sanctioned sheet components.

**"Remove this account from this device"** is now a `VineBottomSheetPrompt` (skeleton-key sticker, destructive primary action). It returns whether the user confirmed instead of taking an `onConfirm` callback, which drops a callback layer from the caller in `nostr_settings_screen.dart` -- the sign-out, progress-overlay and snackbar handling is unchanged.

**"Delete account and data"** is a `VineBottomSheet`. Notable decisions:

- **The form scrolls through the sheet's own `ScrollController`** (`buildScrollBody`), so dragging it down collapses and dismisses the sheet.
- **The actions moved into `bottomInput`**, so they stay reachable instead of scrolling away with the warning text.
- **Footer and form are sibling slots**, not one subtree: a `ValueNotifier<bool>` carries "the typed token matches" out to the footer, and the footer reaches the form through a `GlobalKey` to confirm. The controllers deliberately stay inside the form's `State` rather than in a holder disposed after `VineBottomSheet.show` completes -- the exit animation still rebuilds the field at that point, and a `TextField` re-subscribes to its controller on every rebuild, which throws once it is disposed.
- **The burn-username consent uses `DivineRowCheckbox`, not `DivineCheckboxTile`.** The latter is `ListTile`-based, and a `ListTile` cannot paint its background or ink splashes through the `ColoredBox` the sheet paints its surface with -- Flutter asserts on exactly that.
- **Swipe-to-dismiss stays enabled** rather than reproducing the old `barrierDismissible: false`. Dismissing cancels; nothing is deleted until the token is typed and the destructive button is tapped.
- **The deletion progress indicator is now a non-dismissible `VineBottomSheet`** instead of the file's last raw `showDialog`, with its copy moved to `VineTheme` typography.
- **The progress sheet pins `useRootNavigator: true`.** `showDialog` defaults it to true and `VineBottomSheet.show` to false, so the migration would otherwise have moved a UI-blocking overlay off the root navigator. `dismissProgressSheet` pops that same navigator rather than going through `context.pop()`, which resolves to the innermost one. No behaviour changes at either current caller -- both are root-level routes.

The `material_buttons`, `raw_dialogs` and `raw_textstyle` baselines all shrink for this file and are regenerated so the reclaimed headroom is locked in rather than left open for the next PR to spend.

## Out of Scope

- `delete_account_dialog.dart` keeps its filename although it now holds sheets. Renaming would churn the `ui_service_boundary` and dialog baselines for no behavioural gain; the public functions were renamed to `...Sheet` instead.
- Independent of #6628 (same alert-to-sheet theme in the support forms). Both target `main` and neither depends on the other; they only touch adjacent design-system baselines.

## Verification

- `flutter analyze lib test` -- clean
- `flutter test test/widgets/delete_account_dialog_test.dart` -- 43 tests, including coverage for pinned actions, drag-to-dismiss wiring, dismissal-cancels, and the explicit delete-sheet Cancel button.
- `flutter test test/screens/settings/support_center_screen_test.dart test/screens/settings/settings_screens_light_mode_test.dart test/widgets/nostr_settings_screen_test.dart` -- green (the deletion flow is shared with the support centre)
- `check_raw_dialog_ceiling.sh`, `check_material_button_ceiling.sh`, `check_raw_textstyle_ceiling.sh`, `check_raw_colors_ceiling.sh` -- all OK after regenerating the shrunk baselines
- Manually verified on a real Samsung Galaxy: both sheets, swipe-to-dismiss, pinned footer, and the type-to-confirm gate with the keyboard open

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

