### PR TITLE
fix(profile): use the alert sticker on the unsaved-changes prompt

### DIFF
--- a/mobile/lib/screens/profile_setup/view/profile_setup_view.dart
+++ b/mobile/lib/screens/profile_setup/view/profile_setup_view.dart
@@ -276,7 +276,7 @@ class _ProfileSetupScreenViewState extends ConsumerState<ProfileSetupScreenView>
   }) {
     VineBottomSheetPrompt.show<void>(
       context: context,
-      sticker: .videoClapBoard,
+      sticker: .alert,
       title: context.l10n.profileSetupUnsavedChangesTitle,
       subtitle: context.l10n.profileSetupUnsavedChangesSubtitle,
       primaryButtonText: context.l10n.profileSetupUnsavedChangesSaveButton,


### PR DESCRIPTION
Closes #6665

## Description

The "unsaved changes" prompt on the edit-profile screen (#6657) came from the video editor save-draft sheet and kept its clapperboard sticker. On a screen that edits a profile, a clapperboard reads as "video" and has nothing to do with what the sheet is asking about. Swapped to `DivineStickerName.alert`, which is what this repo already shows on every other "confirm before you lose something" sheet: trash restore/delete, delete video, discard captions, and clips. The video editor prompt keeps the clapperboard.

**Related Issue:** #6657

## Out of Scope

No test. The change is a single design-token swap with no behavior attached; the existing `profile_setup_screen_test.dart` prompt tests assert on the l10n button/title text and stay green. A test pinning the enum value would only restate the source line, not catch a regression.

## Verification

- `dart format` (no changes)
- `flutter analyze lib/screens/profile_setup` - no issues
- `flutter test test/screens/profile_setup_screen_test.dart` - 70/70 pass

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)