### PR TITLE
fix(video-player): distinguish exhausted auth retries

### DIFF
--- a/mobile/lib/blocs/video_playback_status/video_playback_status_cubit.dart
+++ b/mobile/lib/blocs/video_playback_status/video_playback_status_cubit.dart
@@ -59,6 +59,12 @@ class VideoPlaybackStatusCubit extends Cubit<VideoPlaybackStatusState> {
     return true;
   }
 
+  /// Marks that authenticated playback retry still failed for [eventId].
+  void markAuthRetryExhausted(String eventId) {
+    if (state.hasAuthRetryExhausted(eventId)) return;
+    emit(state.withAuthRetryExhausted(eventId));
+  }
+
   /// Consumes one automatic age-verification retry when the current playback
   /// state and viewer policy allow it.
   ///

--- a/mobile/lib/blocs/video_playback_status/video_playback_status_state.dart
+++ b/mobile/lib/blocs/video_playback_status/video_playback_status_state.dart
@@ -22,6 +22,9 @@ enum PlaybackStatus {
   /// Content not found — 404 or unresolved blob hash.
   notFound,
 
+  /// Playback is unavailable after authenticated access was rejected.
+  unavailable,
+
   /// Any other playback failure.
   generic,
 }
@@ -41,6 +44,7 @@ class VideoPlaybackStatusState extends Equatable {
     LinkedHashMap<String, PlaybackStatus>? statuses,
     Set<String>? verifyingIds,
     Set<String>? autoRetryAttemptedIds,
+    Set<String>? authRetryExhaustedIds,
   }) : _statuses = statuses == null
            ? LinkedHashMap<String, PlaybackStatus>()
            : LinkedHashMap<String, PlaybackStatus>.from(statuses),
@@ -49,7 +53,10 @@ class VideoPlaybackStatusState extends Equatable {
            : Set<String>.from(verifyingIds),
        _autoRetryAttemptedIds = autoRetryAttemptedIds == null
            ? <String>{}
-           : Set<String>.from(autoRetryAttemptedIds);
+           : Set<String>.from(autoRetryAttemptedIds),
+       _authRetryExhaustedIds = authRetryExhaustedIds == null
+           ? <String>{}
+           : Set<String>.from(authRetryExhaustedIds);
 
   static const int _defaultMaxEntries = 100;
 
@@ -67,6 +74,10 @@ class VideoPlaybackStatusState extends Equatable {
   /// cannot reset the attempt budget.
   final Set<String> _autoRetryAttemptedIds;
 
+  /// Event IDs whose authenticated age-gate retry still failed for this feed
+  /// session. This downgrades the UI claim from age-gated to unavailable.
+  final Set<String> _authRetryExhaustedIds;
+
   /// Returns the status for [eventId], or [PlaybackStatus.ready] when no
   /// status has been recorded.
   PlaybackStatus statusFor(String eventId) =>
@@ -80,6 +91,10 @@ class VideoPlaybackStatusState extends Equatable {
   /// for [eventId].
   bool hasAutoRetryAttempted(String eventId) =>
       _autoRetryAttemptedIds.contains(eventId);
+
+  /// Whether authenticated playback was retried and still failed for [eventId].
+  bool hasAuthRetryExhausted(String eventId) =>
+      _authRetryExhaustedIds.contains(eventId);
 
   /// Returns a new state with [status] recorded for [eventId].
   ///
@@ -98,6 +113,7 @@ class VideoPlaybackStatusState extends Equatable {
       statuses: next,
       verifyingIds: _verifyingIds,
       autoRetryAttemptedIds: _autoRetryAttemptedIds,
+      authRetryExhaustedIds: _authRetryExhaustedIds,
     );
   }
 
@@ -114,6 +130,7 @@ class VideoPlaybackStatusState extends Equatable {
       statuses: _statuses,
       verifyingIds: next,
       autoRetryAttemptedIds: _autoRetryAttemptedIds,
+      authRetryExhaustedIds: _authRetryExhaustedIds,
     );
   }
 
@@ -125,6 +142,19 @@ class VideoPlaybackStatusState extends Equatable {
       statuses: _statuses,
       verifyingIds: _verifyingIds,
       autoRetryAttemptedIds: next,
+      authRetryExhaustedIds: _authRetryExhaustedIds,
+    );
+  }
+
+  /// Returns a new state with [eventId]'s authenticated retry marked exhausted.
+  VideoPlaybackStatusState withAuthRetryExhausted(String eventId) {
+    final next = Set<String>.from(_authRetryExhaustedIds)..add(eventId);
+    return VideoPlaybackStatusState(
+      maxEntries: maxEntries,
+      statuses: _statuses,
+      verifyingIds: _verifyingIds,
+      autoRetryAttemptedIds: _autoRetryAttemptedIds,
+      authRetryExhaustedIds: next,
     );
   }
 
@@ -148,6 +178,7 @@ class VideoPlaybackStatusState extends Equatable {
       maxEntries,
       _verifyingIds,
       _autoRetryAttemptedIds,
+      _authRetryExhaustedIds,
     ];
   }
 }

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -663,6 +663,8 @@
     "videoErrorUnsupportedFormat": "የማይደገፍ የቪዲዮ ቅርጸት",
     "videoErrorPlayback": "የቪዲዮ መልሶ ማጫወት ስህተት",
     "videoErrorAgeRestricted": "በእድሜ የተገደበ ይዘት",
+    "videoErrorUnavailable": "ቪዲዮ አይገኝም",
+    "videoErrorUnavailableBody": "ይህ ቪዲዮ አሁን አይገኝም።",
     "videoErrorVerifyAge": "ዕድሜን ያረጋግጡ",
     "videoErrorRetry": "እንደገና ይሞክሩ",
     "videoErrorContentRestricted": "ይዘት ተገድቧል",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -577,6 +577,8 @@
     "videoErrorUnsupportedFormat": "تنسيق الفيديو غير مدعوم",
     "videoErrorPlayback": "خطأ في تشغيل الفيديو",
     "videoErrorAgeRestricted": "محتوى مقيّد بالعمر",
+    "videoErrorUnavailable": "الفيديو غير متاح",
+    "videoErrorUnavailableBody": "هذا الفيديو غير متاح الآن.",
     "videoErrorVerifyAge": "تحقق من العمر",
     "videoErrorRetry": "إعادة المحاولة",
     "videoErrorContentRestricted": "المحتوى مقيّد",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -608,6 +608,8 @@
     "videoErrorUnsupportedFormat": "Неподдържан видео формат",
     "videoErrorPlayback": "Грешка при възпроизвеждане",
     "videoErrorAgeRestricted": "Съдържание с възрастово ограничение",
+    "videoErrorUnavailable": "Видеото е недостъпно",
+    "videoErrorUnavailableBody": "Това видео не е налично в момента.",
     "videoErrorVerifyAge": "Потвърди възрастта",
     "videoErrorRetry": "Опитай пак",
     "videoErrorContentRestricted": "Ограничено съдържание",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -577,6 +577,8 @@
     "videoErrorUnsupportedFormat": "Nicht unterstütztes Videoformat",
     "videoErrorPlayback": "Video-Wiedergabefehler",
     "videoErrorAgeRestricted": "Altersbeschränkter Inhalt",
+    "videoErrorUnavailable": "Video nicht verfügbar",
+    "videoErrorUnavailableBody": "Dieses Video ist gerade nicht verfügbar.",
     "videoErrorVerifyAge": "Alter verifizieren",
     "videoErrorRetry": "Erneut versuchen",
     "videoErrorContentRestricted": "Inhalt eingeschränkt",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -777,6 +777,14 @@
   "videoErrorUnsupportedFormat": "Unsupported video format",
   "videoErrorPlayback": "Video playback error",
   "videoErrorAgeRestricted": "Age-restricted content",
+  "videoErrorUnavailable": "Video unavailable",
+  "@videoErrorUnavailable": {
+    "description": "Title shown when authenticated retry still cannot play a video, so the app should not claim age restriction."
+  },
+  "videoErrorUnavailableBody": "This video isn't available right now.",
+  "@videoErrorUnavailableBody": {
+    "description": "Body shown when authenticated retry still cannot play a video. The copy should be neutral and not blame age verification."
+  },
   "videoErrorVerifyAge": "Verify Age",
   "videoErrorRetry": "Retry",
   "videoErrorContentRestricted": "Content restricted",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -577,6 +577,8 @@
     "videoErrorUnsupportedFormat": "Formato de video no soportado",
     "videoErrorPlayback": "Error de reproducción",
     "videoErrorAgeRestricted": "Contenido con restricción de edad",
+    "videoErrorUnavailable": "Video no disponible",
+    "videoErrorUnavailableBody": "Este video no está disponible ahora mismo.",
     "videoErrorVerifyAge": "Verificar edad",
     "videoErrorRetry": "Reintentar",
     "videoErrorContentRestricted": "Contenido restringido",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -412,6 +412,8 @@
     "videoErrorUnsupportedFormat": "Hindi sinusuportahang video format",
     "videoErrorPlayback": "Error sa playback ng video",
     "videoErrorAgeRestricted": "Age-restricted content",
+    "videoErrorUnavailable": "Hindi available ang video",
+    "videoErrorUnavailableBody": "Hindi available ang video na ito ngayon.",
     "videoErrorVerifyAge": "I-verify ang Edad",
     "videoErrorRetry": "Subukan ulit",
     "videoErrorContentRestricted": "Restricted ang content",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -577,6 +577,8 @@
     "videoErrorUnsupportedFormat": "Format vidéo non supporté",
     "videoErrorPlayback": "Erreur de lecture vidéo",
     "videoErrorAgeRestricted": "Contenu réservé aux adultes",
