### PR TITLE
fix(account): retarget profile after account switch

### DIFF
--- a/mobile/lib/providers/swap_account.dart
+++ b/mobile/lib/providers/swap_account.dart
@@ -11,6 +11,7 @@ import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Signs [container]'s fresh [AuthService] in as [account].
@@ -58,6 +59,38 @@ String? _currentRouterLocation(AccountSwitchController controller) {
       .toString();
 }
 
+/// Retargets an own-profile route from the leaving account to the account that
+/// is about to become active.
+///
+/// Most routes are safe to preserve across an account-container swap. An own
+/// profile URL is identity-bearing, though: carrying `/profile/<old npub>` into
+/// the new container renders the leaving account's profile while the rest of
+/// the app already reflects the target account.
+String? accountSwitchInitialLocation({
+  required String? currentLocation,
+  required String? currentNpub,
+  required String targetPubkeyHex,
+}) {
+  if (currentLocation == null) return null;
+
+  final uri = Uri.tryParse(currentLocation);
+  if (uri == null) return currentLocation;
+  final segments = uri.pathSegments;
+  if (segments.length < 2 || segments.first != 'profile') {
+    return currentLocation;
+  }
+
+  final routedNpub = segments[1];
+  if (routedNpub != 'me' && routedNpub != currentNpub) {
+    return currentLocation;
+  }
+
+  final targetNpub = NostrKeyUtils.encodePubKey(targetPubkeyHex);
+  final targetPath =
+      '/profile/$targetNpub${segments.length >= 3 ? '/${segments.skip(2).join('/')}' : ''}';
+  return uri.replace(path: targetPath).toString();
+}
+
 /// Switches the live app to [account] in place: builds a new container on the
 /// shared [deviceScope], signs it in, and swaps it in via [controller].
 ///
