### PR TITLE
fix(profile): flag revalidation on empty tabs so refresh can settle

### DIFF
--- a/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_bloc.dart
@@ -55,7 +55,11 @@ class ProfileCollabVideosBloc
     ProfileCollabVideosFetchRequested event,
     Emitter<ProfileCollabVideosState> emit,
   ) async {
-    if (state.videos.isNotEmpty && !state.isRefreshing) {
+    // Flag the revalidation whenever a settled result is on screen — an empty
+    // one included — so a re-sync always has an observable start edge, matching
+    // the liked/reposted/saved tabs.
+    if (state.status != ProfileCollabVideosStatus.initial &&
+        !state.isRefreshing) {
       emit(state.copyWith(isRefreshing: true));
     }
 
@@ -91,13 +95,29 @@ class ProfileCollabVideosBloc
         emit(state.copyWith(isRefreshing: false));
         return;
       }
-      emit(state.copyWith(status: ProfileCollabVideosStatus.failure));
+      // Clearing the flag is what lets the refresh settle: an empty grid now
+      // enters here with isRefreshing on, and the tab bar waits for it to
+      // drop.
+      emit(
+        state.copyWith(
+          status: ProfileCollabVideosStatus.failure,
+          isRefreshing: false,
+        ),
+      );
     }
   }
 
   /// Cold path: nothing cached. Fetch the first page from the collabs feed.
