### PR TITLE
fix(profile): repair the edit-profile clear and unsaved-edit paths

### DIFF
--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -200,6 +200,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         externalNip05: state.initialExternalNip05 ?? '',
         pendingAvatarStatus: PendingAvatarStatus.idle,
         pendingPictureUrl: null,
+        pictureCleared: false,
         pendingBannerStatus: PendingBannerStatus.idle,
         pendingBannerUrl: null,
         pendingBannerColor: _parseBannerHexColor(state.persistedBanner),
@@ -330,10 +331,10 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     );
   }
 
-  void _onProfilePictureCleared(
+  Future<void> _onProfilePictureCleared(
     ProfilePictureCleared event,
     Emitter<ProfileEditorState> emit,
-  ) {
+  ) async {
     if (state.pendingAvatarStatus == PendingAvatarStatus.uploading) {
       Log.info(
         'Ignoring ProfilePictureCleared received while an upload is in flight',
@@ -341,6 +342,12 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
       );
       return;
     }
+    // Drop the stored staging too, or the next editor build restores the very
+    // picture the user just removed.
+    await _persistStagedProfileMedia(
+      pictureUrl: null,
+      bannerUrl: state.pendingBannerUrl,
+    );
     emit(
       state.copyWith(
         pendingAvatarStatus: PendingAvatarStatus.idle,
@@ -542,10 +549,10 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     );
   }
 
-  void _onProfileBannerUrlSet(
+  Future<void> _onProfileBannerUrlSet(
     ProfileBannerUrlSet event,
     Emitter<ProfileEditorState> emit,
-  ) {
+  ) async {
     if (state.pendingBannerStatus == PendingBannerStatus.uploading) {
       Log.info(
         'Ignoring ProfileBannerUrlSet received while banner upload is in '
@@ -557,6 +564,10 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
 
     final trimmed = event.url.trim();
     if (trimmed.isEmpty) {
+      await _persistStagedProfileMedia(
+        pictureUrl: state.pendingPictureUrl,
+        bannerUrl: null,
+      );
       emit(
         state.copyWith(
           pendingBannerUrl: null,
@@ -566,6 +577,12 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
       return;
     }
 
+    // Mirrors the pasted-picture branch: a link the user pasted is staged the
+    // same as an upload, so it has to survive the editor being rebuilt too.
+    await _persistStagedProfileMedia(
+      pictureUrl: state.pendingPictureUrl,
+      bannerUrl: trimmed,
+    );
     emit(
       state.copyWith(
         pendingBannerUrl: trimmed,
@@ -1278,6 +1295,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         pendingAvatarStatus: PendingAvatarStatus.idle,
         pendingPictureUrl: null,
         persistedPictureUrl: picture,
+        pictureCleared: false,
         pendingBannerStatus: PendingBannerStatus.idle,
         pendingBannerUrl: null,
         pendingBannerColor: _parseBannerHexColor(banner),

--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -130,10 +130,12 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
           ? PendingAvatarStatus.idle
           : PendingAvatarStatus.staged,
       pendingPictureUrl: staged.pictureUrl,
+      pictureCleared: staged.pictureCleared,
       pendingBannerStatus: staged.bannerUrl == null
           ? PendingBannerStatus.idle
           : PendingBannerStatus.staged,
       pendingBannerUrl: staged.bannerUrl,
+      bannerCleared: staged.bannerCleared,
     );
   }
 
@@ -342,8 +344,9 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         pictureCleared: true,
       ),
     );
-    // Drop the stored staging too, or the next editor build restores the very
-    // picture the user just removed.
+    // Writes through the removal *and* drops the staged URL, so the next
+    // editor build neither restores the picture the user just removed nor
+    // forgets that they removed it.
     await _persistStagedProfileMedia();
   }
 
@@ -389,6 +392,13 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     Emitter<ProfileEditorState> emit,
   ) {
     final banner = event.banner;
+    // A removal restored from the staged store outlives this seed: the first
+    // snapshot always seeds the persisted banner, and resetting the flag here
+    // would hand it straight back to a user who had already cleared it.
+    if (state.bannerCleared) {
+      emit(state.copyWith(persistedBanner: banner));
+      return;
+    }
     final parsedColor = state.pendingBannerUrl == null
         ? _parseBannerHexColor(banner)
         : null;
@@ -1315,6 +1325,8 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
       scopedPubkey,
       pictureUrl: state.pendingPictureUrl,
       bannerUrl: state.pendingBannerUrl,
+      pictureCleared: state.pictureCleared,
+      bannerCleared: state.bannerCleared,
     );
   }
 

--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -255,11 +255,6 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         name: 'ProfileEditorBloc',
         category: LogCategory.ui,
       );
-      await _persistStagedProfileMedia(
-        pubkey: event.pubkey,
-        pictureUrl: stagedPictureUrl,
-        bannerUrl: state.pendingBannerUrl,
-      );
       emit(
         state.copyWith(
           pendingAvatarStatus: PendingAvatarStatus.staged,
@@ -267,6 +262,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
           pictureCleared: false,
         ),
       );
+      await _persistStagedProfileMedia(pubkey: event.pubkey);
       return;
     }
 
@@ -317,10 +313,6 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     ProfilePictureUploadCleared event,
     Emitter<ProfileEditorState> emit,
   ) async {
-    await _persistStagedProfileMedia(
-      pictureUrl: null,
-      bannerUrl: state.pendingBannerUrl,
-    );
     emit(
       state.copyWith(
         pendingAvatarStatus: PendingAvatarStatus.idle,
@@ -329,6 +321,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         pictureCleared: false,
       ),
     );
+    await _persistStagedProfileMedia();
   }
 
   Future<void> _onProfilePictureCleared(
@@ -342,12 +335,6 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
       );
       return;
     }
