### PR TITLE
fix(upload): recover stale resumable auth sessions

### DIFF
--- a/mobile/lib/services/upload/upload_progress_reporter.dart
+++ b/mobile/lib/services/upload/upload_progress_reporter.dart
@@ -155,6 +155,11 @@ class UploadProgressReporter {
 
   /// Categorise [error] into a string category constant for monitoring.
   Future<String> categorizeError(dynamic error) async {
+    if (error is BlossomResumableUploadException &&
+        (error.statusCode == 401 || error.statusCode == 403)) {
+      return 'AUTHENTICATION';
+    }
+
     if (isExpiredResumableSessionError(error)) {
       return 'UPLOAD_SESSION_EXPIRED';
     }
@@ -163,6 +168,33 @@ class UploadProgressReporter {
 
     if (connectivity == ConnectivityResult.none) {
       return 'NO_INTERNET';
+    }
+
+    final resumableStatusCode = error is BlossomResumableUploadException
+        ? error.statusCode
+        : null;
+    final resumableFailureReason = error is BlossomResumableUploadException
+        ? error.failureReason
+        : null;
+
+    if (resumableFailureReason == BlossomUploadFailureReason.authUnavailable) {
+      return 'NETWORK_ERROR';
+    }
+
+    if (resumableStatusCode != null) {
+      if (resumableStatusCode == 408) return 'TIMEOUT';
+      if (resumableStatusCode == 413) return 'FILE_TOO_LARGE';
+      if (resumableStatusCode == 429) return 'RATE_LIMITED';
+      if (resumableStatusCode == 401 || resumableStatusCode == 403) {
+        return 'AUTHENTICATION';
+      }
+      if (resumableStatusCode == 502 ||
+          resumableStatusCode == 503 ||
+          resumableStatusCode == 504) {
+        return 'SERVER_UNAVAILABLE';
+      }
+      if (resumableStatusCode >= 500) return 'SERVER_ERROR';
+      if (resumableStatusCode >= 400) return 'CLIENT_ERROR';
     }
 
     if (error is BlossomUploadFailureException) {
@@ -367,6 +399,7 @@ class UploadProgressReporter {
     String errorCategory,
     UploadMetrics? metrics,
     ConnectivityResult connectivity, {
+    required StackTrace stackTrace,
     required bool isManagerInitialized,
   }) async {
     try {
@@ -421,8 +454,6 @@ class UploadProgressReporter {
         );
       }
 
-      final stackTrace = StackTrace.current;
-
       final fileExists = kIsWeb
           ? 'N/A (web)'
           : '${File(upload.localVideoPath).existsSync()}';
@@ -445,6 +476,16 @@ ${metrics != null ? '- File Size: ${metrics.fileSizeMB} MB\n- Duration: ${metric
 
       crashReporting.log('UPLOAD_FAILURE: $detailedError');
 
+      if (!_isReportableUploadFailure(errorCategory)) {
+        Log.info(
+          'Skipping Crashlytics recordError for expected upload failure: '
+          '$errorCategory',
+          name: 'UploadManager',
+          category: LogCategory.video,
+        );
+        return;
+      }
+
       await crashReporting.recordError(
         error,
         stackTrace,
@@ -463,6 +504,13 @@ ${metrics != null ? '- File Size: ${metrics.fileSizeMB} MB\n- Duration: ${metric
         category: LogCategory.video,
       );
     }
+  }
+
+  bool _isReportableUploadFailure(String errorCategory) {
+    return switch (errorCategory) {
+      'OUT_OF_MEMORY' || 'UNKNOWN' => true,
+      _ => false,
+    };
   }
 
   /// Send an initialization-failure report to Crashlytics.

--- a/mobile/lib/services/upload/upload_retry_policy.dart
+++ b/mobile/lib/services/upload/upload_retry_policy.dart
@@ -289,6 +289,31 @@ class UploadRetryPolicy {
       return false;
     }
 
+    if (error is BlossomResumableUploadException) {
+      final reason = error.failureReason;
+      if (reason == BlossomUploadFailureReason.authUnavailable ||
+          reason == BlossomUploadFailureReason.network ||
+          error.isRecoverableResumableFailure) {
+        return true;
+      }
+      if (reason == BlossomUploadFailureReason.auth ||
+          reason == BlossomUploadFailureReason.fileTooLarge ||
+          reason == BlossomUploadFailureReason.cancelled) {
+        return false;
+      }
+
+      final code = error.statusCode;
+      if (code != null) {
+        if (code == 408) return true;
+        if (code == 429) return true;
+        if (code == 500 || code == 502 || code == 503 || code == 504) {
+          return true;
+        }
+        if (code >= 500) return false;
+        if (code >= 400) return false;
+      }
+    }
+
     // Use structured classification when available.
     if (error is BlossomUploadFailureException) {
       // A transient inability to *produce* a signed auth header (the remote

--- a/mobile/lib/services/upload/upload_session_errors.dart
+++ b/mobile/lib/services/upload/upload_session_errors.dart
@@ -4,7 +4,7 @@
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 
 /// Returns true if [error] represents an expired resumable-upload session — the
-/// server returned 404/410, or the message says the session is gone.
+/// server returned 401/403/404/410, or the message says the session is gone.
 ///
 /// This predicate decides both whether the error is retriable *and* whether the
 /// resumable session is nulled on failure, so the two used to drift between
@@ -12,7 +12,10 @@ import 'package:blossom_upload_service/blossom_upload_service.dart';
 /// lives here as a single source of truth to keep those callers in lockstep.
 bool isExpiredResumableSessionError(dynamic error) {
   if (error is BlossomResumableUploadException) {
-    return error.statusCode == 404 || error.statusCode == 410;
+    return error.statusCode == 401 ||
+        error.statusCode == 403 ||
+        error.statusCode == 404 ||
+        error.statusCode == 410;
   }
 
   final errorMessage = error.toString().toLowerCase();

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -849,6 +849,7 @@ class UploadManager implements BackgroundAwareService {
       await _handleUploadFailure(
         upload,
         Exception('Web platform uploads not yet implemented'),
+        StackTrace.current,
       );
       return;
     }
@@ -873,7 +874,11 @@ class UploadManager implements BackgroundAwareService {
         name: 'UploadManager',
         category: LogCategory.video,
       );
-      await _handleUploadFailure(upload, Exception('Video file not found'));
+      await _handleUploadFailure(
+        upload,
+        Exception('Video file not found'),
+        StackTrace.current,
+      );
       return;
     }
 
@@ -903,7 +908,7 @@ class UploadManager implements BackgroundAwareService {
         category: LogCategory.video,
       );
       await _performUploadWithRetry(upload, videoFile, onProgress);
-    } catch (e) {
+    } catch (e, stackTrace) {
       // A user-initiated pause/cancel tears down the in-flight transfer, which
       // surfaces here as a failure. pauseUpload/cancelUpload already wrote the
       // authoritative status, so don't overwrite it or report the stop as a
@@ -921,7 +926,7 @@ class UploadManager implements BackgroundAwareService {
         name: 'UploadManager',
         category: LogCategory.video,
       );
-      await _handleUploadFailure(upload, e);
+      await _handleUploadFailure(upload, e, stackTrace);
     } finally {
       _userStoppedUploadIds.remove(upload.id);
     }
@@ -1249,7 +1254,11 @@ class UploadManager implements BackgroundAwareService {
   }
 
   /// Handle upload failure with comprehensive crash reporting
-  Future<void> _handleUploadFailure(PendingUpload upload, Object error) async {
+  Future<void> _handleUploadFailure(
+    PendingUpload upload,
+    Object error,
+    StackTrace stackTrace,
+  ) async {
     final endTime = DateTime.now();
     final metrics = _reporter.metricsFor(upload.id);
     final latestUpload = getUpload(upload.id) ?? upload;
@@ -1290,6 +1299,7 @@ class UploadManager implements BackgroundAwareService {
       errorCategory,
       metrics,
       connectivity,
+      stackTrace: stackTrace,
       isManagerInitialized: _isInitialized,
     );
 

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -1313,10 +1313,16 @@ class BlossomUploadService {
       ),
     );
 
-    if (response.statusCode == 404 || response.statusCode == 410) {
+    if (response.statusCode == 401 ||
+        response.statusCode == 403 ||
+        response.statusCode == 404 ||
+        response.statusCode == 410) {
       throw BlossomResumableUploadException(
         'Resumable upload session is no longer available',
         statusCode: response.statusCode,
+        failureReason: BlossomUploadFailureReason.fromStatusCode(
+          response.statusCode,
+        ),
       );
     }
     if (response.statusCode != 200 && response.statusCode != 204) {
@@ -1422,10 +1428,16 @@ class BlossomUploadService {
           }
         }
 
-        if (response.statusCode == 404 || response.statusCode == 410) {
+        if (response.statusCode == 401 ||
+            response.statusCode == 403 ||
+            response.statusCode == 404 ||
+            response.statusCode == 410) {
           throw BlossomResumableUploadException(
             'Resumable upload session expired during chunk upload',
             statusCode: response.statusCode,
+            failureReason: BlossomUploadFailureReason.fromStatusCode(
+              response.statusCode,
+            ),
           );
         }
         if (response.statusCode != 200 &&
@@ -1569,7 +1581,12 @@ class BlossomUploadService {
     void Function(double)? onProgress,
     void Function(BlossomResumableUploadSession)? onResumableSessionUpdated,
   }) async {
-    final initialSession = resumableSession == null
+    final now = _clock();
+    final persistedSessionExpired =
+        resumableSession?.expiresAt != null &&
+        !now.isBefore(resumableSession!.expiresAt!);
+
+    final initialSession = resumableSession == null || persistedSessionExpired
         ? await _initResumableUpload(
             serverUrl: serverUrl,
             fileHash: fileHash,

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
@@ -4416,6 +4416,41 @@ void main() {
         );
       });
 
+      test(
+        'resumeUploadSession throws auth-classified exception on 401',
+        () async {
+          when(
+            () => mockDio.head<dynamic>(any(), options: any(named: 'options')),
+          ).thenAnswer(
+            (_) async => Response(
+              requestOptions: RequestOptions(path: '/sessions'),
+              statusCode: 401,
+            ),
+          );
+
+          expect(
+            () => service.resumeUploadSession(
+              session: const BlossomResumableUploadSession(
+                uploadId: 'up_unauthorized',
+                uploadUrl:
+                    'https://upload.divine.video/sessions/up_unauthorized',
+                chunkSize: 1024,
+                nextOffset: 0,
+              ),
+            ),
+            throwsA(
+              isA<BlossomResumableUploadException>()
+                  .having((e) => e.statusCode, 'statusCode', 401)
+                  .having(
+                    (e) => e.failureReason,
+                    'failureReason',
+                    BlossomUploadFailureReason.auth,
+                  ),
+            ),
+          );
+        },
+      );
+
       test('resumeUploadSession throws on unexpected status', () async {
         when(
           () => mockDio.head<dynamic>(any(), options: any(named: 'options')),
@@ -8148,6 +8183,117 @@ void main() {
           await tempDir.delete(recursive: true);
         },
       );
+
+      test('expired resumable session re-inits without session HEAD', () async {
+        service = BlossomUploadService(
+          authProvider: mockAuthProvider,
+          dio: mockDio,
+          defaultServerUrl: 'https://media.divine.video',
+          clock: () => DateTime.utc(2026),
+        );
+
+        when(() => mockAuthProvider.isAuthenticated).thenReturn(true);
+        when(
+          () => mockAuthProvider.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer(
+          (_) async => _signedEvent(_testPublicKey, 24242, const [], 'upload'),
+        );
+
+        final tempDir = await Directory.systemTemp.createTemp(
+          'expired_resume_test_',
+        );
+        final file = File('${tempDir.path}/video.mp4')
+          ..writeAsBytesSync([0x00, 0x01, 0x02]);
+
+        var sessionHeadCalls = 0;
+        when(
+          () => mockDio.head<dynamic>(any(), options: any(named: 'options')),
+        ).thenAnswer((invocation) async {
+          final url = invocation.positionalArguments.first as String;
+          if (url.contains('/sessions/')) {
+            sessionHeadCalls++;
+          }
+          return Response(
+            requestOptions: RequestOptions(path: url),
+            statusCode: 200,
+            headers: Headers.fromMap({
+              'x-divine-upload-extensions': ['resumable-sessions'],
+            }),
+          );
+        });
+
+        when(
+          () => mockDio.post<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+          ),
+        ).thenAnswer((invocation) async {
+          final url = invocation.positionalArguments.first as String;
+          if (url.contains('/upload/init')) {
+            return Response(
+              requestOptions: RequestOptions(path: url),
+              statusCode: 201,
+              data: {
+                'uploadId': 'up_new',
+                'uploadUrl': 'https://upload.divine.video/sessions/up_new',
+                'chunkSize': 1024,
+                'nextOffset': 0,
+              },
+            );
+          }
+          return Response(
+            requestOptions: RequestOptions(path: url),
+            statusCode: 200,
+            data: {
+              'url': 'https://media.divine.video/final',
+              'fallbackUrl': 'https://media.divine.video/final',
+            },
+          );
+        });
+
+        when(
+          () => mockDio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer(
+          (_) async => Response(
+            requestOptions: RequestOptions(path: '/sessions/up_new'),
+            statusCode: 204,
+            headers: Headers.fromMap({
+              'upload-offset': ['3'],
+            }),
+          ),
+        );
+
+        final result = await service.uploadVideo(
+          videoFile: file,
+          nostrPubkey: _testPublicKey,
+          title: 'test',
+          description: null,
+          hashtags: null,
+          proofManifestJson: null,
+          resumableSession: BlossomResumableUploadSession(
+            uploadId: 'up_old',
+            uploadUrl: 'https://upload.divine.video/sessions/up_old',
+            chunkSize: 1024,
+            nextOffset: 0,
+            expiresAt: DateTime.utc(2025),
+          ),
+        );
+
+        expect(result.success, isTrue);
+        expect(sessionHeadCalls, isZero);
+
+        await tempDir.delete(recursive: true);
+      });
     });
 
     group('upload response 409 with progress callback', () {

--- a/mobile/test/services/upload/upload_progress_reporter_test.dart
+++ b/mobile/test/services/upload/upload_progress_reporter_test.dart
@@ -75,11 +75,8 @@ void main() {
       () => crashReporter.setCustomKey(any(), any()),
     ).thenAnswer((_) async {});
     when(
-      () => crashReporter.recordError(
-        any(),
-        any(),
-        reason: any(named: 'reason'),
-      ),
+      () =>
+          crashReporter.recordError(any(), any(), reason: any(named: 'reason')),
     ).thenAnswer((_) async {});
 
     reporter = UploadProgressReporter(
@@ -237,12 +234,35 @@ void main() {
     test(
       'expired session (BlossomResumableUploadException 410) → UPLOAD_SESSION_EXPIRED',
       () async {
-        const error = BlossomResumableUploadException(
-          'Gone',
-          statusCode: 410,
-        );
+        const error = BlossomResumableUploadException('Gone', statusCode: 410);
         final result = await reporter.categorizeError(error);
         expect(result, equals('UPLOAD_SESSION_EXPIRED'));
+      },
+    );
+
+    test(
+      'auth-expired session (BlossomResumableUploadException 401) → AUTHENTICATION',
+      () async {
+        const error = BlossomResumableUploadException(
+          'Unauthorized',
+          statusCode: 401,
+          failureReason: BlossomUploadFailureReason.auth,
+        );
+        final result = await reporter.categorizeError(error);
+        expect(result, equals('AUTHENTICATION'));
+      },
+    );
+
+    test(
+      'auth-expired session (BlossomResumableUploadException 403) → AUTHENTICATION',
+      () async {
+        const error = BlossomResumableUploadException(
+          'Forbidden',
+          statusCode: 403,
+          failureReason: BlossomUploadFailureReason.auth,
+        );
+        final result = await reporter.categorizeError(error);
+        expect(result, equals('AUTHENTICATION'));
       },
     );
   });
@@ -423,12 +443,13 @@ void main() {
   // ---------------------------------------------------------------------------
   group('crash reporting', () {
     test(
-      'sendUploadFailureCrashReport routes the error to the crash port',
+      'sendUploadFailureCrashReport skips expected upload failures',
       () async {
         when(() => store.length).thenReturn(3);
         when(() => store.queuedCount).thenReturn(1);
         final upload = _makeUpload();
         final error = Exception('boom');
+        final stackTrace = StackTrace.current;
 
         await reporter.sendUploadFailureCrashReport(
           upload,
@@ -436,18 +457,52 @@ void main() {
           'NETWORK_ERROR',
           null,
           ConnectivityResult.wifi,
+          stackTrace: stackTrace,
+          isManagerInitialized: true,
+        );
+
+        verifyNever(
+          () => crashReporter.recordError(
+            any(),
+            any(),
+            reason: any(named: 'reason'),
+          ),
+        );
+        verify(
+          () => crashReporter.setCustomKey(any(), any()),
+        ).called(greaterThan(0));
+      },
+    );
+
+    test(
+      'sendUploadFailureCrashReport records reportable failures with caller stack',
+      () async {
+        when(() => store.length).thenReturn(3);
+        when(() => store.queuedCount).thenReturn(1);
+        final upload = _makeUpload();
+        final error = StateError('boom');
+        final stackTrace = StackTrace.current;
+
+        await reporter.sendUploadFailureCrashReport(
+          upload,
+          error,
+          'UNKNOWN',
+          null,
+          ConnectivityResult.wifi,
+          stackTrace: stackTrace,
           isManagerInitialized: true,
         );
 
         final captured = verify(
           () => crashReporter.recordError(
             captureAny(),
-            any(),
+            captureAny(),
             reason: captureAny(named: 'reason'),
           ),
         ).captured;
         expect(captured[0], same(error));
-        expect(captured[1], equals('Video upload failure - NETWORK_ERROR'));
+        expect(captured[1], same(stackTrace));
+        expect(captured[2], equals('Video upload failure - UNKNOWN'));
         verify(
           () => crashReporter.setCustomKey(any(), any()),
         ).called(greaterThan(0));

--- a/mobile/test/services/upload/upload_retry_policy_test.dart
+++ b/mobile/test/services/upload/upload_retry_policy_test.dart
@@ -178,6 +178,32 @@ void main() {
         );
       });
 
+      test('auth-expired BlossomResumableUploadException (401) → false', () {
+        expect(
+          policy.isRetriableError(
+            const BlossomResumableUploadException(
+              'Unauthorized',
+              statusCode: 401,
+              failureReason: BlossomUploadFailureReason.auth,
+            ),
+          ),
+          isFalse,
+        );
+      });
+
+      test('auth-expired BlossomResumableUploadException (403) → false', () {
+        expect(
+          policy.isRetriableError(
+            const BlossomResumableUploadException(
+              'Forbidden',
+              statusCode: 403,
+              failureReason: BlossomUploadFailureReason.auth,
+            ),
+          ),
+          isFalse,
+        );
+      });
+
       test('session expired string → false', () {
         expect(policy.isRetriableError(Exception('session expired')), isFalse);
       });

--- a/mobile/test/services/upload/upload_session_errors_test.dart
+++ b/mobile/test/services/upload/upload_session_errors_test.dart
@@ -25,6 +25,27 @@ void main() {
       );
     });
 
+    test('BlossomResumableUploadException 401 → true', () {
+      expect(
+        isExpiredResumableSessionError(
+          const BlossomResumableUploadException(
+            'Unauthorized',
+            statusCode: 401,
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('BlossomResumableUploadException 403 → true', () {
+      expect(
+        isExpiredResumableSessionError(
+          const BlossomResumableUploadException('Forbidden', statusCode: 403),
+        ),
+        isTrue,
+      );
+    });
+
     test('BlossomResumableUploadException 500 → false', () {
       expect(
         isExpiredResumableSessionError(


### PR DESCRIPTION
## Summary

- forward the real upload failure stack trace into upload Crashlytics reporting
- keep upload failure breadcrumbs/custom keys, but skip `recordError` for expected upload categories
- treat Blossom resumable 401/403 responses as dead persisted sessions while preserving `AUTHENTICATION` categorization
- skip stale-session `HEAD` probes when a persisted resumable session is already past `expiresAt`

Closes #6119

## Verification

- `flutter test test/services/upload/upload_progress_reporter_test.dart test/services/upload/upload_retry_policy_test.dart test/services/upload/upload_session_errors_test.dart`
- `flutter test test/services/upload_manager_error_handling_test.dart test/services/upload_manager_resumable_upload_test.dart`
- `flutter test test/src/blossom_upload_service_test.dart` from `mobile/packages/blossom_upload_service`
- `flutter analyze`
- pre-push hook: analyze + changed-file tests
