### PR TITLE
fix(people-lists): stop a mutation rollback from resurrecting torn-down state

### DIFF
--- a/mobile/lib/features/people_lists/bloc/people_lists_bloc.dart
+++ b/mobile/lib/features/people_lists/bloc/people_lists_bloc.dart
@@ -92,10 +92,7 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
        _clock = clock ?? _defaultClock,
        super(PeopleListsState(ownerPubkey: initialOwnerPubkey)) {
     on<PeopleListsStarted>(_onStarted);
-    on<PeopleListsEnabledChanged>(
-      _onEnabledChanged,
-      transformer: sequential(),
-    );
+    on<PeopleListsEnabledChanged>(_onEnabledChanged, transformer: sequential());
     on<PeopleListsRepositoryChanged>(
       _onRepositoryChanged,
       transformer: sequential(),
@@ -213,7 +210,7 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
       // can learn who is signed in.
       //
       // Dropping `pendingMutations` is also what stops a mutation still in
-      // flight from putting the snapshot back once it resolves — see
+      // flight from applying any result to state that has been torn down — see
       // [_resultStillApplies].
       emit(PeopleListsState(ownerPubkey: state.ownerPubkey, enabled: false));
       return;
@@ -637,13 +634,12 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
   /// Whether a mutation result that arrived after an `await` may still be
   /// written to state.
   ///
-  /// Rollbacks are computed from a snapshot captured before the round-trip and
-  /// were only ever valid for the state that produced it. In between, the bloc
-  /// may have torn that state down — an account switch, a sign-out, or
-  /// `FeatureFlag.curatedLists` going off each emit a fresh state with an empty
-  /// `pendingMutations`. Restoring the captured snapshot there hands one
-  /// owner's lists to whoever is signed in by then, and even a status-only
-  /// write reports an outcome the new state never asked for (#6504).
+  /// Mutation outcomes and rollbacks are only valid for the state that issued
+  /// them. In between, the bloc may have torn that state down — an account
+  /// switch, a sign-out, or `FeatureFlag.curatedLists` going off each emit a
+  /// fresh state with an empty `pendingMutations`. Applying a result there can
+  /// write one owner's lists or mutation status onto whoever is signed in by
+  /// then (#6504).
   ///
   /// The mutation lookup is what actually detects a teardown; the owner check
   /// keeps the guard honest if a future teardown ever preserves the map.

--- a/mobile/lib/features/people_lists/bloc/people_lists_bloc.dart
+++ b/mobile/lib/features/people_lists/bloc/people_lists_bloc.dart
@@ -50,7 +50,10 @@ typedef PeopleListsClock = DateTime Function();
 /// mutations succeed or the repository stream never re-emits.
 ///
 /// A result that lands after the bloc tore down the state its mutation was
-/// issued against writes nothing at all — see [_resultStillApplies].
+/// issued against writes nothing at all — see [_resultStillApplies]. A rollback
+/// that does apply undoes only its own mutation rather than restoring a
+/// pre-flight snapshot, so it cannot revert a repository emission that arrived
+/// meanwhile — see [_emitRollback].
 class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
   /// Creates a new bloc instance.
   ///
@@ -406,8 +409,10 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
       PeopleListsMutationKind.deleteList,
       listId: event.listId,
     );
-    final previousLists = List<UserList>.of(state.lists, growable: false);
-    final previousIndex = _copyReverseIndex(state.listIdsByPubkey);
+    final removedIndex = state.lists.indexWhere(
+      (list) => list.id == event.listId,
+    );
+    final removedList = removedIndex == -1 ? null : state.lists[removedIndex];
 
     // Optimistically remove the list and any reverse-index entries.
     final optimisticLists = state.lists
@@ -424,6 +429,9 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
       ),
     );
 
+    List<UserList> undo(List<UserList> lists) =>
+        _restoreList(lists, removedList, removedIndex);
+
     try {
       final result = await _repository.deleteList(
         ownerPubkey: owner,
@@ -431,26 +439,14 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
       );
       if (!_resultStillApplies(mutation, owner)) return;
       if (!result.submitted) {
-        emit(
-          _withoutMutation(
-            state,
-            mutation.id,
-            failed: true,
-          ).copyWith(lists: previousLists, listIdsByPubkey: previousIndex),
-        );
+        _emitRollback(emit, mutation.id, undo);
         return;
       }
       emit(_withoutMutation(state, mutation.id, resultEventId: result.eventId));
     } catch (e, stackTrace) {
       addError(e, stackTrace);
       if (!_resultStillApplies(mutation, owner)) return;
-      emit(
-        _withoutMutation(
-          state,
-          mutation.id,
-          failed: true,
-        ).copyWith(lists: previousLists, listIdsByPubkey: previousIndex),
-      );
+      _emitRollback(emit, mutation.id, undo);
     }
   }
 
@@ -520,9 +516,6 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
       listId: listId,
       pubkey: pubkey,
     );
-    final previousLists = List<UserList>.of(state.lists, growable: false);
-    final previousIndex = _copyReverseIndex(state.listIdsByPubkey);
-
     final optimisticLists = _applyOptimisticAdd(
       state.lists,
       listId: listId,
@@ -540,6 +533,13 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
       ),
     );
 
+    List<UserList> undo(List<UserList> lists) => _applyOptimisticRemove(
+      lists,
+      listId: listId,
+      pubkey: pubkey,
+      now: _clock(),
+    );
+
     try {
       final result = await _repository.addPubkey(
         ownerPubkey: owner,
@@ -548,26 +548,14 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
       );
       if (!_resultStillApplies(mutation, owner)) return;
       if (!result.submitted) {
-        emit(
-          _withoutMutation(
-            state,
-            mutation.id,
-            failed: true,
-          ).copyWith(lists: previousLists, listIdsByPubkey: previousIndex),
-        );
+        _emitRollback(emit, mutation.id, undo);
         return;
       }
       emit(_withoutMutation(state, mutation.id, resultEventId: result.eventId));
     } catch (e, stackTrace) {
       addError(e, stackTrace);
       if (!_resultStillApplies(mutation, owner)) return;
-      emit(
-        _withoutMutation(
-          state,
-          mutation.id,
-          failed: true,
-        ).copyWith(lists: previousLists, listIdsByPubkey: previousIndex),
-      );
+      _emitRollback(emit, mutation.id, undo);
     }
   }
 
