### PR TITLE
fix(sounds): stop claiming "Credit only" before consent is known

### DIFF
--- a/mobile/lib/providers/sounds_providers.dart
+++ b/mobile/lib/providers/sounds_providers.dart
@@ -141,15 +141,40 @@ Future<int> soundUsageCount(Ref ref, String audioEventId) async {
   return repository.fetchVideosUsingSoundCount(audioEventId);
 }
 
+/// Viewer-independent public reuse terms for sounds.
+///
+/// Returns `null` when a legacy sound needs source-video verification before
+/// the app can claim whether remixing is allowed.
+bool? audioReuseTermsFromEvent(AudioEvent sound) {
+  if (sound.isBundled || sound.isLocalImport) return true;
+  if (sound.externalSource case final external?) {
+    return external.license.allowsDerivatives;
+  }
+  if (sound.allowsReuse) return true;
+  if (sound.hasExplicitReuseConsent) return false;
+  return null;
+}
+
+/// Viewer-independent reuse terms for explicit and legacy audio events.
+@riverpod
+Future<bool> audioReuseTerms(Ref ref, AudioEvent sound) {
+  final knownTerms = audioReuseTermsFromEvent(sound);
+  if (knownTerms != null) return Future.value(knownTerms);
+  return AudioReuseConsentResolver(
+    soundsRepository: ref.watch(soundsRepositoryProvider),
+    videosRepository: ref.watch(videosRepositoryProvider),
+  ).verify(sound);
+}
+
 /// Fail-closed reuse consent for explicit and legacy audio events.
 ///
