### PR TITLE
fix(relays): publish settings edits as kind 10002

### DIFF
--- a/mobile/lib/blocs/relay_settings/relay_settings_cubit.dart
+++ b/mobile/lib/blocs/relay_settings/relay_settings_cubit.dart
@@ -5,6 +5,7 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/blocs/relay_settings/relay_settings_state.dart';
+import 'package:openvine/repositories/relay_list_repository.dart';
 import 'package:openvine/services/relay_capability_service.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/utils/relay_url_utils.dart';
@@ -31,14 +32,17 @@ import 'package:openvine/utils/relay_url_utils.dart';
 class RelaySettingsCubit extends Cubit<RelaySettingsState> {
   RelaySettingsCubit({
     required NostrClient nostrClient,
+    required RelayListRepository relayListRepository,
     required RelayCapabilityService relayCapabilityService,
     required VideoEventService videoEventService,
   }) : _nostrClient = nostrClient,
+       _relayListRepository = relayListRepository,
        _relayCapabilityService = relayCapabilityService,
        _videoEventService = videoEventService,
        super(const RelaySettingsState());
 
   final NostrClient _nostrClient;
+  final RelayListRepository _relayListRepository;
   final RelayCapabilityService _relayCapabilityService;
   final VideoEventService _videoEventService;
 
@@ -106,11 +110,14 @@ class RelaySettingsCubit extends Cubit<RelaySettingsState> {
       );
       refreshRelays();
       if (!success) {
-        return _hasRelayConfigured(trimmed)
+        if (!_hasRelayConfigured(trimmed)) return AddRelayOutcome.failed;
+        return await _publishRelayListAfterLocalChange()
             ? AddRelayOutcome.addedConnectionPending
-            : AddRelayOutcome.failed;
+            : AddRelayOutcome.addedConnectionPendingLocalOnly;
       }
-      return AddRelayOutcome.added;
+      return await _publishRelayListAfterLocalChange()
+          ? AddRelayOutcome.added
+          : AddRelayOutcome.addedLocalOnly;
     } catch (e, stackTrace) {
       addError(e, stackTrace);
       return AddRelayOutcome.failed;
@@ -125,11 +132,14 @@ class RelaySettingsCubit extends Cubit<RelaySettingsState> {
       );
       refreshRelays();
       if (!success) {
-        return _hasRelayConfigured(relayUrl)
-            ? RemoveRelayOutcome.failed
-            : RemoveRelayOutcome.removed;
+        if (_hasRelayConfigured(relayUrl)) return RemoveRelayOutcome.failed;
+        return await _publishRelayListAfterLocalChange()
+            ? RemoveRelayOutcome.removed
+            : RemoveRelayOutcome.removedLocalOnly;
       }
-      return RemoveRelayOutcome.removed;
+      return await _publishRelayListAfterLocalChange()
+          ? RemoveRelayOutcome.removed
+          : RemoveRelayOutcome.removedLocalOnly;
     } catch (e, stackTrace) {
       addError(e, stackTrace);
       return RemoveRelayOutcome.failed;
@@ -144,11 +154,16 @@ class RelaySettingsCubit extends Cubit<RelaySettingsState> {
       );
       refreshRelays();
       if (!success) {
-        return _hasDefaultRelayConfigured()
+        if (!_hasDefaultRelayConfigured()) {
+          return RestoreDefaultRelayOutcome.failed;
+        }
+        return await _publishRelayListAfterLocalChange()
             ? RestoreDefaultRelayOutcome.restoredConnectionPending
-            : RestoreDefaultRelayOutcome.failed;
+            : RestoreDefaultRelayOutcome.restoredConnectionPendingLocalOnly;
       }
-      return RestoreDefaultRelayOutcome.restored;
+      return await _publishRelayListAfterLocalChange()
+          ? RestoreDefaultRelayOutcome.restored
+          : RestoreDefaultRelayOutcome.restoredLocalOnly;
     } catch (e, stackTrace) {
       addError(e, stackTrace);
       return RestoreDefaultRelayOutcome.failed;
@@ -182,5 +197,15 @@ class RelaySettingsCubit extends Cubit<RelaySettingsState> {
 
   bool _hasRelayConfigured(String relayUrl) {
     return state.relays.any((relay) => relayUrlsEquivalent(relay, relayUrl));
+  }
+
+  Future<bool> _publishRelayListAfterLocalChange() async {
+    final result = await _relayListRepository.publishConfiguredRelayList();
+    final error = result.error;
+    final stackTrace = result.stackTrace;
+    if (error != null) {
+      addError(error, stackTrace ?? StackTrace.current);
+    }
+    return !result.localOnly;
   }
 }

--- a/mobile/lib/blocs/relay_settings/relay_settings_cubit.dart
+++ b/mobile/lib/blocs/relay_settings/relay_settings_cubit.dart
@@ -131,11 +131,10 @@ class RelaySettingsCubit extends Cubit<RelaySettingsState> {
         source: RelayRemoveSource.user,
       );
       refreshRelays();
-      if (!success) {
-        if (_hasRelayConfigured(relayUrl)) return RemoveRelayOutcome.failed;
-        return await _publishRelayListAfterLocalChange()
-            ? RemoveRelayOutcome.removed
-            : RemoveRelayOutcome.removedLocalOnly;
+      // A `false` return only means "nothing to remove"; the relay is gone
+      // either way unless it is still configured.
+      if (!success && _hasRelayConfigured(relayUrl)) {
+        return RemoveRelayOutcome.failed;
       }
       return await _publishRelayListAfterLocalChange()
           ? RemoveRelayOutcome.removed

--- a/mobile/lib/blocs/relay_settings/relay_settings_state.dart
+++ b/mobile/lib/blocs/relay_settings/relay_settings_state.dart
@@ -71,6 +71,9 @@ enum AddRelayOutcome {
   /// URL parsed and was accepted by the service.
   added,
 
+  /// URL was saved locally, but the account relay list did not publish yet.
+  addedLocalOnly,
+
   /// URL was empty or didn't use a `wss://` / `ws://` scheme.
   invalidUrl,
 
@@ -80,17 +83,22 @@ enum AddRelayOutcome {
   /// URL was saved, but the relay did not accept a connection yet.
   addedConnectionPending,
 
+  /// URL was saved without a connection and did not publish to the account yet.
+  addedConnectionPendingLocalOnly,
+
   /// The service refused the URL or threw.
   failed,
 }
 
 /// Outcome of `RelaySettingsCubit.removeRelay(...)`.
-enum RemoveRelayOutcome { removed, failed }
+enum RemoveRelayOutcome { removed, removedLocalOnly, failed }
 
 /// Outcome of `RelaySettingsCubit.restoreDefaultRelay()`.
 enum RestoreDefaultRelayOutcome {
   restored,
+  restoredLocalOnly,
   restoredConnectionPending,
+  restoredConnectionPendingLocalOnly,
   failed,
 }
 
@@ -99,10 +107,7 @@ enum RestoreDefaultRelayOutcome {
 /// The View uses [connectedCount] to render the success snackbar (which
 /// embeds the count via l10n).
 class RetryConnectionOutcome extends Equatable {
-  const RetryConnectionOutcome._({
-    required this.kind,
-    this.connectedCount = 0,
-  });
+  const RetryConnectionOutcome._({required this.kind, this.connectedCount = 0});
 
   const RetryConnectionOutcome.connected(int count)
     : this._(kind: RetryConnectionOutcomeKind.connected, connectedCount: count);

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -961,6 +961,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "ከቅብብሎሽ ጋር መገናኘት አልተሳካም። እባክዎ የአውታረ መረብ ግንኙነትዎን ያረጋግጡ።",
+    "relaySettingsSavedLocallyPublishPending": "በዚህ መሣሪያ ላይ ተቀምጧል። ማተም እንደገና ሲሰራ ወደ መለያዎ እናስመሳስለዋለን።",
     "relaySettingsAddRelayTitle": "ቅብብል ጨምር",
     "relaySettingsAddRelayPrompt": "ማከል የምትፈልገውን የሪሌይ WebSocket URL አስገባ:",
     "relaySettingsBrowsePublicRelays": "በ nostr.co.uk ላይ የህዝብ ማሰራጫዎችን ያስሱ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -827,6 +827,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "فشل الاتصال بالمحولات. يرجى التحقق من اتصال الشبكة.",
+    "relaySettingsSavedLocallyPublishPending": "تم الحفظ على هذا الجهاز. سنزامنه مع حسابك عندما يعمل النشر مرة أخرى.",
     "relaySettingsAddRelayTitle": "إضافة محول",
     "relaySettingsAddRelayPrompt": "أدخل رابط WebSocket للمحول الذي تريد إضافته:",
     "relaySettingsBrowsePublicRelays": "تصفّح المحولات العامة في nostr.co.uk",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -906,6 +906,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "Не успяхме да се свържем с релетата. Провери мрежовата си връзка.",
+    "relaySettingsSavedLocallyPublishPending": "Запазено е на това устройство. Ще го синхронизираме с акаунта ти, когато публикуването заработи отново.",
     "relaySettingsAddRelayTitle": "Добави реле",
     "relaySettingsAddRelayPrompt": "Въведи WebSocket URL на релето, което искаш да добавиш:",
     "relaySettingsBrowsePublicRelays": "Разгледай публичните релета на nostr.co.uk",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -830,6 +830,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "Verbindung zu Relays fehlgeschlagen. Bitte prüf deine Netzwerkverbindung.",
+    "relaySettingsSavedLocallyPublishPending": "Auf diesem Gerät gespeichert. Wir synchronisieren es mit deinem Konto, sobald das Veröffentlichen wieder funktioniert.",
     "relaySettingsAddRelayTitle": "Relay hinzufügen",
     "relaySettingsAddRelayPrompt": "Gib die WebSocket-URL des Relays ein, das du hinzufügen willst:",
     "relaySettingsBrowsePublicRelays": "Öffentliche Relays auf nostr.co.uk durchsuchen",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1256,6 +1256,7 @@
     }
   },
   "relaySettingsFailedToConnectCheck": "Failed to connect to relays. Please check your network connection.",
+  "relaySettingsSavedLocallyPublishPending": "Saved on this device. We'll sync it to your account when publishing works again.",
   "relaySettingsAddRelayTitle": "Add Relay",
   "relaySettingsAddRelayPrompt": "Enter the WebSocket URL of the relay you want to add:",
   "relaySettingsBrowsePublicRelays": "Browse public relays at nostr.co.uk",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -830,6 +830,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "No se pudo conectar a los relays. Revisá tu conexión de red.",
+    "relaySettingsSavedLocallyPublishPending": "Guardado en este dispositivo. Lo sincronizaremos con tu cuenta cuando la publicación vuelva a funcionar.",
     "relaySettingsAddRelayTitle": "Agregar relay",
     "relaySettingsAddRelayPrompt": "Ingresá la URL WebSocket del relay que querés agregar:",
     "relaySettingsBrowsePublicRelays": "Mirá relays públicos en nostr.co.uk",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -582,6 +582,7 @@
     "relaySettingsForcingReconnection": "Pinipilit ang muling pagkonekta sa relay...",
     "relaySettingsConnectedToRelays": "Nakakonekta sa {count} relay!",
     "relaySettingsFailedToConnectCheck": "Hindi nakakonekta sa mga relay. Pakitsek ang iyong network connection.",
+    "relaySettingsSavedLocallyPublishPending": "Naka-save sa device na ito. Isi-sync namin ito sa account mo kapag gumana ulit ang publishing.",
     "relaySettingsAddRelayTitle": "Magdagdag ng Relay",
     "relaySettingsAddRelayPrompt": "Ilagay ang WebSocket URL ng relay na gusto mong idagdag:",
     "relaySettingsBrowsePublicRelays": "I-browse ang mga public relay sa nostr.co.uk",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -830,6 +830,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "Échec de la connexion aux relays. Vérifie ta connexion réseau.",
+    "relaySettingsSavedLocallyPublishPending": "Enregistré sur cet appareil. On le synchronisera avec ton compte quand la publication refonctionnera.",
     "relaySettingsAddRelayTitle": "Ajouter un relay",
     "relaySettingsAddRelayPrompt": "Entre l'URL WebSocket du relay que tu veux ajouter :",
     "relaySettingsBrowsePublicRelays": "Parcours les relays publics sur nostr.co.uk",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -827,6 +827,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "Gagal terhubung ke relay. Silakan cek koneksi jaringanmu.",
+    "relaySettingsSavedLocallyPublishPending": "Tersimpan di perangkat ini. Kami akan menyinkronkannya ke akunmu saat penerbitan berfungsi lagi.",
     "relaySettingsAddRelayTitle": "Tambah Relay",
     "relaySettingsAddRelayPrompt": "Masukkan URL WebSocket relay yang ingin kamu tambahkan:",
     "relaySettingsBrowsePublicRelays": "Jelajahi relay publik di nostr.co.uk",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -830,6 +830,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "Impossibile connettersi ai relay. Controlla la connessione di rete.",
+    "relaySettingsSavedLocallyPublishPending": "Salvato su questo dispositivo. Lo sincronizzeremo con il tuo account quando la pubblicazione tornerà a funzionare.",
     "relaySettingsAddRelayTitle": "Aggiungi relay",
     "relaySettingsAddRelayPrompt": "Inserisci l'URL WebSocket del relay che vuoi aggiungere:",
     "relaySettingsBrowsePublicRelays": "Sfoglia relay pubblici su nostr.co.uk",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -827,6 +827,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "リレーに接続できなかった。ネット接続を確認してみて。",
+    "relaySettingsSavedLocallyPublishPending": "この端末に保存しました。公開がまた動くようになったらアカウントに同期します。",
     "relaySettingsAddRelayTitle": "リレーを追加",
     "relaySettingsAddRelayPrompt": "追加したいリレーの WebSocket URL を入力してね:",
     "relaySettingsBrowsePublicRelays": "nostr.co.uk でパブリックリレーを見る",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -519,6 +519,7 @@
     "relaySettingsForcingReconnection": "릴레이 재연결 중...",
     "relaySettingsConnectedToRelays": "릴레이 {count}개에 연결됐어요!",
     "relaySettingsFailedToConnectCheck": "릴레이 연결에 실패했어요. 네트워크 연결을 확인해주세요.",
+    "relaySettingsSavedLocallyPublishPending": "이 기기에 저장됐어요. 게시가 다시 작동하면 계정에 동기화할게요.",
     "relaySettingsAddRelayTitle": "릴레이 추가",
     "relaySettingsAddRelayPrompt": "추가할 릴레이의 WebSocket URL을 입력해주세요:",
     "relaySettingsBrowsePublicRelays": "nostr.co.uk에서 공개 릴레이 둘러보기",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -1184,6 +1184,7 @@
     }
   },
   "relaySettingsFailedToConnectCheck": "Gagal bersambung ke relay. Sila semak sambungan rangkaian anda.",
+  "relaySettingsSavedLocallyPublishPending": "Disimpan pada peranti ini. Kami akan menyegerakkannya ke akaun anda apabila penerbitan berfungsi semula.",
   "relaySettingsAddRelayTitle": "Tambah Relay",
   "relaySettingsAddRelayPrompt": "Masukkan URL WebSocket relay yang mahu anda tambah:",
   "relaySettingsBrowsePublicRelays": "Semak imbas relay awam di nostr.co.uk",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -830,6 +830,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "Verbinden met relays mislukt. Check je netwerkverbinding.",
+    "relaySettingsSavedLocallyPublishPending": "Op dit apparaat opgeslagen. We synchroniseren het met je account zodra publiceren weer werkt.",
     "relaySettingsAddRelayTitle": "Relay toevoegen",
     "relaySettingsAddRelayPrompt": "Voer de WebSocket-URL in van de relay die je wilt toevoegen:",
     "relaySettingsBrowsePublicRelays": "Bekijk publieke relays op nostr.co.uk",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -830,6 +830,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "Nie udało się połączyć z przekaźnikami. Sprawdź połączenie z siecią.",
+    "relaySettingsSavedLocallyPublishPending": "Zapisano na tym urządzeniu. Zsynchronizujemy to z Twoim kontem, gdy publikowanie znów zadziała.",
     "relaySettingsAddRelayTitle": "Dodaj przekaźnik",
     "relaySettingsAddRelayPrompt": "Wprowadź URL WebSocket przekaźnika, który chcesz dodać:",
     "relaySettingsBrowsePublicRelays": "Przeglądaj publiczne przekaźniki na nostr.co.uk",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -830,6 +830,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "Falha ao conectar aos relays. Verifique sua conexão de rede.",
+    "relaySettingsSavedLocallyPublishPending": "Salvo neste dispositivo. Vamos sincronizar com sua conta quando a publicação voltar a funcionar.",
     "relaySettingsAddRelayTitle": "Adicionar relay",
     "relaySettingsAddRelayPrompt": "Digite a URL WebSocket do relay que você quer adicionar:",
     "relaySettingsBrowsePublicRelays": "Navegue por relays públicos em nostr.co.uk",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -830,6 +830,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "N-am putut conecta la relay-uri. Verifică-ți conexiunea la rețea.",
+    "relaySettingsSavedLocallyPublishPending": "Salvat pe acest dispozitiv. Îl vom sincroniza cu contul tău când publicarea funcționează din nou.",
     "relaySettingsAddRelayTitle": "Adaugă relay",
     "relaySettingsAddRelayPrompt": "Introdu URL-ul WebSocket al relay-ului pe care vrei să-l adaugi:",
     "relaySettingsBrowsePublicRelays": "Răsfoiește relay-urile publice la nostr.co.uk",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -830,6 +830,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "Kunde inte ansluta till reler. Kolla din nätverksanslutning.",
+    "relaySettingsSavedLocallyPublishPending": "Sparat på den här enheten. Vi synkar det till ditt konto när publicering fungerar igen.",
     "relaySettingsAddRelayTitle": "Lägg till rel",
     "relaySettingsAddRelayPrompt": "Ange WebSocket-URL:en för relen du vill lägga till:",
     "relaySettingsBrowsePublicRelays": "Bläddra bland publika reler på nostr.co.uk",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -827,6 +827,7 @@
         }
     },
     "relaySettingsFailedToConnectCheck": "Rölelere bağlanılamadı. Lütfen ağ bağlantını kontrol et.",
