### PR TITLE
fix(classics): hide unknown archive import dates

### DIFF
--- a/mobile/docs/BADGE_GUIDE_FOR_DIVINE_WEB.md
+++ b/mobile/docs/BADGE_GUIDE_FOR_DIVINE_WEB.md
@@ -132,16 +132,16 @@ Do this:
 
 - require `platform: vine`
 
-There is also a narrower helper:
+There is also an original-date helper:
 
-- `video.isVintageRecoveredVine`
+- `video.hasUnknownOriginalDate`
 
 That means:
 
 - `isOriginalVine == true`
-- created/published time is before Vine shutdown
+- effective created/published time is at or after Vine shutdown
 
-Mobile uses `isVintageRecoveredVine` for the comments empty-state archive notice, not for the top-level badge choice.
+Mobile uses `isOriginalVine` for the comments empty-state archive notice. It uses `hasUnknownOriginalDate` only to avoid displaying an import timestamp as the original Vine date.
 
 ## Hosting Inputs
 
@@ -347,14 +347,13 @@ This is not part of the badge row, but it is easy to confuse with badge logic.
 
 In comments, mobile shows a `Classic Vine` archive notice when:
 
-- `video.isVintageRecoveredVine == true`
+- `video.isOriginalVine == true`
 
 That means:
 
 - `platform: vine`
-- plus pre-shutdown timestamp
 
-This is stricter than `isOriginalVine` and is specific to the comments empty state.
+This is specific to the comments empty state and independent of whether the original publish date is known.
 
 ## Short Version
 

--- a/mobile/docs/BADGE_GUIDE_FOR_DIVINE_WEB.md
+++ b/mobile/docs/BADGE_GUIDE_FOR_DIVINE_WEB.md
@@ -139,7 +139,8 @@ There is also an original-date helper:
 That means:
 
 - `isOriginalVine == true`