-    // Drop the stored staging too, or the next editor build restores the very
-    // picture the user just removed.
-    await _persistStagedProfileMedia(
-      pictureUrl: null,
-      bannerUrl: state.pendingBannerUrl,
-    );
     emit(
       state.copyWith(
         pendingAvatarStatus: PendingAvatarStatus.idle,
@@ -355,6 +342,9 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         pictureCleared: true,
       ),
     );
+    // Drop the stored staging too, or the next editor build restores the very
+    // picture the user just removed.
+    await _persistStagedProfileMedia();
   }
 
   Future<void> _onProfilePictureUrlSet(
@@ -371,10 +361,6 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
 
     final trimmed = event.url.trim();
     if (trimmed.isEmpty) {
-      await _persistStagedProfileMedia(
-        pictureUrl: null,
-        bannerUrl: state.pendingBannerUrl,
-      );
       emit(
         state.copyWith(
           pendingAvatarStatus: PendingAvatarStatus.idle,
@@ -385,12 +371,9 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
           // branch in [_onProfileBannerUrlSet].
         ),
       );
+      await _persistStagedProfileMedia();
       return;
     }
-    await _persistStagedProfileMedia(
-      pictureUrl: trimmed,
-      bannerUrl: state.pendingBannerUrl,
-    );
     emit(
       state.copyWith(
         pendingAvatarStatus: PendingAvatarStatus.staged,
@@ -398,6 +381,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         pictureCleared: false,
       ),
     );
+    await _persistStagedProfileMedia();
   }
 
   void _onInitialPersistedBannerSet(
@@ -478,11 +462,6 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         name: 'ProfileEditorBloc',
         category: LogCategory.ui,
       );
-      await _persistStagedProfileMedia(
-        pubkey: event.pubkey,
-        pictureUrl: state.pendingPictureUrl,
-        bannerUrl: stagedBannerUrl,
-      );
       emit(
         state.copyWith(
           pendingBannerStatus: PendingBannerStatus.staged,
@@ -492,6 +471,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
           bannerCleared: false,
         ),
       );
+      await _persistStagedProfileMedia(pubkey: event.pubkey);
       return;
     }
 