+    "relaySettingsSavedLocallyPublishPending": "Bu cihazda kaydedildi. Yayınlama tekrar çalıştığında hesabınla eşitleyeceğiz.",
     "relaySettingsAddRelayTitle": "Röle Ekle",
     "relaySettingsAddRelayPrompt": "Eklemek istediğin rölenin WebSocket URL'sini gir:",
     "relaySettingsBrowsePublicRelays": "Herkese açık rölelere nostr.co.uk adresinden göz at",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -1184,6 +1184,7 @@
     }
   },
   "relaySettingsFailedToConnectCheck": "ریلے سے منسلک نہیں ہو سکا۔ براہ کرم اپنا نیٹ ورک کنکشن چیک کریں۔",
+  "relaySettingsSavedLocallyPublishPending": "اس ڈیوائس پر محفوظ ہو گیا۔ اشاعت دوبارہ کام کرنے لگے تو ہم اسے آپ کے اکاؤنٹ سے ہم آہنگ کر دیں گے۔",
   "relaySettingsAddRelayTitle": "ریلے شامل کریں",
   "relaySettingsAddRelayPrompt": "جس ریلے کو شامل کرنا چاہتے ہیں اس کا WebSocket URL درج کریں:",
   "relaySettingsBrowsePublicRelays": "عوامی ریلے nostr.co.uk پر دیکھیں",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -1184,6 +1184,7 @@
     }
   },
   "relaySettingsFailedToConnectCheck": "Không kết nối được với relay. Vui lòng kiểm tra kết nối mạng của bạn.",
