### PR TITLE
fix(comments): pad the video reply icon inside its button

### DIFF
--- a/mobile/lib/screens/comments/widgets/comment_input.dart
+++ b/mobile/lib/screens/comments/widgets/comment_input.dart
@@ -293,7 +293,7 @@ class _VideoReplyButton extends StatelessWidget {
           child: Container(
             width: 40,
             height: 40,
-            margin: const .only(bottom: 4),
+            margin: const EdgeInsets.only(bottom: 4),
             decoration: BoxDecoration(
               color: context.vineColors.containerLow,
               borderRadius: BorderRadius.circular(20),

--- a/mobile/lib/screens/comments/widgets/comment_input.dart
+++ b/mobile/lib/screens/comments/widgets/comment_input.dart
@@ -294,7 +294,6 @@ class _VideoReplyButton extends StatelessWidget {
             width: 40,
             height: 40,
             margin: const .only(bottom: 4),
-            padding: const .all(7),
             decoration: BoxDecoration(
               color: context.vineColors.containerLow,
               borderRadius: BorderRadius.circular(20),

--- a/mobile/lib/screens/comments/widgets/comment_input.dart
+++ b/mobile/lib/screens/comments/widgets/comment_input.dart
@@ -293,10 +293,11 @@ class _VideoReplyButton extends StatelessWidget {
           child: Container(
             width: 40,
             height: 40,
-            margin: const EdgeInsets.only(bottom: 4),
+            margin: const .only(bottom: 4),
+            padding: const .all(7),
             decoration: BoxDecoration(
               color: context.vineColors.containerLow,
-              borderRadius: BorderRadius.circular(17),
+              borderRadius: BorderRadius.circular(20),
             ),
             child: IconButton(
               onPressed: onPressed,

--- a/mobile/lib/screens/comments/widgets/comment_input.dart
+++ b/mobile/lib/screens/comments/widgets/comment_input.dart
@@ -294,9 +294,13 @@ class _VideoReplyButton extends StatelessWidget {
             width: 40,
             height: 40,
             margin: const EdgeInsets.only(bottom: 4),
+            // The camera asset is 29x18, so `contain` sizes it off its height
+            // and it renders 35px wide inside the 40px circle. The padding
+            // caps that width; without it the glyph sits 2px from the edge.
+            padding: const EdgeInsets.all(7),
             decoration: BoxDecoration(
               color: context.vineColors.containerLow,
-              borderRadius: BorderRadius.circular(20),
+              borderRadius: BorderRadius.circular(16),
             ),
             child: IconButton(
               onPressed: onPressed,

--- a/mobile/test/screens/comments/comment_input_test.dart
+++ b/mobile/test/screens/comments/comment_input_test.dart
@@ -105,6 +105,43 @@ void main() {
       expect(tapped, isTrue);
     });
 
+    testWidgets('video reply glyph stays inset from its circle', (
+      tester,
+    ) async {
+      // The camera asset is 29x18, so BoxFit.contain sizes it off its height
+      // and it renders far wider than the requested 22. Unpadded it spans
+      // 35.4px inside the 40px circle, leaving 2.3px of clearance and reading
+      // as a ring drawn around the glyph.
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: CommentInput(
+              controller: controller,
+              onSubmit: () {},
+              onVideoReplyPressed: () {},
+            ),
+          ),
+        ),
+      );
+
+      final glyph = tester.getRect(_divineIcon(DivineIconName.videoCamera));
+      final circle = tester.getRect(
+        find
+            .ancestor(
+              of: _divineIcon(DivineIconName.videoCamera),
+              matching: find.byWidgetPredicate(
+                (widget) =>
+                    widget is Container && widget.constraints?.maxWidth == 40,
+              ),
+            )
+            .first,
+      );
+
+      expect((circle.width - glyph.width) / 2, greaterThanOrEqualTo(6));
+    });
+
     testWidgets(
       'never shows a CircularProgressIndicator on the send button',
       (tester) async {


### PR DESCRIPTION
Closes #6735

## Description

The camera glyph in the comment bar's record-video button sat almost flush against its circle. The cause is the asset, not the layout: `assets/icon/video_camera.svg` has `viewBox="0 0 29 18"`, and `DivineIcon` renders with `BoxFit.contain` off `width: size, height: size` — so a non-square asset is sized by its height and `size: 22` comes out **35.44px wide**. In the 40px circle that leaves 2.28px of clearance on each side, which reads as a ring drawn around the glyph rather than a button holding it.

- Adds 7px inner padding, capping the glyph at 26px wide and restoring 7px of clearance.
- Changes the radius from 17 to 16, matching `DivineIconButton`'s 40px `small` variant. The design system draws these as rounded squares (16 at 40px, 20 at 48px), never full circles.

The tap target, semantics, and callback wiring are untouched.

## Notes for reviewers

An earlier round of review measured the padding as inert, based on a repro built with a square Material `Icon`. That measurement is correct for a square icon — the icon rect is unchanged and only the `IconButton`'s Material box shrinks — but it does not hold for this asset. Measured on the real `CommentInput`, the glyph box goes from 35.44 × 22 (2.28px clearance) to 26 × 22 (7px clearance). Details in the [thread](https://github.com/divinevideo/divine-mobile/pull/6734#issuecomment-5197136442).

The two sibling buttons in the same input row are unaffected: `CaretDown.svg` and `arrow_up.svg` are both `viewBox="0 0 32 32"`, so they render square with 9–10px of clearance. Their radius is still 17; aligning that is a separate, deliberate call rather than something to fold in here.

## Out of Scope

All three buttons in this row hand-roll what `DivineIconButton(size: .small)` already provides, including the 48px tap target. Replacing them is a worthwhile cleanup but a much larger diff than this fix.

## Verification

- `flutter analyze lib/screens/comments test/screens/comments` — clean
- `flutter test test/screens/comments/` — 122/122 pass
- `dart format` — clean
- New regression test asserts the glyph keeps ≥6px of clearance inside its circle; confirmed it fails at 2.28px when the padding is removed
- Padding checked visually on a real Samsung Galaxy device; padding plus the radius change re-checked on macOS

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
