### PR TITLE
fix(nostr): stop a stalled relay from taxing every query with its timeout

### DIFF
--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -124,6 +124,11 @@ class RelayPool {
   /// a removed or replaced relay is not retained by the bookkeeping.
   final Expando<bool> _statusObserved = Expando<bool>('relayStatusObserved');
 
+  /// When each one-shot query's REQ fan-out started, so an abandoned query can
+  /// ask [Relay.isSilentSince] whether a relay that never answered had gone
+  /// quiet altogether. Dropped when the query settles or is unsubscribed.
+  final Map<String, DateTime> _querySentAt = {};
+
   /// Track publishes awaiting OK confirmations (per event id).
   final Map<String, PublishTracker> _pendingPublishes = {};
 
@@ -706,6 +711,7 @@ class RelayPool {
     }
 
     _queryCompleteCallbacks.remove(subId);
+    _querySentAt.remove(subId);
     callback();
   }
 
@@ -729,6 +735,11 @@ class RelayPool {
     // A dropped socket cannot deliver the terminal frame for a REQ that was
     // written to it; the reconnect path re-issues the REQ on a fresh socket.
     if (relay.relayStatus.connected != ClientConnected.connected) return false;
+
+    // A connection being force-cycled as a zombie reports `connected`
+    // throughout, so it would otherwise keep charging concurrent queries the
+    // full timeout for the whole repair.
+    if (_silentRelayRepairsInFlight.contains(relay.url)) return false;
 
     // Behind an auth gate the replay only happens if NIP-42 completes, so wait
     // only while a handshake is actually outstanding. Without one — signing
@@ -757,6 +768,32 @@ class RelayPool {
       previous?.call();
       _settleQueriesBlockedBy(relay);
     };
+  }
+
+  /// Force-cycles the relays that never produced a terminal frame for the
+  /// abandoned query [subId].
+  ///
+  /// A caller only abandons a query by timing out, so any relay still holding
+  /// it demonstrably did not answer. When that same connection also received no
+  /// inbound frame of any kind since the REQ was written, it is the half-open
+  /// zombie [_repairSilentRelays] already remediates on the publish side — a
+  /// socket that still reports `connected` to every health gate while silently
+  /// swallowing everything written to it. Without this, queries never trigger
+  /// that repair, so a zombie keeps charging every subsequent query the full
+  /// timeout until something else happens to cycle the connection.
+  void _repairRelaysThatNeverAnswered(String subId) {
+    final sentAt = _querySentAt.remove(subId);
+    if (sentAt == null) return;
+    final silent = [
+      for (final relay in [
+        ..._relaysSnapshot(),
+        ..._tempRelaysSnapshot(),
+        ..._cacheRelaysSnapshot(),
+      ])
+        if (relay.checkQuery(subId)) relay.url,
+    ];
+    if (silent.isEmpty) return;
+    _repairSilentRelays(silent, sentAt);
   }
 
   /// Releases the one-shot queries [relay] is parked on once it can no longer