@@ -534,10 +514,6 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     ProfileBannerColorSelected event,
     Emitter<ProfileEditorState> emit,
   ) async {
-    await _persistStagedProfileMedia(
-      pictureUrl: state.pendingPictureUrl,
-      bannerUrl: null,
-    );
     emit(
       state.copyWith(
         pendingBannerColor: event.color,
@@ -547,6 +523,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         bannerCleared: false,
       ),
     );
+    await _persistStagedProfileMedia();
   }
 
   Future<void> _onProfileBannerUrlSet(
@@ -564,25 +541,16 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
 
     final trimmed = event.url.trim();
     if (trimmed.isEmpty) {
-      await _persistStagedProfileMedia(
-        pictureUrl: state.pendingPictureUrl,
-        bannerUrl: null,
-      );
       emit(
         state.copyWith(
           pendingBannerUrl: null,
           pendingBannerStatus: PendingBannerStatus.idle,
         ),
       );
+      await _persistStagedProfileMedia();
       return;
     }
 
-    // Mirrors the pasted-picture branch: a link the user pasted is staged the
-    // same as an upload, so it has to survive the editor being rebuilt too.
-    await _persistStagedProfileMedia(
-      pictureUrl: state.pendingPictureUrl,
-      bannerUrl: trimmed,
-    );
     emit(
       state.copyWith(
         pendingBannerUrl: trimmed,
@@ -592,16 +560,15 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         bannerCleared: false,
       ),
     );
+    // Mirrors the pasted-picture branch: a link the user pasted is staged the
+    // same as an upload, so it has to survive the editor being rebuilt too.
+    await _persistStagedProfileMedia();
   }
 
   Future<void> _onProfileBannerCleared(
     ProfileBannerCleared event,
     Emitter<ProfileEditorState> emit,
   ) async {
-    await _persistStagedProfileMedia(
-      pictureUrl: state.pendingPictureUrl,
-      bannerUrl: null,
-    );
     emit(
       state.copyWith(
         pendingBannerUrl: null,
@@ -612,6 +579,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         bannerCleared: true,
       ),
     );
+    await _persistStagedProfileMedia();
   }
 
   bool _shouldDropSaveBecauseUploadInFlight(String saveSource) {
@@ -1333,18 +1301,20 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     }
   }
 