@@ -98,7 +131,12 @@ Future<void> swapAccount({
 }) async {
   await controller.runExclusive(() async {
     await currentAuthService.archiveCurrentSignerInfo();
-    final currentLocation = _currentRouterLocation(controller);
+    final current = controller.currentContainer;
+    final currentLocation = accountSwitchInitialLocation(
+      currentLocation: _currentRouterLocation(controller),
+      currentNpub: current?.read(authServiceProvider).currentNpub,
+      targetPubkeyHex: account.pubkeyHex,
+    );
     final container = buildAccountContainer(
       deviceScope,
       accountOverrides: [

--- a/mobile/lib/providers/swap_account.dart
+++ b/mobile/lib/providers/swap_account.dart
@@ -12,6 +12,7 @@ import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:openvine/utils/npub_hex.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Signs [container]'s fresh [AuthService] in as [account].
@@ -66,9 +67,14 @@ String? _currentRouterLocation(AccountSwitchController controller) {
 /// profile URL is identity-bearing, though: carrying `/profile/<old npub>` into
 /// the new container renders the leaving account's profile while the rest of
 /// the app already reflects the target account.
+///
+/// The routed segment is matched with [routeIdentifiesUser] rather than
+/// compared raw, because the route accepts npub, nprofile and bare hex as well
+/// as the relative `me` — a raw compare leaves the hex and nprofile forms
+/// stranded on the leaving account.
 String? accountSwitchInitialLocation({
   required String? currentLocation,
-  required String? currentNpub,
+  required String? currentPubkeyHex,
   required String targetPubkeyHex,
 }) {
   if (currentLocation == null) return null;
@@ -80,8 +86,7 @@ String? accountSwitchInitialLocation({
     return currentLocation;
   }
 
-  final routedNpub = segments[1];
-  if (routedNpub != 'me' && routedNpub != currentNpub) {
+  if (!routeIdentifiesUser(segments[1], currentPubkeyHex)) {
     return currentLocation;
   }
 
@@ -134,7 +139,7 @@ Future<void> swapAccount({
     final current = controller.currentContainer;
     final currentLocation = accountSwitchInitialLocation(
       currentLocation: _currentRouterLocation(controller),
-      currentNpub: current?.read(authServiceProvider).currentNpub,
+      currentPubkeyHex: current?.read(authServiceProvider).currentPublicKeyHex,
       targetPubkeyHex: account.pubkeyHex,
     );
     final container = buildAccountContainer(

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -225,7 +225,10 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
         ctx.videoIndex != 0;
     final isOtherUserProfile =
         ctx.type == RouteType.profile &&
-        ctx.npub != ref.read(authServiceProvider).currentNpub;
+        !routeIdentifiesUser(
+          ctx.npub,
+          ref.read(authServiceProvider).currentPublicKeyHex,
+        );
     final isProfileVideo =
         ctx.type == RouteType.profile && ctx.videoIndex != null;
 
@@ -346,8 +349,10 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
         chromeCtx != null &&
         chromeCtx.type == RouteType.profile &&
         chromeCtx.videoIndex == null && // Video mode uses the app bar
-        (chromeCtx.npub == 'me' ||
-            chromeCtx.npub == ref.read(authServiceProvider).currentNpub);
+        routeIdentifiesUser(
+          chromeCtx.npub,
+          ref.read(authServiceProvider).currentPublicKeyHex,
+        );
 
     // Inbox manages its own header (segmented toggle replaces app bar)
     final isInbox =

--- a/mobile/lib/screens/profile_screen_router.dart
+++ b/mobile/lib/screens/profile_screen_router.dart
@@ -94,11 +94,11 @@ class _ProfileScreenRouterState extends ConsumerState<ProfileScreenRouter>
         parseRoute(GoRouterState.of(context).uri.path);
 
     // Check if this is own profile grid view (needs own scaffold)
-    final currentNpub = ref.read(authServiceProvider).currentNpub;
+    final currentUserHex = ref.read(authServiceProvider).currentPublicKeyHex;
     final isOwnProfileGrid =
         routeContext.type == RouteType.profile &&
         routeContext.videoIndex == null && // Video mode uses shell
-        (routeContext.npub == 'me' || routeContext.npub == currentNpub);
+        routeIdentifiesUser(routeContext.npub, currentUserHex);
 
     final content = _ProfileContentView(
       routeContext: routeContext,

--- a/mobile/lib/utils/npub_hex.dart
+++ b/mobile/lib/utils/npub_hex.dart
@@ -9,3 +9,29 @@ String? npubToHexOrNull(String? identifier) {
   if (identifier == null || identifier.isEmpty) return null;
   return normalizeToHex(identifier);
 }
+
+/// Whether [routeIdentifier] — a `:npub` route segment — names the signed-in
+/// user identified by [currentUserHex].
+///
+/// A route segment has three valid encodings (npub, nprofile, bare hex) plus
+/// the relative `me`, so a raw string compare against the signed-in npub
+/// reports "not you" for your own account whenever the URL carries a different
+/// encoding — e.g. a deep link to `/profile/<hex>`, which renders you as a
+/// stranger with Message and Follow buttons.
+///
+/// Normalize both sides to hex instead. The profile *body* already does this
+/// (`userIdHex == currentUserHex`); this keeps the scaffold and the shell
+/// chrome in agreement with it, rather than letting one say "own" while the
+/// other says "other" in the same frame.
+bool routeIdentifiesUser(String? routeIdentifier, String? currentUserHex) {
+  if (routeIdentifier == null || routeIdentifier.isEmpty) return false;
+  // `me` is a *relative* reference: it names the own-profile route
+  // structurally, so it holds even before auth resolves. Gating it on a
+  // signed-in pubkey would report "not you" during the cold-start window and
+  // flash an app bar and back button over your own profile before flipping.
+  if (routeIdentifier == 'me') return true;
+  if (currentUserHex == null || currentUserHex.isEmpty) return false;
+  final routeHex = npubToHexOrNull(routeIdentifier);
+  if (routeHex == null) return false;
+  return routeHex.toLowerCase() == currentUserHex.toLowerCase();
+}

--- a/mobile/lib/utils/public_identifier_normalizer.dart
+++ b/mobile/lib/utils/public_identifier_normalizer.dart
@@ -43,7 +43,10 @@ NormalizedPublicIdentifier? normalizePublicIdentifier(
 
   // Try hex format first (most common internally)
   if (NostrKeyUtils.isValidKey(identifier)) {
-    return NormalizedPublicIdentifier(hexPubkey: identifier);
+    // Canonicalize casing: consumers compare this hex against the signed-in
+    // pubkey and key providers with it, so an uppercase deep-link segment must
+    // not read as a different identity than its lowercase form.
+    return NormalizedPublicIdentifier(hexPubkey: identifier.toLowerCase());
   }
 
   // Try npub format

--- a/mobile/test/providers/swap_account_test.dart
+++ b/mobile/test/providers/swap_account_test.dart
@@ -14,6 +14,7 @@ import 'package:openvine/providers/device_scope.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/swap_account.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 bool _isDisposed(ProviderContainer c) {
@@ -63,6 +64,56 @@ void main() {
   });
 
   tearDown(() => database.close());
+
+  group('accountSwitchInitialLocation', () {
+    const leavingHex =
+        '2222222222222222222222222222222222222222222222222222222222222222';
+    const targetHex =
+        '1111111111111111111111111111111111111111111111111111111111111111';
+    final leavingNpub = NostrKeyUtils.encodePubKey(leavingHex);
+    final targetNpub = NostrKeyUtils.encodePubKey(targetHex);
+
+    test('retargets the leaving account own-profile route', () {
+      expect(
+        accountSwitchInitialLocation(
+          currentLocation: '/profile/$leavingNpub',
+          currentNpub: leavingNpub,
+          targetPubkeyHex: targetHex,
+        ),
+        '/profile/$targetNpub',
+      );
+    });
+
+    test('retargets own-profile video routes and preserves URI metadata', () {
+      expect(
+        accountSwitchInitialLocation(
+          currentLocation: '/profile/$leavingNpub/7?source=notification#clip',
+          currentNpub: leavingNpub,
+          targetPubkeyHex: targetHex,
+        ),
+        '/profile/$targetNpub/7?source=notification#clip',
+      );
+    });
+
+    test('preserves another user profile and non-profile routes', () {
+      expect(
+        accountSwitchInitialLocation(
+          currentLocation: '/profile/$targetNpub',
+          currentNpub: leavingNpub,
+          targetPubkeyHex: targetHex,
+        ),
+        '/profile/$targetNpub',
+      );
+      expect(
+        accountSwitchInitialLocation(
+          currentLocation: '/settings',
+          currentNpub: leavingNpub,
+          targetPubkeyHex: targetHex,
+        ),
+        '/settings',
+      );
+    });
+  });
 
   Future<ProviderContainer> pumpHost(WidgetTester tester) async {
     final initial = buildAccountContainer(deviceScope);

--- a/mobile/test/providers/swap_account_test.dart
+++ b/mobile/test/providers/swap_account_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
+import 'package:nostr_sdk/nip19/nip19_tlv.dart';
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/container_swap_host.dart';
@@ -59,6 +60,9 @@ void main() {
   final leavingNpub = NostrKeyUtils.encodePubKey(leavingHex);
   final targetNpub = NostrKeyUtils.encodePubKey(targetHex);
   final strangerNpub = NostrKeyUtils.encodePubKey(strangerHex);
+  final leavingNprofile = NIP19Tlv.encodeNprofile(
+    Nprofile(pubkey: leavingHex, relays: const ['wss://relay.divine.video']),
+  );
 
   final account = KnownAccount(
     pubkeyHex: targetHex,
@@ -91,7 +95,7 @@ void main() {
       expect(
         accountSwitchInitialLocation(
           currentLocation: '/profile/$leavingNpub',
-          currentNpub: leavingNpub,
+          currentPubkeyHex: leavingHex,
           targetPubkeyHex: targetHex,
         ),
         '/profile/$targetNpub',
@@ -102,7 +106,7 @@ void main() {
       expect(
         accountSwitchInitialLocation(
           currentLocation: '/profile/me',
-          currentNpub: leavingNpub,
+          currentPubkeyHex: leavingHex,
           targetPubkeyHex: targetHex,
         ),
         '/profile/$targetNpub',
@@ -113,10 +117,46 @@ void main() {
       expect(
         accountSwitchInitialLocation(
           currentLocation: '/profile/$leavingNpub/7?source=notification#clip',
-          currentNpub: leavingNpub,
+          currentPubkeyHex: leavingHex,
           targetPubkeyHex: targetHex,
         ),
         '/profile/$targetNpub/7?source=notification#clip',
+      );
+    });
+
+    // The own-profile route accepts three encodings of the same identity. A
+    // raw string compare against the npub leaves the other two stranded on the
+    // leaving account — /profile/{hex} is a documented deep-link form.
+    test('retargets an own-profile route carried as bare hex', () {
+      expect(
+        accountSwitchInitialLocation(
+          currentLocation: '/profile/$leavingHex',
+          currentPubkeyHex: leavingHex,
+          targetPubkeyHex: targetHex,
+        ),
+        '/profile/$targetNpub',
+      );
+    });
+
+    test('retargets an own-profile route carried as uppercase hex', () {
+      expect(
+        accountSwitchInitialLocation(
+          currentLocation: '/profile/${leavingHex.toUpperCase()}',
+          currentPubkeyHex: leavingHex,
+          targetPubkeyHex: targetHex,
+        ),
+        '/profile/$targetNpub',
+      );
+    });
+
+    test('retargets an own-profile route carried as nprofile', () {
+      expect(
+        accountSwitchInitialLocation(
+          currentLocation: '/profile/$leavingNprofile',
+          currentPubkeyHex: leavingHex,
+          targetPubkeyHex: targetHex,
+        ),
+        '/profile/$targetNpub',
       );
     });
 
@@ -124,10 +164,36 @@ void main() {
       expect(
         accountSwitchInitialLocation(
           currentLocation: '/profile/$strangerNpub',
-          currentNpub: leavingNpub,
+          currentPubkeyHex: leavingHex,
           targetPubkeyHex: targetHex,
         ),
         '/profile/$strangerNpub',
+      );
+    });
+
+    test('preserves another user profile carried as hex', () {
+      // Normalizing the comparison must not widen it: a stranger's hex is
+      // still a stranger.
+      expect(
+        accountSwitchInitialLocation(
+          currentLocation: '/profile/$strangerHex',
+          currentPubkeyHex: leavingHex,
+          targetPubkeyHex: targetHex,
+        ),
+        '/profile/$strangerHex',
+      );
+    });
+
+    test('preserves an undecodable identifier for an unknown identity', () {
+      // Both sides normalize to null here; treating that as a match would
+      // retarget a garbage route.
+      expect(
+        accountSwitchInitialLocation(
+          currentLocation: '/profile/not-an-identifier',
+          currentPubkeyHex: null,
+          targetPubkeyHex: targetHex,
+        ),
+        '/profile/not-an-identifier',
       );
     });
 
@@ -135,7 +201,7 @@ void main() {
       expect(
         accountSwitchInitialLocation(
           currentLocation: '/profile/$leavingNpub',
-          currentNpub: null,
+          currentPubkeyHex: null,
           targetPubkeyHex: targetHex,
         ),
         '/profile/$leavingNpub',
@@ -148,7 +214,7 @@ void main() {
       expect(
         accountSwitchInitialLocation(
           currentLocation: '/profile-view/$leavingNpub',
-          currentNpub: leavingNpub,
+          currentPubkeyHex: leavingHex,
           targetPubkeyHex: targetHex,
         ),
         '/profile-view/$leavingNpub',
@@ -159,7 +225,7 @@ void main() {
       expect(
         accountSwitchInitialLocation(
           currentLocation: '/settings',
-          currentNpub: leavingNpub,
+          currentPubkeyHex: leavingHex,
           targetPubkeyHex: targetHex,
         ),
         '/settings',
@@ -170,7 +236,7 @@ void main() {
       expect(
         accountSwitchInitialLocation(
           currentLocation: null,
-          currentNpub: leavingNpub,
+          currentPubkeyHex: leavingHex,
           targetPubkeyHex: targetHex,
         ),
         isNull,
@@ -211,7 +277,7 @@ void main() {
     String from,
   ) async {
     final auth = _MockAuthService();
-    when(() => auth.currentNpub).thenReturn(leavingNpub);
+    when(() => auth.currentPublicKeyHex).thenReturn(leavingHex);
     final router = GoRouter(
       initialLocation: from,
       routes: [

--- a/mobile/test/providers/swap_account_test.dart
+++ b/mobile/test/providers/swap_account_test.dart
@@ -70,13 +70,30 @@ void main() {
         '2222222222222222222222222222222222222222222222222222222222222222';
     const targetHex =
         '1111111111111111111111111111111111111111111111111111111111111111';
+    // A third identity, belonging to neither account. A preserve case built on
+    // the target's own npub cannot fail: both the retarget branch and the
+    // preserve branch emit the same string.
+    const strangerHex =
+        '3333333333333333333333333333333333333333333333333333333333333333';
     final leavingNpub = NostrKeyUtils.encodePubKey(leavingHex);
     final targetNpub = NostrKeyUtils.encodePubKey(targetHex);
+    final strangerNpub = NostrKeyUtils.encodePubKey(strangerHex);
 
     test('retargets the leaving account own-profile route', () {
       expect(
         accountSwitchInitialLocation(
           currentLocation: '/profile/$leavingNpub',
+          currentNpub: leavingNpub,
+          targetPubkeyHex: targetHex,
+        ),
+        '/profile/$targetNpub',
+      );
+    });
+
+    test('retargets the relative own-profile route', () {
+      expect(
+        accountSwitchInitialLocation(
+          currentLocation: '/profile/me',
           currentNpub: leavingNpub,
           targetPubkeyHex: targetHex,
         ),
@@ -95,15 +112,42 @@ void main() {
       );
     });
 
-    test('preserves another user profile and non-profile routes', () {
+    test('preserves another user profile', () {
       expect(
         accountSwitchInitialLocation(
-          currentLocation: '/profile/$targetNpub',
+          currentLocation: '/profile/$strangerNpub',
           currentNpub: leavingNpub,
           targetPubkeyHex: targetHex,
         ),
-        '/profile/$targetNpub',
+        '/profile/$strangerNpub',
       );
+    });
+
+    test('preserves a profile route when the leaving identity is unknown', () {
+      expect(
+        accountSwitchInitialLocation(
+          currentLocation: '/profile/$leavingNpub',
+          currentNpub: null,
+          targetPubkeyHex: targetHex,
+        ),
+        '/profile/$leavingNpub',
+      );
+    });
+
+    test('preserves a non-profile route that carries the leaving npub', () {
+      // Two segments, so this reaches the identity clause that `/settings`
+      // exits before — it pins the first-segment guard, not the length guard.
+      expect(
+        accountSwitchInitialLocation(
+          currentLocation: '/profile-view/$leavingNpub',
+          currentNpub: leavingNpub,
+          targetPubkeyHex: targetHex,
+        ),
+        '/profile-view/$leavingNpub',
+      );
+    });
+
+    test('preserves a single-segment route', () {
       expect(
         accountSwitchInitialLocation(
           currentLocation: '/settings',
@@ -111,6 +155,17 @@ void main() {
           targetPubkeyHex: targetHex,
         ),
         '/settings',
+      );
+    });
+
+    test('returns null when there is no current location', () {
+      expect(
+        accountSwitchInitialLocation(
+          currentLocation: null,
+          currentNpub: leavingNpub,
+          targetPubkeyHex: targetHex,
+        ),
+        isNull,
       );
     });
   });

--- a/mobile/test/providers/swap_account_test.dart
+++ b/mobile/test/providers/swap_account_test.dart
@@ -3,9 +3,11 @@
 
 import 'package:db_client/db_client.dart';
 import 'package:drift/native.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/providers/auth_providers.dart';
@@ -13,9 +15,16 @@ import 'package:openvine/providers/container_swap_host.dart';
 import 'package:openvine/providers/device_scope.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/swap_account.dart';
+import 'package:openvine/router/app_router.dart';
+import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
+// Override lives in riverpod's misc barrel; flutter_riverpod does not
+// re-export the type name even though it accepts List<Override>.
+import 'package:riverpod/misc.dart' show Override;
 import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
 
 bool _isDisposed(ProviderContainer c) {
   try {
@@ -38,9 +47,21 @@ void main() {
   late _FakeSecureKeyStorage keyStorage;
   late _FakeAuthService currentAuthService;
 
+  const leavingHex =
+      '2222222222222222222222222222222222222222222222222222222222222222';
+  const targetHex =
+      '1111111111111111111111111111111111111111111111111111111111111111';
+  // A third identity, belonging to neither account. A preserve case built on
+  // the target's own npub cannot fail: both the retarget branch and the
+  // preserve branch emit the same string.
+  const strangerHex =
+      '3333333333333333333333333333333333333333333333333333333333333333';
+  final leavingNpub = NostrKeyUtils.encodePubKey(leavingHex);
+  final targetNpub = NostrKeyUtils.encodePubKey(targetHex);
+  final strangerNpub = NostrKeyUtils.encodePubKey(strangerHex);
+
   final account = KnownAccount(
-    pubkeyHex:
-        '1111111111111111111111111111111111111111111111111111111111111111',
+    pubkeyHex: targetHex,
     authSource: AuthenticationSource.automatic,
     addedAt: DateTime(2026),
     lastUsedAt: DateTime(2026),
@@ -66,19 +87,6 @@ void main() {
   tearDown(() => database.close());
 
   group('accountSwitchInitialLocation', () {
-    const leavingHex =
-        '2222222222222222222222222222222222222222222222222222222222222222';
-    const targetHex =
-        '1111111111111111111111111111111111111111111111111111111111111111';
-    // A third identity, belonging to neither account. A preserve case built on
-    // the target's own npub cannot fail: both the retarget branch and the
-    // preserve branch emit the same string.
-    const strangerHex =
-        '3333333333333333333333333333333333333333333333333333333333333333';
-    final leavingNpub = NostrKeyUtils.encodePubKey(leavingHex);
-    final targetNpub = NostrKeyUtils.encodePubKey(targetHex);
-    final strangerNpub = NostrKeyUtils.encodePubKey(strangerHex);
-
     test('retargets the leaving account own-profile route', () {
       expect(
         accountSwitchInitialLocation(
@@ -170,17 +178,100 @@ void main() {
     });
   });
 
-  Future<ProviderContainer> pumpHost(WidgetTester tester) async {
-    final initial = buildAccountContainer(deviceScope);
+  Future<ProviderContainer> pumpHost(
+    WidgetTester tester, {
+    List<Override> accountOverrides = const [],
+    Widget Function(ProviderContainer container)? childBuilder,
+  }) async {
+    final initial = buildAccountContainer(
+      deviceScope,
+      accountOverrides: accountOverrides,
+    );
     await tester.pumpWidget(
       ContainerSwapHost(
         initialContainer: initial,
         controller: controller,
-        child: const SizedBox(),
+        child: childBuilder?.call(initial) ?? const SizedBox(),
       ),
     );
     return initial;
   }
+
+  /// Switches away from [from] and reports the location [swapAccount] seeded
+  /// into the container it built for the target account.
+  ///
+  /// The router has to be both created in the container and mounted in a
+  /// `Router` widget. `_currentRouterLocation` gates on
+  /// `container.exists(goRouterProvider)`, and `currentConfiguration` stays
+  /// `RouteMatchList.empty` until a `Router` attaches and parses the initial
+  /// location — without either, it returns null and the whole retarget path
+  /// goes inert.
+  Future<String?> seededLocationSwitchingFrom(
+    WidgetTester tester,
+    String from,
+  ) async {
+    final auth = _MockAuthService();
+    when(() => auth.currentNpub).thenReturn(leavingNpub);
+    final router = GoRouter(
+      initialLocation: from,
+      routes: [
+        GoRoute(
+          path: ProfileScreenRouter.pathWithNpub,
+          builder: (_, _) => const SizedBox(),
+        ),
+        GoRoute(
+          path: ProfileScreenRouter.pathWithIndex,
+          builder: (_, _) => const SizedBox(),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await pumpHost(
+      tester,
+      accountOverrides: [
+        goRouterProvider.overrideWithValue(router),
+        authServiceProvider.overrideWithValue(auth),
+      ],
+      childBuilder: (container) =>
+          MaterialApp.router(routerConfig: container.read(goRouterProvider)),
+    );
+
+    String? seeded;
+    await swapAccount(
+      deviceScope: deviceScope,
+      controller: controller,
+      currentAuthService: currentAuthService,
+      account: account,
+      signIn: (container, _) async {
+        seeded = container.read(routerInitialLocationProvider);
+      },
+    );
+    await tester.pump();
+    return seeded;
+  }
+
+  testWidgets('seeds the swapped-in container with the retargeted route', (
+    tester,
+  ) async {
+    expect(
+      await seededLocationSwitchingFrom(
+        tester,
+        ProfileScreenRouter.pathForNpub(leavingNpub),
+      ),
+      ProfileScreenRouter.pathForNpub(targetNpub),
+    );
+  });
+
+  testWidgets('seeds another user profile route unchanged', (tester) async {
+    expect(
+      await seededLocationSwitchingFrom(
+        tester,
+        ProfileScreenRouter.pathForNpub(strangerNpub),
+      ),
+      ProfileScreenRouter.pathForNpub(strangerNpub),
+    );
+  });
 
   testWidgets('signs in a fresh container and swaps it in', (tester) async {
     final initial = await pumpHost(tester);

--- a/mobile/test/router/app_shell_own_profile_encoding_test.dart
+++ b/mobile/test/router/app_shell_own_profile_encoding_test.dart
@@ -1,0 +1,185 @@
+// ABOUTME: AppShell must recognise the own-profile route in every :npub
+// ABOUTME: encoding — a bare-hex deep link is still your own profile.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/app_update/app_update.dart';
+import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
+import 'package:openvine/blocs/notifications/badge/notification_badge_cubit.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/environment_config.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/environment_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/router/router.dart';
+import 'package:openvine/screens/feed/home_feed_retap_cubit.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/test_pubkeys.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockDmUnreadCountCubit extends MockCubit<int>
+    implements DmUnreadCountCubit {}
+
+class _MockNotificationBadgeCubit extends MockCubit<int>
+    implements NotificationBadgeCubit {}
+
+class _MockAppUpdateBloc extends MockBloc<AppUpdateEvent, AppUpdateState>
+    implements AppUpdateBloc {}
+
+List<Override> _overrides({
+  required _MockAuthService mockAuthService,
+  required SharedPreferences sharedPreferences,
+  required RouteContext routeContext,
+}) => [
+  pageContextProvider.overrideWith((ref) => Stream.value(routeContext)),
+  relayStatisticsBridgeProvider.overrideWithValue(null),
+  relaySetChangeBridgeProvider.overrideWithValue(null),
+  zendeskIdentitySyncProvider.overrideWithValue(null),
+  pushNotificationSyncProvider.overrideWithValue(null),
+  blocklistSyncBridgeProvider.overrideWithValue(null),
+  authServiceProvider.overrideWithValue(mockAuthService),
+  sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+  currentEnvironmentProvider.overrideWithValue(EnvironmentConfig.production),
+];
+
+Widget _wrapWithBlocs(Widget child) {
+  final dmCubit = _MockDmUnreadCountCubit();
+  when(() => dmCubit.state).thenReturn(0);
+
+  final notifBadgeCubit = _MockNotificationBadgeCubit();
+  when(() => notifBadgeCubit.state).thenReturn(0);
+
+  final appUpdateBloc = _MockAppUpdateBloc();
+  when(() => appUpdateBloc.state).thenReturn(const AppUpdateState());
+
+  return MultiBlocProvider(
+    providers: [
+      BlocProvider<DmUnreadCountCubit>.value(value: dmCubit),
+      BlocProvider<NotificationBadgeCubit>.value(value: notifBadgeCubit),
+      BlocProvider<AppUpdateBloc>.value(value: appUpdateBloc),
+      BlocProvider<HomeFeedRetapCubit>(create: (_) => HomeFeedRetapCubit()),
+    ],
+    child: child,
+  );
+}
+
+// currentIndex 3 (profile tab) keeps the home/explore app-bar suppression
+// rules out of play, so the app bar is governed solely by the own-profile-grid
+// flag under test. Mirrors app_shell_chrome_freeze_test.
+Widget _buildSubject({
+  required _MockAuthService mockAuthService,
+  required SharedPreferences sharedPreferences,
+  required RouteContext routeContext,
+}) => _wrapWithBlocs(
+  ProviderScope(
+    overrides: _overrides(
+      mockAuthService: mockAuthService,
+      sharedPreferences: sharedPreferences,
+      routeContext: routeContext,
+    ),
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      navigatorObservers: [routeObserver],
+      home: const AppShell(currentIndex: 3, child: SizedBox.shrink()),
+    ),
+  ),
+);
+
+void main() {
+  const selfHex = syntheticTestPubkey;
+  final selfNpub = NostrKeyUtils.encodePubKey(selfHex);
+  final otherNpub = NostrKeyUtils.encodePubKey(syntheticOtherTestPubkey);
+
+  late _MockAuthService mockAuthService;
+  late SharedPreferences sharedPreferences;
+
+  setUp(() async {
+    mockAuthService = _MockAuthService();
+    when(() => mockAuthService.currentPublicKeyHex).thenReturn(selfHex);
+    when(() => mockAuthService.currentNpub).thenReturn(selfNpub);
+    when(() => mockAuthService.isAuthenticated).thenReturn(true);
+    when(() => mockAuthService.authState).thenReturn(AuthState.authenticated);
+
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    sharedPreferences = await SharedPreferences.getInstance();
+  });
+
+  /// The own-profile grid renders its own scrollable header, so AppShell
+  /// suppresses its app bar. A null app bar therefore means "the shell decided
+  /// this route is mine".
+  Future<Object?> shellAppBar(WidgetTester tester, RouteContext ctx) async {
+    await tester.pumpWidget(
+      _buildSubject(
+        mockAuthService: mockAuthService,
+        sharedPreferences: sharedPreferences,
+        routeContext: ctx,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    return tester
+        .widget<Scaffold>(
+          find
+              .descendant(
+                of: find.byType(AppShell, skipOffstage: false),
+                matching: find.byType(Scaffold, skipOffstage: false),
+              )
+              .first,
+        )
+        .appBar;
+  }
+
+  testWidgets('treats a bare-hex own-profile route as mine', (tester) async {
+    // The defect: `/profile/<own hex>` is a documented deep-link form
+    // (DEEP_LINK_URL_REFERENCE.md), but the shell compared the raw segment
+    // against the signed-in npub, so it decided the route belonged to someone
+    // else and popped in the other-user app bar over your own profile.
+    expect(
+      await shellAppBar(
+        tester,
+        const RouteContext(type: RouteType.profile, npub: selfHex),
+      ),
+      isNull,
+    );
+  });
+
+  testWidgets('treats an npub own-profile route as mine', (tester) async {
+    expect(
+      await shellAppBar(
+        tester,
+        RouteContext(type: RouteType.profile, npub: selfNpub),
+      ),
+      isNull,
+    );
+  });
+
+  testWidgets('treats the relative "me" route as mine', (tester) async {
+    expect(
+      await shellAppBar(
+        tester,
+        const RouteContext(type: RouteType.profile, npub: 'me'),
+      ),
+      isNull,
+    );
+  });
+
+  testWidgets("keeps the app bar on another user's profile", (tester) async {
+    expect(
+      await shellAppBar(
+        tester,
+        RouteContext(type: RouteType.profile, npub: otherNpub),
+      ),
+      isNotNull,
+    );
+  });
+}

--- a/mobile/test/utils/npub_hex_test.dart
+++ b/mobile/test/utils/npub_hex_test.dart
@@ -1,0 +1,75 @@
+// ABOUTME: Tests routeIdentifiesUser normalizes every :npub route encoding
+// ABOUTME: so own-profile detection survives hex and nprofile deep links
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nip19/nip19_tlv.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:openvine/utils/npub_hex.dart';
+
+void main() {
+  const selfHex =
+      '1111111111111111111111111111111111111111111111111111111111111111';
+  const otherHex =
+      '2222222222222222222222222222222222222222222222222222222222222222';
+  // Encoded rather than pasted: a bech32 literal that does not decode would
+  // make the "another user" case pass because npubToHexOrNull returned null,
+  // not because the comparison rejected a real, different identity.
+  final selfNpub = NostrKeyUtils.encodePubKey(selfHex);
+  final otherNpub = NostrKeyUtils.encodePubKey(otherHex);
+  final selfNprofile = NIP19Tlv.encodeNprofile(
+    Nprofile(pubkey: selfHex, relays: const ['wss://relay.divine.video']),
+  );
+
+  group('routeIdentifiesUser', () {
+    test('matches the signed-in user by npub', () {
+      expect(routeIdentifiesUser(selfNpub, selfHex), isTrue);
+    });
+
+    // The defect: a deep link to /profile/<hex> for your own account rendered
+    // you as a stranger, because the route segment was compared raw against
+    // the signed-in npub.
+    test('matches the signed-in user by bare hex', () {
+      expect(routeIdentifiesUser(selfHex, selfHex), isTrue);
+    });
+
+    test('matches the signed-in user by uppercase hex', () {
+      expect(routeIdentifiesUser(selfHex.toUpperCase(), selfHex), isTrue);
+    });
+
+    test('matches the signed-in user by nprofile', () {
+      expect(routeIdentifiesUser(selfNprofile, selfHex), isTrue);
+    });
+
+    test('treats the relative "me" segment as the signed-in user', () {
+      expect(routeIdentifiesUser('me', selfHex), isTrue);
+    });
+
+    test('does not match another user', () {
+      expect(routeIdentifiesUser(otherNpub, selfHex), isFalse);
+      expect(routeIdentifiesUser(otherHex, selfHex), isFalse);
+    });
+
+    test('is false for a concrete identifier when nobody is signed in', () {
+      expect(routeIdentifiesUser(selfNpub, null), isFalse);
+      expect(routeIdentifiesUser(selfNpub, ''), isFalse);
+      // Both sides undecodable must not collapse into "equal": null == null
+      // would report a garbage segment as the signed-out user's own profile.
+      expect(routeIdentifiesUser('not-an-identifier', null), isFalse);
+    });
+
+    // `me` is relative, so it names the own-profile route structurally, before
+    // auth resolves. Gating it on a signed-in pubkey would flash an app bar and
+    // back button over your own profile during cold start — the behaviour
+    // app_shell_chrome_freeze_test (#5925) pins.
+    test('treats "me" as own profile even before auth resolves', () {
+      expect(routeIdentifiesUser('me', null), isTrue);
+      expect(routeIdentifiesUser('me', ''), isTrue);
+    });
+
+    test('is false for a missing or undecodable segment', () {
+      expect(routeIdentifiesUser(null, selfHex), isFalse);
+      expect(routeIdentifiesUser('', selfHex), isFalse);
+      expect(routeIdentifiesUser('not-an-identifier', selfHex), isFalse);
+    });
+  });
+}

--- a/mobile/test/utils/public_identifier_normalizer_test.dart
+++ b/mobile/test/utils/public_identifier_normalizer_test.dart
@@ -1,0 +1,29 @@
+// ABOUTME: Pins that normalizeToHex canonicalizes hex casing so every
+// ABOUTME: consumer agrees on identity regardless of deep-link encoding
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:openvine/utils/public_identifier_normalizer.dart';
+
+void main() {
+  const selfHex =
+      'abcdef11111111111111111111111111111111111111111111111111111111ff';
+
+  group('normalizeToHex', () {
+    // The profile body decides own-vs-other by raw hex equality
+    // (profile_screen_router.dart `userIdHex == currentUserHex`), while
+    // routeIdentifiesUser compares case-insensitively. Canonicalizing here is
+    // what keeps the two from disagreeing on an uppercase-hex deep link.
+    test('lowercases an uppercase hex identifier', () {
+      expect(normalizeToHex(selfHex.toUpperCase()), selfHex);
+    });
+
+    test('returns lowercase hex unchanged', () {
+      expect(normalizeToHex(selfHex), selfHex);
+    });
+
+    test('decodes an npub to the same canonical hex', () {
+      expect(normalizeToHex(NostrKeyUtils.encodePubKey(selfHex)), selfHex);
+    });
+  });
+}


### PR DESCRIPTION
Closes #6656

## Summary
- retarget the leaving account own-profile route to the newly active account during an in-place account switch
- preserve other users' profiles, non-profile routes, profile video index, query parameters, and fragments
- normalize profile route identity checks so npub, nprofile, bare hex, uppercase hex, and `me` agree with the profile body
- canonicalize bare-hex public identifiers to lowercase at the shared normalizer so app-wide identity comparisons and provider keys use the same hex form
- add regression coverage for account-switch route seeding, profile-route identifier encodings, and public identifier hex canonicalization

## Root cause
The account container swap correctly replaced auth-scoped services, but it copied the current profile URL verbatim into the new router. When that URL identified the leaving account, the profile screen continued rendering that account while notifications and navigation reflected the target account.

The same profile identity decision was also being made with raw route-string comparisons in shell/profile routing code, while the profile body normalized the route segment to hex. Deep links using bare hex, uppercase hex, or nprofile could therefore make the shell/scaffold disagree with the profile body about whether the route belonged to the signed-in user.

## Verification
- flutter test test/providers/swap_account_test.dart
- flutter test test/utils/npub_hex_test.dart test/utils/public_identifier_normalizer_test.dart
- flutter test test/router/app_shell_own_profile_encoding_test.dart
- flutter analyze lib test integration_test