### PR TITLE
fix(explore): persist selected tab by name

### DIFF
--- a/mobile/lib/blocs/explore_tabs/explore_tabs_state.dart
+++ b/mobile/lib/blocs/explore_tabs/explore_tabs_state.dart
@@ -12,6 +12,21 @@ const exploreForYouTabSlug = 'for-you';
 /// Default tab name selected when no other selection applies.
 const exploreDefaultTabName = 'new';
 
+/// Internal tab name for the Classics tab.
+const exploreClassicsTabName = 'classics';
+
+/// Internal tab name for the Trending tab.
+const explorePopularTabName = 'popular';
+
+/// Internal tab name for the Categories tab.
+const exploreCategoriesTabName = 'categories';
+
+/// Internal tab name for the Lists tab.
+const exploreListsTabName = 'lists';
+
+/// Internal tab name for the integrated Apps tab.
+const exploreAppsTabName = 'apps';
+
 /// Immutable explore tab configuration derived from feature availability.
 class ExploreTabsState extends Equatable {
   /// Creates a tab state with the given optional-tab availability.
@@ -35,13 +50,13 @@ class ExploreTabsState extends Equatable {
   /// Canonical order: `classics?`, `new`, `popular`, `categories`,
   /// `for_you?`, `lists`, `apps?`.
   List<String> get tabNames => [
-    if (classicsAvailable) 'classics',
-    'new',
-    'popular',
-    'categories',
+    if (classicsAvailable) exploreClassicsTabName,
+    exploreDefaultTabName,
+    explorePopularTabName,
+    exploreCategoriesTabName,
     if (forYouAvailable) exploreForYouTabName,
-    'lists',
-    if (appsAvailable) 'apps',
+    exploreListsTabName,
+    if (appsAvailable) exploreAppsTabName,
   ];
 
   /// Number of visible tabs.
@@ -65,7 +80,7 @@ class ExploreTabsState extends Equatable {
   String nameForIndex(int index) {
     final names = tabNames;
     if (index >= 0 && index < names.length) return names[index];
-    return 'popular';
+    return explorePopularTabName;
   }
 
   /// Returns a copy with the given availability overrides.

--- a/mobile/lib/providers/route_feed_providers.dart
+++ b/mobile/lib/providers/route_feed_providers.dart
@@ -4,6 +4,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/explore_tabs/explore_tabs_cubit.dart';
 import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/providers/video_events_providers.dart';
 import 'package:openvine/providers/video_providers.dart';
@@ -38,10 +39,14 @@ final exploreTabVideoUpdateListenerProvider = Provider<void>((ref) {
   ref.onDispose(unregister);
 });
 
-/// Provider to persist the current tab index across widget recreation.
-/// Default to 1. Note: navigate to `ExploreScreen.pathForTab(name)` for
-/// semantic tab selection that survives tab count changes.
-final exploreTabIndexProvider = StateProvider<int>((ref) => 1);
+/// Provider to persist the current Explore tab by stable name across widget
+/// recreation and feed-mode chrome updates.
+///
+/// Tab indices shift whenever optional tabs appear or disappear, so all shared
+/// state outside the live TabController stores tab identity by name.
+final exploreTabNameProvider = StateProvider<String>(
+  (ref) => exploreDefaultTabName,
+);
 
 /// Index of the currently-active bottom-nav branch
 /// (0 = Home, 1 = Explore, 2 = Inbox, 3 = Profile).

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -11,13 +11,12 @@ import 'package:openvine/app_update/app_update.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/notifications/view/notifications_page.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/providers/classic_vines_provider.dart';
-import 'package:openvine/providers/for_you_provider.dart';
 import 'package:openvine/providers/route_feed_providers.dart';
 import 'package:openvine/providers/shell_obscured_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/explore/explore_screen.dart';
+import 'package:openvine/screens/explore/explore_tab_labels.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
@@ -132,21 +131,8 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
       case RouteType.explore:
         // When in feed mode (watching a video), show the tab name
         if (ctx?.videoIndex != null) {
-          final tabIndex = ref.watch(exploreTabIndexProvider);
-          // Build dynamic tab names based on which optional tabs are available
-          // Order: [Classics], New Videos, Trending, [For You], Lists
-          final forYouAvailable = ref.watch(forYouAvailableProvider);
-          final classicsAvailable =
-              ref.watch(classicVinesAvailableProvider).asData?.value ?? false;
-          final tabNames = <String>[];
-          if (classicsAvailable) tabNames.add(l10n.navExploreClassics);
-          tabNames.addAll([l10n.navExploreNewVideos, l10n.navExploreTrending]);
-          if (forYouAvailable) tabNames.add(l10n.navExploreForYou);
-          tabNames.add(l10n.navExploreLists);
-          if (tabIndex >= 0 && tabIndex < tabNames.length) {
-            return tabNames[tabIndex];
-          }
-          return l10n.navExplore;
+          final tabName = ref.watch(exploreTabNameProvider);
+          return labelForExploreTabName(l10n, tabName, shellTitle: true);
         }
         return l10n.navExplore;
       case RouteType.categoryGallery:

--- a/mobile/lib/screens/explore/explore_screen.dart
+++ b/mobile/lib/screens/explore/explore_screen.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/explore_tabs/explore_tabs_cubit.dart';
-import 'package:openvine/providers/route_feed_providers.dart';
 import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/screens/explore/explore_view.dart';
 
@@ -15,13 +14,13 @@ class ExploreScreen extends ConsumerWidget {
   const ExploreScreen({super.key, this.initialTabName});
 
   static const _routeTabNames = <String>{
-    'classics',
-    'new',
-    'popular',
-    'categories',
+    exploreClassicsTabName,
+    exploreDefaultTabName,
+    explorePopularTabName,
+    exploreCategoriesTabName,
     exploreForYouTabName,
-    'lists',
-    'apps',
+    exploreListsTabName,
+    exploreAppsTabName,
   };
 
   /// Route name for this screen.
@@ -63,8 +62,7 @@ class ExploreScreen extends ConsumerWidget {
     return _routeTabNames.contains(name) ? name : null;
   }
 
-  /// Optional tab name to select on first build. Takes precedence over
-  /// the saved [exploreTabIndexProvider].
+  /// Optional tab name to select on first build.
   final String? initialTabName;
 
   @override

--- a/mobile/lib/screens/explore/explore_tab_labels.dart
+++ b/mobile/lib/screens/explore/explore_tab_labels.dart
@@ -1,0 +1,29 @@
+// ABOUTME: Shared localized labels for canonical Explore tab names.
+// ABOUTME: Keeps tab bar and feed-mode shell titles in sync.
+
+import 'package:openvine/blocs/explore_tabs/explore_tabs_cubit.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+
+/// Returns the localized display label for an Explore tab [name].
+///
+/// The shell uses a little more context for video mode ("New Videos",
+/// "Trending") while the tab bar keeps the shorter tab copy ("New", "Popular").
+String labelForExploreTabName(
+  AppLocalizations l10n,
+  String name, {
+  bool shellTitle = false,
+}) => switch (name) {
+  exploreClassicsTabName =>
+    shellTitle ? l10n.navExploreClassics : l10n.exploreTabClassics,
+  exploreDefaultTabName =>
+    shellTitle ? l10n.navExploreNewVideos : l10n.exploreTabNew,
+  explorePopularTabName =>
+    shellTitle ? l10n.navExploreTrending : l10n.exploreTabPopular,
+  exploreCategoriesTabName => l10n.exploreTabCategories,
+  exploreForYouTabName =>
+    shellTitle ? l10n.navExploreForYou : l10n.exploreTabForYou,
+  exploreListsTabName =>
+    shellTitle ? l10n.navExploreLists : l10n.exploreTabLists,
+  exploreAppsTabName => l10n.exploreTabIntegratedApps,
+  _ => l10n.navExplore,
+};

--- a/mobile/lib/screens/explore/explore_view.dart
+++ b/mobile/lib/screens/explore/explore_view.dart
@@ -48,22 +48,22 @@ class _ExploreViewState extends ConsumerState<ExploreView>
   /// Build a new [TabController]. [previousTabName] is the name of the tab the
   /// user was on before a rebuild (resolved while the old availability flags
   /// were still in effect). Resolution order:
-  /// [ExploreView.initialTabName] > previous tab > default. Falls back to the
-  /// default tab by name — never by raw index, because indices shift when
+  /// [ExploreView.initialTabName] > previous tab > persisted tab > default.
+  /// Falls back by name — never by raw index, because indices shift when
   /// optional tabs appear or disappear.
   void _initTabController({String? previousTabName}) {
-    final targetTabName = widget.initialTabName ?? previousTabName;
-    final initialIndex = _tabsState.indexForName(
-      targetTabName ?? exploreDefaultTabName,
-    );
+    final targetTabName =
+        widget.initialTabName ??
+        previousTabName ??
+        ref.read(exploreTabNameProvider) ??
+        exploreDefaultTabName;
+    final initialIndex = _tabsState.indexForName(targetTabName);
 
-    if (targetTabName != null) {
-      Log.info(
-        '🎯 ExploreScreen: Using tab "$targetTabName" -> index $initialIndex',
-        name: 'ExploreScreen',
-        category: LogCategory.ui,
-      );
-    }
+    Log.info(
+      '🎯 ExploreScreen: Using tab "$targetTabName" -> index $initialIndex',
+      name: 'ExploreScreen',
+      category: LogCategory.ui,
+    );
 
     _tabController = TabController(
       length: _tabsState.tabCount,

--- a/mobile/lib/screens/explore/explore_view.dart
+++ b/mobile/lib/screens/explore/explore_view.dart
@@ -129,8 +129,9 @@ class _ExploreViewState extends ConsumerState<ExploreView>
     final index = _tabController!.index;
     final tabName = _tabsState.nameForIndex(index);
 
-    // Always persist the current index
-    ref.read(exploreTabIndexProvider.notifier).state = index;
+    // Persist the selected tab by stable name because optional tabs can shift
+    // raw indices while Explore is alive.
+    ref.read(exploreTabNameProvider.notifier).state = tabName;
 
     // Track tab change
     _tabs.trackTabChange(tabName);

--- a/mobile/lib/screens/explore/widgets/explore_tab_bar.dart
+++ b/mobile/lib/screens/explore/widgets/explore_tab_bar.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:openvine/blocs/explore_tabs/explore_tabs_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/screens/explore/explore_tab_labels.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 
 /// The explore screen's scrollable tab bar.
@@ -59,16 +60,8 @@ class ExploreTabBar extends StatelessWidget {
               ),
               onTap: onTap,
               tabs: [
-                if (tabsState.classicsAvailable)
-                  Tab(text: context.l10n.exploreTabClassics),
-                Tab(text: context.l10n.exploreTabNew),
-                Tab(text: context.l10n.exploreTabPopular),
-                Tab(text: context.l10n.exploreTabCategories),
-                if (tabsState.forYouAvailable)
-                  Tab(text: context.l10n.exploreTabForYou),
-                Tab(text: context.l10n.exploreTabLists),
-                if (tabsState.appsAvailable)
-                  Tab(text: context.l10n.exploreTabIntegratedApps),
+                for (final name in tabsState.tabNames)
+                  Tab(text: labelForExploreTabName(context.l10n, name)),
               ],
             ),
             // Right-edge fade gradient shim

--- a/mobile/test/screens/explore/explore_tab_labels_test.dart
+++ b/mobile/test/screens/explore/explore_tab_labels_test.dart
@@ -1,0 +1,57 @@
+// ABOUTME: Regression tests for shared Explore tab label resolution.
+// ABOUTME: Covers feed-mode shell titles for every canonical Explore tab.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/blocs/explore_tabs/explore_tabs_cubit.dart';
+import 'package:openvine/l10n/generated/app_localizations_en.dart';
+import 'package:openvine/screens/explore/explore_tab_labels.dart';
+
+void main() {
+  group('labelForExploreTabName', () {
+    final l10n = AppLocalizationsEn();
+
+    test('returns tab-bar labels for every canonical tab name', () {
+      const state = ExploreTabsState(
+        classicsAvailable: true,
+        forYouAvailable: true,
+        appsAvailable: true,
+      );
+
+      expect(
+        state.tabNames.map((name) => labelForExploreTabName(l10n, name)),
+        const [
+          'Classics',
+          'New',
+          'Popular',
+          'Categories',
+          'For You',
+          'Lists',
+          'Integrated Apps',
+        ],
+      );
+    });
+
+    test('returns feed-mode shell titles for every canonical tab name', () {
+      const state = ExploreTabsState(
+        classicsAvailable: true,
+        forYouAvailable: true,
+        appsAvailable: true,
+      );
+
+      expect(
+        state.tabNames.map(
+          (name) => labelForExploreTabName(l10n, name, shellTitle: true),
+        ),
+        const [
+          'Classics',
+          'New Videos',
+          'Trending',
+          'Categories',
+          'For You',
+          'Lists',
+          'Integrated Apps',
+        ],
+      );
+    });
+  });
+}

--- a/mobile/test/screens/explore_screen_apps_tab_test.dart
+++ b/mobile/test/screens/explore_screen_apps_tab_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/explore_tabs/explore_tabs_cubit.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
@@ -131,6 +132,44 @@ void main() {
       expect(find.text('Integrated Apps'), findsNothing);
     },
   );
+
+  testWidgets('ExploreScreen restores the selected tab by stable name', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      testProviderScope(
+        additionalOverrides: [
+          appForegroundProvider.overrideWith(_FakeAppForeground.new),
+          videoEventServiceProvider.overrideWithValue(videoEventService),
+          routerLocationStreamProvider.overrideWith(
+            (ref) => Stream.value(ExploreScreen.path),
+          ),
+          exploreTabVideosProvider.overrideWith((ref) => null),
+          exploreTabNameProvider.overrideWith((ref) => explorePopularTabName),
+          classicVinesAvailableProvider.overrideWith((ref) async => false),
+          forYouAvailableProvider.overrideWithValue(false),
+          allListsProvider.overrideWith(
+            (ref) async =>
+                (userLists: <UserList>[], curatedLists: <CuratedList>[]),
+          ),
+          curatedListsStateProvider.overrideWith(_FakeCuratedListsState.new),
+          isFeatureEnabledProvider(
+            FeatureFlag.integratedApps,
+          ).overrideWithValue(false),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: ExploreScreen()),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final tabBar = tester.widget<TabBar>(find.byType(TabBar));
+    expect(tabBar.controller?.index, 1);
+  });
 
   group('People list navigation path', () {
     test('UserListPeopleScreen exposes routable path constants', () {

--- a/mobile/test/screens/explore_screen_lists_tab_test.dart
+++ b/mobile/test/screens/explore_screen_lists_tab_test.dart
@@ -1,84 +1,52 @@
-// ABOUTME: TDD test for Lists tab in ExploreScreen
-// ABOUTME: Ensures Lists tab replaces Divine Team tab - simple unit tests
+// ABOUTME: Unit tests for Explore's Lists tab identity and persistence.
+// ABOUTME: Ensures tab selection is stored by name rather than shifting index.
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/blocs/explore_tabs/explore_tabs_cubit.dart';
 import 'package:openvine/providers/route_feed_providers.dart';
 
 void main() {
-  group('ExploreScreen Lists Tab Structure TDD', () {
-    test('RED: ExploreScreen should have 3 tabs, not 4', () {
-      // This test will pass once we change TabController length from 4 to 3
-      const expectedTabCount = 3;
+  group('ExploreScreen Lists tab structure', () {
+    test('base Explore tab order includes Lists by stable name', () {
+      const state = ExploreTabsState();
 
-      // The actual check will be in the implementation where we create TabController
-      // TabController(length: 3, vsync: this) - currently length is 4
-      expect(
-        expectedTabCount,
-        3,
-        reason:
-            'ExploreScreen should have exactly 3 tabs after removing Divine Team',
-      );
+      expect(state.tabNames, const [
+        exploreDefaultTabName,
+        explorePopularTabName,
+        exploreCategoriesTabName,
+        exploreListsTabName,
+      ]);
     });
 
-    test('RED: Tab labels should be [New, Popular, Lists]', () {
-      // This defines the expected tab configuration
-      const expectedTabs = [
-        'New',
-        'Popular',
-        'Lists', // Replaces 'Divine Team'
-      ];
+    test('Tab name provider supports stable Explore tab identities', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
 
+      // Test representative tab identities without depending on tab order.
+      container.read(exploreTabNameProvider.notifier).state =
+          exploreDefaultTabName;
       expect(
-        expectedTabs.length,
-        3,
-        reason: 'Should have exactly 3 tab labels',
+        container.read(exploreTabNameProvider),
+        exploreDefaultTabName,
+        reason: 'New tab persists by name',
       );
-      expect(expectedTabs[0], 'New', reason: 'First tab should be New');
+
+      container.read(exploreTabNameProvider.notifier).state =
+          explorePopularTabName;
       expect(
-        expectedTabs[1],
-        'Popular',
-        reason: 'Second tab should be Popular',
+        container.read(exploreTabNameProvider),
+        explorePopularTabName,
+        reason: 'Popular tab persists by name',
       );
+
+      container.read(exploreTabNameProvider.notifier).state =
+          exploreListsTabName;
       expect(
-        expectedTabs[2],
-        'Lists',
-        reason: 'Third tab should be Lists (replaces Divine Team)',
+        container.read(exploreTabNameProvider),
+        exploreListsTabName,
+        reason: 'Lists tab persists by name',
       );
     });
-
-    // Widget tests commented out due to Firebase dependency issues
-    // TODO: Add widget tests once Firebase mock setup is completed
-    // For now, we rely on manual testing and the unit tests above
-
-    test(
-      'Tab index provider should support 3 tabs (0=New, 1=Popular, 2=Lists)',
-      () {
-        final container = ProviderContainer();
-        addTearDown(container.dispose);
-
-        // Test all valid tab indices
-        container.read(exploreTabIndexProvider.notifier).state = 0;
-        expect(
-          container.read(exploreTabIndexProvider),
-          0,
-          reason: 'Index 0 = New',
-        );
-
-        container.read(exploreTabIndexProvider.notifier).state = 1;
-        expect(
-          container.read(exploreTabIndexProvider),
-          1,
-          reason: 'Index 1 = Popular',
-        );
-
-        container.read(exploreTabIndexProvider.notifier).state = 2;
-        expect(
-          container.read(exploreTabIndexProvider),
-          2,
-          reason: 'Index 2 = Lists',
-        );
-      },
-    );
   });
 }

--- a/mobile/test/screens/explore_screen_tab_switching_test.dart
+++ b/mobile/test/screens/explore_screen_tab_switching_test.dart
@@ -1,78 +1,48 @@
-// ABOUTME: TDD test for explore screen tab switching behavior while in feed mode
-// ABOUTME: Ensures tapping tabs exits feed mode and shows grid view correctly
+// ABOUTME: Unit tests for Explore tab selection persistence.
+// ABOUTME: Ensures tab identity is stored by name instead of shifting index.
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/blocs/explore_tabs/explore_tabs_cubit.dart';
 import 'package:openvine/providers/route_feed_providers.dart';
 
 void main() {
-  group('ExploreScreen Tab Switching TDD', () {
-    setUp(() {
-      // Tests don't actually need videos - just documenting the bug
-    });
-
-    test(
-      'GREEN: Tapping same tab while in feed mode should exit feed mode',
-      () {
-        // FIXED: Added onTap handler to TabBar widget
-        // Now ANY tab tap (including same tab) will exit feed mode
-        expect(
-          true,
-          isTrue,
-          reason:
-              'TabBar.onTap() handler catches all tab taps and exits feed mode',
-        );
-      },
-    );
-
-    test(
-      'GREEN: Tapping different tab while in feed mode should exit feed mode',
-      () {
-        // This case works via BOTH mechanisms:
-        // 1. TabBar.onTap() fires immediately
-        // 2. TabController listener fires when index changes
-        // Both will call the exit logic, but setState() is idempotent
-        expect(
-          true,
-          isTrue,
-          reason: 'Different tab switching works via onTap handler',
-        );
-      },
-    );
-
-    test('Tab index provider persists state across widget recreation', () {
+  group('Explore tab selection', () {
+    test('Tab name provider persists state across widget recreation', () {
       // Setup: Create container
       final container = ProviderContainer();
       addTearDown(container.dispose);
 
-      // Verify initial state (default is Popular = index 1)
-      expect(container.read(exploreTabIndexProvider), 1);
+      // Verify initial state (default is New Videos by stable name)
+      expect(container.read(exploreTabNameProvider), exploreDefaultTabName);
 
-      // Simulate user switching to "New" tab (index 0)
-      container.read(exploreTabIndexProvider.notifier).state = 0;
+      // Simulate user switching to Trending.
+      container.read(exploreTabNameProvider.notifier).state =
+          explorePopularTabName;
 
       // Verify provider was updated
-      expect(container.read(exploreTabIndexProvider), 0);
+      expect(container.read(exploreTabNameProvider), explorePopularTabName);
 
       // The key insight: The provider state persists outside the widget lifecycle
       // When ExploreScreen is recreated (grid→feed navigation), it reads from
-      // the provider and restores the tab index
+      // the provider and restores the tab name.
 
       // Simulate reading the persisted value (as ExploreScreen.initState would)
-      final savedIndex = container.read(exploreTabIndexProvider);
+      final savedName = container.read(exploreTabNameProvider);
       expect(
-        savedIndex,
-        0,
-        reason: 'Tab index should persist in provider for widget to restore',
+        savedName,
+        explorePopularTabName,
+        reason: 'Tab name should persist in provider for widget to restore',
       );
 
       // Additional test: Verify switching tabs updates the provider
-      container.read(exploreTabIndexProvider.notifier).state =
-          2; // Editor's Pick
-      expect(container.read(exploreTabIndexProvider), 2);
+      container.read(exploreTabNameProvider.notifier).state =
+          exploreCategoriesTabName;
+      expect(container.read(exploreTabNameProvider), exploreCategoriesTabName);
 
-      container.read(exploreTabIndexProvider.notifier).state = 1; // Popular
-      expect(container.read(exploreTabIndexProvider), 1);
+      container.read(exploreTabNameProvider.notifier).state =
+          exploreDefaultTabName;
+      expect(container.read(exploreTabNameProvider), exploreDefaultTabName);
     });
   });
 }


### PR DESCRIPTION
## Summary

- Persist the selected Explore tab by canonical tab name instead of raw index.
- Resolve Explore feed-mode shell titles from shared tab-name labels, including Categories and Integrated Apps.
- Drive the tab bar labels from the same canonical tab-name order while preserving the existing tab-bar copy.
- Clean up obsolete no-op Explore tab tests and add focused label/persistence regressions.

## Verification

- flutter test test/blocs/explore_tabs/explore_tabs_cubit_test.dart test/screens/explore/explore_tab_labels_test.dart test/screens/explore_screen_tab_switching_test.dart test/screens/explore_screen_lists_tab_test.dart
- flutter analyze
- Pre-push hook: analyze + changed tests passed

Closes #6638
Refs #6635