-/// A creator always has consent for their own sound. That exception lives here
-/// rather than at each call site because the call sites had drifted: the sound
-/// detail screen applied it and the picker did not, so the same creator was
-/// told their own private sound was both usable and unusable in one session.
+/// A creator always has consent for their own sound. The shared permission
+/// provider owns that rule so call sites agree; UI may still short-circuit
+/// synchronously knowable cases to avoid one-frame action flicker.
 @riverpod
 Future<bool> audioReuseConsent(Ref ref, AudioEvent sound) {
-  if (sound.allowsReuse) return Future.value(true);
+  final knownTerms = audioReuseTermsFromEvent(sound);
+  if (knownTerms == true) return Future.value(true);
   // Re-read on auth transitions so an account switch cannot leave the previous
   // identity's ownership answer cached against this sound.
   ref.watch(currentAuthStateProvider);
@@ -157,7 +182,7 @@ Future<bool> audioReuseConsent(Ref ref, AudioEvent sound) {
   if (viewer != null && viewer.isNotEmpty && viewer == sound.pubkey) {
     return Future.value(true);
   }
-  if (sound.hasExplicitReuseConsent) return Future.value(false);
+  if (knownTerms == false) return Future.value(false);
   return AudioReuseConsentResolver(
     soundsRepository: ref.watch(soundsRepositoryProvider),
     videosRepository: ref.watch(videosRepositoryProvider),

--- a/mobile/lib/providers/sounds_providers.dart
+++ b/mobile/lib/providers/sounds_providers.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Provides reactive state management for sounds from SoundsRepository.
 
 import 'package:models/models.dart' show AudioEvent;
+import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/sound_library_service_provider.dart';
 import 'package:openvine/providers/video_providers.dart';
@@ -141,9 +142,21 @@ Future<int> soundUsageCount(Ref ref, String audioEventId) async {
 }
 
 /// Fail-closed reuse consent for explicit and legacy audio events.
+///
+/// A creator always has consent for their own sound. That exception lives here
+/// rather than at each call site because the call sites had drifted: the sound
+/// detail screen applied it and the picker did not, so the same creator was
+/// told their own private sound was both usable and unusable in one session.
 @riverpod
 Future<bool> audioReuseConsent(Ref ref, AudioEvent sound) {
   if (sound.allowsReuse) return Future.value(true);
+  // Re-read on auth transitions so an account switch cannot leave the previous
+  // identity's ownership answer cached against this sound.
+  ref.watch(currentAuthStateProvider);
+  final viewer = ref.watch(authServiceProvider).currentPublicKeyHex;
+  if (viewer != null && viewer.isNotEmpty && viewer == sound.pubkey) {
+    return Future.value(true);
+  }
   if (sound.hasExplicitReuseConsent) return Future.value(false);
   return AudioReuseConsentResolver(
     soundsRepository: ref.watch(soundsRepositoryProvider),

--- a/mobile/lib/providers/sounds_providers.g.dart
+++ b/mobile/lib/providers/sounds_providers.g.dart
@@ -597,32 +597,107 @@ final class SoundUsageCountFamily extends $Family
   String toString() => r'soundUsageCountProvider';
 }
 
+/// Viewer-independent reuse terms for explicit and legacy audio events.
+
+@ProviderFor(audioReuseTerms)
+final audioReuseTermsProvider = AudioReuseTermsFamily._();
+
+/// Viewer-independent reuse terms for explicit and legacy audio events.
+
+final class AudioReuseTermsProvider
+    extends $FunctionalProvider<AsyncValue<bool>, bool, FutureOr<bool>>
+    with $FutureModifier<bool>, $FutureProvider<bool> {
+  /// Viewer-independent reuse terms for explicit and legacy audio events.
+  AudioReuseTermsProvider._({
+    required AudioReuseTermsFamily super.from,
+    required AudioEvent super.argument,
+  }) : super(
+         retry: null,
+         name: r'audioReuseTermsProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$audioReuseTermsHash();
+
+  @override
+  String toString() {
+    return r'audioReuseTermsProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<bool> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<bool> create(Ref ref) {
+    final argument = this.argument as AudioEvent;
+    return audioReuseTerms(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is AudioReuseTermsProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$audioReuseTermsHash() => r'f8dde7271c3f3bf5f45dba9a5decbafd5785a33d';
+
+/// Viewer-independent reuse terms for explicit and legacy audio events.
+
+final class AudioReuseTermsFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<bool>, AudioEvent> {
+  AudioReuseTermsFamily._()
+    : super(
+        retry: null,
+        name: r'audioReuseTermsProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Viewer-independent reuse terms for explicit and legacy audio events.
+
+  AudioReuseTermsProvider call(AudioEvent sound) =>
+      AudioReuseTermsProvider._(argument: sound, from: this);
+
+  @override
+  String toString() => r'audioReuseTermsProvider';
+}
+
 /// Fail-closed reuse consent for explicit and legacy audio events.
 ///
-/// A creator always has consent for their own sound. That exception lives here
-/// rather than at each call site because the call sites had drifted: the sound
-/// detail screen applied it and the picker did not, so the same creator was
-/// told their own private sound was both usable and unusable in one session.
+/// A creator always has consent for their own sound. The shared permission
+/// provider owns that rule so call sites agree; UI may still short-circuit
+/// synchronously knowable cases to avoid one-frame action flicker.
 
 @ProviderFor(audioReuseConsent)
 final audioReuseConsentProvider = AudioReuseConsentFamily._();
 
 /// Fail-closed reuse consent for explicit and legacy audio events.
 ///
-/// A creator always has consent for their own sound. That exception lives here
-/// rather than at each call site because the call sites had drifted: the sound
-/// detail screen applied it and the picker did not, so the same creator was
-/// told their own private sound was both usable and unusable in one session.
+/// A creator always has consent for their own sound. The shared permission
+/// provider owns that rule so call sites agree; UI may still short-circuit
+/// synchronously knowable cases to avoid one-frame action flicker.
 
 final class AudioReuseConsentProvider
     extends $FunctionalProvider<AsyncValue<bool>, bool, FutureOr<bool>>
     with $FutureModifier<bool>, $FutureProvider<bool> {
   /// Fail-closed reuse consent for explicit and legacy audio events.
   ///
-  /// A creator always has consent for their own sound. That exception lives here
-  /// rather than at each call site because the call sites had drifted: the sound
-  /// detail screen applied it and the picker did not, so the same creator was
-  /// told their own private sound was both usable and unusable in one session.
+  /// A creator always has consent for their own sound. The shared permission
+  /// provider owns that rule so call sites agree; UI may still short-circuit
+  /// synchronously knowable cases to avoid one-frame action flicker.
   AudioReuseConsentProvider._({
     required AudioReuseConsentFamily super.from,
     required AudioEvent super.argument,
@@ -666,14 +741,13 @@ final class AudioReuseConsentProvider
   }
 }
 
-String _$audioReuseConsentHash() => r'57bf316a48fea51478eee5cec669d4f9e53ff190';
+String _$audioReuseConsentHash() => r'71e983b97064d07c92e7fd97de594d14f4a4fb9b';
 
 /// Fail-closed reuse consent for explicit and legacy audio events.
 ///
-/// A creator always has consent for their own sound. That exception lives here
-/// rather than at each call site because the call sites had drifted: the sound
-/// detail screen applied it and the picker did not, so the same creator was
-/// told their own private sound was both usable and unusable in one session.
+/// A creator always has consent for their own sound. The shared permission
+/// provider owns that rule so call sites agree; UI may still short-circuit
+/// synchronously knowable cases to avoid one-frame action flicker.
 
 final class AudioReuseConsentFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<bool>, AudioEvent> {
@@ -688,10 +762,9 @@ final class AudioReuseConsentFamily extends $Family
 
   /// Fail-closed reuse consent for explicit and legacy audio events.
   ///
-  /// A creator always has consent for their own sound. That exception lives here
-  /// rather than at each call site because the call sites had drifted: the sound
-  /// detail screen applied it and the picker did not, so the same creator was
-  /// told their own private sound was both usable and unusable in one session.
+  /// A creator always has consent for their own sound. The shared permission
+  /// provider owns that rule so call sites agree; UI may still short-circuit
+  /// synchronously knowable cases to avoid one-frame action flicker.
 
   AudioReuseConsentProvider call(AudioEvent sound) =>
       AudioReuseConsentProvider._(argument: sound, from: this);

--- a/mobile/lib/providers/sounds_providers.g.dart
+++ b/mobile/lib/providers/sounds_providers.g.dart
@@ -598,16 +598,31 @@ final class SoundUsageCountFamily extends $Family
 }
 
 /// Fail-closed reuse consent for explicit and legacy audio events.
+///
+/// A creator always has consent for their own sound. That exception lives here
+/// rather than at each call site because the call sites had drifted: the sound
+/// detail screen applied it and the picker did not, so the same creator was
+/// told their own private sound was both usable and unusable in one session.
 
 @ProviderFor(audioReuseConsent)
 final audioReuseConsentProvider = AudioReuseConsentFamily._();
 
 /// Fail-closed reuse consent for explicit and legacy audio events.
+///
+/// A creator always has consent for their own sound. That exception lives here
+/// rather than at each call site because the call sites had drifted: the sound
+/// detail screen applied it and the picker did not, so the same creator was
+/// told their own private sound was both usable and unusable in one session.
 
 final class AudioReuseConsentProvider
     extends $FunctionalProvider<AsyncValue<bool>, bool, FutureOr<bool>>
     with $FutureModifier<bool>, $FutureProvider<bool> {
   /// Fail-closed reuse consent for explicit and legacy audio events.
+  ///
+  /// A creator always has consent for their own sound. That exception lives here
+  /// rather than at each call site because the call sites had drifted: the sound
+  /// detail screen applied it and the picker did not, so the same creator was
+  /// told their own private sound was both usable and unusable in one session.
   AudioReuseConsentProvider._({
     required AudioReuseConsentFamily super.from,
     required AudioEvent super.argument,
@@ -651,9 +666,14 @@ final class AudioReuseConsentProvider
   }
 }
 
-String _$audioReuseConsentHash() => r'4a102b058d8f99eb42e971973629018669c74d6e';
+String _$audioReuseConsentHash() => r'57bf316a48fea51478eee5cec669d4f9e53ff190';
 
 /// Fail-closed reuse consent for explicit and legacy audio events.
+///
+/// A creator always has consent for their own sound. That exception lives here
+/// rather than at each call site because the call sites had drifted: the sound
+/// detail screen applied it and the picker did not, so the same creator was
+/// told their own private sound was both usable and unusable in one session.
 
 final class AudioReuseConsentFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<bool>, AudioEvent> {
@@ -667,6 +687,11 @@ final class AudioReuseConsentFamily extends $Family
       );
 
   /// Fail-closed reuse consent for explicit and legacy audio events.
+  ///
+  /// A creator always has consent for their own sound. That exception lives here
+  /// rather than at each call site because the call sites had drifted: the sound
+  /// detail screen applied it and the picker did not, so the same creator was
+  /// told their own private sound was both usable and unusable in one session.
 
   AudioReuseConsentProvider call(AudioEvent sound) =>
       AudioReuseConsentProvider._(argument: sound, from: this);

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -211,14 +211,12 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
 
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text(
-          switch (result) {
-            SavedSoundSaveResult.saved => context.l10n.soundsSavedToLibrary,
-            SavedSoundSaveResult.alreadySaved =>
-              context.l10n.soundsAlreadySavedToLibrary,
-            null => context.l10n.soundsSaveFailed,
-          },
-        ),
+        content: Text(switch (result) {
+          SavedSoundSaveResult.saved => context.l10n.soundsSavedToLibrary,
+          SavedSoundSaveResult.alreadySaved =>
+            context.l10n.soundsAlreadySavedToLibrary,
+          null => context.l10n.soundsSaveFailed,
+        }),
         duration: const Duration(seconds: 2),
       ),
     );
@@ -234,12 +232,11 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
     if (sound.externalSource case final external?) {
       return external.license.allowsDerivatives;
     }
-    if (sound.allowsReuse) return true;
-    // Owner exception — re-evaluate on auth restore/logout/account-switch so it
-    // can't go stale (authServiceProvider alone is a stable instance).
-    ref.watch(currentAuthStateProvider);
-    final viewer = ref.watch(authServiceProvider).currentPublicKeyHex;
-    if (viewer != null && viewer == sound.pubkey) return true;
+    // The owner exception and the auth-transition re-read now live in
+    // `audioReuseConsentProvider`, so every consumer gets the same answer.
+    // Still fail-closed while it resolves: this gates an action, and offering
+    // a button that might not be permitted is worse than showing it a beat
+    // late.
     return ref.watch(audioReuseConsentProvider(sound)).value ?? false;
   }
 

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -228,16 +228,25 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
   /// verified against their exact source video and otherwise fail closed.
   bool _canReuseSound() {
     final sound = widget.sound;
-    if (sound.isBundled) return true;
-    if (sound.externalSource case final external?) {
-      return external.license.allowsDerivatives;
+    final knownTerms = audioReuseTermsFromEvent(sound);
+    if (knownTerms == true) return true;
+    // Keep the synchronously knowable owner gate local so the button does not
+    // disappear for a frame on the creator's own sound.
+    ref.watch(currentAuthStateProvider);
+    final viewer = ref.watch(authServiceProvider).currentPublicKeyHex;
+    if (viewer != null && viewer.isNotEmpty && viewer == sound.pubkey) {
+      return true;
     }
-    // The owner exception and the auth-transition re-read now live in
-    // `audioReuseConsentProvider`, so every consumer gets the same answer.
-    // Still fail-closed while it resolves: this gates an action, and offering
-    // a button that might not be permitted is worse than showing it a beat
-    // late.
+    if (knownTerms == false) return false;
     return ref.watch(audioReuseConsentProvider(sound)).value ?? false;
+  }
+
+  /// Public reuse terms for [SoundDetailScreen.sound], or `null` while legacy
+  /// consent is still being verified.
+  bool? _reuseTerms() {
+    final sound = widget.sound;
+    return audioReuseTermsFromEvent(sound) ??
+        ref.watch(audioReuseTermsProvider(sound)).value;
   }
 
   void _navigateToVideo(String videoId, int index, List<VideoEvent> videos) {
@@ -284,6 +293,7 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
         widget.sound.isOriginalSound && widget.sourceVideo != null;
     final usageCountAsync = ref.watch(soundUsageCountProvider(soundEventId));
     final canReuseSound = _canReuseSound();
+    final reuseAllowed = _reuseTerms();
     SavedSoundsBloc? savedSoundsBloc;
     try {
       savedSoundsBloc = inherited_provider.Provider.of<SavedSoundsBloc>(
@@ -320,7 +330,7 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
                   isLoadingPreview: _isLoadingPreview,
                   onPreviewTap: _togglePreview,
                   onUseSoundTap: canReuseSound ? _onUseSound : null,
-                  reuseAllowed: canReuseSound,
+                  reuseAllowed: reuseAllowed,
                 ),
 
                 if (savedSoundsBloc != null)
@@ -412,7 +422,7 @@ class _SoundHeader extends ConsumerStatefulWidget {
   final bool isPlaying;
   final bool isLoadingPreview;
   final VoidCallback onPreviewTap;
-  final bool reuseAllowed;
+  final bool? reuseAllowed;
 
   /// Tap handler for the "Use Sound" button, or `null` when the sound may not
   /// be reused — in which case the button is hidden entirely.
@@ -535,16 +545,17 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
                           color: VineTheme.onSurfaceVariant,
                         ),
                       ),
-                    Text(
-                      widget.reuseAllowed
-                          ? context.l10n.soundRemixingAllowed
-                          : context.l10n.soundCreditOnly,
-                      style: VineTheme.labelSmallFont(
-                        color: widget.reuseAllowed
-                            ? VineTheme.vineGreen
-                            : VineTheme.onSurfaceVariant,
+                    if (widget.reuseAllowed case final reuseAllowed?)
+                      Text(
+                        reuseAllowed
+                            ? context.l10n.soundRemixingAllowed
+                            : context.l10n.soundCreditOnly,
+                        style: VineTheme.labelSmallFont(
+                          color: reuseAllowed
+                              ? VineTheme.vineGreen
+                              : VineTheme.onSurfaceVariant,
+                        ),
                       ),
-                    ),
                     if (sound.publicTags.isNotEmpty)
                       Wrap(
                         spacing: 6,

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
@@ -239,11 +239,14 @@ class _AudioSelectionBottomSheetState
   Future<void> _selectSound(AudioEvent sound) async {
     if (_selectedItem?.id == sound.id) return;
 
+    // Bundled / imported / provider-catalog sounds carry their own terms and
+    // never reach the resolver. Everything else — including the creator's own
+    // sounds — is decided by `audioReuseConsentProvider`, which owns the owner
+    // exception this call site used to be missing.
     final canReuse =
         sound.isBundled ||
         sound.isLocalImport ||
         sound.isExternalProviderSound ||
-        sound.allowsReuse ||
         await ref.read(audioReuseConsentProvider(sound).future);
     if (!mounted) return;
     if (!canReuse) {

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -277,14 +277,11 @@ class _SoundListItem extends ConsumerWidget {
                 audio.creatorPubkey != audio.pubkey)
               context.l10n.soundSharedBy(publisherName),
           ].join(' · ');
-    // Null while the resolver is still deciding. Collapsing that to `false`
-    // states another creator's licensing terms before we know them — a legacy
-    // sound rendered "Credit only" for the first frames and then flipped to
-    // "Remixing allowed" once the relay answered, and stayed wrong for as long
-    // as the round-trip took. The badge is withheld until there is an answer.
-    final reuseAllowed = audio.isBundled
-        ? true
-        : ref.watch(audioReuseConsentProvider(audio)).value;
+    // Null while legacy terms are still being verified. The badge states the
+    // sound's public terms, not the current viewer's permission to reuse it.
+    final knownReuseTerms = audioReuseTermsFromEvent(audio);
+    final reuseAllowed =
+        knownReuseTerms ?? ref.watch(audioReuseTermsProvider(audio)).value;
 
     return Semantics(
       button: true,

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -277,9 +277,14 @@ class _SoundListItem extends ConsumerWidget {
                 audio.creatorPubkey != audio.pubkey)
               context.l10n.soundSharedBy(publisherName),
           ].join(' · ');
-    final reuseAllowed =
-        audio.isBundled ||
-        (ref.watch(audioReuseConsentProvider(audio)).value ?? false);
+    // Null while the resolver is still deciding. Collapsing that to `false`
+    // states another creator's licensing terms before we know them — a legacy
+    // sound rendered "Credit only" for the first frames and then flipped to
+    // "Remixing allowed" once the relay answered, and stayed wrong for as long
+    // as the round-trip took. The badge is withheld until there is an answer.
+    final reuseAllowed = audio.isBundled
+        ? true
+        : ref.watch(audioReuseConsentProvider(audio)).value;
 
     return Semantics(
       button: true,
@@ -317,16 +322,17 @@ class _SoundListItem extends ConsumerWidget {
                       color: context.vineColors.onSurfaceVariant,
                     ),
                   ),
-                  Text(
-                    reuseAllowed
-                        ? context.l10n.soundRemixingAllowed
-                        : context.l10n.soundCreditOnly,
-                    style: VineTheme.labelSmallFont(
-                      color: reuseAllowed
-                          ? VineTheme.vineGreen
-                          : VineTheme.onSurfaceVariant,
+                  if (reuseAllowed != null)
+                    Text(
+                      reuseAllowed
+                          ? context.l10n.soundRemixingAllowed
+                          : context.l10n.soundCreditOnly,
+                      style: VineTheme.labelSmallFont(
+                        color: reuseAllowed
+                            ? VineTheme.vineGreen
+                            : VineTheme.onSurfaceVariant,
+                      ),
                     ),
-                  ),
                   if (audio.licenseName case final license?)
                     Text(
                       license,
@@ -386,10 +392,7 @@ class _SoundListItem extends ConsumerWidget {
       // "Sound not found".
       hostContext.pushWithVideoPause(
         SoundDetailScreen.pathForId(audio.id),
-        extra: <String, dynamic>{
-          'sound': audio,
-          'sourceVideo': sourceVideo,
-        },
+        extra: <String, dynamic>{'sound': audio, 'sourceVideo': sourceVideo},
       );
     });
   }

--- a/mobile/test/providers/sounds_providers_test.dart
+++ b/mobile/test/providers/sounds_providers_test.dart
@@ -9,9 +9,11 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/sound_library_service_provider.dart';
 import 'package:openvine/providers/sounds_providers.dart';
+import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/sound_library_service.dart';
 import 'package:sounds_repository/sounds_repository.dart';
 
@@ -21,6 +23,22 @@ class MockNostrClient extends Mock implements NostrClient {}
 class MockSoundsRepository extends Mock implements SoundsRepository {}
 
 class MockSoundLibraryService extends Mock implements SoundLibraryService {}
+
+class _StubAuthService extends Mock implements AuthService {
+  _StubAuthService(this._pubkey);
+
+  final String? _pubkey;
+
+  @override
+  String? get currentPublicKeyHex => _pubkey;
+
+  @override
+  Stream<AuthState> get authStateStream => const Stream<AuthState>.empty();
+
+  @override
+  AuthState get authState =>
+      _pubkey == null ? AuthState.unauthenticated : AuthState.authenticated;
+}
 
 /// Helper to create test AudioEvent instances
 AudioEvent createTestAudioEvent({
@@ -43,6 +61,8 @@ AudioEvent createTestAudioEvent({
 }
 
 void main() {
+  _ownerExceptionTests();
+
   group('SoundsProviders', () {
     late MockNostrClient mockNostrClient;
     late MockSoundsRepository mockRepository;
@@ -503,6 +523,69 @@ void main() {
 
         subscription.close();
       });
+    });
+  });
+}
+
+void _ownerExceptionTests() {
+  group('audioReuseConsent owner exception', () {
+    const ownerPubkey = 'owner-pubkey-hex';
+
+    ProviderContainer buildContainer(String? viewerPubkey) {
+      final container = ProviderContainer(
+        overrides: [
+          authServiceProvider.overrideWithValue(_StubAuthService(viewerPubkey)),
+        ],
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    test(
+      'a creator may reuse their own sound even without a consent tag',
+      () async {
+        // The picker used to skip this check while the detail screen applied
+        // it, so one creator was told the same private sound was both usable
+        // and unusable. The provider is now the only place it lives.
+        // No consent tag and no explicit denial — the "unknown, ask the
+        // resolver" shape a legacy sound loads as.
+        final ownSound = createTestAudioEvent(
+          id: 'own',
+          pubkey: ownerPubkey,
+        ).copyWith(allowsReuse: false);
+        expect(ownSound.allowsReuse, isFalse);
+        expect(ownSound.hasExplicitReuseConsent, isFalse);
+
+        final container = buildContainer(ownerPubkey);
+        await expectLater(
+          container.read(audioReuseConsentProvider(ownSound).future),
+          completion(isTrue),
+        );
+      },
+    );
+
+    test('a signed-out viewer gets no owner exception', () async {
+      final sound = createTestAudioEvent(
+        id: 'own',
+        pubkey: ownerPubkey,
+      ).copyWith(allowsReuse: false, hasExplicitReuseConsent: true);
+      final container = buildContainer(null);
+      await expectLater(
+        container.read(audioReuseConsentProvider(sound).future),
+        completion(isFalse),
+      );
+    });
+
+    test("another creator's sound does not get the owner exception", () async {
+      final sound = createTestAudioEvent(
+        id: 'theirs',
+        pubkey: ownerPubkey,
+      ).copyWith(allowsReuse: false, hasExplicitReuseConsent: true);
+      final container = buildContainer('a-different-viewer-pubkey');
+      await expectLater(
+        container.read(audioReuseConsentProvider(sound).future),
+        completion(isFalse),
+      );
     });
   });
 }

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -612,8 +612,45 @@ void main() {
           await tester.pump();
 
           expect(find.text('Use Sound'), findsOneWidget);
+          expect(find.text('Remixing allowed'), findsOneWidget);
+          expect(find.text('Credit only'), findsNothing);
         },
       );
+
+      testWidgets('withholds reuse badge while legacy terms are pending', (
+        tester,
+      ) async {
+        final termsCompleter = Completer<bool>();
+        final consentCompleter = Completer<bool>();
+        final sound = originalSound(allowReuse: false);
+
+        await tester.pumpWidget(
+          createTestWidget(
+            child: SoundDetailScreen(sound: sound),
+            overrides: [
+              ...gridOverrides(),
+              audioReuseTermsProvider(
+                sound,
+              ).overrideWith((ref) => termsCompleter.future),
+              audioReuseConsentProvider(
+                sound,
+              ).overrideWith((ref) => consentCompleter.future),
+            ],
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('Use Sound'), findsNothing);
+        expect(find.text('Credit only'), findsNothing);
+        expect(find.text('Remixing allowed'), findsNothing);
+
+        termsCompleter.complete(true);
+        consentCompleter.complete(true);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Use Sound'), findsOneWidget);
+        expect(find.text('Remixing allowed'), findsOneWidget);
+      });
 
       testWidgets('shows Use Sound for the creator viewing their own sound', (
         tester,

--- a/mobile/test/widgets/metadata_sounds_section_test.dart
+++ b/mobile/test/widgets/metadata_sounds_section_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for MetadataSoundsSection - audio info in metadata sheet.
 // ABOUTME: Tests both shared audio and original sound display modes.
 
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -136,6 +138,7 @@ void main() {
           buildTestWidget(
             video: createVideoWithAudio(),
             audioOverride: creditedAudio,
+            viewerPubkey: testPubkey,
           ),
         );
         await tester.pumpAndSettle();
@@ -146,6 +149,52 @@ void main() {
         expect(find.text('CC BY 4.0'), findsOneWidget);
         expect(find.text('https://example.com/original'), findsOneWidget);
         expect(find.text('#loops'), findsOneWidget);
+      });
+
+      testWidgets('withholds reuse badge while legacy terms are pending', (
+        tester,
+      ) async {
+        final pendingTerms = Completer<bool>();
+        final legacyAudio = testAudio.copyWith(
+          allowsReuse: false,
+          hasExplicitReuseConsent: false,
+          sourceVideoReference: '34236:$testPubkey:source-video',
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              soundByIdProvider(testAudioEventId).overrideWith((ref) async {
+                return legacyAudio;
+              }),
+              audioReuseTermsProvider(
+                legacyAudio,
+              ).overrideWith((ref) => pendingTerms.future),
+              authServiceProvider.overrideWithValue(_mockAuth()),
+            ],
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              theme: VineTheme.theme,
+              home: Scaffold(
+                backgroundColor: Colors.black,
+                body: MetadataSoundsSection(video: createVideoWithAudio()),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.text('Cool Beat'), findsOneWidget);
+        expect(find.text('Credit only'), findsNothing);
+        expect(find.text('Remixing allowed'), findsNothing);
+
+        pendingTerms.complete(true);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Remixing allowed'), findsOneWidget);
       });
 
       testWidgets('shows Sounds label', (tester) async {

--- a/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
+++ b/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
@@ -71,6 +71,7 @@ void main() {
       List<AudioEvent> savedSounds = const [],
       List<VineSound> bundledSounds = const [],
       AudioPlaybackService? audioService,
+      String? viewerPubkey,
     }) {
       final savedSoundsBloc = _MockSavedSoundsBloc();
       when(() => savedSoundsBloc.state).thenReturn(
@@ -94,7 +95,9 @@ void main() {
           overrides: [
             // `audioReuseConsentProvider` reads the viewer so it can grant a
             // creator consent for their own sound.
-            authServiceProvider.overrideWithValue(_StubAuthService()),
+            authServiceProvider.overrideWithValue(
+              _StubAuthService(viewerPubkey),
+            ),
             soundLibraryServiceProvider.overrideWith(
               (_) async => _FakeSoundLibraryService(bundledSounds),
             ),
@@ -238,6 +241,55 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.byType(AudioEditorSelectionOverlay), findsNothing);
+      });
+
+      testWidgets("selects the creator's own legacy sound", (tester) async {
+        const ownerPubkey = 'owner-pubkey-hex';
+        final audioService = _MockAudioPlaybackService();
+        final ownLegacySound = _createTestAudioEvent(
+          id: 'own-legacy-sound',
+          title: 'Own Legacy Sound',
+          pubkey: ownerPubkey,
+        ).copyWith(allowsReuse: false, hasExplicitReuseConsent: false);
+
+        when(() => audioService.isPlaying).thenReturn(false);
+        when(
+          () => audioService.playingStream,
+        ).thenAnswer((_) => const Stream<bool>.empty());
+        when(
+          () => audioService.durationStream,
+        ).thenAnswer((_) => const Stream<Duration?>.empty());
+        when(
+          () => audioService.positionStream,
+        ).thenAnswer((_) => const Stream<Duration>.empty());
+        when(() => audioService.duration).thenReturn(null);
+        when(
+          () => audioService.seek(Duration.zero),
+        ).thenAnswer((_) => Future<void>.value());
+        when(audioService.stop).thenAnswer((_) => Future<void>.value());
+        when(
+          () => audioService.loadAudio(ownLegacySound.url!),
+        ).thenAnswer((_) => Future.value(const Duration(seconds: 5)));
+        when(audioService.play).thenAnswer((_) => Future<void>.value());
+        when(audioService.pause).thenAnswer((_) => Future<void>.value());
+        when(audioService.dispose).thenAnswer((_) => Future<void>.value());
+
+        await tester.pumpWidget(
+          buildWidget(
+            trendingSoundsAsync: AsyncValue.data([ownLegacySound]),
+            audioService: audioService,
+            viewerPubkey: ownerPubkey,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(find.text(l10n.videoEditorAudioCategoryCommunity));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Own Legacy Sound'));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(AudioEditorSelectionOverlay), findsOneWidget);
       });
 
       testWidgets('renders search empty state when no tab matches', (
@@ -589,15 +641,18 @@ class _FakeSoundLibraryService extends SoundLibraryService {
   Future<void> loadCustomSounds() async {}
 }
 
-/// Signed out, so no sound in these tests is owned by the viewer and the
-/// owner exception in `audioReuseConsentProvider` never short-circuits.
 class _StubAuthService extends Mock implements AuthService {
+  _StubAuthService([this._pubkey]);
+
+  final String? _pubkey;
+
   @override
-  String? get currentPublicKeyHex => null;
+  String? get currentPublicKeyHex => _pubkey;
 
   @override
   Stream<AuthState> get authStateStream => const Stream<AuthState>.empty();
 
   @override
-  AuthState get authState => AuthState.unauthenticated;
+  AuthState get authState =>
+      _pubkey == null ? AuthState.unauthenticated : AuthState.authenticated;
 }

--- a/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
+++ b/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
@@ -15,8 +15,10 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/saved_sounds/saved_sounds_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/saved_sound.dart';
+import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/sound_library_service_provider.dart';
 import 'package:openvine/providers/sounds_providers.dart';
+import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/sound_library_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/audio_category_bar.dart';
@@ -90,6 +92,9 @@ void main() {
         value: savedSoundsBloc,
         child: ProviderScope(
           overrides: [
+            // `audioReuseConsentProvider` reads the viewer so it can grant a
+            // creator consent for their own sound.
+            authServiceProvider.overrideWithValue(_StubAuthService()),
             soundLibraryServiceProvider.overrideWith(
               (_) async => _FakeSoundLibraryService(bundledSounds),
             ),
@@ -582,4 +587,17 @@ class _FakeSoundLibraryService extends SoundLibraryService {
 
   @override
   Future<void> loadCustomSounds() async {}
+}
+
+/// Signed out, so no sound in these tests is owned by the viewer and the
+/// owner exception in `audioReuseConsentProvider` never short-circuits.
+class _StubAuthService extends Mock implements AuthService {
+  @override
+  String? get currentPublicKeyHex => null;
+
+  @override
+  Stream<AuthState> get authStateStream => const Stream<AuthState>.empty();
+
+  @override
+  AuthState get authState => AuthState.unauthenticated;
 }


### PR DESCRIPTION
Closes #6698

## Summary

This fixes two related audio reuse consent defects.

1. Reuse badges now render from viewer-independent sound terms, not from viewer-specific permission. Legacy sound terms can be unresolved while the resolver checks the source video, so the metadata sheet and sound detail screen withhold the "Credit only" / "Remixing allowed" badge until the terms are known.

2. Viewer-specific reuse permission still lives in `audioReuseConsentProvider`, including the owner exception, so a creator can select their own legacy/private sound in the picker. The sound detail screen keeps a synchronous owner/action shortcut to avoid one-frame button flicker, but the badge remains based only on public terms.

## Tests

- `audioReuseConsent owner exception` provider tests
- metadata sheet: owner viewing explicit credit-only still sees credit-only terms
- metadata sheet: pending legacy terms withhold the badge
- sound detail: pending legacy terms withhold the badge while the action gate fails closed
- sound detail: explicitly reusable sounds show the allowed badge immediately
- audio picker: owner + legacy sound is selectable end to end

## Verification

- `dart run build_runner build --delete-conflicting-outputs`
- `flutter test test/widgets/metadata_sounds_section_test.dart test/screens/sound_detail_screen_test.dart test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart test/providers/sounds_providers_test.dart`
- `flutter analyze lib test`
- pre-push hook: merge-conflict check, analyzer, generated-file check, changed-file tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
