### PR TITLE
fix(audio): credit sound creators on detail page

### DIFF
--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -508,9 +508,13 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
                 pubkey: profileCreditPubkey,
                 profile: profileCreditProfile,
               );
+    // Matches the feed pill and the metadata sheet: a credited creator who is
+    // not the signer means the signer only shared the sound. Bundled sounds
+    // carry a marker pubkey rather than a real signer, so they are excluded
+    // instead of being credited to a generated name.
     final showsSeparatePublisher =
         _artistName != null &&
-        sound.creatorPubkey != null &&
+        !sound.isBundled &&
         sound.creatorPubkey != sound.pubkey;
     final publisherProfile = showsSeparatePublisher
         ? ref.watch(userProfileReactiveProvider(sound.pubkey)).value

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -31,6 +31,11 @@ import 'package:sound_service/sound_service.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+const _soundDetailCreatorAttributionIdentifier =
+    'sound_detail_creator_attribution';
+const _soundDetailPublisherAttributionIdentifier =
+    'sound_detail_publisher_attribution';
+
 /// Screen displaying details of a specific sound and videos using it.
 ///
 /// Features:
@@ -569,6 +574,8 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
                       _ProfileAttributionInfo(
                         text: context.l10n.soundCreatorBy(profileCreditName),
                         pubkey: profileCreditPubkey,
+                        semanticsIdentifier:
+                            _soundDetailCreatorAttributionIdentifier,
                         license: _license,
                         sourceUrl: _sourceUrl,
                       )
