### PR TITLE
fix(nostr): drop the per-gift-wrap debug logging from the relay pool

### DIFF
--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -703,10 +703,13 @@ class RelayPool {
           messageType == 'CLOSED' ||
           messageType == 'NOTICE') {
         log('📡 Raw message from ${relay.url}: $json');
-      } else {
-        // Debug-only: this branch fires for every EVENT/EOSE frame and the
-        // unconditional log cost ~6% of main-isolate CPU in on-device
-        // profiling. The assert closure never runs in profile/release.
+      } else if (messageType != 'EVENT') {
+        // EVENT is excluded: it is the highest-volume frame, and a reconnect
+        // replays a whole subscription window at once. OK and COUNT log
+        // themselves below, so this mainly covers EOSE and unknown types.
+        // Debug-only — the assert closure never runs in profile/release, and
+        // logging here unconditionally cost ~6% of main-isolate CPU in
+        // on-device profiling (#5957).
         assert(() {
           log('📡 ${relay.url}: $messageType $msgSubId');
           return true;

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -696,11 +696,10 @@ class RelayPool {
     final messageType = _stringAt(relay, json, 0, 'message type');
     if (messageType == null) return;
 
-    // Log message type + sub ID (full json is too verbose for non-DM events)
+    // Log message type + sub ID (full json is too verbose for data frames)
     if (json.length >= 2) {
       final msgSubId = json[1];
-      if (msgSubId == 'dm_inbox' ||
-          messageType == 'AUTH' ||
+      if (messageType == 'AUTH' ||
           messageType == 'CLOSED' ||
           messageType == 'NOTICE') {
         log('📡 Raw message from ${relay.url}: $json');
@@ -809,25 +808,12 @@ class RelayPool {
           }
         }
 
-        if (event.kind == EventKind.giftWrap) {
-          log(
-            '🎁 Kind 1059 gift wrap received! subId=$subId '
-            'from ${relay.url}, eventId=${event.id}',
-          );
-        }
-
         // add some statistics
         relay.relayStatus.noteReceive();
 
         // check block pubkey
         for (var eventFilter in eventFilters) {
           if (eventFilter.check(event)) {
-            if (event.kind == EventKind.giftWrap) {
-              log(
-                '🎁 Kind 1059 BLOCKED by eventFilter! '
-                'eventId=${event.id}',
-              );
-            }
             return;
           }
         }
@@ -859,9 +845,6 @@ class RelayPool {
     } else if (messageType == 'EOSE') {
       final subId = _stringAt(relay, json, 1, 'EOSE subscription id');
       if (subId == null) return;
-      if (subId == 'dm_inbox') {
-        log('📬 EOSE received for dm_inbox from ${relay.url}');
-      }
       var isQuery = await relay.checkAndCompleteQuery(subId);
       if (isQuery) {
         _fireQueryCompleteIfSettled(subId);

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -699,9 +699,7 @@ class RelayPool {
     // Log message type + sub ID (full json is too verbose for data frames)
     if (json.length >= 2) {
       final msgSubId = json[1];
-      if (messageType == 'AUTH' ||
-          messageType == 'CLOSED' ||
-          messageType == 'NOTICE') {
+      if (messageType == 'CLOSED' || messageType == 'NOTICE') {
         log('📡 Raw message from ${relay.url}: $json');
       } else if (messageType != 'EVENT') {
         // EVENT is excluded: it is the highest-volume frame, and a reconnect


### PR DESCRIPTION
Closes #6685

## Description

Every kind 1059 frame wrote a log line straight from the relay pool's EVENT hot path - ungated, in every build mode. Backgrounding the app is what makes it obvious: after 90s without an inbound frame the heartbeat force-disconnects the socket (`_onHeartbeat` in `web_socket_connection_manager.dart`), the reconnect re-AUTHs, and the pool replays every saved subscription. The DM inbox subscription then re-streams its whole `since: newestSyncedAt - 2d` window and each replayed wrap prints again.

That idle timer is driven purely by inbound relay frames - `_lastActivityAt` is only touched on connect and in `_onMessage`, outbound sends don't reset it - so the same cycle fires in the foreground whenever a relay stays quiet for 90s, e.g. while the user sits in the video editor. Backgrounding just guarantees it.

Three of the four DM debug sites were already dead code. The subscription id became `dm_inbox_<pubkey>` when it was scoped per user, so the exact-match `dm_inbox` branches - the raw-frame JSON dump and the EOSE line - could not fire anymore. The gift-wrap `eventFilter` line was dead for a different reason: `eventFilters` defaults to `const []`, nothing populates it at runtime, and no `EventFilter` implementation exists in the repo, so that loop body never runs. All four are leftovers from the original NIP-17 data layer (#2118).

The second commit closes the same hole in debug builds. The assert-gated frame log added by #5957 still printed one line per EVENT, so a reconnect replaying a whole subscription window kept flooding debug even after the ungated lines went away - only profile/release went quiet. EVENT is the only high-volume frame in that branch, and OK and COUNT log themselves in their own handlers, so excluding EVENT keeps EOSE and unknown frame types visible without the flood.

The takeover follow-up also stops `RelayPool` from raw-dumping AUTH frames that `RelayBase` already raw-logs before dispatch and the typed AUTH handler logs again.

No behaviour changes beyond logging.

**Related Issue:** #6685

## Out of Scope

The replay itself stays. It costs a re-download plus, per event, a `sha256` id recompute and two dedup lookups - but no crypto: `_handleGiftWrapEvent` checks `_alreadyProcessed` (message row + the `processed_gift_wraps` ledger from #5452) before it builds a signer or decrypts, and the signature verify is skipped via the `(id, sig)` cache. Narrowing the 2-day window would touch the NIP-17 randomized-timestamp tolerance it exists for, which wants its own change.

## Verification

- `dart format` / `flutter analyze` on the changed file - clean
- `flutter test` over all twelve `relay_pool_*` suites (auth, closed-frame, malformed-frame, event-signature, verify-dedup, off-main-verify, search, count, publish-targets, concurrency, zombie-remediation, signature-policy) - 81 tests pass
- Takeover: `mise exec -- dart format lib test integration_test` - no changes
- Takeover: `flutter analyze packages/nostr_sdk/lib/relay/relay_pool.dart` - clean
- Takeover: `flutter test` over all twelve `relay_pool_*` suites - 81 tests pass
- Verified on a real Samsung Galaxy: the log flood is gone

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore
