### PR TITLE
fix(account): keep a switched-away account's session alive

### DIFF
--- a/mobile/integration_test/account_swap_integration_test.dart
+++ b/mobile/integration_test/account_swap_integration_test.dart
@@ -117,6 +117,7 @@ void main() {
       () => swapAccount(
         deviceScope: deviceScope,
         controller: controller,
+        currentAuthService: bContainer.read(authServiceProvider),
         account: KnownAccount(
           pubkeyHex: pubkeyA!,
           authSource: AuthenticationSource.automatic,

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -102,6 +102,7 @@
     },
     "settingsCancel": "ተወው",
     "settingsSwitchAnyway": "ለማንኛውም ቀይር",
+    "settingsSessionExpiredSwitchMessage": "የዚያ መለያ ክፍለ ጊዜ አብቅቷል። እንደገና ወደ እሱ መግባት ማለት አሁን ካሉበት መለያ መውጣት ማለት ነው።",
     "settingsAppVersionLabel": "የመተግበሪያ ስሪት",
     "settingsAppLanguage": "የመተግበሪያ ቋንቋ",
     "settingsAppLanguageDeviceDefault": "{language} (የመሣሪያ ነባሪ)",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -102,6 +102,7 @@
     },
     "settingsCancel": "إلغاء",
     "settingsSwitchAnyway": "تبديل على أي حال",
+    "settingsSessionExpiredSwitchMessage": "انتهت جلسة ذلك الحساب. تسجيل الدخول إليه مرة أخرى يعني تسجيل الخروج من الحساب الذي تستخدمه الآن.",
     "settingsAppVersionLabel": "إصدار التطبيق",
     "settingsAppLanguage": "لغة التطبيق",
     "settingsAppLanguageDeviceDefault": "{language} (افتراضي الجهاز)",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -102,6 +102,7 @@
     },
     "settingsCancel": "Отказ",
     "settingsSwitchAnyway": "Смени въпреки това",
+    "settingsSessionExpiredSwitchMessage": "Сесията на този акаунт изтече. Ново влизане в него означава да излезеш от този, който използваш сега.",
     "settingsAppVersionLabel": "Версия на приложението",
     "settingsAppLanguage": "Език на приложението",
     "settingsAppLanguageDeviceDefault": "{language} (език на устройството)",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -102,6 +102,7 @@
     },
     "settingsCancel": "Abbrechen",
     "settingsSwitchAnyway": "Trotzdem wechseln",
+    "settingsSessionExpiredSwitchMessage": "Die Sitzung dieses Kontos ist abgelaufen. Dich dort neu anzumelden heißt, dich aus dem Konto abzumelden, in dem du gerade bist.",
     "settingsAppVersionLabel": "App-Version",
     "settingsAppLanguage": "App-Sprache",
     "settingsAppLanguageDeviceDefault": "{language} (Gerätestandard)",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -93,6 +93,10 @@
   },
   "settingsCancel": "Cancel",
   "settingsSwitchAnyway": "Switch Anyway",
+  "settingsSessionExpiredSwitchMessage": "That account's session ran out. Signing back into it means signing out of the one you're on now.",
+  "@settingsSessionExpiredSwitchMessage": {
+    "description": "Body of the confirmation sheet shown when the account the user picked in the switcher has an unusable session. Confirming signs the current, working account out to reach the sign-in flow, so the copy has to say so."
+  },
   "settingsAppVersionLabel": "App version",
   "settingsAppLanguage": "App Language",
   "settingsAppLanguageDeviceDefault": "{language} (device default)",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -102,6 +102,7 @@
     },
     "settingsCancel": "Cancelar",
     "settingsSwitchAnyway": "Cambiar igual",
+    "settingsSessionExpiredSwitchMessage": "La sesión de esa cuenta caducó. Volver a entrar en ella significa cerrar la sesión de la que estás usando ahora.",
     "settingsAppVersionLabel": "Versión de la app",
     "settingsAppLanguage": "Idioma de la app",
     "settingsAppLanguageDeviceDefault": "{language} (predeterminado del dispositivo)",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -71,6 +71,7 @@
     "settingsUnsavedDraftsMessage": "Mayroon kang {count} na hindi naka-save na {count, plural, =1{draft} other{mga draft}}. Kapag nagpalit ka ng account, mananatili ang iyong {count, plural, =1{draft} other{mga draft}}, pero baka gusto mong i-publish o tingnan muna ang {count, plural, =1{draft na ito} other{mga ito}}.",
     "settingsCancel": "Cancel",
     "settingsSwitchAnyway": "Magpalit pa rin",
+    "settingsSessionExpiredSwitchMessage": "Nag-expire na ang session ng account na iyon. Ang mag-sign in ulit doon ay mangangahulugang mag-sign out sa account na ginagamit mo ngayon.",
     "settingsAppVersionLabel": "App version",
     "settingsAppLanguage": "Wika ng App",
     "settingsAppLanguageDeviceDefault": "{language} (default ng device)",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -102,6 +102,7 @@
     },
     "settingsCancel": "Annuler",
     "settingsSwitchAnyway": "Changer quand même",
+    "settingsSessionExpiredSwitchMessage": "La session de ce compte a expiré. Y revenir signifie te déconnecter de celui que tu utilises maintenant.",
     "settingsAppVersionLabel": "Version de l'app",
     "settingsAppLanguage": "Langue de l'app",
     "settingsAppLanguageDeviceDefault": "{language} (par défaut)",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -102,6 +102,7 @@
     },
     "settingsCancel": "Batal",
     "settingsSwitchAnyway": "Tetap Ganti",
+    "settingsSessionExpiredSwitchMessage": "Sesi akun itu sudah habis. Masuk lagi ke sana berarti keluar dari akun yang kamu pakai sekarang.",
     "settingsAppVersionLabel": "Versi aplikasi",
     "settingsAppLanguage": "Bahasa Aplikasi",
     "settingsAppLanguageDeviceDefault": "{language} (bawaan perangkat)",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -102,6 +102,7 @@
     },
     "settingsCancel": "Annulla",
     "settingsSwitchAnyway": "Cambia comunque",
+    "settingsSessionExpiredSwitchMessage": "La sessione di quell'account è scaduta. Accedere di nuovo significa uscire da quello che stai usando ora.",
     "settingsAppVersionLabel": "Versione dell'app",
     "settingsAppLanguage": "Lingua dell'app",
     "settingsAppLanguageDeviceDefault": "{language} (predefinita del dispositivo)",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -102,6 +102,7 @@
     },
     "settingsCancel": "キャンセル",
     "settingsSwitchAnyway": "それでも切り替える",
+    "settingsSessionExpiredSwitchMessage": "そのアカウントのセッションは切れています。もう一度サインインすると、今使っているアカウントからサインアウトされます。",
     "settingsAppVersionLabel": "アプリのバージョン",
     "settingsAppLanguage": "アプリの言語",
     "settingsAppLanguageDeviceDefault": "{language} (デバイスの既定)",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -71,6 +71,7 @@
     "settingsUnsavedDraftsMessage": "저장되지 않은 초안이 {count}개 있어요. 계정을 바꿔도 초안은 유지되지만, 먼저 게시하거나 검토하는 게 좋아요.",
     "settingsCancel": "취소",
     "settingsSwitchAnyway": "그래도 전환",
+    "settingsSessionExpiredSwitchMessage": "그 계정의 세션이 만료됐어요. 다시 로그인하려면 지금 쓰고 있는 계정에서 로그아웃해야 해요.",
     "settingsAppVersionLabel": "앱 버전",
     "settingsAppLanguage": "앱 언어",
     "settingsAppLanguageDeviceDefault": "{language} (기기 기본값)",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -85,6 +85,7 @@
   },
   "settingsCancel": "Batal",
   "settingsSwitchAnyway": "Tukar Juga",
+  "settingsSessionExpiredSwitchMessage": "Sesi akaun itu telah tamat. Log masuk semula ke sana bermakna anda log keluar daripada akaun yang anda guna sekarang.",
   "settingsAppVersionLabel": "Versi apl",
   "settingsAppLanguage": "Bahasa Aplikasi",
   "settingsAppLanguageDeviceDefault": "{language} (lalai peranti)",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -102,6 +102,7 @@
     },
     "settingsCancel": "Annuleren",
     "settingsSwitchAnyway": "Toch wisselen",
