### PR TITLE
fix(profile): prefetch profile tab pages before the spinner is reachable

### DIFF
--- a/mobile/lib/blocs/hashtag_search/hashtag_search_bloc.dart
+++ b/mobile/lib/blocs/hashtag_search/hashtag_search_bloc.dart
@@ -22,8 +22,9 @@ EventTransformer<E> _debounceRestartable<E>() {
   };
 }
 
-/// Number of results per page for hashtag search pagination.
-const _pageSize = 20;
+/// Hashtag chips are visually short, so each page needs to add enough rows to
+/// stay ahead of `ScrollPaginationMixin`'s viewport-relative prefetch.
+const _pageSize = 50;
 
 /// BLoC for searching hashtags via the Funnelcake API.
 ///
@@ -100,7 +101,10 @@ class HashtagSearchBloc extends Bloc<HashtagSearchEvent, HashtagSearchState> {
     _feedTracker?.startFeedLoad('hashtag_search');
 
     try {
-      final results = await _hashtagRepository.searchHashtags(query: query);
+      final results = await _hashtagRepository.searchHashtags(
+        query: query,
+        limit: _pageSize,
+      );
 
       _feedTracker?.markFirstVideosReceived('hashtag_search', results.length);
 
@@ -140,6 +144,7 @@ class HashtagSearchBloc extends Bloc<HashtagSearchEvent, HashtagSearchState> {
     try {
       final moreResults = await _hashtagRepository.searchHashtags(
         query: state.query,
+        limit: _pageSize,
         offset: state.offset,
       );
 

--- a/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_bloc.dart
@@ -9,6 +9,7 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/blocs/profile_shared/profile_tab_page_size.dart';
 import 'package:openvine/blocs/profile_shared/profile_tab_sync_completion.dart';
 import 'package:openvine/blocs/profile_shared/profile_video_cursor_snapshot.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
@@ -17,9 +18,6 @@ import 'package:videos_repository/videos_repository.dart';
 
 part 'profile_collab_videos_event.dart';
 part 'profile_collab_videos_state.dart';
-
-/// Number of videos to load per page for pagination.
-const _pageSize = 18;
 
 /// BLoC for managing profile collab videos.
 ///
@@ -141,7 +139,7 @@ class ProfileCollabVideosBloc
 
     final videos = await _videosRepository.getCollabVideos(
       taggedPubkey: _targetUserPubkey,
-      limit: _pageSize,
+      limit: profileTabPageSize,
     );
     if (isClosed) return;
 
@@ -149,7 +147,7 @@ class ProfileCollabVideosBloc
         .where((v) => v.isSupportedOnCurrentPlatform)
         .toList();
     final cursor = collabVideos.isNotEmpty ? collabVideos.last.createdAt : null;
-    final hasMore = videos.length >= _pageSize;
+    final hasMore = videos.length >= profileTabPageSize;
 
     emit(
       state.copyWith(
@@ -175,7 +173,7 @@ class ProfileCollabVideosBloc
   Future<void> _warmRevalidate(Emitter<ProfileCollabVideosState> emit) async {
     final firstPage = await _videosRepository.getCollabVideos(
       taggedPubkey: _targetUserPubkey,
-      limit: _pageSize,
+      limit: profileTabPageSize,
     );
     if (isClosed) return;
 
@@ -187,7 +185,7 @@ class ProfileCollabVideosBloc
         .where((v) => v.isSupportedOnCurrentPlatform)
         .toList();
     final freshIds = fresh.map((v) => v.id).toSet();
-    final tail = firstPage.length >= _pageSize
+    final tail = firstPage.length >= profileTabPageSize
         ? state.videos
               .skip(_tailStartAfterFreshOverlap(fresh))
               .where((v) => !freshIds.contains(v.id))
@@ -196,7 +194,8 @@ class ProfileCollabVideosBloc
     final allVideos = [...fresh, ...tail];
     // A short fresh page means the feed ends there; the cached tail (if any)
     // is no longer confirmed.
-    final hasMore = firstPage.length >= _pageSize && state.hasMoreContent;
+    final hasMore =
+        firstPage.length >= profileTabPageSize && state.hasMoreContent;
 
     final unchanged = listEquals(
       allVideos.map((v) => v.id).toList(),
@@ -297,7 +296,7 @@ class ProfileCollabVideosBloc
     try {
       final videos = await _videosRepository.getCollabVideos(
         taggedPubkey: _targetUserPubkey,
-        limit: _pageSize,
+        limit: profileTabPageSize,
         until: state.paginationCursor,
       );
 
@@ -325,7 +324,7 @@ class ProfileCollabVideosBloc
         category: LogCategory.video,
       );
 
-      final hasMore = videos.length >= _pageSize;
+      final hasMore = videos.length >= profileTabPageSize;
       emit(
         state.copyWith(
           videos: allVideos,

--- a/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_bloc.dart
@@ -139,7 +139,7 @@ class ProfileCollabVideosBloc
 
     final videos = await _videosRepository.getCollabVideos(
       taggedPubkey: _targetUserPubkey,
-      limit: profileTabPageSize,
+      limit: ProfileTabPagination.pageSize,
     );
     if (isClosed) return;
 
@@ -147,7 +147,7 @@ class ProfileCollabVideosBloc
         .where((v) => v.isSupportedOnCurrentPlatform)
         .toList();
     final cursor = collabVideos.isNotEmpty ? collabVideos.last.createdAt : null;
-    final hasMore = videos.length >= profileTabPageSize;
+    final hasMore = videos.length >= ProfileTabPagination.pageSize;
 
     emit(
       state.copyWith(
@@ -173,7 +173,7 @@ class ProfileCollabVideosBloc
   Future<void> _warmRevalidate(Emitter<ProfileCollabVideosState> emit) async {
     final firstPage = await _videosRepository.getCollabVideos(
       taggedPubkey: _targetUserPubkey,
-      limit: profileTabPageSize,
+      limit: ProfileTabPagination.pageSize,
     );
     if (isClosed) return;
 
@@ -185,7 +185,7 @@ class ProfileCollabVideosBloc
         .where((v) => v.isSupportedOnCurrentPlatform)
         .toList();
     final freshIds = fresh.map((v) => v.id).toSet();
-    final tail = firstPage.length >= profileTabPageSize
+    final tail = firstPage.length >= ProfileTabPagination.pageSize
         ? state.videos
               .skip(_tailStartAfterFreshOverlap(fresh))
               .where((v) => !freshIds.contains(v.id))
@@ -195,7 +195,8 @@ class ProfileCollabVideosBloc
     // A short fresh page means the feed ends there; the cached tail (if any)
     // is no longer confirmed.
     final hasMore =
-        firstPage.length >= profileTabPageSize && state.hasMoreContent;
+        firstPage.length >= ProfileTabPagination.pageSize &&
+        state.hasMoreContent;
 
     final unchanged = listEquals(
       allVideos.map((v) => v.id).toList(),
@@ -296,7 +297,7 @@ class ProfileCollabVideosBloc
     try {
       final videos = await _videosRepository.getCollabVideos(
         taggedPubkey: _targetUserPubkey,
-        limit: profileTabPageSize,
+        limit: ProfileTabPagination.pageSize,
         until: state.paginationCursor,
       );
 
@@ -324,7 +325,7 @@ class ProfileCollabVideosBloc
         category: LogCategory.video,
       );
 
-      final hasMore = videos.length >= profileTabPageSize;
+      final hasMore = videos.length >= ProfileTabPagination.pageSize;
       emit(
         state.copyWith(
           videos: allVideos,

--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
@@ -36,7 +36,7 @@ part 'profile_liked_videos_state.dart';
 /// - Loading video data with cache-first pattern (SQLite → relay fallback)
 /// - Filtering: excludes unsupported video formats
 /// - Listening for like changes to update the list
-/// - Pagination: loads videos in batches of [profileTabPageSize]
+/// - Pagination: loads videos in batches of [ProfileTabPagination.pageSize]
 class ProfileLikedVideosBloc
     extends Bloc<ProfileLikedVideosEvent, ProfileLikedVideosState> {
   ProfileLikedVideosBloc({
@@ -339,7 +339,7 @@ class ProfileLikedVideosBloc
         max(state.nextPageOffset, state.videos.length) + newAtTop;
     final windowSize = max(
       loadedWindow,
-      profileTabPageSize,
+      ProfileTabPagination.pageSize,
     ).clamp(0, freshIds.length);
     final windowIds = freshIds.take(windowSize).toList();
 
@@ -379,7 +379,7 @@ class ProfileLikedVideosBloc
   /// unchanged-IDs fast path in [_warmRevalidate] would keep the short window
   /// alive on every reopen for anyone whose ID list has settled.
   bool _isWindowUnderfilled(List<String> ids) =>
-      state.nextPageOffset < profileTabPageSize &&
+      state.nextPageOffset < ProfileTabPagination.pageSize &&
       state.nextPageOffset < ids.length;
 
   static const ProfileVideoListSnapshot _emptySnapshot =
@@ -542,10 +542,10 @@ class ProfileLikedVideosBloc
   /// Handle load more request - fetches the next page of videos.
   ///
   /// Uses [state.nextPageOffset] to track the position in [state.likedEventIds]
-  /// and fetches the next [profileTabPageSize] IDs. The offset advances by
-  /// the number of IDs consumed, not the number of videos loaded (some IDs
-  /// may not resolve to videos due to relay unavailability or format
-  /// filtering).
+  /// and fetches the next [ProfileTabPagination.pageSize] IDs. The offset
+  /// advances by the number of IDs consumed, not the number of videos loaded
+  /// (some IDs may not resolve to videos due to relay unavailability or
+  /// format filtering).
   Future<void> _onLoadMoreRequested(
     ProfileLikedVideosLoadMoreRequested event,
     Emitter<ProfileLikedVideosState> emit,
@@ -730,10 +730,10 @@ class ProfileLikedVideosBloc
     );
   }
 
-  /// Fetches videos until a full [profileTabPageSize] page is filled or the
-  /// IDs run out, skipping over IDs that don't resolve (sparse likes) and
-  /// deduping against [excludeVideoIds]. Returns the consumed-ID offset so
-  /// pagination advances past dead IDs.
+  /// Fetches videos until a full [ProfileTabPagination.pageSize] page is
+  /// filled or the IDs run out, skipping over IDs that don't resolve (sparse
+  /// likes) and deduping against [excludeVideoIds]. Returns the consumed-ID
+  /// offset so pagination advances past dead IDs.
   Future<_LikedVideosPage> _fetchVideoPage(
     List<String> likedEventIds, {
     required int startOffset,
@@ -746,10 +746,11 @@ class ProfileLikedVideosBloc
     final pageVideos = <VideoEvent>[];
     final seenIds = {...excludeVideoIds};
 
-    while (offset < totalCount && pageVideos.length < profileTabPageSize) {
+    while (offset < totalCount &&
+        pageVideos.length < ProfileTabPagination.pageSize) {
       final batchIds = likedEventIds
           .skip(offset)
-          .take(profileTabPageSize)
+          .take(ProfileTabPagination.pageSize)
           .toList();
       if (batchIds.isEmpty) break;
 
@@ -757,15 +758,28 @@ class ProfileLikedVideosBloc
         batchIds,
         cacheResults: cacheFirstBatch && isFirstBatch,
       );
+      final batchIndexById = {
+        for (var index = 0; index < batchIds.length; index++)
+          batchIds[index]: index,
+      };
+      var consumedIds = batchIds.length;
 
       for (final video in videos) {
-        if (pageVideos.length >= profileTabPageSize) break;
+        final batchIndex = batchIndexById[video.id];
+        if (pageVideos.length >= ProfileTabPagination.pageSize) {
+          if (batchIndex != null) consumedIds = batchIndex;
+          break;
+        }
         if (seenIds.add(video.id)) {
           pageVideos.add(video);
+          if (pageVideos.length >= ProfileTabPagination.pageSize) {
+            if (batchIndex != null) consumedIds = batchIndex + 1;
+            break;
+          }
         }
       }
 
-      offset += batchIds.length;
+      offset += consumedIds;
       isFirstBatch = false;
     }
 

--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
@@ -14,6 +14,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/blocs/profile_shared/profile_tab_page_size.dart';
 import 'package:openvine/blocs/profile_shared/profile_tab_sync_completion.dart';
 import 'package:openvine/blocs/profile_shared/profile_video_list_snapshot.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
@@ -22,9 +23,6 @@ import 'package:videos_repository/videos_repository.dart';
 
 part 'profile_liked_videos_event.dart';
 part 'profile_liked_videos_state.dart';
-
-/// Number of videos to load per page for pagination.
-const _pageSize = 18;
 
 /// BLoC for managing profile liked videos.
 ///
@@ -38,7 +36,7 @@ const _pageSize = 18;
 /// - Loading video data with cache-first pattern (SQLite → relay fallback)
 /// - Filtering: excludes unsupported video formats
 /// - Listening for like changes to update the list
-/// - Pagination: loads videos in batches of [_pageSize]
+/// - Pagination: loads videos in batches of [profileTabPageSize]
 class ProfileLikedVideosBloc
     extends Bloc<ProfileLikedVideosEvent, ProfileLikedVideosState> {
   ProfileLikedVideosBloc({
@@ -137,9 +135,7 @@ class ProfileLikedVideosBloc
     }
   }
 
-  Future<void> _syncAndRevalidate(
-    Emitter<ProfileLikedVideosState> emit,
-  ) async {
+  Future<void> _syncAndRevalidate(Emitter<ProfileLikedVideosState> emit) async {
     Log.info(
       'ProfileLikedVideosBloc: Starting sync for '
       '${_isOtherUserProfile ? "other user" : "own profile"}',
@@ -341,7 +337,10 @@ class ProfileLikedVideosBloc
     // scrolls, so scroll-driven pagination can never grow it either.
     final loadedWindow =
         max(state.nextPageOffset, state.videos.length) + newAtTop;
-    final windowSize = max(loadedWindow, _pageSize).clamp(0, freshIds.length);
+    final windowSize = max(
+      loadedWindow,
+      profileTabPageSize,
+    ).clamp(0, freshIds.length);
     final windowIds = freshIds.take(windowSize).toList();
 
     final missingIds = windowIds.where((id) => !byId.containsKey(id)).toList();
@@ -380,7 +379,8 @@ class ProfileLikedVideosBloc
   /// unchanged-IDs fast path in [_warmRevalidate] would keep the short window
   /// alive on every reopen for anyone whose ID list has settled.
   bool _isWindowUnderfilled(List<String> ids) =>
-      state.nextPageOffset < _pageSize && state.nextPageOffset < ids.length;
+      state.nextPageOffset < profileTabPageSize &&
+      state.nextPageOffset < ids.length;
 
   static const ProfileVideoListSnapshot _emptySnapshot =
       ProfileVideoListSnapshot(
@@ -542,9 +542,10 @@ class ProfileLikedVideosBloc
   /// Handle load more request - fetches the next page of videos.
   ///
   /// Uses [state.nextPageOffset] to track the position in [state.likedEventIds]
-  /// and fetches the next [_pageSize] IDs. The offset advances by the number
-  /// of IDs consumed, not the number of videos loaded (some IDs may not
-  /// resolve to videos due to relay unavailability or format filtering).
+  /// and fetches the next [profileTabPageSize] IDs. The offset advances by
+  /// the number of IDs consumed, not the number of videos loaded (some IDs
+  /// may not resolve to videos due to relay unavailability or format
+  /// filtering).
   Future<void> _onLoadMoreRequested(
     ProfileLikedVideosLoadMoreRequested event,
     Emitter<ProfileLikedVideosState> emit,
@@ -729,10 +730,10 @@ class ProfileLikedVideosBloc
     );
   }
 
-  /// Fetches videos until a full [_pageSize] page is filled or the IDs run
-  /// out, skipping over IDs that don't resolve (sparse likes) and deduping
-  /// against [excludeVideoIds]. Returns the consumed-ID offset so pagination
-  /// advances past dead IDs.
+  /// Fetches videos until a full [profileTabPageSize] page is filled or the
+  /// IDs run out, skipping over IDs that don't resolve (sparse likes) and
+  /// deduping against [excludeVideoIds]. Returns the consumed-ID offset so
+  /// pagination advances past dead IDs.
   Future<_LikedVideosPage> _fetchVideoPage(
     List<String> likedEventIds, {
     required int startOffset,
@@ -745,8 +746,11 @@ class ProfileLikedVideosBloc
     final pageVideos = <VideoEvent>[];
     final seenIds = {...excludeVideoIds};
 
-    while (offset < totalCount && pageVideos.length < _pageSize) {
-      final batchIds = likedEventIds.skip(offset).take(_pageSize).toList();
+    while (offset < totalCount && pageVideos.length < profileTabPageSize) {
+      final batchIds = likedEventIds
+          .skip(offset)
+          .take(profileTabPageSize)
+          .toList();
       if (batchIds.isEmpty) break;
 
       final videos = await _fetchVideos(
@@ -755,7 +759,7 @@ class ProfileLikedVideosBloc
       );
 
       for (final video in videos) {
-        if (pageVideos.length >= _pageSize) break;
+        if (pageVideos.length >= profileTabPageSize) break;
         if (seenIds.add(video.id)) {
           pageVideos.add(video);
         }

--- a/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
@@ -13,6 +13,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:nostr_sdk/aid.dart';
 import 'package:nostr_sdk/event_kind.dart';
+import 'package:openvine/blocs/profile_shared/profile_tab_page_size.dart';
 import 'package:openvine/blocs/profile_shared/profile_tab_sync_completion.dart';
 import 'package:openvine/blocs/profile_shared/profile_video_list_snapshot.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
@@ -22,9 +23,6 @@ import 'package:videos_repository/videos_repository.dart';
 
 part 'profile_reposted_videos_event.dart';
 part 'profile_reposted_videos_state.dart';
-
-/// Number of videos to load per page for pagination.
-const _pageSize = 18;
 
 /// BLoC for managing profile reposted videos.
 ///
@@ -39,7 +37,7 @@ const _pageSize = 18;
 /// - Resolving addressable IDs to VideoEvents with cache-first pattern
 /// - Filtering: excludes unsupported video formats
 /// - Listening for repost changes to update the list
-/// - Pagination: loads videos in batches of [_pageSize]
+/// - Pagination: loads videos in batches of [profileTabPageSize]
 class ProfileRepostedVideosBloc
     extends Bloc<ProfileRepostedVideosEvent, ProfileRepostedVideosState> {
   ProfileRepostedVideosBloc({
@@ -205,7 +203,7 @@ class ProfileRepostedVideosBloc
       return;
     }
 
-    final firstPageIds = addressableIds.take(_pageSize).toList();
+    final firstPageIds = addressableIds.take(profileTabPageSize).toList();
     final videos = await _fetchVideos(firstPageIds, cacheResults: true);
     if (isClosed) return;
 
@@ -231,9 +229,7 @@ class ProfileRepostedVideosBloc
 
   /// Warm path: cached videos are already on screen. Refresh the reposted-ID
   /// list against the relay and reconcile it against the shown videos.
-  Future<void> _warmRevalidate(
-    Emitter<ProfileRepostedVideosState> emit,
-  ) async {
+  Future<void> _warmRevalidate(Emitter<ProfileRepostedVideosState> emit) async {
     final List<String> freshIds;
     if (_isOtherUserProfile) {
       freshIds = await _repostsRepository.fetchUserReposts(_targetUserPubkey!);
@@ -290,7 +286,10 @@ class ProfileRepostedVideosBloc
     // recover; see ProfileLikedVideosBloc for the lock-in it prevents.
     final loadedWindow =
         max(state.nextPageOffset, state.videos.length) + newAtTop;
-    final windowSize = max(loadedWindow, _pageSize).clamp(0, freshIds.length);
+    final windowSize = max(
+      loadedWindow,
+      profileTabPageSize,
+    ).clamp(0, freshIds.length);
     final windowIds = freshIds.take(windowSize).toList();
 
     final missingIds = windowIds.where((id) => !byId.containsKey(id)).toList();
@@ -327,7 +326,8 @@ class ProfileRepostedVideosBloc
   /// must be topped up even when the ID list itself is unchanged. See
   /// ProfileLikedVideosBloc for the lock-in this prevents.
   bool _isWindowUnderfilled(List<String> ids) =>
-      state.nextPageOffset < _pageSize && state.nextPageOffset < ids.length;
+      state.nextPageOffset < profileTabPageSize &&
+      state.nextPageOffset < ids.length;
 
   static const ProfileVideoListSnapshot _emptySnapshot =
       ProfileVideoListSnapshot(
@@ -500,7 +500,7 @@ class ProfileRepostedVideosBloc
     try {
       final nextPageIds = state.repostedAddressableIds
           .skip(offset)
-          .take(_pageSize)
+          .take(profileTabPageSize)
           .toList();
       final newVideos = await _fetchVideos(nextPageIds, cacheResults: true);
 

--- a/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
@@ -37,7 +37,7 @@ part 'profile_reposted_videos_state.dart';
 /// - Resolving addressable IDs to VideoEvents with cache-first pattern
 /// - Filtering: excludes unsupported video formats
 /// - Listening for repost changes to update the list
-/// - Pagination: loads videos in batches of [profileTabPageSize]
+/// - Pagination: loads videos in batches of [ProfileTabPagination.pageSize]
 class ProfileRepostedVideosBloc
     extends Bloc<ProfileRepostedVideosEvent, ProfileRepostedVideosState> {
   ProfileRepostedVideosBloc({
@@ -203,7 +203,9 @@ class ProfileRepostedVideosBloc
       return;
     }
 
-    final firstPageIds = addressableIds.take(profileTabPageSize).toList();
+    final firstPageIds = addressableIds
+        .take(ProfileTabPagination.pageSize)
+        .toList();
     final videos = await _fetchVideos(firstPageIds, cacheResults: true);
     if (isClosed) return;
 
@@ -288,7 +290,7 @@ class ProfileRepostedVideosBloc
         max(state.nextPageOffset, state.videos.length) + newAtTop;
     final windowSize = max(
       loadedWindow,
-      profileTabPageSize,
+      ProfileTabPagination.pageSize,
     ).clamp(0, freshIds.length);
     final windowIds = freshIds.take(windowSize).toList();
 
@@ -326,7 +328,7 @@ class ProfileRepostedVideosBloc
   /// must be topped up even when the ID list itself is unchanged. See
   /// ProfileLikedVideosBloc for the lock-in this prevents.
   bool _isWindowUnderfilled(List<String> ids) =>
-      state.nextPageOffset < profileTabPageSize &&
+      state.nextPageOffset < ProfileTabPagination.pageSize &&
       state.nextPageOffset < ids.length;
 
   static const ProfileVideoListSnapshot _emptySnapshot =
@@ -500,7 +502,7 @@ class ProfileRepostedVideosBloc
     try {
       final nextPageIds = state.repostedAddressableIds
           .skip(offset)
-          .take(profileTabPageSize)
+          .take(ProfileTabPagination.pageSize)
           .toList();
       final newVideos = await _fetchVideos(nextPageIds, cacheResults: true);
 

--- a/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
@@ -11,6 +11,7 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/blocs/profile_shared/profile_tab_page_size.dart';
 import 'package:openvine/blocs/profile_shared/profile_tab_sync_completion.dart';
 import 'package:openvine/blocs/profile_shared/profile_video_list_snapshot.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
@@ -20,9 +21,6 @@ import 'package:videos_repository/videos_repository.dart';
 
 part 'profile_saved_videos_event.dart';
 part 'profile_saved_videos_state.dart';
-
-/// Number of videos to load per page for pagination.
-const _pageSize = 18;
 
 /// BLoC for managing profile saved (bookmarked) videos.
 ///
@@ -85,9 +83,7 @@ class ProfileSavedVideosBloc
     }
   }
 
-  Future<void> _syncAndRevalidate(
-    Emitter<ProfileSavedVideosState> emit,
-  ) async {
+  Future<void> _syncAndRevalidate(Emitter<ProfileSavedVideosState> emit) async {
     // Flag the revalidation whenever a settled result is on screen — an empty
     // one included — so the sticky cache-revalidation bar runs for the whole
     // re-sync. A re-sync that stays empty emits a state equal to the current
@@ -177,7 +173,7 @@ class ProfileSavedVideosBloc
       return;
     }
 
-    final firstPageIds = savedEventIds.take(_pageSize).toList();
+    final firstPageIds = savedEventIds.take(profileTabPageSize).toList();
     final videos = await _fetchVideos(firstPageIds, cacheResults: true);
     if (isClosed) return;
 
@@ -250,7 +246,10 @@ class ProfileSavedVideosBloc
     // recover; see ProfileLikedVideosBloc for the lock-in it prevents.
     final loadedWindow =
         max(state.nextPageOffset, state.videos.length) + newAtTop;
-    final windowSize = max(loadedWindow, _pageSize).clamp(0, freshIds.length);
+    final windowSize = max(
+      loadedWindow,
+      profileTabPageSize,
+    ).clamp(0, freshIds.length);
     final windowIds = freshIds.take(windowSize).toList();
 
     final missingIds = windowIds.where((id) => !byId.containsKey(id)).toList();
@@ -286,7 +285,8 @@ class ProfileSavedVideosBloc
   /// must be topped up even when the ID list itself is unchanged. See
   /// ProfileLikedVideosBloc for the lock-in this prevents.
   bool _isWindowUnderfilled(List<String> ids) =>
-      state.nextPageOffset < _pageSize && state.nextPageOffset < ids.length;
+      state.nextPageOffset < profileTabPageSize &&
+      state.nextPageOffset < ids.length;
 
   static const ProfileVideoListSnapshot _emptySnapshot =
       ProfileVideoListSnapshot(
@@ -336,10 +336,10 @@ class ProfileSavedVideosBloc
   /// Handle load more request — fetches the next page of videos.
   ///
   /// Uses [state.nextPageOffset] to track the position in
-  /// [state.savedEventIds] and fetches the next [_pageSize] IDs. The offset
-  /// advances by the number of IDs consumed, not the number of videos loaded
-  /// (some IDs may not resolve to videos due to relay unavailability or
-  /// format filtering).
+  /// [state.savedEventIds] and fetches the next [profileTabPageSize] IDs. The
+  /// offset advances by the number of IDs consumed, not the number of videos
+  /// loaded (some IDs may not resolve to videos due to relay unavailability
+  /// or format filtering).
   Future<void> _onLoadMoreRequested(
     ProfileSavedVideosLoadMoreRequested event,
     Emitter<ProfileSavedVideosState> emit,
@@ -370,7 +370,7 @@ class ProfileSavedVideosBloc
     try {
       final nextPageIds = state.savedEventIds
           .skip(offset)
-          .take(_pageSize)
+          .take(profileTabPageSize)
           .toList();
       final newVideos = await _fetchVideos(nextPageIds, cacheResults: true);
 

--- a/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
@@ -173,7 +173,9 @@ class ProfileSavedVideosBloc
       return;
     }
 
-    final firstPageIds = savedEventIds.take(profileTabPageSize).toList();
+    final firstPageIds = savedEventIds
+        .take(ProfileTabPagination.pageSize)
+        .toList();
     final videos = await _fetchVideos(firstPageIds, cacheResults: true);
     if (isClosed) return;
 
@@ -248,7 +250,7 @@ class ProfileSavedVideosBloc
         max(state.nextPageOffset, state.videos.length) + newAtTop;
     final windowSize = max(
       loadedWindow,
-      profileTabPageSize,
+      ProfileTabPagination.pageSize,
     ).clamp(0, freshIds.length);
     final windowIds = freshIds.take(windowSize).toList();
 
@@ -285,7 +287,7 @@ class ProfileSavedVideosBloc
   /// must be topped up even when the ID list itself is unchanged. See
   /// ProfileLikedVideosBloc for the lock-in this prevents.
   bool _isWindowUnderfilled(List<String> ids) =>
-      state.nextPageOffset < profileTabPageSize &&
+      state.nextPageOffset < ProfileTabPagination.pageSize &&
       state.nextPageOffset < ids.length;
 
   static const ProfileVideoListSnapshot _emptySnapshot =
@@ -336,7 +338,7 @@ class ProfileSavedVideosBloc
   /// Handle load more request — fetches the next page of videos.
   ///
   /// Uses [state.nextPageOffset] to track the position in
-  /// [state.savedEventIds] and fetches the next [profileTabPageSize] IDs. The
+  /// [state.savedEventIds] and fetches the next [ProfileTabPagination.pageSize] IDs. The
   /// offset advances by the number of IDs consumed, not the number of videos
   /// loaded (some IDs may not resolve to videos due to relay unavailability
   /// or format filtering).
@@ -370,7 +372,7 @@ class ProfileSavedVideosBloc
     try {
       final nextPageIds = state.savedEventIds
           .skip(offset)
-          .take(profileTabPageSize)
+          .take(ProfileTabPagination.pageSize)
           .toList();
       final newVideos = await _fetchVideos(nextPageIds, cacheResults: true);
 

--- a/mobile/lib/blocs/profile_shared/profile_tab_page_size.dart
+++ b/mobile/lib/blocs/profile_shared/profile_tab_page_size.dart
@@ -1,0 +1,13 @@
+// ABOUTME: Shared page size for the cached profile tab grids
+// ABOUTME: Sized so one page covers about two viewports of a 3-column grid
+
+/// Items fetched per page by the Liked / Reposts / Saved / Collabs tabs.
+///
+/// These tabs render a 3-column square grid, so a phone viewport shows
+/// roughly six rows — about 18 items. A page must cover clearly more than
+/// one viewport: `ScrollPaginationMixin` requests the next page 1.5
+/// viewports before the bottom, so a one-viewport page would leave the grid
+/// permanently mid-fetch and keep the loading-more spinner in view. Twelve
+/// rows gives the prefetch enough headroom to land before the user gets
+/// there.
+const profileTabPageSize = 36;

--- a/mobile/lib/blocs/profile_shared/profile_tab_page_size.dart
+++ b/mobile/lib/blocs/profile_shared/profile_tab_page_size.dart
@@ -2,12 +2,13 @@
 // ABOUTME: Sized so one page covers about two viewports of a 3-column grid
 
 /// Items fetched per page by the Liked / Reposts / Saved / Collabs tabs.
-///
-/// These tabs render a 3-column square grid, so a phone viewport shows
-/// roughly six rows — about 18 items. A page must cover clearly more than
-/// one viewport: `ScrollPaginationMixin` requests the next page 1.5
-/// viewports before the bottom, so a one-viewport page would leave the grid
-/// permanently mid-fetch and keep the loading-more spinner in view. Twelve
-/// rows gives the prefetch enough headroom to land before the user gets
-/// there.
-const profileTabPageSize = 36;
+abstract class ProfileTabPagination {
+  /// These tabs render a 3-column square grid, so a phone viewport shows
+  /// roughly six rows — about 18 items. A page must cover clearly more than
+  /// one viewport: `ScrollPaginationMixin` requests the next page 1.5
+  /// viewports before the bottom, so a one-viewport page would leave the grid
+  /// permanently mid-fetch and keep the loading-more spinner in view. Twelve
+  /// rows gives the prefetch enough headroom to land before the user gets
+  /// there.
+  static const int pageSize = 36;
+}

--- a/mobile/lib/mixins/scroll_pagination_mixin.dart
+++ b/mobile/lib/mixins/scroll_pagination_mixin.dart
@@ -55,11 +55,13 @@ mixin ScrollPaginationMixin<T extends StatefulWidget> on State<T> {
   FutureOr<void> onLoadMore();
 
   /// How many viewports ahead of the bottom edge the next page is requested.
+  ///
+  /// Callers that also choose a page size must keep it comfortably above one
+  /// viewport, or the prefetch fires again the moment the page lands and the
+  /// list never leaves the loading state. `profileTabPageSize` in
+  /// `lib/blocs/profile_shared/` is sized against this factor — revisit it if
+  /// this changes.
   static const double _viewportPrefetchFactor = 1.5;
-
-  /// Distance used before the scroll view has an attached position to read a
-  /// viewport height from.
-  static const double _fallbackThreshold = 200;
 
   /// Distance from the bottom edge (in logical pixels) at which [onLoadMore]
   /// is triggered.
@@ -70,12 +72,17 @@ mixin ScrollPaginationMixin<T extends StatefulWidget> on State<T> {
   /// off screen. A fixed pixel distance is not enough: on a dense grid it is
   /// only a row or two, so the request starts when the user is already at the
   /// bottom. Called on every scroll tick, so keep overrides cheap.
+  ///
+  /// Only valid while [paginationScrollController] has clients, which the
+  /// mixin guarantees at its own call site. Reads the first attached position
+  /// rather than [ScrollController.position] because one controller can drive
+  /// several viewports (profile tabs share the [PrimaryScrollController] of
+  /// their [NestedScrollView]); siblings are the same height, so any of them
+  /// answers the question.
   @protected
-  double get paginationLoadMoreThreshold {
-    final positions = paginationScrollController.positions;
-    if (positions.isEmpty) return _fallbackThreshold;
-    return positions.first.viewportDimension * _viewportPrefetchFactor;
-  }
+  double get paginationLoadMoreThreshold =>
+      paginationScrollController.positions.first.viewportDimension *
+      _viewportPrefetchFactor;
 
   Future<void>? _pendingPaginationLoad;
 

--- a/mobile/lib/mixins/scroll_pagination_mixin.dart
+++ b/mobile/lib/mixins/scroll_pagination_mixin.dart
@@ -54,20 +54,28 @@ mixin ScrollPaginationMixin<T extends StatefulWidget> on State<T> {
   /// ignored.
   FutureOr<void> onLoadMore();
 
-  /// Default distance from the bottom edge (in logical pixels) at which
-  /// loading is triggered.
-  static const double _defaultThreshold = 200;
+  /// How many viewports ahead of the bottom edge the next page is requested.
+  static const double _viewportPrefetchFactor = 1.5;
+
+  /// Distance used before the scroll view has an attached position to read a
+  /// viewport height from.
+  static const double _fallbackThreshold = 200;
 
   /// Distance from the bottom edge (in logical pixels) at which [onLoadMore]
   /// is triggered.
   ///
-  /// Defaults to [_defaultThreshold]. Override with a larger value (for
-  /// example a multiple of the viewport height) to prefetch the next page
-  /// well before the user reaches the bottom, so it is usually ready in time
-  /// and the loading-more indicator is not seen. Called on every scroll tick,
-  /// so keep it cheap.
+  /// Defaults to [_viewportPrefetchFactor] viewports so the next page is
+  /// requested well before the user reaches the bottom and is usually merged
+  /// in by the time they scroll that far — keeping the loading-more indicator
+  /// off screen. A fixed pixel distance is not enough: on a dense grid it is
+  /// only a row or two, so the request starts when the user is already at the
+  /// bottom. Called on every scroll tick, so keep overrides cheap.
   @protected
-  double get paginationLoadMoreThreshold => _defaultThreshold;
+  double get paginationLoadMoreThreshold {
+    final positions = paginationScrollController.positions;
+    if (positions.isEmpty) return _fallbackThreshold;
+    return positions.first.viewportDimension * _viewportPrefetchFactor;
+  }
 
   Future<void>? _pendingPaginationLoad;
 

--- a/mobile/lib/mixins/scroll_pagination_mixin.dart
+++ b/mobile/lib/mixins/scroll_pagination_mixin.dart
@@ -58,9 +58,9 @@ mixin ScrollPaginationMixin<T extends StatefulWidget> on State<T> {
   ///
   /// Callers that also choose a page size must keep it comfortably above one
   /// viewport, or the prefetch fires again the moment the page lands and the
-  /// list never leaves the loading state. `profileTabPageSize` in
-  /// `lib/blocs/profile_shared/` is sized against this factor — revisit it if
-  /// this changes.
+  /// list never leaves the loading state. `ProfileTabPagination.pageSize` in
+  /// `lib/blocs/profile_shared/` is sized against this factor — revisit it
+  /// if this changes.
   static const double _viewportPrefetchFactor = 1.5;
 
   /// Distance from the bottom edge (in logical pixels) at which [onLoadMore]
@@ -73,16 +73,18 @@ mixin ScrollPaginationMixin<T extends StatefulWidget> on State<T> {
   /// only a row or two, so the request starts when the user is already at the
   /// bottom. Called on every scroll tick, so keep overrides cheap.
   ///
-  /// Only valid while [paginationScrollController] has clients, which the
-  /// mixin guarantees at its own call site. Reads the first attached position
-  /// rather than [ScrollController.position] because one controller can drive
-  /// several viewports (profile tabs share the [PrimaryScrollController] of
-  /// their [NestedScrollView]); siblings are the same height, so any of them
-  /// answers the question.
+  /// Reads the first attached position rather than [ScrollController.position]
+  /// because one controller can drive several viewports (profile tabs share
+  /// the [PrimaryScrollController] of their [NestedScrollView]); siblings are
+  /// the same height, so any of them answers the question. Returns zero before
+  /// a position attaches; the mixin's own scroll listener also guards that
+  /// path with [ScrollController.hasClients].
   @protected
-  double get paginationLoadMoreThreshold =>
-      paginationScrollController.positions.first.viewportDimension *
-      _viewportPrefetchFactor;
+  double get paginationLoadMoreThreshold {
+    final positions = paginationScrollController.positions;
+    if (positions.isEmpty) return 0;
+    return positions.first.viewportDimension * _viewportPrefetchFactor;
+  }
 
   Future<void>? _pendingPaginationLoad;
 

--- a/mobile/lib/widgets/profile/profile_collabs_grid.dart
+++ b/mobile/lib/widgets/profile/profile_collabs_grid.dart
@@ -53,15 +53,6 @@ class _ProfileCollabsGridState extends ConsumerState<ProfileCollabsGrid>
   @override
   ScrollController get paginationScrollController => _primaryScrollController!;
 
-  /// Prefetch the next page ~1.5 viewports before the bottom so it is already
-  /// loaded by the time the user scrolls to it.
-  @override
-  double get paginationLoadMoreThreshold {
-    final positions = paginationScrollController.positions;
-    if (positions.isEmpty) return super.paginationLoadMoreThreshold;
-    return positions.first.viewportDimension * 1.5;
-  }
-
   @override
   bool canLoadMore() {
     final bloc = context.read<ProfileCollabVideosBloc>();

--- a/mobile/lib/widgets/profile/profile_liked_grid.dart
+++ b/mobile/lib/widgets/profile/profile_liked_grid.dart
@@ -51,16 +51,6 @@ class _ProfileLikedGridState extends State<ProfileLikedGrid>
   @override
   ScrollController get paginationScrollController => _primaryScrollController!;
 
-  /// Prefetch the next page ~1.5 viewports before the bottom so it is already
-  /// loaded by the time the user scrolls to it — keeping scrolling smooth
-  /// instead of stalling on the loading-more indicator.
-  @override
-  double get paginationLoadMoreThreshold {
-    final positions = paginationScrollController.positions;
-    if (positions.isEmpty) return super.paginationLoadMoreThreshold;
-    return positions.first.viewportDimension * 1.5;
-  }
-
   @override
   bool canLoadMore() {
     final bloc = context.read<ProfileLikedVideosBloc>();

--- a/mobile/lib/widgets/profile/profile_reposts_grid.dart
+++ b/mobile/lib/widgets/profile/profile_reposts_grid.dart
@@ -51,15 +51,6 @@ class _ProfileRepostsGridState extends State<ProfileRepostsGrid>
   @override
   ScrollController get paginationScrollController => _primaryScrollController!;
 
-  /// Prefetch the next page ~1.5 viewports before the bottom so it is already
-  /// loaded by the time the user scrolls to it.
-  @override
-  double get paginationLoadMoreThreshold {
-    final positions = paginationScrollController.positions;
-    if (positions.isEmpty) return super.paginationLoadMoreThreshold;
-    return positions.first.viewportDimension * 1.5;
-  }
-
   @override
   bool canLoadMore() {
     final bloc = context.read<ProfileRepostedVideosBloc>();

--- a/mobile/lib/widgets/profile/profile_saved_grid.dart
+++ b/mobile/lib/widgets/profile/profile_saved_grid.dart
@@ -46,15 +46,6 @@ class _ProfileSavedGridState extends State<ProfileSavedGrid>
   @override
   ScrollController get paginationScrollController => _primaryScrollController!;
 
-  /// Prefetch the next page ~1.5 viewports before the bottom so it is already
-  /// loaded by the time the user scrolls to it.
-  @override
-  double get paginationLoadMoreThreshold {
-    final positions = paginationScrollController.positions;
-    if (positions.isEmpty) return super.paginationLoadMoreThreshold;
-    return positions.first.viewportDimension * 1.5;
-  }
-
   @override
   bool canLoadMore() {
     final bloc = context.read<ProfileSavedVideosBloc>();

--- a/mobile/test/blocs/hashtag_search/hashtag_search_bloc_test.dart
+++ b/mobile/test/blocs/hashtag_search/hashtag_search_bloc_test.dart
@@ -56,7 +56,8 @@ void main() {
         'emits [loading, success] when search succeeds',
         setUp: () {
           when(
-            () => mockHashtagRepository.searchHashtags(query: 'music'),
+            () =>
+                mockHashtagRepository.searchHashtags(query: 'music', limit: 50),
           ).thenAnswer((_) async => ['music', 'musician', 'musicvideo']);
         },
         build: createBloc,
@@ -77,7 +78,8 @@ void main() {
         ],
         verify: (_) {
           verify(
-            () => mockHashtagRepository.searchHashtags(query: 'music'),
+            () =>
+                mockHashtagRepository.searchHashtags(query: 'music', limit: 50),
           ).called(1);
         },
       );
@@ -104,7 +106,8 @@ void main() {
         'emits [loading, failure] when repository throws',
         setUp: () {
           when(
-            () => mockHashtagRepository.searchHashtags(query: 'error'),
+            () =>
+                mockHashtagRepository.searchHashtags(query: 'error', limit: 50),
           ).thenThrow(const FunnelcakeException('search failed'));
         },
         build: createBloc,
@@ -126,7 +129,8 @@ void main() {
         'emits [loading, failure] when repository throws timeout',
         setUp: () {
           when(
-            () => mockHashtagRepository.searchHashtags(query: 'slow'),
+            () =>
+                mockHashtagRepository.searchHashtags(query: 'slow', limit: 50),
           ).thenThrow(const FunnelcakeTimeoutException());
         },
         build: createBloc,
@@ -221,7 +225,10 @@ void main() {
         're-searches when same query is dispatched in failure state',
         setUp: () {
           when(
-            () => mockHashtagRepository.searchHashtags(query: 'flutter'),
+            () => mockHashtagRepository.searchHashtags(
+              query: 'flutter',
+              limit: 50,
+            ),
           ).thenAnswer((_) async => ['flutter', 'flutterdev']);
         },
         build: createBloc,
@@ -246,7 +253,10 @@ void main() {
         ],
         verify: (_) {
           verify(
-            () => mockHashtagRepository.searchHashtags(query: 'flutter'),
+            () => mockHashtagRepository.searchHashtags(
+              query: 'flutter',
+              limit: 50,
+            ),
           ).called(1);
         },
       );
@@ -255,7 +265,8 @@ void main() {
         'normalizes query by trimming and lowercasing',
         setUp: () {
           when(
-            () => mockHashtagRepository.searchHashtags(query: 'cats'),
+            () =>
+                mockHashtagRepository.searchHashtags(query: 'cats', limit: 50),
           ).thenAnswer((_) async => ['cats']);
         },
         build: createBloc,
@@ -276,7 +287,8 @@ void main() {
         ],
         verify: (_) {
           verify(
-            () => mockHashtagRepository.searchHashtags(query: 'cats'),
+            () =>
+                mockHashtagRepository.searchHashtags(query: 'cats', limit: 50),
           ).called(1);
         },
       );
@@ -285,7 +297,8 @@ void main() {
         'debounces rapid query changes and only processes final query',
         setUp: () {
           when(
-            () => mockHashtagRepository.searchHashtags(query: 'final'),
+            () =>
+                mockHashtagRepository.searchHashtags(query: 'final', limit: 50),
           ).thenAnswer((_) async => ['finalize']);
         },
         build: createBloc,
@@ -314,7 +327,8 @@ void main() {
         verify: (_) {
           // Only the final query should be processed due to debounce
           verify(
-            () => mockHashtagRepository.searchHashtags(query: 'final'),
+            () =>
+                mockHashtagRepository.searchHashtags(query: 'final', limit: 50),
           ).called(1);
           verifyNever(
             () => mockHashtagRepository.searchHashtags(
@@ -353,7 +367,8 @@ void main() {
         're-runs the current search, bypassing the same-query guard',
         setUp: () {
           when(
-            () => mockHashtagRepository.searchHashtags(query: 'music'),
+            () =>
+                mockHashtagRepository.searchHashtags(query: 'music', limit: 50),
           ).thenAnswer((_) async => ['music']);
         },
         build: createBloc,
@@ -377,7 +392,8 @@ void main() {
         ],
         verify: (_) {
           verify(
-            () => mockHashtagRepository.searchHashtags(query: 'music'),
+            () =>
+                mockHashtagRepository.searchHashtags(query: 'music', limit: 50),
           ).called(1);
         },
       );
@@ -397,6 +413,7 @@ void main() {
           when(
             () => mockHashtagRepository.searchHashtags(
               query: 'music',
+              limit: 50,
               offset: 20,
             ),
           ).thenAnswer((_) async => ['extra1', 'extra2']);
@@ -434,9 +451,10 @@ void main() {
           when(
             () => mockHashtagRepository.searchHashtags(
               query: 'music',
+              limit: 50,
               offset: 20,
             ),
-          ).thenAnswer((_) async => List.generate(20, (i) => 'tag$i'));
+          ).thenAnswer((_) async => List.generate(50, (i) => 'tag$i'));
         },
         build: createBloc,
         seed: () => const HashtagSearchState(
@@ -459,8 +477,8 @@ void main() {
           HashtagSearchState(
             status: HashtagSearchStatus.success,
             query: 'music',
-            results: ['music', ...List.generate(20, (i) => 'tag$i')],
-            offset: 21,
+            results: ['music', ...List.generate(50, (i) => 'tag$i')],
+            offset: 51,
             hasMore: true,
           ),
         ],
@@ -508,6 +526,7 @@ void main() {
           when(
             () => mockHashtagRepository.searchHashtags(
               query: 'music',
+              limit: 50,
               offset: 20,
             ),
           ).thenThrow(Exception('network error'));
@@ -636,7 +655,7 @@ void main() {
         'markFeedDisplayed on success',
         setUp: () {
           when(
-            () => mockRepo.searchHashtags(query: 'music'),
+            () => mockRepo.searchHashtags(query: 'music', limit: 50),
           ).thenAnswer((_) async => ['music', 'musician', 'musicvideo']);
         },
         build: createBlocWithTracker,
@@ -657,7 +676,7 @@ void main() {
         'calls trackFeedError on failure',
         setUp: () {
           when(
-            () => mockRepo.searchHashtags(query: 'error'),
+            () => mockRepo.searchHashtags(query: 'error', limit: 50),
           ).thenThrow(const FunnelcakeException('search failed'));
         },
         build: createBlocWithTracker,

--- a/mobile/test/blocs/profile_collab_videos/profile_collab_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_collab_videos/profile_collab_videos_bloc_test.dart
@@ -489,7 +489,7 @@ void main() {
             ),
           ).thenAnswer(
             (_) async => [
-              for (var i = 1; i < profileTabPageSize; i++)
+              for (var i = 1; i < ProfileTabPagination.pageSize; i++)
                 createTestVideo(id: 'cached-$i', pubkey: authorPubkey),
               createTestVideo(id: 'new-confirmed', pubkey: authorPubkey),
             ],
@@ -501,7 +501,7 @@ void main() {
             key: '$targetPubkey:profile_collab_videos',
             payload: ProfileVideoCursorSnapshot(
               videos: [
-                for (var i = 1; i < profileTabPageSize; i++)
+                for (var i = 1; i < ProfileTabPagination.pageSize; i++)
                   createTestVideo(id: 'cached-$i', pubkey: authorPubkey),
                 createTestVideo(id: 'tail-1', pubkey: authorPubkey),
               ],
@@ -519,7 +519,8 @@ void main() {
           isA<ProfileCollabVideosState>()
               .having((s) => s.isRefreshing, 'isRefreshing', false)
               .having((s) => s.videos.map((v) => v.id).toList(), 'videos', [
-                for (var i = 1; i < profileTabPageSize; i++) 'cached-$i',
+                for (var i = 1; i < ProfileTabPagination.pageSize; i++)
+                  'cached-$i',
                 'new-confirmed',
                 'tail-1',
               ])

--- a/mobile/test/blocs/profile_collab_videos/profile_collab_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_collab_videos/profile_collab_videos_bloc_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_collab_videos/profile_collab_videos_bloc.dart';
+import 'package:openvine/blocs/profile_shared/profile_tab_page_size.dart';
 import 'package:openvine/blocs/profile_shared/profile_video_cursor_snapshot.dart';
 import 'package:videos_repository/videos_repository.dart';
 
@@ -365,10 +366,7 @@ void main() {
             ),
           ).thenAnswer(
             (_) async => [
-              createTestVideo(
-                id: 'v1',
-                pubkey: targetPubkey,
-              ),
+              createTestVideo(id: 'v1', pubkey: targetPubkey),
               createTestVideo(
                 id: 'v2',
                 pubkey: authorPubkey,
@@ -491,7 +489,7 @@ void main() {
             ),
           ).thenAnswer(
             (_) async => [
-              for (var i = 1; i <= 17; i++)
+              for (var i = 1; i < profileTabPageSize; i++)
                 createTestVideo(id: 'cached-$i', pubkey: authorPubkey),
               createTestVideo(id: 'new-confirmed', pubkey: authorPubkey),
             ],
@@ -503,7 +501,7 @@ void main() {
             key: '$targetPubkey:profile_collab_videos',
             payload: ProfileVideoCursorSnapshot(
               videos: [
-                for (var i = 1; i <= 17; i++)
+                for (var i = 1; i < profileTabPageSize; i++)
                   createTestVideo(id: 'cached-$i', pubkey: authorPubkey),
                 createTestVideo(id: 'tail-1', pubkey: authorPubkey),
               ],
@@ -520,15 +518,11 @@ void main() {
               .having((s) => s.videos.last.id, 'cached tail', 'tail-1'),
           isA<ProfileCollabVideosState>()
               .having((s) => s.isRefreshing, 'isRefreshing', false)
-              .having(
-                (s) => s.videos.map((v) => v.id).toList(),
-                'videos',
-                [
-                  for (var i = 1; i <= 17; i++) 'cached-$i',
-                  'new-confirmed',
-                  'tail-1',
-                ],
-              )
+              .having((s) => s.videos.map((v) => v.id).toList(), 'videos', [
+                for (var i = 1; i < profileTabPageSize; i++) 'cached-$i',
+                'new-confirmed',
+                'tail-1',
+              ])
               .having((s) => s.hasMoreContent, 'hasMoreContent', isTrue),
         ],
       );

--- a/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
@@ -17,14 +17,15 @@ import 'package:openvine/blocs/profile_shared/profile_video_list_snapshot.dart';
 import 'package:videos_repository/videos_repository.dart';
 
 /// A window the user scrolled two pages deep into before leaving the tab.
-const int _scrolledWindow = profileTabPageSize * 2;
+const int _scrolledWindow = ProfileTabPagination.pageSize * 2;
 
 /// Videos already loaded when the sparse load-more test seeds its state.
 const _seededOffset = 2;
 
 /// 1-based ID of the first entry in the second batch a load-more from
 /// [_seededOffset] consumes — the batch that actually resolves to videos.
-const int _secondSparseBatchFirstId = _seededOffset + profileTabPageSize + 1;
+const int _secondSparseBatchFirstId =
+    _seededOffset + ProfileTabPagination.pageSize + 1;
 
 class _MockLikesRepository extends Mock implements LikesRepository {}
 
@@ -440,7 +441,10 @@ void main() {
         'grows a persisted window shorter than a page even when the liked-ID '
         'list is unchanged',
         setUp: () async {
-          final ids = List.generate(profileTabPageSize + 14, (i) => 'like$i');
+          final ids = List.generate(
+            ProfileTabPagination.pageSize + 14,
+            (i) => 'like$i',
+          );
           // A previous run persisted a 6-item window: its cold load resolved
           // the local liked-ID list before the relay sync had filled it in.
           await cacheDao.write(
@@ -485,12 +489,12 @@ void main() {
               .having(
                 (s) => s.videos.length,
                 'grown to a full page',
-                profileTabPageSize,
+                ProfileTabPagination.pageSize,
               )
               .having(
                 (s) => s.nextPageOffset,
                 'nextPageOffset',
-                profileTabPageSize,
+                ProfileTabPagination.pageSize,
               )
               .having((s) => s.hasMoreContent, 'hasMoreContent', true)
               .having((s) => s.isRefreshing, 'isRefreshing', false),
@@ -504,11 +508,11 @@ void main() {
           // The persisted ID list is capped, so it differs from the relay's —
           // reconciliation runs, and must not inherit the 6-item window.
           final cachedIds = List.generate(
-            profileTabPageSize - 6,
+            ProfileTabPagination.pageSize - 6,
             (i) => 'like$i',
           );
           final freshIds = List.generate(
-            profileTabPageSize + 4,
+            ProfileTabPagination.pageSize + 4,
             (i) => 'like$i',
           );
           await cacheDao.write(
@@ -551,12 +555,12 @@ void main() {
               .having(
                 (s) => s.videos.length,
                 'refilled to a page',
-                profileTabPageSize,
+                ProfileTabPagination.pageSize,
               )
               .having(
                 (s) => s.nextPageOffset,
                 'nextPageOffset',
-                profileTabPageSize,
+                ProfileTabPagination.pageSize,
               )
               .having((s) => s.hasMoreContent, 'hasMoreContent', true),
         ],
@@ -843,13 +847,14 @@ void main() {
         'continues initial load through sparse liked IDs until videos render',
         setUp: () {
           final likedIds = List.generate(
-            profileTabPageSize * 2 + 4,
+            ProfileTabPagination.pageSize * 2 + 4,
             (index) => 'event${index + 1}',
           );
           final secondBatchVideos = List.generate(
-            profileTabPageSize,
-            (index) =>
-                createTestVideo('event${index + profileTabPageSize + 1}'),
+            ProfileTabPagination.pageSize,
+            (index) => createTestVideo(
+              'event${index + ProfileTabPagination.pageSize + 1}',
+            ),
           );
 
           when(() => mockLikesRepository.syncUserReactions()).thenAnswer(
@@ -865,7 +870,7 @@ void main() {
             ),
           ).thenAnswer((invocation) async {
             final ids = invocation.positionalArguments[0] as List<String>;
-            if (ids.first == 'event${profileTabPageSize + 1}') {
+            if (ids.first == 'event${ProfileTabPagination.pageSize + 1}') {
               return secondBatchVideos;
             }
             return <VideoEvent>[];
@@ -885,12 +890,12 @@ void main() {
               .having(
                 (s) => s.videos.length,
                 'videos count',
-                profileTabPageSize,
+                ProfileTabPagination.pageSize,
               )
               .having(
                 (s) => s.nextPageOffset,
                 'nextPageOffset',
-                profileTabPageSize * 2,
+                ProfileTabPagination.pageSize * 2,
               )
               .having((s) => s.hasMoreContent, 'hasMoreContent', true),
         ],
@@ -900,7 +905,7 @@ void main() {
               any(
                 that: equals(
                   List.generate(
-                    profileTabPageSize,
+                    ProfileTabPagination.pageSize,
                     (index) => 'event${index + 1}',
                   ),
                 ),
@@ -913,8 +918,9 @@ void main() {
               any(
                 that: equals(
                   List.generate(
-                    profileTabPageSize,
-                    (index) => 'event${index + profileTabPageSize + 1}',
+                    ProfileTabPagination.pageSize,
+                    (index) =>
+                        'event${index + ProfileTabPagination.pageSize + 1}',
                   ),
                 ),
               ),
@@ -1201,7 +1207,7 @@ void main() {
           // The first batch after the seeded offset resolves to nothing, so
           // the bloc must keep consuming IDs into the batch that does.
           final nextVisibleVideos = List.generate(
-            profileTabPageSize,
+            ProfileTabPagination.pageSize,
             (index) =>
                 createTestVideo('event${index + _secondSparseBatchFirstId}'),
           );
@@ -1222,7 +1228,7 @@ void main() {
         seed: () => ProfileLikedVideosState(
           status: ProfileLikedVideosStatus.success,
           likedEventIds: List.generate(
-            _seededOffset + profileTabPageSize * 2 + 4,
+            _seededOffset + ProfileTabPagination.pageSize * 2 + 4,
             (index) => 'event${index + 1}',
           ),
           videos: [createTestVideo('event1'), createTestVideo('event2')],
@@ -1240,12 +1246,70 @@ void main() {
               .having(
                 (s) => s.videos.length,
                 'videos count',
-                _seededOffset + profileTabPageSize,
+                _seededOffset + ProfileTabPagination.pageSize,
               )
               .having(
                 (s) => s.nextPageOffset,
                 'nextPageOffset',
-                _seededOffset + profileTabPageSize * 2,
+                _seededOffset + ProfileTabPagination.pageSize * 2,
+              )
+              .having((s) => s.hasMoreContent, 'hasMoreContent', true),
+        ],
+      );
+
+      blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
+        'does not advance past resolved videos left after a page fills',
+        setUp: () {
+          final firstBatchVideos = List.generate(
+            5,
+            (index) => createTestVideo('event${index + 1}'),
+          );
+          final secondBatchVideos = List.generate(
+            ProfileTabPagination.pageSize,
+            (index) => createTestVideo(
+              'event${index + ProfileTabPagination.pageSize + 1}',
+            ),
+          );
+          when(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).thenAnswer((invocation) async {
+            final ids = invocation.positionalArguments[0] as List<String>;
+            if (ids.first == 'event1') return firstBatchVideos;
+            if (ids.first == 'event${ProfileTabPagination.pageSize + 1}') {
+              return secondBatchVideos;
+            }
+            return <VideoEvent>[];
+          });
+        },
+        build: createBloc,
+        seed: () => ProfileLikedVideosState(
+          status: ProfileLikedVideosStatus.success,
+          likedEventIds: List.generate(
+            ProfileTabPagination.pageSize * 2,
+            (index) => 'event${index + 1}',
+          ),
+        ),
+        act: (bloc) => bloc.add(const ProfileLikedVideosLoadMoreRequested()),
+        expect: () => [
+          isA<ProfileLikedVideosState>().having(
+            (s) => s.isLoadingMore,
+            'isLoadingMore',
+            true,
+          ),
+          isA<ProfileLikedVideosState>()
+              .having((s) => s.isLoadingMore, 'isLoadingMore', false)
+              .having(
+                (s) => s.videos.length,
+                'videos count',
+                ProfileTabPagination.pageSize,
+              )
+              .having(
+                (s) => s.nextPageOffset,
+                'nextPageOffset',
+                ProfileTabPagination.pageSize * 2 - 5,
               )
               .having((s) => s.hasMoreContent, 'hasMoreContent', true),
         ],

--- a/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
@@ -12,8 +12,19 @@ import 'package:likes_repository/likes_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_liked_videos/profile_liked_videos_bloc.dart';
+import 'package:openvine/blocs/profile_shared/profile_tab_page_size.dart';
 import 'package:openvine/blocs/profile_shared/profile_video_list_snapshot.dart';
 import 'package:videos_repository/videos_repository.dart';
+
+/// A window the user scrolled two pages deep into before leaving the tab.
+const int _scrolledWindow = profileTabPageSize * 2;
+
+/// Videos already loaded when the sparse load-more test seeds its state.
+const _seededOffset = 2;
+
+/// 1-based ID of the first entry in the second batch a load-more from
+/// [_seededOffset] consumes — the batch that actually resolves to videos.
+const int _secondSparseBatchFirstId = _seededOffset + profileTabPageSize + 1;
 
 class _MockLikesRepository extends Mock implements LikesRepository {}
 
@@ -429,7 +440,7 @@ void main() {
         'grows a persisted window shorter than a page even when the liked-ID '
         'list is unchanged',
         setUp: () async {
-          final ids = List.generate(50, (i) => 'like$i');
+          final ids = List.generate(profileTabPageSize + 14, (i) => 'like$i');
           // A previous run persisted a 6-item window: its cold load resolved
           // the local liked-ID list before the relay sync had filled it in.
           await cacheDao.write(
@@ -471,8 +482,16 @@ void main() {
             6,
           ),
           isA<ProfileLikedVideosState>()
-              .having((s) => s.videos.length, 'grown to a full page', 18)
-              .having((s) => s.nextPageOffset, 'nextPageOffset', 18)
+              .having(
+                (s) => s.videos.length,
+                'grown to a full page',
+                profileTabPageSize,
+              )
+              .having(
+                (s) => s.nextPageOffset,
+                'nextPageOffset',
+                profileTabPageSize,
+              )
               .having((s) => s.hasMoreContent, 'hasMoreContent', true)
               .having((s) => s.isRefreshing, 'isRefreshing', false),
         ],
@@ -484,8 +503,14 @@ void main() {
         setUp: () async {
           // The persisted ID list is capped, so it differs from the relay's —
           // reconciliation runs, and must not inherit the 6-item window.
-          final cachedIds = List.generate(30, (i) => 'like$i');
-          final freshIds = List.generate(40, (i) => 'like$i');
+          final cachedIds = List.generate(
+            profileTabPageSize - 6,
+            (i) => 'like$i',
+          );
+          final freshIds = List.generate(
+            profileTabPageSize + 4,
+            (i) => 'like$i',
+          );
           await cacheDao.write(
             key: '$currentUserPubkey:$currentUserPubkey:profile_liked_videos',
             payload: ProfileVideoListSnapshot(
@@ -523,8 +548,16 @@ void main() {
             6,
           ),
           isA<ProfileLikedVideosState>()
-              .having((s) => s.videos.length, 'refilled to a page', 18)
-              .having((s) => s.nextPageOffset, 'nextPageOffset', 18)
+              .having(
+                (s) => s.videos.length,
+                'refilled to a page',
+                profileTabPageSize,
+              )
+              .having(
+                (s) => s.nextPageOffset,
+                'nextPageOffset',
+                profileTabPageSize,
+              )
               .having((s) => s.hasMoreContent, 'hasMoreContent', true),
         ],
       );
@@ -647,14 +680,18 @@ void main() {
       blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
         'reopen restores the full scrolled-through list from cache',
         setUp: () async {
-          final cachedVideos = List.generate(36, (i) => createTestVideo('v$i'));
-          final cachedIds = List.generate(40, (i) => 'v$i');
+          // Two pages deep, so restoring page 1 would be visibly wrong.
+          final cachedVideos = List.generate(
+            _scrolledWindow,
+            (i) => createTestVideo('v$i'),
+          );
+          final cachedIds = List.generate(_scrolledWindow + 4, (i) => 'v$i');
           await cacheDao.write(
             key: '$currentUserPubkey:$otherUserPubkey:profile_liked_videos',
             payload: ProfileVideoListSnapshot(
               videos: cachedVideos,
               itemIds: cachedIds,
-              nextPageOffset: 36,
+              nextPageOffset: _scrolledWindow,
               hasMoreContent: true,
             ).toJson(),
           );
@@ -675,16 +712,28 @@ void main() {
         act: (bloc) => bloc.add(const ProfileLikedVideosSyncRequested()),
         wait: const Duration(milliseconds: 100),
         expect: () => [
-          // Cached emit restores all 36 scrolled videos instantly, not page 1.
+          // Cached emit restores every scrolled video instantly, not page 1.
           isA<ProfileLikedVideosState>()
               .having((s) => s.isRefreshing, 'isRefreshing', true)
-              .having((s) => s.videos.length, 'cached videos', 36)
-              .having((s) => s.nextPageOffset, 'nextPageOffset', 36),
-          // Live emit revalidates the same 36-video window (does not shrink).
+              .having((s) => s.videos.length, 'cached videos', _scrolledWindow)
+              .having(
+                (s) => s.nextPageOffset,
+                'nextPageOffset',
+                _scrolledWindow,
+              ),
+          // Live emit revalidates the same window (it does not shrink).
           isA<ProfileLikedVideosState>()
               .having((s) => s.isRefreshing, 'isRefreshing', false)
-              .having((s) => s.videos.length, 'revalidated videos', 36)
-              .having((s) => s.nextPageOffset, 'nextPageOffset', 36),
+              .having(
+                (s) => s.videos.length,
+                'revalidated videos',
+                _scrolledWindow,
+              )
+              .having(
+                (s) => s.nextPageOffset,
+                'nextPageOffset',
+                _scrolledWindow,
+              ),
         ],
       );
 
@@ -793,10 +842,14 @@ void main() {
       blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
         'continues initial load through sparse liked IDs until videos render',
         setUp: () {
-          final likedIds = List.generate(40, (index) => 'event${index + 1}');
+          final likedIds = List.generate(
+            profileTabPageSize * 2 + 4,
+            (index) => 'event${index + 1}',
+          );
           final secondBatchVideos = List.generate(
-            18,
-            (index) => createTestVideo('event${index + 19}'),
+            profileTabPageSize,
+            (index) =>
+                createTestVideo('event${index + profileTabPageSize + 1}'),
           );
 
           when(() => mockLikesRepository.syncUserReactions()).thenAnswer(
@@ -812,7 +865,7 @@ void main() {
             ),
           ).thenAnswer((invocation) async {
             final ids = invocation.positionalArguments[0] as List<String>;
-            if (ids.first == 'event19') {
+            if (ids.first == 'event${profileTabPageSize + 1}') {
               return secondBatchVideos;
             }
             return <VideoEvent>[];
@@ -829,15 +882,28 @@ void main() {
                 'status',
                 ProfileLikedVideosStatus.success,
               )
-              .having((s) => s.videos.length, 'videos count', 18)
-              .having((s) => s.nextPageOffset, 'nextPageOffset', 36)
+              .having(
+                (s) => s.videos.length,
+                'videos count',
+                profileTabPageSize,
+              )
+              .having(
+                (s) => s.nextPageOffset,
+                'nextPageOffset',
+                profileTabPageSize * 2,
+              )
               .having((s) => s.hasMoreContent, 'hasMoreContent', true),
         ],
         verify: (_) {
           verify(
             () => mockVideosRepository.getVideosByIds(
               any(
-                that: equals(List.generate(18, (index) => 'event${index + 1}')),
+                that: equals(
+                  List.generate(
+                    profileTabPageSize,
+                    (index) => 'event${index + 1}',
+                  ),
+                ),
               ),
               cacheResults: true,
             ),
@@ -846,7 +912,10 @@ void main() {
             () => mockVideosRepository.getVideosByIds(
               any(
                 that: equals(
-                  List.generate(18, (index) => 'event${index + 19}'),
+                  List.generate(
+                    profileTabPageSize,
+                    (index) => 'event${index + profileTabPageSize + 1}',
+                  ),
                 ),
               ),
             ),
@@ -1129,9 +1198,12 @@ void main() {
       blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
         'continues load more through sparse liked IDs until a full page renders',
         setUp: () {
+          // The first batch after the seeded offset resolves to nothing, so
+          // the bloc must keep consuming IDs into the batch that does.
           final nextVisibleVideos = List.generate(
-            18,
-            (index) => createTestVideo('event${index + 21}'),
+            profileTabPageSize,
+            (index) =>
+                createTestVideo('event${index + _secondSparseBatchFirstId}'),
           );
           when(
             () => mockVideosRepository.getVideosByIds(
@@ -1140,7 +1212,7 @@ void main() {
             ),
           ).thenAnswer((invocation) async {
             final ids = invocation.positionalArguments[0] as List<String>;
-            if (ids.first == 'event21') {
+            if (ids.first == 'event$_secondSparseBatchFirstId') {
               return nextVisibleVideos;
             }
             return <VideoEvent>[];
@@ -1149,9 +1221,12 @@ void main() {
         build: createBloc,
         seed: () => ProfileLikedVideosState(
           status: ProfileLikedVideosStatus.success,
-          likedEventIds: List.generate(42, (index) => 'event${index + 1}'),
+          likedEventIds: List.generate(
+            _seededOffset + profileTabPageSize * 2 + 4,
+            (index) => 'event${index + 1}',
+          ),
           videos: [createTestVideo('event1'), createTestVideo('event2')],
-          nextPageOffset: 2,
+          nextPageOffset: _seededOffset,
         ),
         act: (bloc) => bloc.add(const ProfileLikedVideosLoadMoreRequested()),
         expect: () => [
@@ -1162,8 +1237,16 @@ void main() {
           ),
           isA<ProfileLikedVideosState>()
               .having((s) => s.isLoadingMore, 'isLoadingMore', false)
-              .having((s) => s.videos.length, 'videos count', 20)
-              .having((s) => s.nextPageOffset, 'nextPageOffset', 38)
+              .having(
+                (s) => s.videos.length,
+                'videos count',
+                _seededOffset + profileTabPageSize,
+              )
+              .having(
+                (s) => s.nextPageOffset,
+                'nextPageOffset',
+                _seededOffset + profileTabPageSize * 2,
+              )
               .having((s) => s.hasMoreContent, 'hasMoreContent', true),
         ],
       );

--- a/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
@@ -10,9 +10,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart';
+import 'package:openvine/blocs/profile_shared/profile_tab_page_size.dart';
 import 'package:openvine/blocs/profile_shared/profile_video_list_snapshot.dart';
 import 'package:reposts_repository/reposts_repository.dart';
 import 'package:videos_repository/videos_repository.dart';
+
+/// A window the user scrolled two pages deep into before leaving the tab.
+const int _scrolledWindow = profileTabPageSize * 2;
 
 class _MockRepostsRepository extends Mock implements RepostsRepository {}
 
@@ -447,7 +451,7 @@ void main() {
         'ID list is unchanged',
         setUp: () async {
           final ids = List.generate(
-            50,
+            profileTabPageSize + 14,
             (i) => createAddressableId(currentUserPubkey, 'd$i'),
           );
           await cacheDao.write(
@@ -499,8 +503,16 @@ void main() {
             6,
           ),
           isA<ProfileRepostedVideosState>()
-              .having((s) => s.videos.length, 'grown to a full page', 18)
-              .having((s) => s.nextPageOffset, 'nextPageOffset', 18)
+              .having(
+                (s) => s.videos.length,
+                'grown to a full page',
+                profileTabPageSize,
+              )
+              .having(
+                (s) => s.nextPageOffset,
+                'nextPageOffset',
+                profileTabPageSize,
+              )
               .having((s) => s.hasMoreContent, 'hasMoreContent', true),
         ],
       );
@@ -584,11 +596,12 @@ void main() {
         'reopen restores the full scrolled-through list from cache',
         setUp: () async {
           final ids = List.generate(
-            40,
+            _scrolledWindow + 4,
             (i) => createAddressableId(currentUserPubkey, 'd$i'),
           );
+          // Two pages deep, so restoring page 1 would be visibly wrong.
           final videos = List.generate(
-            36,
+            _scrolledWindow,
             (i) => createTestVideo(
               id: 'e$i',
               pubkey: currentUserPubkey,
@@ -600,7 +613,7 @@ void main() {
             payload: ProfileVideoListSnapshot(
               videos: videos,
               itemIds: ids,
-              nextPageOffset: 36,
+              nextPageOffset: _scrolledWindow,
               hasMoreContent: true,
             ).toJson(),
           );
@@ -614,11 +627,19 @@ void main() {
         expect: () => [
           isA<ProfileRepostedVideosState>()
               .having((s) => s.isRefreshing, 'isRefreshing', true)
-              .having((s) => s.videos.length, 'cached videos', 36)
-              .having((s) => s.nextPageOffset, 'nextPageOffset', 36),
+              .having((s) => s.videos.length, 'cached videos', _scrolledWindow)
+              .having(
+                (s) => s.nextPageOffset,
+                'nextPageOffset',
+                _scrolledWindow,
+              ),
           isA<ProfileRepostedVideosState>()
               .having((s) => s.isRefreshing, 'isRefreshing', false)
-              .having((s) => s.videos.length, 'revalidated videos', 36),
+              .having(
+                (s) => s.videos.length,
+                'revalidated videos',
+                _scrolledWindow,
+              ),
         ],
       );
 

--- a/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
@@ -16,7 +16,7 @@ import 'package:reposts_repository/reposts_repository.dart';
 import 'package:videos_repository/videos_repository.dart';
 
 /// A window the user scrolled two pages deep into before leaving the tab.
-const int _scrolledWindow = profileTabPageSize * 2;
+const int _scrolledWindow = ProfileTabPagination.pageSize * 2;
 
 class _MockRepostsRepository extends Mock implements RepostsRepository {}
 
@@ -451,7 +451,7 @@ void main() {
         'ID list is unchanged',
         setUp: () async {
           final ids = List.generate(
-            profileTabPageSize + 14,
+            ProfileTabPagination.pageSize + 14,
             (i) => createAddressableId(currentUserPubkey, 'd$i'),
           );
           await cacheDao.write(
@@ -506,12 +506,12 @@ void main() {
               .having(
                 (s) => s.videos.length,
                 'grown to a full page',
-                profileTabPageSize,
+                ProfileTabPagination.pageSize,
               )
               .having(
                 (s) => s.nextPageOffset,
                 'nextPageOffset',
-                profileTabPageSize,
+                ProfileTabPagination.pageSize,
               )
               .having((s) => s.hasMoreContent, 'hasMoreContent', true),
         ],

--- a/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_saved_videos/profile_saved_videos_bloc.dart';
+import 'package:openvine/blocs/profile_shared/profile_tab_page_size.dart';
 import 'package:openvine/blocs/profile_shared/profile_video_list_snapshot.dart';
 import 'package:openvine/services/bookmark_service.dart';
 import 'package:videos_repository/videos_repository.dart';
@@ -147,9 +148,7 @@ void main() {
       test(
         're-sync of a settled empty tab still settles (pull-to-refresh)',
         () async {
-          when(
-            () => mockBookmarkService.globalBookmarks,
-          ).thenReturn(const []);
+          when(() => mockBookmarkService.globalBookmarks).thenReturn(const []);
           final bloc = createBloc();
           addTearDown(bloc.close);
 
@@ -262,7 +261,7 @@ void main() {
         'grows a persisted window shorter than a page even when the bookmark '
         'list is unchanged',
         setUp: () async {
-          final ids = List.generate(50, (i) => 'video-$i');
+          final ids = List.generate(profileTabPageSize + 14, (i) => 'video-$i');
           await cacheDao.write(
             key: '$currentUserPubkey:profile_saved_videos',
             payload: ProfileVideoListSnapshot(
@@ -272,9 +271,9 @@ void main() {
               hasMoreContent: true,
             ).toJson(),
           );
-          when(() => mockBookmarkService.globalBookmarks).thenReturn([
-            for (final id in ids) BookmarkItem(type: 'e', id: id),
-          ]);
+          when(
+            () => mockBookmarkService.globalBookmarks,
+          ).thenReturn([for (final id in ids) BookmarkItem(type: 'e', id: id)]);
           when(
             () => mockVideosRepository.getVideosByIds(
               any(),
@@ -297,8 +296,16 @@ void main() {
             6,
           ),
           isA<ProfileSavedVideosState>()
-              .having((s) => s.videos.length, 'grown to a full page', 18)
-              .having((s) => s.nextPageOffset, 'nextPageOffset', 18)
+              .having(
+                (s) => s.videos.length,
+                'grown to a full page',
+                profileTabPageSize,
+              )
+              .having(
+                (s) => s.nextPageOffset,
+                'nextPageOffset',
+                profileTabPageSize,
+              )
               .having((s) => s.hasMoreContent, 'hasMoreContent', true),
         ],
       );
@@ -324,9 +331,9 @@ void main() {
               hasMoreContent: false,
             ).toJson(),
           );
-          when(() => mockBookmarkService.globalBookmarks).thenReturn([
-            for (final id in ids) BookmarkItem(type: 'e', id: id),
-          ]);
+          when(
+            () => mockBookmarkService.globalBookmarks,
+          ).thenReturn([for (final id in ids) BookmarkItem(type: 'e', id: id)]);
           when(
             () => mockVideosRepository.getVideosByIds(
               any(),
@@ -424,10 +431,11 @@ void main() {
     });
 
     group('ProfileSavedVideosLoadMoreRequested', () {
-      // Build a list that exceeds the 18-item page size so hasMoreContent
-      // starts true and a second fetch is required.
+      // Build a list that exceeds one page so hasMoreContent starts true and
+      // a second fetch is required.
+      const bookmarkCount = profileTabPageSize + 7;
       final manyBookmarks = List.generate(
-        25,
+        bookmarkCount,
         (i) => BookmarkItem(type: 'e', id: 'video-$i'),
       );
 
@@ -458,8 +466,8 @@ void main() {
         },
         verify: (bloc) {
           expect(bloc.state.status, ProfileSavedVideosStatus.success);
-          expect(bloc.state.videos, hasLength(25));
-          expect(bloc.state.nextPageOffset, 25);
+          expect(bloc.state.videos, hasLength(bookmarkCount));
+          expect(bloc.state.nextPageOffset, bookmarkCount);
           expect(bloc.state.hasMoreContent, isFalse);
           expect(bloc.state.isLoadingMore, isFalse);
         },

--- a/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
@@ -261,7 +261,10 @@ void main() {
         'grows a persisted window shorter than a page even when the bookmark '
         'list is unchanged',
         setUp: () async {
-          final ids = List.generate(profileTabPageSize + 14, (i) => 'video-$i');
+          final ids = List.generate(
+            ProfileTabPagination.pageSize + 14,
+            (i) => 'video-$i',
+          );
           await cacheDao.write(
             key: '$currentUserPubkey:profile_saved_videos',
             payload: ProfileVideoListSnapshot(
@@ -299,12 +302,12 @@ void main() {
               .having(
                 (s) => s.videos.length,
                 'grown to a full page',
-                profileTabPageSize,
+                ProfileTabPagination.pageSize,
               )
               .having(
                 (s) => s.nextPageOffset,
                 'nextPageOffset',
-                profileTabPageSize,
+                ProfileTabPagination.pageSize,
               )
               .having((s) => s.hasMoreContent, 'hasMoreContent', true),
         ],
@@ -433,7 +436,7 @@ void main() {
     group('ProfileSavedVideosLoadMoreRequested', () {
       // Build a list that exceeds one page so hasMoreContent starts true and
       // a second fetch is required.
-      const bookmarkCount = profileTabPageSize + 7;
+      const bookmarkCount = ProfileTabPagination.pageSize + 7;
       final manyBookmarks = List.generate(
         bookmarkCount,
         (i) => BookmarkItem(type: 'e', id: 'video-$i'),

--- a/mobile/test/mixins/scroll_pagination_mixin_test.dart
+++ b/mobile/test/mixins/scroll_pagination_mixin_test.dart
@@ -59,6 +59,37 @@ void main() {
       },
     );
 
+    testWidgets('prefetches a viewport ahead of the bottom by default', (
+      tester,
+    ) async {
+      var loadMoreCalls = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: _TestWidget(
+            canLoadMore: () => true,
+            onLoadMore: () async => loadMoreCalls++,
+          ),
+        ),
+      );
+
+      final state = tester.state<_TestWidgetState>(find.byType(_TestWidget));
+      final scrollController = state.paginationScrollController;
+      final viewport = scrollController.position.viewportDimension;
+
+      // Just under one viewport from the bottom — still well outside any
+      // fixed few-hundred-pixel threshold, but inside the 1.5-viewport
+      // prefetch distance.
+      scrollController.jumpTo(
+        scrollController.position.maxScrollExtent - (viewport - 1),
+      );
+      await tester.pump();
+
+      expect(loadMoreCalls, 1);
+    });
+
     testWidgets(
       'a larger paginationLoadMoreThreshold triggers further from the bottom',
       (tester) async {
@@ -71,19 +102,19 @@ void main() {
             home: _TestWidget(
               canLoadMore: () => true,
               onLoadMore: () async => loadMoreCalls++,
-              // Prefetch a full extra screen ahead of the default 200px.
-              loadMoreThreshold: 2000,
+              loadMoreThreshold: 4000,
             ),
           ),
         );
 
         final state = tester.state<_TestWidgetState>(find.byType(_TestWidget));
         final scrollController = state.paginationScrollController;
+        final viewport = scrollController.position.viewportDimension;
 
-        // 1000px from the bottom: past the default 200px threshold (no
-        // trigger) but inside the overridden 2000px one (triggers).
+        // Three viewports from the bottom: past the 1.5-viewport default (no
+        // trigger) but inside the overridden 4000px one (triggers).
         scrollController.jumpTo(
-          scrollController.position.maxScrollExtent - 1000,
+          scrollController.position.maxScrollExtent - viewport * 3,
         );
         await tester.pump();
 


### PR DESCRIPTION
Closes #6672

## Problem

Scrolling profile tabs could keep the loading-more spinner visible. Two independent causes made the prefetch lose the race.

**Trigger fired too late.** `ScrollPaginationMixin` used a fixed 200px distance from the bottom. In a 3-column grid that is barely a row and a half, so the next page was only requested once the user had effectively arrived at the bottom. Liked / Reposts / Saved / Collabs already worked around this with identical 1.5-viewport overrides (#5279); Videos and Comments were missed and still used the default.

**Cached-tab pages were about one screen tall.** The cached tabs fetched 18 items per page. On a 360dp phone a tile is about 117px and a row about 121px, so 18 items is roughly one viewport. Each page pushed the end of the list forward by about one screen while the prefetch fires 1.5 screens ahead, so the grid never got enough headroom.

## Change

Make the viewport-relative prefetch distance the `ScrollPaginationMixin` default and drop the four duplicated profile-grid overrides.

Raise the cached profile tab page size from 18 to `ProfileTabPagination.pageSize` (36), grouped as a shared profile pagination policy value.

Keep the prefetch default safe for non-profile consumers:

- Videos and Comments profile tabs already fetch larger pages (the Videos tab goes through `getAuthorFeed` / `FunnelcakeApiClient.getVideosByAuthor`, which defaults to 50; `ProfileCommentsBloc` uses 50).
- Hashtag search now explicitly fetches 50 chips per page so the inherited viewport-relative threshold does not chain-load short chip pages.
- The default threshold getter now returns `0` before a scroll position attaches, so protected overrides that read `super.paginationLoadMoreThreshold` outside the guarded listener path do not throw.

Fix a liked-videos pagination bug exposed by the larger page size: `_fetchVideoPage` no longer advances past resolved videos left in a batch after the page fills. Those videos remain available to the next load-more instead of being skipped permanently.

## Why a shared constant

The cached profile page size is a function of the shared prefetch distance, not a per-tab preference. Keeping it in `ProfileTabPagination.pageSize` makes the policy visible and prevents the four cached tabs from drifting apart.

## Note on page size and latency

A larger cached profile page does not add relay round trips by itself. `_fetchVideoPage` loops until it has filled a page, so the number of round trips tracks the ID resolution rate, not only the page size.

Load-more on the relay-backed tabs can still be slow for an unrelated reason outside this diff: relay queries do not complete on EOSE and run to their full timeout. That is app-wide, not profile-specific, and is being handled separately.

## Test plan

- `flutter analyze lib test` — clean
- `flutter test test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart test/blocs/profile_collab_videos/profile_collab_videos_bloc_test.dart test/blocs/hashtag_search/hashtag_search_bloc_test.dart test/mixins/scroll_pagination_mixin_test.dart` — passing
- Pre-push hook: merge-conflict check, analyzer, and changed-file tests — passing
- Bloc tests express expectations in terms of `ProfileTabPagination.pageSize`; liked-videos tests include a regression for the previously skipped overflow videos.
- Original manual check from the author: real Samsung Galaxy scrolling Videos and Likes no longer parks on the loading indicator.
