### PR TITLE
feat(upload): report publish phase timings to Firebase Performance

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2760,6 +2760,7 @@ class _DivineAppState extends ConsumerState<DivineApp>
           dmRepository: ref.read(dmRepositoryProvider),
           l10n: currentAppL10n(ref.read(sharedPreferencesProvider)),
         ),
+        performanceMonitor: ref.read(performanceMonitoringServiceProvider),
         onProgressChanged:
             ({required String draftId, required double progress}) {
               onProgress(draftId: draftId, progress: progress);

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -27,6 +27,7 @@ import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/layer_rasterizer_provider.dart';
 import 'package:openvine/providers/preferences_providers.dart';
 import 'package:openvine/providers/repository_providers.dart';
+import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/providers/upload_media_providers.dart';
@@ -164,6 +165,7 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
         l10n: currentAppL10n(ref.read(sharedPreferencesProvider)),
       ),
       languagePreferenceService: ref.read(languagePreferenceServiceProvider),
+      performanceMonitor: ref.read(performanceMonitoringServiceProvider),
       onProgressChanged: ({required String draftId, required double progress}) {
         setUploadProgress(draftId: draftId, progress: progress);
         onProgressChanged(draftId: draftId, progress: progress);

--- a/mobile/lib/services/performance_monitoring_service.dart
+++ b/mobile/lib/services/performance_monitoring_service.dart
@@ -18,6 +18,10 @@ abstract class PerformanceTrace {
   /// Adds an attribute for filtering in the Firebase console.
   void putAttribute(String attribute, String value);
 
+  /// Sets a custom metric on this trace, so an operation can report a
+  /// breakdown (per-phase durations, payload sizes) next to its duration.
+  void setMetric(String metric, int value);
+
   /// Stops the trace and records its duration.
   Future<void> stop();
 }
@@ -49,6 +53,9 @@ class _NoOpPerformanceTrace implements PerformanceTrace {
   void putAttribute(String attribute, String value) {}
 
   @override
+  void setMetric(String metric, int value) {}
+
+  @override
   Future<void> stop() async {}
 }
 
@@ -65,6 +72,18 @@ class _FirebasePerformanceTrace implements PerformanceTrace {
     } catch (e) {
       Log.error(
         'Failed to put attribute $attribute: $e',
+        name: 'PerformanceMonitoring',
+      );
+    }
+  }
+
+  @override
+  void setMetric(String metric, int value) {
+    try {
+      _trace.setMetric(metric, value);
+    } catch (e) {
+      Log.error(
+        'Failed to set metric $metric: $e',
         name: 'PerformanceMonitoring',
       );
     }

--- a/mobile/lib/services/performance_monitoring_service.dart
+++ b/mobile/lib/services/performance_monitoring_service.dart
@@ -1,8 +1,6 @@
 // ABOUTME: Performance monitoring service for tracking app performance metrics
 // ABOUTME: Uses Firebase Performance Monitoring to track screen transitions, network requests, and custom operations
 
-import 'dart:async';
-
 import 'package:firebase_performance/firebase_performance.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -61,9 +59,16 @@ class _NoOpPerformanceTrace implements PerformanceTrace {
 
 /// A [PerformanceTrace] backed by a live Firebase [Trace].
 class _FirebasePerformanceTrace implements PerformanceTrace {
-  _FirebasePerformanceTrace(this._trace);
+  _FirebasePerformanceTrace(this._trace, this._started);
 
   final Trace _trace;
+
+  /// Completion of the trace's start round-trip. [stop] waits on it because
+  /// the plugin drops a stop that arrives before the platform handed back a
+  /// trace handle — the trace is then never reported *and* leaks natively.
+  /// Operations that fail fast (an auth or ownership check that returns after
+  /// a single await) are exactly the ones that would race it.
+  final Future<void> _started;
 
   @override
   void putAttribute(String attribute, String value) {
@@ -92,6 +97,7 @@ class _FirebasePerformanceTrace implements PerformanceTrace {
   @override
   Future<void> stop() async {
     try {
+      await _started;
       await _trace.stop();
     } catch (e) {
       Log.error('Failed to stop trace: $e', name: 'PerformanceMonitoring');
@@ -189,23 +195,22 @@ class PerformanceMonitoringService implements PerformanceTraceMonitor {
   /// Unlike [startTrace], nothing is stored in [_activeTraces]: the caller
   /// owns the returned [PerformanceTrace] and tags/stops it directly, so
   /// overlapping operations of the same name keep independent traces. Start is
-  /// fire-and-forget so callers stay synchronous; attribute/stop calls on the
-  /// handle are delivered to the platform in order after it.
+  /// fire-and-forget so callers stay synchronous; attributes and metrics are
+  /// buffered until stop, and stop itself waits for the start round-trip so a
+  /// short operation cannot end its trace before the platform opened it.
   @override
   PerformanceTrace startOperationTrace(String traceName) {
     if (!_initialized) return const _NoOpPerformanceTrace();
 
     try {
       final trace = _performance.newTrace(traceName);
-      unawaited(
-        trace.start().catchError((Object e) {
-          Log.error(
-            'Failed to start trace $traceName: $e',
-            name: 'PerformanceMonitoring',
-          );
-        }),
-      );
-      return _FirebasePerformanceTrace(trace);
+      final started = trace.start().catchError((Object e) {
+        Log.error(
+          'Failed to start trace $traceName: $e',
+          name: 'PerformanceMonitoring',
+        );
+      });
+      return _FirebasePerformanceTrace(trace, started);
     } catch (e) {
       Log.error(
         'Failed to start trace $traceName: $e',

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -1975,7 +1975,10 @@ class UploadManager implements BackgroundAwareService {
             VideoEditorConstants.defaultThumbnailExtractTime,
       );
       extractWatch.stop();
-      logPublishPhase('upload.thumbnail.extract', extractWatch.elapsed);
+      logPublishPhase(
+        PublishPhases.uploadThumbnailExtract,
+        extractWatch.elapsed,
+      );
 
       if (thumbnailExtraction == null) {
         Log.warning(
@@ -2009,7 +2012,10 @@ class UploadManager implements BackgroundAwareService {
         thumbnailFile.readAsBytesSync(),
       );
       blurhashWatch.stop();
-      logPublishPhase('upload.thumbnail.blurhash', blurhashWatch.elapsed);
+      logPublishPhase(
+        PublishPhases.uploadThumbnailBlurhash,
+        blurhashWatch.elapsed,
+      );
 
       // Upload thumbnail to Blossom server. Divine relay publishing requires
       // a CDN thumbnail, so keep the image upload's own retry enabled here.
@@ -2027,7 +2033,7 @@ class UploadManager implements BackgroundAwareService {
       );
       putWatch.stop();
       logPublishPhase(
-        'upload.thumbnail.put',
+        PublishPhases.uploadThumbnailPut,
         putWatch.elapsed,
         bytes: thumbnailBytes,
       );

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -1119,9 +1119,9 @@ class UploadManager implements BackgroundAwareService {
       } finally {
         transferWatch.stop();
         logPublishPhase(
-          'upload.transfer',
+          PublishPhases.uploadTransfer,
           transferWatch.elapsed,
-          detail: formatTransferDetail(videoBytes, transferWatch.elapsed),
+          bytes: videoBytes,
         );
       }
 
@@ -1897,7 +1897,11 @@ class UploadManager implements BackgroundAwareService {
       // content-addressed, so re-uploading would land on the same hash. The
       // zero-duration line keeps the PUBTIME timeline honest on retries —
       // without it an export reads as "the leg never ran".
-      logPublishPhase('upload.thumbnail', Duration.zero, detail: 'reused');
+      logPublishPhase(
+        PublishPhases.uploadThumbnail,
+        Duration.zero,
+        detail: PublishPhases.reusedDetail,
+      );
       return (cdnUrl: existing, blurhash: upload.blurhash);
     }
 
@@ -1940,7 +1944,7 @@ class UploadManager implements BackgroundAwareService {
       return result;
     } finally {
       watch.stop();
-      logPublishPhase('upload.thumbnail', watch.elapsed);
+      logPublishPhase(PublishPhases.uploadThumbnail, watch.elapsed);
     }
   }
 
@@ -2025,7 +2029,7 @@ class UploadManager implements BackgroundAwareService {
       logPublishPhase(
         'upload.thumbnail.put',
         putWatch.elapsed,
-        detail: formatTransferDetail(thumbnailBytes, putWatch.elapsed),
+        bytes: thumbnailBytes,
       );
 
       // Clean up local thumbnail file

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -1320,7 +1320,7 @@ class VideoEventPublisher {
           // Continue publishing without blurhash - it's optional metadata
         } finally {
           blurhashWatch.stop();
-          logPublishPhase('nostr.blurhash', blurhashWatch.elapsed);
+          logPublishPhase(PublishPhases.nostrBlurhash, blurhashWatch.elapsed);
         }
       }
 
@@ -1748,7 +1748,9 @@ class VideoEventPublisher {
       logPublishPhase(
         PublishPhases.nostrSign,
         signWatch.elapsed,
-        detail: reusedEvent != null ? 'reused' : 'signed',
+        detail: reusedEvent != null
+            ? PublishPhases.reusedDetail
+            : PublishPhases.signedDetail,
       );
 
       if (event == null) {

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -1746,7 +1746,7 @@ class VideoEventPublisher {
           );
       signWatch.stop();
       logPublishPhase(
-        'nostr.sign',
+        PublishPhases.nostrSign,
         signWatch.elapsed,
         detail: reusedEvent != null ? 'reused' : 'signed',
       );
@@ -1789,7 +1789,7 @@ class VideoEventPublisher {
         isRetry: reusedEvent != null,
       );
       publishWatch.stop();
-      logPublishPhase('nostr.publish', publishWatch.elapsed);
+      logPublishPhase(PublishPhases.nostrPublish, publishWatch.elapsed);
 
       if (publishResult) {
         final shouldAddToDiscoveryCache =

--- a/mobile/lib/services/video_publish/publish_timeline.dart
+++ b/mobile/lib/services/video_publish/publish_timeline.dart
@@ -1,6 +1,9 @@
 // ABOUTME: Phase-level timing for a single video publish, emitted as
-// ABOUTME: greppable PUBTIME log lines so a slow publish can be attributed.
+// ABOUTME: greppable PUBTIME log lines and as a Firebase Performance trace.
 
+import 'dart:async';
+
+import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Token every timing line carries, so a log export can be reduced to the
@@ -11,14 +14,87 @@ const String publishTimingToken = 'PUBTIME';
 /// as `[PublishTiming]`, which is the second way to filter for these entries.
 const String publishTimingLogName = 'PublishTiming';
 
+/// Firebase Performance trace name for one publish, from the first upload byte
+/// to the outcome. Sits alongside the existing `video_upload` trace, which
+/// covers only the Blossom call and reports it as a single number.
+const String publishTraceName = 'video_publish';
+
+/// Phase names shared by the sites that emit them and the metric mapping.
+///
+/// The upload and Nostr phases are timed where they happen — deep in the
+/// upload manager and the event publisher — while the mapping to Firebase
+/// metrics lives here, so both ends refer to the same constant.
+abstract class PublishPhases {
+  static const String upload = 'upload';
+  static const String uploadTransfer = 'upload.transfer';
+  static const String uploadThumbnail = 'upload.thumbnail';
+  static const String mentions = 'mentions';
+  static const String subtitles = 'subtitles';
+  static const String nostr = 'nostr';
+  static const String nostrSign = 'nostr.sign';
+  static const String nostrPublish = 'nostr.publish';
+  static const String invites = 'invites';
+
+  /// Detail marker on [uploadThumbnail] for the leg that short-circuited on a
+  /// thumbnail a previous attempt already put on the CDN.
+  static const String reusedDetail = 'reused';
+}
+
+/// Firebase metric name per phase. A phase that never ran reports no metric,
+/// so an absent metric reads as "did not happen" rather than as zero.
+const Map<String, String> _metricByPhase = {
+  PublishPhases.upload: 'upload_ms',
+  PublishPhases.uploadTransfer: 'transfer_ms',
+  PublishPhases.uploadThumbnail: 'thumbnail_ms',
+  PublishPhases.mentions: 'mentions_ms',
+  PublishPhases.subtitles: 'subtitles_ms',
+  PublishPhases.nostr: 'nostr_ms',
+  PublishPhases.nostrSign: 'sign_ms',
+  PublishPhases.nostrPublish: 'nostr_publish_ms',
+  PublishPhases.invites: 'invites_ms',
+};
+
+/// Wall-clock metric for the whole publish.
+const String publishTotalMetric = 'total_ms';
+
+/// Uploaded video size, so throughput can be derived from [publishTraceName]
+/// rather than guessed from a nominal connection speed.
+const String publishPayloadMetric = 'payload_bytes';
+
+/// Zone key the ambient [PublishTimeline] is stored under.
+const Object _timelineZoneKey = #publishTimeline;
+
 /// One finished phase of a publish.
 typedef PublishPhase = ({String name, Duration elapsed});
 
-/// Emits a single timing line for a phase that has just finished.
+/// Emits a single timing line for a phase that has just finished, and folds it
+/// into the ambient [PublishTimeline] when one is running.
 ///
 /// Free function so layers that do not own the [PublishTimeline] (the upload
 /// pipeline) can contribute lines to the same filterable stream.
-void logPublishPhase(String phase, Duration elapsed, {String? detail}) {
+///
+/// Pass [bytes] for a transferred payload; the size and rate are appended to
+/// the line and the size is carried into the publish's metrics.
+void logPublishPhase(
+  String phase,
+  Duration elapsed, {
+  String? detail,
+  int? bytes,
+}) {
+  _logPhaseLine(
+    phase,
+    elapsed,
+    detail ?? (bytes == null ? null : formatTransferDetail(bytes, elapsed)),
+  );
+  PublishTimeline.current?._absorb(
+    phase,
+    elapsed,
+    detail: detail,
+    bytes: bytes,
+  );
+}
+
+void _logPhaseLine(String phase, Duration elapsed, String? detail) {
   final suffix = (detail == null || detail.isEmpty) ? '' : ' $detail';
   Log.info(
     '⏱️ $publishTimingToken $phase ${elapsed.inMilliseconds}ms$suffix',
@@ -40,26 +116,52 @@ String formatTransferDetail(int? bytes, Duration elapsed) {
   return '${megabytes.toStringAsFixed(2)}MB ${rate.toStringAsFixed(2)}MB/s';
 }
 
-/// Collects the phase durations of one publish and emits a summary line.
+/// Collects the phase durations of one publish, emits a summary line, and
+/// reports the same breakdown to Firebase Performance.
 ///
 /// Phases are logged as they finish, so a publish that hangs still leaves the
 /// completed phases in the log; the summary adds the total plus an `other`
 /// bucket for everything not covered by a measured phase.
 class PublishTimeline {
-  PublishTimeline(this.draftId);
+  PublishTimeline(this.draftId, {PerformanceTraceMonitor? performanceMonitor})
+    : _trace = (performanceMonitor ?? const NoOpPerformanceTraceMonitor())
+          .startOperationTrace(publishTraceName);
+
+  /// The timeline of the publish currently running on this call chain, or null
+  /// outside a [run].
+  static PublishTimeline? get current =>
+      Zone.current[_timelineZoneKey] as PublishTimeline?;
 
   /// Draft this publish belongs to — the join key between the timing lines and
   /// the surrounding upload logs.
   final String draftId;
 
+  final PerformanceTrace _trace;
+
   final Stopwatch _total = Stopwatch()..start();
   final List<PublishPhase> _phases = <PublishPhase>[];
+
+  /// Every phase heard of, summed per name. Unlike [_phases] this also holds
+  /// the nested phases that [logPublishPhase] emits from inside the upload and
+  /// Nostr legs, and it adds a retried phase's attempts together.
+  final Map<String, Duration> _elapsedByPhase = <String, Duration>{};
+
+  int? _payloadBytes;
+  bool _thumbnailReused = false;
 
   /// Phases recorded so far, in completion order.
   List<PublishPhase> get phases => List.unmodifiable(_phases);
 
   /// Wall-clock time since this timeline was created.
   Duration get total => _total.elapsed;
+
+  /// Runs [action] with this timeline as the ambient one, so the phases the
+  /// upload and Nostr legs emit through [logPublishPhase] land in this
+  /// publish's metrics without threading the timeline through every layer in
+  /// between. Legs kicked off outside this call chain (a background upload
+  /// resumed from a previous session) simply report no metric.
+  Future<T> run<T>(Future<T> Function() action) =>
+      runZoned<Future<T>>(action, zoneValues: {_timelineZoneKey: this});
 
   /// Runs [action], recording its duration under [phase].
   ///
@@ -78,7 +180,22 @@ class PublishTimeline {
   /// Records an already-measured [phase] and logs its line.
   void record(String phase, Duration elapsed) {
     _phases.add((name: phase, elapsed: elapsed));
-    logPublishPhase(phase, elapsed);
+    _absorb(phase, elapsed);
+    _logPhaseLine(phase, elapsed, null);
+  }
+
+  /// Folds a phase into the metric breakdown without touching the summary's
+  /// top-level phase list.
+  void _absorb(String phase, Duration elapsed, {String? detail, int? bytes}) {
+    _elapsedByPhase[phase] =
+        (_elapsedByPhase[phase] ?? Duration.zero) + elapsed;
+    if (bytes != null && bytes > 0 && phase == PublishPhases.uploadTransfer) {
+      _payloadBytes = bytes;
+    }
+    if (phase == PublishPhases.uploadThumbnail &&
+        detail == PublishPhases.reusedDetail) {
+      _thumbnailReused = true;
+    }
   }
 
   /// Builds the one-line summary for a publish that ended with [outcome].
@@ -105,5 +222,30 @@ class PublishTimeline {
       name: publishTimingLogName,
       category: LogCategory.video,
     );
+  }
+
+  /// Ends the timeline: logs the summary line and reports the same breakdown
+  /// to Firebase Performance, tagged with [outcome] so a failed or abandoned
+  /// publish is distinguishable from one that reached the relay.
+  ///
+  /// The trace is stopped fire-and-forget, so a publish never waits on a
+  /// platform round-trip to return its result.
+  void finish({required String outcome}) {
+    logSummary(outcome: outcome);
+
+    _total.stop();
+    for (final entry in _elapsedByPhase.entries) {
+      final metric = _metricByPhase[entry.key];
+      if (metric != null) _trace.setMetric(metric, entry.value.inMilliseconds);
+    }
+    _trace.setMetric(publishTotalMetric, _total.elapsed.inMilliseconds);
+    final payloadBytes = _payloadBytes;
+    if (payloadBytes != null) {
+      _trace.setMetric(publishPayloadMetric, payloadBytes);
+    }
+    _trace
+      ..putAttribute('outcome', outcome)
+      ..putAttribute('thumbnail', _thumbnailReused ? 'reused' : 'generated');
+    unawaited(_trace.stop());
   }
 }

--- a/mobile/lib/services/video_publish/publish_timeline.dart
+++ b/mobile/lib/services/video_publish/publish_timeline.dart
@@ -28,20 +28,33 @@ abstract class PublishPhases {
   static const String upload = 'upload';
   static const String uploadTransfer = 'upload.transfer';
   static const String uploadThumbnail = 'upload.thumbnail';
+  static const String uploadThumbnailExtract = 'upload.thumbnail.extract';
+  static const String uploadThumbnailBlurhash = 'upload.thumbnail.blurhash';
+  static const String uploadThumbnailPut = 'upload.thumbnail.put';
   static const String mentions = 'mentions';
   static const String subtitles = 'subtitles';
   static const String nostr = 'nostr';
+  static const String nostrBlurhash = 'nostr.blurhash';
   static const String nostrSign = 'nostr.sign';
   static const String nostrPublish = 'nostr.publish';
   static const String invites = 'invites';
 
-  /// Detail marker on [uploadThumbnail] for the leg that short-circuited on a
-  /// thumbnail a previous attempt already put on the CDN.
+  /// Detail marker for a leg that short-circuited on work a previous attempt
+  /// already finished — a thumbnail already on the CDN, or an event the
+  /// signer already signed.
   static const String reusedDetail = 'reused';
+
+  /// Detail marker on [nostrSign] for a signature this attempt really made.
+  static const String signedDetail = 'signed';
 }
 
 /// Firebase metric name per phase. A phase that never ran reports no metric,
 /// so an absent metric reads as "did not happen" rather than as zero.
+///
+/// The metrics are *not* additive: [PublishPhases.uploadThumbnail] runs in
+/// parallel with [PublishPhases.uploadTransfer], so `upload_ms` is roughly the
+/// longer of the two rather than their sum. Only the summary log line's
+/// top-level phases add up to the total.
 const Map<String, String> _metricByPhase = {
   PublishPhases.upload: 'upload_ms',
   PublishPhases.uploadTransfer: 'transfer_ms',
@@ -59,7 +72,18 @@ const String publishTotalMetric = 'total_ms';
 
 /// Uploaded video size, so throughput can be derived from [publishTraceName]
 /// rather than guessed from a nominal connection speed.
+///
+/// It is the size of the file, reported once, while `transfer_ms` sums every
+/// attempt — including one that timed out and one that resumed mid-file. Only
+/// divide the two on traces whose [publishTransferAttemptsMetric] is 1.
 const String publishPayloadMetric = 'payload_bytes';
+
+/// How many times the transfer leg ran for this publish.
+///
+/// `transfer_ms` is the sum across attempts, so without this a retried publish
+/// and a slow one look identical — and a publish whose first attempt hit the
+/// upload timeout carries minutes of dead time in the metric.
+const String publishTransferAttemptsMetric = 'transfer_attempts';
 
 /// Zone key the ambient [PublishTimeline] is stored under.
 const Object _timelineZoneKey = #publishTimeline;
@@ -147,7 +171,12 @@ class PublishTimeline {
   final Map<String, Duration> _elapsedByPhase = <String, Duration>{};
 
   int? _payloadBytes;
-  bool _thumbnailReused = false;
+  int _transferAttempts = 0;
+
+  /// Null until the leg ran at all, so a publish that failed before it reports
+  /// no attribute rather than claiming work it never did.
+  bool? _thumbnailReused;
+  bool? _signatureReused;
 
   /// Phases recorded so far, in completion order.
   List<PublishPhase> get phases => List.unmodifiable(_phases);
@@ -189,14 +218,23 @@ class PublishTimeline {
   void _absorb(String phase, Duration elapsed, {String? detail, int? bytes}) {
     _elapsedByPhase[phase] =
         (_elapsedByPhase[phase] ?? Duration.zero) + elapsed;
-    if (bytes != null && bytes > 0 && phase == PublishPhases.uploadTransfer) {
-      _payloadBytes = bytes;
-    }
-    if (phase == PublishPhases.uploadThumbnail &&
-        detail == PublishPhases.reusedDetail) {
-      _thumbnailReused = true;
+    switch (phase) {
+      case PublishPhases.uploadTransfer:
+        _transferAttempts++;
+        if (bytes != null && bytes > 0) _payloadBytes = bytes;
+      case PublishPhases.uploadThumbnail:
+        _thumbnailReused = _reuseOf(_thumbnailReused, detail);
+      case PublishPhases.nostrSign:
+        _signatureReused = _reuseOf(_signatureReused, detail);
     }
   }
+
+  /// Folds one attempt's [detail] into a leg's reuse flag.
+  ///
+  /// A leg that did real work once is reported as such even if a later attempt
+  /// short-circuited, because its metric then carries that real work.
+  static bool _reuseOf(bool? current, String? detail) =>
+      (current ?? true) && detail == PublishPhases.reusedDetail;
 
   /// Builds the one-line summary for a publish that ended with [outcome].
   String summaryLine({required String outcome}) {
@@ -243,9 +281,31 @@ class PublishTimeline {
     if (payloadBytes != null) {
       _trace.setMetric(publishPayloadMetric, payloadBytes);
     }
-    _trace
-      ..putAttribute('outcome', outcome)
-      ..putAttribute('thumbnail', _thumbnailReused ? 'reused' : 'generated');
+    if (_transferAttempts > 0) {
+      _trace.setMetric(publishTransferAttemptsMetric, _transferAttempts);
+    }
+    _trace.putAttribute('outcome', outcome);
+    _putReuseAttribute('thumbnail', _thumbnailReused, freshValue: 'generated');
+    _putReuseAttribute(
+      'signature',
+      _signatureReused,
+      freshValue: PublishPhases.signedDetail,
+    );
     unawaited(_trace.stop());
+  }
+
+  /// Tags a leg as reused or freshly done, and says nothing at all about a leg
+  /// that never ran — a metric near zero because the work was skipped must be
+  /// filterable out of the distribution for the work itself.
+  void _putReuseAttribute(
+    String attribute,
+    bool? reused, {
+    required String freshValue,
+  }) {
+    if (reused == null) return;
+    _trace.putAttribute(
+      attribute,
+      reused ? PublishPhases.reusedDetail : freshValue,
+    );
   }
 }

--- a/mobile/lib/services/video_publish/publish_timeline.dart
+++ b/mobile/lib/services/video_publish/publish_timeline.dart
@@ -70,20 +70,29 @@ const Map<String, String> _metricByPhase = {
 /// Wall-clock metric for the whole publish.
 const String publishTotalMetric = 'total_ms';
 
-/// Uploaded video size, so throughput can be derived from [publishTraceName]
-/// rather than guessed from a nominal connection speed.
+/// Size of the uploaded video file, reported once.
 ///
-/// It is the size of the file, reported once, while `transfer_ms` sums every
-/// attempt — including one that timed out and one that resumed mid-file. Only
-/// divide the two on traces whose [publishTransferAttemptsMetric] is 1.
+/// Dividing it by `transfer_ms` gives the **effective** throughput of the
+/// publish — bytes delivered per unit of wall clock the user actually waited,
+/// retry overhead included. It is not the line rate, and no combination of
+/// these metrics recovers one: a single transfer leg can contain a whole-file
+/// OS attempt that failed, a chunked resumable fallback that re-sent the same
+/// bytes, iteration across servers, and per-chunk retries, none of which the
+/// publish layer can see. Measuring the line rate means instrumenting
+/// `blossom_upload_service` at the transport boundary.
 const String publishPayloadMetric = 'payload_bytes';
 
-/// How many times the transfer leg ran for this publish.
+/// How many times the transfer *leg* ran for this publish.
 ///
-/// `transfer_ms` is the sum across attempts, so without this a retried publish
-/// and a slow one look identical — and a publish whose first attempt hit the
-/// upload timeout carries minutes of dead time in the metric.
-const String publishTransferAttemptsMetric = 'transfer_attempts';
+/// `transfer_ms` sums the legs, so without this a publish that resumed after a
+/// failure and a genuinely slow one look identical — and a leg that hit the
+/// upload timeout carries minutes of dead time into the sum.
+///
+/// This counts the phase, not the transport: one leg is one
+/// [PublishPhases.uploadTransfer] line, however many attempts the upload
+/// service made inside it. `transfer_legs == 1` therefore means "the publish
+/// entered the transfer once", not "the file went up in one attempt".
+const String publishTransferLegsMetric = 'transfer_legs';
 
 /// Zone key the ambient [PublishTimeline] is stored under.
 const Object _timelineZoneKey = #publishTimeline;
@@ -99,6 +108,29 @@ typedef PublishPhase = ({String name, Duration elapsed});
 ///
 /// Pass [bytes] for a transferred payload; the size and rate are appended to
 /// the line and the size is carried into the publish's metrics.
+///
+/// The timeline is found through the zone, so the metric half of this call is
+/// invisible at the call site: a phase emitted off a call chain that did not
+/// start inside [PublishTimeline.run] still logs its line but reports no
+/// metric. The known emitters and where they sit:
+///
+/// - `UploadManager._performUploadInternal` (`upload.transfer`,
+///   `upload.thumbnail*`) — inside the zone when the publish started the
+///   upload, because `startUpload` awaits `_performUpload` on the publish's
+///   own chain. **Outside** it when the publish joins an upload another chain
+///   already had in flight — a session resumed at app start, or a retry the
+///   recovery sweep kicked off. Those legs belong to whichever chain started
+///   them, so attributing them to the publish that happened to wait would be
+///   the wrong answer, not a missing one.
+/// - `VideoEventPublisher` (`nostr.sign`, `nostr.publish`, `nostr.blurhash`) —
+///   always inside the zone; `publishVideoEvent` is awaited directly by
+///   `VideoPublishService`.
+///
+/// A `Timer`, an isolate hop, or a future scheduled outside `run` would drop
+/// the metric the same silent way. There is deliberately no assert for it:
+/// the joined-upload case above is legitimate and would trip on every resumed
+/// publish. `upload_ms` still covers the leg, so the console shows a duration
+/// with no breakdown rather than nothing at all.
 void logPublishPhase(
   String phase,
   Duration elapsed, {
@@ -171,7 +203,7 @@ class PublishTimeline {
   final Map<String, Duration> _elapsedByPhase = <String, Duration>{};
 
   int? _payloadBytes;
-  int _transferAttempts = 0;
+  int _transferLegs = 0;
 
   /// Null until the leg ran at all, so a publish that failed before it reports
   /// no attribute rather than claiming work it never did.
@@ -220,7 +252,7 @@ class PublishTimeline {
         (_elapsedByPhase[phase] ?? Duration.zero) + elapsed;
     switch (phase) {
       case PublishPhases.uploadTransfer:
-        _transferAttempts++;
+        _transferLegs++;
         if (bytes != null && bytes > 0) _payloadBytes = bytes;
       case PublishPhases.uploadThumbnail:
         _thumbnailReused = _reuseOf(_thumbnailReused, detail);
@@ -281,8 +313,8 @@ class PublishTimeline {
     if (payloadBytes != null) {
       _trace.setMetric(publishPayloadMetric, payloadBytes);
     }
-    if (_transferAttempts > 0) {
-      _trace.setMetric(publishTransferAttemptsMetric, _transferAttempts);
+    if (_transferLegs > 0) {
+      _trace.setMetric(publishTransferLegsMetric, _transferLegs);
     }
     _trace.putAttribute('outcome', outcome);
     _putReuseAttribute('thumbnail', _thumbnailReused, freshValue: 'generated');

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -20,6 +20,7 @@ import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/language_preference_service.dart';
 import 'package:openvine/services/mention_resolution_service.dart';
+import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/subtitle_service.dart';
 import 'package:openvine/services/upload_manager.dart';
 import 'package:openvine/services/video_event_publisher.dart';
@@ -157,8 +158,11 @@ class VideoPublishService {
     this.collaboratorInviteService,
     this.languagePreferenceService,
     this.mentionResolutionService,
+    PerformanceTraceMonitor? performanceMonitor,
     Duration subtitlePublishTimeout = _defaultSubtitlePublishTimeout,
-  }) : _subtitlePublishTimeout = subtitlePublishTimeout;
+  }) : _performanceMonitor =
+           performanceMonitor ?? const NoOpPerformanceTraceMonitor(),
+       _subtitlePublishTimeout = subtitlePublishTimeout;
 
   /// Manages background video uploads.
   final UploadManager uploadManager;
@@ -186,6 +190,10 @@ class VideoPublishService {
 
   /// Resolves typed mentions before publishing Nostr video events.
   final MentionResolutionService? mentionResolutionService;
+
+  /// Reports the publish phase breakdown to Firebase Performance. Optional so
+  /// unit tests get the no-op monitor and never reach Firebase.
+  final PerformanceTraceMonitor _performanceMonitor;
 
   /// Deadline for each optional caption-asset network step. Captions are
   /// best-effort, so a stalled upload / relay publish must never hold up the
@@ -230,7 +238,8 @@ class VideoPublishService {
   /// Returns [PublishSuccess] on success, [PublishError] on failure.
   ///
   /// Wraps the publish in a [PublishTimeline] so every run emits per-phase
-  /// timing plus a summary line, whichever way it ends.
+  /// timing plus a summary line and a `video_publish` performance trace,
+  /// whichever way it ends.
   ///
   /// A successful publish does *not* delete the draft. Reclaiming the draft
   /// row and its unreferenced media is `BackgroundPublishBloc`'s job
@@ -239,13 +248,20 @@ class VideoPublishService {
   /// garbage collection only delays the UI (#6548). The bloc also deletes the
   /// source draft this publish copy came from, which this service never saw.
   Future<PublishResult> publishVideo({required DivineVideoDraft draft}) async {
-    final timeline = PublishTimeline(draft.id);
+    final timeline = PublishTimeline(
+      draft.id,
+      performanceMonitor: _performanceMonitor,
+    );
     PublishResult? result;
     try {
-      result = await _publishVideo(draft: draft, timeline: timeline);
+      // Inside `run` so the phases the upload and Nostr legs time for
+      // themselves are attributed to this publish's trace.
+      result = await timeline.run<PublishResult>(
+        () => _publishVideo(draft: draft, timeline: timeline),
+      );
       return result;
     } finally {
-      timeline.logSummary(
+      timeline.finish(
         outcome: switch (result) {
           PublishSuccess() => 'success',
           PublishError(:final kind) => 'error:${kind.name}',
@@ -305,7 +321,7 @@ class VideoPublishService {
 
       // Use existing upload if available, otherwise start new upload
       final pendingUpload = await timeline.measure(
-        'upload',
+        PublishPhases.upload,
         () => _getOrCreateUpload(pubkey, draft),
       );
       if (pendingUpload == null) {
@@ -349,14 +365,14 @@ class VideoPublishService {
       Log.info('📝 Publishing Nostr event...', category: .video);
 
       final mentionedPubkeys = await timeline.measure(
-        'mentions',
+        PublishPhases.mentions,
         () => _resolveMentionedPubkeys(draft, currentUserPubkey: pubkey),
       );
 
       final captionTrack = _captionTrackForPublish(draft);
       final textTrackRefs = captionTrack != null
           ? await timeline.measure(
-              'subtitles',
+              PublishPhases.subtitles,
               () => _publishSubtitleAssets(captionTrack, pendingUpload),
             )
           : const <String>[];
@@ -367,7 +383,7 @@ class VideoPublishService {
       );
 
       final published = await timeline.measure(
-        'nostr',
+        PublishPhases.nostr,
         () => videoEventPublisher.publishVideoEvent(
           upload: pendingUpload,
           title: draft.title,
@@ -415,7 +431,7 @@ class VideoPublishService {
       onProgressChanged(draftId: draft.id, progress: _progressAfterNostr);
 
       final inviteWarnings = await timeline.measure(
-        'invites',
+        PublishPhases.invites,
         () => _sendCollaboratorInvites(
           draft: draft,
           upload: pendingUpload,

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -38,11 +38,15 @@ class _MockCameraService extends Mock implements CameraService {}
 /// An operation-scoped trace handle that records its attributes and stop count.
 class _RecordingTrace implements PerformanceTrace {
   final Map<String, String> attributes = {};
+  final Map<String, int> metrics = {};
   int stopCount = 0;
 
   @override
   void putAttribute(String attribute, String value) =>
       attributes[attribute] = value;
+
+  @override
+  void setMetric(String metric, int value) => metrics[metric] = value;
 
   @override
   Future<void> stop() async => stopCount++;

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -51,11 +51,15 @@ class _RecordingTrace implements PerformanceTrace {
 
   final String name;
   final Map<String, String> attributes = {};
+  final Map<String, int> metrics = {};
   int stopCount = 0;
 
   @override
   void putAttribute(String attribute, String value) =>
       attributes[attribute] = value;
+
+  @override
+  void setMetric(String metric, int value) => metrics[metric] = value;
 
   @override
   Future<void> stop() async => stopCount++;

--- a/mobile/test/services/performance_monitoring_service_test.dart
+++ b/mobile/test/services/performance_monitoring_service_test.dart
@@ -85,7 +85,9 @@ void main() {
 
         // Tagging and stopping the handle must be safe even when Firebase
         // isn't configured (the uninitialised path returns a no-op handle).
-        trace.putAttribute('outcome', 'success');
+        trace
+          ..putAttribute('outcome', 'success')
+          ..setMetric('phase_ms', 120);
         await expectLater(trace.stop(), completes);
       },
     );
@@ -96,7 +98,9 @@ void main() {
       const monitor = NoOpPerformanceTraceMonitor();
 
       final trace = monitor.startOperationTrace('test_operation');
-      trace.putAttribute('outcome', 'success');
+      trace
+        ..putAttribute('outcome', 'success')
+        ..setMetric('phase_ms', 120);
 
       await expectLater(trace.stop(), completes);
     });

--- a/mobile/test/services/video_publish/publish_timeline_test.dart
+++ b/mobile/test/services/video_publish/publish_timeline_test.dart
@@ -1,9 +1,53 @@
-// ABOUTME: Tests for PublishTimeline — phase capture, summary shape, and the
-// ABOUTME: PUBTIME token contract the log-filtering workflow depends on.
+// ABOUTME: Tests for PublishTimeline — phase capture, summary shape, the
+// ABOUTME: PUBTIME token contract, and the reported performance breakdown.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/video_publish/publish_timeline.dart';
 import 'package:unified_logger/unified_logger.dart';
+
+/// Records what a publish would report to Firebase, without any Firebase.
+class _FakePerformanceTrace implements PerformanceTrace {
+  final Map<String, int> metrics = {};
+  final Map<String, String> attributes = {};
+  int stopCount = 0;
+
+  @override
+  void putAttribute(String attribute, String value) =>
+      attributes[attribute] = value;
+
+  @override
+  void setMetric(String metric, int value) => metrics[metric] = value;
+
+  @override
+  Future<void> stop() async => stopCount++;
+}
+
+class _FakePerformanceMonitor implements PerformanceTraceMonitor {
+  final List<String> startedOperations = [];
+  final _FakePerformanceTrace trace = _FakePerformanceTrace();
+
+  @override
+  PerformanceTrace startOperationTrace(String traceName) {
+    startedOperations.add(traceName);
+    return trace;
+  }
+
+  @override
+  Future<void> startTrace(String traceName) async {}
+
+  @override
+  Future<void> stopTrace(String traceName) async {}
+
+  @override
+  void incrementMetric(String traceName, String metricName, int value) {}
+
+  @override
+  void setMetric(String traceName, String metricName, int value) {}
+
+  @override
+  void putAttribute(String traceName, String attribute, String value) {}
+}
 
 void main() {
   group(PublishTimeline, () {
@@ -63,6 +107,197 @@ void main() {
         expect(summary, contains('outcome=threw'));
         expect(summary, contains('total='));
       });
+
+      test('ignores the nested phases the upload leg emits', () async {
+        await timeline.run(() async {
+          logPublishPhase(
+            PublishPhases.uploadTransfer,
+            const Duration(milliseconds: 700),
+          );
+        });
+        timeline.record(
+          PublishPhases.upload,
+          const Duration(milliseconds: 900),
+        );
+
+        // A nested phase is part of its parent, so counting it in the summary
+        // would double it and drive `other` negative.
+        final summary = timeline.summaryLine(outcome: 'success');
+        expect(summary, contains('upload=900ms'));
+        expect(summary, isNot(contains('upload.transfer=')));
+      });
+    });
+
+    group('run', () {
+      test('makes the timeline ambient only for the duration of the '
+          'action', () async {
+        expect(PublishTimeline.current, isNull);
+
+        await timeline.run(() async {
+          expect(PublishTimeline.current, same(timeline));
+        });
+
+        expect(PublishTimeline.current, isNull);
+      });
+
+      test('stays ambient across an await and inside a parallel leg', () async {
+        await timeline.run(() async {
+          final leg = Future<PublishTimeline?>(() => PublishTimeline.current);
+          await Future<void>.delayed(Duration.zero);
+          expect(PublishTimeline.current, same(timeline));
+          expect(await leg, same(timeline));
+        });
+      });
+    });
+
+    group('finish', () {
+      late _FakePerformanceMonitor monitor;
+      late PublishTimeline traced;
+
+      setUp(() {
+        monitor = _FakePerformanceMonitor();
+        traced = PublishTimeline('draft-1', performanceMonitor: monitor);
+      });
+
+      test('starts one publish trace per timeline', () {
+        expect(monitor.startedOperations, equals([publishTraceName]));
+      });
+
+      test('reports the phases the summary carries', () async {
+        await traced.run(() async {
+          traced
+            ..record(PublishPhases.upload, const Duration(milliseconds: 900))
+            ..record(PublishPhases.nostr, const Duration(milliseconds: 120));
+          logPublishPhase(
+            PublishPhases.uploadTransfer,
+            const Duration(milliseconds: 700),
+            bytes: 16572,
+          );
+          logPublishPhase(
+            PublishPhases.uploadThumbnail,
+            const Duration(milliseconds: 150),
+          );
+          logPublishPhase(
+            PublishPhases.nostrSign,
+            const Duration(milliseconds: 80),
+          );
+          logPublishPhase(
+            PublishPhases.nostrPublish,
+            const Duration(milliseconds: 40),
+          );
+        });
+
+        traced.finish(outcome: 'success');
+
+        expect(
+          monitor.trace.metrics,
+          allOf([
+            containsPair('upload_ms', 900),
+            containsPair('nostr_ms', 120),
+            containsPair('transfer_ms', 700),
+            containsPair('thumbnail_ms', 150),
+            containsPair('sign_ms', 80),
+            containsPair('nostr_publish_ms', 40),
+            containsPair(publishPayloadMetric, 16572),
+            contains(publishTotalMetric),
+          ]),
+        );
+        expect(monitor.trace.stopCount, equals(1));
+      });
+
+      test('reports each phase once, even when it is measured', () async {
+        await traced.run(
+          () => traced.measure(PublishPhases.nostr, () async {}),
+        );
+
+        traced.finish(outcome: 'success');
+
+        expect(monitor.trace.metrics['nostr_ms'], isNotNull);
+      });
+
+      test('adds a retried phase up across its attempts', () async {
+        await traced.run(() async {
+          logPublishPhase(
+            PublishPhases.uploadTransfer,
+            const Duration(milliseconds: 700),
+          );
+          logPublishPhase(
+            PublishPhases.uploadTransfer,
+            const Duration(milliseconds: 500),
+          );
+        });
+
+        traced.finish(outcome: 'success');
+
+        expect(monitor.trace.metrics['transfer_ms'], equals(1200));
+      });
+
+      test('omits a metric for a phase that never ran', () {
+        traced.finish(outcome: 'success');
+
+        expect(monitor.trace.metrics.containsKey('transfer_ms'), isFalse);
+        expect(
+          monitor.trace.metrics.containsKey(publishPayloadMetric),
+          isFalse,
+        );
+      });
+
+      test('distinguishes a failed publish from a successful one', () {
+        traced.finish(outcome: 'error:serverDown');
+
+        expect(monitor.trace.attributes['outcome'], equals('error:serverDown'));
+      });
+
+      test(
+        "tags a publish that reused a previous attempt's thumbnail",
+        () async {
+          await traced.run(() async {
+            logPublishPhase(
+              PublishPhases.uploadThumbnail,
+              Duration.zero,
+              detail: PublishPhases.reusedDetail,
+            );
+          });
+
+          traced.finish(outcome: 'success');
+
+          expect(monitor.trace.attributes['thumbnail'], equals('reused'));
+        },
+      );
+
+      test('tags a publish that generated its own thumbnail', () async {
+        await traced.run(() async {
+          logPublishPhase(
+            PublishPhases.uploadThumbnail,
+            const Duration(milliseconds: 150),
+          );
+        });
+
+        traced.finish(outcome: 'success');
+
+        expect(monitor.trace.attributes['thumbnail'], equals('generated'));
+      });
+
+      test('still logs the summary line', () {
+        traced.record(PublishPhases.upload, const Duration(milliseconds: 900));
+
+        traced.finish(outcome: 'success');
+
+        final summary = LogCaptureService().getRecentLogs(limit: 1).single;
+        expect(summary.message, contains('$publishTimingToken summary'));
+        expect(summary.message, contains('outcome=success'));
+      });
+
+      test('ignores phases emitted outside its own run', () {
+        logPublishPhase(
+          PublishPhases.uploadTransfer,
+          const Duration(milliseconds: 700),
+        );
+
+        traced.finish(outcome: 'success');
+
+        expect(monitor.trace.metrics.containsKey('transfer_ms'), isFalse);
+      });
     });
   });
 
@@ -82,6 +317,18 @@ void main() {
       expect(captured.message, contains('upload.transfer'));
       expect(captured.message, contains('5231ms'));
       expect(captured.message, contains('8.00MB 1.53MB/s'));
+    });
+
+    test('renders a transferred payload as size and rate', () {
+      logPublishPhase(
+        'upload.transfer',
+        const Duration(seconds: 4),
+        bytes: 8 * 1024 * 1024,
+      );
+
+      final captured = LogCaptureService().getRecentLogs(limit: 1).single;
+
+      expect(captured.message, contains('8.00MB 2.00MB/s'));
     });
   });
 

--- a/mobile/test/services/video_publish/publish_timeline_test.dart
+++ b/mobile/test/services/video_publish/publish_timeline_test.dart
@@ -205,14 +205,16 @@ void main() {
         expect(monitor.trace.stopCount, equals(1));
       });
 
-      test('reports each phase once, even when it is measured', () async {
-        await traced.run(
-          () => traced.measure(PublishPhases.nostr, () async {}),
-        );
+      test('counts a phase it records itself only once', () async {
+        // A recorded phase logs its own line rather than going back through
+        // logPublishPhase, which would fold it in a second time from the zone.
+        await traced.run(() async {
+          traced.record(PublishPhases.nostr, const Duration(milliseconds: 120));
+        });
 
         traced.finish(outcome: 'success');
 
-        expect(monitor.trace.metrics['nostr_ms'], isNotNull);
+        expect(monitor.trace.metrics['nostr_ms'], equals(120));
       });
 
       test('adds a retried phase up across its attempts', () async {
@@ -232,12 +234,40 @@ void main() {
         expect(monitor.trace.metrics['transfer_ms'], equals(1200));
       });
 
+      test('reports how many attempts the summed transfer covers', () async {
+        await traced.run(() async {
+          logPublishPhase(
+            PublishPhases.uploadTransfer,
+            const Duration(milliseconds: 700),
+            bytes: 16572,
+          );
+          logPublishPhase(
+            PublishPhases.uploadTransfer,
+            const Duration(milliseconds: 500),
+            bytes: 16572,
+          );
+        });
+
+        traced.finish(outcome: 'success');
+
+        // Without this, payload_bytes / transfer_ms silently reads as half the
+        // real throughput on any publish that retried.
+        expect(
+          monitor.trace.metrics[publishTransferAttemptsMetric],
+          equals(2),
+        );
+      });
+
       test('omits a metric for a phase that never ran', () {
         traced.finish(outcome: 'success');
 
         expect(monitor.trace.metrics.containsKey('transfer_ms'), isFalse);
         expect(
           monitor.trace.metrics.containsKey(publishPayloadMetric),
+          isFalse,
+        );
+        expect(
+          monitor.trace.metrics.containsKey(publishTransferAttemptsMetric),
           isFalse,
         );
       });
@@ -276,6 +306,69 @@ void main() {
         traced.finish(outcome: 'success');
 
         expect(monitor.trace.attributes['thumbnail'], equals('generated'));
+      });
+
+      test('says nothing about a leg the publish never reached', () {
+        traced.finish(outcome: 'error:notSignedIn');
+
+        // Claiming `generated` here would put publishes that never touched a
+        // thumbnail into the distribution for ones that built a thumbnail.
+        expect(monitor.trace.attributes.containsKey('thumbnail'), isFalse);
+        expect(monitor.trace.attributes.containsKey('signature'), isFalse);
+      });
+
+      test(
+        "tags a publish that reused a previous attempt's signature",
+        () async {
+          await traced.run(() async {
+            logPublishPhase(
+              PublishPhases.nostrSign,
+              Duration.zero,
+              detail: PublishPhases.reusedDetail,
+            );
+          });
+
+          traced.finish(outcome: 'success');
+
+          // A reused signature reports ~0ms, which would drag the signer latency
+          // distribution down if it could not be filtered out.
+          expect(monitor.trace.attributes['signature'], equals('reused'));
+        },
+      );
+
+      test('tags a publish that really signed its event', () async {
+        await traced.run(() async {
+          logPublishPhase(
+            PublishPhases.nostrSign,
+            const Duration(milliseconds: 800),
+            detail: PublishPhases.signedDetail,
+          );
+        });
+
+        traced.finish(outcome: 'success');
+
+        expect(monitor.trace.attributes['signature'], equals('signed'));
+      });
+
+      test('counts a leg as fresh when any attempt did the work', () async {
+        await traced.run(() async {
+          logPublishPhase(
+            PublishPhases.nostrSign,
+            const Duration(milliseconds: 800),
+            detail: PublishPhases.signedDetail,
+          );
+          logPublishPhase(
+            PublishPhases.nostrSign,
+            Duration.zero,
+            detail: PublishPhases.reusedDetail,
+          );
+        });
+
+        traced.finish(outcome: 'success');
+
+        // sign_ms carries the 800ms the first attempt really spent, so this
+        // trace belongs in the signer distribution.
+        expect(monitor.trace.attributes['signature'], equals('signed'));
       });
 
       test('still logs the summary line', () {

--- a/mobile/test/services/video_publish/publish_timeline_test.dart
+++ b/mobile/test/services/video_publish/publish_timeline_test.dart
@@ -234,7 +234,7 @@ void main() {
         expect(monitor.trace.metrics['transfer_ms'], equals(1200));
       });
 
-      test('reports how many attempts the summed transfer covers', () async {
+      test('reports how many legs the summed transfer covers', () async {
         await traced.run(() async {
           logPublishPhase(
             PublishPhases.uploadTransfer,
@@ -250,12 +250,30 @@ void main() {
 
         traced.finish(outcome: 'success');
 
-        // Without this, payload_bytes / transfer_ms silently reads as half the
-        // real throughput on any publish that retried.
-        expect(
-          monitor.trace.metrics[publishTransferAttemptsMetric],
-          equals(2),
-        );
+        // Without this, a publish that resumed after a failure and a genuinely
+        // slow one are indistinguishable in the console.
+        expect(monitor.trace.metrics[publishTransferLegsMetric], equals(2));
+      });
+
+      test('counts one leg however many attempts it took inside', () async {
+        // The upload service can burn a whole-file OS attempt, fall back to
+        // chunked resumable, iterate servers and retry chunks — all inside the
+        // single uploadVideoWithResume call this one phase wraps. The publish
+        // layer sees none of that, so the metric must not be read as a count
+        // of transport attempts: transfer_legs == 1 means the publish entered
+        // the transfer once, not that the file went up in one attempt.
+        await traced.run(() async {
+          logPublishPhase(
+            PublishPhases.uploadTransfer,
+            const Duration(minutes: 4),
+            bytes: 16572,
+          );
+        });
+
+        traced.finish(outcome: 'success');
+
+        expect(monitor.trace.metrics[publishTransferLegsMetric], equals(1));
+        expect(monitor.trace.metrics['transfer_ms'], equals(240000));
       });
 
       test('omits a metric for a phase that never ran', () {
@@ -267,7 +285,7 @@ void main() {
           isFalse,
         );
         expect(
-          monitor.trace.metrics.containsKey(publishTransferAttemptsMetric),
+          monitor.trace.metrics.containsKey(publishTransferLegsMetric),
           isFalse,
         );
       });

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -17,9 +17,11 @@ import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/mention_resolution_service.dart';
+import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/upload_manager.dart';
 import 'package:openvine/services/video_event_publisher.dart';
 import 'package:openvine/services/video_publish/publish_error_kind.dart';
+import 'package:openvine/services/video_publish/publish_timeline.dart';
 import 'package:openvine/services/video_publish/video_publish_service.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -41,6 +43,49 @@ class MockCollaboratorInviteService extends Mock
 class MockMentionResolutionService extends Mock
     implements MentionResolutionService {}
 
+/// Captures what a publish would report to Firebase, without any Firebase.
+class _FakePerformanceTrace implements PerformanceTrace {
+  final Map<String, int> metrics = {};
+  final Map<String, String> attributes = {};
+  int stopCount = 0;
+
+  @override
+  void putAttribute(String attribute, String value) =>
+      attributes[attribute] = value;
+
+  @override
+  void setMetric(String metric, int value) => metrics[metric] = value;
+
+  @override
+  Future<void> stop() async => stopCount++;
+}
+
+class _FakePerformanceMonitor implements PerformanceTraceMonitor {
+  final List<String> startedOperations = [];
+  final _FakePerformanceTrace trace = _FakePerformanceTrace();
+
+  @override
+  PerformanceTrace startOperationTrace(String traceName) {
+    startedOperations.add(traceName);
+    return trace;
+  }
+
+  @override
+  Future<void> startTrace(String traceName) async {}
+
+  @override
+  Future<void> stopTrace(String traceName) async {}
+
+  @override
+  void incrementMetric(String traceName, String metricName, int value) {}
+
+  @override
+  void setMetric(String traceName, String metricName, int value) {}
+
+  @override
+  void putAttribute(String traceName, String attribute, String value) {}
+}
+
 void main() {
   const descriptionMentionPubkey =
       'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
@@ -56,6 +101,7 @@ void main() {
   late MockDraftStorageService mockDraftService;
   late MockCollaboratorInviteService mockCollaboratorInviteService;
   late MockMentionResolutionService mockMentionResolutionService;
+  late _FakePerformanceMonitor fakePerformanceMonitor;
   late VideoPublishService service;
 
   late List<double> progressChanges;
@@ -83,6 +129,7 @@ void main() {
     mockDraftService = MockDraftStorageService();
     mockCollaboratorInviteService = MockCollaboratorInviteService();
     mockMentionResolutionService = MockMentionResolutionService();
+    fakePerformanceMonitor = _FakePerformanceMonitor();
 
     progressChanges = [];
 
@@ -100,6 +147,7 @@ void main() {
       draftService: mockDraftService,
       collaboratorInviteService: mockCollaboratorInviteService,
       mentionResolutionService: mockMentionResolutionService,
+      performanceMonitor: fakePerformanceMonitor,
       onProgressChanged:
           ({required double progress, required String draftId}) =>
               progressChanges.add(progress),
@@ -121,6 +169,43 @@ void main() {
         // Assert
         expect(result, isA<PublishError>());
         expect((result as PublishError).kind, PublishErrorKind.notSignedIn);
+      });
+
+      test('reports the publish breakdown as one performance trace', () async {
+        _setupSuccessfulPublish(
+          mockAuthService: mockAuthService,
+          mockUploadManager: mockUploadManager,
+          mockDraftService: mockDraftService,
+          mockVideoEventPublisher: mockVideoEventPublisher,
+        );
+
+        await service.publishVideo(draft: _createTestDraft());
+
+        expect(
+          fakePerformanceMonitor.startedOperations,
+          equals([publishTraceName]),
+        );
+        expect(
+          fakePerformanceMonitor.trace.attributes['outcome'],
+          equals('success'),
+        );
+        expect(
+          fakePerformanceMonitor.trace.metrics,
+          contains(publishTotalMetric),
+        );
+        expect(fakePerformanceMonitor.trace.stopCount, equals(1));
+      });
+
+      test('tags a failed publish with the error it ended on', () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(() => mockDraftService.saveDraft(any())).thenAnswer((_) async {});
+
+        await service.publishVideo(draft: _createTestDraft());
+
+        expect(
+          fakePerformanceMonitor.trace.attributes['outcome'],
+          equals('error:notSignedIn'),
+        );
       });
 
       test(

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -208,6 +208,26 @@ void main() {
         );
       });
 
+      test('still reports a publish that threw its way out', () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        when(
+          () => mockDraftService.isDraftOwnedByAnotherAccount(any()),
+        ).thenThrow(StateError('storage gone'));
+
+        await expectLater(
+          service.publishVideo(draft: _createTestDraft()),
+          throwsStateError,
+        );
+
+        // A publish that escapes by exception is the one most worth seeing in
+        // the console, and it must not land in the success distribution.
+        expect(
+          fakePerformanceMonitor.trace.attributes['outcome'],
+          equals('threw'),
+        );
+        expect(fakePerformanceMonitor.trace.stopCount, equals(1));
+      });
+
       test(
         'returns success and leaves the draft for the bloc to reclaim',
         () async {


### PR DESCRIPTION
## Description

The publish pipeline already times every phase, but only into the log — so the numbers exist for one person, on one device, on one network. That was enough to find the client-side waste in #6554. What is left on the clock is server- and signer-bound (`net.put` between 2.3 s and 7.2 s for a constant 16 KB payload, Keycast signatures between 0.3 s and 1.4 s), and only a distribution across real users can say whether that is systemic or an artefact of one Samsung on one line.

Each publish now also reports a `video_publish` Firebase Performance trace:

- **Metrics** — `transfer_ms`, `thumbnail_ms`, `sign_ms`, `nostr_publish_ms`, the coarse `upload_ms` / `nostr_ms` containers, `mentions_ms` / `subtitles_ms` / `invites_ms`, `total_ms`, plus `payload_bytes` and `transfer_legs`. A phase that never ran reports no metric, so an absent metric reads as "did not happen" rather than as zero, and a retried phase adds its attempts together.
- **Attributes** — `outcome` (`success` / `error:<kind>` / `threw`), `thumbnail` (`reused` / `generated`) and `signature` (`reused` / `signed`), so a failed, abandoned or short-circuited publish is filterable in the console instead of skewing the distribution for the work itself.

Three design points worth calling out:

**Why a zone instead of a parameter.** The interesting phases are timed several layers below `PublishTimeline` — `upload.transfer` and `upload.thumbnail` inside `UploadManager`, `nostr.sign` and `nostr.publish` inside `VideoEventPublisher` — and reach the log through the free `logPublishPhase` function. The timeline now installs itself as a zone value for the length of the publish and folds those lines in. Threading it through as a parameter would have meant touching five methods in the upload manager alone, and would still have missed the resume/retry paths, which re-enter `_performUpload` from outside the publish call chain.

**Why the summary line is unaffected.** Nested phases are folded into the metric map only, not into the summary's top-level phase list — counting `upload.transfer` there would double it against its `upload` parent and drive the `other` bucket negative. The `PUBTIME` lines are byte-for-byte what they were.

**Why a leg that was skipped is tagged rather than dropped.** A retry reuses a thumbnail already on the CDN and an event the signer already signed, so those legs report ~0 ms. Without the `thumbnail` / `signature` attributes a retry-heavy population would drag `thumbnail_ms` and `sign_ms` toward zero invisibly — and signer latency is half of what this trace exists to measure. A leg that did real work on one attempt stays tagged as such when a later attempt short-circuits, because its metric then carries that work. A leg the publish never reached reports no attribute at all, which is the same rule the metrics follow.

Two things the metrics do *not* say, both documented at the constants:

- They are **not additive**. `upload.thumbnail` runs parallel to `upload.transfer`, so `upload_ms` is roughly the longer of the two rather than their sum. Only the summary log line's top-level phases add up to the total.
- `payload_bytes / transfer_ms` is **effective** throughput — bytes delivered per unit of wall clock the user waited, retry overhead included — not the line rate. `transfer_legs` counts how many times the publish entered the transfer phase, not how many attempts the upload service made inside one: a single leg can contain a failed whole-file OS attempt, a chunked resumable fallback that re-sent the same bytes, server iteration and chunk retries, none of which the publish layer can see. Recovering the line rate means instrumenting `blossom_upload_service` at the transport boundary, which is out of scope here.

The monitor is injected and optional (`NoOpPerformanceTraceMonitor` by default), so unit tests never reach Firebase, and the trace is stopped fire-and-forget so a publish never waits on a platform round-trip to return its result.

`PerformanceTrace` gained `setMetric` — `startOperationTrace` handed out a handle that could be tagged but not measured, which is the API this needs.

**Fixed along the way:** `startOperationTrace` fires `trace.start()` and returns the handle synchronously, so a short operation could call `stop()` while the start round-trip was still in flight. The plugin's `stop()` early-returns when the platform has not handed back a trace handle yet — that trace is then never reported *and* leaks natively. The publish trace made this reachable: an ownership or auth check that rejects returns after a single await, which is exactly the `outcome=error:*` population the console filter is for. `stop()` now waits for the start future. Attributes and metrics were never at risk; the plugin buffers them in Dart and flushes them with the stop call.

**Related Issue:** Closes #6556

## Out of Scope

`auth.sign` and `net.put` are timed inside the `blossom_upload_service` package, which cannot import the app-layer timeline, so they stay log-only. Both sit inside `upload.transfer`, so the reported transfer metric still brackets them — a P95 on `transfer_ms` answers the "is the PUT systemically slow" question without a reporter port through the package.

An upload already in flight from an earlier session is joined rather than started by the publish that waits on it, so its `upload.transfer` line is emitted outside this publish's zone and reports no `transfer_ms`. The publish still reports `upload_ms`, measured by the timeline itself, so the leg is visible as a duration — just not broken down. Attributing a joined upload to whichever publish happened to wait on it would be the wrong answer anyway.

## Verification

- Verified on a real Samsung Galaxy device.
- `flutter analyze lib test integration_test` — clean
- `dart format` — clean
- `flutter test test/services/video_publish/ test/services/performance_monitoring_service_test.dart test/services/upload_manager_*.dart test/services/video_event_publisher*.dart test/blocs/video_recorder/ test/blocs/background_publish_bloc/ test/providers/video_editor_provider_test.dart test/providers/video_publish_provider_test.dart` — 657 passing
- New coverage: the timeline against a fake monitor (phases reported once with the values the summary carries, retries summed, transfer-leg count reported, one leg counted however many transport attempts it contained, absent phases omitted, outcome / thumbnail-reuse / signature-reuse attributes, no attribute for a leg the publish never reached, trace stopped once, phases emitted outside the publish ignored), and the service end-to-end reporting `success` / `error:notSignedIn` / `threw` through an injected fake.

Note for whoever reads the console first: Firebase surfaces percentile distributions for trace *duration*; custom metrics are aggregated. If a P95 on `transfer_ms` specifically is what we want rather than an average, that needs the BigQuery export of Performance data — the instrumentation is the same either way.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