+    "settingsSessionExpiredSwitchMessage": "De sessie van dat account is verlopen. Er opnieuw op inloggen betekent uitloggen bij het account waar je nu op zit.",
     "settingsAppVersionLabel": "App-versie",
     "settingsAppLanguage": "App-taal",
     "settingsAppLanguageDeviceDefault": "{language} (standaard op apparaat)",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -102,6 +102,7 @@
     },
     "settingsCancel": "Anuluj",
     "settingsSwitchAnyway": "Przełącz mimo to",
+    "settingsSessionExpiredSwitchMessage": "Sesja tego konta wygasła. Ponowne zalogowanie się do niego oznacza wylogowanie z konta, na którym jesteś teraz.",
     "settingsAppVersionLabel": "Wersja aplikacji",
     "settingsAppLanguage": "Język aplikacji",
     "settingsAppLanguageDeviceDefault": "{language} (domyślny język urządzenia)",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -102,6 +102,7 @@
     },
     "settingsCancel": "Cancelar",
     "settingsSwitchAnyway": "Trocar mesmo assim",
+    "settingsSessionExpiredSwitchMessage": "A sessão dessa conta expirou. Entrar nela de novo significa sair da conta que você está usando agora.",
     "settingsAppVersionLabel": "Versão do app",
     "settingsAppLanguage": "Idioma do app",
     "settingsAppLanguageDeviceDefault": "{language} (padrão do dispositivo)",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -102,6 +102,7 @@
     },
     "settingsCancel": "Anulează",
     "settingsSwitchAnyway": "Schimbă oricum",
+    "settingsSessionExpiredSwitchMessage": "Sesiunea acelui cont a expirat. Ca să intri din nou în el, ieși din contul pe care îl folosești acum.",
     "settingsAppVersionLabel": "Versiunea aplicației",
     "settingsAppLanguage": "Limba aplicației",
     "settingsAppLanguageDeviceDefault": "{language} (implicit pe dispozitiv)",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -102,6 +102,7 @@
     },
     "settingsCancel": "Avbryt",
     "settingsSwitchAnyway": "Byt ändå",
+    "settingsSessionExpiredSwitchMessage": "Sessionen för det kontot har gått ut. Att logga in där igen betyder att du loggas ut från det du använder nu.",
     "settingsAppVersionLabel": "Appversion",
     "settingsAppLanguage": "Appspråk",
     "settingsAppLanguageDeviceDefault": "{language} (enhetens standard)",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -102,6 +102,7 @@
     },
     "settingsCancel": "İptal",
     "settingsSwitchAnyway": "Yine de Değiştir",
+    "settingsSessionExpiredSwitchMessage": "O hesabın oturumu doldu. Yeniden giriş yapmak, şu an kullandığın hesaptan çıkmak demek.",
     "settingsAppVersionLabel": "Uygulama sürümü",
     "settingsAppLanguage": "Uygulama Dili",
     "settingsAppLanguageDeviceDefault": "{language} (cihaz varsayılanı)",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -85,6 +85,7 @@
   },
   "settingsCancel": "منسوخ کریں",
   "settingsSwitchAnyway": "پھر بھی تبدیل کریں",
+  "settingsSessionExpiredSwitchMessage": "اس اکاؤنٹ کا سیشن ختم ہو چکا ہے۔ اس میں دوبارہ سائن ان کرنے کا مطلب ہے کہ آپ اس اکاؤنٹ سے سائن آؤٹ ہو جائیں گے جو ابھی استعمال کر رہے ہیں۔",
   "settingsAppVersionLabel": "ایپ ورژن",
   "settingsAppLanguage": "ایپ کی زبان",
   "settingsAppLanguageDeviceDefault": "{language} (ڈیوائس ڈیفالٹ)",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -85,6 +85,7 @@
   },
   "settingsCancel": "Hủy",
   "settingsSwitchAnyway": "Vẫn chuyển",
+  "settingsSessionExpiredSwitchMessage": "Phiên của tài khoản đó đã hết hạn. Đăng nhập lại vào đó nghĩa là bạn sẽ đăng xuất khỏi tài khoản đang dùng.",
   "settingsAppVersionLabel": "Phiên bản ứng dụng",
   "settingsAppLanguage": "Ngôn ngữ ứng dụng",
   "settingsAppLanguageDeviceDefault": "{language} (mặc định của thiết bị)",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -85,6 +85,7 @@
   },
   "settingsCancel": "取消",
   "settingsSwitchAnyway": "仍然切换",
