### PR TITLE
fix(profile): hand pull-to-refresh a completer instead of a settled state

### DIFF
--- a/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_bloc.dart
@@ -1,12 +1,15 @@
 // ABOUTME: BLoC for managing profile collab videos grid
 // ABOUTME: Fetches Funnelcake-confirmed collaborator videos for a profile
 
+import 'dart:async';
+
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:cache_sync/cache_sync.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/blocs/profile_shared/profile_tab_sync_completion.dart';
 import 'package:openvine/blocs/profile_shared/profile_video_cursor_snapshot.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -35,7 +38,10 @@ class ProfileCollabVideosBloc
        super(const ProfileCollabVideosState()) {
     on<ProfileCollabVideosFetchRequested>(
       _onFetchRequested,
-      transformer: droppable(),
+      // Sequential, not droppable: a dropped event never reaches the handler,
+      // so nothing would complete its completer and pull-to-refresh would spin
+      // forever. Rapid fetches queue instead of coalescing.
+      transformer: sequential(),
     );
     on<ProfileCollabVideosLoadMoreRequested>(_onLoadMoreRequested);
   }
@@ -51,8 +57,22 @@ class ProfileCollabVideosBloc
   /// On reopen the persisted snapshot is served immediately; revalidation then
   /// re-fetches just the first page and prepends any genuinely-new collab
   /// videos — it never re-fetches the whole loaded feed.
