### PR TITLE
fix(profile): stop the avatar placeholder shimmering through the skeleton

### DIFF
--- a/mobile/lib/widgets/profile/profile_header_media.dart
+++ b/mobile/lib/widgets/profile/profile_header_media.dart
@@ -376,23 +376,29 @@ class _ProfileAvatarWithColor extends StatelessWidget {
       placeholderSeed: userIdHex,
       size: avatarSize,
     );
-    final avatar = hasAvatar
-        ? GestureDetector(
-            onTap: () => _showAvatarLightbox(
-              context,
-              imageUrl: imageUrl,
-              userIdHex: userIdHex,
-            ),
-            child: Hero(
-              tag: _avatarHeroTag(userIdHex),
-              flightShuttleBuilder: (_, _, _, _, _) => _AvatarHeroFlightShuttle(
+    final avatar = Skeleton.replace(
+      width: avatarSize,
+      height: avatarSize,
+      replacement: const _AvatarBone(size: avatarSize),
+      child: hasAvatar
+          ? GestureDetector(
+              onTap: () => _showAvatarLightbox(
+                context,
                 imageUrl: imageUrl,
                 userIdHex: userIdHex,
               ),
-              child: avatarWidget,
-            ),
-          )
-        : avatarWidget;
+              child: Hero(
+                tag: _avatarHeroTag(userIdHex),
+                flightShuttleBuilder: (_, _, _, _, _) =>
+                    _AvatarHeroFlightShuttle(
+                      imageUrl: imageUrl,
+                      userIdHex: userIdHex,
+                    ),
+                child: avatarWidget,
+              ),
+            )
+          : avatarWidget,
+    );
 
     if (pendingActions.isEmpty) return avatar;
 
@@ -416,6 +422,49 @@ class _ProfileAvatarWithColor extends StatelessWidget {
               ),
             ),
           ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Stand-in painted in place of the avatar while the identity loads: a flat
+/// tile in the avatar's own geometry with the brand mark animating on top.
+///
+/// [Skeletonizer] repaints leaf shapes with the shimmer but keeps the
+/// decoration of every container that has children, so shimmering the real
+/// [UserAvatar] leaves its generated placeholder — a gradient tile with a
+/// person silhouette cut into it — showing through the sweep.
+class _AvatarBone extends StatelessWidget {
+  const _AvatarBone({required this.size});
+
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        // Positioned.fill because a childless DecoratedBox takes the smallest
+        // size its constraints allow, and Stack hands non-positioned children
+        // loose ones — the tile would collapse to nothing.
+        Positioned.fill(
+          child: Skeleton.leaf(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: context.vineColors.skeleton,
+                borderRadius: BorderRadius.circular(
+                  UserAvatar.cornerRadiusForSize(size),
+                ),
+              ),
+            ),
+          ),
+        ),
+        // Skeleton.keep, not .ignore: `ignore` paints nothing while the
+        // enclosing Skeletonizer is enabled, which is the only time this
+        // widget is on screen.
+        Skeleton.keep(
+          child: BrandedLoadingIndicator(size: min(size * 0.8, 64)),
         ),
       ],
     );