-  Future<void> _persistStagedProfileMedia({
-    required String? pictureUrl,
-    required String? bannerUrl,
-    String? pubkey,
-  }) async {
+  /// Mirrors the staged media on [state] into the durable store.
+  ///
+  /// Reads the fields off `state` rather than taking them as arguments, so it
+  /// must be called *after* the matching `emit`. Hand-threaded arguments are
+  /// what let two handlers ship without writing through at all (#6680); there
+  /// is only one source of truth now, and it is the state the UI renders.
+  Future<void> _persistStagedProfileMedia({String? pubkey}) async {
     final scopedPubkey = pubkey ?? _currentUserPubkey;
     final store = _stagedProfileMediaStore;
     if (store == null || scopedPubkey == null) return;
     await store.save(
       scopedPubkey,
-      pictureUrl: pictureUrl,
-      bannerUrl: bannerUrl,
+      pictureUrl: state.pendingPictureUrl,
+      bannerUrl: state.pendingBannerUrl,
     );
   }
 

--- a/mobile/lib/screens/profile_setup/widgets/profile_setup_listeners.dart
+++ b/mobile/lib/screens/profile_setup/widgets/profile_setup_listeners.dart
@@ -134,20 +134,30 @@ class _ProfileSetupListenersState extends ConsumerState<ProfileSetupListeners> {
     }
 
     final editorBloc = context.read<ProfileEditorBloc>();
+    // The baseline the unsaved-changes guard compares against is whatever was
+    // last *seeded*, which is not the same as what the profile now says: a
+    // field the user has typed into keeps its old baseline so the edit still
+    // counts as unsaved. Refreshing it on every snapshot — not just the first —
+    // is what stops a relay copy that disagrees with the cache from reading as
+    // an edit on a form nobody touched. The current values come back off the
+    // controllers, because a field the user touched is not the seed.
+    editorBloc
+      ..add(
+        InitialProfileFieldsSet(
+          displayName: _seededName ?? '',
+          about: _seededBio ?? '',
+          website: _seededWebsite ?? '',
+        ),
+      )
+      ..add(DisplayNameChanged(widget.nameController.text))
+      ..add(AboutChanged(widget.bioController.text))
+      ..add(WebsiteChanged(widget.websiteController.text));
     if (!_hasSeeded) {
       _hasSeeded = true;
       // Seed bloc with the persisted picture so the avatar widget can
       // render `pendingPictureUrl ?? persistedPictureUrl` purely from
-      // state, no widget-local fallback for the existing avatar. The initial
-      // fields set the baseline that Revert changes restores.
+      // state, no widget-local fallback for the existing avatar.
       editorBloc
-        ..add(
-          InitialProfileFieldsSet(
-            displayName: profile.displayName ?? profile.name ?? '',
-            about: profile.about ?? '',
-            website: profile.website ?? '',
-          ),
-        )
         ..add(InitialPersistedPictureSet(profile.picture))
         ..add(InitialPersistedBannerSet(profile.banner));
     } else {

--- a/mobile/lib/services/staged_profile_media_store.dart
+++ b/mobile/lib/services/staged_profile_media_store.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Persists pre-save staged profile avatar/banner media URLs.
-// ABOUTME: Keeps Blossom upload URLs recoverable across editor recreation.
+// ABOUTME: Persists pre-save staged profile avatar/banner media edits.
+// ABOUTME: Keeps Blossom upload URLs and removals recoverable across editor recreation.
 
 import 'dart:async';
 import 'dart:convert';
@@ -11,21 +11,42 @@ class StagedProfileMedia {
     required this.stagedAt,
     this.pictureUrl,
     this.bannerUrl,
+    this.pictureCleared = false,
+    this.bannerCleared = false,
   });
 
   final String? pictureUrl;
   final String? bannerUrl;
+
+  /// Whether the user staged the removal of their persisted picture.
+  ///
+  /// Carried alongside the URLs because a removal is as much an unsaved media
+  /// edit as an upload: without it the editor rebuilds with the persisted
+  /// picture back in place and the removal is silently forgotten.
+  final bool pictureCleared;
+
+  /// Whether the user staged the removal of their persisted banner.
+  final bool bannerCleared;
+
   final DateTime stagedAt;
 
   bool get isEmpty =>
       (pictureUrl == null || pictureUrl!.isEmpty) &&
-      (bannerUrl == null || bannerUrl!.isEmpty);
+      (bannerUrl == null || bannerUrl!.isEmpty) &&
+      !pictureCleared &&
+      !bannerCleared;
 }
 
 abstract interface class StagedProfileMediaStore {
   StagedProfileMedia? load(String pubkey);
 
-  Future<void> save(String pubkey, {String? pictureUrl, String? bannerUrl});
+  Future<void> save(
+    String pubkey, {
+    String? pictureUrl,
+    String? bannerUrl,
+    bool pictureCleared,
+    bool bannerCleared,
+  });
 
   Future<void> clear(String pubkey);
 }
@@ -67,6 +88,10 @@ class SharedPreferencesStagedProfileMediaStore
       final media = StagedProfileMedia(
         pictureUrl: _nonEmptyString(decoded['pictureUrl']),
         bannerUrl: _nonEmptyString(decoded['bannerUrl']),
+        // Absent on payloads written before removals were staged; a missing
+        // flag reads as "nothing removed", which is what those payloads meant.
+        pictureCleared: decoded['pictureCleared'] == true,
+        bannerCleared: decoded['bannerCleared'] == true,
         stagedAt: stagedAt,
       );
       if (media.isEmpty) return _clearInvalid(pubkey);