+    "videoErrorUnavailable": "Vidéo indisponible",
+    "videoErrorUnavailableBody": "Cette vidéo n'est pas disponible pour le moment.",
     "videoErrorVerifyAge": "Vérifier l'âge",
     "videoErrorRetry": "Réessayer",
     "videoErrorContentRestricted": "Contenu restreint",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -577,6 +577,8 @@
     "videoErrorUnsupportedFormat": "Format video tidak didukung",
     "videoErrorPlayback": "Kesalahan pemutaran video",
     "videoErrorAgeRestricted": "Konten dengan pembatasan usia",
+    "videoErrorUnavailable": "Video tidak tersedia",
+    "videoErrorUnavailableBody": "Video ini belum tersedia saat ini.",
     "videoErrorVerifyAge": "Verifikasi Usia",
     "videoErrorRetry": "Coba Lagi",
     "videoErrorContentRestricted": "Konten dibatasi",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -577,6 +577,8 @@
     "videoErrorUnsupportedFormat": "Formato video non supportato",
     "videoErrorPlayback": "Errore di riproduzione video",
     "videoErrorAgeRestricted": "Contenuto con limite d'età",
+    "videoErrorUnavailable": "Video non disponibile",
+    "videoErrorUnavailableBody": "Questo video non è disponibile al momento.",
     "videoErrorVerifyAge": "Verifica età",
     "videoErrorRetry": "Riprova",
     "videoErrorContentRestricted": "Contenuto con restrizioni",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -577,6 +577,8 @@
     "videoErrorUnsupportedFormat": "対応してない動画フォーマット",
     "videoErrorPlayback": "動画の再生エラー",
     "videoErrorAgeRestricted": "年齢制限のあるコンテンツ",
+    "videoErrorUnavailable": "動画を見れないよ",
+    "videoErrorUnavailableBody": "この動画は現在利用できません。",
     "videoErrorVerifyAge": "年齢を確認",
     "videoErrorRetry": "もう一回",
     "videoErrorContentRestricted": "コンテンツが制限されてる",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -382,6 +382,8 @@
     "videoErrorUnsupportedFormat": "지원하지 않는 영상 형식",
     "videoErrorPlayback": "영상 재생 오류",
     "videoErrorAgeRestricted": "연령 제한 콘텐츠",
+    "videoErrorUnavailable": "영상을 사용할 수 없어요",
+    "videoErrorUnavailableBody": "이 영상은 지금 사용할 수 없어요.",
     "videoErrorVerifyAge": "나이 인증",
     "videoErrorRetry": "다시 시도",
     "videoErrorContentRestricted": "콘텐츠 제한됨",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -715,6 +715,8 @@
   "videoErrorUnsupportedFormat": "Format video tidak disokong",
   "videoErrorPlayback": "Ralat main balik video",
   "videoErrorAgeRestricted": "Kandungan terhad mengikut umur",
+  "videoErrorUnavailable": "Video tidak tersedia",
+  "videoErrorUnavailableBody": "Video ini tidak tersedia buat masa ini.",
   "videoErrorVerifyAge": "Sahkan Umur",
   "videoErrorRetry": "Cuba Semula",
   "videoErrorContentRestricted": "Kandungan dihadkan",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -577,6 +577,8 @@
     "videoErrorUnsupportedFormat": "Niet-ondersteund videoformaat",
     "videoErrorPlayback": "Fout bij afspelen video",
     "videoErrorAgeRestricted": "Leeftijdsbeperkte inhoud",
+    "videoErrorUnavailable": "Video niet beschikbaar",
+    "videoErrorUnavailableBody": "Deze video is nu niet beschikbaar.",
     "videoErrorVerifyAge": "Leeftijd verifiëren",
     "videoErrorRetry": "Opnieuw",
     "videoErrorContentRestricted": "Inhoud beperkt",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -577,6 +577,8 @@
     "videoErrorUnsupportedFormat": "Nieobsługiwany format filmu",
     "videoErrorPlayback": "Błąd odtwarzania filmu",
     "videoErrorAgeRestricted": "Treść z ograniczeniem wiekowym",
+    "videoErrorUnavailable": "Film niedostępny",
+    "videoErrorUnavailableBody": "Ten film nie jest teraz dostępny.",
     "videoErrorVerifyAge": "Zweryfikuj wiek",
     "videoErrorRetry": "Spróbuj ponownie",
     "videoErrorContentRestricted": "Treść ograniczona",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -577,6 +577,8 @@
     "videoErrorUnsupportedFormat": "Formato de vídeo não suportado",
     "videoErrorPlayback": "Erro na reprodução do vídeo",
     "videoErrorAgeRestricted": "Conteúdo com restrição de idade",
+    "videoErrorUnavailable": "Vídeo indisponível",
+    "videoErrorUnavailableBody": "Este vídeo não está disponível no momento.",
     "videoErrorVerifyAge": "Verificar idade",
     "videoErrorRetry": "Tentar novamente",
     "videoErrorContentRestricted": "Conteúdo restrito",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -577,6 +577,8 @@
     "videoErrorUnsupportedFormat": "Format video nesuportat",
     "videoErrorPlayback": "Eroare de redare video",
     "videoErrorAgeRestricted": "Conținut cu restricție de vârstă",
+    "videoErrorUnavailable": "Videoclip indisponibil",
+    "videoErrorUnavailableBody": "Acest videoclip nu este disponibil acum.",
     "videoErrorVerifyAge": "Verifică vârsta",
     "videoErrorRetry": "Reîncearcă",
     "videoErrorContentRestricted": "Conținut restricționat",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -577,6 +577,8 @@
     "videoErrorUnsupportedFormat": "Videoformat stöds inte",
     "videoErrorPlayback": "Fel vid videouppspelning",
     "videoErrorAgeRestricted": "Åldersbegränsat innehåll",
+    "videoErrorUnavailable": "Videon är otillgänglig",
+    "videoErrorUnavailableBody": "Den här videon är inte tillgänglig just nu.",
     "videoErrorVerifyAge": "Verifiera ålder",
     "videoErrorRetry": "Försök igen",
     "videoErrorContentRestricted": "Innehåll begränsat",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -577,6 +577,8 @@
     "videoErrorUnsupportedFormat": "Desteklenmeyen video formatı",
     "videoErrorPlayback": "Video oynatma hatası",
     "videoErrorAgeRestricted": "Yaş kısıtlamalı içerik",
+    "videoErrorUnavailable": "Video kullanılamıyor",
+    "videoErrorUnavailableBody": "Bu video şu anda kullanılamıyor.",
     "videoErrorVerifyAge": "Yaşı Doğrula",
     "videoErrorRetry": "Tekrar Dene",
     "videoErrorContentRestricted": "İçerik kısıtlandı",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -715,6 +715,8 @@
   "videoErrorUnsupportedFormat": "غیر تعاون یافتہ ویڈیو فارمیٹ",
   "videoErrorPlayback": "ویڈیو پلے بیک خرابی",
   "videoErrorAgeRestricted": "عمر محدود مواد",
+  "videoErrorUnavailable": "ویڈیو دستیاب نہیں",
+  "videoErrorUnavailableBody": "یہ ویڈیو اس وقت دستیاب نہیں ہے۔",
   "videoErrorVerifyAge": "عمر کی تصدیق کریں",
   "videoErrorRetry": "دوبارہ کوشش کریں",
   "videoErrorContentRestricted": "مواد محدود",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -715,6 +715,8 @@
   "videoErrorUnsupportedFormat": "Định dạng video không được hỗ trợ",
   "videoErrorPlayback": "Lỗi phát video",
   "videoErrorAgeRestricted": "Nội dung giới hạn độ tuổi",
+  "videoErrorUnavailable": "Video không khả dụng",
+  "videoErrorUnavailableBody": "Video này hiện không khả dụng.",
   "videoErrorVerifyAge": "Xác minh tuổi",
   "videoErrorRetry": "Thử lại",
   "videoErrorContentRestricted": "Nội dung bị hạn chế",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -715,6 +715,8 @@
   "videoErrorUnsupportedFormat": "不支持的视频格式",
   "videoErrorPlayback": "视频播放出错",
   "videoErrorAgeRestricted": "年龄限制内容",
