### PR TITLE
fix(metadata): stop the late sheet sections jumping, and cap the reposter chips

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -811,6 +811,7 @@
     "metadataCollaboratorsLabel": "ተባባሪዎች",
     "metadataInspiredByLabel": "ተመስጦ",
     "metadataRepostedByLabel": "በድጋሚ የተለጠፈው በ",
+    "metadataMoreReposters": "+{count} ተጨማሪ",
     "metadataLoopsLabel": "{count, plural, =1{ሉፕ} other{ሉፖች}}",
     "@metadataLoopsLabel": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -692,6 +692,7 @@
     "metadataCollaboratorsLabel": "المتعاونون",
     "metadataInspiredByLabel": "مستوحى من",
     "metadataRepostedByLabel": "أعاد نشره",
+    "metadataMoreReposters": "+{count} آخرين",
     "metadataLoopsLabel": "التكرارات",
     "metadataLikesLabel": "الإعجابات",
     "metadataCommentsLabel": "التعليقات",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -756,6 +756,7 @@
     "metadataCollaboratorsLabel": "Сътрудници",
     "metadataInspiredByLabel": "Вдъхновено от",
     "metadataRepostedByLabel": "Повторно публикувано от",
+    "metadataMoreReposters": "още {count}",
     "metadataLoopsLabel": "{count, plural, =1{Луп} other{Лупове}}",
     "@metadataLoopsLabel": {
         "placeholders": {

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -695,6 +695,7 @@
     "metadataCollaboratorsLabel": "Mitwirkende",
     "metadataInspiredByLabel": "Inspiriert von",
     "metadataRepostedByLabel": "Repostet von",
+    "metadataMoreReposters": "+{count} weitere",
     "metadataLoopsLabel": "Loops",
     "metadataLikesLabel": "Likes",
     "metadataCommentsLabel": "Kommentare",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1053,6 +1053,15 @@
   "metadataCollaboratorsLabel": "Collaborators",
   "metadataInspiredByLabel": "Inspired by",
   "metadataRepostedByLabel": "Reposted by",
+  "metadataMoreReposters": "+{count} more",
+  "@metadataMoreReposters": {
+    "description": "Chip in the video metadata sheet opening the full reposters list, showing how many reposters are not displayed.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "metadataLoopsLabel": "{count, plural, =1{Loop} other{Loops}}",
   "@metadataLoopsLabel": {
     "placeholders": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -695,6 +695,7 @@
     "metadataCollaboratorsLabel": "Colaboradores",
     "metadataInspiredByLabel": "Inspirado en",
     "metadataRepostedByLabel": "Reposteado por",
+    "metadataMoreReposters": "+{count} más",
     "metadataLoopsLabel": "Loops",
     "metadataLikesLabel": "Me gusta",
     "metadataCommentsLabel": "Comentarios",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -515,6 +515,7 @@
     "metadataCollaboratorsLabel": "Mga Collaborator",
     "metadataInspiredByLabel": "Inspirasyon mula kay",
     "metadataRepostedByLabel": "Na-repost ni",
+    "metadataMoreReposters": "+{count} pa",
     "metadataLoopsLabel": "{count, plural, =1{Loop} other{Loops}}",
     "metadataLikesLabel": "Mga Like",
     "metadataCommentsLabel": "Mga Komento",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -695,6 +695,7 @@
     "metadataCollaboratorsLabel": "Collaborateurs",
     "metadataInspiredByLabel": "Inspiré par",
     "metadataRepostedByLabel": "Reposté par",
+    "metadataMoreReposters": "+{count} autres",
     "metadataLoopsLabel": "Loops",
     "metadataLikesLabel": "J'aime",
     "metadataCommentsLabel": "Commentaires",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -692,6 +692,7 @@
     "metadataCollaboratorsLabel": "Kolaborator",
     "metadataInspiredByLabel": "Terinspirasi oleh",
     "metadataRepostedByLabel": "Di-repost oleh",
+    "metadataMoreReposters": "+{count} lainnya",
     "metadataLoopsLabel": "Loop",
     "metadataLikesLabel": "Suka",
     "metadataCommentsLabel": "Komentar",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -695,6 +695,7 @@
     "metadataCollaboratorsLabel": "Collaboratori",
     "metadataInspiredByLabel": "Ispirato da",
     "metadataRepostedByLabel": "Ripubblicato da",
+    "metadataMoreReposters": "+{count} altri",
     "metadataLoopsLabel": "Loop",
     "metadataLikesLabel": "Mi piace",
     "metadataCommentsLabel": "Commenti",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -692,6 +692,7 @@
     "metadataCollaboratorsLabel": "コラボレーター",
     "metadataInspiredByLabel": "インスパイア元",
     "metadataRepostedByLabel": "リポスト元",
+    "metadataMoreReposters": "他{count}人",
     "metadataLoopsLabel": "ループ",
     "metadataLikesLabel": "いいね",
     "metadataCommentsLabel": "コメント",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -452,6 +452,7 @@
     "metadataCollaboratorsLabel": "콜라보레이터",
     "metadataInspiredByLabel": "영감",
     "metadataRepostedByLabel": "리포스트",
+    "metadataMoreReposters": "외 {count}명",
     "metadataLoopsLabel": "루프",
     "metadataLikesLabel": "좋아요",
     "metadataCommentsLabel": "댓글",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -991,6 +991,7 @@
   "metadataCollaboratorsLabel": "Kolaborator",
   "metadataInspiredByLabel": "Diilhamkan oleh",
   "metadataRepostedByLabel": "Disiarkan semula oleh",
+  "metadataMoreReposters": "+{count} lagi",
   "metadataLoopsLabel": "{count, plural, =1{Loop} other{Loop}}",
   "@metadataLoopsLabel": {
     "placeholders": {

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -695,6 +695,7 @@
     "metadataCollaboratorsLabel": "Samenwerkers",
     "metadataInspiredByLabel": "Geïnspireerd door",
     "metadataRepostedByLabel": "Gerepost door",
+    "metadataMoreReposters": "+{count} meer",
     "metadataLoopsLabel": "Loops",
     "metadataLikesLabel": "Likes",
     "metadataCommentsLabel": "Reacties",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -695,6 +695,7 @@
     "metadataCollaboratorsLabel": "Współtwórcy",
     "metadataInspiredByLabel": "Zainspirowane przez",
     "metadataRepostedByLabel": "Repostowane przez",
+    "metadataMoreReposters": "+{count} więcej",
     "metadataLoopsLabel": "Pętle",
     "metadataLikesLabel": "Polubienia",
     "metadataCommentsLabel": "Komentarze",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -695,6 +695,7 @@
     "metadataCollaboratorsLabel": "Colaboradores",
     "metadataInspiredByLabel": "Inspirado em",
     "metadataRepostedByLabel": "Repostado por",
+    "metadataMoreReposters": "+{count} mais",
     "metadataLoopsLabel": "Loops",
     "metadataLikesLabel": "Curtidas",
     "metadataCommentsLabel": "Comentários",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -695,6 +695,7 @@
     "metadataCollaboratorsLabel": "Colaboratori",
     "metadataInspiredByLabel": "Inspirat de",
     "metadataRepostedByLabel": "Redistribuit de",
+    "metadataMoreReposters": "încă {count}",
     "metadataLoopsLabel": "Bucle",
     "metadataLikesLabel": "Aprecieri",
     "metadataCommentsLabel": "Comentarii",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -695,6 +695,7 @@
     "metadataCollaboratorsLabel": "Samarbetspartner",
     "metadataInspiredByLabel": "Inspirerad av",
     "metadataRepostedByLabel": "Återpublicerad av",
+    "metadataMoreReposters": "+{count} till",
     "metadataLoopsLabel": "Loopar",
     "metadataLikesLabel": "Gillamarkeringar",
     "metadataCommentsLabel": "Kommentarer",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -692,6 +692,7 @@
     "metadataCollaboratorsLabel": "İşbirlikçiler",
     "metadataInspiredByLabel": "İlham alındı",
     "metadataRepostedByLabel": "Yeniden paylaşan",
+    "metadataMoreReposters": "+{count} daha",
     "metadataLoopsLabel": "Döngüler",
     "metadataLikesLabel": "Beğeniler",
     "metadataCommentsLabel": "Yorumlar",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -991,6 +991,7 @@
   "metadataCollaboratorsLabel": "شریک کار",
   "metadataInspiredByLabel": "متاثر از",
   "metadataRepostedByLabel": "ریپوسٹ کرنے والے",
+  "metadataMoreReposters": "+{count} مزید",
   "metadataLoopsLabel": "{count, plural, =1{لوپ} other{لوپ}}",
   "@metadataLoopsLabel": {
     "placeholders": {

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -991,6 +991,7 @@
   "metadataCollaboratorsLabel": "Cộng tác viên",
   "metadataInspiredByLabel": "Lấy cảm hứng từ",
   "metadataRepostedByLabel": "Được đăng lại bởi",
+  "metadataMoreReposters": "+{count} người nữa",
   "metadataLoopsLabel": "{count, plural, =1{Loop} other{Loop}}",
   "@metadataLoopsLabel": {
     "placeholders": {

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -991,6 +991,7 @@
   "metadataCollaboratorsLabel": "协作者",
   "metadataInspiredByLabel": "灵感来自",
   "metadataRepostedByLabel": "转发自",
+  "metadataMoreReposters": "还有 {count} 人",
   "metadataLoopsLabel": "{count, plural, =1{次循环} other{次循环}}",
   "@metadataLoopsLabel": {
     "placeholders": {

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -3222,6 +3222,12 @@ abstract class AppLocalizations {
   /// **'Reposted by'**
   String get metadataRepostedByLabel;
 
+  /// Chip in the video metadata sheet opening the full reposters list, showing how many reposters are not displayed.
+  ///
+  /// In en, this message translates to:
+  /// **'+{count} more'**
+  String metadataMoreReposters(int count);
+
   /// No description provided for @metadataLoopsLabel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1790,6 +1790,11 @@ class AppLocalizationsAm extends AppLocalizations {
   String get metadataRepostedByLabel => 'በድጋሚ የተለጠፈው በ';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count ተጨማሪ';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1814,6 +1814,11 @@ class AppLocalizationsAr extends AppLocalizations {
   String get metadataRepostedByLabel => 'أعاد نشره';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count آخرين';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'التكرارات';
   }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -1850,6 +1850,11 @@ class AppLocalizationsBg extends AppLocalizations {
   String get metadataRepostedByLabel => 'Повторно публикувано от';
 
   @override
+  String metadataMoreReposters(int count) {
+    return 'още $count';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -1847,6 +1847,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get metadataRepostedByLabel => 'Repostet von';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count weitere';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Loops';
   }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1822,6 +1822,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get metadataRepostedByLabel => 'Reposted by';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count more';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -1845,6 +1845,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get metadataRepostedByLabel => 'Reposteado por';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count más';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Loops';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -1855,6 +1855,11 @@ class AppLocalizationsFil extends AppLocalizations {
   String get metadataRepostedByLabel => 'Na-repost ni';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count pa';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -1855,6 +1855,11 @@ class AppLocalizationsFr extends AppLocalizations {
   String get metadataRepostedByLabel => 'Reposté par';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count autres';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Loops';
   }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1787,6 +1787,11 @@ class AppLocalizationsId extends AppLocalizations {
   String get metadataRepostedByLabel => 'Di-repost oleh';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count lainnya';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Loop';
   }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -1849,6 +1849,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get metadataRepostedByLabel => 'Ripubblicato da';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count altri';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Loop';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1714,6 +1714,11 @@ class AppLocalizationsJa extends AppLocalizations {
   String get metadataRepostedByLabel => 'リポスト元';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '他$count人';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'ループ';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1724,6 +1724,11 @@ class AppLocalizationsKo extends AppLocalizations {
   String get metadataRepostedByLabel => '리포스트';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '외 $count명';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return '루프';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -1836,6 +1836,11 @@ class AppLocalizationsMs extends AppLocalizations {
   String get metadataRepostedByLabel => 'Disiarkan semula oleh';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count lagi';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -1835,6 +1835,11 @@ class AppLocalizationsNl extends AppLocalizations {
   String get metadataRepostedByLabel => 'Gerepost door';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count meer';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Loops';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -1860,6 +1860,11 @@ class AppLocalizationsPl extends AppLocalizations {
   String get metadataRepostedByLabel => 'Repostowane przez';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count więcej';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Pętle';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -1842,6 +1842,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get metadataRepostedByLabel => 'Repostado por';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count mais';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Loops';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -1869,6 +1869,11 @@ class AppLocalizationsRo extends AppLocalizations {
   String get metadataRepostedByLabel => 'Redistribuit de';
 
   @override
+  String metadataMoreReposters(int count) {
+    return 'încă $count';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Bucle';
   }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1821,6 +1821,11 @@ class AppLocalizationsSv extends AppLocalizations {
   String get metadataRepostedByLabel => 'Återpublicerad av';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count till';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Loopar';
   }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1792,6 +1792,11 @@ class AppLocalizationsTr extends AppLocalizations {
   String get metadataRepostedByLabel => 'Yeniden paylaşan';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count daha';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Döngüler';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -1826,6 +1826,11 @@ class AppLocalizationsUr extends AppLocalizations {
   String get metadataRepostedByLabel => 'ریپوسٹ کرنے والے';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count مزید';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -1831,6 +1831,11 @@ class AppLocalizationsVi extends AppLocalizations {
   String get metadataRepostedByLabel => 'Được đăng lại bởi';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count người nữa';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -1733,6 +1733,11 @@ class AppLocalizationsZh extends AppLocalizations {
   String get metadataRepostedByLabel => '转发自';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '还有 $count 人';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
@@ -225,10 +225,11 @@ class MetadataRepostedBySection extends StatelessWidget {
 /// times, and every chip resolves its own profile — rendering the full set
 /// would fire a profile fetch per reposter and lay them all out at once.
 ///
-/// Renders nothing while [pubkeys] is empty. The reposters resolve from a
-/// relay round-trip, so the section is revealed through an [AnimatedReveal]
-/// rather than snapping the sections below it down on arrival.
-class _RepostedByContent extends ConsumerWidget {
+/// Renders nothing until the first capped set of chip names has resolved,
+/// and while [pubkeys] is empty. The reposters resolve from a relay
+/// round-trip, so the section is revealed through an [AnimatedReveal] rather
+/// than snapping the sections below it down on arrival.
+class _RepostedByContent extends ConsumerStatefulWidget {
   const _RepostedByContent({required this.pubkeys, required this.video});
 
   /// Roughly three rows of chips on a phone — nine came out at five.
@@ -241,12 +242,35 @@ class _RepostedByContent extends ConsumerWidget {
   final VideoEvent video;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final visible = pubkeys.take(_maxVisibleReposters).toList();
-    final hiddenCount = pubkeys.length - visible.length;
+  ConsumerState<_RepostedByContent> createState() => _RepostedByContentState();
+}
+
+class _RepostedByContentState extends ConsumerState<_RepostedByContent> {
+  /// The last capped set whose chip names had all resolved.
+  ///
+  /// Feed consolidation can pre-populate fewer reposters than the cap, so a
+  /// relay answer widens a row that is already on screen. Re-gating the whole
+  /// section on the widened set would pull it back down to nothing while the
+  /// new profiles load — a bigger jump than the one the gate exists to
+  /// prevent. The row keeps rendering what it already revealed until the
+  /// wider set has settled too.
+  List<String> _revealed = const [];
+
+  @override
+  Widget build(BuildContext context) {
+    final candidate = widget.pubkeys
+        .take(_RepostedByContent._maxVisibleReposters)
+        .toList();
+    // A derived cache, not a rebuild trigger — this build already carries the
+    // resolved names, so there is nothing to schedule.
+    if (_namesSettled(ref, candidate)) {
+      _revealed = candidate;
+    }
+    final visible = _revealed;
+    final hiddenCount = widget.pubkeys.length - visible.length;
 
     return AnimatedReveal(
-      child: pubkeys.isEmpty || !_namesSettled(ref, visible)
+      child: visible.isEmpty
           ? null
           : MetadataSection(
               label: context.l10n.metadataRepostedByLabel,
@@ -258,7 +282,10 @@ class _RepostedByContent extends ConsumerWidget {
                   for (final pubkey in visible)
                     _TappableUserChip(pubkey: pubkey),
                   if (hiddenCount > 0)
-                    _MoreRepostersChip(count: hiddenCount, video: video),
+                    _MoreRepostersChip(
+                      count: hiddenCount,
+                      video: widget.video,
+                    ),
                 ],
               ),
             ),

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Creator, Collaborators, Inspired By, and Reposted By sections
 // ABOUTME: using tappable chips that navigate to user profiles.
 
+import 'dart:async';
+
 import 'package:collaborator_repository/collaborator_repository.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -34,8 +36,10 @@ bool _namesSettled(WidgetRef ref, List<String> pubkeys) {
   final profiles = [
     for (final pubkey in pubkeys) ref.watch(fetchUserProfileProvider(pubkey)),
   ];
-  return profiles.every((profile) => !profile.isLoading);
+  return profiles.every((profile) => profile.hasValue || profile.hasError);
 }
+
+const _nameRevealGrace = Duration(seconds: 1);
 
 /// Creator section showing the video author as a tappable chip.
 class MetadataCreatorSection extends StatelessWidget {
@@ -131,23 +135,43 @@ class _CollaboratorsSectionStatusAware extends StatelessWidget {
 /// a mock repository. A `ProviderScope` is still required: the chip names
 /// come from [fetchUserProfileProvider].
 @visibleForTesting
-class MetadataCollaboratorsSectionBody extends ConsumerWidget {
-  const MetadataCollaboratorsSectionBody({
-    required this.visibility,
-    super.key,
-  });
+class MetadataCollaboratorsSectionBody extends ConsumerStatefulWidget {
+  const MetadataCollaboratorsSectionBody({required this.visibility, super.key});
 
   final CollaboratorVisibility visibility;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final visible = visibility.visiblePubkeys;
+  ConsumerState<MetadataCollaboratorsSectionBody> createState() =>
+      _MetadataCollaboratorsSectionBodyState();
+}
+
+class _MetadataCollaboratorsSectionBodyState
+    extends ConsumerState<MetadataCollaboratorsSectionBody> {
+  List<String> _waitingFor = const [];
+  bool _graceElapsed = false;
+  Timer? _graceTimer;
+
+  @override
+  void dispose() {
+    _graceTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final visible = widget.visibility.visiblePubkeys;
+    final namesSettled = _namesSettled(ref, visible);
+    final canReveal = visible.isNotEmpty && (namesSettled || _graceElapsed);
+
+    _syncGraceTimer(visible, namesSettled);
+
     // A tagged collaborator stays hidden until their confirmation status
-    // resolves, so this section arrives late on videos that have one.
+    // resolves, so this section arrives late on videos that have one. Profile
+    // names get a short grace window to avoid common label reflows without
+    // hiding the whole section behind network tails.
     return AnimatedReveal(
-      child: visible.isEmpty || !_namesSettled(ref, visible)
-          ? null
-          : MetadataSection(
+      child: canReveal
+          ? MetadataSection(
               label: context.l10n.metadataCollaboratorsLabel,
               child: Wrap(
                 spacing: 8,
@@ -156,12 +180,43 @@ class MetadataCollaboratorsSectionBody extends ConsumerWidget {
                   for (final pubkey in visible)
                     _TappableUserChip(
                       pubkey: pubkey,
-                      isPending: visibility.isPendingForInviter(pubkey),
+                      isPending: widget.visibility.isPendingForInviter(pubkey),
                     ),
                 ],
               ),
-            ),
+            )
+          : null,
     );
+  }
+
+  void _syncGraceTimer(List<String> visible, bool namesSettled) {
+    if (visible.isEmpty || namesSettled) {
+      _cancelGraceTimer();
+      _waitingFor = visible;
+      _graceElapsed = false;
+      return;
+    }
+
+    if (_samePubkeys(_waitingFor, visible) &&
+        (_graceTimer != null || _graceElapsed)) {
+      return;
+    }
+
+    _graceTimer?.cancel();
+    _waitingFor = List.unmodifiable(visible);
+    _graceElapsed = false;
+    _graceTimer = Timer(_nameRevealGrace, () {
+      if (!mounted || !_samePubkeys(_waitingFor, visible)) return;
+      setState(() {
+        _graceElapsed = true;
+        _graceTimer = null;
+      });
+    });
+  }
+
+  void _cancelGraceTimer() {
+    _graceTimer?.cancel();
+    _graceTimer = null;
   }
 }
 
@@ -255,19 +310,30 @@ class _RepostedByContentState extends ConsumerState<_RepostedByContent> {
   /// prevent. The row keeps rendering what it already revealed until the
   /// wider set has settled too.
   List<String> _revealed = const [];
+  List<String> _waitingFor = const [];
+  bool _graceElapsed = false;
+  Timer? _graceTimer;
+
+  @override
+  void dispose() {
+    _graceTimer?.cancel();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     final candidate = widget.pubkeys
         .take(_RepostedByContent._maxVisibleReposters)
         .toList();
+    final namesSettled = _namesSettled(ref, candidate);
     // A derived cache, not a rebuild trigger — this build already carries the
     // resolved names, so there is nothing to schedule.
-    if (_namesSettled(ref, candidate)) {
+    if (namesSettled || (_revealed.isEmpty && _graceElapsed)) {
       _revealed = candidate;
     }
+    _syncGraceTimer(candidate, namesSettled);
     final visible = _revealed;
-    final hiddenCount = widget.pubkeys.length - visible.length;
+    final hiddenCount = widget.pubkeys.length - candidate.length;
 
     return AnimatedReveal(
       child: visible.isEmpty
@@ -282,15 +348,50 @@ class _RepostedByContentState extends ConsumerState<_RepostedByContent> {
                   for (final pubkey in visible)
                     _TappableUserChip(pubkey: pubkey),
                   if (hiddenCount > 0)
-                    _MoreRepostersChip(
-                      count: hiddenCount,
-                      video: widget.video,
-                    ),
+                    _MoreRepostersChip(count: hiddenCount, video: widget.video),
                 ],
               ),
             ),
     );
   }
+
+  void _syncGraceTimer(List<String> candidate, bool namesSettled) {
+    if (candidate.isEmpty || namesSettled || _revealed.isNotEmpty) {
+      _cancelGraceTimer();
+      _waitingFor = candidate;
+      _graceElapsed = false;
+      return;
+    }
+
+    if (_samePubkeys(_waitingFor, candidate) &&
+        (_graceTimer != null || _graceElapsed)) {
+      return;
+    }
+
+    _graceTimer?.cancel();
+    _waitingFor = List.unmodifiable(candidate);
+    _graceElapsed = false;
+    _graceTimer = Timer(_nameRevealGrace, () {
+      if (!mounted || !_samePubkeys(_waitingFor, candidate)) return;
+      setState(() {
+        _graceElapsed = true;
+        _graceTimer = null;
+      });
+    });
+  }
+
+  void _cancelGraceTimer() {
+    _graceTimer?.cancel();
+    _graceTimer = null;
+  }
+}
+
+bool _samePubkeys(List<String> a, List<String> b) {
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
 }
 
 /// Button that opens the full reposters list for [video].

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
@@ -21,6 +21,22 @@ import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_section.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/video_reposters_cubit.dart';
 
+/// Whether every chip in [pubkeys] already knows the name it will render.
+///
+/// [_TappableUserChip] falls back to a generated name while its profile
+/// loads, so a row shown before the profiles settle swaps every label — and
+/// reflows itself around the new widths — a moment later. Sections that can
+/// afford to arrive late hold their reveal until this is true.
+///
+/// Every provider is watched unconditionally so the rebuild arrives for
+/// whichever profile resolves last.
+bool _namesSettled(WidgetRef ref, List<String> pubkeys) {
+  final profiles = [
+    for (final pubkey in pubkeys) ref.watch(fetchUserProfileProvider(pubkey)),
+  ];
+  return profiles.every((profile) => !profile.isLoading);
+}
+
 /// Creator section showing the video author as a tappable chip.
 class MetadataCreatorSection extends StatelessWidget {
   const MetadataCreatorSection({required this.pubkey, super.key});
@@ -114,7 +130,7 @@ class _CollaboratorsSectionStatusAware extends StatelessWidget {
 /// can exercise every render branch without standing up a Riverpod
 /// container, a `BlocProvider`, or a mock repository.
 @visibleForTesting
-class MetadataCollaboratorsSectionBody extends StatelessWidget {
+class MetadataCollaboratorsSectionBody extends ConsumerWidget {
   const MetadataCollaboratorsSectionBody({
     required this.visibility,
     super.key,
@@ -123,12 +139,12 @@ class MetadataCollaboratorsSectionBody extends StatelessWidget {
   final CollaboratorVisibility visibility;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final visible = visibility.visiblePubkeys;
     // A tagged collaborator stays hidden until their confirmation status
     // resolves, so this section arrives late on videos that have one.
     return AnimatedReveal(
-      child: visible.isEmpty
+      child: visible.isEmpty || !_namesSettled(ref, visible)
           ? null
           : MetadataSection(
               label: context.l10n.metadataCollaboratorsLabel,
@@ -211,7 +227,7 @@ class MetadataRepostedBySection extends StatelessWidget {
 /// Renders nothing while [pubkeys] is empty. The reposters resolve from a
 /// relay round-trip, so the section is revealed through an [AnimatedReveal]
 /// rather than snapping the sections below it down on arrival.
-class _RepostedByContent extends StatelessWidget {
+class _RepostedByContent extends ConsumerWidget {
   const _RepostedByContent({required this.pubkeys, required this.video});
 
   /// Roughly three rows of chips on a phone — nine came out at five.
@@ -224,12 +240,12 @@ class _RepostedByContent extends StatelessWidget {
   final VideoEvent video;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final visible = pubkeys.take(_maxVisibleReposters).toList();
     final hiddenCount = pubkeys.length - visible.length;
 
     return AnimatedReveal(
-      child: pubkeys.isEmpty
+      child: pubkeys.isEmpty || !_namesSettled(ref, visible)
           ? null
           : MetadataSection(
               label: context.l10n.metadataRepostedByLabel,

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
@@ -318,12 +318,23 @@ class _MoreRepostersChip extends StatelessWidget {
 
   void _openRepostersList(BuildContext context) {
     final addressableId = video.addressableId;
-    final location = GoRouter.of(context).namedLocation(
+    // Dismiss the sheet first, then navigate from the root navigator context
+    // — the same handoff every other destination in this sheet uses. Both the
+    // router lookup and the push run against the host context, which is
+    // outside the modal's widget tree.
+    final hostContext = Navigator.of(context, rootNavigator: true).context;
+    final location = GoRouter.of(hostContext).namedLocation(
       VideoEngagementListScreen.repostersRouteName,
       pathParameters: {'eventId': video.id},
       queryParameters: addressableId == null ? const {} : {'a': addressableId},
     );
-    context.pushWithVideoPause<void>(location);
+    Navigator.of(context).pop();
+    // Defer to the next frame so the modal route's pop has settled in the
+    // route stack before we push the destination route.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!hostContext.mounted) return;
+      hostContext.pushWithVideoPause<void>(location);
+    });
   }
 }
 

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
@@ -40,7 +40,7 @@ class MetadataCreatorSection extends StatelessWidget {
 /// `ignored` for this video. Pending collaborator chips are dimmed when
 /// the current user is the video's creator.
 ///
-/// Returns [SizedBox.shrink] when the resulting list is empty.
+/// Renders nothing while the resulting list is empty.
 class MetadataCollaboratorsSection extends ConsumerWidget {
   const MetadataCollaboratorsSection({required this.video, super.key});
 
@@ -123,21 +123,25 @@ class MetadataCollaboratorsSectionBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final visible = visibility.visiblePubkeys;
-    if (visible.isEmpty) return const SizedBox.shrink();
-
-    return MetadataSection(
-      label: context.l10n.metadataCollaboratorsLabel,
-      child: Wrap(
-        spacing: 8,
-        runSpacing: 8,
-        children: [
-          for (final pubkey in visible)
-            _TappableUserChip(
-              pubkey: pubkey,
-              isPending: visibility.isPendingForInviter(pubkey),
+    // A tagged collaborator stays hidden until their confirmation status
+    // resolves, so this section arrives late on videos that have one.
+    return AnimatedReveal(
+      child: visible.isEmpty
+          ? null
+          : MetadataSection(
+              label: context.l10n.metadataCollaboratorsLabel,
+              child: Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  for (final pubkey in visible)
+                    _TappableUserChip(
+                      pubkey: pubkey,
+                      isPending: visibility.isPendingForInviter(pubkey),
+                    ),
+                ],
+              ),
             ),
-        ],
-      ),
     );
   }
 }
@@ -167,7 +171,7 @@ class MetadataInspiredBySection extends StatelessWidget {
 /// Reads reposter pubkeys from [VideoRepostersCubit] (provided by the
 /// metadata sheet) and merges with any pre-populated
 /// [VideoEvent.reposterPubkeys] from feed consolidation.
-/// Returns [SizedBox.shrink] when no reposters are found.
+/// Renders nothing while no reposters are found.
 class MetadataRepostedBySection extends StatelessWidget {
   const MetadataRepostedBySection({required this.video, super.key});
 
@@ -194,7 +198,9 @@ class MetadataRepostedBySection extends StatelessWidget {
 
 /// Content widget for the Reposted-by section.
 ///
-/// Returns [SizedBox.shrink] when [pubkeys] is empty.
+/// Renders nothing while [pubkeys] is empty. The reposters resolve from a
+/// relay round-trip, so the section is revealed through an [AnimatedReveal]
+/// rather than snapping the sections below it down on arrival.
 class _RepostedByContent extends StatelessWidget {
   const _RepostedByContent({required this.pubkeys});
 
@@ -202,17 +208,20 @@ class _RepostedByContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (pubkeys.isEmpty) return const SizedBox.shrink();
-
-    return MetadataSection(
-      label: context.l10n.metadataRepostedByLabel,
-      child: Wrap(
-        spacing: 8,
-        runSpacing: 8,
-        children: [
-          for (final pubkey in pubkeys) _TappableUserChip(pubkey: pubkey),
-        ],
-      ),
+    return AnimatedReveal(
+      child: pubkeys.isEmpty
+          ? null
+          : MetadataSection(
+              label: context.l10n.metadataRepostedByLabel,
+              child: Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  for (final pubkey in pubkeys)
+                    _TappableUserChip(pubkey: pubkey),
+                ],
+              ),
+            ),
     );
   }
 }

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
@@ -7,12 +7,14 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/video_collaborator_status/video_collaborator_status_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
+import 'package:openvine/screens/video_engagement/video_engagement_list_screen.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:openvine/utils/public_identifier_normalizer.dart';
 import 'package:openvine/widgets/user_avatar.dart';
@@ -187,10 +189,13 @@ class MetadataRepostedBySection extends StatelessWidget {
         }.toList();
 
         if (state.isLoading && allPubkeys.isEmpty) {
-          return _RepostedByContent(pubkeys: video.reposterPubkeys ?? []);
+          return _RepostedByContent(
+            pubkeys: video.reposterPubkeys ?? [],
+            video: video,
+          );
         }
 
-        return _RepostedByContent(pubkeys: allPubkeys);
+        return _RepostedByContent(pubkeys: allPubkeys, video: video);
       },
     );
   }
@@ -198,16 +203,31 @@ class MetadataRepostedBySection extends StatelessWidget {
 
 /// Content widget for the Reposted-by section.
 ///
+/// Shows at most [_maxVisibleReposters] chips and hands the rest to the
+/// reposters list screen. A popular video can be reposted thousands of
+/// times, and every chip resolves its own profile — rendering the full set
+/// would fire a profile fetch per reposter and lay them all out at once.
+///
 /// Renders nothing while [pubkeys] is empty. The reposters resolve from a
 /// relay round-trip, so the section is revealed through an [AnimatedReveal]
 /// rather than snapping the sections below it down on arrival.
 class _RepostedByContent extends StatelessWidget {
-  const _RepostedByContent({required this.pubkeys});
+  const _RepostedByContent({required this.pubkeys, required this.video});
+
+  /// Roughly three rows of chips on a phone — nine came out at five.
+  ///
+  /// Not an exact row count: chip width follows the display name, and those
+  /// resolve per chip after this has already been laid out.
+  static const _maxVisibleReposters = 5;
 
   final List<String> pubkeys;
+  final VideoEvent video;
 
   @override
   Widget build(BuildContext context) {
+    final visible = pubkeys.take(_maxVisibleReposters).toList();
+    final hiddenCount = pubkeys.length - visible.length;
+
     return AnimatedReveal(
       child: pubkeys.isEmpty
           ? null
@@ -216,13 +236,50 @@ class _RepostedByContent extends StatelessWidget {
               child: Wrap(
                 spacing: 8,
                 runSpacing: 8,
+                crossAxisAlignment: WrapCrossAlignment.center,
                 children: [
-                  for (final pubkey in pubkeys)
+                  for (final pubkey in visible)
                     _TappableUserChip(pubkey: pubkey),
+                  if (hiddenCount > 0)
+                    _MoreRepostersChip(count: hiddenCount, video: video),
                 ],
               ),
             ),
     );
+  }
+}
+
+/// Button that opens the full reposters list for [video].
+///
+/// [DivineButtonSize.small] paints a 40px pill with the same 16px radius and
+/// 16/8 padding as [_TappableUserChip], so it sits on the chips' baseline
+/// while its outlined variant reads as an action rather than a person. The
+/// row centres its children because this carries a 4px tap-target halo the
+/// chips do not.
+class _MoreRepostersChip extends StatelessWidget {
+  const _MoreRepostersChip({required this.count, required this.video});
+
+  final int count;
+  final VideoEvent video;
+
+  @override
+  Widget build(BuildContext context) {
+    return DivineButton(
+      label: context.l10n.metadataMoreReposters(count),
+      type: DivineButtonType.secondary,
+      size: DivineButtonSize.small,
+      onPressed: () => _openRepostersList(context),
+    );
+  }
+
+  void _openRepostersList(BuildContext context) {
+    final addressableId = video.addressableId;
+    final location = GoRouter.of(context).namedLocation(
+      VideoEngagementListScreen.repostersRouteName,
+      pathParameters: {'eventId': video.id},
+      queryParameters: addressableId == null ? const {} : {'a': addressableId},
+    );
+    context.pushWithVideoPause<void>(location);
   }
 }
 

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
@@ -127,8 +127,9 @@ class _CollaboratorsSectionStatusAware extends StatelessWidget {
 /// Renders the collaborators section from a [CollaboratorVisibility].
 ///
 /// Promoted to a top-level class with [visibleForTesting] so widget tests
-/// can exercise every render branch without standing up a Riverpod
-/// container, a `BlocProvider`, or a mock repository.
+/// can exercise every render branch without standing up a `BlocProvider` or
+/// a mock repository. A `ProviderScope` is still required: the chip names
+/// come from [fetchUserProfileProvider].
 @visibleForTesting
 class MetadataCollaboratorsSectionBody extends ConsumerWidget {
   const MetadataCollaboratorsSectionBody({

--- a/mobile/packages/divine_ui/lib/divine_ui.dart
+++ b/mobile/packages/divine_ui/lib/divine_ui.dart
@@ -1,3 +1,4 @@
+export 'src/animated_reveal.dart';
 export 'src/app_bar/app_bar.dart';
 export 'src/bottom_sheet/bottom_sheet.dart';
 export 'src/button/button.dart';

--- a/mobile/packages/divine_ui/lib/src/animated_reveal.dart
+++ b/mobile/packages/divine_ui/lib/src/animated_reveal.dart
@@ -1,0 +1,61 @@
+// ABOUTME: Grows late-arriving content into place instead of snapping it in.
+// ABOUTME: A null child is the empty state, keeping the box mounted at 0 high.
+
+import 'package:flutter/material.dart';
+
+/// Reveals content that arrives after its surroundings have painted.
+///
+/// Asynchronous data — a relay round-trip, a profile fetch, a confirmation
+/// status — lands on an already-painted screen. Swapping an empty box for the
+/// finished widget in a single frame shoves everything below it down. This
+/// grows the box into place instead, so its siblings slide rather than jump:
+///
+/// ```dart
+/// AnimatedReveal(
+///   child: reposters.isEmpty ? null : RepostersRow(reposters),
+/// )
+/// ```
+///
+/// A null [child] is the empty state. Keep this widget mounted while empty
+/// rather than dropping it from the tree behind a conditional — one that only
+/// appears together with its content mounts at its final size and has nothing
+/// to animate from.
+///
+/// The empty state spans the full available width so only the height
+/// animates. Honours [MediaQueryData.disableAnimations].
+class AnimatedReveal extends StatelessWidget {
+  /// Creates an [AnimatedReveal].
+  const AnimatedReveal({
+    this.child,
+    this.duration = _defaultDuration,
+    super.key,
+  });
+
+  static const _defaultDuration = Duration(milliseconds: 220);
+
+  /// The content to reveal, or null while there is nothing to show.
+  final Widget? child;
+
+  /// How long the reveal takes.
+  final Duration duration;
+
+  @override
+  Widget build(BuildContext context) {
+    final content = child ?? const SizedBox(width: .infinity);
+    // Drop the animators entirely under reduce motion rather than passing them
+    // Duration.zero: a zero-duration AnimatedSize completes its controller
+    // synchronously inside performLayout, which re-dirties the render object
+    // mid-layout and trips a framework assertion.
+    if (MediaQuery.disableAnimationsOf(context)) return content;
+
+    // AnimatedSwitcher alone would not do: it stacks the outgoing and incoming
+    // child and adopts the larger size at once, fading the content in while
+    // the layout still jumps. The height has to come from AnimatedSize.
+    return AnimatedSize(
+      duration: duration,
+      curve: Curves.easeOutCubic,
+      alignment: Alignment.topCenter,
+      child: AnimatedSwitcher(duration: duration, child: content),
+    );
+  }
+}

--- a/mobile/packages/divine_ui/lib/src/animated_reveal.dart
+++ b/mobile/packages/divine_ui/lib/src/animated_reveal.dart
@@ -21,9 +21,11 @@ import 'package:flutter/material.dart';
 /// appears together with its content mounts at its final size and has nothing
 /// to animate from.
 ///
-/// The empty state spans the full available width so only the height
-/// animates. Honours [MediaQueryData.disableAnimations].
-class AnimatedReveal extends StatelessWidget {
+/// Layout-transparent: the child is laid out under the constraints this
+/// widget receives, so wrapping an existing widget does not move or resize
+/// it. Content already present when this mounts is not animated. Honours
+/// [MediaQueryData.disableAnimations].
+class AnimatedReveal extends StatefulWidget {
   /// Creates an [AnimatedReveal].
   const AnimatedReveal({
     this.child,
@@ -40,22 +42,43 @@ class AnimatedReveal extends StatelessWidget {
   final Duration duration;
 
   @override
+  State<AnimatedReveal> createState() => _AnimatedRevealState();
+}
+
+class _AnimatedRevealState extends State<AnimatedReveal> {
+  /// Content that is already there when this mounts has not "arrived", so it
+  /// must not fade in on first paint.
+  late final bool _startsRevealed = widget.child != null;
+
+  @override
   Widget build(BuildContext context) {
-    final content = child ?? const SizedBox(width: .infinity);
+    final content = widget.child;
     // Drop the animators entirely under reduce motion rather than passing them
     // Duration.zero: a zero-duration AnimatedSize completes its controller
     // synchronously inside performLayout, which re-dirties the render object
     // mid-layout and trips a framework assertion.
-    if (MediaQuery.disableAnimationsOf(context)) return content;
+    if (MediaQuery.disableAnimationsOf(context)) {
+      return content ?? const SizedBox(width: .infinity);
+    }
 
-    // AnimatedSwitcher alone would not do: it stacks the outgoing and incoming
-    // child and adopts the larger size at once, fading the content in while
-    // the layout still jumps. The height has to come from AnimatedSize.
     return AnimatedSize(
-      duration: duration,
+      duration: widget.duration,
       curve: Curves.easeOutCubic,
-      alignment: Alignment.topCenter,
-      child: AnimatedSwitcher(duration: duration, child: content),
+      alignment: AlignmentDirectional.topStart,
+      // The empty state spans the full available width so only the height
+      // animates when content arrives.
+      child: content == null
+          ? const SizedBox(width: .infinity)
+          // Opacity rather than an AnimatedSwitcher: the switcher stacks its
+          // children and hands them loose constraints, which shrink-wraps and
+          // centres a child that the surrounding layout meant to stretch.
+          : TweenAnimationBuilder<double>(
+              tween: Tween(begin: _startsRevealed ? 1.0 : 0.0, end: 1),
+              duration: widget.duration,
+              builder: (context, opacity, child) =>
+                  Opacity(opacity: opacity, child: child),
+              child: content,
+            ),
     );
   }
 }

--- a/mobile/packages/divine_ui/lib/src/animated_reveal.dart
+++ b/mobile/packages/divine_ui/lib/src/animated_reveal.dart
@@ -25,6 +25,10 @@ import 'package:flutter/material.dart';
 /// widget receives, so wrapping an existing widget does not move or resize
 /// it. Content already present when this mounts is not animated. Honours
 /// [MediaQueryData.disableAnimations].
+///
+/// Needs a bounded-width parent: the empty state spans the full available
+/// width so only the height animates, which throws under an unbounded width
+/// (an unconstrained [Row] child, a horizontal list).
 class AnimatedReveal extends StatefulWidget {
   /// Creates an [AnimatedReveal].
   const AnimatedReveal({

--- a/mobile/packages/divine_ui/test/src/animated_reveal_test.dart
+++ b/mobile/packages/divine_ui/test/src/animated_reveal_test.dart
@@ -64,6 +64,32 @@ void main() {
       expect(tester.getSize(subject()).height, 40);
     });
 
+    testWidgets('lays the child out under the parent constraints', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 300,
+              child: AnimatedReveal(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [Text('leading')],
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Stacking the child (as an AnimatedSwitcher does) would hand it loose
+      // constraints, shrink-wrapping the column and centring it instead.
+      expect(tester.getSize(find.byType(Column)).width, 300);
+      expect(tester.getTopLeft(find.text('leading')).dx, 0);
+    });
+
     testWidgets('lands at full height when animations are disabled', (
       tester,
     ) async {

--- a/mobile/packages/divine_ui/test/src/animated_reveal_test.dart
+++ b/mobile/packages/divine_ui/test/src/animated_reveal_test.dart
@@ -1,0 +1,84 @@
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group(AnimatedReveal, () {
+    Widget buildSubject({
+      Widget? child,
+      Duration? duration,
+      bool disableAnimations = false,
+    }) {
+      return MaterialApp(
+        home: Builder(
+          builder: (context) => MediaQuery(
+            data: MediaQuery.of(
+              context,
+            ).copyWith(disableAnimations: disableAnimations),
+            child: Scaffold(
+              body: Align(
+                alignment: Alignment.topCenter,
+                child: AnimatedReveal(
+                  duration: duration ?? const Duration(milliseconds: 220),
+                  child: child,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    Finder subject() => find.byType(AnimatedReveal);
+
+    testWidgets('renders the child once it is settled', (tester) async {
+      await tester.pumpWidget(
+        buildSubject(child: const SizedBox(height: 40, child: Text('badge'))),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('badge'), findsOneWidget);
+      expect(tester.getSize(subject()).height, 40);
+    });
+
+    testWidgets('takes no height while the child is null', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(tester.getSize(subject()).height, 0);
+    });
+
+    testWidgets('grows into place when the child arrives', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      await tester.pumpWidget(
+        buildSubject(child: const SizedBox(height: 40, child: Text('badge'))),
+      );
+      await tester.pump();
+      final revealingHeight = tester.getSize(subject()).height;
+
+      await tester.pumpAndSettle();
+
+      expect(revealingHeight, lessThan(40));
+      expect(tester.getSize(subject()).height, 40);
+    });
+
+    testWidgets('lands at full height when animations are disabled', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject(disableAnimations: true));
+      await tester.pumpAndSettle();
+
+      await tester.pumpWidget(
+        buildSubject(
+          disableAnimations: true,
+          child: const SizedBox(height: 40, child: Text('badge')),
+        ),
+      );
+      await tester.pump();
+
+      expect(tester.getSize(subject()).height, 40);
+    });
+  });
+}

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -61,6 +61,12 @@ const _parentEventId =
 const _parentAddressableId =
     '34236:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:parent-d-tag';
 
+/// Chips dimmed by [Opacity]. Deliberately ignores fully opaque wrappers so
+/// the assertion means "nothing is dimmed" rather than "nothing anywhere
+/// uses Opacity".
+Finder _dimmed() =>
+    find.byWidgetPredicate((widget) => widget is Opacity && widget.opacity < 1);
+
 AppLocalizations _l10n(WidgetTester tester) =>
     AppLocalizations.of(tester.element(find.byType(Scaffold).first));
 
@@ -889,7 +895,7 @@ void main() {
           find.text(l10n.videoCollaboratorPendingDecoration),
           findsNothing,
         );
-        expect(find.byType(Opacity), findsNothing);
+        expect(_dimmed(), findsNothing);
       },
     );
 
@@ -927,10 +933,10 @@ void main() {
           find.text(l10n.videoCollaboratorPendingDecoration),
           findsOneWidget,
         );
-        // The pending chip is wrapped in an Opacity.
-        final opacityWidgets = tester.widgetList<Opacity>(find.byType(Opacity));
-        expect(opacityWidgets, hasLength(1));
-        expect(opacityWidgets.first.opacity, closeTo(0.7, 0.001));
+        // The pending chip is the only one wrapped in a dimming Opacity.
+        final dimmed = tester.widgetList<Opacity>(_dimmed());
+        expect(dimmed, hasLength(1));
+        expect(dimmed.first.opacity, closeTo(0.7, 0.001));
       },
     );
 
@@ -1014,7 +1020,7 @@ void main() {
           find.text(l10n.videoCollaboratorPendingDecoration),
           findsNothing,
         );
-        expect(find.byType(Opacity), findsNothing);
+        expect(_dimmed(), findsNothing);
       },
     );
   });

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
@@ -20,6 +21,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/screens/video_engagement/video_engagement_list_screen.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_badges_row.dart';
@@ -1149,6 +1151,100 @@ void main() {
           find.text(_l10n(tester).metadataMoreReposters(7)),
           findsOneWidget,
         );
+      },
+    );
+
+    testWidgetsWithSurfaceSize(
+      'the more-reposters button dismisses the sheet before navigating',
+      (tester) async {
+        final pubkeys = List<String>.generate(
+          12,
+          (index) => (index + 1).toRadixString(16).padLeft(64, '0'),
+        );
+        when(() => mockRepostersCubit.state).thenReturn(
+          VideoRepostersState(pubkeys: pubkeys, isLoading: false),
+        );
+
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(
+              createMockSharedPreferences(),
+            ),
+            videosRepositoryProvider.overrideWithValue(mockVideosRepository),
+            for (final pubkey in pubkeys)
+              fetchUserProfileProvider(
+                pubkey,
+              ).overrideWith((ref) async => null),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final router = GoRouter(
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (context, state) => Scaffold(
+                body: Builder(
+                  builder: (context) => TextButton(
+                    onPressed: () => showModalBottomSheet<void>(
+                      context: context,
+                      builder: (_) => MultiBlocProvider(
+                        providers: [
+                          BlocProvider<VideoInteractionsBloc>.value(
+                            value: mockInteractionsBloc,
+                          ),
+                          BlocProvider<VideoRepostersCubit>.value(
+                            value: mockRepostersCubit,
+                          ),
+                        ],
+                        child: MetadataRepostedBySection(video: _makeVideo()),
+                      ),
+                    ),
+                    child: const Text('open sheet'),
+                  ),
+                ),
+              ),
+            ),
+            GoRoute(
+              path: '/video/:eventId/reposters',
+              name: VideoEngagementListScreen.repostersRouteName,
+              builder: (context, state) =>
+                  const Scaffold(body: Text('reposters list')),
+            ),
+          ],
+        );
+        addTearDown(router.dispose);
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: MaterialApp.router(
+              routerConfig: router,
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+            ),
+          ),
+        );
+        await tester.tap(find.text('open sheet'));
+        await tester.pumpAndSettle();
+
+        final moreLabel = _l10n(tester).metadataMoreReposters(7);
+        expect(find.text('Reposted by'), findsOneWidget);
+
+        await tester.tap(find.text(moreLabel));
+        await tester.pumpAndSettle();
+
+        expect(find.text('reposters list'), findsOneWidget);
+
+        // Every other destination in this sheet hands off the same way:
+        // dismiss, then push from the root navigator. Pushing with the sheet
+        // still mounted leaves it stacked over the list, so backing out of
+        // the list drops the user onto the sheet again instead of the video.
+        router.pop();
+        await tester.pumpAndSettle();
+
+        expect(find.text('open sheet'), findsOneWidget);
+        expect(find.text('Reposted by'), findsNothing);
       },
     );
 

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -474,9 +474,7 @@ void main() {
 
         await tester.pumpWidget(
           buildSubject(
-            child: MetadataStatsRow(
-              video: video.copyWith(originalReposts: 10),
-            ),
+            child: MetadataStatsRow(video: video.copyWith(originalReposts: 10)),
           ),
         );
 
@@ -498,9 +496,7 @@ void main() {
       'falls back to live nostr counts in the breakdown while loading',
       (tester) async {
         when(() => mockInteractionsBloc.state).thenReturn(
-          const VideoInteractionsState(
-            status: VideoInteractionsStatus.loading,
-          ),
+          const VideoInteractionsState(status: VideoInteractionsStatus.loading),
         );
 
         final video = _makeVideo(
@@ -1026,6 +1022,42 @@ void main() {
         expect(_dimmed(), findsNothing);
       },
     );
+
+    testWidgetsWithSurfaceSize(
+      'reveals fallback names after the profile grace window',
+      (tester) async {
+        final profile = Completer<UserProfile?>();
+
+        await tester.pumpWidget(
+          buildSubject(
+            providerOverrides: [
+              fetchUserProfileProvider(
+                _collaborator1,
+              ).overrideWith((ref) => profile.future),
+            ],
+            child: const MetadataCollaboratorsSectionBody(
+              visibility: CollaboratorVisibility.fallback(
+                taggedPubkeys: [_collaborator1],
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        final l10n = _l10n(tester);
+        expect(find.text(l10n.metadataCollaboratorsLabel), findsNothing);
+
+        await tester.pump(const Duration(seconds: 1));
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.metadataCollaboratorsLabel), findsOneWidget);
+
+        profile.complete(_makeProfile(_collaborator1, 'Alice'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Alice'), findsOneWidget);
+      },
+    );
   });
 
   // ---------------------------------------------------------------------------
@@ -1161,9 +1193,9 @@ void main() {
           12,
           (index) => (index + 1).toRadixString(16).padLeft(64, '0'),
         );
-        when(() => mockRepostersCubit.state).thenReturn(
-          VideoRepostersState(pubkeys: pubkeys, isLoading: false),
-        );
+        when(
+          () => mockRepostersCubit.state,
+        ).thenReturn(VideoRepostersState(pubkeys: pubkeys, isLoading: false));
 
         final container = ProviderContainer(
           overrides: [
@@ -1273,6 +1305,41 @@ void main() {
         // Showing the row first would swap every label a moment later and
         // reflow the rows around the new widths.
         expect(find.text('Reposted by'), findsNothing);
+
+        profile.complete(_makeProfile(_reposterPubkey, 'Improvising'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Improvising'), findsOneWidget);
+      },
+    );
+
+    testWidgetsWithSurfaceSize(
+      'reveals fallback chips after the profile grace window',
+      (tester) async {
+        final profile = Completer<UserProfile?>();
+
+        await tester.pumpWidget(
+          buildSubject(
+            repostersState: const VideoRepostersState(
+              pubkeys: [_reposterPubkey],
+              isLoading: false,
+            ),
+            providerOverrides: [
+              fetchUserProfileProvider(
+                _reposterPubkey,
+              ).overrideWith((ref) => profile.future),
+            ],
+            child: MetadataRepostedBySection(video: _makeVideo()),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('Reposted by'), findsNothing);
+
+        await tester.pump(const Duration(seconds: 1));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Reposted by'), findsOneWidget);
 
         profile.complete(_makeProfile(_reposterPubkey, 'Improvising'));
         await tester.pumpAndSettle();
@@ -1405,6 +1472,7 @@ void main() {
         // while the four new profiles load — a bigger jump than the one the
         // gate prevents. The already-named chip keeps its place.
         expect(find.text('Improvising'), findsOneWidget);
+        expect(find.textContaining('more'), findsNothing);
         expect(tester.getSize(section).height, revealedHeight);
 
         for (final completer in relayProfiles.values) {

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -1257,6 +1257,68 @@ void main() {
       expect(find.text('Reposted by'), findsOneWidget);
       expect(revealingHeight, lessThan(tester.getSize(section).height));
     });
+
+    testWidgetsWithSurfaceSize(
+      'stays revealed while a late relay answer widens the row',
+      (tester) async {
+        final relayPubkeys = List<String>.generate(
+          4,
+          (index) => (index + 1).toRadixString(16).padLeft(64, '0'),
+        );
+        final relayProfiles = {
+          for (final pubkey in relayPubkeys) pubkey: Completer<UserProfile?>(),
+        };
+
+        final reposters = StreamController<VideoRepostersState>.broadcast();
+        addTearDown(reposters.close);
+        when(
+          () => mockRepostersCubit.stream,
+        ).thenAnswer((_) => reposters.stream);
+
+        await tester.pumpWidget(
+          buildSubject(
+            repostersState: const VideoRepostersState(),
+            providerOverrides: [
+              fetchUserProfileProvider(_reposterPubkey).overrideWith(
+                (ref) async => _makeProfile(_reposterPubkey, 'Improvising'),
+              ),
+              for (final entry in relayProfiles.entries)
+                fetchUserProfileProvider(
+                  entry.key,
+                ).overrideWith((ref) => entry.value.future),
+            ],
+            // Feed consolidation pre-populated a single reposter, so the row
+            // is already on screen when the relay answers.
+            child: MetadataRepostedBySection(
+              video: _makeVideo(reposterPubkeys: const [_reposterPubkey]),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final section = find.byType(AnimatedReveal);
+        final revealedHeight = tester.getSize(section).height;
+        expect(revealedHeight, greaterThan(0));
+
+        reposters.add(
+          VideoRepostersState(pubkeys: [_reposterPubkey, ...relayPubkeys]),
+        );
+        await tester.pumpAndSettle();
+
+        // Re-gating on the widened set would drop the section to nothing
+        // while the four new profiles load — a bigger jump than the one the
+        // gate prevents. The already-named chip keeps its place.
+        expect(find.text('Improvising'), findsOneWidget);
+        expect(tester.getSize(section).height, revealedHeight);
+
+        for (final completer in relayProfiles.values) {
+          completer.complete(null);
+        }
+        await tester.pumpAndSettle();
+
+        expect(find.byType(UserAvatar), findsNWidgets(5));
+      },
+    );
   });
 
   // ---------------------------------------------------------------------------

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -21,6 +21,7 @@ import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
+import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_badges_row.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_sounds_section.dart';
@@ -1115,6 +1116,65 @@ void main() {
       expect(find.text('Reposted by'), findsOneWidget);
       expect(find.text('Improvising'), findsOneWidget);
     });
+
+    testWidgetsWithSurfaceSize(
+      'caps the chips and offers the rest through the full list',
+      (tester) async {
+        final pubkeys = List<String>.generate(
+          12,
+          (index) => (index + 1).toRadixString(16).padLeft(64, '0'),
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            repostersState: VideoRepostersState(
+              pubkeys: pubkeys,
+              isLoading: false,
+            ),
+            providerOverrides: [
+              for (final pubkey in pubkeys)
+                fetchUserProfileProvider(
+                  pubkey,
+                ).overrideWith((ref) async => null),
+            ],
+            child: MetadataRepostedBySection(video: _makeVideo()),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Every reposter would otherwise be a chip that fetches its own
+        // profile — a popular video has thousands.
+        expect(find.byType(UserAvatar), findsNWidgets(5));
+        expect(
+          find.text(_l10n(tester).metadataMoreReposters(7)),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgetsWithSurfaceSize(
+      'shows every reposter when they fit under the cap',
+      (tester) async {
+        await tester.pumpWidget(
+          buildSubject(
+            repostersState: const VideoRepostersState(
+              pubkeys: [_reposterPubkey],
+              isLoading: false,
+            ),
+            providerOverrides: [
+              fetchUserProfileProvider(_reposterPubkey).overrideWith(
+                (ref) async => _makeProfile(_reposterPubkey, 'Improvising'),
+              ),
+            ],
+            child: MetadataRepostedBySection(video: _makeVideo()),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Improvising'), findsOneWidget);
+        expect(find.textContaining('more'), findsNothing);
+      },
+    );
 
     testWidgetsWithSurfaceSize(
       'hides when relay returns empty and no pre-populated data',

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -1153,6 +1153,39 @@ void main() {
     );
 
     testWidgetsWithSurfaceSize(
+      'waits for the chip names before revealing the section',
+      (tester) async {
+        final profile = Completer<UserProfile?>();
+
+        await tester.pumpWidget(
+          buildSubject(
+            repostersState: const VideoRepostersState(
+              pubkeys: [_reposterPubkey],
+              isLoading: false,
+            ),
+            providerOverrides: [
+              fetchUserProfileProvider(
+                _reposterPubkey,
+              ).overrideWith((ref) => profile.future),
+            ],
+            child: MetadataRepostedBySection(video: _makeVideo()),
+          ),
+        );
+        await tester.pump();
+
+        // A chip falls back to a generated name while its profile loads.
+        // Showing the row first would swap every label a moment later and
+        // reflow the rows around the new widths.
+        expect(find.text('Reposted by'), findsNothing);
+
+        profile.complete(_makeProfile(_reposterPubkey, 'Improvising'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Improvising'), findsOneWidget);
+      },
+    );
+
+    testWidgetsWithSurfaceSize(
       'shows every reposter when they fit under the cap',
       (tester) async {
         await tester.pumpWidget(

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -3,6 +3,8 @@
 // ABOUTME: data is absent. Covers badges, title, stats, creator, tags,
 // ABOUTME: collaborators, inspired by, reposted by, and sounds sections.
 
+import 'dart:async';
+
 import 'package:collaborator_repository/collaborator_repository.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -1121,6 +1123,41 @@ void main() {
         expect(find.text('Reposted by'), findsNothing);
       },
     );
+
+    testWidgetsWithSurfaceSize('grows in when the relay answers late', (
+      tester,
+    ) async {
+      final reposters = StreamController<VideoRepostersState>.broadcast();
+      addTearDown(reposters.close);
+      when(() => mockRepostersCubit.stream).thenAnswer((_) => reposters.stream);
+
+      await tester.pumpWidget(
+        buildSubject(
+          providerOverrides: [
+            fetchUserProfileProvider(_reposterPubkey).overrideWith(
+              (ref) async => _makeProfile(_reposterPubkey, 'Improvising'),
+            ),
+          ],
+          child: MetadataRepostedBySection(video: _makeVideo()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final section = find.byType(AnimatedReveal);
+      expect(tester.getSize(section).height, 0);
+
+      reposters.add(const VideoRepostersState(pubkeys: [_reposterPubkey]));
+      // The reposters are laid out on this frame, but the section is still
+      // collapsed — it grows from there rather than snapping the sections
+      // below it down.
+      await tester.pump();
+      final revealingHeight = tester.getSize(section).height;
+
+      await tester.pumpAndSettle();
+
+      expect(find.text('Reposted by'), findsOneWidget);
+      expect(revealingHeight, lessThan(tester.getSize(section).height));
+    });
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #6695

## Description

Three of the metadata sheet's sections resolve after the sheet has already opened, and each landed badly. This fixes all three symptoms of the same thing, and puts a hard ceiling on how much the **Reposted by** section is allowed to render: a video with thousands of reposts now shows five chips and a button instead of thousands of chips.

**1. Sections snapped into place.** **Reposted by** waits on a relay round-trip through `VideoRepostersCubit`, and **Collaborators** waits on each tagged collaborator's confirmation status. Both rendered `SizedBox.shrink()` until their data arrived and then took full height in a single frame — and because they sit in the middle of the list, every section below them jumped down while the user was reading. Both now render through `AnimatedReveal`, a new `divine_ui` primitive: an `AnimatedSize` that grows the block into place while the content fades in.

**2. Chip labels swapped a moment after that.** A user chip falls back to a generated "Adjective Animal Number" name while its profile loads. Chip width follows the name, so every swap reflowed the row — a second round of jumps right after the section had finished growing in. It happened on every open, not only for strangers: `fetchUserProfile` awaits the local cache lookup, so even a cached profile costs a frame with the fallback showing. Both sections now hold their reveal until every visible chip's profile has settled, with a one-second grace window so slow or unavailable profile fetches reveal fallback names instead of hiding the whole section behind the network tail.

**3. Reposted by rendered one chip per reposter, with no upper bound at all.** Every chip resolves its own profile through `fetchUserProfileProvider`, and the `Wrap` is a single list item, so all of them are built and laid out at once. On a popular video that is thousands of chips and thousands of profile fetches fired the moment the sheet opens — the sheet's cost scaled directly with how successful the video was.

It now renders at most five chips no matter how many reposters there are (three rows on a phone, measured on device), and hands the rest to the reposters list screen through a `+N more` button. That screen already exists at `/video/:eventId/reposters` and is reachable from the repost button's long press, so this is a second entry point rather than new surface. An exact row count is not available at build time: chip width follows the display name, and those resolve asynchronously per chip — anything measuring rows would have to wait for every profile first, which is the cost being avoided.

Four things worth calling out for review:

- **`AnimatedSwitcher` cannot do this job.** It stacks the outgoing and incoming child, adopts the larger size at once — so the content fades while the layout still jumps — and hands its children loose constraints, which shrink-wraps and centres a section the surrounding layout meant to stretch. `AnimatedReveal` fades with an `Opacity` driven by `TweenAnimationBuilder` instead, and stays layout-transparent.
- **A null `child` is the empty state, and the widget stays mounted while empty.** That is the whole point of the API shape — a wrapper that only appears together with its content mounts at its final size and has nothing to animate from.
- **Under reduce motion the widget drops both animators** instead of passing them `Duration.zero`. A zero-duration `AnimatedSize` completes its controller synchronously inside `performLayout`, which re-dirties the render object mid-layout and trips `A RenderAnimatedSize was mutated in its own performLayout implementation`. The `divine_ui` coverage gate is what surfaced this — the accessibility path had no test before.
- **`metadataMoreReposters` is a new key, translated in all 22 locales.** Its copy is identical to `profileBadgeMoreRecipients`, which is deliberately not reused: that key is scoped to the badge sheet and its `description` says so. It is also untranslated in 18 locales, so reusing it would have spread that debt.

**Related Issue:** 

## Out of Scope

**Creator and Inspired-by still show the fallback name briefly.** Gating them would trade a label swap for a real jump: they render immediately today and sit above everything else, so appearing late would push the whole sheet down. Neither reflows anything — each is a lone chip on its own row.

**The reposters fetch is still unbounded, only the rendering is capped.** `RepostsRepository.fetchEventReposters` builds `Filter(kinds: [6, 16], e: [eventId])` with no `limit`, even though `_defaultRepostFetchLimit = 500` exists and three sibling methods in that file pass it. It then queries deletions with `Filter(kinds: [5], authors: <every reposter pubkey>)` — a REQ carrying thousands of authors on a popular video. The UI cap stops the expensive client-side part (profile fetches and widget build); the two relay queries want a follow-up in `reposts_repository`, which is a strict-coverage package and deserves its own PR. Follow-up: #6742.

**The first profile load in the profile header still snaps.** #6686 fixes the same class of jump there and carries its own private copy of this widget, since it was opened before the primitive existed. Once this lands I will point that PR at `AnimatedReveal` and drop the copy.

#6692 was the standalone version of the cap. It is superseded by this PR and closed — the two changes overlapped in the same widget, and splitting them made the branch untestable in isolation.

## Verification

- Takeover verification: `flutter test test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart` — passed; `flutter analyze` — no issues.
- `flutter analyze lib test integration_test` — clean
- `flutter test test/widgets/video_feed_item/metadata` — 59 passed
- `flutter test --coverage` in `packages/divine_ui` — 831 passed, every line of `animated_reveal.dart` covered
- `flutter test test/l10n/arb_consistency_test.dart` — passed, `flutter gen-l10n` output committed
- `check_raw_colors_ceiling.sh` / `check_raw_textstyle_ceiling.sh` — no growth
- New tests: five for `AnimatedReveal` itself (renders, zero height while empty, grows on arrival, keeps the parent's constraints instead of centring, lands instantly under reduce motion); the Reposted-by section still collapsed on the frame after the relay answers; the section hidden while a profile is pending, fallback reveal after the one-second grace window, and 12 reposters rendering 5 chips plus a `+7 more` button
- Manually verified on a real Samsung Galaxy: opened the metadata sheet on videos with reposters and with collaborators, watched both sections grow in with final labels, checked the chip count and the `+N more` button

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
