### PR TITLE
fix(avatar): validate remote svg payloads

### DIFF
--- a/mobile/lib/blocs/avatar_svg/avatar_svg_cubit.dart
+++ b/mobile/lib/blocs/avatar_svg/avatar_svg_cubit.dart
@@ -20,17 +20,23 @@ class AvatarSvgCubit extends Cubit<AvatarSvgState> {
   final String _url;
 
   Future<void> load() async {
-    if (state.status == AvatarSvgStatus.loading) return;
+    if (isClosed || state.status == AvatarSvgStatus.loading) return;
 
-    emit(state.copyWith(status: AvatarSvgStatus.loading));
+    _emitIfOpen(state.copyWith(status: AvatarSvgStatus.loading));
     try {
       final bytes = await _repository.load(_url);
+      if (isClosed) return;
+
       if (bytes == null) {
-        emit(state.copyWith(status: AvatarSvgStatus.unavailable));
+        _emitIfOpen(
+          state.copyWith(status: AvatarSvgStatus.unavailable, bytes: null),
+        );
         return;
       }
-      emit(state.copyWith(status: AvatarSvgStatus.ready, bytes: bytes));
+      _emitIfOpen(state.copyWith(status: AvatarSvgStatus.ready, bytes: bytes));
     } on Object catch (error, stackTrace) {
+      if (isClosed) return;
+
       Log.error(
         'Avatar SVG load failed',
         name: 'AvatarSvgCubit',
@@ -39,7 +45,13 @@ class AvatarSvgCubit extends Cubit<AvatarSvgState> {
         stackTrace: stackTrace,
       );
       addError(error, stackTrace);
-      emit(state.copyWith(status: AvatarSvgStatus.unavailable));
+      _emitIfOpen(
+        state.copyWith(status: AvatarSvgStatus.unavailable, bytes: null),
+      );
     }
+  }
+
+  void _emitIfOpen(AvatarSvgState nextState) {
+    if (!isClosed) emit(nextState);
   }
 }

--- a/mobile/lib/blocs/avatar_svg/avatar_svg_cubit.dart
+++ b/mobile/lib/blocs/avatar_svg/avatar_svg_cubit.dart
@@ -1,0 +1,45 @@
+// ABOUTME: Cubit for loading validated remote SVG avatar bytes.
+// ABOUTME: Keeps UserAvatar rendering state separate from repository/network work.
+
+import 'dart:typed_data';
+
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/repositories/avatar_svg_repository.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+part 'avatar_svg_state.dart';
+
+class AvatarSvgCubit extends Cubit<AvatarSvgState> {
+  AvatarSvgCubit({required AvatarSvgRepository repository, required String url})
+    : _repository = repository,
+      _url = url,
+      super(const AvatarSvgState());
+
+  final AvatarSvgRepository _repository;
+  final String _url;
+
+  Future<void> load() async {
+    if (state.status == AvatarSvgStatus.loading) return;
+
+    emit(state.copyWith(status: AvatarSvgStatus.loading));
+    try {
+      final bytes = await _repository.load(_url);
+      if (bytes == null) {
+        emit(state.copyWith(status: AvatarSvgStatus.unavailable));
+        return;
+      }
+      emit(state.copyWith(status: AvatarSvgStatus.ready, bytes: bytes));
+    } on Object catch (error, stackTrace) {
+      Log.error(
+        'Avatar SVG load failed',
+        name: 'AvatarSvgCubit',
+        category: LogCategory.ui,
+        error: error,
+        stackTrace: stackTrace,
+      );
+      addError(error, stackTrace);
+      emit(state.copyWith(status: AvatarSvgStatus.unavailable));
+    }
+  }
+}

--- a/mobile/lib/blocs/avatar_svg/avatar_svg_state.dart
+++ b/mobile/lib/blocs/avatar_svg/avatar_svg_state.dart
@@ -2,16 +2,23 @@ part of 'avatar_svg_cubit.dart';
 
 enum AvatarSvgStatus { initial, loading, ready, unavailable }
 
+const _avatarSvgBytesUnset = Object();
+
 class AvatarSvgState extends Equatable {
   const AvatarSvgState({this.status = AvatarSvgStatus.initial, this.bytes});
 
   final AvatarSvgStatus status;
   final Uint8List? bytes;
 
-  AvatarSvgState copyWith({AvatarSvgStatus? status, Uint8List? bytes}) {
+  AvatarSvgState copyWith({
+    AvatarSvgStatus? status,
+    Object? bytes = _avatarSvgBytesUnset,
+  }) {
     return AvatarSvgState(
       status: status ?? this.status,
-      bytes: bytes ?? this.bytes,
+      bytes: identical(bytes, _avatarSvgBytesUnset)
+          ? this.bytes
+          : bytes as Uint8List?,
     );
   }
 

--- a/mobile/lib/blocs/avatar_svg/avatar_svg_state.dart
+++ b/mobile/lib/blocs/avatar_svg/avatar_svg_state.dart
@@ -1,0 +1,20 @@
+part of 'avatar_svg_cubit.dart';
+
+enum AvatarSvgStatus { initial, loading, ready, unavailable }
+
+class AvatarSvgState extends Equatable {
+  const AvatarSvgState({this.status = AvatarSvgStatus.initial, this.bytes});
+
+  final AvatarSvgStatus status;
+  final Uint8List? bytes;
+
+  AvatarSvgState copyWith({AvatarSvgStatus? status, Uint8List? bytes}) {
+    return AvatarSvgState(
+      status: status ?? this.status,
+      bytes: bytes ?? this.bytes,
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, bytes];
+}

--- a/mobile/lib/repositories/avatar_svg_repository.dart
+++ b/mobile/lib/repositories/avatar_svg_repository.dart
@@ -1,0 +1,190 @@
+// ABOUTME: Validates remote avatar SVG payloads before flutter_svg sees them.
+// ABOUTME: Prevents malformed profile-picture markup from surfacing as zone errors.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:unified_logger/unified_logger.dart';
+import 'package:xml/xml.dart';
+
+abstract class AvatarSvgRepository {
+  /// Loads and validates a remote avatar SVG.
+  ///
+  /// Returns `null` for expected remote-data failures: malformed URLs,
+  /// non-200 responses, oversized responses, non-SVG payloads, malformed XML,
+  /// or network failures. Callers should render the normal avatar placeholder
+  /// for `null`.
+  Future<Uint8List?> load(String url);
+}
+
+class AvatarSvgRepositoryConfig {
+  const AvatarSvgRepositoryConfig._();
+
+  static const int maxBytes = 256 * 1024;
+  static const int maxCacheEntries = 128;
+  static const Duration requestTimeout = Duration(seconds: 5);
+  static const Duration positiveTtl = Duration(hours: 1);
+  static const Duration negativeTtl = Duration(minutes: 10);
+}
+
+typedef AvatarSvgClock = DateTime Function();
+
+class HttpAvatarSvgRepository implements AvatarSvgRepository {
+  HttpAvatarSvgRepository({
+    http.Client? client,
+    AvatarSvgClock clock = DateTime.now,
+  }) : _client = client ?? http.Client(),
+       _clock = clock;
+
+  final http.Client _client;
+  final AvatarSvgClock _clock;
+  final _cache = <String, _AvatarSvgCacheEntry>{};
+
+  @override
+  Future<Uint8List?> load(String url) async {
+    final cached = _readCache(url);
+    if (cached != null) return cached.bytes;
+
+    final uri = Uri.tryParse(url);
+    if (uri == null || !uri.hasScheme || !uri.hasAuthority) {
+      _writeCache(url, null, AvatarSvgRepositoryConfig.negativeTtl);
+      return null;
+    }
+
+    try {
+      final bytes = await _fetch(uri);
+      _writeCache(
+        url,
+        bytes,
+        bytes == null
+            ? AvatarSvgRepositoryConfig.negativeTtl
+            : AvatarSvgRepositoryConfig.positiveTtl,
+      );
+      return bytes;
+    } on Object catch (error) {
+      UnifiedLogger.warning(
+        'Avatar SVG validation failed for URL: $url - Error: $error',
+        name: 'AvatarSvgRepository',
+      );
+      _writeCache(url, null, AvatarSvgRepositoryConfig.negativeTtl);
+      return null;
+    }
+  }
+
+  Future<Uint8List?> _fetch(Uri uri) async {
+    final request = http.Request('GET', uri)
+      ..headers['accept'] = 'image/svg+xml,image/*;q=0.8,*/*;q=0.1';
+    final response = await _client
+        .send(request)
+        .timeout(AvatarSvgRepositoryConfig.requestTimeout);
+
+    if (response.statusCode != 200) {
+      unawaited(response.stream.drain<void>());
+      _logRejected(uri, response.headers['content-type'], 'status');
+      return null;
+    }
+
+    final bytes = await _readBounded(response.stream);
+    if (bytes == null) {
+      _logRejected(uri, response.headers['content-type'], 'oversized');
+      return null;
+    }
+
+    final contentType = response.headers['content-type'];
+    if (!_hasSvgContentType(contentType) && !_startsLikeSvg(bytes)) {
+      _logRejected(uri, contentType, 'non-svg-payload');
+      return null;
+    }
+
+    if (!_isWellFormedSvg(bytes)) {
+      _logRejected(uri, contentType, 'malformed-svg');
+      return null;
+    }
+
+    return bytes;
+  }
+
+  Future<Uint8List?> _readBounded(Stream<List<int>> stream) async {
+    final builder = BytesBuilder(copy: false);
+    await for (final chunk in stream) {
+      builder.add(chunk);
+      if (builder.length > AvatarSvgRepositoryConfig.maxBytes) {
+        return null;
+      }
+    }
+    return builder.takeBytes();
+  }
+
+  bool _hasSvgContentType(String? contentType) =>
+      contentType?.toLowerCase().trim().startsWith('image/svg+xml') ?? false;
+
+  bool _startsLikeSvg(Uint8List bytes) {
+    var index = 0;
+    if (bytes.length >= 3 &&
+        bytes[0] == 0xEF &&
+        bytes[1] == 0xBB &&
+        bytes[2] == 0xBF) {
+      index = 3;
+    }
+    while (index < bytes.length && _isAsciiWhitespace(bytes[index])) {
+      index++;
+    }
+    final remaining = utf8.decode(bytes.skip(index).take(16).toList());
+    return remaining.startsWith('<svg') || remaining.startsWith('<?xml');
+  }
+
+  bool _isAsciiWhitespace(int byte) =>
+      byte == 0x09 || byte == 0x0A || byte == 0x0D || byte == 0x20;
+
+  bool _isWellFormedSvg(Uint8List bytes) {
+    final source = utf8.decode(bytes, allowMalformed: false);
+    final document = XmlDocument.parse(source);
+    return document.rootElement.name.local.toLowerCase() == 'svg';
+  }
+
+  _AvatarSvgCacheEntry? _readCache(String url) {
+    final cached = _cache.remove(url);
+    if (cached == null) return null;
+    if (!_clock().isBefore(cached.expiresAt)) return null;
+    _cache[url] = cached;
+    return cached;
+  }
+
+  void _writeCache(String url, Uint8List? bytes, Duration ttl) {
+    if (url.isEmpty || ttl <= Duration.zero) return;
+    _cache.remove(url);
+    _cache[url] = _AvatarSvgCacheEntry(
+      bytes: bytes,
+      expiresAt: _clock().add(ttl),
+    );
+
+    while (_cache.length > AvatarSvgRepositoryConfig.maxCacheEntries) {
+      _cache.remove(_cache.keys.first);
+    }
+  }
+
+  void _logRejected(Uri uri, String? contentType, String reason) {
+    UnifiedLogger.warning(
+      'Avatar SVG rejected: url=$uri contentType=${contentType ?? '<none>'} reason=$reason',
+      name: 'AvatarSvgRepository',
+    );
+  }
+
+  @visibleForTesting
+  void clearCache() {
+    _cache.clear();
+  }
+}
+
+class _AvatarSvgCacheEntry {
+  const _AvatarSvgCacheEntry({required this.bytes, required this.expiresAt});
+
+  final Uint8List? bytes;
+  final DateTime expiresAt;
+}
+
+final AvatarSvgRepository defaultAvatarSvgRepository =
+    HttpAvatarSvgRepository();

--- a/mobile/lib/repositories/avatar_svg_repository.dart
+++ b/mobile/lib/repositories/avatar_svg_repository.dart
@@ -5,7 +5,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:unified_logger/unified_logger.dart';
 import 'package:xml/xml.dart';
@@ -36,18 +35,31 @@ class HttpAvatarSvgRepository implements AvatarSvgRepository {
   HttpAvatarSvgRepository({
     http.Client? client,
     AvatarSvgClock clock = DateTime.now,
+    Duration requestTimeout = AvatarSvgRepositoryConfig.requestTimeout,
   }) : _client = client ?? http.Client(),
-       _clock = clock;
+       _clock = clock,
+       _requestTimeout = requestTimeout;
 
   final http.Client _client;
   final AvatarSvgClock _clock;
+  final Duration _requestTimeout;
   final _cache = <String, _AvatarSvgCacheEntry>{};
+  final _inFlight = <String, Future<Uint8List?>>{};
 
   @override
   Future<Uint8List?> load(String url) async {
     final cached = _readCache(url);
     if (cached != null) return cached.bytes;
 
+    final inFlight = _inFlight[url];
+    if (inFlight != null) return inFlight;
+
+    final pending = _loadUncached(url);
+    _inFlight[url] = pending;
+    return pending.whenComplete(() => _inFlight.remove(url));
+  }
+
+  Future<Uint8List?> _loadUncached(String url) async {
     final uri = Uri.tryParse(url);
     if (uri == null || !uri.hasScheme || !uri.hasAuthority) {
       _writeCache(url, null, AvatarSvgRepositoryConfig.negativeTtl);
@@ -77,12 +89,10 @@ class HttpAvatarSvgRepository implements AvatarSvgRepository {
   Future<Uint8List?> _fetch(Uri uri) async {
     final request = http.Request('GET', uri)
       ..headers['accept'] = 'image/svg+xml,image/*;q=0.8,*/*;q=0.1';
-    final response = await _client
-        .send(request)
-        .timeout(AvatarSvgRepositoryConfig.requestTimeout);
+    final response = await _client.send(request).timeout(_requestTimeout);
 
     if (response.statusCode != 200) {
-      unawaited(response.stream.drain<void>());
+      await _cancelResponseBody(response.stream);
       _logRejected(uri, response.headers['content-type'], 'status');
       return null;
     }
@@ -109,13 +119,37 @@ class HttpAvatarSvgRepository implements AvatarSvgRepository {
 
   Future<Uint8List?> _readBounded(Stream<List<int>> stream) async {
     final builder = BytesBuilder(copy: false);
-    await for (final chunk in stream) {
+    await for (final chunk in _withBodyTimeout(stream)) {
       builder.add(chunk);
       if (builder.length > AvatarSvgRepositoryConfig.maxBytes) {
         return null;
       }
     }
     return builder.takeBytes();
+  }
+
+  Stream<List<int>> _withBodyTimeout(Stream<List<int>> stream) {
+    return stream.timeout(
+      _requestTimeout,
+      onTimeout: (sink) {
+        sink.addError(
+          TimeoutException('Avatar SVG body read timed out', _requestTimeout),
+        );
+        sink.close();
+      },
+    );
+  }
+
+  Future<void> _cancelResponseBody(Stream<List<int>> stream) async {
+    final subscription = stream.listen(null, onError: (_, _) {});
+    try {
+      await subscription.cancel().timeout(_requestTimeout);
+    } on Object catch (error) {
+      UnifiedLogger.debug(
+        'Avatar SVG response body cancel failed: $error',
+        name: 'AvatarSvgRepository',
+      );
+    }
   }
 
   bool _hasSvgContentType(String? contentType) =>
@@ -132,7 +166,10 @@ class HttpAvatarSvgRepository implements AvatarSvgRepository {
     while (index < bytes.length && _isAsciiWhitespace(bytes[index])) {
       index++;
     }
-    final remaining = utf8.decode(bytes.skip(index).take(16).toList());
+    final remaining = utf8.decode(
+      bytes.skip(index).take(16).toList(),
+      allowMalformed: true,
+    );
     return remaining.startsWith('<svg') || remaining.startsWith('<?xml');
   }
 
@@ -171,11 +208,6 @@ class HttpAvatarSvgRepository implements AvatarSvgRepository {
       'Avatar SVG rejected: url=$uri contentType=${contentType ?? '<none>'} reason=$reason',
       name: 'AvatarSvgRepository',
     );
-  }
-
-  @visibleForTesting
-  void clearCache() {
-    _cache.clear();
   }
 }
 

--- a/mobile/lib/widgets/user_avatar.dart
+++ b/mobile/lib/widgets/user_avatar.dart
@@ -5,7 +5,10 @@ import 'dart:math' as math;
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:openvine/blocs/avatar_svg/avatar_svg_cubit.dart';
+import 'package:openvine/repositories/avatar_svg_repository.dart';
 import 'package:openvine/widgets/avatar_failure_cache.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -34,6 +37,7 @@ class UserAvatar extends StatelessWidget {
     this.placeholderSeed,
     this.cornerRadius,
     this.contentOverride,
+    this.avatarSvgRepository,
   });
 
   final String? imageUrl;
@@ -63,6 +67,9 @@ class UserAvatar extends StatelessWidget {
   /// For rows whose identity is known ahead of the network and whose remote
   /// picture cannot be trusted to render.
   final Widget? contentOverride;
+
+  @visibleForTesting
+  final AvatarSvgRepository? avatarSvgRepository;
 
   @visibleForTesting
   static bool isSvgImageUrl(String? url) {
@@ -147,18 +154,10 @@ class UserAvatar extends StatelessWidget {
         return _buildPlaceholder();
       }
 
-      return SvgPicture.network(
-        imageUrl!,
-        fit: BoxFit.cover,
-        placeholderBuilder: (context) => _buildPlaceholder(),
-        errorBuilder: (context, error, stackTrace) {
-          UnifiedLogger.debug(
-            'Avatar SVG failed to load URL: $imageUrl - Error: $error',
-            name: 'UserAvatar',
-          );
-          AvatarFailureCache.instance.recordFailureForError(imageUrl!, error);
-          return _buildPlaceholder();
-        },
+      return _AvatarSvgContent(
+        imageUrl: imageUrl!,
+        repository: avatarSvgRepository ?? defaultAvatarSvgRepository,
+        placeholderBuilder: _buildPlaceholder,
       );
     }
 
@@ -193,6 +192,51 @@ class UserAvatar extends StatelessWidget {
     }
 
     return _buildPlaceholder();
+  }
+}
+
+class _AvatarSvgContent extends StatelessWidget {
+  const _AvatarSvgContent({
+    required this.imageUrl,
+    required this.repository,
+    required this.placeholderBuilder,
+  });
+
+  final String imageUrl;
+  final AvatarSvgRepository repository;
+  final Widget Function() placeholderBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider<AvatarSvgCubit>(
+      key: ValueKey((imageUrl, repository)),
+      create: (_) =>
+          AvatarSvgCubit(repository: repository, url: imageUrl)..load(),
+      child: BlocBuilder<AvatarSvgCubit, AvatarSvgState>(
+        builder: (context, state) {
+          final bytes = state.bytes;
+          if (state.status != AvatarSvgStatus.ready || bytes == null) {
+            return placeholderBuilder();
+          }
+
+          return SvgPicture.memory(
+            bytes,
+            fit: BoxFit.cover,
+            errorBuilder: (context, error, stackTrace) {
+              UnifiedLogger.debug(
+                'Avatar SVG failed to render URL: $imageUrl - Error: $error',
+                name: 'UserAvatar',
+              );
+              AvatarFailureCache.instance.recordFailureForError(
+                imageUrl,
+                error,
+              );
+              return placeholderBuilder();
+            },
+          );
+        },
+      ),
+    );
   }
 }
 

--- a/mobile/test/blocs/avatar_svg/avatar_svg_cubit_test.dart
+++ b/mobile/test/blocs/avatar_svg/avatar_svg_cubit_test.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/blocs/avatar_svg/avatar_svg_cubit.dart';
+import 'package:openvine/repositories/avatar_svg_repository.dart';
+
+void main() {
+  const url = 'https://divine.video/avatar.svg';
+  final bytes = Uint8List.fromList(
+    utf8.encode('<svg xmlns="http://www.w3.org/2000/svg" />'),
+  );
+
+  group(AvatarSvgCubit, () {
+    blocTest<AvatarSvgCubit, AvatarSvgState>(
+      'emits ready when repository returns bytes',
+      build: () =>
+          AvatarSvgCubit(repository: _FakeAvatarSvgRepository(bytes), url: url),
+      act: (cubit) => cubit.load(),
+      expect: () => [
+        const AvatarSvgState(status: AvatarSvgStatus.loading),
+        AvatarSvgState(status: AvatarSvgStatus.ready, bytes: bytes),
+      ],
+    );
+
+    blocTest<AvatarSvgCubit, AvatarSvgState>(
+      'emits unavailable when repository returns null',
+      build: () => AvatarSvgCubit(
+        repository: const _FakeAvatarSvgRepository(null),
+        url: url,
+      ),
+      act: (cubit) => cubit.load(),
+      expect: () => [
+        const AvatarSvgState(status: AvatarSvgStatus.loading),
+        const AvatarSvgState(status: AvatarSvgStatus.unavailable),
+      ],
+    );
+  });
+}
+
+class _FakeAvatarSvgRepository implements AvatarSvgRepository {
+  const _FakeAvatarSvgRepository(this.bytes);
+
+  final Uint8List? bytes;
+
+  @override
+  Future<Uint8List?> load(String url) async => bytes;
+}

--- a/mobile/test/blocs/avatar_svg/avatar_svg_cubit_test.dart
+++ b/mobile/test/blocs/avatar_svg/avatar_svg_cubit_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -36,6 +37,20 @@ void main() {
         const AvatarSvgState(status: AvatarSvgStatus.unavailable),
       ],
     );
+
+    test('does not throw when closed before repository completes', () async {
+      final repository = _CompleterAvatarSvgRepository();
+      final cubit = AvatarSvgCubit(repository: repository, url: url);
+
+      final load = cubit.load();
+      await Future<void>.delayed(Duration.zero);
+      expect(cubit.state.status, AvatarSvgStatus.loading);
+
+      await cubit.close();
+      repository.complete(bytes);
+
+      await expectLater(load, completes);
+    });
   });
 }
 
@@ -46,4 +61,13 @@ class _FakeAvatarSvgRepository implements AvatarSvgRepository {
 
   @override
   Future<Uint8List?> load(String url) async => bytes;
+}
+
+class _CompleterAvatarSvgRepository implements AvatarSvgRepository {
+  final _completer = Completer<Uint8List?>();
+
+  void complete(Uint8List? bytes) => _completer.complete(bytes);
+
+  @override
+  Future<Uint8List?> load(String url) => _completer.future;
 }

--- a/mobile/test/repositories/avatar_svg_repository_test.dart
+++ b/mobile/test/repositories/avatar_svg_repository_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -15,7 +16,10 @@ void main() {
   );
 
   HttpAvatarSvgRepository repositoryFor(http.Response response) {
-    return HttpAvatarSvgRepository(client: MockClient((_) async => response));
+    return HttpAvatarSvgRepository(
+      client: MockClient((_) async => response),
+      requestTimeout: const Duration(milliseconds: 20),
+    );
   }
 
   test('accepts well-formed SVG payloads', () async {
@@ -48,6 +52,18 @@ void main() {
     expect(repository.load(url), completion(isNull));
   });
 
+  test('rejects binary payloads without throwing while sniffing', () {
+    final repository = repositoryFor(
+      http.Response.bytes(
+        Uint8List.fromList([0x89, 0x50, 0x4E, 0x47]),
+        200,
+        headers: {'content-type': 'text/html'},
+      ),
+    );
+
+    expect(repository.load(url), completion(isNull));
+  });
+
   test('rejects malformed SVG before flutter_svg sees it', () {
     final repository = repositoryFor(
       http.Response(
@@ -70,6 +86,48 @@ void main() {
     );
 
     expect(repository.load(url), completion(isNull));
+  });
+
+  test('does not leave non-200 response stream errors unhandled', () async {
+    final controller = StreamController<List<int>>();
+    final repository = HttpAvatarSvgRepository(
+      client: _StreamedAvatarClient(
+        (_) async => http.StreamedResponse(
+          controller.stream,
+          503,
+          headers: {'content-type': 'image/svg+xml'},
+        ),
+      ),
+      requestTimeout: const Duration(milliseconds: 20),
+    );
+
+    final result = await repository.load(url);
+    controller.addError(Exception('socket reset while discarding body'));
+
+    expect(result, isNull);
+    await controller.close();
+  });
+
+  test('times out incomplete response bodies', () async {
+    var bodyCanceled = false;
+    final controller = StreamController<List<int>>(
+      onCancel: () {
+        bodyCanceled = true;
+      },
+    );
+    final repository = HttpAvatarSvgRepository(
+      client: _StreamedAvatarClient(
+        (_) async => http.StreamedResponse(
+          controller.stream,
+          200,
+          headers: {'content-type': 'image/svg+xml'},
+        ),
+      ),
+      requestTimeout: const Duration(milliseconds: 20),
+    );
+
+    await expectLater(repository.load(url), completion(isNull));
+    expect(bodyCanceled, isTrue);
   });
 
   test('rejects oversized responses', () {
@@ -96,6 +154,7 @@ void main() {
         requests++;
         return http.Response('<html>gone</html>', 200);
       }),
+      requestTimeout: const Duration(milliseconds: 20),
     );
 
     await repository.load(url);
@@ -103,4 +162,114 @@ void main() {
 
     expect(requests, 1);
   });
+
+  test('expires cached positive results after the positive TTL', () async {
+    var now = DateTime(2026);
+    var requests = 0;
+    final repository = HttpAvatarSvgRepository(
+      client: MockClient((_) async {
+        requests++;
+        return http.Response.bytes(
+          validSvgBytes,
+          200,
+          headers: {'content-type': 'image/svg+xml'},
+        );
+      }),
+      clock: () => now,
+      requestTimeout: const Duration(milliseconds: 20),
+    );
+
+    await repository.load(url);
+    now = now.add(const Duration(minutes: 30));
+    await repository.load(url);
+    now = now.add(const Duration(hours: 1, minutes: 1));
+    await repository.load(url);
+
+    expect(requests, 2);
+  });
+
+  test('expires cached negative results after the negative TTL', () async {
+    var now = DateTime(2026);
+    var requests = 0;
+    final repository = HttpAvatarSvgRepository(
+      client: MockClient((_) async {
+        requests++;
+        return http.Response('<html>gone</html>', 200);
+      }),
+      clock: () => now,
+      requestTimeout: const Duration(milliseconds: 20),
+    );
+
+    await repository.load(url);
+    now = now.add(const Duration(minutes: 5));
+    await repository.load(url);
+    now = now.add(const Duration(minutes: 11));
+    await repository.load(url);
+
+    expect(requests, 2);
+  });
+
+  test('evicts least recently used cache entries', () async {
+    var requests = 0;
+    final repository = HttpAvatarSvgRepository(
+      client: MockClient((_) async {
+        requests++;
+        return http.Response.bytes(
+          validSvgBytes,
+          200,
+          headers: {'content-type': 'image/svg+xml'},
+        );
+      }),
+      requestTimeout: const Duration(milliseconds: 20),
+    );
+
+    for (
+      var index = 0;
+      index <= AvatarSvgRepositoryConfig.maxCacheEntries;
+      index++
+    ) {
+      await repository.load('https://divine.video/avatar-$index.svg');
+    }
+    await repository.load('https://divine.video/avatar-0.svg');
+
+    expect(requests, AvatarSvgRepositoryConfig.maxCacheEntries + 2);
+  });
+
+  test('deduplicates concurrent requests for the same URL', () async {
+    var requests = 0;
+    final responseCompleter = Completer<http.Response>();
+    final repository = HttpAvatarSvgRepository(
+      client: MockClient((_) {
+        requests++;
+        return responseCompleter.future;
+      }),
+      requestTimeout: const Duration(milliseconds: 20),
+    );
+
+    final first = repository.load(url);
+    final second = repository.load(url);
+    responseCompleter.complete(
+      http.Response.bytes(
+        validSvgBytes,
+        200,
+        headers: {'content-type': 'image/svg+xml'},
+      ),
+    );
+
+    await expectLater(
+      Future.wait([first, second]),
+      completion([validSvgBytes, validSvgBytes]),
+    );
+    expect(requests, 1);
+  });
+}
+
+class _StreamedAvatarClient extends http.BaseClient {
+  _StreamedAvatarClient(this._send);
+
+  final Future<http.StreamedResponse> Function(http.BaseRequest request) _send;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) =>
+      _send(request);
 }

--- a/mobile/test/repositories/avatar_svg_repository_test.dart
+++ b/mobile/test/repositories/avatar_svg_repository_test.dart
@@ -1,0 +1,106 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:openvine/repositories/avatar_svg_repository.dart';
+
+void main() {
+  const url = 'https://divine.video/avatar.svg';
+  final validSvgBytes = Uint8List.fromList(
+    utf8.encode(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1" />',
+    ),
+  );
+
+  HttpAvatarSvgRepository repositoryFor(http.Response response) {
+    return HttpAvatarSvgRepository(client: MockClient((_) async => response));
+  }
+
+  test('accepts well-formed SVG payloads', () async {
+    final repository = repositoryFor(
+      http.Response.bytes(
+        validSvgBytes,
+        200,
+        headers: {'content-type': 'image/svg+xml; charset=utf-8'},
+      ),
+    );
+
+    await expectLater(repository.load(url), completion(validSvgBytes));
+  });
+
+  test('accepts SVG payloads by sniffing when content type is missing', () {
+    final repository = repositoryFor(http.Response.bytes(validSvgBytes, 200));
+
+    expect(repository.load(url), completion(validSvgBytes));
+  });
+
+  test('rejects HTML returned from a .svg URL', () {
+    final repository = repositoryFor(
+      http.Response(
+        '<html><body>not an svg</body></html>',
+        200,
+        headers: {'content-type': 'text/html'},
+      ),
+    );
+
+    expect(repository.load(url), completion(isNull));
+  });
+
+  test('rejects malformed SVG before flutter_svg sees it', () {
+    final repository = repositoryFor(
+      http.Response(
+        '<svg xmlns="http://www.w3.org/2000/svg"><path',
+        200,
+        headers: {'content-type': 'image/svg+xml'},
+      ),
+    );
+
+    expect(repository.load(url), completion(isNull));
+  });
+
+  test('rejects non-200 responses', () {
+    final repository = repositoryFor(
+      http.Response(
+        '<svg xmlns="http://www.w3.org/2000/svg" />',
+        503,
+        headers: {'content-type': 'image/svg+xml'},
+      ),
+    );
+
+    expect(repository.load(url), completion(isNull));
+  });
+
+  test('rejects oversized responses', () {
+    final oversized = Uint8List.fromList(
+      utf8.encode(
+        '<svg xmlns="http://www.w3.org/2000/svg"><text>${'x' * AvatarSvgRepositoryConfig.maxBytes}</text></svg>',
+      ),
+    );
+    final repository = repositoryFor(
+      http.Response.bytes(
+        oversized,
+        200,
+        headers: {'content-type': 'image/svg+xml'},
+      ),
+    );
+
+    expect(repository.load(url), completion(isNull));
+  });
+
+  test('caches negative results', () async {
+    var requests = 0;
+    final repository = HttpAvatarSvgRepository(
+      client: MockClient((_) async {
+        requests++;
+        return http.Response('<html>gone</html>', 200);
+      }),
+    );
+
+    await repository.load(url);
+    await repository.load(url);
+
+    expect(requests, 1);
+  });
+}

--- a/mobile/test/widgets/user_avatar_svg_test.dart
+++ b/mobile/test/widgets/user_avatar_svg_test.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -9,6 +8,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:media_cache/media_cache.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:openvine/repositories/avatar_svg_repository.dart';
 import 'package:openvine/widgets/avatar_failure_cache.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
@@ -86,25 +86,36 @@ final Uint8List _transparentImageBytes = Uint8List.fromList(<int>[
 ]);
 
 void main() {
-  Widget buildAvatar({String? imageUrl}) {
+  final validSvgBytes = Uint8List.fromList(
+    utf8.encode(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1" />',
+    ),
+  );
+
+  Widget buildAvatar({
+    String? imageUrl,
+    AvatarSvgRepository? avatarSvgRepository,
+  }) {
     return MaterialApp(
       home: Scaffold(
-        body: UserAvatar(imageUrl: imageUrl, name: 'Test User'),
+        body: UserAvatar(
+          imageUrl: imageUrl,
+          name: 'Test User',
+          avatarSvgRepository: avatarSvgRepository,
+        ),
       ),
     );
   }
 
-  Future<void> pumpAvatarWithValidSvgResponse(
-    WidgetTester tester,
-    String imageUrl,
-  ) {
-    return HttpOverrides.runZoned(
-      () async {
-        await tester.pumpWidget(buildAvatar(imageUrl: imageUrl));
-        await tester.pump();
-      },
-      createHttpClient: (_) => _ValidSvgHttpClient(),
+  Future<void> pumpAvatarWithSvgRepository(
+    WidgetTester tester, {
+    required String imageUrl,
+    required AvatarSvgRepository repository,
+  }) async {
+    await tester.pumpWidget(
+      buildAvatar(imageUrl: imageUrl, avatarSvgRepository: repository),
     );
+    await tester.pump();
   }
 
   Finder gradientPlaceholderFinder() => find.byWidgetPredicate((widget) {
@@ -225,10 +236,14 @@ void main() {
       expect(AvatarFailureCache.instance.isFailed(failedUrl), isTrue);
     });
 
-    testWidgets('SVG transient failures are cached briefly', (tester) async {
+    testWidgets('SVG render failures are cached briefly', (tester) async {
       const failedUrl = 'https://divine.video/divine-logo.svg';
 
-      await pumpAvatarWithValidSvgResponse(tester, failedUrl);
+      await pumpAvatarWithSvgRepository(
+        tester,
+        imageUrl: failedUrl,
+        repository: _FakeAvatarSvgRepository(validSvgBytes),
+      );
       final svg = tester.widget<SvgPicture>(find.byType(SvgPicture));
 
       svg.errorBuilder!(
@@ -263,7 +278,11 @@ void main() {
         AvatarFailureKind.deterministic,
       );
 
-      await pumpAvatarWithValidSvgResponse(tester, failedUrl);
+      await pumpAvatarWithSvgRepository(
+        tester,
+        imageUrl: failedUrl,
+        repository: _FakeAvatarSvgRepository(validSvgBytes),
+      );
       final svg = tester.widget<SvgPicture>(find.byType(SvgPicture));
       svg.errorBuilder!(
         tester.element(find.byType(SvgPicture)),
@@ -272,6 +291,46 @@ void main() {
       );
 
       expect(AvatarFailureCache.instance.isFailed(failedUrl), isTrue);
+    });
+
+    testWidgets('HTML returned for a .svg URL renders placeholder only', (
+      tester,
+    ) async {
+      const failedUrl = 'https://divine.video/html-error.svg';
+
+      await pumpAvatarWithSvgRepository(
+        tester,
+        imageUrl: failedUrl,
+        repository: const _FakeAvatarSvgRepository(null),
+      );
+
+      expect(find.byType(SvgPicture), findsNothing);
+      expect(find.byType(VineCachedImage), findsNothing);
+      expect(gradientPlaceholderFinder(), findsAtLeastNWidgets(1));
+    });
+
+    testWidgets('rejected .svg URL does not raise a zone error', (
+      tester,
+    ) async {
+      const failedUrl = 'https://divine.video/html-error.svg';
+      Object? zoneError;
+
+      await runZonedGuarded(
+        () async {
+          await pumpAvatarWithSvgRepository(
+            tester,
+            imageUrl: failedUrl,
+            repository: const _FakeAvatarSvgRepository(null),
+          );
+          await tester.pumpAndSettle();
+        },
+        (error, stackTrace) {
+          zoneError = error;
+        },
+      );
+
+      expect(zoneError, isNull);
+      expect(find.byType(SvgPicture), findsNothing);
     });
 
     testWidgets('raster completed download failures are cached', (
@@ -293,37 +352,34 @@ void main() {
       expect(AvatarFailureCache.instance.isFailed(failedUrl), isTrue);
     });
 
-    testWidgets(
-      'caches a broken raster URL through the real image provider',
-      (tester) async {
-        const brokenUrl = 'https://blotcdn.com/dead-avatar.png';
-        final cache = _MockMediaCacheManager();
-        when(
-          () => cache.getFileFromCache(any()),
-        ).thenAnswer((_) async => null);
-        when(
-          () => cache.cacheFileCancellable(
-            any(),
-            key: any(named: 'key'),
-            aliasKey: any(named: 'aliasKey'),
-            authHeaders: any(named: 'authHeaders'),
-          ),
-          // An empty stream resolves the download to a null file — exactly
-          // what a dead URL (non-2xx / DNS failure) produces in production.
-        ).thenReturn(
-          CancellableCacheOperation.fromStream(
-            const Stream<FileResponse>.empty(),
-          ),
-        );
-        debugImageCacheOverride = cache;
-        addTearDown(() => debugImageCacheOverride = null);
+    testWidgets('caches a broken raster URL through the real image provider', (
+      tester,
+    ) async {
+      const brokenUrl = 'https://blotcdn.com/dead-avatar.png';
+      final cache = _MockMediaCacheManager();
+      when(() => cache.getFileFromCache(any())).thenAnswer((_) async => null);
+      when(
+        () => cache.cacheFileCancellable(
+          any(),
+          key: any(named: 'key'),
+          aliasKey: any(named: 'aliasKey'),
+          authHeaders: any(named: 'authHeaders'),
+        ),
+        // An empty stream resolves the download to a null file — exactly
+        // what a dead URL (non-2xx / DNS failure) produces in production.
+      ).thenReturn(
+        CancellableCacheOperation.fromStream(
+          const Stream<FileResponse>.empty(),
+        ),
+      );
+      debugImageCacheOverride = cache;
+      addTearDown(() => debugImageCacheOverride = null);
 
-        await tester.pumpWidget(buildAvatar(imageUrl: brokenUrl));
-        await tester.pumpAndSettle();
+      await tester.pumpWidget(buildAvatar(imageUrl: brokenUrl));
+      await tester.pumpAndSettle();
 
-        expect(AvatarFailureCache.instance.isFailed(brokenUrl), isTrue);
-      },
-    );
+      expect(AvatarFailureCache.instance.isFailed(brokenUrl), isTrue);
+    });
 
     testWidgets('keeps raster avatar URLs on VineCachedImage', (tester) async {
       await tester.pumpWidget(
@@ -375,109 +431,11 @@ void main() {
   });
 }
 
-class _ValidSvgHttpClient implements HttpClient {
-  @override
-  Future<HttpClientRequest> openUrl(String method, Uri url) async =>
-      _ValidSvgRequest();
+class _FakeAvatarSvgRepository implements AvatarSvgRepository {
+  const _FakeAvatarSvgRepository(this.bytes);
 
   @override
-  Future<HttpClientRequest> getUrl(Uri url) async => _ValidSvgRequest();
+  Future<Uint8List?> load(String url) async => bytes;
 
-  @override
-  void close({bool force = false}) {}
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
-
-class _ValidSvgRequest implements HttpClientRequest {
-  final _headers = _EmptyHttpHeaders();
-
-  @override
-  bool followRedirects = true;
-
-  @override
-  int maxRedirects = 5;
-
-  @override
-  bool persistentConnection = false;
-
-  @override
-  int contentLength = 0;
-
-  @override
-  HttpHeaders get headers => _headers;
-
-  @override
-  Future<void> addStream(Stream<List<int>> stream) async {
-    await stream.drain<void>();
-  }
-
-  @override
-  Future<HttpClientResponse> close() async => _ValidSvgResponse();
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
-
-class _ValidSvgResponse extends Stream<List<int>>
-    implements HttpClientResponse {
-  _ValidSvgResponse()
-    : _body = utf8.encode(
-        '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1" />',
-      );
-
-  final List<int> _body;
-  final _headers = _EmptyHttpHeaders();
-
-  @override
-  int get statusCode => HttpStatus.ok;
-
-  @override
-  int get contentLength => _body.length;
-
-  @override
-  bool get persistentConnection => false;
-
-  @override
-  HttpHeaders get headers => _headers;
-
-  @override
-  bool get isRedirect => false;
-
-  @override
-  List<RedirectInfo> get redirects => const [];
-
-  @override
-  String get reasonPhrase => 'OK';
-
-  @override
-  HttpClientResponseCompressionState get compressionState =>
-      HttpClientResponseCompressionState.notCompressed;
-
-  @override
-  StreamSubscription<List<int>> listen(
-    void Function(List<int> event)? onData, {
-    Function? onError,
-    void Function()? onDone,
-    bool? cancelOnError,
-  }) {
-    return Stream<List<int>>.value(_body).listen(
-      onData,
-      onError: onError,
-      onDone: onDone,
-      cancelOnError: cancelOnError,
-    );
-  }
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
-
-class _EmptyHttpHeaders implements HttpHeaders {
-  @override
-  void forEach(void Function(String name, List<String> values) action) {}
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+  final Uint8List? bytes;
 }


### PR DESCRIPTION
## Summary
- add a validating AvatarSvgRepository with timeout, byte cap, XML/SVG validation, and bounded positive/negative cache
- route remote SVG avatars through AvatarSvgCubit and render only validated bytes with SvgPicture.memory
- keep placeholder fallback behavior for rejected SVG payloads and existing raster failure cache behavior

## Verification
- flutter analyze
- flutter test test/repositories/avatar_svg_repository_test.dart test/blocs/avatar_svg/avatar_svg_cubit_test.dart test/widgets/user_avatar_svg_test.dart
- flutter test test/widgets/comprehensive_user_avatar_test.dart
- pre-push hook: analyze + changed-file tests

Closes #6118