### PR TITLE
fix(bloc): guard add after close

### DIFF
--- a/mobile/lib/blocs/background_publish/background_publish_bloc.dart
+++ b/mobile/lib/blocs/background_publish/background_publish_bloc.dart
@@ -228,6 +228,7 @@ class BackgroundPublishBloc
       );
     }
     for (final upload in inFlight) {
+      if (isClosed) return;
       add(BackgroundPublishVanished(draftId: upload.draft.id));
     }
   }
@@ -292,6 +293,7 @@ class BackgroundPublishBloc
 
     final videoPublishService = await _videoPublishServiceFactory(
       onProgress: ({required String draftId, required double progress}) {
+        if (isClosed) return;
         add(
           BackgroundPublishProgressChanged(
             draftId: draftId,
@@ -300,6 +302,7 @@ class BackgroundPublishBloc
         );
       },
     );
+    if (isClosed) return;
 
     final newPublishProcess = videoPublishService.publishVideo(
       draft: uploadToRetry.draft,

--- a/mobile/lib/blocs/my_following/my_following_bloc.dart
+++ b/mobile/lib/blocs/my_following/my_following_bloc.dart
@@ -147,6 +147,7 @@ class MyFollowingBloc extends Bloc<MyFollowingEvent, MyFollowingState> {
 
     try {
       await _followRepository.toggleFollow(event.pubkey);
+      if (isClosed || emit.isDone) return;
       if (!state.hasLocalFollowEdit) {
         emit(state.copyWith(hasLocalFollowEdit: true));
       }
@@ -156,6 +157,7 @@ class MyFollowingBloc extends Bloc<MyFollowingEvent, MyFollowingState> {
         name: 'MyFollowingBloc',
         category: LogCategory.system,
       );
+      if (isClosed || emit.isDone) return;
       emit(state.copyWith(status: MyFollowingStatus.toggleFailure));
     }
   }

--- a/mobile/lib/observability/divine_bloc_observer.dart
+++ b/mobile/lib/observability/divine_bloc_observer.dart
@@ -26,10 +26,12 @@ const String kBlocDiagnosticNotObserved = '<not observed>';
 ///
 /// All three are written to the unified log (so the in-memory bug-report
 /// capture flow stays complete). Forwarding to Crashlytics is **gated** on
-/// the error implementing [ReportableError] — without that gate, expected
-/// domain errors (network timeouts, "no public key yet" during cold start,
-/// 4xx responses, validation failures) flood the dashboard and drown the
-/// real bugs. See the decision matrix in `.claude/rules/error_handling.md`.
+/// the error implementing [ReportableError] or being a bare programming
+/// invariant error ([StateError], [TypeError], or [RangeError]) — without that
+/// gate, expected domain errors (network timeouts, "no public key yet" during
+/// cold start, 4xx responses, validation failures) flood the dashboard and
+/// drown the real bugs. See the decision matrix in
+/// `.claude/rules/error_handling.md`.
 ///
 /// On a forwarded error the observer also attaches the bloc's most recent
 /// event, state, and transition time as Crashlytics custom keys
@@ -86,7 +88,8 @@ class DivineBlocObserver extends BlocObserver {
       error: error,
       stackTrace: stackTrace,
     );
-    if (error is! ReportableError) return;
+    final reportableError = _asReportable(error);
+    if (reportableError == null) return;
     // Dispatch the diagnostic keys before recordError so they attach to the
     // report it emits. Both are fire-and-forget, but invoked synchronously and
     // in order, so the platform-channel messages stay ordered without blocking
@@ -95,7 +98,17 @@ class DivineBlocObserver extends BlocObserver {
     // crash_reporting_service.dart).
     _attachDiagnosticKeys(_diagnostics[bloc]);
     final reason = sanitizeForCrashReport('Bloc.addError $runtimeType');
-    unawaited(_crashReporting.recordError(error, stackTrace, reason: reason));
+    unawaited(
+      _crashReporting.recordError(reportableError, stackTrace, reason: reason),
+    );
+  }
+
+  ReportableError? _asReportable(Object error) {
+    if (error is ReportableError) return error;
+    if (error is StateError || error is TypeError || error is RangeError) {
+      return Reportable(error, context: 'DivineBlocObserver.onError');
+    }
+    return null;
   }
 
   void _attachDiagnosticKeys(_BlocDiagnostics? diagnostics) {

--- a/mobile/lib/screens/profile_setup/widgets/verifier_flow.dart
+++ b/mobile/lib/screens/profile_setup/widgets/verifier_flow.dart
@@ -51,8 +51,10 @@ Future<bool> launchVerifierFlow({
     );
   }
 
+  if (editorBloc.isClosed) return launched;
   editorBloc.add(const VerifierLaunchHandled());
   if (launched && isWeb) {
+    if (myProfileBloc.isClosed) return launched;
     myProfileBloc.add(const MyProfileFetchRequested());
   }
   return launched;

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_actions.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_actions.dart
@@ -172,7 +172,7 @@ class _StabilizationButton extends StatelessWidget {
       ],
     );
 
-    if (selected == null) return;
+    if (selected == null || !context.mounted || bloc.isClosed) return;
     bloc.add(
       VideoRecorderStabilizationModeSet(
         DivineVideoStabilizationMode.fromNativeString(selected),

--- a/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
@@ -77,6 +77,7 @@ Future<void> openVideoEditorFromRecorder(
   // the navigation can't start (or leave) a recording on the camera we are
   // about to release. The camera is still live here, so the lock can reset any
   // in-flight recording cleanly — without racing the deferred dispose below.
+  if (bloc.isClosed) return;
   bloc.add(const VideoRecorderRecordingLockedForNavigation());
 
   final navigation = recorderMode.hasVideoEditor
@@ -84,6 +85,7 @@ Future<void> openVideoEditorFromRecorder(
       : context.push(VideoMetadataScreen.path);
 
   await awaitPushTransition(context);
+  if (bloc.isClosed) return;
   await _pauseCameraForNavigation(bloc);
   if (recorderMode.hasVideoEditor) {
     await ref.read(audioSessionServiceProvider).configureForMixedPlayback();
@@ -92,7 +94,7 @@ Future<void> openVideoEditorFromRecorder(
   }
 
   await navigation;
-  if (!context.mounted) return;
+  if (!context.mounted || bloc.isClosed) return;
   bloc.add(const VideoRecorderInitializeRequested());
 }
 
@@ -115,6 +117,7 @@ Future<void> openRecorderLibrary(BuildContext context, WidgetRef ref) async {
   // the navigation can't start (or leave) a recording on the camera we are
   // about to release. The camera is still live here, so the lock can reset any
   // in-flight recording cleanly — without racing the deferred dispose below.
+  if (bloc.isClosed) return;
   bloc.add(const VideoRecorderRecordingLockedForNavigation());
 
   final navigation = context.pushNamed(
@@ -123,11 +126,12 @@ Future<void> openRecorderLibrary(BuildContext context, WidgetRef ref) async {
   );
 
   await awaitPushTransition(context);
+  if (bloc.isClosed) return;
   await _pauseCameraForNavigation(bloc);
   await ref.read(audioSessionServiceProvider).resetAudioSession();
 
   await navigation;
-  if (!context.mounted) return;
+  if (!context.mounted || bloc.isClosed) return;
   bloc.add(const VideoRecorderInitializeRequested());
 }
 

--- a/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
+++ b/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
@@ -823,10 +823,7 @@ void main() {
           ],
         ),
         act: (bloc) async {
-          await expectLater(
-            bloc.parkInFlight(),
-            throwsA(isA<Exception>()),
-          );
+          await expectLater(bloc.parkInFlight(), throwsA(isA<Exception>()));
         },
         errors: () => [isA<Exception>()],
       );
@@ -852,10 +849,7 @@ void main() {
           ],
         ),
         act: (bloc) async {
-          await expectLater(
-            bloc.parkInFlight(),
-            throwsA(isA<StateError>()),
-          );
+          await expectLater(bloc.parkInFlight(), throwsA(isA<StateError>()));
         },
         errors: () => [isA<StateError>()],
       );
@@ -1120,6 +1114,71 @@ void main() {
           verify(() => mockPublishService.publishVideo(draft: draft)).called(1);
         },
       );
+
+      test(
+        'does not add retry publish event after close while service loads',
+        () async {
+          final serviceCompleter = Completer<_MockVideoPublishService>();
+          final bloc = BackgroundPublishBloc(
+            videoPublishServiceFactory:
+                ({required OnProgressChanged onProgress}) {
+                  return serviceCompleter.future;
+                },
+            draftStorageService: mockDraftStorageService,
+          );
+          bloc.add(
+            BackgroundPublishFailed(
+              draft: draft,
+              error: const PublishError(PublishErrorKind.generic),
+            ),
+          );
+          await Future<void>.delayed(Duration.zero);
+
+          bloc.add(BackgroundPublishRetryRequested(draftId: draftId));
+          await Future<void>.delayed(Duration.zero);
+
+          final closeFuture = bloc.close();
+          serviceCompleter.complete(mockPublishService);
+
+          await expectLater(closeFuture, completes);
+          verifyNever(() => mockPublishService.publishVideo(draft: draft));
+        },
+      );
+
+      test('ignores progress callbacks after close', () async {
+        late OnProgressChanged capturedProgress;
+        final publishCompleter = Completer<PublishResult>();
+        final bloc = BackgroundPublishBloc(
+          videoPublishServiceFactory:
+              ({required OnProgressChanged onProgress}) {
+                capturedProgress = onProgress;
+                return Future.value(mockPublishService);
+              },
+          draftStorageService: mockDraftStorageService,
+        );
+
+        bloc.add(
+          BackgroundPublishFailed(
+            draft: draft,
+            error: const PublishError(PublishErrorKind.generic),
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+        when(
+          () => mockPublishService.publishVideo(draft: draft),
+        ).thenAnswer((_) => publishCompleter.future);
+
+        bloc.add(BackgroundPublishRetryRequested(draftId: draftId));
+        await Future<void>.delayed(Duration.zero);
+        final closeFuture = bloc.close();
+
+        expect(
+          () => capturedProgress(draftId: draftId, progress: 0.5),
+          returnsNormally,
+        );
+        publishCompleter.complete(const PublishSuccess());
+        await expectLater(closeFuture, completes);
+      });
     });
   });
 }