@@ -81,11 +106,16 @@ class SharedPreferencesStagedProfileMediaStore
     String pubkey, {
     String? pictureUrl,
     String? bannerUrl,
+    bool pictureCleared = false,
+    bool bannerCleared = false,
   }) async {
     try {
       final trimmedPicture = _nonEmptyString(pictureUrl);
       final trimmedBanner = _nonEmptyString(bannerUrl);
-      if (trimmedPicture == null && trimmedBanner == null) {
+      if (trimmedPicture == null &&
+          trimmedBanner == null &&
+          !pictureCleared &&
+          !bannerCleared) {
         await clear(pubkey);
         return;
       }
@@ -96,6 +126,8 @@ class SharedPreferencesStagedProfileMediaStore
           'version': _schemaVersion,
           'pictureUrl': trimmedPicture,
           'bannerUrl': trimmedBanner,
+          'pictureCleared': pictureCleared,
+          'bannerCleared': bannerCleared,
           'stagedAt': _now().millisecondsSinceEpoch,
         }),
       );

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -3176,6 +3176,26 @@ void main() {
       );
 
       blocTest<ProfileEditorBloc, ProfileEditorState>(
+        'ProfileEditDiscarded puts a cleared avatar back',
+        build: createBloc,
+        seed: () => const ProfileEditorState(
+          persistedPictureUrl: 'https://cdn.example.com/old-avatar.jpg',
+          pictureCleared: true,
+        ),
+        act: (bloc) => bloc.add(const ProfileEditDiscarded()),
+        expect: () => [
+          isA<ProfileEditorState>()
+              .having((s) => s.pictureCleared, 'pictureCleared', isFalse)
+              .having(
+                (s) => s.effectivePictureUrl,
+                'effectivePictureUrl',
+                'https://cdn.example.com/old-avatar.jpg',
+              )
+              .having((s) => s.hasUnsavedChanges, 'hasUnsavedChanges', isFalse),
+        ],
+      );
+
+      blocTest<ProfileEditorBloc, ProfileEditorState>(
         'ProfileSaved with no staged change publishes the persisted picture',
         setUp: () {
           when(
@@ -3264,7 +3284,7 @@ void main() {
             picture: testPersistedUrl,
           ),
         ),
-        verify: (_) {
+        verify: (bloc) {
           final captured = verify(
             () => mockProfileRepository.enqueuePendingSave(
               captureAny(),
@@ -3273,6 +3293,9 @@ void main() {
           ).captured;
           final payload = captured[0] as PendingProfileSave;
           expect(payload.picture, isNull);
+          // The removal is spent once it is published. Left standing, it keeps
+          // vetoing every later persisted-picture seed for the session.
+          expect(bloc.state.pictureCleared, isFalse);
         },
       );
 
@@ -3628,6 +3651,47 @@ void main() {
                 isNull,
               ),
         ],
+      );
+
+      blocTest<ProfileEditorBloc, ProfileEditorState>(
+        'ProfilePictureCleared drops the staged picture from the store',
+        build: () {
+          final store = _FakeStagedProfileMediaStore()
+            ..values[testPubkey] = StagedProfileMedia(
+              pictureUrl: testStagedUrl,
+              stagedAt: DateTime.utc(2026, 8, 4),
+            );
+          addTearDown(() {
+            // Left behind, `_initialState` restores it on the next editor
+            // build and the removed avatar comes back.
+            expect(store.values[testPubkey]?.pictureUrl, isNull);
+          });
+          return createBloc(
+            stagedProfileMediaStore: store,
+            currentUserPubkey: testPubkey,
+          );
+        },
+        seed: () => const ProfileEditorState(
+          persistedPictureUrl: 'https://cdn.example.com/old-avatar.jpg',
+          pendingPictureUrl: testStagedUrl,
+          pendingAvatarStatus: PendingAvatarStatus.staged,
+        ),
+        act: (bloc) => bloc.add(const ProfilePictureCleared()),
+      );
+
+      blocTest<ProfileEditorBloc, ProfileEditorState>(
+        'ProfileBannerUrlSet persists the pasted banner link',
+        build: () {
+          final store = _FakeStagedProfileMediaStore();
+          addTearDown(() {
+            expect(store.values[testPubkey]?.bannerUrl, testStagedUrl);
+          });
+          return createBloc(
+            stagedProfileMediaStore: store,
+            currentUserPubkey: testPubkey,
+          );
+        },
+        act: (bloc) => bloc.add(const ProfileBannerUrlSet(testStagedUrl)),
       );
 
       blocTest<ProfileEditorBloc, ProfileEditorState>(

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -42,10 +42,14 @@ class _FakeStagedProfileMediaStore implements StagedProfileMediaStore {
     String pubkey, {
     String? pictureUrl,
     String? bannerUrl,
+    bool pictureCleared = false,
+    bool bannerCleared = false,
   }) async {
     final staged = StagedProfileMedia(
       pictureUrl: pictureUrl,
       bannerUrl: bannerUrl,
+      pictureCleared: pictureCleared,
+      bannerCleared: bannerCleared,
       stagedAt: DateTime.utc(2026, 8, 4),
     );
     if (staged.isEmpty) {
@@ -2663,6 +2667,50 @@ void main() {
         ],
       );
 
+      test('restores a staged removal when bloc is recreated', () {
+        final store = _FakeStagedProfileMediaStore()
+          ..values[testPubkey] = StagedProfileMedia(
+            pictureCleared: true,
+            bannerCleared: true,
+            stagedAt: DateTime.utc(2026, 8, 4),
+          );
+
+        final bloc = createBloc(
+          stagedProfileMediaStore: store,
+          currentUserPubkey: testPubkey,
+        );
+        addTearDown(bloc.close);
+
+        expect(bloc.state.pictureCleared, isTrue);
+        expect(bloc.state.bannerCleared, isTrue);
+      });
+
+      blocTest<ProfileEditorBloc, ProfileEditorState>(
+        'seeding the persisted profile does not undo a restored removal',
+        build: () {
+          final store = _FakeStagedProfileMediaStore()
+            ..values[testPubkey] = StagedProfileMedia(
+              pictureCleared: true,
+              bannerCleared: true,
+              stagedAt: DateTime.utc(2026, 8, 4),
+            );
+          return createBloc(
+            stagedProfileMediaStore: store,
+            currentUserPubkey: testPubkey,
+          );
+        },
+        // What the editor dispatches off its first profile snapshot. It runs
+        // unconditionally, so it is the one thing a restored removal has to
+        // survive.
+        act: (bloc) => bloc
+          ..add(const InitialPersistedPictureSet(testPersistedUrl))
+          ..add(const InitialPersistedBannerSet('0x33ccbf')),
+        verify: (bloc) {
+          expect(bloc.state.effectivePictureUrl, isNull);
+          expect(bloc.state.effectiveBanner, isNull);
+        },
+      );
+
       blocTest<ProfileEditorBloc, ProfileEditorState>(
         'upload failure leaves pendingPictureUrl untouched and emits failed',
         setUp: () {
@@ -3692,6 +3740,43 @@ void main() {
           );
         },
         act: (bloc) => bloc.add(const ProfileBannerUrlSet(testStagedUrl)),
+      );
+
+      blocTest<ProfileEditorBloc, ProfileEditorState>(
+        'ProfilePictureCleared writes the removal through to the store',
+        build: () {
+          final store = _FakeStagedProfileMediaStore();
+          addTearDown(() {
+            // Dropping the staged URL is only half of it: without the flag the
+            // rebuilt editor seeds the persisted picture back and the removal
+            // is forgotten instead of merely un-staged.
+            expect(store.values[testPubkey]?.pictureCleared, isTrue);
+          });
+          return createBloc(
+            stagedProfileMediaStore: store,
+            currentUserPubkey: testPubkey,
+          );
+        },
+        seed: () => const ProfileEditorState(
+          persistedPictureUrl: 'https://cdn.example.com/old-avatar.jpg',
+        ),
+        act: (bloc) => bloc.add(const ProfilePictureCleared()),
+      );
+
+      blocTest<ProfileEditorBloc, ProfileEditorState>(
+        'ProfileBannerCleared writes the removal through to the store',
+        build: () {
+          final store = _FakeStagedProfileMediaStore();
+          addTearDown(() {
+            expect(store.values[testPubkey]?.bannerCleared, isTrue);
+          });
+          return createBloc(
+            stagedProfileMediaStore: store,
+            currentUserPubkey: testPubkey,
+          );
+        },
+        seed: () => const ProfileEditorState(persistedBanner: '0x33ccbf'),
+        act: (bloc) => bloc.add(const ProfileBannerCleared()),
       );
 
       blocTest<ProfileEditorBloc, ProfileEditorState>(

--- a/mobile/test/screens/profile_setup_screen_test.dart
+++ b/mobile/test/screens/profile_setup_screen_test.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -30,6 +31,8 @@ class _MockProfileEditorBloc
 
 class _MockMyProfileBloc extends MockBloc<MyProfileEvent, MyProfileState>
     implements MyProfileBloc {}
+
+class _MockBlossomUploadService extends Mock implements BlossomUploadService {}
 
 Finder _divineIcon(DivineIconName name) =>
     find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
@@ -1253,6 +1256,128 @@ void main() {
           findsNothing,
         );
         expect(find.text('Profile destination'), findsOneWidget);
+      });
+
+      /// The guard compares each field against a baseline the seeding path
+      /// supplies. Seeding runs more than once — the cache fills the form and
+      /// the relay's copy refreshes whatever the user has not touched — so the
+      /// baseline has to keep up with it.
+      group('against the real editor bloc', () {
+        late ProfileEditorBloc editorBloc;
+        late StreamController<MyProfileState> profileStates;
+
+        setUp(() {
+          editorBloc = ProfileEditorBloc(
+            profileRepository: mockProfileRepository,
+            blossomUploadService: _MockBlossomUploadService(),
+            hasExistingProfile: true,
+            currentUserPubkey: testPubkeyHex,
+          );
+          addTearDown(editorBloc.close);
+
+          profileStates = StreamController<MyProfileState>();
+          addTearDown(profileStates.close);
+          whenListen(
+            mockMyProfileBloc,
+            profileStates.stream,
+            initialState: const MyProfileInitial(),
+          );
+        });
+
+        Future<void> pumpRealBloc(WidgetTester tester) async {
+          await tester.pumpWidget(
+            testProviderScope(
+              additionalOverrides: [
+                authServiceProvider.overrideWithValue(mockAuthService),
+                profileRepositoryProvider.overrideWith(
+                  (ref) => mockProfileRepository,
+                ),
+                fetchUserProfileProvider(
+                  testPubkeyHex,
+                ).overrideWith((ref) async => null),
+                userProfileReactiveProvider(
+                  testPubkeyHex,
+                ).overrideWith(
+                  (ref) => Stream<models.UserProfile?>.value(null),
+                ),
+              ],
+              child: MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                theme: VineTheme.theme,
+                home: MultiBlocProvider(
+                  providers: [
+                    BlocProvider<ProfileEditorBloc>.value(value: editorBloc),
+                    BlocProvider<MyProfileBloc>.value(value: mockMyProfileBloc),
+                  ],
+                  child: const ProfileSetupScreenView(isNewUser: false),
+                ),
+              ),
+            ),
+          );
+        }
+
+        testWidgets('a seeded profile alone is not an unsaved change', (
+          tester,
+        ) async {
+          await pumpRealBloc(tester);
+          profileStates.add(MyProfileLoading(profile: cachedProfile()));
+          await tester.pumpAndSettle();
+
+          expect(editorBloc.state.hasUnsavedChanges, isFalse);
+        });
+
+        testWidgets(
+          'a relay name that differs from the cache is not an unsaved change',
+          (tester) async {
+            await pumpRealBloc(tester);
+            profileStates.add(MyProfileLoading(profile: cachedProfile()));
+            await tester.pumpAndSettle();
+
+            // Renamed on another device: the cache is stale and the relay's
+            // copy refreshes the untouched field. The user has typed nothing,
+            // so leaving must not claim there is anything to save.
+            profileStates.add(
+              MyProfileLoaded(
+                profile: cachedProfile(
+                  displayName: 'Relay Name',
+                  eventId: freshEventId,
+                ),
+                isFresh: true,
+              ),
+            );
+            await tester.pumpAndSettle();
+
+            expect(find.text('Relay Name'), findsOneWidget);
+            expect(editorBloc.state.hasUnsavedChanges, isFalse);
+          },
+        );
+
+        testWidgets('a fresher profile does not clear a typed edit', (
+          tester,
+        ) async {
+          await pumpRealBloc(tester);
+          profileStates.add(MyProfileLoading(profile: cachedProfile()));
+          await tester.pumpAndSettle();
+
+          await tester.enterText(find.byType(TextField).first, 'My Own Name');
+          await tester.pumpAndSettle();
+          expect(editorBloc.state.hasUnsavedChanges, isTrue);
+
+          profileStates.add(
+            MyProfileLoaded(
+              profile: cachedProfile(
+                displayName: 'Relay Name',
+                eventId: freshEventId,
+              ),
+              isFresh: true,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(editorBloc.state.displayName, 'My Own Name');
+          expect(editorBloc.state.hasUnsavedChanges, isTrue);
+        });
       });
     });
 

--- a/mobile/test/services/staged_profile_media_store_test.dart
+++ b/mobile/test/services/staged_profile_media_store_test.dart
@@ -105,5 +105,38 @@ void main() {
       expect(store.load(pubkeyA), isNull);
       expect(preferences.getKeys(), isEmpty);
     });
+
+    test('round-trips a removal that stages no URL of its own', () async {
+      final store = await createStore();
+
+      await store.save(pubkeyA, pictureCleared: true);
+
+      // A removal with no URLs is still an unsaved edit, so it must not fall
+      // through the "nothing staged" shortcut that clears the payload.
+      final restored = store.load(pubkeyA);
+      expect(restored, isNotNull);
+      expect(restored!.pictureCleared, isTrue);
+      expect(restored.bannerCleared, isFalse);
+      expect(restored.pictureUrl, isNull);
+    });
+
+    test('reads payloads written before removals were staged', () async {
+      preferences = await SharedPreferences.getInstance();
+      await preferences.setString(
+        'staged_profile_media_v1_$pubkeyA',
+        '{"version":1,"pictureUrl":"https://media.divine.video/a",'
+            '"bannerUrl":null,"stagedAt":${now.millisecondsSinceEpoch}}',
+      );
+      final store = SharedPreferencesStagedProfileMediaStore(
+        preferences: preferences,
+        now: () => now,
+      );
+
+      final restored = store.load(pubkeyA);
+      expect(restored, isNotNull);
+      expect(restored!.pictureUrl, 'https://media.divine.video/a');
+      expect(restored.pictureCleared, isFalse);
+      expect(restored.bannerCleared, isFalse);
+    });
   });
 }