+  ///
+  /// A settled-empty grid re-syncs through here too (the routing keys off
+  /// `videos.isEmpty`). Tearing it down for the full-tab spinner would flash
+  /// the tab on every pull-to-refresh, so the loading state is only emitted
+  /// when there is no settled result to keep. A failure screen is still
+  /// replaced by the spinner — an explicit retry should look like one.
   Future<void> _coldLoad(Emitter<ProfileCollabVideosState> emit) async {
-    emit(state.copyWith(status: ProfileCollabVideosStatus.loading));
+    if (state.status != ProfileCollabVideosStatus.success) {
+      emit(state.copyWith(status: ProfileCollabVideosStatus.loading));
+    }
 
     final videos = await _videosRepository.getCollabVideos(
       taggedPubkey: _targetUserPubkey,

--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
@@ -129,9 +129,14 @@ class ProfileLikedVideosBloc
       category: LogCategory.video,
     );
 
-    // Reopen / refresh: keep the cached grid on screen and surface the thin
+    // Reopen / refresh: keep the settled grid on screen and surface the thin
     // progress bar straight away rather than flashing the full-screen spinner.
-    if (state.videos.isNotEmpty && !state.isRefreshing) {
+    // An empty settled grid needs the flag too: a re-sync that stays empty
+    // emits a state equal to the current one, which bloc suppresses, so
+    // without this transition the profile pull-to-refresh (it awaits the next
+    // settled state) hangs.
+    if (state.status != ProfileLikedVideosStatus.initial &&
+        !state.isRefreshing) {
       emit(state.copyWith(isRefreshing: true));
     }
 

--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_state.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_state.dart
@@ -65,8 +65,8 @@ final class ProfileLikedVideosState extends Equatable {
   /// Whether more videos are being loaded (pagination)
   final bool isLoadingMore;
 
-  /// Whether a background revalidation is in progress while cached content is
-  /// already on screen. Drives the thin progress bar in the grid.
+  /// Whether a background revalidation is in progress while a settled result
+  /// is already on screen. Drives the thin progress bar in the grid.
   final bool isRefreshing;
 
   /// Whether there are more videos to load

--- a/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
@@ -95,7 +95,12 @@ class ProfileRepostedVideosBloc
     ProfileRepostedVideosSyncRequested event,
     Emitter<ProfileRepostedVideosState> emit,
   ) async {
-    if (state.videos.isNotEmpty && !state.isRefreshing) {
+    // Flag the revalidation whenever a settled result is on screen — an empty
+    // one included. A re-sync that stays empty emits a state equal to the
+    // current one, which bloc suppresses, so without this transition the
+    // profile pull-to-refresh (it awaits the next settled state) hangs.
+    if (state.status != ProfileRepostedVideosStatus.initial &&
+        !state.isRefreshing) {
       emit(state.copyWith(isRefreshing: true));
     }
 

--- a/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_state.dart
+++ b/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_state.dart
@@ -67,8 +67,8 @@ final class ProfileRepostedVideosState extends Equatable {
   /// Whether more videos are being loaded (pagination)
   final bool isLoadingMore;
 
-  /// Whether a background revalidation is in progress while cached content is
-  /// already on screen. Drives the sticky progress bar in the tab bar.
+  /// Whether a background revalidation is in progress while a settled result
+  /// is already on screen. Drives the sticky progress bar in the tab bar.
   final bool isRefreshing;
 
   /// Whether there are more videos to load

--- a/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
@@ -70,7 +70,12 @@ class ProfileSavedVideosBloc
     ProfileSavedVideosSyncRequested event,
     Emitter<ProfileSavedVideosState> emit,
   ) async {
-    if (state.videos.isNotEmpty && !state.isRefreshing) {
+    // Flag the revalidation whenever a settled result is on screen — an empty
+    // one included. A re-sync that stays empty emits a state equal to the
+    // current one, which bloc suppresses, so without this transition the
+    // profile pull-to-refresh (it awaits the next settled state) hangs.
+    if (state.status != ProfileSavedVideosStatus.initial &&
+        !state.isRefreshing) {
       emit(state.copyWith(isRefreshing: true));
     }
 

--- a/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_state.dart
+++ b/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_state.dart
@@ -56,8 +56,8 @@ final class ProfileSavedVideosState extends Equatable {
   /// Whether more videos are being loaded (pagination).
   final bool isLoadingMore;
 
-  /// Whether a background revalidation is in progress while cached content is
-  /// already on screen. Drives the sticky progress bar in the tab bar.
+  /// Whether a background revalidation is in progress while a settled result
+  /// is already on screen. Drives the sticky progress bar in the tab bar.
   final bool isRefreshing;
 
   /// Whether there are more videos to load.

--- a/mobile/test/blocs/profile_collab_videos/profile_collab_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_collab_videos/profile_collab_videos_bloc_test.dart
@@ -230,6 +230,88 @@ void main() {
         ],
       );
 
+      test(
+        're-fetch of a settled empty tab keeps it, without the loading state',
+        () async {
+          when(
+            () => mockVideosRepository.getCollabVideos(
+              taggedPubkey: targetPubkey,
+              limit: any(named: 'limit'),
+            ),
+          ).thenAnswer((_) async => []);
+          final bloc = createBloc();
+          addTearDown(bloc.close);
+
+          bloc.add(const ProfileCollabVideosFetchRequested());
+          await bloc.stream.firstWhere(
+            (state) => state.status == ProfileCollabVideosStatus.success,
+          );
+
+          // Mirrors how ProfileGridView's RefreshIndicator awaits this tab:
+          // it holds the spinner until the bloc reports a settled state.
+          final emitted = <ProfileCollabVideosState>[];
+          final subscription = bloc.stream.listen(emitted.add);
+          addTearDown(subscription.cancel);
+
+          bloc.add(const ProfileCollabVideosFetchRequested());
+          final settled = await bloc.stream
+              .firstWhere(
+                (state) =>
+                    !state.isRefreshing &&
+                    state.status != ProfileCollabVideosStatus.loading,
+              )
+              .timeout(const Duration(seconds: 1));
+
+          expect(settled.status, ProfileCollabVideosStatus.success);
+          expect(settled.videos, isEmpty);
+          // The empty grid stays put under the thin bar — no full-tab spinner
+          // flash — and the bar's start/end edges are what let the refresh
+          // settle.
+          expect(
+            emitted.map((state) => (state.status, state.isRefreshing)),
+            const [
+              (ProfileCollabVideosStatus.success, true),
+              (ProfileCollabVideosStatus.success, false),
+            ],
+          );
+        },
+      );
+
+      test('a failing re-fetch of a settled empty tab still settles', () async {
+        var calls = 0;
+        when(
+          () => mockVideosRepository.getCollabVideos(
+            taggedPubkey: targetPubkey,
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) async {
+          calls++;
+          if (calls > 1) throw Exception('Network error');
+          return <VideoEvent>[];
+        });
+        final bloc = createBloc();
+        addTearDown(bloc.close);
+
+        bloc.add(const ProfileCollabVideosFetchRequested());
+        await bloc.stream.firstWhere(
+          (state) => state.status == ProfileCollabVideosStatus.success,
+        );
+
+        bloc.add(const ProfileCollabVideosFetchRequested());
+        final settled = await bloc.stream
+            .firstWhere(
+              (state) =>
+                  !state.isRefreshing &&
+                  state.status != ProfileCollabVideosStatus.loading,
+            )
+            .timeout(const Duration(seconds: 1));
+
+        // The empty grid now enters the catch block with the bar on, so the
+        // failure emit has to turn it back off or the refresh never settles.
+        expect(settled.status, ProfileCollabVideosStatus.failure);
+        expect(settled.isRefreshing, isFalse);
+      });
+
       blocTest<ProfileCollabVideosBloc, ProfileCollabVideosState>(
         'trusts repository results as confirmed collabs without p-tag filtering',
         build: () {

--- a/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
@@ -241,17 +241,30 @@ void main() {
 
           // Mirrors how ProfileGridView's RefreshIndicator awaits this tab:
           // it holds the spinner until the bloc reports a settled state.
-          bloc.add(const ProfileLikedVideosSyncRequested());
-          final settled = bloc.stream.firstWhere(
-            (state) =>
-                !state.isRefreshing &&
-                state.status != ProfileLikedVideosStatus.syncing &&
-                state.status != ProfileLikedVideosStatus.loading,
-          );
+          final emitted = <ProfileLikedVideosState>[];
+          final subscription = bloc.stream.listen(emitted.add);
+          addTearDown(subscription.cancel);
 
-          await expectLater(
-            settled.timeout(const Duration(seconds: 1)),
-            completes,
+          bloc.add(const ProfileLikedVideosSyncRequested());
+          final settled = await bloc.stream
+              .firstWhere(
+                (state) =>
+                    !state.isRefreshing &&
+                    state.status != ProfileLikedVideosStatus.syncing &&
+                    state.status != ProfileLikedVideosStatus.loading,
+              )
+              .timeout(const Duration(seconds: 1));
+
+          expect(settled.status, ProfileLikedVideosStatus.success);
+          expect(settled.videos, isEmpty);
+          // The start/end edges are what let the refresh settle — without them
+          // the terminal state equals the current one and bloc suppresses it.
+          expect(
+            emitted.map((state) => (state.status, state.isRefreshing)),
+            const [
+              (ProfileLikedVideosStatus.success, true),
+              (ProfileLikedVideosStatus.success, false),
+            ],
           );
         },
       );

--- a/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
@@ -225,6 +225,37 @@ void main() {
         ],
       );
 
+      test(
+        're-sync of a settled empty tab still settles (pull-to-refresh)',
+        () async {
+          when(
+            () => mockLikesRepository.syncUserReactions(),
+          ).thenAnswer((_) async => const LikesSyncResult.empty());
+          final bloc = createBloc();
+          addTearDown(bloc.close);
+
+          bloc.add(const ProfileLikedVideosSyncRequested());
+          await bloc.stream.firstWhere(
+            (state) => state.status == ProfileLikedVideosStatus.success,
+          );
+
+          // Mirrors how ProfileGridView's RefreshIndicator awaits this tab:
+          // it holds the spinner until the bloc reports a settled state.
+          bloc.add(const ProfileLikedVideosSyncRequested());
+          final settled = bloc.stream.firstWhere(
+            (state) =>
+                !state.isRefreshing &&
+                state.status != ProfileLikedVideosStatus.syncing &&
+                state.status != ProfileLikedVideosStatus.loading,
+          );
+
+          await expectLater(
+            settled.timeout(const Duration(seconds: 1)),
+            completes,
+          );
+        },
+      );
+
       blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
         'emits [success] with videos when liked videos found',
         setUp: () {

--- a/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
@@ -236,6 +236,37 @@ void main() {
         ],
       );
 
+      test(
+        're-sync of a settled empty tab still settles (pull-to-refresh)',
+        () async {
+          when(
+            () => mockRepostsRepository.syncUserReposts(),
+          ).thenAnswer((_) async => const RepostsSyncResult.empty());
+          final bloc = createBloc();
+          addTearDown(bloc.close);
+
+          bloc.add(const ProfileRepostedVideosSyncRequested());
+          await bloc.stream.firstWhere(
+            (state) => state.status == ProfileRepostedVideosStatus.success,
+          );
+
+          // Mirrors how ProfileGridView's RefreshIndicator awaits this tab:
+          // it holds the spinner until the bloc reports a settled state.
+          bloc.add(const ProfileRepostedVideosSyncRequested());
+          final settled = bloc.stream.firstWhere(
+            (state) =>
+                !state.isRefreshing &&
+                state.status != ProfileRepostedVideosStatus.syncing &&
+                state.status != ProfileRepostedVideosStatus.loading,
+          );
+
+          await expectLater(
+            settled.timeout(const Duration(seconds: 1)),
+            completes,
+          );
+        },
+      );
+
       blocTest<ProfileRepostedVideosBloc, ProfileRepostedVideosState>(
         'emits [success] with videos when reposts found',
         setUp: () {

--- a/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
@@ -252,17 +252,30 @@ void main() {
 
           // Mirrors how ProfileGridView's RefreshIndicator awaits this tab:
           // it holds the spinner until the bloc reports a settled state.
-          bloc.add(const ProfileRepostedVideosSyncRequested());
-          final settled = bloc.stream.firstWhere(
-            (state) =>
-                !state.isRefreshing &&
-                state.status != ProfileRepostedVideosStatus.syncing &&
-                state.status != ProfileRepostedVideosStatus.loading,
-          );
+          final emitted = <ProfileRepostedVideosState>[];
+          final subscription = bloc.stream.listen(emitted.add);
+          addTearDown(subscription.cancel);
 
-          await expectLater(
-            settled.timeout(const Duration(seconds: 1)),
-            completes,
+          bloc.add(const ProfileRepostedVideosSyncRequested());
+          final settled = await bloc.stream
+              .firstWhere(
+                (state) =>
+                    !state.isRefreshing &&
+                    state.status != ProfileRepostedVideosStatus.syncing &&
+                    state.status != ProfileRepostedVideosStatus.loading,
+              )
+              .timeout(const Duration(seconds: 1));
+
+          expect(settled.status, ProfileRepostedVideosStatus.success);
+          expect(settled.videos, isEmpty);
+          // The start/end edges are what let the refresh settle — without them
+          // the terminal state equals the current one and bloc suppresses it.
+          expect(
+            emitted.map((state) => (state.status, state.isRefreshing)),
+            const [
+              (ProfileRepostedVideosStatus.success, true),
+              (ProfileRepostedVideosStatus.success, false),
+            ],
           );
         },
       );

--- a/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
@@ -137,6 +137,37 @@ void main() {
         ],
       );
 
+      test(
+        're-sync of a settled empty tab still settles (pull-to-refresh)',
+        () async {
+          when(
+            () => mockBookmarkService.globalBookmarks,
+          ).thenReturn(const []);
+          final bloc = createBloc();
+          addTearDown(bloc.close);
+
+          bloc.add(const ProfileSavedVideosSyncRequested());
+          await bloc.stream.firstWhere(
+            (state) => state.status == ProfileSavedVideosStatus.success,
+          );
+
+          // Mirrors how ProfileGridView's RefreshIndicator awaits this tab:
+          // it holds the spinner until the bloc reports a settled state.
+          bloc.add(const ProfileSavedVideosSyncRequested());
+          final settled = bloc.stream.firstWhere(
+            (state) =>
+                !state.isRefreshing &&
+                state.status != ProfileSavedVideosStatus.syncing &&
+                state.status != ProfileSavedVideosStatus.loading,
+          );
+
+          await expectLater(
+            settled.timeout(const Duration(seconds: 1)),
+            completes,
+          );
+        },
+      );
+
       blocTest<ProfileSavedVideosBloc, ProfileSavedVideosState>(
         'reopen restores the cached list, then flips the bar off when '
         'bookmarks are unchanged',

--- a/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
@@ -153,17 +153,30 @@ void main() {
 
           // Mirrors how ProfileGridView's RefreshIndicator awaits this tab:
           // it holds the spinner until the bloc reports a settled state.
-          bloc.add(const ProfileSavedVideosSyncRequested());
-          final settled = bloc.stream.firstWhere(
-            (state) =>
-                !state.isRefreshing &&
-                state.status != ProfileSavedVideosStatus.syncing &&
-                state.status != ProfileSavedVideosStatus.loading,
-          );
+          final emitted = <ProfileSavedVideosState>[];
+          final subscription = bloc.stream.listen(emitted.add);
+          addTearDown(subscription.cancel);
 
-          await expectLater(
-            settled.timeout(const Duration(seconds: 1)),
-            completes,
+          bloc.add(const ProfileSavedVideosSyncRequested());
+          final settled = await bloc.stream
+              .firstWhere(
+                (state) =>
+                    !state.isRefreshing &&
+                    state.status != ProfileSavedVideosStatus.syncing &&
+                    state.status != ProfileSavedVideosStatus.loading,
+              )
+              .timeout(const Duration(seconds: 1));
+
+          expect(settled.status, ProfileSavedVideosStatus.success);
+          expect(settled.videos, isEmpty);
+          // The start/end edges are what let the refresh settle — without them
+          // the terminal state equals the current one and bloc suppresses it.
+          expect(
+            emitted.map((state) => (state.status, state.isRefreshing)),
+            const [
+              (ProfileSavedVideosStatus.success, true),
+              (ProfileSavedVideosStatus.success, false),
+            ],
           );
         },
       );

--- a/mobile/test/widgets/profile/profile_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_grid_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:comments_repository/comments_repository.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
@@ -18,6 +20,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/bookmark_service.dart';
 import 'package:openvine/widgets/profile/profile_grid.dart';
+import 'package:openvine/widgets/profile/profile_tab_kind.dart';
 import 'package:openvine/widgets/profile/profile_videos_grid_skeleton.dart';
 import 'package:reposts_repository/reposts_repository.dart';
 import 'package:videos_repository/videos_repository.dart';
@@ -284,6 +287,33 @@ void main() {
         await tester.pump();
 
         expect(find.byType(ProfileVideosGridSkeleton), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'pull-to-refresh completes after a viewed tab settled empty',
+      (tester) async {
+        await tester.pumpWidget(buildSubject(isOwnProfile: true));
+        await tester.pump();
+
+        // View Saved so it joins the set of tabs a refresh re-syncs, and let
+        // it settle on the empty bookmark list.
+        final tabBar = tester.widget<TabBar>(find.byType(TabBar));
+        tabBar.controller!.animateTo(
+          profileTabKinds(isOwnProfile: true).indexOf(ProfileTabKind.saved),
+        );
+        await tester.pumpAndSettle();
+
+        final refreshIndicator = tester.widget<RefreshIndicator>(
+          find.byType(RefreshIndicator),
+        );
+        var refreshed = false;
+        unawaited(refreshIndicator.onRefresh().then((_) => refreshed = true));
+        await tester.pumpAndSettle();
+
+        // The spinner runs until this future resolves, so a tab that reports
+        // no state change leaves the user stuck on it forever.
+        expect(refreshed, isTrue);
       },
     );
 


### PR DESCRIPTION
Closes #6643

## Description

Pull-to-refresh on the own profile could spin forever and never release.

`ProfileGridView._refreshProfileContent` holds the `RefreshIndicator` until every viewed tab reports its next settled state, waiting on each tab bloc's stream. The saved/liked/reposted sync handlers only emitted `isRefreshing: true` when videos were already on screen. So when a tab had settled *empty*, a re-sync emitted a terminal state equal to the current one — and bloc suppresses equal states. Zero stream events, the awaited future never resolved, spinner stuck until the user left the screen.

Why this hits the own profile hardest: Saved only exists there, and an empty bookmark list is the common case. Liked and Reposted have the same shape and hit both own and other profiles once they are empty.

The fix sets the flag whenever a settled result is already on screen — empty included — so every re-sync has an observable start and end edge. The cold load (`status == initial`) is untouched, so first-load visuals do not change. Side effect worth noting: an empty tab now shows the thin revalidation bar during a refresh, where it previously gave no feedback at all.

Fixing it at the call site instead (timeout on the wait) would have masked the bloc lying about its own refresh state; `isRefreshing` documented itself as "cached content on screen" while the tab bar actually wants "a settled result is on screen", so the doc comments were corrected to match.

Comments is not affected — it emits a `loading` state on the way, which is already an observable transition.

Collabs does not hang for that same reason, but the second commit fixes it anyway: its `loading` emit is exactly what made a settled-empty re-fetch trade the empty grid for a full-tab spinner on every pull, leaving the fourth grid tab behaving differently from the three above. It now keeps the empty grid under the thin bar like the others, still shows the spinner when retrying from a failure screen, and clears `isRefreshing` in its catch block — without that last part an empty grid would reach the failure emit with the flag still on and hang the refresh in the new shape.

The residual hang window behind all of this — `droppable()` discarding a sync event during the post-settle cache write, which no `isRefreshing` edge can rescue — is tracked separately in #6644 and deliberately left out of this PR, since fixing it means moving every profile tab off `droppable()`.

**Related Issue:** 

## Out of Scope

None.

## Verification

- Repro captured as a test first: without the fix `pull-to-refresh completes after a viewed tab settled empty` fails in ~1s; with it, green.
- 3 bloc-level regression tests (saved / liked / reposted) mirror the exact predicate the widget waits on.
- `flutter analyze lib test integration_test` — clean.
- `flutter test` over `test/blocs/profile_*` and `test/widgets/profile` — 430 passing.
- Manually verified on a real Samsung Galaxy: own profile → open Saved (empty) → pull to refresh → spinner releases.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