@@ -582,6 +589,8 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
                       _ProfileCreditLink(
                         text: context.l10n.soundSharedBy(publisherName),
                         pubkey: sound.pubkey,
+                        semanticsIdentifier:
+                            _soundDetailPublisherAttributionIdentifier,
                       ),
                     if (widget.reuseAllowed case final reuseAllowed?)
                       Text(
@@ -711,7 +720,7 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
   }
 
   String? _profileCreditPubkey(AudioEvent sound) {
-    if (sound.isBundled) return null;
+    if (sound.isBundled || sound.isLocalImport) return null;
     final creatorPubkey = sound.creatorPubkey;
     if (creatorPubkey != null && creatorPubkey.isNotEmpty) {
       return creatorPubkey;
@@ -726,12 +735,14 @@ class _ProfileAttributionInfo extends StatelessWidget {
   const _ProfileAttributionInfo({
     required this.text,
     required this.pubkey,
+    required this.semanticsIdentifier,
     this.license,
     this.sourceUrl,
   });
 
   final String text;
   final String pubkey;
+  final String semanticsIdentifier;
   final String? license;
   final String? sourceUrl;
 
@@ -739,14 +750,16 @@ class _ProfileAttributionInfo extends StatelessWidget {
   Widget build(BuildContext context) {
     return Text.rich(
       TextSpan(
-        style: VineTheme.bodySmallFont(
-          color: context.vineColors.secondaryText,
-        ),
+        style: VineTheme.bodySmallFont(color: context.vineColors.secondaryText),
         children: [
           WidgetSpan(
             alignment: PlaceholderAlignment.baseline,
             baseline: TextBaseline.alphabetic,
-            child: _ProfileCreditLink(text: text, pubkey: pubkey),
+            child: _ProfileCreditLink(
+              text: text,
+              pubkey: pubkey,
+              semanticsIdentifier: semanticsIdentifier,
+            ),
           ),
           if (license != null) TextSpan(text: ' · $license'),
           if (sourceUrl != null) ...[
@@ -764,15 +777,20 @@ class _ProfileAttributionInfo extends StatelessWidget {
 }
 
 class _ProfileCreditLink extends StatelessWidget {
-  const _ProfileCreditLink({required this.text, required this.pubkey});
+  const _ProfileCreditLink({
+    required this.text,
+    required this.pubkey,
+    required this.semanticsIdentifier,
+  });
 
   final String text;
   final String pubkey;
+  final String semanticsIdentifier;
 
   @override
   Widget build(BuildContext context) {
     return Semantics(
-      identifier: 'sound_detail_creator_attribution',
+      identifier: semanticsIdentifier,
       button: true,
       label: context.l10n.profileChipTapHint(text),
       child: GestureDetector(
@@ -781,7 +799,7 @@ class _ProfileCreditLink extends StatelessWidget {
         child: Text(
           text,
           style: VineTheme.bodySmallFont(
-            color: VineTheme.onSurfaceVariant,
+            color: context.vineColors.secondaryText,
           ).copyWith(decoration: TextDecoration.underline),
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
@@ -812,7 +830,7 @@ class _AttributionInfo extends StatelessWidget {
 
     return Text.rich(
       TextSpan(
-        style: TextStyle(color: context.vineColors.secondaryText, fontSize: 12),
+        style: VineTheme.bodySmallFont(color: context.vineColors.secondaryText),
         children: [
           TextSpan(text: attributionText),
           if (sourceUrl != null) ...[
@@ -845,9 +863,7 @@ class _SourceLink extends StatelessWidget {
       },
       child: Text(
         context.l10n.soundViewSource,
-        style: const TextStyle(
-          color: VineTheme.vineGreen,
-          fontSize: 12,
+        style: VineTheme.bodySmallFont(color: VineTheme.vineGreen).copyWith(
           decoration: TextDecoration.underline,
           decorationColor: VineTheme.vineGreen,
         ),

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -449,11 +449,11 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
     final sound = widget.sound;
     _artistName = sound.creatorName;
     _license = sound.licenseName;
-    _sourceUrl = sound.source;
+    _sourceUrl = _launchableUrl(sound.source);
     if (sound.externalSource case final external?) {
       _artistName ??= external.creatorName;
       _license ??= external.license.name;
-      _sourceUrl ??= external.sourceUrl;
+      _sourceUrl ??= _launchableUrl(external.sourceUrl);
     }
     if (!sound.isBundled) return;
 
@@ -463,8 +463,18 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
     if (vineSound != null) {
       _artistName = vineSound.artist;
       _license = vineSound.license;
-      _sourceUrl = vineSound.sourceUrl;
+      _sourceUrl = _launchableUrl(vineSound.sourceUrl);
     }
+  }
+
+  /// [AudioEvent.source] carries free-text attribution ("Original Sound",
+  /// "Artist via Freesound") as often as a real URL, so only an absolute URL
+  /// becomes a tappable "View source" link — anything else would render a link
+  /// that `canLaunchUrl` rejects on tap.
+  static String? _launchableUrl(String? value) {
+    if (value == null) return null;
+    final uri = Uri.tryParse(value);
+    return uri != null && uri.hasScheme && uri.hasAuthority ? value : null;
   }
 
   String get _formattedDuration {

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -18,11 +18,13 @@ import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/sound_library_service_provider.dart';
 import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/router/nav_extensions.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/saved_sound_context_builder.dart';
 import 'package:openvine/services/saved_sounds_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/library/saved_sound_details_editor.dart';
+import 'package:openvine/widgets/video_feed_item/audio_attribution_credit.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:provider/provider.dart' as inherited_provider;
 import 'package:sound_service/sound_service.dart';
@@ -485,12 +487,30 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
   @override
   Widget build(BuildContext context) {
     final sound = widget.sound;
-    final publisherProfile = _artistName == null
+    final profileCreditPubkey = _profileCreditPubkey(sound);
+    final profileCreditProfile = profileCreditPubkey == null
         ? null
-        : ref.watch(userProfileReactiveProvider(sound.pubkey)).value;
+        : ref.watch(userProfileReactiveProvider(profileCreditPubkey)).value;
+    final profileCreditName = profileCreditPubkey == null
+        ? null
+        : _artistName ??
+              AudioAttributionCredit.displayNameForPubkey(
+                pubkey: profileCreditPubkey,
+                profile: profileCreditProfile,
+              );
     final showsSeparatePublisher =
         _artistName != null &&
-        (sound.creatorPubkey == null || sound.creatorPubkey != sound.pubkey);
+        sound.creatorPubkey != null &&
+        sound.creatorPubkey != sound.pubkey;
+    final publisherProfile = showsSeparatePublisher
+        ? ref.watch(userProfileReactiveProvider(sound.pubkey)).value
+        : null;
+    final publisherName = showsSeparatePublisher
+        ? AudioAttributionCredit.publisherNameFor(
+            audio: sound,
+            publisherProfile: publisherProfile,
+          )
+        : null;
     return Container(
       padding: const EdgeInsets.all(16),
       color: context.vineColors.card,
@@ -530,20 +550,24 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
                       overflow: TextOverflow.ellipsis,
                     ),
                     _buildMetadataRow(),
-                    if (_artistName != null)
+                    if (profileCreditPubkey != null &&
+                        profileCreditName != null)
+                      _ProfileAttributionInfo(
+                        text: context.l10n.soundCreatorBy(profileCreditName),
+                        pubkey: profileCreditPubkey,
+                        license: _license,
+                        sourceUrl: _sourceUrl,
+                      )
+                    else if (_artistName != null)
                       _AttributionInfo(
                         artistName: _artistName!,
                         license: _license,
                         sourceUrl: _sourceUrl,
                       ),
-                    if (showsSeparatePublisher && publisherProfile != null)
-                      Text(
-                        context.l10n.soundSharedBy(
-                          publisherProfile.bestDisplayName,
-                        ),
-                        style: VineTheme.bodySmallFont(
-                          color: VineTheme.onSurfaceVariant,
-                        ),
+                    if (showsSeparatePublisher && publisherName != null)
+                      _ProfileCreditLink(
+                        text: context.l10n.soundSharedBy(publisherName),
+                        pubkey: sound.pubkey,
                       ),
                     if (widget.reuseAllowed case final reuseAllowed?)
                       Text(
@@ -597,9 +621,12 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
                               strokeWidth: 2,
                             ),
                           )
-                        : Icon(
-                            widget.isPlaying ? Icons.stop : Icons.play_arrow,
+                        : DivineIcon(
+                            icon: widget.isPlaying
+                                ? DivineIconName.squareFill
+                                : DivineIconName.play,
                             size: 20,
+                            color: VineTheme.vineGreen,
                           ),
                     label: Text(
                       widget.isPlaying
@@ -668,6 +695,86 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
       style: TextStyle(color: context.vineColors.secondaryText, fontSize: 14),
     );
   }
+
+  String? _profileCreditPubkey(AudioEvent sound) {
+    if (sound.isBundled) return null;
+    final creatorPubkey = sound.creatorPubkey;
+    if (creatorPubkey != null && creatorPubkey.isNotEmpty) {
+      return creatorPubkey;
+    }
+    if (_artistName == null) return sound.pubkey;
+    return null;
+  }
+}
+
+/// Displays a profile-backed creator credit with optional license/source text.
+class _ProfileAttributionInfo extends StatelessWidget {
+  const _ProfileAttributionInfo({
+    required this.text,
+    required this.pubkey,
+    this.license,
+    this.sourceUrl,
+  });
+
+  final String text;
+  final String pubkey;
+  final String? license;
+  final String? sourceUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text.rich(
+      TextSpan(
+        style: VineTheme.bodySmallFont(
+          color: context.vineColors.secondaryText,
+        ),
+        children: [
+          WidgetSpan(
+            alignment: PlaceholderAlignment.baseline,
+            baseline: TextBaseline.alphabetic,
+            child: _ProfileCreditLink(text: text, pubkey: pubkey),
+          ),
+          if (license != null) TextSpan(text: ' · $license'),
+          if (sourceUrl != null) ...[
+            const TextSpan(text: ' · '),
+            WidgetSpan(
+              alignment: PlaceholderAlignment.baseline,
+              baseline: TextBaseline.alphabetic,
+              child: _SourceLink(sourceUrl: sourceUrl!),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _ProfileCreditLink extends StatelessWidget {
+  const _ProfileCreditLink({required this.text, required this.pubkey});
+
+  final String text;
+  final String pubkey;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      identifier: 'sound_detail_creator_attribution',
+      button: true,
+      label: context.l10n.profileChipTapHint(text),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => context.pushOtherProfile(pubkey),
+        child: Text(
+          text,
+          style: VineTheme.bodySmallFont(
+            color: VineTheme.onSurfaceVariant,
+          ).copyWith(decoration: TextDecoration.underline),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+      ),
+    );
+  }
 }
 
 /// Displays artist name, license, and optional "View on Freesound" link.
@@ -699,26 +806,37 @@ class _AttributionInfo extends StatelessWidget {
             WidgetSpan(
               alignment: PlaceholderAlignment.baseline,
               baseline: TextBaseline.alphabetic,
-              child: GestureDetector(
-                onTap: () async {
-                  final uri = Uri.parse(sourceUrl!);
-                  if (await canLaunchUrl(uri)) {
-                    await launchUrl(uri, mode: LaunchMode.externalApplication);
-                  }
-                },
-                child: Text(
-                  context.l10n.soundViewSource,
-                  style: const TextStyle(
-                    color: VineTheme.vineGreen,
-                    fontSize: 12,
-                    decoration: TextDecoration.underline,
-                    decorationColor: VineTheme.vineGreen,
-                  ),
-                ),
-              ),
+              child: _SourceLink(sourceUrl: sourceUrl!),
             ),
           ],
         ],
+      ),
+    );
+  }
+}
+
+class _SourceLink extends StatelessWidget {
+  const _SourceLink({required this.sourceUrl});
+
+  final String sourceUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () async {
+        final uri = Uri.parse(sourceUrl);
+        if (await canLaunchUrl(uri)) {
+          await launchUrl(uri, mode: LaunchMode.externalApplication);
+        }
+      },
+      child: Text(
+        context.l10n.soundViewSource,
+        style: const TextStyle(
+          color: VineTheme.vineGreen,
+          fontSize: 12,
+          decoration: TextDecoration.underline,
+          decorationColor: VineTheme.vineGreen,
+        ),
       ),
     );
   }

--- a/mobile/lib/widgets/video_feed_item/audio_attribution_credit.dart
+++ b/mobile/lib/widgets/video_feed_item/audio_attribution_credit.dart
@@ -7,6 +7,18 @@ import 'package:models/models.dart';
 class AudioAttributionCredit {
   const AudioAttributionCredit._();
 
+  /// Best display name for a pubkey-backed sound/profile credit.
+  static String displayNameForPubkey({
+    required String pubkey,
+    required UserProfile? profile,
+  }) => profile?.bestDisplayName ?? UserProfile.defaultDisplayNameFor(pubkey);
+
+  /// Display name for the signer/publisher of a Kind 1063 audio event.
+  static String publisherNameFor({
+    required AudioEvent audio,
+    required UserProfile? publisherProfile,
+  }) => displayNameForPubkey(pubkey: audio.pubkey, profile: publisherProfile);
+
   /// The reused sound's original creator, carried on the video via its
   /// inspired-by source. Null when absent, so the video's own author is
   /// credited.

--- a/mobile/lib/widgets/video_feed_item/audio_attribution_row.dart
+++ b/mobile/lib/widgets/video_feed_item/audio_attribution_row.dart
@@ -90,9 +90,10 @@ class _AudioAttributionContent extends ConsumerWidget {
       final publisherProfile = ref
           .watch(userProfileReactiveProvider(audio.pubkey))
           .value;
-      publisherName =
-          publisherProfile?.bestDisplayName ??
-          UserProfile.defaultDisplayNameFor(audio.pubkey);
+      publisherName = AudioAttributionCredit.publisherNameFor(
+        audio: audio,
+        publisherProfile: publisherProfile,
+      );
     }
     final creditedCreator = audio.creatorName;
     final creditText = [
@@ -127,10 +128,7 @@ class _AudioAttributionContent extends ConsumerWidget {
 
     context.pushWithVideoPause(
       SoundDetailScreen.pathForId(audio.id),
-      extra: <String, dynamic>{
-        'sound': audio,
-        'sourceVideo': sourceVideo,
-      },
+      extra: <String, dynamic>{'sound': audio, 'sourceVideo': sourceVideo},
     );
   }
 }
@@ -215,10 +213,9 @@ class _AudioAttributionPill extends StatelessWidget {
           Flexible(
             child: Text(
               '$soundName · $creatorName',
-              style: VineTheme.labelMediumFont(color: VineTheme.whiteText)
-                  .copyWith(
-                    shadows: [const Shadow(blurRadius: 4)],
-                  ),
+              style: VineTheme.labelMediumFont(
+                color: VineTheme.whiteText,
+              ).copyWith(shadows: [const Shadow(blurRadius: 4)]),
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
             ),

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -264,9 +264,10 @@ class _SoundListItem extends ConsumerWidget {
       final publisherProfile = ref
           .watch(userProfileReactiveProvider(audio.pubkey))
           .value;
-      publisherName =
-          publisherProfile?.bestDisplayName ??
-          UserProfile.defaultDisplayNameFor(audio.pubkey);
+      publisherName = AudioAttributionCredit.publisherNameFor(
+        audio: audio,
+        publisherProfile: publisherProfile,
+      );
     }
     final creatorName = audio.creatorName;
     final creditText = creatorName == null

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -573,6 +573,39 @@ void main() {
           findsOneWidget,
         );
       });
+
+      testWidgets('omits the source link when the source is not a URL', (
+        tester,
+      ) async {
+        // `fromVideoOriginalSound` puts the label "Original Sound" in `source`,
+        // which is not launchable — the credit must still render without a
+        // dead "View source" link next to it.
+        final video = createTestVideoEvent(id: 'video1');
+        final testSound = AudioEvent.fromVideoOriginalSound(video);
+
+        await tester.pumpWidget(
+          createTestWidget(
+            child: SoundDetailScreen(sound: testSound, sourceVideo: video),
+            overrides: [
+              soundUsageCountProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(0)),
+              videosUsingSoundProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(<String>[])),
+              audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
+            ],
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text('By ${UserProfile.defaultDisplayNameFor(video.pubkey)}'),
+          findsOneWidget,
+        );
+        expect(find.text('View source'), findsNothing);
+      });
     });
 
     group('Action Buttons', () {

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -574,6 +574,51 @@ void main() {
         );
       });
 
+      testWidgets('credits the publisher of an externally sourced sound', (
+        tester,
+      ) async {
+        // The external-provider publish path credits the provider's artist by
+        // name and never sets a creator pubkey, so the signer is a separate
+        // publisher — same credit the feed pill and metadata sheet show.
+        const publisherPubkey =
+            'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+        final testSound = createTestAudioEvent(
+          id: 'sound1',
+          pubkey: publisherPubkey,
+        ).copyWith(creatorName: 'Freesound Artist', licenseName: 'CC0');
+
+        await tester.pumpWidget(
+          createTestWidget(
+            child: SoundDetailScreen(sound: testSound),
+            overrides: [
+              userProfileReactiveProvider(publisherPubkey).overrideWith((
+                ref,
+              ) async* {
+                yield UserProfile(
+                  pubkey: publisherPubkey,
+                  rawData: const {},
+                  createdAt: DateTime.fromMillisecondsSinceEpoch(0),
+                  eventId: 'profile-event',
+                  displayName: 'Publisher Pat',
+                );
+              }),
+              soundUsageCountProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(0)),
+              videosUsingSoundProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(<String>[])),
+              audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
+            ],
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('By Freesound Artist'), findsOneWidget);
+        expect(find.text('Shared by Publisher Pat'), findsOneWidget);
+      });
+
       testWidgets('omits the source link when the source is not a URL', (
         tester,
       ) async {

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:golden_toolkit/golden_toolkit.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
@@ -16,9 +17,12 @@ import 'package:openvine/blocs/saved_sounds/saved_sounds_scope.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/providers/sound_library_service_provider.dart';
 import 'package:openvine/providers/sounds_providers.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/sound_detail_screen.dart';
 import 'package:openvine/services/saved_sounds_service.dart';
+import 'package:openvine/services/sound_library_service.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -132,10 +136,7 @@ Widget createTestWidget({
   final mockAuth = createMockAuthService();
   when(() => mockAuth.currentPublicKeyHex).thenReturn(viewerPubkey);
   return ProviderScope(
-    overrides: [
-      authServiceProvider.overrideWithValue(mockAuth),
-      ...?overrides,
-    ],
+    overrides: [authServiceProvider.overrideWithValue(mockAuth), ...?overrides],
     child: MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
@@ -456,6 +457,122 @@ void main() {
 
         expect(_divineIcon(DivineIconName.musicNote), findsOneWidget);
       });
+
+      testWidgets('keeps bundled sound artist and license attribution', (
+        tester,
+      ) async {
+        SharedPreferences.setMockInitialValues({});
+        final soundLibraryService = SoundLibraryService();
+        final vineSound = VineSound(
+          id: 'classic-loop',
+          title: 'Classic Loop',
+          assetPath: 'assets/sounds/classic-loop.mp3',
+          duration: const Duration(seconds: 6),
+          artist: 'Bundled Artist',
+          license: 'CC0',
+          sourceUrl: 'https://freesound.org/s/123',
+        );
+        await soundLibraryService.addCustomSound(vineSound);
+        final testSound = AudioEvent.fromBundledSound(vineSound);
+
+        await tester.pumpWidget(
+          createTestWidget(
+            child: SoundDetailScreen(sound: testSound),
+            overrides: [
+              soundLibraryServiceSyncProvider.overrideWithValue(
+                soundLibraryService,
+              ),
+              soundUsageCountProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(0)),
+              videosUsingSoundProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(<String>[])),
+              audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
+            ],
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('By Bundled Artist'), findsOneWidget);
+        expect(find.textContaining('CC0'), findsOneWidget);
+        expect(find.text('View source'), findsOneWidget);
+      });
+
+      testWidgets('shows resolved community sound creator attribution', (
+        tester,
+      ) async {
+        const creatorPubkey =
+            '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+        final testSound = createTestAudioEvent(
+          id: 'sound1',
+          pubkey: creatorPubkey,
+        );
+
+        await tester.pumpWidget(
+          createTestWidget(
+            child: SoundDetailScreen(sound: testSound),
+            overrides: [
+              userProfileReactiveProvider(creatorPubkey).overrideWith((
+                ref,
+              ) async* {
+                yield UserProfile(
+                  pubkey: creatorPubkey,
+                  rawData: const {},
+                  createdAt: DateTime.fromMillisecondsSinceEpoch(0),
+                  eventId: 'profile-event',
+                  displayName: 'Alice Beats',
+                );
+              }),
+              soundUsageCountProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(0)),
+              videosUsingSoundProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(<String>[])),
+              audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
+            ],
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(find.text('By Alice Beats'), findsOneWidget);
+      });
+
+      testWidgets('falls back for community sound creator with no profile', (
+        tester,
+      ) async {
+        const creatorPubkey =
+            'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+        final testSound = createTestAudioEvent(
+          id: 'sound1',
+          pubkey: creatorPubkey,
+        );
+
+        await tester.pumpWidget(
+          createTestWidget(
+            child: SoundDetailScreen(sound: testSound),
+            overrides: [
+              soundUsageCountProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(0)),
+              videosUsingSoundProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(<String>[])),
+              audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
+            ],
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text('By ${UserProfile.defaultDisplayNameFor(creatorPubkey)}'),
+          findsOneWidget,
+        );
+      });
     });
 
     group('Action Buttons', () {
@@ -518,7 +635,7 @@ void main() {
         await tester.pump();
 
         expect(find.text('Preview'), findsOneWidget);
-        expect(find.byIcon(Icons.play_arrow), findsWidgets);
+        expect(_divineIcon(DivineIconName.play), findsWidgets);
       });
 
       testWidgets('has Use Sound button', (tester) async {
@@ -727,7 +844,7 @@ void main() {
 
         // Now shows Stop
         expect(find.text('Stop'), findsOneWidget);
-        expect(find.byIcon(Icons.stop), findsWidgets);
+        expect(_divineIcon(DivineIconName.squareFill), findsWidgets);
       });
 
       testWidgets('tapping Stop stops playback', (tester) async {
@@ -905,9 +1022,7 @@ void main() {
             SavedSoundsService(
               sharedPreferences,
             ).loadSavedSounds().map((sound) => sound.id),
-            [
-              testSound.id,
-            ],
+            [testSound.id],
           );
           expect(container.read(selectedSoundProvider), isNull);
         },
@@ -1275,6 +1390,65 @@ void main() {
           verify(() => mockGoRouter.pop<Object?>()).called(1);
         },
       );
+
+      testWidgets('creator attribution opens creator profile', (tester) async {
+        const creatorPubkey =
+            '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+        final testSound = createTestAudioEvent(
+          id: 'sound1',
+          pubkey: creatorPubkey,
+        );
+        final router = GoRouter(
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (context, state) => SoundDetailScreen(sound: testSound),
+            ),
+            GoRoute(
+              path: '/profile-view/:npub',
+              builder: (context, state) =>
+                  Text('profile ${state.pathParameters['npub']}'),
+            ),
+          ],
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              userProfileReactiveProvider(creatorPubkey).overrideWith((
+                ref,
+              ) async* {
+                yield UserProfile(
+                  pubkey: creatorPubkey,
+                  rawData: const {},
+                  createdAt: DateTime.fromMillisecondsSinceEpoch(0),
+                  eventId: 'profile-event',
+                  displayName: 'Alice Beats',
+                );
+              }),
+              soundUsageCountProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(0)),
+              videosUsingSoundProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(<String>[])),
+              audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
+            ],
+            child: MaterialApp.router(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              theme: VineTheme.theme,
+              routerConfig: router,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('By Alice Beats'));
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('profile npub1'), findsOneWidget);
+      });
 
       testWidgets('use sound button shows existing saved feedback', (
         tester,

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -619,6 +619,94 @@ void main() {
         expect(find.text('Shared by Publisher Pat'), findsOneWidget);
       });
 
+      testWidgets('uses distinct semantics for creator and publisher credits', (
+        tester,
+      ) async {
+        const creatorPubkey =
+            '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+        const publisherPubkey =
+            'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+        final testSound = createTestAudioEvent(
+          id: 'sound1',
+          pubkey: publisherPubkey,
+        ).copyWith(creatorName: 'Alice Beats', creatorPubkey: creatorPubkey);
+
+        await tester.pumpWidget(
+          createTestWidget(
+            child: SoundDetailScreen(sound: testSound),
+            overrides: [
+              userProfileReactiveProvider(publisherPubkey).overrideWith((
+                ref,
+              ) async* {
+                yield UserProfile(
+                  pubkey: publisherPubkey,
+                  rawData: const {},
+                  createdAt: DateTime.fromMillisecondsSinceEpoch(0),
+                  eventId: 'publisher-profile-event',
+                  displayName: 'Publisher Pat',
+                );
+              }),
+              soundUsageCountProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(0)),
+              videosUsingSoundProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(<String>[])),
+              audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
+            ],
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(find.text('By Alice Beats'), findsOneWidget);
+        expect(find.text('Shared by Publisher Pat'), findsOneWidget);
+        expect(
+          find.bySemanticsIdentifier('sound_detail_creator_attribution'),
+          findsOneWidget,
+        );
+        expect(
+          find.bySemanticsIdentifier('sound_detail_publisher_attribution'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('does not profile-link draft-local imported audio', (
+        tester,
+      ) async {
+        final testSound = AudioEvent.fromLocalImport(
+          id: '${AudioEvent.localImportMarker}_sound1',
+          filePath: '/tmp/sound.m4a',
+          createdAt: 1700000000,
+          title: 'Imported loop',
+          mimeType: 'audio/mp4',
+        );
+
+        await tester.pumpWidget(
+          createTestWidget(
+            child: SoundDetailScreen(sound: testSound),
+            overrides: [
+              soundUsageCountProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(0)),
+              videosUsingSoundProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(<String>[])),
+              audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
+            ],
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(find.text('Imported loop'), findsOneWidget);
+        expect(find.textContaining('By '), findsNothing);
+        expect(
+          find.bySemanticsIdentifier('sound_detail_creator_attribution'),
+          findsNothing,
+        );
+      });
+
       testWidgets('omits the source link when the source is not a URL', (
         tester,
       ) async {


### PR DESCRIPTION
## Summary

- Show community sound creator attribution on the sound detail header, using resolved profile names and generated fallbacks.
- Make profile-backed sound credits tappable so users can open the credited creator or publisher profile.
- Keep bundled/source attribution intact and move sound attribution display-name fallback into the shared audio credit helper.
- Replace the adjacent raw preview play/stop icons with Divine design-system icons.

## Scope notes

This narrows #6227 to the remaining sound-detail creator-credit gap. Reuse counts and the dedicated sound page already exist. Standalone sound upload remains intentionally out of scope and is tracked in #6743. Creator-facing sound reuse analytics was split to #6726.

Refs #6227

## Verification

- flutter test test/screens/sound_detail_screen_test.dart test/widgets/metadata_sounds_section_test.dart test/widgets/audio_attribution_row_test.dart
- flutter analyze