### PR TITLE
feat(clip-reuse): credit reused clip sources

### DIFF
--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -545,7 +545,8 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   /// populates [selectedAudioEventId] and [selectedAudioRelay] for the
   /// publisher to add an `["e", ..., "audio"]` tag. Also auto-populates
   /// [inspiredByVideo] from the sound's [sourceVideoReference] if not
-  /// already set.
+  /// already set, falling back to a single imported clip source when every
+  /// provenance-bearing clip agrees.
   DivineVideoDraft getActiveDraft({bool isAutosave = false, String? draftId}) {
     // Read selected sound from local state. The recorder flow sets
     // [selectedSound]; the editor's "add music" flow instead appends reused
@@ -556,7 +557,9 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         state.selectedSound ??
         (isAutosave ? null : _attributionSoundFromEditorTracks());
 
-    // Auto-populate inspired-by from selected sound's source video
+    // Auto-populate inspired-by from selected sound's source video.
+    // Sound wins because the existing audio attribution flow already exposes
+    // that credit in metadata and publish tags.
     var inspiredByVideo = state.inspiredByVideo;
     if (inspiredByVideo == null &&
         selectedSound?.sourceVideoReference != null) {
@@ -565,6 +568,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         relayUrl: selectedSound.sourceVideoRelay,
       );
     }
+    inspiredByVideo ??= _attributionSourceFromClips();
 
     return DivineVideoDraft.create(
       id:
@@ -1504,6 +1508,31 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       if (track.attributionEventId != null) return track;
     }
     return null;
+  }
+
+  /// The imported clip source to credit when the timeline has exactly one
+  /// attributable source. Clips without provenance are local/original material
+  /// and do not conflict with the reused source; multiple reused sources do.
+  InspiredByInfo? _attributionSourceFromClips() {
+    InspiredByInfo? source;
+    for (final clip in _clips) {
+      final addressableId = clip.sourceAddressableId;
+      if (addressableId == null || addressableId.isEmpty) continue;
+
+      final candidate = InspiredByInfo(
+        addressableId: addressableId,
+        relayUrl: clip.sourceRelayHint,
+      );
+      if (source == null) {
+        source = candidate;
+        continue;
+      }
+      if (source.addressableId != candidate.addressableId ||
+          source.relayUrl != candidate.relayUrl) {
+        return null;
+      }
+    }
+    return source;
   }
 
   /// Build render parameters for video export.

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -1389,8 +1389,22 @@ class VideoEventPublisher {
         ),
       );
 
+      final inspiredByCreatorPubkey = inspiredByAddressableId == null
+          ? null
+          : InspiredByInfo(
+              addressableId: inspiredByAddressableId,
+            ).creatorPubkey.trim().toLowerCase();
+      final selfPubkey = _authService?.currentPublicKeyHex
+          ?.trim()
+          .toLowerCase();
+      final shouldEmitInspiredByATag =
+          inspiredByAddressableId != null &&
+          (inspiredByCreatorPubkey == null ||
+              inspiredByCreatorPubkey.isEmpty ||
+              inspiredByCreatorPubkey != selfPubkey);
+
       // Add Inspired By a-tag (specific video reference)