--- a/mobile/test/blocs/my_following/my_following_bloc_test.dart
+++ b/mobile/test/blocs/my_following/my_following_bloc_test.dart
@@ -401,6 +401,45 @@ void main() {
         },
       );
 
+      test(
+        'does not emit after close when a successful toggle completes',
+        () async {
+          final pubkey = validPubkey('user');
+          final toggleCompleter = Completer<void>();
+          when(
+            () => mockFollowRepository.toggleFollow(pubkey),
+          ).thenAnswer((_) => toggleCompleter.future);
+
+          final bloc = createBloc();
+          bloc.add(MyFollowingToggleRequested(pubkey));
+          await Future<void>.delayed(Duration.zero);
+
+          final closeFuture = bloc.close();
+          toggleCompleter.complete();
+
+          await expectLater(closeFuture, completes);
+          expect(bloc.state.hasLocalFollowEdit, isFalse);
+        },
+      );
+
+      test('does not emit after close when a toggle fails', () async {
+        final pubkey = validPubkey('user');
+        final toggleCompleter = Completer<void>();
+        when(
+          () => mockFollowRepository.toggleFollow(pubkey),
+        ).thenAnswer((_) => toggleCompleter.future);
+
+        final bloc = createBloc();
+        bloc.add(MyFollowingToggleRequested(pubkey));
+        await Future<void>.delayed(Duration.zero);
+
+        final closeFuture = bloc.close();
+        toggleCompleter.completeError(Exception('Network error'));
+
+        await expectLater(closeFuture, completes);
+        expect(bloc.state.status, MyFollowingStatus.initial);
+      });
+
       blocTest<MyFollowingBloc, MyFollowingState>(
         'uses droppable transformer — second rapid toggle is dropped',
         setUp: () {

--- a/mobile/test/observability/divine_bloc_observer_test.dart
+++ b/mobile/test/observability/divine_bloc_observer_test.dart
@@ -87,7 +87,7 @@ void main() {
       ).called(1);
     });
 