+  "relaySettingsSavedLocallyPublishPending": "Đã lưu trên thiết bị này. Chúng tôi sẽ đồng bộ với tài khoản của bạn khi việc đăng lại hoạt động.",
   "relaySettingsAddRelayTitle": "Thêm relay",
   "relaySettingsAddRelayPrompt": "Nhập URL WebSocket của relay bạn muốn thêm:",
   "relaySettingsBrowsePublicRelays": "Duyệt relay công khai tại nostr.co.uk",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -1184,6 +1184,7 @@
     }
   },
   "relaySettingsFailedToConnectCheck": "连接中继失败。请检查网络连接。",
+  "relaySettingsSavedLocallyPublishPending": "已保存在此设备上。发布恢复正常后，我们会将它同步到你的账号。",
   "relaySettingsAddRelayTitle": "添加中继",
   "relaySettingsAddRelayPrompt": "输入要添加的中继 WebSocket URL：",
   "relaySettingsBrowsePublicRelays": "在 nostr.co.uk 浏览公共中继",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -3652,6 +3652,12 @@ abstract class AppLocalizations {
   /// **'Failed to connect to relays. Please check your network connection.'**
   String get relaySettingsFailedToConnectCheck;
 
+  /// No description provided for @relaySettingsSavedLocallyPublishPending.
+  ///
+  /// In en, this message translates to:
+  /// **'Saved on this device. We\'ll sync it to your account when publishing works again.'**
+  String get relaySettingsSavedLocallyPublishPending;
+
   /// No description provided for @relaySettingsAddRelayTitle.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -2047,6 +2047,10 @@ class AppLocalizationsAm extends AppLocalizations {
       'ከቅብብሎሽ ጋር መገናኘት አልተሳካም። እባክዎ የአውታረ መረብ ግንኙነትዎን ያረጋግጡ።';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      'በዚህ መሣሪያ ላይ ተቀምጧል። ማተም እንደገና ሲሰራ ወደ መለያዎ እናስመሳስለዋለን።';
+
+  @override
   String get relaySettingsAddRelayTitle => 'ቅብብል ጨምር';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -2068,6 +2068,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'فشل الاتصال بالمحولات. يرجى التحقق من اتصال الشبكة.';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      'تم الحفظ على هذا الجهاز. سنزامنه مع حسابك عندما يعمل النشر مرة أخرى.';
+
+  @override
   String get relaySettingsAddRelayTitle => 'إضافة محول';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -2118,6 +2118,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Не успяхме да се свържем с релетата. Провери мрежовата си връзка.';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      'Запазено е на това устройство. Ще го синхронизираме с акаунта ти, когато публикуването заработи отново.';
+
+  @override
   String get relaySettingsAddRelayTitle => 'Добави реле';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -2105,6 +2105,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Verbindung zu Relays fehlgeschlagen. Bitte prüf deine Netzwerkverbindung.';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      'Auf diesem Gerät gespeichert. Wir synchronisieren es mit deinem Konto, sobald das Veröffentlichen wieder funktioniert.';
+
+  @override
   String get relaySettingsAddRelayTitle => 'Relay hinzufügen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -2082,6 +2082,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Failed to connect to relays. Please check your network connection.';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      'Saved on this device. We\'ll sync it to your account when publishing works again.';
+
+  @override
   String get relaySettingsAddRelayTitle => 'Add Relay';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -2105,6 +2105,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'No se pudo conectar a los relays. Revisá tu conexión de red.';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      'Guardado en este dispositivo. Lo sincronizaremos con tu cuenta cuando la publicación vuelva a funcionar.';
+
+  @override
   String get relaySettingsAddRelayTitle => 'Agregar relay';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -2119,6 +2119,10 @@ class AppLocalizationsFil extends AppLocalizations {
       'Hindi nakakonekta sa mga relay. Pakitsek ang iyong network connection.';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      'Naka-save sa device na ito. Isi-sync namin ito sa account mo kapag gumana ulit ang publishing.';
+
+  @override
   String get relaySettingsAddRelayTitle => 'Magdagdag ng Relay';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -2114,6 +2114,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Échec de la connexion aux relays. Vérifie ta connexion réseau.';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      'Enregistré sur cet appareil. On le synchronisera avec ton compte quand la publication refonctionnera.';
+
+  @override
   String get relaySettingsAddRelayTitle => 'Ajouter un relay';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -2043,6 +2043,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Gagal terhubung ke relay. Silakan cek koneksi jaringanmu.';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      'Tersimpan di perangkat ini. Kami akan menyinkronkannya ke akunmu saat penerbitan berfungsi lagi.';
+
+  @override
   String get relaySettingsAddRelayTitle => 'Tambah Relay';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -2108,6 +2108,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Impossibile connettersi ai relay. Controlla la connessione di rete.';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      'Salvato su questo dispositivo. Lo sincronizzeremo con il tuo account quando la pubblicazione tornerà a funzionare.';
+
+  @override
   String get relaySettingsAddRelayTitle => 'Aggiungi relay';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1963,6 +1963,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get relaySettingsFailedToConnectCheck => 'リレーに接続できなかった。ネット接続を確認してみて。';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      'この端末に保存しました。公開がまた動くようになったらアカウントに同期します。';
+
+  @override
   String get relaySettingsAddRelayTitle => 'リレーを追加';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1974,6 +1974,10 @@ class AppLocalizationsKo extends AppLocalizations {
       '릴레이 연결에 실패했어요. 네트워크 연결을 확인해주세요.';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      '이 기기에 저장됐어요. 게시가 다시 작동하면 계정에 동기화할게요.';
+
+  @override
   String get relaySettingsAddRelayTitle => '릴레이 추가';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -2098,6 +2098,10 @@ class AppLocalizationsMs extends AppLocalizations {
       'Gagal bersambung ke relay. Sila semak sambungan rangkaian anda.';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      'Disimpan pada peranti ini. Kami akan menyegerakkannya ke akaun anda apabila penerbitan berfungsi semula.';
+
+  @override
   String get relaySettingsAddRelayTitle => 'Tambah Relay';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -2093,6 +2093,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Verbinden met relays mislukt. Check je netwerkverbinding.';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      'Op dit apparaat opgeslagen. We synchroniseren het met je account zodra publiceren weer werkt.';
+
+  @override
   String get relaySettingsAddRelayTitle => 'Relay toevoegen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -2126,6 +2126,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Nie udało się połączyć z przekaźnikami. Sprawdź połączenie z siecią.';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      'Zapisano na tym urządzeniu. Zsynchronizujemy to z Twoim kontem, gdy publikowanie znów zadziała.';
+
+  @override
   String get relaySettingsAddRelayTitle => 'Dodaj przekaźnik';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -2101,6 +2101,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Falha ao conectar aos relays. Verifique sua conexão de rede.';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      'Salvo neste dispositivo. Vamos sincronizar com sua conta quando a publicação voltar a funcionar.';
+
+  @override
   String get relaySettingsAddRelayTitle => 'Adicionar relay';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -2134,6 +2134,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'N-am putut conecta la relay-uri. Verifică-ți conexiunea la rețea.';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      'Salvat pe acest dispozitiv. Îl vom sincroniza cu contul tău când publicarea funcționează din nou.';
+
+  @override
   String get relaySettingsAddRelayTitle => 'Adaugă relay';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -2076,6 +2076,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Kunde inte ansluta till reler. Kolla din nätverksanslutning.';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      'Sparat på den här enheten. Vi synkar det till ditt konto när publicering fungerar igen.';
+
+  @override
   String get relaySettingsAddRelayTitle => 'Lägg till rel';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -2050,6 +2050,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Rölelere bağlanılamadı. Lütfen ağ bağlantını kontrol et.';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      'Bu cihazda kaydedildi. Yayınlama tekrar çalıştığında hesabınla eşitleyeceğiz.';
+
+  @override
   String get relaySettingsAddRelayTitle => 'Röle Ekle';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -2087,6 +2087,10 @@ class AppLocalizationsUr extends AppLocalizations {
       'ریلے سے منسلک نہیں ہو سکا۔ براہ کرم اپنا نیٹ ورک کنکشن چیک کریں۔';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      'اس ڈیوائس پر محفوظ ہو گیا۔ اشاعت دوبارہ کام کرنے لگے تو ہم اسے آپ کے اکاؤنٹ سے ہم آہنگ کر دیں گے۔';
+
+  @override
   String get relaySettingsAddRelayTitle => 'ریلے شامل کریں';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -2092,6 +2092,10 @@ class AppLocalizationsVi extends AppLocalizations {
       'Không kết nối được với relay. Vui lòng kiểm tra kết nối mạng của bạn.';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      'Đã lưu trên thiết bị này. Chúng tôi sẽ đồng bộ với tài khoản của bạn khi việc đăng lại hoạt động.';
+
+  @override
   String get relaySettingsAddRelayTitle => 'Thêm relay';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -1986,6 +1986,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get relaySettingsFailedToConnectCheck => '连接中继失败。请检查网络连接。';
 
   @override
+  String get relaySettingsSavedLocallyPublishPending =>
+      '已保存在此设备上。发布恢复正常后，我们会将它同步到你的账号。';
+
+  @override
   String get relaySettingsAddRelayTitle => '添加中继';
 
   @override

--- a/mobile/lib/providers/relay_list_repository_provider.dart
+++ b/mobile/lib/providers/relay_list_repository_provider.dart
@@ -1,0 +1,50 @@
+// ABOUTME: Riverpod wiring for NIP-65 relay-list publishing and dirty retry.
+// ABOUTME: Activated from app shell alongside other relay side-effect bridges.
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/environment_provider.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/relay_discovery_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/repositories/relay_list_repository.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+final relayListRepositoryProvider = Provider<RelayListRepository>((ref) {
+  final authService = ref.watch(authServiceProvider);
+  return RelayListRepository(
+    nostrClient: ref.watch(nostrServiceProvider),
+    environment: ref.watch(currentEnvironmentProvider),
+    relayDiscoveryService: ref.watch(relayDiscoveryServiceProvider),
+    sharedPreferences: ref.watch(sharedPreferencesProvider),
+    discoveredRelays: () => authService.userRelays,
+  );
+});
+
+final relayListDirtyPublishBridgeProvider = Provider<void>((ref) {
+  Future<void> retryIfDirty(NostrSessionReadiness readiness) async {
+    if (!readiness.isReadyForActiveClient) return;
+    final pubkey = readiness.pubkey;
+    if (pubkey == null || pubkey.isEmpty) return;
+
+    final repository = ref.read(relayListRepositoryProvider);
+    if (!repository.isDirty(pubkey)) return;
+
+    final result = await repository.retryDirtyPublish();
+    if (result.localOnly) {
+      Log.warning(
+        'kind:10002 dirty relay-list retry did not reach an indexer',
+        name: 'RelayListDirtyPublishBridge',
+        category: LogCategory.relay,
+      );
+    }
+  }
+
+  unawaited(retryIfDirty(ref.read(nostrSessionProvider)));
+  ref.listen<NostrSessionReadiness>(
+    nostrSessionProvider,
+    (_, next) => unawaited(retryIfDirty(next)),
+  );
+});

--- a/mobile/lib/repositories/relay_list_repository.dart
+++ b/mobile/lib/repositories/relay_list_repository.dart
@@ -18,6 +18,7 @@ enum RelayListPublishStatus {
   published,
   skippedNoKeys,
   skippedNonProduction,
+  skippedNotDirty,
   failed,
 }
 
@@ -37,6 +38,9 @@ class RelayListPublishResult {
   const RelayListPublishResult.skippedNonProduction()
     : this._(status: RelayListPublishStatus.skippedNonProduction);
 
+  const RelayListPublishResult.skippedNotDirty()
+    : this._(status: RelayListPublishStatus.skippedNotDirty);
+
   const RelayListPublishResult.failed(Object error, StackTrace stackTrace)
     : this._(
         status: RelayListPublishStatus.failed,
@@ -53,7 +57,8 @@ class RelayListPublishResult {
     RelayListPublishStatus.skippedNoKeys ||
     RelayListPublishStatus.failed => true,
     RelayListPublishStatus.published ||
-    RelayListPublishStatus.skippedNonProduction => false,
+    RelayListPublishStatus.skippedNonProduction ||
+    RelayListPublishStatus.skippedNotDirty => false,
   };
 }
 
@@ -115,9 +120,13 @@ class RelayListRepository {
 
   Future<RelayListPublishResult> retryDirtyPublish() async {
     final pubkey = _nostrClient.publicKey;
-    if (!_nostrClient.hasKeys || pubkey.isEmpty || !isDirty(pubkey)) {
+    if (!_nostrClient.hasKeys || pubkey.isEmpty) {
       return const RelayListPublishResult.skippedNoKeys();
     }
+    // Nothing pending is a no-op, not a failed sync — reporting it as
+    // localOnly would make the retry bridge warn about a publish it never
+    // attempted.
+    if (!isDirty(pubkey)) return const RelayListPublishResult.skippedNotDirty();
     return publishConfiguredRelayList();
   }
 

--- a/mobile/lib/repositories/relay_list_repository.dart
+++ b/mobile/lib/repositories/relay_list_repository.dart
@@ -1,0 +1,218 @@
+// ABOUTME: Publishes the user's configured relay set as NIP-65 kind:10002.
+// ABOUTME: Keeps relay-list event construction and retry state out of UI/BLoC.
+
+import 'dart:async';
+
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:openvine/models/environment_config.dart';
+import 'package:openvine/services/relay_discovery_service.dart';
+import 'package:openvine/utils/relay_url_utils.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+const _relayListSignTimeout = Duration(seconds: 10);
+const _dirtyRelayListPublishPrefix = 'relay_list_publish_dirty_';
+
+enum RelayListPublishStatus {
+  published,
+  skippedNoKeys,
+  skippedNonProduction,
+  failed,
+}
+
+class RelayListPublishResult {
+  const RelayListPublishResult._({
+    required this.status,
+    this.error,
+    this.stackTrace,
+  });
+
+  const RelayListPublishResult.published()
+    : this._(status: RelayListPublishStatus.published);
+
+  const RelayListPublishResult.skippedNoKeys()
+    : this._(status: RelayListPublishStatus.skippedNoKeys);
+
+  const RelayListPublishResult.skippedNonProduction()
+    : this._(status: RelayListPublishStatus.skippedNonProduction);
+
+  const RelayListPublishResult.failed(Object error, StackTrace stackTrace)
+    : this._(
+        status: RelayListPublishStatus.failed,
+        error: error,
+        stackTrace: stackTrace,
+      );
+
+  final RelayListPublishStatus status;
+  final Object? error;
+  final StackTrace? stackTrace;
+
+  bool get synced => status == RelayListPublishStatus.published;
+  bool get localOnly => switch (status) {
+    RelayListPublishStatus.skippedNoKeys ||
+    RelayListPublishStatus.failed => true,
+    RelayListPublishStatus.published ||
+    RelayListPublishStatus.skippedNonProduction => false,
+  };
+}
+
+class RelayListRepository {
+  RelayListRepository({
+    required NostrClient nostrClient,
+    required EnvironmentConfig environment,
+    required RelayDiscoveryService relayDiscoveryService,
+    required SharedPreferences sharedPreferences,
+    required List<DiscoveredRelay> Function() discoveredRelays,
+  }) : _nostrClient = nostrClient,
+       _environment = environment,
+       _relayDiscoveryService = relayDiscoveryService,
+       _sharedPreferences = sharedPreferences,
+       _discoveredRelays = discoveredRelays;
+
+  final NostrClient _nostrClient;
+  final EnvironmentConfig _environment;
+  final RelayDiscoveryService _relayDiscoveryService;
+  final SharedPreferences _sharedPreferences;
+  final List<DiscoveredRelay> Function() _discoveredRelays;
+
+  Future<RelayListPublishResult> publishConfiguredRelayList() async {
+    final pubkey = _nostrClient.publicKey;
+    if (!_nostrClient.hasKeys || pubkey.isEmpty) {
+      return const RelayListPublishResult.skippedNoKeys();
+    }
+
+    if (!_environment.isProduction) {
+      Log.info(
+        'Skipping kind:10002 publish outside production so environment-locked '
+        'relay lists do not replace a user production list (#3183)',
+        name: 'RelayListRepository',
+        category: LogCategory.relay,
+      );
+      return const RelayListPublishResult.skippedNonProduction();
+    }
+
+    try {
+      final result = await _publishForPubkey(pubkey);
+      if (result.synced) {
+        await _clearDirty(pubkey);
+      } else if (result.localOnly) {
+        await _markDirty(pubkey);
+      }
+      return result;
+    } catch (e, stackTrace) {
+      await _markDirty(pubkey);
+      Log.error(
+        'kind:10002 relay-list publish failed: $e',
+        name: 'RelayListRepository',
+        category: LogCategory.relay,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return RelayListPublishResult.failed(e, stackTrace);
+    }
+  }
+
+  Future<RelayListPublishResult> retryDirtyPublish() async {
+    final pubkey = _nostrClient.publicKey;
+    if (!_nostrClient.hasKeys || pubkey.isEmpty || !isDirty(pubkey)) {
+      return const RelayListPublishResult.skippedNoKeys();
+    }
+    return publishConfiguredRelayList();
+  }
+
+  bool isDirty(String pubkey) =>
+      _sharedPreferences.getBool(_dirtyKey(pubkey)) ?? false;
+
+  Future<RelayListPublishResult> _publishForPubkey(String pubkey) async {
+    final unsigned = Event(
+      pubkey,
+      EventKind.relayListMetadata,
+      _buildRelayTags(_nostrClient.configuredRelays),
+      '',
+    );
+
+    final Event? signed;
+    try {
+      signed = await _nostrClient.signer
+          .signEvent(unsigned)
+          .timeout(_relayListSignTimeout);
+    } on TimeoutException catch (e, stackTrace) {
+      Log.warning(
+        'kind:10002 relay-list publish signer timed out after '
+        '${_relayListSignTimeout.inSeconds}s: $e',
+        name: 'RelayListRepository',
+        category: LogCategory.relay,
+      );
+      return RelayListPublishResult.failed(e, stackTrace);
+    }
+
+    if (signed == null || signed.sig.isEmpty) {
+      return RelayListPublishResult.failed(
+        StateError('Signer returned an unsigned kind:10002 event'),
+        StackTrace.current,
+      );
+    }
+
+    final targetRelays = _publishTargets();
+    final outcome = await _nostrClient.publishEventAwaitOk(
+      signed,
+      targetRelays: targetRelays,
+      diagnosticTag: 'relay-list-kind-10002',
+    );
+    final acceptedByIndexer = outcome.acceptedBy.any(
+      _environment.indexerRelays.contains,
+    );
+    if (!acceptedByIndexer) {
+      return RelayListPublishResult.failed(
+        StateError('kind:10002 accepted by no indexer: ${outcome.summary}'),
+        StackTrace.current,
+      );
+    }
+
+    final npub = Nip19.encodePubKey(pubkey);
+    await _relayDiscoveryService.clearCache(npub);
+    Log.info(
+      'Published kind:10002 relay list for $pubkey to an indexer',
+      name: 'RelayListRepository',
+      category: LogCategory.relay,
+    );
+    return const RelayListPublishResult.published();
+  }
+
+  List<List<String>> _buildRelayTags(List<String> configuredRelays) {
+    final discovered = _discoveredRelays();
+    return configuredRelays
+        .map((relayUrl) {
+          final marker = _markerFor(relayUrl, discovered);
+          if (marker == null) return <String>['r', relayUrl];
+          return <String>['r', relayUrl, marker];
+        })
+        .toList(growable: false);
+  }
+
+  String? _markerFor(String relayUrl, List<DiscoveredRelay> discovered) {
+    for (final relay in discovered) {
+      if (!relayUrlsEquivalent(relay.url, relayUrl)) continue;
+      if (relay.read && !relay.write) return 'read';
+      if (!relay.read && relay.write) return 'write';
+      return null;
+    }
+    return null;
+  }
+
+  List<String> _publishTargets() {
+    final targets = <String>{}
+      ..addAll(_nostrClient.configuredRelays)
+      ..addAll(_environment.indexerRelays);
+    return targets.toList(growable: false);
+  }
+
+  Future<void> _markDirty(String pubkey) =>
+      _sharedPreferences.setBool(_dirtyKey(pubkey), true);
+
+  Future<void> _clearDirty(String pubkey) =>
+      _sharedPreferences.remove(_dirtyKey(pubkey));
+
+  String _dirtyKey(String pubkey) => '$_dirtyRelayListPublishPrefix$pubkey';
+}

--- a/mobile/lib/repositories/relay_list_repository.dart
+++ b/mobile/lib/repositories/relay_list_repository.dart
@@ -12,6 +12,14 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 const _relayListSignTimeout = Duration(seconds: 10);
+
+/// Settings add/remove/restore awaits this publish before it can show the
+/// user a result, so the OK wait is capped well below
+/// [NostrClient.publishEventAwaitOk]'s 15s default: stacked on the signer
+/// timeout that would leave the screen silent for 25s. A relay that has not
+/// answered by now is not about to, and the dirty flag retries next session.
+const _relayListPublishTimeout = Duration(seconds: 5);
+
 const _dirtyRelayListPublishPrefix = 'relay_list_publish_dirty_';
 
 enum RelayListPublishStatus {
@@ -167,6 +175,7 @@ class RelayListRepository {
     final outcome = await _nostrClient.publishEventAwaitOk(
       signed,
       targetRelays: targetRelays,
+      timeout: _relayListPublishTimeout,
       diagnosticTag: 'relay-list-kind-10002',
     );
     final acceptedByIndexer = outcome.acceptedBy.any(

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -11,6 +11,7 @@ import 'package:openvine/app_update/app_update.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/notifications/view/notifications_page.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/relay_list_repository_provider.dart';
 import 'package:openvine/providers/route_feed_providers.dart';
 import 'package:openvine/providers/shell_obscured_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
@@ -308,6 +309,8 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
     // Transitional scaffold: refreshes feeds when the relay set changes.
     // TODO(#4338): remove when feed refresh is driven by a relay event stream in a cubit.
     ref.watch(relaySetChangeBridgeProvider);
+
+    ref.watch(relayListDirtyPublishBridgeProvider);
 
     // Initialize Zendesk identity sync to keep user identity in sync with auth
     ref.watch(zendeskIdentitySyncProvider);

--- a/mobile/lib/screens/relay_settings_screen.dart
+++ b/mobile/lib/screens/relay_settings_screen.dart
@@ -12,6 +12,7 @@ import 'package:openvine/blocs/relay_settings/relay_settings_state.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/relay_list_repository_provider.dart';
 import 'package:openvine/services/relay_statistics_service.dart';
 import 'package:openvine/utils/relay_url_utils.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
@@ -32,12 +33,19 @@ class RelaySettingsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final nostrService = ref.watch(nostrServiceProvider);
+    final relayListRepository = ref.watch(relayListRepositoryProvider);
     final capabilityService = ref.watch(relayCapabilityServiceProvider);
     final videoService = ref.watch(videoEventServiceProvider);
     return BlocProvider(
-      key: ValueKey((nostrService, capabilityService, videoService)),
+      key: ValueKey((
+        nostrService,
+        relayListRepository,
+        capabilityService,
+        videoService,
+      )),
       create: (_) => RelaySettingsCubit(
         nostrClient: nostrService,
+        relayListRepository: relayListRepository,
         relayCapabilityService: capabilityService,
         videoEventService: videoService,
       )..load(),
@@ -717,6 +725,12 @@ Future<void> _showAddRelayDialog(BuildContext context) async {
         'Successfully added relay: $relayUrl',
         name: 'RelaySettingsScreen',
       );
+    case AddRelayOutcome.addedLocalOnly:
+      _showWarning(messenger, l10n.relaySettingsSavedLocallyPublishPending);
+      Log.warning(
+        'Added relay locally but kind:10002 publish is pending: $relayUrl',
+        name: 'RelaySettingsScreen',
+      );
     case AddRelayOutcome.addedConnectionPending:
       messenger.showSnackBar(
         SnackBar(
@@ -726,6 +740,12 @@ Future<void> _showAddRelayDialog(BuildContext context) async {
       );
       Log.info(
         'Added relay without connection: $relayUrl',
+        name: 'RelaySettingsScreen',
+      );
+    case AddRelayOutcome.addedConnectionPendingLocalOnly:
+      _showWarning(messenger, l10n.relaySettingsSavedLocallyPublishPending);
+      Log.warning(
+        'Added relay locally without connection and kind:10002 publish is pending: $relayUrl',
         name: 'RelaySettingsScreen',
       );
     case AddRelayOutcome.invalidUrl:
@@ -804,6 +824,12 @@ Future<void> _confirmRemoveRelay(
         'Successfully removed relay: $relayUrl',
         name: 'RelaySettingsScreen',
       );
+    case RemoveRelayOutcome.removedLocalOnly:
+      _showWarning(messenger, l10n.relaySettingsSavedLocallyPublishPending);
+      Log.warning(
+        'Removed relay locally but kind:10002 publish is pending: $relayUrl',
+        name: 'RelaySettingsScreen',
+      );
     case RemoveRelayOutcome.failed:
       _showError(messenger, l10n.relaySettingsFailedToRemoveRelay);
   }
@@ -846,6 +872,12 @@ Future<void> _restoreDefaultRelay(BuildContext context) async {
         ),
       );
       Log.info('Restored default relay', name: 'RelaySettingsScreen');
+    case RestoreDefaultRelayOutcome.restoredLocalOnly:
+      _showWarning(messenger, l10n.relaySettingsSavedLocallyPublishPending);
+      Log.warning(
+        'Restored default relay locally but kind:10002 publish is pending',
+        name: 'RelaySettingsScreen',
+      );
     case RestoreDefaultRelayOutcome.restoredConnectionPending:
       messenger.showSnackBar(
         SnackBar(
@@ -855,6 +887,12 @@ Future<void> _restoreDefaultRelay(BuildContext context) async {
       );
       Log.info(
         'Restored default relay without connection',
+        name: 'RelaySettingsScreen',
+      );
+    case RestoreDefaultRelayOutcome.restoredConnectionPendingLocalOnly:
+      _showWarning(messenger, l10n.relaySettingsSavedLocallyPublishPending);
+      Log.warning(
+        'Restored default relay locally without connection and kind:10002 publish is pending',
         name: 'RelaySettingsScreen',
       );
     case RestoreDefaultRelayOutcome.failed:
@@ -889,6 +927,12 @@ Future<void> _launchExternalUrl(BuildContext context, Uri url) async {
 void _showError(ScaffoldMessengerState messenger, String message) {
   messenger.showSnackBar(
     DivineSnackbarContainer.snackBar(message, error: true),
+  );
+}
+
+void _showWarning(ScaffoldMessengerState messenger, String message) {
+  messenger.showSnackBar(
+    SnackBar(content: Text(message), backgroundColor: VineTheme.warning),
   );
 }
 

--- a/mobile/lib/screens/relay_settings_screen.dart
+++ b/mobile/lib/screens/relay_settings_screen.dart
@@ -743,7 +743,11 @@ Future<void> _showAddRelayDialog(BuildContext context) async {
         name: 'RelaySettingsScreen',
       );
     case AddRelayOutcome.addedConnectionPendingLocalOnly:
-      _showWarning(messenger, l10n.relaySettingsSavedLocallyPublishPending);
+      _showWarning(
+        messenger,
+        '${l10n.relaySettingsFailedToConnectCheck} '
+        '${l10n.relaySettingsSavedLocallyPublishPending}',
+      );
       Log.warning(
         'Added relay locally without connection and kind:10002 publish is pending: $relayUrl',
         name: 'RelaySettingsScreen',
@@ -890,7 +894,11 @@ Future<void> _restoreDefaultRelay(BuildContext context) async {
         name: 'RelaySettingsScreen',
       );
     case RestoreDefaultRelayOutcome.restoredConnectionPendingLocalOnly:
-      _showWarning(messenger, l10n.relaySettingsSavedLocallyPublishPending);
+      _showWarning(
+        messenger,
+        '${l10n.relaySettingsFailedToConnectCheck} '
+        '${l10n.relaySettingsSavedLocallyPublishPending}',
+      );
       Log.warning(
         'Restored default relay locally without connection and kind:10002 publish is pending',
         name: 'RelaySettingsScreen',

--- a/mobile/test/blocs/relay_settings/relay_settings_cubit_test.dart
+++ b/mobile/test/blocs/relay_settings/relay_settings_cubit_test.dart
@@ -8,6 +8,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/blocs/relay_settings/relay_settings_cubit.dart';
 import 'package:openvine/blocs/relay_settings/relay_settings_state.dart';
+import 'package:openvine/repositories/relay_list_repository.dart';
 import 'package:openvine/services/relay_capability_service.dart';
 import 'package:openvine/services/video_event_service.dart';
 
@@ -15,6 +16,8 @@ class _MockNostrClient extends Mock implements NostrClient {}
 
 class _MockRelayCapabilityService extends Mock
     implements RelayCapabilityService {}
+
+class _MockRelayListRepository extends Mock implements RelayListRepository {}
 
 class _MockVideoEventService extends Mock implements VideoEventService {}
 
@@ -26,11 +29,13 @@ void main() {
 
   group(RelaySettingsCubit, () {
     late _MockNostrClient nostr;
+    late _MockRelayListRepository relayListRepository;
     late _MockRelayCapabilityService capabilities;
     late _MockVideoEventService videos;
 
     setUp(() {
       nostr = _MockNostrClient();
+      relayListRepository = _MockRelayListRepository();
       capabilities = _MockRelayCapabilityService();
       videos = _MockVideoEventService();
       when(() => nostr.configuredRelays).thenReturn(const []);
@@ -41,12 +46,16 @@ void main() {
       when(
         () => nostr.removeRelay(any(), source: any(named: 'source')),
       ).thenAnswer((_) async => true);
+      when(
+        relayListRepository.publishConfiguredRelayList,
+      ).thenAnswer((_) async => const RelayListPublishResult.published());
       when(nostr.forceReconnectAll).thenAnswer((_) async {});
       when(videos.resetAndResubscribeAll).thenAnswer((_) async {});
     });
 
     RelaySettingsCubit buildCubit() => RelaySettingsCubit(
       nostrClient: nostr,
+      relayListRepository: relayListRepository,
       relayCapabilityService: capabilities,
       videoEventService: videos,
     );
@@ -178,6 +187,7 @@ void main() {
             source: RelayAddSource.user,
           ),
         ).called(1);
+        verify(relayListRepository.publishConfiguredRelayList).called(1);
       },
     );
 
@@ -194,6 +204,9 @@ void main() {
         expect(outcome, AddRelayOutcome.failed);
       },
       expect: () => [const RelaySettingsState()],
+      verify: (_) {
+        verifyNever(relayListRepository.publishConfiguredRelayList);
+      },
     );
 
     blocTest<RelaySettingsCubit, RelaySettingsState>(
@@ -214,6 +227,31 @@ void main() {
       expect: () => [
         const RelaySettingsState(relays: ['wss://pending.example']),
       ],
+      verify: (_) {
+        verify(relayListRepository.publishConfiguredRelayList).called(1);
+      },
+    );
+
+    blocTest<RelaySettingsCubit, RelaySettingsState>(
+      'addRelay returns local-only when publish fails after local save',
+      setUp: () {
+        when(() => nostr.configuredRelays).thenReturn(['wss://added.example']);
+        when(relayListRepository.publishConfiguredRelayList).thenAnswer(
+          (_) async => RelayListPublishResult.failed(
+            StateError('no indexer accepted'),
+            StackTrace.current,
+          ),
+        );
+      },
+      build: buildCubit,
+      act: (cubit) async {
+        final outcome = await cubit.addRelay('wss://added.example');
+        expect(outcome, AddRelayOutcome.addedLocalOnly);
+      },
+      expect: () => [
+        const RelaySettingsState(relays: ['wss://added.example']),
+      ],
+      errors: () => [isA<StateError>()],
     );
 
     blocTest<RelaySettingsCubit, RelaySettingsState>(
@@ -257,6 +295,7 @@ void main() {
             source: RelayRemoveSource.user,
           ),
         ).called(1);
+        verify(relayListRepository.publishConfiguredRelayList).called(1);
       },
     );
 
@@ -278,6 +317,9 @@ void main() {
       expect: () => [
         const RelaySettingsState(relays: ['wss://a.example']),
       ],
+      verify: (_) {
+        verifyNever(relayListRepository.publishConfiguredRelayList);
+      },
     );
 
     blocTest<RelaySettingsCubit, RelaySettingsState>(
@@ -297,6 +339,32 @@ void main() {
         );
       },
       expect: () => [const RelaySettingsState()],
+      verify: (_) {
+        verify(relayListRepository.publishConfiguredRelayList).called(1);
+      },
+    );
+
+    blocTest<RelaySettingsCubit, RelaySettingsState>(
+      'removeRelay returns local-only when publish fails after local removal',
+      seed: () => const RelaySettingsState(relays: ['wss://gone.example']),
+      setUp: () {
+        when(() => nostr.configuredRelays).thenReturn(const []);
+        when(relayListRepository.publishConfiguredRelayList).thenAnswer(
+          (_) async => RelayListPublishResult.failed(
+            StateError('no indexer accepted'),
+            StackTrace.current,
+          ),
+        );
+      },
+      build: buildCubit,
+      act: (cubit) async {
+        expect(
+          await cubit.removeRelay('wss://gone.example'),
+          RemoveRelayOutcome.removedLocalOnly,
+        );
+      },
+      expect: () => [const RelaySettingsState()],
+      errors: () => [isA<StateError>()],
     );
 
     blocTest<RelaySettingsCubit, RelaySettingsState>(
@@ -321,6 +389,7 @@ void main() {
             source: RelayAddSource.user,
           ),
         ).called(1);
+        verify(relayListRepository.publishConfiguredRelayList).called(1);
       },
     );
 
@@ -357,7 +426,37 @@ void main() {
             source: RelayAddSource.user,
           ),
         ).called(1);
+        verify(relayListRepository.publishConfiguredRelayList).called(1);
       },
+    );
+
+    blocTest<RelaySettingsCubit, RelaySettingsState>(
+      'restoreDefaultRelay returns local-only when publish fails after restore',
+      setUp: () {
+        when(
+          () => nostr.defaultRelayUrl,
+        ).thenReturn('wss://relay.staging.divine.video');
+        when(
+          () => nostr.configuredRelays,
+        ).thenReturn(['wss://relay.staging.divine.video']);
+        when(relayListRepository.publishConfiguredRelayList).thenAnswer(
+          (_) async => RelayListPublishResult.failed(
+            StateError('no indexer accepted'),
+            StackTrace.current,
+          ),
+        );
+      },
+      build: buildCubit,
+      act: (cubit) async {
+        expect(
+          await cubit.restoreDefaultRelay(),
+          RestoreDefaultRelayOutcome.restoredLocalOnly,
+        );
+      },
+      expect: () => [
+        const RelaySettingsState(relays: ['wss://relay.staging.divine.video']),
+      ],
+      errors: () => [isA<StateError>()],
     );
 
     blocTest<RelaySettingsCubit, RelaySettingsState>(

--- a/mobile/test/repositories/relay_list_repository_test.dart
+++ b/mobile/test/repositories/relay_list_repository_test.dart
@@ -1,0 +1,218 @@
+// ABOUTME: Tests for NIP-65 kind:10002 relay-list publishing.
+// ABOUTME: Covers marker preservation, indexer acceptance, cache, and retry state.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:openvine/models/environment_config.dart';
+import 'package:openvine/repositories/relay_list_repository.dart';
+import 'package:openvine/services/relay_discovery_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockRelayDiscoveryService extends Mock
+    implements RelayDiscoveryService {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _MockNostrClient nostrClient;
+  late _MockRelayDiscoveryService relayDiscoveryService;
+  late SharedPreferences prefs;
+  late LocalNostrSigner signer;
+  late String pubkey;
+  late List<DiscoveredRelay> discoveredRelays;
+
+  setUpAll(() {
+    registerFallbackValue(
+      Event('0' * 64, EventKind.relayListMetadata, const [], ''),
+    );
+  });
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    nostrClient = _MockNostrClient();
+    relayDiscoveryService = _MockRelayDiscoveryService();
+    signer = LocalNostrSigner(generatePrivateKey());
+    pubkey = (await signer.getPublicKey())!;
+    discoveredRelays = const [];
+
+    when(() => nostrClient.hasKeys).thenReturn(true);
+    when(() => nostrClient.publicKey).thenReturn(pubkey);
+    when(() => nostrClient.signer).thenReturn(signer);
+    when(() => nostrClient.configuredRelays).thenReturn(const [
+      'wss://relay.divine.video',
+      'wss://read.example',
+      'wss://write.example',
+      'wss://new.example',
+    ]);
+    when(
+      () => relayDiscoveryService.clearCache(any()),
+    ).thenAnswer((_) async {});
+    when(
+      () => nostrClient.publishEventAwaitOk(
+        any(),
+        targetRelays: any(named: 'targetRelays'),
+        diagnosticTag: any(named: 'diagnosticTag'),
+      ),
+    ).thenAnswer((invocation) async {
+      final event = invocation.positionalArguments.first as Event;
+      return PublishOutcome(
+        eventId: event.id,
+        acceptedBy: const ['wss://purplepag.es'],
+        rejectedBy: const {},
+        noResponseFrom: const [],
+      );
+    });
+  });
+
+  RelayListRepository buildRepository({
+    EnvironmentConfig environment = EnvironmentConfig.production,
+  }) {
+    return RelayListRepository(
+      nostrClient: nostrClient,
+      environment: environment,
+      relayDiscoveryService: relayDiscoveryService,
+      sharedPreferences: prefs,
+      discoveredRelays: () => discoveredRelays,
+    );
+  }
+
+  test(
+    'publishes configured relays as kind 10002 and preserves markers',
+    () async {
+      discoveredRelays = const [
+        DiscoveredRelay(url: 'wss://read.example', write: false),
+        DiscoveredRelay(url: 'wss://write.example', read: false),
+      ];
+
+      final result = await buildRepository().publishConfiguredRelayList();
+
+      expect(result.status, RelayListPublishStatus.published);
+      final captured = verify(
+        () => nostrClient.publishEventAwaitOk(
+          captureAny(),
+          targetRelays: captureAny(named: 'targetRelays'),
+          diagnosticTag: 'relay-list-kind-10002',
+        ),
+      ).captured;
+      final event = captured[0] as Event;
+      final targetRelays = captured[1] as List<String>;
+
+      expect(event.kind, EventKind.relayListMetadata);
+      expect(event.pubkey, pubkey);
+      expect(event.tags, [
+        ['r', 'wss://relay.divine.video'],
+        ['r', 'wss://read.example', 'read'],
+        ['r', 'wss://write.example', 'write'],
+        ['r', 'wss://new.example'],
+      ]);
+      expect(targetRelays, contains('wss://relay.divine.video'));
+      expect(targetRelays, contains('wss://purplepag.es'));
+      verify(
+        () => relayDiscoveryService.clearCache(Nip19.encodePubKey(pubkey)),
+      ).called(1);
+      expect(buildRepository().isDirty(pubkey), isFalse);
+    },
+  );
+
+  test('skips without dirtying when the client has no signing keys', () async {
+    when(() => nostrClient.hasKeys).thenReturn(false);
+    when(() => nostrClient.publicKey).thenReturn('');
+
+    final result = await buildRepository().publishConfiguredRelayList();
+
+    expect(result.status, RelayListPublishStatus.skippedNoKeys);
+    verifyNever(
+      () => nostrClient.publishEventAwaitOk(
+        any(),
+        targetRelays: any(named: 'targetRelays'),
+        diagnosticTag: any(named: 'diagnosticTag'),
+      ),
+    );
+    expect(buildRepository().isDirty(pubkey), isFalse);
+  });
+
+  test('skips publishing in non-production environments', () async {
+    final result = await buildRepository(
+      environment: const EnvironmentConfig(environment: AppEnvironment.staging),
+    ).publishConfiguredRelayList();
+
+    expect(result.status, RelayListPublishStatus.skippedNonProduction);
+    verifyNever(
+      () => nostrClient.publishEventAwaitOk(
+        any(),
+        targetRelays: any(named: 'targetRelays'),
+        diagnosticTag: any(named: 'diagnosticTag'),
+      ),
+    );
+    expect(buildRepository().isDirty(pubkey), isFalse);
+  });
+
+  test(
+    'marks dirty and does not clear cache when no indexer accepts',
+    () async {
+      when(
+        () => nostrClient.publishEventAwaitOk(
+          any(),
+          targetRelays: any(named: 'targetRelays'),
+          diagnosticTag: any(named: 'diagnosticTag'),
+        ),
+      ).thenAnswer((invocation) async {
+        final event = invocation.positionalArguments.first as Event;
+        return PublishOutcome(
+          eventId: event.id,
+          acceptedBy: const ['wss://relay.divine.video'],
+          rejectedBy: const {},
+          noResponseFrom: const [],
+        );
+      });
+
+      final repository = buildRepository();
+      final result = await repository.publishConfiguredRelayList();
+
+      expect(result.status, RelayListPublishStatus.failed);
+      expect(repository.isDirty(pubkey), isTrue);
+      verifyNever(() => relayDiscoveryService.clearCache(any()));
+    },
+  );
+
+  test(
+    'retryDirtyPublish republishes only when the dirty flag is set',
+    () async {
+      final repository = buildRepository();
+
+      expect(
+        await repository.retryDirtyPublish(),
+        isA<RelayListPublishResult>().having(
+          (result) => result.status,
+          'status',
+          RelayListPublishStatus.skippedNoKeys,
+        ),
+      );
+      verifyNever(
+        () => nostrClient.publishEventAwaitOk(
+          any(),
+          targetRelays: any(named: 'targetRelays'),
+          diagnosticTag: any(named: 'diagnosticTag'),
+        ),
+      );
+
+      await prefs.setBool('relay_list_publish_dirty_$pubkey', true);
+      final result = await repository.retryDirtyPublish();
+
+      expect(result.status, RelayListPublishStatus.published);
+      verify(
+        () => nostrClient.publishEventAwaitOk(
+          any(),
+          targetRelays: any(named: 'targetRelays'),
+          diagnosticTag: any(named: 'diagnosticTag'),
+        ),
+      ).called(1);
+      expect(repository.isDirty(pubkey), isFalse);
+    },
+  );
+}

--- a/mobile/test/repositories/relay_list_repository_test.dart
+++ b/mobile/test/repositories/relay_list_repository_test.dart
@@ -187,11 +187,13 @@ void main() {
 
       expect(
         await repository.retryDirtyPublish(),
-        isA<RelayListPublishResult>().having(
-          (result) => result.status,
-          'status',
-          RelayListPublishStatus.skippedNoKeys,
-        ),
+        isA<RelayListPublishResult>()
+            .having(
+              (result) => result.status,
+              'status',
+              RelayListPublishStatus.skippedNotDirty,
+            )
+            .having((result) => result.localOnly, 'localOnly', isFalse),
       );
       verifyNever(
         () => nostrClient.publishEventAwaitOk(

--- a/mobile/test/repositories/relay_list_repository_test.dart
+++ b/mobile/test/repositories/relay_list_repository_test.dart
@@ -29,6 +29,7 @@ void main() {
     registerFallbackValue(
       Event('0' * 64, EventKind.relayListMetadata, const [], ''),
     );
+    registerFallbackValue(Duration.zero);
   });
 
   setUp(() async {
@@ -56,6 +57,7 @@ void main() {
       () => nostrClient.publishEventAwaitOk(
         any(),
         targetRelays: any(named: 'targetRelays'),
+        timeout: any(named: 'timeout'),
         diagnosticTag: any(named: 'diagnosticTag'),
       ),
     ).thenAnswer((invocation) async {
@@ -96,11 +98,14 @@ void main() {
         () => nostrClient.publishEventAwaitOk(
           captureAny(),
           targetRelays: captureAny(named: 'targetRelays'),
+          timeout: captureAny(named: 'timeout'),
           diagnosticTag: 'relay-list-kind-10002',
         ),
       ).captured;
+      // mocktail returns captures ordered by argument name, not call order.
       final event = captured[0] as Event;
-      final targetRelays = captured[1] as List<String>;
+      final timeout = captured[1] as Duration;
+      final targetRelays = captured[2] as List<String>;
 
       expect(event.kind, EventKind.relayListMetadata);
       expect(event.pubkey, pubkey);
@@ -112,6 +117,9 @@ void main() {
       ]);
       expect(targetRelays, contains('wss://relay.divine.video'));
       expect(targetRelays, contains('wss://purplepag.es'));
+      // Settings blocks on this publish, so it must not inherit the 15s
+      // default on top of the signer timeout.
+      expect(timeout, lessThan(const Duration(seconds: 15)));
       verify(
         () => relayDiscoveryService.clearCache(Nip19.encodePubKey(pubkey)),
       ).called(1);
@@ -130,6 +138,7 @@ void main() {
       () => nostrClient.publishEventAwaitOk(
         any(),
         targetRelays: any(named: 'targetRelays'),
+        timeout: any(named: 'timeout'),
         diagnosticTag: any(named: 'diagnosticTag'),
       ),
     );
@@ -146,6 +155,7 @@ void main() {
       () => nostrClient.publishEventAwaitOk(
         any(),
         targetRelays: any(named: 'targetRelays'),
+        timeout: any(named: 'timeout'),
         diagnosticTag: any(named: 'diagnosticTag'),
       ),
     );
@@ -159,6 +169,7 @@ void main() {
         () => nostrClient.publishEventAwaitOk(
           any(),
           targetRelays: any(named: 'targetRelays'),
+          timeout: any(named: 'timeout'),
           diagnosticTag: any(named: 'diagnosticTag'),
         ),
       ).thenAnswer((invocation) async {
@@ -199,6 +210,7 @@ void main() {
         () => nostrClient.publishEventAwaitOk(
           any(),
           targetRelays: any(named: 'targetRelays'),
+          timeout: any(named: 'timeout'),
           diagnosticTag: any(named: 'diagnosticTag'),
         ),
       );
@@ -211,6 +223,7 @@ void main() {
         () => nostrClient.publishEventAwaitOk(
           any(),
           targetRelays: any(named: 'targetRelays'),
+          timeout: any(named: 'timeout'),
           diagnosticTag: any(named: 'diagnosticTag'),
         ),
       ).called(1);

--- a/mobile/test/screens/relay_settings_screen_layout_test.dart
+++ b/mobile/test/screens/relay_settings_screen_layout_test.dart
@@ -11,6 +11,8 @@ import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/relay_list_repository_provider.dart';
+import 'package:openvine/repositories/relay_list_repository.dart';
 import 'package:openvine/screens/relay_settings_screen.dart';
 import 'package:openvine/services/relay_capability_service.dart';
 import 'package:openvine/services/relay_statistics_service.dart';
@@ -18,6 +20,22 @@ import 'package:openvine/services/video_event_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockNostrService extends Mock implements NostrClient {}
+
+/// The real provider reaches AuthService and SharedPreferences, which this
+/// layout-focused suite does not wire up. Publishing always succeeds here so
+/// the assertions stay about the screen.
+class _FakeRelayListRepository implements RelayListRepository {
+  @override
+  Future<RelayListPublishResult> publishConfiguredRelayList() async =>
+      const RelayListPublishResult.published();
+
+  @override
+  Future<RelayListPublishResult> retryDirtyPublish() async =>
+      const RelayListPublishResult.published();
+
+  @override
+  bool isDirty(String pubkey) => false;
+}
 
 class _MockRelayCapabilityService extends Mock
     implements RelayCapabilityService {}
@@ -70,6 +88,9 @@ void main() {
           relayStatisticsStreamProvider.overrideWith(
             (_) => Stream.value({'wss://relay.divine.video': stats}),
           ),
+          relayListRepositoryProvider.overrideWithValue(
+            _FakeRelayListRepository(),
+          ),
           videoEventServiceProvider.overrideWithValue(videoEventService),
         ],
       );
@@ -120,6 +141,9 @@ void main() {
         relayStatisticsServiceProvider.overrideWithValue(statsService),
         relayStatisticsStreamProvider.overrideWith(
           (_) => Stream.value({defaultRelay: stats}),
+        ),
+        relayListRepositoryProvider.overrideWithValue(
+          _FakeRelayListRepository(),
         ),
         videoEventServiceProvider.overrideWithValue(videoEventService),
       ],
@@ -187,6 +211,9 @@ void main() {
         relayStatisticsStreamProvider.overrideWith(
           (_) => Stream.value({customRelay: stats}),
         ),
+        relayListRepositoryProvider.overrideWithValue(
+          _FakeRelayListRepository(),
+        ),
         videoEventServiceProvider.overrideWithValue(videoEventService),
       ],
     );
@@ -245,6 +272,9 @@ void main() {
           relayStatisticsServiceProvider.overrideWithValue(statsService),
           relayStatisticsStreamProvider.overrideWith(
             (_) => const Stream<Map<String, RelayStatistics>>.empty(),
+          ),
+          relayListRepositoryProvider.overrideWithValue(
+            _FakeRelayListRepository(),
           ),
           videoEventServiceProvider.overrideWithValue(videoEventService),
         ],

--- a/mobile/test/screens/relay_settings_screen_layout_test.dart
+++ b/mobile/test/screens/relay_settings_screen_layout_test.dart
@@ -37,6 +37,15 @@ class _FakeRelayListRepository implements RelayListRepository {
   bool isDirty(String pubkey) => false;
 }
 
+class _FailingRelayListRepository extends _FakeRelayListRepository {
+  @override
+  Future<RelayListPublishResult> publishConfiguredRelayList() async =>
+      RelayListPublishResult.failed(
+        StateError('no indexer accepted'),
+        StackTrace.current,
+      );
+}
+
 class _MockRelayCapabilityService extends Mock
     implements RelayCapabilityService {}
 
@@ -251,6 +260,7 @@ void main() {
     Future<void> pumpScreen(
       WidgetTester tester, {
       required _MockNostrService nostrService,
+      RelayListRepository? relayListRepository,
     }) async {
       SharedPreferences.setMockInitialValues({});
 
@@ -274,7 +284,7 @@ void main() {
             (_) => const Stream<Map<String, RelayStatistics>>.empty(),
           ),
           relayListRepositoryProvider.overrideWithValue(
-            _FakeRelayListRepository(),
+            relayListRepository ?? _FakeRelayListRepository(),
           ),
           videoEventServiceProvider.overrideWithValue(videoEventService),
         ],
@@ -396,6 +406,51 @@ void main() {
         () => nostrService.addRelay(relay, source: RelayAddSource.user),
       ).called(1);
     });
+
+    testWidgets(
+      'still reports the connection failure when the relay list also '
+      'failed to publish',
+      (tester) async {
+        const relay = 'wss://pending.example.com';
+        final nostrService = _MockNostrService();
+        final configuredRelays = <String>[];
+        when(
+          () => nostrService.defaultRelayUrl,
+        ).thenReturn('wss://relay.divine.video');
+        when(
+          () => nostrService.configuredRelays,
+        ).thenAnswer((_) => List.unmodifiable(configuredRelays));
+        when(
+          () => nostrService.addRelay(relay, source: RelayAddSource.user),
+        ).thenAnswer((_) async {
+          configuredRelays.add(relay);
+          return false;
+        });
+
+        await pumpScreen(
+          tester,
+          nostrService: nostrService,
+          relayListRepository: _FailingRelayListRepository(),
+        );
+        // pumpScreen pins configuredRelays to const []; restore the live view
+        // so the cubit sees the relay that addRelay just saved locally.
+        when(
+          () => nostrService.configuredRelays,
+        ).thenAnswer((_) => List.unmodifiable(configuredRelays));
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await openAddSheetAndSubmit(tester, relay, l10n);
+
+        expect(
+          find.textContaining(l10n.relaySettingsFailedToConnectCheck),
+          findsOneWidget,
+        );
+        expect(
+          find.textContaining(l10n.relaySettingsSavedLocallyPublishPending),
+          findsOneWidget,
+        );
+      },
+    );
 
     testWidgets('accepts uppercase WSS:// URL and forwards to NostrClient', (
       tester,


### PR DESCRIPTION
## Summary

- publish successful relay Settings edits as NIP-65 kind 10002 events
- preserve discovered read/write markers when rebuilding relay-list tags
- keep local edits successful when publish fails, mark the relay list dirty, and retry on next active session
- clear relay discovery cache after accepted indexer publish

Closes #6648

## Tests

- flutter test test/repositories/relay_list_repository_test.dart test/blocs/relay_settings/relay_settings_cubit_test.dart test/l10n/arb_consistency_test.dart
- flutter analyze

## Follow-ups

- #6719 tracks durable relay provenance.
- #6720 tracks first-class read/write marker support.