+  "videoErrorUnavailable": "视频不可用",
+  "videoErrorUnavailableBody": "此视频目前不可用。",
   "videoErrorVerifyAge": "验证年龄",
   "videoErrorRetry": "重试",
   "videoErrorContentRestricted": "内容受限",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -2658,6 +2658,18 @@ abstract class AppLocalizations {
   /// **'Age-restricted content'**
   String get videoErrorAgeRestricted;
 
+  /// Title shown when authenticated retry still cannot play a video, so the app should not claim age restriction.
+  ///
+  /// In en, this message translates to:
+  /// **'Video unavailable'**
+  String get videoErrorUnavailable;
+
+  /// Body shown when authenticated retry still cannot play a video. The copy should be neutral and not blame age verification.
+  ///
+  /// In en, this message translates to:
+  /// **'This video isn\'t available right now.'**
+  String get videoErrorUnavailableBody;
+
   /// No description provided for @videoErrorVerifyAge.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1462,6 +1462,12 @@ class AppLocalizationsAm extends AppLocalizations {
   String get videoErrorAgeRestricted => 'በእድሜ የተገደበ ይዘት';
 
   @override
+  String get videoErrorUnavailable => 'ቪዲዮ አይገኝም';
+
+  @override
+  String get videoErrorUnavailableBody => 'ይህ ቪዲዮ አሁን አይገኝም።';
+
+  @override
   String get videoErrorVerifyAge => 'ዕድሜን ያረጋግጡ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1478,6 +1478,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoErrorAgeRestricted => 'محتوى مقيّد بالعمر';
 
   @override
+  String get videoErrorUnavailable => 'الفيديو غير متاح';
+
+  @override
+  String get videoErrorUnavailableBody => 'هذا الفيديو غير متاح الآن.';
+
+  @override
   String get videoErrorVerifyAge => 'تحقق من العمر';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -1514,6 +1514,12 @@ class AppLocalizationsBg extends AppLocalizations {
   String get videoErrorAgeRestricted => 'Съдържание с възрастово ограничение';
 
   @override
+  String get videoErrorUnavailable => 'Видеото е недостъпно';
+
+  @override
+  String get videoErrorUnavailableBody => 'Това видео не е налично в момента.';
+
+  @override
   String get videoErrorVerifyAge => 'Потвърди възрастта';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -1511,6 +1511,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get videoErrorAgeRestricted => 'Altersbeschränkter Inhalt';
 
   @override
+  String get videoErrorUnavailable => 'Video nicht verfügbar';
+
+  @override
+  String get videoErrorUnavailableBody =>
+      'Dieses Video ist gerade nicht verfügbar.';
+
+  @override
   String get videoErrorVerifyAge => 'Alter verifizieren';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1493,6 +1493,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get videoErrorAgeRestricted => 'Age-restricted content';
 
   @override
+  String get videoErrorUnavailable => 'Video unavailable';
+
+  @override
+  String get videoErrorUnavailableBody =>
+      'This video isn\'t available right now.';
+
+  @override
   String get videoErrorVerifyAge => 'Verify Age';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -1514,6 +1514,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get videoErrorAgeRestricted => 'Contenido con restricción de edad';
 
   @override
+  String get videoErrorUnavailable => 'Video no disponible';
+
+  @override
+  String get videoErrorUnavailableBody =>
+      'Este video no está disponible ahora mismo.';
+
+  @override
   String get videoErrorVerifyAge => 'Verificar edad';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -1523,6 +1523,13 @@ class AppLocalizationsFil extends AppLocalizations {
   String get videoErrorAgeRestricted => 'Age-restricted content';
 
   @override
+  String get videoErrorUnavailable => 'Hindi available ang video';
+
+  @override
+  String get videoErrorUnavailableBody =>
+      'Hindi available ang video na ito ngayon.';
+
+  @override
   String get videoErrorVerifyAge => 'I-verify ang Edad';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -1521,6 +1521,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get videoErrorAgeRestricted => 'Contenu réservé aux adultes';
 
   @override
+  String get videoErrorUnavailable => 'Vidéo indisponible';
+
+  @override
+  String get videoErrorUnavailableBody =>
+      'Cette vidéo n\'est pas disponible pour le moment.';
+
+  @override
   String get videoErrorVerifyAge => 'Vérifier l\'âge';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1458,6 +1458,12 @@ class AppLocalizationsId extends AppLocalizations {
   String get videoErrorAgeRestricted => 'Konten dengan pembatasan usia';
 
   @override
+  String get videoErrorUnavailable => 'Video tidak tersedia';
+
+  @override
+  String get videoErrorUnavailableBody => 'Video ini belum tersedia saat ini.';
+
+  @override
   String get videoErrorVerifyAge => 'Verifikasi Usia';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -1516,6 +1516,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get videoErrorAgeRestricted => 'Contenuto con limite d\'età';
 
   @override
+  String get videoErrorUnavailable => 'Video non disponibile';
+
+  @override
+  String get videoErrorUnavailableBody =>
+      'Questo video non è disponibile al momento.';
+
+  @override
   String get videoErrorVerifyAge => 'Verifica età';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1389,6 +1389,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoErrorAgeRestricted => '年齢制限のあるコンテンツ';
 
   @override
+  String get videoErrorUnavailable => '動画を見れないよ';
+
+  @override
+  String get videoErrorUnavailableBody => 'この動画は現在利用できません。';
+
+  @override
   String get videoErrorVerifyAge => '年齢を確認';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1399,6 +1399,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoErrorAgeRestricted => '연령 제한 콘텐츠';
 
   @override
+  String get videoErrorUnavailable => '영상을 사용할 수 없어요';
+
+  @override
+  String get videoErrorUnavailableBody => '이 영상은 지금 사용할 수 없어요.';
+
+  @override
   String get videoErrorVerifyAge => '나이 인증';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -1504,6 +1504,13 @@ class AppLocalizationsMs extends AppLocalizations {
   String get videoErrorAgeRestricted => 'Kandungan terhad mengikut umur';
 
   @override
+  String get videoErrorUnavailable => 'Video tidak tersedia';
+
+  @override
+  String get videoErrorUnavailableBody =>
+      'Video ini tidak tersedia buat masa ini.';
+
+  @override
   String get videoErrorVerifyAge => 'Sahkan Umur';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -1502,6 +1502,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get videoErrorAgeRestricted => 'Leeftijdsbeperkte inhoud';
 
   @override
+  String get videoErrorUnavailable => 'Video niet beschikbaar';
+
+  @override
+  String get videoErrorUnavailableBody => 'Deze video is nu niet beschikbaar.';
+
+  @override
   String get videoErrorVerifyAge => 'Leeftijd verifiëren';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -1520,6 +1520,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get videoErrorAgeRestricted => 'Treść z ograniczeniem wiekowym';
 
   @override
+  String get videoErrorUnavailable => 'Film niedostępny';
+
+  @override
+  String get videoErrorUnavailableBody => 'Ten film nie jest teraz dostępny.';
+
+  @override
   String get videoErrorVerifyAge => 'Zweryfikuj wiek';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -1510,6 +1510,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get videoErrorAgeRestricted => 'Conteúdo com restrição de idade';
 
   @override
+  String get videoErrorUnavailable => 'Vídeo indisponível';
+
+  @override
+  String get videoErrorUnavailableBody =>
+      'Este vídeo não está disponível no momento.';
+
+  @override
   String get videoErrorVerifyAge => 'Verificar idade';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -1534,6 +1534,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get videoErrorAgeRestricted => 'Conținut cu restricție de vârstă';
 
   @override
+  String get videoErrorUnavailable => 'Videoclip indisponibil';
+
+  @override
+  String get videoErrorUnavailableBody =>
+      'Acest videoclip nu este disponibil acum.';
+
+  @override
   String get videoErrorVerifyAge => 'Verifică vârsta';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1489,6 +1489,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get videoErrorAgeRestricted => 'Åldersbegränsat innehåll';
 
   @override
+  String get videoErrorUnavailable => 'Videon är otillgänglig';
+
+  @override
+  String get videoErrorUnavailableBody =>
+      'Den här videon är inte tillgänglig just nu.';
+
+  @override
   String get videoErrorVerifyAge => 'Verifiera ålder';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1461,6 +1461,12 @@ class AppLocalizationsTr extends AppLocalizations {
   String get videoErrorAgeRestricted => 'Yaş kısıtlamalı içerik';
 
   @override
+  String get videoErrorUnavailable => 'Video kullanılamıyor';
+
+  @override
+  String get videoErrorUnavailableBody => 'Bu video şu anda kullanılamıyor.';
+
+  @override
   String get videoErrorVerifyAge => 'Yaşı Doğrula';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -1496,6 +1496,12 @@ class AppLocalizationsUr extends AppLocalizations {
   String get videoErrorAgeRestricted => 'عمر محدود مواد';
 
   @override
+  String get videoErrorUnavailable => 'ویڈیو دستیاب نہیں';
+
+  @override
+  String get videoErrorUnavailableBody => 'یہ ویڈیو اس وقت دستیاب نہیں ہے۔';
+
+  @override
   String get videoErrorVerifyAge => 'عمر کی تصدیق کریں';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -1500,6 +1500,12 @@ class AppLocalizationsVi extends AppLocalizations {
   String get videoErrorAgeRestricted => 'Nội dung giới hạn độ tuổi';
 
   @override
+  String get videoErrorUnavailable => 'Video không khả dụng';
+
+  @override
+  String get videoErrorUnavailableBody => 'Video này hiện không khả dụng.';
+
+  @override
   String get videoErrorVerifyAge => 'Xác minh tuổi';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -1408,6 +1408,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get videoErrorAgeRestricted => '年龄限制内容';
 
   @override
+  String get videoErrorUnavailable => '视频不可用';
+
+  @override
+  String get videoErrorUnavailableBody => '此视频目前不可用。';
+
+  @override
   String get videoErrorVerifyAge => '验证年龄';
 
   @override

--- a/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
+++ b/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
@@ -90,7 +90,9 @@ Future<void> retryAgeRestrictedPooledVideo({
         final playbackSucceeded = await retryPlayback(headers);
         if (!context.mounted) return;
         if (!playbackSucceeded) {
-          _showVerifyAgeFailed(context);
+          playbackStatusCubit.markAuthRetryExhausted(video.id);
+          playbackStatusCubit.report(video.id, PlaybackStatus.unavailable);
+          _showVideoUnavailable(context);
           return;
         }
         playbackStatusCubit.report(video.id, PlaybackStatus.ready);
@@ -153,7 +155,12 @@ Future<void> autoRetryAgeRestrictedPooledVideo({
     switch (authResult) {
       case ViewerAuthAuthorized(:final headers):
         final playbackSucceeded = await retryPlayback(headers);
-        if (!context.mounted || !playbackSucceeded) return;
+        if (!context.mounted) return;
+        if (!playbackSucceeded) {
+          playbackStatusCubit.markAuthRetryExhausted(video.id);
+          playbackStatusCubit.report(video.id, PlaybackStatus.unavailable);
+          return;
+        }
         playbackStatusCubit.report(video.id, PlaybackStatus.ready);
       case ViewerAuthSignerUnreachable():
       case ViewerAuthBlockedByPreference():
@@ -173,6 +180,14 @@ void _showVerifyAgeFailed(BuildContext context) {
   if (!context.mounted) return;
   ScaffoldMessenger.of(context).showSnackBar(
     DivineSnackbarContainer.snackBar(context.l10n.videoErrorVerifyAgeFailed),
+  );
+}
+
+/// Surfaces a neutral unavailable message after valid auth was rejected.
+void _showVideoUnavailable(BuildContext context) {
+  if (!context.mounted) return;
+  ScaffoldMessenger.of(context).showSnackBar(
+    DivineSnackbarContainer.snackBar(context.l10n.videoErrorUnavailable),
   );
 }
 

--- a/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
+++ b/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
@@ -203,10 +203,13 @@ void _showVerifyAgeFailed(BuildContext context) {
 }
 
 /// Surfaces a neutral unavailable message after valid auth was rejected.
+///
+/// Uses the body copy rather than the title so the snackbar reads as a
+/// sentence instead of repeating the overlay heading verbatim.
 void _showVideoUnavailable(BuildContext context) {
   if (!context.mounted) return;
   ScaffoldMessenger.of(context).showSnackBar(
-    DivineSnackbarContainer.snackBar(context.l10n.videoErrorUnavailable),
+    DivineSnackbarContainer.snackBar(context.l10n.videoErrorUnavailableBody),
   );
 }
 

--- a/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
+++ b/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
@@ -4,6 +4,8 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:infinite_video_feed/infinite_video_feed.dart'
+    show VideoErrorType;
 import 'package:models/models.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_state.dart';
@@ -18,6 +20,18 @@ const _logName = 'PooledAgeRestrictedRetry';
 typedef PooledAgeRestrictedSha256Resolver =
     String? Function({String? explicitSha256, String? videoUrl});
 
+/// Outcome of a viewer-auth playback retry.
+///
+/// [errorType] carries the error the player classified for the retried item
+/// when [succeeded] is `false`. Only a repeated [VideoErrorType.ageRestricted]
+/// proves the age gate itself is unclearable; every other failure is an
+/// unrelated playback problem that must stay retryable. #6253
+typedef PooledRetryOutcome = ({bool succeeded, VideoErrorType? errorType});
+
+/// Reloads playback for the retried item with signed viewer-auth headers.
+typedef PooledRetryPlayback =
+    FutureOr<PooledRetryOutcome> Function(Map<String, String> httpHeaders);
+
 /// Verifies access to an age-restricted pooled video, then retries playback
 /// with viewer auth headers on the active pooled controller item.
 Future<void> retryAgeRestrictedPooledVideo({
@@ -26,7 +40,7 @@ Future<void> retryAgeRestrictedPooledVideo({
   required VideoEvent video,
   required int index,
   required PooledAgeRestrictedSha256Resolver resolveSha256,
-  required FutureOr<bool> Function(Map<String, String>) retryPlayback,
+  required PooledRetryPlayback retryPlayback,
 }) async {
   Log.info(
     '🔐 [AGE-GATE] Starting age-restricted pooled retry for video ${video.id}',
@@ -87,9 +101,13 @@ Future<void> retryAgeRestrictedPooledVideo({
         // The hash-bound token authorizes any variant of the blob, so the feed
         // applies these headers to every resolved playback source
         // (optimized/HLS/raw) for the retried item.
-        final playbackSucceeded = await retryPlayback(headers);
+        final outcome = await retryPlayback(headers);
         if (!context.mounted) return;
-        if (!playbackSucceeded) {
+        if (!outcome.succeeded) {
+          if (!_isAuthRejection(outcome)) {
+            _showVerifyAgeFailed(context);
+            return;
+          }
           playbackStatusCubit.markAuthRetryExhausted(video.id);
           playbackStatusCubit.report(video.id, PlaybackStatus.unavailable);
           _showVideoUnavailable(context);
@@ -131,7 +149,7 @@ Future<void> autoRetryAgeRestrictedPooledVideo({
   required VideoEvent video,
   required int index,
   required PooledAgeRestrictedSha256Resolver resolveSha256,
-  required FutureOr<bool> Function(Map<String, String>) retryPlayback,
+  required PooledRetryPlayback retryPlayback,
 }) async {
   final mediaAuthInterceptor = ref.read(mediaAuthInterceptorProvider);
   if (!mediaAuthInterceptor.canAutoAuthorizeAdultMedia) return;
@@ -154,9 +172,10 @@ Future<void> autoRetryAgeRestrictedPooledVideo({
 
     switch (authResult) {
       case ViewerAuthAuthorized(:final headers):
-        final playbackSucceeded = await retryPlayback(headers);
+        final outcome = await retryPlayback(headers);
         if (!context.mounted) return;
-        if (!playbackSucceeded) {
+        if (!outcome.succeeded) {
+          if (!_isAuthRejection(outcome)) return;
           playbackStatusCubit.markAuthRetryExhausted(video.id);
           playbackStatusCubit.report(video.id, PlaybackStatus.unavailable);
           return;
@@ -190,6 +209,15 @@ void _showVideoUnavailable(BuildContext context) {
     DivineSnackbarContainer.snackBar(context.l10n.videoErrorUnavailable),
   );
 }
+
+/// Whether a failed retry was the media server rejecting the signed request
+/// again, rather than an unrelated playback failure on the same reload.
+///
+/// A network drop, decode failure, or timeout also fails the retry, and
+/// treating those as an exhausted age gate would strand a recoverable video
+/// as permanently unavailable for the rest of the session.
+bool _isAuthRejection(PooledRetryOutcome outcome) =>
+    outcome.errorType == VideoErrorType.ageRestricted;
 
 /// Tells an age-verified viewer that adult content is switched off in their
 /// Content Filters, so they know where to opt in rather than re-verifying.

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -196,12 +196,10 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
   Future<void> animateToPage(int index) =>
       _feedKey.currentState?.animateToPage(index) ?? Future.value();
 
-  Future<bool> _retryPooledVideoAt(
+  Future<PooledRetryOutcome> _retryPooledVideoAt(
     int index,
     Map<String, String> httpHeaders,
-  ) =>
-      _feedKey.currentState?.retryAt(index, httpHeaders: httpHeaders) ??
-      Future.value(false);
+  ) => _retryFeedItem(_feedKey.currentState, index, httpHeaders);
 
   void _skipPooledVideoAt(int index) {
     unawaited(_feedKey.currentState?.animateToPage(index + 1));
@@ -561,6 +559,22 @@ class _OverlayUnavailableMode extends _OverlayMode {
   const _OverlayUnavailableMode();
 }
 
+/// Retries [index] on [feedState] and reports the error the player classified
+/// afterwards, so the age-gate retry can tell a repeated auth rejection apart
+/// from an unrelated playback failure. #6253
+Future<PooledRetryOutcome> _retryFeedItem(
+  InfiniteVideoFeedState? feedState,
+  int index,
+  Map<String, String> httpHeaders,
+) async {
+  if (feedState == null) return (succeeded: false, errorType: null);
+  final succeeded = await feedState.retryAt(index, httpHeaders: httpHeaders);
+  return (
+    succeeded: succeeded,
+    errorType: succeeded ? null : feedState.errorTypeAt(index),
+  );
+}
+
 class _OverlayContentWarningMode extends _OverlayMode {
   const _OverlayContentWarningMode(this.labels);
 
@@ -704,8 +718,7 @@ class __OverlayState extends ConsumerState<_Overlay> {
       index: widget.index,
       resolveSha256: VideoModerationStatusService.resolveSha256,
       retryPlayback: (httpHeaders) =>
-          _feedState?.retryAt(widget.index, httpHeaders: httpHeaders) ??
-          Future.value(false),
+          _retryFeedItem(_feedState, widget.index, httpHeaders),
     );
   }
 
@@ -1211,11 +1224,11 @@ class _FeedLoadingOrRestrictedOverlayView extends ConsumerWidget {
             video: video,
             index: index,
             resolveSha256: VideoModerationStatusService.resolveSha256,
-            retryPlayback: (httpHeaders) =>
-                context
-                    .findAncestorStateOfType<InfiniteVideoFeedState>()
-                    ?.retryAt(index, httpHeaders: httpHeaders) ??
-                Future.value(false),
+            retryPlayback: (httpHeaders) => _retryFeedItem(
+              context.findAncestorStateOfType<InfiniteVideoFeedState>(),
+              index,
+              httpHeaders,
+            ),
           ),
         );
       },
@@ -1236,11 +1249,11 @@ class _FeedLoadingOrRestrictedOverlayView extends ConsumerWidget {
                           ?.animateToPage(index + 1),
                     );
                   },
-                  retryPlayback: (httpHeaders) =>
-                      context
-                          .findAncestorStateOfType<InfiniteVideoFeedState>()
-                          ?.retryAt(index, httpHeaders: httpHeaders) ??
-                      Future.value(false),
+                  retryPlayback: (httpHeaders) => _retryFeedItem(
+                    context.findAncestorStateOfType<InfiniteVideoFeedState>(),
+                    index,
+                    httpHeaders,
+                  ),
                   errorType: VideoErrorType.forbidden,
                   shouldPortraitExpand: shouldPortraitExpand,
                   isSquare: isSquare,
@@ -1261,11 +1274,11 @@ class _FeedLoadingOrRestrictedOverlayView extends ConsumerWidget {
                           ?.animateToPage(index + 1),
                     );
                   },
-                  retryPlayback: (httpHeaders) =>
-                      context
-                          .findAncestorStateOfType<InfiniteVideoFeedState>()
-                          ?.retryAt(index, httpHeaders: httpHeaders) ??
-                      Future.value(false),
+                  retryPlayback: (httpHeaders) => _retryFeedItem(
+                    context.findAncestorStateOfType<InfiniteVideoFeedState>(),
+                    index,
+                    httpHeaders,
+                  ),
                   errorType: VideoErrorType.ageRestricted,
                   shouldPortraitExpand: shouldPortraitExpand,
                   isSquare: isSquare,

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -557,6 +557,10 @@ class _OverlayAgeRestrictedMode extends _OverlayMode {
   const _OverlayAgeRestrictedMode();
 }
 
+class _OverlayUnavailableMode extends _OverlayMode {
+  const _OverlayUnavailableMode();
+}
+
 class _OverlayContentWarningMode extends _OverlayMode {
   const _OverlayContentWarningMode(this.labels);
 
@@ -714,6 +718,7 @@ class __OverlayState extends ConsumerState<_Overlay> {
     return switch (playbackStatus) {
       PlaybackStatus.forbidden => const _OverlayForbiddenMode(),
       PlaybackStatus.ageRestricted => const _OverlayAgeRestrictedMode(),
+      PlaybackStatus.unavailable => const _OverlayUnavailableMode(),
       _ =>
         showContentWarningOverlay && !widget.contentWarningRevealed
             ? _OverlayContentWarningMode(overlayLabels)
@@ -820,6 +825,11 @@ class __OverlayState extends ConsumerState<_Overlay> {
           onSkip: _skipToNextVideo,
           onVerifyAge: _verifyAgeForVideo,
           isVerifying: isVerifyingAge,
+        );
+      case _OverlayUnavailableMode():
+        return ModeratedContentOverlay(
+          status: playbackStatus,
+          onSkip: _skipToNextVideo,
         );
       case _OverlayContentWarningMode(:final labels):
         return ContentWarningBlurOverlay(
@@ -1244,6 +1254,13 @@ class _FeedLoadingOrRestrictedOverlayView extends ConsumerWidget {
                   resolveSha256: VideoModerationStatusService.resolveSha256,
                   // Retry is hidden while age-gated playback uses Verify age.
                   onRetry: () {},
+                  onSkip: () {
+                    unawaited(
+                      context
+                          .findAncestorStateOfType<InfiniteVideoFeedState>()
+                          ?.animateToPage(index + 1),
+                    );
+                  },
                   retryPlayback: (httpHeaders) =>
                       context
                           .findAncestorStateOfType<InfiniteVideoFeedState>()

--- a/mobile/lib/widgets/video_feed_item/moderated_content_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/moderated_content_overlay.dart
@@ -7,12 +7,10 @@ import 'package:openvine/blocs/video_playback_status/video_playback_status_state
 import 'package:openvine/l10n/l10n.dart';
 
 /// Displayed in place of the normal feed overlay when the active video's
-/// [PlaybackStatus] is [PlaybackStatus.forbidden] or
-/// [PlaybackStatus.ageRestricted].
+/// [PlaybackStatus] is [PlaybackStatus.forbidden],
+/// [PlaybackStatus.ageRestricted], or [PlaybackStatus.unavailable].
 ///
-/// This widget is only valid for [PlaybackStatus.forbidden] and
-/// [PlaybackStatus.ageRestricted]. Other values throw an assertion in debug
-/// builds.
+/// Other values throw an assertion in debug builds.
 ///
 /// When [status] is [PlaybackStatus.ageRestricted], [onVerifyAge] MUST be
 /// provided so the primary CTA can be wired to the caller's auth flow.
@@ -25,8 +23,10 @@ class ModeratedContentOverlay extends StatelessWidget {
     super.key,
   }) : assert(
          status == PlaybackStatus.forbidden ||
-             status == PlaybackStatus.ageRestricted,
-         'ModeratedContentOverlay only supports forbidden and ageRestricted',
+             status == PlaybackStatus.ageRestricted ||
+             status == PlaybackStatus.unavailable,
+         'ModeratedContentOverlay only supports forbidden, ageRestricted, '
+         'and unavailable',
        ),
        assert(
          status != PlaybackStatus.ageRestricted || onVerifyAge != null,
@@ -48,16 +48,23 @@ class ModeratedContentOverlay extends StatelessWidget {
   final bool isVerifying;
 
   bool get _isAgeRestricted => status == PlaybackStatus.ageRestricted;
+  bool get _isUnavailable => status == PlaybackStatus.unavailable;
 
   @override
   Widget build(BuildContext context) {
-    final icon = _isAgeRestricted
+    final icon = _isUnavailable
+        ? DivineIconName.warningCircle
+        : _isAgeRestricted
         ? DivineIconName.lockSimple
         : DivineIconName.shieldCheck;
-    final title = _isAgeRestricted
+    final title = _isUnavailable
+        ? context.l10n.videoErrorUnavailable
+        : _isAgeRestricted
         ? context.l10n.videoErrorAgeRestricted
         : context.l10n.videoErrorContentRestricted;
-    final body = _isAgeRestricted
+    final body = _isUnavailable
+        ? context.l10n.videoErrorUnavailableBody
+        : _isAgeRestricted
         ? context.l10n.videoErrorVerifyAgeBody
         : context.l10n.videoErrorContentRestrictedBody;
 

--- a/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
@@ -37,6 +37,7 @@ class PooledVideoErrorOverlay extends ConsumerStatefulWidget {
     this.onSkip,
     this.onVerifyAge,
     this.isVerifying = false,
+    this.isAuthRetryExhausted = false,
     this.shouldPortraitExpand = true,
     this.isSquare = false,
     super.key,
@@ -50,6 +51,9 @@ class PooledVideoErrorOverlay extends ConsumerStatefulWidget {
   /// Whether an age-verification retry is in flight. Shows the Verify age
   /// button's loading state (which also disables it, preventing double taps).
   final bool isVerifying;
+
+  /// Whether authenticated retry already failed for this video in this session.
+  final bool isAuthRetryExhausted;
 
   final VideoErrorType? errorType;
 
@@ -128,45 +132,63 @@ class _PooledVideoErrorOverlayState
         (shouldEnrichNotFoundWithModeration &&
             moderationStatus != null &&
             moderationStatus.isUnavailableDueToModeration);
+    final isUnavailableAfterAuthRetry = widget.isAuthRetryExhausted;
     final isAgeRestricted =
-        type == VideoErrorType.ageRestricted || isModerationAgeRestricted;
+        !isUnavailableAfterAuthRetry &&
+        (type == VideoErrorType.ageRestricted || isModerationAgeRestricted);
 
     final DivineIconName icon = switch ((
       type,
+      isUnavailableAfterAuthRetry,
       isAgeRestricted,
       isModerationRestricted,
     )) {
-      (_, true, _) => DivineIconName.lockSimple,
-      (VideoErrorType.notFound, false, true) => DivineIconName.shieldCheck,
-      (VideoErrorType.notFound, false, false) => DivineIconName.warningCircle,
-      (_, false, true) => DivineIconName.shieldCheck,
+      (_, true, _, _) => DivineIconName.warningCircle,
+      (_, false, true, _) => DivineIconName.lockSimple,
+      (VideoErrorType.notFound, false, false, true) =>
+        DivineIconName.shieldCheck,
+      (VideoErrorType.notFound, false, false, false) =>
+        DivineIconName.warningCircle,
+      (_, false, false, true) => DivineIconName.shieldCheck,
       _ => DivineIconName.warningCircle,
     };
 
-    final message = switch ((type, isAgeRestricted, isModerationRestricted)) {
-      (_, true, _) => context.l10n.videoErrorAgeRestricted,
-      (VideoErrorType.notFound, false, true) =>
+    final message = switch ((
+      type,
+      isUnavailableAfterAuthRetry,
+      isAgeRestricted,
+      isModerationRestricted,
+    )) {
+      (_, true, _, _) => context.l10n.videoErrorUnavailable,
+      (_, false, true, _) => context.l10n.videoErrorAgeRestricted,
+      (VideoErrorType.notFound, false, false, true) =>
         context.l10n.videoErrorContentRestricted,
-      (VideoErrorType.notFound, false, false) =>
+      (VideoErrorType.notFound, false, false, false) =>
         context.l10n.videoErrorNotFound,
-      (VideoErrorType.forbidden, false, true) =>
+      (VideoErrorType.forbidden, false, false, true) =>
         context.l10n.videoErrorContentRestricted,
-      (VideoErrorType.forbidden, false, false) =>
+      (VideoErrorType.forbidden, false, false, false) =>
         context.l10n.videoErrorPlayback,
-      (VideoErrorType.ageRestricted, false, _) =>
-        context.l10n.videoErrorAgeRestricted,
-      (VideoErrorType.generic, false, _) => context.l10n.videoErrorPlayback,
+      (VideoErrorType.ageRestricted, false, false, _) =>
+        context.l10n.videoErrorUnavailable,
+      (VideoErrorType.generic, false, false, _) =>
+        context.l10n.videoErrorPlayback,
     };
-    final body = isAgeRestricted
+    final body = isUnavailableAfterAuthRetry
+        ? context.l10n.videoErrorUnavailableBody
+        : isAgeRestricted
         ? context.l10n.videoErrorVerifyAgeBody
         : isModerationRestricted
         ? context.l10n.videoErrorContentRestrictedBody
         : null;
     final showVerifyAge = isAgeRestricted && widget.onVerifyAge != null;
     final showSkip =
-        isModerationRestricted && !isAgeRestricted && widget.onSkip != null;
+        (isUnavailableAfterAuthRetry ||
+            (isModerationRestricted && !isAgeRestricted)) &&
+        widget.onSkip != null;
     final showRetry =
         (!isModerationRestricted || (isAgeRestricted && !showVerifyAge)) &&
+        !isUnavailableAfterAuthRetry &&
         !showSkip &&
         !showVerifyAge;
     _maybeAutoRetryAgeRestricted(showVerifyAge: showVerifyAge);
@@ -178,7 +200,10 @@ class _PooledVideoErrorOverlayState
     // moderation result lands. Plain notFound / generic failures keep the event
     // blurhash and thumbnail fallback. #6242
     final suppressPreviewMedia =
-        isModerationStatusLoading || isModerationRestricted || isAgeRestricted;
+        isModerationStatusLoading ||
+        isModerationRestricted ||
+        isAgeRestricted ||
+        isUnavailableAfterAuthRetry;
 
     return Stack(
       fit: StackFit.expand,

--- a/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
@@ -169,8 +169,11 @@ class _PooledVideoErrorOverlayState
         context.l10n.videoErrorContentRestricted,
       (VideoErrorType.forbidden, false, false, false) =>
         context.l10n.videoErrorPlayback,
+      // Unreachable: `isAgeRestricted` is true whenever the type is
+      // ageRestricted and the auth retry is not exhausted. Present only to
+      // keep the switch exhaustive.
       (VideoErrorType.ageRestricted, false, false, _) =>
-        context.l10n.videoErrorUnavailable,
+        context.l10n.videoErrorAgeRestricted,
       (VideoErrorType.generic, false, false, _) =>
         context.l10n.videoErrorPlayback,
     };

--- a/mobile/lib/widgets/video_feed_item/verifying_aware_video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/verifying_aware_video_error_overlay.dart
@@ -1,8 +1,6 @@
 // ABOUTME: Wraps PooledVideoErrorOverlay with the live "verifying age" flag
 // ABOUTME: from VideoPlaybackStatusCubit plus the Verify-age retry wiring.
 
-import 'dart:async';
-
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -47,7 +45,7 @@ class VerifyingAwareVideoErrorOverlay extends ConsumerWidget {
   final VoidCallback? onSkip;
 
   /// Reloads playback for the retried item with the signed viewer-auth headers.
-  final FutureOr<bool> Function(Map<String, String>) retryPlayback;
+  final PooledRetryPlayback retryPlayback;
 
   final VideoErrorType? errorType;
   final bool shouldPortraitExpand;

--- a/mobile/lib/widgets/video_feed_item/verifying_aware_video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/verifying_aware_video_error_overlay.dart
@@ -58,10 +58,13 @@ class VerifyingAwareVideoErrorOverlay extends ConsumerWidget {
     return BlocSelector<
       VideoPlaybackStatusCubit,
       VideoPlaybackStatusState,
-      bool
+      ({bool isAuthRetryExhausted, bool isVerifying})
     >(
-      selector: (state) => state.isVerifying(video.id),
-      builder: (context, isVerifying) => PooledVideoErrorOverlay(
+      selector: (state) => (
+        isAuthRetryExhausted: state.hasAuthRetryExhausted(video.id),
+        isVerifying: state.isVerifying(video.id),
+      ),
+      builder: (context, status) => PooledVideoErrorOverlay(
         video: video,
         onRetry: onRetry,
         onSkip: onSkip,
@@ -74,7 +77,8 @@ class VerifyingAwareVideoErrorOverlay extends ConsumerWidget {
           retryPlayback: retryPlayback,
         ),
         errorType: errorType,
-        isVerifying: isVerifying,
+        isVerifying: status.isVerifying,
+        isAuthRetryExhausted: status.isAuthRetryExhausted,
         shouldPortraitExpand: shouldPortraitExpand,
         isSquare: isSquare,
       ),

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -1283,6 +1283,20 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     }
   }
 
+  /// The error the player classified for [index], or `null` when that slot is
+  /// not currently in an error state.
+  ///
+  /// Mirrors the value handed to `errorBuilder`, so a caller that just awaited
+  /// [retryAt] can tell a repeated auth rejection apart from an unrelated
+  /// playback failure (network drop, decode error) that happened to land on
+  /// the same reload.
+  VideoErrorType? errorTypeAt(int index) {
+    if (!_errors.contains(index)) return null;
+    return _terminalErrorTypeAt(index) ??
+        _errorTypes[index] ??
+        VideoErrorType.generic;
+  }
+
   // coverage:ignore-start
   // Manual retry delegates back into native controller init, which is not
   // executable in package tests without platform players.

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -4,6 +4,7 @@ import 'package:divine_video_player/divine_video_player.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:infinite_video_feed/src/models/video_error_type.dart';
 import 'package:infinite_video_feed/src/widgets/infinite_video_feed.dart';
 import 'package:infinite_video_feed/src/widgets/video_item.dart';
 import 'package:media_cache/media_cache.dart';
@@ -3329,6 +3330,59 @@ void main() {
 
           expect(harness.countCalls('setClips'), equals(setClipsAfterError));
           expect(find.text('VIDEO_ERROR'), findsOneWidget);
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+    });
+
+    group('errorTypeAt', () {
+      testWidgets('is null before failure and reports the classified type '
+          'after', (tester) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(playerIds: const <int>[0, 1, 2, 3]);
+        final key = GlobalKey<InfiniteVideoFeedState>();
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: [_makeVideo('error_type_at')],
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+                autoRetryBaseDelay: const Duration(milliseconds: 200),
+                errorBuilder: (_, _, _, errorType) =>
+                    Text('VIDEO_ERROR:${errorType.name}'),
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          expect(key.currentState!.errorTypeAt(0), isNull);
+
+          await harness.sendEvent(0, const <Object?, Object?>{
+            'status': 'error',
+            'errorCode': 'network_error',
+            'errorMessage': 'HTTP 401 Unauthorized',
+          });
+          await tester.pump();
+          await tester.pump();
+
+          // Matches what errorBuilder was handed, so a caller awaiting
+          // retryAt can tell a repeated 401 from an unrelated failure.
+          expect(find.text('VIDEO_ERROR:ageRestricted'), findsOneWidget);
+          expect(
+            key.currentState!.errorTypeAt(0),
+            equals(VideoErrorType.ageRestricted),
+          );
+          // Out-of-range and healthy slots stay null.
+          expect(key.currentState!.errorTypeAt(1), isNull);
         } finally {
           await tester.pumpWidget(const SizedBox.shrink());
           await tester.pump();

--- a/mobile/test/blocs/video_playback_status/video_playback_status_cubit_test.dart
+++ b/mobile/test/blocs/video_playback_status/video_playback_status_cubit_test.dart
@@ -261,6 +261,55 @@ void main() {
       });
     });
 
+    group('authenticated retry exhaustion', () {
+      test('markAuthRetryExhausted records the per-video marker', () {
+        final cubit = VideoPlaybackStatusCubit();
+
+        expect(cubit.state.hasAuthRetryExhausted(id1), isFalse);
+
+        cubit.markAuthRetryExhausted(id1);
+
+        expect(cubit.state.hasAuthRetryExhausted(id1), isTrue);
+        expect(cubit.state.hasAuthRetryExhausted(id2), isFalse);
+      });
+
+      blocTest<VideoPlaybackStatusCubit, VideoPlaybackStatusState>(
+        'markAuthRetryExhausted short-circuits when already marked',
+        build: VideoPlaybackStatusCubit.new,
+        act: (cubit) {
+          cubit.markAuthRetryExhausted(id1);
+          cubit.markAuthRetryExhausted(id1);
+        },
+        expect: () => hasLength(1),
+      );
+
+      test('reporting a status preserves the exhausted marker', () {
+        final cubit = VideoPlaybackStatusCubit();
+        cubit.markAuthRetryExhausted(id1);
+        cubit.report(id1, PlaybackStatus.unavailable);
+
+        expect(cubit.state.hasAuthRetryExhausted(id1), isTrue);
+        expect(cubit.state.statusFor(id1), PlaybackStatus.unavailable);
+      });
+
+      test('verifying changes preserve the exhausted marker', () {
+        final cubit = VideoPlaybackStatusCubit();
+        cubit.markAuthRetryExhausted(id1);
+        cubit.markVerifying(id1);
+        cubit.clearVerifying(id1);
+
+        expect(cubit.state.hasAuthRetryExhausted(id1), isTrue);
+      });
+
+      test('clear() drops exhausted markers', () {
+        final cubit = VideoPlaybackStatusCubit();
+        cubit.markAuthRetryExhausted(id1);
+        cubit.clear();
+
+        expect(cubit.state.hasAuthRetryExhausted(id1), isFalse);
+      });
+    });
+
     group('playbackStatusFromError', () {
       test('maps each VideoErrorType to the expected PlaybackStatus', () {
         expect(

--- a/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
+++ b/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
@@ -39,7 +39,7 @@ String get _failureText =>
     lookupAppLocalizations(const Locale('en')).videoErrorVerifyAgeFailed;
 
 String get _unavailableText =>
-    lookupAppLocalizations(const Locale('en')).videoErrorUnavailable;
+    lookupAppLocalizations(const Locale('en')).videoErrorUnavailableBody;
 
 /// Retry recovered playback.
 const PooledRetryOutcome _retryRecovered = (succeeded: true, errorType: null);

--- a/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
+++ b/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
@@ -36,6 +36,9 @@ const _videoUrl = 'https://media.divine.video/$_sha256/720p.mp4';
 String get _failureText =>
     lookupAppLocalizations(const Locale('en')).videoErrorVerifyAgeFailed;
 
+String get _unavailableText =>
+    lookupAppLocalizations(const Locale('en')).videoErrorUnavailable;
+
 String get _signerUnreachableText => lookupAppLocalizations(
   const Locale('en'),
 ).videoErrorVerifyAgeSignerUnreachable;
@@ -302,7 +305,7 @@ void main() {
       },
     );
 
-    testWidgets('surfaces feedback when authenticated retry fails', (
+    testWidgets('marks unavailable when authenticated retry fails', (
       tester,
     ) async {
       final mediaAuthInterceptor = _MockMediaAuthInterceptor();
@@ -343,9 +346,11 @@ void main() {
       expect(retryCount, 1);
       expect(
         playbackStatusCubit.state.statusFor(_videoId),
-        PlaybackStatus.ageRestricted,
+        PlaybackStatus.unavailable,
       );
-      expect(find.text(_failureText), findsOneWidget);
+      expect(playbackStatusCubit.state.hasAuthRetryExhausted(_videoId), isTrue);
+      expect(find.text(_unavailableText), findsOneWidget);
+      expect(find.text(_failureText), findsNothing);
     });
 
     testWidgets(
@@ -503,6 +508,56 @@ void main() {
       },
     );
   });
+
+  group('autoRetryAgeRestrictedPooledVideo', () {
+    testWidgets('marks authenticated retry exhausted silently when playback '
+        'still fails', (tester) async {
+      final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+      final playbackStatusCubit = VideoPlaybackStatusCubit();
+      var retryCount = 0;
+      addTearDown(playbackStatusCubit.close);
+
+      when(
+        () => mediaAuthInterceptor.canAutoAuthorizeAdultMedia,
+      ).thenReturn(true);
+      when(
+        () => mediaAuthInterceptor.createAutoAuthHeadersForAdultMedia(
+          sha256Hash: _sha256,
+          url: _videoUrl,
+          serverUrl: 'https://media.divine.video',
+        ),
+      ).thenAnswer(
+        (_) async =>
+            const ViewerAuthAuthorized({'Authorization': 'Nostr token'}),
+      );
+
+      await tester.pumpWidget(
+        _AutoRetryHarness(
+          mediaAuthInterceptor: mediaAuthInterceptor,
+          playbackStatusCubit: playbackStatusCubit,
+          retryPlayback: (_) {
+            retryCount++;
+            return false;
+          },
+        ),
+      );
+
+      playbackStatusCubit.report(_videoId, PlaybackStatus.ageRestricted);
+
+      await tester.tap(find.text('Auto retry'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(retryCount, 1);
+      expect(
+        playbackStatusCubit.state.statusFor(_videoId),
+        PlaybackStatus.unavailable,
+      );
+      expect(playbackStatusCubit.state.hasAuthRetryExhausted(_videoId), isTrue);
+      expect(find.text(_unavailableText), findsNothing);
+      expect(find.text(_failureText), findsNothing);
+    });
+  });
 }
 
 class _RetryHarness extends StatelessWidget {
@@ -548,6 +603,51 @@ class _RetryHarness extends StatelessWidget {
                     retryPlayback: retryPlayback,
                   ),
                   child: const Text('Verify'),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AutoRetryHarness extends StatelessWidget {
+  const _AutoRetryHarness({
+    required this.mediaAuthInterceptor,
+    required this.playbackStatusCubit,
+    required this.retryPlayback,
+  });
+
+  final MediaAuthInterceptor mediaAuthInterceptor;
+  final VideoPlaybackStatusCubit playbackStatusCubit;
+  final bool Function(Map<String, String>) retryPlayback;
+
+  @override
+  Widget build(BuildContext context) {
+    return ProviderScope(
+      overrides: [
+        mediaAuthInterceptorProvider.overrideWithValue(mediaAuthInterceptor),
+      ],
+      child: BlocProvider<VideoPlaybackStatusCubit>.value(
+        value: playbackStatusCubit,
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Consumer(
+              builder: (context, ref, _) {
+                return TextButton(
+                  onPressed: () => autoRetryAgeRestrictedPooledVideo(
+                    context: context,
+                    ref: ref,
+                    video: _video,
+                    index: 0,
+                    resolveSha256: _resolveSha256,
+                    retryPlayback: retryPlayback,
+                  ),
+                  child: const Text('Auto retry'),
                 );
               },
             ),

--- a/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
+++ b/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
@@ -7,6 +7,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:infinite_video_feed/infinite_video_feed.dart'
+    show VideoErrorType;
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
@@ -38,6 +40,21 @@ String get _failureText =>
 
 String get _unavailableText =>
     lookupAppLocalizations(const Locale('en')).videoErrorUnavailable;
+
+/// Retry recovered playback.
+const PooledRetryOutcome _retryRecovered = (succeeded: true, errorType: null);
+
+/// Retry ran with valid auth headers and the media server rejected it again.
+const PooledRetryOutcome _retryStillUnauthorized = (
+  succeeded: false,
+  errorType: VideoErrorType.ageRestricted,
+);
+
+/// Retry failed for a reason unrelated to the age gate (network, decode).
+const PooledRetryOutcome _retryFailedUnrelated = (
+  succeeded: false,
+  errorType: VideoErrorType.generic,
+);
 
 String get _signerUnreachableText => lookupAppLocalizations(
   const Locale('en'),
@@ -87,7 +104,7 @@ void main() {
           retryPlayback: (headers) {
             retryCount++;
             retryHeaders = headers;
-            return true;
+            return _retryRecovered;
           },
         ),
       );
@@ -132,7 +149,7 @@ void main() {
         _RetryHarness(
           mediaAuthInterceptor: mediaAuthInterceptor,
           playbackStatusCubit: playbackStatusCubit,
-          retryPlayback: (_) => true,
+          retryPlayback: (_) => _retryRecovered,
         ),
       );
 
@@ -178,7 +195,7 @@ void main() {
             playbackStatusCubit: playbackStatusCubit,
             retryPlayback: (_) {
               retryCount++;
-              return true;
+              return _retryRecovered;
             },
           ),
         );
@@ -237,7 +254,7 @@ void main() {
           ageVerificationService: _ageService(verified: false),
           retryPlayback: (_) {
             retryCount++;
-            return true;
+            return _retryRecovered;
           },
         ),
       );
@@ -285,7 +302,7 @@ void main() {
             ageVerificationService: _ageService(verified: true),
             retryPlayback: (_) {
               retryCount++;
-              return true;
+              return _retryRecovered;
             },
           ),
         );
@@ -332,7 +349,7 @@ void main() {
           playbackStatusCubit: playbackStatusCubit,
           retryPlayback: (_) {
             retryCount++;
-            return false;
+            return _retryStillUnauthorized;
           },
         ),
       );
@@ -351,6 +368,58 @@ void main() {
       expect(playbackStatusCubit.state.hasAuthRetryExhausted(_videoId), isTrue);
       expect(find.text(_unavailableText), findsOneWidget);
       expect(find.text(_failureText), findsNothing);
+    });
+
+    testWidgets('keeps the age-gated card when the retry fails for an '
+        'unrelated reason', (tester) async {
+      final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+      final playbackStatusCubit = VideoPlaybackStatusCubit();
+      var retryCount = 0;
+      addTearDown(playbackStatusCubit.close);
+
+      when(
+        () => mediaAuthInterceptor.handleUnauthorizedMedia(
+          context: any(named: 'context'),
+          sha256Hash: _sha256,
+          url: _videoUrl,
+          serverUrl: 'https://media.divine.video',
+          category: 'video',
+        ),
+      ).thenAnswer(
+        (_) async =>
+            const ViewerAuthAuthorized({'Authorization': 'Nostr token'}),
+      );
+
+      await tester.pumpWidget(
+        _RetryHarness(
+          mediaAuthInterceptor: mediaAuthInterceptor,
+          playbackStatusCubit: playbackStatusCubit,
+          retryPlayback: (_) {
+            retryCount++;
+            return _retryFailedUnrelated;
+          },
+        ),
+      );
+
+      playbackStatusCubit.report(_videoId, PlaybackStatus.ageRestricted);
+
+      await tester.tap(find.text('Verify'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(retryCount, 1);
+      // A network / decode failure is not evidence the age gate is
+      // unclearable, so the viewer keeps the retryable age-gated card.
+      expect(
+        playbackStatusCubit.state.statusFor(_videoId),
+        PlaybackStatus.ageRestricted,
+      );
+      expect(
+        playbackStatusCubit.state.hasAuthRetryExhausted(_videoId),
+        isFalse,
+      );
+      expect(find.text(_failureText), findsOneWidget);
+      expect(find.text(_unavailableText), findsNothing);
     });
 
     testWidgets(
@@ -381,7 +450,7 @@ void main() {
             ageVerificationService: _ageService(verified: true),
             retryPlayback: (_) {
               retryCount++;
-              return true;
+              return _retryRecovered;
             },
           ),
         );
@@ -429,7 +498,7 @@ void main() {
             playbackStatusCubit: playbackStatusCubit,
             retryPlayback: (_) {
               retryCount++;
-              return true;
+              return _retryRecovered;
             },
           ),
         );
@@ -479,7 +548,7 @@ void main() {
             video: video,
             retryPlayback: (_) {
               retryCount++;
-              return true;
+              return _retryRecovered;
             },
           ),
         );
@@ -537,7 +606,7 @@ void main() {
           playbackStatusCubit: playbackStatusCubit,
           retryPlayback: (_) {
             retryCount++;
-            return false;
+            return _retryStillUnauthorized;
           },
         ),
       );
@@ -557,6 +626,55 @@ void main() {
       expect(find.text(_unavailableText), findsNothing);
       expect(find.text(_failureText), findsNothing);
     });
+
+    testWidgets('leaves the age-gated status alone when the retry fails for '
+        'an unrelated reason', (tester) async {
+      final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+      final playbackStatusCubit = VideoPlaybackStatusCubit();
+      var retryCount = 0;
+      addTearDown(playbackStatusCubit.close);
+
+      when(
+        () => mediaAuthInterceptor.canAutoAuthorizeAdultMedia,
+      ).thenReturn(true);
+      when(
+        () => mediaAuthInterceptor.createAutoAuthHeadersForAdultMedia(
+          sha256Hash: _sha256,
+          url: _videoUrl,
+          serverUrl: 'https://media.divine.video',
+        ),
+      ).thenAnswer(
+        (_) async =>
+            const ViewerAuthAuthorized({'Authorization': 'Nostr token'}),
+      );
+
+      await tester.pumpWidget(
+        _AutoRetryHarness(
+          mediaAuthInterceptor: mediaAuthInterceptor,
+          playbackStatusCubit: playbackStatusCubit,
+          retryPlayback: (_) {
+            retryCount++;
+            return _retryFailedUnrelated;
+          },
+        ),
+      );
+
+      playbackStatusCubit.report(_videoId, PlaybackStatus.ageRestricted);
+
+      await tester.tap(find.text('Auto retry'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(retryCount, 1);
+      expect(
+        playbackStatusCubit.state.statusFor(_videoId),
+        PlaybackStatus.ageRestricted,
+      );
+      expect(
+        playbackStatusCubit.state.hasAuthRetryExhausted(_videoId),
+        isFalse,
+      );
+    });
   });
 }
 
@@ -571,7 +689,7 @@ class _RetryHarness extends StatelessWidget {
 
   final MediaAuthInterceptor mediaAuthInterceptor;
   final VideoPlaybackStatusCubit playbackStatusCubit;
-  final bool Function(Map<String, String>) retryPlayback;
+  final PooledRetryPlayback retryPlayback;
   final VideoEvent? video;
   final AgeVerificationService? ageVerificationService;
 
@@ -622,7 +740,7 @@ class _AutoRetryHarness extends StatelessWidget {
 
   final MediaAuthInterceptor mediaAuthInterceptor;
   final VideoPlaybackStatusCubit playbackStatusCubit;
-  final bool Function(Map<String, String>) retryPlayback;
+  final PooledRetryPlayback retryPlayback;
 
   @override
   Widget build(BuildContext context) {

--- a/mobile/test/widgets/pooled_video_error_overlay_test.dart
+++ b/mobile/test/widgets/pooled_video_error_overlay_test.dart
@@ -68,6 +68,7 @@ void main() {
       VoidCallback? onVerifyAge,
       VoidCallback? onSkip,
       bool isVerifying = false,
+      bool isAuthRetryExhausted = false,
       VideoPlaybackStatusCubit? playbackStatusCubit,
     }) {
       final overlay = PooledVideoErrorOverlay(
@@ -77,6 +78,7 @@ void main() {
         onVerifyAge: onVerifyAge,
         errorType: errorType,
         isVerifying: isVerifying,
+        isAuthRetryExhausted: isAuthRetryExhausted,
       );
       return ProviderScope(
         overrides: [
@@ -191,32 +193,31 @@ void main() {
         expect(find.text(l10n.videoErrorRetry), findsNothing);
       });
 
-      testWidgets(
-        'shows retryable playback error for third-party video URLs',
-        (tester) async {
-          await tester.pumpWidget(
-            buildWidget(
-              errorType: VideoErrorType.forbidden,
-              video: thirdPartyVideo,
-              onSkip: () => skipPressed = true,
-            ),
-          );
-          await tester.pumpAndSettle();
+      testWidgets('shows retryable playback error for third-party video URLs', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(
+            errorType: VideoErrorType.forbidden,
+            video: thirdPartyVideo,
+            onSkip: () => skipPressed = true,
+          ),
+        );
+        await tester.pumpAndSettle();
 
-          expect(_findDivineIcon(DivineIconName.warningCircle), findsOneWidget);
-          expect(find.text(l10n.videoErrorPlayback), findsOneWidget);
-          expect(find.text(l10n.videoErrorContentRestricted), findsNothing);
-          expect(find.text(l10n.videoErrorContentRestrictedBody), findsNothing);
-          expect(find.text(l10n.videoErrorSkip), findsNothing);
-          expect(find.text(l10n.videoErrorRetry), findsOneWidget);
+        expect(_findDivineIcon(DivineIconName.warningCircle), findsOneWidget);
+        expect(find.text(l10n.videoErrorPlayback), findsOneWidget);
+        expect(find.text(l10n.videoErrorContentRestricted), findsNothing);
+        expect(find.text(l10n.videoErrorContentRestrictedBody), findsNothing);
+        expect(find.text(l10n.videoErrorSkip), findsNothing);
+        expect(find.text(l10n.videoErrorRetry), findsOneWidget);
 
-          await tester.tap(find.text(l10n.videoErrorRetry));
-          await tester.pump();
+        await tester.tap(find.text(l10n.videoErrorRetry));
+        await tester.pump();
 
-          expect(retryPressed, isTrue);
-          expect(skipPressed, isFalse);
-        },
-      );
+        expect(retryPressed, isTrue);
+        expect(skipPressed, isFalse);
+      });
     });
 
     group('ageRestricted', () {
@@ -334,6 +335,40 @@ void main() {
 
         expect(verifyAgePressed, isFalse);
       });
+
+      testWidgets(
+        'shows unavailable copy after authenticated retry is exhausted',
+        (tester) async {
+          final playbackStatusCubit = VideoPlaybackStatusCubit();
+          addTearDown(playbackStatusCubit.close);
+          playbackStatusCubit.markAuthRetryExhausted(divineVideo.id);
+
+          await tester.pumpWidget(
+            buildWidget(
+              errorType: VideoErrorType.ageRestricted,
+              onVerifyAge: () => verifyAgePressed = true,
+              onSkip: () => skipPressed = true,
+              isAuthRetryExhausted: true,
+              playbackStatusCubit: playbackStatusCubit,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(_findDivineIcon(DivineIconName.warningCircle), findsOneWidget);
+          expect(find.text(l10n.videoErrorUnavailable), findsOneWidget);
+          expect(find.text(l10n.videoErrorUnavailableBody), findsOneWidget);
+          expect(find.text(l10n.videoErrorAgeRestricted), findsNothing);
+          expect(find.text(l10n.videoErrorVerifyAgeButton), findsNothing);
+          expect(find.text(l10n.videoErrorRetry), findsNothing);
+          expect(find.text(l10n.videoErrorSkip), findsOneWidget);
+
+          await tester.tap(find.text(l10n.videoErrorSkip));
+          await tester.pump();
+
+          expect(skipPressed, isTrue);
+          expect(verifyAgePressed, isFalse);
+        },
+      );
     });
 
     group('notFound', () {

--- a/mobile/test/widgets/video_feed_item/moderated_content_overlay_test.dart
+++ b/mobile/test/widgets/video_feed_item/moderated_content_overlay_test.dart
@@ -62,6 +62,17 @@ void main() {
       expect(find.text(enL10n.videoErrorSkip), findsOneWidget);
     });
 
+    testWidgets('renders unavailable message with Skip and no Verify age', (
+      tester,
+    ) async {
+      await pumpOverlay(tester, status: PlaybackStatus.unavailable);
+
+      expect(find.text(enL10n.videoErrorUnavailable), findsOneWidget);
+      expect(find.text(enL10n.videoErrorUnavailableBody), findsOneWidget);
+      expect(find.text(enL10n.videoErrorSkip), findsOneWidget);
+      expect(find.text(enL10n.videoErrorVerifyAgeButton), findsNothing);
+    });
+
     testWidgets('calls onSkip when Skip is tapped', (tester) async {
       var skipped = 0;
       await pumpOverlay(

--- a/mobile/test/widgets/video_feed_item/verifying_aware_video_error_overlay_test.dart
+++ b/mobile/test/widgets/video_feed_item/verifying_aware_video_error_overlay_test.dart
@@ -81,7 +81,7 @@ void main() {
                   index: 0,
                   resolveSha256: _resolveSha256,
                   onRetry: () {},
-                  retryPlayback: (_) => true,
+                  retryPlayback: (_) => (succeeded: true, errorType: null),
                   errorType: VideoErrorType.ageRestricted,
                   shouldPortraitExpand: true,
                   isSquare: false,


### PR DESCRIPTION
## Summary
- track session-scoped authenticated retry exhaustion for age-gated playback
- mark authorized-but-still-failed retry attempts as neutral unavailable instead of age verification failures
- keep skip-only unavailable overlays while leaving classifier, availability checks, and pruning untouched
- add localized unavailable video copy and generated l10n outputs

## Verification
- flutter test test/blocs/video_playback_status/video_playback_status_cubit_test.dart test/screens/feed/pooled_age_restricted_retry_test.dart test/widgets/pooled_video_error_overlay_test.dart test/widgets/video_feed_item/feed_videos_test.dart test/widgets/video_feed_item/moderated_content_overlay_test.dart test/l10n/arb_consistency_test.dart
- flutter analyze lib test
- pre-push hook: analyzer + changed-file tests

Closes #6253