### PR TITLE
fix(account): purge Hive pending uploads on destructive cleanup

### DIFF
--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -69,6 +69,12 @@ const _relayRepairTimeout = Duration(seconds: 15);
 
 typedef PendingUploadOwnerCleanup = Future<int> Function(String ownerPubkey);
 
+final openVineImageCacheClearProvider = Provider<Future<void> Function()>((
+  ref,
+) {
+  return clearOpenVineImageCache;
+});
+
 final pendingUploadOwnerCleanupProvider = Provider<PendingUploadOwnerCleanup>((
   ref,
 ) {
@@ -689,7 +695,7 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
           () => ref.read(dmRepositoryProvider).stopListening(),
         );
         try {
-          await clearOpenVineImageCache();
+          await ref.read(openVineImageCacheClearProvider)();
           ref
               .read(adultMediaAccessRevocationVersionProvider.notifier)
               .increment();

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -38,6 +38,7 @@ import 'package:openvine/services/pending_action_service.dart';
 import 'package:openvine/services/product_event_queue.dart';
 import 'package:openvine/services/profile_save_retry_service.dart';
 import 'package:openvine/services/social_service.dart';
+import 'package:openvine/services/upload/pending_upload_store.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/services/view_event_retry_service.dart';
@@ -65,6 +66,25 @@ Stream<void> _dmRetryConnectivityTriggerStream() => Connectivity()
 /// must not starve the retry sweep indefinitely — on timeout the sweep runs
 /// and the SDK's own OK-timeout remediation backstops any still-stale socket.
 const _relayRepairTimeout = Duration(seconds: 15);
+
+typedef PendingUploadOwnerCleanup = Future<int> Function(String ownerPubkey);
+
+final pendingUploadOwnerCleanupProvider = Provider<PendingUploadOwnerCleanup>((
+  ref,
+) {
+  return (ownerPubkey) async {
+    final store = PendingUploadStore(
+      scopeUploadsToCurrentUser: false,
+      currentNostrPubkey: null,
+    );
+    try {
+      await store.open();
+      return store.deleteAllForOwner(ownerPubkey);
+    } finally {
+      store.disposeStore();
+    }
+  };
+});
 
 /// Connectivity trigger for the message retry sweep: fires on EVERY
 /// connectivity transition, including `→ none`. [OutgoingDmRetryService] runs
@@ -649,11 +669,25 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
   // those rows are already scoped by ownerPubkey.
   service.onDatabaseCleanup =
       ({String? userPubkey, bool deleteUserData = false}) async {
-        try {
-          await ref.read(dmRepositoryProvider).stopListening();
-        } catch (_) {
-          // DmRepository may not exist yet (e.g., first launch).
+        Future<void> safeCleanup(
+          String name,
+          Future<void> Function() fn,
+        ) async {
+          try {
+            await fn();
+          } catch (e) {
+            Log.warning(
+              'Failed to clean $name for ${userPubkey ?? "unknown user"}: $e',
+              name: 'UserDataCleanup',
+              category: LogCategory.auth,
+            );
+          }
         }
+
+        await safeCleanup(
+          'dmRepository',
+          () => ref.read(dmRepositoryProvider).stopListening(),
+        );
         try {
           await clearOpenVineImageCache();
           ref
@@ -666,26 +700,35 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
             category: LogCategory.auth,
           );
         }
-        await db.directMessagesDao.clearAll();
-        await db.conversationsDao.clearAll();
+        await safeCleanup('directMessages', db.directMessagesDao.clearAll);
+        await safeCleanup('conversations', db.conversationsDao.clearAll);
         // Raw failed-decrypt gift wraps are encrypted DM data of the same
         // class as direct_messages — wipe them on the same path so they never
         // outlive the account's decrypted DMs. See #5202.
-        await db.pendingGiftWrapsDao.clearAll();
+        await safeCleanup('pendingGiftWraps', db.pendingGiftWrapsDao.clearAll);
         // Wipe the processed-wrap dedup ledger on the same path: a stale ledger
         // must never suppress re-population of an account's reactions/deletions
         // after its DM data is cleared. See #5452.
-        await db.processedGiftWrapsDao.clearAll();
+        await safeCleanup(
+          'processedGiftWraps',
+          db.processedGiftWrapsDao.clearAll,
+        );
         // Scoped to the leaving account so a switch does not wipe the other
         // account's cached inbox along with this one's.
-        await db.notificationsDao.clearAll(ownerPubkey: userPubkey);
+        await safeCleanup(
+          'notifications',
+          () => db.notificationsDao.clearAll(ownerPubkey: userPubkey),
+        );
         // Issue #3936 requires the NIP-39 identity caches to clear on logout
         // and account switches rather than persisting across identities.
-        await db.identityEventsDao.clearAll();
-        await db.identityVerificationsDao.clearAll();
+        await safeCleanup('identityEvents', db.identityEventsDao.clearAll);
+        await safeCleanup(
+          'identityVerifications',
+          db.identityVerificationsDao.clearAll,
+        );
         // Clear DM sync cursors so the next login triggers a full re-fetch
         // from relays instead of using stale `since:` boundaries.
-        await DmSyncState(prefs).clearAll();
+        await safeCleanup('dmSyncState', () => DmSyncState(prefs).clearAll());
 
         // Per-user data cleanup (#2999): only on destructive paths
         if (deleteUserData && userPubkey != null) {
@@ -715,6 +758,10 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
           await safeDelete(
             'pendingUploads',
             () => db.pendingUploadsDao.deleteAllForUser(userPubkey),
+          );
+          await safeDelete(
+            'pendingUploadsHive',
+            () => ref.read(pendingUploadOwnerCleanupProvider)(userPubkey),
           );
           await safeDelete(
             'personalReactions',

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -20,6 +20,7 @@ import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/relay_providers.dart';
 import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/providers/upload_media_providers.dart';
 import 'package:openvine/providers/video_providers.dart';
 import 'package:openvine/services/analytics_ingest_client.dart';
 import 'package:openvine/services/analytics_service.dart';
@@ -38,7 +39,6 @@ import 'package:openvine/services/pending_action_service.dart';
 import 'package:openvine/services/product_event_queue.dart';
 import 'package:openvine/services/profile_save_retry_service.dart';
 import 'package:openvine/services/social_service.dart';
-import 'package:openvine/services/upload/pending_upload_store.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/services/view_event_retry_service.dart';
@@ -78,18 +78,8 @@ final openVineImageCacheClearProvider = Provider<Future<void> Function()>((
 final pendingUploadOwnerCleanupProvider = Provider<PendingUploadOwnerCleanup>((
   ref,
 ) {
-  return (ownerPubkey) async {
-    final store = PendingUploadStore(
-      scopeUploadsToCurrentUser: false,
-      currentNostrPubkey: null,
-    );
-    try {
-      await store.open();
-      return store.deleteAllForOwner(ownerPubkey);
-    } finally {
-      store.disposeStore();
-    }
-  };
+  return (ownerPubkey) =>
+      ref.read(uploadManagerProvider).deleteAllForOwner(ownerPubkey);
 });
 
 /// Connectivity trigger for the message retry sweep: fires on EVERY

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -626,7 +626,7 @@ final class UserDataCleanupServiceProvider
 }
 
 String _$userDataCleanupServiceHash() =>
-    r'8da4c0c036d38d3b84b67ea082c63a4fdc344441';
+    r'e3db9dbf75857e3f814c04eea2026f74498aff64';
 
 /// Hashtag service depends on Video event service and cache service
 

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -626,7 +626,7 @@ final class UserDataCleanupServiceProvider
 }
 
 String _$userDataCleanupServiceHash() =>
-    r'e3db9dbf75857e3f814c04eea2026f74498aff64';
+    r'd6f753049d1ee1e217e24b5841c04fc5046af72f';
 
 /// Hashtag service depends on Video event service and cache service
 

--- a/mobile/lib/services/cache_recovery_service.dart
+++ b/mobile/lib/services/cache_recovery_service.dart
@@ -135,6 +135,11 @@ class CacheRecoveryService {
     'database',
   ];
 
+  static const List<List<String>> _durablePendingUploadsBoxSegments = [
+    ['openvine', 'pending_uploads.hive'],
+    ['openvine', 'pending_uploads.lock'],
+  ];
+
   /// Clear app support directory (NOT Documents - that's sandboxed on macOS),
   /// preserving the durable database directory (see [_durableDatabaseDirSegments]).
   static Future<int> _clearAppSupportDirectory() async {
@@ -145,9 +150,14 @@ class CacheRecoveryService {
         appSupportDir.path,
         ..._durableDatabaseDirSegments,
       ]);
+      final protectedPendingUploadsPaths = [
+        for (final segments in _durablePendingUploadsBoxSegments)
+          p.joinAll([appSupportDir.path, ...segments]),
+      ];
       return await deleteDirectoryContentsExcept(
         appSupportDir,
         protectedPath: protectedPath,
+        additionalProtectedPaths: protectedPendingUploadsPaths,
       );
     } catch (e) {
       Log.warning(
@@ -172,23 +182,31 @@ class CacheRecoveryService {
   static Future<int> deleteDirectoryContentsExcept(
     Directory dir, {
     required String protectedPath,
+    List<String> additionalProtectedPaths = const [],
   }) async {
-    // Only apply protection when the path actually exists; otherwise there is
-    // nothing to preserve and ancestors should be cleared like anything else.
-    final protect = Directory(protectedPath).existsSync();
-    if (protect && p.equals(dir.path, protectedPath)) {
+    final protectedPaths = [
+      protectedPath,
+      ...additionalProtectedPaths,
+    ].where(_pathExists).toList();
+    if (protectedPaths.any((path) => p.equals(dir.path, path))) {
       return 0;
     }
     var cleared = 0;
     for (final entity in dir.listSync()) {
       final path = entity.path;
-      if (protect && p.equals(path, protectedPath)) {
+      if (protectedPaths.any(
+        (protectedPath) => p.equals(path, protectedPath),
+      )) {
         continue;
       }
-      if (protect && entity is Directory && p.isWithin(path, protectedPath)) {
+      if (entity is Directory &&
+          protectedPaths.any(
+            (protectedPath) => p.isWithin(path, protectedPath),
+          )) {
         cleared += await deleteDirectoryContentsExcept(
           entity,
-          protectedPath: protectedPath,
+          protectedPath: protectedPaths.first,
+          additionalProtectedPaths: protectedPaths.skip(1).toList(),
         );
         continue;
       }
@@ -205,6 +223,9 @@ class CacheRecoveryService {
     }
     return cleared;
   }
+
+  static bool _pathExists(String path) =>
+      FileSystemEntity.typeSync(path) != FileSystemEntityType.notFound;
 
   /// Clear temporary files directory
   static Future<int> _clearTempDirectory() async {

--- a/mobile/lib/services/cache_recovery_service.dart
+++ b/mobile/lib/services/cache_recovery_service.dart
@@ -67,7 +67,6 @@ class CacheRecoveryService {
         'personal_events',
         'personal_events_metadata',
         'bookmarks',
-        'pending_uploads',
         'video_cache',
         'secure_keys',
       ];
@@ -117,6 +116,9 @@ class CacheRecoveryService {
 
     return cleared;
   }
+
+  @visibleForTesting
+  static Future<int> clearHiveBoxesForTesting() => _clearHiveBoxes();
 
   /// Durable database directory under Application Support that must NEVER be
   /// deleted by cache clearing. It holds the live SQLite database

--- a/mobile/lib/services/upload/pending_upload_store.dart
+++ b/mobile/lib/services/upload/pending_upload_store.dart
@@ -187,6 +187,39 @@ class PendingUploadStore {
     await _box!.delete(id);
   }
 
+  /// Delete every upload persisted for [ownerPubkey].
+  ///
+  /// This is intentionally not owner-scoped to [currentNostrPubkey]: destructive
+  /// account cleanup passes the departing account explicitly, and must work even
+  /// after provider auth state has moved on.
+  Future<int> deleteAllForOwner(String ownerPubkey) async {
+    final queueIds = _pendingSaveQueue.entries
+        .where((entry) => entry.value.nostrPubkey == ownerPubkey)
+        .map((entry) => entry.key)
+        .toList();
+    for (final id in queueIds) {
+      _pendingSaveQueue.remove(id);
+    }
+    if (_pendingSaveQueue.isEmpty) {
+      _saveQueueTimer?.cancel();
+      _saveQueueTimer = null;
+    }
+
+    if (_box == null || !_box!.isOpen) {
+      await ensureOpen();
+    }
+    if (_box == null || !_box!.isOpen) return 0;
+
+    final uploadIds = _allUploads
+        .where((upload) => upload.nostrPubkey == ownerPubkey)
+        .map((upload) => upload.id)
+        .toList();
+    for (final id in uploadIds) {
+      await _box!.delete(id);
+    }
+    return uploadIds.length;
+  }
+
   // ---------------------------------------------------------------------------
   // Deferred-save queue
   // ---------------------------------------------------------------------------

--- a/mobile/lib/services/upload/pending_upload_store.dart
+++ b/mobile/lib/services/upload/pending_upload_store.dart
@@ -206,7 +206,16 @@ class PendingUploadStore {
     }
 
     if (_box == null || !_box!.isOpen) {
-      await ensureOpen();
+      try {
+        await ensureOpen();
+      } catch (e) {
+        Log.warning(
+          'Unable to open pending uploads box for owner cleanup: $e',
+          name: 'UploadManager',
+          category: LogCategory.video,
+        );
+        return 0;
+      }
     }
     if (_box == null || !_box!.isOpen) return 0;
 
@@ -334,6 +343,13 @@ class PendingUploadStore {
     if (!scopeUploadsToCurrentUser) return uploads;
     return uploads.where(_isVisibleToCurrentOwner).toList();
   }
+
+  /// All uploads persisted for [ownerPubkey], ignoring current-user scoping.
+  ///
+  /// Destructive account cleanup passes the departing owner explicitly and can
+  /// run after auth state has already moved to another account.
+  List<PendingUpload> uploadsForOwner(String ownerPubkey) =>
+      _allUploads.where((upload) => upload.nostrPubkey == ownerPubkey).toList();
 
   bool _isVisibleToCurrentOwner(PendingUpload upload) {
     if (!scopeUploadsToCurrentUser) return true;

--- a/mobile/lib/services/upload/upload_retry_policy.dart
+++ b/mobile/lib/services/upload/upload_retry_policy.dart
@@ -24,6 +24,7 @@ class UploadRetryPolicy {
 
   final Map<String, Future<void>> _sessionPersistFutures = {};
   final Map<String, Completer<void>> _backoffWakeCompleters = {};
+  final Set<String> _discardedUploadIds = <String>{};
   bool _isDisposed = false;
 
   // ---------------------------------------------------------------------------
@@ -36,6 +37,7 @@ class UploadRetryPolicy {
     required bool Function(dynamic) isRetriable,
   }) async {
     if (_isDisposed) return;
+    if (_discardedUploadIds.contains(upload.id)) return;
 
     // Local-only counter for how many auto-attempts have been made in this
     // call. Must NOT be persisted to Hive: PendingUpload.retryCount is the
@@ -46,8 +48,10 @@ class UploadRetryPolicy {
 
     try {
       while (!_isDisposed && autoAttempt <= _retryConfig.maxRetries) {
+        if (_discardedUploadIds.contains(upload.id)) return;
         try {
           await drainSessionPersist(upload.id);
+          if (_discardedUploadIds.contains(upload.id)) return;
           final currentUpload = _store.getUpload(upload.id) ?? upload;
 
           // autoAttempt is local to this performWithRetry invocation and is
@@ -59,6 +63,7 @@ class UploadRetryPolicy {
             category: LogCategory.video,
           );
 
+          if (_discardedUploadIds.contains(upload.id)) return;
           await _store.update(
             currentUpload.copyWith(
               status: autoAttempt == 1
@@ -112,7 +117,7 @@ class UploadRetryPolicy {
           );
 
           await _waitForBackoff(upload.id, delay);
-          if (_isDisposed) return;
+          if (_isDisposed || _discardedUploadIds.contains(upload.id)) return;
         }
       }
     } catch (e) {
@@ -138,14 +143,27 @@ class UploadRetryPolicy {
   bool isWaitingForBackoff(String uploadId) =>
       _backoffWakeCompleters.containsKey(uploadId);
 
+  void discardUploads(Iterable<String> uploadIds) {
+    for (final uploadId in uploadIds) {
+      _discardedUploadIds.add(uploadId);
+      final completer = _backoffWakeCompleters.remove(uploadId);
+      if (completer != null && !completer.isCompleted) {
+        completer.complete();
+      }
+      _sessionPersistFutures.remove(uploadId);
+    }
+  }
+
   void enqueueSessionPersist(
     String uploadId,
     BlossomResumableUploadSession session,
     int fileSizeBytes,
   ) {
+    if (_discardedUploadIds.contains(uploadId)) return;
     final previous = _sessionPersistFutures[uploadId] ?? Future<void>.value();
     final persistFuture = previous.then((_) async {
       try {
+        if (_discardedUploadIds.contains(uploadId)) return;
         await _storeResumableSessionProgress(uploadId, session, fileSizeBytes);
       } catch (e, s) {
         Log.error(
@@ -168,6 +186,7 @@ class UploadRetryPolicy {
   }
 
   Future<void> drainSessionPersist(String uploadId) async {
+    if (_discardedUploadIds.contains(uploadId)) return;
     await (_sessionPersistFutures[uploadId] ?? Future<void>.value());
   }
 
@@ -214,6 +233,7 @@ class UploadRetryPolicy {
     String uploadId, {
     required Future<void> Function(PendingUpload) performUpload,
   }) {
+    if (_discardedUploadIds.contains(uploadId)) return;
     final upload = _store.getUpload(uploadId);
     if (upload == null) return;
     if (upload.status != UploadStatus.uploading &&
@@ -396,6 +416,7 @@ class UploadRetryPolicy {
     }
     _backoffWakeCompleters.clear();
     _sessionPersistFutures.clear();
+    _discardedUploadIds.clear();
   }
 
   // ---------------------------------------------------------------------------
@@ -429,6 +450,7 @@ class UploadRetryPolicy {
     BlossomResumableUploadSession session,
     int fileSizeBytes,
   ) async {
+    if (_discardedUploadIds.contains(uploadId)) return;
     final upload = _store.getUpload(uploadId);
     if (upload == null) return;
 
@@ -445,6 +467,7 @@ class UploadRetryPolicy {
         ? upload.uploadProgress
         : math.max(checkpoint, upload.uploadProgress ?? 0.0);
 
+    if (_discardedUploadIds.contains(uploadId)) return;
     await _store.update(
       upload.copyWith(
         resumableSession: session,

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -368,6 +368,10 @@ class UploadManager implements BackgroundAwareService {
   PendingUpload? getUploadByFilePath(String filePath) =>
       _store.getUploadByFilePath(filePath);
 
+  /// Delete all persisted uploads belonging to [ownerPubkey].
+  Future<int> deleteAllForOwner(String ownerPubkey) =>
+      _store.deleteAllForOwner(ownerPubkey);
+
   /// Finds a reusable upload for the given video file path.
   ///
   /// Returns the most recent upload matching [filePath] that is in a

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -249,6 +249,11 @@ class UploadManager implements BackgroundAwareService {
   // upload pipelines for the same PendingUpload.
   final Map<String, Future<void>> _inFlightUploads = <String, Future<void>>{};
 
+  // Owners whose local pending-upload state was destructively purged during
+  // account cleanup. Late callbacks from already-started uploads must not
+  // recreate rows for accounts that have just been removed.
+  final Set<String> _purgedUploadOwners = <String>{};
+
   // Re-entrancy latch for [_recoverStuckUploads]; startup and app-resume
   // recovery can run close together while missing-file updates are awaiting.
   bool _isRecovering = false;
@@ -369,8 +374,37 @@ class UploadManager implements BackgroundAwareService {
       _store.getUploadByFilePath(filePath);
 
   /// Delete all persisted uploads belonging to [ownerPubkey].
-  Future<int> deleteAllForOwner(String ownerPubkey) =>
-      _store.deleteAllForOwner(ownerPubkey);
+  Future<int> deleteAllForOwner(String ownerPubkey) async {
+    _purgedUploadOwners.add(ownerPubkey);
+    final uploads = _store.uploadsForOwner(ownerPubkey);
+    final uploadIds = uploads.map((upload) => upload.id).toSet();
+
+    _retryPolicy.discardUploads(uploadIds);
+    for (final uploadId in uploadIds) {
+      _userStoppedUploadIds.add(uploadId);
+      _reporter.cancelAndRemoveSubscription(uploadId);
+      _processingPollTimers.remove(uploadId)?.cancel();
+    }
+
+    if (useBackgroundUpload) {
+      for (final uploadId in uploadIds) {
+        try {
+          await _blossomService.cancelBackgroundUpload(uploadId);
+        } catch (e) {
+          Log.warning(
+            'Failed to cancel upload $uploadId during owner cleanup: $e',
+            name: 'UploadManager',
+            category: LogCategory.video,
+          );
+        }
+      }
+    }
+
+    return _store.deleteAllForOwner(ownerPubkey);
+  }
+
+  bool _isPurgedOwnerUpload(PendingUpload upload) =>
+      _purgedUploadOwners.contains(upload.nostrPubkey);
 
   /// Finds a reusable upload for the given video file path.
   ///
@@ -775,6 +809,12 @@ class UploadManager implements BackgroundAwareService {
     try {
       await _performUpload(upload, onProgress: onProgress);
 
+      if (_isPurgedOwnerUpload(upload)) {
+        throw StateError(
+          'Upload was purged during account cleanup: ${upload.id}',
+        );
+      }
+
       // Fetch the updated upload with videoId and cdnUrl populated
       final completedUpload = getUpload(upload.id);
       if (completedUpload == null) {
@@ -807,6 +847,7 @@ class UploadManager implements BackgroundAwareService {
     PendingUpload upload, {
     ValueChanged<double>? onProgress,
   }) async {
+    if (_isPurgedOwnerUpload(upload)) return;
     final existing = _inFlightUploads[upload.id];
     if (existing != null) {
       Log.info(
@@ -947,7 +988,9 @@ class UploadManager implements BackgroundAwareService {
     ValueChanged<double>? onProgress,
   ) async {
     await _retryPolicy.performWithRetry(upload, () async {
+      if (_isPurgedOwnerUpload(upload)) return;
       final currentUpload = _store.getUpload(upload.id) ?? upload;
+      if (_isPurgedOwnerUpload(currentUpload)) return;
 
       // Validate file still exists
       if (!videoFile.existsSync()) {
@@ -1215,6 +1258,7 @@ class UploadManager implements BackgroundAwareService {
     final metrics = _reporter.metricsFor(upload.id);
 
     if (result.success == true) {
+      if (_isPurgedOwnerUpload(upload)) return;
       if (_userStoppedUploadIds.contains(upload.id)) {
         Log.info(
           'Upload ${upload.id} stopped by user; ignoring late success result',
@@ -1226,6 +1270,7 @@ class UploadManager implements BackgroundAwareService {
 
       // Get the LATEST upload record from Hive (may have been updated with thumbnail URL)
       final latestUpload = getUpload(upload.id) ?? upload;
+      if (_isPurgedOwnerUpload(latestUpload)) return;
 
       // Create updated upload with success metadata
       final updatedUpload = createSuccessfulUpload(latestUpload, result);
@@ -1266,6 +1311,7 @@ class UploadManager implements BackgroundAwareService {
     final endTime = DateTime.now();
     final metrics = _reporter.metricsFor(upload.id);
     final latestUpload = getUpload(upload.id) ?? upload;
+    if (_isPurgedOwnerUpload(latestUpload)) return;
 
     // Check network connectivity and categorize error
     final connectivity = await _reporter.checkNetworkConnectivity();
@@ -1535,6 +1581,7 @@ class UploadManager implements BackgroundAwareService {
         }
         // A user just paused/cancelled; leave the authoritative status alone.
         if (_userStoppedUploadIds.contains(upload.id)) continue;
+        if (_isPurgedOwnerUpload(upload)) continue;
 
         if (!File(upload.localVideoPath).existsSync()) {
           // The source file is gone (e.g. temp cleared by the OS), so resume
@@ -1931,6 +1978,7 @@ class UploadManager implements BackgroundAwareService {
       if (result.cdnUrl != null || result.blurhash != null) {
         try {
           final current = _store.getUpload(upload.id) ?? upload;
+          if (_isPurgedOwnerUpload(current)) return result;
           await _store.update(
             current.copyWith(
               thumbnailPath: result.cdnUrl ?? current.thumbnailPath,

--- a/mobile/test/mocks/mock_path_provider_platform.dart
+++ b/mobile/test/mocks/mock_path_provider_platform.dart
@@ -10,6 +10,7 @@ class MockPathProviderPlatform
   String? _temporaryPath;
   String? _applicationDocumentsPath;
   String? _applicationSupportPath;
+  String? _applicationCachePath;
 
   void setTemporaryPath(String path) {
     _temporaryPath = path;
@@ -21,6 +22,10 @@ class MockPathProviderPlatform
 
   void setApplicationSupportPath(String path) {
     _applicationSupportPath = path;
+  }
+
+  void setApplicationCachePath(String path) {
+    _applicationCachePath = path;
   }
 
   @override
@@ -40,7 +45,7 @@ class MockPathProviderPlatform
 
   @override
   Future<String?> getApplicationCachePath() async {
-    return null;
+    return _applicationCachePath;
   }
 
   @override

--- a/mobile/test/providers/social_providers_cleanup_test.dart
+++ b/mobile/test/providers/social_providers_cleanup_test.dart
@@ -1,0 +1,121 @@
+// ABOUTME: Regression tests for account cleanup provider wiring.
+// ABOUTME: Ensures destructive cleanup reaches the live Hive upload store.
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' as model;
+import 'package:openvine/providers/database_provider.dart';
+import 'package:openvine/providers/repository_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/providers/social_providers.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/test_helpers.dart';
+
+class _MockDmRepository extends Mock implements DmRepository {}
+
+const _pubkeyA =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _pubkeyB =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+void main() {
+  group(userDataCleanupServiceProvider, () {
+    late AppDatabase db;
+    late SharedPreferences prefs;
+    late _MockDmRepository dmRepository;
+    late List<String> purgedUploadOwners;
+    late ProviderContainer container;
+
+    setUpAll(() async {
+      await initializeServiceTestEnvironment();
+    });
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      prefs = await SharedPreferences.getInstance();
+      db = AppDatabase.test(NativeDatabase.memory());
+      dmRepository = _MockDmRepository();
+      purgedUploadOwners = [];
+      when(() => dmRepository.stopListening()).thenAnswer((_) async {});
+
+      container = ProviderContainer(
+        overrides: [
+          databaseProvider.overrideWithValue(db),
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          dmRepositoryProvider.overrideWithValue(dmRepository),
+          pendingUploadOwnerCleanupProvider.overrideWithValue((ownerPubkey) {
+            purgedUploadOwners.add(ownerPubkey);
+            return Future.value(1);
+          }),
+        ],
+      );
+    });
+
+    tearDown(() async {
+      container.dispose();
+      await db.close();
+    });
+
+    test(
+      'destructive cleanup purges Hive uploads for the departing user',
+      () async {
+        await db.pendingUploadsDao.upsertUpload(
+          model.PendingUpload.create(
+            localVideoPath: '/tmp/a.mp4',
+            nostrPubkey: _pubkeyA,
+          ),
+        );
+        await db.pendingUploadsDao.upsertUpload(
+          model.PendingUpload.create(
+            localVideoPath: '/tmp/b.mp4',
+            nostrPubkey: _pubkeyB,
+          ),
+        );
+
+        final subscription = container.listen(
+          userDataCleanupServiceProvider,
+          (_, _) {},
+        );
+        addTearDown(subscription.close);
+        final service = subscription.read();
+
+        expect(service.onDatabaseCleanup, isNotNull);
+        await service.onDatabaseCleanup!(
+          userPubkey: _pubkeyA,
+          deleteUserData: true,
+        );
+
+        expect(
+          await db.pendingUploadsDao.getAllUploads(ownerPubkey: _pubkeyA),
+          isEmpty,
+        );
+        final remainingDriftUploads = await db.pendingUploadsDao.getAllUploads(
+          ownerPubkey: _pubkeyB,
+        );
+        expect(remainingDriftUploads, hasLength(1));
+        expect(purgedUploadOwners, [_pubkeyA]);
+      },
+    );
+
+    test('non-destructive cleanup preserves pending uploads', () async {
+      final subscription = container.listen(
+        userDataCleanupServiceProvider,
+        (_, _) {},
+      );
+      addTearDown(subscription.close);
+      final service = subscription.read();
+
+      expect(service.onDatabaseCleanup, isNotNull);
+      await service.onDatabaseCleanup!(
+        userPubkey: _pubkeyA,
+      );
+
+      expect(purgedUploadOwners, isEmpty);
+    });
+  });
+}

--- a/mobile/test/providers/social_providers_cleanup_test.dart
+++ b/mobile/test/providers/social_providers_cleanup_test.dart
@@ -48,6 +48,7 @@ void main() {
           databaseProvider.overrideWithValue(db),
           sharedPreferencesProvider.overrideWithValue(prefs),
           dmRepositoryProvider.overrideWithValue(dmRepository),
+          openVineImageCacheClearProvider.overrideWithValue(() async {}),
           pendingUploadOwnerCleanupProvider.overrideWithValue((ownerPubkey) {
             purgedUploadOwners.add(ownerPubkey);
             return Future.value(1);

--- a/mobile/test/providers/social_providers_cleanup_test.dart
+++ b/mobile/test/providers/social_providers_cleanup_test.dart
@@ -1,22 +1,33 @@
 // ABOUTME: Regression tests for account cleanup provider wiring.
 // ABOUTME: Ensures destructive cleanup reaches the live Hive upload store.
 
+import 'dart:io';
+
+import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:db_client/db_client.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' as model;
+import 'package:openvine/models/pending_upload.dart' as hive_model;
 import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/social_providers.dart';
+import 'package:openvine/providers/upload_media_providers.dart';
+import 'package:openvine/services/upload_manager.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../helpers/test_helpers.dart';
+import '../mocks/mock_path_provider_platform.dart';
 
 class _MockDmRepository extends Mock implements DmRepository {}
+
+class _MockBlossomUploadService extends Mock implements BlossomUploadService {}
 
 const _pubkeyA =
     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
@@ -28,7 +39,10 @@ void main() {
     late AppDatabase db;
     late SharedPreferences prefs;
     late _MockDmRepository dmRepository;
-    late List<String> purgedUploadOwners;
+    late _MockBlossomUploadService blossomUploadService;
+    late UploadManager uploadManager;
+    late Directory tempDir;
+    late PathProviderPlatform originalPathProviderInstance;
     late ProviderContainer container;
 
     setUpAll(() async {
@@ -40,8 +54,32 @@ void main() {
       prefs = await SharedPreferences.getInstance();
       db = AppDatabase.test(NativeDatabase.memory());
       dmRepository = _MockDmRepository();
-      purgedUploadOwners = [];
+      blossomUploadService = _MockBlossomUploadService();
       when(() => dmRepository.stopListening()).thenAnswer((_) async {});
+      when(
+        () => blossomUploadService.isBlossomEnabled(),
+      ).thenAnswer((_) async => false);
+
+      tempDir = await Directory.systemTemp.createTemp(
+        'social_cleanup_uploads_',
+      );
+      originalPathProviderInstance = PathProviderPlatform.instance;
+      final mockPathProvider = MockPathProviderPlatform()
+        ..setTemporaryPath(tempDir.path)
+        ..setApplicationDocumentsPath('${tempDir.path}/documents')
+        ..setApplicationSupportPath('${tempDir.path}/support')
+        ..setApplicationCachePath('${tempDir.path}/cache');
+      PathProviderPlatform.instance = mockPathProvider;
+
+      uploadManager = UploadManager(
+        blossomService: blossomUploadService,
+        currentNostrPubkey: _pubkeyB,
+        scopeUploadsToCurrentUser: true,
+      );
+      await uploadManager.initialize();
+      await TestHelpers.ensureBoxEmpty<hive_model.PendingUpload>(
+        'pending_uploads',
+      );
 
       container = ProviderContainer(
         overrides: [
@@ -49,17 +87,20 @@ void main() {
           sharedPreferencesProvider.overrideWithValue(prefs),
           dmRepositoryProvider.overrideWithValue(dmRepository),
           openVineImageCacheClearProvider.overrideWithValue(() async {}),
-          pendingUploadOwnerCleanupProvider.overrideWithValue((ownerPubkey) {
-            purgedUploadOwners.add(ownerPubkey);
-            return Future.value(1);
-          }),
+          uploadManagerProvider.overrideWithValue(uploadManager),
         ],
       );
     });
 
     tearDown(() async {
       container.dispose();
+      uploadManager.dispose();
       await db.close();
+      await TestHelpers.cleanupHiveBox('pending_uploads');
+      PathProviderPlatform.instance = originalPathProviderInstance;
+      if (tempDir.existsSync()) {
+        await tempDir.delete(recursive: true);
+      }
     });
 
     test(
@@ -77,6 +118,22 @@ void main() {
             nostrPubkey: _pubkeyB,
           ),
         );
+        final box = Hive.box<hive_model.PendingUpload>('pending_uploads');
+        final a1 = hive_model.PendingUpload.create(
+          localVideoPath: '/tmp/a1.mp4',
+          nostrPubkey: _pubkeyA,
+        );
+        final a2 = hive_model.PendingUpload.create(
+          localVideoPath: '/tmp/a2.mp4',
+          nostrPubkey: _pubkeyA,
+        );
+        final b1 = hive_model.PendingUpload.create(
+          localVideoPath: '/tmp/b1.mp4',
+          nostrPubkey: _pubkeyB,
+        );
+        await box.put(a1.id, a1);
+        await box.put(a2.id, a2);
+        await box.put(b1.id, b1);
 
         final subscription = container.listen(
           userDataCleanupServiceProvider,
@@ -99,7 +156,9 @@ void main() {
           ownerPubkey: _pubkeyB,
         );
         expect(remainingDriftUploads, hasLength(1));
-        expect(purgedUploadOwners, [_pubkeyA]);
+        expect(box.get(a1.id), isNull);
+        expect(box.get(a2.id), isNull);
+        expect(box.get(b1.id), isNotNull);
       },
     );
 
@@ -116,7 +175,10 @@ void main() {
         userPubkey: _pubkeyA,
       );
 
-      expect(purgedUploadOwners, isEmpty);
+      expect(
+        Hive.box<hive_model.PendingUpload>('pending_uploads').values,
+        isEmpty,
+      );
     });
   });
 }

--- a/mobile/test/services/cache_recovery_service_test.dart
+++ b/mobile/test/services/cache_recovery_service_test.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_ce/hive.dart';
+import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/cache_recovery_service.dart';
 import 'package:path/path.dart' as p;
 
@@ -17,6 +18,12 @@ void main() {
 
       setUpAll(() async {
         await initializeServiceTestEnvironment();
+        if (!Hive.isAdapterRegistered(1)) {
+          Hive.registerAdapter(UploadStatusAdapter());
+        }
+        if (!Hive.isAdapterRegistered(2)) {
+          Hive.registerAdapter(PendingUploadAdapter());
+        }
       });
 
       setUp(() async {
@@ -35,16 +42,27 @@ void main() {
       test(
         'preserves pending uploads while clearing disposable Hive caches',
         () async {
-          final pendingUploads = await Hive.openBox('pending_uploads');
-          final videoCache = await Hive.openBox('video_cache');
-          await pendingUploads.put('upload-id', 'durable upload');
+          final pendingUploads = Hive.isBoxOpen('pending_uploads')
+              ? Hive.box<PendingUpload>('pending_uploads')
+              : await Hive.openBox<PendingUpload>('pending_uploads');
+          final videoCache = Hive.isBoxOpen('video_cache')
+              ? Hive.box('video_cache')
+              : await Hive.openBox('video_cache');
+          final upload = PendingUpload.create(
+            localVideoPath: '/tmp/durable-upload.mp4',
+            nostrPubkey:
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          );
+          await pendingUploads.put(upload.id, upload);
           await videoCache.put('cache-id', 'cached video');
 
           await CacheRecoveryService.clearHiveBoxesForTesting();
 
           expect(
-            Hive.box('pending_uploads').get('upload-id'),
-            'durable upload',
+            Hive.box<PendingUpload>(
+              'pending_uploads',
+            ).get(upload.id)?.localVideoPath,
+            upload.localVideoPath,
           );
           if (Hive.isBoxOpen('video_cache')) {
             expect(Hive.box('video_cache').get('cache-id'), isNull);

--- a/mobile/test/services/cache_recovery_service_test.dart
+++ b/mobile/test/services/cache_recovery_service_test.dart
@@ -8,8 +8,10 @@ import 'package:hive_ce/hive.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/cache_recovery_service.dart';
 import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 
 import '../helpers/test_helpers.dart';
+import '../mocks/mock_path_provider_platform.dart';
 
 void main() {
   group(CacheRecoveryService, () {
@@ -64,11 +66,72 @@ void main() {
             ).get(upload.id)?.localVideoPath,
             upload.localVideoPath,
           );
-          if (Hive.isBoxOpen('video_cache')) {
-            expect(Hive.box('video_cache').get('cache-id'), isNull);
-          }
+          expect(Hive.isBoxOpen('video_cache'), isFalse);
+          final reopenedVideoCache = await Hive.openBox('video_cache');
+          addTearDown(reopenedVideoCache.close);
+          expect(reopenedVideoCache.get('cache-id'), isNull);
         },
       );
+    });
+
+    group('full cache recovery', () {
+      late Directory tmp;
+      late PathProviderPlatform originalPathProviderInstance;
+
+      setUp(() {
+        tmp = Directory.systemTemp.createTempSync('cache_recovery_full_test');
+        originalPathProviderInstance = PathProviderPlatform.instance;
+        final mockPathProvider = MockPathProviderPlatform()
+          ..setTemporaryPath(p.join(tmp.path, 'temp'))
+          ..setApplicationSupportPath(p.join(tmp.path, 'support'))
+          ..setApplicationCachePath(p.join(tmp.path, 'cache'));
+        PathProviderPlatform.instance = mockPathProvider;
+      });
+
+      tearDown(() {
+        PathProviderPlatform.instance = originalPathProviderInstance;
+        if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+      });
+
+      File write(String relative, String contents) {
+        final file = File(p.join(tmp.path, relative))
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(contents);
+        return file;
+      }
+
+      test('preserves durable pending uploads during clearAllCaches', () async {
+        final db = write(
+          'support/openvine/database/divine_db.db',
+          'database',
+        );
+        final pendingUploads = write(
+          'support/openvine/pending_uploads.hive',
+          'pending uploads',
+        );
+        final pendingUploadsLock = write(
+          'support/openvine/pending_uploads.lock',
+          'lock',
+        );
+        final cacheSync = write(
+          'support/openvine/cache/cache_sync.db',
+          'cache',
+        );
+        final scratch = write('support/openvine/scratch.txt', 'scratch');
+        final temp = write('temp/transient.tmp', 'temp');
+        final cache = write('cache/download.bin', 'cache');
+
+        final recovered = await CacheRecoveryService.clearAllCaches();
+
+        expect(recovered, isTrue);
+        expect(db.existsSync(), isTrue);
+        expect(pendingUploads.existsSync(), isTrue);
+        expect(pendingUploadsLock.existsSync(), isTrue);
+        expect(cacheSync.existsSync(), isFalse);
+        expect(scratch.existsSync(), isFalse);
+        expect(temp.existsSync(), isFalse);
+        expect(cache.existsSync(), isFalse);
+      });
     });
 
     group('deleteDirectoryContentsExcept', () {

--- a/mobile/test/services/cache_recovery_service_test.dart
+++ b/mobile/test/services/cache_recovery_service_test.dart
@@ -4,11 +4,55 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
 import 'package:openvine/services/cache_recovery_service.dart';
 import 'package:path/path.dart' as p;
 
+import '../helpers/test_helpers.dart';
+
 void main() {
   group(CacheRecoveryService, () {
+    group('Hive box clearing', () {
+      late Directory tmp;
+
+      setUpAll(() async {
+        await initializeServiceTestEnvironment();
+      });
+
+      setUp(() async {
+        tmp = Directory.systemTemp.createTempSync('cache_recovery_hive_test');
+        Hive.init(tmp.path);
+        await TestHelpers.cleanupHiveBox('pending_uploads');
+        await TestHelpers.cleanupHiveBox('video_cache');
+      });
+
+      tearDown(() async {
+        await TestHelpers.cleanupHiveBox('pending_uploads');
+        await TestHelpers.cleanupHiveBox('video_cache');
+        if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+      });
+
+      test(
+        'preserves pending uploads while clearing disposable Hive caches',
+        () async {
+          final pendingUploads = await Hive.openBox('pending_uploads');
+          final videoCache = await Hive.openBox('video_cache');
+          await pendingUploads.put('upload-id', 'durable upload');
+          await videoCache.put('cache-id', 'cached video');
+
+          await CacheRecoveryService.clearHiveBoxesForTesting();
+
+          expect(
+            Hive.box('pending_uploads').get('upload-id'),
+            'durable upload',
+          );
+          if (Hive.isBoxOpen('video_cache')) {
+            expect(Hive.box('video_cache').get('cache-id'), isNull);
+          }
+        },
+      );
+    });
+
     group('deleteDirectoryContentsExcept', () {
       late Directory tmp;
 

--- a/mobile/test/services/upload/pending_upload_store_test.dart
+++ b/mobile/test/services/upload/pending_upload_store_test.dart
@@ -637,6 +637,43 @@ void main() {
         expect(box.get(uploads['b']!.id), isNotNull);
         expect(box.values.map((upload) => upload.nostrPubkey), [_pubkeyB]);
       });
+
+      test(
+        'deleteAllForOwner purges queued saves for the requested owner',
+        () async {
+          final isolatedDir = await _forceStorageFailure();
+
+          final store = PendingUploadStore(
+            scopeUploadsToCurrentUser: false,
+            currentNostrPubkey: null,
+          );
+          addTearDown(store.disposeStore);
+
+          final uploadA = PendingUpload.create(
+            localVideoPath: '${isolatedDir.path}/a.mp4',
+            nostrPubkey: _pubkeyA,
+          );
+          final uploadB = PendingUpload.create(
+            localVideoPath: '${isolatedDir.path}/b.mp4',
+            nostrPubkey: _pubkeyB,
+          );
+
+          await expectLater(
+            () => store.save(uploadA),
+            throwsA(isA<Exception>()),
+          );
+          await expectLater(
+            () => store.save(uploadB),
+            throwsA(isA<Exception>()),
+          );
+          expect(store.queuedCount, equals(2));
+
+          final deleted = await store.deleteAllForOwner(_pubkeyA);
+
+          expect(deleted, equals(0));
+          expect(store.queuedCount, equals(1));
+        },
+      );
     });
 
     // -----------------------------------------------------------------------

--- a/mobile/test/services/upload/pending_upload_store_test.dart
+++ b/mobile/test/services/upload/pending_upload_store_test.dart
@@ -618,6 +618,25 @@ void main() {
         final stats = store.uploadStats;
         expect(stats['total'], equals(1));
       });
+
+      test('deleteAllForOwner removes only the requested owner', () async {
+        final store = await _openStore(
+          scopeUploadsToCurrentUser: true,
+          currentNostrPubkey: _pubkeyA,
+        );
+        addTearDown(store.disposeStore);
+        await TestHelpers.ensureBoxEmpty<PendingUpload>('pending_uploads');
+        final uploads = await seedTwoAccounts(store);
+
+        final deleted = await store.deleteAllForOwner(_pubkeyA);
+
+        expect(deleted, equals(1));
+        expect(store.getUpload(uploads['a']!.id), isNull);
+
+        final box = Hive.box<PendingUpload>('pending_uploads');
+        expect(box.get(uploads['b']!.id), isNotNull);
+        expect(box.values.map((upload) => upload.nostrPubkey), [_pubkeyB]);
+      });
     });
 
     // -----------------------------------------------------------------------

--- a/mobile/test/services/upload_manager_owner_scope_test.dart
+++ b/mobile/test/services/upload_manager_owner_scope_test.dart
@@ -191,5 +191,24 @@ void main() {
 
       expect(box.values, isEmpty);
     });
+
+    test(
+      'owner cleanup scans all accounts even when manager is scoped elsewhere',
+      () async {
+        final manager = await createManager(currentPubkey: pubkeyB);
+        addTearDown(manager.dispose);
+        final uploads = await seedUploads();
+        manager.startProcessingPoll(uploads['aProcessing']!);
+
+        final deleted = await manager.deleteAllForOwner(pubkeyA);
+
+        final box = Hive.box<PendingUpload>('pending_uploads');
+        expect(deleted, equals(2));
+        expect(box.get(uploads['aPending']!.id), isNull);
+        expect(box.get(uploads['aProcessing']!.id), isNull);
+        expect(box.get(uploads['bPending']!.id), isNotNull);
+        expect(box.get(uploads['bProcessing']!.id), isNotNull);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
- route owner-scoped Hive pending upload purge through the live UploadManager instead of a throwaway store
- discard departing-owner upload work before deletion so retry/backoff/session/thumbnail callbacks cannot recreate purged rows
- preserve pending_uploads Hive data and lock files during full cache recovery because they are durable local-only upload state
- keep account cleanup moving if an earlier cleanup step fails, so later destructive purges are not skipped

Refs #5853

## Verification
- flutter test test/providers/social_providers_cleanup_test.dart test/services/upload/pending_upload_store_test.dart test/services/upload_manager_owner_scope_test.dart test/services/cache_recovery_service_test.dart
- flutter analyze
- pre-push checks: analyzer, generated verification, changed-file tests