@@ -592,8 +580,11 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
       listId: listId,
       pubkey: pubkey,
     );
-    final previousLists = List<UserList>.of(state.lists, growable: false);
-    final previousIndex = _copyReverseIndex(state.listIdsByPubkey);
+    final removedIndex = _memberIndex(
+      state.lists,
+      listId: listId,
+      pubkey: pubkey,
+    );
 
     final optimisticLists = _applyOptimisticRemove(
       state.lists,
@@ -612,6 +603,14 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
       ),
     );
 
+    List<UserList> undo(List<UserList> lists) => _restorePubkey(
+      lists,
+      listId: listId,
+      pubkey: pubkey,
+      index: removedIndex,
+      now: _clock(),
+    );
+
     try {
       final result = await _repository.removePubkey(
         ownerPubkey: owner,
@@ -620,26 +619,14 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
       );
       if (!_resultStillApplies(mutation, owner)) return;
       if (!result.submitted) {
-        emit(
-          _withoutMutation(
-            state,
-            mutation.id,
-            failed: true,
-          ).copyWith(lists: previousLists, listIdsByPubkey: previousIndex),
-        );
+        _emitRollback(emit, mutation.id, undo);
         return;
       }
       emit(_withoutMutation(state, mutation.id, resultEventId: result.eventId));
     } catch (e, stackTrace) {
       addError(e, stackTrace);
       if (!_resultStillApplies(mutation, owner)) return;
-      emit(
-        _withoutMutation(
-          state,
-          mutation.id,
-          failed: true,
-        ).copyWith(lists: previousLists, listIdsByPubkey: previousIndex),
-      );
+      _emitRollback(emit, mutation.id, undo);
     }
   }
 
@@ -663,6 +650,33 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
   bool _resultStillApplies(PeopleListsMutation mutation, String owner) {
     return state.activeOwnerPubkey == owner &&
         state.pendingMutations.containsKey(mutation.id);
+  }
+
+  /// Emits the failure state for [mutationId] with [undo] applied to the
+  /// *current* lists.
+  ///
+  /// Rollbacks used to restore a whole `lists`/`listIdsByPubkey` snapshot
+  /// captured before the round-trip. That snapshot also loses to a repository
+  /// emission that lands mid-flight — `_onRepositoryListsChanged` keeps
+  /// `pendingMutations`, so the guard passes and the restore drops whatever
+  /// arrived meanwhile (a list synced from a relay, another device's edit).
+  ///
+  /// Undoing just this mutation's own change instead leaves everything else
+  /// alone. The repository writes its cache only after a successful publish, so
+  /// a mid-flight emission carries the pre-mutation truth and every [undo] here
+  /// is a no-op against it — which also makes the rollback order-independent.
+  void _emitRollback(
+    Emitter<PeopleListsState> emit,
+    String mutationId,
+    List<UserList> Function(List<UserList> lists) undo,
+  ) {
+    final restored = undo(state.lists);
+    emit(
+      _withoutMutation(state, mutationId, failed: true).copyWith(
+        lists: restored,
+        listIdsByPubkey: _buildReverseIndex(restored),
+      ),
+    );
   }
 
   /// Builds a mutation record with a unique id.
@@ -735,12 +749,49 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
     return index;
   }
 
-  static Map<String, Set<String>> _copyReverseIndex(
-    Map<String, Set<String>> index,
+  /// Position of [pubkey] within [listId]'s members, or `-1` when absent.
+  static int _memberIndex(
+    List<UserList> lists, {
+    required String listId,
+    required String pubkey,
+  }) {
+    for (final list in lists) {
+      if (list.id == listId) return list.pubkeys.indexOf(pubkey);
+    }
+    return -1;
+  }
+
+  /// Re-inserts [list] at [index], unless it is already back.
+  static List<UserList> _restoreList(
+    List<UserList> lists,
+    UserList? list,
+    int index,
   ) {
-    return {
-      for (final entry in index.entries) entry.key: Set<String>.of(entry.value),
-    };
+    if (list == null) return lists;
+    if (lists.any((candidate) => candidate.id == list.id)) return lists;
+    final restored = List<UserList>.of(lists)
+      ..insert(index.clamp(0, lists.length), list);
+    return restored.toList(growable: false);
+  }
+
+  /// Re-inserts [pubkey] into [listId] at [index], unless it is already back.
+  static List<UserList> _restorePubkey(
+    List<UserList> lists, {
+    required String listId,
+    required String pubkey,
+    required int index,
+    required DateTime now,
+  }) {
+    if (index < 0) return lists;
+    return lists
+        .map((list) {
+          if (list.id != listId) return list;
+          if (list.pubkeys.contains(pubkey)) return list;
+          final pubkeys = List<String>.of(list.pubkeys)
+            ..insert(index.clamp(0, list.pubkeys.length), pubkey);
+          return list.copyWith(pubkeys: pubkeys, updatedAt: now);
+        })
+        .toList(growable: false);
   }
 
   static List<UserList> _applyOptimisticAdd(

--- a/mobile/lib/features/people_lists/bloc/people_lists_bloc.dart
+++ b/mobile/lib/features/people_lists/bloc/people_lists_bloc.dart
@@ -42,12 +42,15 @@ typedef PeopleListsClock = DateTime Function();
 ///
 /// ## Failure recovery contract
 ///
-/// A mutation that throws transitions [PeopleListsState.status] to
-/// [PeopleListsStatus.failure] and reports the error via `addError`. The
-/// status automatically recovers to [PeopleListsStatus.ready] once all
-/// pending mutations drain without a fresh failure, so the UI does not
-/// stay stuck on `failure` when subsequent mutations succeed or the
-/// repository stream never re-emits.
+/// A mutation that throws — or comes back unsubmitted — transitions
+/// [PeopleListsState.status] to [PeopleListsStatus.failure] and reports any
+/// error via `addError`. The status automatically recovers to
+/// [PeopleListsStatus.ready] once all pending mutations drain without a fresh
+/// failure, so the UI does not stay stuck on `failure` when subsequent
+/// mutations succeed or the repository stream never re-emits.
+///
+/// A result that lands after the bloc tore down the state its mutation was
+/// issued against writes nothing at all — see [_resultStillApplies].
 class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
   /// Creates a new bloc instance.
   ///
@@ -206,9 +209,9 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
       // owner stream is not seeded, so state is the only place a later flag-on
       // can learn who is signed in.
       //
-      // A mutation still in flight resumes against the snapshot it captured
-      // before this emit and puts it back — the pre-existing account-switch
-      // race, tracked in #6504.
+      // Dropping `pendingMutations` is also what stops a mutation still in
+      // flight from putting the snapshot back once it resolves — see
+      // [_resultStillApplies].
       emit(PeopleListsState(ownerPubkey: state.ownerPubkey, enabled: false));
       return;
     }
@@ -377,9 +380,15 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
         imageUrl: event.imageUrl,
         initialPubkeys: event.initialPubkeys,
       );
