### PR TITLE
fix(support): apply square-only filter in video service

### DIFF
--- a/mobile/lib/providers/moderation_providers.dart
+++ b/mobile/lib/providers/moderation_providers.dart
@@ -126,8 +126,8 @@ ContentFilterService contentFilterService(Ref ref) {
   return service;
 }
 
-/// Tracks content filter preference changes. Feed providers watch this
-/// to rebuild when the user changes a Show/Warn/Hide setting.
+/// Tracks feed-filter preference changes. Feed providers watch this to rebuild
+/// when the user changes a Show/Warn/Hide or video-shape setting.
 final contentFilterVersionProvider =
     NotifierProvider<ContentFilterVersion, int>(ContentFilterVersion.new);
 

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -149,6 +149,9 @@ VideoEventService videoEventService(Ref ref) {
   final likesRepository = ref.watch(likesRepositoryProvider);
   final moderationLabelService = ref.watch(moderationLabelServiceProvider);
   final divineHostFilterService = ref.read(divineHostFilterServiceProvider);
+  final feedAspectRatioPreference = ref.watch(
+    feedAspectRatioPreferenceServiceProvider,
+  );
   final prefs = ref.watch(sharedPreferencesProvider);
 
   final service = VideoEventService(
@@ -190,6 +193,7 @@ VideoEventService videoEventService(Ref ref) {
   service.setContentFilterService(ref.watch(contentFilterServiceProvider));
   service.setModerationLabelService(moderationLabelService);
   service.setDivineHostFilterService(divineHostFilterService);
+  service.setFeedAspectRatioPreferenceService(feedAspectRatioPreference);
 
   // Attach the scoped broken-video tracker so videos confirmed unavailable stay
   // filtered out of every list surface across restarts. `fireImmediately`

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -269,7 +269,7 @@ final class VideoEventServiceProvider
   }
 }
 
-String _$videoEventServiceHash() => r'a7c6b23e1f8d4f9fd8828e8b4adab600999eccd5';
+String _$videoEventServiceHash() => r'058ce434fa5549b725a62b3199decdb496e18e53';
 
 /// Video event publisher for publishing video events to Nostr relays
 

--- a/mobile/lib/screens/explore/widgets/explore_feed_content.dart
+++ b/mobile/lib/screens/explore/widgets/explore_feed_content.dart
@@ -30,7 +30,11 @@ class ExploreFeedContent extends ConsumerStatefulWidget {
 class _ExploreFeedContentState extends ConsumerState<ExploreFeedContent> {
   @override
   Widget build(BuildContext context) {
+    // Both counters, because filterVideoList below applies the Divine-host,
+    // content-label, and video-shape preferences, and exploreTabVideosProvider
+    // is a plain StateProvider that a toggle does not invalidate.
     ref.watch(divineHostFilterVersionProvider);
+    ref.watch(contentFilterVersionProvider);
     final videoEventService = ref.read(videoEventServiceProvider);
     final videos = videoEventService.filterVideoList(
       ref.watch(exploreTabVideosProvider) ?? const <VideoEvent>[],

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -4953,7 +4953,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
     if (shouldHideVideo(videoEvent)) {
       Log.verbose(
-        'Filtering non-Divine-hosted video ${videoEvent.id} from $subscriptionType',
+        'Filtering hidden video ${videoEvent.id} from $subscriptionType',
         name: 'VideoEventService',
         category: LogCategory.video,
       );

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -41,6 +41,7 @@ import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/divine_host_filter_service.dart';
 import 'package:openvine/services/effective_content_labels.dart';
 import 'package:openvine/services/event_router.dart';
+import 'package:openvine/services/feed_aspect_ratio_preference_service.dart';
 import 'package:openvine/services/moderation_label_service.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/repost_resolver.dart';
@@ -259,6 +260,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   ContentFilterService? _contentFilterService;
   ModerationLabelService? _moderationLabelService;
   DivineHostFilterService? _divineHostFilterService;
+  FeedAspectRatioPreferenceService? _feedAspectRatioPreferenceService;
   BrokenVideoTracker? _brokenVideoTracker;
   final SubscriptionManager _subscriptionManager;
 
@@ -486,6 +488,18 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     );
   }
 
+  /// Set the feed aspect-ratio preference service.
+  void setFeedAspectRatioPreferenceService(
+    FeedAspectRatioPreferenceService service,
+  ) {
+    _feedAspectRatioPreferenceService = service;
+    Log.debug(
+      'Feed aspect-ratio preference service attached to VideoEventService',
+      name: 'VideoEventService',
+      category: LogCategory.video,
+    );
+  }
+
   /// Set the broken-video tracker used to filter videos confirmed unavailable.
   /// Marked entries are persisted by the tracker, so this keeps unavailable
   /// videos out of every list surface (home, profile, hashtag, grids) across
@@ -505,7 +519,8 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   /// Returns true when this video should be hidden — either because its author
   /// is blocked/muted (the viewer blocked them, or they blocked the viewer via
   /// kind-30000 `d=block` / muted via kind-10000), or because the viewer's
-  /// Divine-hosted-only preference is on and the video is not Divine-hosted.
+  /// Divine-hosted-only preference is on and the video is not Divine-hosted, or
+  /// because the viewer's feed video-shape preference excludes this video.
   ///
   /// Detail/by-id surfaces (sound detail, video detail, curated lists,
   /// notifications) resolve videos directly and bypass the reception-time
@@ -515,7 +530,10 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     if (_blocklistRepository?.shouldFilterFromFeeds(video.pubkey) ?? false) {
       return true;
     }
-    return shouldFilterNonDivineVideos && !video.isFromDivineServer;
+    if (shouldFilterNonDivineVideos && !video.isFromDivineServer) {
+      return true;
+    }
+    return _feedAspectRatioPreferenceService?.shouldHideVideo(video) ?? false;
   }
 
   /// Returns true if adult content should be filtered from feeds

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -519,8 +519,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   /// Returns true when this video should be hidden — either because its author
   /// is blocked/muted (the viewer blocked them, or they blocked the viewer via
   /// kind-30000 `d=block` / muted via kind-10000), or because the viewer's
-  /// Divine-hosted-only preference is on and the video is not Divine-hosted, or
-  /// because the viewer's feed video-shape preference excludes this video.
+  /// Divine-hosted-only preference is on and the video is not Divine-hosted.
   ///
   /// Detail/by-id surfaces (sound detail, video detail, curated lists,
   /// notifications) resolve videos directly and bypass the reception-time
@@ -533,8 +532,11 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     if (shouldFilterNonDivineVideos && !video.isFromDivineServer) {
       return true;
     }
-    return _feedAspectRatioPreferenceService?.shouldHideVideo(video) ?? false;
+    return false;
   }
+
+  bool _shouldHideForFeedShapePreference(VideoEvent video) =>
+      _feedAspectRatioPreferenceService?.shouldHideVideo(video) ?? false;
 
   /// Returns true if adult content should be filtered from feeds
   bool get shouldFilterAdultContent =>
@@ -670,6 +672,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         .where(
           (video) =>
               !shouldHideVideo(video) &&
+              !_shouldHideForFeedShapePreference(video) &&
               !(tracker?.isVideoBroken(video.id) ?? false),
         )
         .toList();

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -252,7 +252,7 @@ class VideoStats {
               }
             }
           }