+  "settingsSessionExpiredSwitchMessage": "该账号的登录状态已过期。重新登录它意味着要退出你现在使用的账号。",
   "settingsAppVersionLabel": "应用版本",
   "settingsAppLanguage": "应用语言",
   "settingsAppLanguageDeviceDefault": "{language}（系统默认）",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -372,6 +372,12 @@ abstract class AppLocalizations {
   /// **'Switch Anyway'**
   String get settingsSwitchAnyway;
 
+  /// Body of the confirmation sheet shown when the account the user picked in the switcher has an unusable session. Confirming signs the current, working account out to reach the sign-in flow, so the copy has to say so.
+  ///
+  /// In en, this message translates to:
+  /// **'That account\'s session ran out. Signing back into it means signing out of the one you\'re on now.'**
+  String get settingsSessionExpiredSwitchMessage;
+
   /// No description provided for @settingsAppVersionLabel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -174,6 +174,10 @@ class AppLocalizationsAm extends AppLocalizations {
   String get settingsSwitchAnyway => 'ለማንኛውም ቀይር';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      'የዚያ መለያ ክፍለ ጊዜ አብቅቷል። እንደገና ወደ እሱ መግባት ማለት አሁን ካሉበት መለያ መውጣት ማለት ነው።';
+
+  @override
   String get settingsAppVersionLabel => 'የመተግበሪያ ስሪት';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -160,6 +160,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get settingsSwitchAnyway => 'تبديل على أي حال';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      'انتهت جلسة ذلك الحساب. تسجيل الدخول إليه مرة أخرى يعني تسجيل الخروج من الحساب الذي تستخدمه الآن.';
+
+  @override
   String get settingsAppVersionLabel => 'إصدار التطبيق';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -172,6 +172,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get settingsSwitchAnyway => 'Смени въпреки това';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      'Сесията на този акаунт изтече. Ново влизане в него означава да излезеш от този, който използваш сега.';
+
+  @override
   String get settingsAppVersionLabel => 'Версия на приложението';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -171,6 +171,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settingsSwitchAnyway => 'Trotzdem wechseln';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      'Die Sitzung dieses Kontos ist abgelaufen. Dich dort neu anzumelden heißt, dich aus dem Konto abzumelden, in dem du gerade bist.';
+
+  @override
   String get settingsAppVersionLabel => 'App-Version';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -171,6 +171,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsSwitchAnyway => 'Switch Anyway';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      'That account\'s session ran out. Signing back into it means signing out of the one you\'re on now.';
+
+  @override
   String get settingsAppVersionLabel => 'App version';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -171,6 +171,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settingsSwitchAnyway => 'Cambiar igual';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      'La sesión de esa cuenta caducó. Volver a entrar en ella significa cerrar la sesión de la que estás usando ahora.';
+
+  @override
   String get settingsAppVersionLabel => 'Versión de la app';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -171,6 +171,10 @@ class AppLocalizationsFil extends AppLocalizations {
   String get settingsSwitchAnyway => 'Magpalit pa rin';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      'Nag-expire na ang session ng account na iyon. Ang mag-sign in ulit doon ay mangangahulugang mag-sign out sa account na ginagamit mo ngayon.';
+
+  @override
   String get settingsAppVersionLabel => 'App version';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -177,6 +177,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsSwitchAnyway => 'Changer quand même';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      'La session de ce compte a expiré. Y revenir signifie te déconnecter de celui que tu utilises maintenant.';
+
+  @override
   String get settingsAppVersionLabel => 'Version de l\'app';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -141,6 +141,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get settingsSwitchAnyway => 'Tetap Ganti';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      'Sesi akun itu sudah habis. Masuk lagi ke sana berarti keluar dari akun yang kamu pakai sekarang.';
+
+  @override
   String get settingsAppVersionLabel => 'Versi aplikasi';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -171,6 +171,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settingsSwitchAnyway => 'Cambia comunque';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      'La sessione di quell\'account è scaduta. Accedere di nuovo significa uscire da quello che stai usando ora.';
+
+  @override
   String get settingsAppVersionLabel => 'Versione dell\'app';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -134,6 +134,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settingsSwitchAnyway => 'それでも切り替える';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      'そのアカウントのセッションは切れています。もう一度サインインすると、今使っているアカウントからサインアウトされます。';
+
+  @override
   String get settingsAppVersionLabel => 'アプリのバージョン';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -135,6 +135,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settingsSwitchAnyway => '그래도 전환';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      '그 계정의 세션이 만료됐어요. 다시 로그인하려면 지금 쓰고 있는 계정에서 로그아웃해야 해요.';
+
+  @override
   String get settingsAppVersionLabel => '앱 버전';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -171,6 +171,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get settingsSwitchAnyway => 'Tukar Juga';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      'Sesi akaun itu telah tamat. Log masuk semula ke sana bermakna anda log keluar daripada akaun yang anda guna sekarang.';
+
+  @override
   String get settingsAppVersionLabel => 'Versi apl';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -171,6 +171,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settingsSwitchAnyway => 'Toch wisselen';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      'De sessie van dat account is verlopen. Er opnieuw op inloggen betekent uitloggen bij het account waar je nu op zit.';
+
+  @override
   String get settingsAppVersionLabel => 'App-versie';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -175,6 +175,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get settingsSwitchAnyway => 'Przełącz mimo to';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      'Sesja tego konta wygasła. Ponowne zalogowanie się do niego oznacza wylogowanie z konta, na którym jesteś teraz.';
+
+  @override
   String get settingsAppVersionLabel => 'Wersja aplikacji';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -171,6 +171,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settingsSwitchAnyway => 'Trocar mesmo assim';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      'A sessão dessa conta expirou. Entrar nela de novo significa sair da conta que você está usando agora.';
+
+  @override
   String get settingsAppVersionLabel => 'Versão do app';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -186,6 +186,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get settingsSwitchAnyway => 'Schimbă oricum';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      'Sesiunea acelui cont a expirat. Ca să intri din nou în el, ieși din contul pe care îl folosești acum.';
+
+  @override
   String get settingsAppVersionLabel => 'Versiunea aplicației';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -159,6 +159,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get settingsSwitchAnyway => 'Byt ändå';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      'Sessionen för det kontot har gått ut. Att logga in där igen betyder att du loggas ut från det du använder nu.';
+
+  @override
   String get settingsAppVersionLabel => 'Appversion';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -142,6 +142,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get settingsSwitchAnyway => 'Yine de Değiştir';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      'O hesabın oturumu doldu. Yeniden giriş yapmak, şu an kullandığın hesaptan çıkmak demek.';
+
+  @override
   String get settingsAppVersionLabel => 'Uygulama sürümü';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -171,6 +171,10 @@ class AppLocalizationsUr extends AppLocalizations {
   String get settingsSwitchAnyway => 'پھر بھی تبدیل کریں';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      'اس اکاؤنٹ کا سیشن ختم ہو چکا ہے۔ اس میں دوبارہ سائن ان کرنے کا مطلب ہے کہ آپ اس اکاؤنٹ سے سائن آؤٹ ہو جائیں گے جو ابھی استعمال کر رہے ہیں۔';
+
+  @override
   String get settingsAppVersionLabel => 'ایپ ورژن';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -171,6 +171,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get settingsSwitchAnyway => 'Vẫn chuyển';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      'Phiên của tài khoản đó đã hết hạn. Đăng nhập lại vào đó nghĩa là bạn sẽ đăng xuất khỏi tài khoản đang dùng.';
+
+  @override
   String get settingsAppVersionLabel => 'Phiên bản ứng dụng';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -164,6 +164,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settingsSwitchAnyway => '仍然切换';
 
   @override
+  String get settingsSessionExpiredSwitchMessage =>
+      '该账号的登录状态已过期。重新登录它意味着要退出你现在使用的账号。';
+
+  @override
   String get settingsAppVersionLabel => '应用版本';
 
   @override

--- a/mobile/lib/providers/swap_account.dart
+++ b/mobile/lib/providers/swap_account.dart
@@ -11,6 +11,7 @@ import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 /// Signs [container]'s fresh [AuthService] in as [account].
 ///
@@ -67,6 +68,10 @@ String? _currentRouterLocation(AccountSwitchController controller) {
 /// to do that; without it the leaving account comes back as "session expired"
 /// with no refresh token left to recover from.
 ///
+/// That archive is a precondition, not a best-effort side trip: it throws if
+/// the write fails, aborting before anything is mutated, because a swap that
+/// carries on past it destroys the credentials it was meant to preserve.
+///
 /// Prove-then-commit: nothing user-visible changes until the new account's
 /// sign-in succeeds. On failure the half-built container is disposed and the
 /// current account's container is left untouched — the rollback the previous
@@ -79,7 +84,9 @@ String? _currentRouterLocation(AccountSwitchController controller) {
 /// enough to fail has already restored the *target* account's signer keys over
 /// the shared slots and persisted its auth source, which the live container
 /// never re-reads but the next cold launch does. The rollback restores the
-/// leaving account's keys from the archive written above.
+/// leaving account's keys from the archive written above. It cannot throw:
+/// callers dispatch on the sign-in failure's type, so a rollback that escaped
+/// would swap out the type they match on and cost the user the recovery route.
 ///
 /// [signIn] is injectable for testing; production uses [signInForAccount].
 Future<void> swapAccount({
@@ -108,11 +115,18 @@ Future<void> swapAccount({
       await container.read(authServiceProvider).claimLegacyRowsForCurrentUser();
     } catch (_) {
       try {
-        // Ordered first because it cannot throw: a failing primary-key
-        // restore must not skip it and strand this account on the target's
-        // signer.
         await currentAuthService.restoreSignerInfoForCurrentAccount();
         await keyStorage.restorePrimaryKeyContainer(previousPrimary);
+      } catch (rollbackError, rollbackStack) {
+        // Swallowed on purpose: the caller dispatches on the sign-in failure's
+        // type to decide between the re-auth offer and the generic snackbar,
+        // and letting a rollback failure escape here replaces that type.
+        Log.error(
+          'Account swap rollback failed',
+          name: 'swapAccount',
+          error: rollbackError,
+          stackTrace: rollbackStack,
+        );
       } finally {
         container.dispose();
       }

--- a/mobile/lib/providers/swap_account.dart
+++ b/mobile/lib/providers/swap_account.dart
@@ -75,6 +75,12 @@ String? _currentRouterLocation(AccountSwitchController controller) {
 /// intentionally: it only ever copies the leaving account's own credentials
 /// into its own slot.
 ///
+/// Rolling the container back is not enough on its own: a sign-in that got far
+/// enough to fail has already restored the *target* account's signer keys over
+/// the shared slots and persisted its auth source, which the live container
+/// never re-reads but the next cold launch does. The rollback restores the
+/// leaving account's keys from the archive written above.
+///
 /// [signIn] is injectable for testing; production uses [signInForAccount].
 Future<void> swapAccount({
   required DeviceScope deviceScope,
@@ -102,6 +108,10 @@ Future<void> swapAccount({
       await container.read(authServiceProvider).claimLegacyRowsForCurrentUser();
     } catch (_) {
       try {
+        // Ordered first because it cannot throw: a failing primary-key
+        // restore must not skip it and strand this account on the target's
+        // signer.
+        await currentAuthService.restoreSignerInfoForCurrentAccount();
         await keyStorage.restorePrimaryKeyContainer(previousPrimary);
       } finally {
         container.dispose();

--- a/mobile/lib/providers/swap_account.dart
+++ b/mobile/lib/providers/swap_account.dart
@@ -10,6 +10,7 @@ import 'package:openvine/providers/device_scope.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/app_router.dart';
+import 'package:openvine/services/auth_service.dart';
 
 /// Signs [container]'s fresh [AuthService] in as [account].
 ///
@@ -59,20 +60,31 @@ String? _currentRouterLocation(AccountSwitchController controller) {
 /// Switches the live app to [account] in place: builds a new container on the
 /// shared [deviceScope], signs it in, and swaps it in via [controller].
 ///
+/// [currentAuthService] is the live container's service — the account being
+/// left. Its signer credentials (OAuth session, bunker URL, Amber info) live in
+/// shared secure-storage slots that the incoming account's sign-in overwrites,
+/// so they are archived per-account first. The sign-out this swap replaced used
+/// to do that; without it the leaving account comes back as "session expired"
+/// with no refresh token left to recover from.
+///
 /// Prove-then-commit: nothing user-visible changes until the new account's
 /// sign-in succeeds. On failure the half-built container is disposed and the
 /// current account's container is left untouched — the rollback the previous
 /// welcome-bounce flow could not guarantee (#4623). Rethrows so the caller can
-/// surface a "couldn't switch" affordance.
+/// surface a "couldn't switch" affordance. The archive survives that rollback
+/// intentionally: it only ever copies the leaving account's own credentials
+/// into its own slot.
 ///
 /// [signIn] is injectable for testing; production uses [signInForAccount].
 Future<void> swapAccount({
   required DeviceScope deviceScope,
   required AccountSwitchController controller,
+  required AuthService currentAuthService,
   required KnownAccount account,
   AccountSignIn signIn = _defaultSignIn,
 }) async {
   await controller.runExclusive(() async {
+    await currentAuthService.archiveCurrentSignerInfo();
     final currentLocation = _currentRouterLocation(controller);
     final container = buildAccountContainer(
       deviceScope,

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -178,7 +178,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     if (!mounted) return;
     final proceed = await _confirmSwitch(
       title: context.l10n.settingsSessionExpired,
-      message: context.l10n.settingsSessionExpiredSubtitle,
+      message: context.l10n.settingsSessionExpiredSwitchMessage,
       confirmLabel: context.l10n.authSignInTitle,
       confirmType: DivineButtonType.primary,
     );

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -8,6 +8,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:keycast_flutter/keycast_flutter.dart'
+    show SessionExpiredException;
 import 'package:models/models.dart';
 import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
@@ -103,10 +105,13 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   }
 
   /// Confirmation sheet shown before an account switch that would disturb
-  /// unfinished work. Returns true when the user chose to switch anyway.
-  Future<bool> _confirmSwitchAnyway({
+  /// unfinished work, or that has to sign the current account out to recover
+  /// the target one. Returns true when the user chose to proceed.
+  Future<bool> _confirmSwitch({
     required String title,
     required String message,
+    required String confirmLabel,
+    DivineButtonType confirmType = DivineButtonType.error,
   }) async {
     final proceed = await VineBottomSheet.show<bool>(
       context: context,
@@ -137,8 +142,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               ),
               Expanded(
                 child: DivineButton(
-                  label: context.l10n.settingsSwitchAnyway,
-                  type: DivineButtonType.error,
+                  label: confirmLabel,
+                  type: confirmType,
                   expanded: true,
                   onPressed: () => Navigator.of(context).pop(true),
                 ),
@@ -149,6 +154,39 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       ],
     );
     return proceed ?? false;
+  }
+
+  /// Offers a fresh sign-in when [account]'s stored credentials turn out to be
+  /// unusable — an OAuth session with nothing left to refresh from, or a
+  /// restore that resolved to a different identity.
+  ///
+  /// The in-place swap cannot recover on its own: it needs credentials that
+  /// already work. Recovery is the route the welcome flow takes for these same
+  /// two failures — remember the account, sign out, and let the router land on
+  /// the welcome screen with that account pre-selected. Signing the working
+  /// account out is the user's call, so it is confirmed first.
+  Future<void> _offerReauthentication(
+    KnownAccount account,
+    Object error,
+  ) async {
+    Log.warning(
+      'Account switch to ${account.pubkeyHex} has no usable session '
+      '($error) — offering re-authentication',
+      name: 'SettingsScreen',
+      category: LogCategory.auth,
+    );
+    if (!mounted) return;
+    final proceed = await _confirmSwitch(
+      title: context.l10n.settingsSessionExpired,
+      message: context.l10n.settingsSessionExpiredSubtitle,
+      confirmLabel: context.l10n.authSignInTitle,
+      confirmType: DivineButtonType.primary,
+    );
+    if (!proceed || !mounted) return;
+
+    final authService = ref.read(authServiceProvider);
+    authService.pendingAccountSwitchPubkey = account.pubkeyHex;
+    await authService.signOut();
   }
 
   Future<bool> _parkUploadsBeforeAccountChange(
@@ -188,17 +226,19 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         .where((upload) => upload.result == null)
         .length;
     if (inFlightCount > 0) {
-      final proceed = await _confirmSwitchAnyway(
+      final proceed = await _confirmSwitch(
         title: context.l10n.settingsUploadInProgressTitle,
         message: context.l10n.settingsUploadInProgressMessage(inFlightCount),
+        confirmLabel: context.l10n.settingsSwitchAnyway,
       );
       if (!proceed) return;
     } else if (accountState.hasDrafts) {
-      final proceed = await _confirmSwitchAnyway(
+      final proceed = await _confirmSwitch(
         title: context.l10n.settingsUnsavedDraftsTitle,
         message: context.l10n.settingsUnsavedDraftsMessage(
           accountState.draftCount,
         ),
+        confirmLabel: context.l10n.settingsSwitchAnyway,
       );
       if (!proceed) return;
     }
@@ -232,8 +272,13 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 await swapAccount(
                   deviceScope: deviceScope,
                   controller: deviceScope.switchController,
+                  currentAuthService: ref.read(authServiceProvider),
                   account: account,
                 );
+              } on SessionExpiredException catch (e) {
+                await _offerReauthentication(account, e);
+              } on AccountRestoreFailedException catch (e) {
+                await _offerReauthentication(account, e);
               } catch (e, stackTrace) {
                 Log.error(
                   'Account switch failed',

--- a/mobile/lib/services/auth/signer_secure_store.dart
+++ b/mobile/lib/services/auth/signer_secure_store.dart
@@ -189,7 +189,12 @@ class SignerSecureStore {
 
   /// Archives the currently-active signer keys under per-account keys for
   /// [pubkeyHex], so they can be restored when switching back to this account.
-  Future<void> archive(String pubkeyHex) async {
+  ///
+  /// Failures are logged and swallowed by default, which suits sign-out: the
+  /// session is going away either way. Pass [throwOnFailure] when the caller
+  /// depends on the archive having landed — the in-place account switch does,
+  /// because the incoming sign-in overwrites the shared slots it copies from.
+  Future<void> archive(String pubkeyHex, {bool throwOnFailure = false}) async {
     if (_storage == null) return;
     try {
       // Archive Amber info
@@ -257,6 +262,7 @@ class SignerSecureStore {
         name: 'SignerSecureStore',
         category: LogCategory.auth,
       );
+      if (throwOnFailure) rethrow;
     }
   }
 

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -1567,6 +1567,28 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   Future<void> _archiveSignerInfo(String pubkeyHex) =>
       _signerStore.archive(pubkeyHex);
 
+  /// Archives the active signer keys under the currently signed-in account.
+  ///
+  /// The in-place account switch swaps the container instead of signing out,
+  /// so the sign-out archival above never runs for the leaving account. Signing
+  /// the incoming account in then overwrites the shared signer slots — for a
+  /// local-key account [SignerSecureStore.restoreActiveKeys] even clears the
+  /// OAuth session outright — and the leaving account is left with no session
+  /// and no refresh token to recover from. Call this before the incoming
+  /// account's sign-in.
+  Future<void> archiveCurrentSignerInfo() async {
+    final pubkeyHex = currentPublicKeyHex;
+    if (pubkeyHex == null) {
+      Log.warning(
+        'archiveCurrentSignerInfo: no signed-in account to archive',
+        name: 'AuthService',
+        category: LogCategory.auth,
+      );
+      return;
+    }
+    await _archiveSignerInfo(pubkeyHex);
+  }
+
   /// Restores per-account signer keys to the active-session keys.
   ///
   /// Called before sign-in when switching to a previously used account.

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -1576,6 +1576,12 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// OAuth session outright — and the leaving account is left with no session
   /// and no refresh token to recover from. Call this before the incoming
   /// account's sign-in.
+  ///
+  /// Throws when the archive write fails, unlike the sign-out path that
+  /// swallows it. The swap has no second chance: the incoming sign-in wipes the
+  /// shared slots this copies from, so carrying on after a failed write
+  /// destroys the leaving account's session for a log line. Aborting is safe
+  /// because this runs before the swap mutates anything.
   Future<void> archiveCurrentSignerInfo() async {
     final pubkeyHex = currentPublicKeyHex;
     if (pubkeyHex == null) {
@@ -1586,7 +1592,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       );
       return;
     }
-    await _archiveSignerInfo(pubkeyHex);
+    await _signerStore.archive(pubkeyHex, throwOnFailure: true);
   }
 
   /// Restores the currently signed-in account's archived signer keys back into

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -1589,6 +1589,28 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     await _archiveSignerInfo(pubkeyHex);
   }
 
+  /// Restores the currently signed-in account's archived signer keys back into
+  /// the shared slots, undoing a different account's restore.
+  ///
+  /// The counterpart to [archiveCurrentSignerInfo]: a failed in-place switch
+  /// has already run the target account's [_restoreSignerInfo], which
+  /// overwrote the shared signer slots and the persisted auth source. Rolling
+  /// the container back does not undo either — this account keeps working from
+  /// memory but reads the wrong signer at the next launch. Call this on the
+  /// swap's rollback path.
+  Future<void> restoreSignerInfoForCurrentAccount() async {
+    final pubkeyHex = currentPublicKeyHex;
+    if (pubkeyHex == null) {
+      Log.warning(
+        'restoreSignerInfoForCurrentAccount: no signed-in account to restore',
+        name: 'AuthService',
+        category: LogCategory.auth,
+      );
+      return;
+    }
+    await _restoreSignerInfo(pubkeyHex, _authSource);
+  }
+
   /// Restores per-account signer keys to the active-session keys.
   ///
   /// Called before sign-in when switching to a previously used account.

--- a/mobile/packages/nostr_key_manager/lib/src/secure_key_storage.dart
+++ b/mobile/packages/nostr_key_manager/lib/src/secure_key_storage.dart
@@ -494,13 +494,21 @@ class SecureKeyStorage {
   /// Account switching snapshots PRIMARY before probing the target account. If
   /// the probe fails after `switchToIdentity` has already committed, callers
   /// use this method to put cold-launch identity back where it was.
+  ///
+  /// The snapshot is usually the cached container itself — [getKeyContainer]
+  /// returns the cache on a hit and caches what it retrieves on a miss — so the
+  /// outgoing container is only disposed when it is a *different* object.
+  /// Disposing it unconditionally killed the very container being restored, and
+  /// `storeKey` then threw on the disposed private key.
   Future<void> restorePrimaryKeyContainer(
     SecureKeyContainer? keyContainer, {
     String? biometricPrompt,
   }) async {
     await _ensureInitialized();
 
-    _cachedKeyContainer?.dispose();
+    if (!identical(_cachedKeyContainer, keyContainer)) {
+      _cachedKeyContainer?.dispose();
+    }
     _clearCache();
 
     if (keyContainer == null) {

--- a/mobile/packages/nostr_key_manager/test/src/secure_key_storage_restore_primary_test.dart
+++ b/mobile/packages/nostr_key_manager/test/src/secure_key_storage_restore_primary_test.dart
@@ -1,0 +1,56 @@
+// ABOUTME: Tests SecureKeyStorage.restorePrimaryKeyContainer round-tripping the
+// ABOUTME: cached container, which account-switch rollback always hands it.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_key_manager/nostr_key_manager.dart';
+
+import '../test_setup.dart';
+
+void main() {
+  group('SecureKeyStorage.restorePrimaryKeyContainer', () {
+    late SecureKeyStorage storage;
+
+    setUp(() async {
+      setupTestEnvironment();
+      storage = SecureKeyStorage();
+      await storage.initialize();
+    });
+
+    test('restores the container getKeyContainer just handed out', () async {
+      // The account-switch rollback snapshots PRIMARY with getKeyContainer and
+      // hands that same object back here. getKeyContainer returns the cached
+      // container, so disposing the cache unconditionally destroyed the
+      // snapshot and storeKey threw on its disposed private key — masking the
+      // sign-in failure the caller was trying to surface.
+      await storage.generateAndStoreKeys();
+      final snapshot = await storage.getKeyContainer();
+      expect(snapshot, isNotNull);
+
+      await expectLater(
+        storage.restorePrimaryKeyContainer(snapshot),
+        completes,
+      );
+
+      expect(snapshot!.isDisposed, isFalse);
+      final restored = await storage.getKeyContainer();
+      expect(restored!.npub, equals(snapshot.npub));
+    });
+
+    test(
+      'disposes the cached container when restoring a different one',
+      () async {
+        await storage.generateAndStoreKeys();
+        final outgoing = await storage.getKeyContainer();
+        final incoming = await SecureKeyContainer.generate();
+
+        await storage.restorePrimaryKeyContainer(incoming);
+
+        // Only the container being replaced is released.
+        expect(outgoing!.isDisposed, isTrue);
+        expect(incoming.isDisposed, isFalse);
+        final restored = await storage.getKeyContainer();
+        expect(restored!.npub, equals(incoming.npub));
+      },
+    );
+  });
+}

--- a/mobile/test/providers/swap_account_test.dart
+++ b/mobile/test/providers/swap_account_test.dart
@@ -7,13 +7,13 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
-import 'package:openvine/models/authentication_source.dart';
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/container_swap_host.dart';
 import 'package:openvine/providers/device_scope.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/swap_account.dart';
+import 'package:openvine/services/auth_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 bool _isDisposed(ProviderContainer c) {
@@ -35,6 +35,7 @@ void main() {
   late DeviceScope deviceScope;
   late AccountSwitchController controller;
   late _FakeSecureKeyStorage keyStorage;
+  late _FakeAuthService currentAuthService;
 
   final account = KnownAccount(
     pubkeyHex:
@@ -50,6 +51,7 @@ void main() {
     final prefs = await SharedPreferences.getInstance();
     controller = AccountSwitchController();
     keyStorage = _FakeSecureKeyStorage();
+    currentAuthService = _FakeAuthService();
     deviceScope = DeviceScope(
       database: database,
       sharedPreferences: prefs,
@@ -81,6 +83,7 @@ void main() {
     await swapAccount(
       deviceScope: deviceScope,
       controller: controller,
+      currentAuthService: currentAuthService,
       account: account,
       signIn: (container, acct) async {
         signedInto = container;
@@ -110,6 +113,7 @@ void main() {
       swapAccount(
         deviceScope: deviceScope,
         controller: controller,
+        currentAuthService: currentAuthService,
         account: account,
         signIn: (container, acct) async {
           attempted = container;
@@ -126,6 +130,37 @@ void main() {
     expect(_isDisposed(initial), isFalse);
     expect(keyStorage.restoredPrimary, same(keyStorage.primary));
   });
+
+  testWidgets('archives the leaving account before signing the new one in', (
+    tester,
+  ) async {
+    await pumpHost(tester);
+    final order = <String>[];
+    currentAuthService.onArchive = () => order.add('archive');
+
+    await swapAccount(
+      deviceScope: deviceScope,
+      controller: controller,
+      currentAuthService: currentAuthService,
+      account: account,
+      signIn: (_, _) async => order.add('signIn'),
+    );
+    await tester.pump();
+
+    // Signing the incoming account in overwrites the shared signer slots, so
+    // the leaving account's credentials must already be in its own archive.
+    expect(order, equals(['archive', 'signIn']));
+  });
+}
+
+class _FakeAuthService implements AuthService {
+  void Function()? onArchive;
+
+  @override
+  Future<void> archiveCurrentSignerInfo() async => onArchive?.call();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 class _FakeSecureKeyStorage extends SecureKeyStorage {

--- a/mobile/test/providers/swap_account_test.dart
+++ b/mobile/test/providers/swap_account_test.dart
@@ -129,35 +129,42 @@ void main() {
     expect(_isDisposed(attempted!), isTrue);
     expect(_isDisposed(initial), isFalse);
     expect(keyStorage.restoredPrimary, same(keyStorage.primary));
+    // A sign-in that got far enough to fail already restored the target
+    // account's signer keys and auth source over the shared slots. Disposing
+    // its container does not undo that — the leaving account's own keys have
+    // to go back, or it reads the wrong signer at the next launch.
+    expect(currentAuthService.calls, equals(['archive', 'restore']));
   });
 
   testWidgets('archives the leaving account before signing the new one in', (
     tester,
   ) async {
     await pumpHost(tester);
-    final order = <String>[];
-    currentAuthService.onArchive = () => order.add('archive');
 
     await swapAccount(
       deviceScope: deviceScope,
       controller: controller,
       currentAuthService: currentAuthService,
       account: account,
-      signIn: (_, _) async => order.add('signIn'),
+      signIn: (_, _) async => currentAuthService.calls.add('signIn'),
     );
     await tester.pump();
 
     // Signing the incoming account in overwrites the shared signer slots, so
     // the leaving account's credentials must already be in its own archive.
-    expect(order, equals(['archive', 'signIn']));
+    expect(currentAuthService.calls, equals(['archive', 'signIn']));
   });
 }
 
 class _FakeAuthService implements AuthService {
-  void Function()? onArchive;
+  final calls = <String>[];
 
   @override
-  Future<void> archiveCurrentSignerInfo() async => onArchive?.call();
+  Future<void> archiveCurrentSignerInfo() async => calls.add('archive');
+
+  @override
+  Future<void> restoreSignerInfoForCurrentAccount() async =>
+      calls.add('restore');
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/mobile/test/providers/swap_account_test.dart
+++ b/mobile/test/providers/swap_account_test.dart
@@ -154,13 +154,78 @@ void main() {
     // the leaving account's credentials must already be in its own archive.
     expect(currentAuthService.calls, equals(['archive', 'signIn']));
   });
+
+  testWidgets('aborts before building anything when the archive fails', (
+    tester,
+  ) async {
+    final initial = await pumpHost(tester);
+    currentAuthService.archiveError = Exception('keychain unavailable');
+    var signInAttempted = false;
+
+    await expectLater(
+      swapAccount(
+        deviceScope: deviceScope,
+        controller: controller,
+        currentAuthService: currentAuthService,
+        account: account,
+        signIn: (_, _) async => signInAttempted = true,
+      ),
+      throwsException,
+    );
+    await tester.pump();
+
+    // Carrying on past a failed archive would let the incoming sign-in wipe
+    // the shared slots the archive was meant to copy, destroying the leaving
+    // account's session for a log line.
+    expect(signInAttempted, isFalse);
+    expect(_isDisposed(initial), isFalse);
+  });
+
+  testWidgets('surfaces the sign-in failure even when the rollback throws', (
+    tester,
+  ) async {
+    await pumpHost(tester);
+    keyStorage.primary = _FakeSecureKeyContainer(
+      npub: 'npub_previous',
+      publicKeyHex:
+          '2222222222222222222222222222222222222222222222222222222222222222',
+    );
+    keyStorage.restoreError = Exception('primary restore failed');
+
+    // The caller dispatches on this type to offer a fresh sign-in, so a
+    // rollback failure must not replace it with its own.
+    await expectLater(
+      swapAccount(
+        deviceScope: deviceScope,
+        controller: controller,
+        currentAuthService: currentAuthService,
+        account: account,
+        signIn: (_, _) async => throw _FakeSignInException(),
+      ),
+      throwsA(isA<_FakeSignInException>()),
+    );
+    await tester.pump();
+
+    // The signer restore is ordered ahead of the throwing primary restore, so
+    // it still ran.
+    expect(currentAuthService.calls, equals(['archive', 'restore']));
+  });
 }
+
+class _FakeSignInException implements Exception {}
 
 class _FakeAuthService implements AuthService {
   final calls = <String>[];
 
+  /// Set to make the pre-swap archive fail, as a keychain write would.
+  Object? archiveError;
+
   @override
-  Future<void> archiveCurrentSignerInfo() async => calls.add('archive');
+  Future<void> archiveCurrentSignerInfo() async {
+    calls.add('archive');
+    final error = archiveError;
+    if (error != null) throw error;
+  }
 
   @override
   Future<void> restoreSignerInfoForCurrentAccount() async =>
@@ -174,6 +239,10 @@ class _FakeSecureKeyStorage extends SecureKeyStorage {
   SecureKeyContainer? primary;
   SecureKeyContainer? restoredPrimary;
 
+  /// Set to make the rollback's primary restore fail. The real one can: it
+  /// hands the snapshot to `storeKey`, which reaches into the private key.
+  Object? restoreError;
+
   @override
   Future<SecureKeyContainer?> getKeyContainer({String? biometricPrompt}) async {
     return primary;
@@ -184,6 +253,8 @@ class _FakeSecureKeyStorage extends SecureKeyStorage {
     SecureKeyContainer? keyContainer, {
     String? biometricPrompt,
   }) async {
+    final error = restoreError;
+    if (error != null) throw error;
     restoredPrimary = keyContainer;
     primary = keyContainer;
   }

--- a/mobile/test/screens/settings/settings_account_switch_test.dart
+++ b/mobile/test/screens/settings/settings_account_switch_test.dart
@@ -412,40 +412,49 @@ void main() {
     expect(find.text(l10n.settingsAccountSwitchFailed), findsOneWidget);
   });
 
-  testWidgets('offers a fresh sign-in when the target session is unusable', (
-    tester,
-  ) async {
-    // Same seam as the `_MockDeviceScope` note above: reading
-    // `switchController` throws inside the tile's try, standing in for a swap
-    // that dies on the target account's dead session.
-    when(() => deviceScope.switchController).thenThrow(
-      SessionExpiredException(),
-    );
-    when(() => authService.signOut()).thenAnswer((_) async {});
+  // Both failures mean the same thing to the user — the stored credentials
+  // cannot be used — and both take the re-auth route, so both clauses are
+  // covered here rather than only the one that happens to be listed first.
+  final unusableSessionFailures = <String, Object>{
+    'SessionExpiredException': SessionExpiredException(),
+    'AccountRestoreFailedException': const AccountRestoreFailedException(
+      otherPubkey,
+      AuthState.unauthenticated,
+    ),
+  };
 
-    final l10n = await pumpAndTapSwitch(tester);
-    await tester.tap(accountTile(otherPubkey));
-    await tester.pumpAndSettle();
+  for (final entry in unusableSessionFailures.entries) {
+    testWidgets('offers a fresh sign-in on ${entry.key}', (tester) async {
+      // Same seam as the `_MockDeviceScope` note above: reading
+      // `switchController` throws inside the tile's try, standing in for a
+      // swap that dies on the target account's unusable credentials.
+      when(() => deviceScope.switchController).thenThrow(entry.value);
+      when(() => authService.signOut()).thenAnswer((_) async {});
 
-    // A dead session is recoverable by signing in again, so the user gets that
-    // offer instead of the dead-end "couldn't switch" snackbar — and the copy
-    // says what confirming costs, since it signs the working account out.
-    expect(
-      find.text(l10n.settingsSessionExpiredSwitchMessage),
-      findsOneWidget,
-    );
-    expect(find.text(l10n.settingsAccountSwitchFailed), findsNothing);
+      final l10n = await pumpAndTapSwitch(tester);
+      await tester.tap(accountTile(otherPubkey));
+      await tester.pumpAndSettle();
 
-    await tester.tap(find.text(l10n.authSignInTitle));
-    await tester.pumpAndSettle();
+      // Recoverable by signing in again, so the user gets that offer instead
+      // of the dead-end "couldn't switch" snackbar — and the copy says what
+      // confirming costs, since it signs the working account out.
+      expect(
+        find.text(l10n.settingsSessionExpiredSwitchMessage),
+        findsOneWidget,
+      );
+      expect(find.text(l10n.settingsAccountSwitchFailed), findsNothing);
 
-    // Signing out lands on the welcome screen, where the pending pubkey
-    // pre-selects the account the user was trying to reach.
-    verify(
-      () => authService.pendingAccountSwitchPubkey = otherPubkey,
-    ).called(1);
-    verify(() => authService.signOut()).called(1);
-  });
+      await tester.tap(find.text(l10n.authSignInTitle));
+      await tester.pumpAndSettle();
+
+      // Signing out lands on the welcome screen, where the pending pubkey
+      // pre-selects the account the user was trying to reach.
+      verify(
+        () => authService.pendingAccountSwitchPubkey = otherPubkey,
+      ).called(1);
+      verify(() => authService.signOut()).called(1);
+    });
+  }
 
   testWidgets('declining the fresh sign-in keeps the current account', (
     tester,

--- a/mobile/test/screens/settings/settings_account_switch_test.dart
+++ b/mobile/test/screens/settings/settings_account_switch_test.dart
@@ -12,6 +12,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
+import 'package:keycast_flutter/keycast_flutter.dart'
+    show SessionExpiredException;
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' as models;
 import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
@@ -408,6 +410,54 @@ void main() {
 
     verifyNever(() => deviceScope.switchController);
     expect(find.text(l10n.settingsAccountSwitchFailed), findsOneWidget);
+  });
+
+  testWidgets('offers a fresh sign-in when the target session is unusable', (
+    tester,
+  ) async {
+    // Same seam as the `_MockDeviceScope` note above: reading
+    // `switchController` throws inside the tile's try, standing in for a swap
+    // that dies on the target account's dead session.
+    when(() => deviceScope.switchController).thenThrow(
+      SessionExpiredException(),
+    );
+    when(() => authService.signOut()).thenAnswer((_) async {});
+
+    final l10n = await pumpAndTapSwitch(tester);
+    await tester.tap(accountTile(otherPubkey));
+    await tester.pumpAndSettle();
+
+    // A dead session is recoverable by signing in again, so the user gets that
+    // offer instead of the dead-end "couldn't switch" snackbar.
+    expect(find.text(l10n.settingsSessionExpiredSubtitle), findsOneWidget);
+    expect(find.text(l10n.settingsAccountSwitchFailed), findsNothing);
+
+    await tester.tap(find.text(l10n.authSignInTitle));
+    await tester.pumpAndSettle();
+
+    // Signing out lands on the welcome screen, where the pending pubkey
+    // pre-selects the account the user was trying to reach.
+    verify(
+      () => authService.pendingAccountSwitchPubkey = otherPubkey,
+    ).called(1);
+    verify(() => authService.signOut()).called(1);
+  });
+
+  testWidgets('declining the fresh sign-in keeps the current account', (
+    tester,
+  ) async {
+    when(() => deviceScope.switchController).thenThrow(
+      SessionExpiredException(),
+    );
+    when(() => authService.signOut()).thenAnswer((_) async {});
+
+    final l10n = await pumpAndTapSwitch(tester);
+    await tester.tap(accountTile(otherPubkey));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(l10n.settingsCancel));
+    await tester.pumpAndSettle();
+
+    verifyNever(() => authService.signOut());
   });
 
   testWidgets('adding an account parks the in-flight uploads', (tester) async {

--- a/mobile/test/screens/settings/settings_account_switch_test.dart
+++ b/mobile/test/screens/settings/settings_account_switch_test.dart
@@ -428,8 +428,12 @@ void main() {
     await tester.pumpAndSettle();
 
     // A dead session is recoverable by signing in again, so the user gets that
-    // offer instead of the dead-end "couldn't switch" snackbar.
-    expect(find.text(l10n.settingsSessionExpiredSubtitle), findsOneWidget);
+    // offer instead of the dead-end "couldn't switch" snackbar — and the copy
+    // says what confirming costs, since it signs the working account out.
+    expect(
+      find.text(l10n.settingsSessionExpiredSwitchMessage),
+      findsOneWidget,
+    );
     expect(find.text(l10n.settingsAccountSwitchFailed), findsNothing);
 
     await tester.tap(find.text(l10n.authSignInTitle));
@@ -458,6 +462,9 @@ void main() {
     await tester.pumpAndSettle();
 
     verifyNever(() => authService.signOut());
+    // Nothing is remembered for the welcome screen either — backing out has to
+    // leave the session exactly as it was, not stage a switch for later.
+    verifyNever(() => authService.pendingAccountSwitchPubkey = any());
   });
 
   testWidgets('adding an account parks the in-flight uploads', (tester) async {

--- a/mobile/test/services/auth/signer_secure_store_test.dart
+++ b/mobile/test/services/auth/signer_secure_store_test.dart
@@ -263,6 +263,42 @@ void main() {
         await SignerSecureStore(null).archive(_pubkeyA);
         expect(mocks.secureStorage, isEmpty);
       });
+
+      group('when the archive write fails', () {
+        late SignerSecureStore throwingStore;
+
+        setUp(() {
+          final throwingStorage = _MockSecureStorage();
+          when(
+            () => throwingStorage.read(key: any(named: 'key')),
+          ).thenAnswer((_) async => null);
+          when(
+            () => throwingStorage.read(key: 'bunker_info'),
+          ).thenAnswer((_) async => 'bunker://a');
+          when(
+            () => throwingStorage.write(
+              key: any(named: 'key'),
+              value: any(named: 'value'),
+            ),
+          ).thenThrow(Exception('keychain unavailable'));
+          throwingStore = SignerSecureStore(throwingStorage);
+        });
+
+        test('rethrows for a caller that depends on it landing', () async {
+          // The in-place account switch does: the incoming sign-in overwrites
+          // the shared slots this copies from, so carrying on past a failed
+          // write destroys the leaving account's session for a log line.
+          await expectLater(
+            throwingStore.archive(_pubkeyA, throwOnFailure: true),
+            throwsA(isA<Exception>()),
+          );
+        });
+
+        test('still swallows it on the sign-out path', () async {
+          // Sign-out keeps the default: that session is going away either way.
+          await expectLater(throwingStore.archive(_pubkeyA), completes);
+        });
+      });
     });
 
     group('restoreActiveKeys', () {

--- a/mobile/test/services/auth_service_bunker_lifecycle_test.dart
+++ b/mobile/test/services/auth_service_bunker_lifecycle_test.dart
@@ -128,9 +128,10 @@ void main() {
 
   group('AuthService bunker signer lifecycle', () {
     late _MockNostrRemoteSigner mockBunkerSigner;
+    late AuthServiceChannelMocks channelMocks;
 
     setUp(() {
-      AuthServiceChannelMocks.install();
+      channelMocks = AuthServiceChannelMocks.install();
       SharedPreferences.setMockInitialValues({kKnownAccountsKey: '[]'});
       stubUserDataCleanupSuccess(mockCleanupService);
       mockBunkerSigner = _MockNostrRemoteSigner();
@@ -167,6 +168,34 @@ void main() {
       expect(result.success, isTrue);
       return service;
     }
+
+    // The account-switch round trip, on the one auth source where the archive
+    // is addressed by pubkey. The local-key sources clear the shared slots
+    // without reading the account's own, so they cannot tell a correct pubkey
+    // from a wrong one.
+    test('archives and restores this account, addressed by its pubkey', () async {
+      final service = await connectedService();
+      addTearDown(service.dispose);
+      final pubkeyHex = service.currentPublicKeyHex!;
+      final ownBunkerUrl = channelMocks.secureStorage['bunker_info'];
+      expect(ownBunkerUrl, isNotNull);
+
+      await service.archiveCurrentSignerInfo();
+      expect(
+        channelMocks.secureStorage['bunker_info_$pubkeyHex'],
+        equals(ownBunkerUrl),
+      );
+
+      // Stands in for the switch: the target account's sign-in restored its own
+      // credentials over the shared slot before it failed.
+      channelMocks.secureStorage['bunker_info'] = 'bunker://someone-else';
+
+      await service.restoreSignerInfoForCurrentAccount();
+
+      // Restored from this account's archive — a wrong pubkey would read a slot
+      // that does not exist and leave the other account's URL in place.
+      expect(channelMocks.secureStorage['bunker_info'], equals(ownBunkerUrl));
+    });
 
     test('onAppBackgrounded pauses the active bunker signer', () async {
       final service = await connectedService();

--- a/mobile/test/services/auth_service_multi_account_test.dart
+++ b/mobile/test/services/auth_service_multi_account_test.dart
@@ -810,6 +810,33 @@ void main() {
       ).called(1);
       expect(authService.isAuthenticated, isTrue);
     });
+
+    test('surfaces a failed archive write rather than swallowing it', () async {
+      // The swap depends on this having landed: it runs before anything is
+      // mutated, and carrying on past a failed write hands the incoming
+      // sign-in a shared slot it then wipes, destroying the leaving account's
+      // session for a log line. Sign-out's own archive keeps swallowing.
+      final pubkeyHex = testKeyContainer.publicKeyHex;
+      when(() => mockSecureStorage.read(key: 'keycast_session')).thenAnswer(
+        (_) async => jsonEncode({
+          'bunker_url': 'wss://keycast.example.com',
+          'access_token': 'test_token',
+          'scope': 'policy:full',
+          'user_pubkey': pubkeyHex,
+        }),
+      );
+      when(
+        () => mockSecureStorage.write(
+          key: 'keycast_session_$pubkeyHex',
+          value: any(named: 'value'),
+        ),
+      ).thenThrow(Exception('keychain unavailable'));
+
+      await expectLater(
+        authService.archiveCurrentSignerInfo(),
+        throwsA(isA<Exception>()),
+      );
+    });
   });
 
   group('restoreSignerInfoForCurrentAccount', () {

--- a/mobile/test/services/auth_service_multi_account_test.dart
+++ b/mobile/test/services/auth_service_multi_account_test.dart
@@ -780,6 +780,38 @@ void main() {
     });
   });
 
+  group('archiveCurrentSignerInfo', () {
+    setUp(() async {
+      await _ignoringDiscoveryErrors(authService.createNewIdentity);
+    });
+
+    test('archives the OAuth session while staying signed in', () async {
+      // The in-place account switch never signs out, so the archival that
+      // sign-out used to do has to happen here — otherwise the incoming
+      // account's sign-in overwrites the global slot and this account is left
+      // with nothing to refresh from.
+      final pubkeyHex = testKeyContainer.publicKeyHex;
+      when(() => mockSecureStorage.read(key: 'keycast_session')).thenAnswer(
+        (_) async => jsonEncode({
+          'bunker_url': 'wss://keycast.example.com',
+          'access_token': 'test_token',
+          'scope': 'policy:full',
+          'user_pubkey': pubkeyHex,
+        }),
+      );
+
+      await authService.archiveCurrentSignerInfo();
+
+      verify(
+        () => mockSecureStorage.write(
+          key: 'keycast_session_$pubkeyHex',
+          value: any(named: 'value'),
+        ),
+      ).called(1);
+      expect(authService.isAuthenticated, isTrue);
+    });
+  });
+
   group('_restoreSignerInfo (via signInForAccount)', () {
     test('restores Amber info for amber auth source', () async {
       final pubkeyHex = testKeyContainer.publicKeyHex;

--- a/mobile/test/services/auth_service_multi_account_test.dart
+++ b/mobile/test/services/auth_service_multi_account_test.dart
@@ -812,6 +812,29 @@ void main() {
     });
   });
 
+  group('restoreSignerInfoForCurrentAccount', () {
+    setUp(() async {
+      await _ignoringDiscoveryErrors(authService.createNewIdentity);
+    });
+
+    test('puts this account back as the persisted auth source', () async {
+      // Stands in for a failed in-place switch: the target account's sign-in
+      // got as far as restoring its own signer info, which persisted its auth
+      // source. Disposing its container leaves that behind, so the next launch
+      // would look for a bunker this local-key account never had.
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString('authentication_source', 'bunker');
+
+      await authService.restoreSignerInfoForCurrentAccount();
+
+      expect(prefs.getString('authentication_source'), equals('automatic'));
+      verify(
+        () => mockSecureStorage.delete(key: 'bunker_info'),
+      ).called(greaterThanOrEqualTo(1));
+      expect(authService.isAuthenticated, isTrue);
+    });
+  });
+
   group('_restoreSignerInfo (via signInForAccount)', () {
     test('restores Amber info for amber auth source', () async {
       final pubkeyHex = testKeyContainer.publicKeyHex;


### PR DESCRIPTION
Closes #6677

## Description

Switching accounts in Settings destroyed the session of the account you switched away from. The OAuth session, bunker URL, and Amber info all live in **single global** secure-storage slots, and only `signOut()` ever copied them into the per-account archive. The in-place container swap (#6342) replaced that sign-out, so nothing archived anymore: the incoming account's `restoreActiveKeys` overwrites the global slot — for a local-key account it calls `KeycastSession.clear` and wipes it outright.

On the way back there was nothing left to refresh from. The account either returned with the "Session expired" banner (local-key fallback) or failed the switch entirely with `SessionExpiredException` and a "Couldn't switch accounts" snackbar, with no way in from there.

Three parts:

**1. Archive the leaving account before the incoming one signs in.** `AuthService.archiveCurrentSignerInfo()` exposes the archival that `signOut()` already did, and `swapAccount` calls it on the live container's service first. The archive intentionally survives a failed swap's rollback — it only ever copies an account's own credentials into its own slot, so there is nothing to undo.

**2. Put the leaving account's keys back when the swap fails.** A sign-in that gets far enough to fail has already run the *target* account's `_restoreSignerInfo`, which overwrote the shared signer slots and persisted its auth source. Disposing the half-built container undid neither, so the leaving account kept working from memory but would read the wrong signer at the next cold launch — visible whenever the user backs out of the offer in part 3, or on any failure that takes the generic snackbar path. `restoreSignerInfoForCurrentAccount()` is the counterpart to part 1's archive, so the rollback can restore the account's own keys from the archive it wrote on the way in. It runs before the primary-key restore because it cannot throw; a failing key restore must not skip it.

**3. Offer a fresh sign-in instead of a dead end.** An account already in that state cannot be recovered by a swap — a swap needs credentials that already work. `SessionExpiredException` and `AccountRestoreFailedException` now take the same route `WelcomeBloc` already takes for these two failures: remember the pubkey in `pendingAccountSwitchPubkey`, sign out, land on the welcome screen with that account pre-selected. Since that signs the *working* account out, it is confirmed in a sheet first ("Session Expired" / Cancel / Sign in) rather than happening silently.

One new ARB key, `settingsSessionExpiredSwitchMessage`, translated in all 22 locales. The obvious reuse — `settingsSessionExpiredSubtitle`, "Sign in again to restore full access" — was written for the *current* account's expired-session tile. In this sheet the dead session belongs to the account the user picked and confirming signs the working account out, which is the one thing the sheet exists to get consent for and the one thing that copy never said. `settingsSessionExpired`, `authSignInTitle`, and `settingsCancel` are reused as-is.

**Related Issue:**  — Relates to #4623

## Out of Scope

Re-authenticating the target account **in place**, without signing the current one out. That needs the OAuth browser flow wired into the swap; the sign-out route is what the welcome flow already does for the same failures.

## Verification

- `flutter analyze lib test integration_test` — no issues
- `flutter test test/screens/settings test/providers test/l10n` plus `auth_service_multi_account_test.dart`, `auth_service_signout_cleanup_test.dart`, and `auth/signer_secure_store_test.dart` — 965 passed, including four runs under `--test-randomize-ordering-seed random`
- `flutter test test/services/auth_service_oauth_recovery_test.dart test/services/auth_service_expired_session_downgrade_test.dart` — passed
- New coverage: archive-before-sign-in ordering and the rollback restore in `swap_account_test.dart`, `archiveCurrentSignerInfo` archiving without signing out plus `restoreSignerInfoForCurrentAccount` putting the persisted auth source back in `auth_service_multi_account_test.dart`, and the re-auth offer plus its cancel path in `settings_account_switch_test.dart`
- Manually verified on a real Samsung Galaxy device: an account switch that previously died on "Session has expired" now offers the sign-in and gets through, and switching away and back keeps the session alive

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