+      if (!_resultStillApplies(mutation, owner)) return;
+      if (!result.submitted) {
+        emit(_withoutMutation(state, mutation.id, failed: true));
+        return;
+      }
       emit(_withoutMutation(state, mutation.id, resultEventId: result.eventId));
     } catch (e, stackTrace) {
       addError(e, stackTrace);
+      if (!_resultStillApplies(mutation, owner)) return;
       emit(_withoutMutation(state, mutation.id, failed: true));
     }
   }
@@ -420,6 +429,7 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
         ownerPubkey: owner,
         listId: event.listId,
       );
+      if (!_resultStillApplies(mutation, owner)) return;
       if (!result.submitted) {
         emit(
           _withoutMutation(
@@ -433,6 +443,7 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
       emit(_withoutMutation(state, mutation.id, resultEventId: result.eventId));
     } catch (e, stackTrace) {
       addError(e, stackTrace);
+      if (!_resultStillApplies(mutation, owner)) return;
       emit(
         _withoutMutation(
           state,
@@ -535,6 +546,7 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
         listId: listId,
         pubkey: pubkey,
       );
+      if (!_resultStillApplies(mutation, owner)) return;
       if (!result.submitted) {
         emit(
           _withoutMutation(
@@ -548,6 +560,7 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
       emit(_withoutMutation(state, mutation.id, resultEventId: result.eventId));
     } catch (e, stackTrace) {
       addError(e, stackTrace);
+      if (!_resultStillApplies(mutation, owner)) return;
       emit(
         _withoutMutation(
           state,
@@ -605,6 +618,7 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
         listId: listId,
         pubkey: pubkey,
       );
+      if (!_resultStillApplies(mutation, owner)) return;
       if (!result.submitted) {
         emit(
           _withoutMutation(
@@ -618,6 +632,7 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
       emit(_withoutMutation(state, mutation.id, resultEventId: result.eventId));
     } catch (e, stackTrace) {
       addError(e, stackTrace);
+      if (!_resultStillApplies(mutation, owner)) return;
       emit(
         _withoutMutation(
           state,
@@ -631,6 +646,24 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
   // --------------------------------------------------------------------------
   // Helpers
   // --------------------------------------------------------------------------
+
+  /// Whether a mutation result that arrived after an `await` may still be
+  /// written to state.
+  ///
+  /// Rollbacks are computed from a snapshot captured before the round-trip and
+  /// were only ever valid for the state that produced it. In between, the bloc
+  /// may have torn that state down — an account switch, a sign-out, or
+  /// `FeatureFlag.curatedLists` going off each emit a fresh state with an empty
+  /// `pendingMutations`. Restoring the captured snapshot there hands one
+  /// owner's lists to whoever is signed in by then, and even a status-only
+  /// write reports an outcome the new state never asked for (#6504).
+  ///
+  /// The mutation lookup is what actually detects a teardown; the owner check
+  /// keeps the guard honest if a future teardown ever preserves the map.
+  bool _resultStillApplies(PeopleListsMutation mutation, String owner) {
+    return state.activeOwnerPubkey == owner &&
+        state.pendingMutations.containsKey(mutation.id);
+  }
 
   /// Builds a mutation record with a unique id.
   ///

--- a/mobile/lib/screens/user_list_people_screen.dart
+++ b/mobile/lib/screens/user_list_people_screen.dart
@@ -46,43 +46,58 @@ class UserListPeopleScreen extends StatefulWidget {
 }
 
 class _UserListPeopleScreenState extends State<UserListPeopleScreen> {
-  String? _pendingDeleteListId;
+  /// The delete this screen is waiting on, with the owner it was issued for.
+  ///
+  /// The owner is part of the record because the bloc clears its pending
+  /// mutations wholesale whenever it tears its state down. On the mutation map
+  /// alone, an account switch or a `FeatureFlag.curatedLists` flag-off is
+  /// indistinguishable from the delete settling (#6504).
+  ({String listId, String? ownerPubkey})? _pendingDelete;
 
   void _deleteList(String listId) {
+    final bloc = context.read<PeopleListsBloc>();
     setState(() {
-      _pendingDeleteListId = listId;
+      _pendingDelete = (listId: listId, ownerPubkey: bloc.state.ownerPubkey);
     });
-    context.read<PeopleListsBloc>().add(
-      PeopleListsDeleteRequested(listId: listId),
-    );
+    bloc.add(PeopleListsDeleteRequested(listId: listId));
   }
 
-  bool _deleteSettled(PeopleListsState previous, PeopleListsState current) {
-    final pendingListId = _pendingDeleteListId;
-    if (pendingListId == null) return false;
+  bool _pendingDeleteResolved(
+    PeopleListsState previous,
+    PeopleListsState current,
+  ) {
+    final pending = _pendingDelete;
+    if (pending == null) return false;
+    return _hasPendingDelete(previous, pending.listId) &&
+        !_hasPendingDelete(current, pending.listId);
+  }
 
-    final hadPendingDelete = previous.pendingMutations.values.any(
+  static bool _hasPendingDelete(PeopleListsState state, String listId) {
+    return state.pendingMutations.values.any(
       (mutation) =>
           mutation.kind == PeopleListsMutationKind.deleteList &&
-          mutation.listId == pendingListId,
+          mutation.listId == listId,
     );
-    final hasPendingDelete = current.pendingMutations.values.any(
-      (mutation) =>
-          mutation.kind == PeopleListsMutationKind.deleteList &&
-          mutation.listId == pendingListId,
-    );
-    return hadPendingDelete && !hasPendingDelete;
   }
 
   @override
   Widget build(BuildContext context) {
     return BlocListener<PeopleListsBloc, PeopleListsState>(
-      listenWhen: _deleteSettled,
+      listenWhen: _pendingDeleteResolved,
       listener: (context, state) {
+        final pending = _pendingDelete;
         final failed = state.status == PeopleListsStatus.failure;
         setState(() {
-          _pendingDeleteListId = null;
+          _pendingDelete = null;
         });
+        // The bloc dropped the mutation rather than resolving it: the feature
+        // was turned off, or another account took over. Nothing settled, so
+        // announce nothing and stay on the route.
+        if (pending == null ||
+            !state.enabled ||
+            state.ownerPubkey != pending.ownerPubkey) {
+          return;
+        }
         if (failed) {
           final message = context.l10n.peopleListsDeleteFailed;
           SemanticsService.sendAnnouncement(

--- a/mobile/lib/screens/user_list_people_screen.dart
+++ b/mobile/lib/screens/user_list_people_screen.dart
@@ -52,13 +52,14 @@ class _UserListPeopleScreenState extends State<UserListPeopleScreen> {
   /// mutations wholesale whenever it tears its state down. On the mutation map
   /// alone, an account switch or a `FeatureFlag.curatedLists` flag-off is
   /// indistinguishable from the delete settling (#6504).
+  ///
+  /// Only [_pendingDeleteResolved] and the listener read this — [build] does
+  /// not — so it is assigned without `setState`.
   ({String listId, String? ownerPubkey})? _pendingDelete;
 
   void _deleteList(String listId) {
     final bloc = context.read<PeopleListsBloc>();
-    setState(() {
-      _pendingDelete = (listId: listId, ownerPubkey: bloc.state.ownerPubkey);
-    });
+    _pendingDelete = (listId: listId, ownerPubkey: bloc.state.ownerPubkey);
     bloc.add(PeopleListsDeleteRequested(listId: listId));
   }
 
@@ -87,9 +88,7 @@ class _UserListPeopleScreenState extends State<UserListPeopleScreen> {
       listener: (context, state) {
         final pending = _pendingDelete;
         final failed = state.status == PeopleListsStatus.failure;
-        setState(() {
-          _pendingDelete = null;
-        });
+        _pendingDelete = null;
         // The bloc dropped the mutation rather than resolving it: the feature
         // was turned off, or another account took over. Nothing settled, so
         // announce nothing and stay on the route.

--- a/mobile/test/features/people_lists/bloc/people_lists_bloc_test.dart
+++ b/mobile/test/features/people_lists/bloc/people_lists_bloc_test.dart
@@ -586,6 +586,27 @@ void main() {
     );
 
     blocTest<PeopleListsBloc, PeopleListsState>(
+      'reports failure when a create is not submitted',
+      build: buildBloc,
+      setUp: () {
+        when(
+          () => repository.createList(ownerPubkey: _ownerA, name: 'New List'),
+        ).thenAnswer((_) async => const PeopleListPublishResult.failed());
+      },
+      seed: () => const PeopleListsState(
+        status: PeopleListsStatus.ready,
+        ownerPubkey: _ownerA,
+      ),
+      act: (bloc) =>
+          bloc.add(const PeopleListsCreateRequested(name: 'New List')),
+      verify: (bloc) {
+        expect(bloc.state.status, equals(PeopleListsStatus.failure));
+        expect(bloc.state.pendingMutations, isEmpty);
+        expect(bloc.state.lastSubmittedEventId, isNull);
+      },
+    );
+
+    blocTest<PeopleListsBloc, PeopleListsState>(
       'emits optimistic state for delete list before repository returns',
       build: buildBloc,
       setUp: () {
@@ -1211,6 +1232,158 @@ void main() {
         expect(ownerBListsController.hasListener, isTrue);
         expect(ownerAListsController.hasListener, isFalse);
       });
+    });
+
+    // #6504: rollbacks are computed from a snapshot captured before the
+    // repository round-trip. A teardown in between — flag-off or account
+    // switch — drops that snapshot on purpose, so applying it afterwards puts
+    // one owner's lists back under whoever is signed in by then.
+    group('mutation results that outlive the state they were issued for', () {
+      Future<PeopleListsBloc> startedWithOwnerAList() async {
+        final bloc = buildBloc()..add(const PeopleListsStarted());
+        await _flush();
+        ownerPubkeyController.add(_ownerA);
+        await _flush();
+        ownerAListsController.add([
+          _buildList(id: 'l1', name: 'Friends', pubkeys: const [_memberAlice]),
+        ]);
+        await _flush();
+        return bloc;
+      }
+
+      test('a delete rollback discards a flag-off teardown snapshot', () async {
+        final publish = Completer<PeopleListPublishResult>();
+        when(
+          () => repository.deleteList(ownerPubkey: _ownerA, listId: 'l1'),
+        ).thenAnswer((_) => publish.future);
+
+        final bloc = await startedWithOwnerAList();
+        addTearDown(bloc.close);
+
+        bloc.add(const PeopleListsDeleteRequested(listId: 'l1'));
+        await _flush();
+        expect(bloc.state.pendingMutations, hasLength(1));
+
+        enabledController.add(false);
+        await _flush();
+        await _flush();
+
+        publish.complete(const PeopleListPublishResult.failed());
+        await _flush();
+        await _flush();
+
+        expect(bloc.state.enabled, isFalse);
+        expect(bloc.state.status, equals(PeopleListsStatus.initial));
+        expect(bloc.state.lists, isEmpty);
+        expect(bloc.state.listIdsByPubkey, isEmpty);
+        expect(bloc.state.pendingMutations, isEmpty);
+      });
+
+      test(
+        'a delete rollback leaves the account that took over alone',
+        () async {
+          final publish = Completer<PeopleListPublishResult>();
+          when(
+            () => repository.deleteList(ownerPubkey: _ownerA, listId: 'l1'),
+          ).thenAnswer((_) => publish.future);
+
+          final bloc = await startedWithOwnerAList();
+          addTearDown(bloc.close);
+
+          bloc.add(const PeopleListsDeleteRequested(listId: 'l1'));
+          await _flush();
+
+          ownerPubkeyController.add(_ownerB);
+          await _flush();
+          await _flush();
+          ownerBListsController.add([
+            _buildList(id: 'l2', name: 'Crew', pubkeys: const [_memberBob]),
+          ]);
+          await _flush();
+
+          publish.complete(const PeopleListPublishResult.failed());
+          await _flush();
+          await _flush();
+
+          expect(bloc.state.ownerPubkey, equals(_ownerB));
+          expect(bloc.state.status, equals(PeopleListsStatus.ready));
+          expect(bloc.state.lists.single.id, equals('l2'));
+          expect(
+            bloc.state.listIdsByPubkey,
+            equals({
+              _memberBob: {'l2'},
+            }),
+          );
+          expect(bloc.state.pendingMutations, isEmpty);
+        },
+      );
+
+      test('an add that throws after a teardown restores nothing', () async {
+        final publish = Completer<PeopleListPublishResult>();
+        when(
+          () => repository.addPubkey(
+            ownerPubkey: _ownerA,
+            listId: 'l1',
+            pubkey: _memberBob,
+          ),
+        ).thenAnswer((_) => publish.future);
+
+        final bloc = await startedWithOwnerAList();
+        addTearDown(bloc.close);
+
+        bloc.add(
+          const PeopleListsPubkeyAddRequested(
+            listId: 'l1',
+            pubkey: _memberBob,
+          ),
+        );
+        await _flush();
+        expect(bloc.state.lists.single.pubkeys, contains(_memberBob));
+
+        enabledController.add(false);
+        await _flush();
+        await _flush();
+
+        publish.completeError(StateError('no public key available'));
+        await _flush();
+        await _flush();
+
+        expect(bloc.state.enabled, isFalse);
+        expect(bloc.state.status, equals(PeopleListsStatus.initial));
+        expect(bloc.state.lists, isEmpty);
+      });
+
+      // Create captures no snapshot, so all it can leak is a status — but a
+      // `failure` (or `ready`) written onto a torn-down state still reports an
+      // outcome the account now in state never asked for.
+      test(
+        'a create that resolves after a teardown writes no status',
+        () async {
+          final publish = Completer<PeopleListPublishResult>();
+          when(
+            () => repository.createList(ownerPubkey: _ownerA, name: 'Crew'),
+          ).thenAnswer((_) => publish.future);
+
+          final bloc = await startedWithOwnerAList();
+          addTearDown(bloc.close);
+
+          bloc.add(const PeopleListsCreateRequested(name: 'Crew'));
+          await _flush();
+          expect(bloc.state.pendingMutations, hasLength(1));
+
+          enabledController.add(false);
+          await _flush();
+          await _flush();
+
+          publish.complete(const PeopleListPublishResult.failed());
+          await _flush();
+          await _flush();
+
+          expect(bloc.state.enabled, isFalse);
+          expect(bloc.state.status, equals(PeopleListsStatus.initial));
+          expect(bloc.state.pendingMutations, isEmpty);
+        },
+      );
     });
 
     // #6480: peopleListsRepositoryProvider is keepAlive but not

--- a/mobile/test/features/people_lists/bloc/people_lists_bloc_test.dart
+++ b/mobile/test/features/people_lists/bloc/people_lists_bloc_test.dart
@@ -1234,6 +1234,148 @@ void main() {
       });
     });
 
+    // A rollback undoes only its own mutation. `_onRepositoryListsChanged`
+    // keeps `pendingMutations`, so an emission that lands mid-round-trip
+    // passes the teardown guard — restoring a pre-flight snapshot there would
+    // drop whatever arrived meanwhile.
+    group('rollbacks that race a repository emission', () {
+      Future<PeopleListsBloc> startedWithOwnerALists(
+        List<UserList> lists,
+      ) async {
+        final bloc = buildBloc()..add(const PeopleListsStarted());
+        await _flush();
+        ownerPubkeyController.add(_ownerA);
+        await _flush();
+        ownerAListsController.add(lists);
+        await _flush();
+        return bloc;
+      }
+
+      test('a failed delete keeps a list that synced mid-round-trip', () async {
+        final publish = Completer<PeopleListPublishResult>();
+        when(
+          () => repository.deleteList(ownerPubkey: _ownerA, listId: 'l1'),
+        ).thenAnswer((_) => publish.future);
+
+        final bloc = await startedWithOwnerALists([
+          _buildList(id: 'l1', name: 'Friends', pubkeys: const [_memberAlice]),
+        ]);
+        addTearDown(bloc.close);
+
+        bloc.add(const PeopleListsDeleteRequested(listId: 'l1'));
+        await _flush();
+        expect(bloc.state.lists, isEmpty);
+
+        // l3 arrives from a relay while the deletion is still publishing.
+        ownerAListsController.add([
+          _buildList(id: 'l1', name: 'Friends', pubkeys: const [_memberAlice]),
+          _buildList(id: 'l3', name: 'From Relay', pubkeys: const [_memberBob]),
+        ]);
+        await _flush();
+
+        publish.complete(const PeopleListPublishResult.failed());
+        await _flush();
+        await _flush();
+
+        expect(bloc.state.status, equals(PeopleListsStatus.failure));
+        expect(
+          bloc.state.lists.map((list) => list.id).toList(),
+          equals(['l1', 'l3']),
+        );
+        expect(
+          bloc.state.listIdsByPubkey,
+          equals({
+            _memberAlice: {'l1'},
+            _memberBob: {'l3'},
+          }),
+        );
+      });
+
+      test('a failed add undoes only its own pubkey', () async {
+        final publish = Completer<PeopleListPublishResult>();
+        when(
+          () => repository.addPubkey(
+            ownerPubkey: _ownerA,
+            listId: 'l1',
+            pubkey: _memberBob,
+          ),
+        ).thenAnswer((_) => publish.future);
+
+        final bloc = await startedWithOwnerALists([
+          _buildList(id: 'l1', name: 'Friends', pubkeys: const [_memberAlice]),
+        ]);
+        addTearDown(bloc.close);
+
+        bloc.add(
+          const PeopleListsPubkeyAddRequested(
+            listId: 'l1',
+            pubkey: _memberBob,
+          ),
+        );
+        await _flush();
+        expect(bloc.state.lists.single.pubkeys, contains(_memberBob));
+
+        ownerAListsController.add([
+          _buildList(id: 'l1', name: 'Friends', pubkeys: const [_memberAlice]),
+          _buildList(id: 'l3', name: 'From Relay', pubkeys: const [_memberBob]),
+        ]);
+        await _flush();
+
+        publish.complete(const PeopleListPublishResult.failed());
+        await _flush();
+        await _flush();
+
+        expect(bloc.state.status, equals(PeopleListsStatus.failure));
+        expect(
+          bloc.state.lists.map((list) => list.id).toList(),
+          equals(['l1', 'l3']),
+        );
+        // Undone on l1, untouched on the list that arrived meanwhile.
+        expect(bloc.state.lists.first.pubkeys, equals([_memberAlice]));
+        expect(bloc.state.lists.last.pubkeys, equals([_memberBob]));
+      });
+
+      test('a failed remove restores the member at its old index', () async {
+        final publish = Completer<PeopleListPublishResult>();
+        when(
+          () => repository.removePubkey(
+            ownerPubkey: _ownerA,
+            listId: 'l1',
+            pubkey: _memberAlice,
+          ),
+        ).thenAnswer((_) => publish.future);
+
+        final bloc = await startedWithOwnerALists([
+          _buildList(
+            id: 'l1',
+            name: 'Friends',
+            pubkeys: const [_memberAlice, _memberBob],
+          ),
+        ]);
+        addTearDown(bloc.close);
+
+        bloc.add(
+          const PeopleListsPubkeyRemoveRequested(
+            listId: 'l1',
+            pubkey: _memberAlice,
+          ),
+        );
+        await _flush();
+        expect(bloc.state.lists.single.pubkeys, equals([_memberBob]));
+
+        publish.complete(const PeopleListPublishResult.failed());
+        await _flush();
+        await _flush();
+
+        expect(bloc.state.status, equals(PeopleListsStatus.failure));
+        // Back at index 0, not appended after bob.
+        expect(
+          bloc.state.lists.single.pubkeys,
+          equals([_memberAlice, _memberBob]),
+        );
+      });
+    });
+
     // #6504: rollbacks are computed from a snapshot captured before the
     // repository round-trip. A teardown in between — flag-off or account
     // switch — drops that snapshot on purpose, so applying it afterwards puts

--- a/mobile/test/features/people_lists/bloc/people_lists_bloc_test.dart
+++ b/mobile/test/features/people_lists/bloc/people_lists_bloc_test.dart
@@ -1307,10 +1307,7 @@ void main() {
         addTearDown(bloc.close);
 
         bloc.add(
-          const PeopleListsPubkeyAddRequested(
-            listId: 'l1',
-            pubkey: _memberBob,
-          ),
+          const PeopleListsPubkeyAddRequested(listId: 'l1', pubkey: _memberBob),
         );
         await _flush();
         expect(bloc.state.lists.single.pubkeys, contains(_memberBob));
@@ -1474,10 +1471,7 @@ void main() {
         addTearDown(bloc.close);
 
         bloc.add(
-          const PeopleListsPubkeyAddRequested(
-            listId: 'l1',
-            pubkey: _memberBob,
-          ),
+          const PeopleListsPubkeyAddRequested(listId: 'l1', pubkey: _memberBob),
         );
         await _flush();
         expect(bloc.state.lists.single.pubkeys, contains(_memberBob));
@@ -1487,6 +1481,41 @@ void main() {
         await _flush();
 
         publish.completeError(StateError('no public key available'));
+        await _flush();
+        await _flush();
+
+        expect(bloc.state.enabled, isFalse);
+        expect(bloc.state.status, equals(PeopleListsStatus.initial));
+        expect(bloc.state.lists, isEmpty);
+      });
+
+      test('a remove that throws after a teardown restores nothing', () async {
+        final publish = Completer<PeopleListPublishResult>();
+        when(
+          () => repository.removePubkey(
+            ownerPubkey: _ownerA,
+            listId: 'l1',
+            pubkey: _memberAlice,
+          ),
+        ).thenAnswer((_) => publish.future);
+
+        final bloc = await startedWithOwnerAList();
+        addTearDown(bloc.close);
+
+        bloc.add(
+          const PeopleListsPubkeyRemoveRequested(
+            listId: 'l1',
+            pubkey: _memberAlice,
+          ),
+        );
+        await _flush();
+        expect(bloc.state.lists.single.pubkeys, isEmpty);
+
+        enabledController.add(false);
+        await _flush();
+        await _flush();
+
+        publish.completeError(StateError('relay rejected removal'));
         await _flush();
         await _flush();
 

--- a/mobile/test/screens/user_list_people_screen_test.dart
+++ b/mobile/test/screens/user_list_people_screen_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -23,6 +24,8 @@ class _MockPeopleListsBloc extends MockBloc<PeopleListsEvent, PeopleListsState>
 
 const _ownerPubkey =
     'f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0';
+const _otherOwnerPubkey =
+    '0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a';
 
 UserList _buildList({
   String id = 'list-1',
@@ -59,6 +62,92 @@ Future<void> _pumpPeopleListScreen(
     ),
   );
   await tester.pump();
+}
+
+/// Pushes the list route on top of a home route, so a pop is observable as
+/// `Open list` coming back into view.
+Future<void> _pumpPushedListRoute(
+  WidgetTester tester, {
+  required PeopleListsBloc bloc,
+  required UserList list,
+}) async {
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => Scaffold(
+          body: Center(
+            child: ElevatedButton(
+              onPressed: () =>
+                  context.push('/people-lists/${Uri.encodeComponent(list.id)}'),
+              child: const Text('Open list'),
+            ),
+          ),
+        ),
+      ),
+      GoRoute(
+        path: UserListPeopleScreen.path,
+        name: UserListPeopleScreen.routeName,
+        builder: (context, state) {
+          final listId = state.pathParameters['listId'];
+          if (listId == null || listId.isEmpty) {
+            return const Scaffold(body: Center(child: Text('Invalid list')));
+          }
+          return UserListPeopleScreen(listId: listId);
+        },
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(
+    testProviderScope(
+      child: BlocProvider<PeopleListsBloc>.value(
+        value: bloc,
+        child: MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          routerConfig: router,
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  await tester.tap(find.text('Open list'));
+  await tester.pumpAndSettle();
+}
+
+/// Collects screen-reader announcements until the test ends.
+List<String> _captureAnnouncements(WidgetTester tester) {
+  final announcements = <String>[];
+  tester.binding.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(
+    SystemChannels.accessibility,
+    (Object? message) async {
+      if (message is Map && message['type'] == 'announce') {
+        final data = message['data'];
+        if (data is Map) announcements.add('${data['message']}');
+      }
+      return null;
+    },
+  );
+  addTearDown(
+    () => tester.binding.defaultBinaryMessenger
+        .setMockDecodedMessageHandler<Object?>(
+          SystemChannels.accessibility,
+          null,
+        ),
+  );
+  return announcements;
+}
+
+/// Opens the delete confirmation from the overflow menu and confirms it.
+Future<void> _confirmDelete(WidgetTester tester, AppLocalizations l10n) async {
+  await tester.tap(find.byTooltip(l10n.peopleListsActionsTooltip));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text(l10n.listDeleteAction));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text(l10n.commonDelete));
+  await tester.pumpAndSettle();
 }
 
 void main() {
@@ -375,60 +464,8 @@ void main() {
           ),
         );
 
-        final router = GoRouter(
-          initialLocation: '/',
-          routes: [
-            GoRoute(
-              path: '/',
-              builder: (context, state) => Scaffold(
-                body: Center(
-                  child: ElevatedButton(
-                    onPressed: () => context.push(
-                      '/people-lists/${Uri.encodeComponent(list.id)}',
-                    ),
-                    child: const Text('Open list'),
-                  ),
-                ),
-              ),
-            ),
-            GoRoute(
-              path: UserListPeopleScreen.path,
-              name: UserListPeopleScreen.routeName,
-              builder: (context, state) {
-                final listId = state.pathParameters['listId'];
-                if (listId == null || listId.isEmpty) {
-                  return const Scaffold(
-                    body: Center(child: Text('Invalid list')),
-                  );
-                }
-                return UserListPeopleScreen(listId: listId);
-              },
-            ),
-          ],
-        );
-
-        await tester.pumpWidget(
-          testProviderScope(
-            child: BlocProvider<PeopleListsBloc>.value(
-              value: bloc,
-              child: MaterialApp.router(
-                localizationsDelegates: AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                routerConfig: router,
-              ),
-            ),
-          ),
-        );
-        await tester.pump();
-        await tester.tap(find.text('Open list'));
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.byTooltip(l10n.peopleListsActionsTooltip));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text(l10n.listDeleteAction));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text(l10n.commonDelete));
-        await tester.pumpAndSettle();
+        await _pumpPushedListRoute(tester, bloc: bloc, list: list);
+        await _confirmDelete(tester, l10n);
 
         verify(
           () => bloc.add(
@@ -461,6 +498,107 @@ void main() {
 
         expect(find.text('Confirm Delete List'), findsNothing);
         expect(find.text('Open list'), findsOneWidget);
+      },
+    );
+
+    // #6504: a teardown clears `pendingMutations` wholesale, which reads
+    // exactly like the delete settling. The relay still has the list, so
+    // announcing a delete and popping the route would be a lie.
+    testWidgets('a delete dropped by a flag-off neither announces nor pops', (
+      tester,
+    ) async {
+      final bloc = _MockPeopleListsBloc();
+      final list = _buildList(id: 'flag-off-list', name: 'Flag Off List');
+      final controller = StreamController<PeopleListsState>.broadcast();
+      addTearDown(controller.close);
+      whenListen(
+        bloc,
+        controller.stream,
+        initialState: PeopleListsState(
+          status: PeopleListsStatus.ready,
+          ownerPubkey: _ownerPubkey,
+          lists: [list],
+        ),
+      );
+
+      await _pumpPushedListRoute(tester, bloc: bloc, list: list);
+      await _confirmDelete(tester, l10n);
+      final announcements = _captureAnnouncements(tester);
+
+      controller
+        ..add(
+          const PeopleListsState(
+            status: PeopleListsStatus.submitting,
+            ownerPubkey: _ownerPubkey,
+            pendingMutations: {
+              'delete-1': PeopleListsMutation(
+                id: 'delete-1',
+                kind: PeopleListsMutationKind.deleteList,
+                listId: 'flag-off-list',
+              ),
+            },
+          ),
+        )
+        // What `_onEnabledChanged` emits when the curated-lists flag goes off.
+        ..add(
+          const PeopleListsState(ownerPubkey: _ownerPubkey, enabled: false),
+        );
+      await tester.pumpAndSettle();
+
+      expect(announcements, isEmpty);
+      expect(find.text(l10n.peopleListsDeleteFailed), findsNothing);
+      expect(find.text('Open list'), findsNothing);
+      expect(find.text(l10n.peopleListsListNotFoundTitle), findsOneWidget);
+    });
+
+    testWidgets(
+      'a delete dropped by an account switch neither announces nor pops',
+      (tester) async {
+        final bloc = _MockPeopleListsBloc();
+        final list = _buildList(id: 'switch-list', name: 'Switch List');
+        final controller = StreamController<PeopleListsState>.broadcast();
+        addTearDown(controller.close);
+        whenListen(
+          bloc,
+          controller.stream,
+          initialState: PeopleListsState(
+            status: PeopleListsStatus.ready,
+            ownerPubkey: _ownerPubkey,
+            lists: [list],
+          ),
+        );
+
+        await _pumpPushedListRoute(tester, bloc: bloc, list: list);
+        await _confirmDelete(tester, l10n);
+        final announcements = _captureAnnouncements(tester);
+
+        controller
+          ..add(
+            const PeopleListsState(
+              status: PeopleListsStatus.submitting,
+              ownerPubkey: _ownerPubkey,
+              pendingMutations: {
+                'delete-1': PeopleListsMutation(
+                  id: 'delete-1',
+                  kind: PeopleListsMutationKind.deleteList,
+                  listId: 'switch-list',
+                ),
+              },
+            ),
+          )
+          // What `_onOwnerChanged` emits when another account signs in.
+          ..add(
+            const PeopleListsState(
+              status: PeopleListsStatus.loading,
+              ownerPubkey: _otherOwnerPubkey,
+            ),
+          );
+        await tester.pumpAndSettle();
+
+        expect(announcements, isEmpty);
+        expect(find.text(l10n.peopleListsDeleteFailed), findsNothing);
+        expect(find.text('Open list'), findsNothing);
+        expect(find.text(l10n.peopleListsListNotFoundTitle), findsOneWidget);
       },
     );
 


### PR DESCRIPTION
## Description

Three failures that share one root cause: a mutation result applied to state that no longer belongs to the mutation.

**A mutation rollback resurrects state the bloc tore down.** Each rollback is computed from a `previousLists`/`previousIndex` snapshot captured before the repository round-trip and was applied unconditionally afterwards. An account switch, a sign-out, or `FeatureFlag.curatedLists` going off in between all emit a fresh state on purpose — and the rollback put the dropped snapshot straight back, attributed to whoever is signed in by then. On a plain account switch the restored lists land on `enabled: true` and actually render.

The fix is one guard, `_resultStillApplies(mutation, owner)`, on every post-`await` emit in all four mutation handlers. A result may write only when the owner still matches *and* its mutation is still in `pendingMutations`. The mutation lookup is what actually detects the teardown — every teardown path clears the map — while the owner check keeps the guard correct if a future teardown ever preserves it. `addError` still fires before the guard, so a dropped failure is still reported.

**A false "Deleted list" confirmation.** The teardown emit clears `pendingMutations` wholesale, which `_deleteSettled` read as the delete resolving: the screen announced a successful delete and popped the route for a list still on the relay. The screen now records the owner it issued the delete for, and the listener returns without announcing or popping when the state that dropped the mutation belongs to another owner or has the feature off.

**A rollback reverts a repository emission that arrived mid-flight.** The same pre-flight snapshot also loses to `_onRepositoryListsChanged`, which keeps `pendingMutations` — so an emission that lands during the round-trip passes the teardown guard above, and restoring the snapshot afterwards drops whatever arrived meanwhile: a list synced from a relay, another device's edit. Milder than the cross-account leak (transient, and it self-heals on the next emission) but the same bug shape, and it sits on the lines this PR already touches.

So the rollback stops being snapshot-based. Each handler now undoes just its own change against the *current* lists — delete re-inserts the removed list at its old index, add reuses `_applyOptimisticRemove`, remove re-inserts the pubkey at its old index — and the reverse index is rebuilt from the result. All three undos are guarded by a `contains` check, and the repository writes its cache only after a successful publish, so a mid-flight emission carries the pre-mutation truth and every undo is a no-op against it. That also makes the rollback order-independent, which the snapshot never was. `previousLists`, `previousIndex`, and `_copyReverseIndex` are gone.

**Also folded in** (@realmeylisdev's finding on the issue): `_onCreateRequested` never read `result.submitted`, so a create the relay rejected landed on `status: ready`, contradicting the bloc's own failure-recovery contract. Latent today — `PeopleListsStatus.failure` is read in exactly one place and both create entry points dispatch and pop without waiting — but wrong, and cheap to fix in the same pass.

**Related Issue:** Closes #6504

## Out of Scope

`UserListPeopleScreen` still infers this delete's failure from the global people-lists status. That is pre-existing adjacent debt and is tracked in #6696 because a clean fix needs per-mutation completion state rather than a list-presence heuristic.

## Verification

- `flutter analyze lib test integration_test` — clean.
- `flutter test test/features/people_lists test/screens/user_list_people_screen_test.dart test/router/people_lists_route_order_test.dart test/main_app_shell_repository_sync_test.dart test/widgets/profile test/screens/other_profile_screen_test.dart test/widgets/user_profile_tile_feature_flag_test.dart` — 426 green.
- `flutter analyze lib/features/people_lists/bloc/people_lists_bloc.dart test/features/people_lists/bloc/people_lists_bloc_test.dart` — clean.
- `flutter test test/features/people_lists/bloc/people_lists_bloc_test.dart` — 46 green.
- Design-system, process-global, shared-channel, file-size, todo and test-structure ratchets — all green.
- Every new test was confirmed red against the unfixed code first. The two screen tests fail with exactly the reported symptom (`Actual: ['Deleted list']`); the two mid-flight rollback tests fail with `Expected: ['l1', 'l3'] / Actual: ['l1']`.
- One new test is green both before and after by design: `a failed remove restores the member at its old index` pins the member ordering the snapshot restored for free. It is a guard on the rewrite, not a regression test — implementing the undo with `_applyOptimisticAdd` (which appends) turns it red.
- Manually verified on a real Samsung Galaxy (SM S942B, Android 16): a delete with Curated Lists turned off mid-publish and a delete across an account switch both stay put — no announcement, no pop, and the previous owner's lists do not surface under the new account. A failed delete restores the list at its original position, and a failed member removal restores the person at their original index in the carousel rather than appending them.

New regression coverage: 5 bloc cases for the teardown guard (delete rollback vs. flag-off, delete rollback vs. account switch, add that throws after a teardown, remove that throws after a teardown, create that resolves after a teardown), 3 for the mid-flight rollback race (delete, add, remove), the create-not-submitted case, and 2 screen cases asserting no announcement and no pop. The duplicated `GoRouter` setup in the screen tests moved into a shared `_pumpPushedListRoute` helper now that three tests need it.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
