### PR TITLE
fix(categories): give the category gallery a Material ancestor

### DIFF
--- a/mobile/lib/screens/category_gallery_screen.dart
+++ b/mobile/lib/screens/category_gallery_screen.dart
@@ -154,7 +154,10 @@ class CategoryGalleryView extends StatelessWidget {
   Widget build(BuildContext context) {
     final visuals = CategoryVisuals.forCategory(category, 0);
 
-    return ColoredBox(
+    // This screen is a root-navigator route, so nothing above it provides a
+    // `Material`. Without one every `Text` inherits Flutter's yellow
+    // double-underline fallback style from `MaterialApp`.
+    return Material(
       color: context.vineColors.surfaceContainerHigh,
       child: Column(
         children: [
@@ -208,18 +211,17 @@ class _CategoryGalleryBody extends StatelessWidget {
         return Center(
           child: Column(
             mainAxisSize: MainAxisSize.min,
+            spacing: 16,
             children: [
               Text(
                 context.l10n.categoryGalleryCouldNotLoadVideos,
-                style: TextStyle(
+                style: VineTheme.bodyLargeFont(
                   color: context.vineColors.secondaryText,
-                  fontSize: 16,
                 ),
               ),
-              const SizedBox(height: 16),
-              ElevatedButton(
+              DivineButton(
+                label: context.l10n.commonRetry,
                 onPressed: onRetry,
-                child: Text(context.l10n.commonRetry),
               ),
             ],
           ),
@@ -229,9 +231,8 @@ class _CategoryGalleryBody extends StatelessWidget {
           return Center(
             child: Text(
               context.l10n.categoryGalleryNoVideosInCategory,
-              style: TextStyle(
+              style: VineTheme.bodyLargeFont(
                 color: context.vineColors.secondaryText,
-                fontSize: 16,
               ),
             ),
           );
@@ -297,12 +298,9 @@ class _CategoryGalleryHeader extends StatelessWidget {
                       localizedCategoryName(context.l10n, category.name),
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
-                      style:
-                          VineTheme.titleMediumFont(
-                            color: context.vineColors.onNav,
-                          ).copyWith(
-                            decoration: TextDecoration.none,
-                          ),
+                      style: VineTheme.titleMediumFont(
+                        color: context.vineColors.onNav,
+                      ),
                     ),
                   ),
                 ),

--- a/mobile/scripts/baseline/material_buttons.txt
+++ b/mobile/scripts/baseline/material_buttons.txt
@@ -14,7 +14,6 @@ lib/notifications/view/notifications_view.dart	2
 lib/screens/auth/create_account_screen.dart	3
 lib/screens/auth/invite_gate_screen.dart	2
 lib/screens/auth/nostr_connect_screen.dart	1
-lib/screens/category_gallery_screen.dart	1
 lib/screens/comments/widgets/comment_input.dart	3
 lib/screens/comments/widgets/comment_options_modal.dart	1
 lib/screens/comments/widgets/comments_header.dart	1

--- a/mobile/scripts/baseline/raw_textstyle.txt
+++ b/mobile/scripts/baseline/raw_textstyle.txt
@@ -18,7 +18,6 @@ lib/screens/auth/login_options_screen.dart	4
 lib/screens/auth/nostr_connect_screen.dart	12
 lib/screens/auth/reset_password.dart	2
 lib/screens/auth/welcome_screen.dart	1
-lib/screens/category_gallery_screen.dart	2
 lib/screens/comments/widgets/comment_item.dart	1
 lib/screens/comments/widgets/comments_empty_state.dart	2
 lib/screens/curated_list_feed_screen.dart	12

--- a/mobile/test/screens/category_gallery_screen_test.dart
+++ b/mobile/test/screens/category_gallery_screen_test.dart
@@ -3,7 +3,6 @@
 
 import 'package:categories_repository/categories_repository.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
-import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -30,21 +29,21 @@ void main() {
     VoidCallback? onRetry,
     Widget? galleryOverride,
   }) {
+    // No Scaffold: the route mounts this view on the root navigator, so
+    // nothing above it supplies a Material. Pump it the same way here.
     return MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: Scaffold(
-        body: CategoryGalleryView(
-          category: category,
-          state: state,
-          onBack: onBack ?? () {},
-          onRetry: onRetry ?? () {},
-          onSortChanged: onSortChanged ?? (_) {},
-          onVideoTap: (videos, index) {},
-          onLoadMore: () async {},
-          onRefresh: () async {},
-          galleryOverride: galleryOverride,
-        ),
+      home: CategoryGalleryView(
+        category: category,
+        state: state,
+        onBack: onBack ?? () {},
+        onRetry: onRetry ?? () {},
+        onSortChanged: onSortChanged ?? (_) {},
+        onVideoTap: (videos, index) {},
+        onLoadMore: () async {},
+        onRefresh: () async {},
+        galleryOverride: galleryOverride,
       ),
     );
   }
@@ -187,25 +186,14 @@ void main() {
     ) async {
       final l10n = lookupAppLocalizations(const Locale('en'));
 
-      // The route mounts this view on the root navigator, so nothing above
-      // it supplies a Material — pump it the same way here. Without one,
-      // every Text inherits MaterialApp's yellow double-underline fallback.
+      // Without a Material the view's Text widgets inherit MaterialApp's
+      // yellow double-underline fallback style.
       await tester.pumpWidget(
-        MaterialApp(
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: CategoryGalleryView(
-            category: category,
-            state: const CategoriesState(
-              selectedCategory: category,
-              videosStatus: CategoriesVideosStatus.error,
-            ),
-            onBack: () {},
-            onRetry: () {},
-            onSortChanged: (_) {},
-            onVideoTap: (videos, index) {},
-            onLoadMore: () async {},
-            onRefresh: () async {},
+        buildSubject(
+          category: category,
+          state: const CategoriesState(
+            selectedCategory: category,
+            videosStatus: CategoriesVideosStatus.error,
           ),
         ),
       );
@@ -214,7 +202,6 @@ void main() {
         tester.element(find.text(l10n.categoryGalleryCouldNotLoadVideos)),
       ).style;
       expect(inheritedStyle.decoration, isNot(TextDecoration.underline));
-      expect(find.byType(DivineButton), findsOneWidget);
     });
 
     testWidgets('shows empty state when selected category has no videos', (

--- a/mobile/test/screens/category_gallery_screen_test.dart
+++ b/mobile/test/screens/category_gallery_screen_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:categories_repository/categories_repository.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -179,6 +180,41 @@ void main() {
       expect(find.text('Could not load videos'), findsOneWidget);
       await tester.tap(find.text('Retry'));
       expect(retries, 1);
+    });
+
+    testWidgets('provides a $Material ancestor for its own text', (
+      tester,
+    ) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      // The route mounts this view on the root navigator, so nothing above
+      // it supplies a Material — pump it the same way here. Without one,
+      // every Text inherits MaterialApp's yellow double-underline fallback.
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: CategoryGalleryView(
+            category: category,
+            state: const CategoriesState(
+              selectedCategory: category,
+              videosStatus: CategoriesVideosStatus.error,
+            ),
+            onBack: () {},
+            onRetry: () {},
+            onSortChanged: (_) {},
+            onVideoTap: (videos, index) {},
+            onLoadMore: () async {},
+            onRefresh: () async {},
+          ),
+        ),
+      );
+
+      final inheritedStyle = DefaultTextStyle.of(
+        tester.element(find.text(l10n.categoryGalleryCouldNotLoadVideos)),
+      ).style;
+      expect(inheritedStyle.decoration, isNot(TextDecoration.underline));
+      expect(find.byType(DivineButton), findsOneWidget);
     });
 
     testWidgets('shows empty state when selected category has no videos', (


### PR DESCRIPTION
Closes #6689

## Description

The category gallery renders its retry button and its texts with a yellow double underline, and the retry button is a stock `ElevatedButton` rather than a design-system button.

Both come from the same root cause: `CategoryGalleryScreen` is registered in `searchRoutes()` as a top-level route (sibling of `shellRoutes()`), so it mounts on the root navigator with no `Scaffold`/`Material` above it. `MaterialApp` installs Flutter's fallback text style in that situation — `decoration: underline`, `decorationColor: 0xFFFFFF00`, `debugLabel: 'fallback style; consider putting your text in a Material'` — and every `Text` whose own style leaves `decoration` unset inherits it. The header title already carried a `.copyWith(decoration: TextDecoration.none)` workaround for exactly this.

Fix at the root instead of per-`Text`: the view's root `ColoredBox` becomes a `Material` with the same background color, which supplies a real default text style to the whole subtree. The header workaround is then dead and removed.

While in the error/empty states, they move onto the design system: `ElevatedButton` → `DivineButton`, and the two raw `TextStyle(fontSize: 16)` → `VineTheme.bodyLargeFont`. That empties this file's `raw_textstyle` (2 → 0) and `material_buttons` (1 → 0) ceiling entries, so both baselines are regenerated — a drop to zero fails CI otherwise.

The second commit removes the `Scaffold` from the test helper. That `Scaffold` supplied the `Material` the router never does, which is precisely why the existing suite stayed green while the screen shipped yellow underlined text. Mounting the view bare makes every test exercise the real condition, not just the new regression test.

## Out of Scope

- The hardcoded header colors in this file (`_categoryHeaderActionFill`, `_categoryHeaderActionBorder`, shadows) stay as-is; they are a separate design-system migration.
- Other root-navigator routes were not audited for the same missing-`Material` pattern.

## Verification

- `flutter analyze lib/screens/category_gallery_screen.dart test/screens/category_gallery_screen_test.dart` — clean
- `flutter test test/screens/category_gallery_screen_test.dart` — 7/7 pass
- New regression test pumps `CategoryGalleryView` **without** a `Scaffold` and asserts the inherited style carries no underline. Verified it fails when the `Material` wrapper is reverted to `ColoredBox`, and passes with it — re-confirmed after the test-helper change.
- `check_raw_textstyle_ceiling.sh` and `check_material_button_ceiling.sh` — both OK
- Manually verified on a real Samsung Galaxy: the gallery texts and the retry button render without the yellow double underline, and the retry button renders as a `DivineButton`.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
