### PR TITLE
fix(recorder): flush autosave on background

### DIFF
--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -720,6 +720,18 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     });
   }
 
+  /// Immediately persist a debounced autosave that has not fired yet.
+  ///
+  /// Returns `false` when there is no pending autosave or the write fails.
+  Future<bool> flushPendingAutosave() async {
+    final timer = _autosaveTimer;
+    if (timer == null || !timer.isActive) return false;
+
+    timer.cancel();
+    _autosaveTimer = null;
+    return autosaveChanges();
+  }
+
   /// Automatically save the current video project state.
   ///
   /// This method is typically called periodically or on significant changes

--- a/mobile/lib/screens/video_recorder_screen.dart
+++ b/mobile/lib/screens/video_recorder_screen.dart
@@ -208,12 +208,10 @@ class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
     );
 
     final draftService = ref.read(draftStorageServiceProvider);
-    final draft = await draftService.getDraftById(
-      VideoEditorConstants.autoSaveId,
-    );
+    final draft = await draftService.getAutosaveDraft();
     if (!mounted) return;
 
-    if (draft != null && draft.hasBeenEdited) {
+    if (draft != null && draft.clips.isNotEmpty) {
       Log.info(
         '📹 Found valid autosaved draft',
         name: 'VideoRecorderScreen',

--- a/mobile/lib/screens/video_recorder_screen.dart
+++ b/mobile/lib/screens/video_recorder_screen.dart
@@ -211,7 +211,7 @@ class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
     final draft = await draftService.getAutosaveDraft();
     if (!mounted) return;
 
-    if (draft != null && draft.clips.isNotEmpty) {
+    if (draft != null) {
       Log.info(
         '📹 Found valid autosaved draft',
         name: 'VideoRecorderScreen',

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -464,12 +464,6 @@ class DraftStorageService {
     return getValidatedDraftById(VideoEditorConstants.autoSaveId);
   }
 
-  /// Check if a valid autosave draft exists (with at least one valid clip).
-  Future<bool> hasValidAutosave() async {
-    final draft = await getAutosaveDraft();
-    return draft != null && draft.clips.isNotEmpty;
-  }
-
   DivineVideoDraft? _validatedDraft(DivineVideoDraft draft) {
     final validClips = _filterValidClips(draft.clips);
     if (validClips.isEmpty) {

--- a/mobile/lib/widgets/app_lifecycle_handler.dart
+++ b/mobile/lib/widgets/app_lifecycle_handler.dart
@@ -13,6 +13,7 @@ import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/services/account_state_resume_refresher.dart';
 import 'package:openvine/services/auth_service.dart';
@@ -149,6 +150,9 @@ class _AppLifecycleHandlerState extends ConsumerState<AppLifecycleHandler>
         );
 
       case AppLifecycleState.inactive:
+        unawaited(
+          ref.read(videoEditorProvider.notifier).flushPendingAutosave(),
+        );
         // On desktop, inactive happens during normal UI operations (clicking, menu interactions, etc.)
         // Don't treat this as backgrounded - videos should continue playing
         Log.debug(
@@ -159,6 +163,9 @@ class _AppLifecycleHandlerState extends ConsumerState<AppLifecycleHandler>
 
       case AppLifecycleState.paused:
       case AppLifecycleState.hidden:
+        unawaited(
+          ref.read(videoEditorProvider.notifier).flushPendingAutosave(),
+        );
         Log.info(
           '📱 App backgrounded - disabling foreground playback gates',
           name: 'AppLifecycleHandler',

--- a/mobile/lib/widgets/app_lifecycle_handler.dart
+++ b/mobile/lib/widgets/app_lifecycle_handler.dart
@@ -98,6 +98,15 @@ class _AppLifecycleHandlerState extends ConsumerState<AppLifecycleHandler>
     // Notify background activity manager first
     _backgroundManager.onAppLifecycleStateChanged(state);
 
+    if (state != AppLifecycleState.resumed) {
+      // Inactive is routine on desktop, but this no-ops unless an editor
+      // autosave debounce is pending. Detached may be the only signal before
+      // process teardown, so flush before the state-specific work below.
+      unawaited(
+        ref.read(videoEditorProvider.notifier).flushPendingAutosave(),
+      );
+    }
+
     switch (state) {
       case AppLifecycleState.resumed:
         Log.info(
@@ -150,9 +159,6 @@ class _AppLifecycleHandlerState extends ConsumerState<AppLifecycleHandler>
         );
 
       case AppLifecycleState.inactive:
-        unawaited(
-          ref.read(videoEditorProvider.notifier).flushPendingAutosave(),
-        );
         // On desktop, inactive happens during normal UI operations (clicking, menu interactions, etc.)
         // Don't treat this as backgrounded - videos should continue playing
         Log.debug(
@@ -163,9 +169,6 @@ class _AppLifecycleHandlerState extends ConsumerState<AppLifecycleHandler>
 
       case AppLifecycleState.paused:
       case AppLifecycleState.hidden:
-        unawaited(
-          ref.read(videoEditorProvider.notifier).flushPendingAutosave(),
-        );
         Log.info(
           '📱 App backgrounded - disabling foreground playback gates',
           name: 'AppLifecycleHandler',

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -2883,6 +2883,96 @@ void main() {
     });
   });
 
+  group('flushPendingAutosave', () {
+    late _MockDraftStorageService mockDraftStorage;
+    late AppDatabase database;
+    late ProviderContainer container;
+
+    setUpAll(() {
+      registerFallbackValue(
+        DivineVideoDraft.create(
+          id: 'fallback',
+          clips: const [],
+          title: '',
+          description: '',
+          hashtags: const {},
+          selectedApproach: 'video',
+        ),
+      );
+    });
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      mockDraftStorage = _MockDraftStorageService();
+      database = AppDatabase.test(NativeDatabase.memory());
+      container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          draftStorageServiceProvider.overrideWithValue(mockDraftStorage),
+          databaseProvider.overrideWithValue(database),
+        ],
+      );
+    });
+
+    tearDown(() async {
+      container.dispose();
+      await database.close();
+    });
+
+    void stubSuccessfulAutosave() {
+      when(
+        () => mockDraftStorage.saveDraft(
+          any(),
+          deferOrphanCleanup: any(named: 'deferOrphanCleanup'),
+        ),
+      ).thenAnswer((_) async {});
+    }
+
+    test('returns false without writing when no autosave is pending', () async {
+      final result = await container
+          .read(videoEditorProvider.notifier)
+          .flushPendingAutosave();
+
+      expect(result, isFalse);
+      verifyNever(
+        () => mockDraftStorage.saveDraft(
+          any(),
+          deferOrphanCleanup: any(named: 'deferOrphanCleanup'),
+        ),
+      );
+    });
+
+    test('persists pending autosave and prevents timer re-fire', () {
+      stubSuccessfulAutosave();
+
+      fakeAsync((async) {
+        final notifier = container.read(videoEditorProvider.notifier);
+        notifier.updateMetadata(title: 'Almost lost');
+
+        bool? result;
+        notifier.flushPendingAutosave().then((value) => result = value);
+        async.flushMicrotasks();
+
+        expect(result, isTrue);
+        final captured =
+            verify(
+                  () => mockDraftStorage.saveDraft(
+                    captureAny(),
+                    deferOrphanCleanup: any(named: 'deferOrphanCleanup'),
+                  ),
+                ).captured.single
+                as DivineVideoDraft;
+        expect(captured.title, 'Almost lost');
+
+        async.elapse(const Duration(milliseconds: 801));
+        async.flushMicrotasks();
+
+        verifyNoMoreInteractions(mockDraftStorage);
+      });
+    });
+  });
+
   group('VideoEditorProvider deferred file cleanup', () {
     late _MockDraftStorageService mockDraftStorage;
     late AppDatabase database;

--- a/mobile/test/screens/video_recorder_screen_test.dart
+++ b/mobile/test/screens/video_recorder_screen_test.dart
@@ -637,9 +637,16 @@ void main() {
         await tester.pump();
 
         // Bottom sheet should be visible
-        expect(find.text('We found work in progress'), findsOneWidget);
-        expect(find.text('Yes, continue'), findsOneWidget);
-        expect(find.text('No, start a new video'), findsOneWidget);
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.videoRecorderAutosaveFoundTitle), findsOneWidget);
+        expect(
+          find.text(l10n.videoRecorderAutosaveContinueButton),
+          findsOneWidget,
+        );
+        expect(
+          find.text(l10n.videoRecorderAutosaveDiscardButton),
+          findsOneWidget,
+        );
       });
 
       testWidgets('shows bottom sheet when autosaved draft only has clips', (
@@ -705,8 +712,12 @@ void main() {
         await tester.pump();
 
         // Clips-only sessions still represent user work and must be reachable.
-        expect(find.text('We found work in progress'), findsOneWidget);
-        expect(find.text('Yes, continue'), findsOneWidget);
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.videoRecorderAutosaveFoundTitle), findsOneWidget);
+        expect(
+          find.text(l10n.videoRecorderAutosaveContinueButton),
+          findsOneWidget,
+        );
       });
 
       testWidgets('does not show bottom sheet when no draft exists', (
@@ -750,7 +761,8 @@ void main() {
         await tester.pump(const Duration(milliseconds: 100));
         await tester.pump();
 
-        expect(find.text('We found work in progress'), findsNothing);
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.videoRecorderAutosaveFoundTitle), findsNothing);
       });
     });
   });

