### PR TITLE
fix(models): preserve addressable d-tag state

### DIFF
--- a/mobile/lib/blocs/profile_feed/profile_feed_enrichment_merge.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_enrichment_merge.dart
@@ -68,6 +68,7 @@ VideoEvent _mergeEnrichmentIntoCurrent(
         ? current.hashtags
         : enriched.hashtags,
     vineId: current.vineId ?? enriched.vineId,
+    addressableDTag: current.addressableDTag ?? enriched.addressableDTag,
     group: current.group ?? enriched.group,
     altText: current.altText ?? enriched.altText,
     blurhash: current.blurhash ?? enriched.blurhash,

--- a/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
@@ -11,8 +11,6 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart' hide LogCategory;
-import 'package:nostr_sdk/aid.dart';
-import 'package:nostr_sdk/event_kind.dart';
 import 'package:openvine/blocs/profile_shared/profile_tab_page_size.dart';
 import 'package:openvine/blocs/profile_shared/profile_tab_sync_completion.dart';
 import 'package:openvine/blocs/profile_shared/profile_video_list_snapshot.dart';
@@ -586,13 +584,8 @@ class ProfileRepostedVideosBloc
   /// Compute the addressable ID for a video event.
   ///
   /// Format: `kind:pubkey:d-tag`
-  /// Returns null if the video doesn't have a d-tag (vineId).
+  /// Returns null if the video doesn't have a real d-tag.
   String? _computeAddressableId(VideoEvent video) {
-    if (video.vineId == null) return null;
-    return AId(
-      kind: EventKind.videoVertical,
-      pubkey: video.pubkey,
-      dTag: video.vineId!,
-    ).toAString();
+    return video.addressableId;
   }
 }

--- a/mobile/lib/repositories/community_content_label_repository.dart
+++ b/mobile/lib/repositories/community_content_label_repository.dart
@@ -253,7 +253,7 @@ class CommunityContentLabelRepository {
   }
 
   String? _addressableTargetFor(VideoEvent video) {
-    final dTag = video.vineId;
+    final dTag = video.addressableDTag;
     if (!video.isAddressableShareKind || dTag == null || dTag.isEmpty) {
       return null;
     }

--- a/mobile/lib/services/content_deletion_service.dart
+++ b/mobile/lib/services/content_deletion_service.dart
@@ -542,19 +542,9 @@ class ContentDeletionService {
   }
 
   String? _addressableDeletionTarget(VideoEvent video) {
-    final dTag = video.rawTags['d'];
-    final stableDTag = dTag != null && dTag.isNotEmpty
-        ? dTag
-        : video.vineId != null &&
-              video.vineId!.isNotEmpty &&
-              video.vineId != video.id
-        ? video.vineId
-        : null;
-    if (stableDTag == null || stableDTag.isEmpty) {
-      return null;
-    }
-    return '${NIP71VideoKinds.getPreferredAddressableKind()}'
-        ':${video.pubkey}:$stableDTag';
+    // Do not emit an empty-d coordinate for d-less addressable videos; delete
+    // only the concrete event id when the event carried no real d tag.
+    return video.hasAddressableDTag ? video.addressableId : null;
   }
 
   /// Get delete reason text for common cases

--- a/mobile/lib/services/view_event_publisher.dart
+++ b/mobile/lib/services/view_event_publisher.dart
@@ -137,12 +137,16 @@ class ViewEventPublisher {
     }
 
     try {
-      // Build the addressable coordinate (a tag)
-      // Format: "<kind>:author_pubkey:d_tag"
-      // Use event ID as fallback if vineId (d-tag) is null
-      final dTag = video.vineId ?? video.id;
-      final aTag =
-          '${NIP71VideoKinds.addressableShortVideo}:${video.pubkey}:$dTag';
+      // View events require an addressable video reference.
+      final aTag = video.addressableId;
+      if (aTag == null) {
+        Log.warning(
+          'Skipping view event: video has no addressable d tag',
+          name: 'ViewEventPublisher',
+          category: LogCategory.video,
+        );
+        return false;
+      }
 
       // Get relay hint
       String relayHint = _defaultRelayHint;
@@ -256,9 +260,15 @@ class ViewEventPublisher {
     }
 
     try {
-      final dTag = video.vineId ?? video.id;
-      final aTag =
-          '${NIP71VideoKinds.addressableShortVideo}:${video.pubkey}:$dTag';
+      final aTag = video.addressableId;
+      if (aTag == null) {
+        Log.warning(
+          'Skipping view event: video has no addressable d tag',
+          name: 'ViewEventPublisher',
+          category: LogCategory.video,
+        );
+        return false;
+      }
 
       String relayHint = _defaultRelayHint;
       if (_nostrService.connectedRelays.isNotEmpty) {

--- a/mobile/lib/utils/video_nostr_enrichment.dart
+++ b/mobile/lib/utils/video_nostr_enrichment.dart
@@ -209,6 +209,7 @@ Future<List<VideoEvent>> enrichVideosWithNostrTags(
           hashtags: video.hashtags.isEmpty ? parsed.hashtags : video.hashtags,
           publishedAt: video.publishedAt ?? parsed.publishedAt,
           vineId: video.vineId ?? parsed.vineId,
+          addressableDTag: video.addressableDTag ?? parsed.addressableDTag,
           group: video.group ?? parsed.group,
           altText: video.altText ?? parsed.altText,
           blurhash: video.blurhash ?? parsed.blurhash,

--- a/mobile/packages/models/lib/src/audio_event.dart
+++ b/mobile/packages/models/lib/src/audio_event.dart
@@ -239,7 +239,7 @@ class AudioEvent {
       duration: video.duration?.toDouble(),
       title: creatorName == null ? null : 'Original sound - $creatorName',
       source: 'Original Sound',
-      sourceVideoReference: '34236:${video.pubkey}:${video.vineId ?? video.id}',
+      sourceVideoReference: video.addressableId,
       allowsReuse: video.allowAudioReuse,
     );
   }

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -168,6 +168,7 @@ class VideoEvent {
     this.publishedAt,
     this.rawTags = const {},
     this.vineId,
+    this.addressableDTag,
     this.group,
     this.altText,
     this.blurhash,
@@ -228,6 +229,13 @@ class VideoEvent {
     final timestamp = json['timestamp'];
     final textTrackRef = json['textTrackRef'] as String?;
     final textTrackRefs = stringList(json['textTrackRefs']);
+    final rawTags =
+        (json['rawTags'] as Map<String, dynamic>?)?.map(
+          (key, value) => MapEntry(key, value.toString()),
+        ) ??
+        const <String, String>{};
+    final persistedAddressableDTag = json['addressableDTag'] as String?;
+    final rawDTag = rawTags['d'];
     return VideoEvent(
       id: json['id'] as String? ?? '',
       pubkey: json['pubkey'] as String? ?? '',
@@ -248,12 +256,15 @@ class VideoEvent {
       categories: stringList(json['categories']),
       eventCreatedAt: optInt(json['eventCreatedAt']),
       publishedAt: json['publishedAt'] as String?,
-      rawTags:
-          (json['rawTags'] as Map<String, dynamic>?)?.map(
-            (key, value) => MapEntry(key, value.toString()),
-          ) ??
-          const {},
+      rawTags: rawTags,
       vineId: json['vineId'] as String?,
+      addressableDTag:
+          persistedAddressableDTag != null &&
+              persistedAddressableDTag.isNotEmpty
+          ? persistedAddressableDTag
+          : rawDTag != null && rawDTag.isNotEmpty
+          ? rawDTag
+          : null,
       group: json['group'] as String?,
       altText: json['altText'] as String?,
       blurhash: json['blurhash'] as String?,
@@ -345,6 +356,7 @@ class VideoEvent {
     String? audioEventId;
     String? audioEventRelay;
     String? sourceRelay;
+    String? addressableDTag;
     final collaboratorPubkeys = <String>[];
     InspiredByInfo? inspiredByVideo;
     final textTrackRefsLocal = <String>[];
@@ -472,6 +484,7 @@ class VideoEvent {
         case 'd':
           // Replaceable event ID - original vine ID
           vineId = tagValue as String?;
+          addressableDTag = tagValue as String?;
         case 'vine_id':
           // Some clients use 'vine_id' instead of 'd' for the original Vine ID
           vineId ??= tagValue as String?;
@@ -706,6 +719,9 @@ class VideoEvent {
       publishedAt: publishedAt,
       rawTags: rawTags,
       vineId: vineId,
+      addressableDTag: addressableDTag != null && addressableDTag.isNotEmpty
+          ? addressableDTag
+          : null,
       group: group,
       altText: altText,
       blurhash: blurhash,
@@ -764,6 +780,14 @@ class VideoEvent {
 
   // Vine-specific fields from NIP-71 spec
   final String? vineId; // 'd' tag - original vine ID for replaceable events
+
+  /// The real NIP-33 `d` tag value carried by this event.
+  ///
+  /// Null when the source event or REST row had no non-empty `d` tag. Unlike
+  /// [vineId], this is never filled from `vine_id` and never falls back to the
+  /// event id, so protocol coordinate builders can distinguish a missing `d`.
+  final String? addressableDTag;
+
   final String? group; // 'h' tag - group/community identification
   final String? altText; // 'alt' tag - accessibility text
   final String? blurhash; // 'blurhash' tag - for progressive image loading
@@ -1229,11 +1253,14 @@ class VideoEvent {
         proofSummary?.hasUsableC2paManifest == true;
   }
 
-  String? get addressableId => vineId != null
+  bool get hasAddressableDTag =>
+      addressableDTag != null && addressableDTag!.isNotEmpty;
+
+  String? get addressableId => hasAddressableDTag
       ? AId(
           kind: EventKind.videoVertical,
           pubkey: pubkey,
-          dTag: vineId!,
+          dTag: addressableDTag!,
         ).toAString()
       : null;
 
@@ -1593,6 +1620,8 @@ class VideoEvent {
     String? publishedAt,
     Map<String, String>? rawTags,
     String? vineId,
+    String? addressableDTag,
+    bool clearAddressableDTag = false,
     String? group,
     String? altText,
     String? blurhash,
@@ -1652,6 +1681,9 @@ class VideoEvent {
     publishedAt: publishedAt ?? this.publishedAt,
     rawTags: rawTags ?? this.rawTags,
     vineId: vineId ?? this.vineId,
+    addressableDTag: clearAddressableDTag
+        ? null
+        : (addressableDTag ?? this.addressableDTag),
     group: group ?? this.group,
     altText: altText ?? this.altText,
     blurhash: blurhash ?? this.blurhash,
@@ -1743,6 +1775,7 @@ class VideoEvent {
     'publishedAt': publishedAt,
     'rawTags': rawTags,
     'vineId': vineId,
+    'addressableDTag': addressableDTag,
     'group': group,
     'altText': altText,
     'blurhash': blurhash,

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -573,6 +573,7 @@ class VideoStats {
       vineId: normalizedDTag.isNotEmpty ? normalizedDTag : null,
       publishedAt: publishedAt?.toString(),
       sha256: sha256,
+      addressableDTag: dTag.isNotEmpty ? dTag : null,
       authorName: authorName,
       authorAvatar: authorAvatar,
       blurhash: blurhash,

--- a/mobile/packages/models/test/src/audio_event_test.dart
+++ b/mobile/packages/models/test/src/audio_event_test.dart
@@ -429,6 +429,7 @@ void main() {
           videoUrl: 'https://example.com/video.mp4',
           duration: 6,
           vineId: 'vine-123',
+          addressableDTag: 'vine-123',
         );
 
         final audioEvent = AudioEvent.fromVideoOriginalSound(
@@ -454,6 +455,7 @@ void main() {
           videoUrl: 'https://example.com/video.mp4',
           duration: 6,
           vineId: 'vine-123',
+          addressableDTag: 'vine-123',
         );
 
         final audioEvent = AudioEvent.fromVideoOriginalSound(video);
@@ -461,6 +463,26 @@ void main() {
         expect(audioEvent.title, isNull);
         expect(audioEvent.pubkey, equals(testPubkey));
       });
+
+      test(
+        'omits sourceVideoReference when source video has no real d tag',
+        () {
+          final video = VideoEvent(
+            id: testHexId,
+            pubkey: testPubkey,
+            createdAt: 1700000000,
+            content: 'classic vine',
+            timestamp: DateTime(2026),
+            videoUrl: 'https://example.com/video.mp4',
+            duration: 6,
+            vineId: 'legacy-vine-id',
+          );
+
+          final audioEvent = AudioEvent.fromVideoOriginalSound(video);
+
+          expect(audioEvent.sourceVideoReference, isNull);
+        },
+      );
 
       test('carries allowsReuse from the source video', () {
         VideoEvent video({required bool allowReuse}) => VideoEvent(
@@ -472,6 +494,7 @@ void main() {
           videoUrl: 'https://example.com/video.mp4',
           duration: 6,
           vineId: 'vine-123',
+          addressableDTag: 'vine-123',
           rawTags: allowReuse ? const {'allow_audio_reuse': 'true'} : const {},
         );
 

--- a/mobile/packages/models/test/src/video_event_addressable_id_test.dart
+++ b/mobile/packages/models/test/src/video_event_addressable_id_test.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Tests VideoEvent.addressableId preserves the legacy app-wide
-// ABOUTME: 34236 coordinate key while scoped callers can derive richer targets.
+// ABOUTME: Tests VideoEvent.addressableId uses only real addressable d tags.
+// ABOUTME: Preserves the legacy app-wide 34236 coordinate key for real d tags.
 
 import 'package:models/models.dart';
 import 'package:test/test.dart';
@@ -11,33 +11,46 @@ void main() {
     const eventId =
         'f1e2d3c4b5a6f1e2d3c4b5a6f1e2d3c4b5a6f1e2d3c4b5a6f1e2d3c4b5a6f1e2';
 
-    VideoEvent build({int? eventKind, String? vineId}) => VideoEvent(
+    VideoEvent build({
+      int? eventKind,
+      String? vineId,
+      String? addressableDTag,
+    }) => VideoEvent(
       id: eventId,
       pubkey: pubkey,
       createdAt: 1704067200,
       content: '',
       timestamp: DateTime.fromMillisecondsSinceEpoch(1704067200 * 1000),
       vineId: vineId,
+      addressableDTag: addressableDTag,
       eventKind: eventKind,
     );
 
     test('uses kind 34236 for an addressable short video', () {
-      final video = build(eventKind: 34236, vineId: 'vine123');
+      final video = build(
+        eventKind: 34236,
+        vineId: 'vine123',
+        addressableDTag: 'vine123',
+      );
       expect(video.addressableId, equals('34236:$pubkey:vine123'));
     });
 
     test('keeps legacy 34236 coordinates for app-wide compatibility', () {
-      final video = build(eventKind: 34235, vineId: 'reel456');
+      final video = build(
+        eventKind: 34235,
+        vineId: 'reel456',
+        addressableDTag: 'reel456',
+      );
       expect(video.addressableId, equals('34236:$pubkey:reel456'));
     });
 
-    test('keeps non-addressable video coordinates on the legacy key', () {
+    test('does not fall back to the event id for d-less videos', () {
       final video = build(eventKind: 22, vineId: eventId);
-      expect(video.addressableId, equals('34236:$pubkey:$eventId'));
+      expect(video.addressableId, isNull);
     });
 
     test('falls back to 34236 when the event kind is unknown', () {
-      final video = build(vineId: 'vine789');
+      final video = build(vineId: 'vine789', addressableDTag: 'vine789');
       expect(video.addressableId, equals('34236:$pubkey:vine789'));
     });
 

--- a/mobile/packages/models/test/src/video_event_parsing_test.dart
+++ b/mobile/packages/models/test/src/video_event_parsing_test.dart
@@ -168,6 +168,14 @@ void main() {
 
       final videoEvent1 = VideoEvent.fromNostrEvent(eventWithDTag);
       expect(videoEvent1.vineId, equals('vine-id-from-d-tag'));
+      expect(videoEvent1.addressableDTag, equals('vine-id-from-d-tag'));
+      expect(videoEvent1.hasAddressableDTag, isTrue);
+      expect(
+        videoEvent1.addressableId,
+        equals(
+          '34236:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef:vine-id-from-d-tag',
+        ),
+      );
 
       // Test with 'vine_id' tag
       final eventWithVineIdTag = Event(
@@ -183,7 +191,32 @@ void main() {
 
       final videoEvent2 = VideoEvent.fromNostrEvent(eventWithVineIdTag);
       expect(videoEvent2.vineId, equals('vine-id-from-vine-id-tag'));
+      expect(videoEvent2.addressableDTag, isNull);
+      expect(videoEvent2.hasAddressableDTag, isFalse);
+      expect(videoEvent2.addressableId, isNull);
     });
+
+    test(
+      'preserves missing d tag state while keeping stable vineId fallback',
+      () {
+        final eventWithoutDTag = Event(
+          '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+          34236,
+          [
+            ['url', 'https://example.com/video.mp4'],
+          ],
+          'Test video',
+          createdAt: 1757385263,
+        );
+
+        final videoEvent = VideoEvent.fromNostrEvent(eventWithoutDTag);
+
+        expect(videoEvent.vineId, equals(eventWithoutDTag.id));
+        expect(videoEvent.addressableDTag, isNull);
+        expect(videoEvent.hasAddressableDTag, isFalse);
+        expect(videoEvent.addressableId, isNull);
+      },
+    );
 
     test(
       'should parse imeta tag with blurhash from divine.video events (OLD FORMAT - space-separated)',
@@ -747,25 +780,22 @@ void main() {
       },
     );
 
-    test(
-      'should not treat a single-newline-prefixed attribution as '
-      'inspiredByNpub',
-      () {
-        final nostrEvent = Event(
-          authorPubkey,
-          34236,
-          [
-            ['url', 'https://example.com/video.mp4'],
-          ],
-          'my caption\nInspired by nostr:npub1singlenewline',
-          createdAt: 1757385263,
-        );
+    test('should not treat a single-newline-prefixed attribution as '
+        'inspiredByNpub', () {
+      final nostrEvent = Event(
+        authorPubkey,
+        34236,
+        [
+          ['url', 'https://example.com/video.mp4'],
+        ],
+        'my caption\nInspired by nostr:npub1singlenewline',
+        createdAt: 1757385263,
+      );
 
-        final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+      final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
 
-        expect(videoEvent.inspiredByNpub, isNull);
-      },
-    );
+      expect(videoEvent.inspiredByNpub, isNull);
+    });
 
     test('should resolve the trailing attribution npub when an inline mention '
         'appears earlier in content', () {
@@ -782,10 +812,7 @@ void main() {
 
       final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
 
-      expect(
-        videoEvent.inspiredByNpub,
-        equals('npub1realattribution'),
-      );
+      expect(videoEvent.inspiredByNpub, equals('npub1realattribution'));
     });
 
     test(
@@ -805,10 +832,7 @@ void main() {
 
         final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
 
-        expect(
-          videoEvent.inspiredByNpub,
-          equals('npub1onlyattribution'),
-        );
+        expect(videoEvent.inspiredByNpub, equals('npub1onlyattribution'));
       },
     );
 

--- a/mobile/packages/models/test/src/video_event_to_json_test.dart
+++ b/mobile/packages/models/test/src/video_event_to_json_test.dart
@@ -41,8 +41,9 @@ VideoEvent _fullVideo() => VideoEvent(
   hashtags: const ['vine', 'test'],
   categories: const ['music'],
   publishedAt: '1704067200',
-  rawTags: const {'platform': 'vine', 'views': '42'},
+  rawTags: const {'d': 'abc123def', 'platform': 'vine', 'views': '42'},
   vineId: 'abc123def',
+  addressableDTag: 'abc123def',
   group: 'community',
   altText: 'A person waves at the camera',
   blurhash: 'LKO2?U%2Tw=w',
@@ -121,6 +122,7 @@ const _expectedKeys = <String>{
   'publishedAt',
   'rawTags',
   'vineId',
+  'addressableDTag',
   'group',
   'altText',
   'blurhash',
@@ -163,6 +165,7 @@ const _excludedDerivedGetters = <String>{
   'shareKind',
   'isAddressableShareKind',
   'stableId',
+  'hasAddressableDTag',
   'addressableId',
   'effectiveThumbnailUrl',
   'displayPubkey',
@@ -209,10 +212,7 @@ const _excludedDerivedGetters = <String>{
   'isWebM',
 };
 
-const _excludedInternalFields = <String>{
-  'nostrEventTags',
-  'warnLabels',
-};
+const _excludedInternalFields = <String>{'nostrEventTags', 'warnLabels'};
 
 /// Adding a new persisted field to [VideoEvent] requires THREE coordinated
 /// edits — default-deny is intentional, but the cost is on the contributor:
@@ -335,6 +335,7 @@ void main() {
       expect(restored.publishedAt, equals(original.publishedAt));
       expect(restored.rawTags, equals(original.rawTags));
       expect(restored.vineId, equals(original.vineId));
+      expect(restored.addressableDTag, equals(original.addressableDTag));
       expect(restored.group, equals(original.group));
       expect(restored.altText, equals(original.altText));
       expect(restored.blurhash, equals(original.blurhash));
@@ -373,6 +374,15 @@ void main() {
         equals(original.contentWarningLabels),
       );
       expect(restored.proofSummary, equals(original.proofSummary));
+    });
+
+    test('hydrates addressableDTag from rawTags for older cache entries', () {
+      final json = _fullVideo().toJson()..remove('addressableDTag');
+
+      final restored = VideoEvent.fromJson(json);
+
+      expect(restored.addressableDTag, equals('abc123def'));
+      expect(restored.addressableId, equals('34236:$_pubkey:abc123def'));
     });
 
     test('round-trips a minimal video with only required fields', () {

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -1496,6 +1496,9 @@ void main() {
         expect(videoEvent.thumbnailUrl, isNull);
         // When dTag is empty, vineId falls back to the event id.
         expect(videoEvent.vineId, equals('test-id'));
+        expect(videoEvent.addressableDTag, isNull);
+        expect(videoEvent.hasAddressableDTag, isFalse);
+        expect(videoEvent.addressableId, isNull);
       });
 
       test('handles null description', () {
@@ -1517,6 +1520,30 @@ void main() {
         final videoEvent = stats.toVideoEvent();
 
         expect(videoEvent.content, equals(''));
+      });
+
+      test('preserves non-empty dTag as addressableDTag', () {
+        final stats = VideoStats(
+          id: 'test-id',
+          pubkey: 'test-pubkey',
+          createdAt: DateTime(2024),
+          kind: 34236,
+          dTag: 'test-dtag',
+          title: 'Test',
+          thumbnail: 'https://example.com/thumb.jpg',
+          videoUrl: 'https://example.com/video.mp4',
+          reactions: 0,
+          comments: 0,
+          reposts: 0,
+          engagementScore: 0,
+        );
+
+        final videoEvent = stats.toVideoEvent();
+
+        expect(videoEvent.vineId, equals('test-dtag'));
+        expect(videoEvent.addressableDTag, equals('test-dtag'));
+        expect(videoEvent.hasAddressableDTag, isTrue);
+        expect(videoEvent.addressableId, equals('34236:test-pubkey:test-dtag'));
       });
 
       test(

--- a/mobile/packages/videos_repository/lib/src/profile_video_merge.dart
+++ b/mobile/packages/videos_repository/lib/src/profile_video_merge.dart
@@ -69,6 +69,7 @@ VideoEvent mergeProfileFeedVideos(VideoEvent existing, VideoEvent incoming) {
         ? primary.hashtags
         : secondary.hashtags,
     vineId: primary.vineId ?? secondary.vineId,
+    addressableDTag: primary.addressableDTag ?? secondary.addressableDTag,
     group: primary.group ?? secondary.group,
     altText: primary.altText ?? secondary.altText,
     blurhash: primary.blurhash ?? secondary.blurhash,

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -1465,13 +1465,9 @@ class VideosRepository {
         // Find videos matching our d-tags and convert to VideoEvent
         for (final videoStats in result.videos) {
           final video = videoStats.toVideoEvent();
-          if (video.vineId != null && dTags.contains(video.vineId)) {
-            final videoAddressableId = AId(
-              kind: EventKind.videoVertical,
-              pubkey: video.pubkey,
-              dTag: video.vineId!,
-            ).toAString();
-
+          final videoAddressableId = video.addressableId;
+          if (videoAddressableId != null &&
+              dTags.contains(video.addressableDTag)) {
             // Apply content filter if configured
             if (_blockFilter?.call(video.pubkey) ?? false) continue;
             if (!video.hasVideo) continue;

--- a/mobile/packages/videos_repository/test/src/profile_video_merge_test.dart
+++ b/mobile/packages/videos_repository/test/src/profile_video_merge_test.dart
@@ -13,6 +13,7 @@ VideoEvent _video({
   String? videoUrl,
   String? publishedAt,
   String? vineId,
+  String? addressableDTag,
   Map<String, String> rawTags = const {},
   List<String> hashtags = const [],
   List<String> collaboratorPubkeys = const [],
@@ -40,6 +41,7 @@ VideoEvent _video({
     videoUrl: videoUrl,
     publishedAt: publishedAt,
     vineId: vineId,
+    addressableDTag: addressableDTag,
     rawTags: rawTags,
     hashtags: hashtags,
     collaboratorPubkeys: collaboratorPubkeys,
@@ -140,6 +142,20 @@ void main() {
       );
 
       expect(merged.title, equals('new'));
+    });
+
+    test('fills addressable d tag from the secondary copy', () {
+      final merged = mergeProfileFeedVideos(
+        _video(id: 'rest', vineId: 'video-d-tag'),
+        _video(
+          id: 'nostr',
+          vineId: 'video-d-tag',
+          addressableDTag: 'video-d-tag',
+        ),
+      );
+
+      expect(merged.addressableDTag, equals('video-d-tag'));
+      expect(merged.addressableId, equals('34236:author:video-d-tag'));
     });
 
     test('fills plural text-track refs from the secondary copy', () {

--- a/mobile/test/blocs/profile_feed/profile_feed_enrichment_merge_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_enrichment_merge_test.dart
@@ -10,6 +10,7 @@ VideoEvent _video({
   required String id,
   String pubkey = 'pubkey',
   String? vineId,
+  String? addressableDTag,
   String? textTrackRef,
   List<String> textTrackRefs = const [],
   String? textTrackContent,
@@ -21,6 +22,7 @@ VideoEvent _video({
     content: '',
     timestamp: DateTime.fromMillisecondsSinceEpoch(1704067200 * 1000),
     vineId: vineId,
+    addressableDTag: addressableDTag,
     textTrackRef: textTrackRef,
     textTrackRefs: textTrackRefs,
     textTrackContent: textTrackContent,
@@ -29,6 +31,25 @@ VideoEvent _video({
 
 void main() {
   group('mergeProfileFeedEnrichment', () {
+    test('fills addressable d tag from enriched Nostr copy', () {
+      final current = _video(id: 'rest', vineId: 'video-d-tag');
+      final enriched = _video(
+        id: 'nostr',
+        vineId: 'video-d-tag',
+        addressableDTag: 'video-d-tag',
+      );
+
+      final merged = mergeProfileFeedEnrichment(
+        current: [current],
+        sourceKeys: {canonicalProfileFeedVideoKey(current)},
+        incoming: [enriched],
+        removeTombstones: (videos) => videos,
+      );
+
+      expect(merged.single.addressableDTag, equals('video-d-tag'));
+      expect(merged.single.addressableId, equals('34236:pubkey:video-d-tag'));
+    });
+
     test('fills plural text-track refs from enriched Nostr copy', () {
       final current = _video(id: 'rest', vineId: 'video-subtitles');
       final enriched = _video(

--- a/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
@@ -119,6 +119,7 @@ void main() {
         videoUrl: 'https://example.com/video.mp4',
         thumbnailUrl: 'https://example.com/thumb.jpg',
         vineId: vineId,
+        addressableDTag: vineId,
       );
     }
 

--- a/mobile/test/blocs/video_feed/home_feed_resume_manager_test.dart
+++ b/mobile/test/blocs/video_feed/home_feed_resume_manager_test.dart
@@ -64,6 +64,7 @@ VideoEvent _video(String id, {String? vineId}) => VideoEvent(
   ),
   videoUrl: 'https://cdn.divine.video/$id.mp4',
   vineId: vineId,
+  addressableDTag: vineId,
 );
 
 Future<void> _pump() => Future<void>.delayed(Duration.zero);

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -145,6 +145,7 @@ void main() {
         videoUrl: 'https://example.com/$id.mp4',
         thumbnailUrl: 'https://example.com/$id.jpg',
         vineId: vineId,
+        addressableDTag: vineId,
       );
     }
 

--- a/mobile/test/providers/feed_refresh_helpers_test.dart
+++ b/mobile/test/providers/feed_refresh_helpers_test.dart
@@ -304,6 +304,7 @@ void main() {
         ),
         videoUrl: 'https://example.com/$id.mp4',
         vineId: dTag,
+        addressableDTag: dTag,
       );
     }
 

--- a/mobile/test/repositories/community_content_label_repository_test.dart
+++ b/mobile/test/repositories/community_content_label_repository_test.dart
@@ -73,6 +73,7 @@ void main() {
       when(() => video.pubkey).thenReturn(creatorPubkey);
       when(() => video.addressableId).thenReturn(addressableId);
       when(() => video.vineId).thenReturn('vine123');
+      when(() => video.addressableDTag).thenReturn('vine123');
       when(() => video.shareKind).thenReturn(34236);
       when(() => video.isAddressableShareKind).thenReturn(true);
       // Default: every author resolves to a Divine identity unless overridden.
@@ -470,6 +471,7 @@ void main() {
 
       test('does not publish an a tag for non-addressable videos', () async {
         when(() => video.vineId).thenReturn(videoId);
+        when(() => video.addressableDTag).thenReturn(null);
         when(() => video.shareKind).thenReturn(22);
         when(() => video.isAddressableShareKind).thenReturn(false);
         when(() => nostrClient.publicKey).thenReturn(authorA);

--- a/mobile/test/services/audio_reuse_consent_resolver_test.dart
+++ b/mobile/test/services/audio_reuse_consent_resolver_test.dart
@@ -46,6 +46,7 @@ VideoEvent _video({
       isUtc: true,
     ),
     vineId: vineId,
+    addressableDTag: vineId,
     rawTags: allowsReuse
         ? const {'allow_audio_reuse': 'true'}
         : const {'allow_audio_reuse': 'false'},

--- a/mobile/test/services/content_deletion_service_test.dart
+++ b/mobile/test/services/content_deletion_service_test.dart
@@ -186,6 +186,7 @@ void main() {
         timestamp: DateTime.now(),
         videoUrl: 'https://example.com/video.mp4',
         vineId: 'rest-vine-id',
+        addressableDTag: 'rest-vine-id',
       );
     }
 
@@ -201,6 +202,7 @@ void main() {
         timestamp: DateTime.now(),
         videoUrl: 'https://example.com/video.mp4',
         rawTags: {'d': dTag},
+        addressableDTag: dTag,
       );
     }
 
@@ -440,54 +442,49 @@ void main() {
         },
       );
 
-      test(
-        'saves locally and reports someRelays when one relay accepts and '
-        'another rejects',
-        () async {
-          final video = createTestVideoEvent(testPublicKey);
-          final deleteEvent = createTestEvent(
-            pubkey: testPublicKey,
-            kind: 5,
-            tags: [
-              ['e', video.id],
-              ['a', video.addressableId!],
-              ['k', '34236'],
-            ],
-            content: 'CONTENT DELETION',
-          );
+      test('saves locally and reports someRelays when one relay accepts and '
+          'another rejects', () async {
+        final video = createTestVideoEvent(testPublicKey);
+        final deleteEvent = createTestEvent(
+          pubkey: testPublicKey,
+          kind: 5,
+          tags: [
+            ['e', video.id],
+            ['a', video.addressableId!],
+            ['k', '34236'],
+          ],
+          content: 'CONTENT DELETION',
+        );
 
-          when(
-            () => mockAuthService.createAndSignEvent(
-              kind: any(named: 'kind'),
-              content: any(named: 'content'),
-              tags: any(named: 'tags'),
-            ),
-          ).thenAnswer((_) async => deleteEvent);
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((_) async => deleteEvent);
 
-          when(
-            () => mockNostrService.publishEventAwaitOk(
-              any(),
-              timeout: any(named: 'timeout'),
-            ),
-          ).thenAnswer((_) async => partiallyAccepted(deleteEvent.id));
+        when(
+          () => mockNostrService.publishEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((_) async => partiallyAccepted(deleteEvent.id));
 
-          final result = await service.deleteContent(
-            video: video,
-            reason: 'Personal choice',
-          );
+        final result = await service.deleteContent(
+          video: video,
+          reason: 'Personal choice',
+        );
 
-          // The tombstone exists on a relay, so the video leaves this device's
-          // library. Retrying would only re-ask the relay that refused, which
-          // answers the same way.
-          expect(result.success, isTrue);
-          expect(result.acceptance, equals(DeleteAcceptance.someRelays));
-          expect(service.hasBeenDeleted(video.id), isTrue);
-          expect(service.deletionHistory, hasLength(1));
-          verify(
-            () => mockProfileStatsDao.deleteStats(testPublicKey),
-          ).called(1);
-        },
-      );
+        // The tombstone exists on a relay, so the video leaves this device's
+        // library. Retrying would only re-ask the relay that refused, which
+        // answers the same way.
+        expect(result.success, isTrue);
+        expect(result.acceptance, equals(DeleteAcceptance.someRelays));
+        expect(service.hasBeenDeleted(video.id), isTrue);
+        expect(service.deletionHistory, hasLength(1));
+        verify(() => mockProfileStatsDao.deleteStats(testPublicKey)).called(1);
+      });
 
       test(
         'saves locally and reports someRelays when a targeted relay was never '
@@ -630,6 +627,67 @@ void main() {
           ).captured;
 
           final tags = captured.first as List<List<String>>;
+          expect(tags, contains(equals(['e', video.id])));
+          expect(tags.any((tag) => tag.isNotEmpty && tag[0] == 'a'), isFalse);
+          expect(tags, contains(equals(['k', '34236'])));
+        },
+      );
+
+      test(
+        'does not include a tag when vine_id exists without a real d tag',
+        () async {
+          final event = Event(
+            testPublicKey,
+            34236,
+            [
+              ['title', 'Test Video'],
+              ['vine_id', 'legacy-vine-id'],
+              ['url', 'https://example.com/video.mp4'],
+            ],
+            'Test video content',
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          );
+          event.id = 'vine_id_only_event_id';
+          event.sig = 'test_signature';
+          final video = VideoEvent.fromNostrEvent(event);
+          final deleteEvent = createTestEvent(
+            pubkey: testPublicKey,
+            kind: 5,
+            tags: [
+              ['e', video.id],
+              ['k', '34236'],
+            ],
+            content: 'CONTENT DELETION',
+          );
+
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => deleteEvent);
+
+          when(
+            () => mockNostrService.publishEventAwaitOk(
+              any(),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => accepted(deleteEvent.id));
+
+          await service.deleteContent(video: video, reason: 'Personal choice');
+
+          final captured = verify(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: captureAny(named: 'tags'),
+            ),
+          ).captured;
+
+          final tags = captured.first as List<List<String>>;
+          expect(video.vineId, equals('legacy-vine-id'));
+          expect(video.addressableDTag, isNull);
           expect(tags, contains(equals(['e', video.id])));
           expect(tags.any((tag) => tag.isNotEmpty && tag[0] == 'a'), isFalse);
           expect(tags, contains(equals(['k', '34236'])));

--- a/mobile/test/services/effective_content_labels_test.dart
+++ b/mobile/test/services/effective_content_labels_test.dart
@@ -56,6 +56,7 @@ VideoEvent _video({
   List<String> hashtags = const [],
   String? sha256,
   String? vineId,
+  String? addressableDTag,
 }) => VideoEvent(
   id: id,
   pubkey: pubkey,
@@ -65,6 +66,7 @@ VideoEvent _video({
   hashtags: hashtags,
   sha256: sha256,
   vineId: vineId,
+  addressableDTag: addressableDTag ?? vineId,
   contentWarningLabels: contentWarningLabels,
 );
 

--- a/mobile/test/services/nsfw_content_filter_test.dart
+++ b/mobile/test/services/nsfw_content_filter_test.dart
@@ -50,6 +50,7 @@ VideoEvent _createVideo({
     hashtags: hashtags,
     sha256: sha256,
     vineId: vineId,
+    addressableDTag: vineId,
   );
 }
 

--- a/mobile/test/services/video_clip_import_service_test.dart
+++ b/mobile/test/services/video_clip_import_service_test.dart
@@ -46,6 +46,7 @@ models.VideoEvent _video({
     dimensions: dimensions,
     rawTags: rawTags,
     vineId: vineId,
+    addressableDTag: vineId,
     textTrackContent: textTrackContent,
     sourceRelay: sourceRelay,
   );

--- a/mobile/test/services/video_event_service_content_filter_test.dart
+++ b/mobile/test/services/video_event_service_content_filter_test.dart
@@ -46,6 +46,7 @@ VideoEvent _createVideo({
     timestamp: DateTime(2025),
     sha256: sha256,
     vineId: vineId,
+    addressableDTag: vineId,
     contentWarningLabels: contentWarningLabels,
   );
 }

--- a/mobile/test/services/view_event_publisher_test.dart
+++ b/mobile/test/services/view_event_publisher_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Unit tests for ViewEventPublisher (Kind 22236 ephemeral view events)
-// ABOUTME: Tests self-view publishing, vineId fallback, auth checks, and tag
+// ABOUTME: Tests self-view publishing, addressable tags, auth checks, and tag
 // ABOUTME: construction
 
 import 'package:flutter_test/flutter_test.dart';
@@ -139,6 +139,29 @@ void main() {
         );
         expect(tags.firstWhere((t) => t[0] == 'viewed'), ['viewed', '0', '5']);
         expect(tags.firstWhere((t) => t[0] == 'source'), ['source', 'profile']);
+      });
+
+      test('returns false when video has no real d tag', () async {
+        final result = await publisher.publishViewEvent(
+          video: createTestVideoEvent(
+            id: 'event_id_without_d',
+            pubkey: creatorPubkey,
+            vineId: 'legacy_vine_id',
+            clearAddressableDTag: true,
+          ),
+          startSeconds: 0,
+          endSeconds: 5,
+        );
+
+        expect(result, isFalse);
+        verifyNever(
+          () => mockAuth.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        );
+        verifyNever(() => mockNostr.publishEvent(any()));
       });
 
       test('publishes event successfully', () async {
@@ -480,6 +503,28 @@ void main() {
         );
 
         expect(result, isFalse);
+        verifyNever(() => mockNostr.publishEvent(any()));
+      });
+
+      test('returns false for segments when video has no real d tag', () async {
+        final result = await publisher.publishViewEventWithSegments(
+          video: createTestVideoEvent(
+            id: 'event_id_without_d',
+            pubkey: creatorPubkey,
+            vineId: 'legacy_vine_id',
+            clearAddressableDTag: true,
+          ),
+          segments: [(0, 5), (10, 15)],
+        );
+
+        expect(result, isFalse);
+        verifyNever(
+          () => mockAuth.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        );
         verifyNever(() => mockNostr.publishEvent(any()));
       });
 

--- a/mobile/test/test_data/video_test_data.dart
+++ b/mobile/test/test_data/video_test_data.dart
@@ -18,6 +18,8 @@ VideoEvent createTestVideoEvent({
   String? publishedAt,
   Map<String, String> rawTags = const {},
   String? vineId,
+  String? addressableDTag,
+  bool clearAddressableDTag = false,
   String? group,
   String? altText,
   String? blurhash,
@@ -48,6 +50,9 @@ VideoEvent createTestVideoEvent({
     publishedAt: publishedAt,
     rawTags: rawTags,
     vineId: vineId ?? id,
+    addressableDTag: clearAddressableDTag
+        ? null
+        : (addressableDTag ?? vineId ?? id),
     group: group,
     altText: altText,
     blurhash: blurhash,

--- a/mobile/test/utils/video_nostr_enrichment_views_test.dart
+++ b/mobile/test/utils/video_nostr_enrichment_views_test.dart
@@ -80,6 +80,8 @@ void main() {
 
         expect(enriched, hasLength(1));
         expect(enriched.single.rawTags['views'], equals('34'));
+        expect(enriched.single.addressableDTag, equals('video-1'));
+        expect(enriched.single.addressableId, equals('34236:$pubkey:video-1'));
         expect(enriched.single.totalLoops, equals(34));
         expect(enriched.single.hasLoopMetadata, isTrue);
       },


### PR DESCRIPTION
## Summary

- add explicit `VideoEvent.addressableDTag` / `hasAddressableDTag` state for the real NIP-33 `d` tag
- keep `vineId` identity fallback behavior while moving protocol coordinate builders to the explicit d-tag state
- stop delete/view/audio/repost/community-label paths from fabricating `a` coordinates from `vine_id` or event-id fallbacks
- preserve older cached JSON by hydrating `addressableDTag` from persisted `rawTags['d']`

## Verification

- `flutter test test/src/video_event_parsing_test.dart test/src/video_stats_test.dart test/src/video_event_to_json_test.dart test/src/audio_event_test.dart` from `mobile/packages/models`
- `flutter test test/src/video_event_addressable_id_test.dart` from `mobile/packages/models`
- `flutter test test/src/profile_video_merge_test.dart` from `mobile/packages/videos_repository`
- `flutter test test/blocs/profile_feed/profile_feed_enrichment_merge_test.dart test/utils/video_nostr_enrichment_views_test.dart test/services/content_deletion_service_test.dart test/services/view_event_publisher_test.dart` from `mobile`
- `flutter test test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart` from `mobile`
- `flutter test test/repositories/community_content_label_repository_test.dart test/services/effective_content_labels_test.dart` from `mobile`
- `flutter analyze` from `mobile`
- pre-push hook: analyze + changed-file tests

Closes #6713