### PR DESCRIPTION
## Description

Three defects in the edit-profile screen that only exist once #6630 and #6657 are
both in. Neither branch was wrong on its own: #6657 added the staged-media store
and the unsaved-changes guard against a screen that could clear the *banner*;
#6630 added the avatar clear affordance and made the form seed from the cache
before the relay answers. The overlap is what breaks.

**A stale cache fakes an unsaved edit.** `InitialProfileFieldsSet` supplies the
baseline the guard compares against, and it only ran on the first snapshot. The
cached profile fills the form first, then the relay's copy refreshes whatever the
user has not touched — so whenever the two disagree, the refreshed field no
longer matches its baseline and leaving the screen claims there are changes to
save on a form nobody touched. Renaming yourself on another device is enough to
reproduce it.

The baseline now follows every seed. The current values come back off the
controllers rather than from the profile, so a field the user really did type
into keeps its old baseline and still reads as unsaved.

**A removed avatar comes back.** `ProfilePictureCleared` never dropped the staged
URL from `StagedProfileMediaStore`, so `_initialState` restored it the next time
the editor was built and the picture the user had just removed reappeared, with
Save ready to republish it. `ProfileBannerUrlSet` had the mirror of the same
omission — a pasted banner link vanished on a rebuild while an uploaded one
survived. Both now write through, matching what the pasted-picture branch
already did.

