### PR TITLE
fix(profile): stop showing the signed-in user a generated name at cold start

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -249,6 +249,8 @@ jobs:
         run: bash scripts/check_raw_dialog_ceiling.sh
       - name: 🎨 Verify no VineTheme.*Font( call omits its color (light-mode ratchet)
         run: bash scripts/check_implicit_font_color_ceiling.sh
+      - name: 🔐 Verify no profile publish reaches the ungated read provider (#6423)
+        run: bash scripts/check_profile_read_write_split.sh
       - name: 🔨 Verify generated files are up-to-date
         run: |
           dart run build_runner build

--- a/mobile/lib/blocs/my_profile/my_profile_bloc.dart
+++ b/mobile/lib/blocs/my_profile/my_profile_bloc.dart
@@ -15,7 +15,7 @@ part 'my_profile_state.dart';
 /// BLoC for the current user's own profile.
 class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
   MyProfileBloc({
-    required ProfileRepository profileRepository,
+    required ProfileReader profileRepository,
     required this.pubkey,
     IdentityClaimsRepository? identityClaimsRepository,
   }) : _profileRepository = profileRepository,
@@ -37,7 +37,7 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
     );
   }
 
-  final ProfileRepository _profileRepository;
+  final ProfileReader _profileRepository;
   final IdentityClaimsRepository? _identityClaimsRepository;
 
   /// The pubkey of the current user.

--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -38,7 +38,7 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
     required VideoEvent video,
     required String relayUrl,
     required VideoSharingService videoSharingService,
-    required ProfileRepository profileRepository,
+    required ProfileReader profileRepository,
     required FollowRepository followRepository,
     Future<BookmarkService?>? bookmarkServiceFuture,
     BaseCacheManager? cacheManager,
@@ -69,7 +69,7 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
   final VideoEvent _video;
   final String _relayUrl;
   final VideoSharingService _videoSharingService;
-  final ProfileRepository _profileRepository;
+  final ProfileReader _profileRepository;
   final FollowRepository _followRepository;
   final Future<BookmarkService?>? _bookmarkServiceFuture;
   final BaseCacheManager? _cacheManager;