-      if (inspiredByAddressableId != null) {
+      if (shouldEmitInspiredByATag) {
         tags.add([
           'a',
           inspiredByAddressableId,

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -2539,6 +2539,23 @@ void main() {
           .updateEditorEditingParameters(params);
     }
 
+    DivineVideoClip timelineClip({
+      String id = 'clip-1',
+      String? sourceAddressableId,
+      String? sourceRelayHint,
+    }) {
+      return DivineVideoClip(
+        id: id,
+        video: EditorVideo.file('/docs/$id.mp4'),
+        duration: const Duration(seconds: 2),
+        recordedAt: DateTime(2026),
+        targetAspectRatio: .vertical,
+        originalAspectRatio: 9 / 16,
+        sourceAddressableId: sourceAddressableId,
+        sourceRelayHint: sourceRelayHint,
+      );
+    }
+
     test('credits a reused editor timeline sound in the publish draft', () {
       seedEditorAudioTrack(reusedOriginalSound());
 
@@ -2572,6 +2589,88 @@ void main() {
           .getActiveDraft();
 
       expect(draft.selectedSound, isNull);
+    });
+
+    test('credits a single reused clip source in the publish draft', () {
+      container.read(clipManagerProvider.notifier).replaceClips([
+        timelineClip(
+          sourceAddressableId: '34236:$sourceCreator:clip-source',
+          sourceRelayHint: 'wss://source.relay',
+        ),
+      ], autosave: false);
+
+      final draft = container
+          .read(videoEditorProvider.notifier)
+          .getActiveDraft();
+
+      expect(
+        draft.inspiredByVideo?.addressableId,
+        equals('34236:$sourceCreator:clip-source'),
+      );
+      expect(draft.inspiredByVideo?.relayUrl, equals('wss://source.relay'));
+    });
+
+    test('keeps sound attribution ahead of reused clip attribution', () {
+      container.read(clipManagerProvider.notifier).replaceClips([
+        timelineClip(
+          sourceAddressableId: '34236:${'d' * 64}:clip-source',
+          sourceRelayHint: 'wss://clip.relay',
+        ),
+      ], autosave: false);
+      container
+          .read(videoEditorProvider.notifier)
+          .selectSound(reusedOriginalSound());
+
+      final draft = container
+          .read(videoEditorProvider.notifier)
+          .getActiveDraft();
+
+      expect(
+        draft.inspiredByVideo?.addressableId,
+        equals('34236:$sourceCreator:vine-xyz'),
+      );
+      expect(draft.inspiredByVideo?.relayUrl, isNull);
+    });
+
+    test('credits one reused clip source mixed with local clips', () {
+      container.read(clipManagerProvider.notifier).replaceClips([
+        timelineClip(id: 'local-clip'),
+        timelineClip(
+          id: 'reused-clip',
+          sourceAddressableId: '34236:$sourceCreator:clip-source',
+          sourceRelayHint: 'wss://source.relay',
+        ),
+      ], autosave: false);
+
+      final draft = container
+          .read(videoEditorProvider.notifier)
+          .getActiveDraft();
+
+      expect(
+        draft.inspiredByVideo?.addressableId,
+        equals('34236:$sourceCreator:clip-source'),
+      );
+    });
+
+    test('does not credit clips when reused sources disagree', () {
+      container.read(clipManagerProvider.notifier).replaceClips([
+        timelineClip(
+          id: 'source-a',
+          sourceAddressableId: '34236:${'d' * 64}:source-a',
+          sourceRelayHint: 'wss://source-a.relay',
+        ),
+        timelineClip(
+          id: 'source-b',
+          sourceAddressableId: '34236:${'e' * 64}:source-b',
+          sourceRelayHint: 'wss://source-b.relay',
+        ),
+      ], autosave: false);
+
+      final draft = container
+          .read(videoEditorProvider.notifier)
+          .getActiveDraft();
+
+      expect(draft.inspiredByVideo, isNull);
     });
   });
 

--- a/mobile/test/services/video_event_publisher_inspired_by_tags_test.dart
+++ b/mobile/test/services/video_event_publisher_inspired_by_tags_test.dart
@@ -263,6 +263,24 @@ void main() {
     expect(_countPTagsFor(capturedTags, testPubkey), equals(0));
   });
 
+  test("skips the a-tag when inspired by the publisher's own video", () async {
+    stubSignAndPublish();
+
+    const ownAddressableId = '34236:$testPubkey:own-d-tag';
+    final result = await publisher.publishDirectUpload(
+      createUpload(),
+      inspiredByAddressableId: ownAddressableId,
+    );
+
+    expect(result, isTrue);
+    expect(
+      capturedTags.any(
+        (tag) => tag.length >= 2 && tag[0] == 'a' && tag[1] == ownAddressableId,
+      ),
+      isFalse,
+    );
+  });
+
   test(
     'keeps the collaborator p-tag when the creator is also a collaborator',
     () async {
@@ -376,6 +394,16 @@ void main() {
       );
 
       expect(result, isTrue);
+      expect(
+        _containsTag(capturedTags, const [
+          'a',
+          '34236:',
+          'wss://relay.divine.video',
+          'mention',
+        ]),
+        isTrue,
+        reason: 'only malformed p-tags are suppressed; the a-tag is unchanged',
+      );
       expect(
         capturedTags.any(
           (tag) =>


### PR DESCRIPTION
## Description

Carries Phase 0 imported clip provenance into publish attribution by deriving the existing inspired-by video reference from the timeline when there is a single reused clip source. Existing explicit and sound-derived attribution keep precedence.

Also fixes the existing self-attribution hole by suppressing inspired-by a-tags when the referenced video was created by the publisher, while preserving malformed addressable-id behavior for the existing a-tag path.

**Related Issue:** Relates to #6315

## Out of Scope

Creator-facing clip reuse settings and source watermarking remain out of scope for this PR.

## Verification

- `flutter analyze lib test integration_test`
- `flutter test test/providers/video_editor_provider_test.dart test/services/video_event_publisher_inspired_by_tags_test.dart`
- Pre-push changed-file checks: analyzer plus `test/providers/video_editor_provider_test.dart`, `test/services/video_event_publisher_inspired_by_tags_test.dart`, and `test/services/video_event_publisher_test.dart`

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