--- a/mobile/lib/widgets/profile/profile_header_media.dart
+++ b/mobile/lib/widgets/profile/profile_header_media.dart
@@ -341,13 +341,20 @@ class _StatDivider extends StatelessWidget {
 /// on the label when more than one action is pending. Tapping either the
 /// avatar or the label triggers [onActionTap].
 ///
-/// The avatar shimmers when an enclosing [Skeletonizer] is enabled. The
-/// pending-action label is decorative chrome and is wrapped in
-/// [Skeleton.keep] so it stays interactive and unshimmered (#4163).
+/// While [showSkeleton] is set the avatar is swapped for an [_AvatarBone] and
+/// the pending-action label is dropped, so neither is tappable during the
+/// loading window (#4163).
+///
+/// The swap is driven by that flag rather than by [Skeleton.replace] because
+/// `Skeleton.replace` resolves against the enclosing [Skeletonizer]'s scope,
+/// which sits above the switch animation's `AnimatedSwitcher`. The outgoing
+/// half of the cross-fade would then rebuild into the real avatar too, putting
+/// two [Hero]s with the same tag in the tree for the length of the animation.
 class _ProfileAvatarWithColor extends StatelessWidget {
   const _ProfileAvatarWithColor({
     required this.imageUrl,
     required this.userIdHex,
+    required this.showSkeleton,
     this.profileColor,
     this.pendingActions = const [],
     this.onActionTap,
@@ -358,6 +365,11 @@ class _ProfileAvatarWithColor extends StatelessWidget {
   /// Hex pubkey used as the placeholder tone seed so the same user gets
   /// the same accent color here as in notifications and other surfaces.
   final String userIdHex;
+
+  /// Whether the identity is still resolving. Mirrors the `enabled` flag of
+  /// the [Skeletonizer] this widget sits under.
+  final bool showSkeleton;
+
   final Color? profileColor;
 
   /// Ordered list of pending profile actions. The first action determines
@@ -370,17 +382,17 @@ class _ProfileAvatarWithColor extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     const avatarSize = 144.0;
-    final hasAvatar = imageUrl != null && imageUrl!.isNotEmpty;
-    final avatarWidget = UserAvatar(
-      imageUrl: imageUrl,
-      placeholderSeed: userIdHex,
-      size: avatarSize,
-    );
-    final avatar = Skeleton.replace(
-      width: avatarSize,
-      height: avatarSize,
-      replacement: const _AvatarBone(size: avatarSize),
-      child: hasAvatar
+    final Widget avatar;
+    if (showSkeleton) {
+      avatar = const _AvatarBone(size: avatarSize);
+    } else {
+      final avatarWidget = UserAvatar(
+        imageUrl: imageUrl,
+        placeholderSeed: userIdHex,
+        size: avatarSize,
+      );
+      final hasAvatar = imageUrl != null && imageUrl!.isNotEmpty;
+      avatar = hasAvatar
           ? GestureDetector(
               onTap: () => _showAvatarLightbox(
                 context,
@@ -397,8 +409,8 @@ class _ProfileAvatarWithColor extends StatelessWidget {
                 child: avatarWidget,
               ),
             )
-          : avatarWidget,
-    );
+          : avatarWidget;
+    }
 
     if (pendingActions.isEmpty) return avatar;
 
@@ -410,10 +422,9 @@ class _ProfileAvatarWithColor extends StatelessWidget {
         // Reserve space for label overflow below the avatar.
         const SizedBox(width: avatarSize, height: avatarSize + 16),
         avatar,
-        Positioned(
-          bottom: 0,
-          child: Skeleton.replace(
-            replacement: const SizedBox.shrink(),
+        if (!showSkeleton)
+          Positioned(
+            bottom: 0,
             child: GestureDetector(
               onTap: onActionTap,
               child: _ProfileActionLabel(
@@ -422,7 +433,6 @@ class _ProfileAvatarWithColor extends StatelessWidget {
               ),
             ),
           ),
-        ),
       ],
     );
   }
@@ -438,35 +448,40 @@ class _ProfileAvatarWithColor extends StatelessWidget {
 class _AvatarBone extends StatelessWidget {
   const _AvatarBone({required this.size});
 
+  /// Diameter of the brand mark centred on the tile.
+  static const double _markSize = 64;
+
   final double size;
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      alignment: Alignment.center,
-      children: [
-        // Positioned.fill because a childless DecoratedBox takes the smallest
-        // size its constraints allow, and Stack hands non-positioned children
-        // loose ones — the tile would collapse to nothing.
-        Positioned.fill(
-          child: Skeleton.leaf(
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                color: context.vineColors.skeleton,
-                borderRadius: BorderRadius.circular(
-                  UserAvatar.cornerRadiusForSize(size),
+    return SizedBox.square(
+      dimension: size,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          // Positioned.fill because a childless DecoratedBox takes the
+          // smallest size its constraints allow, and Stack hands
+          // non-positioned children loose ones — the tile would collapse to
+          // nothing.
+          Positioned.fill(
+            child: Skeleton.leaf(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  color: context.vineColors.skeleton,
+                  borderRadius: BorderRadius.circular(
+                    UserAvatar.cornerRadiusForSize(size),
+                  ),
                 ),
               ),
             ),
           ),
-        ),
-        // Skeleton.keep, not .ignore: `ignore` paints nothing while the
-        // enclosing Skeletonizer is enabled, which is the only time this
-        // widget is on screen.
-        Skeleton.keep(
-          child: BrandedLoadingIndicator(size: min(size * 0.8, 64)),
-        ),
-      ],
+          // Skeleton.keep, not .ignore: `ignore` paints nothing while the
+          // enclosing Skeletonizer is enabled, which is the only time this
+          // widget is on screen.
+          const Skeleton.keep(child: BrandedLoadingIndicator(size: _markSize)),
+        ],
+      ),
     );
   }
 }

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Reusable between own profile and others' profile screens
 
 import 'dart:async';
+import 'dart:math';
 import 'dart:ui';
 
 import 'package:badge_repository/badge_repository.dart';
@@ -35,6 +36,7 @@ import 'package:openvine/utils/deferred_login_options_navigator.dart';
 import 'package:openvine/utils/divine_login_banner_dismissal.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/user_profile_utils.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
 import 'package:openvine/widgets/profile/profile_action_buttons_widget.dart';
 import 'package:openvine/widgets/profile/profile_actions_sheet/profile_actions_sheet.dart';
@@ -356,6 +358,7 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
           // during the loading window (#4183 review).
           Skeletonizer(
             enabled: showIdentitySkeleton,
+            enableSwitchAnimation: true,
             effect: vineSkeletonEffectOf(context),
             child: Column(
               mainAxisSize: MainAxisSize.min,

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -2,7 +2,6 @@
 // ABOUTME: Reusable between own profile and others' profile screens
 
 import 'dart:async';
-import 'dart:math';
 import 'dart:ui';
 
 import 'package:badge_repository/badge_repository.dart';
@@ -368,6 +367,7 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
                   child: _ProfileAvatarWithColor(
                     imageUrl: profilePictureUrl,
                     userIdHex: widget.userIdHex,
+                    showSkeleton: showIdentitySkeleton,
                     profileColor: profileColor,
                     pendingActions: pendingActions,
                     onActionTap: pendingActions.isNotEmpty

--- a/mobile/lib/widgets/user_avatar.dart
+++ b/mobile/lib/widgets/user_avatar.dart
@@ -64,6 +64,12 @@ class UserAvatar extends StatelessWidget {
   /// picture cannot be trusted to render.
   final Widget? contentOverride;
 
+  /// Corner radius of an avatar rendered at [size] without a [cornerRadius]
+  /// override. Exposed so skeleton stand-ins can match avatar geometry
+  /// without duplicating the ratio.
+  static double cornerRadiusForSize(double size) =>
+      size <= 24 ? size / 3 : math.min(size * 0.4, 56);
+
   @visibleForTesting
   static bool isSvgImageUrl(String? url) {
     if (url == null || url.isEmpty) return false;
@@ -111,8 +117,7 @@ class UserAvatar extends StatelessWidget {
     );
   }
 
-  double get _cornerRadius =>
-      cornerRadius ?? (size <= 24 ? size / 3 : math.min(size * 0.4, 56));
+  double get _cornerRadius => cornerRadius ?? cornerRadiusForSize(size);
 
   double get _borderWidth => size >= 120 ? 3 : 1;
 

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -2415,6 +2415,73 @@ void main() {
           expect(find.byType(UserAvatar), findsOneWidget);
         },
       );
+
+      testWidgets(
+        'never mounts two avatar Heroes while the skeleton cross-fades out',
+        (tester) async {
+          // The hint carries the avatar URL through the loading window (the
+          // feed → profile path), so the Hero is already mounted while the
+          // skeleton is on. Without it there is no Hero to double.
+          const avatarUrl = 'https://example.com/avatar.png';
+
+          await tester.pumpWidget(
+            buildTestWidget(
+              userIdHex: testUserHex,
+              isOwnProfile: true,
+              avatarUrlHint: avatarUrl,
+              myProfileState: const MyProfileInitial(),
+            ),
+          );
+          await tester.pump();
+          expect(findIdentitySkeletonizer(tester).enabled, isTrue);
+
+          await tester.pumpWidget(
+            buildTestWidget(
+              userIdHex: testUserHex,
+              isOwnProfile: true,
+              avatarUrlHint: avatarUrl,
+              myProfileState: MyProfileLoaded(
+                profile: createTestProfile(
+                  displayName: 'Loaded',
+                  picture: avatarUrl,
+                ),
+                isFresh: true,
+              ),
+            ),
+          );
+
+          // enableSwitchAnimation keeps both halves of the AnimatedSwitcher
+          // mounted for the length of the cross-fade. Selecting the bone off
+          // Skeletonizer's own scope (as Skeleton.replace does) rebuilds the
+          // outgoing half into the real avatar too, and two Heroes sharing a
+          // tag in one subtree trip Hero's duplicate-tag assert on the next
+          // route push.
+          final heroFinder = find.byWidgetPredicate(
+            (widget) =>
+                widget is Hero &&
+                widget.tag == 'profile_avatar_hero_$testUserHex',
+          );
+          for (final step in const [
+            Duration.zero,
+            Duration(milliseconds: 50),
+            Duration(milliseconds: 100),
+            Duration(milliseconds: 100),
+            Duration(milliseconds: 200),
+          ]) {
+            await tester.pump(step);
+            expect(
+              heroFinder.evaluate().length,
+              lessThanOrEqualTo(1),
+              reason:
+                  'Two avatar Heroes sharing '
+                  'profile_avatar_hero_$testUserHex were mounted at once '
+                  'during the skeleton cross-fade.',
+            );
+          }
+
+          expect(heroFinder, findsOneWidget);
+        },
+      );
     });
   });
 

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -31,6 +31,7 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
 import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/profile/profile_action_buttons_widget.dart';
 import 'package:openvine/widgets/profile/profile_header_widget.dart';
 import 'package:openvine/widgets/profile/profile_stats_row_widget.dart';
@@ -2370,6 +2371,50 @@ void main() {
               'tappable during the loading window (#4183 review).',
         );
       });
+
+      testWidgets('avatar is swapped for a flat bone while the identity '
+          'skeleton is enabled', (tester) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            myProfileState: const MyProfileInitial(),
+          ),
+        );
+        await tester.pump();
+
+        expect(findIdentitySkeletonizer(tester).enabled, isTrue);
+        expect(
+          find.byType(UserAvatar),
+          findsNothing,
+          reason:
+              'Skeletonizer keeps the decoration of containers that have '
+              'children, so leaving the real UserAvatar in the tree shimmers '
+              'its generated placeholder art (gradient tile + person '
+              'silhouette) instead of a plain bone.',
+        );
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
+      });
+
+      testWidgets(
+        'avatar comes back once the identity skeleton is disabled',
+        (tester) async {
+          await tester.pumpWidget(
+            buildTestWidget(
+              userIdHex: testUserHex,
+              isOwnProfile: true,
+              myProfileState: MyProfileLoaded(
+                profile: createTestProfile(displayName: 'Loaded'),
+                isFresh: true,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          expect(findIdentitySkeletonizer(tester).enabled, isFalse);
+          expect(find.byType(UserAvatar), findsOneWidget);
+        },
+      );
     });
   });
 