--- a/mobile/lib/features/app_review/app_review_coordinator.dart
+++ b/mobile/lib/features/app_review/app_review_coordinator.dart
@@ -131,7 +131,7 @@ class _AppReviewCoordinatorState extends ConsumerState<AppReviewCoordinator> {
   }
 
   Future<ProfileStats?> _loadProfileStats(String pubkey) async {
-    final repository = ref.read(profileStatsRepositoryProvider);
+    final repository = ref.read(profileReadRepositoryProvider);
     if (repository == null) return null;
     return _profileStatsLoader.load(
       refresh: () async {

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -295,23 +295,31 @@ ProfileRepository? profileRepository(Ref ref) {
   return _buildProfileRepository(ref, warmCache: true);
 }
 
-/// Lightweight ProfileRepository gated on **identity-known** (a pubkey is
+/// Read-only profile access gated on **identity-known** (a pubkey is
 /// available) rather than the full `nostrReady` relay-connect settle.
 ///
-/// The follower/following/video COUNTS are populated by a PUBLIC funnelcake
-/// REST call (`getUserProfile` → `_cacheProfileStatsFromResult`, no signer,
-/// no relay) and read back from Drift via `watchProfileStats`. None of that
-/// needs the relay-ready client, so gating those counts behind `nostrReady`
-/// is what left them stuck on "—" for the ~4s relay-connect window at cold
-/// start (#5863). This provider hands over the same repository as soon as the
-/// user's identity is known, so the counts render as soon as REST returns.
+/// Everything reachable through [ProfileReader] is signer-free: it either
+/// reads Drift directly or falls back to a PUBLIC funnelcake REST call
+/// (`getUserProfile` → `_cacheProfileStatsFromResult`). None of it needs the
+/// relay-ready client, so gating these reads behind `nostrReady` is what left
+/// the follower/following/video counts stuck on "—" for the ~4s relay-connect
+/// window at cold start (#5863), and what replaced the signed-in user's own
+/// name and avatar with a generated placeholder for that same window (#6423).
+/// This provider hands over the repository as soon as the identity is known.
+///
+/// **The return type is the security boundary.** The identity-known phase
+/// carries a pubkey but no client, so signing there is unsafe even though
+/// Drift reads are not. [ProfileReader] cannot express `saveProfileEvent`,
+/// `claimUsername`, `releaseUsername` or `drivePendingSave`, so a consumer of
+/// this provider cannot publish by accident. Everything that signs must keep
+/// using [profileRepository] — today that is
+/// `MonetizationLinksSettingsCubit`, `ProfileEditorBloc`, the account-deletion
+/// action and `profileSaveRetryService`.
 ///
 /// It does NOT warm the Kind-0 cache — that side effect belongs to the
-/// relay-backed [profileRepository]. Only [userProfileStatsReactiveProvider]
-/// consumes this; everything relay-dependent must keep using
-/// [profileRepository].
+/// relay-backed [profileRepository].
 @Riverpod(keepAlive: true)
-ProfileRepository? profileStatsRepository(Ref ref) {
+ProfileReader? profileReadRepository(Ref ref) {
   final identityPubkey = ref.watch(
     nostrSessionProvider.select((readiness) {
       if (readiness.phase == NostrSessionPhase.identityKnown ||
@@ -328,7 +336,7 @@ ProfileRepository? profileStatsRepository(Ref ref) {
   return _buildProfileRepository(ref, warmCache: false);
 }
 
-/// Shared construction for [profileRepository] and [profileStatsRepository].
+/// Shared construction for [profileRepository] and [profileReadRepository].
 /// When [warmCache] is true, pre-loads known cached pubkeys into the
 /// SubscriptionManager so Kind-0 relay requests skip already-cached authors.
 ProfileRepository _buildProfileRepository(Ref ref, {required bool warmCache}) {

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -400,100 +400,118 @@ final class ProfileRepositoryProvider
 
 String _$profileRepositoryHash() => r'92a8519f8d195b5c33727803820aa82e94a8b0b2';
 
-/// Lightweight ProfileRepository gated on **identity-known** (a pubkey is
+/// Read-only profile access gated on **identity-known** (a pubkey is
 /// available) rather than the full `nostrReady` relay-connect settle.
 ///
-/// The follower/following/video COUNTS are populated by a PUBLIC funnelcake
-/// REST call (`getUserProfile` → `_cacheProfileStatsFromResult`, no signer,
-/// no relay) and read back from Drift via `watchProfileStats`. None of that
-/// needs the relay-ready client, so gating those counts behind `nostrReady`
-/// is what left them stuck on "—" for the ~4s relay-connect window at cold
-/// start (#5863). This provider hands over the same repository as soon as the
-/// user's identity is known, so the counts render as soon as REST returns.
+/// Everything reachable through [ProfileReader] is signer-free: it either
+/// reads Drift directly or falls back to a PUBLIC funnelcake REST call
+/// (`getUserProfile` → `_cacheProfileStatsFromResult`). None of it needs the
+/// relay-ready client, so gating these reads behind `nostrReady` is what left
+/// the follower/following/video counts stuck on "—" for the ~4s relay-connect
+/// window at cold start (#5863), and what replaced the signed-in user's own
+/// name and avatar with a generated placeholder for that same window (#6423).
+/// This provider hands over the repository as soon as the identity is known.
+///
+/// **The return type is the security boundary.** The identity-known phase
+/// carries a pubkey but no client, so signing there is unsafe even though
+/// Drift reads are not. [ProfileReader] cannot express `saveProfileEvent`,
+/// `claimUsername`, `releaseUsername` or `drivePendingSave`, so a consumer of
+/// this provider cannot publish by accident. Everything that signs must keep
+/// using [profileRepository] — today that is
+/// `MonetizationLinksSettingsCubit`, `ProfileEditorBloc`, the account-deletion
+/// action and `profileSaveRetryService`.
 ///
 /// It does NOT warm the Kind-0 cache — that side effect belongs to the
-/// relay-backed [profileRepository]. Only [userProfileStatsReactiveProvider]
-/// consumes this; everything relay-dependent must keep using
-/// [profileRepository].
+/// relay-backed [profileRepository].
 
-@ProviderFor(profileStatsRepository)
-final profileStatsRepositoryProvider = ProfileStatsRepositoryProvider._();
+@ProviderFor(profileReadRepository)
+final profileReadRepositoryProvider = ProfileReadRepositoryProvider._();
 
-/// Lightweight ProfileRepository gated on **identity-known** (a pubkey is
+/// Read-only profile access gated on **identity-known** (a pubkey is
 /// available) rather than the full `nostrReady` relay-connect settle.
 ///
-/// The follower/following/video COUNTS are populated by a PUBLIC funnelcake
-/// REST call (`getUserProfile` → `_cacheProfileStatsFromResult`, no signer,
-/// no relay) and read back from Drift via `watchProfileStats`. None of that
-/// needs the relay-ready client, so gating those counts behind `nostrReady`
-/// is what left them stuck on "—" for the ~4s relay-connect window at cold
-/// start (#5863). This provider hands over the same repository as soon as the
-/// user's identity is known, so the counts render as soon as REST returns.
+/// Everything reachable through [ProfileReader] is signer-free: it either
+/// reads Drift directly or falls back to a PUBLIC funnelcake REST call
+/// (`getUserProfile` → `_cacheProfileStatsFromResult`). None of it needs the
+/// relay-ready client, so gating these reads behind `nostrReady` is what left
+/// the follower/following/video counts stuck on "—" for the ~4s relay-connect
+/// window at cold start (#5863), and what replaced the signed-in user's own
+/// name and avatar with a generated placeholder for that same window (#6423).
+/// This provider hands over the repository as soon as the identity is known.
+///
+/// **The return type is the security boundary.** The identity-known phase
+/// carries a pubkey but no client, so signing there is unsafe even though
+/// Drift reads are not. [ProfileReader] cannot express `saveProfileEvent`,
+/// `claimUsername`, `releaseUsername` or `drivePendingSave`, so a consumer of
+/// this provider cannot publish by accident. Everything that signs must keep
+/// using [profileRepository] — today that is
+/// `MonetizationLinksSettingsCubit`, `ProfileEditorBloc`, the account-deletion
+/// action and `profileSaveRetryService`.
 ///
 /// It does NOT warm the Kind-0 cache — that side effect belongs to the
-/// relay-backed [profileRepository]. Only [userProfileStatsReactiveProvider]
-/// consumes this; everything relay-dependent must keep using
-/// [profileRepository].
+/// relay-backed [profileRepository].
 
-final class ProfileStatsRepositoryProvider
-    extends
-        $FunctionalProvider<
-          ProfileRepository?,
-          ProfileRepository?,
-          ProfileRepository?
-        >
-    with $Provider<ProfileRepository?> {
-  /// Lightweight ProfileRepository gated on **identity-known** (a pubkey is
+final class ProfileReadRepositoryProvider
+    extends $FunctionalProvider<ProfileReader?, ProfileReader?, ProfileReader?>
+    with $Provider<ProfileReader?> {
+  /// Read-only profile access gated on **identity-known** (a pubkey is
   /// available) rather than the full `nostrReady` relay-connect settle.
   ///
-  /// The follower/following/video COUNTS are populated by a PUBLIC funnelcake
-  /// REST call (`getUserProfile` → `_cacheProfileStatsFromResult`, no signer,
-  /// no relay) and read back from Drift via `watchProfileStats`. None of that
-  /// needs the relay-ready client, so gating those counts behind `nostrReady`
-  /// is what left them stuck on "—" for the ~4s relay-connect window at cold
-  /// start (#5863). This provider hands over the same repository as soon as the
-  /// user's identity is known, so the counts render as soon as REST returns.
+  /// Everything reachable through [ProfileReader] is signer-free: it either
+  /// reads Drift directly or falls back to a PUBLIC funnelcake REST call
+  /// (`getUserProfile` → `_cacheProfileStatsFromResult`). None of it needs the
+  /// relay-ready client, so gating these reads behind `nostrReady` is what left
+  /// the follower/following/video counts stuck on "—" for the ~4s relay-connect
+  /// window at cold start (#5863), and what replaced the signed-in user's own
+  /// name and avatar with a generated placeholder for that same window (#6423).
+  /// This provider hands over the repository as soon as the identity is known.
+  ///
+  /// **The return type is the security boundary.** The identity-known phase
+  /// carries a pubkey but no client, so signing there is unsafe even though
+  /// Drift reads are not. [ProfileReader] cannot express `saveProfileEvent`,
+  /// `claimUsername`, `releaseUsername` or `drivePendingSave`, so a consumer of
+  /// this provider cannot publish by accident. Everything that signs must keep
+  /// using [profileRepository] — today that is
+  /// `MonetizationLinksSettingsCubit`, `ProfileEditorBloc`, the account-deletion
+  /// action and `profileSaveRetryService`.
   ///
   /// It does NOT warm the Kind-0 cache — that side effect belongs to the
-  /// relay-backed [profileRepository]. Only [userProfileStatsReactiveProvider]
-  /// consumes this; everything relay-dependent must keep using
-  /// [profileRepository].
-  ProfileStatsRepositoryProvider._()
+  /// relay-backed [profileRepository].
+  ProfileReadRepositoryProvider._()
     : super(
         from: null,
         argument: null,
         retry: null,
-        name: r'profileStatsRepositoryProvider',
+        name: r'profileReadRepositoryProvider',
         isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
 
   @override
-  String debugGetCreateSourceHash() => _$profileStatsRepositoryHash();
+  String debugGetCreateSourceHash() => _$profileReadRepositoryHash();
 
   @$internal
   @override
-  $ProviderElement<ProfileRepository?> $createElement(
-    $ProviderPointer pointer,
-  ) => $ProviderElement(pointer);
+  $ProviderElement<ProfileReader?> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
 
   @override
-  ProfileRepository? create(Ref ref) {
-    return profileStatsRepository(ref);
+  ProfileReader? create(Ref ref) {
+    return profileReadRepository(ref);
   }
 
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(ProfileRepository? value) {
+  Override overrideWithValue(ProfileReader? value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $SyncValueProvider<ProfileRepository?>(value),
+      providerOverride: $SyncValueProvider<ProfileReader?>(value),
     );
   }
 }
 
-String _$profileStatsRepositoryHash() =>
-    r'80251b83ada9ba843c40f64b98a0e7d02ae46fc6';
+String _$profileReadRepositoryHash() =>
+    r'6a1e6da7d10b16ef607eaf7c1b771201ebb753a4';
 
 /// Curation Service - manages NIP-51 video curation sets
 

--- a/mobile/lib/providers/user_profile_providers.dart
+++ b/mobile/lib/providers/user_profile_providers.dart
@@ -25,9 +25,9 @@ final userProfileStatsReactiveProvider =
     StreamProvider.family<ProfileStats?, String>((ref, pubkey) {
       // Counts come from a public funnelcake REST call + Drift; they need only
       // an identity-known session, not the full nostrReady relay-connect settle.
-      // Using the identity-known-gated stats repo lets counts render as soon as
+      // Using the identity-known-gated read repo lets counts render as soon as
       // REST returns instead of stalling on "—" until relays connect (#5863).
-      final repo = ref.watch(profileStatsRepositoryProvider);
+      final repo = ref.watch(profileReadRepositoryProvider);
       if (repo == null) {
         return const Stream<ProfileStats?>.empty();
       }
@@ -36,7 +36,7 @@ final userProfileStatsReactiveProvider =
     });
 
 Stream<ProfileStats?> _watchProfileStats(
-  ProfileRepository repo,
+  ProfileReader repo,
   String pubkey,
 ) async* {
   unawaited(
@@ -57,18 +57,26 @@ Stream<ProfileStats?> _watchProfileStats(
 ///
 /// Consumers get `AsyncValue<UserProfile?>` — same API as the old
 /// FutureProvider, so widget code changes are minimal.
+///
+/// Reads through [profileReadRepositoryProvider], which is available at the
+/// identity-known phase. Waiting for the relay-connect settle here is what
+/// made the signed-in user's own header render a generated fallback name for
+/// the whole cold-start window (#6423); nothing on this path signs.
 @riverpod
 Stream<UserProfile?> userProfileReactive(Ref ref, String pubkey) {
-  final repo = ref.watch(profileRepositoryProvider);
+  final repo = ref.watch(profileReadRepositoryProvider);
   if (repo == null) {
-    return const Stream<UserProfile?>.empty();
+    // Resolve to AsyncData(null) rather than an empty stream: a stream that
+    // closes without emitting leaves the StreamProvider in AsyncLoading
+    // forever, which callers cannot tell apart from "still fetching".
+    return Stream<UserProfile?>.value(null);
   }
 
   return _watchUserProfile(repo, pubkey);
 }
 
 Stream<UserProfile?> _watchUserProfile(
-  ProfileRepository repo,
+  ProfileReader repo,
   String pubkey,
 ) async* {
   // Kick off a background fetch if nothing is cached yet.
@@ -84,9 +92,11 @@ Stream<UserProfile?> _watchUserProfile(
 ///
 /// Use this when you need a single read (e.g., building a share sheet)
 /// rather than a reactive stream.
+///
+/// Same read gate as [userProfileReactive] — both paths are signer-free.
 @riverpod
 Future<UserProfile?> fetchUserProfile(Ref ref, String pubkey) async {
-  final repo = ref.watch(profileRepositoryProvider);
+  final repo = ref.watch(profileReadRepositoryProvider);
   if (repo == null) return null;
 
   final cached = await repo.getCachedProfile(pubkey: pubkey);

--- a/mobile/lib/providers/user_profile_providers.dart
+++ b/mobile/lib/providers/user_profile_providers.dart
@@ -29,11 +29,17 @@ final userProfileStatsReactiveProvider =
       // REST returns instead of stalling on "—" until relays connect (#5863).
       final repo = ref.watch(profileReadRepositoryProvider);
       if (repo == null) {
-        return const Stream<ProfileStats?>.empty();
+        // Match userProfileReactiveProvider: emit null instead of an empty
+        // stream so callers get AsyncData(null), not permanent AsyncLoading.
+        return _nullProfileStatsStream();
       }
 
       return _watchProfileStats(repo, pubkey);
     });
+
+Stream<ProfileStats?> _nullProfileStatsStream() async* {
+  yield null;
+}
 
 Stream<ProfileStats?> _watchProfileStats(
   ProfileReader repo,

--- a/mobile/lib/providers/user_profile_providers.g.dart
+++ b/mobile/lib/providers/user_profile_providers.g.dart
@@ -17,6 +17,11 @@ part of 'user_profile_providers.dart';
 ///
 /// Consumers get `AsyncValue<UserProfile?>` — same API as the old
 /// FutureProvider, so widget code changes are minimal.
+///
+/// Reads through [profileReadRepositoryProvider], which is available at the
+/// identity-known phase. Waiting for the relay-connect settle here is what
+/// made the signed-in user's own header render a generated fallback name for
+/// the whole cold-start window (#6423); nothing on this path signs.
 
 @ProviderFor(userProfileReactive)
 final userProfileReactiveProvider = UserProfileReactiveFamily._();
@@ -30,6 +35,11 @@ final userProfileReactiveProvider = UserProfileReactiveFamily._();
 ///
 /// Consumers get `AsyncValue<UserProfile?>` — same API as the old
 /// FutureProvider, so widget code changes are minimal.
+///
+/// Reads through [profileReadRepositoryProvider], which is available at the
+/// identity-known phase. Waiting for the relay-connect settle here is what
+/// made the signed-in user's own header render a generated fallback name for
+/// the whole cold-start window (#6423); nothing on this path signs.
 
 final class UserProfileReactiveProvider
     extends
@@ -48,6 +58,11 @@ final class UserProfileReactiveProvider
   ///
   /// Consumers get `AsyncValue<UserProfile?>` — same API as the old
   /// FutureProvider, so widget code changes are minimal.
+  ///
+  /// Reads through [profileReadRepositoryProvider], which is available at the
+  /// identity-known phase. Waiting for the relay-connect settle here is what
+  /// made the signed-in user's own header render a generated fallback name for
+  /// the whole cold-start window (#6423); nothing on this path signs.
   UserProfileReactiveProvider._({
     required UserProfileReactiveFamily super.from,
     required String super.argument,
@@ -93,7 +108,7 @@ final class UserProfileReactiveProvider
 }
 
 String _$userProfileReactiveHash() =>
-    r'f0c15277edfd883bf7d28cb94b19822f01f94934';
+    r'a3c10ea57bfa00094e9bb26d62e8dcd93312435e';
 
 /// Reactive profile provider backed by Drift's watchProfile stream.
 ///
@@ -104,6 +119,11 @@ String _$userProfileReactiveHash() =>
 ///
 /// Consumers get `AsyncValue<UserProfile?>` — same API as the old
 /// FutureProvider, so widget code changes are minimal.
+///
+/// Reads through [profileReadRepositoryProvider], which is available at the
+/// identity-known phase. Waiting for the relay-connect settle here is what
+/// made the signed-in user's own header render a generated fallback name for
+/// the whole cold-start window (#6423); nothing on this path signs.
 
 final class UserProfileReactiveFamily extends $Family
     with $FunctionalFamilyOverride<Stream<UserProfile?>, String> {
@@ -125,6 +145,11 @@ final class UserProfileReactiveFamily extends $Family
   ///
   /// Consumers get `AsyncValue<UserProfile?>` — same API as the old
   /// FutureProvider, so widget code changes are minimal.
+  ///
+  /// Reads through [profileReadRepositoryProvider], which is available at the
+  /// identity-known phase. Waiting for the relay-connect settle here is what
+  /// made the signed-in user's own header render a generated fallback name for
+  /// the whole cold-start window (#6423); nothing on this path signs.
 
   UserProfileReactiveProvider call(String pubkey) =>
       UserProfileReactiveProvider._(argument: pubkey, from: this);
@@ -137,6 +162,8 @@ final class UserProfileReactiveFamily extends $Family
 ///
 /// Use this when you need a single read (e.g., building a share sheet)
 /// rather than a reactive stream.
+///
+/// Same read gate as [userProfileReactive] — both paths are signer-free.
 
 @ProviderFor(fetchUserProfile)
 final fetchUserProfileProvider = FetchUserProfileFamily._();
@@ -145,6 +172,8 @@ final fetchUserProfileProvider = FetchUserProfileFamily._();
 ///
 /// Use this when you need a single read (e.g., building a share sheet)
 /// rather than a reactive stream.
+///
+/// Same read gate as [userProfileReactive] — both paths are signer-free.
 
 final class FetchUserProfileProvider
     extends
@@ -158,6 +187,8 @@ final class FetchUserProfileProvider
   ///
   /// Use this when you need a single read (e.g., building a share sheet)
   /// rather than a reactive stream.
+  ///
+  /// Same read gate as [userProfileReactive] — both paths are signer-free.
   FetchUserProfileProvider._({
     required FetchUserProfileFamily super.from,
     required String super.argument,
@@ -202,12 +233,14 @@ final class FetchUserProfileProvider
   }
 }
 
-String _$fetchUserProfileHash() => r'6f16ff504ee65f0b1f8dbdf51674de0d4f375d94';
+String _$fetchUserProfileHash() => r'83353a4223c0c0ca7feee6e08c2f8116ca551c66';
 
 /// One-shot provider: returns cached profile or fetches fresh.
 ///
 /// Use this when you need a single read (e.g., building a share sheet)
 /// rather than a reactive stream.
+///
+/// Same read gate as [userProfileReactive] — both paths are signer-free.
 
 final class FetchUserProfileFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<UserProfile?>, String> {
@@ -224,6 +257,8 @@ final class FetchUserProfileFamily extends $Family
   ///
   /// Use this when you need a single read (e.g., building a share sheet)
   /// rather than a reactive stream.
+  ///
+  /// Same read gate as [userProfileReactive] — both paths are signer-free.
 
   FetchUserProfileProvider call(String pubkey) =>
       FetchUserProfileProvider._(argument: pubkey, from: this);

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -355,7 +355,10 @@ SubscribedListVideoCache? subscribedListVideoCache(Ref ref) {
 VideoSharingService? videoSharingService(Ref ref) {
   final nostrService = ref.watch(nostrServiceProvider);
   final authService = ref.watch(authServiceProvider);
-  final profileRepository = ref.watch(profileRepositoryProvider);
+  // Read-only handle: the service only reads profiles, and gating it on the
+  // relay-ready client made Share a dead tap during cold start (#6423). The
+  // send path gates itself on `canPublishNostrWritesNow`.
+  final profileRepository = ref.watch(profileReadRepositoryProvider);
   final dmRepository = ref.watch(dmRepositoryProvider);
 
   if (profileRepository == null) {

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -502,7 +502,7 @@ final class VideoSharingServiceProvider
 }
 
 String _$videoSharingServiceHash() =>
-    r'c67ca5b381903ab2a6d29bc2f64e057661279598';
+    r'7406fd516a93ac8becbf4df73335ffa387ad25c6';
 
 /// Unified resolver for fetching a [VideoEvent] by its event id, with
 /// in-memory → personal cache → relay fallback. See [VideoEventResolver].

--- a/mobile/lib/screens/profile_screen_router.dart
+++ b/mobile/lib/screens/profile_screen_router.dart
@@ -67,8 +67,12 @@ class _ProfileScreenRouterState extends ConsumerState<ProfileScreenRouter>
   void _fetchProfileIfNeeded(String userIdHex, bool isOwnProfile) {
     if (isOwnProfile) return; // Own profile loads automatically
 
-    // Trigger a background fetch via ProfileRepository
-    ref.read(profileRepositoryProvider)?.fetchFreshProfile(pubkey: userIdHex);
+    // Trigger a background fetch via the read-only handle.
+    ref
+        .read(profileReadRepositoryProvider)
+        ?.fetchFreshProfile(
+          pubkey: userIdHex,
+        );
   }
 
   @override
@@ -113,18 +117,20 @@ class _ProfileScreenRouterState extends ConsumerState<ProfileScreenRouter>
 
     if (isOwnProfileGrid) {
       final userIdHex = ref.read(authServiceProvider).currentPublicKeyHex;
-      final profileRepository = ref.watch(profileRepositoryProvider);
+      // Read-only handle: available at identity-known, so the own-profile
+      // header renders the user's real cached name and avatar instead of a
+      // generated placeholder while relays connect (#6423). MyProfileBloc
+      // only reads.
+      final profileRepository = ref.watch(profileReadRepositoryProvider);
       final identityClaimsRepository = ref.watch(
         identityClaimsRepositoryProvider,
       );
 
       if (userIdHex == null || profileRepository == null) {
-        // profileRepository isn't ready yet (cold start before the
-        // signer-backed client is up). Render the real profile layout — its
-        // header, stats, and video grid degrade to skeletons while
-        // MyProfileBloc is absent — instead of a separate loading view. Once
-        // the repository resolves, the BlocProvider below mounts and the
-        // layout fills in with real data.
+        // No identity at all yet. Render the real profile layout — its header,
+        // stats, and video grid degrade to skeletons while MyProfileBloc is
+        // absent — instead of a separate loading view. Once the identity
+        // resolves, the BlocProvider below mounts and the layout fills in.
         return _ProfileScaffold(body: content);
       }
 
@@ -168,7 +174,7 @@ class _ProfileScreenRouterState extends ConsumerState<ProfileScreenRouter>
     try {
       // Get profile info for better share text
       final profile = await ref
-          .read(profileRepositoryProvider)
+          .read(profileReadRepositoryProvider)
           ?.getCachedProfile(pubkey: userIdHex);
       final displayName = profile?.bestDisplayName ?? 'User';
 

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -502,7 +502,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     return switch (_currentIdentity) {
       null => false,
       LocalNostrIdentity() => true,
-      KeycastNostrIdentity() => true,
+      KeycastNostrIdentity(:final signsWithLocalKey) =>
+        signsWithLocalKey || _authRpcCapability == AuthRpcCapability.rpcReady,
       PubkeyOnlyNostrIdentity() => false,
       AmberNostrIdentity() => true,
       BunkerNostrIdentity() => true,

--- a/mobile/lib/services/video_sharing_service.dart
+++ b/mobile/lib/services/video_sharing_service.dart
@@ -71,7 +71,7 @@ class VideoSharingService {
   VideoSharingService({
     required NostrClient nostrService,
     required AuthService authService,
-    required ProfileRepository profileRepository,
+    required ProfileReader profileRepository,
     DmRepository? dmRepository,
   }) : _nostrService = nostrService,
        _authService = authService,
@@ -79,7 +79,7 @@ class VideoSharingService {
        _dmRepository = dmRepository;
   final NostrClient _nostrService;
   final AuthService _authService;
-  final ProfileRepository _profileRepository;
+  final ProfileReader _profileRepository;
   final DmRepository? _dmRepository;
 
   final List<ShareableUser> _recentlySharedWith = [];
@@ -108,6 +108,16 @@ class VideoSharingService {
 
       if (!_authService.isAuthenticated) {
         return ShareResult.failure('User not authenticated');
+      }
+
+      // Explicit publish-readiness gate. This service used to inherit one by
+      // accident: it was built from the relay-gated profile repository, so a
+      // not-yet-ready session made the whole service — and therefore the
+      // share sheet — null. That turned Share into a silent dead tap for the
+      // entire cold-start window. The sheet now opens on the read-only
+      // handle, so the send path has to state the requirement itself (#6423).
+      if (!_authService.canPublishNostrWritesNow) {
+        return ShareResult.failure('Signing is not available yet');
       }
 
       final dmContent = _createShareMessage(video, personalMessage);

--- a/mobile/lib/widgets/profile/profile_header_identity.dart
+++ b/mobile/lib/widgets/profile/profile_header_identity.dart
@@ -64,6 +64,9 @@ class _ProfileNameAndBio extends StatelessWidget {
                   style: VineTheme.titleLargeFont(
                     color: context.vineColors.primaryText,
                   ),
+                  // A kind-0 with empty name and display_name still falls
+                  // through to the generated handle without this (#6423).
+                  neverGenerateName: isOwnProfile,
                 )
               else
                 UserName.fromPubKey(

--- a/mobile/lib/widgets/profile/profile_header_identity.dart
+++ b/mobile/lib/widgets/profile/profile_header_identity.dart
@@ -72,6 +72,9 @@ class _ProfileNameAndBio extends StatelessWidget {
                     color: context.vineColors.primaryText,
                   ),
                   anonymousName: displayNameHint,
+                  // Never show the signed-in user a generated handle in place
+                  // of their own name — that is the #6423 report verbatim.
+                  neverGenerateName: isOwnProfile,
                 ),
               Skeleton.keep(
                 child: _UniqueIdentifier(

--- a/mobile/lib/widgets/profile/profile_header_identity.dart
+++ b/mobile/lib/widgets/profile/profile_header_identity.dart
@@ -65,7 +65,14 @@ class _ProfileNameAndBio extends StatelessWidget {
                     color: context.vineColors.primaryText,
                   ),
                   // A kind-0 with empty name and display_name still falls
-                  // through to the generated handle without this (#6423).
+                  // through to the generated handle without this (#6423). Use
+                  // the route hint, then the full npub, as the non-generated
+                  // steady state so the header never renders a blank title.
+                  anonymousName: _ownProfileNamePlaceholder(
+                    isOwnProfile: isOwnProfile,
+                    displayNameHint: displayNameHint,
+                    userIdHex: userIdHex,
+                  ),
                   neverGenerateName: isOwnProfile,
                 )
               else
@@ -74,7 +81,13 @@ class _ProfileNameAndBio extends StatelessWidget {
                   style: VineTheme.titleLargeFont(
                     color: context.vineColors.primaryText,
                   ),
-                  anonymousName: displayNameHint,
+                  anonymousName:
+                      _ownProfileNamePlaceholder(
+                        isOwnProfile: isOwnProfile,
+                        displayNameHint: displayNameHint,
+                        userIdHex: userIdHex,
+                      ) ??
+                      displayNameHint,
                   // Never show the signed-in user a generated handle in place
                   // of their own name — that is the #6423 report verbatim.
                   neverGenerateName: isOwnProfile,
@@ -123,6 +136,17 @@ class _ProfileNameAndBio extends StatelessWidget {
       ],
     );
   }
+}
+
+String? _ownProfileNamePlaceholder({
+  required bool isOwnProfile,
+  required String? displayNameHint,
+  required String userIdHex,
+}) {
+  if (!isOwnProfile) return null;
+  final hint = displayNameHint?.trim();
+  if (hint != null && hint.isNotEmpty) return hint;
+  return NostrKeyUtils.encodePubKey(userIdHex);
 }
 
 /// Horizontal inset applied to the name/bio identity block. Shared so the

--- a/mobile/lib/widgets/user_name.dart
+++ b/mobile/lib/widgets/user_name.dart
@@ -27,6 +27,7 @@ class UserName extends ConsumerWidget {
   /// author_name), it will be used as a fallback when the profile isn't
   /// cached yet. This avoids unnecessary WebSocket profile fetches for
   /// videos that already have author data embedded.
+  ///
   /// Set [neverGenerateName] on surfaces that show the signed-in user their
   /// own identity. A generated "Adjective Animal NN" handle is a plausible
   /// human name the user never chose, so showing it back to them reads as
@@ -62,6 +63,7 @@ class UserName extends ConsumerWidget {
     bool? selectable,
     String? anonymousName,
     TextOverflow? overflow,
+    bool neverGenerateName = false,
   }) => UserName._(
     userProfile: userProfile,
     key: key,
@@ -70,6 +72,7 @@ class UserName extends ConsumerWidget {
     overflow: overflow,
     selectable: selectable,
     anonymousName: anonymousName,
+    neverGenerateName: neverGenerateName,
   );
 
   final String? pubkey;
@@ -86,7 +89,8 @@ class UserName extends ConsumerWidget {
 
   /// Suppresses the generated "Adjective Animal NN" fallback entirely.
   ///
-  /// Only meaningful with [UserName.fromPubKey]; see that factory's doc.
+  /// See [UserName.fromPubKey]'s doc for why. Applies to a resolved profile
+  /// with an empty name as well as to the unresolved case.
   final bool neverGenerateName;
 
   @override
@@ -94,20 +98,24 @@ class UserName extends ConsumerWidget {
     late String displayName;
     late String effectivePubkey;
     UserProfile? resolvedProfile;
+
+    // When [neverGenerateName] is set, an empty placeholder replaces the
+    // generated handle everywhere it would otherwise appear, so the caller
+    // renders blank (typically under a Skeletonizer) instead of a name the
+    // user never chose. It has to apply to a *resolved* profile too: a kind-0
+    // with empty name and display_name still falls through to the generated
+    // handle, and that is a state users reach — publishing from divine-web
+    // with an empty name strips both fields.
+    final placeholder = anonymousName ?? (neverGenerateName ? '' : null);
+
     if (userProfile case final userProfile?) {
       resolvedProfile = userProfile;
       effectivePubkey = userProfile.pubkey;
-      displayName = userProfile.betterDisplayName(anonymousName);
+      displayName = userProfile.betterDisplayName(placeholder);
     } else {
       final profileAsync = ref.watch(userProfileReactiveProvider(pubkey!));
       resolvedProfile = profileAsync.value;
       effectivePubkey = pubkey!;
-
-      // When [neverGenerateName] is set, an empty placeholder replaces the
-      // generated handle everywhere it would otherwise appear, so the caller
-      // renders blank (typically under a Skeletonizer) instead of a name the
-      // user never chose.
-      final placeholder = anonymousName ?? (neverGenerateName ? '' : null);
 
       // Precedence mirrors UserProfile.betterDisplayName: a real name embedded
       // in a REST response beats a caller-supplied placeholder, which beats

--- a/mobile/lib/widgets/user_name.dart
+++ b/mobile/lib/widgets/user_name.dart
@@ -18,6 +18,7 @@ class UserName extends ConsumerWidget {
     this.overflow,
     this.selectable = false,
     this.anonymousName,
+    this.neverGenerateName = false,
   });
 
   /// Create a UserName widget from a pubkey.
@@ -26,6 +27,11 @@ class UserName extends ConsumerWidget {
   /// author_name), it will be used as a fallback when the profile isn't
   /// cached yet. This avoids unnecessary WebSocket profile fetches for
   /// videos that already have author data embedded.
+  /// Set [neverGenerateName] on surfaces that show the signed-in user their
+  /// own identity. A generated "Adjective Animal NN" handle is a plausible
+  /// human name the user never chose, so showing it back to them reads as
+  /// their account having been reset (#6423). Those surfaces render blank —
+  /// normally under a `Skeletonizer` — until a real name resolves.
   factory UserName.fromPubKey(
     String pubkey, {
     String? embeddedName,
@@ -35,6 +41,7 @@ class UserName extends ConsumerWidget {
     bool? selectable,
     String? anonymousName,
     TextOverflow? overflow,
+    bool neverGenerateName = false,
   }) => UserName._(
     pubkey: pubkey,
     embeddedName: embeddedName,
@@ -44,6 +51,7 @@ class UserName extends ConsumerWidget {
     overflow: overflow,
     selectable: selectable,
     anonymousName: anonymousName,
+    neverGenerateName: neverGenerateName,
   );
 
   factory UserName.fromUserProfile(
@@ -76,6 +84,11 @@ class UserName extends ConsumerWidget {
   final bool? selectable;
   final String? anonymousName;
 
+  /// Suppresses the generated "Adjective Animal NN" fallback entirely.
+  ///
+  /// Only meaningful with [UserName.fromPubKey]; see that factory's doc.
+  final bool neverGenerateName;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     late String displayName;
@@ -90,14 +103,23 @@ class UserName extends ConsumerWidget {
       resolvedProfile = profileAsync.value;
       effectivePubkey = pubkey!;
 
-      // Use embedded name from REST API as fallback, then generated name.
+      // When [neverGenerateName] is set, an empty placeholder replaces the
+      // generated handle everywhere it would otherwise appear, so the caller
+      // renders blank (typically under a Skeletonizer) instead of a name the
+      // user never chose.
+      final placeholder = anonymousName ?? (neverGenerateName ? '' : null);
+
+      // Precedence mirrors UserProfile.betterDisplayName: a real name embedded
+      // in a REST response beats a caller-supplied placeholder, which beats
+      // the generated handle. Honouring the placeholder here is what makes
+      // the header's displayNameHint reach the failure case at all (#6423).
       final fallbackName = embeddedName != null
           ? UserProfile.sanitizeDisplayName(embeddedName!)
-          : UserProfile.defaultDisplayNameFor(pubkey!);
+          : placeholder ?? UserProfile.defaultDisplayNameFor(pubkey!);
 
       displayName = switch (profileAsync) {
         AsyncData(:final value) when value != null => value.betterDisplayName(
-          anonymousName,
+          placeholder,
         ),
         AsyncLoading() || AsyncData() => fallbackName,
         AsyncError() => fallbackName,

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -490,7 +490,7 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
   }
 
   Future<void> _handleSaveWithWatermark() async {
-    final profileRepo = ref.read(profileRepositoryProvider);
+    final profileRepo = ref.read(profileReadRepositoryProvider);
     final profile = await profileRepo?.getCachedProfile(
       pubkey: widget.video.pubkey,
     );

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -75,9 +75,10 @@ class ShareActionButton extends StatelessWidget {
   /// same bottom-sheet wiring without duplicating setup logic.
   static void showShareSheet(BuildContext context, VideoEvent video) {
     // Read here so the sheet receives guaranteed non-null sharing dependencies.
-    // If Nostr client hasn't initialized yet, skip opening the sheet.
+    // Both are read-only handles, available once the identity is known — the
+    // sheet no longer waits for relays to connect (#6423).
     final container = ProviderScope.containerOf(context);
-    final profileRepository = container.read(profileRepositoryProvider);
+    final profileRepository = container.read(profileReadRepositoryProvider);
     final videoSharingService = container.read(videoSharingServiceProvider);
     if (profileRepository == null || videoSharingService == null) return;
 
@@ -126,7 +127,7 @@ class _UnifiedShareSheet extends ConsumerStatefulWidget {
   });
 
   final VideoEvent video;
-  final ProfileRepository profileRepository;
+  final ProfileReader profileRepository;
   final VideoSharingService videoSharingService;
 
   /// Context from the widget that opened the sheet (not the modal builder).

--- a/mobile/packages/profile_repository/lib/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/profile_repository.dart
@@ -8,6 +8,7 @@ export 'src/exceptions.dart';
 export 'src/identity_claim.dart';
 export 'src/identity_claims_repository.dart';
 export 'src/pending_profile_save.dart';
+export 'src/profile_reader.dart';
 export 'src/profile_repository.dart';
 export 'src/progressive_search_result.dart';
 export 'src/username_availability_result.dart';

--- a/mobile/packages/profile_repository/lib/src/profile_reader.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_reader.dart
@@ -1,0 +1,80 @@
+// ABOUTME: Read-only view of [ProfileRepository] — the members that need
+// ABOUTME: neither a signer nor a relay-ready client.
+
+import 'package:models/models.dart';
+import 'package:profile_repository/profile_repository.dart';
+
+/// The subset of [ProfileRepository] that reads profile data without ever
+/// signing or publishing.
+///
+/// This exists to make a **security boundary compile-time enforceable**.
+/// `profileRepositoryProvider` withholds the repository until the
+/// signer-backed `NostrClient` has rebuilt for the active identity, which
+/// prevents a publish from being signed by the wrong key (#1048). But that
+/// same gate was also withholding purely local Drift reads, so the signed-in
+/// user's own name and avatar were replaced by a generated placeholder for
+/// the whole relay-connect window (#6423).
+///
+/// `profileReadRepositoryProvider` therefore hands over a [ProfileReader] as
+/// soon as the identity is known. Because the type cannot express
+/// `saveProfileEvent`, `claimUsername`, `releaseUsername` or
+/// `drivePendingSave`, a consumer of the loose provider cannot publish even
+/// by accident — the ungated phase carries a pubkey but no client, so signing
+/// there is unsafe while Drift reads are not.
+///
+/// Every member below is signer-free and relay-optional: each either reads
+/// Drift directly or falls back to a public, unauthenticated funnelcake REST
+/// call.
+///
+/// **Do not widen this interface without re-checking that invariant.** The
+/// write-intent members (`cacheProfile`, `deleteCachedProfile`,
+/// `enqueuePendingSave`, `clearPendingSave`, `resetInterruptedPendingSave`)
+/// are deliberately absent too — they do not sign, but a caller reaching for
+/// them through the read handle is a design smell worth catching in review.
+/// `mobile/scripts/check_profile_read_write_split.sh` guards the indirect
+/// route a type cannot see.
+abstract interface class ProfileReader {
+  /// Returns the cached profile from local storage (SQLite) only.
+  ///
+  /// Returns `null` if no cached profile exists for the given pubkey.
+  Future<UserProfile?> getCachedProfile({required String pubkey});
+
+  /// Watches the cached profile for [pubkey], emitting on every cache write.
+  Stream<UserProfile?> watchProfile({required String pubkey});
+
+  /// Watches the follower/following/video counts for [pubkey].
+  ///
+  /// Emits `null` if no stats exist, and an empty stream when no stats DAO
+  /// was injected.
+  Stream<ProfileStats?> watchProfileStats({required String pubkey});
+
+  /// Fetches the freshest profile for [pubkey] and caches it locally.
+  ///
+  /// Reads only — the relay query and the funnelcake REST fallback are both
+  /// unauthenticated. Returns `null` when no profile exists anywhere.
+  Future<UserProfile?> fetchFreshProfile({
+    required String pubkey,
+    bool requireRawKind0,
+    List<Duration> rawKind0RetryDelays,
+  });
+
+  /// Resolves many profiles at once, preferring the Drift cache.
+  ///
+  /// Partial results are returned rather than throwing.
+  Future<Map<String, UserProfile>> fetchBatchProfiles({
+    required List<String> pubkeys,
+  });
+
+  /// Returns the cached NIP-39 `i` tag list for [pubkey] from local storage.
+  ///
+  /// Does NOT hit the network. Returns `null` when nothing is cached.
+  Future<List<List<String>>?> cachedIdentityTags(String pubkey);
+
+  /// Fetches the freshest NIP-39 identity-claims source for [pubkey].
+  ///
+  /// Never throws — relay failures fall through the consult order.
+  Future<List<List<String>>> freshIdentityTags({
+    required String pubkey,
+    required List<List<String>> kind0Tags,
+  });
+}

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -76,7 +76,7 @@ const defaultProfileIndexerRelays = [
 ];
 
 /// Repository for fetching and publishing user profiles (Kind 0 metadata).
-class ProfileRepository {
+class ProfileRepository implements ProfileReader {
   /// Creates a new profile repository.
   ProfileRepository({
     required NostrClient nostrClient,
@@ -336,6 +336,7 @@ class ProfileRepository {
   /// while [fetchFreshProfile] runs in parallel.
   ///
   /// Returns `null` if no cached profile exists for the given pubkey.
+  @override
   Future<UserProfile?> getCachedProfile({required String pubkey}) async {
     return _userProfilesDao.getProfile(pubkey);
   }
@@ -393,6 +394,7 @@ class ProfileRepository {
   /// Use this for reactive UI updates (e.g., BlocBuilder subscriptions).
   /// Pair with [fetchFreshProfile] to trigger relay fetches that write
   /// back to the cache and automatically flow through this stream.
+  @override
   Stream<UserProfile?> watchProfile({required String pubkey}) {
     return _userProfilesDao.watchProfile(pubkey);
   }
@@ -403,6 +405,7 @@ class ProfileRepository {
   /// been cached yet, when the cached row is corrupt, or when no
   /// [IdentityEventsDao] is wired. Use for instant chip rendering while
   /// [freshIdentityTags] runs (#3936).
+  @override
   Future<List<List<String>>?> cachedIdentityTags(String pubkey) async {
     final dao = _identityEventsDao;
     if (dao == null) return null;
@@ -424,6 +427,7 @@ class ProfileRepository {
   /// Never throws — relay failures fall through the consult order, and
   /// cache reads/writes are best-effort so a local persistence failure
   /// never discards tags already in hand.
+  @override
   Future<List<List<String>>> freshIdentityTags({
     required String pubkey,
     required List<List<String>> kind0Tags,
@@ -552,6 +556,7 @@ class ProfileRepository {
   /// [ProfileStats] domain models. Emits `null` if no stats exist.
   ///
   /// Returns an empty stream if [ProfileStatsDao] was not injected.
+  @override
   Stream<ProfileStats?> watchProfileStats({required String pubkey}) {
     final dao = _profileStatsDao;
     if (dao == null) return const Stream.empty();
@@ -625,6 +630,7 @@ class ProfileRepository {
   ///
   /// Returns `null` if no profile exists across all sources.
   /// On success, the profile is automatically cached locally.
+  @override
   Future<UserProfile?> fetchFreshProfile({
     required String pubkey,
     bool requireRawKind0 = false,
@@ -2228,6 +2234,7 @@ class ProfileRepository {
   /// Errors from the API or relay layers are caught and
   /// logged — partial results are returned rather than
   /// throwing.
+  @override
   Future<Map<String, UserProfile>> fetchBatchProfiles({
     required List<String> pubkeys,
   }) async {

--- a/mobile/packages/profile_repository/test/src/profile_reader_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_reader_test.dart
@@ -1,0 +1,107 @@
+// ABOUTME: Pins the ProfileReader read/write split — the compile-time
+// ABOUTME: boundary that keeps signing off the ungated profile provider.
+
+import 'package:db_client/db_client.dart' hide Filter, ProfileStats;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:profile_repository/profile_repository.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockUserProfilesDao extends Mock implements UserProfilesDao {}
+
+class _MockHttpClient extends Mock implements Client {}
+
+const _pubkey =
+    'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+
+/// A standalone [ProfileReader] that implements the interface **without**
+/// extending [ProfileRepository].
+///
+/// This is the guard: adding any member to [ProfileReader] stops this class
+/// from compiling, so the whole suite goes red. That is deliberate — the
+/// interface is a security boundary (see `profile_reader.dart`), and widening
+/// it must be a conscious act, not a drive-by. If you are here because this
+/// failed to compile, confirm the new member is signer-free before adding it
+/// below.
+class _ExhaustiveReader implements ProfileReader {
+  @override
+  Future<UserProfile?> getCachedProfile({required String pubkey}) async => null;
+
+  @override
+  Stream<UserProfile?> watchProfile({required String pubkey}) =>
+      const Stream.empty();
+
+  @override
+  Stream<ProfileStats?> watchProfileStats({required String pubkey}) =>
+      const Stream.empty();
+
+  @override
+  Future<UserProfile?> fetchFreshProfile({
+    required String pubkey,
+    bool requireRawKind0 = false,
+    List<Duration> rawKind0RetryDelays = const [],
+  }) async => null;
+
+  @override
+  Future<Map<String, UserProfile>> fetchBatchProfiles({
+    required List<String> pubkeys,
+  }) async => {};
+
+  @override
+  Future<List<List<String>>?> cachedIdentityTags(String pubkey) async => null;
+
+  @override
+  Future<List<List<String>>> freshIdentityTags({
+    required String pubkey,
+    required List<List<String>> kind0Tags,
+  }) async => const [];
+}
+
+void main() {
+  group(ProfileReader, () {
+    late _MockUserProfilesDao userProfilesDao;
+    late ProfileRepository repository;
+
+    setUp(() {
+      userProfilesDao = _MockUserProfilesDao();
+      repository = ProfileRepository(
+        nostrClient: _MockNostrClient(),
+        userProfilesDao: userProfilesDao,
+        httpClient: _MockHttpClient(),
+      );
+    });
+
+    test('is implemented by $ProfileRepository', () {
+      expect(repository, isA<ProfileReader>());
+    });
+
+    test('reads the Drift cache through the interface handle', () async {
+      final cached = UserProfile(
+        pubkey: _pubkey,
+        name: 'real-name',
+        rawData: const {},
+        createdAt: DateTime.utc(2026),
+        eventId: 'event-id',
+      );
+      when(
+        () => userProfilesDao.getProfile(_pubkey),
+      ).thenAnswer((_) async => cached);
+
+      // Deliberately typed as the interface: this is the handle the
+      // identity-known provider hands to display code.
+      final ProfileReader reader = repository;
+
+      expect(await reader.getCachedProfile(pubkey: _pubkey), cached);
+    });
+
+    test('an implementation needs no signer and no relay client', () {
+      // _ExhaustiveReader satisfies the contract with neither. If this stops
+      // compiling, a signing member reached the interface.
+      expect(_ExhaustiveReader(), isA<ProfileReader>());
+    });
+  });
+}

--- a/mobile/scripts/check_profile_read_write_split.sh
+++ b/mobile/scripts/check_profile_read_write_split.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Profile read/write split invariant (#6423).
+#
+# profileReadRepositoryProvider hands over a ProfileReader at the
+# identity-known phase — before the signer-backed NostrClient exists. That is
+# safe for Drift reads and unsafe for signing, so no file may reach a profile
+# publish through the loose provider.
+#
+# The ProfileReader type already makes the DIRECT route impossible: it cannot
+# express saveProfileEvent / claimUsername / releaseUsername / drivePendingSave.
+# This guard covers the INDIRECT route a type cannot see — a file that reads
+# the loose provider and separately calls a publish method on something else
+# (a repository it also holds, a service, a bloc field).
+#
+# Detector (code only — comments and string literals are stripped first by
+# lib/dart_code_only.awk, so a doc comment naming saveProfileEvent never trips
+# it): files under mobile/lib mentioning profileReadRepositoryProvider are
+# intersected with files calling a publish method.
+#
+# There is no baseline: the correct count is zero, always. If this fires, move
+# the publish to profileRepositoryProvider (which stays gated on
+# isReadyForActiveClient) rather than widening ProfileReader.
+#
+# Usage (from the repo root or mobile/):
+#   bash mobile/scripts/check_profile_read_write_split.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOBILE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+LOOSE_PROVIDER='profileReadRepositoryProvider'
+# Publish methods on ProfileRepository — each signs a Nostr event.
+PUBLISH_METHODS='saveProfileEvent|claimUsername|releaseUsername|drivePendingSave'
+
+violations=()
+
+while IFS= read -r f; do
+  code="$(awk -f "$SCRIPT_DIR/lib/dart_code_only.awk" "$f" 2>/dev/null || true)"
+  [ -n "$code" ] || continue
+
+  printf '%s' "$code" | grep -q "$LOOSE_PROVIDER" || continue
+
+  hits="$(printf '%s' "$code" \
+    | grep -oE "\.($PUBLISH_METHODS)\(" \
+    | sed 's/^\.//; s/($//; s/(//' \
+    | LC_ALL=C sort -u \
+    | tr '\n' ' ' || true)"
+
+  if [ -n "${hits// /}" ]; then
+    rel="${f#"$MOBILE_DIR/"}"
+    violations+=("mobile/$rel — calls: ${hits% }")
+  fi
+done < <(find "$MOBILE_DIR/lib" -name '*.dart' ! -name '*.g.dart' \
+           ! -name '*.freezed.dart' | LC_ALL=C sort)
+
+if [ ${#violations[@]} -gt 0 ]; then
+  echo "profile read/write split VIOLATION (${#violations[@]} file(s)):"
+  printf '  %s\n' "${violations[@]}"
+  cat <<'EOF'
+
+A file that reads profileReadRepositoryProvider also publishes a profile.
+
+That provider resolves at the identity-known phase, which carries a pubkey but
+no signer-backed client, so a publish reached from there can be signed by the
+wrong key or not at all (#1048, #6423).
+
+Fix: take the publish dependency from profileRepositoryProvider instead — it
+stays gated on isReadyForActiveClient. Do NOT widen ProfileReader to make the
+call compile.
+EOF
+  exit 1
+fi
+
+echo "profile read/write split OK (no file both reads $LOOSE_PROVIDER and publishes)"

--- a/mobile/test/features/app_review/app_review_coordinator_test.dart
+++ b/mobile/test/features/app_review/app_review_coordinator_test.dart
@@ -109,7 +109,7 @@ void main() {
           authServiceProvider.overrideWithValue(authService),
           currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
           installSourceProvider.overrideWithValue(InstallSource.playStore),
-          profileStatsRepositoryProvider.overrideWithValue(profileRepository),
+          profileReadRepositoryProvider.overrideWithValue(profileRepository),
           sharedPreferencesProvider.overrideWithValue(prefs),
         ],
         child: const MaterialApp(home: AppReviewCoordinator()),

--- a/mobile/test/helpers/test_provider_overrides.dart
+++ b/mobile/test/helpers/test_provider_overrides.dart
@@ -395,8 +395,14 @@ List<dynamic> getStandardTestOverrides({
       authServiceProvider.overrideWithValue(mockAuth),
     if (mockSocialService != null)
       socialServiceProvider.overrideWithValue(mockSocial),
-    if (mockProfileRepository != null)
+    if (mockProfileRepository != null) ...[
       profileRepositoryProvider.overrideWithValue(mockProfile),
+      // Display code reads the identity-known-gated handle, not the
+      // relay-gated one (#6423). ProfileRepository implements ProfileReader,
+      // so the same mock serves both; overriding only the tight provider
+      // leaves every profile read resolving to null.
+      profileReadRepositoryProvider.overrideWithValue(mockProfile),
+    ],
   ];
 }
 

--- a/mobile/test/providers/owned_divine_username_provider_test.dart
+++ b/mobile/test/providers/owned_divine_username_provider_test.dart
@@ -34,6 +34,7 @@ void main() {
         overrides: [
           authServiceProvider.overrideWithValue(auth),
           profileRepositoryProvider.overrideWithValue(repository),
+          profileReadRepositoryProvider.overrideWithValue(repository),
         ],
       );
       addTearDown(container.dispose);
@@ -49,6 +50,7 @@ void main() {
         overrides: [
           authServiceProvider.overrideWithValue(auth),
           profileRepositoryProvider.overrideWithValue(repository),
+          profileReadRepositoryProvider.overrideWithValue(repository),
         ],
       );
       addTearDown(container.dispose);
@@ -62,6 +64,7 @@ void main() {
         overrides: [
           authServiceProvider.overrideWithValue(auth),
           profileRepositoryProvider.overrideWithValue(null),
+          profileReadRepositoryProvider.overrideWithValue(null),
         ],
       );
       addTearDown(container.dispose);

--- a/mobile/test/providers/user_profile_providers_test.dart
+++ b/mobile/test/providers/user_profile_providers_test.dart
@@ -58,7 +58,7 @@ void main() {
       profileRepository = _MockProfileRepository();
       container = ProviderContainer(
         overrides: [
-          profileRepositoryProvider.overrideWithValue(profileRepository),
+          profileReadRepositoryProvider.overrideWithValue(profileRepository),
         ],
       );
       addTearDown(container.dispose);
@@ -188,27 +188,35 @@ void main() {
       expect(wasCancelled, isTrue);
     });
 
-    test('completes safely when profile repository is unavailable', () async {
-      final emptyContainer = ProviderContainer(
-        overrides: [
-          profileRepositoryProvider.overrideWithValue(null),
-        ],
-      );
-      addTearDown(emptyContainer.dispose);
+    test(
+      'resolves to AsyncData(null) when no repository is available',
+      () async {
+        final emptyContainer = ProviderContainer(
+          overrides: [
+            profileReadRepositoryProvider.overrideWithValue(null),
+          ],
+        );
+        addTearDown(emptyContainer.dispose);
 
-      final emitted = <AsyncValue<UserProfile?>>[];
-      final sub = emptyContainer.listen(
-        userProfileReactiveProvider(pubkey),
-        (_, next) => emitted.add(next),
-        fireImmediately: true,
-      );
-      addTearDown(sub.close);
+        final emitted = <AsyncValue<UserProfile?>>[];
+        final sub = emptyContainer.listen(
+          userProfileReactiveProvider(pubkey),
+          (_, next) => emitted.add(next),
+          fireImmediately: true,
+        );
+        addTearDown(sub.close);
 
-      await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
 
-      expect(emitted, isNotEmpty);
-      expect(emitted.last, isA<AsyncLoading<UserProfile?>>());
-    });
+        expect(emitted, isNotEmpty);
+        // Not AsyncLoading: a stream that closes without ever emitting
+        // strands the provider in AsyncLoading forever, which callers cannot
+        // tell apart from "still fetching" — so UserName fell through to a
+        // generated name and never revisited it (#6423).
+        expect(emitted.last, isA<AsyncData<UserProfile?>>());
+        expect(emitted.last.value, isNull);
+      },
+    );
   });
 
   group('fetchUserProfileProvider', () {
@@ -219,7 +227,7 @@ void main() {
       profileRepository = _MockProfileRepository();
       container = ProviderContainer(
         overrides: [
-          profileRepositoryProvider.overrideWithValue(profileRepository),
+          profileReadRepositoryProvider.overrideWithValue(profileRepository),
         ],
       );
       addTearDown(container.dispose);
@@ -268,7 +276,7 @@ void main() {
         final profileRepository = _MockProfileRepository();
         final container = ProviderContainer(
           overrides: [
-            profileStatsRepositoryProvider.overrideWithValue(profileRepository),
+            profileReadRepositoryProvider.overrideWithValue(profileRepository),
           ],
         );
         addTearDown(container.dispose);
@@ -308,7 +316,7 @@ void main() {
       container = ProviderContainer(
         overrides: [
           // #5863: counts now source from the identity-known-gated stats repo.
-          profileStatsRepositoryProvider.overrideWithValue(profileRepository),
+          profileReadRepositoryProvider.overrideWithValue(profileRepository),
         ],
       );
       addTearDown(container.dispose);
@@ -375,7 +383,7 @@ void main() {
                 const NostrSessionReadiness.identityKnown(pubkey: pubkey),
               ),
             ),
-            profileStatsRepositoryProvider.overrideWith((ref) {
+            profileReadRepositoryProvider.overrideWith((ref) {
               final identityPubkey = ref.watch(
                 nostrSessionProvider.select((readiness) {
                   if (readiness.phase == NostrSessionPhase.identityKnown ||
@@ -419,6 +427,52 @@ void main() {
     );
   });
 
+  group('read/write split (#6423)', () {
+    test(
+      'the reactive profile resolves from cache while the signing gate is '
+      'still shut',
+      () async {
+        final repository = _MockProfileRepository();
+        final cached = UserProfile(
+          pubkey: pubkey,
+          name: 'real-name',
+          rawData: const {},
+          createdAt: DateTime.utc(2026),
+          eventId: 'event-id',
+        );
+        when(
+          () => repository.getCachedProfile(pubkey: pubkey),
+        ).thenAnswer((_) async => cached);
+        when(
+          () => repository.watchProfile(pubkey: pubkey),
+        ).thenAnswer((_) => Stream<UserProfile?>.value(cached));
+
+        final container = ProviderContainer(
+          overrides: [
+            // The state the reporter was stuck in: identity known, relays not
+            // yet connected, so the signing-gated repository is null.
+            profileRepositoryProvider.overrideWithValue(null),
+            profileReadRepositoryProvider.overrideWithValue(repository),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final emitted = <AsyncValue<UserProfile?>>[];
+        final sub = container.listen(
+          userProfileReactiveProvider(pubkey),
+          (_, next) => emitted.add(next),
+          fireImmediately: true,
+        );
+        addTearDown(sub.close);
+
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(emitted.last.value?.name, 'real-name');
+      },
+    );
+  });
+
   group('profileStatsRepository gating (#5863)', () {
     ProviderContainer containerWith(NostrSessionReadiness readiness) {
       final container = ProviderContainer(
@@ -434,7 +488,7 @@ void main() {
       final container = containerWith(
         const NostrSessionReadiness.signedOut(),
       );
-      expect(container.read(profileStatsRepositoryProvider), isNull);
+      expect(container.read(profileReadRepositoryProvider), isNull);
     });
 
     test(
@@ -500,7 +554,7 @@ void main() {
         addTearDown(container.dispose);
 
         final identityKnownRepo = container.read(
-          profileStatsRepositoryProvider,
+          profileReadRepositoryProvider,
         );
         expect(identityKnownRepo, isNotNull);
 
@@ -513,7 +567,7 @@ void main() {
               ),
             );
 
-        final nostrReadyRepo = container.read(profileStatsRepositoryProvider);
+        final nostrReadyRepo = container.read(profileReadRepositoryProvider);
         expect(identical(identityKnownRepo, nostrReadyRepo), isTrue);
       },
     );

--- a/mobile/test/providers/video_sharing_service_provider_test.dart
+++ b/mobile/test/providers/video_sharing_service_provider_test.dart
@@ -9,12 +9,15 @@ import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:profile_repository/profile_repository.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
 
 class _MockAuthService extends Mock implements AuthService {}
 
 class _MockDmRepository extends Mock implements DmRepository {}
+
+class _MockProfileRepository extends Mock implements ProfileRepository {}
 
 void main() {
   test(
@@ -24,7 +27,7 @@ void main() {
         overrides: [
           nostrServiceProvider.overrideWithValue(_MockNostrClient()),
           authServiceProvider.overrideWithValue(_MockAuthService()),
-          profileRepositoryProvider.overrideWithValue(null),
+          profileReadRepositoryProvider.overrideWithValue(null),
           dmRepositoryProvider.overrideWithValue(_MockDmRepository()),
         ],
       );
@@ -33,4 +36,25 @@ void main() {
       expect(container.read(videoSharingServiceProvider), isNull);
     },
   );
+
+  test('is available once the identity is known, before relays connect', () {
+    // The service reads profiles and nothing more, so gating it on the
+    // relay-ready client left Share a silent dead tap for the whole
+    // cold-start window (#6423). Publishing readiness is enforced on the
+    // send path instead, via AuthService.canPublishNostrWritesNow.
+    final container = ProviderContainer(
+      overrides: [
+        nostrServiceProvider.overrideWithValue(_MockNostrClient()),
+        authServiceProvider.overrideWithValue(_MockAuthService()),
+        profileRepositoryProvider.overrideWithValue(null),
+        profileReadRepositoryProvider.overrideWithValue(
+          _MockProfileRepository(),
+        ),
+        dmRepositoryProvider.overrideWithValue(_MockDmRepository()),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    expect(container.read(videoSharingServiceProvider), isNotNull);
+  });
 }

--- a/mobile/test/router/nip05_settings_navigation_test.dart
+++ b/mobile/test/router/nip05_settings_navigation_test.dart
@@ -108,6 +108,7 @@ void main() {
             (ref) async => MinorAccountReviewStatus.active(),
           ),
           profileRepositoryProvider.overrideWithValue(profileRepository),
+          profileReadRepositoryProvider.overrideWithValue(profileRepository),
           blossomUploadServiceProvider.overrideWithValue(blossomUploadService),
         ],
       );

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -200,6 +200,7 @@ void main() {
             mockWatermarkDownloadService,
           ),
           profileRepositoryProvider.overrideWithValue(null),
+          profileReadRepositoryProvider.overrideWithValue(null),
           fetchUserProfileProvider(
             otherPubkey,
           ).overrideWith((ref) async => otherProfile),

--- a/mobile/test/screens/inbox/inbox_page_test.dart
+++ b/mobile/test/screens/inbox/inbox_page_test.dart
@@ -253,6 +253,10 @@ void main() {
               (ref) =>
                   ref.watch(_profileRepoSwap) == 0 ? null : readyProfileRepo,
             ),
+            profileReadRepositoryProvider.overrideWith(
+              (ref) =>
+                  ref.watch(_profileRepoSwap) == 0 ? null : readyProfileRepo,
+            ),
             goRouterProvider.overrideWithValue(mockGoRouter),
           ],
         );

--- a/mobile/test/screens/profile_setup_screen_test.dart
+++ b/mobile/test/screens/profile_setup_screen_test.dart
@@ -558,6 +558,9 @@ void main() {
       return [
         authServiceProvider.overrideWithValue(mockAuthService),
         profileRepositoryProvider.overrideWith((ref) => mockProfileRepository),
+        profileReadRepositoryProvider.overrideWith(
+          (ref) => mockProfileRepository,
+        ),
         fetchUserProfileProvider(
           testPubkeyHex,
         ).overrideWith((ref) async => null),
@@ -678,6 +681,9 @@ void main() {
             profileRepositoryProvider.overrideWith(
               (ref) => mockProfileRepository,
             ),
+            profileReadRepositoryProvider.overrideWith(
+              (ref) => mockProfileRepository,
+            ),
             fetchUserProfileProvider(
               testPubkeyHex,
             ).overrideWith((ref) async => null),
@@ -736,6 +742,9 @@ void main() {
           additionalOverrides: [
             authServiceProvider.overrideWithValue(mockAuthService),
             profileRepositoryProvider.overrideWith(
+              (ref) => mockProfileRepository,
+            ),
+            profileReadRepositoryProvider.overrideWith(
               (ref) => mockProfileRepository,
             ),
             fetchUserProfileProvider(
@@ -1290,6 +1299,9 @@ void main() {
               additionalOverrides: [
                 authServiceProvider.overrideWithValue(mockAuthService),
                 profileRepositoryProvider.overrideWith(
+                  (ref) => mockProfileRepository,
+                ),
+                profileReadRepositoryProvider.overrideWith(
                   (ref) => mockProfileRepository,
                 ),
                 fetchUserProfileProvider(

--- a/mobile/test/screens/settings/bluesky_settings_screen_test.dart
+++ b/mobile/test/screens/settings/bluesky_settings_screen_test.dart
@@ -86,6 +86,7 @@ void main() {
           authServiceProvider.overrideWithValue(authService),
           crosspostApiClientProvider.overrideWithValue(apiClient),
           profileRepositoryProvider.overrideWithValue(profileRepository),
+          profileReadRepositoryProvider.overrideWithValue(profileRepository),
         ],
         child: MaterialApp.router(
           localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/mobile/test/screens/settings/monetization_links_settings_screen_test.dart
+++ b/mobile/test/screens/settings/monetization_links_settings_screen_test.dart
@@ -75,6 +75,7 @@ void main() {
           authServiceProvider.overrideWithValue(authService),
           currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
           profileRepositoryProvider.overrideWithValue(repository),
+          profileReadRepositoryProvider.overrideWithValue(repository),
           analyticsEventSinkProvider.overrideWithValue(
             const NoOpAnalyticsEventSink(),
           ),
@@ -144,6 +145,7 @@ void main() {
           authServiceProvider.overrideWithValue(authService),
           currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
           profileRepositoryProvider.overrideWithValue(repository),
+          profileReadRepositoryProvider.overrideWithValue(repository),
           analyticsEventSinkProvider.overrideWithValue(
             const NoOpAnalyticsEventSink(),
           ),
@@ -205,6 +207,7 @@ void main() {
           authServiceProvider.overrideWithValue(authService),
           currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
           profileRepositoryProvider.overrideWithValue(repository),
+          profileReadRepositoryProvider.overrideWithValue(repository),
           analyticsEventSinkProvider.overrideWithValue(
             const NoOpAnalyticsEventSink(),
           ),
@@ -322,6 +325,7 @@ void main() {
           authServiceProvider.overrideWithValue(authService),
           currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
           profileRepositoryProvider.overrideWithValue(repository),
+          profileReadRepositoryProvider.overrideWithValue(repository),
           analyticsEventSinkProvider.overrideWithValue(
             const NoOpAnalyticsEventSink(),
           ),

--- a/mobile/test/screens/settings/settings_account_switch_test.dart
+++ b/mobile/test/screens/settings/settings_account_switch_test.dart
@@ -231,8 +231,8 @@ void main() {
         authServiceProvider.overrideWithValue(authService),
         deviceScopeProvider.overrideWithValue(deviceScope),
         currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
-        // Null repository keeps userProfileReactiveProvider on an empty stream,
-        // so the account header renders from fallbacks without any network.
+        // Null repository keeps profile reads offline, so the account header
+        // renders from fallbacks without any network.
         profileRepositoryProvider.overrideWithValue(null),
         profileReadRepositoryProvider.overrideWithValue(null),
         draftStorageServiceProvider.overrideWithValue(draftStorageService),

--- a/mobile/test/screens/settings/settings_account_switch_test.dart
+++ b/mobile/test/screens/settings/settings_account_switch_test.dart
@@ -234,6 +234,7 @@ void main() {
         // Null repository keeps userProfileReactiveProvider on an empty stream,
         // so the account header renders from fallbacks without any network.
         profileRepositoryProvider.overrideWithValue(null),
+        profileReadRepositoryProvider.overrideWithValue(null),
         draftStorageServiceProvider.overrideWithValue(draftStorageService),
         isFeatureEnabledProvider(
           FeatureFlag.accountSwitching,

--- a/mobile/test/screens/settings/support_center_screen_test.dart
+++ b/mobile/test/screens/settings/support_center_screen_test.dart
@@ -53,6 +53,7 @@ void main() {
             // lookup behind the confirmation gate both resolve to null
             // without touching the network.
             profileRepositoryProvider.overrideWithValue(null),
+            profileReadRepositoryProvider.overrideWithValue(null),
           ],
           child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/mobile/test/services/auth_service_local_first_startup_test.dart
+++ b/mobile/test/services/auth_service_local_first_startup_test.dart
@@ -9,10 +9,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
-import 'package:nostr_sdk/nostr_sdk.dart' show generatePrivateKey;
+import 'package:nostr_sdk/nostr_sdk.dart' show NostrSigner, generatePrivateKey;
 import 'package:openvine/models/auth_rpc_capability.dart';
 import 'package:openvine/services/auth/nostr_identity.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/local_key_signer.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -22,6 +23,8 @@ class _MockUserDataCleanupService extends Mock
     implements UserDataCleanupService {}
 
 class _MockKeycastOAuth extends Mock implements KeycastOAuth {}
+
+class _MockNostrSigner extends Mock implements NostrSigner {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -105,9 +108,7 @@ void main() {
 
     /// Helper: stores a Keycast session and a valid local nsec that matches
     /// the session pubkey.
-    String arrangeSessionWithMatchingLocalKeys({
-      required DateTime expiresAt,
-    }) {
+    String arrangeSessionWithMatchingLocalKeys({required DateTime expiresAt}) {
       final privateKeyHex = generatePrivateKey();
       final container = SecureKeyContainer.fromPrivateKeyHex(privateKeyHex);
       final pubkey = container.publicKeyHex;
@@ -257,6 +258,35 @@ void main() {
     test('canPublishNostrWritesNow is false when not authenticated', () {
       final authService = createAuthService();
       expect(authService.canPublishNostrWritesNow, isFalse);
+    });
+
+    test('canPublishNostrWritesNow waits for RPC-backed Keycast readiness', () {
+      final authService = createAuthService();
+      const pubkey =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+      authService.debugSetIdentity(
+        KeycastNostrIdentity(pubkey: pubkey, rpcSigner: _MockNostrSigner()),
+      );
+
+      expect(authService.authRpcCapability, AuthRpcCapability.unavailable);
+      expect(authService.canPublishNostrWritesNow, isFalse);
+    });
+
+    test('canPublishNostrWritesNow allows Keycast with a local signer', () {
+      final authService = createAuthService();
+      final privateKeyHex = generatePrivateKey();
+      final container = SecureKeyContainer.fromPrivateKeyHex(privateKeyHex);
+
+      authService.debugSetIdentity(
+        KeycastNostrIdentity(
+          pubkey: container.publicKeyHex,
+          rpcSigner: _MockNostrSigner(),
+          localSigner: LocalKeySigner(container),
+        ),
+      );
+
+      expect(authService.canPublishNostrWritesNow, isTrue);
     });
 
     test('matching local key authenticates before refresh completes', () async {

--- a/mobile/test/services/video_sharing_service_test.dart
+++ b/mobile/test/services/video_sharing_service_test.dart
@@ -64,6 +64,7 @@ void main() {
     test('returns recently shared users after sharing', () async {
       // Arrange - set up successful share
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(() => mockAuthService.canPublishNostrWritesNow).thenReturn(true);
       when(
         () => mockAuthService.createAndSignEvent(
           kind: any(named: 'kind'),
@@ -121,6 +122,7 @@ void main() {
     test('respects limit parameter', () async {
       // Arrange - share with multiple users
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(() => mockAuthService.canPublishNostrWritesNow).thenReturn(true);
       when(
         () => mockAuthService.createAndSignEvent(
           kind: any(named: 'kind'),
@@ -258,8 +260,44 @@ void main() {
       expect(result.error, contains('not authenticated'));
     });
 
+    test('returns failure when the signer is not ready yet (#6423)', () async {
+      // The service used to inherit this check by accident: it was built from
+      // the relay-gated profile repository, so a not-yet-ready session made
+      // the whole service null and Share a silent dead tap. Now the sheet
+      // opens on the read-only handle and the send path owns the requirement.
+      when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(
+        () => mockAuthService.canPublishNostrWritesNow,
+      ).thenReturn(false);
+
+      final now = DateTime.now();
+      final result = await service.shareVideoWithUser(
+        video: VideoEvent(
+          id: _testVideoId,
+          pubkey: _testPubkey,
+          createdAt: now.millisecondsSinceEpoch ~/ 1000,
+          timestamp: now,
+          content: 'Test',
+        ),
+        recipientPubkey: _recipientPubkey,
+      );
+
+      expect(result.success, isFalse);
+      expect(result.error, contains('Signing is not available'));
+      // Never reached the signer: the gate short-circuits before any event is
+      // created, rather than letting it fail 30s later on an RPC timeout.
+      verifyNever(
+        () => mockAuthService.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      );
+    });
+
     test('returns failure when event creation fails', () async {
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(() => mockAuthService.canPublishNostrWritesNow).thenReturn(true);
       when(
         () => mockAuthService.createAndSignEvent(
           kind: any(named: 'kind'),
@@ -286,6 +324,7 @@ void main() {
 
     test('returns success on successful publish', () async {
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(() => mockAuthService.canPublishNostrWritesNow).thenReturn(true);
       final signedEvent = Event(_testPubkey, 4, <List<String>>[], 'test');
       signedEvent.id = 'signed_event_id';
 
@@ -323,6 +362,7 @@ void main() {
 
     test('returns failure when publish fails', () async {
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(() => mockAuthService.canPublishNostrWritesNow).thenReturn(true);
       when(
         () => mockAuthService.createAndSignEvent(
           kind: any(named: 'kind'),
@@ -371,6 +411,7 @@ void main() {
 
     test('uses NIP-17 when DmRepository is available', () async {
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(() => mockAuthService.canPublishNostrWritesNow).thenReturn(true);
       when(
         () => mockDmRepository.sendSharedVideo(
           recipientPubkey: any(named: 'recipientPubkey'),
@@ -439,6 +480,7 @@ void main() {
       'rest, and each outcome is reported',
       () async {
         when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        when(() => mockAuthService.canPublishNostrWritesNow).thenReturn(true);
         when(
           () => mockProfileRepository.fetchFreshProfile(
             pubkey: any(named: 'pubkey'),
@@ -507,6 +549,7 @@ void main() {
       'returns success without waiting on the recents profile fetch (#5391)',
       () async {
         when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        when(() => mockAuthService.canPublishNostrWritesNow).thenReturn(true);
         when(
           () => mockDmRepository.sendSharedVideo(
             recipientPubkey: any(named: 'recipientPubkey'),
@@ -555,6 +598,7 @@ void main() {
 
     test('returns failure when NIP-17 send fails', () async {
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(() => mockAuthService.canPublishNostrWritesNow).thenReturn(true);
       when(
         () => mockDmRepository.sendSharedVideo(
           recipientPubkey: any(named: 'recipientPubkey'),
@@ -588,6 +632,7 @@ void main() {
 
     test('includes personal message in content', () async {
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(() => mockAuthService.canPublishNostrWritesNow).thenReturn(true);
       when(
         () => mockDmRepository.sendSharedVideo(
           recipientPubkey: any(named: 'recipientPubkey'),
@@ -643,6 +688,7 @@ void main() {
 
     test('share message contains quoted title and share URL', () async {
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(() => mockAuthService.canPublishNostrWritesNow).thenReturn(true);
       when(
         () => mockDmRepository.sendSharedVideo(
           recipientPubkey: any(named: 'recipientPubkey'),
@@ -702,6 +748,7 @@ void main() {
 
     test('share message without title contains only share URL', () async {
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(() => mockAuthService.canPublishNostrWritesNow).thenReturn(true);
       when(
         () => mockDmRepository.sendSharedVideo(
           recipientPubkey: any(named: 'recipientPubkey'),
@@ -760,6 +807,7 @@ void main() {
 
     test('computes correct conversationId', () async {
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(() => mockAuthService.canPublishNostrWritesNow).thenReturn(true);
       when(
         () => mockDmRepository.sendSharedVideo(
           recipientPubkey: any(named: 'recipientPubkey'),
@@ -804,6 +852,7 @@ void main() {
 
     test('updates sharing history on NIP-17 success', () async {
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(() => mockAuthService.canPublishNostrWritesNow).thenReturn(true);
       when(
         () => mockDmRepository.sendSharedVideo(
           recipientPubkey: any(named: 'recipientPubkey'),
@@ -889,6 +938,7 @@ void main() {
     test('hasSharedWithRecently returns true after sharing', () async {
       // Arrange
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(() => mockAuthService.canPublishNostrWritesNow).thenReturn(true);
       when(
         () => mockAuthService.createAndSignEvent(
           kind: any(named: 'kind'),
@@ -927,6 +977,7 @@ void main() {
     test('clearSharingHistory removes all data', () async {
       // Arrange - populate some history
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(() => mockAuthService.canPublishNostrWritesNow).thenReturn(true);
       when(
         () => mockAuthService.createAndSignEvent(
           kind: any(named: 'kind'),

--- a/mobile/test/widgets/clickable_hashtag_text_test.dart
+++ b/mobile/test/widgets/clickable_hashtag_text_test.dart
@@ -390,6 +390,7 @@ void main() {
         ProviderScope(
           overrides: [
             profileRepositoryProvider.overrideWithValue(profileRepository),
+            profileReadRepositoryProvider.overrideWithValue(profileRepository),
           ],
           child: MaterialApp.router(
             localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/mobile/test/widgets/find_people_sheet_test.dart
+++ b/mobile/test/widgets/find_people_sheet_test.dart
@@ -53,6 +53,7 @@ void main() {
         ),
         additionalOverrides: [
           profileRepositoryProvider.overrideWithValue(mockProfileRepo),
+          profileReadRepositoryProvider.overrideWithValue(mockProfileRepo),
         ],
       );
     }
@@ -304,6 +305,9 @@ void main() {
               ),
               additionalOverrides: [
                 profileRepositoryProvider.overrideWithValue(mockProfileRepo),
+                profileReadRepositoryProvider.overrideWithValue(
+                  mockProfileRepo,
+                ),
               ],
             ),
           );

--- a/mobile/test/widgets/share_video_menu_comprehensive_test.dart
+++ b/mobile/test/widgets/share_video_menu_comprehensive_test.dart
@@ -140,6 +140,7 @@ void main() {
       mockAuthService: mockAuthService,
       additionalOverrides: [
         profileRepositoryProvider.overrideWithValue(mockProfileRepository),
+        profileReadRepositoryProvider.overrideWithValue(mockProfileRepository),
         bookmarkServiceProvider.overrideWith((ref) => mockBookmarkService),
         videoSharingServiceProvider.overrideWith(
           (ref) => mockVideoSharingService,
@@ -514,6 +515,9 @@ void main() {
         mockFollowRepository: mockFollowRepository,
         additionalOverrides: [
           profileRepositoryProvider.overrideWithValue(mockProfileRepository),
+          profileReadRepositoryProvider.overrideWithValue(
+            mockProfileRepository,
+          ),
           bookmarkServiceProvider.overrideWith((ref) => mockBookmarkService),
           videoSharingServiceProvider.overrideWith(
             (ref) => mockVideoSharingService,

--- a/mobile/test/widgets/user_name_generated_fallback_test.dart
+++ b/mobile/test/widgets/user_name_generated_fallback_test.dart
@@ -1,0 +1,130 @@
+// ABOUTME: Pins UserName's fallback precedence — the signed-in user must
+// ABOUTME: never be shown a generated "Adjective Animal NN" name (#6423).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/repository_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/widgets/user_name.dart';
+import 'package:profile_repository/profile_repository.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockProfileRepository extends Mock implements ProfileRepository {}
+
+void main() {
+  // The reporter's own pubkey, from the Zendesk ticket behind #6423.
+  const pubkey =
+      '389ea93870dd1240e67e4d957cdc8949be0d7dd5f6fd927ee1912ebe084181d3';
+
+  /// What `UserProfile.defaultDisplayNameFor` invents for [pubkey] — the
+  /// string the reporter saw in place of their own name.
+  final generatedName = UserProfile.defaultDisplayNameFor(pubkey);
+
+  Future<Widget> buildSubject({
+    required ProfileReader? repository,
+    String? anonymousName,
+    bool neverGenerateName = false,
+  }) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+
+    return ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        profileReadRepositoryProvider.overrideWithValue(repository),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Center(
+            child: UserName.fromPubKey(
+              pubkey,
+              anonymousName: anonymousName,
+              neverGenerateName: neverGenerateName,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  group(UserName, () {
+    test('the generated name is a plausible human name, not an npub', () {
+      // Guards the premise of every assertion below: if the app-wide fallback
+      // strategy changes back to a truncated npub, these tests stop testing
+      // what they claim to and should be revisited.
+      expect(generatedName, matches(RegExp(r'^\w+ \w+ \d+$')));
+    });
+
+    testWidgets(
+      'renders the cached profile name when the signing gate is shut',
+      (tester) async {
+        final repository = _MockProfileRepository();
+        final cached = UserProfile(
+          pubkey: pubkey,
+          name: 'Wolf',
+          rawData: const {},
+          createdAt: DateTime.utc(2026),
+          eventId: 'kind0_event_id',
+        );
+        when(
+          () => repository.getCachedProfile(pubkey: pubkey),
+        ).thenAnswer((_) async => cached);
+        when(
+          () => repository.watchProfile(pubkey: pubkey),
+        ).thenAnswer((_) => Stream<UserProfile?>.value(cached));
+
+        await tester.pumpWidget(await buildSubject(repository: repository));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Wolf'), findsOneWidget);
+        expect(find.text(generatedName), findsNothing);
+      },
+    );
+
+    testWidgets('falls back to the generated name for other users', (
+      tester,
+    ) async {
+      // The generated handle is still the right treatment for a stranger
+      // whose profile has not resolved — this is the control arm proving the
+      // assertions below are about the own-identity opt-in, not about the
+      // fallback disappearing everywhere.
+      await tester.pumpWidget(await buildSubject(repository: null));
+      await tester.pumpAndSettle();
+
+      expect(find.text(generatedName), findsOneWidget);
+    });
+
+    testWidgets('honours anonymousName instead of generating one', (
+      tester,
+    ) async {
+      // Before #6423 this hint was threaded down by the profile header and
+      // then silently dropped, so the header's displayNameHint could never
+      // reach the failure case it existed for.
+      await tester.pumpWidget(
+        await buildSubject(repository: null, anonymousName: 'Wolf'),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Wolf'), findsOneWidget);
+      expect(find.text(generatedName), findsNothing);
+    });
+
+    testWidgets('renders nothing rather than a generated name for self', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        await buildSubject(repository: null, neverGenerateName: true),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(generatedName), findsNothing);
+      expect(find.text(''), findsOneWidget);
+    });
+  });
+}

--- a/mobile/test/widgets/user_name_generated_fallback_test.dart
+++ b/mobile/test/widgets/user_name_generated_fallback_test.dart
@@ -16,12 +16,12 @@ import 'package:shared_preferences/shared_preferences.dart';
 class _MockProfileRepository extends Mock implements ProfileRepository {}
 
 void main() {
-  // The reporter's own pubkey, from the Zendesk ticket behind #6423.
+  // Synthetic full-length pubkey chosen for a stable generated fallback.
   const pubkey =
-      '389ea93870dd1240e67e4d957cdc8949be0d7dd5f6fd927ee1912ebe084181d3';
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
   /// What `UserProfile.defaultDisplayNameFor` invents for [pubkey] — the
-  /// string the reporter saw in place of their own name.
+  /// kind of string the reporter saw in place of their own name.
   final generatedName = UserProfile.defaultDisplayNameFor(pubkey);
 
   Future<Widget> buildSubject({
@@ -163,6 +163,46 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text(generatedName), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'uses anonymousName as the steady state for a nameless own profile',
+      (tester) async {
+        // Own-profile surfaces pass a concrete handle/npub placeholder so the
+        // generated-name suppression does not leave the title line blank.
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final nameless = UserProfile(
+          pubkey: pubkey,
+          rawData: const {},
+          createdAt: DateTime.utc(2026),
+          eventId: 'kind0_event_id',
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: Center(
+                  child: UserName.fromUserProfile(
+                    nameless,
+                    anonymousName: 'npub_placeholder',
+                    neverGenerateName: true,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('npub_placeholder'), findsOneWidget);
+        expect(find.text(generatedName), findsNothing);
+        expect(find.text(''), findsNothing);
       },
     );
   });

--- a/mobile/test/widgets/user_name_generated_fallback_test.dart
+++ b/mobile/test/widgets/user_name_generated_fallback_test.dart
@@ -126,5 +126,44 @@ void main() {
       expect(find.text(generatedName), findsNothing);
       expect(find.text(''), findsOneWidget);
     });
+
+    testWidgets(
+      'suppresses the generated name for a resolved but nameless profile',
+      (tester) async {
+        // A kind-0 that exists but carries neither name nor display_name is a
+        // state users reach: publishing from divine-web with an empty name
+        // strips both fields. Without the opt-in this resolved-profile path
+        // falls through to the generated handle just like the unresolved one.
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final nameless = UserProfile(
+          pubkey: pubkey,
+          rawData: const {},
+          createdAt: DateTime.utc(2026),
+          eventId: 'kind0_event_id',
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: Center(
+                  child: UserName.fromUserProfile(
+                    nameless,
+                    neverGenerateName: true,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text(generatedName), findsNothing);
+      },
+    );
   });
 }

--- a/mobile/test/widgets/user_picker_sheet_test.dart
+++ b/mobile/test/widgets/user_picker_sheet_test.dart
@@ -232,6 +232,7 @@ void main() {
           ProviderScope(
             overrides: [
               profileRepositoryProvider.overrideWithValue(mockProfileRepo),
+              profileReadRepositoryProvider.overrideWithValue(mockProfileRepo),
               followRepositoryProvider.overrideWithValue(mockFollowRepo),
               contentBlocklistRepositoryProvider.overrideWithValue(
                 _createMockContentBlocklistRepository(),
@@ -350,6 +351,7 @@ void main() {
           ProviderScope(
             overrides: [
               profileRepositoryProvider.overrideWithValue(mockProfileRepo),
+              profileReadRepositoryProvider.overrideWithValue(mockProfileRepo),
               followRepositoryProvider.overrideWithValue(mockFollowRepo),
               contentBlocklistRepositoryProvider.overrideWithValue(
                 _createMockContentBlocklistRepository(),
@@ -413,6 +415,7 @@ void main() {
           ProviderScope(
             overrides: [
               profileRepositoryProvider.overrideWithValue(mockProfileRepo),
+              profileReadRepositoryProvider.overrideWithValue(mockProfileRepo),
               followRepositoryProvider.overrideWithValue(mockFollowRepo),
               contentBlocklistRepositoryProvider.overrideWithValue(
                 _createMockContentBlocklistRepository(),
@@ -477,6 +480,7 @@ void main() {
           ProviderScope(
             overrides: [
               profileRepositoryProvider.overrideWithValue(mockProfileRepo),
+              profileReadRepositoryProvider.overrideWithValue(mockProfileRepo),
               followRepositoryProvider.overrideWithValue(mockFollowRepo),
               contentBlocklistRepositoryProvider.overrideWithValue(
                 mockBlocklistRepo,
@@ -528,6 +532,9 @@ void main() {
             ProviderScope(
               overrides: [
                 profileRepositoryProvider.overrideWithValue(mockProfileRepo),
+                profileReadRepositoryProvider.overrideWithValue(
+                  mockProfileRepo,
+                ),
                 followRepositoryProvider.overrideWithValue(mockFollowRepo),
                 contentBlocklistRepositoryProvider.overrideWithValue(
                   _createMockContentBlocklistRepository(),
@@ -648,6 +655,7 @@ void main() {
           ProviderScope(
             overrides: [
               profileRepositoryProvider.overrideWithValue(mockProfileRepo),
+              profileReadRepositoryProvider.overrideWithValue(mockProfileRepo),
               followRepositoryProvider.overrideWithValue(
                 _createMockFollowRepository(),
               ),
@@ -758,6 +766,9 @@ void main() {
             ProviderScope(
               overrides: [
                 profileRepositoryProvider.overrideWithValue(mockProfileRepo),
+                profileReadRepositoryProvider.overrideWithValue(
+                  mockProfileRepo,
+                ),
                 followRepositoryProvider.overrideWithValue(mockFollowRepo),
               ],
               child: const MaterialApp(
@@ -885,6 +896,7 @@ void main() {
           ProviderScope(
             overrides: [
               profileRepositoryProvider.overrideWithValue(mockProfileRepo),
+              profileReadRepositoryProvider.overrideWithValue(mockProfileRepo),
               followRepositoryProvider.overrideWithValue(
                 _createMockFollowRepository(),
               ),
@@ -1000,6 +1012,7 @@ void main() {
             ProviderScope(
               overrides: [
                 profileRepositoryProvider.overrideWithValue(null),
+                profileReadRepositoryProvider.overrideWithValue(null),
                 followRepositoryProvider.overrideWithValue(
                   _createMockFollowRepository(),
                 ),
@@ -1034,6 +1047,7 @@ void main() {
           ProviderScope(
             overrides: [
               profileRepositoryProvider.overrideWithValue(null),
+              profileReadRepositoryProvider.overrideWithValue(null),
               followRepositoryProvider.overrideWithValue(
                 _createMockFollowRepository(),
               ),


### PR DESCRIPTION
## Description

On every cold start the app replaced the signed-in user's own name and avatar with a generated
`Adjective Animal NN` handle — the reporter saw "Beneficial Stoat" — and held it for as long as
the relay connect took. On a good network that is a flash; on a degraded one it lasted a minute
or more, every single launch. Because the generated string is a *plausible human name* rather
than an obvious placeholder, it reads as the account having been reset rather than as loading.

**Nothing was ever lost.** The real kind-0 was sitting in the local Drift `user_profiles` table
the whole time, and the reads that would have surfaced it touch neither signer nor relay.

### Root cause

`profileRepositoryProvider` returns `null` until the signer-backed `NostrClient` has rebuilt for
the active identity. That gate is correct for *publishing* — it is what stops an event being
signed by the previous identity's key (#1048) — and unnecessary for a local read. Every
identity-display provider hung off it, so during the window:

- `userProfileReactive` returned `const Stream.empty()`. A stream that closes without emitting
  leaves a `StreamProvider` in `AsyncLoading` **forever**, which callers cannot distinguish from
  "still fetching".
- `UserName` maps *both* `AsyncLoading` and `AsyncData(null)` to its fallback, so the symptom was
  invariant to which state the provider settled in.
- `MyProfileBloc` was never constructed at all.

### The fix — reads loose, writes tight

`profileStatsRepository` (added by #5863 for this same bug class, on the counts) is generalised
rather than a third repository instance being introduced:

- **`ProfileReader`** — a new interface over the seven signer-free members. The return type *is*
  the boundary: it cannot express `saveProfileEvent`, `claimUsername`, `releaseUsername` or
  `drivePendingSave`, so a consumer of the ungated provider cannot publish by accident. The
  identity-known phase carries a pubkey but no client, so signing there is genuinely unsafe even
  though Drift reads are not.
- **`profileStatsRepository` → `profileReadRepository`**, now returning `ProfileReader?`, still
  gated on identity-known with `warmCache: false`.
- Read paths (`userProfileReactive`, `fetchUserProfile`, `MyProfileBloc`, the profile router)
  move onto it. **Every signing path stays on `profileRepositoryProvider`** — the four publish
  consumers are named in the provider's doc comment.
- The empty stream becomes `AsyncData(null)`, so "resolved, nothing there" is distinguishable
  from "still loading".

Two defence-in-depth changes, because #4183 already papered over this once with a 7s skeleton and
it came back:

- `UserName` now honours `anonymousName` — the profile header was threading `displayNameHint`
  down and it was being silently dropped in exactly the failure case it existed for — and gains
  `neverGenerateName`, which own-identity surfaces opt into. Other users' profiles keep the
  generated handle; that is the right treatment for a stranger.
- `check_profile_read_write_split.sh` asserts no file both reads the loose provider and
  publishes. A 7-member interface is a weaker guard than it looks, and a type cannot see the
  indirect route. No baseline — the correct count is zero, always.

### Share was collateral damage

`ShareActionButton` built its sheet from the relay-gated repository, so **Share was a silent dead
tap for the entire window**. It now opens on the read handle. `VideoSharingService` had been
inheriting its publish-readiness check by accident (it was null whenever the repository was), so
the send path now states the requirement itself via `canPublishNostrWritesNow` and fails into a
`ShareResult.failure` rather than a dead tap.

**Related Issue:** Closes #6423. Also reported as #5851 and #5920.

Supersedes draft PR #5970, which implemented the profile half of this and has been stalled since
2026-07-12; @rabble's review noted its conflicts across publish/profile/notification code made it
unsafe to rebase. That PR's approach (a `??` fallback at the two read providers) is the same
direction; this one adds the compile-time boundary, the CI guard, and the bloc/Share/header half.

## Out of Scope

- **The trigger is not fixed.** The window exists because of `SignerFactory` Keycast-RPC
  timeouts (30s) and `NostrService` init timeouts (90s) on the reporter's device network path. A
  relay-side incident is independently refuted. This PR makes the app degrade gracefully during
  that window; it does not shorten it.
- The vanish-eviction interaction: the NIP-62 tombstone guard lives at the DAO, and the only
  self-heal runs inside `fetchFreshProfile`, so a loose cached-read provider cannot recover an
  evicted row while the gate is shut. Filing separately, not stacking.
- Kind-0 tags have no column in the Drift profile cache, so a publish falling back to the local
  seed still erases them. Separate issue.

## Verification

```
flutter analyze lib test integration_test          # no issues
flutter test test/providers/ test/blocs/my_profile/ test/blocs/share_sheet/ \
             test/widgets/user_name*.dart test/widgets/profile/ \
             test/features/app_review/ test/services/video_sharing_service_test.dart
cd packages/profile_repository && flutter test --coverage
bash mobile/scripts/check_profile_read_write_split.sh
```

The regression test is load-bearing, not decorative: reverting `userProfileReactive` to the tight
provider makes it fail with `Expected: 'real-name'  Actual: <null>`, verified by executing it.
The new ratchet was likewise verified in both directions — it fires on a planted violation and
ignores a comment/string-literal mention of the same method names.

Note the test-design trap for anyone extending this: the generated name is in the widget tree
from frame 0 and `Skeletonizer` only shimmers *over* it, so `find.text('<generated name>')`
matches during the shimmer window. Assert after `pumpAndSettle`, or against the skeleton directly.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Build configuration change
