### PR TITLE
feat(lists): notify when videos are added to public lists

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3404,7 +3404,34 @@
             }
         }
     },
-    "notificationRepliedToYourComment": "{actorName} ለአስተያየትዎ ምላሽ ሰጥተዋል",
+    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationRepliedToYourComment": "{actorName} ለአስተያየትዎ ምላሽ ሰጥተዋል",
     "@notificationRepliedToYourComment": {
         "description": "Verb phrase shown after the actor name in a reply notification."
     },

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3285,7 +3285,34 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "عرض الملفات الشخصية",
-    "notificationRepliedToYourComment": "{actorName} ردّ على تعليقك",
+    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationRepliedToYourComment": "{actorName} ردّ على تعليقك",
     "notificationAndConnector": "و",
     "notificationOthersCount": "{count, plural, =1{شخص آخر} other{{count} أشخاص آخرين}}",
     "@notificationOthersCount": {

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3013,7 +3013,34 @@
             }
         }
     },
-    "notificationRepliedToYourComment": "{actorName} Отговори на коментара ти",
+    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationRepliedToYourComment": "{actorName} Отговори на коментара ти",
     "@notificationRepliedToYourComment": {
         "description": "Verb phrase shown after the actor name in a reply notification."
     },

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3292,7 +3292,34 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Profile öffnen",
-    "notificationRepliedToYourComment": "{actorName} hat auf deinen Kommentar geantwortet",
+    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationRepliedToYourComment": "{actorName} hat auf deinen Kommentar geantwortet",
     "notificationAndConnector": "und",
     "notificationOthersCount": "{count, plural, =1{1 weitere Person} other{{count} weitere Personen}}",
     "@notificationOthersCount": {

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4668,6 +4668,33 @@
       }
     }
   },
