### PR TITLE
fix(metadata): cap the reposter chips instead of rendering every one

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -811,6 +811,7 @@
     "metadataCollaboratorsLabel": "ተባባሪዎች",
     "metadataInspiredByLabel": "ተመስጦ",
     "metadataRepostedByLabel": "በድጋሚ የተለጠፈው በ",
+    "metadataMoreReposters": "+{count} ተጨማሪ",
     "metadataLoopsLabel": "{count, plural, =1{ሉፕ} other{ሉፖች}}",
     "@metadataLoopsLabel": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -692,6 +692,7 @@
     "metadataCollaboratorsLabel": "المتعاونون",
     "metadataInspiredByLabel": "مستوحى من",
     "metadataRepostedByLabel": "أعاد نشره",
+    "metadataMoreReposters": "+{count} آخرين",
     "metadataLoopsLabel": "التكرارات",
     "metadataLikesLabel": "الإعجابات",
     "metadataCommentsLabel": "التعليقات",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -756,6 +756,7 @@
     "metadataCollaboratorsLabel": "Сътрудници",
     "metadataInspiredByLabel": "Вдъхновено от",
     "metadataRepostedByLabel": "Повторно публикувано от",
+    "metadataMoreReposters": "още {count}",
     "metadataLoopsLabel": "{count, plural, =1{Луп} other{Лупове}}",
     "@metadataLoopsLabel": {
         "placeholders": {

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -695,6 +695,7 @@
     "metadataCollaboratorsLabel": "Mitwirkende",
     "metadataInspiredByLabel": "Inspiriert von",
     "metadataRepostedByLabel": "Repostet von",
+    "metadataMoreReposters": "+{count} weitere",
     "metadataLoopsLabel": "Loops",
     "metadataLikesLabel": "Likes",
     "metadataCommentsLabel": "Kommentare",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1053,6 +1053,15 @@
   "metadataCollaboratorsLabel": "Collaborators",
   "metadataInspiredByLabel": "Inspired by",
   "metadataRepostedByLabel": "Reposted by",
+  "metadataMoreReposters": "+{count} more",
+  "@metadataMoreReposters": {
+    "description": "Chip in the video metadata sheet opening the full reposters list, showing how many reposters are not displayed.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "metadataLoopsLabel": "{count, plural, =1{Loop} other{Loops}}",
   "@metadataLoopsLabel": {
     "placeholders": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -695,6 +695,7 @@
     "metadataCollaboratorsLabel": "Colaboradores",
     "metadataInspiredByLabel": "Inspirado en",
     "metadataRepostedByLabel": "Reposteado por",
+    "metadataMoreReposters": "+{count} más",
     "metadataLoopsLabel": "Loops",
     "metadataLikesLabel": "Me gusta",
     "metadataCommentsLabel": "Comentarios",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -515,6 +515,7 @@
     "metadataCollaboratorsLabel": "Mga Collaborator",
     "metadataInspiredByLabel": "Inspirasyon mula kay",
     "metadataRepostedByLabel": "Na-repost ni",
+    "metadataMoreReposters": "+{count} pa",
     "metadataLoopsLabel": "{count, plural, =1{Loop} other{Loops}}",
     "metadataLikesLabel": "Mga Like",
     "metadataCommentsLabel": "Mga Komento",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -695,6 +695,7 @@
     "metadataCollaboratorsLabel": "Collaborateurs",
     "metadataInspiredByLabel": "Inspiré par",
     "metadataRepostedByLabel": "Reposté par",
+    "metadataMoreReposters": "+{count} autres",
     "metadataLoopsLabel": "Loops",
     "metadataLikesLabel": "J'aime",
     "metadataCommentsLabel": "Commentaires",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -692,6 +692,7 @@
     "metadataCollaboratorsLabel": "Kolaborator",
     "metadataInspiredByLabel": "Terinspirasi oleh",
     "metadataRepostedByLabel": "Di-repost oleh",
+    "metadataMoreReposters": "+{count} lainnya",
     "metadataLoopsLabel": "Loop",
     "metadataLikesLabel": "Suka",
     "metadataCommentsLabel": "Komentar",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -695,6 +695,7 @@
     "metadataCollaboratorsLabel": "Collaboratori",
     "metadataInspiredByLabel": "Ispirato da",
     "metadataRepostedByLabel": "Ripubblicato da",
+    "metadataMoreReposters": "+{count} altri",
     "metadataLoopsLabel": "Loop",
     "metadataLikesLabel": "Mi piace",
     "metadataCommentsLabel": "Commenti",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -692,6 +692,7 @@
     "metadataCollaboratorsLabel": "コラボレーター",
     "metadataInspiredByLabel": "インスパイア元",
     "metadataRepostedByLabel": "リポスト元",
+    "metadataMoreReposters": "他{count}人",
     "metadataLoopsLabel": "ループ",
     "metadataLikesLabel": "いいね",
     "metadataCommentsLabel": "コメント",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -452,6 +452,7 @@
     "metadataCollaboratorsLabel": "콜라보레이터",
     "metadataInspiredByLabel": "영감",
     "metadataRepostedByLabel": "리포스트",
+    "metadataMoreReposters": "외 {count}명",
     "metadataLoopsLabel": "루프",
     "metadataLikesLabel": "좋아요",
     "metadataCommentsLabel": "댓글",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -991,6 +991,7 @@
   "metadataCollaboratorsLabel": "Kolaborator",
   "metadataInspiredByLabel": "Diilhamkan oleh",
   "metadataRepostedByLabel": "Disiarkan semula oleh",
+  "metadataMoreReposters": "+{count} lagi",
   "metadataLoopsLabel": "{count, plural, =1{Loop} other{Loop}}",
   "@metadataLoopsLabel": {
     "placeholders": {

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -695,6 +695,7 @@
     "metadataCollaboratorsLabel": "Samenwerkers",
     "metadataInspiredByLabel": "Geïnspireerd door",
     "metadataRepostedByLabel": "Gerepost door",
+    "metadataMoreReposters": "+{count} meer",
     "metadataLoopsLabel": "Loops",
     "metadataLikesLabel": "Likes",
     "metadataCommentsLabel": "Reacties",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -695,6 +695,7 @@
     "metadataCollaboratorsLabel": "Współtwórcy",
     "metadataInspiredByLabel": "Zainspirowane przez",
     "metadataRepostedByLabel": "Repostowane przez",
+    "metadataMoreReposters": "+{count} więcej",
     "metadataLoopsLabel": "Pętle",
     "metadataLikesLabel": "Polubienia",
     "metadataCommentsLabel": "Komentarze",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -695,6 +695,7 @@
     "metadataCollaboratorsLabel": "Colaboradores",
     "metadataInspiredByLabel": "Inspirado em",
     "metadataRepostedByLabel": "Repostado por",
+    "metadataMoreReposters": "+{count} mais",
     "metadataLoopsLabel": "Loops",
     "metadataLikesLabel": "Curtidas",
     "metadataCommentsLabel": "Comentários",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -695,6 +695,7 @@
     "metadataCollaboratorsLabel": "Colaboratori",
     "metadataInspiredByLabel": "Inspirat de",
     "metadataRepostedByLabel": "Redistribuit de",
+    "metadataMoreReposters": "încă {count}",
     "metadataLoopsLabel": "Bucle",
     "metadataLikesLabel": "Aprecieri",
     "metadataCommentsLabel": "Comentarii",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -695,6 +695,7 @@
     "metadataCollaboratorsLabel": "Samarbetspartner",
     "metadataInspiredByLabel": "Inspirerad av",
     "metadataRepostedByLabel": "Återpublicerad av",
+    "metadataMoreReposters": "+{count} till",
     "metadataLoopsLabel": "Loopar",
     "metadataLikesLabel": "Gillamarkeringar",
     "metadataCommentsLabel": "Kommentarer",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -692,6 +692,7 @@
     "metadataCollaboratorsLabel": "İşbirlikçiler",
     "metadataInspiredByLabel": "İlham alındı",
     "metadataRepostedByLabel": "Yeniden paylaşan",
+    "metadataMoreReposters": "+{count} daha",
     "metadataLoopsLabel": "Döngüler",
     "metadataLikesLabel": "Beğeniler",
     "metadataCommentsLabel": "Yorumlar",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -991,6 +991,7 @@
   "metadataCollaboratorsLabel": "شریک کار",
   "metadataInspiredByLabel": "متاثر از",
   "metadataRepostedByLabel": "ریپوسٹ کرنے والے",
+  "metadataMoreReposters": "+{count} مزید",
   "metadataLoopsLabel": "{count, plural, =1{لوپ} other{لوپ}}",
   "@metadataLoopsLabel": {
     "placeholders": {

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -991,6 +991,7 @@
   "metadataCollaboratorsLabel": "Cộng tác viên",
   "metadataInspiredByLabel": "Lấy cảm hứng từ",
   "metadataRepostedByLabel": "Được đăng lại bởi",
+  "metadataMoreReposters": "+{count} người nữa",
   "metadataLoopsLabel": "{count, plural, =1{Loop} other{Loop}}",
   "@metadataLoopsLabel": {
     "placeholders": {

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -991,6 +991,7 @@
   "metadataCollaboratorsLabel": "协作者",
   "metadataInspiredByLabel": "灵感来自",
   "metadataRepostedByLabel": "转发自",
+  "metadataMoreReposters": "还有 {count} 人",
   "metadataLoopsLabel": "{count, plural, =1{次循环} other{次循环}}",
   "@metadataLoopsLabel": {
     "placeholders": {

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -3222,6 +3222,12 @@ abstract class AppLocalizations {
   /// **'Reposted by'**
   String get metadataRepostedByLabel;
 
+  /// Chip in the video metadata sheet opening the full reposters list, showing how many reposters are not displayed.
+  ///
+  /// In en, this message translates to:
+  /// **'+{count} more'**
+  String metadataMoreReposters(int count);
+
   /// No description provided for @metadataLoopsLabel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1790,6 +1790,11 @@ class AppLocalizationsAm extends AppLocalizations {
   String get metadataRepostedByLabel => 'በድጋሚ የተለጠፈው በ';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count ተጨማሪ';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1814,6 +1814,11 @@ class AppLocalizationsAr extends AppLocalizations {
   String get metadataRepostedByLabel => 'أعاد نشره';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count آخرين';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'التكرارات';
   }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -1850,6 +1850,11 @@ class AppLocalizationsBg extends AppLocalizations {
   String get metadataRepostedByLabel => 'Повторно публикувано от';
 
   @override
+  String metadataMoreReposters(int count) {
+    return 'още $count';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -1847,6 +1847,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get metadataRepostedByLabel => 'Repostet von';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count weitere';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Loops';
   }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1822,6 +1822,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get metadataRepostedByLabel => 'Reposted by';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count more';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -1845,6 +1845,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get metadataRepostedByLabel => 'Reposteado por';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count más';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Loops';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -1855,6 +1855,11 @@ class AppLocalizationsFil extends AppLocalizations {
   String get metadataRepostedByLabel => 'Na-repost ni';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count pa';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -1855,6 +1855,11 @@ class AppLocalizationsFr extends AppLocalizations {
   String get metadataRepostedByLabel => 'Reposté par';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count autres';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Loops';
   }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1787,6 +1787,11 @@ class AppLocalizationsId extends AppLocalizations {
   String get metadataRepostedByLabel => 'Di-repost oleh';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count lainnya';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Loop';
   }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -1849,6 +1849,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get metadataRepostedByLabel => 'Ripubblicato da';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count altri';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Loop';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1714,6 +1714,11 @@ class AppLocalizationsJa extends AppLocalizations {
   String get metadataRepostedByLabel => 'リポスト元';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '他$count人';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'ループ';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1724,6 +1724,11 @@ class AppLocalizationsKo extends AppLocalizations {
   String get metadataRepostedByLabel => '리포스트';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '외 $count명';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return '루프';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -1836,6 +1836,11 @@ class AppLocalizationsMs extends AppLocalizations {
   String get metadataRepostedByLabel => 'Disiarkan semula oleh';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count lagi';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -1835,6 +1835,11 @@ class AppLocalizationsNl extends AppLocalizations {
   String get metadataRepostedByLabel => 'Gerepost door';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count meer';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Loops';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -1860,6 +1860,11 @@ class AppLocalizationsPl extends AppLocalizations {
   String get metadataRepostedByLabel => 'Repostowane przez';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count więcej';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Pętle';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -1842,6 +1842,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get metadataRepostedByLabel => 'Repostado por';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count mais';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Loops';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -1869,6 +1869,11 @@ class AppLocalizationsRo extends AppLocalizations {
   String get metadataRepostedByLabel => 'Redistribuit de';
 
   @override
+  String metadataMoreReposters(int count) {
+    return 'încă $count';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Bucle';
   }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1821,6 +1821,11 @@ class AppLocalizationsSv extends AppLocalizations {
   String get metadataRepostedByLabel => 'Återpublicerad av';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count till';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Loopar';
   }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1792,6 +1792,11 @@ class AppLocalizationsTr extends AppLocalizations {
   String get metadataRepostedByLabel => 'Yeniden paylaşan';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count daha';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     return 'Döngüler';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -1826,6 +1826,11 @@ class AppLocalizationsUr extends AppLocalizations {
   String get metadataRepostedByLabel => 'ریپوسٹ کرنے والے';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count مزید';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -1831,6 +1831,11 @@ class AppLocalizationsVi extends AppLocalizations {
   String get metadataRepostedByLabel => 'Được đăng lại bởi';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '+$count người nữa';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -1733,6 +1733,11 @@ class AppLocalizationsZh extends AppLocalizations {
   String get metadataRepostedByLabel => '转发自';
 
   @override
+  String metadataMoreReposters(int count) {
+    return '还有 $count 人';
+  }
+
+  @override
   String metadataLoopsLabel(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
@@ -7,12 +7,14 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/video_collaborator_status/video_collaborator_status_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
+import 'package:openvine/screens/video_engagement/video_engagement_list_screen.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:openvine/utils/public_identifier_normalizer.dart';
 import 'package:openvine/widgets/user_avatar.dart';
@@ -183,10 +185,13 @@ class MetadataRepostedBySection extends StatelessWidget {
         }.toList();
 
         if (state.isLoading && allPubkeys.isEmpty) {
-          return _RepostedByContent(pubkeys: video.reposterPubkeys ?? []);
+          return _RepostedByContent(
+            pubkeys: video.reposterPubkeys ?? [],
+            video: video,
+          );
         }
 
-        return _RepostedByContent(pubkeys: allPubkeys);
+        return _RepostedByContent(pubkeys: allPubkeys, video: video);
       },
     );
   }
@@ -194,15 +199,30 @@ class MetadataRepostedBySection extends StatelessWidget {
 
 /// Content widget for the Reposted-by section.
 ///
+/// Shows at most [_maxVisibleReposters] chips and hands the rest to the
+/// reposters list screen. A popular video can be reposted thousands of
+/// times, and every chip resolves its own profile — rendering the full set
+/// would fire a profile fetch per reposter and lay them all out at once.
+///
 /// Returns [SizedBox.shrink] when [pubkeys] is empty.
 class _RepostedByContent extends StatelessWidget {
-  const _RepostedByContent({required this.pubkeys});
+  const _RepostedByContent({required this.pubkeys, required this.video});
+
+  /// Roughly three rows of chips on a phone.
+  ///
+  /// Not an exact row count: chip width follows the display name, and those
+  /// resolve per chip after this has already been laid out.
+  static const _maxVisibleReposters = 9;
 
   final List<String> pubkeys;
+  final VideoEvent video;
 
   @override
   Widget build(BuildContext context) {
     if (pubkeys.isEmpty) return const SizedBox.shrink();
+
+    final visible = pubkeys.take(_maxVisibleReposters);
+    final hiddenCount = pubkeys.length - visible.length;
 
     return MetadataSection(
       label: context.l10n.metadataRepostedByLabel,
@@ -210,10 +230,62 @@ class _RepostedByContent extends StatelessWidget {
         spacing: 8,
         runSpacing: 8,
         children: [
-          for (final pubkey in pubkeys) _TappableUserChip(pubkey: pubkey),
+          for (final pubkey in visible) _TappableUserChip(pubkey: pubkey),
+          if (hiddenCount > 0)
+            _MoreRepostersChip(count: hiddenCount, video: video),
         ],
       ),
     );
+  }
+}
+
+/// Chip that opens the full reposters list for [video].
+///
+/// Styled as a sibling of [_TappableUserChip] so it reads as the tail of the
+/// same row rather than a separate control.
+class _MoreRepostersChip extends StatelessWidget {
+  const _MoreRepostersChip({required this.count, required this.video});
+
+  final int count;
+  final VideoEvent video;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = context.l10n.metadataMoreReposters(count);
+    return Semantics(
+      button: true,
+      label: label,
+      child: GestureDetector(
+        onTap: () => _openRepostersList(context),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 48),
+          child: Container(
+            alignment: Alignment.center,
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(16),
+              color: context.vineColors.surfaceContainer,
+            ),
+            child: ExcludeSemantics(
+              child: Text(
+                label,
+                style: VineTheme.titleSmallFont(color: VineTheme.vineGreen),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _openRepostersList(BuildContext context) {
+    final addressableId = video.addressableId;
+    final location = GoRouter.of(context).namedLocation(
+      VideoEngagementListScreen.repostersRouteName,
+      pathParameters: {'eventId': video.id},
+      queryParameters: addressableId == null ? const {} : {'a': addressableId},
+    );
+    context.pushWithVideoPause<void>(location);
   }
 }
 

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -19,6 +19,7 @@ import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
+import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_badges_row.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_sounds_section.dart';
@@ -1107,6 +1108,65 @@ void main() {
       expect(find.text('Reposted by'), findsOneWidget);
       expect(find.text('Improvising'), findsOneWidget);
     });
+
+    testWidgetsWithSurfaceSize(
+      'caps the chips and offers the rest through the full list',
+      (tester) async {
+        final pubkeys = List<String>.generate(
+          12,
+          (index) => (index + 1).toRadixString(16).padLeft(64, '0'),
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            repostersState: VideoRepostersState(
+              pubkeys: pubkeys,
+              isLoading: false,
+            ),
+            providerOverrides: [
+              for (final pubkey in pubkeys)
+                fetchUserProfileProvider(
+                  pubkey,
+                ).overrideWith((ref) async => null),
+            ],
+            child: MetadataRepostedBySection(video: _makeVideo()),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Every reposter would otherwise be a chip that fetches its own
+        // profile — a popular video has thousands.
+        expect(find.byType(UserAvatar), findsNWidgets(9));
+        expect(
+          find.text(_l10n(tester).metadataMoreReposters(3)),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgetsWithSurfaceSize(
+      'shows every reposter when they fit under the cap',
+      (tester) async {
+        await tester.pumpWidget(
+          buildSubject(
+            repostersState: const VideoRepostersState(
+              pubkeys: [_reposterPubkey],
+              isLoading: false,
+            ),
+            providerOverrides: [
+              fetchUserProfileProvider(_reposterPubkey).overrideWith(
+                (ref) async => _makeProfile(_reposterPubkey, 'Improvising'),
+              ),
+            ],
+            child: MetadataRepostedBySection(video: _makeVideo()),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Improvising'), findsOneWidget);
+        expect(find.textContaining('more'), findsNothing);
+      },
+    );
 
     testWidgetsWithSurfaceSize(
       'hides when relay returns empty and no pre-populated data',


### PR DESCRIPTION
Closes #6693

## Description

The **Reposted by** section rendered one chip per reposter with no upper bound, and every chip resolves its own profile through `fetchUserProfileProvider`. The `Wrap` is a single list item, so all of them are built and laid out at once — a video with thousands of reposts fired thousands of profile fetches and built thousands of chips the moment the sheet opened.

It now shows at most nine and hands the rest to the reposters list screen through a `+N more` chip. That screen already exists (`/video/:eventId/reposters`) and is reachable from the repost button's long press, so this is a second entry point rather than new surface.

Two notes for review:

- **Nine is "roughly three rows", not exactly three.** An exact row count is not available at build time: chip width follows the display name, and those resolve asynchronously per chip. Anything that measured rows would have to wait for every profile to load first, which is the cost this is avoiding. Happy to change the number.
- **`metadataMoreReposters` is a new key, translated in all 22 locales** rather than mirrored as English. Its copy is identical to `profileBadgeMoreRecipients`, which is deliberately not reused: that key is scoped to the badge sheet and its `description` says so. (It is also untranslated in 18 locales, so reusing it would have spread that debt.)

**Related Issue:** 

## Out of Scope

The fetch itself is still unbounded. `RepostsRepository.fetchEventReposters` builds `Filter(kinds: [6, 16], e: [eventId])` with no `limit`, even though `_defaultRepostFetchLimit = 500` exists and three sibling methods in that file pass it. It then queries deletions with `Filter(kinds: [5], authors: <every reposter pubkey>)` — a REQ carrying thousands of authors on a popular video. The UI cap stops the expensive part (profile fetches and widget build), but the two relay queries are worth a follow-up in `reposts_repository`; it is a strict-coverage package, so it wants its own PR and tests.

Touches the same widget as #6690, which is still open. Whichever lands first, I will rebase the other — they are independent changes that happen to overlap in `_RepostedByContent`.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test test/widgets/video_feed_item/metadata` — 57 passed
- `flutter test test/l10n/arb_consistency_test.dart` — passed, and `flutter gen-l10n` output is committed
- `check_raw_colors_ceiling.sh` / `check_raw_textstyle_ceiling.sh` — no growth
- New tests: 12 reposters render 9 chips plus a `+3 more` chip, and a single reposter renders no `more` affordance
- Manually verified on a real Samsung Galaxy: opened the metadata sheet on a video with many reposters, checked the chip count and that `+N more` opens the full list

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore