### PR TITLE
fix(support): hide feed tuning until backend ships

### DIFF
--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -47,7 +47,8 @@ enum FeatureFlag {
     'Feed Tuning Swipes',
     'Swipe left/right on the fullscreen feed to send "less/more like this" '
         'signals that personalize recommendations. Off by default until the '
-        'relay and recommendation backend are ready.',
+        'relay and recommendation backend are ready (funnelcake #691).',
+    audience: FeatureFlagAudience.internal,
   ),
   profileMonetizationLinks(
     'Profile Monetization Links',

--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -47,7 +47,7 @@ enum FeatureFlag {
     'Feed Tuning Swipes',
     'Swipe left/right on the fullscreen feed to send "less/more like this" '
         'signals that personalize recommendations. Off by default until the '
-        'relay and recommendation backend are ready (funnelcake #691).',
+        'relay and recommendation backend are ready.',
     audience: FeatureFlagAudience.internal,
   ),
   profileMonetizationLinks(

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -38,6 +38,7 @@ class BuildConfiguration {
         // Default OFF until the backend relay accepts kind-10050 (#4974 RC3).
         return const bool.fromEnvironment('FF_PUBLISH_DM_RELAY_LIST');
       case FeatureFlag.feedTuning:
+        // TODO(#6649): Re-promote after divine-funnelcake#691 ships.
         return const bool.fromEnvironment('FF_FEED_TUNING');
       case FeatureFlag.profileMonetizationLinks:
         return const bool.fromEnvironment('FF_PROFILE_MONETIZATION_LINKS');

--- a/mobile/test/core/feature_flag_test.dart
+++ b/mobile/test/core/feature_flag_test.dart
@@ -63,6 +63,7 @@ void main() {
         FeatureFlag.publishDmRelayList.audience,
         FeatureFlagAudience.internal,
       );
+      expect(FeatureFlag.feedTuning.audience, FeatureFlagAudience.internal);
       expect(
         FeatureFlag.communityContentWarnings.audience,
         FeatureFlagAudience.internal,
@@ -77,7 +78,6 @@ void main() {
       expect(FeatureFlag.curatedLists.audience, FeatureFlagAudience.user);
       expect(FeatureFlag.blueskyPublishing.audience, FeatureFlagAudience.user);
       expect(FeatureFlag.videoReplies.audience, FeatureFlagAudience.user);
-      expect(FeatureFlag.feedTuning.audience, FeatureFlagAudience.user);
     });
   });
 }

--- a/mobile/test/screens/feature_flag_screen_test.dart
+++ b/mobile/test/screens/feature_flag_screen_test.dart
@@ -96,6 +96,7 @@ void main() {
         find.text(FeatureFlag.publishDmRelayList.displayName),
         findsNothing,
       );
+      expect(find.text(FeatureFlag.feedTuning.displayName), findsNothing);
     });
 
     testWidgets('shows internal flags when developer mode is on', (
@@ -121,6 +122,7 @@ void main() {
         find.text(FeatureFlag.publishDmRelayList.displayName),
         findsOneWidget,
       );
+      expect(find.text(FeatureFlag.feedTuning.displayName), findsOneWidget);
     });
 
     testWidgets('should display all flags', (tester) async {
@@ -346,9 +348,7 @@ void main() {
       // The app bar's reset-all action is the only way back to defaults.
       await tester.tap(
         find.bySemanticsLabel(
-          lookupAppLocalizations(
-            const Locale('en'),
-          ).featureFlagResetAllTooltip,
+          lookupAppLocalizations(const Locale('en')).featureFlagResetAllTooltip,
         ),
       );
       await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
- mark Feed Tuning Swipes as an internal-only experiment while divine-funnelcake#691 is still outstanding
- keep the flag description user-readable and document the backend dependency in `BuildConfiguration`
- add mobile follow-up #6649 to re-promote the flag after backend support ships
- pin feedTuning in the staged/internal flag tests and screen visibility coverage

## Verification
- flutter test test/core/feature_flag_test.dart test/services/feature_flag_service_test.dart test/providers/feature_flag_provider_test.dart test/screens/feature_flag_screen_test.dart
- flutter analyze
- pre-push hook: analyzer + changed-file tests

Closes #6344

Backend tracker: divinevideo/divine-funnelcake#691
Mobile follow-up: #6649