+  "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
   "notificationRepliedToYourComment": "{actorName} replied to your comment",
   "@notificationRepliedToYourComment": {
     "description": "Full sentence shown for a reply notification.",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3300,7 +3300,34 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Ver perfiles",
-    "notificationRepliedToYourComment": "{actorName} respondió a tu comentario",
+    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationRepliedToYourComment": "{actorName} respondió a tu comentario",
     "notificationAndConnector": "y",
     "notificationOthersCount": "{count, plural, =1{1 persona más} other{{count} personas más}}",
     "@notificationOthersCount": {

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2233,7 +2233,34 @@
     "nostrAppPermissionTitle": "Hinihingi ng {appName} ang pag-apruba mo",
     "notificationAndConnector": "at",
     "notificationOthersCount": "{count, plural, =1{1 iba pa} other{{count} iba pa}}",
-    "notificationRepliedToYourComment": "nag-reply si {actorName} sa comment mo",
+    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationRepliedToYourComment": "nag-reply si {actorName} sa comment mo",
     "notificationsEmptySubtitle": "Kapag nag-interact ang mga tao sa content mo, makikita mo dito",
     "notificationsEmptyTitle": "Wala pang activity",
     "notificationsViewProfileSemanticLabel": "Tingnan ang profile ni {displayName}",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3292,7 +3292,34 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Voir les profils",
-    "notificationRepliedToYourComment": "{actorName} a répondu à ton commentaire",
+    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationRepliedToYourComment": "{actorName} a répondu à ton commentaire",
     "notificationAndConnector": "et",
     "notificationOthersCount": "{count, plural, =1{1 autre} other{{count} autres}}",
     "@notificationOthersCount": {

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3292,7 +3292,34 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Lihat profil",
-    "notificationRepliedToYourComment": "{actorName} membalas komentar Anda",
+    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationRepliedToYourComment": "{actorName} membalas komentar Anda",
     "notificationAndConnector": "dan",
     "notificationOthersCount": "{count, plural, other{{count} lainnya}}",
     "@notificationOthersCount": {

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3292,7 +3292,34 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Vedi profili",
-    "notificationRepliedToYourComment": "{actorName} ha risposto al tuo commento",
+    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationRepliedToYourComment": "{actorName} ha risposto al tuo commento",
     "notificationAndConnector": "e",
     "notificationOthersCount": "{count, plural, =1{1 altro} other{{count} altri}}",
     "@notificationOthersCount": {

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3285,7 +3285,34 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "プロフィールを開く",
-    "notificationRepliedToYourComment": "{actorName}さんがあなたのコメントに返信しました",
+    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationRepliedToYourComment": "{actorName}さんがあなたのコメントに返信しました",
     "notificationAndConnector": "と",
     "notificationOthersCount": "{count, plural, other{他{count}人}}",
     "@notificationOthersCount": {

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2623,7 +2623,34 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "프로필 보기",
-    "notificationRepliedToYourComment": "{actorName}님이 회원님의 댓글에 답글을 남겼습니다",
+    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationRepliedToYourComment": "{actorName}님이 회원님의 댓글에 답글을 남겼습니다",
     "notificationAndConnector": "및",
     "notificationOthersCount": "{count, plural, other{외 {count}명}}",
     "@notificationOthersCount": {

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -4774,6 +4774,33 @@
     }
   },
   "notificationPostedNewVine": "{actorName} menyiarkan vine baharu",
+  "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
   "notificationRepliedToYourComment": "{actorName} membalas komen anda",
   "@notificationRepliedToYourComment": {
     "description": "Full sentence shown for a reply notification.",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3292,7 +3292,34 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Profielen bekijken",
-    "notificationRepliedToYourComment": "{actorName} heeft op je reactie gereageerd",
+    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationRepliedToYourComment": "{actorName} heeft op je reactie gereageerd",
     "notificationAndConnector": "en",
     "notificationOthersCount": "{count, plural, =1{1 ander} other{{count} anderen}}",
     "@notificationOthersCount": {

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3292,7 +3292,34 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Zobacz profile",
-    "notificationRepliedToYourComment": "{actorName} odpowiedział(a) na Twój komentarz",
+    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationRepliedToYourComment": "{actorName} odpowiedział(a) na Twój komentarz",
     "notificationAndConnector": "i",
     "notificationOthersCount": "{count, plural, =1{1 inna osoba} other{{count} innych osób}}",
     "@notificationOthersCount": {

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3292,7 +3292,34 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Ver perfis",
-    "notificationRepliedToYourComment": "{actorName} respondeu ao teu comentário",
+    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationRepliedToYourComment": "{actorName} respondeu ao teu comentário",
     "notificationAndConnector": "e",
     "notificationOthersCount": "{count, plural, =1{mais 1 pessoa} other{mais {count} pessoas}}",
     "@notificationOthersCount": {

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3292,7 +3292,34 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Vezi profilurile",
-    "notificationRepliedToYourComment": "{actorName} a răspuns la comentariul tău",
+    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationRepliedToYourComment": "{actorName} a răspuns la comentariul tău",
     "notificationAndConnector": "și",
     "notificationOthersCount": "{count, plural, =1{încă 1 persoană} other{încă {count} persoane}}",
     "@notificationOthersCount": {

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3292,7 +3292,34 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Visa profiler",
-    "notificationRepliedToYourComment": "{actorName} svarade på din kommentar",
+    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationRepliedToYourComment": "{actorName} svarade på din kommentar",
     "notificationAndConnector": "och",
     "notificationOthersCount": "{count, plural, =1{1 till} other{{count} till}}",
     "@notificationOthersCount": {

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3292,7 +3292,34 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Profilleri görüntüle",
-    "notificationRepliedToYourComment": "{actorName} yorumuna yanıt verdi",
+    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationRepliedToYourComment": "{actorName} yorumuna yanıt verdi",
     "notificationAndConnector": "ve",
     "notificationOthersCount": "{count, plural, =1{1 kişi daha} other{{count} kişi daha}}",
     "@notificationOthersCount": {

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -4774,6 +4774,33 @@
     }
   },
   "notificationPostedNewVine": "{actorName} نے نئی ویڈیو پوسٹ کی",
+  "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
   "notificationRepliedToYourComment": "{actorName} نے آپ کے تبصرے کا جواب دیا",
   "@notificationRepliedToYourComment": {
     "description": "Full sentence shown for a reply notification.",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -4774,6 +4774,33 @@
     }
   },
   "notificationPostedNewVine": "{actorName} đã đăng một vine mới",
+  "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
   "notificationRepliedToYourComment": "{actorName} đã trả lời bình luận của bạn",
   "@notificationRepliedToYourComment": {
     "description": "Full sentence shown for a reply notification.",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -4774,6 +4774,33 @@
     }
   },
   "notificationPostedNewVine": "{actorName} 发布了新视频",
+  "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
+  "@notificationAddedYourVideoToList": {
+    "description": "Shown when someone adds one of the user's videos to a public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "@notificationAddedYourVideosToList": {
+    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "listName": {
+        "type": "String"
+      }
+    }
+  },
   "notificationRepliedToYourComment": "{actorName} 回复了你的评论",
   "@notificationRepliedToYourComment": {
     "description": "Full sentence shown for a reply notification.",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -13826,6 +13826,22 @@ abstract class AppLocalizations {
   /// **'{actorName} posted a new vine'**
   String notificationPostedNewVine(String actorName);
 
+  /// Shown when someone adds one of the user's videos to a public curated list.
+  ///
+  /// In en, this message translates to:
+  /// **'{actorName} added your vine to {listName}'**
+  String notificationAddedYourVideoToList(String actorName, String listName);
+
+  /// Shown when someone adds multiple of the user's videos to the same public curated list.
+  ///
+  /// In en, this message translates to:
+  /// **'{actorName} added {count} of your vines to {listName}'**
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  );
+
   /// Full sentence shown for a reply notification.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7836,6 +7836,20 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName ለአስተያየትዎ ምላሽ ሰጥተዋል';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -7948,6 +7948,20 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName ردّ على تعليقك';
   }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -8074,6 +8074,20 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName Отговори на коментара ти';
   }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -8097,6 +8097,20 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName hat auf deinen Kommentar geantwortet';
   }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -7990,6 +7990,20 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName replied to your comment';
   }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -8076,6 +8076,20 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName respondió a tu comentario';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -8096,6 +8096,20 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return 'nag-reply si $actorName sa comment mo';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -8106,6 +8106,20 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName a répondu à ton commentaire';
   }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -7962,6 +7962,20 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName membalas komentar Anda';
   }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -8079,6 +8079,20 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName ha risposto al tuo commento';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7657,6 +7657,20 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorNameさんがあなたのコメントに返信しました';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -7681,6 +7681,20 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName님이 회원님의 댓글에 답글을 남겼습니다';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -8050,6 +8050,20 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName membalas komen anda';
   }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -8036,6 +8036,20 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName heeft op je reactie gereageerd';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -8177,6 +8177,20 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName odpowiedział(a) na Twój komentarz';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -8056,6 +8056,20 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName respondeu ao teu comentário';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -8177,6 +8177,20 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName a răspuns la comentariul tău';
   }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -7995,6 +7995,20 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName svarade på din kommentar';
   }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -7961,6 +7961,20 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName yorumuna yanıt verdi';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -8005,6 +8005,20 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName نے آپ کے تبصرے کا جواب دیا';
   }

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -8007,6 +8007,20 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName đã trả lời bình luận của bạn';
   }

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -7603,6 +7603,20 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String notificationAddedYourVideoToList(String actorName, String listName) {
+    return '$actorName added your vine to $listName';
+  }
+
+  @override
+  String notificationAddedYourVideosToList(
+    String actorName,
+    int count,
+    String listName,
+  ) {
+    return '$actorName added $count of your vines to $listName';
+  }
+
+  @override
   String notificationRepliedToYourComment(String actorName) {
     return '$actorName 回复了你的评论';
   }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -417,6 +417,12 @@ Future<void> _routeNotificationTap({
   );
 
   switch (target) {
+    case OpenListTarget(:final pubkey, :final listId):
+      container
+          .read(goRouterProvider)
+          .push(
+            CuratedListByAuthorScreen.pathFor(pubkey: pubkey, listId: listId),
+          );
     case OpenProfileTarget(:final actorPubkey):
       _navigateToNotificationProfile(container, actorPubkey);
     case OpenInboxTarget():

--- a/mobile/lib/notifications/routing/notification_tap_target.dart
+++ b/mobile/lib/notifications/routing/notification_tap_target.dart
@@ -6,6 +6,8 @@ import 'package:models/models.dart' show NIP71VideoKinds, NotificationKind;
 import 'package:openvine/services/notification_helpers.dart'
     show parseAddressableId;
 
+const int _curatedListKind = 30005;
+
 /// Normalized destination for a notification tap.
 ///
 /// Built from either a `NotificationItem` (in-app row tap) or a push/local
@@ -53,6 +55,20 @@ class OpenProfileTarget extends NotificationTapTarget {
   List<Object?> get props => [actorPubkey];
 }
 
+/// Open a public curated list by its author and d-tag.
+class OpenListTarget extends NotificationTapTarget {
+  const OpenListTarget({required this.pubkey, required this.listId});
+
+  /// Hex pubkey of the list author.
+  final String pubkey;
+
+  /// The list's `d` tag.
+  final String listId;
+
+  @override
+  List<Object?> get props => [pubkey, listId];
+}
+
 /// Deterministic safe fallback: open the notifications inbox.
 ///
 /// Used when a tap carries no resolvable video target and no actor pubkey, so
@@ -84,9 +100,9 @@ bool notificationKindOpensComments(
 ///
 /// `divine-push-service` sends a lowercase vocabulary
 /// (`like`/`comment`/`follow`/`mention`/`repost`) plus the camelCase
-/// `newPost`, which matches that service's `NotificationType::display_name()`
-/// exactly — the string is a wire contract, not a display value. It never
-/// sends `reply`, `likeComment`, or `system`. Unknown / absent values return
+/// `newPost`; Funnelcake inbox rows also use `list_add`. The string is a wire
+/// contract, not a display value. It never sends `reply`, `likeComment`, or
+/// `system`. Unknown / absent values return
 /// `null`, which [resolveNotificationTapTarget] treats as a best-effort
 /// video/profile/inbox tap.
 NotificationKind? notificationKindFromPushType(String? type) {
@@ -103,11 +119,23 @@ NotificationKind? notificationKindFromPushType(String? type) {
       return NotificationKind.repost;
     case 'newPost':
       return NotificationKind.newPost;
+    case 'list_add':
+      return NotificationKind.listAdd;
     default:
       // Keep unknown values non-fatal: a mistyped or legacy-cased payload
       // should still fall back to the best available target.
       return null;
   }
+}
+
+/// Parses a public curated-list coordinate into an in-app route target.
+OpenListTarget? listTargetFromCoordinate(String? listCoordinate) {
+  if (listCoordinate == null || listCoordinate.isEmpty) return null;
+  final parsed = parseAddressableId(listCoordinate);
+  if (parsed == null) return null;
+  if (parsed.kind != _curatedListKind) return null;
+  if (parsed.pubkey.isEmpty || parsed.dTag.isEmpty) return null;
+  return OpenListTarget(pubkey: parsed.pubkey, listId: parsed.dTag);
 }
 
 /// Returns [referencedAddress] when it is a usable video coordinate, else null.
@@ -151,7 +179,12 @@ NotificationTapTarget resolveNotificationTapTarget({
   required bool hasVideoTarget,
   bool hasCommentTarget = false,
   String? actorPubkey,
+  String? listCoordinate,
 }) {
+  if (kind == NotificationKind.listAdd) {
+    final listTarget = listTargetFromCoordinate(listCoordinate);
+    if (listTarget != null) return listTarget;
+  }
   if (kind == NotificationKind.follow) {
     return _profileOrInbox(actorPubkey);
   }

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -14,6 +14,7 @@ import 'package:openvine/notifications/routing/notification_tap_target.dart';
 import 'package:openvine/notifications/widgets/widgets.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/screens/curated_list_by_author_screen.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/services/notification_target_resolver.dart';
@@ -190,12 +191,16 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
         :final videoEventId,
         :final videoAddressableId,
         :final type,
+        :final listCoordinate,
       ):
         final target = resolveNotificationTapTarget(
           kind: type,
           hasVideoTarget: true,
+          listCoordinate: listCoordinate,
         );
         switch (target) {
+          case OpenListTarget(:final pubkey, :final listId):
+            _navigateToList(context, pubkey: pubkey, listId: listId);
           case OpenVideoTarget():
             await _navigateToVideo(
               context,
@@ -228,6 +233,8 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
           actorPubkey: actor.pubkey,
         );
         switch (target) {
+          case OpenListTarget(:final pubkey, :final listId):
+            _navigateToList(context, pubkey: pubkey, listId: listId);
           case OpenVideoTarget():
             // targetEventId is the event the resolver walks to find the root
             // video. Any comment/reply/likeComment/mention whose root video
@@ -259,6 +266,16 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
             break;
         }
     }
+  }
+
+  void _navigateToList(
+    BuildContext context, {
+    required String pubkey,
+    required String listId,
+  }) {
+    context.push(
+      CuratedListByAuthorScreen.pathFor(pubkey: pubkey, listId: listId),
+    );
   }
 
   /// Resolves the video route and pushes [VideoDetailScreen].

--- a/mobile/lib/notifications/widgets/actor_notification_row.dart
+++ b/mobile/lib/notifications/widgets/actor_notification_row.dart
@@ -247,6 +247,7 @@ String _messageFor(
     NotificationKind.like ||
     NotificationKind.comment ||
     NotificationKind.repost ||
-    NotificationKind.newPost => '',
+    NotificationKind.newPost ||
+    NotificationKind.listAdd => '',
   };
 }

--- a/mobile/lib/notifications/widgets/notification_type_icon_spec.dart
+++ b/mobile/lib/notifications/widgets/notification_type_icon_spec.dart
@@ -64,6 +64,11 @@ NotificationTypeIconSpec notificationTypeIconSpec(
       background: VineTheme.accentBlueBackground,
       foreground: VineTheme.accentBlue,
     ),
+    NotificationKind.listAdd => const NotificationTypeIconSpec(
+      icon: DivineIconName.listPlus,
+      background: VineTheme.accentYellowBackground,
+      foreground: VineTheme.accentYellow,
+    ),
     NotificationKind.system => const NotificationTypeIconSpec(
       icon: DivineIconName.logo,
       background: VineTheme.onPrimaryButton,

--- a/mobile/lib/notifications/widgets/video_notification_row.dart
+++ b/mobile/lib/notifications/widgets/video_notification_row.dart
@@ -196,6 +196,45 @@ class _MessageText extends StatelessWidget {
     final videoTitle = notification.videoTitle;
     final othersCount = notification.totalCount - 1;
 
+    if (type == NotificationKind.listAdd) {
+      final listName = notification.listTitle?.isNotEmpty == true
+          ? notification.listTitle!
+          : l10n.routeDefaultListName;
+      final fullText = notification.totalCount > 1
+          ? l10n.notificationAddedYourVideosToList(
+              actors.first.displayName,
+              notification.totalCount,
+              listName,
+            )
+          : l10n.notificationAddedYourVideoToList(
+              actors.first.displayName,
+              listName,
+            );
+      spans.addAll(
+        _localizedActorAndListSentenceSpans(
+          fullText: fullText,
+          actorName: actors.first.displayName,
+          listName: listName,
+          colors: context.vineColors,
+        ),
+      );
+      final ts = timestamp;
+      if (ts != null && ts.isNotEmpty) {
+        spans.add(
+          TextSpan(
+            text: ' $ts',
+            style: VineTheme.bodyMediumFont(
+              color: context.vineColors.onSurfaceMuted,
+            ),
+          ),
+        );
+      }
+      return Text.rich(
+        TextSpan(children: spans),
+        textScaler: MediaQuery.textScalerOf(context),
+      );
+    }
+
     if (othersCount == 0) {
       spans.addAll(
         localizedActorSentenceSpans(
@@ -300,9 +339,11 @@ String _verbFor(AppLocalizations l10n, NotificationKind type) {
     NotificationKind.mention => l10n.notificationMentionedYou('').trimLeft(),
     NotificationKind.newPost => l10n.notificationPostedNewVine('').trimLeft(),
     // VideoNotification asserts type ∈ {like, likeComment, comment, mention,
-    // repost, newPost}; the remaining cases satisfy switch exhaustivity only.
+    // repost, newPost, listAdd}; the remaining cases satisfy switch
+    // exhaustivity only.
     NotificationKind.reply ||
     NotificationKind.follow ||
+    NotificationKind.listAdd ||
     NotificationKind.system => '',
   };
 }
@@ -325,6 +366,43 @@ String _messageFor(
     NotificationKind.newPost => l10n.notificationPostedNewVine(actorName),
     NotificationKind.reply ||
     NotificationKind.follow ||
+    NotificationKind.listAdd ||
     NotificationKind.system => '',
   };
+}
+
+List<InlineSpan> _localizedActorAndListSentenceSpans({
+  required String fullText,
+  required String actorName,
+  required String listName,
+  required VineThemeColors colors,
+}) {
+  final bodyStyle = VineTheme.bodyMediumFont(color: colors.primaryText);
+  final boldStyle = VineTheme.labelLargeFont(color: colors.primaryText);
+  final actorStart = fullText.indexOf(actorName);
+  if (actorName.isEmpty || actorStart < 0) {
+    return [TextSpan(text: fullText, style: bodyStyle)];
+  }
+
+  final actorEnd = actorStart + actorName.length;
+  final listStart = fullText.indexOf(listName, actorEnd);
+  if (listName.isEmpty || listStart < 0) {
+    return localizedActorSentenceSpans(
+      fullText: fullText,
+      actorName: actorName,
+      colors: colors,
+    );
+  }
+
+  final listEnd = listStart + listName.length;
+  return [
+    if (actorStart > 0)
+      TextSpan(text: fullText.substring(0, actorStart), style: bodyStyle),
+    TextSpan(text: actorName, style: boldStyle),
+    if (actorEnd < listStart)
+      TextSpan(text: fullText.substring(actorEnd, listStart), style: bodyStyle),
+    TextSpan(text: listName, style: boldStyle),
+    if (listEnd < fullText.length)
+      TextSpan(text: fullText.substring(listEnd), style: bodyStyle),
+  ];
 }

--- a/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
@@ -24,6 +24,8 @@ class RelayNotification {
     this.rootDTag,
     this.rootAddressableId,
     this.targetCommentId,
+    this.listTitle,
+    this.listCoordinate,
   });
 
   /// Parses a notification payload from the FunnelCake API.
@@ -79,6 +81,8 @@ class RelayNotification {
       rootDTag: _nonEmpty(json['root_d_tag'] as String?),
       rootAddressableId: _nonEmpty(json['root_addressable_id'] as String?),
       targetCommentId: _nonEmpty(json['target_comment_id'] as String?),
+      listTitle: _nonEmpty(json['list_title'] as String?),
+      listCoordinate: _nonEmpty(json['list_coordinate'] as String?),
     );
   }
 
@@ -171,6 +175,14 @@ class RelayNotification {
 
   /// Comment event ID included by Funnelcake for NIP-22 comment notifications.
   final String? targetCommentId;
+
+  /// Curated-list title for `notification_type: "list_add"`.
+  final String? listTitle;
+
+  /// Full kind-30005 coordinate for the curated list.
+  ///
+  /// Shape: `30005:<curator_pubkey>:<d-tag>`.
+  final String? listCoordinate;
 
   /// Stable dedup key -- falls back to sourceEventId if id is empty.
   String get dedupeKey => id.isNotEmpty ? id : sourceEventId;

--- a/mobile/packages/funnelcake_api_client/test/src/models/relay_notification_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/models/relay_notification_test.dart
@@ -197,6 +197,57 @@ void main() {
         expect(notification.referencedDTag, isNull);
       });
 
+      test('parses list_add list context', () {
+        final json = {
+          'id': 'notif_123',
+          'source_pubkey': 'aabbccdd' * 8,
+          'source_event_id': '11223344' * 8,
+          'source_kind': 30005,
+          'referenced_event_id': '55667788' * 8,
+          'notification_type': 'list_add',
+          'created_at': 1712345678,
+          'read': false,
+          'list_title': 'Literature',
+          'list_coordinate': '30005:${'aabbccdd' * 8}:literature',
+        };
+
+        final notification = RelayNotification.fromJson(json);
+
+        expect(notification.listTitle, equals('Literature'));
+        expect(
+          notification.listCoordinate,
+          equals('30005:${'aabbccdd' * 8}:literature'),
+        );
+      });
+
+      test('treats absent and empty list_add context as null', () {
+        final absent = RelayNotification.fromJson({
+          'id': 'notif_123',
+          'source_pubkey': 'aabbccdd' * 8,
+          'source_event_id': '11223344' * 8,
+          'source_kind': 30005,
+          'notification_type': 'list_add',
+          'created_at': 1712345678,
+          'read': false,
+        });
+        final empty = RelayNotification.fromJson({
+          'id': 'notif_123',
+          'source_pubkey': 'aabbccdd' * 8,
+          'source_event_id': '11223344' * 8,
+          'source_kind': 30005,
+          'notification_type': 'list_add',
+          'created_at': 1712345678,
+          'read': false,
+          'list_title': '',
+          'list_coordinate': '',
+        });
+
+        expect(absent.listTitle, isNull);
+        expect(absent.listCoordinate, isNull);
+        expect(empty.listTitle, isNull);
+        expect(empty.listCoordinate, isNull);
+      });
+
       test('parses thumbnail from referenced_video.thumbnail', () {
         final json = {
           'id': 'notif_123',

--- a/mobile/packages/models/lib/src/notification_item.dart
+++ b/mobile/packages/models/lib/src/notification_item.dart
@@ -25,6 +25,9 @@ enum NotificationKind {
   /// user's own content — it comes from a subscription list the user
   /// publishes. See `Nip51PeopleListCodec.notifyDTag`.
   newPost,
+
+  /// Someone added one of the user's videos to a public curated list.
+  listAdd,
 }
 
 /// Base for all displayable notifications.

--- a/mobile/packages/models/lib/src/video_notification.dart
+++ b/mobile/packages/models/lib/src/video_notification.dart
@@ -26,15 +26,18 @@ class VideoNotification extends NotificationItem {
     this.videoTitle,
     this.videoAddressableId,
     this.commentText,
+    this.listTitle,
+    this.listCoordinate,
   }) : assert(
          type == NotificationKind.like ||
              type == NotificationKind.likeComment ||
              type == NotificationKind.comment ||
              type == NotificationKind.mention ||
              type == NotificationKind.repost ||
-             type == NotificationKind.newPost,
+             type == NotificationKind.newPost ||
+             type == NotificationKind.listAdd,
          'VideoNotification only supports like, likeComment, comment, '
-         'mention, repost, newPost',
+         'mention, repost, newPost, listAdd',
        ),
        assert(actors.length > 0, 'must have at least one actor'),
        assert(
@@ -75,6 +78,12 @@ class VideoNotification extends NotificationItem {
   /// text.
   final String? commentText;
 
+  /// Title of the public curated list for [NotificationKind.listAdd].
+  final String? listTitle;
+
+  /// Full kind-30005 coordinate for the public curated list.
+  final String? listCoordinate;
+
   /// Returns a copy with the given fields replaced.
   VideoNotification copyWith({
     String? id,
@@ -88,6 +97,8 @@ class VideoNotification extends NotificationItem {
     DateTime? timestamp,
     bool? isRead,
     String? commentText,
+    String? listTitle,
+    String? listCoordinate,
     List<String>? sourceEventIds,
     List<String>? notificationIds,
   }) {
@@ -103,6 +114,8 @@ class VideoNotification extends NotificationItem {
       timestamp: timestamp ?? this.timestamp,
       isRead: isRead ?? this.isRead,
       commentText: commentText ?? this.commentText,
+      listTitle: listTitle ?? this.listTitle,
+      listCoordinate: listCoordinate ?? this.listCoordinate,
       sourceEventIds: sourceEventIds ?? this.sourceEventIds,
       notificationIds: notificationIds ?? this.notificationIds,
     );
@@ -121,6 +134,8 @@ class VideoNotification extends NotificationItem {
     timestamp,
     isRead,
     commentText,
+    listTitle,
+    listCoordinate,
     sourceEventIds,
     notificationIds,
   ];

--- a/mobile/packages/models/test/src/video_notification_test.dart
+++ b/mobile/packages/models/test/src/video_notification_test.dart
@@ -36,6 +36,25 @@ void main() {
         );
       });
 
+      test('accepts listAdd with curated-list context', () {
+        final notification = VideoNotification(
+          id: 'n1',
+          type: NotificationKind.listAdd,
+          videoEventId: 'v1',
+          actors: [actorAlice],
+          totalCount: 1,
+          timestamp: timestamp,
+          listTitle: 'Literature',
+          listCoordinate: '30005:${actorAlice.pubkey}:literature',
+        );
+
+        expect(notification.listTitle, equals('Literature'));
+        expect(
+          notification.listCoordinate,
+          equals('30005:${actorAlice.pubkey}:literature'),
+        );
+      });
+
       test('exposes optional commentText for comment kind', () {
         // Comment notifications carry an excerpt of the most recent
         // comment so the row can quote it under the message text.
@@ -167,6 +186,27 @@ void main() {
         final updated = original.copyWith(isRead: true);
 
         expect(updated.commentText, equals('Original comment'));
+      });
+
+      test('preserves list context when not overridden', () {
+        final original = VideoNotification(
+          id: 'n1',
+          type: NotificationKind.listAdd,
+          videoEventId: 'v1',
+          actors: [actorAlice],
+          totalCount: 1,
+          timestamp: timestamp,
+          listTitle: 'Literature',
+          listCoordinate: '30005:${actorAlice.pubkey}:literature',
+        );
+
+        final updated = original.copyWith(isRead: true);
+
+        expect(updated.listTitle, equals('Literature'));
+        expect(
+          updated.listCoordinate,
+          equals('30005:${actorAlice.pubkey}:literature'),
+        );
       });
     });
 

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -728,6 +728,10 @@ class NotificationRepository {
         timestamp: timestamp,
         isRead: row.isRead,
         commentText: videoKind == NotificationKind.comment ? row.content : null,
+        listTitle: videoKind == NotificationKind.listAdd ? row.content : null,
+        listCoordinate: videoKind == NotificationKind.listAdd
+            ? _nonEmpty(row.targetPubkey)
+            : null,
         notificationIds: row.id.isNotEmpty ? [row.id] : const [],
         // sourceEventIds intentionally empty — the cache stores only the
         // persisted row id and the videoEventId (`targetEventId`), not the
@@ -764,6 +768,7 @@ class NotificationRepository {
         'videoMention' => NotificationKind.mention,
         'repost' => NotificationKind.repost,
         'newPost' => NotificationKind.newPost,
+        'listAdd' => NotificationKind.listAdd,
         _ => null,
       };
 
@@ -812,6 +817,22 @@ class NotificationRepository {
       content,
       hasCommentTarget,
     ) = switch (item) {
+      VideoNotification(
+        type: NotificationKind.listAdd,
+        :final actors,
+        :final videoEventId,
+        :final videoAddressableId,
+        :final listTitle,
+        :final listCoordinate,
+      ) =>
+        (
+          actors.isNotEmpty ? actors.first.pubkey : '',
+          videoEventId,
+          videoAddressableId,
+          listCoordinate,
+          listTitle,
+          false,
+        ),
       VideoNotification(
         :final actors,
         :final videoEventId,
@@ -874,6 +895,7 @@ class NotificationRepository {
     NotificationKind.reply => 'reply',
     NotificationKind.system => 'system',
     NotificationKind.newPost => 'newPost',
+    NotificationKind.listAdd => 'listAdd',
   };
 
   static List<String>? _serverTypesForFilter(NotificationKind? filter) =>
@@ -886,8 +908,9 @@ class NotificationRepository {
         NotificationKind.mention => const ['mention'],
         NotificationKind.likeComment => const ['reaction', 'zap'],
         NotificationKind.reply => const ['reply'],
-        NotificationKind.system => const ['list_add'],
+        NotificationKind.system => const ['system'],
         NotificationKind.newPost => const ['newPost'],
+        NotificationKind.listAdd => const ['list_add'],
       };
 
   static final math.Random _jitter = math.Random();
@@ -1177,7 +1200,7 @@ class NotificationRepository {
     for (var i = 0; i < result.length; i++) {
       final item = result[i];
       if (item is VideoNotification) {
-        videoGroupIndex[(item.videoEventId, item.type)] = i;
+        videoGroupIndex[_snapshotVideoGroupKey(item)] = i;
       } else if (item is ActorNotification &&
           item.type == NotificationKind.follow) {
         followIndex[item.actor.pubkey] = i;
@@ -1188,7 +1211,7 @@ class NotificationRepository {
     // valid for the `result[idx] = …` merges below.
     for (final item in incoming) {
       if (item is VideoNotification) {
-        final idx = videoGroupIndex[(item.videoEventId, item.type)];
+        final idx = videoGroupIndex[_snapshotVideoGroupKey(item)];
         if (idx != null) {
           result[idx] = _mergeAppendedVideoGroup(
             result[idx] as VideoNotification,
@@ -1220,11 +1243,23 @@ class NotificationRepository {
       result.add(item);
       allSourceEventIds.addAll(item.sourceEventIds);
       allIds.add(item.id);
+      if (item is VideoNotification) {
+        videoGroupIndex[_snapshotVideoGroupKey(item)] = result.length - 1;
+      }
       if (item is ActorNotification && item.type == NotificationKind.follow) {
         followIndex[item.actor.pubkey] = result.length - 1;
       }
     }
     return result;
+  }
+
+  static (String, NotificationKind) _snapshotVideoGroupKey(
+    VideoNotification item,
+  ) {
+    final groupId = item.type == NotificationKind.listAdd
+        ? _nonEmpty(item.listCoordinate) ?? item.videoEventId
+        : item.videoEventId;
+    return (groupId, item.type);
   }
 
   static ActorNotification _mergeAppendedFollow(
@@ -1317,6 +1352,10 @@ class NotificationRepository {
       videoAddressableId:
           _nonEmpty(existing.videoAddressableId) ??
           _nonEmpty(incoming.videoAddressableId),
+      listTitle: _nonEmpty(existing.listTitle) ?? _nonEmpty(incoming.listTitle),
+      listCoordinate:
+          _nonEmpty(existing.listCoordinate) ??
+          _nonEmpty(incoming.listCoordinate),
       commentText: mergedCommentText,
     );
   }
@@ -1645,6 +1684,16 @@ class NotificationRepository {
           videoAddressableId: addressableId,
           videoThumbnailUrl: thumbnailUrl,
           videoTitle: videoTitle,
+          listTitle: entry.key.kind == NotificationKind.listAdd
+              ? group
+                    .map((n) => n.listTitle)
+                    .firstWhere((t) => t != null, orElse: () => null)
+              : null,
+          listCoordinate: entry.key.kind == NotificationKind.listAdd
+              ? group
+                    .map((n) => n.listCoordinate)
+                    .firstWhere((c) => c != null, orElse: () => null)
+              : null,
           actors: actors,
           totalCount: totalCount,
           timestamp: group.first.createdAt,
@@ -1668,7 +1717,8 @@ class NotificationRepository {
       kind == NotificationKind.like ||
       kind == NotificationKind.comment ||
       kind == NotificationKind.repost ||
-      kind == NotificationKind.newPost;
+      kind == NotificationKind.newPost ||
+      kind == NotificationKind.listAdd;
 
   static bool _isVideoAnchoredNotification(
     NotificationKind kind,
@@ -2195,6 +2245,7 @@ class NotificationRepository {
       'repost' => NotificationKind.repost,
       'mention' => NotificationKind.mention,
       'newPost' => NotificationKind.newPost,
+      'list_add' => NotificationKind.listAdd,
       'follow' || 'contact' => NotificationKind.follow,
       _ when n.sourceKind == 6 => NotificationKind.repost,
       _ when n.sourceKind == 16 => NotificationKind.repost,
@@ -2216,6 +2267,9 @@ class NotificationRepository {
   }) {
     if (kind == NotificationKind.mention && _isVideoSourcedMention(n)) {
       return _trustedSourceRootAddressableId(n, video: video) ?? eventId;
+    }
+    if (kind == NotificationKind.listAdd) {
+      return _nonEmpty(n.listCoordinate) ?? eventId;
     }
     return eventId;
   }
@@ -2269,6 +2323,9 @@ class NotificationRepository {
       if (n.rootEventId != null && n.rootEventId!.isNotEmpty) {
         return n.rootEventId;
       }
+    }
+    if (kind == NotificationKind.listAdd) {
+      return _nonEmpty(n.referencedEventId) ?? _nonEmpty(n.rootEventId);
     }
     return n.referencedEventId;
   }

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -137,6 +137,8 @@ void main() {
     bool isReferencedVideo = true,
     String? referencedVideoTitle,
     String? referencedVideoThumbnail,
+    String? listTitle,
+    String? listCoordinate,
   }) {
     return RelayNotification(
       id: id,
@@ -158,6 +160,8 @@ void main() {
       isReferencedVideo: isReferencedVideo,
       referencedVideoTitle: referencedVideoTitle,
       referencedVideoThumbnail: referencedVideoThumbnail,
+      listTitle: listTitle,
+      listCoordinate: listCoordinate,
     );
   }
 
@@ -395,6 +399,27 @@ void main() {
 
         final signedUri = Uri.parse(signedUrl);
         expect(signedUri.queryParameters['types'], equals('reaction,zap'));
+      });
+
+      test('maps list-add filter to list_add server type', () async {
+        var signedUrl = '';
+        repository = NotificationRepository(
+          funnelcakeApiClient: funnelcakeApiClient,
+          profileRepository: profileRepository,
+          notificationsDao: notificationsDao,
+          userPubkey: userPubkey,
+          authHeadersProvider: (url, method, {body}) async {
+            signedUrl = url;
+            return {'Authorization': 'Nostr test-token'};
+          },
+        );
+        stubNotifications([]);
+        stubProfiles({});
+
+        await repository.getNotifications(filter: NotificationKind.listAdd);
+
+        final signedUri = Uri.parse(signedUrl);
+        expect(signedUri.queryParameters['types'], equals('list_add'));
       });
 
       test('comment feed keeps comment-target mentions', () async {
@@ -836,6 +861,42 @@ void main() {
           ),
         ).called(1);
       });
+
+      test(
+        'persists listAdd cache fields without degrading to system',
+        () async {
+          const listCoordinate = '30005:pubkey_alice:literature';
+          stubProfiles({
+            'pubkey_alice': makeProfile('pubkey_alice', displayName: 'Alice'),
+          });
+          stubNotifications([
+            makeNotification(
+              id: 'list_add_1',
+              sourceKind: 30005,
+              notificationType: 'list_add',
+              referencedEventId: 'video_1',
+              listTitle: 'Literature',
+              listCoordinate: listCoordinate,
+            ),
+          ]);
+
+          await repository.refresh();
+
+          final rows =
+              verify(
+                    () => notificationsDao.replaceAll(
+                      captureAny(),
+                      ownerPubkey: any(named: 'ownerPubkey'),
+                    ),
+                  ).captured.single
+                  as List<NotificationCacheRow>;
+          final row = rows.singleWhere((r) => r.type != 'seen_marker');
+          expect(row.type, equals('listAdd'));
+          expect(row.targetEventId, equals('video_1'));
+          expect(row.targetPubkey, equals(listCoordinate));
+          expect(row.content, equals('Literature'));
+        },
+      );
 
       test('passes cursor for pagination', () async {
         stubNotifications([], nextCursor: 'cursor_abc', hasMore: true);
@@ -1575,6 +1636,76 @@ void main() {
         final page = await repository.getNotifications();
         final item = page.items.single as VideoNotification;
         expect(item.type, equals(NotificationKind.like));
+      });
+
+      test(
+        'list_add maps to video-anchored listAdd with list context',
+        () async {
+          const listCoordinate = '30005:pubkey_alice:literature';
+          stubNotifications([
+            makeNotification(
+              id: 'list_add_1',
+              sourceKind: 30005,
+              notificationType: 'list_add',
+              referencedEventId: 'video_1',
+              referencedDTag: 'vine-1',
+              listTitle: 'Literature',
+              listCoordinate: listCoordinate,
+            ),
+          ]);
+          stubProfiles({
+            'pubkey_alice': makeProfile('pubkey_alice', displayName: 'Alice'),
+          });
+
+          final page = await repository.getNotifications();
+
+          final item = page.items.single as VideoNotification;
+          expect(item.type, equals(NotificationKind.listAdd));
+          expect(item.videoEventId, equals('video_1'));
+          expect(item.videoAddressableId, equals('34236:$userPubkey:vine-1'));
+          expect(item.listTitle, equals('Literature'));
+          expect(item.listCoordinate, equals(listCoordinate));
+          expect(item.actors.single.displayName, equals('Alice'));
+        },
+      );
+
+      test('list_add groups multiple videos by list coordinate', () async {
+        const listCoordinate = '30005:pubkey_alice:literature';
+        stubNotifications([
+          makeNotification(
+            id: 'list_add_1',
+            sourceEventId: 'list_evt_1',
+            sourceKind: 30005,
+            notificationType: 'list_add',
+            referencedEventId: 'video_1',
+            listTitle: 'Literature',
+            listCoordinate: listCoordinate,
+            createdAt: DateTime(2026, 1, 2),
+          ),
+          makeNotification(
+            id: 'list_add_2',
+            sourceEventId: 'list_evt_2',
+            sourceKind: 30005,
+            notificationType: 'list_add',
+            referencedEventId: 'video_2',
+            listTitle: 'Literature',
+            listCoordinate: listCoordinate,
+            createdAt: DateTime(2026, 1, 1, 1),
+          ),
+        ]);
+        stubProfiles({
+          'pubkey_alice': makeProfile('pubkey_alice', displayName: 'Alice'),
+        });
+
+        final page = await repository.getNotifications();
+
+        final item = page.items.single as VideoNotification;
+        expect(item.type, equals(NotificationKind.listAdd));
+        expect(item.totalCount, equals(2));
+        expect(item.actors, hasLength(1));
+        expect(item.videoEventId, equals('video_1'));
+        expect(item.sourceEventIds, equals(['list_evt_1', 'list_evt_2']));
+        expect(item.notificationIds, equals(['list_add_1', 'list_add_2']));
       });
 
       test('reaction with a target comment maps to likeComment even when '
@@ -2855,6 +2986,53 @@ void main() {
               (p) => p.items.length == 1 && p.items.first.id == 'cached_1',
               'snapshot contains the hydrated row',
             ),
+          ),
+        );
+      });
+
+      test('hydrates listAdd rows with list context from cache', () async {
+        const listCoordinate = '30005:cached_actor:literature';
+        when(
+          () => notificationsDao.getAllNotifications(
+            limit: any(named: 'limit'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer(
+          (_) async => [
+            NotificationRow(
+              id: 'cached_list_add',
+              type: 'listAdd',
+              fromPubkey: 'cached_actor',
+              timestamp: 1700000000,
+              targetEventId: 'cached_video',
+              targetPubkey: listCoordinate,
+              content: 'Literature',
+              hasCommentTarget: false,
+              isRead: false,
+              cachedAt: DateTime(2026),
+            ),
+          ],
+        );
+
+        final hydrated = NotificationRepository(
+          funnelcakeApiClient: funnelcakeApiClient,
+          profileRepository: profileRepository,
+          notificationsDao: notificationsDao,
+          userPubkey: userPubkey,
+        );
+        addTearDown(hydrated.close);
+
+        await expectLater(
+          hydrated.watchSnapshot(),
+          emitsThrough(
+            predicate<NotificationPage>((p) {
+              if (p.items.singleOrNull case final VideoNotification item) {
+                return item.type == NotificationKind.listAdd &&
+                    item.listTitle == 'Literature' &&
+                    item.listCoordinate == listCoordinate;
+              }
+              return false;
+            }, 'snapshot contains hydrated listAdd row'),
           ),
         );
       });

--- a/mobile/test/goldens/widgets/notification_rows_golden_test.dart
+++ b/mobile/test/goldens/widgets/notification_rows_golden_test.dart
@@ -32,15 +32,16 @@ void main() {
         await _pumpScenario(
           tester,
           textScaleFactor: 1,
-          surfaceSize: const Size(420, 560),
+          surfaceSize: const Size(420, 680),
         );
 
         expect(find.byType(ActorNotificationRow), findsOneWidget);
-        expect(find.byType(VideoNotificationRow), findsOneWidget);
+        expect(find.byType(VideoNotificationRow), findsNWidgets(2));
         expect(find.text(_l10n.notificationFollowBack), findsOneWidget);
+        expect(find.textContaining('Literature'), findsOneWidget);
         expect(
           find.byType(NotificationVideoThumbnail),
-          findsOneWidget,
+          findsNWidgets(2),
           reason: 'Default layout should keep the thumbnail inline.',
         );
         final actorAvatar = find.descendant(
@@ -56,13 +57,15 @@ void main() {
           reason: 'Default layout should keep Follow back inline with avatar.',
         );
         final message = tester.getTopLeft(
-          find.descendant(
-            of: find.byType(VideoNotificationRow),
-            matching: find.textContaining('Alice'),
-          ),
+          find
+              .descendant(
+                of: find.byType(VideoNotificationRow),
+                matching: find.textContaining('Alice'),
+              )
+              .first,
         );
         final thumbnail = tester.getTopLeft(
-          find.byType(NotificationVideoThumbnail),
+          find.byType(NotificationVideoThumbnail).first,
         );
         expect(
           thumbnail.dy,
@@ -78,15 +81,16 @@ void main() {
         await _pumpScenario(
           tester,
           textScaleFactor: 2,
-          surfaceSize: const Size(420, 1200),
+          surfaceSize: const Size(420, 1400),
         );
 
         expect(find.byType(ActorNotificationRow), findsOneWidget);
-        expect(find.byType(VideoNotificationRow), findsOneWidget);
+        expect(find.byType(VideoNotificationRow), findsNWidgets(2));
         expect(find.text(_l10n.notificationFollowBack), findsOneWidget);
+        expect(find.textContaining('Literature'), findsOneWidget);
         expect(
           find.byType(NotificationVideoThumbnail),
-          findsOneWidget,
+          findsNWidgets(2),
           reason: 'Large-text layout should still render the thumbnail.',
         );
         final actorAvatar = find.descendant(
@@ -101,13 +105,15 @@ void main() {
           reason: 'Large-text layout should stack Follow back below avatar.',
         );
         final message = tester.getTopLeft(
-          find.descendant(
-            of: find.byType(VideoNotificationRow),
-            matching: find.textContaining('Alice'),
-          ),
+          find
+              .descendant(
+                of: find.byType(VideoNotificationRow),
+                matching: find.textContaining('Alice'),
+              )
+              .first,
         );
         final thumbnail = tester.getTopLeft(
-          find.byType(NotificationVideoThumbnail),
+          find.byType(NotificationVideoThumbnail).first,
         );
         expect(
           thumbnail.dy,
@@ -139,6 +145,19 @@ Widget _scenarioColumn({required double textScaleFactor}) {
     commentText:
         'This is a longer preview comment that should still render cleanly.',
   );
+  final listAddNotification = VideoNotification(
+    id: 'list-add-1',
+    type: NotificationKind.listAdd,
+    videoEventId:
+        '2222222222222222222222222222222222222222222222222222222222222222',
+    actors: const [_alice],
+    totalCount: 1,
+    timestamp: _notificationTimestamp,
+    videoTitle: 'A vine that found a new shelf',
+    listTitle: 'Literature',
+    listCoordinate:
+        '30005:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:literature',
+  );
 
   return Column(
     mainAxisSize: MainAxisSize.min,
@@ -157,6 +176,16 @@ Widget _scenarioColumn({required double textScaleFactor}) {
         textScaleFactor: textScaleFactor,
         child: VideoNotificationRow(
           notification: videoNotification,
+          onTap: () {},
+          onProfileTap: () {},
+          onThumbnailTap: () {},
+        ),
+      ),
+      const SizedBox(height: 16),
+      _scenario(
+        textScaleFactor: textScaleFactor,
+        child: VideoNotificationRow(
+          notification: listAddNotification,
           onTap: () {},
           onProfileTap: () {},
           onThumbnailTap: () {},

--- a/mobile/test/notifications/routing/notification_tap_target_test.dart
+++ b/mobile/test/notifications/routing/notification_tap_target_test.dart
@@ -33,6 +33,7 @@ void main() {
       NotificationKind.repost,
       NotificationKind.follow,
       NotificationKind.system,
+      NotificationKind.listAdd,
     ]) {
       test('is false for $kind', () {
         expect(notificationKindOpensComments(kind), isFalse);
@@ -60,6 +61,13 @@ void main() {
       expect(notificationKindFromPushType('newPost'), NotificationKind.newPost);
     });
 
+    test('maps the inbox list_add type', () {
+      expect(
+        notificationKindFromPushType('list_add'),
+        NotificationKind.listAdd,
+      );
+    });
+
     test('routes a newPost tap to the video, not the profile', () {
       expect(
         resolveNotificationTapTarget(
@@ -80,6 +88,31 @@ void main() {
       expect(notificationKindFromPushType('zap'), isNull);
       expect(notificationKindFromPushType(null), isNull);
       expect(notificationKindFromPushType(''), isNull);
+    });
+  });
+
+  group('listTargetFromCoordinate', () {
+    test('parses kind 30005 list coordinates', () {
+      expect(
+        listTargetFromCoordinate('30005:pubkey_alice:literature'),
+        const OpenListTarget(pubkey: 'pubkey_alice', listId: 'literature'),
+      );
+    });
+
+    test('keeps colons in the list d-tag', () {
+      expect(
+        listTargetFromCoordinate('30005:pubkey_alice:lit:erature'),
+        const OpenListTarget(pubkey: 'pubkey_alice', listId: 'lit:erature'),
+      );
+    });
+
+    test('rejects malformed and non-list coordinates', () {
+      expect(listTargetFromCoordinate(null), isNull);
+      expect(listTargetFromCoordinate(''), isNull);
+      expect(listTargetFromCoordinate('34236:pubkey:dtag'), isNull);
+      expect(listTargetFromCoordinate('30005::dtag'), isNull);
+      expect(listTargetFromCoordinate('30005:pubkey:'), isNull);
+      expect(listTargetFromCoordinate('not-a-coordinate'), isNull);
     });
   });
 
@@ -117,6 +150,31 @@ void main() {
         const OpenInboxTarget(),
       );
     });
+
+    test('listAdd with a valid list coordinate opens the list', () {
+      expect(
+        resolveNotificationTapTarget(
+          kind: NotificationKind.listAdd,
+          hasVideoTarget: true,
+          listCoordinate: '30005:pubkey_alice:literature',
+        ),
+        const OpenListTarget(pubkey: 'pubkey_alice', listId: 'literature'),
+      );
+    });
+
+    test(
+      'listAdd without a valid list coordinate falls back to video target',
+      () {
+        expect(
+          resolveNotificationTapTarget(
+            kind: NotificationKind.listAdd,
+            hasVideoTarget: true,
+            listCoordinate: '34236:pubkey_alice:video',
+          ),
+          const OpenVideoTarget(autoOpenComments: false),
+        );
+      },
+    );
 
     test(
       'like / repost with a video target open the video without comments',

--- a/mobile/test/notifications/widgets/notification_type_icon_spec_test.dart
+++ b/mobile/test/notifications/widgets/notification_type_icon_spec_test.dart
@@ -74,6 +74,13 @@ void main() {
       expect(spec.foreground, equals(VineTheme.accentBlue));
     });
 
+    test('listAdd uses listPlus on accentYellow', () {
+      final spec = notificationTypeIconSpec(NotificationKind.listAdd);
+      expect(spec.icon, equals(DivineIconName.listPlus));
+      expect(spec.background, equals(VineTheme.accentYellowBackground));
+      expect(spec.foreground, equals(VineTheme.accentYellow));
+    });
+
     test('system uses logo on the primary accent', () {
       final spec = notificationTypeIconSpec(NotificationKind.system);
       expect(spec.icon, equals(DivineIconName.logo));

--- a/mobile/test/notifications/widgets/video_notification_row_test.dart
+++ b/mobile/test/notifications/widgets/video_notification_row_test.dart
@@ -39,6 +39,8 @@ VideoNotification _video({
   String? videoThumbnailUrl,
   String? videoTitle,
   String? commentText,
+  String? listTitle,
+  String? listCoordinate,
   bool isRead = false,
 }) {
   return VideoNotification(
@@ -52,6 +54,8 @@ VideoNotification _video({
     videoThumbnailUrl: videoThumbnailUrl,
     videoTitle: videoTitle,
     commentText: commentText,
+    listTitle: listTitle,
+    listCoordinate: listCoordinate,
     isRead: isRead,
   );
 }
@@ -170,6 +174,49 @@ void main() {
             '${_l10n.notificationOthersCount(49)} $verb',
           ),
           findsOneWidget,
+        );
+      });
+
+      testWidgets('listAdd message names the curated list', (tester) async {
+        await _pump(
+          tester,
+          notification: _video(
+            type: NotificationKind.listAdd,
+            listTitle: 'Literature',
+            listCoordinate: '30005:${_alice.pubkey}:literature',
+          ),
+        );
+
+        expect(
+          find.textContaining(
+            _l10n.notificationAddedYourVideoToList('Alice', 'Literature'),
+          ),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('grouped listAdd counts videos, not other actors', (
+        tester,
+      ) async {
+        await _pump(
+          tester,
+          notification: _video(
+            type: NotificationKind.listAdd,
+            totalCount: 3,
+            listTitle: 'Literature',
+            listCoordinate: '30005:${_alice.pubkey}:literature',
+          ),
+        );
+
+        expect(
+          find.textContaining(
+            _l10n.notificationAddedYourVideosToList('Alice', 3, 'Literature'),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.textContaining(_l10n.notificationOthersCount(2)),
+          findsNothing,
         );
       });
 


### PR DESCRIPTION
## Summary
- add list_add DTO/domain parsing and preserve list context through notification repository caching/grouping
- render list-add notification rows with list title copy and a listPlus icon
- route list_add taps to /list/:pubkey/:listId via the public curated-list coordinate

Closes #6391

## Verification
- flutter analyze lib test (mobile)
- flutter analyze lib test (packages/funnelcake_api_client)
- flutter analyze lib test (packages/models)
- flutter analyze lib test (packages/notification_repository)
- flutter test test/notifications/routing/notification_tap_target_test.dart test/notifications/widgets/notification_type_icon_spec_test.dart test/notifications/widgets/video_notification_row_test.dart test/l10n/arb_consistency_test.dart test/goldens/widgets/notification_rows_golden_test.dart (mobile)
- flutter test test/src/models/relay_notification_test.dart (packages/funnelcake_api_client)
- flutter test test/src/video_notification_test.dart (packages/models)
- flutter test test/src/notification_repository_test.dart (packages/notification_repository)
- scripts/golden.sh verify test/goldens/widgets/notification_rows_golden_test.dart
- pre-push hook: analyze and changed-file tests