### PR TITLE
fix(profile): filter invalid identity claims before verify

### DIFF
--- a/mobile/packages/profile_repository/lib/src/identity_claims_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/identity_claims_repository.dart
@@ -76,11 +76,12 @@ class IdentityClaimsRepository {
   /// Parses NIP-39 identity claims out of the given identity-event tag
   /// list (kind 10011, or kind 0 for pre-migration profiles).
   ///
-  /// Filters to `['i', '<platform>:<identity>', '<proof>']` shape, skips
-  /// malformed entries, dedupes case-insensitively on `<platform>:<identity>`
-  /// (preferring the first occurrence — matches verifier UI behaviour at
-  /// `divine-identify-verification-service/src/index.ts:1784`), caps at
-  /// [VerifierClient.maxBatchSize] (10) so a single batch suffices.
+  /// Filters to `['i', '<platform>:<identity>', '<proof>']` shape and the
+  /// verifier's request contract, skips malformed entries, dedupes
+  /// case-insensitively on `<platform>:<identity>` (preferring the first
+  /// valid occurrence — matches verifier UI behaviour at
+  /// `divine-identify-verification-service/src/index.ts:1784`), caps valid
+  /// claims at [VerifierClient.maxBatchSize] (10) so a single batch suffices.
   static List<IdentityClaim> parseClaims(
     String pubkey,
     List<List<String>> tags,
@@ -95,16 +96,16 @@ class IdentityClaimsRepository {
       if (colon <= 0 || colon == claimKey.length - 1) continue;
       final platform = claimKey.substring(0, colon);
       final identity = claimKey.substring(colon + 1);
+      final claim = IdentityClaim(
+        pubkey: pubkey,
+        platform: platform,
+        identity: identity,
+        proof: tag[2],
+      );
+      if (!claim.isServerValid) continue;
       final dedupeKey = '$platform:$identity'.toLowerCase();
       if (!seen.add(dedupeKey)) continue;
-      claims.add(
-        IdentityClaim(
-          pubkey: pubkey,
-          platform: platform,
-          identity: identity,
-          proof: tag[2],
-        ),
-      );
+      claims.add(claim);
       if (claims.length >= VerifierClient.maxBatchSize) break;
     }
     return claims;

--- a/mobile/packages/profile_repository/test/src/identity_claims_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/identity_claims_repository_test.dart
@@ -73,6 +73,41 @@ void main() {
       expect(IdentityClaimsRepository.parseClaims(_pubkey, tags), isEmpty);
     });
 
+    test('skips i tags whose claims fail the verifier contract', () {
+      final longIdentity = List.filled(
+        IdentityClaim.maxServerTextLength + 1,
+        'a',
+      ).join();
+      final tags = [
+        ['i', 'github:bad"identity', 'abc'],
+        ['i', 'github:bad<identity', 'abc'],
+        ['i', 'github:bad${String.fromCharCode(1)}identity', 'abc'],
+        ['i', 'github:$longIdentity', 'abc'],
+        ['i', 'github:octocat', 'bad>proof'],
+      ];
+      expect(IdentityClaimsRepository.parseClaims(_pubkey, tags), isEmpty);
+    });
+
+    test('skips unsupported verifier platforms', () {
+      final tags = [
+        ['i', 'reddit:octocat', 'abc'],
+        ['i', 'github:octocat', 'abc'],
+      ];
+      final claims = IdentityClaimsRepository.parseClaims(_pubkey, tags);
+      expect(claims, hasLength(1));
+      expect(claims.single.platform, equals('github'));
+    });
+
+    test('keeps bluesky claims with blank proof', () {
+      final tags = [
+        ['i', 'bluesky:octocat.bsky.social', ''],
+      ];
+      final claims = IdentityClaimsRepository.parseClaims(_pubkey, tags);
+      expect(claims, hasLength(1));
+      expect(claims.single.platform, equals('bluesky'));
+      expect(claims.single.proof, isEmpty);
+    });
+
     test('skips empty tag entries', () {
       final tags = [
         <String>[],
@@ -86,7 +121,7 @@ void main() {
 
     test('dedupes by case-insensitive platform:identity, keeping first', () {
       final tags = [
-        ['i', 'GitHub:Octocat', 'first'],
+        ['i', 'github:Octocat', 'first'],
         ['i', 'github:octocat', 'second'],
       ];
       final claims = IdentityClaimsRepository.parseClaims(_pubkey, tags);
@@ -101,6 +136,29 @@ void main() {
       );
       final claims = IdentityClaimsRepository.parseClaims(_pubkey, tags);
       expect(claims, hasLength(10));
+    });
+
+    test('caps at 10 valid claims after verifier-contract filtering', () {
+      final tags = [
+        ['i', 'github:bad"identity', 'bad>proof'],
+        ...List<List<String>>.generate(
+          10,
+          (i) => ['i', 'github:user$i', 'p$i'],
+        ),
+      ];
+      final claims = IdentityClaimsRepository.parseClaims(_pubkey, tags);
+      expect(claims, hasLength(10));
+      expect(claims.map((claim) => claim.identity), contains('user9'));
+    });
+
+    test('does not let an invalid duplicate block a valid claim', () {
+      final tags = [
+        ['i', 'github:octocat', 'bad>proof'],
+        ['i', 'github:octocat', 'abc'],
+      ];
+      final claims = IdentityClaimsRepository.parseClaims(_pubkey, tags);
+      expect(claims, hasLength(1));
+      expect(claims.single.proof, equals('abc'));
     });
 
     test('attaches the pubkey to each claim', () {
@@ -155,6 +213,40 @@ void main() {
       expect(result.single.platform, equals('github'));
     });
 
+    test('sends only verifier-valid claims to the verifier', () async {
+      when(() => client.verifyBatch(any())).thenAnswer(
+        (_) async => const [
+          VerificationResult(
+            platform: 'github',
+            identity: 'octocat',
+            verified: true,
+            checkedAt: 1,
+            cached: false,
+          ),
+        ],
+      );
+
+      final result = await repo.resolveClaims(
+        pubkey: _pubkey,
+        freshTags: const [
+          [
+            'i',
+            'bluesky:Verifying my account on nostr My Public Key: "npub1"',
+            '',
+          ],
+          ['i', 'github:octocat', 'abc'],
+        ],
+        cached: null,
+      );
+
+      expect(result, hasLength(1));
+      final sent = verify(() => client.verifyBatch(captureAny())).captured;
+      final claims = sent.single as List<IdentityClaim>;
+      expect(claims, hasLength(1));
+      expect(claims.single.platform, equals('github'));
+      expect(claims.single.identity, equals('octocat'));
+    });
+
     test(
       'returns empty and skips the verifier when there are no i tags',
       () async {
@@ -187,12 +279,12 @@ void main() {
       final result = await repo.resolveClaims(
         pubkey: _pubkey,
         freshTags: [
-          ['i', 'GitHub:Octocat', 'a'],
+          ['i', 'github:Octocat', 'a'],
         ],
         cached: null,
       );
       expect(result, hasLength(1));
-      expect(result.single.platform, equals('GitHub'));
+      expect(result.single.platform, equals('github'));
       expect(result.single.identity, equals('Octocat'));
     });
 
@@ -395,13 +487,13 @@ void main() {
         final cached = await repo.cachedVerifiedClaims(
           pubkey: _pubkey,
           tags: [
-            ['i', 'GitHub:Octocat', 'a'],
+            ['i', 'github:Octocat', 'a'],
             ['i', 'twitter:unverified', 'b'],
           ],
         );
         expect(cached, isNotNull);
         expect(cached!.claims, hasLength(1));
-        expect(cached.claims.single.platform, equals('GitHub'));
+        expect(cached.claims.single.platform, equals('github'));
         expect(cached.isFresh, isTrue);
       },
     );
@@ -876,7 +968,7 @@ void main() {
         final result = await repo.resolveClaims(
           pubkey: _pubkey,
           freshTags: [
-            ['i', 'GitHub:Octocat', 'new-proof'],
+            ['i', 'github:Octocat', 'new-proof'],
           ],
           cached: null,
           renderedClaims: const [renderedClaim],

--- a/mobile/packages/verifier_client/lib/src/models/identity_claim.dart
+++ b/mobile/packages/verifier_client/lib/src/models/identity_claim.dart
@@ -23,9 +23,12 @@ class IdentityClaim extends Equatable {
   /// 64-character lowercase hex pubkey.
   final String pubkey;
 
-  /// Platform identifier — one of `github | twitter | mastodon |
-  /// telegram | bluesky | discord | youtube | tiktok` at the time of
-  /// writing. Forward-compatible: the verifier may add platforms.
+  /// Platform identifier accepted by the verifier.
+  ///
+  /// Mobile filters against [supportedPlatforms] before batching claims so
+  /// unsupported NIP-39 tags cannot 400 the whole verifier request. Keep this
+  /// in sync with
+  /// `divine-identify-verification-service/src/utils/validation.ts:3`.
   final String platform;
 
   /// Platform-specific user identifier (handle, account ID).
@@ -34,6 +37,71 @@ class IdentityClaim extends Equatable {
   /// Proof material (URL, post ID, OAuth token reference, …) — opaque
   /// to mobile.
   final String proof;
+
+  /// Platforms accepted by the verifier service.
+  ///
+  /// Mirrors
+  /// `divine-identify-verification-service/src/utils/validation.ts:3`.
+  static const supportedPlatforms = <String>{
+    'github',
+    'twitter',
+    'mastodon',
+    'telegram',
+    'bluesky',
+    'discord',
+    'youtube',
+    'tiktok',
+  };
+
+  static final RegExp _hexPubkeyPattern = RegExp(r'^[0-9a-fA-F]+$');
+  static final RegExp _invalidServerTextPattern = RegExp(
+    r'''[<>"'{}|\\^`;]''',
+  );
+  static final RegExp _controlCharacterPattern = RegExp(r'[\x00-\x1f\x7f]');
+
+  /// Maximum verifier-accepted identity/proof length.
+  ///
+  /// Mirrors
+  /// `divine-identify-verification-service/src/utils/validation.ts:16,24`.
+  static const int maxServerTextLength = 500;
+
+  /// Whether [value] is a verifier-accepted 64-character hex pubkey.
+  ///
+  /// Mirrors
+  /// `divine-identify-verification-service/src/utils/validation.ts:7`.
+  static bool isServerValidPubkey(String value) =>
+      value.length == 64 && _hexPubkeyPattern.hasMatch(value);
+
+  /// Whether [value] is a verifier-accepted platform.
+  ///
+  /// Mirrors
+  /// `divine-identify-verification-service/src/utils/validation.ts:5`.
+  static bool isServerValidPlatform(String value) =>
+      supportedPlatforms.contains(value);
+
+  /// Whether [value] is a verifier-accepted identity string.
+  ///
+  /// Mirrors
+  /// `divine-identify-verification-service/src/utils/validation.ts:24-28`.
+  static bool isServerValidIdentity(String value) => _isServerValidText(value);
+
+  /// Whether [value] is a verifier-accepted proof string.
+  ///
+  /// Mirrors
+  /// `divine-identify-verification-service/src/utils/validation.ts:16-21`.
+  static bool isServerValidProof(String value) => _isServerValidText(value);
+
+  /// Whether this claim matches the verifier's request validation contract.
+  ///
+  /// Mirrors
+  /// `divine-identify-verification-service/src/utils/validation.ts:62-78`.
+  bool get isServerValid {
+    if (!isServerValidPubkey(pubkey)) return false;
+    if (!isServerValidPlatform(platform)) return false;
+    if (!isServerValidIdentity(identity)) return false;
+    if (platform == 'bluesky' && proof.trim().isEmpty) return true;
+    return isServerValidProof(proof);
+  }
 
   /// Serializes this claim to the verifier API JSON shape.
   Map<String, dynamic> toJson() => <String, dynamic>{
@@ -45,4 +113,11 @@ class IdentityClaim extends Equatable {
 
   @override
   List<Object?> get props => [pubkey, platform, identity, proof];
+
+  static bool _isServerValidText(String value) {
+    if (value.isEmpty || value.length > maxServerTextLength) return false;
+    if (_invalidServerTextPattern.hasMatch(value)) return false;
+    if (_controlCharacterPattern.hasMatch(value)) return false;
+    return true;
+  }
 }

--- a/mobile/packages/verifier_client/test/src/models/identity_claim_test.dart
+++ b/mobile/packages/verifier_client/test/src/models/identity_claim_test.dart
@@ -54,5 +54,82 @@ void main() {
       );
       expect(a, isNot(equals(b)));
     });
+
+    test('accepts claims matching the verifier contract', () {
+      const claim = IdentityClaim(
+        pubkey: _hex64,
+        platform: 'github',
+        identity: 'octocat',
+        proof: 'abc123',
+      );
+      expect(claim.isServerValid, isTrue);
+    });
+
+    test('accepts bluesky claims with a blank proof', () {
+      const claim = IdentityClaim(
+        pubkey: _hex64,
+        platform: 'bluesky',
+        identity: 'octocat.bsky.social',
+        proof: '',
+      );
+      expect(claim.isServerValid, isTrue);
+    });
+
+    test('rejects invalid pubkeys', () {
+      for (final pubkey in ['short', '${_hex64}a', 'g${_hex64.substring(1)}']) {
+        final claim = IdentityClaim(
+          pubkey: pubkey,
+          platform: 'github',
+          identity: 'octocat',
+          proof: 'abc123',
+        );
+        expect(claim.isServerValid, isFalse);
+      }
+    });
+
+    test('rejects unsupported platforms', () {
+      const claim = IdentityClaim(
+        pubkey: _hex64,
+        platform: 'reddit',
+        identity: 'octocat',
+        proof: 'abc123',
+      );
+      expect(claim.isServerValid, isFalse);
+    });
+
+    test('rejects identities the verifier would reject', () {
+      for (final identity in [
+        'bad"identity',
+        "bad'identity",
+        'bad<identity',
+        'bad${String.fromCharCode(1)}identity',
+        List.filled(IdentityClaim.maxServerTextLength + 1, 'a').join(),
+      ]) {
+        final claim = IdentityClaim(
+          pubkey: _hex64,
+          platform: 'github',
+          identity: identity,
+          proof: 'abc123',
+        );
+        expect(claim.isServerValid, isFalse);
+      }
+    });
+
+    test('rejects non-bluesky proofs the verifier would reject', () {
+      for (final proof in [
+        '',
+        'bad>proof',
+        'bad${String.fromCharCode(1)}proof',
+        List.filled(IdentityClaim.maxServerTextLength + 1, 'a').join(),
+      ]) {
+        final claim = IdentityClaim(
+          pubkey: _hex64,
+          platform: 'github',
+          identity: 'octocat',
+          proof: proof,
+        );
+        expect(claim.isServerValid, isFalse);
+      }
+    });
   });
 }


### PR DESCRIPTION
## Summary

- mirror the verifier's claim validation contract on `IdentityClaim`
- filter NIP-39 claims before batching so malformed tags do not 400 the verifier
- apply the batch cap after filtering and cover the malformed-claim regression

Closes #6553.

## Follow-ups

- Verifier service should soft-fail invalid claims within a batch: divinevideo/divine-identify-verification-service#35
- Verifier UI should stop writing/carrying malformed NIP-39 tags: divinevideo/divine-web#534

## Verification

- `dart test` from `mobile/packages/verifier_client`
- `dart analyze` from `mobile/packages/verifier_client`
- `flutter test test/src/identity_claims_repository_test.dart` from `mobile/packages/profile_repository`
- `flutter analyze` from `mobile/packages/profile_repository`
- `flutter analyze lib test integration_test` from `mobile`
- pre-push hook analyzer and changed-file tests
