### PR TITLE
fix(feed): narrow dead-media prune

### DIFF
--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -40,8 +40,10 @@ typedef OnVideoConfirmedUnavailable = void Function(String videoId);
 /// Confirms whether a player-reported unavailable video is safe to prune.
 ///
 /// Production passes [DeadMediaFeedGuard.isConfirmedUnavailable], which first
-/// HEAD-confirms a 404 and then requires moderation to say the blob is blocked
-/// or quarantined. Tests may inject a smaller predicate.
+/// HEAD-confirms a 404 and then requires moderation to say the blob is
+/// `blocked`. Quarantined and age-restricted blobs also 404 but are reversible,
+/// so they keep their error tile instead of being pruned. Tests may inject a
+/// smaller predicate.
 typedef ConfirmVideoUnavailable =
     Future<bool> Function({required String? videoUrl, String? explicitSha256});
 

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -15,7 +15,6 @@ import 'package:media_cache/media_cache.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/services/dead_media_feed_guard.dart';
-import 'package:openvine/services/media_availability_checker.dart';
 import 'package:openvine/utils/video_identity.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -617,13 +616,12 @@ class FullscreenFeedBloc
     );
   }
 
+  /// Fails closed: without an injected confirmer there is no moderation
+  /// verdict, and a bare 404 is not grounds for the persistent prune (#6251).
   static Future<bool> _defaultConfirmVideoUnavailable({
     required String? videoUrl,
     String? explicitSha256,
-  }) async {
-    if (videoUrl == null || videoUrl.isEmpty) return false;
-    return const MediaAvailabilityChecker().isConfirmedMissing(videoUrl);
-  }
+  }) async => false;
 
   /// Handle UI acknowledgement of a pending skip signal.
   void _onSkipAcknowledged(

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -14,6 +14,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:media_cache/media_cache.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/extensions/video_event_extensions.dart';
+import 'package:openvine/services/dead_media_feed_guard.dart';
 import 'package:openvine/services/media_availability_checker.dart';
 import 'package:openvine/utils/video_identity.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -29,13 +30,21 @@ part 'fullscreen_feed_state.dart';
 typedef OnRemoveVideo = void Function(String videoId);
 
 /// Callback invoked by [FullscreenFeedBloc] when a video has been confirmed
-/// unavailable (a hard 404 verified via [MediaAvailabilityChecker]).
+/// unavailable by the shared prune guard.
 ///
 /// Unlike [OnRemoveVideo] — which only drops the id from in-memory caches for
 /// the current session — this persists the id so the video stays filtered out
 /// of every list surface across app restarts. A callback keeps the BLoC free
 /// of direct dependencies on concrete services.
 typedef OnVideoConfirmedUnavailable = void Function(String videoId);
+
+/// Confirms whether a player-reported unavailable video is safe to prune.
+///
+/// Production passes [DeadMediaFeedGuard.isConfirmedUnavailable], which first
+/// HEAD-confirms a 404 and then requires moderation to say the blob is blocked
+/// or quarantined. Tests may inject a smaller predicate.
+typedef ConfirmVideoUnavailable =
+    Future<bool> Function({required String? videoUrl, String? explicitSha256});
 
 /// Returns `true` when [pubkey]'s content must be hidden (blocked / muted /
 /// blocked-us / muted-us). Injected so the BLoC stays free of Riverpod and
@@ -45,8 +54,8 @@ typedef OnVideoConfirmedUnavailable = void Function(String videoId);
 /// across mutations.
 typedef BlockAuthorFilter = bool Function(String pubkey);
 
-/// Returns `true` when [videoId] has been confirmed unavailable (a persisted
-/// hard 404). Injected so the BLoC stays free of concrete service
+/// Returns `true` when [videoId] has been confirmed unavailable and persisted.
+/// Injected so the BLoC stays free of concrete service
 /// dependencies — the launching `ConsumerWidget` resolves it from
 /// `BrokenVideoTracker.isVideoBroken`. The bound method reads live tracker
 /// state on every call, so newly-confirmed-missing videos are filtered from
@@ -97,7 +106,7 @@ class FullscreenFeedBloc
     BlossomAuthService? blossomAuthService,
     OnRemoveVideo? onRemoveVideo,
     OnVideoConfirmedUnavailable? onVideoConfirmedUnavailable,
-    MediaAvailabilityChecker? availabilityChecker,
+    ConfirmVideoUnavailable? confirmVideoUnavailable,
     BlockAuthorFilter? blockFilter,
     UnavailableVideoFilter? unavailableFilter,
     FeedTuningRepository? feedTuningRepository,
@@ -111,8 +120,8 @@ class FullscreenFeedBloc
        _blossomAuthService = blossomAuthService,
        _onRemoveVideo = onRemoveVideo,
        _onVideoConfirmedUnavailable = onVideoConfirmedUnavailable,
-       _availabilityChecker =
-           availabilityChecker ?? const MediaAvailabilityChecker(),
+       _confirmVideoUnavailable =
+           confirmVideoUnavailable ?? _defaultConfirmVideoUnavailable,
        _blockFilter = blockFilter,
        _unavailableFilter = unavailableFilter,
        _feedTuningRepository = feedTuningRepository,
@@ -153,7 +162,7 @@ class FullscreenFeedBloc
   final BlossomAuthService? _blossomAuthService;
   final OnRemoveVideo? _onRemoveVideo;
   final OnVideoConfirmedUnavailable? _onVideoConfirmedUnavailable;
-  final MediaAvailabilityChecker _availabilityChecker;
+  final ConfirmVideoUnavailable _confirmVideoUnavailable;
   final BlockAuthorFilter? _blockFilter;
   final UnavailableVideoFilter? _unavailableFilter;
   final FeedTuningRepository? _feedTuningRepository;
@@ -549,9 +558,9 @@ class FullscreenFeedBloc
 
   /// Handle a player-reported unavailable video.
   ///
-  /// Confirms the asset really is missing via a HEAD request before
-  /// permanently removing it. Transient player errors (network flake, slow
-  /// TLS, etc.) must not trigger removal — only a hard 404 counts.
+  /// Confirms the asset is safe to prune before permanently removing it.
+  /// Transient player errors (network flake, slow TLS, etc.) and recoverable
+  /// age-restricted media must not trigger removal.
   ///
   /// Uses `sequential()` to serialize concurrent unavailable events so the
   /// dedupe set in [FullscreenFeedState.removedVideoIds] is authoritative
@@ -567,14 +576,18 @@ class FullscreenFeedBloc
     final index = state.videos.indexWhere((v) => v.id == videoId);
     if (index < 0) return;
 
-    final videoUrl = state.videos[index].videoUrl;
+    final video = state.videos[index];
+    final videoUrl = video.videoUrl;
     if (videoUrl == null || videoUrl.isEmpty) return;
 
-    final isMissing = await _availabilityChecker.isConfirmedMissing(videoUrl);
-    if (!isMissing) {
+    final unavailable = await _confirmVideoUnavailable(
+      videoUrl: videoUrl,
+      explicitSha256: video.sha256,
+    );
+    if (!unavailable) {
       Log.warning(
-        'FullscreenFeedBloc: Player reported notFound for $videoId but HEAD '
-        'did not confirm 404 — treating as transient error, video stays.',
+        'FullscreenFeedBloc: Player reported notFound for $videoId but '
+        'confirmation did not allow prune — video stays.',
         name: 'FullscreenFeedBloc',
         category: LogCategory.video,
       );
@@ -602,6 +615,14 @@ class FullscreenFeedBloc
         pendingSkipTarget: nextIndex,
       ),
     );
+  }
+
+  static Future<bool> _defaultConfirmVideoUnavailable({
+    required String? videoUrl,
+    String? explicitSha256,
+  }) async {
+    if (videoUrl == null || videoUrl.isEmpty) return false;
+    return const MediaAvailabilityChecker().isConfirmedMissing(videoUrl);
   }
 
   /// Handle UI acknowledgement of a pending skip signal.
@@ -683,11 +704,11 @@ class FullscreenFeedBloc
     return videos.where((v) => !blockFilter(v.pubkey)).toList();
   }
 
