### PR TITLE
fix(profile): clarify staged banner uploads

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -439,7 +439,6 @@
     "profileSetupBannerSectionTitle": "ባነር",
     "profileSetupBannerUploadButton": "ፎቶ ስቀል",
     "profileSetupBannerClearButton": "ባነርን አጥፋ",
-    "profileSetupBannerUploadSuccess": "ባነር ተዘመነ",
     "profileSetupUsernameChecking": "ተገኝነትን በማጣራት ላይ...",
     "profileSetupUsernameAvailable": "የተጠቃሚ ስም አለ!",
     "profileSetupUsernameTakenIndicator": "የተጠቃሚ ስም አስቀድሞ ተወስዷል",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -382,7 +382,6 @@
     "profileSetupBannerSectionTitle": "الغلاف",
     "profileSetupBannerUploadButton": "رفع صورة",
     "profileSetupBannerClearButton": "مسح الغلاف",
-    "profileSetupBannerUploadSuccess": "تم تحديث الغلاف",
     "profileSetupUsernameChecking": "جاري التحقق من التوفر...",
     "profileSetupUsernameAvailable": "اسم المستخدم متاح!",
     "profileSetupUsernameTakenIndicator": "اسم المستخدم مأخوذ مسبقًا",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -413,7 +413,6 @@
     "profileSetupBannerSectionTitle": "Банер",
     "profileSetupBannerUploadButton": "Качи снимка",
     "profileSetupBannerClearButton": "Изчисти банера",
-    "profileSetupBannerUploadSuccess": "Банерът е обновен",
     "profileSetupUsernameChecking": "Проверява се наличността...",
     "profileSetupUsernameAvailable": "Потребителското име е свободно!",
     "profileSetupUsernameTakenIndicator": "Потребителското име вече е заето",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -382,7 +382,6 @@
     "profileSetupBannerSectionTitle": "Banner",
     "profileSetupBannerUploadButton": "Foto hochladen",
     "profileSetupBannerClearButton": "Banner entfernen",
-    "profileSetupBannerUploadSuccess": "Banner aktualisiert",
     "profileSetupUsernameChecking": "Verfügbarkeit wird geprüft...",
     "profileSetupUsernameAvailable": "Benutzername verfügbar!",
     "profileSetupUsernameTakenIndicator": "Benutzername bereits vergeben",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -489,10 +489,6 @@
   "@profileSetupBannerClearButton": {
     "description": "Label on the button that removes the currently selected profile banner image."
   },
-  "profileSetupBannerUploadSuccess": "Banner updated",
-  "@profileSetupBannerUploadSuccess": {
-    "description": "Snackbar message shown after a profile banner image is successfully uploaded."
-  },
   "profileSetupUsernameChecking": "Checking availability...",
   "profileSetupUsernameAvailable": "Username available!",
   "profileSetupUsernameTakenIndicator": "Username already taken",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -382,7 +382,6 @@
     "profileSetupBannerSectionTitle": "Banner",
     "profileSetupBannerUploadButton": "Subir foto",
     "profileSetupBannerClearButton": "Quitar banner",
-    "profileSetupBannerUploadSuccess": "Banner actualizado",
     "profileSetupUsernameChecking": "Verificando disponibilidad...",
     "profileSetupUsernameAvailable": "¡Nombre de usuario disponible!",
     "profileSetupUsernameTakenIndicator": "Ese nombre de usuario ya está ocupado",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -229,7 +229,6 @@
     "profileSetupBannerSectionTitle": "Banner",
     "profileSetupBannerUploadButton": "Mag-upload ng larawan",
     "profileSetupBannerClearButton": "I-clear ang banner",
-    "profileSetupBannerUploadSuccess": "Na-update ang banner",
     "profileSetupUsernameChecking": "Tinitingnan ang availability...",
     "profileSetupUsernameAvailable": "Available ang username!",
     "profileSetupUsernameTakenIndicator": "Nakuha na ang username",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -382,7 +382,6 @@
     "profileSetupBannerSectionTitle": "Bannière",
     "profileSetupBannerUploadButton": "Importer une photo",
     "profileSetupBannerClearButton": "Supprimer la bannière",