-    test('does not forward non-Reportable errors to Crashlytics', () {
+    test('does not forward non-Reportable exceptions to Crashlytics', () {
       final cubit = _CountCubit();
       addTearDown(cubit.close);
 
@@ -101,6 +101,36 @@ void main() {
         ),
       );
     });
+
+    test(
+      'forwards bare invariant errors as Reportable errors to Crashlytics',
+      () async {
+        final cubit = _CountCubit();
+        addTearDown(cubit.close);
+
+        final invariantErrors = <Object>[
+          StateError('closed'),
+          TypeError(),
+          RangeError.index(2, const [1]),
+        ];
+
+        for (final error in invariantErrors) {
+          final stack = StackTrace.current;
+          observer.onError(cubit, error, stack);
+          await Future<void>.delayed(Duration.zero);
+
+          final captured = verify(
+            () => mockCrash.recordError(
+              captureAny<dynamic>(),
+              stack,
+              reason: 'Bloc.addError _CountCubit',
+            ),
+          ).captured;
+          expect(captured.single, isA<ReportableError>());
+          expect((captured.single as Reportable<Object>).unwrap(), same(error));
+        }
+      },
+    );
 
     test('includes the error string in the visible log message', () async {
       final cubit = _CountCubit();

--- a/mobile/test/screens/profile_setup_screen_test.dart
+++ b/mobile/test/screens/profile_setup_screen_test.dart
@@ -663,9 +663,11 @@ void main() {
 
       mockEditorBloc = _MockProfileEditorBloc();
       when(() => mockEditorBloc.state).thenReturn(const ProfileEditorState());
+      when(() => mockEditorBloc.isClosed).thenReturn(false);
 
       mockMyProfileBloc = _MockMyProfileBloc();
       when(() => mockMyProfileBloc.state).thenReturn(const MyProfileInitial());
+      when(() => mockMyProfileBloc.isClosed).thenReturn(false);
     });
 
     /// Pumps the screen with mocked blocs. The bloc state is owned by the
@@ -1716,6 +1718,8 @@ void main() {
       UrlLauncherPlatform.instance = launcher;
       editorBloc = _MockProfileEditorBloc();
       myProfileBloc = _MockMyProfileBloc();
+      when(() => editorBloc.isClosed).thenReturn(false);
+      when(() => myProfileBloc.isClosed).thenReturn(false);
     });
 
     tearDown(() {
@@ -1823,5 +1827,21 @@ void main() {
         );
       },
     );
+
+    test('does not add events after verifier blocs close', () async {
+      when(() => editorBloc.isClosed).thenReturn(true);
+      when(() => myProfileBloc.isClosed).thenReturn(true);
+
+      final launched = await launchVerifierFlow(
+        editorBloc: editorBloc,
+        myProfileBloc: myProfileBloc,
+        isWeb: true,
+        pushVerifierRoute: (_, {extra}) async {},
+      );
+
+      expect(launched, isTrue);
+      verifyNever(() => editorBloc.add(const VerifierLaunchHandled()));
+      verifyNever(() => myProfileBloc.add(const MyProfileFetchRequested()));
+    });
   });
 }

--- a/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_actions_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_actions_test.dart
@@ -32,6 +32,7 @@ void main() {
 
     setUp(() {
       recorderBloc = _MockVideoRecorderBloc();
+      when(() => recorderBloc.isClosed).thenReturn(false);
     });
 
     Widget buildWidget({


### PR DESCRIPTION
## Summary
- Forward bare invariant Bloc errors (StateError, TypeError, RangeError) through Crashlytics with Bloc diagnostic keys so add-after-close reports identify the Bloc type and last event/state.
- Guard post-await Bloc.add/emit paths in background publish, profile verifier, recorder navigation/stabilization, and MyFollowing toggle lifecycle edges.
- Add regression coverage for closed Bloc paths and observer forwarding.

Closes #6120

## Verification
- flutter analyze
- flutter test test/observability/divine_bloc_observer_test.dart test/blocs/my_following/my_following_bloc_test.dart test/blocs/background_publish_bloc/background_publish_bloc_test.dart test/screens/profile_setup_screen_test.dart test/widgets/video_recorder/modes/capture/video_recorder_capture_actions_test.dart test/widgets/video_recorder/video_recorder_navigation_test.dart
- pre-push hook: analyzer + changed-file tests