### PR TITLE
docs(agents): forbid sensitive external identities in public artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,10 @@ If a Divine Brain search or ask tool is available, you may use it for company me
 - During PR review, if GitHub reports no merge conflicts and the update is only addressing review feedback, do not rebase just to refresh history. Push the review fix normally; the PR is squash-merged anyway.
 - Never merge `main` into a feature branch — always rebase.
 
+## Security
+
+- Public issues, PRs, branch names, commit messages, screenshots, and descriptions must not mention corporate partners, customers, brands, campaign names, or other sensitive external identities unless a maintainer explicitly approves it. Use generic descriptors instead. The same applies to identifying values in code, tests, and fixtures — prefer keeping them in server-side configuration over committing them.
+
 ## PR Guardrails
 
 - Every PR title must use Conventional Commit format: `type(scope): summary` or `docs: summary` for docs-only PRs.
@@ -57,7 +61,6 @@ If a Divine Brain search or ask tool is available, you may use it for company me
 - Commit the completed work on the task branch before handoff.
 - Open a pull request for that branch once the change is ready for review. Do not leave finished work sitting only in a local branch or worktree.
 - Keep PRs focused and reviewable. If two pieces of work are *truly independent*, split them into separate PRs each targeting `main`. If they depend on each other, **combine them into one PR** rather than splitting and stacking.
-- Public issues, PRs, branch names, commit messages, screenshots, and descriptions must not mention corporate partners, customers, brands, campaign names, or other sensitive external identities unless a maintainer explicitly approves it. Use generic descriptors instead. The same applies to identifying values in code, tests, and fixtures — prefer keeping them in server-side configuration over committing them.
 
 ## No Technical Debt, No Failing Tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ If a Divine Brain search or ask tool is available, you may use it for company me
 - Commit the completed work on the task branch before handoff.
 - Open a pull request for that branch once the change is ready for review. Do not leave finished work sitting only in a local branch or worktree.
 - Keep PRs focused and reviewable. If two pieces of work are *truly independent*, split them into separate PRs each targeting `main`. If they depend on each other, **combine them into one PR** rather than splitting and stacking.
+- Public issues, PRs, branch names, commit messages, screenshots, and descriptions must not mention corporate partners, customers, brands, campaign names, or other sensitive external identities unless a maintainer explicitly approves it. Use generic descriptors instead. The same applies to identifying values in code, tests, and fixtures — prefer keeping them in server-side configuration over committing them.
 
 ## No Technical Debt, No Failing Tests
 


### PR DESCRIPTION
Closes #6637

## Summary

Adds a confidentiality clause to `AGENTS.md` that already exists in
`divine-funnelcake` and `divine-moderation-service`, but was missing here.

`divine-mobile` is the highest-traffic repo in the org and the likeliest
place for a sensitive external identity to end up in a public issue, PR
title, or branch name. It should carry the same rule as its siblings.

## What changed

One bullet under **Issue And PR Guardrails**:

> Public issues, PRs, branch names, commit messages, screenshots, and
> descriptions must not mention corporate partners, customers, brands,
> campaign names, or other sensitive external identities unless a
> maintainer explicitly approves it. Use generic descriptors instead.
> The same applies to identifying values in code, tests, and fixtures —
> prefer keeping them in server-side configuration over committing them.

Two deliberate extensions over the sibling repos' wording:

- **commit messages** added to the list. The original covers issues, PRs,
  branch names, screenshots, and descriptions, but not commits.
- **a second sentence about code, tests, and fixtures.** The sibling
  version is about prose only. In a client repo the more likely leak is a
  hardcoded value in a fixture, so the rule points at server-side
  configuration as the default.

## Test plan

Docs only — no code, no tests, no CI surface affected.

Companion PR adding the same clause to `divine-web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)