-    "profileSetupBannerUploadSuccess": "Bannière mise à jour",
     "profileSetupUsernameChecking": "Vérification de la disponibilité...",
     "profileSetupUsernameAvailable": "Nom d'utilisateur disponible !",
     "profileSetupUsernameTakenIndicator": "Nom d'utilisateur déjà pris",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -382,7 +382,6 @@
     "profileSetupBannerSectionTitle": "Banner",
     "profileSetupBannerUploadButton": "Unggah foto",
     "profileSetupBannerClearButton": "Hapus banner",
-    "profileSetupBannerUploadSuccess": "Banner diperbarui",
     "profileSetupUsernameChecking": "Mengecek ketersediaan...",
     "profileSetupUsernameAvailable": "Username tersedia!",
     "profileSetupUsernameTakenIndicator": "Username sudah diambil",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -382,7 +382,6 @@
     "profileSetupBannerSectionTitle": "Banner",
     "profileSetupBannerUploadButton": "Carica foto",
     "profileSetupBannerClearButton": "Rimuovi banner",
-    "profileSetupBannerUploadSuccess": "Banner aggiornato",
     "profileSetupUsernameChecking": "Controllo disponibilità...",
     "profileSetupUsernameAvailable": "Nome utente disponibile!",
     "profileSetupUsernameTakenIndicator": "Nome utente già preso",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -382,7 +382,6 @@
     "profileSetupBannerSectionTitle": "バナー",
     "profileSetupBannerUploadButton": "写真をアップロード",
     "profileSetupBannerClearButton": "バナーをクリア",
-    "profileSetupBannerUploadSuccess": "バナーを更新したよ",
     "profileSetupUsernameChecking": "使えるか確認中...",
     "profileSetupUsernameAvailable": "このユーザー名、使えるよ！",
     "profileSetupUsernameTakenIndicator": "このユーザー名はもう使われてる",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -229,7 +229,6 @@
     "profileSetupBannerSectionTitle": "배너",
     "profileSetupBannerUploadButton": "사진 업로드",
     "profileSetupBannerClearButton": "배너 지우기",
-    "profileSetupBannerUploadSuccess": "배너가 업데이트되었어요",
     "profileSetupUsernameChecking": "사용 가능 여부 확인 중...",
     "profileSetupUsernameAvailable": "사용 가능한 이름이에요!",
     "profileSetupUsernameTakenIndicator": "이미 사용 중인 이름이에요",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -481,10 +481,6 @@
   "@profileSetupBannerClearButton": {
     "description": "Label on the button that removes the currently selected profile banner image."
   },
-  "profileSetupBannerUploadSuccess": "Sepanduk dikemas kini",
-  "@profileSetupBannerUploadSuccess": {
-    "description": "Snackbar message shown after a profile banner image is successfully uploaded."
-  },
   "profileSetupUsernameChecking": "Menyemak ketersediaan...",
   "profileSetupUsernameAvailable": "Nama pengguna tersedia!",
   "profileSetupUsernameTakenIndicator": "Nama pengguna sudah diambil",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -382,7 +382,6 @@
     "profileSetupBannerSectionTitle": "Banner",
     "profileSetupBannerUploadButton": "Foto uploaden",
     "profileSetupBannerClearButton": "Banner wissen",
-    "profileSetupBannerUploadSuccess": "Banner bijgewerkt",
     "profileSetupUsernameChecking": "Beschikbaarheid controleren...",
     "profileSetupUsernameAvailable": "Gebruikersnaam beschikbaar!",
     "profileSetupUsernameTakenIndicator": "Gebruikersnaam al in gebruik",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -382,7 +382,6 @@
     "profileSetupBannerSectionTitle": "Baner",
     "profileSetupBannerUploadButton": "Prześlij zdjęcie",
     "profileSetupBannerClearButton": "Wyczyść baner",
-    "profileSetupBannerUploadSuccess": "Baner zaktualizowany",
     "profileSetupUsernameChecking": "Sprawdzanie dostępności...",
     "profileSetupUsernameAvailable": "Nazwa użytkownika dostępna!",
     "profileSetupUsernameTakenIndicator": "Nazwa użytkownika już zajęta",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -382,7 +382,6 @@
     "profileSetupBannerSectionTitle": "Banner",
     "profileSetupBannerUploadButton": "Enviar foto",
     "profileSetupBannerClearButton": "Remover banner",
-    "profileSetupBannerUploadSuccess": "Banner atualizado",
     "profileSetupUsernameChecking": "Verificando disponibilidade...",
     "profileSetupUsernameAvailable": "Nome de usuário disponível!",
     "profileSetupUsernameTakenIndicator": "Nome de usuário já em uso",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -382,7 +382,6 @@
     "profileSetupBannerSectionTitle": "Banner",
     "profileSetupBannerUploadButton": "Încarcă fotografie",
     "profileSetupBannerClearButton": "Șterge bannerul",
-    "profileSetupBannerUploadSuccess": "Banner actualizat",
     "profileSetupUsernameChecking": "Se verifică disponibilitatea...",
     "profileSetupUsernameAvailable": "Numele e disponibil!",
     "profileSetupUsernameTakenIndicator": "Numele e deja luat",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -382,7 +382,6 @@
     "profileSetupBannerSectionTitle": "Banner",
     "profileSetupBannerUploadButton": "Ladda upp foto",
     "profileSetupBannerClearButton": "Rensa banner",
-    "profileSetupBannerUploadSuccess": "Banner uppdaterad",
     "profileSetupUsernameChecking": "Kollar tillgänglighet...",
     "profileSetupUsernameAvailable": "Användarnamnet är ledigt!",
     "profileSetupUsernameTakenIndicator": "Användarnamnet är redan taget",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -382,7 +382,6 @@
     "profileSetupBannerSectionTitle": "Afiş",
     "profileSetupBannerUploadButton": "Fotoğraf yükle",
     "profileSetupBannerClearButton": "Afişi temizle",
-    "profileSetupBannerUploadSuccess": "Afiş güncellendi",
     "profileSetupUsernameChecking": "Uygunluk kontrol ediliyor...",
     "profileSetupUsernameAvailable": "Kullanıcı adı uygun!",
     "profileSetupUsernameTakenIndicator": "Kullanıcı adı zaten alınmış",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -481,10 +481,6 @@
   "@profileSetupBannerClearButton": {
     "description": "Label on the button that removes the currently selected profile banner image."
   },
-  "profileSetupBannerUploadSuccess": "بینر اپڈیٹ ہو گیا",
-  "@profileSetupBannerUploadSuccess": {
-    "description": "Snackbar message shown after a profile banner image is successfully uploaded."
-  },
   "profileSetupUsernameChecking": "دستیابی چیک ہو رہی ہے...",
   "profileSetupUsernameAvailable": "صارف نام دستیاب ہے!",
   "profileSetupUsernameTakenIndicator": "صارف نام پہلے ہی لیا جا چکا ہے",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -481,10 +481,6 @@
   "@profileSetupBannerClearButton": {
     "description": "Label on the button that removes the currently selected profile banner image."
   },
-  "profileSetupBannerUploadSuccess": "Đã cập nhật ảnh bìa",
-  "@profileSetupBannerUploadSuccess": {
-    "description": "Snackbar message shown after a profile banner image is successfully uploaded."
-  },
   "profileSetupUsernameChecking": "Đang kiểm tra...",
   "profileSetupUsernameAvailable": "Tên người dùng còn trống!",
   "profileSetupUsernameTakenIndicator": "Tên người dùng đã có người dùng",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -481,10 +481,6 @@
   "@profileSetupBannerClearButton": {
     "description": "Label on the button that removes the currently selected profile banner image."
   },
