### PR TITLE
fix(profile): grow late-arriving header blocks in instead of snapping

### DIFF
--- a/mobile/lib/widgets/profile/profile_header_identity.dart
+++ b/mobile/lib/widgets/profile/profile_header_identity.dart
@@ -142,18 +142,19 @@ class _ProfileHeaderReveal extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final duration = MediaQuery.disableAnimationsOf(context)
-        ? Duration.zero
-        : _duration;
+    // The empty state spans the full width so only the height animates.
+    final content = child ?? const SizedBox(width: double.infinity);
+    // Drop the animators entirely under reduce motion rather than passing
+    // them Duration.zero: a zero-duration AnimatedSize completes its
+    // controller synchronously inside performLayout, which re-dirties the
+    // render object mid-layout and trips a framework assertion.
+    if (MediaQuery.disableAnimationsOf(context)) return content;
+
     return AnimatedSize(
-      duration: duration,
+      duration: _duration,
       curve: Curves.easeOutCubic,
       alignment: Alignment.topCenter,
-      child: AnimatedSwitcher(
-        duration: duration,
-        // The empty state spans the full width so only the height animates.
-        child: child ?? const SizedBox(width: double.infinity),
-      ),
+      child: AnimatedSwitcher(duration: _duration, child: content),
     );
   }
 }

--- a/mobile/lib/widgets/profile/profile_header_identity.dart
+++ b/mobile/lib/widgets/profile/profile_header_identity.dart
@@ -165,8 +165,9 @@ class _ProfileBadgesBlock extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // Loading and error both read as "no badges": most profiles have none, so
-    // reserving a placeholder row would trade one jump for a worse one.
+    // A refresh keeps the badges it already had; a first load and an outright
+    // error read as "no badges". Most profiles have none, so reserving a
+    // placeholder row would trade one jump for a worse one.
     final items =
         ref.watch(profileAcceptedBadgesProvider(userIdHex)).value ??
         const <ProfileBadgeViewData>[];

--- a/mobile/lib/widgets/profile/profile_header_identity.dart
+++ b/mobile/lib/widgets/profile/profile_header_identity.dart
@@ -89,17 +89,27 @@ class _ProfileNameAndBio extends StatelessWidget {
           padding: inset,
           child: Column(
             children: [
-              if (about != null && about!.isNotEmpty) ...[
-                const SizedBox(height: 16),
-                Skeleton.keep(child: _AboutText(about: about!)),
-              ],
+              _ProfileHeaderReveal(
+                child: about != null && about!.isNotEmpty
+                    ? Padding(
+                        padding: const EdgeInsets.only(top: 16),
+                        child: Skeleton.keep(child: _AboutText(about: about!)),
+                      )
+                    : null,
+              ),
               Skeleton.keep(
                 child: _ProfileSupportButton(links: monetizationLinks),
               ),
-              if (showWebsite) ...[
-                const SizedBox(height: 8),
-                Skeleton.keep(child: ProfileWebsiteRow(url: website!)),
-              ],
+              _ProfileHeaderReveal(
+                child: showWebsite
+                    ? Padding(
+                        padding: const EdgeInsets.only(top: 8),
+                        child: Skeleton.keep(
+                          child: ProfileWebsiteRow(url: website!),
+                        ),
+                      )
+                    : null,
+              ),
               _VerifiedAccountsBlock(isOwnProfile: isOwnProfile),
             ],
           ),
@@ -113,6 +123,41 @@ class _ProfileNameAndBio extends StatelessWidget {
 /// badge row can break out of it and scroll edge-to-edge.
 const double _profileIdentityHorizontalInset = 16;
 
+/// Grows a late-arriving header block into place instead of snapping it in.
+///
+/// The profile, its verified claims, and its badges all resolve after the
+/// header has painted, each on its own timing. Revealing them over a short
+/// window keeps everything below — bio, stats row, action buttons, grid —
+/// sliding down smoothly rather than jumping.
+///
+/// A null [child] is the empty state. The wrapper stays mounted at zero
+/// height so the arrival it is waiting for has a size to animate from;
+/// dropping it from the tree instead would mount the content at full size.
+class _ProfileHeaderReveal extends StatelessWidget {
+  const _ProfileHeaderReveal({this.child});
+
+  static const _duration = Duration(milliseconds: 220);
+
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    final duration = MediaQuery.disableAnimationsOf(context)
+        ? Duration.zero
+        : _duration;
+    return AnimatedSize(
+      duration: duration,
+      curve: Curves.easeOutCubic,
+      alignment: Alignment.topCenter,
+      child: AnimatedSwitcher(
+        duration: duration,
+        // The empty state spans the full width so only the height animates.
+        child: child ?? const SizedBox(width: double.infinity),
+      ),
+    );
+  }
+}
+
 class _ProfileBadgesBlock extends ConsumerWidget {
   const _ProfileBadgesBlock({required this.userIdHex});
 
@@ -120,42 +165,52 @@ class _ProfileBadgesBlock extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final badges = ref.watch(profileAcceptedBadgesProvider(userIdHex));
-    return badges.when(
-      data: (items) {
-        if (items.isEmpty) return const SizedBox.shrink();
-        return Padding(
-          padding: const EdgeInsets.only(top: 12),
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              // The block spans the full width (its siblings carry the
-              // horizontal inset instead), so the row scrolls edge-to-edge.
-              // A resting lead keeps chips aligned with the text above while
-              // letting them peek past the screen edge once they overflow.
-              const inset = _profileIdentityHorizontalInset;
-              return SingleChildScrollView(
-                scrollDirection: Axis.horizontal,
-                padding: const EdgeInsets.symmetric(horizontal: inset),
-                // Centered when the badges fit; scrollable once they overflow.
-                child: ConstrainedBox(
-                  constraints: BoxConstraints(
-                    minWidth: constraints.maxWidth - inset * 2,
-                  ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    spacing: 8,
-                    children: [
-                      for (final item in items) _ProfileBadgeChip(badge: item),
-                    ],
-                  ),
-                ),
-              );
-            },
-          ),
-        );
-      },
-      error: (_, _) => const SizedBox.shrink(),
-      loading: () => const SizedBox.shrink(),
+    // Loading and error both read as "no badges": most profiles have none, so
+    // reserving a placeholder row would trade one jump for a worse one.
+    final items =
+        ref.watch(profileAcceptedBadgesProvider(userIdHex)).value ??
+        const <ProfileBadgeViewData>[];
+    return _ProfileHeaderReveal(
+      child: items.isEmpty ? null : _ProfileBadgesRow(items: items),
+    );
+  }
+}
+
+class _ProfileBadgesRow extends StatelessWidget {
+  const _ProfileBadgesRow({required this.items});
+
+  final List<ProfileBadgeViewData> items;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 12),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          // The block spans the full width (its siblings carry the horizontal
+          // inset instead), so the row scrolls edge-to-edge. A resting lead
+          // keeps chips aligned with the text above while letting them peek
+          // past the screen edge once they overflow.
+          const inset = _profileIdentityHorizontalInset;
+          return SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: inset),
+            // Centered when the badges fit; scrollable once they overflow.
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                minWidth: constraints.maxWidth - inset * 2,
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                spacing: 8,
+                children: [
+                  for (final item in items) _ProfileBadgeChip(badge: item),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
     );
   }
 }