-  /// Returns [videos] with videos confirmed unavailable (persisted hard 404)
-  /// removed, or the same list unchanged when no [UnavailableVideoFilter] was
-  /// injected. Applied at the stream boundary so static sources (liked, saved,
-  /// reposts, collabs, curated lists) drop videos that 404'd in a previous
-  /// session, which their by-id repositories don't filter. See #5237.
+  /// Returns [videos] with persisted unavailable videos removed, or the same
+  /// list unchanged when no [UnavailableVideoFilter] was injected. Applied at
+  /// the stream boundary so static sources (liked, saved, reposts, collabs,
+  /// curated lists) drop videos confirmed in a previous session, which their
+  /// by-id repositories don't filter. See #5237 / #6251.
   List<VideoEvent> _applyUnavailableFilter(List<VideoEvent> videos) {
     final unavailableFilter = _unavailableFilter;
     if (unavailableFilter == null) return videos;

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_event.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_event.dart
@@ -65,10 +65,10 @@ final class FullscreenFeedVideoCacheStarted extends FullscreenFeedEvent {
 /// Dispatched when a video appears to be unavailable (player reported
 /// [PlaybackStatus.notFound], web HEAD 404, etc.).
 ///
-/// The BLoC confirms the failure with a HEAD request via the injected
-/// [MediaAvailabilityChecker] before permanently removing the video. If
-/// the asset actually responds 2xx/5xx/network-error, the event is treated
-/// as a transient player failure and the video stays in place.
+/// The BLoC gates removal on the injected [ConfirmVideoUnavailable]. Production
+/// requires a HEAD-confirmed 404 *and* a terminal moderation verdict, so a
+/// transient player failure, a network error, or a recoverable withhold leaves
+/// the video in place.
 ///
 /// Dedupe is owned by the BLoC — repeated dispatches for the same
 /// [videoId] are no-ops after the first confirmed removal.

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -425,10 +425,16 @@ Future<BrokenVideoTracker> brokenVideoTracker(Ref ref) async {
 }
 
 /// Guard that HEAD-confirms a feed item's media is 404 and verifies moderation
-/// says blocked/quarantined before marking it broken. Reuses the singleton
+/// says the blob is `blocked` before marking it broken. Reuses the singleton
 /// [brokenVideoTrackerProvider] so a mark here is visible to every surface's
 /// `filterVideoList`. See #5953 / #6251.
-@riverpod
+///
+/// `keepAlive: true` for the same reason as [brokenVideoTrackerProvider]: the
+/// fullscreen feed reads this imperatively from a BLoC callback, and an
+/// autoDispose future provider that nothing listens to is disposed right after
+/// each `ref.read`, so `asData` is always null and the prune never fires. It
+/// worked only while an unrelated widget happened to be watching it.
+@Riverpod(keepAlive: true)
 Future<DeadMediaFeedGuard> deadMediaFeedGuard(Ref ref) async {
   // Watched before the await. A dispose *or* a rebuild during the suspension
   // replaces the element's `ref`, and any `ref` use after that throws

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -430,10 +430,17 @@ Future<BrokenVideoTracker> brokenVideoTracker(Ref ref) async {
 /// `filterVideoList`. See #5953 / #6251.
 @riverpod
 Future<DeadMediaFeedGuard> deadMediaFeedGuard(Ref ref) async {
+  // Watched before the await. A dispose *or* a rebuild during the suspension
+  // replaces the element's `ref`, and any `ref` use after that throws
+  // UnmountedRefException — which lands in an orphaned future, so the guard
+  // silently never resolves and the prune stops firing.
+  final moderationStatusService = ref.watch(
+    videoModerationStatusServiceProvider,
+  );
   final tracker = await ref.watch(brokenVideoTrackerProvider.future);
   return DeadMediaFeedGuard(
     brokenVideoTracker: tracker,
-    moderationStatusService: ref.watch(videoModerationStatusServiceProvider),
+    moderationStatusService: moderationStatusService,
   );
 }
 

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -408,13 +408,18 @@ VideoMetadataUpdateService videoMetadataUpdateService(Ref ref) {
 
 /// Broken video tracker service for filtering non-functional videos.
 ///
-/// `keepAlive: true` so this stays the single app-session-stable instance —
+/// `keepAlive: true` so this stays the single instance per identity —
 /// [videoEventServiceProvider] attaches it to `VideoEventService` for
 /// `filterVideoList`, and [deadMediaFeedGuardProvider] must mark broken
 /// videos on that *same* instance. Without `keepAlive`, this autodisposes
 /// once its initial watchers drop, so a later read can rebuild a fresh
 /// tracker that `VideoEventService` never sees — the home feed would then
 /// mark an item broken without it ever being filtered. See #5953 review.
+///
+/// It does rebuild on every auth transition, by design: the marks are stored
+/// per pubkey so one account's prunes cannot hide videos from another. That is
+/// safe only because [videoEventServiceProvider] reattaches the new tracker
+/// through a `ref.listen` rather than capturing one at build time.
 @Riverpod(keepAlive: true)
 Future<BrokenVideoTracker> brokenVideoTracker(Ref ref) async {
   ref.watch(currentAuthStateProvider);

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -42,6 +42,7 @@ import 'package:openvine/services/video_event_resolver.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/services/video_filter_builder.dart';
 import 'package:openvine/services/video_metadata_update_service.dart';
+import 'package:openvine/services/video_moderation_status_service.dart';
 import 'package:openvine/services/video_sharing_service.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:reposts_repository/reposts_repository.dart';
@@ -190,25 +191,24 @@ VideoEventService videoEventService(Ref ref) {
   service.setModerationLabelService(moderationLabelService);
   service.setDivineHostFilterService(divineHostFilterService);
 
-  // Attach the broken-video tracker (async init) so videos confirmed
-  // unavailable (hard 404) stay filtered out of every list surface across
-  // restarts. Fire-and-forget: the tracker hydrates from SharedPreferences and
-  // is safe to attach once ready. See #5237.
-  unawaited(
-    ref
-        .read(brokenVideoTrackerProvider.future)
-        .then(service.setBrokenVideoTracker)
-        .catchError((Object error, StackTrace stackTrace) {
-          Log.error(
-            'Failed to attach broken video tracker to VideoEventService: '
-            '$error',
-            name: 'VideoEventService',
-            category: LogCategory.system,
-            error: error,
-            stackTrace: stackTrace,
-          );
-        }),
-  );
+  // Attach the scoped broken-video tracker so videos confirmed unavailable stay
+  // filtered out of every list surface across restarts. `fireImmediately`
+  // attaches the initial async tracker once it hydrates; later auth transitions
+  // rebuild the tracker under a different pubkey scope and reattach it here.
+  // See #5237 / #6251.
+  ref.listen(brokenVideoTrackerProvider, (_, next) {
+    next.whenData(service.setBrokenVideoTracker);
+    if (next.hasError) {
+      Log.error(
+        'Failed to attach broken video tracker to VideoEventService: '
+        '${next.error}',
+        name: 'VideoEventService',
+        category: LogCategory.system,
+        error: next.error,
+        stackTrace: next.stackTrace,
+      );
+    }
+  }, fireImmediately: true);
 
   // Teach the OG Viner badge cache from every video that flows through the
   // service. The cache filters internally (only `isOriginalVine` videos
@@ -417,19 +417,24 @@ VideoMetadataUpdateService videoMetadataUpdateService(Ref ref) {
 /// mark an item broken without it ever being filtered. See #5953 review.
 @Riverpod(keepAlive: true)
 Future<BrokenVideoTracker> brokenVideoTracker(Ref ref) async {
-  final tracker = BrokenVideoTracker();
+  ref.watch(currentAuthStateProvider);
+  final ownerPubkey = ref.watch(authServiceProvider).currentPublicKeyHex;
+  final tracker = BrokenVideoTracker(ownerPubkey: ownerPubkey);
   await tracker.initialize();
   return tracker;
 }
 
-/// Guard that HEAD-confirms a feed item's media is a hard 404 and marks it
-/// broken so the home feed can skip past + persistently prune it. Reuses the
-/// singleton [brokenVideoTrackerProvider] so a mark here is visible to every
-/// surface's `filterVideoList`. See #5953.
+/// Guard that HEAD-confirms a feed item's media is 404 and verifies moderation
+/// says blocked/quarantined before marking it broken. Reuses the singleton
+/// [brokenVideoTrackerProvider] so a mark here is visible to every surface's
+/// `filterVideoList`. See #5953 / #6251.
 @riverpod
 Future<DeadMediaFeedGuard> deadMediaFeedGuard(Ref ref) async {
   final tracker = await ref.watch(brokenVideoTrackerProvider.future);
-  return DeadMediaFeedGuard(brokenVideoTracker: tracker);
+  return DeadMediaFeedGuard(
+    brokenVideoTracker: tracker,
+    moderationStatusService: ref.watch(videoModerationStatusServiceProvider),
+  );
 }
 
 /// Provider for VideoLocalStorage instance (SQLite-backed)

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -269,7 +269,7 @@ final class VideoEventServiceProvider
   }
 }
 
-String _$videoEventServiceHash() => r'e2aabe88e273a2b1748f596b7b32fa920122911d';
+String _$videoEventServiceHash() => r'a7c6b23e1f8d4f9fd8828e8b4adab600999eccd5';
 
 /// Video event publisher for publishing video events to Nostr relays
 
@@ -683,20 +683,20 @@ final class BrokenVideoTrackerProvider
 }
 
 String _$brokenVideoTrackerHash() =>
-    r'c22a5abecce15fbb6194948c3b23af91f1a7ebab';
+    r'a0b2af154496e50f633f49069986b3c0ee1f5585';
 
-/// Guard that HEAD-confirms a feed item's media is a hard 404 and marks it
-/// broken so the home feed can skip past + persistently prune it. Reuses the
-/// singleton [brokenVideoTrackerProvider] so a mark here is visible to every
-/// surface's `filterVideoList`. See #5953.
+/// Guard that HEAD-confirms a feed item's media is 404 and verifies moderation
+/// says blocked/quarantined before marking it broken. Reuses the singleton
+/// [brokenVideoTrackerProvider] so a mark here is visible to every surface's
+/// `filterVideoList`. See #5953 / #6251.
 
 @ProviderFor(deadMediaFeedGuard)
 final deadMediaFeedGuardProvider = DeadMediaFeedGuardProvider._();
 
-/// Guard that HEAD-confirms a feed item's media is a hard 404 and marks it
-/// broken so the home feed can skip past + persistently prune it. Reuses the
-/// singleton [brokenVideoTrackerProvider] so a mark here is visible to every
-/// surface's `filterVideoList`. See #5953.
+/// Guard that HEAD-confirms a feed item's media is 404 and verifies moderation
+/// says blocked/quarantined before marking it broken. Reuses the singleton
+/// [brokenVideoTrackerProvider] so a mark here is visible to every surface's
+/// `filterVideoList`. See #5953 / #6251.
 
 final class DeadMediaFeedGuardProvider
     extends
@@ -708,10 +708,10 @@ final class DeadMediaFeedGuardProvider
     with
         $FutureModifier<DeadMediaFeedGuard>,
         $FutureProvider<DeadMediaFeedGuard> {
-  /// Guard that HEAD-confirms a feed item's media is a hard 404 and marks it
-  /// broken so the home feed can skip past + persistently prune it. Reuses the
-  /// singleton [brokenVideoTrackerProvider] so a mark here is visible to every
-  /// surface's `filterVideoList`. See #5953.
+  /// Guard that HEAD-confirms a feed item's media is 404 and verifies moderation
+  /// says blocked/quarantined before marking it broken. Reuses the singleton
+  /// [brokenVideoTrackerProvider] so a mark here is visible to every surface's
+  /// `filterVideoList`. See #5953 / #6251.
   DeadMediaFeedGuardProvider._()
     : super(
         from: null,
@@ -739,7 +739,7 @@ final class DeadMediaFeedGuardProvider
 }
 
 String _$deadMediaFeedGuardHash() =>
-    r'c0eed3bb2461ee831a2619dd662ebaf88f0da3a5';
+    r'faeda2741f550e4c61e2e7d8e90bbc2171aa5c77';
 
 /// Provider for VideoLocalStorage instance (SQLite-backed)
 ///

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -686,17 +686,29 @@ String _$brokenVideoTrackerHash() =>
     r'a0b2af154496e50f633f49069986b3c0ee1f5585';
 
 /// Guard that HEAD-confirms a feed item's media is 404 and verifies moderation
-/// says blocked/quarantined before marking it broken. Reuses the singleton
+/// says the blob is `blocked` before marking it broken. Reuses the singleton
 /// [brokenVideoTrackerProvider] so a mark here is visible to every surface's
 /// `filterVideoList`. See #5953 / #6251.
+///
+/// `keepAlive: true` for the same reason as [brokenVideoTrackerProvider]: the
+/// fullscreen feed reads this imperatively from a BLoC callback, and an
+/// autoDispose future provider that nothing listens to is disposed right after
+/// each `ref.read`, so `asData` is always null and the prune never fires. It
+/// worked only while an unrelated widget happened to be watching it.
 
 @ProviderFor(deadMediaFeedGuard)
 final deadMediaFeedGuardProvider = DeadMediaFeedGuardProvider._();
 
 /// Guard that HEAD-confirms a feed item's media is 404 and verifies moderation
-/// says blocked/quarantined before marking it broken. Reuses the singleton
+/// says the blob is `blocked` before marking it broken. Reuses the singleton
 /// [brokenVideoTrackerProvider] so a mark here is visible to every surface's
 /// `filterVideoList`. See #5953 / #6251.
+///
+/// `keepAlive: true` for the same reason as [brokenVideoTrackerProvider]: the
+/// fullscreen feed reads this imperatively from a BLoC callback, and an
+/// autoDispose future provider that nothing listens to is disposed right after
+/// each `ref.read`, so `asData` is always null and the prune never fires. It
+/// worked only while an unrelated widget happened to be watching it.
 
 final class DeadMediaFeedGuardProvider
     extends
@@ -709,16 +721,22 @@ final class DeadMediaFeedGuardProvider
         $FutureModifier<DeadMediaFeedGuard>,
         $FutureProvider<DeadMediaFeedGuard> {
   /// Guard that HEAD-confirms a feed item's media is 404 and verifies moderation
-  /// says blocked/quarantined before marking it broken. Reuses the singleton
+  /// says the blob is `blocked` before marking it broken. Reuses the singleton
   /// [brokenVideoTrackerProvider] so a mark here is visible to every surface's
   /// `filterVideoList`. See #5953 / #6251.
+  ///
+  /// `keepAlive: true` for the same reason as [brokenVideoTrackerProvider]: the
+  /// fullscreen feed reads this imperatively from a BLoC callback, and an
+  /// autoDispose future provider that nothing listens to is disposed right after
+  /// each `ref.read`, so `asData` is always null and the prune never fires. It
+  /// worked only while an unrelated widget happened to be watching it.
   DeadMediaFeedGuardProvider._()
     : super(
         from: null,
         argument: null,
         retry: null,
         name: r'deadMediaFeedGuardProvider',
-        isAutoDispose: true,
+        isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
@@ -739,7 +757,7 @@ final class DeadMediaFeedGuardProvider
 }
 
 String _$deadMediaFeedGuardHash() =>
-    r'07d64f9bdd2bff2e8c34252023cd6c906e6362f0';
+    r'958fa1e62ea46ed215cdc446b81e0f21b4822344';
 
 /// Provider for VideoLocalStorage instance (SQLite-backed)
 ///

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -739,7 +739,7 @@ final class DeadMediaFeedGuardProvider
 }
 
 String _$deadMediaFeedGuardHash() =>
-    r'faeda2741f550e4c61e2e7d8e90bbc2171aa5c77';
+    r'07d64f9bdd2bff2e8c34252023cd6c906e6362f0';
 
 /// Provider for VideoLocalStorage instance (SQLite-backed)
 ///

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -616,26 +616,36 @@ String _$videoMetadataUpdateServiceHash() =>
 
 /// Broken video tracker service for filtering non-functional videos.
 ///
-/// `keepAlive: true` so this stays the single app-session-stable instance —
+/// `keepAlive: true` so this stays the single instance per identity —
 /// [videoEventServiceProvider] attaches it to `VideoEventService` for
 /// `filterVideoList`, and [deadMediaFeedGuardProvider] must mark broken
 /// videos on that *same* instance. Without `keepAlive`, this autodisposes
 /// once its initial watchers drop, so a later read can rebuild a fresh
 /// tracker that `VideoEventService` never sees — the home feed would then
 /// mark an item broken without it ever being filtered. See #5953 review.
+///
+/// It does rebuild on every auth transition, by design: the marks are stored
+/// per pubkey so one account's prunes cannot hide videos from another. That is
+/// safe only because [videoEventServiceProvider] reattaches the new tracker
+/// through a `ref.listen` rather than capturing one at build time.
 
 @ProviderFor(brokenVideoTracker)
 final brokenVideoTrackerProvider = BrokenVideoTrackerProvider._();
 
 /// Broken video tracker service for filtering non-functional videos.
 ///
-/// `keepAlive: true` so this stays the single app-session-stable instance —
+/// `keepAlive: true` so this stays the single instance per identity —
 /// [videoEventServiceProvider] attaches it to `VideoEventService` for
 /// `filterVideoList`, and [deadMediaFeedGuardProvider] must mark broken
 /// videos on that *same* instance. Without `keepAlive`, this autodisposes
 /// once its initial watchers drop, so a later read can rebuild a fresh
 /// tracker that `VideoEventService` never sees — the home feed would then
 /// mark an item broken without it ever being filtered. See #5953 review.
+///
+/// It does rebuild on every auth transition, by design: the marks are stored
+/// per pubkey so one account's prunes cannot hide videos from another. That is
+/// safe only because [videoEventServiceProvider] reattaches the new tracker
+/// through a `ref.listen` rather than capturing one at build time.
 
 final class BrokenVideoTrackerProvider
     extends
@@ -649,13 +659,18 @@ final class BrokenVideoTrackerProvider
         $FutureProvider<BrokenVideoTracker> {
   /// Broken video tracker service for filtering non-functional videos.
   ///
-  /// `keepAlive: true` so this stays the single app-session-stable instance —
+  /// `keepAlive: true` so this stays the single instance per identity —
   /// [videoEventServiceProvider] attaches it to `VideoEventService` for
   /// `filterVideoList`, and [deadMediaFeedGuardProvider] must mark broken
   /// videos on that *same* instance. Without `keepAlive`, this autodisposes
   /// once its initial watchers drop, so a later read can rebuild a fresh
   /// tracker that `VideoEventService` never sees — the home feed would then
   /// mark an item broken without it ever being filtered. See #5953 review.
+  ///
+  /// It does rebuild on every auth transition, by design: the marks are stored
+  /// per pubkey so one account's prunes cannot hide videos from another. That is
+  /// safe only because [videoEventServiceProvider] reattaches the new tracker
+  /// through a `ref.listen` rather than capturing one at build time.
   BrokenVideoTrackerProvider._()
     : super(
         from: null,

--- a/mobile/lib/screens/feed/feed_auto_advance_error_listener.dart
+++ b/mobile/lib/screens/feed/feed_auto_advance_error_listener.dart
@@ -15,13 +15,14 @@ import 'package:openvine/blocs/video_playback_status/video_playback_status_state
 /// Behavior by mode (see #5953):
 /// * **Auto mode** ([isAutoAdvanceActive] true) — skips immediately on any
 ///   non-ready status (unchanged), and additionally, when
-///   [confirmAndMarkMissing] is supplied, marks a HEAD-confirmed hard-404 item
-///   broken (fire-and-forget) so it is pruned from every surface on refetch.
+///   [confirmAndMarkMissing] is supplied, marks a moderation-confirmed
+///   unavailable item broken (fire-and-forget) so it is pruned from every
+///   surface on refetch.
 /// * **Manual scroll** — skips *only* when [confirmAndMarkMissing] resolves
-///   `true` (a HEAD-confirmed hard 404, which also marks it broken). Transient
-///   or non-404 failures keep the error tile, so a network flake can't evict a
-///   valid video. Without a [confirmAndMarkMissing] callback, manual scroll
-///   never auto-skips (prior behavior).
+///   `true` (which also marks it broken). Transient or recoverable failures
+///   keep the error tile, so a network flake or age-gate can't evict a valid
+///   video. Without a [confirmAndMarkMissing] callback, manual scroll never
+///   auto-skips (prior behavior).
 ///
 /// Gated on [isActive] so background / preloaded pages can't yank the feed
 /// forward if they fail while the user is still on an earlier page.
@@ -103,15 +104,17 @@ class _FeedAutoAdvancePastErrorListenerState
     final confirm = widget.confirmAndMarkMissing;
     if (widget.isAutoAdvanceActive) {
       // Auto already skips any non-ready item — preserve that immediately, and
-      // mark a hard-404 item broken (fire-and-forget) so it's pruned on refetch.
+      // mark a confirmed unavailable item broken (fire-and-forget) so it's
+      // pruned on refetch.
       _firedForCurrentBreak = true;
       _deferSkip();
       if (confirm != null) unawaited(confirm());
       return;
     }
 
-    // Manual scroll: only skip past a HEAD-confirmed hard 404 (which also
-    // marks it broken). Transient / non-404 failures keep the error tile.
+    // Manual scroll: only skip past a moderation-confirmed unavailable item
+    // (which also marks it broken). Transient / recoverable failures keep the
+    // error tile.
     //
     // Don't latch `_firedForCurrentBreak` when the guard isn't loaded yet —
     // no confirmation attempt happened, so `didUpdateWidget` must be able to

--- a/mobile/lib/screens/feed/feed_auto_advance_error_listener.dart
+++ b/mobile/lib/screens/feed/feed_auto_advance_error_listener.dart
@@ -43,9 +43,10 @@ class FeedAutoAdvancePastErrorListener extends StatefulWidget {
   final VoidCallback onSkipBrokenVideo;
   final Widget child;
 
-  /// Confirms (via a HEAD request) whether the active item's media is a hard
-  /// 404 and, if so, marks it broken. Returns `true` only for a confirmed 404.
-  /// Injected by the feed item from `deadMediaFeedGuardProvider`.
+  /// Confirms whether the active item's media is permanently unavailable — a
+  /// HEAD-confirmed 404 *plus* a terminal moderation verdict — and, if so,
+  /// marks it broken. Injected by the feed item from
+  /// `deadMediaFeedGuardProvider`.
   final Future<bool> Function()? confirmAndMarkMissing;
 
   @override

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -238,9 +238,11 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
         .read(videoEventServiceProvider)
         .removedVideoIds;
 
-    // Persist confirmed-404 ids so the video stays filtered out of every list
-    // surface (feed, profile, hashtag, grids) across restarts. The bloc only
-    // fires this after a HEAD request confirms a hard 404 (#5237).
+    // Persist moderation-confirmed unavailable ids so the video stays filtered
+    // out of every list surface (feed, profile, hashtag, grids) across
+    // restarts. The bloc only fires this after DeadMediaFeedGuard confirms both
+    // a 404 and a requester-independent blocked/quarantined moderation
+    // verdict (#6251).
     void persistConfirmedUnavailable(String videoId) {
       unawaited(
         ref
@@ -248,7 +250,7 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
             .then(
               (tracker) => tracker.markVideoBroken(
                 videoId,
-                'Confirmed 404 in fullscreen feed',
+                'Confirmed moderation-unavailable 404 in fullscreen feed',
               ),
             )
             .catchError((Object error) {
@@ -261,11 +263,11 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
       );
     }
 
-    // Filter videos confirmed unavailable (persisted hard 404) out of the
-    // fullscreen list at the stream boundary. This covers static / by-id
-    // sources (liked, saved, reposts, collabs, curated lists) whose
-    // repositories don't run the central feed filters, so a video that 404'd
-    // in a previous session won't reappear when opened fullscreen. Reads live
+    // Filter persisted unavailable videos out of the fullscreen list at the
+    // stream boundary. This covers static / by-id sources (liked, saved,
+    // reposts, collabs, curated lists) whose repositories don't run the central
+    // feed filters, so a video confirmed unavailable in a previous session
+    // won't reappear when opened fullscreen. Reads live
     // tracker state on every call via the provider (rather than capturing a
     // snapshot in `create:`, which would stay `null` if the tracker's async
     // init hadn't resolved by first build and never recover): before init
@@ -277,6 +279,18 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
           data: (tracker) => tracker.isVideoBroken(videoId),
           orElse: () => false,
         );
+
+    Future<bool> confirmVideoUnavailable({
+      required String? videoUrl,
+      String? explicitSha256,
+    }) async {
+      final guard = ref.read(deadMediaFeedGuardProvider).asData?.value;
+      if (guard == null) return false;
+      return guard.isConfirmedUnavailable(
+        videoUrl: videoUrl,
+        explicitSha256: explicitSha256,
+      );
+    }
 
     // Stable, keepAlive repository; reads `publicKey` live at publish time, so
     // capturing it once in `create:` stays correct across auth changes (no
@@ -295,6 +309,7 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
             removedIdsStream: removedIdsStream,
             onLoadMore: () => unawaited(feedRepository.loadMore(source)),
             onVideoConfirmedUnavailable: persistConfirmedUnavailable,
+            confirmVideoUnavailable: confirmVideoUnavailable,
             mediaCache: mediaCache,
             blossomAuthService: blossomAuthService,
             blockFilter: blockFilter,

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -238,11 +238,10 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
         .read(videoEventServiceProvider)
         .removedVideoIds;
 
-    // Persist moderation-confirmed unavailable ids so the video stays filtered
-    // out of every list surface (feed, profile, hashtag, grids) across
-    // restarts. The bloc only fires this after DeadMediaFeedGuard confirms both
-    // a 404 and a requester-independent blocked/quarantined moderation
-    // verdict (#6251).
+    // Persist permanently-unavailable ids so the video stays filtered out of
+    // every list surface (feed, profile, hashtag, grids) across restarts. The
+    // bloc only fires this after DeadMediaFeedGuard confirms both a 404 and a
+    // requester-independent, terminal moderation verdict (#6251).
     void persistConfirmedUnavailable(String videoId) {
       unawaited(
         ref
@@ -630,7 +629,7 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                 },
               ),
             // Dispatch FullscreenFeedVideoUnavailable when the active video's
-            // playback status becomes notFound. The BLoC owns the HEAD-confirm,
+            // playback status becomes notFound. The BLoC owns the confirm,
             // removal, and dedupe logic — this listener is the screen-level
             // bridge that replaces the per-item post-frame callback.
             BlocListener<VideoPlaybackStatusCubit, VideoPlaybackStatusState>(

--- a/mobile/lib/services/broken_video_tracker.dart
+++ b/mobile/lib/services/broken_video_tracker.dart
@@ -30,6 +30,7 @@ class BrokenVideoTracker {
 
   Future<void> initialize() async {
     _prefs = await SharedPreferences.getInstance();
+    await _dropLegacyUnscopedEntries();
     await _loadBrokenVideos();
     await _cleanupOldEntries();
 
@@ -38,6 +39,18 @@ class BrokenVideoTracker {
       name: 'BrokenVideoTracker',
       category: LogCategory.system,
     );
+  }
+
+  /// Pre-#6251 marks were stored under unscoped keys that no scope reads and
+  /// the 7-day sweep never visits, so they would sit in storage forever. Those
+  /// marks are already unreachable — dropping them reclaims the bytes without
+  /// changing what is filtered.
+  Future<void> _dropLegacyUnscopedEntries() async {
+    for (final key in const ['broken_video_urls', 'broken_video_timestamps']) {
+      if (_prefs.containsKey(key)) {
+        await _prefs.remove(key);
+      }
+    }
   }
 
   Future<void> _loadBrokenVideos() async {

--- a/mobile/lib/services/broken_video_tracker.dart
+++ b/mobile/lib/services/broken_video_tracker.dart
@@ -7,15 +7,26 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 class BrokenVideoTracker {
-  static const String _storageKey = 'broken_video_urls';
-  static const String _timestampKey = 'broken_video_timestamps';
+  BrokenVideoTracker({String? ownerPubkey})
+    : _storageKey = _scopedKey('broken_video_urls', ownerPubkey),
+      _timestampKey = _scopedKey('broken_video_timestamps', ownerPubkey);
+
   static const Duration _cleanupDuration = Duration(
     days: 7,
   ); // Clean up old entries after 7 days
 
+  final String _storageKey;
+  final String _timestampKey;
   late SharedPreferences _prefs;
   Set<String> _brokenVideoIds = {};
   Map<String, DateTime> _brokenTimestamps = {};
+
+  static String _scopedKey(String baseKey, String? ownerPubkey) {
+    final scope = ownerPubkey == null || ownerPubkey.isEmpty
+        ? 'anonymous'
+        : ownerPubkey;
+    return '${baseKey}_$scope';
+  }
 
   Future<void> initialize() async {
     _prefs = await SharedPreferences.getInstance();

--- a/mobile/lib/services/dead_media_feed_guard.dart
+++ b/mobile/lib/services/dead_media_feed_guard.dart
@@ -1,8 +1,9 @@
-// ABOUTME: Confirms a feed item's media is a hard 404 and marks it broken so
-// ABOUTME: the home feed can skip past + persistently prune it. See #5953.
+// ABOUTME: Confirms feed media is 404 plus moderation-unavailable before
+// ABOUTME: the home feed skips past + persistently prunes it. See #6251.
 
 import 'package:openvine/services/broken_video_tracker.dart';
 import 'package:openvine/services/media_availability_checker.dart';
+import 'package:openvine/services/video_moderation_status_service.dart';
 
 /// Decides whether a feed item whose player failed should be treated as
 /// permanently unavailable.
@@ -18,44 +19,66 @@ import 'package:openvine/services/media_availability_checker.dart';
 /// via [MediaAvailabilityChecker] — NOT the playback error string, which is
 /// platform-divergent (see #5953 findings).
 ///
-/// The 404 is deliberately the *only* status that acts here. An age-restricted
-/// blob answers **401**, and the feed already has a real affordance for it: the
-/// player's `ageRestricted` status routes to the Verify-age overlay, and
-/// `FeedLoadingModerationCubit` recovers a mis-classified 401 asynchronously
-/// (moderation-api → auth → retry). Skipping on 401 would beat that recovery
-/// and silently scroll past content the viewer can watch, so this guard leaves
-/// 401 alone entirely. See #6251 for the age-gate work.
+/// A 404 is only the first gate. Blossom can answer 404 for blobs that
+/// moderation still classifies as age-restricted, so a HEAD-confirmed 404 is
+/// persisted only when the requester-independent moderation status confirms the
+/// blob is blocked or quarantined. Age-restricted and unknown moderation states
+/// stay recoverable and must not be marked broken. See #6251.
 class DeadMediaFeedGuard {
   const DeadMediaFeedGuard({
     required BrokenVideoTracker brokenVideoTracker,
+    required VideoModerationStatusService moderationStatusService,
     MediaAvailabilityChecker availabilityChecker =
         const MediaAvailabilityChecker(),
   }) : _tracker = brokenVideoTracker,
-       _checker = availabilityChecker;
+       _checker = availabilityChecker,
+       _moderationStatusService = moderationStatusService;
 
   final BrokenVideoTracker _tracker;
   final MediaAvailabilityChecker _checker;
+  final VideoModerationStatusService _moderationStatusService;
 
-  /// Returns `true` iff [videoUrl] is a HEAD-confirmed hard 404, in which case
-  /// [videoId] is persisted as broken so [BrokenVideoTracker.isVideoBroken]
-  /// (and therefore `filterVideoList`) drops it from every list surface across
-  /// restarts.
+  /// Returns `true` iff [videoUrl] is a HEAD-confirmed 404 and moderation
+  /// confirms the blob is blocked or quarantined.
   ///
   /// Returns `false` when [videoUrl] is missing, reachable, returns any status
-  /// other than 404, or the HEAD request fails with a network error — the
-  /// caller must then treat the failure as transient and keep the item. This
-  /// conservative gate is what prevents a one-off network flake from evicting a
-  /// valid video.
-  Future<bool> confirmAndMarkMissing({
-    required String videoId,
+  /// other than 404, the HEAD request fails, the blob hash cannot be resolved,
+  /// the moderation lookup fails, or moderation says the blob is only
+  /// age-restricted. The caller must then keep the item recoverable.
+  Future<bool> isConfirmedUnavailable({
     required String? videoUrl,
+    String? explicitSha256,
   }) async {
     if (videoUrl == null || videoUrl.isEmpty) return false;
     final missing = await _checker.isConfirmedMissing(videoUrl);
     if (!missing) return false;
+
+    final sha256 = VideoModerationStatusService.resolveSha256(
+      explicitSha256: explicitSha256,
+      videoUrl: videoUrl,
+    );
+    if (sha256 == null) return false;
+
+    final status = await _moderationStatusService.fetchStatus(sha256);
+    return status?.blocked == true || status?.quarantined == true;
+  }
+
+  /// Persists [videoId] as broken iff [isConfirmedUnavailable] returns `true`,
+  /// so [BrokenVideoTracker.isVideoBroken] (and therefore `filterVideoList`)
+  /// drops it from every list surface across restarts.
+  Future<bool> confirmAndMarkMissing({
+    required String videoId,
+    required String? videoUrl,
+    String? explicitSha256,
+  }) async {
+    final unavailable = await isConfirmedUnavailable(
+      videoUrl: videoUrl,
+      explicitSha256: explicitSha256,
+    );
+    if (!unavailable) return false;
     await _tracker.markVideoBroken(
       videoId,
-      'Confirmed 404 in home feed',
+      'Confirmed moderation-unavailable 404 in home feed',
     );
     return true;
   }

--- a/mobile/lib/services/dead_media_feed_guard.dart
+++ b/mobile/lib/services/dead_media_feed_guard.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Confirms feed media is 404 plus moderation-unavailable before
+// ABOUTME: Confirms feed media is 404 plus a terminal moderation block before
 // ABOUTME: the home feed skips past + persistently prunes it. See #6251.
 
 import 'package:openvine/services/broken_video_tracker.dart';
@@ -19,11 +19,13 @@ import 'package:openvine/services/video_moderation_status_service.dart';
 /// via [MediaAvailabilityChecker] — NOT the playback error string, which is
 /// platform-divergent (see #5953 findings).
 ///
-/// A 404 is only the first gate. Blossom can answer 404 for blobs that
-/// moderation still classifies as age-restricted, so a HEAD-confirmed 404 is
-/// persisted only when the requester-independent moderation status confirms the
-/// blob is blocked or quarantined. Age-restricted and unknown moderation states
-/// stay recoverable and must not be marked broken. See #6251.
+/// A 404 is only the first gate. Blossom answers 404 for quarantined blobs and
+/// for blobs moderation classifies as age-restricted, so a HEAD-confirmed 404
+/// is persisted only when the requester-independent moderation status says the
+/// blob is `blocked` — the single terminal verdict. Quarantine maps to a
+/// reversible RESTRICT (an approval-required uploader's SAFE clip is rewritten
+/// to it), so quarantined, age-restricted and unknown states stay recoverable
+/// and must not be marked broken. See #6251.
 class DeadMediaFeedGuard {
   const DeadMediaFeedGuard({
     required BrokenVideoTracker brokenVideoTracker,
@@ -39,12 +41,13 @@ class DeadMediaFeedGuard {
   final VideoModerationStatusService _moderationStatusService;
 
   /// Returns `true` iff [videoUrl] is a HEAD-confirmed 404 and moderation
-  /// confirms the blob is blocked or quarantined.
+  /// confirms the blob is `blocked`.
   ///
   /// Returns `false` when [videoUrl] is missing, reachable, returns any status
   /// other than 404, the HEAD request fails, the blob hash cannot be resolved,
-  /// the moderation lookup fails, or moderation says the blob is only
-  /// age-restricted. The caller must then keep the item recoverable.
+  /// the moderation lookup fails, or moderation reports a reversible verdict
+  /// (quarantined / age-restricted). The caller must then keep the item
+  /// recoverable.
   Future<bool> isConfirmedUnavailable({
     required String? videoUrl,
     String? explicitSha256,
@@ -60,7 +63,10 @@ class DeadMediaFeedGuard {
     if (sha256 == null) return false;
 
     final status = await _moderationStatusService.fetchStatus(sha256);
-    return status?.blocked == true || status?.quarantined == true;
+    // `blocked` (PERMANENT_BAN) is the only terminal verdict. QUARANTINE maps
+    // to blossom RESTRICT: reversible and pending review, so a quarantined
+    // blob 404s now but must stay recoverable. See #6251.
+    return status?.blocked == true;
   }
 
   /// Persists [videoId] as broken iff [isConfirmedUnavailable] returns `true`,

--- a/mobile/lib/services/media_availability_checker.dart
+++ b/mobile/lib/services/media_availability_checker.dart
@@ -33,10 +33,11 @@ class MediaAvailabilityChecker {
   /// that consults it. Measured at 8.0% of `classic=true` blobs (n=600) — a
   /// larger class than the 5.5% that 404. See #5953 / #6251.
   ///
-  /// Note that `true` means "not retrievable", not "the bytes are gone":
+  /// Note that `true` means "not retrievable *now*", not "the bytes are gone":
   /// blossom collapses `Banned`, `Deleted`, `Restricted` *and* genuinely-absent
-  /// metadata into 404. It remains the only status that justifies a persistent
-  /// prune, because none of those become retrievable by authenticating.
+  /// metadata into 404, and `Restricted` is reversible by a moderator. A 404
+  /// alone therefore does not justify a persistent prune — see
+  /// `DeadMediaFeedGuard`, which also requires a terminal moderation verdict.
   ///
   /// When no [client] is injected a throwaway [http.Client] is created and
   /// closed after the request.

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -486,10 +486,10 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     );
   }
 
-  /// Set the broken-video tracker used to filter videos confirmed unavailable
-  /// (hard 404). Marked entries are persisted by the tracker, so this keeps
-  /// videos that 404'd in the fullscreen player out of every list surface
-  /// (home, profile, hashtag, grids) across app restarts. See #5237.
+  /// Set the broken-video tracker used to filter videos confirmed unavailable.
+  /// Marked entries are persisted by the tracker, so this keeps unavailable
+  /// videos out of every list surface (home, profile, hashtag, grids) across
+  /// app restarts. See #5237 / #6251.
   void setBrokenVideoTracker(BrokenVideoTracker tracker) {
     _brokenVideoTracker = tracker;
     Log.debug(
@@ -4901,12 +4901,11 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       return; // Don't resurrect deleted videos
     }
 
-    // Filter out videos confirmed unavailable (hard 404) so they don't
-    // resurface on any list surface after being skipped in the player. See
-    // #5237.
+    // Filter out videos confirmed unavailable so they don't resurface on any
+    // list surface after being skipped in the player. See #5237 / #6251.
     if (_brokenVideoTracker?.isVideoBroken(videoEvent.id) == true) {
       Log.debug(
-        'Filtering out unavailable (404) video ${videoEvent.id} from $subscriptionType feed',
+        'Filtering out confirmed-unavailable video ${videoEvent.id} from $subscriptionType feed',
         name: 'VideoEventService',
         category: LogCategory.video,
       );

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -785,9 +785,10 @@ class __OverlayState extends ConsumerState<_Overlay> {
 
     final effectiveAutoActive = autoAdvanceAvailable && autoEffectivelyActive;
 
-    // Guard that HEAD-confirms a hard 404 and marks the item broken so the home
+    // Guard that HEAD-confirms a 404 and requires moderation-confirmed
+    // blocked/quarantined status before marking the item broken so the home
     // feed can skip past + prune dead imported-Vine media. Null until its
-    // one-time tracker init resolves. See #5953.
+    // one-time tracker init resolves. See #5953 / #6251.
     final deadMediaGuard = ref.watch(deadMediaFeedGuardProvider).asData?.value;
 
     final playbackStatus = context.select(
@@ -851,6 +852,7 @@ class __OverlayState extends ConsumerState<_Overlay> {
               : () => deadMediaGuard.confirmAndMarkMissing(
                   videoId: video.id,
                   videoUrl: video.videoUrl,
+                  explicitSha256: video.sha256,
                 ),
           child: BlocProvider<VideoInteractionsBloc>(
             key: videoInteractionsBlocKey(

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -785,10 +785,10 @@ class __OverlayState extends ConsumerState<_Overlay> {
 
     final effectiveAutoActive = autoAdvanceAvailable && autoEffectivelyActive;
 
-    // Guard that HEAD-confirms a 404 and requires moderation-confirmed
-    // blocked/quarantined status before marking the item broken so the home
-    // feed can skip past + prune dead imported-Vine media. Null until its
-    // one-time tracker init resolves. See #5953 / #6251.
+    // Guard that HEAD-confirms a 404 and requires a terminal moderation verdict
+    // before marking the item broken so the home feed can skip past + prune
+    // dead imported-Vine media. Null until its one-time tracker init resolves.
+    // See #5953 / #6251.
     final deadMediaGuard = ref.watch(deadMediaFeedGuardProvider).asData?.value;
 
     final playbackStatus = context.select(

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -10,13 +10,10 @@ import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:feed_tuning_repository/feed_tuning_repository.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:http/http.dart' as http;
-import 'package:http/testing.dart';
 import 'package:media_cache/media_cache.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/fullscreen_feed/fullscreen_feed_bloc.dart';
-import 'package:openvine/services/media_availability_checker.dart';
 
 class MockFileInfo extends Mock implements FileInfo {}
 
@@ -95,7 +92,7 @@ void main() {
       BlossomAuthService? blossomAuthService,
       OnRemoveVideo? onRemoveVideo,
       OnVideoConfirmedUnavailable? onVideoConfirmedUnavailable,
-      MediaAvailabilityChecker? availabilityChecker,
+      ConfirmVideoUnavailable? confirmVideoUnavailable,
       BlockAuthorFilter? blockFilter,
       UnavailableVideoFilter? unavailableFilter,
       FeedTuningRepository? feedTuningRepository,
@@ -110,11 +107,19 @@ void main() {
       blossomAuthService: blossomAuthService,
       onRemoveVideo: onRemoveVideo,
       onVideoConfirmedUnavailable: onVideoConfirmedUnavailable,
-      availabilityChecker: availabilityChecker,
+      confirmVideoUnavailable: confirmVideoUnavailable,
       blockFilter: blockFilter,
       unavailableFilter: unavailableFilter,
       feedTuningRepository: feedTuningRepository,
     );
+
+    ConfirmVideoUnavailable confirmerReturning(
+      bool result, {
+      void Function(String? videoUrl, String? explicitSha256)? onCall,
+    }) => ({required videoUrl, explicitSha256}) async {
+      onCall?.call(videoUrl, explicitSha256);
+      return result;
+    };
 
     test('initial state has correct values', () {
       final bloc = createBloc(initialIndex: 2);
@@ -575,10 +580,8 @@ void main() {
 
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
         'opens tapped grid video when repository list filters an earlier item',
-        build: () => createBloc(
-          initialIndex: 2,
-          initialVideoId: 'tapped-video',
-        ),
+        build: () =>
+            createBloc(initialIndex: 2, initialVideoId: 'tapped-video'),
         act: (bloc) async {
           final tapped = createTestVideo('tapped-video');
 
@@ -594,11 +597,7 @@ void main() {
         expect: () => [
           isA<FullscreenFeedState>()
               .having((s) => s.currentIndex, 'currentIndex', 1)
-              .having(
-                (s) => s.currentVideo?.id,
-                'currentVideo',
-                'tapped-video',
-              )
+              .having((s) => s.currentVideo?.id, 'currentVideo', 'tapped-video')
               .having(
                 (s) => s.initialTargetResolved,
                 'initialTargetResolved',
@@ -642,11 +641,7 @@ void main() {
               ),
           isA<FullscreenFeedState>()
               .having((s) => s.currentIndex, 'currentIndex', 1)
-              .having(
-                (s) => s.currentVideo?.id,
-                'currentVideo',
-                'target-video',
-              )
+              .having((s) => s.currentVideo?.id, 'currentVideo', 'target-video')
               .having(
                 (s) => s.initialTargetResolved,
                 'initialTargetResolved',
@@ -807,11 +802,11 @@ void main() {
         act: (bloc) => bloc.add(const FullscreenFeedBlocklistChanged()),
         expect: () => [
           isA<FullscreenFeedState>()
-              .having(
-                (s) => s.videos.map((v) => v.id).toList(),
-                'video ids',
-                ['a', 'c', 'd'],
-              )
+              .having((s) => s.videos.map((v) => v.id).toList(), 'video ids', [
+                'a',
+                'c',
+                'd',
+              ])
               .having((s) => s.currentIndex, 'currentIndex', 1)
               .having((s) => s.currentVideo?.id, 'currentVideo', 'c'),
         ],
@@ -837,11 +832,11 @@ void main() {
         act: (bloc) => bloc.add(const FullscreenFeedBlocklistChanged()),
         expect: () => [
           isA<FullscreenFeedState>()
-              .having(
-                (s) => s.videos.map((v) => v.id).toList(),
-                'video ids',
-                ['c', 'd', 'e'],
-              )
+              .having((s) => s.videos.map((v) => v.id).toList(), 'video ids', [
+                'c',
+                'd',
+                'e',
+              ])
               .having((s) => s.currentIndex, 'currentIndex', 1)
               .having((s) => s.currentVideo?.id, 'currentVideo', 'd'),
         ],
@@ -862,11 +857,10 @@ void main() {
         act: (bloc) => bloc.add(const FullscreenFeedBlocklistChanged()),
         expect: () => [
           isA<FullscreenFeedState>()
-              .having(
-                (s) => s.videos.map((v) => v.id).toList(),
-                'video ids',
-                ['a', 'c'],
-              )
+              .having((s) => s.videos.map((v) => v.id).toList(), 'video ids', [
+                'a',
+                'c',
+              ])
               .having((s) => s.currentIndex, 'currentIndex', 1)
               .having((s) => s.currentVideo?.id, 'currentVideo', 'c'),
         ],
@@ -889,11 +883,10 @@ void main() {
         act: (bloc) => bloc.add(const FullscreenFeedBlocklistChanged()),
         expect: () => [
           isA<FullscreenFeedState>()
-              .having(
-                (s) => s.videos.map((v) => v.id).toList(),
-                'video ids',
-                ['b', 'c'],
-              )
+              .having((s) => s.videos.map((v) => v.id).toList(), 'video ids', [
+                'b',
+                'c',
+              ])
               .having((s) => s.currentIndex, 'currentIndex', 0)
               .having((s) => s.currentVideo?.id, 'currentVideo', 'b'),
         ],
@@ -1437,7 +1430,7 @@ void main() {
       );
     });
 
-    group('unavailableFilter (persisted 404)', () {
+    group('unavailableFilter (persisted unavailable media)', () {
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
         'filters known-unavailable videos from incoming stream lists',
         build: () => createBloc(unavailableFilter: (id) => id == 'broken'),
@@ -1497,25 +1490,13 @@ void main() {
     });
 
     group('FullscreenFeedVideoUnavailable', () {
-      MediaAvailabilityChecker checkerReturning(int statusCode) {
-        final client = MockClient((_) async => http.Response('', statusCode));
-        return MediaAvailabilityChecker(client: client);
-      }
-
-      MediaAvailabilityChecker throwingChecker() {
-        final client = MockClient(
-          (_) async => throw http.ClientException('timeout'),
-        );
-        return MediaAvailabilityChecker(client: client);
-      }
-
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
-        'removes video and emits pending skip when HEAD confirms 404',
+        'removes video and emits pending skip when confirmation allows prune',
         build: () {
           final removed = <String>[];
           return createBloc(
             onRemoveVideo: removed.add,
-            availabilityChecker: checkerReturning(404),
+            confirmVideoUnavailable: confirmerReturning(true),
           );
         },
         seed: () => FullscreenFeedState(
@@ -1540,12 +1521,12 @@ void main() {
       );
 
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
-        'calls onRemoveVideo callback when HEAD confirms 404',
+        'calls onRemoveVideo callback when confirmation allows prune',
         build: () => createBloc(
           onRemoveVideo: expectAsync1<void, String>((id) {
             expect(id, equals('video1'));
           }),
-          availabilityChecker: checkerReturning(404),
+          confirmVideoUnavailable: confirmerReturning(true),
         ),
         seed: () => FullscreenFeedState(
           status: FullscreenFeedStatus.ready,
@@ -1556,11 +1537,11 @@ void main() {
       );
 
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
-        'does not remove or skip when HEAD returns 200 (transient error)',
+        'does not remove or skip when confirmation rejects prune',
         build: () {
           return createBloc(
-            onRemoveVideo: (_) => fail('should not remove on non-404'),
-            availabilityChecker: checkerReturning(200),
+            onRemoveVideo: (_) => fail('should not remove on rejected prune'),
+            confirmVideoUnavailable: confirmerReturning(false),
           );
         },
         seed: () => FullscreenFeedState(
@@ -1573,11 +1554,11 @@ void main() {
       );
 
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
-        'does not remove when HEAD request throws (network error)',
+        'does not remove when confirmation is conservative after lookup failure',
         build: () {
           return createBloc(
-            onRemoveVideo: (_) => fail('should not remove on network error'),
-            availabilityChecker: throwingChecker(),
+            onRemoveVideo: (_) => fail('should not remove on failed lookup'),
+            confirmVideoUnavailable: confirmerReturning(false),
           );
         },
         seed: () => FullscreenFeedState(
@@ -1590,12 +1571,12 @@ void main() {
       );
 
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
-        'calls onVideoConfirmedUnavailable when HEAD confirms 404',
+        'calls onVideoConfirmedUnavailable when confirmation allows prune',
         build: () => createBloc(
           onVideoConfirmedUnavailable: expectAsync1<void, String>((id) {
             expect(id, equals('video1'));
           }),
-          availabilityChecker: checkerReturning(404),
+          confirmVideoUnavailable: confirmerReturning(true),
         ),
         seed: () => FullscreenFeedState(
           status: FullscreenFeedStatus.ready,
@@ -1606,11 +1587,11 @@ void main() {
       );
 
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
-        'does not call onVideoConfirmedUnavailable on transient error (200)',
+        'does not call onVideoConfirmedUnavailable when confirmation rejects',
         build: () => createBloc(
           onVideoConfirmedUnavailable: (_) =>
-              fail('should not persist on non-404'),
-          availabilityChecker: checkerReturning(200),
+              fail('should not persist on rejected prune'),
+          confirmVideoUnavailable: confirmerReturning(false),
         ),
         seed: () => FullscreenFeedState(
           status: FullscreenFeedStatus.ready,
@@ -1622,11 +1603,11 @@ void main() {
       );
 
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
-        'does not call onVideoConfirmedUnavailable when HEAD throws',
+        'does not call onVideoConfirmedUnavailable after lookup failure',
         build: () => createBloc(
           onVideoConfirmedUnavailable: (_) =>
-              fail('should not persist on network error'),
-          availabilityChecker: throwingChecker(),
+              fail('should not persist after failed lookup'),
+          confirmVideoUnavailable: confirmerReturning(false),
         ),
         seed: () => FullscreenFeedState(
           status: FullscreenFeedStatus.ready,
@@ -1643,7 +1624,7 @@ void main() {
           var callCount = 0;
           return createBloc(
             onRemoveVideo: (_) => callCount++,
-            availabilityChecker: checkerReturning(404),
+            confirmVideoUnavailable: confirmerReturning(true),
           );
         },
         seed: () => FullscreenFeedState(
@@ -1677,7 +1658,7 @@ void main() {
         'no-ops when video id is not in the current list',
         build: () => createBloc(
           onRemoveVideo: (_) => fail('unknown video should not trigger remove'),
-          availabilityChecker: checkerReturning(404),
+          confirmVideoUnavailable: confirmerReturning(true),
         ),
         seed: () => FullscreenFeedState(
           status: FullscreenFeedStatus.ready,
@@ -1693,7 +1674,7 @@ void main() {
         'no-ops when video has no URL',
         build: () => createBloc(
           onRemoveVideo: (_) => fail('videos without URL cannot be confirmed'),
-          availabilityChecker: checkerReturning(404),
+          confirmVideoUnavailable: confirmerReturning(true),
         ),
         seed: () => FullscreenFeedState(
           status: FullscreenFeedStatus.ready,
@@ -1717,7 +1698,7 @@ void main() {
         'skip target matches index of removed video + 1',
         build: () => createBloc(
           onRemoveVideo: (_) {},
-          availabilityChecker: checkerReturning(404),
+          confirmVideoUnavailable: confirmerReturning(true),
         ),
         seed: () => FullscreenFeedState(
           status: FullscreenFeedStatus.ready,
@@ -1737,6 +1718,25 @@ void main() {
             equals(2),
           ),
         ],
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'passes video URL and explicit sha256 to confirmation',
+        build: () => createBloc(
+          confirmVideoUnavailable: confirmerReturning(
+            true,
+            onCall: expectAsync2((videoUrl, explicitSha256) {
+              expect(videoUrl, equals('https://example.com/video_video1.mp4'));
+              expect(explicitSha256, equals('a' * 64));
+            }),
+          ),
+        ),
+        seed: () => FullscreenFeedState(
+          status: FullscreenFeedStatus.ready,
+          videos: [createTestVideo('video1', sha256: 'a' * 64)],
+        ),
+        act: (bloc) => bloc.add(const FullscreenFeedVideoUnavailable('video1')),
+        wait: const Duration(milliseconds: 100),
       );
     });
 
@@ -1771,9 +1771,7 @@ void main() {
         'allows subsequent unavailable events to emit a new skip',
         build: () => createBloc(
           onRemoveVideo: (_) {},
-          availabilityChecker: MediaAvailabilityChecker(
-            client: MockClient((_) async => http.Response('', 404)),
-          ),
+          confirmVideoUnavailable: confirmerReturning(true),
         ),
         seed: () => FullscreenFeedState(
           status: FullscreenFeedStatus.ready,

--- a/mobile/test/providers/broken_video_tracker_identity_test.dart
+++ b/mobile/test/providers/broken_video_tracker_identity_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/providers/video_providers.dart';
 import 'package:openvine/services/dead_media_feed_guard.dart';
 import 'package:openvine/services/media_availability_checker.dart';
+import 'package:openvine/services/video_moderation_status_service.dart';
 
 import '../helpers/test_helpers.dart';
 import '../helpers/test_provider_overrides.dart';
@@ -19,6 +20,22 @@ class _AlwaysConfirmedMissingChecker implements MediaAvailabilityChecker {
 
   @override
   Future<bool> isConfirmedMissing(String url) async => true;
+}
+
+class _AlwaysBlockedModerationStatusService
+    extends VideoModerationStatusService {
+  _AlwaysBlockedModerationStatusService();
+
+  @override
+  Future<VideoModerationStatus?> fetchStatus(String sha256) async =>
+      const VideoModerationStatus(
+        moderated: true,
+        blocked: true,
+        quarantined: false,
+        ageRestricted: false,
+        needsReview: false,
+        aiGenerated: false,
+      );
 }
 
 void main() {
@@ -46,9 +63,7 @@ void main() {
         container.read(videoEventServiceProvider);
 
         final first = await container.read(brokenVideoTrackerProvider.future);
-        final second = await container.read(
-          brokenVideoTrackerProvider.future,
-        );
+        final second = await container.read(brokenVideoTrackerProvider.future);
 
         expect(
           identical(first, second),
@@ -63,75 +78,72 @@ void main() {
       },
     );
 
-    test(
-      'a mark made through deadMediaFeedGuardProvider.confirmAndMarkMissing '
-      'is reflected by VideoEventService.filterVideoList',
-      () async {
-        // Rebuild the container with deadMediaFeedGuardProvider overridden to
-        // swap in a checker that deterministically reports a confirmed 404 —
-        // everything else about the provider's body (resolving the tracker
-        // via brokenVideoTrackerProvider) matches production exactly, so this
-        // still exercises the real provider identifier and the real
-        // confirmAndMarkMissing mark path, just without a live HEAD request.
-        container.dispose();
-        container = ProviderContainer(
-          overrides: [
-            ...getStandardTestOverrides().cast(),
-            deadMediaFeedGuardProvider.overrideWith((ref) async {
-              final tracker = await ref.watch(
-                brokenVideoTrackerProvider.future,
-              );
-              return DeadMediaFeedGuard(
-                brokenVideoTracker: tracker,
-                availabilityChecker: const _AlwaysConfirmedMissingChecker(),
-              );
-            }),
-          ],
-        );
+    test('a mark made through deadMediaFeedGuardProvider.confirmAndMarkMissing '
+        'is reflected by VideoEventService.filterVideoList', () async {
+      // Rebuild the container with deadMediaFeedGuardProvider overridden to
+      // swap in a checker that deterministically reports a confirmed 404 —
+      // everything else about the provider's body (resolving the tracker
+      // via brokenVideoTrackerProvider) matches production exactly, so this
+      // still exercises the real provider identifier and the real
+      // confirmAndMarkMissing mark path, just without a live HEAD request.
+      container.dispose();
+      container = ProviderContainer(
+        overrides: [
+          ...getStandardTestOverrides().cast(),
+          deadMediaFeedGuardProvider.overrideWith((ref) async {
+            final tracker = await ref.watch(brokenVideoTrackerProvider.future);
+            return DeadMediaFeedGuard(
+              brokenVideoTracker: tracker,
+              moderationStatusService: _AlwaysBlockedModerationStatusService(),
+              availabilityChecker: const _AlwaysConfirmedMissingChecker(),
+            );
+          }),
+        ],
+      );
 
-        // Build VideoEventService first (production attaches its tracker via
-        // a fire-and-forget ref.read inside the provider's build function).
-        final service = container.read(videoEventServiceProvider);
+      // Build VideoEventService first (production attaches its tracker via
+      // a fire-and-forget ref.read inside the provider's build function).
+      final service = container.read(videoEventServiceProvider);
 
-        // Let the fire-and-forget setBrokenVideoTracker(...) attach.
-        await container.read(brokenVideoTrackerProvider.future);
-        await Future<void>.delayed(Duration.zero);
+      // Let the fire-and-forget setBrokenVideoTracker(...) attach.
+      await container.read(brokenVideoTrackerProvider.future);
+      await Future<void>.delayed(Duration.zero);
 
-        // media.divine.video so the videos survive the default
-        // divine-hosted-only preference and only the tracker mark decides
-        // whether they're filtered — matching the real #5953 scenario of a
-        // missing media.divine.video blob.
-        final good = TestHelpers.createVideoEvent(
-          id: 'good1',
-          videoUrl: 'https://media.divine.video/good1hash',
-        );
-        final dead = TestHelpers.createVideoEvent(
-          id: 'dead1',
-          videoUrl: 'https://media.divine.video/dead1hash',
-        );
+      // media.divine.video so the videos survive the default
+      // divine-hosted-only preference and only the tracker mark decides
+      // whether they're filtered — matching the real #5953 scenario of a
+      // missing media.divine.video blob.
+      final good = TestHelpers.createVideoEvent(
+        id: 'good1',
+        videoUrl: 'https://media.divine.video/good1hash',
+      );
+      final dead = TestHelpers.createVideoEvent(
+        id: 'dead1',
+        videoUrl: 'https://media.divine.video/dead1hash',
+      );
 
-        expect(
-          service.filterVideoList([good, dead]).map((v) => v.id),
-          containsAll(<String>['good1', 'dead1']),
-        );
+      expect(
+        service.filterVideoList([good, dead]).map((v) => v.id),
+        containsAll(<String>['good1', 'dead1']),
+      );
 
-        final guard = await container.read(deadMediaFeedGuardProvider.future);
-        final marked = await guard.confirmAndMarkMissing(
-          videoId: 'dead1',
-          videoUrl: dead.videoUrl,
-        );
-        expect(marked, isTrue);
+      final guard = await container.read(deadMediaFeedGuardProvider.future);
+      final marked = await guard.confirmAndMarkMissing(
+        videoId: 'dead1',
+        videoUrl: dead.videoUrl,
+        explicitSha256: 'a' * 64,
+      );
+      expect(marked, isTrue);
 
-        expect(
-          service.filterVideoList([good, dead]).map((v) => v.id),
-          equals(['good1']),
-          reason:
-              'VideoEventService must filter against the exact tracker '
-              'instance the home-feed guard marks — a stale/duplicate '
-              'tracker (the pre-fix autoDispose bug) would leave the dead '
-              'item visible in the home scrolling feed.',
-        );
-      },
-    );
+      expect(
+        service.filterVideoList([good, dead]).map((v) => v.id),
+        equals(['good1']),
+        reason:
+            'VideoEventService must filter against the exact tracker '
+            'instance the home-feed guard marks — a stale/duplicate '
+            'tracker (the pre-fix autoDispose bug) would leave the dead '
+            'item visible in the home scrolling feed.',
+      );
+    });
   });
 }

--- a/mobile/test/screens/feed/feed_auto_advance_error_listener_test.dart
+++ b/mobile/test/screens/feed/feed_auto_advance_error_listener_test.dart
@@ -297,7 +297,7 @@ void main() {
     );
 
     testWidgets(
-      'manual scroll: does NOT skip when the failure is not a confirmed 404',
+      'manual scroll: does NOT skip when the guard rejects the prune',
       (tester) async {
         var confirmCalls = 0;
         final updated = VideoPlaybackStatusState().withStatus(

--- a/mobile/test/screens/feed/feed_auto_advance_error_listener_test.dart
+++ b/mobile/test/screens/feed/feed_auto_advance_error_listener_test.dart
@@ -260,7 +260,7 @@ void main() {
     );
 
     testWidgets(
-      'manual scroll: skips when confirmAndMarkMissing confirms a hard 404',
+      'manual scroll: skips when confirmAndMarkMissing confirms unavailable media',
       (tester) async {
         var confirmCalls = 0;
         final updated = VideoPlaybackStatusState().withStatus(
@@ -282,7 +282,7 @@ void main() {
             onSkip: () => skipCount++,
             confirmAndMarkMissing: () async {
               confirmCalls++;
-              return true; // confirmed hard 404
+              return true; // confirmed unavailable
             },
           ),
         );
@@ -430,7 +430,7 @@ void main() {
               'confirmAndMarkMissing becomes available for this same item',
         );
 
-        confirmCompleter.complete(true); // confirmed hard 404
+        confirmCompleter.complete(true); // confirmed unavailable
         // A bare completer resolving outside any widget rebuild doesn't
         // schedule a frame on its own, so nudge the test binding to draw one
         // — otherwise pump() only flushes microtasks and the post-frame
@@ -486,7 +486,7 @@ void main() {
           ),
         );
 
-        confirmCompleter.complete(true); // confirms a hard 404, too late
+        confirmCompleter.complete(true); // confirms unavailable media, too late
         await tester.pump();
         await tester.pump();
 

--- a/mobile/test/services/dead_media_feed_guard_test.dart
+++ b/mobile/test/services/dead_media_feed_guard_test.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Tests DeadMediaFeedGuard — confirms a hard 404 via HEAD and marks
-// ABOUTME: the item broken; transient / non-404 / missing-URL cases keep it.
+// ABOUTME: Tests DeadMediaFeedGuard — confirms 404 plus blocked/quarantined
+// ABOUTME: moderation before marking broken; recoverable cases keep the item.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
@@ -8,41 +8,66 @@ import 'package:mocktail/mocktail.dart';
 import 'package:openvine/services/broken_video_tracker.dart';
 import 'package:openvine/services/dead_media_feed_guard.dart';
 import 'package:openvine/services/media_availability_checker.dart';
+import 'package:openvine/services/video_moderation_status_service.dart';
 
 class _MockChecker extends Mock implements MediaAvailabilityChecker {}
 
 class _MockTracker extends Mock implements BrokenVideoTracker {}
 
+class _MockModerationStatusService extends Mock
+    implements VideoModerationStatusService {}
+
 void main() {
   group(DeadMediaFeedGuard, () {
     late _MockChecker checker;
     late _MockTracker tracker;
+    late _MockModerationStatusService moderationStatusService;
     late DeadMediaFeedGuard guard;
 
     setUp(() {
       checker = _MockChecker();
       tracker = _MockTracker();
+      moderationStatusService = _MockModerationStatusService();
       when(
         () => tracker.markVideoBroken(any(), any()),
       ).thenAnswer((_) async {});
       guard = DeadMediaFeedGuard(
         brokenVideoTracker: tracker,
+        moderationStatusService: moderationStatusService,
         availabilityChecker: checker,
       );
     });
 
+    VideoModerationStatus status({
+      bool blocked = false,
+      bool quarantined = false,
+      bool ageRestricted = false,
+    }) => VideoModerationStatus(
+      moderated: true,
+      blocked: blocked,
+      quarantined: quarantined,
+      ageRestricted: ageRestricted,
+      needsReview: false,
+      aiGenerated: false,
+    );
+
     group('confirmAndMarkMissing', () {
       test(
-        'returns true and marks broken when HEAD confirms a hard 404',
+        'returns true and marks broken when HEAD 404 is blocked by moderation',
         () async {
           const url = 'https://media.divine.video/deadhash';
+          final sha256 = 'a' * 64;
           when(
             () => checker.isConfirmedMissing(url),
           ).thenAnswer((_) async => true);
+          when(
+            () => moderationStatusService.fetchStatus(sha256),
+          ).thenAnswer((_) async => status(blocked: true));
 
           final result = await guard.confirmAndMarkMissing(
             videoId: 'v1',
             videoUrl: url,
+            explicitSha256: sha256,
           );
 
           expect(result, isTrue);
@@ -60,10 +85,12 @@ void main() {
           final result = await guard.confirmAndMarkMissing(
             videoId: 'v1',
             videoUrl: 'https://media.divine.video/live',
+            explicitSha256: 'a' * 64,
           );
 
           expect(result, isFalse);
           verifyNever(() => tracker.markVideoBroken(any(), any()));
+          verifyNever(() => moderationStatusService.fetchStatus(any()));
         },
       );
 
@@ -76,6 +103,7 @@ void main() {
         expect(result, isFalse);
         verifyNever(() => checker.isConfirmedMissing(any()));
         verifyNever(() => tracker.markVideoBroken(any(), any()));
+        verifyNever(() => moderationStatusService.fetchStatus(any()));
       });
 
       test('returns false without a HEAD when videoUrl is empty', () async {
@@ -86,6 +114,7 @@ void main() {
 
         expect(result, isFalse);
         verifyNever(() => checker.isConfirmedMissing(any()));
+        verifyNever(() => moderationStatusService.fetchStatus(any()));
       });
 
       // Driven through a real MediaAvailabilityChecker rather than a stubbed
@@ -96,6 +125,7 @@ void main() {
       test('never prunes an age-gated 401', () async {
         final gatedGuard = DeadMediaFeedGuard(
           brokenVideoTracker: tracker,
+          moderationStatusService: moderationStatusService,
           availabilityChecker: MediaAvailabilityChecker(
             client: MockClient((_) async => http.Response('', 401)),
           ),
@@ -108,6 +138,70 @@ void main() {
 
         expect(result, isFalse);
         verifyNever(() => tracker.markVideoBroken(any(), any()));
+        verifyNever(() => moderationStatusService.fetchStatus(any()));
+      });
+
+      test(
+        'does not prune a 404 when moderation says age-restricted',
+        () async {
+          const url = 'https://media.divine.video/agegated';
+          final sha256 = 'b' * 64;
+          when(
+            () => checker.isConfirmedMissing(url),
+          ).thenAnswer((_) async => true);
+          when(
+            () => moderationStatusService.fetchStatus(sha256),
+          ).thenAnswer((_) async => status(ageRestricted: true));
+
+          final result = await guard.confirmAndMarkMissing(
+            videoId: 'v1',
+            videoUrl: url,
+            explicitSha256: sha256,
+          );
+
+          expect(result, isFalse);
+          verifyNever(() => tracker.markVideoBroken(any(), any()));
+        },
+      );
+
+      test('does not prune a 404 when moderation lookup fails', () async {
+        const url = 'https://media.divine.video/unknown';
+        final sha256 = 'c' * 64;
+        when(
+          () => checker.isConfirmedMissing(url),
+        ).thenAnswer((_) async => true);
+        when(
+          () => moderationStatusService.fetchStatus(sha256),
+        ).thenAnswer((_) async => null);
+
+        final result = await guard.confirmAndMarkMissing(
+          videoId: 'v1',
+          videoUrl: url,
+          explicitSha256: sha256,
+        );
+
+        expect(result, isFalse);
+        verifyNever(() => tracker.markVideoBroken(any(), any()));
+      });
+
+      test('prunes a 404 when moderation says quarantined', () async {
+        const url = 'https://media.divine.video/quarantined';
+        final sha256 = 'd' * 64;
+        when(
+          () => checker.isConfirmedMissing(url),
+        ).thenAnswer((_) async => true);
+        when(
+          () => moderationStatusService.fetchStatus(sha256),
+        ).thenAnswer((_) async => status(quarantined: true));
+
+        final result = await guard.confirmAndMarkMissing(
+          videoId: 'v1',
+          videoUrl: url,
+          explicitSha256: sha256,
+        );
+
+        expect(result, isTrue);
+        verify(() => tracker.markVideoBroken('v1', any())).called(1);
       });
     });
   });

--- a/mobile/test/services/dead_media_feed_guard_test.dart
+++ b/mobile/test/services/dead_media_feed_guard_test.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Tests DeadMediaFeedGuard — confirms 404 plus blocked/quarantined
-// ABOUTME: moderation before marking broken; recoverable cases keep the item.
+// ABOUTME: Tests DeadMediaFeedGuard — confirms 404 plus a terminal `blocked`
+// ABOUTME: verdict before marking broken; reversible cases keep the item.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
@@ -184,7 +184,11 @@ void main() {
         verifyNever(() => tracker.markVideoBroken(any(), any()));
       });
 
-      test('prunes a 404 when moderation says quarantined', () async {
+      // QUARANTINE maps to blossom RESTRICT — the reversible, pending-review
+      // withhold, and the state an approval-required uploader's SAFE clip is
+      // rewritten to. BrokenVideoTracker holds marks for 7 days and nothing
+      // calls unmarkVideoBroken, so an un-quarantine never reaches the client.
+      test('does not prune a 404 when moderation says quarantined', () async {
         const url = 'https://media.divine.video/quarantined';
         final sha256 = 'd' * 64;
         when(
@@ -200,8 +204,50 @@ void main() {
           explicitSha256: sha256,
         );
 
-        expect(result, isTrue);
-        verify(() => tracker.markVideoBroken('v1', any())).called(1);
+        expect(result, isFalse);
+        verifyNever(() => tracker.markVideoBroken(any(), any()));
+      });
+    });
+
+    // The fullscreen feed injects this predicate straight into
+    // FullscreenFeedBloc (pooled_fullscreen_video_feed_screen.dart) and
+    // persists off its bool, so the reversible verdicts must be pinned here
+    // too — not only through confirmAndMarkMissing.
+    group('isConfirmedUnavailable', () {
+      const url = 'https://media.divine.video/hash';
+
+      setUp(() {
+        when(
+          () => checker.isConfirmedMissing(url),
+        ).thenAnswer((_) async => true);
+      });
+
+      test('is true for a 404 blocked by moderation', () async {
+        when(
+          () => moderationStatusService.fetchStatus(any()),
+        ).thenAnswer((_) async => status(blocked: true));
+
+        expect(
+          await guard.isConfirmedUnavailable(
+            videoUrl: url,
+            explicitSha256: 'e' * 64,
+          ),
+          isTrue,
+        );
+      });
+
+      test('is false for a 404 that is only quarantined', () async {
+        when(
+          () => moderationStatusService.fetchStatus(any()),
+        ).thenAnswer((_) async => status(quarantined: true));
+
+        expect(
+          await guard.isConfirmedUnavailable(
+            videoUrl: url,
+            explicitSha256: 'e' * 64,
+          ),
+          isFalse,
+        );
       });
     });
   });

--- a/mobile/test/services/media_availability_checker_test.dart
+++ b/mobile/test/services/media_availability_checker_test.dart
@@ -58,11 +58,11 @@ void main() {
         expect(result, isFalse);
       });
 
-      // Blossom answers 401 (not 404) for an age-restricted blob and serves it
-      // to any authenticated request, so an anonymous probe cannot conclude the
-      // media is gone. Callers persist this answer via BrokenVideoTracker, so
-      // widening the predicate to 401 would hide viewable content for the
-      // tracker's full TTL. See #5953 / #6251.
+      // Blossom answers 401 for an age-gated fetch and serves the blob to any
+      // authenticated request, so an anonymous probe cannot conclude the media
+      // is gone. DeadMediaFeedGuard persists this answer once moderation
+      // confirms a terminal verdict, so widening the predicate to 401 would
+      // hide viewable content for the tracker's full TTL. See #5953 / #6251.
       test('returns false for the 401 age gate', () async {
         final client = MockClient((_) async => http.Response('', 401));
         final checker = MediaAvailabilityChecker(client: client);

--- a/mobile/test/services/video_event_service_broken_filter_test.dart
+++ b/mobile/test/services/video_event_service_broken_filter_test.dart
@@ -109,6 +109,26 @@ void main() {
       },
     );
 
+    // Scoping the keys orphaned the pre-#6251 unscoped pair: no scope reads
+    // them and `_cleanupOldEntries` only sweeps the loaded scope, so they
+    // would never expire. The containsKey assertions are the load-bearing
+    // ones — isVideoBroken already returns false without the cleanup.
+    test('drops the orphaned pre-#6251 unscoped entries', () async {
+      SharedPreferences.setMockInitialValues({
+        'broken_video_urls': '["legacy1"]',
+        'broken_video_timestamps':
+            '{"legacy1":${DateTime.now().millisecondsSinceEpoch}}',
+      });
+
+      final scopedTracker = BrokenVideoTracker();
+      await scopedTracker.initialize();
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.containsKey('broken_video_urls'), isFalse);
+      expect(prefs.containsKey('broken_video_timestamps'), isFalse);
+      expect(scopedTracker.isVideoBroken('legacy1'), isFalse);
+    });
+
     test(
       'tracker persistence is scoped between anonymous and signed-in users',
       () async {

--- a/mobile/test/services/video_event_service_broken_filter_test.dart
+++ b/mobile/test/services/video_event_service_broken_filter_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Tests that VideoEventService filters videos confirmed unavailable
-// ABOUTME: (hard 404) via the attached BrokenVideoTracker across list surfaces.
+// ABOUTME: via the attached BrokenVideoTracker across list surfaces.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -72,37 +72,28 @@ void main() {
       service.dispose();
     });
 
-    test(
-      'filterVideoList drops videos marked broken by the tracker',
-      () async {
-        await tracker.markVideoBroken('broken1', 'Confirmed 404');
-        service.setBrokenVideoTracker(tracker);
+    test('filterVideoList drops videos marked broken by the tracker', () async {
+      await tracker.markVideoBroken('broken1', 'Confirmed unavailable');
+      service.setBrokenVideoTracker(tracker);
 
-        final videos = [
-          _videoEvent(id: 'good1'),
-          _videoEvent(id: 'broken1'),
-          _videoEvent(id: 'good2'),
-        ];
+      final videos = [
+        _videoEvent(id: 'good1'),
+        _videoEvent(id: 'broken1'),
+        _videoEvent(id: 'good2'),
+      ];
 
-        final filtered = service.filterVideoList(videos);
+      final filtered = service.filterVideoList(videos);
 
-        expect(
-          filtered.map((v) => v.id),
-          equals(['good1', 'good2']),
-        );
-      },
-    );
+      expect(filtered.map((v) => v.id), equals(['good1', 'good2']));
+    });
 
-    test(
-      'filterVideoList keeps all videos when no tracker attached',
-      () {
-        final videos = [_videoEvent(id: 'a'), _videoEvent(id: 'b')];
+    test('filterVideoList keeps all videos when no tracker attached', () {
+      final videos = [_videoEvent(id: 'a'), _videoEvent(id: 'b')];
 
-        final filtered = service.filterVideoList(videos);
+      final filtered = service.filterVideoList(videos);
 
-        expect(filtered.map((v) => v.id), equals(['a', 'b']));
-      },
-    );
+      expect(filtered.map((v) => v.id), equals(['a', 'b']));
+    });
 
     test(
       'filterVideoList keeps videos that become broken only after attach',
@@ -113,8 +104,44 @@ void main() {
         expect(service.filterVideoList(videos).map((v) => v.id), ['x', 'y']);
 
         // Tracker reads live state, so a later mark is reflected immediately.
-        await tracker.markVideoBroken('x', 'Confirmed 404');
+        await tracker.markVideoBroken('x', 'Confirmed unavailable');
         expect(service.filterVideoList(videos).map((v) => v.id), ['y']);
+      },
+    );
+
+    test(
+      'tracker persistence is scoped between anonymous and signed-in users',
+      () async {
+        final anonymousTracker = BrokenVideoTracker();
+        await anonymousTracker.initialize();
+        await anonymousTracker.markVideoBroken('signed-in-can-watch', '404');
+
+        final signedInTracker = BrokenVideoTracker(ownerPubkey: 'a' * 64);
+        await signedInTracker.initialize();
+
+        expect(signedInTracker.isVideoBroken('signed-in-can-watch'), isFalse);
+
+        await signedInTracker.markVideoBroken('blocked-for-user', '404');
+
+        final reloadedSignedInTracker = BrokenVideoTracker(
+          ownerPubkey: 'a' * 64,
+        );
+        await reloadedSignedInTracker.initialize();
+        final reloadedAnonymousTracker = BrokenVideoTracker();
+        await reloadedAnonymousTracker.initialize();
+
+        expect(
+          reloadedSignedInTracker.isVideoBroken('blocked-for-user'),
+          isTrue,
+        );
+        expect(
+          reloadedAnonymousTracker.isVideoBroken('blocked-for-user'),
+          isFalse,
+        );
+        expect(
+          reloadedAnonymousTracker.isVideoBroken('signed-in-can-watch'),
+          isTrue,
+        );
       },
     );
   });


### PR DESCRIPTION
## Summary
- gate persistent dead-media pruning on 404 plus moderation-confirmed blocked/quarantined status
- keep age-restricted or unknown moderation states recoverable instead of marking them broken
- scope BrokenVideoTracker persistence by anonymous/current pubkey and reattach the scoped tracker on auth changes

## Tests
- flutter test test/services/dead_media_feed_guard_test.dart test/services/video_event_service_broken_filter_test.dart test/providers/broken_video_tracker_identity_test.dart test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart test/screens/feed/feed_auto_advance_error_listener_test.dart
- flutter analyze lib test integration_test
- push hook: analyzer, generated files, changed-file tests

Fixes #6251