-  "profileSetupBannerUploadSuccess": "头图已更新",
-  "@profileSetupBannerUploadSuccess": {
-    "description": "Snackbar message shown after a profile banner image is successfully uploaded."
-  },
   "profileSetupUsernameChecking": "正在检查可用性...",
   "profileSetupUsernameAvailable": "用户名可用！",
   "profileSetupUsernameTakenIndicator": "用户名已被占用",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -1614,12 +1614,6 @@ abstract class AppLocalizations {
   /// **'Clear banner'**
   String get profileSetupBannerClearButton;
 
-  /// Snackbar message shown after a profile banner image is successfully uploaded.
-  ///
-  /// In en, this message translates to:
-  /// **'Banner updated'**
-  String get profileSetupBannerUploadSuccess;
-
   /// No description provided for @profileSetupUsernameChecking.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -887,9 +887,6 @@ class AppLocalizationsAm extends AppLocalizations {
   String get profileSetupBannerClearButton => 'ባነርን አጥፋ';
 
   @override
-  String get profileSetupBannerUploadSuccess => 'ባነር ተዘመነ';
-
-  @override
   String get profileSetupUsernameChecking => 'ተገኝነትን በማጣራት ላይ...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -890,9 +890,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get profileSetupBannerClearButton => 'مسح الغلاف';
 
   @override
-  String get profileSetupBannerUploadSuccess => 'تم تحديث الغلاف';
-
-  @override
   String get profileSetupUsernameChecking => 'جاري التحقق من التوفر...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -916,9 +916,6 @@ class AppLocalizationsBg extends AppLocalizations {
   String get profileSetupBannerClearButton => 'Изчисти банера';
 
   @override
-  String get profileSetupBannerUploadSuccess => 'Банерът е обновен';
-
-  @override
   String get profileSetupUsernameChecking => 'Проверява се наличността...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -916,9 +916,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get profileSetupBannerClearButton => 'Banner entfernen';
 
   @override
-  String get profileSetupBannerUploadSuccess => 'Banner aktualisiert';
-
-  @override
   String get profileSetupUsernameChecking => 'Verfügbarkeit wird geprüft...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -907,9 +907,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileSetupBannerClearButton => 'Clear banner';
 
   @override
-  String get profileSetupBannerUploadSuccess => 'Banner updated';
-
-  @override
   String get profileSetupUsernameChecking => 'Checking availability...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -915,9 +915,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get profileSetupBannerClearButton => 'Quitar banner';
 
   @override
-  String get profileSetupBannerUploadSuccess => 'Banner actualizado';
-
-  @override
   String get profileSetupUsernameChecking => 'Verificando disponibilidad...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -920,9 +920,6 @@ class AppLocalizationsFil extends AppLocalizations {
   String get profileSetupBannerClearButton => 'I-clear ang banner';
 
   @override
-  String get profileSetupBannerUploadSuccess => 'Na-update ang banner';
-
-  @override
   String get profileSetupUsernameChecking => 'Tinitingnan ang availability...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -925,9 +925,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get profileSetupBannerClearButton => 'Supprimer la bannière';
 
   @override
-  String get profileSetupBannerUploadSuccess => 'Bannière mise à jour';
-
-  @override
   String get profileSetupUsernameChecking =>
       'Vérification de la disponibilité...';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -880,9 +880,6 @@ class AppLocalizationsId extends AppLocalizations {
   String get profileSetupBannerClearButton => 'Hapus banner';
 
   @override
-  String get profileSetupBannerUploadSuccess => 'Banner diperbarui';
-
-  @override
   String get profileSetupUsernameChecking => 'Mengecek ketersediaan...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -918,9 +918,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get profileSetupBannerClearButton => 'Rimuovi banner';
 
   @override
-  String get profileSetupBannerUploadSuccess => 'Banner aggiornato';
-
-  @override
   String get profileSetupUsernameChecking => 'Controllo disponibilità...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -833,9 +833,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get profileSetupBannerClearButton => 'バナーをクリア';
 
   @override
-  String get profileSetupBannerUploadSuccess => 'バナーを更新したよ';
-
-  @override
   String get profileSetupUsernameChecking => '使えるか確認中...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -836,9 +836,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get profileSetupBannerClearButton => '배너 지우기';
 
   @override
-  String get profileSetupBannerUploadSuccess => '배너가 업데이트되었어요';
-
-  @override
   String get profileSetupUsernameChecking => '사용 가능 여부 확인 중...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -911,9 +911,6 @@ class AppLocalizationsMs extends AppLocalizations {
   String get profileSetupBannerClearButton => 'Kosongkan sepanduk';
 
   @override
-  String get profileSetupBannerUploadSuccess => 'Sepanduk dikemas kini';
-
-  @override
   String get profileSetupUsernameChecking => 'Menyemak ketersediaan...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -910,9 +910,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get profileSetupBannerClearButton => 'Banner wissen';
 
   @override
-  String get profileSetupBannerUploadSuccess => 'Banner bijgewerkt';
-
-  @override
   String get profileSetupUsernameChecking => 'Beschikbaarheid controleren...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -926,9 +926,6 @@ class AppLocalizationsPl extends AppLocalizations {
   String get profileSetupBannerClearButton => 'Wyczyść baner';
 
   @override
-  String get profileSetupBannerUploadSuccess => 'Baner zaktualizowany';
-
-  @override
   String get profileSetupUsernameChecking => 'Sprawdzanie dostępności...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -919,9 +919,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get profileSetupBannerClearButton => 'Remover banner';
 
   @override
-  String get profileSetupBannerUploadSuccess => 'Banner atualizado';
-
-  @override
   String get profileSetupUsernameChecking => 'Verificando disponibilidade...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -942,9 +942,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get profileSetupBannerClearButton => 'Șterge bannerul';
 
   @override
-  String get profileSetupBannerUploadSuccess => 'Banner actualizat';
-
-  @override
   String get profileSetupUsernameChecking => 'Se verifică disponibilitatea...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -892,9 +892,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get profileSetupBannerClearButton => 'Rensa banner';
 
   @override
-  String get profileSetupBannerUploadSuccess => 'Banner uppdaterad';
-
-  @override
   String get profileSetupUsernameChecking => 'Kollar tillgänglighet...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -877,9 +877,6 @@ class AppLocalizationsTr extends AppLocalizations {
   String get profileSetupBannerClearButton => 'Afişi temizle';
 
   @override
-  String get profileSetupBannerUploadSuccess => 'Afiş güncellendi';
-
-  @override
   String get profileSetupUsernameChecking => 'Uygunluk kontrol ediliyor...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -909,9 +909,6 @@ class AppLocalizationsUr extends AppLocalizations {
   String get profileSetupBannerClearButton => 'بینر ہٹائیں';
 
   @override
-  String get profileSetupBannerUploadSuccess => 'بینر اپڈیٹ ہو گیا';
-
-  @override
   String get profileSetupUsernameChecking => 'دستیابی چیک ہو رہی ہے...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -911,9 +911,6 @@ class AppLocalizationsVi extends AppLocalizations {
   String get profileSetupBannerClearButton => 'Xóa ảnh bìa';
 
   @override
-  String get profileSetupBannerUploadSuccess => 'Đã cập nhật ảnh bìa';
-
-  @override
   String get profileSetupUsernameChecking => 'Đang kiểm tra...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -850,9 +850,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get profileSetupBannerClearButton => '清除头图';
 
   @override
-  String get profileSetupBannerUploadSuccess => '头图已更新';
-
-  @override
   String get profileSetupUsernameChecking => '正在检查可用性...';
 
   @override

--- a/mobile/lib/screens/profile_setup/widgets/profile_setup_listeners.dart
+++ b/mobile/lib/screens/profile_setup/widgets/profile_setup_listeners.dart
@@ -257,9 +257,7 @@ class ProfileSetupListeners extends ConsumerWidget {
               case PendingBannerStatus.staged:
                 ScaffoldMessenger.of(context).showSnackBar(
                   SnackBar(
-                    content: Text(
-                      context.l10n.profileSetupBannerUploadSuccess,
-                    ),
+                    content: Text(context.l10n.profileSetupUploadStaged),
                     backgroundColor: VineTheme.vineGreen,
                   ),
                 );

--- a/mobile/lib/widgets/profile/profile_header_media.dart
+++ b/mobile/lib/widgets/profile/profile_header_media.dart
@@ -117,14 +117,38 @@ class ProfileBanner extends StatelessWidget {
       ),
     );
 
+    final fallback = _BannerFallback(
+      height: height,
+      profileColor: profileColor,
+      scrimDecoration: scrimDecoration,
+    );
+
     if (bannerUrl != null) {
       return _BannerImage(
         bannerUrl: bannerUrl!,
         height: height,
         scrimDecoration: scrimDecoration,
+        fallback: fallback,
       );
     }
 
+    return fallback;
+  }
+}
+
+class _BannerFallback extends StatelessWidget {
+  const _BannerFallback({
+    required this.height,
+    required this.profileColor,
+    required this.scrimDecoration,
+  });
+
+  final double height;
+  final Color? profileColor;
+  final BoxDecoration scrimDecoration;
+
+  @override
+  Widget build(BuildContext context) {
     final backgroundGradient = profileColor != null
         ? LinearGradient(
             begin: Alignment.topCenter,
@@ -141,6 +165,7 @@ class ProfileBanner extends StatelessWidget {
           );
 
     return Container(
+      key: const ValueKey('profile_banner_fallback'),
       width: double.infinity,
       height: height,
       decoration: BoxDecoration(gradient: backgroundGradient),
@@ -157,11 +182,13 @@ class _BannerImage extends StatelessWidget {
     required this.bannerUrl,
     required this.height,
     required this.scrimDecoration,
+    required this.fallback,
   });
 
   final String bannerUrl;
   final double height;
   final BoxDecoration scrimDecoration;
+  final Widget fallback;
 
   @override
   Widget build(BuildContext context) {
@@ -173,7 +200,7 @@ class _BannerImage extends StatelessWidget {
       decoration: BoxDecoration(color: context.vineColors.surface),
       child: VineCachedImage(
         imageUrl: bannerUrl,
-        errorWidget: (_, _, _) => const SizedBox.shrink(),
+        errorWidget: (_, _, _) => fallback,
       ),
     );
   }

--- a/mobile/test/screens/profile_setup_screen_test.dart
+++ b/mobile/test/screens/profile_setup_screen_test.dart
@@ -737,6 +737,25 @@ void main() {
       },
     );
 
+    testWidgets('banner staged snackbar uses staged-save copy', (tester) async {
+      whenListen(
+        mockEditorBloc,
+        Stream<ProfileEditorState>.fromIterable([
+          const ProfileEditorState(
+            pendingBannerStatus: PendingBannerStatus.staged,
+          ),
+        ]),
+        initialState: const ProfileEditorState(),
+      );
+
+      await pumpScreen(tester);
+      await tester.pump();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.profileSetupUploadStaged), findsOneWidget);
+      expect(find.text('Banner updated'), findsNothing);
+    });
+
     group('banner block', () {
       testWidgets(
         'pre-filled hex banner shows color preview',

--- a/mobile/test/widgets/profile/profile_banner_test.dart
+++ b/mobile/test/widgets/profile/profile_banner_test.dart
@@ -1,0 +1,59 @@
+// ABOUTME: Tests for the standalone profile banner media widget
+// ABOUTME: Verifies banner image fallback behavior
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/widgets/profile/profile_header_widget.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
+
+void main() {
+  group(ProfileBanner, () {
+    testWidgets('image load error renders the profile color fallback', (
+      tester,
+    ) async {
+      const profileColor = Color(0xFF33CCBF);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: VineTheme.theme,
+          home: const Scaffold(
+            body: ProfileBanner(
+              bannerUrl: 'https://cdn.example.com/missing-banner.jpg',
+              profileColor: profileColor,
+              height: 334,
+            ),
+          ),
+        ),
+      );
+
+      final image = tester.widget<VineCachedImage>(
+        find.byType(VineCachedImage),
+      );
+      final imageContext = tester.element(find.byType(VineCachedImage));
+      final fallback = image.errorWidget!(
+        imageContext,
+        image.imageUrl,
+        Exception('load failed'),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: VineTheme.theme,
+          home: Scaffold(body: fallback),
+        ),
+      );
+
+      final fallbackFinder = find.byKey(
+        const ValueKey('profile_banner_fallback'),
+      );
+      expect(fallbackFinder, findsOneWidget);
+      expect(tester.getSize(fallbackFinder).height, 334);
+
+      final container = tester.widget<Container>(fallbackFinder);
+      final decoration = container.decoration! as BoxDecoration;
+      final gradient = decoration.gradient! as LinearGradient;
+      expect(gradient.colors, equals([profileColor, profileColor]));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- show the staged-upload snackbar for banner uploads so users know they still need to tap Save
- remove the now-unused banner-upload-success l10n key and regenerate localizations
- render the profile color/default banner fallback when a banner image fails to load instead of showing an empty surface
- add regression coverage for banner staged copy and banner image error fallback

## Root cause

Banner uploads were correctly staged in ProfileEditorBloc, but the banner listener used copy that implied the banner had already been updated. Separately, a failed banner image fetch rendered an empty SizedBox inside the banner surface, making network/image failures look like the banner was missing.

## Follow-up

Filed #6652 for durable staged avatar/banner uploads across process death. That needs a focused persistence design aligned with #3494.

Closes #6568

## Verification

- flutter gen-l10n
- dart format lib/screens/profile_setup/widgets/profile_setup_listeners.dart lib/widgets/profile/profile_header_media.dart test/screens/profile_setup_screen_test.dart test/widgets/profile/profile_banner_test.dart
- flutter test test/screens/profile_setup_screen_test.dart test/widgets/profile/profile_banner_test.dart test/l10n/arb_consistency_test.dart
- flutter analyze lib test integration_test
- pre-push checks: analyze and changed-file tests