@@ -415,10 +470,13 @@ class _VerifiedAccountsBlock extends StatelessWidget {
     final claims = isOwnProfile
         ? _readMyClaims(context)
         : _readOtherClaims(context);
-    if (claims.isEmpty) return const SizedBox.shrink();
-    return Padding(
-      padding: const EdgeInsets.only(top: 12),
-      child: VerifiedAccountsRow(claims: claims),
+    return _ProfileHeaderReveal(
+      child: claims.isEmpty
+          ? null
+          : Padding(
+              padding: const EdgeInsets.only(top: 12),
+              child: VerifiedAccountsRow(claims: claims),
+            ),
     );
   }
 

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -520,19 +520,22 @@ class _ProfileSupportButton extends ConsumerWidget {
     final enabled = ref.watch(
       isFeatureEnabledProvider(FeatureFlag.profileMonetizationLinks),
     );
-    if (links.isEmpty || !enabled) return const SizedBox.shrink();
 
-    return Padding(
-      padding: const EdgeInsets.only(top: 8),
-      child: Align(
-        child: DivineButton(
-          key: const Key('profile-support-button'),
-          type: .secondary,
-          size: .tiny,
-          label: _supportAffordanceLabel(context),
-          onPressed: () => _openSupportSheet(context, ref, links),
-        ),
-      ),
+    return _ProfileHeaderReveal(
+      child: links.isEmpty || !enabled
+          ? null
+          : Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Align(
+                child: DivineButton(
+                  key: const Key('profile-support-button'),
+                  type: .secondary,
+                  size: .tiny,
+                  label: _supportAffordanceLabel(context),
+                  onPressed: () => _openSupportSheet(context, ref, links),
+                ),
+              ),
+            ),
     );
   }
 }

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -326,6 +326,7 @@ void main() {
       MockGoRouter? goRouter,
       bool monetizationLinksEnabled = false,
       ThemeData? theme,
+      bool disableAnimations = false,
     }) {
       final authService = MockAuthService(
         isAnonymousValue: isAnonymous,
@@ -438,7 +439,14 @@ void main() {
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           theme: theme,
-          home: Scaffold(body: SingleChildScrollView(child: header)),
+          home: Builder(
+            builder: (context) => MediaQuery(
+              data: MediaQuery.of(
+                context,
+              ).copyWith(disableAnimations: disableAnimations),
+              child: Scaffold(body: SingleChildScrollView(child: header)),
+            ),
+          ),
         ),
       );
 
@@ -630,6 +638,26 @@ void main() {
 
       expect(settledHeight, greaterThan(0));
       expect(revealingHeight, lessThan(settledHeight));
+    });
+
+    testWidgets('lands the badge row at once under reduce motion', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          userIdHex: testUserHex,
+          isOwnProfile: false,
+          suppliedProfile: createTestProfile(displayName: 'Badged User'),
+          acceptedProfileBadges: [_acceptedBadge('Badge One', 'badge-one')],
+          disableAnimations: true,
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      // A zero-duration AnimatedSize would assert here instead of rendering.
+      expect(find.text('Badge One'), findsOneWidget);
+      expect(find.byType(AnimatedSize), findsNothing);
     });
 
     testWidgets('displays user avatar when profile is loaded', (tester) async {

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -227,6 +227,28 @@ Event _badgeAwardEvent() {
   });
 }
 