-          if ((tagName == 'dim' || tagName == 'size') && dimensions == null) {
+          if (tagName == 'dim' && dimensions == null) {
             dimensions = tagValue;
           }
           if (tagName == 'summary' && summaryFromTag == null) {
@@ -464,7 +464,7 @@ class VideoStats {
   /// Blurhash for placeholder thumbnail.
   final String? blurhash;
 
-  /// Video dimensions from REST or Nostr `dim`/`size` metadata.
+  /// Video dimensions from REST or Nostr `dim` metadata.
   final String? dimensions;
 
   /// Reaction/like count.

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -377,14 +377,14 @@ void main() {
         expect(stats.loops, equals(5000));
       });
 
-      test('extracts dimensions from size tag when dim tag is absent', () {
+      test('ignores size tag when dim tag is absent', () {
         final json = {
           'id': 'test-id',
           'pubkey': 'test-pubkey',
           'created_at': 1700000000,
           'kind': 34236,
           'tags': [
-            ['size', '480x480'],
+            ['size', '480000'],
           ],
           'thumbnail': 'https://example.com/thumb.jpg',
           'video_url': 'https://example.com/video.mp4',
@@ -396,7 +396,7 @@ void main() {
 
         final stats = VideoStats.fromJson(json);
 
-        expect(stats.dimensions, equals('480x480'));
+        expect(stats.dimensions, isNull);
       });
 
       test('parses dimensions from direct REST fields', () {

--- a/mobile/test/providers/video_event_service_aspect_ratio_wiring_test.dart
+++ b/mobile/test/providers/video_event_service_aspect_ratio_wiring_test.dart
@@ -1,0 +1,71 @@
+// ABOUTME: Regression test for the #6714 PR review — videoEventServiceProvider
+// ABOUTME: must attach the same FeedAspectRatioPreferenceService instance the
+// ABOUTME: settings toggle mutates, so a live flip re-filters list surfaces.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/providers/preferences_providers.dart';
+import 'package:openvine/providers/video_providers.dart';
+import 'package:openvine/services/feed_aspect_ratio_preference_service.dart';
+
+import '../helpers/test_helpers.dart';
+import '../helpers/test_provider_overrides.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('videoEventServiceProvider aspect-ratio wiring (#6714 review)', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      container = ProviderContainer(
+        overrides: getStandardTestOverrides().cast(),
+      );
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test(
+      'a preference flip made through feedAspectRatioPreferenceServiceProvider '
+      'is reflected by VideoEventService.filterVideoList',
+      () async {
+        final service = container.read(videoEventServiceProvider);
+        final preference = container.read(
+          feedAspectRatioPreferenceServiceProvider,
+        );
+
+        // media.divine.video so both survive the default
+        // Divine-hosted-only preference and only the shape filter decides.
+        final square = TestHelpers.createVideoEvent(
+          id: 'square1',
+          videoUrl: 'https://media.divine.video/square1hash',
+          dimensions: '640x640',
+        );
+        final portrait = TestHelpers.createVideoEvent(
+          id: 'portrait1',
+          videoUrl: 'https://media.divine.video/portrait1hash',
+          dimensions: '720x1280',
+        );
+
+        expect(
+          service.filterVideoList([square, portrait]).map((v) => v.id),
+          containsAll(<String>['square1', 'portrait1']),
+        );
+
+        await preference.setPreference(FeedAspectRatioPreference.squareOnly);
+
+        expect(
+          service.filterVideoList([square, portrait]).map((v) => v.id),
+          equals(['square1']),
+          reason:
+              'VideoEventService must filter against the exact preference '
+              'instance the settings toggle mutates. Dropping the '
+              'setFeedAspectRatioPreferenceService(...) call in '
+              'videoEventServiceProvider leaves this list unfiltered.',
+        );
+      },
+    );
+  });
+}

--- a/mobile/test/services/feed_aspect_ratio_preference_service_test.dart
+++ b/mobile/test/services/feed_aspect_ratio_preference_service_test.dart
@@ -15,7 +15,7 @@ void main() {
       prefs = await SharedPreferences.getInstance();
     });
 
-    VideoEvent video({required String dimensions}) {
+    VideoEvent video({String? dimensions}) {
       return VideoEvent(
         id: 'event-id',
         pubkey: 'pubkey',
@@ -57,7 +57,19 @@ void main() {
       final service = FeedAspectRatioPreferenceService(prefs);
       await service.setPreference(FeedAspectRatioPreference.squareOnly);
 
+      expect(service.shouldHideVideo(video()), isFalse);
       expect(service.shouldHideVideo(video(dimensions: '')), isFalse);
+    });
+
+    test('square-only keeps videos with malformed dimensions', () async {
+      final service = FeedAspectRatioPreferenceService(prefs);
+      await service.setPreference(FeedAspectRatioPreference.squareOnly);
+
+      // A bare integer is what a NIP-94 `size` (bytes) tag looks like if it
+      // ever reaches `dimensions`; `480x` is a truncated `dim`. Neither
+      // yields a height, and the filter must fail open rather than hide.
+      expect(service.shouldHideVideo(video(dimensions: '480000')), isFalse);
+      expect(service.shouldHideVideo(video(dimensions: '480x')), isFalse);
     });
   });
 }

--- a/mobile/test/services/video_event_service_aspect_ratio_filter_test.dart
+++ b/mobile/test/services/video_event_service_aspect_ratio_filter_test.dart
@@ -1,0 +1,104 @@
+// ABOUTME: Tests VideoEventService filtering for the feed video-shape preference.
+// ABOUTME: Verifies square-only filtering at the shared list-surface chokepoint.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/services/feed_aspect_ratio_preference_service.dart';
+import 'package:openvine/services/subscription_manager.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockSubscriptionManager extends Mock implements SubscriptionManager {}
+
+VideoEvent _video({required String id, String? dimensions}) {
+  return VideoEvent(
+    id: id,
+    pubkey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    createdAt: 1704067200,
+    content: '',
+    timestamp: DateTime.fromMillisecondsSinceEpoch(1704067200 * 1000),
+    title: 'Test Video',
+    videoUrl: 'https://example.com/$id.mp4',
+    dimensions: dimensions,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('VideoEventService aspect-ratio filtering', () {
+    late VideoEventService service;
+    late FeedAspectRatioPreferenceService aspectRatioPreference;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      aspectRatioPreference = FeedAspectRatioPreferenceService(prefs);
+      service = VideoEventService(
+        _MockNostrClient(),
+        subscriptionManager: _MockSubscriptionManager(),
+      );
+      service.setFeedAspectRatioPreferenceService(aspectRatioPreference);
+    });
+
+    tearDown(() {
+      service.dispose();
+    });
+
+    test(
+      'filterVideoList hides portrait videos when square-only is enabled',
+      () async {
+        await aspectRatioPreference.setPreference(
+          FeedAspectRatioPreference.squareOnly,
+        );
+
+        final filtered = service.filterVideoList([
+          _video(id: 'square', dimensions: '640x640'),
+          _video(id: 'portrait', dimensions: '720x1280'),
+        ]);
+
+        expect(filtered.map((video) => video.id), equals(['square']));
+      },
+    );
+
+    test(
+      'filterVideoList keeps square and portrait videos when preference is off',
+      () {
+        final filtered = service.filterVideoList([
+          _video(id: 'square', dimensions: '640x640'),
+          _video(id: 'portrait', dimensions: '720x1280'),
+        ]);
+
+        expect(
+          filtered.map((video) => video.id),
+          equals(['square', 'portrait']),
+        );
+      },
+    );
+
+    test(
+      'filterVideoList keeps videos with unknown or malformed dimensions',
+      () async {
+        await aspectRatioPreference.setPreference(
+          FeedAspectRatioPreference.squareOnly,
+        );
+
+        final filtered = service.filterVideoList([
+          _video(id: 'missing'),
+          _video(id: 'empty', dimensions: ''),
+          _video(id: 'malformed', dimensions: '480000'),
+          _video(id: 'partial', dimensions: '480x'),
+        ]);
+
+        expect(
+          filtered.map((video) => video.id),
+          equals(['missing', 'empty', 'malformed', 'partial']),
+        );
+      },
+    );
+  });
+}

--- a/mobile/test/services/video_event_service_aspect_ratio_filter_test.dart
+++ b/mobile/test/services/video_event_service_aspect_ratio_filter_test.dart
@@ -66,37 +66,29 @@ void main() {
     );
 
     test(
-      'filterVideoList keeps square and portrait videos when preference is off',
-      () {
-        final filtered = service.filterVideoList([
+      'filterVideoList re-filters an already-loaded list when the '
+      'preference flips',
+      () async {
+        final videos = [
           _video(id: 'square', dimensions: '640x640'),
           _video(id: 'portrait', dimensions: '720x1280'),
-        ]);
+        ];
 
         expect(
-          filtered.map((video) => video.id),
+          service.filterVideoList(videos).map((video) => video.id),
           equals(['square', 'portrait']),
         );
-      },
-    );
 
-    test(
-      'filterVideoList keeps videos with unknown or malformed dimensions',
-      () async {
         await aspectRatioPreference.setPreference(
           FeedAspectRatioPreference.squareOnly,
         );
 
-        final filtered = service.filterVideoList([
-          _video(id: 'missing'),
-          _video(id: 'empty', dimensions: ''),
-          _video(id: 'malformed', dimensions: '480000'),
-          _video(id: 'partial', dimensions: '480x'),
-        ]);
-
         expect(
-          filtered.map((video) => video.id),
-          equals(['missing', 'empty', 'malformed', 'partial']),
+          service.filterVideoList(videos).map((video) => video.id),
+          equals(['square']),
+          reason:
+              'The reported bug (#6511) is a live toggle: the service must '
+              'read the preference at filter time, not snapshot it at attach.',
         );
       },
     );

--- a/mobile/test/services/video_event_service_aspect_ratio_filter_test.dart
+++ b/mobile/test/services/video_event_service_aspect_ratio_filter_test.dart
@@ -46,8 +46,28 @@ void main() {
     });
 
     tearDown(() {
+      aspectRatioPreference.dispose();
       service.dispose();
     });
+
+    test(
+      'shouldHideVideo keeps portrait videos when square-only is enabled',
+      () async {
+        await aspectRatioPreference.setPreference(
+          FeedAspectRatioPreference.squareOnly,
+        );
+
+        expect(
+          service.shouldHideVideo(
+            _video(id: 'portrait', dimensions: '720x1280'),
+          ),
+          isFalse,
+          reason:
+              'The shape preference is a feed-list preference, not a '
+              'detail/by-id/search/reception hard-hide rule.',
+        );
+      },
+    );
 
     test(
       'filterVideoList hides portrait videos when square-only is enabled',
@@ -65,32 +85,29 @@ void main() {
       },
     );
 
-    test(
-      'filterVideoList re-filters an already-loaded list when the '
-      'preference flips',
-      () async {
-        final videos = [
-          _video(id: 'square', dimensions: '640x640'),
-          _video(id: 'portrait', dimensions: '720x1280'),
-        ];
+    test('filterVideoList re-filters an already-loaded list when the '
+        'preference flips', () async {
+      final videos = [
+        _video(id: 'square', dimensions: '640x640'),
+        _video(id: 'portrait', dimensions: '720x1280'),
+      ];
 
-        expect(
-          service.filterVideoList(videos).map((video) => video.id),
-          equals(['square', 'portrait']),
-        );
+      expect(
+        service.filterVideoList(videos).map((video) => video.id),
+        equals(['square', 'portrait']),
+      );
 
-        await aspectRatioPreference.setPreference(
-          FeedAspectRatioPreference.squareOnly,
-        );
+      await aspectRatioPreference.setPreference(
+        FeedAspectRatioPreference.squareOnly,
+      );
 
-        expect(
-          service.filterVideoList(videos).map((video) => video.id),
-          equals(['square']),
-          reason:
-              'The reported bug (#6511) is a live toggle: the service must '
-              'read the preference at filter time, not snapshot it at attach.',
-        );
-      },
-    );
+      expect(
+        service.filterVideoList(videos).map((video) => video.id),
+        equals(['square']),
+        reason:
+            'The reported bug (#6511) is a live toggle: the service must '
+            'read the preference at filter time, not snapshot it at attach.',
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary
- wires FeedAspectRatioPreferenceService into the legacy VideoEventService feed/list filtering path so square-only applies outside the VideosRepository path
- keeps square-only feed-scoped by leaving shouldHideVideo for safety/host gates only, so detail/by-id/search/reception paths do not treat portrait videos as missing
- re-filters Explore when content or shape filter preferences change
- stops treating NIP-94 size tags as video dimensions in VideoStats parsing

## Verification
- flutter analyze lib test
- flutter test test/services/video_event_service_aspect_ratio_filter_test.dart test/providers/video_event_service_aspect_ratio_wiring_test.dart test/services/feed_aspect_ratio_preference_service_test.dart test/providers/moderation_providers_test.dart test/providers/videos_repository_filter_reactivity_test.dart
- flutter test test/src/video_stats_test.dart (from mobile/packages/models)
- dart run build_runner build --delete-conflicting-outputs
- pre-push hook: merge-conflict check, analyzer, generated-file verification, changed-file tests

Refs #6511

Note: this intentionally does not close #6511 on merge. The reported home-feed symptom also requires the backend compact/list response dimensions projection in divinevideo/divine-funnelcake#787.