### PR DESCRIPTION
Closes #6670

## Description

The profile avatar's loading state rendered as a lopsided dark blob with a hard diagonal edge and the ghost of a person silhouette sweeping through it.

Cause: `Skeletonizer` only repaints *leaf* shapes with the shimmer shader — every container that has children keeps its own decoration. `UserAvatar`'s generated placeholder is exactly that shape: a gradient tile with head and body ellipses stacked on top, so the sweep landed on the silhouette while the tile below it kept its accent colours. The result read as a rendering glitch rather than as "not loaded yet".

While the identity is still resolving, the avatar is now swapped for a flat tile in the avatar's own geometry, with the animated brand mark centred on it. `Skeleton.keep` — not `Skeleton.ignore` — on the mark, because `ignore` paints nothing while the enclosing `Skeletonizer` is enabled, which is the only window in which this widget is on screen at all.

The identity `Skeletonizer` also gets `enableSwitchAnimation: true`, so the hand-off from skeleton to the loaded avatar and name cross-fades instead of popping.

Three notes on the implementation:

- The swap is driven by the same `showIdentitySkeleton` flag the `Skeletonizer` gets, **not** by `Skeleton.replace`. `Skeleton.replace` resolves against the enclosing `Skeletonizer`'s scope, and that scope sits above the `AnimatedSwitcher` that `enableSwitchAnimation` installs — so the outgoing half of the cross-fade rebuilds into the real avatar too, mounting `profile_avatar_hero_<hex>` twice for the length of the animation. That is long enough for a route push in that window (tapping the avatar to open the lightbox, for one) to trip Hero's duplicate-tag assert, and it also meant the bone popped out on the first frame instead of fading. The pending-action label is on the same flag for the same reason.
- `UserAvatar`'s default corner-radius formula moved into a `cornerRadiusForSize` static so the stand-in matches real avatar geometry instead of duplicating `min(size * 0.4, 56)` at a second callsite. Pure refactor, same math.
- The tile sits in a `Positioned.fill`: a childless `DecoratedBox` takes the smallest size its constraints allow, and `Stack` hands non-positioned children loose ones, so without it the tile collapses to nothing and only the brand mark renders.

**Related Issue:** 

## Out of Scope

Other surfaces that render `UserAvatar` under a skeleton (notification rows, user tiles, comment rows) hit the same Skeletonizer behaviour, but at 36–44 px the artefact is barely legible. Left untouched rather than widened into a sweep across every avatar callsite.

## Verification

- `flutter analyze lib test integration_test` — no issues
- `flutter test test/widgets/profile test/widgets/comprehensive_user_avatar_test.dart test/unit/user_avatar_tdd_test.dart test/widgets/user_avatar_svg_test.dart` — 325 passing, including three new cases: the real `UserAvatar` is out of the tree while the skeleton is on, it is back once the profile resolves, and there are never two avatar `Hero`s mounted at once while the skeleton cross-fades out. The last one fails against the `Skeleton.replace` version with `Actual: <2>`.
- Manually verified on a real Samsung Galaxy device (SM-S942B), including the Hero / cross-fade follow-up: the bone now fades into the loaded avatar instead of popping, and opening the lightbox immediately after the profile resolves no longer trips Hero's duplicate-tag assert

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