+ProfileBadgeViewData _acceptedBadge(String name, String dTag) {
+  final coordinate = '30009:$issuerUserHex:$dTag';
+  return ProfileBadgeViewData(
+    badge: Nip58ProfileBadgeRef(
+      definitionCoordinate: coordinate,
+      awardEventId:
+          '00000000000000000000000000000000000000000000000000000000000000aa',
+    ),
+    award: Nip58BadgeAward(
+      event: _badgeAwardEvent(),
+      definitionCoordinate: coordinate,
+      recipientPubkeys: const [testUserHex],
+    ),
+    definition: Nip58BadgeDefinition(
+      event: _badgeDefinitionEvent(),
+      coordinate: coordinate,
+      dTag: dTag,
+      name: name,
+    ),
+  );
+}
+
 void main() {
   group('ProfileHeaderWidget', () {
     late MockFollowRepository mockFollowRepository;
@@ -465,8 +487,7 @@ void main() {
           ],
         ),
       );
-      await tester.pump();
-      await tester.pump();
+      await tester.pumpAndSettle();
 
       expect(find.text('Diviner of the Day'), findsOneWidget);
       expect(
@@ -535,8 +556,7 @@ void main() {
           ],
         ),
       );
-      await tester.pump();
-      await tester.pump();
+      await tester.pumpAndSettle();
 
       await tester.tap(find.text('Diviner of the Day'));
       await tester.pumpAndSettle();