+  ///
+  /// [ProfileCollabVideosFetchRequested.completer] fires only once all of that
+  /// is done, snapshot write included, so a refresh waiter is released exactly
+  /// when the bloc is free to take the next fetch.
   Future<void> _onFetchRequested(
     ProfileCollabVideosFetchRequested event,
+    Emitter<ProfileCollabVideosState> emit,
+  ) async {
+    try {
+      await _fetchAndRevalidate(emit);
+    } finally {
+      completeProfileTabSync(event.completer);
+    }
+  }
+
+  Future<void> _fetchAndRevalidate(
     Emitter<ProfileCollabVideosState> emit,
   ) async {
     // Flag the revalidation whenever a settled result is on screen — an empty

--- a/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_bloc.dart
@@ -76,8 +76,8 @@ class ProfileCollabVideosBloc
     Emitter<ProfileCollabVideosState> emit,
   ) async {
     // Flag the revalidation whenever a settled result is on screen — an empty
-    // one included — so a re-sync always has an observable start edge, matching
-    // the liked/reposted/saved tabs.
+    // one included — so the sticky cache-revalidation bar runs for the whole
+    // re-sync, matching the liked/reposted/saved tabs.
     if (state.status != ProfileCollabVideosStatus.initial &&
         !state.isRefreshing) {
       emit(state.copyWith(isRefreshing: true));

--- a/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_event.dart
+++ b/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_event.dart
@@ -12,7 +12,12 @@ sealed class ProfileCollabVideosEvent {
 ///
 /// This triggers the repository's Funnelcake-confirmed collaborator read path.
 final class ProfileCollabVideosFetchRequested extends ProfileCollabVideosEvent {
-  const ProfileCollabVideosFetchRequested();
+  const ProfileCollabVideosFetchRequested({this.completer});
+
+  /// Optional completion signal for UI refresh affordances, completed once the
+  /// handler is fully done — snapshot write included. See
+  /// [completeProfileTabSync].
+  final Completer<void>? completer;
 }
 
 /// Request to load more collab videos (pagination).

--- a/mobile/lib/blocs/profile_comments/profile_comments_bloc.dart
+++ b/mobile/lib/blocs/profile_comments/profile_comments_bloc.dart
@@ -2,9 +2,13 @@
 // ABOUTME: Splits results into video replies and text comments for UI display.
 // ABOUTME: Supports lazy loading and cursor-based pagination.
 
+import 'dart:async';
+
 import 'package:bloc/bloc.dart';
+import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:comments_repository/comments_repository.dart';
 import 'package:equatable/equatable.dart';
+import 'package:openvine/blocs/profile_shared/profile_tab_sync_completion.dart';
 
 part 'profile_comments_event.dart';
 part 'profile_comments_state.dart';
@@ -32,7 +36,12 @@ class ProfileCommentsBloc
        _targetUserPubkey = targetUserPubkey,
        _includeVideoReplies = includeVideoReplies,
        super(const ProfileCommentsState()) {
-    on<ProfileCommentsSyncRequested>(_onSyncRequested);
+    on<ProfileCommentsSyncRequested>(
+      _onSyncRequested,
+      // Sequential so every sync runs — and therefore completes its completer,
+      // which is what holds the profile pull-to-refresh indicator.
+      transformer: sequential(),
+    );
     on<ProfileCommentsLoadMoreRequested>(_onLoadMoreRequested);
   }
 
@@ -40,12 +49,21 @@ class ProfileCommentsBloc
   final String _targetUserPubkey;
   final bool _includeVideoReplies;
 
+  /// Loads the target user's comments, completing
+  /// [ProfileCommentsSyncRequested.completer] once the load has settled so the
+  /// profile pull-to-refresh can release its indicator.
   Future<void> _onSyncRequested(
     ProfileCommentsSyncRequested event,
     Emitter<ProfileCommentsState> emit,
   ) async {
-    if (state.status == ProfileCommentsStatus.loading) return;
+    try {
+      await _sync(emit);
+    } finally {
+      completeProfileTabSync(event.completer);
+    }
+  }
 
+  Future<void> _sync(Emitter<ProfileCommentsState> emit) async {
     emit(state.copyWith(status: ProfileCommentsStatus.loading));
 
     try {

--- a/mobile/lib/blocs/profile_comments/profile_comments_event.dart
+++ b/mobile/lib/blocs/profile_comments/profile_comments_event.dart
@@ -10,7 +10,11 @@ sealed class ProfileCommentsEvent {
 
 /// Requests the initial sync of comments for the target user.
 final class ProfileCommentsSyncRequested extends ProfileCommentsEvent {
-  const ProfileCommentsSyncRequested();
+  const ProfileCommentsSyncRequested({this.completer});
+
+  /// Optional completion signal for UI refresh affordances, completed once the
+  /// handler is fully done. See [completeProfileTabSync].
+  final Completer<void>? completer;
 }
 
 /// Requests loading more comments for pagination.

--- a/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
@@ -14,6 +14,7 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_feed/profile_feed_enrichment_merge.dart';
 import 'package:openvine/blocs/profile_feed/profile_video_metadata_cache.dart';
 import 'package:openvine/blocs/profile_feed/profile_video_snapshot_cache.dart';
+import 'package:openvine/blocs/profile_shared/profile_tab_sync_completion.dart';
 import 'package:openvine/blocs/profile_shared/profile_video_offset_snapshot.dart';
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/services/video_event_service.dart';
@@ -308,10 +309,23 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
     }
   }
 
+  /// Refreshes the feed, completing
+  /// [ProfileFeedRefreshRequested.completer] once the load has settled so the
+  /// profile pull-to-refresh can release its indicator.
+  ///
+  /// Safe under `restartable()`: unlike `droppable()`, it invokes the handler
+  /// for every event and only cancels the superseded one's emitter, so a
+  /// refresh that loses the race still reaches this `finally`.
   Future<void> _onRefresh(
     ProfileFeedRefreshRequested event,
     Emitter<ProfileFeedState> emit,
-  ) => _doRefresh(emit);
+  ) async {
+    try {
+      await _doRefresh(emit);
+    } finally {
+      completeProfileTabSync(event.completer);
+    }
+  }
 
   Future<void> _onVideoUpdated(
     ProfileFeedVideoUpdated event,

--- a/mobile/lib/blocs/profile_feed/profile_feed_event.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_event.dart
@@ -21,7 +21,15 @@ final class ProfileFeedLoadMoreRequested extends ProfileFeedEvent {
 
 /// Forces a full refresh. `restartable` — the latest refresh wins.
 final class ProfileFeedRefreshRequested extends ProfileFeedEvent {
-  const ProfileFeedRefreshRequested();
+  const ProfileFeedRefreshRequested({this.completer});
+
+  /// Optional completion signal for UI refresh affordances, completed once the
+  /// handler is fully done. See [completeProfileTabSync].
+  ///
+  /// Deliberately not in [props]: the completer is an out-of-band callback, not
+  /// part of the event's identity, and equality is what lets a caller verify
+  /// `add(const ProfileFeedRefreshRequested())` regardless of the waiter.
+  final Completer<void>? completer;
 }
 
 /// Re-applies feed filters in place over the cached source (no re-fetch).

--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
@@ -14,6 +14,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/blocs/profile_shared/profile_tab_sync_completion.dart';
 import 'package:openvine/blocs/profile_shared/profile_video_list_snapshot.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -54,7 +55,10 @@ class ProfileLikedVideosBloc
        super(const ProfileLikedVideosState()) {
     on<ProfileLikedVideosSyncRequested>(
       _onSyncRequested,
-      transformer: droppable(),
+      // Sequential, not droppable: a dropped event never reaches the handler,
+      // so nothing would complete its completer and pull-to-refresh would spin
+      // forever. Rapid syncs queue instead of coalescing.
+      transformer: sequential(),
     );
     on<ProfileLikedVideosSubscriptionRequested>(_onSubscriptionRequested);
     on<ProfileLikedVideosReconcileRequested>(
@@ -118,8 +122,22 @@ class ProfileLikedVideosBloc
   /// re-serializes the whole window, which previously janked the UI thread
   /// when fresh data arrived. On a cold open the state stays loading until
   /// the first page resolves.
+  ///
+  /// [ProfileLikedVideosSyncRequested.completer] fires only once all of that
+  /// is done, snapshot write included, so a refresh waiter is released exactly
+  /// when the bloc is free to take the next sync.
   Future<void> _onSyncRequested(
     ProfileLikedVideosSyncRequested event,
+    Emitter<ProfileLikedVideosState> emit,
+  ) async {
+    try {
+      await _syncAndRevalidate(emit);
+    } finally {
+      completeProfileTabSync(event.completer);
+    }
+  }
+
+  Future<void> _syncAndRevalidate(
     Emitter<ProfileLikedVideosState> emit,
   ) async {
     Log.info(

--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
@@ -151,8 +151,7 @@ class ProfileLikedVideosBloc
     // progress bar straight away rather than flashing the full-screen spinner.
     // An empty settled grid needs the flag too: a re-sync that stays empty
     // emits a state equal to the current one, which bloc suppresses, so
-    // without this transition the profile pull-to-refresh (it awaits the next
-    // settled state) hangs.
+    // without this transition the bar would never appear for an empty tab.
     if (state.status != ProfileLikedVideosStatus.initial &&
         !state.isRefreshing) {
       emit(state.copyWith(isRefreshing: true));

--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_event.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_event.dart
@@ -14,7 +14,12 @@ sealed class ProfileLikedVideosEvent {
 /// 1. Sync of liked event IDs from LikesRepository
 /// 2. Fetch of video data for those IDs from cache/relays
 final class ProfileLikedVideosSyncRequested extends ProfileLikedVideosEvent {
-  const ProfileLikedVideosSyncRequested();
+  const ProfileLikedVideosSyncRequested({this.completer});
+
+  /// Optional completion signal for UI refresh affordances, completed once the
+  /// handler is fully done — snapshot write included. See
+  /// [completeProfileTabSync].
+  final Completer<void>? completer;
 }
 
 /// Request to start listening for liked IDs changes from the repository.

--- a/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
@@ -114,9 +114,10 @@ class ProfileRepostedVideosBloc
     Emitter<ProfileRepostedVideosState> emit,
   ) async {
     // Flag the revalidation whenever a settled result is on screen — an empty
-    // one included. A re-sync that stays empty emits a state equal to the
-    // current one, which bloc suppresses, so without this transition the
-    // profile pull-to-refresh (it awaits the next settled state) hangs.
+    // one included — so the sticky cache-revalidation bar runs for the whole
+    // re-sync. A re-sync that stays empty emits a state equal to the current
+    // one, which bloc suppresses, so without this transition the bar would
+    // never appear for an empty tab.
     if (state.status != ProfileRepostedVideosStatus.initial &&
         !state.isRefreshing) {
       emit(state.copyWith(isRefreshing: true));

--- a/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
@@ -13,6 +13,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:nostr_sdk/aid.dart';
 import 'package:nostr_sdk/event_kind.dart';
+import 'package:openvine/blocs/profile_shared/profile_tab_sync_completion.dart';
 import 'package:openvine/blocs/profile_shared/profile_video_list_snapshot.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:reposts_repository/reposts_repository.dart';
@@ -53,7 +54,10 @@ class ProfileRepostedVideosBloc
        super(const ProfileRepostedVideosState()) {
     on<ProfileRepostedVideosSyncRequested>(
       _onSyncRequested,
-      transformer: droppable(),
+      // Sequential, not droppable: a dropped event never reaches the handler,
+      // so nothing would complete its completer and pull-to-refresh would spin
+      // forever. Rapid syncs queue instead of coalescing.
+      transformer: sequential(),
     );
     on<ProfileRepostedVideosSubscriptionRequested>(_onSubscriptionRequested);
     on<ProfileRepostedVideosReconcileRequested>(
@@ -91,8 +95,22 @@ class ProfileRepostedVideosBloc
   /// On reopen the persisted snapshot is deserialized once and served
   /// immediately; revalidation then only refreshes the reposted-ID list and
   /// reconciles it against the shown videos (no bulk re-fetch / re-serialize).
+  ///
+  /// [ProfileRepostedVideosSyncRequested.completer] fires only once all of that
+  /// is done, snapshot write included, so a refresh waiter is released exactly
+  /// when the bloc is free to take the next sync.
   Future<void> _onSyncRequested(
     ProfileRepostedVideosSyncRequested event,
+    Emitter<ProfileRepostedVideosState> emit,
+  ) async {
+    try {
+      await _syncAndRevalidate(emit);
+    } finally {
+      completeProfileTabSync(event.completer);
+    }
+  }
+
+  Future<void> _syncAndRevalidate(
     Emitter<ProfileRepostedVideosState> emit,
   ) async {
     // Flag the revalidation whenever a settled result is on screen — an empty

--- a/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_event.dart
+++ b/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_event.dart
@@ -15,7 +15,12 @@ sealed class ProfileRepostedVideosEvent {
 /// 2. Resolution of addressable IDs to VideoEvents
 final class ProfileRepostedVideosSyncRequested
     extends ProfileRepostedVideosEvent {
-  const ProfileRepostedVideosSyncRequested();
+  const ProfileRepostedVideosSyncRequested({this.completer});
+
+  /// Optional completion signal for UI refresh affordances, completed once the
+  /// handler is fully done — snapshot write included. See
+  /// [completeProfileTabSync].
+  final Completer<void>? completer;
 }
 
 /// Request to start listening for repost changes from the repository.

--- a/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
@@ -89,9 +89,10 @@ class ProfileSavedVideosBloc
     Emitter<ProfileSavedVideosState> emit,
   ) async {
     // Flag the revalidation whenever a settled result is on screen — an empty
-    // one included. A re-sync that stays empty emits a state equal to the
-    // current one, which bloc suppresses, so without this transition the
-    // profile pull-to-refresh (it awaits the next settled state) hangs.
+    // one included — so the sticky cache-revalidation bar runs for the whole
+    // re-sync. A re-sync that stays empty emits a state equal to the current
+    // one, which bloc suppresses, so without this transition the bar would
+    // never appear for an empty tab.
     if (state.status != ProfileSavedVideosStatus.initial &&
         !state.isRefreshing) {
       emit(state.copyWith(isRefreshing: true));

--- a/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
@@ -11,6 +11,7 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/blocs/profile_shared/profile_tab_sync_completion.dart';
 import 'package:openvine/blocs/profile_shared/profile_video_list_snapshot.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/services/bookmark_service.dart';
@@ -45,7 +46,10 @@ class ProfileSavedVideosBloc
        super(const ProfileSavedVideosState()) {
     on<ProfileSavedVideosSyncRequested>(
       _onSyncRequested,
-      transformer: droppable(),
+      // Sequential, not droppable: a dropped event never reaches the handler,
+      // so nothing would complete its completer and pull-to-refresh would spin
+      // forever. Rapid syncs queue instead of coalescing.
+      transformer: sequential(),
     );
     on<ProfileSavedVideosLoadMoreRequested>(_onLoadMoreRequested);
   }
@@ -66,8 +70,22 @@ class ProfileSavedVideosBloc
   /// On reopen the persisted snapshot is served immediately; revalidation then
   /// re-reads the (in-memory, SharedPreferences-cached) bookmark list and only
   /// reconciles it against the shown videos — no bulk re-fetch / re-serialize.
+  ///
+  /// [ProfileSavedVideosSyncRequested.completer] fires only once all of that is
+  /// done, snapshot write included, so a refresh waiter is released exactly
+  /// when the bloc is free to take the next sync.
   Future<void> _onSyncRequested(
     ProfileSavedVideosSyncRequested event,
+    Emitter<ProfileSavedVideosState> emit,
+  ) async {
+    try {
+      await _syncAndRevalidate(emit);
+    } finally {
+      completeProfileTabSync(event.completer);
+    }
+  }
+
+  Future<void> _syncAndRevalidate(
     Emitter<ProfileSavedVideosState> emit,
   ) async {
     // Flag the revalidation whenever a settled result is on screen — an empty

--- a/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_event.dart
+++ b/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_event.dart
@@ -11,7 +11,12 @@ sealed class ProfileSavedVideosEvent {
 /// Request to load saved bookmark IDs from [BookmarkService] and fetch the
 /// first page of videos.
 final class ProfileSavedVideosSyncRequested extends ProfileSavedVideosEvent {
-  const ProfileSavedVideosSyncRequested();
+  const ProfileSavedVideosSyncRequested({this.completer});
+
+  /// Optional completion signal for UI refresh affordances, completed once the
+  /// handler is fully done — snapshot write included. See
+  /// [completeProfileTabSync].
+  final Completer<void>? completer;
 }
 
 /// Request to load more saved videos (pagination).

--- a/mobile/lib/blocs/profile_shared/profile_tab_sync_completion.dart
+++ b/mobile/lib/blocs/profile_shared/profile_tab_sync_completion.dart
@@ -5,7 +5,8 @@ import 'dart:async';
 
 /// Releases the refresh waiter attached to a profile tab sync event.
 ///
-/// Every profile tab sync event carries an optional `Completer<void>`, and
+/// Every profile tab sync event — the five cached tabs plus the Videos tab's
+/// `ProfileFeedRefreshRequested` — carries an optional `Completer<void>`, and
 /// `ProfileGridView` awaits those completers to hold the pull-to-refresh
 /// indicator. Call this exactly once per handled event, from a `finally`, so
 /// the waiter is released on the error path too.

--- a/mobile/lib/blocs/profile_shared/profile_tab_sync_completion.dart
+++ b/mobile/lib/blocs/profile_shared/profile_tab_sync_completion.dart
@@ -1,0 +1,21 @@
+// ABOUTME: Completion handshake shared by the profile tab sync events
+// ABOUTME: Lets pull-to-refresh await a sync's real end, cache write included
+
+import 'dart:async';
+
+/// Completes [completer] unless it has already fired.
+///
+/// Every profile tab sync event carries an optional `Completer<void>` that its
+/// handler completes in a `finally`, and `ProfileGridView` awaits those
+/// completers to hold the pull-to-refresh indicator.
+///
+/// Watching the state stream instead cannot express this: a re-sync that finds
+/// nothing changed emits a state equal to the current one, which bloc
+/// suppresses, and a handler can stay busy past its terminal emit — the
+/// cache-backed tabs write their snapshot there. That leaves a window in which
+/// the tab looks settled while its handler is still running.
+void completeProfileTabSync(Completer<void>? completer) {
+  if (completer != null && !completer.isCompleted) {
+    completer.complete();
+  }
+}

--- a/mobile/lib/blocs/profile_shared/profile_tab_sync_completion.dart
+++ b/mobile/lib/blocs/profile_shared/profile_tab_sync_completion.dart
@@ -3,19 +3,17 @@
 
 import 'dart:async';
 
-/// Completes [completer] unless it has already fired.
+/// Releases the refresh waiter attached to a profile tab sync event.
 ///
-/// Every profile tab sync event carries an optional `Completer<void>` that its
-/// handler completes in a `finally`, and `ProfileGridView` awaits those
-/// completers to hold the pull-to-refresh indicator.
+/// Every profile tab sync event carries an optional `Completer<void>`, and
+/// `ProfileGridView` awaits those completers to hold the pull-to-refresh
+/// indicator. Call this exactly once per handled event, from a `finally`, so
+/// the waiter is released on the error path too.
 ///
 /// Watching the state stream instead cannot express this: a re-sync that finds
 /// nothing changed emits a state equal to the current one, which bloc
 /// suppresses, and a handler can stay busy past its terminal emit — the
 /// cache-backed tabs write their snapshot there. That leaves a window in which
 /// the tab looks settled while its handler is still running.
-void completeProfileTabSync(Completer<void>? completer) {
-  if (completer != null && !completer.isCompleted) {
-    completer.complete();
-  }
-}
+void completeProfileTabSync(Completer<void>? completer) =>
+    completer?.complete();

--- a/mobile/lib/widgets/profile/profile_grid.dart
+++ b/mobile/lib/widgets/profile/profile_grid.dart
@@ -293,6 +293,16 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
     unawaited(_refreshSyncedTabs());
   }
 
+  /// Re-syncs every tab the user has viewed and resolves once all of them have
+  /// finished.
+  ///
+  /// Each sync event carries its own [Completer], which its handler completes
+  /// in a `finally`. Watching the state stream instead cannot express this: an
+  /// unchanged re-sync emits a state equal to the current one and bloc
+  /// suppresses it, and a handler stays busy past its terminal emit while it
+  /// writes its snapshot to the cache — so a settled-looking tab could still be
+  /// mid-handler. Holding the indicator until the completers fire also keeps
+  /// the next pull from landing on a bloc that is still working.
   Future<void> _refreshSyncedTabs() async {
     // Re-dispatch sync only for tabs that have been viewed (lazy load still
     // applies).
@@ -304,64 +314,33 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
         case ProfileTabKind.collabs:
           final bloc = _collabVideosBloc;
           if (bloc == null) break;
-          bloc.add(const ProfileCollabVideosFetchRequested());
-          refreshes.add(
-            bloc.stream.firstWhere(
-              (state) =>
-                  !state.isRefreshing &&
-                  state.status != ProfileCollabVideosStatus.loading,
-              orElse: () => bloc.state,
-            ),
-          );
+          final completer = Completer<void>();
+          bloc.add(ProfileCollabVideosFetchRequested(completer: completer));
+          refreshes.add(completer.future);
         case ProfileTabKind.liked:
           final bloc = _likedVideosBloc;
           if (bloc == null) break;
-          bloc.add(const ProfileLikedVideosSyncRequested());
-          refreshes.add(
-            bloc.stream.firstWhere(
-              (state) =>
-                  !state.isRefreshing &&
-                  state.status != ProfileLikedVideosStatus.syncing &&
-                  state.status != ProfileLikedVideosStatus.loading,
-              orElse: () => bloc.state,
-            ),
-          );
+          final completer = Completer<void>();
+          bloc.add(ProfileLikedVideosSyncRequested(completer: completer));
+          refreshes.add(completer.future);
         case ProfileTabKind.reposts:
           final bloc = _repostedVideosBloc;
           if (bloc == null) break;
-          bloc.add(const ProfileRepostedVideosSyncRequested());
-          refreshes.add(
-            bloc.stream.firstWhere(
-              (state) =>
-                  !state.isRefreshing &&
-                  state.status != ProfileRepostedVideosStatus.syncing &&
-                  state.status != ProfileRepostedVideosStatus.loading,
-              orElse: () => bloc.state,
-            ),
-          );
+          final completer = Completer<void>();
+          bloc.add(ProfileRepostedVideosSyncRequested(completer: completer));
+          refreshes.add(completer.future);
         case ProfileTabKind.saved:
           final bloc = _savedVideosBloc;
           if (bloc == null) break;
-          bloc.add(const ProfileSavedVideosSyncRequested());
-          refreshes.add(
-            bloc.stream.firstWhere(
-              (state) =>
-                  !state.isRefreshing &&
-                  state.status != ProfileSavedVideosStatus.syncing &&
-                  state.status != ProfileSavedVideosStatus.loading,
-              orElse: () => bloc.state,
-            ),
-          );
+          final completer = Completer<void>();
+          bloc.add(ProfileSavedVideosSyncRequested(completer: completer));
+          refreshes.add(completer.future);
         case ProfileTabKind.comments:
           final bloc = _commentsBloc;
           if (bloc == null) break;
-          bloc.add(const ProfileCommentsSyncRequested());
-          refreshes.add(
-            bloc.stream.firstWhere(
-              (state) => state.status != ProfileCommentsStatus.loading,
-              orElse: () => bloc.state,
-            ),
-          );
+          final completer = Completer<void>();
+          bloc.add(ProfileCommentsSyncRequested(completer: completer));
+          refreshes.add(completer.future);
       }
     }
     await Future.wait(refreshes);

--- a/mobile/lib/widgets/profile/profile_grid.dart
+++ b/mobile/lib/widgets/profile/profile_grid.dart
@@ -361,15 +361,21 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
       profileRefresh.complete();
     }
 
-    final profileFeedCubit = context.read<ProfileFeedCubit>();
-    profileFeedCubit.add(const ProfileFeedRefreshRequested());
-    final feedRefresh = profileFeedCubit.stream.firstWhere(
-      (state) => !state.isRefreshing && !state.isFetchingTotalCount,
-      orElse: () => profileFeedCubit.state,
+    // The Videos tab uses the same completer handshake as the other tabs, for
+    // the same reason: its terminal emit is not the end of the handler, and a
+    // refresh that changes nothing would emit a suppressed state.
+    final feedRefresh = Completer<void>();
+    context.read<ProfileFeedCubit>().add(
+      ProfileFeedRefreshRequested(completer: feedRefresh),
     );
+
     final tabRefresh = _refreshSyncedTabs();
 
-    await Future.wait([profileRefresh.future, feedRefresh, tabRefresh]);
+    await Future.wait([
+      profileRefresh.future,
+      feedRefresh.future,
+      tabRefresh,
+    ]);
   }
 
   @override

--- a/mobile/test/blocs/profile_collab_videos/profile_collab_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_collab_videos/profile_collab_videos_bloc_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for ProfileCollabVideosBloc - fetching and paginating collab
 // ABOUTME: videos. Tests confirmed repository fetch and state management.
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:cache_sync/cache_sync.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -17,6 +19,10 @@ class _MockVideosRepository extends Mock implements VideosRepository {}
 class _InMemoryCacheDao implements CacheDao {
   final Map<String, String> _store = {};
 
+  /// When set, [write] parks until it completes, holding a fetch handler in the
+  /// post-emit snapshot write the way a real disk write does.
+  Completer<void>? writeGate;
+
   @override
   Future<String?> read(String key) async => _store[key];
 
@@ -26,6 +32,7 @@ class _InMemoryCacheDao implements CacheDao {
     required String payload,
     Duration? ttl,
   }) async {
+    await writeGate?.future;
     _store[key] = payload;
   }
 
@@ -229,6 +236,42 @@ void main() {
               .having((s) => s.hasMoreContent, 'hasMoreContent', isFalse),
         ],
       );
+
+      test('a fetch arriving during the snapshot write still runs', () async {
+        when(
+          () => mockVideosRepository.getCollabVideos(
+            taggedPubkey: targetPubkey,
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) async => []);
+        final bloc = createBloc();
+        addTearDown(bloc.close);
+
+        // Park the first fetch in its post-emit snapshot write — the window in
+        // which the tab already looks settled but the handler is still busy.
+        final writeGate = Completer<void>();
+        cacheDao.writeGate = writeGate;
+        final firstFetch = Completer<void>();
+        bloc.add(ProfileCollabVideosFetchRequested(completer: firstFetch));
+        await bloc.stream.firstWhere(
+          (state) => state.status == ProfileCollabVideosStatus.success,
+        );
+        expect(firstFetch.isCompleted, isFalse);
+
+        // A pull landing in that window used to be discarded outright, leaving
+        // the RefreshIndicator with nothing left to wait for.
+        final secondFetch = Completer<void>();
+        bloc.add(ProfileCollabVideosFetchRequested(completer: secondFetch));
+        writeGate.complete();
+
+        await Future.wait([firstFetch.future, secondFetch.future]).timeout(
+          const Duration(seconds: 1),
+          onTimeout: () => fail(
+            'a fetch dispatched during the snapshot write never completed — '
+            'pull-to-refresh would spin forever',
+          ),
+        );
+      });
 
       test(
         're-fetch of a settled empty tab keeps it, without the loading state',
@@ -491,7 +534,7 @@ void main() {
       );
 
       blocTest<ProfileCollabVideosBloc, ProfileCollabVideosState>(
-        'droppable: ignores a second fetch while one is in flight',
+        'sequential: queues a second fetch behind one in flight',
         build: () {
           when(
             () => mockVideosRepository.getCollabVideos(
@@ -508,12 +551,14 @@ void main() {
         },
         wait: const Duration(milliseconds: 50),
         verify: (_) {
+          // Both run: dropping the second would strand its completer and hang
+          // the pull-to-refresh that is waiting on it.
           verify(
             () => mockVideosRepository.getCollabVideos(
               taggedPubkey: targetPubkey,
               limit: any(named: 'limit'),
             ),
-          ).called(1);
+          ).called(2);
         },
       );
     });

--- a/mobile/test/blocs/profile_comments/profile_comments_bloc_test.dart
+++ b/mobile/test/blocs/profile_comments/profile_comments_bloc_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:comments_repository/comments_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -234,33 +236,6 @@ void main() {
       );
 
       blocTest<ProfileCommentsBloc, ProfileCommentsState>(
-        'does not re-fetch when already loading',
-        build: () {
-          when(
-            () => mockCommentsRepository.loadCommentsByAuthor(
-              authorPubkey: any(named: 'authorPubkey'),
-              limit: any(named: 'limit'),
-              includeVideoReplies: true,
-            ),
-          ).thenAnswer((_) async => []);
-          return createBloc();
-        },
-        seed: () =>
-            const ProfileCommentsState(status: ProfileCommentsStatus.loading),
-        act: (bloc) => bloc.add(const ProfileCommentsSyncRequested()),
-        expect: () => <ProfileCommentsState>[],
-        verify: (_) {
-          verifyNever(
-            () => mockCommentsRepository.loadCommentsByAuthor(
-              authorPubkey: any(named: 'authorPubkey'),
-              limit: any(named: 'limit'),
-              includeVideoReplies: true,
-            ),
-          );
-        },
-      );
-
-      blocTest<ProfileCommentsBloc, ProfileCommentsState>(
         'sets hasMoreContent to true when page is full',
         build: () {
           // Return exactly 50 comments (page size)
@@ -295,6 +270,44 @@ void main() {
           ),
         ],
       );
+
+      test('a sync arriving while another is in flight still runs', () async {
+        final inFlight = Completer<List<Comment>>();
+        var calls = 0;
+        when(
+          () => mockCommentsRepository.loadCommentsByAuthor(
+            authorPubkey: any(named: 'authorPubkey'),
+            limit: any(named: 'limit'),
+            includeVideoReplies: true,
+          ),
+        ).thenAnswer((_) {
+          calls++;
+          return calls == 1 ? inFlight.future : Future.value(const <Comment>[]);
+        });
+        final bloc = createBloc();
+        addTearDown(bloc.close);
+
+        final firstSync = Completer<void>();
+        bloc.add(ProfileCommentsSyncRequested(completer: firstSync));
+        await bloc.stream.firstWhere(
+          (state) => state.status == ProfileCommentsStatus.loading,
+        );
+
+        // This one used to hit the in-handler "already loading" guard and
+        // return without doing anything — including without completing.
+        final secondSync = Completer<void>();
+        bloc.add(ProfileCommentsSyncRequested(completer: secondSync));
+        inFlight.complete(const []);
+
+        await Future.wait([firstSync.future, secondSync.future]).timeout(
+          const Duration(seconds: 1),
+          onTimeout: () => fail(
+            'a sync dispatched during an in-flight sync never completed — '
+            'pull-to-refresh would spin forever',
+          ),
+        );
+        expect(calls, 2);
+      });
     });
 
     group('ProfileCommentsLoadMoreRequested', () {

--- a/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
@@ -1043,5 +1043,65 @@ void main() {
         expect(cubit.state.videos.single.originalLikes, isNull);
       },
     );
+
+    group('ProfileFeedRefreshRequested completer', () {
+      test('fires once the refresh has settled', () async {
+        final cubit = await buildReady(_result([_video('a')]));
+        addTearDown(cubit.close);
+
+        final refresh = Completer<void>();
+        cubit.add(ProfileFeedRefreshRequested(completer: refresh));
+
+        await refresh.future.timeout(
+          const Duration(seconds: 1),
+          onTimeout: () => fail(
+            'the refresh completer never fired — pull-to-refresh '
+            'would spin forever',
+          ),
+        );
+      });
+
+      test('a superseded refresh still fires its own completer', () async {
+        Completer<AuthorFeedResult>? gate;
+        when(
+          () => h.repo.getAuthorFeed(
+            authorPubkey: any(named: 'authorPubkey'),
+            offset: any(named: 'offset'),
+            relaySeed: any(named: 'relaySeed'),
+            skipCache: any(named: 'skipCache'),
+          ),
+        ).thenAnswer((_) {
+          final parked = gate;
+          gate = null;
+          return parked?.future ?? Future.value(_result([_video('a')]));
+        });
+
+        final cubit = h.build();
+        addTearDown(cubit.close);
+        await pumpEventQueue();
+
+        // Park the first refresh mid-load, then supersede it. `restartable()`
+        // cancels the loser's emitter but still runs its handler, so its
+        // `finally` — and therefore its waiter — must survive the swap.
+        final firstLoad = Completer<AuthorFeedResult>();
+        gate = firstLoad;
+        final first = Completer<void>();
+        cubit.add(ProfileFeedRefreshRequested(completer: first));
+        await pumpEventQueue();
+        expect(first.isCompleted, isFalse);
+
+        final second = Completer<void>();
+        cubit.add(ProfileFeedRefreshRequested(completer: second));
+        firstLoad.complete(_result([_video('b')]));
+
+        await Future.wait([first.future, second.future]).timeout(
+          const Duration(seconds: 1),
+          onTimeout: () => fail(
+            'a superseded refresh stranded its completer — '
+            'pull-to-refresh would spin forever',
+          ),
+        );
+      });
+    });
   });
 }

--- a/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
@@ -27,6 +27,10 @@ class _MockContentBlocklistRepository extends Mock
 class _InMemoryCacheDao implements CacheDao {
   final Map<String, String> _store = {};
 
+  /// When set, [write] parks until it completes, holding a sync handler in the
+  /// post-emit snapshot write the way a real disk write does.
+  Completer<void>? writeGate;
+
   @override
   Future<String?> read(String key) async => _store[key];
 
@@ -36,6 +40,7 @@ class _InMemoryCacheDao implements CacheDao {
     required String payload,
     Duration? ttl,
   }) async {
+    await writeGate?.future;
     _store[key] = payload;
   }
 
@@ -268,6 +273,39 @@ void main() {
           );
         },
       );
+
+      test('a sync arriving during the snapshot write still runs', () async {
+        when(
+          () => mockLikesRepository.syncUserReactions(),
+        ).thenAnswer((_) async => const LikesSyncResult.empty());
+        final bloc = createBloc();
+        addTearDown(bloc.close);
+
+        // Park the first sync in its post-emit snapshot write — the window in
+        // which the tab already looks settled but the handler is still busy.
+        final writeGate = Completer<void>();
+        cacheDao.writeGate = writeGate;
+        final firstSync = Completer<void>();
+        bloc.add(ProfileLikedVideosSyncRequested(completer: firstSync));
+        await bloc.stream.firstWhere(
+          (state) => state.status == ProfileLikedVideosStatus.success,
+        );
+        expect(firstSync.isCompleted, isFalse);
+
+        // A pull landing in that window used to be discarded outright, leaving
+        // the RefreshIndicator with nothing left to wait for.
+        final secondSync = Completer<void>();
+        bloc.add(ProfileLikedVideosSyncRequested(completer: secondSync));
+        writeGate.complete();
+
+        await Future.wait([firstSync.future, secondSync.future]).timeout(
+          const Duration(seconds: 1),
+          onTimeout: () => fail(
+            'a sync dispatched during the snapshot write never completed — '
+            'pull-to-refresh would spin forever',
+          ),
+        );
+      });
 
       blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
         'emits [success] with videos when liked videos found',

--- a/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
@@ -23,6 +23,10 @@ class _MockVideosRepository extends Mock implements VideosRepository {}
 class _InMemoryCacheDao implements CacheDao {
   final Map<String, String> _store = {};
 
+  /// When set, [write] parks until it completes, holding a sync handler in the
+  /// post-emit snapshot write the way a real disk write does.
+  Completer<void>? writeGate;
+
   @override
   Future<String?> read(String key) async => _store[key];
 
@@ -32,6 +36,7 @@ class _InMemoryCacheDao implements CacheDao {
     required String payload,
     Duration? ttl,
   }) async {
+    await writeGate?.future;
     _store[key] = payload;
   }
 
@@ -279,6 +284,39 @@ void main() {
           );
         },
       );
+
+      test('a sync arriving during the snapshot write still runs', () async {
+        when(
+          () => mockRepostsRepository.syncUserReposts(),
+        ).thenAnswer((_) async => const RepostsSyncResult.empty());
+        final bloc = createBloc();
+        addTearDown(bloc.close);
+
+        // Park the first sync in its post-emit snapshot write — the window in
+        // which the tab already looks settled but the handler is still busy.
+        final writeGate = Completer<void>();
+        cacheDao.writeGate = writeGate;
+        final firstSync = Completer<void>();
+        bloc.add(ProfileRepostedVideosSyncRequested(completer: firstSync));
+        await bloc.stream.firstWhere(
+          (state) => state.status == ProfileRepostedVideosStatus.success,
+        );
+        expect(firstSync.isCompleted, isFalse);
+
+        // A pull landing in that window used to be discarded outright, leaving
+        // the RefreshIndicator with nothing left to wait for.
+        final secondSync = Completer<void>();
+        bloc.add(ProfileRepostedVideosSyncRequested(completer: secondSync));
+        writeGate.complete();
+
+        await Future.wait([firstSync.future, secondSync.future]).timeout(
+          const Duration(seconds: 1),
+          onTimeout: () => fail(
+            'a sync dispatched during the snapshot write never completed — '
+            'pull-to-refresh would spin forever',
+          ),
+        );
+      });
 
       blocTest<ProfileRepostedVideosBloc, ProfileRepostedVideosState>(
         'emits [success] with videos when reposts found',

--- a/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for ProfileSavedVideosBloc — loading bookmarked videos from
 // ABOUTME: BookmarkService and paginating through VideosRepository.
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:cache_sync/cache_sync.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -20,6 +22,10 @@ class _MockVideosRepository extends Mock implements VideosRepository {}
 class _InMemoryCacheDao implements CacheDao {
   final Map<String, String> _store = {};
 
+  /// When set, [write] parks until it completes, holding a sync handler in the
+  /// post-emit snapshot write the way a real disk write does.
+  Completer<void>? writeGate;
+
   @override
   Future<String?> read(String key) async => _store[key];
 
@@ -29,6 +35,7 @@ class _InMemoryCacheDao implements CacheDao {
     required String payload,
     Duration? ttl,
   }) async {
+    await writeGate?.future;
     _store[key] = payload;
   }
 
@@ -180,6 +187,37 @@ void main() {
           );
         },
       );
+
+      test('a sync arriving during the snapshot write still runs', () async {
+        when(() => mockBookmarkService.globalBookmarks).thenReturn(const []);
+        final bloc = createBloc();
+        addTearDown(bloc.close);
+
+        // Park the first sync in its post-emit snapshot write — the window in
+        // which the tab already looks settled but the handler is still busy.
+        final writeGate = Completer<void>();
+        cacheDao.writeGate = writeGate;
+        final firstSync = Completer<void>();
+        bloc.add(ProfileSavedVideosSyncRequested(completer: firstSync));
+        await bloc.stream.firstWhere(
+          (state) => state.status == ProfileSavedVideosStatus.success,
+        );
+        expect(firstSync.isCompleted, isFalse);
+
+        // A pull landing in that window used to be discarded outright, leaving
+        // the RefreshIndicator with nothing left to wait for.
+        final secondSync = Completer<void>();
+        bloc.add(ProfileSavedVideosSyncRequested(completer: secondSync));
+        writeGate.complete();
+
+        await Future.wait([firstSync.future, secondSync.future]).timeout(
+          const Duration(seconds: 1),
+          onTimeout: () => fail(
+            'a sync dispatched during the snapshot write never completed — '
+            'pull-to-refresh would spin forever',
+          ),
+        );
+      });
 
       blocTest<ProfileSavedVideosBloc, ProfileSavedVideosState>(
         'reopen restores the cached list, then flips the bar off when '

--- a/mobile/test/widgets/profile/profile_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_grid_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:cache_sync/cache_sync.dart';
 import 'package:comments_repository/comments_repository.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:content_policy/content_policy.dart';
@@ -40,6 +41,41 @@ class _MockContentBlocklistRepository extends Mock
 
 class _MockBookmarkService extends Mock implements BookmarkService {}
 
+/// In-memory [CacheDao] whose writes can be parked, so a test can hold a tab
+/// BLoC in the post-emit snapshot write the way a real disk write does.
+class _GatedCacheDao implements CacheDao {
+  final Map<String, String> _store = {};
+
+  Completer<void>? writeGate;
+
+  @override
+  Future<String?> read(String key) async => _store[key];
+
+  @override
+  Future<void> write({
+    required String key,
+    required String payload,
+    Duration? ttl,
+  }) async {
+    await writeGate?.future;
+    _store[key] = payload;
+  }
+
+  @override
+  Future<void> delete(String key) async => _store.remove(key);
+
+  @override
+  Future<void> deletePrefix(String prefix) async =>
+      _store.removeWhere((key, _) => key.startsWith(prefix));
+
+  @override
+  Future<int> totalPayloadBytes() async =>
+      _store.values.fold<int>(0, (sum, v) => sum + v.length);
+
+  @override
+  Future<void> evictOldest(int bytesToFree) async {}
+}
+
 class _MockProfileFeedCubit extends MockBloc<ProfileFeedEvent, ProfileFeedState>
     implements ProfileFeedCubit {}
 
@@ -60,13 +96,16 @@ void main() {
     late _MockProfileFeedCubit profileFeedCubit;
     late _MockMyProfileBloc myProfileBloc;
     late MockNostrClient nostrClient;
+    late _GatedCacheDao cacheDao;
 
     setUpAll(() {
       registerFallbackValue(const MyProfileLoadRequested());
       registerFallbackValue(const ProfileFeedStarted());
     });
 
-    setUp(() {
+    setUp(() async {
+      cacheDao = _GatedCacheDao();
+      await CacheSync.init(dao: cacheDao);
       likesRepository = _MockLikesRepository();
       repostsRepository = _MockRepostsRepository();
       videosRepository = _MockVideosRepository();
@@ -314,6 +353,52 @@ void main() {
         // The spinner runs until this future resolves, so a tab that reports
         // no state change leaves the user stuck on it forever.
         expect(refreshed, isTrue);
+      },
+    );
+
+    testWidgets(
+      "pull-to-refresh completes when the next pull lands during a tab's "
+      'snapshot write',
+      (tester) async {
+        await tester.pumpWidget(buildSubject(isOwnProfile: true));
+        await tester.pump();
+
+        // View Saved so it joins the set of tabs a refresh re-syncs, and let
+        // it settle on the empty bookmark list.
+        final tabBar = tester.widget<TabBar>(find.byType(TabBar));
+        tabBar.controller!.animateTo(
+          profileTabKinds(isOwnProfile: true).indexOf(ProfileTabKind.saved),
+        );
+        await tester.pumpAndSettle();
+
+        final refreshIndicator = tester.widget<RefreshIndicator>(
+          find.byType(RefreshIndicator),
+        );
+
+        // Park the first refresh in the tab's post-emit snapshot write. The
+        // grid already looks settled here, so nothing on screen tells the user
+        // to hold off on the next pull.
+        cacheDao.writeGate = Completer<void>();
+        var firstRefreshed = false;
+        var secondRefreshed = false;
+        unawaited(
+          refreshIndicator.onRefresh().then((_) => firstRefreshed = true),
+        );
+        await tester.pumpAndSettle();
+        expect(firstRefreshed, isFalse);
+
+        // A pull landing in that window used to be discarded by the tab BLoC,
+        // so its refresh had nothing left to wait for.
+        unawaited(
+          refreshIndicator.onRefresh().then((_) => secondRefreshed = true),
+        );
+        await tester.pumpAndSettle();
+
+        cacheDao.writeGate!.complete();
+        await tester.pumpAndSettle();
+
+        expect(firstRefreshed, isTrue);
+        expect(secondRefreshed, isTrue);
       },
     );
 

--- a/mobile/test/widgets/profile/profile_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_grid_test.dart
@@ -161,6 +161,14 @@ void main() {
           event.completer?.complete();
         }
       });
+      // A MockBloc never runs a handler, so stand in for the one thing the
+      // refresh waits on: the completer the real handler fires in its finally.
+      when(() => profileFeedCubit.add(any())).thenAnswer((invocation) {
+        final event = invocation.positionalArguments.first;
+        if (event is ProfileFeedRefreshRequested) {
+          event.completer?.complete();
+        }
+      });
     });
 
     Widget buildSubject({


### PR DESCRIPTION
Closes #6644

## Description

Pull-to-refresh on a profile could still spin forever, even after #6642 fixed the settled-empty case.

`ProfileGridView._refreshSyncedTabs()` held the `RefreshIndicator` by awaiting each tab bloc's next settled state. That handshake has two blind spots. An unchanged re-sync emits a state equal to the current one, which bloc suppresses. And every sync handler stays busy past its terminal emit while it awaits the snapshot write — a window in which the tab already looks settled but the handler is still running, and `droppable()` discarded any sync arriving there. No handler ran, nothing was emitted, and `firstWhere`'s `orElse` only fires when the stream closes (bloc disposal), so the future never resolved and the spinner ran until the user left the screen.

The window is not microscopic: `CacheSync.write` → `CacheDaoImpl.write` runs `_ensureTotalBytes()` (a full-table `SELECT COALESCE(SUM(LENGTH(payload)),0)`) on the first write of a session, after every 256 writes, and after any `deletePrefix`, plus the upsert and a possible `evictOldest` transaction. It was also self-inviting: the old wait resolved at the terminal emit, so the spinner retracted while the bloc was still persisting and handed the user an immediate invitation to pull again, straight into the window.

Each sync event now carries an optional `Completer<void>` that its handler completes in a `finally` — the pattern `MyProfileRefreshRequested` already uses four lines away in `_refreshProfileContent`. Because that `finally` runs after the snapshot write, the indicator is released exactly when the bloc can accept the next sync, which closes the self-inviting half too.

The completer alone does not fix this. `droppable()` discards the event before the handler runs, so the completer would never be completed either — a suppressed-state hang traded for a never-completed-completer hang. All five sync handlers therefore move to `sequential()`. That is the deliberate part of this change: rapid pulls now queue instead of coalescing. The alternative considered in the issue — `unawaited(_persistSnapshot(...))` on the settle paths — was rejected because it only shrinks the window rather than removing it, and it would let two writes race on the same cache key.

Bloc teardown is not a new hang path: `Bloc.close()` documents that pending events still finish processing, and I verified a queued `sequential()` event does reach its handler after close (it hits the `isClosed` early return, and the `finally` still completes the completer).

Comments was already the odd one out — not `droppable()`, but guarded by an in-handler `state.status == loading` early return. Under `sequential()` a queued sync can never enter with that status, because no handler leaves it there, so the guard is unreachable and is removed rather than left as dead code.

The `completeProfileTabSync` guard is shared in `lib/blocs/profile_shared/` so the contract is documented once instead of five times. The `_InMemoryCacheDao` write gate stays duplicated per test file, per the private-mocks rule in `.claude/rules/testing.md`.

Two existing tests pinned the behaviour this replaces and are updated rather than worked around:

- collabs' `droppable: ignores a second fetch while one is in flight` → `sequential: queues a second fetch behind one in flight`, now expecting both to run
- comments' `does not re-fetch when already loading` seeded a synthetic `loading` state that is now unreachable; it is dropped in favour of one asserting a sync dispatched mid-flight still runs

## The Videos tab

`_refreshProfileContent` awaits three things, and the first pass left one of them on the old mechanism: `ProfileFeedCubit` was still awaited through `stream.firstWhere` on a settled state while the profile and the five cached tabs handed back a completer.

That wait was not broken — `_doRefresh` flips `isRefreshing` true then false, so even a refresh that changes nothing has an observable edge. But it makes a UI progress flag load-bearing for the refresh handshake, which is precisely the coupling this branch exists to remove: the flag's only real job is driving the sticky cache-revalidation bar under the pinned tab bar. So `ProfileFeedRefreshRequested` now carries the same optional completer, fired from a `finally`, and all three participants use one mechanism.

`restartable()` stays. It is safe with a completer in a way `droppable()` is not: `switchMap` still invokes the handler for every event and only cancels the superseded one's *emitter*, so a refresh that loses the race still reaches its `finally`. A test pins that — flipping the transformer to `droppable()` turns it red.

The completer is deliberately left out of `props`. `ProfileFeedEvent` extends `Equatable` (unlike the five tab event bases), and that equality is what lets callers keep verifying `add(const ProfileFeedRefreshRequested())` regardless of which waiter is attached — the same convention `MyProfileRefreshRequested` already follows.

While in there, the four cache-backed tab blocs still justified their `isRefreshing` transition with "the profile pull-to-refresh (it awaits the next settled state) hangs", describing the handshake this branch removes. The transition itself stays; the comments now point at the reason it actually still has.

## Out of Scope

A sync and a `LoadMoreRequested` can still write the same cache key concurrently — they are separate event buckets, so no transformer on the sync bucket serialises them. That is pre-existing and untouched here.

## Verification

- Repro captured as a test first. Flipping saved back to `droppable()` turns both the bloc test and the widget test red; restoring `sequential()` turns them green.
- 5 bloc-level regression tests (saved / liked / reposted / collabs / comments) — each parks a handler in its snapshot write, dispatches a second sync into that window, and fails loudly if either completer is stranded.
- 2 cubit-level tests for the Videos tab: the completer fires once a refresh settles, and a refresh superseded by a newer one still fires its own. The second flips red under `droppable()`.
- 1 widget test on `ProfileGridView` pins the user-visible behaviour end to end, including the early-retract half: it asserts the first refresh is still pending while the write is parked, which the old stream-based wait would have failed.
- `flutter analyze lib test integration_test` — clean. `dart format` over `lib` and `test` — clean.
- `flutter test test/blocs test/widgets test/screens` — 7494 passing, 104 skipped. CI's four test shards, which run the merged-isolate `very_good test --optimization` build, are green on this head.
- `check_process_global_mutations.sh`, `check_test_unit_structure.sh`, `check_untested_services_floor.sh`, `check_shared_channel_overrides.sh` — all OK.
- Manually verified on a real Samsung Galaxy. Worth watching in review: the spinner now stays up marginally longer since it waits through the cache write, most noticeably on the first pull after launch when `_ensureTotalBytes()` runs.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