@@ -1395,6 +1432,7 @@ class RelayPool {
       // never-fired callback in [_queryCompleteCallbacks].
       _queryCompleteCallbacks.remove(id);
       _queryFanoutInProgress.remove(id);
+      _repairRelaysThatNeverAnswered(id);
 
       // check query and send close
       var it = _relaysSnapshot();
@@ -1474,6 +1512,7 @@ class RelayPool {
     if (onComplete != null) {
       _queryCompleteCallbacks[subscription.id] = onComplete;
       _queryFanoutInProgress.add(subscription.id);
+      _querySentAt[subscription.id] = DateTime.now();
     }
 
     // Collect futures so we can await them before the early-completion

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -108,6 +108,22 @@ class RelayPool {
   // Track pending AUTH events to match with OK responses
   final Map<String, String> _pendingAuthEvents = {};
 
+  /// Relay urls with a NIP-42 handshake outstanding.
+  ///
+  /// Entered when the relay's AUTH challenge starts being answered and left
+  /// when the relay resolves it (`OK`) or answering it fails. A one-shot query
+  /// parked behind an auth gate is only worth waiting for while this holds —
+  /// see [_canStillSettleQuery].
+  ///
+  /// Distinct from [_pendingAuthEvents], which is keyed by event id and only
+  /// populated once signing has finished; this is set first so the async
+  /// signing gap does not read as "no handshake".
+  final Set<String> _authHandshakeRelays = {};
+
+  /// Relays whose status callback this pool has already chained onto. Weak, so
+  /// a removed or replaced relay is not retained by the bookkeeping.
+  final Expando<bool> _statusObserved = Expando<bool>('relayStatusObserved');
+
   /// Track publishes awaiting OK confirmations (per event id).
   final Map<String, PublishTracker> _pendingPublishes = {};
 
@@ -349,6 +365,7 @@ class RelayPool {
     }
 
     relay.onMessage = _onEvent;
+    _observeRelayStatus(relay);
 
     if (await relay.connect()) {
       if (autoSubscribe) {
@@ -685,11 +702,75 @@ class RelayPool {
     ];
     for (final r in list) {
       // Some relay still owes us a terminal frame for this query.
-      if (r.checkQuery(subId)) return;
+      if (r.checkQuery(subId) && _canStillSettleQuery(r)) return;
     }
 
     _queryCompleteCallbacks.remove(subId);
     callback();
+  }
+
+  /// Whether a query saved on [relay] can still produce a terminal frame, and
+  /// therefore deserves to hold [_fireQueryCompleteIfSettled] back.
+  ///
+  /// A saved query means one of two different things, and only the first is
+  /// worth waiting for:
+  ///
+  /// * the REQ is live on the current socket and its `EOSE`/`CLOSED` is still
+  ///   coming, or
+  /// * the REQ is parked for replay — the relay refused it with
+  ///   `auth-required`, or the socket died under it.
+  ///
+  /// A parked query is replayed after NIP-42 succeeds or after a reconnect,
+  /// both of which land far outside the caller's timeout. Counting it as
+  /// outstanding makes *every* query in the app pay its full timeout for as
+  /// long as one relay sits behind a closed auth gate, even when the healthy
+  /// relays already answered.
+  bool _canStillSettleQuery(Relay relay) {
+    // A dropped socket cannot deliver the terminal frame for a REQ that was
+    // written to it; the reconnect path re-issues the REQ on a fresh socket.
+    if (relay.relayStatus.connected != ClientConnected.connected) return false;
+
+    // Behind an auth gate the replay only happens if NIP-42 completes, so wait
+    // only while a handshake is actually outstanding. Without one — signing
+    // unavailable, challenge never answered, AUTH refused — nothing is going
+    // to release this query.
+    if (relay.relayStatus.alwaysAuth && !relay.relayStatus.authed) {
+      return _authHandshakeRelays.contains(relay.url);
+    }
+
+    return true;
+  }
+
+  /// Watches [relay]'s connection state so a dropped socket releases the
+  /// one-shot queries that were still riding on it.
+  ///
+  /// [Relay.relayStatusCallback] is a single slot that NIP-46 also uses on its
+  /// own (non-pool) relays, so any existing callback is chained rather than
+  /// replaced. Wiring is idempotent: `add` is public and re-entrant for relay
+  /// types it does not de-duplicate, and a chain that grew per call would
+  /// re-run the settle sweep once per `add`.
+  void _observeRelayStatus(Relay relay) {
+    if (_statusObserved[relay] ?? false) return;
+    _statusObserved[relay] = true;
+    final previous = relay.relayStatusCallback;
+    relay.relayStatusCallback = () {
+      previous?.call();
+      _settleQueriesBlockedBy(relay);
+    };
+  }
+
+  /// Releases the one-shot queries [relay] is parked on once it can no longer
+  /// answer them.
+  ///
+  /// [_fireQueryCompleteIfSettled] only runs off a terminal frame or the end of
+  /// fan-out. When a relay goes quiet instead — socket dropped, AUTH refused —
+  /// nothing re-runs the check, so the callers blocked behind it have to be
+  /// released here.
+  void _settleQueriesBlockedBy(Relay relay) {
+    if (_canStillSettleQuery(relay)) return;
+    for (final query in relay.getQueries()) {
+      _fireQueryCompleteIfSettled(query.id);
+    }
   }
 
   Future<void> _onEvent(Relay relay, List<dynamic> json) async {
@@ -972,6 +1053,7 @@ class RelayPool {
       // Check if this is responding to our AUTH event
       if (_pendingAuthEvents.containsKey(eventId)) {
         _pendingAuthEvents.remove(eventId);
+        _authHandshakeRelays.remove(relay.url);
 
         if (success) {
           relay.relayStatus.authed = true;
@@ -1016,6 +1098,9 @@ class RelayPool {
           relay.relayStatus.authed = false;
           log('🔐 AUTH failed for ${relay.url}: $message');
           _rejectAuthRequiredPublishesForRelay(relay, message);
+          // The gate stayed shut, so the queries parked for the post-AUTH
+          // replay will never be replayed.
+          _settleQueriesBlockedBy(relay);
         }
       }
     } else if (messageType == "NOTICE") {
@@ -1034,6 +1119,10 @@ class RelayPool {
         final challenge = _stringAt(relay, json, 1, 'AUTH challenge');
         if (challenge == null) return;
         relay.relayStatus.alwaysAuth = true;
+        // Marks the handshake outstanding before the async signing below, so
+        // queries parked behind this gate keep waiting instead of reading the
+        // signing gap as "nothing is coming". See [_canStillSettleQuery].
+        _authHandshakeRelays.add(relay.url);
         final challengePreview = challenge.length > 16
             ? challenge.substring(0, 16)
             : challenge;
@@ -1066,11 +1155,15 @@ class RelayPool {
           }
         } else {
           log('🔐 AUTH signing returned null for ${relay.url}');
+          _authHandshakeRelays.remove(relay.url);
           _rejectAuthRequiredPublishesForRelay(relay, '');
+          _settleQueriesBlockedBy(relay);
         }
       } catch (err, stackTrace) {
         log('🔐 AUTH handling failed for ${relay.url}: $err\n$stackTrace');
+        _authHandshakeRelays.remove(relay.url);
         _rejectAuthRequiredPublishesForRelay(relay, '');
+        _settleQueriesBlockedBy(relay);
       }
     } else if (messageType == 'COUNT') {
       // NIP-45 COUNT response

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -118,7 +118,21 @@ class RelayPool {
   /// Distinct from [_pendingAuthEvents], which is keyed by event id and only
   /// populated once signing has finished; this is set first so the async
   /// signing gap does not read as "no handshake".
+  ///
+  /// Cleared on every connection-state transition: a handshake belongs to the
+  /// socket it started on, and a relay that takes our AUTH event and never
+  /// answers it would otherwise stay marked outstanding forever.
   final Set<String> _authHandshakeRelays = {};
+
+  /// Relays whose NIP-42 gate is demonstrably shut on the current connection.
+  ///
+  /// Entered only on evidence the relay produced: it refused a REQ with
+  /// `auth-required`, rejected our AUTH event, or we could not answer its
+  /// challenge at all. Absence is not evidence — a freshly connected relay
+  /// that has not sent its challenge yet still has a handshake coming, so it
+  /// keeps holding the query. Cleared on a new challenge and on every
+  /// connection-state transition.
+  final Set<String> _authGateClosed = {};
 
   /// Relays whose status callback this pool has already chained onto. Weak, so
   /// a removed or replaced relay is not retained by the bookkeeping.
@@ -142,6 +156,16 @@ class RelayPool {
   /// ask [Relay.isSilentSince] whether a relay that never answered had gone
   /// quiet altogether. Dropped when the query settles or is unsubscribed.
   final Map<String, DateTime> _querySentAt = {};
+
+  /// One-shot queries at least one relay has already answered.
+  ///
+  /// Sticky for the query's lifetime rather than a property of the call that
+  /// observed the frame: a terminal frame that lands while the REQ fan-out is
+  /// still running is swallowed by the fan-out guard in
+  /// [_fireQueryCompleteIfSettled], and the post-fan-out sweep would otherwise
+  /// have no way to know the fan-out is being served — leaving the caller to
+  /// pay its full timeout, which is the stall this whole path exists to stop.
+  final Set<String> _queryAnswered = {};
 
   /// Track publishes awaiting OK confirmations (per event id).
   final Map<String, PublishTracker> _pendingPublishes = {};
@@ -433,9 +457,17 @@ class RelayPool {
     for (var url in keys) {
       _relays[url]?.disconnect();
       _relays[url]?.dispose();
-      _lastSilentRepairAt.remove(url);
+      _forgetRelayBookkeeping(url);
     }
     _relays.clear();
+  }
+
+  /// Drops the pool-side state keyed by [url] so a relay that comes back is
+  /// not judged on the previous instance's connection.
+  void _forgetRelayBookkeeping(String url) {
+    _lastSilentRepairAt.remove(url);
+    _authHandshakeRelays.remove(url);
+    _authGateClosed.remove(url);
   }
 
   void remove(String url, {int relayType = RelayType.normal}) {
@@ -449,7 +481,7 @@ class RelayPool {
       _cacheRelays[url]?.dispose();
       _cacheRelays.remove(url);
     }
-    _lastSilentRepairAt.remove(url);
+    _forgetRelayBookkeeping(url);
   }
 
   Relay? getRelay(String url) {
@@ -718,6 +750,7 @@ class RelayPool {
   }) {
     final callback = _queryCompleteCallbacks[subId];
     if (callback == null) return;
+    if (afterTerminalFrame) _queryAnswered.add(subId);
     if (_queryFanoutInProgress.contains(subId)) return;
 
     final list = [
@@ -728,7 +761,7 @@ class RelayPool {
     for (final r in list) {
       // Some relay still owes us a terminal frame for this query.
       if (r.checkQuery(subId) && _canStillSettleQuery(r)) {
-        if (afterTerminalFrame) _armQuerySettleWindow(subId);
+        if (_queryAnswered.contains(subId)) _armQuerySettleWindow(subId);
         return;
       }
     }
@@ -767,9 +800,41 @@ class RelayPool {
 
   void _completeQuery(String subId, Function callback) {
     _queryCompleteCallbacks.remove(subId);
-    _querySentAt.remove(subId);
+    _queryAnswered.remove(subId);
     _querySettleTimers.remove(subId)?.cancel();
+    _releaseQuery(subId);
     callback();
+  }
+
+  /// Tears down [subId] on every relay that still has it saved.
+  ///
+  /// The caller is done, so a relay that never produced its terminal frame is
+  /// holding a REQ nobody is listening to. Left alone it stays open for the
+  /// life of the socket — relays cap concurrent subscriptions, the saved
+  /// [Subscription] pins the caller's event box, and both the post-AUTH replay
+  /// and the zombie reconnect re-issue it on every future cycle. That matters
+  /// most for exactly the relay this path exists for: one that never sends a
+  /// terminal frame leaks a subscription per query for the whole session.
+  ///
+  /// A relay that never answered is also the zombie-socket candidate, so it is
+  /// offered to [_repairSilentRelays] first — while [_querySentAt] still holds
+  /// the fan-out timestamp that check needs.
+  void _releaseQuery(String subId) {
+    _repairRelaysThatNeverAnswered(subId);
+    for (final relay in [
+      ..._relaysSnapshot(),
+      ..._tempRelaysSnapshot(),
+      ..._cacheRelaysSnapshot(),
+    ]) {
+      if (!relay.checkQuery(subId)) continue;
+      if (relay.relayStatus.connected == ClientConnected.connected) {
+        unawaited(relay.checkAndCompleteQuery(subId));
+      } else {
+        // No socket to send `CLOSE` on; queueing it would only replay a
+        // subscription the caller has already abandoned.
+        relay.discardQuery(subId);
+      }
+    }
   }
 
   /// Whether a query saved on [relay] can still produce a terminal frame, and
@@ -798,15 +863,30 @@ class RelayPool {
     // full timeout for the whole repair.
     if (_silentRelayRepairsInFlight.contains(relay.url)) return false;
 
-    // Behind an auth gate the replay only happens if NIP-42 completes, so wait
-    // only while a handshake is actually outstanding. Without one — signing
-    // unavailable, challenge never answered, AUTH refused — nothing is going
-    // to release this query.
+    // Behind an auth gate the replay only happens if NIP-42 completes. Wait
+    // while a handshake is outstanding, and stop waiting once the relay has
+    // shown the gate is shut — it refused the REQ with auth-required, refused
+    // our AUTH event, or we could never answer its challenge.
+    //
+    // "No handshake" on its own is not that evidence: `alwaysAuth` latches for
+    // the session, so a relay that has just reconnected sits in exactly that
+    // state for the round trip before its challenge arrives. Treating that as
+    // settled would silently drop the results of every read-gated relay on
+    // cold start.
     if (relay.relayStatus.alwaysAuth && !relay.relayStatus.authed) {
-      return _authHandshakeRelays.contains(relay.url);
+      if (_authHandshakeRelays.contains(relay.url)) return true;
+      return !_authGateClosed.contains(relay.url);
     }
 
     return true;
+  }
+
+  /// Records that [relay]'s NIP-42 gate is shut and releases whatever was
+  /// parked behind it.
+  void _closeAuthGate(Relay relay) {
+    _authHandshakeRelays.remove(relay.url);
+    _authGateClosed.add(relay.url);
+    _settleQueriesBlockedBy(relay);
   }
 
   /// Watches [relay]'s connection state so a dropped socket releases the
@@ -823,6 +903,12 @@ class RelayPool {
     final previous = relay.relayStatusCallback;
     relay.relayStatusCallback = () {
       previous?.call();
+      // NIP-42 state belongs to one socket: `authed` is reset on connect and a
+      // fresh connection re-challenges from scratch. Carrying either marker
+      // across a transition would let a relay that swallowed our AUTH event
+      // read as "handshake outstanding" for the rest of the session.
+      _authHandshakeRelays.remove(relay.url);
+      _authGateClosed.remove(relay.url);
       _settleQueriesBlockedBy(relay);
     };
   }
@@ -1194,7 +1280,7 @@ class RelayPool {
           _rejectAuthRequiredPublishesForRelay(relay, message);
           // The gate stayed shut, so the queries parked for the post-AUTH
           // replay will never be replayed.
-          _settleQueriesBlockedBy(relay);
+          _closeAuthGate(relay);
         }
       }
     } else if (messageType == "NOTICE") {
@@ -1217,6 +1303,8 @@ class RelayPool {
         // queries parked behind this gate keep waiting instead of reading the
         // signing gap as "nothing is coming". See [_canStillSettleQuery].
         _authHandshakeRelays.add(relay.url);
+        // A new challenge supersedes whatever the last one concluded.
+        _authGateClosed.remove(relay.url);
         final challengePreview = challenge.length > 16
             ? challenge.substring(0, 16)
             : challenge;
@@ -1249,15 +1337,13 @@ class RelayPool {
           }
         } else {
           log('🔐 AUTH signing returned null for ${relay.url}');
-          _authHandshakeRelays.remove(relay.url);
           _rejectAuthRequiredPublishesForRelay(relay, '');
-          _settleQueriesBlockedBy(relay);
+          _closeAuthGate(relay);
         }
       } catch (err, stackTrace) {
         log('🔐 AUTH handling failed for ${relay.url}: $err\n$stackTrace');
-        _authHandshakeRelays.remove(relay.url);
         _rejectAuthRequiredPublishesForRelay(relay, '');
-        _settleQueriesBlockedBy(relay);
+        _closeAuthGate(relay);
       }
     } else if (messageType == 'COUNT') {
       // NIP-45 COUNT response
@@ -1307,8 +1393,12 @@ class RelayPool {
 
       // A refused/abandoned REQ is terminal unless it is the pre-AUTH probe
       // that must stay saved for replay after NIP-42 succeeds.
-      if (!_shouldReplayQueryAfterAuth(relay, reason) &&
-          relay.discardQuery(subscriptionId)) {
+      if (_shouldReplayQueryAfterAuth(relay, reason)) {
+        // The relay named the gate itself. With no handshake outstanding
+        // nothing is going to run that replay, and this refusal is the
+        // evidence [_canStillSettleQuery] waits for before giving up on it.
+        if (!_authHandshakeRelays.contains(relay.url)) _closeAuthGate(relay);
+      } else if (relay.discardQuery(subscriptionId)) {
         _fireQueryCompleteIfSettled(subscriptionId, afterTerminalFrame: true);
       }
     }
@@ -1489,24 +1579,9 @@ class RelayPool {
       // never-fired callback in [_queryCompleteCallbacks].
       _queryCompleteCallbacks.remove(id);
       _queryFanoutInProgress.remove(id);
+      _queryAnswered.remove(id);
       _querySettleTimers.remove(id)?.cancel();
-      _repairRelaysThatNeverAnswered(id);
-
-      // check query and send close
-      var it = _relaysSnapshot();
-      for (var relay in it) {
-        relay.checkAndCompleteQuery(id);
-      }
-
-      it = _tempRelaysSnapshot();
-      for (var relay in it) {
-        relay.checkAndCompleteQuery(id);
-      }
-
-      it = _cacheRelaysSnapshot();
-      for (var relay in it) {
-        relay.checkAndCompleteQuery(id);
-      }
+      _releaseQuery(id);
     }
   }
 
@@ -2177,6 +2252,9 @@ class RelayPool {
     if (tempRelay == null) {
       tempRelay = tempRelayGener(addr);
       tempRelay.onMessage = _onEvent;
+      // Temp relays serve one-shot queries like any other relay, so they need
+      // the same drop-releases-the-query sweep [add] wires up.
+      _observeRelayStatus(tempRelay);
       tempRelay.connect();
       _tempRelays[addr] = tempRelay;
     }

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -108,7 +108,7 @@ class RelayPool {
   // Track pending AUTH events to match with OK responses
   final Map<String, String> _pendingAuthEvents = {};
 
-  /// Relay urls with a NIP-42 handshake outstanding.
+  /// When each relay's outstanding NIP-42 handshake started.
   ///
   /// Entered when the relay's AUTH challenge starts being answered and left
   /// when the relay resolves it (`OK`) or answering it fails. A one-shot query
@@ -122,7 +122,18 @@ class RelayPool {
   /// Cleared on every connection-state transition: a handshake belongs to the
   /// socket it started on, and a relay that takes our AUTH event and never
   /// answers it would otherwise stay marked outstanding forever.
-  final Set<String> _authHandshakeRelays = {};
+  final Map<String, DateTime> _authHandshakeStartedAt = {};
+
+  /// How long an outstanding NIP-42 handshake may hold a one-shot query open
+  /// past [querySettleWindow].
+  ///
+  /// A relay mid-handshake is not silent — it challenged us, and its `OK` is
+  /// the thing that runs the post-AUTH replay — so the silence bound does not
+  /// apply to it. But the handshake still has to be bounded on its own: a
+  /// relay that takes our AUTH event and never answers it looks identical to
+  /// one that is about to. Wide enough for a NIP-46 remote signer round trip,
+  /// which is a network call rather than a local signature.
+  static const authHandshakeWindow = Duration(seconds: 3);
 
   /// Relays whose NIP-42 gate is demonstrably shut on the current connection.
   ///
@@ -466,7 +477,7 @@ class RelayPool {
   /// not judged on the previous instance's connection.
   void _forgetRelayBookkeeping(String url) {
     _lastSilentRepairAt.remove(url);
-    _authHandshakeRelays.remove(url);
+    _authHandshakeStartedAt.remove(url);
     _authGateClosed.remove(url);
   }
 
@@ -780,6 +791,15 @@ class RelayPool {
       _querySettleTimers.remove(subId);
       final callback = _queryCompleteCallbacks[subId];
       if (callback == null) return;
+      // A relay mid-NIP-42 is not silent, so the silence bound does not apply
+      // to it: it challenged us, and its `OK` is what runs the post-AUTH
+      // replay that this query is parked for. Completing here would send
+      // `CLOSE` and drop the parked query, and the replay would find nothing.
+      // [authHandshakeWindow] is what keeps the re-arming finite.
+      if (_queryHasRelayMidHandshake(subId)) {
+        _armQuerySettleWindow(subId);
+        return;
+      }
       log(
         'Query $subId settled without ${_queryStragglers(subId)} — '
         'completing on the relays that answered',
@@ -787,6 +807,13 @@ class RelayPool {
       _completeQuery(subId, callback);
     });
   }
+
+  /// Whether any relay still holding [subId] is inside its NIP-42 handshake.
+  bool _queryHasRelayMidHandshake(String subId) => [
+    ..._relaysSnapshot(),
+    ..._tempRelaysSnapshot(),
+    ..._cacheRelaysSnapshot(),
+  ].any((r) => r.checkQuery(subId) && _hasLiveAuthHandshake(r));
 
   /// Restarts an armed settle window for [subId] because a relay is still
   /// streaming its result set.
@@ -892,17 +919,29 @@ class RelayPool {
     // settled would silently drop the results of every read-gated relay on
     // cold start.
     if (relay.relayStatus.alwaysAuth && !relay.relayStatus.authed) {
-      if (_authHandshakeRelays.contains(relay.url)) return true;
+      if (_hasLiveAuthHandshake(relay)) return true;
       return !_authGateClosed.contains(relay.url);
     }
 
     return true;
   }
 
+  /// Whether [relay]'s NIP-42 handshake is outstanding and still inside
+  /// [authHandshakeWindow].
+  ///
+  /// The age check is what stops a relay that accepts our AUTH event and never
+  /// answers it from holding queries open for the life of the connection —
+  /// nothing else about that relay distinguishes it from one still working.
+  bool _hasLiveAuthHandshake(Relay relay) {
+    final startedAt = _authHandshakeStartedAt[relay.url];
+    if (startedAt == null) return false;
+    return DateTime.now().difference(startedAt) < authHandshakeWindow;
+  }
+
   /// Records that [relay]'s NIP-42 gate is shut and releases whatever was
   /// parked behind it.
   void _closeAuthGate(Relay relay) {
-    _authHandshakeRelays.remove(relay.url);
+    _authHandshakeStartedAt.remove(relay.url);
     _authGateClosed.add(relay.url);
     _settleQueriesBlockedBy(relay);
   }
@@ -925,7 +964,7 @@ class RelayPool {
       // fresh connection re-challenges from scratch. Carrying either marker
       // across a transition would let a relay that swallowed our AUTH event
       // read as "handshake outstanding" for the rest of the session.
-      _authHandshakeRelays.remove(relay.url);
+      _authHandshakeStartedAt.remove(relay.url);
       _authGateClosed.remove(relay.url);
       _settleQueriesBlockedBy(relay);
     };
@@ -1257,7 +1296,7 @@ class RelayPool {
       // Check if this is responding to our AUTH event
       if (_pendingAuthEvents.containsKey(eventId)) {
         _pendingAuthEvents.remove(eventId);
-        _authHandshakeRelays.remove(relay.url);
+        _authHandshakeStartedAt.remove(relay.url);
 
         if (success) {
           relay.relayStatus.authed = true;
@@ -1326,7 +1365,7 @@ class RelayPool {
         // Marks the handshake outstanding before the async signing below, so
         // queries parked behind this gate keep waiting instead of reading the
         // signing gap as "nothing is coming". See [_canStillSettleQuery].
-        _authHandshakeRelays.add(relay.url);
+        _authHandshakeStartedAt[relay.url] = DateTime.now();
         // A new challenge supersedes whatever the last one concluded.
         _authGateClosed.remove(relay.url);
         final challengePreview = challenge.length > 16
@@ -1421,7 +1460,9 @@ class RelayPool {
         // The relay named the gate itself. With no handshake outstanding
         // nothing is going to run that replay, and this refusal is the
         // evidence [_canStillSettleQuery] waits for before giving up on it.
-        if (!_authHandshakeRelays.contains(relay.url)) _closeAuthGate(relay);
+        if (!_authHandshakeStartedAt.containsKey(relay.url)) {
+          _closeAuthGate(relay);
+        }
       } else if (relay.discardQuery(subscriptionId)) {
         _fireQueryCompleteIfSettled(subscriptionId, afterTerminalFrame: true);
       }
@@ -2271,6 +2312,9 @@ class RelayPool {
       _tempRelays.remove(addr);
       unawaited(tempRelay.disconnect());
       tempRelay.dispose();
+      // The replacement is a different socket, so nothing the pool concluded
+      // about the old one carries over.
+      _forgetRelayBookkeeping(addr);
       tempRelay = null;
     }
     if (tempRelay == null) {
@@ -2331,7 +2375,7 @@ class RelayPool {
     if (relay != null) {
       relay.disconnect();
     }
-    _lastSilentRepairAt.remove(addr);
+    _forgetRelayBookkeeping(addr);
   }
 
   Relay? getTempRelay(String url) {

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -124,6 +124,20 @@ class RelayPool {
   /// a removed or replaced relay is not retained by the bookkeeping.
   final Expando<bool> _statusObserved = Expando<bool>('relayStatusObserved');
 
+  /// Grace period granted to the remaining relays after the first terminal
+  /// frame for a one-shot query.
+  ///
+  /// Mirrors [PublishTracker.settleWindow] and exists for the same reason: a
+  /// healthy relay answers a REQ within a few hundred milliseconds, so making
+  /// every caller wait the full query timeout for one silent sibling stalls
+  /// the whole app behind the slowest connection. Unlike a dropped socket or a
+  /// closed auth gate, a relay that stays connected and simply never sends
+  /// `EOSE` gives off no signal at all — the only bound available is time.
+  static const querySettleWindow = Duration(seconds: 1);
+
+  /// Armed settle windows, keyed by subscription id.
+  final Map<String, Timer> _querySettleTimers = {};
+
   /// When each one-shot query's REQ fan-out started, so an abandoned query can
   /// ask [Relay.isSilentSince] whether a relay that never answered had gone
   /// quiet altogether. Dropped when the query settles or is unsubscribed.
@@ -695,7 +709,13 @@ class RelayPool {
   /// stored events) and `CLOSED` (the relay ended the subscription without
   /// finishing). Either way the caller must be released rather than left to
   /// burn its whole timeout budget.
-  void _fireQueryCompleteIfSettled(String subId) {
+  /// Set [afterTerminalFrame] when the call is driven by a relay's own `EOSE`
+  /// or `CLOSED`. That is the proof at least one relay is answering, and it is
+  /// what arms [querySettleWindow] for whichever relays are still silent.
+  void _fireQueryCompleteIfSettled(
+    String subId, {
+    bool afterTerminalFrame = false,
+  }) {
     final callback = _queryCompleteCallbacks[subId];
     if (callback == null) return;
     if (_queryFanoutInProgress.contains(subId)) return;
@@ -707,11 +727,48 @@ class RelayPool {
     ];
     for (final r in list) {
       // Some relay still owes us a terminal frame for this query.
-      if (r.checkQuery(subId) && _canStillSettleQuery(r)) return;
+      if (r.checkQuery(subId) && _canStillSettleQuery(r)) {
+        if (afterTerminalFrame) _armQuerySettleWindow(subId);
+        return;
+      }
     }
 
+    _completeQuery(subId, callback);
+  }
+
+  /// Bounds how long the relays that have not answered [subId] can hold the
+  /// caller, once some other relay has proven the fan-out is being served.
+  ///
+  /// Only a timer can bound this: a connected relay that never sends `EOSE`
+  /// looks identical to one that is about to.
+  void _armQuerySettleWindow(String subId) {
+    if (_querySettleTimers.containsKey(subId)) return;
+    _querySettleTimers[subId] = Timer(querySettleWindow, () {
+      _querySettleTimers.remove(subId);
+      final callback = _queryCompleteCallbacks[subId];
+      if (callback == null) return;
+      log(
+        'Query $subId settled without ${_queryStragglers(subId)} — '
+        'completing on the relays that answered',
+      );
+      _completeQuery(subId, callback);
+    });
+  }
+
+  /// Relay urls that never answered [subId]; diagnostic only.
+  List<String> _queryStragglers(String subId) => [
+    for (final r in [
+      ..._relaysSnapshot(),
+      ..._tempRelaysSnapshot(),
+      ..._cacheRelaysSnapshot(),
+    ])
+      if (r.checkQuery(subId)) r.url,
+  ];
+
+  void _completeQuery(String subId, Function callback) {
     _queryCompleteCallbacks.remove(subId);
     _querySentAt.remove(subId);
+    _querySettleTimers.remove(subId)?.cancel();
     callback();
   }
 
@@ -982,7 +1039,7 @@ class RelayPool {
       }
       var isQuery = await relay.checkAndCompleteQuery(subId);
       if (isQuery) {
-        _fireQueryCompleteIfSettled(subId);
+        _fireQueryCompleteIfSettled(subId, afterTerminalFrame: true);
       } else {
         // Handle EOSE for long-running subscriptions
         final subscription = _subscriptions[subId];
@@ -1252,7 +1309,7 @@ class RelayPool {
       // that must stay saved for replay after NIP-42 succeeds.
       if (!_shouldReplayQueryAfterAuth(relay, reason) &&
           relay.discardQuery(subscriptionId)) {
-        _fireQueryCompleteIfSettled(subscriptionId);
+        _fireQueryCompleteIfSettled(subscriptionId, afterTerminalFrame: true);
       }
     }
   }
@@ -1432,6 +1489,7 @@ class RelayPool {
       // never-fired callback in [_queryCompleteCallbacks].
       _queryCompleteCallbacks.remove(id);
       _queryFanoutInProgress.remove(id);
+      _querySettleTimers.remove(id)?.cancel();
       _repairRelaysThatNeverAnswered(id);
 
       // check query and send close

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1457,12 +1457,13 @@ class RelayPool {
       // A refused/abandoned REQ is terminal unless it is the pre-AUTH probe
       // that must stay saved for replay after NIP-42 succeeds.
       if (_shouldReplayQueryAfterAuth(relay, reason)) {
-        // The relay named the gate itself. With no handshake outstanding
-        // nothing is going to run that replay, and this refusal is the
-        // evidence [_canStillSettleQuery] waits for before giving up on it.
-        if (!_authHandshakeStartedAt.containsKey(relay.url)) {
-          _closeAuthGate(relay);
-        }
+        // The relay named the gate itself. With no live handshake nothing is
+        // going to run that replay, and this refusal is the evidence
+        // [_canStillSettleQuery] waits for before giving up on it. Judged on
+        // the same bound as everywhere else: a handshake the relay swallowed
+        // must stop suppressing its own refusal once it goes stale, or every
+        // later query on that socket pays its full budget.
+        if (!_hasLiveAuthHandshake(relay)) _closeAuthGate(relay);
       } else if (relay.discardQuery(subscriptionId)) {
         _fireQueryCompleteIfSettled(subscriptionId, afterTerminalFrame: true);
       }

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -788,6 +788,24 @@ class RelayPool {
     });
   }
 
+  /// Restarts an armed settle window for [subId] because a relay is still
+  /// streaming its result set.
+  ///
+  /// The window bounds *silence* — a relay that never terminates a REQ gives
+  /// off no other signal. A relay part-way through answering is not that: it
+  /// is being served, just not finished. Expiring the window under it closes
+  /// the REQ mid-stream, and the caller is told the query completed normally,
+  /// so a truncated result set is indistinguishable from a complete one.
+  ///
+  /// No-op unless a window is already armed, so a query nobody has answered
+  /// yet still gets the caller's full timeout.
+  void _restartQuerySettleWindow(String subId) {
+    final armed = _querySettleTimers.remove(subId);
+    if (armed == null) return;
+    armed.cancel();
+    _armQuerySettleWindow(subId);
+  }
+
   /// Relay urls that never answered [subId]; diagnostic only.
   List<String> _queryStragglers(String subId) => [
     for (final r in [
@@ -1112,7 +1130,13 @@ class RelayPool {
           subscription.onEvent(event);
         } else {
           subscription = relay.getRequestSubscription(subId);
-          subscription?.onEvent(event);
+          if (subscription != null) {
+            // The relay is mid-answer for this one-shot query, so it has not
+            // gone silent — restart the grace period rather than cut its
+            // result set off part-way through.
+            _restartQuerySettleWindow(subId);
+            subscription.onEvent(event);
+          }
         }
       } catch (err) {
         log(err.toString());

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
@@ -443,6 +443,89 @@ void main() {
       );
     });
 
+    test(
+      'an outstanding NIP-42 handshake survives the settle window',
+      () async {
+        final nostr = _newNostr();
+        final answering = _SilentRelay('wss://answers.example');
+        final gated = _SilentRelay('wss://gated.example');
+        expect(await nostr.relayPool.add(answering), isTrue);
+        expect(await nostr.relayPool.add(gated), isTrue);
+
+        final pending = nostr.queryEventsDetailed([
+          {
+            'kinds': [1],
+          },
+        ], timeout: _timeout);
+
+        final subId = await answering.awaitPendingQuery();
+        await gated.awaitPendingQuery();
+
+        // The gate challenges us and parks the query for the post-AUTH replay.
+        // Signing is a network call under a NIP-46 remote signer, so the `OK`
+        // can easily land after the settle window a sibling arms.
+        await gated.deliver(['AUTH', 'test-challenge']);
+        await gated.deliver(['CLOSED', subId, 'auth-required: sign in']);
+        expect(gated.capturedAuthEventId, isNotNull);
+
+        await answering.deliver(['EOSE', subId]);
+        await Future<void>.delayed(RelayPool.querySettleWindow * 1.5);
+
+        // Closing the REQ here would leave the replay loop in the AUTH `OK`
+        // handler nothing to re-issue, so a read-gated relay would contribute
+        // nothing to any query a sibling answers first.
+        expect(
+          gated.getQueries(),
+          isNotEmpty,
+          reason: 'a relay mid-handshake is being served, not silent',
+        );
+        expect(gated.closedSubIds, isNot(contains(subId)));
+
+        await gated.deliver(['OK', gated.capturedAuthEventId, true, '']);
+        expect(
+          gated.sentMessages.where((m) => m.isNotEmpty && m[0] == 'REQ'),
+          hasLength(2),
+          reason: 'the post-AUTH replay still reaches the original caller',
+        );
+
+        await pending;
+      },
+    );
+
+    test('a handshake that is never answered still gets bounded', () async {
+      final nostr = _newNostr();
+      final answering = _SilentRelay('wss://answers.example');
+      final gated = _SilentRelay('wss://swallows-auth.example');
+      expect(await nostr.relayPool.add(answering), isTrue);
+      expect(await nostr.relayPool.add(gated), isTrue);
+
+      final stopwatch = Stopwatch()..start();
+      final pending = nostr.queryEventsDetailed([
+        {
+          'kinds': [1],
+        },
+      ], timeout: RelayPool.authHandshakeWindow * 3);
+
+      final subId = await answering.awaitPendingQuery();
+      await gated.awaitPendingQuery();
+      // Our AUTH event goes out and the relay never answers it. Nothing about
+      // that relay distinguishes it from one still working, so only the
+      // handshake window can end the wait.
+      await gated.deliver(['AUTH', 'test-challenge']);
+      await gated.deliver(['CLOSED', subId, 'auth-required: sign in']);
+      await answering.deliver(['EOSE', subId]);
+
+      final result = await pending;
+      stopwatch.stop();
+
+      expect(result.timedOut, isFalse);
+      expect(
+        stopwatch.elapsed,
+        lessThan(RelayPool.authHandshakeWindow * 3),
+        reason: 'a swallowed AUTH must not cost the caller its whole budget',
+      );
+    });
+
     test('a healthy relay still holds the query until its EOSE', () async {
       final nostr = _newNostr();
       final fast = _SilentRelay('wss://fast.example');

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
@@ -22,6 +22,22 @@ class _SilentRelay extends Relay {
   /// When false, [send] reports failure the way a dead socket does.
   bool sendSucceeds = true;
 
+  /// When set, a `REQ` write blocks until [releaseReq], which holds the pool's
+  /// fan-out open while other relays answer.
+  Completer<void>? reqGate;
+
+  void releaseReq() {
+    final gate = reqGate;
+    if (gate != null && !gate.isCompleted) gate.complete();
+  }
+
+  /// `CLOSE` frames this relay was sent, by subscription id.
+  List<String> get closedSubIds => [
+    for (final message in sentMessages)
+      if (message.isNotEmpty && message[0] == 'CLOSE' && message.length > 1)
+        message[1] as String,
+  ];
+
   @override
   Future<bool> doConnect() async {
     if (!_connectSucceeds) return false;
@@ -45,6 +61,8 @@ class _SilentRelay extends Relay {
     sentMessages.add(message);
     if (message.isNotEmpty && message[0] == 'REQ' && message.length > 1) {
       capturedSubId = message[1] as String;
+      final gate = reqGate;
+      if (gate != null) await gate.future;
     } else if (message.isNotEmpty &&
         message[0] == 'AUTH' &&
         message.length > 1 &&
@@ -228,6 +246,156 @@ void main() {
         stopwatch.elapsed,
         greaterThanOrEqualTo(RelayPool.querySettleWindow),
         reason: 'the silent relay still gets its grace period first',
+      );
+    });
+
+    test('the settle window closes the REQ it abandons', () async {
+      final nostr = _newNostr();
+      final answering = _SilentRelay('wss://answers.example');
+      final mute = _SilentRelay('wss://never-eoses.example');
+      expect(await nostr.relayPool.add(answering), isTrue);
+      expect(await nostr.relayPool.add(mute), isTrue);
+
+      final pending = nostr.queryEventsDetailed([
+        {
+          'kinds': [1],
+        },
+      ], timeout: _timeout);
+
+      final subId = await answering.awaitPendingQuery();
+      await mute.awaitPendingQuery();
+      await answering.deliver(['EOSE', subId]);
+      await pending;
+
+      // The caller is gone, so the REQ it left on the silent relay has to go
+      // with it. Left open it stays live for the life of the socket — against
+      // the relay's concurrent-subscription cap, pinning the caller's event
+      // box, and re-issued by every post-AUTH and zombie-reconnect replay.
+      expect(
+        mute.closedSubIds,
+        contains(subId),
+        reason: 'the abandoned REQ must be closed on the relay',
+      );
+      expect(
+        mute.checkQuery(subId),
+        isFalse,
+        reason: 'and dropped from the pool-side query book',
+      );
+    });
+
+    test('a terminal frame that lands during fan-out still arms the settle '
+        'window', () async {
+      final nostr = _newNostr();
+      final fast = _SilentRelay('wss://fast.example');
+      final blocked = _SilentRelay('wss://slow-to-accept.example')
+        ..reqGate = Completer<void>();
+      expect(await nostr.relayPool.add(fast), isTrue);
+      expect(await nostr.relayPool.add(blocked), isTrue);
+
+      final stopwatch = Stopwatch()..start();
+      final pending = nostr.queryEventsDetailed([
+        {
+          'kinds': [1],
+        },
+      ], timeout: _timeout);
+
+      // `fast` answers while `blocked` has not finished accepting its REQ, so
+      // the completion sweep driven by that EOSE is swallowed by the fan-out
+      // guard. The window still has to arm off it once fan-out ends.
+      final subId = await fast.awaitPendingQuery();
+      await fast.deliver(['EOSE', subId]);
+      blocked.releaseReq();
+
+      final result = await pending;
+      stopwatch.stop();
+
+      expect(result.timedOut, isFalse);
+      expect(
+        stopwatch.elapsed,
+        lessThan(_timeout),
+        reason: 'an EOSE during fan-out is still proof the fan-out is served',
+      );
+    });
+
+    test('an auth-gated relay that has not been challenged yet still holds '
+        'the query', () async {
+      final nostr = _newNostr();
+      final answering = _SilentRelay('wss://answers.example');
+      final gated = _SilentRelay('wss://gated.example');
+      expect(await nostr.relayPool.add(answering), isTrue);
+      expect(await nostr.relayPool.add(gated), isTrue);
+
+      // `alwaysAuth` latches for the session, so a relay that has just
+      // reconnected sits in this state for the round trip before its challenge
+      // arrives. Writing it off there would drop every read-gated relay's
+      // results on cold start.
+      gated.relayStatus.alwaysAuth = true;
+
+      final stopwatch = Stopwatch()..start();
+      final pending = nostr.queryEventsDetailed([
+        {
+          'kinds': [1],
+        },
+      ], timeout: _timeout);
+
+      final subId = await answering.awaitPendingQuery();
+      await gated.awaitPendingQuery();
+      await answering.deliver(['EOSE', subId]);
+
+      await pending;
+      stopwatch.stop();
+
+      expect(
+        stopwatch.elapsed,
+        greaterThanOrEqualTo(RelayPool.querySettleWindow),
+        reason: 'an unchallenged auth gate is not evidence the gate is shut',
+      );
+    });
+
+    test('a reconnect gives a relay whose auth gate was shut a fresh '
+        'handshake', () async {
+      final nostr = _newNostr();
+      final gated = _SilentRelay('wss://gated.example');
+      expect(await nostr.relayPool.add(gated), isTrue);
+      gated.relayStatus.alwaysAuth = true;
+
+      // First connection: the relay refuses the REQ outright, so the gate is
+      // recorded shut and the caller stops waiting on it.
+      final first = nostr.queryEventsDetailed([
+        {
+          'kinds': [1],
+        },
+      ], timeout: _timeout);
+      final firstSubId = await gated.awaitPendingQuery();
+      await gated.deliver(['CLOSED', firstSubId, 'auth-required: sign in']);
+      expect((await first).timedOut, isFalse);
+
+      // The socket cycles. Whatever the previous connection concluded about
+      // NIP-42 does not carry over to the new one.
+      gated.onError('socket closed', reconnect: true);
+      expect(await gated.connect(), isTrue);
+
+      final answering = _SilentRelay('wss://answers.example');
+      expect(await nostr.relayPool.add(answering), isTrue);
+
+      final stopwatch = Stopwatch()..start();
+      final pending = nostr.queryEventsDetailed([
+        {
+          'kinds': [1],
+        },
+      ], timeout: _timeout);
+
+      final subId = await answering.awaitPendingQuery();
+      await gated.awaitPendingQuery();
+      await answering.deliver(['EOSE', subId]);
+
+      await pending;
+      stopwatch.stop();
+
+      expect(
+        stopwatch.elapsed,
+        greaterThanOrEqualTo(RelayPool.querySettleWindow),
+        reason: 'the fresh connection has not refused anything yet',
       );
     });
 

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
@@ -1,0 +1,228 @@
+// ABOUTME: Regression tests for one-shot query completion accounting.
+// ABOUTME: A relay that can no longer answer must not hold a query open.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:nostr_sdk/relay/client_connected.dart';
+
+/// Relay that records what it was sent and only answers when the test says so.
+class _SilentRelay extends Relay {
+  _SilentRelay(String url, {bool connectSucceeds = true})
+    : _connectSucceeds = connectSucceeds,
+      super(url, RelayStatus(url));
+
+  final bool _connectSucceeds;
+
+  String? capturedSubId;
+  String? capturedAuthEventId;
+  final List<List<dynamic>> sentMessages = [];
+
+  /// When false, [send] reports failure the way a dead socket does.
+  bool sendSucceeds = true;
+
+  @override
+  Future<bool> doConnect() async {
+    if (!_connectSucceeds) return false;
+    relayStatus.connected = ClientConnected.connected;
+    return true;
+  }
+
+  @override
+  Future<void> disconnect() async {
+    relayStatus.connected = ClientConnected.disconnect;
+  }
+
+  @override
+  Future<bool> send(
+    List<dynamic> message, {
+    bool? forceSend,
+    bool queueIfFailed = true,
+    bool skipReconnect = false,
+    DateTime? deadline,
+  }) async {
+    sentMessages.add(message);
+    if (message.isNotEmpty && message[0] == 'REQ' && message.length > 1) {
+      capturedSubId = message[1] as String;
+    } else if (message.isNotEmpty &&
+        message[0] == 'AUTH' &&
+        message.length > 1 &&
+        message[1] is Map) {
+      capturedAuthEventId = (message[1] as Map)['id'] as String?;
+    }
+    return sendSucceeds;
+  }
+
+  Future<void> deliver(List<dynamic> json) async {
+    final handler = onMessage;
+    expect(handler, isNotNull, reason: 'RelayPool did not wire onMessage');
+    final dynamic result = handler!(this, json);
+    if (result is Future) await result;
+  }
+
+  Future<String> awaitPendingQuery() async {
+    for (var i = 0; i < 1000; i++) {
+      final subId = capturedSubId;
+      if (subId != null && checkQuery(subId)) return subId;
+      await Future<void>.delayed(Duration.zero);
+    }
+    fail('RelayPool never registered a pending query for the REQ');
+  }
+}
+
+/// A query timeout long enough that reaching it means the pool stalled rather
+/// than that the test was slow.
+const _timeout = Duration(seconds: 4);
+
+Nostr _newNostr() => Nostr(
+  LocalNostrSigner(
+    '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+  ),
+  [],
+  (url) => RelayBase(url, RelayStatus(url)),
+);
+
+void main() {
+  group('RelayPool one-shot query settling', () {
+    test('an auth-gated relay with no handshake outstanding does not hold the '
+        'query open', () async {
+      final nostr = _newNostr();
+      final relay = _SilentRelay('wss://auth-gated.example');
+      expect(await nostr.relayPool.add(relay), isTrue);
+
+      // The relay challenged us at some earlier point in the session, so
+      // alwaysAuth is latched on. Nothing ever completed NIP-42 — signing was
+      // unavailable, or the challenge was never answered — so no AUTH event is
+      // in flight and the gate will never open on its own.
+      relay.relayStatus.alwaysAuth = true;
+
+      final stopwatch = Stopwatch()..start();
+      final pending = nostr.queryEventsDetailed([
+        {
+          'kinds': [1],
+        },
+      ], timeout: _timeout);
+
+      final subId = await relay.awaitPendingQuery();
+      await relay.deliver(['CLOSED', subId, 'auth-required: sign in']);
+
+      final result = await pending;
+      stopwatch.stop();
+
+      expect(
+        result.timedOut,
+        isFalse,
+        reason: 'nothing was going to release this query but the timeout',
+      );
+      expect(
+        stopwatch.elapsed,
+        lessThan(_timeout),
+        reason: 'the caller must not pay the full query timeout',
+      );
+    });
+
+    test(
+      'a rejected AUTH releases queries parked for post-AUTH replay',
+      () async {
+        final nostr = _newNostr();
+        final relay = _SilentRelay('wss://auth-rejects.example');
+        expect(await nostr.relayPool.add(relay), isTrue);
+
+        final stopwatch = Stopwatch()..start();
+        final pending = nostr.queryEventsDetailed([
+          {
+            'kinds': [1],
+          },
+        ], timeout: _timeout);
+
+        final subId = await relay.awaitPendingQuery();
+        await relay.deliver(['AUTH', 'test-challenge']);
+        await relay.deliver(['CLOSED', subId, 'auth-required: sign in']);
+
+        // The handshake is outstanding here, so the query is legitimately parked
+        // waiting for the replay (pinned by relay_pool_closed_frame_test).
+        final authEventId = relay.capturedAuthEventId;
+        expect(authEventId, isNotNull);
+
+        // The relay refuses our AUTH: the replay is never going to happen.
+        await relay.deliver([
+          'OK',
+          authEventId,
+          false,
+          'invalid: bad signature',
+        ]);
+
+        final result = await pending;
+        stopwatch.stop();
+
+        expect(result.timedOut, isFalse);
+        expect(
+          stopwatch.elapsed,
+          lessThan(_timeout),
+          reason: 'a refused AUTH must release the parked query immediately',
+        );
+      },
+    );
+
+    test('a relay that drops its socket does not hold the query open', () async {
+      final nostr = _newNostr();
+      final dropping = _SilentRelay('wss://drops.example');
+      expect(await nostr.relayPool.add(dropping), isTrue);
+
+      final stopwatch = Stopwatch()..start();
+      final pending = nostr.queryEventsDetailed([
+        {
+          'kinds': [1],
+        },
+      ], timeout: _timeout);
+
+      await dropping.awaitPendingQuery();
+      // The socket dies before any terminal frame arrives. The REQ that was on
+      // it is gone; a reconnect replays it on a fresh socket, long after this
+      // caller has given up.
+      dropping.onError('socket closed', reconnect: true);
+
+      final result = await pending;
+      stopwatch.stop();
+
+      expect(result.timedOut, isFalse);
+      expect(
+        stopwatch.elapsed,
+        lessThan(_timeout),
+        reason: 'a dropped socket cannot deliver EOSE for its REQ',
+      );
+    });
+
+    test('a healthy relay still holds the query until its EOSE', () async {
+      final nostr = _newNostr();
+      final fast = _SilentRelay('wss://fast.example');
+      final slow = _SilentRelay('wss://slow.example');
+      expect(await nostr.relayPool.add(fast), isTrue);
+      expect(await nostr.relayPool.add(slow), isTrue);
+
+      var completedEarly = false;
+      final pending = nostr.queryEventsDetailed([
+        {
+          'kinds': [1],
+        },
+      ], timeout: _timeout);
+      unawaited(pending.whenComplete(() => completedEarly = true));
+
+      final fastSubId = await fast.awaitPendingQuery();
+      final slowSubId = await slow.awaitPendingQuery();
+
+      await fast.deliver(['EOSE', fastSubId]);
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        completedEarly,
+        isFalse,
+        reason: 'the second, still-connected relay owes a terminal frame',
+      );
+
+      await slow.deliver(['EOSE', slowSubId]);
+      final result = await pending;
+      expect(result.timedOut, isFalse);
+    });
+  });
+}

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
@@ -399,6 +399,50 @@ void main() {
       );
     });
 
+    test('a relay still streaming its result set is not cut off by the settle '
+        'window', () async {
+      final nostr = _newNostr();
+      final fast = _SilentRelay('wss://fast.example');
+      final streaming = _SilentRelay('wss://streams-slowly.example');
+      expect(await nostr.relayPool.add(fast), isTrue);
+      expect(await nostr.relayPool.add(streaming), isTrue);
+      final pubkey = await nostr.ensurePublicKey();
+
+      final pending = nostr.queryEventsDetailed([
+        {
+          'kinds': [1],
+        },
+      ], timeout: _timeout);
+
+      final subId = await fast.awaitPendingQuery();
+      await streaming.awaitPendingQuery();
+      // `fast` has nothing to return and answers at once, arming the window.
+      await fast.deliver(['EOSE', subId]);
+
+      // `streaming` is healthy and part-way through a result set larger than
+      // the window. Its events are the proof it has not gone silent, so the
+      // window must not expire under it and truncate the caller's results.
+      const streamed = 5;
+      for (var i = 0; i < streamed; i++) {
+        await Future<void>.delayed(RelayPool.querySettleWindow ~/ 2);
+        final event = await nostr.nostrSigner.signEvent(
+          Event(pubkey, EventKind.textNote, const [], 'streamed-$i'),
+        );
+        await streaming.deliver(['EVENT', subId, event!.toJson()]);
+      }
+      await streaming.deliver(['EOSE', subId]);
+
+      final result = await pending;
+      expect(result.timedOut, isFalse);
+      expect(
+        result.events,
+        hasLength(streamed),
+        reason:
+            'every event the relay sent must reach the caller — a '
+            'truncated result set reads as a complete one',
+      );
+    });
+
     test('a healthy relay still holds the query until its EOSE', () async {
       final nostr = _newNostr();
       final fast = _SilentRelay('wss://fast.example');

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
@@ -526,6 +526,53 @@ void main() {
       );
     });
 
+    test(
+      "a stale handshake stops suppressing the relay's own refusal",
+      () async {
+        final nostr = _newNostr();
+        final gated = _SilentRelay('wss://swallows-auth.example');
+        expect(await nostr.relayPool.add(gated), isTrue);
+
+        // The relay challenges us, takes our AUTH event, and never answers it.
+        final first = nostr.queryEventsDetailed([
+          {
+            'kinds': [1],
+          },
+        ], timeout: const Duration(milliseconds: 300));
+        final firstSubId = await gated.awaitPendingQuery();
+        await gated.deliver(['AUTH', 'test-challenge']);
+        await gated.deliver(['CLOSED', firstSubId, 'auth-required: sign in']);
+        expect(gated.capturedAuthEventId, isNotNull);
+        await first;
+
+        // No `OK` lands and the socket never cycles, so the marker is still
+        // there while the handshake it describes is long dead.
+        await Future<void>.delayed(RelayPool.authHandshakeWindow * 1.2);
+
+        final stopwatch = Stopwatch()..start();
+        final pending = nostr.queryEventsDetailed([
+          {
+            'kinds': [1],
+          },
+        ], timeout: _timeout);
+        final subId = await gated.awaitPendingQuery();
+        // The relay names the gate again. A dead handshake is not a reason to
+        // discard that evidence — nothing is going to run the replay it parks
+        // the query for, so every later query would pay its full budget.
+        await gated.deliver(['CLOSED', subId, 'auth-required: sign in']);
+
+        final result = await pending;
+        stopwatch.stop();
+
+        expect(result.timedOut, isFalse);
+        expect(
+          stopwatch.elapsed,
+          lessThan(RelayPool.querySettleWindow),
+          reason: 'the refusal releases the query outright, not on a timer',
+        );
+      },
+    );
+
     test('a healthy relay still holds the query until its EOSE', () async {
       final nostr = _newNostr();
       final fast = _SilentRelay('wss://fast.example');

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
@@ -194,6 +194,43 @@ void main() {
       );
     });
 
+    test('one relay that never answers cannot hold the caller past the settle '
+        'window once another relay has', () async {
+      final nostr = _newNostr();
+      final answering = _SilentRelay('wss://answers.example');
+      final mute = _SilentRelay('wss://never-eoses.example');
+      expect(await nostr.relayPool.add(answering), isTrue);
+      expect(await nostr.relayPool.add(mute), isTrue);
+
+      final stopwatch = Stopwatch()..start();
+      final pending = nostr.queryEventsDetailed([
+        {
+          'kinds': [1],
+        },
+      ], timeout: _timeout);
+
+      final subId = await answering.awaitPendingQuery();
+      await mute.awaitPendingQuery();
+      // `mute` stays connected and simply never sends a terminal frame — the
+      // shape measured against relay.divine.video.
+      await answering.deliver(['EOSE', subId]);
+
+      final result = await pending;
+      stopwatch.stop();
+
+      expect(result.timedOut, isFalse);
+      expect(
+        stopwatch.elapsed,
+        lessThan(_timeout),
+        reason: 'the settle window must bound the silent relay',
+      );
+      expect(
+        stopwatch.elapsed,
+        greaterThanOrEqualTo(RelayPool.querySettleWindow),
+        reason: 'the silent relay still gets its grace period first',
+      );
+    });
+
     test('a healthy relay still holds the query until its EOSE', () async {
       final nostr = _newNostr();
       final fast = _SilentRelay('wss://fast.example');

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_zombie_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_zombie_test.dart
@@ -89,6 +89,45 @@ void main() {
       );
     });
 
+    test(
+      'a straggler the settle window abandons is still force-reconnected',
+      () async {
+        // A second relay answers, so the caller is released by the settle
+        // window rather than by the timeout. Remediation keys off the query
+        // being abandoned, not off how the caller was released.
+        const answeringUrl = 'wss://answers.example';
+        final answeringFactory = FakeWebSocketChannelFactory();
+        await nostr.relayPool.add(
+          RelayBase(
+            answeringUrl,
+            RelayStatus(answeringUrl),
+            channelFactory: answeringFactory,
+          ),
+        );
+        final answeringChannel = answeringFactory.createdChannels.single;
+
+        final pending = nostr.queryEventsDetailed([
+          {
+            'kinds': [1],
+          },
+        ], timeout: const Duration(seconds: 4));
+        await Future<void>.delayed(Duration.zero);
+        answeringChannel.simulateMessage(
+          jsonEncode(['EOSE', _lastReqSubId(answeringChannel)]),
+        );
+
+        final result = await pending;
+        expect(result.timedOut, isFalse);
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(
+          factory.createdChannels,
+          hasLength(2),
+          reason: 'the relay that swallowed the REQ is still the zombie',
+        );
+      },
+    );
+
     test('a relay that stays inbound-active is left alone — silence '
         'discriminates zombie from slow', () async {
       final channel = factory.createdChannels.single;

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_zombie_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_zombie_test.dart
@@ -1,0 +1,113 @@
+// ABOUTME: Regression tests for zombie-socket remediation driven by a timed-out
+// ABOUTME: one-shot query, mirroring the OK-timeout path on the publish side.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+import '../support/fake_web_socket.dart';
+
+/// Subscription id of the most recent REQ frame written to [channel].
+String _lastReqSubId(FakeWebSocketChannel channel) {
+  final frames = channel.sentMessages
+      .map((m) => jsonDecode(m as String) as List<dynamic>)
+      .where((m) => m.first == 'REQ');
+  return frames.last[1] as String;
+}
+
+void main() {
+  group('RelayPool zombie-socket remediation on query timeout', () {
+    const relayUrl = 'wss://relay.divine.video';
+    late Nostr nostr;
+    late FakeWebSocketChannelFactory factory;
+    late RelayBase relay;
+
+    setUp(() async {
+      final signer = LocalNostrSigner(
+        '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+      );
+      nostr = Nostr(signer, [], (url) => RelayBase(url, RelayStatus(url)));
+      await nostr.refreshPublicKey();
+      factory = FakeWebSocketChannelFactory();
+      relay = RelayBase(
+        relayUrl,
+        RelayStatus(relayUrl),
+        channelFactory: factory,
+      );
+      await nostr.relayPool.add(relay);
+    });
+
+    Future<({List<Event> events, bool timedOut})> queryOnce() {
+      return nostr.queryEventsDetailed([
+        {
+          'kinds': [1],
+        },
+      ], timeout: const Duration(milliseconds: 100));
+    }
+
+    test('a relay that accepts the REQ and never sends a terminal frame is '
+        'force-reconnected', () async {
+      expect(factory.createdChannels, hasLength(1));
+      final zombieChannel = factory.createdChannels.single;
+
+      final result = await queryOnce();
+
+      // The REQ was written; nothing came back, so the caller had to time out.
+      expect(
+        zombieChannel.sentMessages
+            .map((m) => jsonDecode(m as String) as List<dynamic>)
+            .where((m) => m.first == 'REQ'),
+        hasLength(1),
+      );
+      expect(result.timedOut, isTrue);
+
+      // Remediation runs asynchronously once the caller abandons the query.
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(
+        factory.createdChannels,
+        hasLength(2),
+        reason: 'a socket that swallowed the REQ must be cycled',
+      );
+    });
+
+    test('a relay that answers the REQ is left alone', () async {
+      final channel = factory.createdChannels.single;
+
+      final pending = queryOnce();
+      await Future<void>.delayed(Duration.zero);
+      channel.simulateMessage(jsonEncode(['EOSE', _lastReqSubId(channel)]));
+
+      final result = await pending;
+      expect(result.timedOut, isFalse);
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(
+        factory.createdChannels,
+        hasLength(1),
+        reason: 'an EOSE-ing relay is healthy and must not be cycled',
+      );
+    });
+
+    test('a relay that stays inbound-active is left alone — silence '
+        'discriminates zombie from slow', () async {
+      final channel = factory.createdChannels.single;
+
+      final pending = queryOnce();
+      await Future<void>.delayed(Duration.zero);
+      // No terminal frame for our REQ, but the connection is demonstrably
+      // alive: it is serving other traffic.
+      channel.simulateMessage(jsonEncode(['NOTICE', 'busy']));
+
+      final result = await pending;
+      expect(result.timedOut, isTrue);
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(
+        factory.createdChannels,
+        hasLength(1),
+        reason: 'an inbound-active connection must not be cycled',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #6679

## Problem

Relay queries did not complete on EOSE — they ran to their full 5s timeout, app-wide. On-device measurement while paginating a profile:

```
relay query total=5481ms timedOut=true events=344 kinds=[[7]]
relay query total=5402ms timedOut=true events=1   kinds=[[0]]
```

344 events had already arrived and the caller still waited the whole budget. Because `NostrClient` caps concurrent one-shot REQs at 6, the stalled queries then jammed the pool for everything behind them (`poolWait` up to 4926ms, pushing individual queries past 9s). A single liked-tab page spent **24.7s** across five batches of ~5.5s each.

## Root cause

Instrumenting the timeout to report which relays still owed a terminal frame named it directly:

```
still owed by: [wss://relay.divine.video(conn=2, authed=false,
                alwaysAuth=false, handshake=false, blocks=true)]
repair wss://relay.divine.video skipped=inboundActive
```

`relay.divine.video` is connected, behind no auth gate, and receiving inbound frames the whole time — it simply never sends `EOSE` or `CLOSED` for some REQs. It is not a dead socket, which is why the existing zombie remediation correctly declines to cycle it.

`RelayPool` released a query's caller only once **no** relay still had it saved. With one relay permanently silent, that condition never held, so every query in the app ran to its full timeout no matter how fast the healthy relays answered.

Two narrower variants of the same conflation also existed: a saved query can mean the REQ is live on the socket, or that it is parked for replay after NIP-42 or a reconnect. Only the first is worth waiting for — a parked query is re-issued far outside the caller's timeout.

## Change

Six commits. The first three are the fix, in the order the evidence narrowed things down; the last three are review passes over them.

**1. Completion accounting.** A relay counts as settled once it can no longer produce a terminal frame — socket down, or auth-gated with no NIP-42 handshake outstanding. Waiting through an *outstanding* handshake is preserved, so the intended post-AUTH replay still reaches the original caller; that is deliberate and pinned by `relay_pool_closed_frame_test.dart`. Since a relay going quiet does not itself fire the completion check, the sweep also runs when a socket drops and when an AUTH is refused.

**2. Zombie remediation from queries.** A caller only abandons a query by timing out, so any relay still holding it demonstrably did not answer — feed those into the existing `_repairSilentRelays` on unsubscribe. Previously only the publish path could trigger it.

**3. Query settle window — this is the one that fixes the measured case.** Neither of the above applies to `relay.divine.video`: it is connected and receiving frames throughout, it just never sends `EOSE` for some REQs. The remediation correctly declines (`skipped=inboundActive`), because that connection is alive by any test available.

A connected relay that never terminates a REQ emits no signal at all, so time is the only bound. The publish side already solved exactly this — `PublishTracker.settleWindow` grants the remaining relays a grace period after the first answer, documented as *"the settle window bounds the cost of one wedged relay: healthy relays answer in single-digit milliseconds, so waiting the full timeout for a silent sibling would stall every publish behind the slowest connection."* Queries had no equivalent.

The same window is now armed on the first terminal frame for a query. That frame is the proof the fan-out is being served, so the stragglers get a bounded grace period instead of the caller's whole budget. Queries where *no* relay has answered yet are untouched and still get the full timeout.

Tradeoff, identical to the publish side: a healthy but unusually slow relay can lose its events to the window. One second is orders of magnitude above observed relay latency.

**4. Review pass.** Five findings in the completion path the three commits above introduce.

Query completion used to imply every relay had already dropped the query, so the caller returning was also the end of the subscription. Both new early-completion paths break that, and `queryEventsDetailed` only unsubscribes on its timeout branch — so an abandoned REQ stayed live for the life of the socket, against the relay's concurrent-subscription cap, pinning the caller's event box, and re-issued by every post-AUTH and zombie-reconnect replay. On a relay that never sends a terminal frame that is one leaked subscription per query for the whole session. Completion now tears the query down on every relay that still holds it.

That also restores the zombie remediation's reach: it runs from the teardown rather than only from unsubscribe, so the straggler the settle window walks away from is still offered to the repair. Previously the window resolved the caller first and the repair only fired when no relay had answered at all.

A terminal frame arriving while the REQ fan-out was still running never armed the settle window — measured at the full timeout with two relays where the fast one EOSEs during the slow one's REQ write, the exact stall this path exists to stop. "Some relay answered" is now sticky per query rather than a property of the call that observed the frame.

Auth-gate accounting rested on a signal that could only say "no handshake right now", which is not evidence the gate is shut: `alwaysAuth` latches for the session, so a relay that just reconnected sits in that state for the round trip before its challenge arrives, and writing it off there drops every read-gated relay's results on cold start. The gate is now recorded shut only on evidence the relay produced, and both markers are dropped on every connection-state transition and when the relay leaves the pool — so a relay that swallows an AUTH event cannot stay marked "handshake outstanding" for the rest of the session.

Temp relays serve one-shot queries like any other relay but were never wired to the status observer, so a dropped temp socket never ran the sweep that observer exists for.

**5. Review: the window has to bound silence, not progress.** A relay part-way through a result set had its REQ closed one second after any sibling EOSE'd, and the caller was still told the query completed normally — a truncated page indistinguishable from a complete one. An `EVENT` for a one-shot query now restarts the window; a relay that says nothing is bounded exactly as before.

**6. Review: the same distinction for an outstanding NIP-42 handshake.** A relay mid-handshake is being served too — it challenged us, and its `OK` is what runs the post-AUTH replay the query is parked for. The window armed over that branch and the teardown dropped the parked query, so a read-gated relay contributed nothing to any query a sibling answered first, and the claim in commit 1 above did not hold. The window now re-arms while a straggler is inside its handshake, bounded by `authHandshakeWindow` so a relay that swallows our AUTH event cannot hold the query for the life of the connection.

## What this does not do

It does not make `relay.divine.video` answer. Not sending `EOSE` for a REQ is a NIP-01 violation and needs fixing in the relay; this is the client-side containment so one misbehaving relay costs ~1s instead of the full timeout on every query in the app.

## Test plan

- `relay_pool_query_settle_test.dart` — the settle window bounds a relay that never answers once another has; an auth-gated relay with no handshake does not hold the query; a rejected AUTH releases parked queries; a dropped socket does not hold the query; a healthy connected relay **does** still hold until its EOSE; the settle window closes the REQ it abandons; a terminal frame landing during fan-out still arms the window; an auth-gated relay that has not been challenged yet still holds the query; and a reconnect gives a relay whose gate was shut a fresh handshake. Every failure case was verified to reproduce without its fix, each burning the full test timeout
- `relay_pool_query_zombie_test.dart` — a relay that swallows the REQ is force-reconnected; a straggler the settle window abandons is force-reconnected too; one that EOSEs is left alone; one that is inbound-active on other traffic is left alone. Verified to fail without the fix
- `flutter test` in `packages/nostr_sdk` — 438 pass, including the existing post-AUTH replay, CLOSED-frame and publish-side zombie regression tests
- `flutter test` in `packages/nostr_client` — 324 pass
- `flutter analyze packages/nostr_sdk packages/nostr_client lib` — clean

- Manually verified on a real Samsung Galaxy: the repeated 5s `timedOut=true` on `relay.divine.video` no longer stalls the query path.

