### PR TITLE
fix(library): show in-progress autosave draft

### DIFF
--- a/mobile/lib/blocs/drafts_library/drafts_library_bloc.dart
+++ b/mobile/lib/blocs/drafts_library/drafts_library_bloc.dart
@@ -15,7 +15,7 @@ part 'drafts_library_state.dart';
 /// BLoC for managing draft video projects in the library.
 ///
 /// Loads drafts from [DraftStorageService] and handles deletion.
-/// Filters out autosave and already published drafts.
+/// Filters out empty autosaves and already published drafts.
 class DraftsLibraryBloc extends Bloc<DraftsLibraryEvent, DraftsLibraryState> {
   DraftsLibraryBloc({required DraftStorageService draftStorageService})
     : _draftStorageService = draftStorageService,
@@ -48,7 +48,8 @@ class DraftsLibraryBloc extends Bloc<DraftsLibraryEvent, DraftsLibraryState> {
     try {
       final allDrafts = await _draftStorageService.getAllDrafts();
 
-      // Filter out autosave and already published drafts, sort by newest first
+      // Filter out empty autosaves and already published drafts, sort by
+      // newest first.
       final filteredDrafts =
           allDrafts
               .where(

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2939,6 +2939,7 @@
     "libraryDraftDeletedSnackbar": "ረቂቅ ተሰርዟል።",
     "libraryDraftDuplicatedSnackbar": "ረቂቅ ተባዝቷል።",
     "libraryDraftDuplicateFailedSnackbar": "ረቂቅን ማባዛት አልተሳካም።",
+    "libraryDraftInProgressBadge": "In progress",
     "libraryDraftActionDuplicate": "አባዛ",
     "libraryDraftCopyTitle": "{title} (ቅጂ {number})",
     "@libraryDraftCopyTitle": {

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2489,6 +2489,7 @@
     "libraryDraftDeletedSnackbar": "تم حذف المسودة",
     "libraryDraftDuplicatedSnackbar": "تم تكرار المسودة",
     "libraryDraftDuplicateFailedSnackbar": "تعذّر تكرار المسودة",
+    "libraryDraftInProgressBadge": "In progress",
     "libraryDraftActionDuplicate": "تكرار",
     "libraryDraftCopyTitle": "{title} (نسخة {number})",
     "@libraryDraftCopyTitle": {

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2702,6 +2702,7 @@
     "libraryDraftDeletedSnackbar": "Черновата е изтрита",
     "libraryDraftDuplicatedSnackbar": "Черновата е дублирана",
     "libraryDraftDuplicateFailedSnackbar": "Не успяхме да дублираме черновата",
+    "libraryDraftInProgressBadge": "In progress",
     "libraryDraftActionDuplicate": "Дублирай",
     "libraryDraftCopyTitle": "{title} (копие {number})",
     "@libraryDraftCopyTitle": {

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2497,6 +2497,7 @@
     "libraryDraftDeletedSnackbar": "Entwurf gelöscht",
     "libraryDraftDuplicatedSnackbar": "Entwurf dupliziert",
     "libraryDraftDuplicateFailedSnackbar": "Entwurf konnte nicht dupliziert werden",
+    "libraryDraftInProgressBadge": "In progress",
     "libraryDraftActionDuplicate": "Duplizieren",
     "libraryDraftCopyTitle": "{title} (Kopie {number})",
     "@libraryDraftCopyTitle": {

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3791,6 +3791,7 @@
   "libraryDraftDeleteFailedSnackbar": "Failed to delete draft",
   "libraryDraftDuplicatedSnackbar": "Draft duplicated",
   "libraryDraftDuplicateFailedSnackbar": "Failed to duplicate draft",
+  "libraryDraftInProgressBadge": "In progress",
   "libraryDraftActionPost": "Post",
   "libraryDraftActionEdit": "Edit",
   "libraryDraftActionDuplicate": "Duplicate",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2505,6 +2505,7 @@
     "libraryDraftDeletedSnackbar": "Borrador eliminado",
     "libraryDraftDuplicatedSnackbar": "Borrador duplicado",
     "libraryDraftDuplicateFailedSnackbar": "No se pudo duplicar el borrador",
+    "libraryDraftInProgressBadge": "In progress",
     "libraryDraftActionDuplicate": "Duplicar",
     "libraryDraftCopyTitle": "{title} (copia {number})",
     "@libraryDraftCopyTitle": {

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1614,6 +1614,7 @@
     "libraryDraftDeletedSnackbar": "Nabura ang draft",
     "libraryDraftDuplicatedSnackbar": "Na-duplicate ang draft",
     "libraryDraftDuplicateFailedSnackbar": "Hindi na-duplicate ang draft",
+    "libraryDraftInProgressBadge": "In progress",
     "libraryDraftActionDuplicate": "I-duplicate",
     "libraryDraftCopyTitle": "{title} (kopya {number})",
     "@libraryDraftCopyTitle": {

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2497,6 +2497,7 @@
     "libraryDraftDeletedSnackbar": "Brouillon supprimé",
     "libraryDraftDuplicatedSnackbar": "Brouillon dupliqué",
     "libraryDraftDuplicateFailedSnackbar": "Échec de la duplication du brouillon",
+    "libraryDraftInProgressBadge": "In progress",
     "libraryDraftActionDuplicate": "Dupliquer",
     "libraryDraftCopyTitle": "{title} (copie {number})",
     "@libraryDraftCopyTitle": {

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2496,6 +2496,7 @@
     "libraryDraftDeletedSnackbar": "Draf dihapus",
     "libraryDraftDuplicatedSnackbar": "Draf diduplikat",
     "libraryDraftDuplicateFailedSnackbar": "Gagal menduplikat draf",
+    "libraryDraftInProgressBadge": "In progress",
     "libraryDraftActionDuplicate": "Duplikat",
     "libraryDraftCopyTitle": "{title} (salinan {number})",
     "@libraryDraftCopyTitle": {

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2497,6 +2497,7 @@
     "libraryDraftDeletedSnackbar": "Bozza eliminata",
     "libraryDraftDuplicatedSnackbar": "Bozza duplicata",
     "libraryDraftDuplicateFailedSnackbar": "Duplicazione bozza non riuscita",
+    "libraryDraftInProgressBadge": "In progress",
     "libraryDraftActionDuplicate": "Duplica",
     "libraryDraftCopyTitle": "{title} (copia {number})",
     "@libraryDraftCopyTitle": {

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2489,6 +2489,7 @@
     "libraryDraftDeletedSnackbar": "下書きを削除しました",
     "libraryDraftDuplicatedSnackbar": "下書きを複製しました",
     "libraryDraftDuplicateFailedSnackbar": "下書きを複製できませんでした",
+    "libraryDraftInProgressBadge": "In progress",
     "libraryDraftActionDuplicate": "複製",
     "libraryDraftCopyTitle": "{title}（コピー {number}）",
     "@libraryDraftCopyTitle": {

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1827,6 +1827,7 @@
     "libraryDraftDeletedSnackbar": "임시 저장을 삭제했어요",
     "libraryDraftDuplicatedSnackbar": "임시 저장을 복제했어요",
     "libraryDraftDuplicateFailedSnackbar": "임시 저장을 복제하지 못했어요",
+    "libraryDraftInProgressBadge": "In progress",
     "libraryDraftActionDuplicate": "복제",
     "libraryDraftCopyTitle": "{title} (사본 {number})",
     "@libraryDraftCopyTitle": {

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -3742,6 +3742,7 @@
   "libraryDraftDeleteFailedSnackbar": "Gagal memadam draf",
   "libraryDraftDuplicatedSnackbar": "Draf diduplikasi",
   "libraryDraftDuplicateFailedSnackbar": "Gagal menduplikasi draf",
+  "libraryDraftInProgressBadge": "In progress",
   "libraryDraftActionPost": "Siarkan",
   "libraryDraftActionEdit": "Sunting",
   "libraryDraftActionDuplicate": "Duplikasi",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2497,6 +2497,7 @@
     "libraryDraftDeletedSnackbar": "Concept verwijderd",
     "libraryDraftDuplicatedSnackbar": "Concept gedupliceerd",
     "libraryDraftDuplicateFailedSnackbar": "Concept dupliceren mislukt",
+    "libraryDraftInProgressBadge": "In progress",
     "libraryDraftActionDuplicate": "Dupliceren",
     "libraryDraftCopyTitle": "{title} (kopie {number})",
     "@libraryDraftCopyTitle": {

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2497,6 +2497,7 @@
     "libraryDraftDeletedSnackbar": "Usunięto wersję roboczą",
     "libraryDraftDuplicatedSnackbar": "Zduplikowano wersję roboczą",
     "libraryDraftDuplicateFailedSnackbar": "Nie udało się zduplikować wersji roboczej",
+    "libraryDraftInProgressBadge": "In progress",
     "libraryDraftActionDuplicate": "Duplikuj",
     "libraryDraftCopyTitle": "{title} (kopia {number})",
     "@libraryDraftCopyTitle": {

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2497,6 +2497,7 @@
     "libraryDraftDeletedSnackbar": "Rascunho excluído",
     "libraryDraftDuplicatedSnackbar": "Rascunho duplicado",
     "libraryDraftDuplicateFailedSnackbar": "Falha ao duplicar rascunho",
+    "libraryDraftInProgressBadge": "In progress",
     "libraryDraftActionDuplicate": "Duplicar",
     "libraryDraftCopyTitle": "{title} (cópia {number})",
     "@libraryDraftCopyTitle": {

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2497,6 +2497,7 @@
     "libraryDraftDeletedSnackbar": "Ciornă ștearsă",
     "libraryDraftDuplicatedSnackbar": "Ciornă duplicată",
     "libraryDraftDuplicateFailedSnackbar": "Nu s-a putut duplica ciorna",
+    "libraryDraftInProgressBadge": "In progress",
     "libraryDraftActionDuplicate": "Duplică",
     "libraryDraftCopyTitle": "{title} (copie {number})",
     "@libraryDraftCopyTitle": {

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2497,6 +2497,7 @@
     "libraryDraftDeletedSnackbar": "Utkast borttaget",
     "libraryDraftDuplicatedSnackbar": "Utkast duplicerat",
     "libraryDraftDuplicateFailedSnackbar": "Det gick inte att duplicera utkastet",
+    "libraryDraftInProgressBadge": "In progress",
     "libraryDraftActionDuplicate": "Duplicera",
     "libraryDraftCopyTitle": "{title} (kopia {number})",
     "@libraryDraftCopyTitle": {

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2496,6 +2496,7 @@
     "libraryDraftDeletedSnackbar": "Taslak silindi",
     "libraryDraftDuplicatedSnackbar": "Taslak çoğaltıldı",
     "libraryDraftDuplicateFailedSnackbar": "Taslak çoğaltılamadı",
+    "libraryDraftInProgressBadge": "In progress",
     "libraryDraftActionDuplicate": "Çoğalt",
     "libraryDraftCopyTitle": "{title} (kopya {number})",
     "@libraryDraftCopyTitle": {

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -3742,6 +3742,7 @@
   "libraryDraftDeleteFailedSnackbar": "مسودہ حذف نہیں ہو سکا",
   "libraryDraftDuplicatedSnackbar": "مسودہ نقل ہو گیا",
   "libraryDraftDuplicateFailedSnackbar": "مسودہ نقل نہیں ہو سکا",
+  "libraryDraftInProgressBadge": "In progress",
   "libraryDraftActionPost": "پوسٹ کریں",
   "libraryDraftActionEdit": "ترمیم",
   "libraryDraftActionDuplicate": "نقل کریں",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -3742,6 +3742,7 @@
   "libraryDraftDeleteFailedSnackbar": "Không xóa được bản nháp",
   "libraryDraftDuplicatedSnackbar": "Đã nhân bản bản nháp",
   "libraryDraftDuplicateFailedSnackbar": "Không nhân bản được bản nháp",
+  "libraryDraftInProgressBadge": "In progress",
   "libraryDraftActionPost": "Đăng",
   "libraryDraftActionEdit": "Sửa",
   "libraryDraftActionDuplicate": "Nhân bản",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -3742,6 +3742,7 @@
   "libraryDraftDeleteFailedSnackbar": "删除草稿失败",
   "libraryDraftDuplicatedSnackbar": "草稿已复制",
   "libraryDraftDuplicateFailedSnackbar": "复制草稿失败",
+  "libraryDraftInProgressBadge": "In progress",
   "libraryDraftActionPost": "发布",
   "libraryDraftActionEdit": "编辑",
   "libraryDraftActionDuplicate": "创建副本",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -11006,6 +11006,12 @@ abstract class AppLocalizations {
   /// **'Failed to duplicate draft'**
   String get libraryDraftDuplicateFailedSnackbar;
 
+  /// No description provided for @libraryDraftInProgressBadge.
+  ///
+  /// In en, this message translates to:
+  /// **'In progress'**
+  String get libraryDraftInProgressBadge;
+
   /// No description provided for @libraryDraftActionPost.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -6185,6 +6185,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get libraryDraftDuplicateFailedSnackbar => 'ረቂቅን ማባዛት አልተሳካም።';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => 'ለጥፍ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -6267,6 +6267,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get libraryDraftDuplicateFailedSnackbar => 'تعذّر تكرار المسودة';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => 'نشر';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -6371,6 +6371,9 @@ class AppLocalizationsBg extends AppLocalizations {
       'Не успяхме да дублираме черновата';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => 'Публикувай';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -6388,6 +6388,9 @@ class AppLocalizationsDe extends AppLocalizations {
       'Entwurf konnte nicht dupliziert werden';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => 'Posten';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -6308,6 +6308,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get libraryDraftDuplicateFailedSnackbar => 'Failed to duplicate draft';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => 'Post';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -6363,6 +6363,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'No se pudo duplicar el borrador';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => 'Publicar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -6386,6 +6386,9 @@ class AppLocalizationsFil extends AppLocalizations {
       'Hindi na-duplicate ang draft';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => 'I-post';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -6391,6 +6391,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'Échec de la duplication du brouillon';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => 'Publier';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -6275,6 +6275,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get libraryDraftDuplicateFailedSnackbar => 'Gagal menduplikat draf';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => 'Posting';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -6367,6 +6367,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'Duplicazione bozza non riuscita';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => 'Pubblica';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -6030,6 +6030,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get libraryDraftDuplicateFailedSnackbar => '下書きを複製できませんでした';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => '投稿';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -6059,6 +6059,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get libraryDraftDuplicateFailedSnackbar => '임시 저장을 복제하지 못했어요';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => '게시';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -6359,6 +6359,9 @@ class AppLocalizationsMs extends AppLocalizations {
   String get libraryDraftDuplicateFailedSnackbar => 'Gagal menduplikasi draf';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => 'Siarkan';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -6341,6 +6341,9 @@ class AppLocalizationsNl extends AppLocalizations {
       'Concept dupliceren mislukt';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => 'Plaatsen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6468,6 +6468,9 @@ class AppLocalizationsPl extends AppLocalizations {
       'Nie udało się zduplikować wersji roboczej';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => 'Opublikuj';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -6352,6 +6352,9 @@ class AppLocalizationsPt extends AppLocalizations {
       'Falha ao duplicar rascunho';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => 'Publicar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6467,6 +6467,9 @@ class AppLocalizationsRo extends AppLocalizations {
       'Nu s-a putut duplica ciorna';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => 'Publică';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -6306,6 +6306,9 @@ class AppLocalizationsSv extends AppLocalizations {
       'Det gick inte att duplicera utkastet';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => 'Publicera';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -6276,6 +6276,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get libraryDraftDuplicateFailedSnackbar => 'Taslak çoğaltılamadı';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => 'Paylaş';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -6317,6 +6317,9 @@ class AppLocalizationsUr extends AppLocalizations {
   String get libraryDraftDuplicateFailedSnackbar => 'مسودہ نقل نہیں ہو سکا';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => 'پوسٹ کریں';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -6319,6 +6319,9 @@ class AppLocalizationsVi extends AppLocalizations {
       'Không nhân bản được bản nháp';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => 'Đăng';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -6009,6 +6009,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get libraryDraftDuplicateFailedSnackbar => '复制草稿失败';
 
   @override
+  String get libraryDraftInProgressBadge => 'In progress';
+
+  @override
   String get libraryDraftActionPost => '发布';
 
   @override

--- a/mobile/lib/screens/library_screen.dart
+++ b/mobile/lib/screens/library_screen.dart
@@ -827,7 +827,7 @@ class _TabBody extends StatelessWidget {
     return TabBarView(
       controller: tabController,
       children: [
-        const DraftsTab(showRecordButton: false, showAutosavedDraft: false),
+        const DraftsTab(showRecordButton: false),
         ClipsTab(
           clips: clips,
           selectionEnabled: selectionEnabled,

--- a/mobile/lib/widgets/library/drafts_tab.dart
+++ b/mobile/lib/widgets/library/drafts_tab.dart
@@ -25,16 +25,9 @@ import 'package:unified_logger/unified_logger.dart';
 /// (post, edit, delete) internally.
 class DraftsTab extends ConsumerWidget {
   /// Creates a drafts tab.
-  const DraftsTab({
-    required this.showRecordButton,
-    this.showAutosavedDraft = true,
-    super.key,
-  });
+  const DraftsTab({required this.showRecordButton, super.key});
 
   final bool showRecordButton;
-
-  /// Whether to include the autosaved draft in the list.
-  final bool showAutosavedDraft;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -109,12 +102,7 @@ class DraftsTab extends ConsumerWidget {
           DraftsLibraryDuplicateFailed(:final drafts) ||
           DraftsLibraryDraftDeleted(:final drafts) ||
           DraftsLibraryDeleteFailed(:final drafts) => () {
-            final filtered = showAutosavedDraft
-                ? drafts
-                : drafts
-                      .where((d) => d.id != VideoEditorConstants.autoSaveId)
-                      .toList();
-            if (filtered.isEmpty) {
+            if (drafts.isEmpty) {
               return EmptyLibraryState(
                 showRecordButton: showRecordButton,
                 icon: DivineIconName.pencilSimple,
@@ -123,9 +111,9 @@ class DraftsTab extends ConsumerWidget {
               );
             }
             return ListView.builder(
-              itemCount: filtered.length,
+              itemCount: drafts.length,
               itemBuilder: (context, index) {
-                final draft = filtered[index];
+                final draft = drafts[index];
                 return DraftListTile(
                   draft: draft,
                   onTap: () => _openDraft(context, ref, draft),
@@ -362,6 +350,7 @@ class DraftListTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final thumbnailPath = draft.coverThumbnailPath;
+    final isAutosaveDraft = draft.id == VideoEditorConstants.autoSaveId;
 
     return ListTile(
       onTap: onTap,
@@ -406,11 +395,23 @@ class DraftListTile extends StatelessWidget {
                 size: 20,
               ),
       ),
-      title: Text(
-        draft.title.isEmpty ? context.l10n.draftUntitled : draft.title,
-        style: VineTheme.titleSmallFont(color: context.vineColors.primaryText),
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
+      title: Row(
+        children: [
+          Flexible(
+            child: Text(
+              draft.title.isEmpty ? context.l10n.draftUntitled : draft.title,
+              style: VineTheme.titleSmallFont(
+                color: context.vineColors.primaryText,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (isAutosaveDraft) ...[
+            const SizedBox(width: 8),
+            _DraftStatusBadge(label: context.l10n.libraryDraftInProgressBadge),
+          ],
+        ],
       ),
       subtitle: Text(
         _formatDraftSubtitle(context, draft.lastModified),
@@ -426,6 +427,32 @@ class DraftListTile extends StatelessWidget {
                 size: 28,
               ),
             ),
+    );
+  }
+}
+
+class _DraftStatusBadge extends StatelessWidget {
+  const _DraftStatusBadge({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: VineTheme.vineGreen.withValues(alpha: 0.16),
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: VineTheme.vineGreen.withValues(alpha: 0.45)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+        child: Text(
+          label,
+          style: VineTheme.labelSmallFont(color: VineTheme.vineGreen),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+      ),
     );
   }
 }

--- a/mobile/test/widgets/library/drafts_tab_test.dart
+++ b/mobile/test/widgets/library/drafts_tab_test.dart
@@ -65,10 +65,7 @@ void main() {
       mockBloc = _MockDraftsLibraryBloc();
     });
 
-    Widget buildWidget({
-      bool isSelectionMode = true,
-      bool showAutosavedDraft = true,
-    }) {
+    Widget buildWidget({bool isSelectionMode = true}) {
       return ProviderScope(
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -77,10 +74,7 @@ void main() {
           home: Scaffold(
             body: BlocProvider<DraftsLibraryBloc>.value(
               value: mockBloc,
-              child: DraftsTab(
-                showRecordButton: isSelectionMode,
-                showAutosavedDraft: showAutosavedDraft,
-              ),
+              child: DraftsTab(showRecordButton: isSelectionMode),
             ),
           ),
         ),
@@ -141,29 +135,7 @@ void main() {
         expect(find.byType(DraftListTile), findsNWidgets(2));
       });
 
-      testWidgets('hides autosaved draft when showAutosavedDraft is false', (
-        tester,
-      ) async {
-        when(() => mockBloc.state).thenReturn(
-          DraftsLibraryLoaded(
-            drafts: [
-              createDraft(
-                id: VideoEditorConstants.autoSaveId,
-                title: 'Autosaved',
-              ),
-              createDraft(id: 'real-draft', title: 'Real Draft'),
-            ],
-          ),
-        );
-
-        await tester.pumpWidget(buildWidget(showAutosavedDraft: false));
-
-        expect(find.byType(DraftListTile), findsOneWidget);
-        expect(find.text('Real Draft'), findsOneWidget);
-        expect(find.text('Autosaved'), findsNothing);
-      });
-
-      testWidgets('shows autosaved draft when showAutosavedDraft is true', (
+      testWidgets('shows autosaved draft with in-progress badge', (
         tester,
       ) async {
         when(() => mockBloc.state).thenReturn(
@@ -181,25 +153,8 @@ void main() {
         await tester.pumpWidget(buildWidget());
 
         expect(find.byType(DraftListTile), findsNWidgets(2));
-      });
-
-      testWidgets('shows $EmptyLibraryState when only autosaved draft '
-          'and showAutosavedDraft is false', (tester) async {
-        when(() => mockBloc.state).thenReturn(
-          DraftsLibraryLoaded(
-            drafts: [
-              createDraft(
-                id: VideoEditorConstants.autoSaveId,
-                title: 'Autosaved',
-              ),
-            ],
-          ),
-        );
-
-        await tester.pumpWidget(buildWidget(showAutosavedDraft: false));
-
-        expect(find.byType(EmptyLibraryState), findsOneWidget);
-        expect(find.text('No Drafts Yet'), findsOneWidget);
+        expect(find.text('Autosaved'), findsOneWidget);
+        expect(find.text(en.libraryDraftInProgressBadge), findsOneWidget);
       });
     });
 
@@ -448,6 +403,14 @@ void main() {
       await tester.pumpWidget(buildWidget(draft: createDraft(title: '')));
 
       expect(find.text(en.draftUntitled), findsOneWidget);
+    });
+
+    testWidgets('shows in-progress badge for autosaved draft', (tester) async {
+      await tester.pumpWidget(
+        buildWidget(draft: createDraft(id: VideoEditorConstants.autoSaveId)),
+      );
+
+      expect(find.text(en.libraryDraftInProgressBadge), findsOneWidget);
     });
 
     testWidgets('calls onTap when tapped', (tester) async {


### PR DESCRIPTION
## Summary
- show the autosave draft in Library -> Drafts when the drafts BLoC includes it
- remove the DraftsTab-level autosave filter so inclusion stays owned by DraftsLibraryBloc
- add an in-progress badge for autosave draft rows with regenerated l10n output

## Why
Creators need a visible recovery point after Divine autosaves an in-progress recording session. The BLoC already filters out empty autosaves while keeping autosaves with clips; the Library UI was hiding that valid recovery draft.

Closes #6562

## Verification
- mise exec -- flutter test test/widgets/library/drafts_tab_test.dart test/blocs/drafts_library/drafts_library_bloc_test.dart test/l10n/arb_consistency_test.dart
- mise exec -- flutter analyze
- pre-push hook: changed-file analyzer and tests passed
