### PR TITLE
fix(support): persist edited captions

### DIFF
--- a/mobile/lib/blocs/profile_feed/profile_feed_enrichment_merge.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_enrichment_merge.dart
@@ -97,7 +97,12 @@ VideoEvent _mergeEnrichmentIntoCurrent(
     textTrackRefs: current.textTrackRefs.isNotEmpty
         ? current.textTrackRefs
         : enriched.textTrackRefs,
-    textTrackContent: current.textTrackContent ?? enriched.textTrackContent,
+    textTrackContent:
+        current.textTrackContent ??
+        ((current.textTrackRef?.isNotEmpty ?? false) ||
+                current.textTrackRefs.isNotEmpty
+            ? null
+            : enriched.textTrackContent),
     nostrEventTags: current.nostrEventTags.isNotEmpty
         ? current.nostrEventTags
         : enriched.nostrEventTags,

--- a/mobile/lib/blocs/subtitle_editor/subtitle_editor_cubit.dart
+++ b/mobile/lib/blocs/subtitle_editor/subtitle_editor_cubit.dart
@@ -73,7 +73,7 @@ class SubtitleEditorCubit extends Cubit<SubtitleEditorState> {
     if (isClosed) return;
     emit(state.copyWith(status: SubtitleEditorStatus.saving));
     try {
-      await _repository.publishEditedSubtitles(
+      final updatedVideo = await _repository.publishEditedSubtitles(
         video: _video,
         cues: state.cues.map((c) => c.toCue()).toList(),
       );
@@ -82,6 +82,7 @@ class SubtitleEditorCubit extends Cubit<SubtitleEditorState> {
         state.copyWith(
           status: SubtitleEditorStatus.success,
           isDirty: false,
+          updatedVideo: updatedVideo,
         ),
       );
     } catch (e, st) {

--- a/mobile/lib/blocs/subtitle_editor/subtitle_editor_state.dart
+++ b/mobile/lib/blocs/subtitle_editor/subtitle_editor_state.dart
@@ -71,6 +71,7 @@ class SubtitleEditorState extends Equatable {
     this.status = SubtitleEditorStatus.loading,
     this.cues = const [],
     this.isDirty = false,
+    this.updatedVideo,
   });
 
   /// Current editor status.
@@ -82,19 +83,24 @@ class SubtitleEditorState extends Equatable {
   /// Whether [cues] have been modified since the last save or load.
   final bool isDirty;
 
+  /// Updated video event returned after a successful subtitle republish.
+  final VideoEvent? updatedVideo;
+
   /// Returns a copy with selected fields replaced.
   SubtitleEditorState copyWith({
     SubtitleEditorStatus? status,
     List<EditableCue>? cues,
     bool? isDirty,
+    VideoEvent? updatedVideo,
   }) {
     return SubtitleEditorState(
       status: status ?? this.status,
       cues: cues ?? this.cues,
       isDirty: isDirty ?? this.isDirty,
+      updatedVideo: updatedVideo ?? this.updatedVideo,
     );
   }
 
   @override
-  List<Object?> get props => [status, cues, isDirty];
+  List<Object?> get props => [status, cues, isDirty, updatedVideo];
 }

--- a/mobile/lib/repositories/subtitle_repository.dart
+++ b/mobile/lib/repositories/subtitle_repository.dart
@@ -70,6 +70,7 @@ class SubtitleRepository {
                 video.textTrackRef!,
             ],
       sha256: video.sha256,
+      sourcePreference: SubtitleSourcePreference.refsFirst,
     );
   }
 
@@ -83,7 +84,7 @@ class SubtitleRepository {
   /// * [SubtitleEditException] when the Blossom upload fails.
   /// * [SubtitleEditException] when the subtitle event publish fails.
   /// * [SubtitleEditException] when the video republish fails.
-  Future<void> publishEditedSubtitles({
+  Future<VideoEvent> publishEditedSubtitles({
     required VideoEvent video,
     required List<SubtitleCue> cues,
     String lang = 'en',
@@ -115,14 +116,15 @@ class SubtitleRepository {
       throw SubtitleEditException('Subtitle event publish failed');
     }
 
-    final ok = await _publisher.republishWithSubtitles(
+    final updatedVideo = await _publisher.republishWithSubtitles(
       existingEvent: video,
       textTrackRef: blossomUrl,
       extraTextTrackRefs: [coordsRef],
       textTrackLang: lang,
     );
-    if (!ok) {
+    if (updatedVideo == null) {
       throw SubtitleEditException('Video republish failed');
     }
+    return updatedVideo;
   }
 }

--- a/mobile/lib/screens/subtitle_editor/subtitle_editor_screen.dart
+++ b/mobile/lib/screens/subtitle_editor/subtitle_editor_screen.dart
@@ -132,7 +132,7 @@ class SubtitleEditorView extends StatelessWidget {
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(content: Text(l10n.subtitleEditorSaveSuccess)),
             );
-            context.pop();
+            context.pop(state.updatedVideo);
           } else if (state.status == SubtitleEditorStatus.failure) {
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(

--- a/mobile/lib/services/subtitle_fetcher.dart
+++ b/mobile/lib/services/subtitle_fetcher.dart
@@ -15,6 +15,15 @@ const _maxBlossomPollAttempts = 4;
 const _maxBlossomPollWait = Duration(seconds: 15);
 const _defaultBlossomRetryAfter = Duration(seconds: 3);
 
+/// Source ordering for [fetchSubtitleCues].
+enum SubtitleSourcePreference {
+  /// Prefer embedded REST VTT before trying text-track refs.
+  embeddedFirst,
+
+  /// Prefer text-track refs before embedded REST VTT.
+  refsFirst,
+}
+
 Duration _parseRetryAfter(Map<String, String> headers) {
   final rawValue = headers['retry-after'];
   if (rawValue == null) return _defaultBlossomRetryAfter;
@@ -124,9 +133,17 @@ Future<List<SubtitleCue>> fetchSubtitleCues({
   String? textTrackContent,
   List<String> textTrackRefs = const [],
   String? sha256,
+  SubtitleSourcePreference sourcePreference =
+      SubtitleSourcePreference.embeddedFirst,
 }) async {
-  if (textTrackContent != null && textTrackContent.isNotEmpty) {
+  List<SubtitleCue>? embeddedCues() {
+    if (textTrackContent == null || textTrackContent.isEmpty) return null;
     return SubtitleService.parseVtt(textTrackContent);
+  }
+
+  if (sourcePreference == SubtitleSourcePreference.embeddedFirst) {
+    final cues = embeddedCues();
+    if (cues != null) return cues;
   }
 
   for (final ref in textTrackRefs) {
@@ -149,6 +166,11 @@ Future<List<SubtitleCue>> fetchSubtitleCues({
         );
       }
     }
+  }
+
+  if (sourcePreference == SubtitleSourcePreference.refsFirst) {
+    final cues = embeddedCues();
+    if (cues != null) return cues;
   }
 
   if (sha256 != null && sha256.isNotEmpty) {

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -31,6 +31,7 @@ import 'package:openvine/services/personal_event_cache_service.dart';
 import 'package:openvine/services/saved_sounds_service.dart';
 import 'package:openvine/services/upload_manager.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/services/video_event_tag_source.dart';
 import 'package:openvine/services/video_publish/publish_timeline.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:openvine/utils/collaborator_tags.dart';
@@ -1875,19 +1876,32 @@ class VideoEventPublisher {
   ///
   /// Strips any existing text-track tags from the original event, then emits
   /// one tag per ref ([textTrackRef] followed by each entry in
-  /// [extraTextTrackRefs]) for read-time redundancy. Returns true if
-  /// publishing succeeded.
-  Future<bool> republishWithSubtitles({
+  /// [extraTextTrackRefs]) for read-time redundancy. Returns the updated
+  /// video event after relay acceptance, or `null` if publishing failed.
+  Future<VideoEvent?> republishWithSubtitles({
     required VideoEvent existingEvent,
     required String textTrackRef,
     List<String> extraTextTrackRefs = const [],
     String textTrackLang = 'en',
   }) async {
     // Start from the original Nostr event tags, stripping old text-track tags.
-    final tags = existingEvent.nostrEventTags
-        .where((t) => t.isNotEmpty && t.first != 'text-track')
-        .map(List<String>.from)
-        .toList();
+    final tags =
+        sourceOriginalVideoTags(
+              video: existingEvent,
+              personalEventCache: _personalEventCache,
+            )
+            .where((t) => t.isNotEmpty && t.first != 'text-track')
+            .map(List<String>.from)
+            .toList();
+
+    if (!tags.any((tag) => tag.length >= 2 && tag.first == 'd')) {
+      Log.error(
+        'Cannot republish subtitles for video ${existingEvent.id}: missing d tag',
+        name: 'VideoEventPublisher',
+        category: LogCategory.video,
+      );
+      return null;
+    }
 
     for (final ref in [textTrackRef, ...extraTextTrackRefs]) {
       tags.add([
@@ -1904,6 +1918,7 @@ class VideoEventPublisher {
       kind: NIP71VideoKinds.getPreferredAddressableKind(),
       content: existingEvent.content,
       tags: tags,
+      createdAt: existingEvent.createdAt + 1,
     );
 
     if (event == null) {
@@ -1912,16 +1927,19 @@ class VideoEventPublisher {
         name: 'VideoEventPublisher',
         category: LogCategory.video,
       );
-      return false;
+      return null;
     }
 
     // Publish to relays before updating local cache. A WebSocket send is not
     // enough here; rejected subtitle republishes must not appear locally.
     final published = await _publishEventToNostr(event);
-    if (!published) return false;
+    if (!published) return null;
+
+    final updatedVideo = VideoEvent.fromNostrEvent(event);
 
     try {
-      _videoEventService?.addVideoEvent(VideoEvent.fromNostrEvent(event));
+      _personalEventCache?.cacheUserEvent(event);
+      _videoEventService?.updateVideoEvent(updatedVideo);
     } catch (e) {
       Log.warning(
         'Failed to update local cache after subtitle republish: $e',
@@ -1930,7 +1948,7 @@ class VideoEventPublisher {
       );
     }
 
-    return true;
+    return updatedVideo;
   }
 
   /// Publishes a Kind 39307 subtitle event for [video] and returns its

--- a/mobile/lib/services/video_event_tag_source.dart
+++ b/mobile/lib/services/video_event_tag_source.dart
@@ -1,0 +1,19 @@
+// ABOUTME: Shared helpers for sourcing raw Nostr tags before republishing.
+// ABOUTME: Recovers tags from the personal cache when JSON rehydration omits them.
+
+import 'package:models/models.dart' show VideoEvent;
+import 'package:openvine/services/personal_event_cache_service.dart';
+
+/// Returns the raw tags for [video], recovering them from [personalEventCache]
+/// when the in-memory copy came from a JSON snapshot that omits raw tags.
+List<List<String>> sourceOriginalVideoTags({
+  required VideoEvent video,
+  required PersonalEventCacheService? personalEventCache,
+}) {
+  if (video.nostrEventTags.isNotEmpty) return video.nostrEventTags;
+  final cached = personalEventCache?.getEventById(video.id);
+  if (cached == null) return const [];
+  return cached.tags
+      .map((tag) => (tag as List).map((e) => e.toString()).toList())
+      .toList();
+}

--- a/mobile/lib/services/video_metadata_update_service.dart
+++ b/mobile/lib/services/video_metadata_update_service.dart
@@ -12,6 +12,7 @@ import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/services/personal_event_cache_service.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/services/video_event_tag_source.dart';
 import 'package:openvine/utils/collaborator_tags.dart';
 import 'package:openvine/utils/inspired_by_tags.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -422,12 +423,10 @@ class VideoMetadataUpdateService {
   /// the personal cache so preservation is not silently defeated; if it is
   /// not cached, fall back to an empty list (the pre-existing behavior).
   List<List<String>> _sourceOriginalTags(VideoEvent video) {
-    if (video.nostrEventTags.isNotEmpty) return video.nostrEventTags;
-    final cached = _personalEventCache.getEventById(video.id);
-    if (cached == null) return const [];
-    return cached.tags
-        .map((tag) => (tag as List).map((e) => e.toString()).toList())
-        .toList();
+    return sourceOriginalVideoTags(
+      video: video,
+      personalEventCache: _personalEventCache,
+    );
   }
 
   /// Extracts all valid HTTP video URLs from the event's imeta tags.

--- a/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar.dart
+++ b/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar.dart
@@ -26,12 +26,14 @@ class VideoMetadataEditBottomBar extends ConsumerStatefulWidget {
     required this.video,
     required this.initialCollaboratorPubkeys,
     this.pendingThumbnailPath,
+    this.onVideoUpdated,
     super.key,
   });
 
   final VideoEvent video;
   final Set<String> initialCollaboratorPubkeys;
   final String? pendingThumbnailPath;
+  final ValueChanged<VideoEvent>? onVideoUpdated;
 
   @override
   ConsumerState<VideoMetadataEditBottomBar> createState() =>
@@ -45,11 +47,13 @@ class _VideoMetadataEditBottomBarState
 
   bool get _isBusy => _isUpdating || _isDeleting;
 
-  void _editSubtitles() {
-    context.push(
+  Future<void> _editSubtitles() async {
+    final updatedVideo = await context.push<VideoEvent>(
       SubtitleEditorScreen.pathFor(widget.video.id),
       extra: widget.video,
     );
+    if (!mounted || updatedVideo == null) return;
+    widget.onVideoUpdated?.call(updatedVideo);
   }
 
   Future<void> _updateVideo() async {

--- a/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_stack.dart
+++ b/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_stack.dart
@@ -33,10 +33,12 @@ class VideoMetadataEditStack extends StatefulWidget {
 
 class _VideoMetadataEditStackState extends State<VideoMetadataEditStack> {
   late final Set<String> _initialCollaboratorPubkeys;
+  late VideoEvent _video;
 
   @override
   void initState() {
     super.initState();
+    _video = widget.video;
     _initialCollaboratorPubkeys = widget.video.collaboratorPubkeys.toSet();
   }
 
@@ -45,8 +47,9 @@ class _VideoMetadataEditStackState extends State<VideoMetadataEditStack> {
     return ProviderScope(
       overrides: [videoEditorProvider.overrideWith(VideoEditorNotifier.new)],
       child: _VideoMetadataEditStackContent(
-        video: widget.video,
+        video: _video,
         initialCollaboratorPubkeys: _initialCollaboratorPubkeys,
+        onVideoUpdated: (video) => setState(() => _video = video),
       ),
     );
   }
@@ -58,10 +61,12 @@ class _VideoMetadataEditStackContent extends ConsumerStatefulWidget {
   const _VideoMetadataEditStackContent({
     required this.video,
     required this.initialCollaboratorPubkeys,
+    required this.onVideoUpdated,
   });
 
   final VideoEvent video;
   final Set<String> initialCollaboratorPubkeys;
+  final ValueChanged<VideoEvent> onVideoUpdated;
 
   @override
   ConsumerState<_VideoMetadataEditStackContent> createState() =>
@@ -168,6 +173,7 @@ class _VideoMetadataEditStackContentState
               video: widget.video,
               initialCollaboratorPubkeys: widget.initialCollaboratorPubkeys,
               pendingThumbnailPath: _pendingThumbnailPath,
+              onVideoUpdated: widget.onVideoUpdated,
             ),
           ),
         ],

--- a/mobile/packages/videos_repository/lib/src/profile_video_merge.dart
+++ b/mobile/packages/videos_repository/lib/src/profile_video_merge.dart
@@ -98,7 +98,12 @@ VideoEvent mergeProfileFeedVideos(VideoEvent existing, VideoEvent incoming) {
     textTrackRefs: primary.textTrackRefs.isNotEmpty
         ? primary.textTrackRefs
         : secondary.textTrackRefs,
-    textTrackContent: primary.textTrackContent ?? secondary.textTrackContent,
+    textTrackContent:
+        primary.textTrackContent ??
+        ((primary.textTrackRef?.isNotEmpty ?? false) ||
+                primary.textTrackRefs.isNotEmpty
+            ? null
+            : secondary.textTrackContent),
     nostrEventTags: primary.nostrEventTags.isNotEmpty
         ? primary.nostrEventTags
         : secondary.nostrEventTags,

--- a/mobile/packages/videos_repository/test/src/profile_video_merge_test.dart
+++ b/mobile/packages/videos_repository/test/src/profile_video_merge_test.dart
@@ -19,6 +19,7 @@ VideoEvent _video({
   List<List<String>> nostrEventTags = const [],
   String? textTrackRef,
   List<String> textTrackRefs = const [],
+  String? textTrackContent,
   List<String> contentWarningLabels = const [],
   int? originalLikes,
   int? originalComments,
@@ -45,6 +46,7 @@ VideoEvent _video({
     nostrEventTags: nostrEventTags,
     textTrackRef: textTrackRef,
     textTrackRefs: textTrackRefs,
+    textTrackContent: textTrackContent,
     contentWarningLabels: contentWarningLabels,
     originalLikes: originalLikes,
     originalComments: originalComments,
@@ -202,6 +204,31 @@ void main() {
         'https://media.divine.video/current-vtt',
         '39307:pubkey:subtitles:current-video-subtitles',
       ]);
+    });
+
+    test('does not inherit stale embedded text when primary has refs', () {
+      final merged = mergeProfileFeedVideos(
+        _video(
+          id: 'primary',
+          pubkey: 'pubkey',
+          createdAt: 2000,
+          vineId: 'video-subtitles',
+          textTrackRef: 'https://media.divine.video/current-vtt',
+        ),
+        _video(
+          id: 'secondary',
+          pubkey: 'pubkey',
+          createdAt: 1000,
+          vineId: 'video-subtitles',
+          textTrackContent: 'WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nstale\n',
+        ),
+      );
+
+      expect(
+        merged.textTrackRef,
+        equals('https://media.divine.video/current-vtt'),
+      );
+      expect(merged.textTrackContent, isNull);
     });
 
     test('primary fields fall back to secondary when null', () {

--- a/mobile/test/blocs/profile_feed/profile_feed_enrichment_merge_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_enrichment_merge_test.dart
@@ -12,6 +12,7 @@ VideoEvent _video({
   String? vineId,
   String? textTrackRef,
   List<String> textTrackRefs = const [],
+  String? textTrackContent,
 }) {
   return VideoEvent(
     id: id,
@@ -22,6 +23,7 @@ VideoEvent _video({
     vineId: vineId,
     textTrackRef: textTrackRef,
     textTrackRefs: textTrackRefs,
+    textTrackContent: textTrackContent,
   );
 }
 
@@ -55,6 +57,29 @@ void main() {
         'https://media.divine.video/subtitle-vtt',
         '39307:pubkey:subtitles:video-subtitles',
       ]);
+    });
+
+    test('does not inherit stale embedded text when current has refs', () {
+      final current = _video(
+        id: 'nostr',
+        vineId: 'video-subtitles',
+        textTrackRef: 'https://media.divine.video/edited.vtt',
+      );
+      final enriched = _video(
+        id: 'rest',
+        vineId: 'video-subtitles',
+        textTrackContent: 'WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nstale\n',
+      );
+
+      final merged = mergeProfileFeedEnrichment(
+        current: [current],
+        sourceKeys: {canonicalProfileFeedVideoKey(current)},
+        incoming: [enriched],
+        removeTombstones: (videos) => videos,
+      );
+
+      expect(merged.single.textTrackRef, current.textTrackRef);
+      expect(merged.single.textTrackContent, isNull);
     });
 
     test('does not reintroduce source videos missing from current state', () {

--- a/mobile/test/blocs/subtitle_editor/subtitle_editor_cubit_test.dart
+++ b/mobile/test/blocs/subtitle_editor/subtitle_editor_cubit_test.dart
@@ -21,6 +21,11 @@ final _video = VideoEvent(
   vineId: 'd1',
 );
 
+final VideoEvent _updatedVideo = _video.copyWith(
+  id: 'updated',
+  textTrackRef: 'https://media.divine.video/edited.vtt',
+);
+
 void main() {
   setUpAll(() => registerFallbackValue(_video));
 
@@ -115,7 +120,7 @@ void main() {
             video: any(named: 'video'),
             cues: any(named: 'cues'),
           ),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => _updatedVideo);
       },
       build: () => SubtitleEditorCubit(repository: repo, video: _video),
       act: (c) async {
@@ -131,7 +136,8 @@ void main() {
         ),
         isA<SubtitleEditorState>()
             .having((s) => s.status, 'status', SubtitleEditorStatus.success)
-            .having((s) => s.isDirty, 'isDirty', false),
+            .having((s) => s.isDirty, 'isDirty', false)
+            .having((s) => s.updatedVideo, 'updatedVideo', _updatedVideo),
       ],
     );
 
@@ -178,15 +184,15 @@ void main() {
       expect(cubit.state.status, SubtitleEditorStatus.loading);
 
       await cubit.close();
-      completer.complete(
-        const [SubtitleCue(start: 0, end: 1000, text: 'late')],
-      );
+      completer.complete(const [
+        SubtitleCue(start: 0, end: 1000, text: 'late'),
+      ]);
 
       await expectLater(loadFuture, completes);
     });
 
     test('save completes without emitting after close', () async {
-      final completer = Completer<void>();
+      final completer = Completer<VideoEvent>();
       when(
         () => repo.publishEditedSubtitles(
           video: any(named: 'video'),
@@ -199,7 +205,7 @@ void main() {
       expect(cubit.state.status, SubtitleEditorStatus.saving);
 
       await cubit.close();
-      completer.complete();
+      completer.complete(_updatedVideo);
 
       await expectLater(saveFuture, completes);
     });

--- a/mobile/test/repositories/subtitle_repository_test.dart
+++ b/mobile/test/repositories/subtitle_repository_test.dart
@@ -34,6 +34,15 @@ final _video = VideoEvent(
   vineId: 'my-vine-id',
 );
 
+final VideoEvent _updatedVideo = _video.copyWith(
+  id: 'vid2',
+  textTrackRef: 'https://media.divine.video/hash',
+  textTrackRefs: const [
+    'https://media.divine.video/hash',
+    '39307:pk1:subtitles:my-vine-id',
+  ],
+);
+
 const _cues = [SubtitleCue(start: 0, end: 1000, text: 'hi')];
 
 void main() {
@@ -90,6 +99,34 @@ void main() {
       expect(cues.single.text, equals('corrected'));
     });
 
+    test(
+      'loadCues prefers refs over stale embedded textTrackContent',
+      () async {
+        when(() => httpClient.get(any())).thenAnswer(
+          (_) async => http.Response(
+            'WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nedited\n',
+            200,
+          ),
+        );
+
+        final cues = await repo.loadCues(
+          VideoEvent(
+            id: 'vid1',
+            pubkey: 'pk1',
+            createdAt: 1,
+            content: '',
+            timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+            textTrackRef: 'https://media.divine.video/edited.vtt',
+            textTrackContent:
+                'WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nstale\n',
+          ),
+        );
+
+        expect(cues, hasLength(1));
+        expect(cues.single.text, equals('edited'));
+      },
+    );
+
     test('uploads VTT, publishes 39307, republishes with both refs', () async {
       when(
         () => blossom.uploadSubtitleVtt(bytes: any(named: 'bytes')),
@@ -115,9 +152,14 @@ void main() {
           extraTextTrackRefs: any(named: 'extraTextTrackRefs'),
           textTrackLang: any(named: 'textTrackLang'),
         ),
-      ).thenAnswer((_) async => true);
+      ).thenAnswer((_) async => _updatedVideo);
 
-      await repo.publishEditedSubtitles(video: _video, cues: _cues);
+      final updated = await repo.publishEditedSubtitles(
+        video: _video,
+        cues: _cues,
+      );
+
+      expect(updated, _updatedVideo);
 
       verify(
         () => publisher.republishWithSubtitles(

--- a/mobile/test/services/subtitle_fetcher_test.dart
+++ b/mobile/test/services/subtitle_fetcher_test.dart
@@ -35,6 +35,25 @@ void main() {
       expect(cues.first.text, equals('hello'));
     });
 
+    test('can prefer refs before embedded textTrackContent', () async {
+      final cues = await fetchSubtitleCues(
+        httpClient: _FakeClient(
+          (_) async => http.Response(
+            'WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nedited\n',
+            200,
+          ),
+        ),
+        nostrClient: null,
+        delay: (_) async {},
+        textTrackContent: 'WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nstale\n',
+        textTrackRefs: const ['https://media.divine.video/edited.vtt'],
+        sourcePreference: SubtitleSourcePreference.refsFirst,
+      );
+
+      expect(cues, hasLength(1));
+      expect(cues.first.text, equals('edited'));
+    });
+
     test(
       'falls back to second ref when first http ref is unavailable',
       () async {

--- a/mobile/test/services/video_event_publisher_subtitle_test.dart
+++ b/mobile/test/services/video_event_publisher_subtitle_test.dart
@@ -10,6 +10,7 @@ import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/personal_event_cache_service.dart';
 import 'package:openvine/services/upload_manager.dart';
 import 'package:openvine/services/video_event_publisher.dart';
 import 'package:openvine/services/video_event_service.dart';
@@ -21,6 +22,9 @@ class _MockNostrClient extends Mock implements NostrClient {}
 class _MockAuthService extends Mock implements AuthService {}
 
 class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _MockPersonalEventCacheService extends Mock
+    implements PersonalEventCacheService {}
 
 // Fake fallback values for mocktail any() matchers
 class _FakeEvent extends Fake implements Event {}
@@ -39,6 +43,7 @@ void main() {
   late _MockNostrClient mockNostrClient;
   late _MockAuthService mockAuthService;
   late _MockVideoEventService mockVideoEventService;
+  late _MockPersonalEventCacheService mockPersonalEventCache;
   late VideoEventPublisher publisher;
 
   setUpAll(() {
@@ -52,11 +57,13 @@ void main() {
     mockNostrClient = _MockNostrClient();
     mockAuthService = _MockAuthService();
     mockVideoEventService = _MockVideoEventService();
+    mockPersonalEventCache = _MockPersonalEventCacheService();
 
     publisher = VideoEventPublisher(
       uploadManager: mockUploadManager,
       nostrService: mockNostrClient,
       authService: mockAuthService,
+      personalEventCache: mockPersonalEventCache,
       videoEventService: mockVideoEventService,
     );
 
@@ -70,6 +77,9 @@ void main() {
     when(
       () => mockNostrClient.connectedRelays,
     ).thenReturn(['wss://relay.divine.video']);
+    when(() => mockPersonalEventCache.getEventById(any())).thenReturn(null);
+    when(() => mockPersonalEventCache.cacheUserEvent(any())).thenReturn(null);
+    when(() => mockVideoEventService.updateVideoEvent(any())).thenReturn(null);
   });
 
   group('republishWithSubtitles', () {
@@ -115,6 +125,7 @@ void main() {
             kind: any(named: 'kind'),
             content: any(named: 'content'),
             tags: any(named: 'tags'),
+            createdAt: any(named: 'createdAt'),
           ),
         ).thenAnswer((invocation) async {
           capturedTags = invocation.namedArguments[#tags] as List<List<String>>;
@@ -135,14 +146,16 @@ void main() {
           ),
         );
 
-        when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
+        when(
+          () => mockVideoEventService.updateVideoEvent(any()),
+        ).thenReturn(null);
 
         final result = await publisher.republishWithSubtitles(
           existingEvent: existingEvent,
           textTrackRef: textTrackRef,
         );
 
-        expect(result, isTrue);
+        expect(result, isA<VideoEvent>());
 
         // Verify createAndSignEvent was called with correct kind
         verify(
@@ -150,6 +163,7 @@ void main() {
             kind: NIP71VideoKinds.getPreferredAddressableKind(),
             content: existingEvent.content,
             tags: any(named: 'tags'),
+            createdAt: existingEvent.createdAt + 1,
           ),
         ).called(1);
 
@@ -185,6 +199,7 @@ void main() {
           kind: any(named: 'kind'),
           content: any(named: 'content'),
           tags: any(named: 'tags'),
+          createdAt: any(named: 'createdAt'),
         ),
       ).thenAnswer((invocation) async {
         capturedTags = invocation.namedArguments[#tags] as List<List<String>>;
@@ -205,7 +220,9 @@ void main() {
         ),
       );
 
-      when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
+      when(
+        () => mockVideoEventService.updateVideoEvent(any()),
+      ).thenReturn(null);
 
       await publisher.republishWithSubtitles(
         existingEvent: existingEvent,
@@ -228,6 +245,7 @@ void main() {
           kind: any(named: 'kind'),
           content: any(named: 'content'),
           tags: any(named: 'tags'),
+          createdAt: any(named: 'createdAt'),
         ),
       ).thenAnswer((_) async => createSignedEvent(existingTags));
 
@@ -245,7 +263,9 @@ void main() {
         ),
       );
 
-      when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
+      when(
+        () => mockVideoEventService.updateVideoEvent(any()),
+      ).thenReturn(null);
 
       await publisher.republishWithSubtitles(
         existingEvent: existingEvent,
@@ -257,6 +277,7 @@ void main() {
           kind: 34236,
           content: any(named: 'content'),
           tags: any(named: 'tags'),
+          createdAt: existingEvent.createdAt + 1,
         ),
       ).called(1);
     });
@@ -269,6 +290,7 @@ void main() {
           kind: any(named: 'kind'),
           content: any(named: 'content'),
           tags: any(named: 'tags'),
+          createdAt: any(named: 'createdAt'),
         ),
       ).thenAnswer((_) async => signedEvent);
 
@@ -286,7 +308,9 @@ void main() {
         ),
       );
 
-      when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
+      when(
+        () => mockVideoEventService.updateVideoEvent(any()),
+      ).thenReturn(null);
 
       await publisher.republishWithSubtitles(
         existingEvent: existingEvent,
@@ -301,12 +325,13 @@ void main() {
       ).called(1);
     });
 
-    test('returns false when signing fails', () async {
+    test('returns null when signing fails', () async {
       when(
         () => mockAuthService.createAndSignEvent(
           kind: any(named: 'kind'),
           content: any(named: 'content'),
           tags: any(named: 'tags'),
+          createdAt: any(named: 'createdAt'),
         ),
       ).thenAnswer((_) async => null);
 
@@ -315,7 +340,7 @@ void main() {
         textTrackRef: textTrackRef,
       );
 
-      expect(result, isFalse);
+      expect(result, isNull);
       verifyNever(
         () => mockNostrClient.publishEventAwaitOk(
           any(),
@@ -356,6 +381,7 @@ void main() {
           kind: any(named: 'kind'),
           content: any(named: 'content'),
           tags: any(named: 'tags'),
+          createdAt: any(named: 'createdAt'),
         ),
       ).thenAnswer((invocation) async {
         capturedTags = invocation.namedArguments[#tags] as List<List<String>>;
@@ -376,7 +402,9 @@ void main() {
         ),
       );
 
-      when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
+      when(
+        () => mockVideoEventService.updateVideoEvent(any()),
+      ).thenReturn(null);
 
       await publisher.republishWithSubtitles(
         existingEvent: eventWithTextTrack,
@@ -405,6 +433,7 @@ void main() {
           kind: any(named: 'kind'),
           content: any(named: 'content'),
           tags: any(named: 'tags'),
+          createdAt: any(named: 'createdAt'),
         ),
       ).thenAnswer((invocation) async {
         capturedTags = invocation.namedArguments[#tags] as List<List<String>>;
@@ -425,7 +454,9 @@ void main() {
         ),
       );
 
-      when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
+      when(
+        () => mockVideoEventService.updateVideoEvent(any()),
+      ).thenReturn(null);
 
       await publisher.republishWithSubtitles(
         existingEvent: existingEvent,
@@ -452,6 +483,7 @@ void main() {
           kind: any(named: 'kind'),
           content: any(named: 'content'),
           tags: any(named: 'tags'),
+          createdAt: any(named: 'createdAt'),
         ),
       ).thenAnswer((_) async => createSignedEvent(existingTags));
 
@@ -469,15 +501,105 @@ void main() {
         ),
       );
 
-      when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
+      when(
+        () => mockVideoEventService.updateVideoEvent(any()),
+      ).thenReturn(null);
 
       await publisher.republishWithSubtitles(
         existingEvent: existingEvent,
         textTrackRef: textTrackRef,
       );
 
-      verify(() => mockVideoEventService.addVideoEvent(any())).called(1);
+      verify(() => mockVideoEventService.updateVideoEvent(any())).called(1);
+      verify(() => mockPersonalEventCache.cacheUserEvent(any())).called(1);
     });
+
+    test(
+      'recovers original tags from personal cache when event tags are empty',
+      () async {
+        final taglessEvent = existingEvent.copyWith(nostrEventTags: const []);
+        final cachedEvent = Event(
+          testPubkey,
+          NIP71VideoKinds.getPreferredAddressableKind(),
+          existingTags,
+          existingEvent.content,
+          createdAt: existingEvent.createdAt,
+        );
+        late List<List<String>> capturedTags;
+
+        when(
+          () => mockPersonalEventCache.getEventById(taglessEvent.id),
+        ).thenReturn(cachedEvent);
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+            createdAt: any(named: 'createdAt'),
+          ),
+        ).thenAnswer((invocation) async {
+          capturedTags = invocation.namedArguments[#tags] as List<List<String>>;
+          return createSignedEvent(capturedTags);
+        });
+        when(
+          () => mockNostrClient.publishEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (invocation) async => PublishOutcome(
+            eventId: (invocation.positionalArguments.first as Event).id,
+            acceptedBy: const ['wss://relay.divine.video'],
+            rejectedBy: const {},
+            noResponseFrom: const [],
+          ),
+        );
+
+        final result = await publisher.republishWithSubtitles(
+          existingEvent: taglessEvent,
+          textTrackRef: textTrackRef,
+        );
+
+        expect(result, isA<VideoEvent>());
+        expect(_containsTag(capturedTags, ['d', 'test-vine-id']), isTrue);
+        expect(
+          _containsTag(capturedTags, [
+            'imeta',
+            'url https://cdn.example.com/video.mp4',
+            'm video/mp4',
+          ]),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'returns null without publishing when original d tag cannot be recovered',
+      () async {
+        final taglessEvent = existingEvent.copyWith(nostrEventTags: const []);
+
+        final result = await publisher.republishWithSubtitles(
+          existingEvent: taglessEvent,
+          textTrackRef: textTrackRef,
+        );
+
+        expect(result, isNull);
+        verifyNever(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+            createdAt: any(named: 'createdAt'),
+          ),
+        );
+        verifyNever(
+          () => mockNostrClient.publishEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+          ),
+        );
+      },
+    );
 
     test('does not update local cache when relay rejects republish', () async {
       when(
@@ -485,6 +607,7 @@ void main() {
           kind: any(named: 'kind'),
           content: any(named: 'content'),
           tags: any(named: 'tags'),
+          createdAt: any(named: 'createdAt'),
         ),
       ).thenAnswer((_) async => createSignedEvent(existingTags));
 
@@ -509,16 +632,14 @@ void main() {
         textTrackRef: textTrackRef,
       );
 
-      expect(result, isFalse);
-      verifyNever(() => mockVideoEventService.addVideoEvent(any()));
+      expect(result, isNull);
+      verifyNever(() => mockVideoEventService.updateVideoEvent(any()));
     });
 
     test(
       'publishSubtitleEvent signs a 39307 with d=subtitles:<vineId>',
       () async {
-        when(
-          () => mockAuthService.currentPublicKeyHex,
-        ).thenReturn(testPubkey);
+        when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPubkey);
 
         when(
           () => mockAuthService.createAndSignEvent(
@@ -593,6 +714,7 @@ void main() {
           kind: any(named: 'kind'),
           content: any(named: 'content'),
           tags: any(named: 'tags'),
+          createdAt: any(named: 'createdAt'),
         ),
       ).thenAnswer((invocation) async {
         capturedTags = invocation.namedArguments[#tags] as List<List<String>>;
@@ -613,7 +735,9 @@ void main() {
         ),
       );
 
-      when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
+      when(
+        () => mockVideoEventService.updateVideoEvent(any()),
+      ).thenReturn(null);
 
       await publisher.republishWithSubtitles(
         existingEvent: existingEvent,
@@ -627,6 +751,7 @@ void main() {
                   kind: any(named: 'kind'),
                   content: any(named: 'content'),
                   tags: captureAny(named: 'tags'),
+                  createdAt: any(named: 'createdAt'),
                 ),
               ).captured.single
               as List;

--- a/mobile/test/services/video_event_tag_source_test.dart
+++ b/mobile/test/services/video_event_tag_source_test.dart
@@ -1,0 +1,79 @@
+// ABOUTME: Tests for recovering raw Nostr tags before video republishing.
+// ABOUTME: Covers JSON-rehydrated VideoEvent copies that lost nostrEventTags.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:openvine/services/personal_event_cache_service.dart';
+import 'package:openvine/services/video_event_tag_source.dart';
+
+class _MockPersonalEventCacheService extends Mock
+    implements PersonalEventCacheService {}
+
+void main() {
+  group('sourceOriginalVideoTags', () {
+    const eventId = 'event-id';
+    const pubkey =
+        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+
+    final tags = <List<String>>[
+      ['d', 'video-id'],
+      ['title', 'Original title'],
+    ];
+
+    VideoEvent videoWithTags() => VideoEvent(
+      id: eventId,
+      pubkey: pubkey,
+      createdAt: 1700000000,
+      content: 'caption',
+      timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+      nostrEventTags: tags,
+    );
+
+    VideoEvent videoWithoutTags() => VideoEvent(
+      id: eventId,
+      pubkey: pubkey,
+      createdAt: 1700000000,
+      content: 'caption',
+      timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+    );
+
+    test('returns tags already present on the video', () {
+      final cache = _MockPersonalEventCacheService();
+
+      final result = sourceOriginalVideoTags(
+        video: videoWithTags(),
+        personalEventCache: cache,
+      );
+
+      expect(result, tags);
+      verifyNever(() => cache.getEventById(any()));
+    });
+
+    test('recovers tags from the personal cache when video tags are empty', () {
+      final cache = _MockPersonalEventCacheService();
+      final cachedEvent = Event(pubkey, 32222, tags, 'caption');
+      when(() => cache.getEventById(eventId)).thenReturn(cachedEvent);
+
+      final result = sourceOriginalVideoTags(
+        video: videoWithoutTags(),
+        personalEventCache: cache,
+      );
+
+      expect(result, tags);
+    });
+
+    test('returns an empty list when no tags can be recovered', () {
+      final cache = _MockPersonalEventCacheService();
+      when(() => cache.getEventById(eventId)).thenReturn(null);
+
+      final result = sourceOriginalVideoTags(
+        video: videoWithoutTags(),
+        personalEventCache: cache,
+      );
+
+      expect(result, isEmpty);
+    });
+  });
+}

--- a/mobile/test/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar_test.dart
@@ -26,7 +26,10 @@ void main() {
       );
     });
 
-    Widget buildSubject(MockGoRouter goRouter) {
+    Widget buildSubject(
+      MockGoRouter goRouter, {
+      ValueChanged<VideoEvent>? onVideoUpdated,
+    }) {
       return ProviderScope(
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -37,6 +40,7 @@ void main() {
               child: VideoMetadataEditBottomBar(
                 video: testVideo,
                 initialCollaboratorPubkeys: const {},
+                onVideoUpdated: onVideoUpdated,
               ),
             ),
           ),
@@ -47,7 +51,7 @@ void main() {
     testWidgets('navigates to subtitle editor when tapped', (tester) async {
       final mockGoRouter = MockGoRouter();
       when(
-        () => mockGoRouter.push<Object?>(any(), extra: any(named: 'extra')),
+        () => mockGoRouter.push<VideoEvent>(any(), extra: any(named: 'extra')),
       ).thenAnswer((_) async => null);
 
       await tester.pumpWidget(buildSubject(mockGoRouter));
@@ -56,11 +60,32 @@ void main() {
       await tester.pump();
 
       verify(
-        () => mockGoRouter.push<Object?>(
+        () => mockGoRouter.push<VideoEvent>(
           SubtitleEditorScreen.pathFor(testVideo.id),
           extra: testVideo,
         ),
       ).called(1);
+    });
+
+    testWidgets('adopts returned subtitle editor video', (tester) async {
+      final mockGoRouter = MockGoRouter();
+      final updatedVideo = testVideo.copyWith(
+        id: '1111111111111111111111111111111111111111111111111111111111111111',
+        textTrackRef: 'https://media.divine.video/edited.vtt',
+      );
+      VideoEvent? adopted;
+      when(
+        () => mockGoRouter.push<VideoEvent>(any(), extra: any(named: 'extra')),
+      ).thenAnswer((_) async => updatedVideo);
+
+      await tester.pumpWidget(
+        buildSubject(mockGoRouter, onVideoUpdated: (video) => adopted = video),
+      );
+
+      await tester.tap(find.text(l10n.videoEditEditSubtitles));
+      await tester.pump();
+
+      expect(adopted, updatedVideo);
     });
 
     testWidgets('uses DivineButton styling for subtitle editing', (


### PR DESCRIPTION
## Summary
- recover raw video tags from the personal event cache before subtitle republish, and refuse to publish when the addressable d tag cannot be recovered
- write accepted subtitle republishes through the personal cache and VideoEventService replacement path, returning the updated VideoEvent through the editor flow
- prefer signed text-track refs over stale embedded VTT while editing, and stop feed enrichment from reattaching stale embedded subtitle content when refs exist

## Notes
- Subtitle republish now signs with createdAt = existingEvent.createdAt + 1, matching the metadata-edit replacement path while preserving feed position.

Closes #6474

## Verification
- flutter analyze
- flutter test test/services/video_event_publisher_subtitle_test.dart test/repositories/subtitle_repository_test.dart test/services/subtitle_fetcher_test.dart test/blocs/profile_feed/profile_feed_enrichment_merge_test.dart test/blocs/subtitle_editor/subtitle_editor_cubit_test.dart test/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar_test.dart
- flutter test test/screens/subtitle_editor/subtitle_editor_screen_test.dart
- cd mobile/packages/videos_repository && flutter test test/src/profile_video_merge_test.dart
- cd mobile/packages/videos_repository && flutter test --coverage (100.0% line coverage)
- pre-push hook: analyze + changed-file tests