-- effective created/published time is at or after Vine shutdown
+- no usable `published_at` tag
+- and missing/zero `created_at`, or `created_at` at/after Vine shutdown
 
 Mobile uses `isOriginalVine` for the comments empty-state archive notice. It uses `hasUnknownOriginalDate` only to avoid displaying an import timestamp as the original Vine date.
 

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -588,7 +588,7 @@ class _CommentsScreenBody extends StatelessWidget {
           ],
           child: SizedBox(
             child: CommentsList(
-              showClassicVineNotice: videoEvent.isVintageRecoveredVine,
+              showClassicVineNotice: videoEvent.isOriginalVine,
               scrollController: sheetScrollController,
               showVideoReplies: showVideoReplies,
             ),

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart
@@ -198,7 +198,7 @@ class _OverviewSection extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (formattedDate != null && semanticDate != null)
+          if (formattedDate != null)
             Semantics(
               label: semanticDate,
               child: ExcludeSemantics(
@@ -219,13 +219,13 @@ class _OverviewSection extends StatelessWidget {
               spacing: 8,
               children: titleCluster,
             ),
-          // ⚠ LOAD-BEARING 12 px (NOT 16). The first chip row's 4 px
-          // invisible top padding stacks on this to produce the visible
-          // 16 px gap matching the date → title-cluster gap. Sibling
-          // of the bottom-padding tweak above; see `MetadataTagsSection`
-          // for the full dependency map.
+          // ⚠ LOAD-BEARING 12 px (NOT 16). When content precedes the chip row,
+          // the first chip row's 4 px invisible top padding stacks on this to
+          // produce a visible 16 px gap. Sibling of the bottom-padding tweak
+          // above; see `MetadataTagsSection` for the full dependency map.
           if (hasTags) ...[
-            const SizedBox(height: 12),
+            if (formattedDate != null || titleCluster.isNotEmpty)
+              const SizedBox(height: 12),
             MetadataTagsSection(video: video),
           ],
         ],

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart
@@ -144,13 +144,15 @@ class _OverviewSection extends StatelessWidget {
     final title = video.displayTitle;
     final description = video.displayContent;
 
-    final publishedAtSeconds =
-        int.tryParse(video.publishedAt ?? '') ?? video.createdAt;
-    final formattedDate = TimeFormatter.formatLongDate(
-      publishedAtSeconds,
-      locale: Localizations.localeOf(context).toString(),
-    );
-    final semanticDate = l10n.metadataPostedDateSemantics(formattedDate);
+    final formattedDate = video.hasUnknownOriginalDate
+        ? null
+        : TimeFormatter.formatLongDate(
+            int.tryParse(video.publishedAt ?? '') ?? video.createdAt,
+            locale: Localizations.localeOf(context).toString(),
+          );
+    final semanticDate = formattedDate == null
+        ? null
+        : l10n.metadataPostedDateSemantics(formattedDate);
 
     final hasTitle = title != null && title.isNotEmpty;
     final hasDescription = description.isNotEmpty;
@@ -196,25 +198,27 @@ class _OverviewSection extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Semantics(
-            label: semanticDate,
-            child: ExcludeSemantics(
-              child: Text(
-                formattedDate,
-                style: VineTheme.labelSmallFont(
-                  color: context.vineColors.onSurfaceVariant,
+          if (formattedDate != null && semanticDate != null)
+            Semantics(
+              label: semanticDate,
+              child: ExcludeSemantics(
+                child: Text(
+                  formattedDate,
+                  style: VineTheme.labelSmallFont(
+                    color: context.vineColors.onSurfaceVariant,
+                  ),
                 ),
               ),
             ),
-          ),
-          if (titleCluster.isNotEmpty) ...[
+          if (formattedDate != null && titleCluster.isNotEmpty) ...[
             const SizedBox(height: 16),
+          ],
+          if (titleCluster.isNotEmpty)
             Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               spacing: 8,
               children: titleCluster,
             ),
-          ],
           // ⚠ LOAD-BEARING 12 px (NOT 16). The first chip row's 4 px
           // invisible top padding stacks on this to produce the visible
           // 16 px gap matching the date → title-cluster gap. Sibling

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -1295,14 +1295,15 @@ class VideoEvent {
   /// All hashtags including the synthetic "classic" tag for original Vines.
   List<String> get allHashtags => [if (isOriginalVine) 'classic', ...hashtags];
 
-  /// True when this is a genuine Vine archive import but the best available
-  /// timestamp lands after Vine shut down, so the original publish date is not
-  /// known to the client.
+  /// True when this is a genuine Vine archive import without a usable original
+  /// publish date.
   bool get hasUnknownOriginalDate {
     if (!isOriginalVine) return false;
 
-    final effectiveCreatedAt = int.tryParse(publishedAt ?? '') ?? createdAt;
-    return effectiveCreatedAt >= _vineShutdownAtUtcSeconds;
+    final taggedPublishedAt = int.tryParse(rawTags['published_at'] ?? '');
+    if (taggedPublishedAt != null && taggedPublishedAt > 0) return false;
+
+    return createdAt <= 0 || createdAt >= _vineShutdownAtUtcSeconds;
   }
 
   /// Check if this is original content (not a repost)

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -1295,17 +1295,14 @@ class VideoEvent {
   /// All hashtags including the synthetic "classic" tag for original Vines.
   List<String> get allHashtags => [if (isOriginalVine) 'classic', ...hashtags];
 
-  /// Vintage recovered Vine: original Vine metrics plus a pre-shutdown date.
-  ///
-  /// New Divine videos can also carry loop stats, so loop count alone is not
-  /// sufficient when the UI needs to know whether this is genuinely old archive
-  /// content.
-  bool get isVintageRecoveredVine {
+  /// True when this is a genuine Vine archive import but the best available
+  /// timestamp lands after Vine shut down, so the original publish date is not
+  /// known to the client.
+  bool get hasUnknownOriginalDate {
     if (!isOriginalVine) return false;
 
     final effectiveCreatedAt = int.tryParse(publishedAt ?? '') ?? createdAt;
-    return effectiveCreatedAt > 0 &&
-        effectiveCreatedAt < _vineShutdownAtUtcSeconds;
+    return effectiveCreatedAt >= _vineShutdownAtUtcSeconds;
   }
 
   /// Check if this is original content (not a repost)

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -294,13 +294,6 @@ class VideoStats {
       }
     }
 
-    // Funnelcake currently mirrors event created_at into this field when the
-    // event lacks a published_at tag. Keep the fallback so server-side field
-    // backfills can flow through without a client change.
-    publishedAt ??= _parseNullableInt(
-      eventData['published_at'] ?? json['published_at'],
-    );
-
     // Fall back to summary tag if content is empty
     description ??= summaryFromTag;
 
@@ -689,13 +682,6 @@ int _parseInt(dynamic value) {
   if (value is double) return value.toInt();
   if (value is String) return int.tryParse(value) ?? 0;
   return 0;
-}
-
-int? _parseNullableInt(dynamic value) {
-  if (value is int) return value;
-  if (value is double) return value.toInt();
-  if (value is String) return int.tryParse(value);
-  return null;
 }
 
 final _hexPattern = RegExp(r'^[0-9a-fA-F]+$');

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -294,6 +294,13 @@ class VideoStats {
       }
     }
 
+    // Funnelcake currently mirrors event created_at into this field when the
+    // event lacks a published_at tag. Keep the fallback so server-side field
+    // backfills can flow through without a client change.
+    publishedAt ??= _parseNullableInt(
+      eventData['published_at'] ?? json['published_at'],
+    );
+
     // Fall back to summary tag if content is empty
     description ??= summaryFromTag;
 
@@ -682,6 +689,13 @@ int _parseInt(dynamic value) {
   if (value is double) return value.toInt();
   if (value is String) return int.tryParse(value) ?? 0;
   return 0;
+}
+
+int? _parseNullableInt(dynamic value) {
+  if (value is int) return value;
+  if (value is double) return value.toInt();
+  if (value is String) return int.tryParse(value);
+  return null;
 }
 
 final _hexPattern = RegExp(r'^[0-9a-fA-F]+$');

--- a/mobile/packages/models/test/src/video_event_display_test.dart
+++ b/mobile/packages/models/test/src/video_event_display_test.dart
@@ -108,7 +108,7 @@ void main() {
   });
 
   group('VideoEvent.hasUnknownOriginalDate', () {
-    test('is true for original Vines with a post-shutdown effective date', () {
+    test('is true for original Vines without a tag after shutdown', () {
       final video = build(
         createdAt: 1777489813,
         rawTags: const {'platform': 'vine'},
@@ -121,10 +121,38 @@ void main() {
       final video = build(
         createdAt: 1777489813,
         publishedAt: '1473050841',
+        rawTags: const {'platform': 'vine', 'published_at': '1473050841'},
+      );
+
+      expect(video.hasUnknownOriginalDate, isFalse);
+    });
+
+    test(
+      'is false for original Vines with a farewell-day published_at tag',
+      () {
+        final video = build(
+          createdAt: 1777489813,
+          publishedAt: '1484627482',
+          rawTags: const {'platform': 'vine', 'published_at': '1484627482'},
+        );
+
+        expect(video.hasUnknownOriginalDate, isFalse);
+      },
+    );
+
+    test('is false for no-tag original Vines before shutdown', () {
+      final video = build(
+        createdAt: 1473050841,
         rawTags: const {'platform': 'vine'},
       );
 
       expect(video.hasUnknownOriginalDate, isFalse);
+    });
+
+    test('is true for original Vines with a zero timestamp', () {
+      final video = build(createdAt: 0, rawTags: const {'platform': 'vine'});
+
+      expect(video.hasUnknownOriginalDate, isTrue);
     });
 
     test('is false for non-Vine videos with a post-shutdown date', () {

--- a/mobile/packages/models/test/src/video_event_display_test.dart
+++ b/mobile/packages/models/test/src/video_event_display_test.dart
@@ -9,14 +9,22 @@ void main() {
     String? title,
     String content = '',
     String? authorName,
+    int createdAt = 1735689600,
+    String? publishedAt,
+    Map<String, String> rawTags = const {},
   }) => VideoEvent(
     id: 'a' * 64,
     pubkey: 'b' * 64,
-    createdAt: 1735689600,
+    createdAt: createdAt,
     content: content,
-    timestamp: DateTime.utc(2026),
+    timestamp: DateTime.fromMillisecondsSinceEpoch(
+      createdAt * 1000,
+      isUtc: true,
+    ),
     title: title,
     authorName: authorName,
+    publishedAt: publishedAt,
+    rawTags: rawTags,
   );
 
   group('VideoEvent.displayTitle', () {
@@ -96,6 +104,33 @@ void main() {
         build(authorName: malformed).displayAuthorName,
         equals('\uFFFDa\uFFFD'),
       );
+    });
+  });
+
+  group('VideoEvent.hasUnknownOriginalDate', () {
+    test('is true for original Vines with a post-shutdown effective date', () {
+      final video = build(
+        createdAt: 1777489813,
+        rawTags: const {'platform': 'vine'},
+      );
+
+      expect(video.hasUnknownOriginalDate, isTrue);
+    });
+
+    test('is false for original Vines with a Vine-era published_at tag', () {
+      final video = build(
+        createdAt: 1777489813,
+        publishedAt: '1473050841',
+        rawTags: const {'platform': 'vine'},
+      );
+
+      expect(video.hasUnknownOriginalDate, isFalse);
+    });
+
+    test('is false for non-Vine videos with a post-shutdown date', () {
+      final video = build(createdAt: 1777489813);
+
+      expect(video.hasUnknownOriginalDate, isFalse);
     });
   });
 }

--- a/mobile/packages/models/test/src/video_event_to_json_test.dart
+++ b/mobile/packages/models/test/src/video_event_to_json_test.dart
@@ -196,7 +196,7 @@ const _excludedDerivedGetters = <String>{
   'isVerifiedWeb',
   'hasBasicProof',
   'isOriginalVine',
-  'isVintageRecoveredVine',
+  'hasUnknownOriginalDate',
   'isOriginalContent',
   'width',
   'height',
@@ -209,10 +209,7 @@ const _excludedDerivedGetters = <String>{
   'isWebM',
 };
 
-const _excludedInternalFields = <String>{
-  'nostrEventTags',
-  'warnLabels',
-};
+const _excludedInternalFields = <String>{'nostrEventTags', 'warnLabels'};
 
 /// Adding a new persisted field to [VideoEvent] requires THREE coordinated
 /// edits — default-deny is intentional, but the cost is on the contributor:

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -123,52 +123,7 @@ void main() {
         expect(stats.trendingScore, equals(0.75));
       });
 
-      test('parses top-level published_at when no tag is present', () {
-        final stats = VideoStats.fromJson(const {
-          'id': 'abc123',
-          'pubkey': 'pub456',
-          'created_at': 1777489813,
-          'published_at': 1473050841,
-          'kind': 34236,
-          'd_tag': 'video-1',
-          'title': 'My Video',
-          'thumbnail': 'https://example.com/thumb.jpg',
-          'video_url': 'https://example.com/video.mp4',
-          'reactions': 0,
-          'comments': 0,
-          'reposts': 0,
-          'engagement_score': 0,
-        });
-
-        expect(stats.publishedAt, equals(1473050841));
-      });
-
-      test('parses nested event published_at when no tag is present', () {
-        final stats = VideoStats.fromJson(const {
-          'event': {
-            'id': 'event-id',
-            'pubkey': 'event-pubkey',
-            'created_at': 1777489813,
-            'published_at': '1473050841',
-            'kind': 34236,
-            'tags': [
-              ['d', 'video-1'],
-              ['url', 'https://example.com/video.mp4'],
-              ['thumb', 'https://example.com/thumb.jpg'],
-            ],
-          },
-          'stats': {
-            'reactions': 0,
-            'comments': 0,
-            'reposts': 0,
-            'engagement_score': 0,
-          },
-        });
-
-        expect(stats.publishedAt, equals(1473050841));
-      });
-
-      test('published_at tag wins over REST field', () {
+      test('parses published_at from tags instead of REST fields', () {
         final stats = VideoStats.fromJson(const {
           'id': 'abc123',
           'pubkey': 'pub456',

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -123,6 +123,73 @@ void main() {
         expect(stats.trendingScore, equals(0.75));
       });
 
+      test('parses top-level published_at when no tag is present', () {
+        final stats = VideoStats.fromJson(const {
+          'id': 'abc123',
+          'pubkey': 'pub456',
+          'created_at': 1777489813,
+          'published_at': 1473050841,
+          'kind': 34236,
+          'd_tag': 'video-1',
+          'title': 'My Video',
+          'thumbnail': 'https://example.com/thumb.jpg',
+          'video_url': 'https://example.com/video.mp4',
+          'reactions': 0,
+          'comments': 0,
+          'reposts': 0,
+          'engagement_score': 0,
+        });
+
+        expect(stats.publishedAt, equals(1473050841));
+      });
+
+      test('parses nested event published_at when no tag is present', () {
+        final stats = VideoStats.fromJson(const {
+          'event': {
+            'id': 'event-id',
+            'pubkey': 'event-pubkey',
+            'created_at': 1777489813,
+            'published_at': '1473050841',
+            'kind': 34236,
+            'tags': [
+              ['d', 'video-1'],
+              ['url', 'https://example.com/video.mp4'],
+              ['thumb', 'https://example.com/thumb.jpg'],
+            ],
+          },
+          'stats': {
+            'reactions': 0,
+            'comments': 0,
+            'reposts': 0,
+            'engagement_score': 0,
+          },
+        });
+
+        expect(stats.publishedAt, equals(1473050841));
+      });
+
+      test('published_at tag wins over REST field', () {
+        final stats = VideoStats.fromJson(const {
+          'id': 'abc123',
+          'pubkey': 'pub456',
+          'created_at': 1777489813,
+          'published_at': 1777489813,
+          'kind': 34236,
+          'tags': [
+            ['d', 'video-1'],
+            ['published_at', '1473050841'],
+          ],
+          'thumbnail': 'https://example.com/thumb.jpg',
+          'video_url': 'https://example.com/video.mp4',
+          'reactions': 0,
+          'comments': 0,
+          'reposts': 0,
+          'engagement_score': 0,
+        });
+
+        expect(stats.publishedAt, equals(1473050841));
+      });
+
       test('normalizes invalid engagement counters to zero', () {
         final stats = VideoStats.fromJson(const {
           'id': 'test-id',

--- a/mobile/test/screens/comments/comments_screen_test.dart
+++ b/mobile/test/screens/comments/comments_screen_test.dart
@@ -905,6 +905,36 @@ void main() {
 
         expect(find.text('Classic Vine'), findsOneWidget);
       });
+
+      testWidgets(
+        'shows archive notice for original Vines with unknown original dates',
+        (tester) async {
+          const state = CommentsListState(
+            rootEventId: testVideoEventId,
+            rootAuthorPubkey: testVideoAuthorPubkey,
+            status: CommentsStatus.success,
+          );
+
+          final vineWithUnknownOriginalDate = VideoEvent(
+            id: '0e5e24db5148c7eda48b874dd44d5365071020e131a4f399f3ea6c7b996d3196',
+            pubkey: testVideoAuthorPubkey,
+            createdAt: 1777489813,
+            content: 'classic vine',
+            timestamp: DateTime.fromMillisecondsSinceEpoch(1777489813 * 1000),
+            rawTags: const {'platform': 'vine'},
+          );
+
+          await tester.pumpWidget(
+            buildTestWidget(
+              listState: state,
+              videoEvent: vineWithUnknownOriginalDate,
+            ),
+          );
+          await tester.pump();
+
+          expect(find.text('Classic Vine'), findsOneWidget);
+        },
+      );
     });
 
     group('error handling', () {
@@ -996,64 +1026,61 @@ void main() {
     });
 
     group('sheet controller disposal', () {
-      testWidgets(
-        'cancels an in-flight expand before disposing so no '
-        '"used after disposed" assert fires',
-        (tester) async {
-          final controller = DraggableScrollableController();
+      testWidgets('cancels an in-flight expand before disposing so no '
+          '"used after disposed" assert fires', (tester) async {
+        final controller = DraggableScrollableController();
 
-          await tester.pumpWidget(
-            MaterialApp(
-              home: Scaffold(
-                body: DraggableScrollableSheet(
-                  controller: controller,
-                  expand: false,
-                  initialChildSize: 0.7,
-                  minChildSize: 0.5,
-                  maxChildSize: 0.93,
-                  snap: true,
-                  snapSizes: const [0.7, 0.93],
-                  builder: (context, scrollController) => ListView(
-                    controller: scrollController,
-                    children: const [SizedBox(height: 2000)],
-                  ),
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: DraggableScrollableSheet(
+                controller: controller,
+                expand: false,
+                initialChildSize: 0.7,
+                minChildSize: 0.5,
+                maxChildSize: 0.93,
+                snap: true,
+                snapSizes: const [0.7, 0.93],
+                builder: (context, scrollController) => ListView(
+                  controller: scrollController,
+                  children: const [SizedBox(height: 2000)],
                 ),
               ),
             ),
-          );
-          await tester.pump();
-          expect(controller.isAttached, isTrue);
+          ),
+        );
+        await tester.pump();
+        expect(controller.isAttached, isTrue);
 
-          // Arm a focus-style expand and interrupt it mid-flight, exactly as a
-          // scrim / back dismiss does while _expandSheetForKeyboard is still
-          // animating. The sheet future disposes the controller at pop-start,
-          // before the sheet unmounts and detaches it.
-          controller.animateTo(
-            0.93,
-            duration: const Duration(milliseconds: 250),
-            curve: Curves.easeOut,
-          );
-          await tester.pump(); // start the animation
-          await tester.pump(const Duration(milliseconds: 80)); // mid-flight
-          expect(controller.size, greaterThan(0.7));
-          expect(controller.size, lessThan(0.93));
+        // Arm a focus-style expand and interrupt it mid-flight, exactly as a
+        // scrim / back dismiss does while _expandSheetForKeyboard is still
+        // animating. The sheet future disposes the controller at pop-start,
+        // before the sheet unmounts and detaches it.
+        controller.animateTo(
+          0.93,
+          duration: const Duration(milliseconds: 250),
+          curve: Curves.easeOut,
+        );
+        await tester.pump(); // start the animation
+        await tester.pump(const Duration(milliseconds: 80)); // mid-flight
+        expect(controller.size, greaterThan(0.7));
+        expect(controller.size, lessThan(0.93));
 
-          disposeCommentsSheetController(controller);
+        disposeCommentsSheetController(controller);
 
-          // Advance past where the leftover animation ticks would have fired.
-          // The plain-dispose path notifies the disposed controller on each
-          // tick and throws; the cancel-first path leaves nothing ticking.
-          for (var i = 0; i < 6; i++) {
-            await tester.pump(const Duration(milliseconds: 40));
-          }
-          expect(tester.takeException(), isNull);
+        // Advance past where the leftover animation ticks would have fired.
+        // The plain-dispose path notifies the disposed controller on each
+        // tick and throws; the cancel-first path leaves nothing ticking.
+        for (var i = 0; i < 6; i++) {
+          await tester.pump(const Duration(milliseconds: 40));
+        }
+        expect(tester.takeException(), isNull);
 
-          // Unmounting the still-mounted sheet detaches the disposed
-          // controller; that path must stay clean too.
-          await tester.pumpWidget(const SizedBox());
-          expect(tester.takeException(), isNull);
-        },
-      );
+        // Unmounting the still-mounted sheet detaches the disposed
+        // controller; that path must stay clean too.
+        await tester.pumpWidget(const SizedBox());
+        expect(tester.takeException(), isNull);
+      });
     });
   });
 }
@@ -1087,7 +1114,7 @@ class _CommentsScreenTestContent extends StatelessWidget {
           const Divider(color: Colors.white24, height: 1),
           Expanded(
             child: CommentsList(
-              showClassicVineNotice: videoEvent.isVintageRecoveredVine,
+              showClassicVineNotice: videoEvent.isOriginalVine,
               scrollController: sheetScrollController,
             ),
           ),

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -72,6 +72,8 @@ UserProfile _makeProfile(String pubkey, String name) => UserProfile(
 );
 
 VideoEvent _makeVideo({
+  String id =
+      'test_video_id_00000000000000000000000000000000000000000000000000',
   List<String> hashtags = const [],
   List<String> categories = const [],
   List<String> collaboratorPubkeys = const [],
@@ -86,7 +88,7 @@ VideoEvent _makeVideo({
   String? publishedAt,
   List<List<String>> nostrEventTags = const [],
 }) => VideoEvent(
-  id: 'test_video_id_00000000000000000000000000000000000000000000000000',
+  id: id,
   pubkey: _creatorPubkey,
   createdAt: createdAt,
   content: content,
@@ -334,6 +336,30 @@ void main() {
     );
 
     testWidgetsWithSurfaceSize(
+      'hides posted date when an original Vine has no original date',
+      (tester) async {
+        const importedAt = 1777489813;
+        final video = _makeVideo(
+          id: '0e5e24db5148c7eda48b874dd44d5365071020e131a4f399f3ea6c7b996d3196',
+          title: 'Classic vine',
+          content: 'From the archive',
+          createdAt: importedAt,
+          rawTags: {'platform': 'vine'},
+        );
+
+        await tester.pumpWidget(
+          buildSubject(child: MetadataExpandedSheet(video: video)),
+        );
+
+        final importedDate = DateFormat.yMMMMd('en').format(
+          DateTime.fromMillisecondsSinceEpoch(importedAt * 1000, isUtc: true),
+        );
+        expect(find.text(importedDate), findsNothing);
+        expect(find.text('Classic vine'), findsOneWidget);
+      },
+    );
+
+    testWidgetsWithSurfaceSize(
       'renders Vine-era date for a classic vine timestamp',
       (tester) async {
         // 2012-12-11 21:38 UTC — a classic Vine-era timestamp.
@@ -463,9 +489,7 @@ void main() {
 
         await tester.pumpWidget(
           buildSubject(
-            child: MetadataStatsRow(
-              video: video.copyWith(originalReposts: 10),
-            ),
+            child: MetadataStatsRow(video: video.copyWith(originalReposts: 10)),
           ),
         );
 
@@ -487,9 +511,7 @@ void main() {
       'falls back to live nostr counts in the breakdown while loading',
       (tester) async {
         when(() => mockInteractionsBloc.state).thenReturn(
-          const VideoInteractionsState(
-            status: VideoInteractionsStatus.loading,
-          ),
+          const VideoInteractionsState(status: VideoInteractionsStatus.loading),
         );
 
         final video = _makeVideo(

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -360,6 +360,29 @@ void main() {
     );
 
     testWidgetsWithSurfaceSize(
+      'renders farewell-day date when original Vine has a published_at tag',
+      (tester) async {
+        const publishedAt = 1484627482;
+        final video = _makeVideo(
+          title: 'Final vine',
+          content: 'Thanks for everything',
+          createdAt: 1777489813,
+          publishedAt: '$publishedAt',
+          rawTags: const {'platform': 'vine', 'published_at': '1484627482'},
+        );
+
+        await tester.pumpWidget(
+          buildSubject(child: MetadataExpandedSheet(video: video)),
+        );
+
+        final expectedDate = DateFormat.yMMMMd('en').format(
+          DateTime.fromMillisecondsSinceEpoch(publishedAt * 1000, isUtc: true),
+        );
+        expect(find.text(expectedDate), findsOneWidget);
+      },
+    );
+
+    testWidgetsWithSurfaceSize(
       'renders Vine-era date for a classic vine timestamp',
       (tester) async {
         // 2012-12-11 21:38 UTC — a classic Vine-era timestamp.


### PR DESCRIPTION
## Summary
- hide the metadata date when an original Vine archive import has no usable `published_at` tag and only carries an import/post-shutdown timestamp
- replace the removed vintage-date heuristic with a server-controlled original Vine notice predicate for comments
- keep `published_at` tag precedence explicit without adding a speculative REST field fallback
- update regression tests and related badge-guide docs

## Verification
- `dart format --output=none --set-exit-if-changed mobile/packages/models/lib/src/video_event.dart mobile/packages/models/test/src/video_event_display_test.dart mobile/packages/models/test/src/video_stats_test.dart mobile/packages/models/test/src/video_event_to_json_test.dart mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart mobile/test/screens/comments/comments_screen_test.dart mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart`
- `flutter test test/src/video_event_display_test.dart test/src/video_stats_test.dart test/src/video_event_to_json_test.dart` (from `mobile/packages/models`)
- `flutter test test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart test/screens/comments/comments_screen_test.dart` (from `mobile`)
- `flutter analyze lib test` (from `mobile`)
- pre-push hook analyzer and changed-file tests

Closes #6545