**`pictureCleared` outlives the edit.** `ProfileEditDiscarded` and the
save-success emit both reset `bannerCleared` and neither reset `pictureCleared`,
because they were written before an avatar clear existed. Discard left the avatar
drawn as removed, and after a clear-then-save the stale flag vetoed every later
persisted-picture seed for the rest of the session.

**Related Issue:** Relates to #6631

## Out of Scope

- The `@alice` username-field copy question left open on #6630 — that is a
  product decision, not a defect.

## Verification

- Each fix confirmed against the merged `b2285e42a4` before it was written: the
  stale-cache prompt reproduced red, and reverting any one of the three guards
  afterwards turns exactly the matching test red and nothing else.
- `flutter test test/blocs/profile_editor/ test/screens/profile_setup_screen_test.dart test/screens/profile_setup/ test/services/staged_profile_media_store_test.dart` — 263 green
- `flutter analyze lib test` — clean
- `dart format` — clean
- Walked by hand in a debug build on `fb08bf4`, against production relays with a
  throwaway identity. Opening the editor and leaving once the relay copy lands
  no longer prompts about unsaved changes; a pasted banner link and an avatar
  removal each survive a force-quit; Save publishes the removal and the profile
  drops the picture; and a picture staged after that clear-then-save is no
  longer vetoed by the stale flag.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