@@ -549,27 +569,6 @@ void main() {
       tester,
     ) async {
       final testProfile = createTestProfile(displayName: 'Badged User');
-      ProfileBadgeViewData acceptedBadge(String name, String dTag) {
-        final coordinate = '30009:$issuerUserHex:$dTag';
-        return ProfileBadgeViewData(
-          badge: Nip58ProfileBadgeRef(
-            definitionCoordinate: coordinate,
-            awardEventId:
-                '00000000000000000000000000000000000000000000000000000000000000aa',
-          ),
-          award: Nip58BadgeAward(
-            event: _badgeAwardEvent(),
-            definitionCoordinate: coordinate,
-            recipientPubkeys: const [testUserHex],
-          ),
-          definition: Nip58BadgeDefinition(
-            event: _badgeDefinitionEvent(),
-            coordinate: coordinate,
-            dTag: dTag,
-            name: name,
-          ),
-        );
-      }
 
       await tester.pumpWidget(
         buildTestWidget(
@@ -577,14 +576,13 @@ void main() {
           isOwnProfile: false,
           suppliedProfile: testProfile,
           acceptedProfileBadges: [
-            acceptedBadge('Badge One', 'badge-one'),
-            acceptedBadge('Badge Two', 'badge-two'),
-            acceptedBadge('Badge Three', 'badge-three'),
+            _acceptedBadge('Badge One', 'badge-one'),
+            _acceptedBadge('Badge Two', 'badge-two'),
+            _acceptedBadge('Badge Three', 'badge-three'),
           ],
         ),
       );
-      await tester.pump();
-      await tester.pump();
+      await tester.pumpAndSettle();
 
       // All badges render — they are not truncated to a single row.
       expect(find.text('Badge One'), findsOneWidget);
@@ -603,6 +601,35 @@ void main() {
       );
       expect(horizontalScrollAbove('Badge One'), findsOneWidget);
       expect(horizontalScrollAbove('Badge Three'), findsOneWidget);
+    });
+
+    testWidgets('grows the badge row in instead of snapping the layout', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          userIdHex: testUserHex,
+          isOwnProfile: false,
+          suppliedProfile: createTestProfile(displayName: 'Badged User'),
+          acceptedProfileBadges: [_acceptedBadge('Badge One', 'badge-one')],
+        ),
+      );
+      // Two frames: the badge future resolves, then the row is built for the
+      // first time — the reveal has only just started at that point.
+      await tester.pump();
+      await tester.pump();
+
+      final block = find.ancestor(
+        of: find.text('Badge One'),
+        matching: find.byType(AnimatedSize),
+      );
+      final revealingHeight = tester.getSize(block).height;
+
+      await tester.pumpAndSettle();
+      final settledHeight = tester.getSize(block).height;
+
+      expect(settledHeight, greaterThan(0));
+      expect(revealingHeight, lessThan(settledHeight));
     });
 
     testWidgets('displays user avatar when profile is loaded', (tester) async {
@@ -1510,6 +1537,44 @@ void main() {
         // Should now show "Show less"
         expect(find.text('Show less'), findsOneWidget);
         expect(find.text('Show more'), findsNothing);
+      });
+
+      testWidgets('expanding the bio grows it instead of snapping open', (
+        tester,
+      ) async {
+        tester.view.physicalSize = const Size(400, 800);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            profile: createTestProfile(
+              displayName: 'Test User',
+              about: longBio,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        Finder bioBlock(String toggleLabel) => find.ancestor(
+          of: find.text(toggleLabel),
+          matching: find.byType(AnimatedSize),
+        );
+        final collapsedHeight = tester.getSize(bioBlock('Show more')).height;
+
+        await tester.tap(find.text('Show more'));
+        // The expanded text is laid out on this frame, but the block is still
+        // at its collapsed height — it grows from there rather than snapping.
+        await tester.pump();
+        expect(tester.getSize(bioBlock('Show less')).height, collapsedHeight);
+
+        await tester.pumpAndSettle();
+        expect(
+          tester.getSize(bioBlock('Show less')).height,
+          greaterThan(collapsedHeight),
+        );
       });
 
       testWidgets('tapping "Show less" collapses bio and shows "Show more"', (


### PR DESCRIPTION
Closes #6687

## Description

Badges, verified claims and profile fields each resolve on their own timing, well after the profile header has painted. Every arrival flipped its block from `SizedBox.shrink()` to full height in a single frame, shoving the bio, stats row, action buttons and the whole grid below it down.

Each of those blocks now renders through a shared `_ProfileHeaderReveal`: an `AnimatedSize` that grows the block into place while an `AnimatedSwitcher` fades the content in. Siblings below slide down over the same window instead of teleporting.

Applied to the accepted-badges row, the bio, the website row, the tip/support button and the verified-accounts row.

Three things worth calling out for review:

- **`AnimatedSwitcher` alone would not have fixed this.** It stacks the outgoing and incoming child and takes the larger size immediately, so the content would fade in while the layout still jumped. The height has to come from `AnimatedSize`.
- **The wrapper stays mounted while empty** (`child: null`) instead of being dropped by a collection-if, which is why the bio and website rows moved off `if (...) ...[]`. A wrapper that only appears together with its content mounts at full size and never animates.
- **Reserving space during loading was the alternative and is worse.** Most profiles have no badges and no verified claims, so the majority would trade a jump on arrival for a permanent gap that collapses instead.

As a side effect the bio's own "Show more" expansion is now animated too — it used to snap open.

**Related Issue:** 

## Out of Scope

The first profile load, where the identity skeleton turns off, still jumps. `Skeletonizer` swaps `SkeletonizerRenderObjectWidget` for a `KeyedSubtree` under a different key when it disables, which unmounts and rebuilds its entire subtree — so every `AnimatedSize` inside mounts at full size and has nothing to animate from. Fixing that one means giving the skeleton a bio-shaped placeholder so the height barely changes across the swap, which is a separate design decision (profiles without a bio would then shrink at the swap).

That window swallows more than the identity block: the bio, the website row and the tip button all arrive *with* the profile, which is the same moment the skeleton disables, so on a cold load those three still mount at full size and snap. Only the badge row and the verified-accounts row resolve after that point and reliably grow in. The other three still earn their wrapper on a cached profile (no skeleton, so no remount), on an edit-profile round trip, and — for the bio — on "Show more".

Wrapping the `Skeletonizer` itself in an `AnimatedSize` was considered and rejected: it nests over the inner reveals, and a nested outer animator clips everything below each inner reveal for its duration instead of letting it slide — worse than the current behaviour.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test test/widgets/profile` — 281 passed
- Two new tests: the badge row grows in rather than appearing at full height, and the bio is still at its collapsed height on the frame after "Show more" is tapped
- Manually verified on a real Samsung Galaxy: opened profiles with and without badges, watched the badge row and the verified-accounts row land, expanded and collapsed a long bio

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