--- a/mobile/test/screens/video_recorder_screen_test.dart
+++ b/mobile/test/screens/video_recorder_screen_test.dart
@@ -86,9 +86,7 @@ late SharedPreferences testPrefs;
 /// recorder's autosave/clip checks resolve to empty during tests.
 List<Override> _stubStorageOverrides() {
   final mockDraftStorage = _MockDraftStorageService();
-  when(
-    () => mockDraftStorage.getDraftById(any()),
-  ).thenAnswer((_) async => null);
+  when(mockDraftStorage.getAutosaveDraft).thenAnswer((_) async => null);
   final mockClipLibrary = _MockClipLibraryService();
   when(mockClipLibrary.getAllClips).thenAnswer((_) async => []);
   return [
@@ -603,7 +601,7 @@ void main() {
           publishAttempts: 0,
         );
         when(
-          () => mockDraftStorage.getDraftById(any()),
+          mockDraftStorage.getAutosaveDraft,
         ).thenAnswer((_) async => editedDraft);
 
         final mockClipLibrary = _MockClipLibraryService();
@@ -644,15 +642,14 @@ void main() {
         expect(find.text('No, start a new video'), findsOneWidget);
       });
 
-      testWidgets('does not show bottom sheet when draft has no edits', (
+      testWidgets('shows bottom sheet when autosaved draft only has clips', (
         tester,
       ) async {
         SharedPreferences.setMockInitialValues({'why_six_seconds_shown': true});
         final prefs = await SharedPreferences.getInstance();
 
         final mockDraftStorage = _MockDraftStorageService();
-        // Draft with clips but no metadata edits → hasBeenEdited = false
-        final uneditedDraft = DivineVideoDraft(
+        final clipsOnlyDraft = DivineVideoDraft(
           id: 'autosave',
           clips: [
             DivineVideoClip(
@@ -674,8 +671,8 @@ void main() {
           publishAttempts: 0,
         );
         when(
-          () => mockDraftStorage.getDraftById(any()),
-        ).thenAnswer((_) async => uneditedDraft);
+          mockDraftStorage.getAutosaveDraft,
+        ).thenAnswer((_) async => clipsOnlyDraft);
 
         final mockClipLibrary = _MockClipLibraryService();
         when(mockClipLibrary.getAllClips).thenAnswer((_) async => []);
@@ -707,8 +704,9 @@ void main() {
         await tester.pump(const Duration(milliseconds: 100));
         await tester.pump();
 
-        // Bottom sheet should NOT appear
-        expect(find.text('We found work in progress'), findsNothing);
+        // Clips-only sessions still represent user work and must be reachable.
+        expect(find.text('We found work in progress'), findsOneWidget);
+        expect(find.text('Yes, continue'), findsOneWidget);
       });
 
       testWidgets('does not show bottom sheet when no draft exists', (
@@ -719,7 +717,7 @@ void main() {
 
         final mockDraftStorage = _MockDraftStorageService();
         when(
-          () => mockDraftStorage.getDraftById(any()),
+          mockDraftStorage.getAutosaveDraft,
         ).thenAnswer((_) async => null);
 
         final mockClipLibrary = _MockClipLibraryService();

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -833,7 +833,6 @@ void main() {
         expect(autosave, isNotNull);
         expect(autosave!.clips, hasLength(1));
         expect(autosave.clips.single.isStopMotion, isTrue);
-        expect(await service.hasValidAutosave(), isTrue);
       });
 
       test(

--- a/mobile/test/widgets/app_lifecycle_handler_test.dart
+++ b/mobile/test/widgets/app_lifecycle_handler_test.dart
@@ -1,19 +1,34 @@
 // ABOUTME: Regression tests for app-level lifecycle autosave handling
 // ABOUTME: Verifies pending editor autosaves flush before background kills
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
+import 'package:openvine/models/video_publish/video_publish_provider_state.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/background_activity_manager.dart';
+import 'package:openvine/services/clip_library_service.dart';
+import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/widgets/app_lifecycle_handler.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
+
+class _MockClipLibraryService extends Mock implements ClipLibraryService {}
+
+class _MockDraftStorageService extends Mock implements DraftStorageService {}
+
+class _NoopVideoPublishNotifier extends VideoPublishNotifier {
+  @override
+  VideoPublishProviderState build() => const VideoPublishProviderState();
+
+  @override
+  Future<void> resumePendingPublishes(BuildContext context) async {}
+}
 
 class _FlushTrackingVideoEditorNotifier extends VideoEditorNotifier {
   int flushCalls = 0;
@@ -33,11 +48,21 @@ void main() {
     tester,
   ) async {
     final authService = _MockAuthService();
-    final authStateController = StreamController<AuthState>();
-    when(() => authService.isAuthenticated).thenReturn(false);
+    addTearDown(() {
+      BackgroundActivityManager().onAppLifecycleStateChanged(
+        AppLifecycleState.resumed,
+      );
+    });
+
+    when(() => authService.isAuthenticated).thenReturn(true);
     when(
       () => authService.authStateStream,
-    ).thenAnswer((_) => authStateController.stream);
+    ).thenAnswer((_) => const Stream<AuthState>.empty());
+    final clipLibraryService = _MockClipLibraryService();
+    when(clipLibraryService.migrateOldClips).thenAnswer((_) async {});
+    when(clipLibraryService.purgeExpiredTrash).thenAnswer((_) async => 0);
+    final draftStorageService = _MockDraftStorageService();
+    when(draftStorageService.migrateOldDrafts).thenAnswer((_) async {});
 
     final editorNotifier = _FlushTrackingVideoEditorNotifier();
 
@@ -46,6 +71,9 @@ void main() {
         overrides: [
           authServiceProvider.overrideWithValue(authService),
           videoEditorProvider.overrideWith(() => editorNotifier),
+          videoPublishProvider.overrideWith(_NoopVideoPublishNotifier.new),
+          clipLibraryServiceProvider.overrideWithValue(clipLibraryService),
+          draftStorageServiceProvider.overrideWithValue(draftStorageService),
         ],
         child: const MaterialApp(
           home: AppLifecycleHandler(child: SizedBox.shrink()),
@@ -57,7 +85,9 @@ void main() {
     tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
     tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
 
+    // Do not simulate detached here: flutter_tester treats it as shell teardown.
     expect(editorNotifier.flushCalls, 3);
+    // Drain BackgroundActivityManager's private 30-second suspension timer.
     await tester.pump(const Duration(seconds: 31));
   });
 }

--- a/mobile/test/widgets/app_lifecycle_handler_test.dart
+++ b/mobile/test/widgets/app_lifecycle_handler_test.dart
@@ -1,0 +1,63 @@
+// ABOUTME: Regression tests for app-level lifecycle autosave handling
+// ABOUTME: Verifies pending editor autosaves flush before background kills
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/widgets/app_lifecycle_handler.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _FlushTrackingVideoEditorNotifier extends VideoEditorNotifier {
+  int flushCalls = 0;
+
+  @override
+  VideoEditorProviderState build() => VideoEditorProviderState();
+
+  @override
+  Future<bool> flushPendingAutosave() async {
+    flushCalls++;
+    return true;
+  }
+}
+
+void main() {
+  testWidgets('flushes pending autosave before background lifecycle states', (
+    tester,
+  ) async {
+    final authService = _MockAuthService();
+    final authStateController = StreamController<AuthState>();
+    when(() => authService.isAuthenticated).thenReturn(false);
+    when(
+      () => authService.authStateStream,
+    ).thenAnswer((_) => authStateController.stream);
+
+    final editorNotifier = _FlushTrackingVideoEditorNotifier();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authServiceProvider.overrideWithValue(authService),
+          videoEditorProvider.overrideWith(() => editorNotifier),
+        ],
+        child: const MaterialApp(
+          home: AppLifecycleHandler(child: SizedBox.shrink()),
+        ),
+      ),
+    );
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+
+    expect(editorNotifier.flushCalls, 3);
+    await tester.pump(const Duration(seconds: 31));
+  });
+}


### PR DESCRIPTION
## Summary
- flush pending debounced editor autosaves when the app becomes inactive, paused, or hidden
- restore autosave recovery from the validated autosave draft path
- prompt for clips-only autosave drafts so recorded cuts are reachable after relaunch

## Verification
- flutter test test/providers/video_editor_provider_test.dart
- flutter test test/screens/video_recorder_screen_test.dart
- flutter test test/widgets/app_lifecycle_handler_test.dart
- flutter analyze
- pre-push hook analyzer and changed tests

Closes #6562