### PR TITLE
fix(comments): vote on addressable comment targets with their own coordinate

### DIFF
--- a/mobile/lib/blocs/comments/comment_reactions/comment_reactions_bloc.dart
+++ b/mobile/lib/blocs/comments/comment_reactions/comment_reactions_bloc.dart
@@ -141,8 +141,14 @@ class CommentReactionsBloc
 
     try {
       final results = await Future.wait([
-        _likesRepository.getVoteCounts(event.commentIds),
-        _likesRepository.getUserVoteStatuses(event.commentIds),
+        _likesRepository.getVoteCounts(
+          event.commentIds,
+          addressableIds: event.addressableIdsByCommentId,
+        ),
+        _likesRepository.getUserVoteStatuses(
+          event.commentIds,
+          addressableIds: event.addressableIdsByCommentId,
+        ),
       ]);
 
       final voteCounts =

--- a/mobile/lib/blocs/comments/comment_reactions/comment_reactions_bloc.dart
+++ b/mobile/lib/blocs/comments/comment_reactions/comment_reactions_bloc.dart
@@ -245,10 +245,21 @@ class CommentReactionsBloc
       // upvotes in _likeRecords and downvotes in _downvoteRecords; pick the
       // right teardown call based on which side actually had it.
       if (hadSameVote || hadOppositeVote) {
-        if (wasUpvoted) {
-          await _likesRepository.unlikeEvent(commentId);
-        } else {
-          await _likesRepository.removeDownvote(commentId);
+        // A teardown miss must not abort the placement below. The repo's
+        // downvote cache is in-memory only, so after a cold start removing a
+        // pre-restart vote reports "not voted" even though the new vote still
+        // needs publishing — previously that threw past the placement and the
+        // UI showed a vote that was never sent (#6124).
+        try {
+          if (wasUpvoted) {
+            await _likesRepository.unlikeEvent(commentId);
+          } else {
+            await _likesRepository.removeDownvote(commentId);
+          }
+        } on NotLikedException {
+          // Nothing to remove; the optimistic update already reflects that.
+        } on NotDownvotedException {
+          // Nothing to remove; the optimistic update already reflects that.
         }
       }
 
@@ -279,14 +290,6 @@ class CommentReactionsBloc
             ..remove(commentId),
         ),
       );
-    } on NotLikedException {
-      // State-sync sentinel (silent): repo had no upvote to remove.
-      emit(
-        state.copyWith(
-          upvotedCommentIds: Set<String>.from(state.upvotedCommentIds)
-            ..remove(commentId),
-        ),
-      );
     } on AlreadyDownvotedException {
       // State-sync sentinel (silent): repo already had the downvote.
       emit(
@@ -294,14 +297,6 @@ class CommentReactionsBloc
           downvotedCommentIds: Set<String>.from(state.downvotedCommentIds)
             ..add(commentId),
           upvotedCommentIds: Set<String>.from(state.upvotedCommentIds)
-            ..remove(commentId),
-        ),
-      );
-    } on NotDownvotedException {
-      // State-sync sentinel (silent): repo had no downvote to remove.
-      emit(
-        state.copyWith(
-          downvotedCommentIds: Set<String>.from(state.downvotedCommentIds)
             ..remove(commentId),
         ),
       );

--- a/mobile/lib/blocs/comments/comment_reactions/comment_reactions_bloc.dart
+++ b/mobile/lib/blocs/comments/comment_reactions/comment_reactions_bloc.dart
@@ -252,7 +252,10 @@ class CommentReactionsBloc
         // UI showed a vote that was never sent (#6124).
         try {
           if (wasUpvoted) {
-            await _likesRepository.unlikeEvent(commentId);
+            await _likesRepository.unlikeEvent(
+              commentId,
+              addressableId: event.addressableId,
+            );
           } else {
             await _likesRepository.removeDownvote(
               commentId,

--- a/mobile/lib/blocs/comments/comment_reactions/comment_reactions_bloc.dart
+++ b/mobile/lib/blocs/comments/comment_reactions/comment_reactions_bloc.dart
@@ -254,7 +254,10 @@ class CommentReactionsBloc
           if (wasUpvoted) {
             await _likesRepository.unlikeEvent(commentId);
           } else {
-            await _likesRepository.removeDownvote(commentId);
+            await _likesRepository.removeDownvote(
+              commentId,
+              addressableId: event.addressableId,
+            );
           }
         } on NotLikedException {
           // Nothing to remove; the optimistic update already reflects that.
@@ -265,17 +268,24 @@ class CommentReactionsBloc
 
       // Place the new vote (only when this tap isn't a same-side removal).
       if (!hadSameVote) {
+        // NIP-25: `a` and `k` describe the event being reacted to, so both
+        // come from the target itself. A Kind 34236 video reply is
+        // addressable and carries a coordinate; a Kind 1111 comment does not
+        // and passes null (#6124).
+        final targetKind = event.targetKind ?? EventKind.comment;
         if (isUpvote) {
           await _likesRepository.likeEvent(
             eventId: commentId,
             authorPubkey: event.authorPubkey,
-            targetKind: EventKind.comment,
+            targetKind: targetKind,
+            addressableId: event.addressableId,
           );
         } else {
           await _likesRepository.downvoteEvent(
             eventId: commentId,
             authorPubkey: event.authorPubkey,
-            targetKind: EventKind.comment,
+            targetKind: targetKind,
+            addressableId: event.addressableId,
           );
         }
       }

--- a/mobile/lib/blocs/comments/comment_reactions/comment_reactions_event.dart
+++ b/mobile/lib/blocs/comments/comment_reactions/comment_reactions_event.dart
@@ -64,10 +64,22 @@ final class CommentVoteToggled extends CommentReactionsEvent {
 /// the loaded-comment set changes so the reactions cubit can populate counts
 /// for the visible list.
 final class CommentVoteCountsFetchRequested extends CommentReactionsEvent {
-  const CommentVoteCountsFetchRequested(this.commentIds);
+  const CommentVoteCountsFetchRequested(
+    this.commentIds, {
+    this.addressableIdsByCommentId = const {},
+  });
 
   /// The set of comment IDs to fetch vote counts for.
   final List<String> commentIds;
+
+  /// Own addressable coordinates for those of [commentIds] that have one,
+  /// keyed by comment id.
+  ///
+  /// Votes on an addressable target carry its coordinate, and an edit mints a
+  /// new event id — so without this the counts and the viewer's own arrow
+  /// read as zero/unvoted for every revision after the first (#6124). Empty
+  /// for threads of plain Kind 1111 comments.
+  final Map<String, String> addressableIdsByCommentId;
 }
 
 /// Report a comment (publishes Kind 1984 / NIP-56).

--- a/mobile/lib/blocs/comments/comment_reactions/comment_reactions_event.dart
+++ b/mobile/lib/blocs/comments/comment_reactions/comment_reactions_event.dart
@@ -30,6 +30,8 @@ final class CommentVoteToggled extends CommentReactionsEvent {
     required this.commentId,
     required this.authorPubkey,
     required this.vote,
+    this.addressableId,
+    this.targetKind,
   });
 
   /// The ID of the comment being voted on.
@@ -40,6 +42,20 @@ final class CommentVoteToggled extends CommentReactionsEvent {
 
   /// Whether this is an upvote or a downvote tap.
   final Vote vote;
+
+  /// The target's **own** addressable coordinate, when it has one.
+  ///
+  /// A Kind 34236 video reply is addressable, and an edit re-publishes it
+  /// under the same coordinate with a new event id — so without this the
+  /// reaction strands on the superseded id (#6124). Null for Kind 1111
+  /// comments, which are regular events.
+  final String? addressableId;
+
+  /// The kind of the event being reacted to, for NIP-25's `k` tag.
+  ///
+  /// Null when the source did not report one, in which case the handler falls
+  /// back to [EventKind.comment].
+  final int? targetKind;
 }
 
 /// Request to batch-fetch vote counts for a set of comments.

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -396,8 +396,20 @@ class OutboxBridges extends StatelessWidget {
                 )
                 .toList();
             if (newIds.isEmpty) return;
+            // Video replies are addressable; their votes are only reachable by
+            // coordinate once the reply has been edited (#6124).
+            final addressableIds = <String, String>{};
+            for (final id in newIds) {
+              final coordinate = state.commentsById[id]?.addressableId;
+              if (coordinate != null && coordinate.isNotEmpty) {
+                addressableIds[id] = coordinate;
+              }
+            }
             ctx.read<CommentReactionsBloc>().add(
-              CommentVoteCountsFetchRequested(newIds),
+              CommentVoteCountsFetchRequested(
+                newIds,
+                addressableIdsByCommentId: addressableIds,
+              ),
             );
           },
         ),

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -199,6 +199,8 @@ class _CommentItemState extends ConsumerState<CommentItem> {
                         _ActionsRow(
                           commentId: widget.comment.id,
                           authorPubkey: widget.comment.authorPubkey,
+                          addressableId: widget.comment.addressableId,
+                          targetKind: widget.comment.eventKind,
                         ),
                       ],
                     ),
@@ -453,13 +455,24 @@ class _CommentContent extends StatelessWidget {
 }
 
 class _ActionsRow extends StatelessWidget {
-  const _ActionsRow({required this.commentId, required this.authorPubkey});
+  const _ActionsRow({
+    required this.commentId,
+    required this.authorPubkey,
+    this.addressableId,
+    this.targetKind,
+  });
 
   /// ID of the comment (for reply targeting and vote toggling)
   final String commentId;
 
   /// Pubkey of the comment author (for vote toggling)
   final String authorPubkey;
+
+  /// The comment's own addressable coordinate, when it has one (#6124).
+  final String? addressableId;
+
+  /// The kind of the event being voted on, for NIP-25's `k` tag.
+  final int? targetKind;
 
   @override
   Widget build(BuildContext context) {
@@ -515,7 +528,12 @@ class _ActionsRow extends StatelessWidget {
           ),
         ),
         const SizedBox(width: 20),
-        _CommentVoteButtons(commentId: commentId, authorPubkey: authorPubkey),
+        _CommentVoteButtons(
+          commentId: commentId,
+          authorPubkey: authorPubkey,
+          addressableId: addressableId,
+          targetKind: targetKind,
+        ),
       ],
     );
   }
@@ -529,10 +547,14 @@ class _CommentVoteButtons extends StatelessWidget {
   const _CommentVoteButtons({
     required this.commentId,
     required this.authorPubkey,
+    this.addressableId,
+    this.targetKind,
   });
 
   final String commentId;
   final String authorPubkey;
+  final String? addressableId;
+  final int? targetKind;
 
   @override
   Widget build(BuildContext context) {
@@ -566,6 +588,8 @@ class _CommentVoteButtons extends StatelessWidget {
                     CommentVoteToggled(
                       commentId: commentId,
                       authorPubkey: authorPubkey,
+                      addressableId: addressableId,
+                      targetKind: targetKind,
                       vote: Vote.up,
                     ),
                   );
@@ -613,6 +637,8 @@ class _CommentVoteButtons extends StatelessWidget {
                     CommentVoteToggled(
                       commentId: commentId,
                       authorPubkey: authorPubkey,
+                      addressableId: addressableId,
+                      targetKind: targetKind,
                       vote: Vote.down,
                     ),
                   );

--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -954,7 +954,11 @@ class CommentsRepository {
         authorPubkey: event.pubkey,
         createdAt: event.createdAtDateTime,
         eventKind: event.kind,
-        addressableId: _ownAddressableId(event),
+        addressableId: _ownAddressableId(
+          kind: event.kind,
+          pubkey: event.pubkey,
+          tags: event.tags,
+        ),
         rootEventId: parsedRootEventId ?? rootEventId,
         // For top-level comments, replyToEventId should be null
         replyToEventId: isTopLevel ? null : replyToEventId,
@@ -980,11 +984,24 @@ class CommentsRepository {
   /// than substituting the event id the way `VideoEvent` does — that would
   /// mint a well-formed coordinate addressing nothing, and a reaction tagged
   /// with it would be unresolvable (#6124).
-  String? _ownAddressableId(Event event) {
-    if (event.kind < 30000 || event.kind > 39999) return null;
-    final dTag = event.dTagValue;
-    if (dTag.isEmpty) return null;
-    return AId(kind: event.kind, pubkey: event.pubkey, dTag: dTag).toAString();
+  ///
+  /// Takes raw tags rather than an [Event] so the funnelcake REST payload,
+  /// which carries the same tag list on a different type, resolves identically.
+  String? _ownAddressableId({
+    required int kind,
+    required String pubkey,
+    required List<dynamic> tags,
+  }) {
+    if (kind < 30000 || kind > 39999) return null;
+    for (final rawTag in tags) {
+      final tag = rawTag as List<dynamic>;
+      if (tag.length < 2 || tag[0] != 'd') continue;
+      final dTag = tag[1] as String;
+      return dTag.isEmpty
+          ? null
+          : AId(kind: kind, pubkey: pubkey, dTag: dTag).toAString();
+    }
+    return null;
   }
 
   /// Checks whether an event's uppercase `E` or `A` tag matches the queried
@@ -1112,6 +1129,17 @@ class CommentsRepository {
         authorPubkey: restComment.pubkey,
         createdAt: DateTime.fromMillisecondsSinceEpoch(
           restComment.createdAt * 1000,
+        ),
+        // The REST payload carries Kind 34236 video replies too, so the same
+        // coordinate/kind the relay path derives must be derived here — this
+        // path is REST-first and serves the first page in production (#6124).
+        // `kind` defaults to 0 when the payload omits it; map that back to
+        // null so the vote handler still falls back to Kind 1111.
+        eventKind: restComment.kind > 0 ? restComment.kind : null,
+        addressableId: _ownAddressableId(
+          kind: restComment.kind,
+          pubkey: restComment.pubkey,
+          tags: restComment.tags,
         ),
         rootEventId: parsedRootEventId ?? rootEventId,
         rootAuthorPubkey: rootAuthorPubkey ?? '',

--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -953,6 +953,8 @@ class CommentsRepository {
         content: event.content,
         authorPubkey: event.pubkey,
         createdAt: event.createdAtDateTime,
+        eventKind: event.kind,
+        addressableId: _ownAddressableId(event),
         rootEventId: parsedRootEventId ?? rootEventId,
         // For top-level comments, replyToEventId should be null
         replyToEventId: isTopLevel ? null : replyToEventId,
@@ -968,6 +970,21 @@ class CommentsRepository {
     } on Exception {
       return null;
     }
+  }
+
+  /// Builds an event's **own** addressable coordinate, or `null` when it has
+  /// none.
+  ///
+  /// Only addressable kinds (30000-39999) have coordinates, and only when the
+  /// event actually carries a `d` tag. A missing `d` must yield `null` rather
+  /// than substituting the event id the way `VideoEvent` does — that would
+  /// mint a well-formed coordinate addressing nothing, and a reaction tagged
+  /// with it would be unresolvable (#6124).
+  String? _ownAddressableId(Event event) {
+    if (event.kind < 30000 || event.kind > 39999) return null;
+    final dTag = event.dTagValue;
+    if (dTag.isEmpty) return null;
+    return AId(kind: event.kind, pubkey: event.pubkey, dTag: dTag).toAString();
   }
 
   /// Checks whether an event's uppercase `E` or `A` tag matches the queried

--- a/mobile/packages/comments_repository/lib/src/models/comment.dart
+++ b/mobile/packages/comments_repository/lib/src/models/comment.dart
@@ -25,6 +25,8 @@ class Comment extends Equatable {
     required this.rootEventId,
     required this.rootAuthorPubkey,
     this.rootAddressableId,
+    this.addressableId,
+    this.eventKind,
     this.replyToEventId,
     this.replyToAuthorPubkey,
     this.videoUrl,
@@ -54,6 +56,25 @@ class Comment extends Equatable {
 
   /// Addressable identifier of the root event, when the root is parameterized.
   final String? rootAddressableId;
+
+  /// This comment's **own** addressable coordinate (`kind:pubkey:d-tag`).
+  ///
+  /// Non-null only when the comment wraps an addressable event that carries a
+  /// `d` tag — a Kind 34236 video reply, for example. Plain Kind 1111 comments
+  /// are regular events with no coordinate, and so are `null`.
+  ///
+  /// Distinct from [rootAddressableId], which addresses the *parent* video.
+  /// Reactions must be tagged with this one: NIP-25's `a` tag identifies the
+  /// event being reacted to, and using the parent's coordinate would credit
+  /// the parent video's engagement counts instead (#6124).
+  final String? addressableId;
+
+  /// The Nostr event kind this comment was parsed from.
+  ///
+  /// `null` when the source did not report a kind (the funnelcake REST path,
+  /// which only ever returns Kind 1111). Reactions use this for NIP-25's `k`
+  /// tag, which must name the kind of the event being reacted to.
+  final int? eventKind;
 
   /// If this is a reply, the ID of the parent comment.
   ///
@@ -90,6 +111,8 @@ class Comment extends Equatable {
     String? rootEventId,
     String? rootAuthorPubkey,
     String? rootAddressableId,
+    String? addressableId,
+    int? eventKind,
     String? replyToEventId,
     String? replyToAuthorPubkey,
     String? videoUrl,
@@ -105,6 +128,8 @@ class Comment extends Equatable {
     rootEventId: rootEventId ?? this.rootEventId,
     rootAuthorPubkey: rootAuthorPubkey ?? this.rootAuthorPubkey,
     rootAddressableId: rootAddressableId ?? this.rootAddressableId,
+    addressableId: addressableId ?? this.addressableId,
+    eventKind: eventKind ?? this.eventKind,
     replyToEventId: replyToEventId ?? this.replyToEventId,
     replyToAuthorPubkey: replyToAuthorPubkey ?? this.replyToAuthorPubkey,
     videoUrl: videoUrl ?? this.videoUrl,
@@ -123,6 +148,8 @@ class Comment extends Equatable {
     rootEventId,
     rootAuthorPubkey,
     rootAddressableId,
+    addressableId,
+    eventKind,
     replyToEventId,
     replyToAuthorPubkey,
     videoUrl,

--- a/mobile/packages/comments_repository/lib/src/models/comment.dart
+++ b/mobile/packages/comments_repository/lib/src/models/comment.dart
@@ -71,9 +71,9 @@ class Comment extends Equatable {
 
   /// The Nostr event kind this comment was parsed from.
   ///
-  /// `null` when the source did not report a kind (the funnelcake REST path,
-  /// which only ever returns Kind 1111). Reactions use this for NIP-25's `k`
-  /// tag, which must name the kind of the event being reacted to.
+  /// `null` when the source did not report a kind or reported the REST
+  /// omitted-kind sentinel. Reactions use this for NIP-25's `k` tag, which
+  /// must name the kind of the event being reacted to.
   final int? eventKind;
 
   /// If this is a reply, the ID of the parent comment.

--- a/mobile/packages/comments_repository/test/src/comments_repository_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_test.dart
@@ -313,6 +313,111 @@ void main() {
         verifyNever(() => mockNostrClient.queryEvents(any()));
       });
 
+      test(
+        'maps coordinate and kind from a REST video reply (#6124)',
+        () async {
+          // loadComments is REST-first, so this — not the relay mapper — is the
+          // path that serves the first page in production. Without it a vote on
+          // a REST-delivered video reply still carries k:1111 and no `a` tag.
+          when(() => mockFunnelcakeApiClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeApiClient.getVideoComments(
+              videoId: any(named: 'videoId'),
+              sort: any(named: 'sort'),
+              limit: any(named: 'limit'),
+              offset: any(named: 'offset'),
+              cacheBustToken: any(named: 'cacheBustToken'),
+            ),
+          ).thenAnswer(
+            (_) async => VideoCommentsResponse(
+              comments: [
+                VideoComment(
+                  id: 'rest_video_reply',
+                  pubkey: testUserPubkey,
+                  createdAt: 1000,
+                  kind: EventKind.videoVertical,
+                  content: 'REST video reply',
+                  sig: 'sig',
+                  tags: [
+                    ['E', testRootEventId],
+                    ['P', testRootAuthorPubkey],
+                    ['d', 'rest_reply_d'],
+                    ['imeta', 'url https://media.divine.video/reply/12345'],
+                  ],
+                ),
+              ],
+              total: 1,
+            ),
+          );
+
+          repository = CommentsRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeApiClient,
+          );
+
+          final result = await repository.loadComments(
+            rootEventId: testRootEventId,
+            rootEventKind: _testRootEventKind,
+            includeVideoReplies: true,
+          );
+
+          expect(result.comments, hasLength(1));
+          expect(result.comments.first.eventKind, EventKind.videoVertical);
+          expect(
+            result.comments.first.addressableId,
+            equals('${EventKind.videoVertical}:$testUserPubkey:rest_reply_d'),
+          );
+        },
+      );
+
+      test('leaves eventKind null when REST omits the kind (#6124)', () async {
+        // VideoComment.fromJson defaults an absent kind to 0. Forwarding that
+        // verbatim would put k:0 on the reaction; null keeps the handler's
+        // Kind 1111 fallback in charge.
+        when(() => mockFunnelcakeApiClient.isAvailable).thenReturn(true);
+        when(
+          () => mockFunnelcakeApiClient.getVideoComments(
+            videoId: any(named: 'videoId'),
+            sort: any(named: 'sort'),
+            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
+            cacheBustToken: any(named: 'cacheBustToken'),
+          ),
+        ).thenAnswer(
+          (_) async => VideoCommentsResponse(
+            comments: [
+              VideoComment(
+                id: 'rest_comment_no_kind',
+                pubkey: testUserPubkey,
+                createdAt: 1000,
+                kind: 0,
+                content: 'plain',
+                sig: 'sig',
+                tags: [
+                  ['E', testRootEventId],
+                  ['P', testRootAuthorPubkey],
+                ],
+              ),
+            ],
+            total: 1,
+          ),
+        );
+
+        repository = CommentsRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcakeApiClient,
+        );
+
+        final result = await repository.loadComments(
+          rootEventId: testRootEventId,
+          rootEventKind: _testRootEventKind,
+        );
+
+        expect(result.comments, hasLength(1));
+        expect(result.comments.first.eventKind, isNull);
+        expect(result.comments.first.addressableId, isNull);
+      });
+
       test('falls back to relay query when REST bootstrap throws', () async {
         when(() => mockFunnelcakeApiClient.isAvailable).thenReturn(true);
         when(

--- a/mobile/packages/comments_repository/test/src/comments_repository_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_test.dart
@@ -329,7 +329,7 @@ void main() {
               cacheBustToken: any(named: 'cacheBustToken'),
             ),
           ).thenAnswer(
-            (_) async => VideoCommentsResponse(
+            (_) async => const VideoCommentsResponse(
               comments: [
                 VideoComment(
                   id: 'rest_video_reply',
@@ -384,7 +384,7 @@ void main() {
             cacheBustToken: any(named: 'cacheBustToken'),
           ),
         ).thenAnswer(
-          (_) async => VideoCommentsResponse(
+          (_) async => const VideoCommentsResponse(
             comments: [
               VideoComment(
                 id: 'rest_comment_no_kind',

--- a/mobile/packages/comments_repository/test/src/comments_repository_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_test.dart
@@ -355,6 +355,62 @@ void main() {
         verify(() => mockNostrClient.queryEvents(any())).called(1);
       });
 
+      test(
+        'leaves addressableId null for a Kind 1111 comment (#6124)',
+        () async {
+          final plainComment = _createCommentEvent(
+            id: 'plain_comment',
+            content: 'no coordinate here',
+            pubkey: testUserPubkey,
+            rootEventId: testRootEventId,
+            rootAuthorPubkey: testRootAuthorPubkey,
+            rootEventKind: _testRootEventKind,
+          );
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [plainComment]);
+
+          final result = await repository.loadComments(
+            rootEventId: testRootEventId,
+            rootEventKind: _testRootEventKind,
+          );
+
+          expect(result.comments, hasLength(1));
+          expect(result.comments.first.addressableId, isNull);
+          expect(result.comments.first.eventKind, _commentKind);
+        },
+      );
+
+      test('leaves addressableId null when an addressable event has no d tag '
+          '(#6124)', () async {
+        // Must NOT fall back to the event id the way VideoEvent does — that
+        // mints a well-formed coordinate that addresses nothing.
+        final noDTag = _createCommentEvent(
+          id: 'reply_without_d',
+          kind: EventKind.videoVertical,
+          content: 'Reply title',
+          pubkey: testUserPubkey,
+          rootEventId: testRootEventId,
+          rootAuthorPubkey: testRootAuthorPubkey,
+          rootEventKind: _testRootEventKind,
+          extraTags: const [
+            ['imeta', 'url https://media.divine.video/video.mp4'],
+          ],
+        );
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [noDTag]);
+
+        final result = await repository.loadComments(
+          rootEventId: testRootEventId,
+          rootEventKind: _testRootEventKind,
+          includeVideoReplies: true,
+        );
+
+        expect(result.comments, hasLength(1));
+        expect(result.comments.first.addressableId, isNull);
+      });
+
       test('loads NIP-71 video reply events in the comments thread', () async {
         const rootAddressableId = '34236:$testRootAuthorPubkey:video-dtag';
         final videoReplyEvent = _createCommentEvent(
@@ -368,6 +424,7 @@ void main() {
           extraTags: const [
             ['A', rootAddressableId, ''],
             ['a', rootAddressableId, ''],
+            ['d', 'video_reply_d'],
             ['imeta', 'url https://media.divine.video/video.mp4'],
             ['title', 'Reply title'],
             ['summary', 'Video reply summary'],
@@ -388,6 +445,17 @@ void main() {
         expect(result.comments.first.id, equals('video_reply'));
         expect(result.comments.first.rootAddressableId, rootAddressableId);
         expect(result.comments.first.hasVideo, isTrue);
+        // Its OWN coordinate and kind, not the parent video's — a reaction
+        // tagged with the parent's would credit the parent's counts (#6124).
+        expect(result.comments.first.eventKind, EventKind.videoVertical);
+        expect(
+          result.comments.first.addressableId,
+          equals('${EventKind.videoVertical}:$testUserPubkey:video_reply_d'),
+        );
+        expect(
+          result.comments.first.addressableId,
+          isNot(equals(rootAddressableId)),
+        );
         expect(
           result.comments.first.videoUrl,
           equals('https://media.divine.video/video.mp4'),

--- a/mobile/packages/comments_repository/test/src/models/comment_test.dart
+++ b/mobile/packages/comments_repository/test/src/models/comment_test.dart
@@ -174,6 +174,8 @@ void main() {
           createdAt: DateTime(2024),
           rootEventId: 'root',
           rootAuthorPubkey: 'rootAuthor',
+          addressableId: '34236:author:d-tag',
+          eventKind: 34236,
           replyToEventId: 'replyTo',
           replyToAuthorPubkey: 'replyAuthor',
           videoUrl: 'https://example.com/video.mp4',
@@ -183,7 +185,7 @@ void main() {
           videoBlurhash: 'LEHV6nWB2y',
         );
 
-        expect(comment.props, hasLength(14));
+        expect(comment.props, hasLength(16));
         expect(
           comment.props,
           equals([
@@ -194,6 +196,8 @@ void main() {
             'root',
             'rootAuthor',
             null,
+            '34236:author:d-tag',
+            34236,
             'replyTo',
             'replyAuthor',
             'https://example.com/video.mp4',

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -1133,7 +1133,14 @@ class LikesRepository {
   Future<void> removeDownvote(String eventId) async {
     await _ensureInitialized();
 
-    final record = _downvoteRecords[eventId];
+    // [_downvoteRecords] is in-memory only in v1, so a cold start leaves it
+    // empty while the kind-7 downvote is still live on relays. Falling back
+    // to the relay copy keeps the deletion honest: without it this throws
+    // [NotDownvotedException], the caller clears its UI, and the downvote
+    // survives untouched and reappears on the next fetch (#6124).
+    final record =
+        _downvoteRecords[eventId] ??
+        await _resolveRemoteDownvoteRecord(eventId);
     if (record == null) {
       throw NotDownvotedException(eventId);
     }
@@ -1854,5 +1861,57 @@ class LikesRepository {
       }
     }
     return null;
+  }
+
+  /// Resolves the current user's still-live downvote on [eventId] from relays.
+  ///
+  /// Returns the newest non-deleted kind-7 `-` reaction the user has published
+  /// against [eventId], or `null` when there is none. Used by
+  /// [removeDownvote] to recover from an empty in-memory cache after a cold
+  /// start, since downvotes are not persisted locally in v1.
+  Future<LikeRecord?> _resolveRemoteDownvoteRecord(String eventId) async {
+    final reactions = await _nostrClient.queryEvents([
+      Filter(
+        kinds: const [EventKind.reaction],
+        authors: [_nostrClient.publicKey],
+        e: [eventId],
+      ),
+    ]);
+
+    final candidates = reactions
+        .where((event) => event.content == _downvoteContent)
+        .where((event) => _extractTargetEventId(event) == eventId)
+        .toList();
+    if (candidates.isEmpty) return null;
+
+    final deletions = await _nostrClient.queryEvents([
+      Filter(
+        kinds: const [EventKind.eventDeletion],
+        authors: [_nostrClient.publicKey],
+        e: candidates.map((event) => event.id).toList(),
+      ),
+    ]);
+
+    final deletedIds = <String>{};
+    for (final deletion in deletions) {
+      for (final tag in deletion.tags) {
+        if (tag.isNotEmpty && tag[0] == 'e' && tag.length > 1) {
+          deletedIds.add(tag[1]);
+        }
+      }
+    }
+
+    final live =
+        candidates.where((event) => !deletedIds.contains(event.id)).toList()
+          ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    if (live.isEmpty) return null;
+
+    final newest = live.first;
+    return LikeRecord(
+      targetEventId: eventId,
+      reactionEventId: newest.id,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(newest.createdAt * 1000),
+      addressableId: _extractAddressableId(newest),
+    );
   }
 }

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -1190,12 +1190,18 @@ class LikesRepository {
   /// cast against a superseded revision of an addressable target still lands
   /// on the revision the caller is currently showing (#6124). Returns `null`
   /// when the reaction targets nothing in the queried set.
+  ///
+  /// Scans the `e` tags last-first: NIP-25 says that when a reaction carries
+  /// more than one, "the target event `id` should be last of the `e` tags".
+  /// Reading forwards credits a copied ancestor tag instead of the real
+  /// target — Divine's own writer emits a single `e` tag, so this only
+  /// affects reactions from other clients.
   String? _resolveVoteTarget(
     Event event,
     Set<String> knownEventIds,
     Map<String, String> eventIdByCoordinate,
   ) {
-    for (final tag in event.tags) {
+    for (final tag in event.tags.reversed) {
       if (tag.isNotEmpty && tag[0] == 'e' && tag.length > 1) {
         final targetId = tag[1];
         if (knownEventIds.contains(targetId)) return targetId;

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -1053,10 +1053,18 @@ class LikesRepository {
       downvotes[eventId] = 0;
     }
 
+    // Retracted votes have to be excluded here, not just in
+    // [getUserVoteStatuses]. The coordinate leg reaches reactions cast against
+    // every earlier revision of the target, including ones their author has
+    // since deleted — switching an upvote to a downvote on an edited reply
+    // publishes exactly that pair, and counting both leaves netScore 0, which
+    // `comment_item.dart` renders by hiding the score outright (#6124).
+    final reactionsById = {for (final event in events) event.id: event};
+    final deletedReactionIds = await _deletedReactionIds(reactionsById);
+
     final knownEventIds = eventIds.toSet();
-    final counted = <String>{};
-    for (final event in events) {
-      if (!counted.add(event.id)) continue;
+    for (final event in reactionsById.values) {
+      if (deletedReactionIds.contains(event.id)) continue;
       final targetId = _resolveVoteTarget(
         event,
         knownEventIds,
@@ -1698,46 +1706,7 @@ class LikesRepository {
       return {for (final eventId in eventIds) eventId: <String>[]};
     }
 
-    // Scope the deletion query to the reaction ids we fetched. The consumer
-    // below only honors a Kind 5 whose `e` tag points at a fetched reaction
-    // AND whose author matches it, so `#e`-scoping is semantics-preserving and
-    // an `authors:` filter is redundant (dropped to halve the frame size).
-    // Chunk the `#e` list so a very high-engagement video can't build a single
-    // REQ frame over the relay's `max_message_length` — an oversized frame
-    // errors the socket and the query fails open, counting deletes (#5751).
-    final reactionIds = allReactionsById.keys.toList();
-    final deletionEvents = <Event>[];
-    if (reactionIds.isNotEmpty) {
-      final chunkedDeletions = await Future.wait([
-        for (var i = 0; i < reactionIds.length; i += _deletionReqEidChunkSize)
-          _nostrClient.queryEvents([
-            Filter(
-              kinds: const [EventKind.eventDeletion],
-              e: reactionIds.sublist(
-                i,
-                min(i + _deletionReqEidChunkSize, reactionIds.length),
-              ),
-            ),
-          ]),
-      ]);
-      chunkedDeletions.forEach(deletionEvents.addAll);
-    }
-
-    // Only honor a Kind 5 deletion when its author matches the reaction's
-    // author — otherwise anyone could suppress someone else's like by
-    // publishing a deletion that references the other user's reaction id.
-    final deletedReactionIds = <String>{};
-    for (final deletion in deletionEvents) {
-      for (final tag in deletion.tags) {
-        if (tag.length > 1 && tag[0] == 'e') {
-          final targetId = tag[1];
-          final target = allReactionsById[targetId];
-          if (target != null && target.pubkey == deletion.pubkey) {
-            deletedReactionIds.add(targetId);
-          }
-        }
-      }
-    }
+    final deletedReactionIds = await _deletedReactionIds(allReactionsById);
 
     return {
       for (final entry in reactionsByTarget.entries)
@@ -1746,6 +1715,54 @@ class LikesRepository {
           deletedReactionIds: deletedReactionIds,
         ),
     };
+  }
+
+  /// Resolves which of [reactionsById] their own author has since retracted.
+  ///
+  /// Scopes the deletion query to the reaction ids already fetched, so an
+  /// `authors:` filter would be redundant (dropped to halve the frame size).
+  /// Chunks the `#e` list so a very high-engagement target can't build a
+  /// single REQ frame over the relay's `max_message_length` — an oversized
+  /// frame errors the socket and the query fails open, counting deletes
+  /// (#5751).
+  ///
+  /// Only honors a Kind 5 whose author matches the reaction's author —
+  /// otherwise anyone could suppress someone else's vote by publishing a
+  /// deletion that references the other user's reaction id.
+  Future<Set<String>> _deletedReactionIds(
+    Map<String, Event> reactionsById,
+  ) async {
+    final reactionIds = reactionsById.keys.toList();
+    if (reactionIds.isEmpty) return const {};
+
+    final chunkedDeletions = await Future.wait([
+      for (var i = 0; i < reactionIds.length; i += _deletionReqEidChunkSize)
+        _nostrClient.queryEvents([
+          Filter(
+            kinds: const [EventKind.eventDeletion],
+            e: reactionIds.sublist(
+              i,
+              min(i + _deletionReqEidChunkSize, reactionIds.length),
+            ),
+          ),
+        ]),
+    ]);
+
+    final deleted = <String>{};
+    for (final chunk in chunkedDeletions) {
+      for (final deletion in chunk) {
+        for (final tag in deletion.tags) {
+          if (tag.length > 1 && tag[0] == 'e') {
+            final targetId = tag[1];
+            final target = reactionsById[targetId];
+            if (target != null && target.pubkey == deletion.pubkey) {
+              deleted.add(targetId);
+            }
+          }
+        }
+      }
+    }
+    return deleted;
   }
 
   Set<String> _reactionTargetEventIds(

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -1112,6 +1112,10 @@ class LikesRepository {
   /// when the network call hasn't been awaited yet (offline or pre-publish
   /// failure).
   ///
+  /// Pass [addressableId] (`kind:pubkey:d-tag`) when the target is
+  /// addressable, so the reaction carries NIP-25's `a` tag and survives an
+  /// edit of the target.
+  ///
   /// Throws [AlreadyDownvotedException] if the event is already downvoted.
   /// Throws [LikeFailedException] if the publish fails.
   Future<String> downvoteEvent({
@@ -1176,7 +1180,13 @@ class LikesRepository {
   /// BEFORE the kind-5 deletion publish. On failure restores the record and
   /// re-ticks the stream. Mirrors [unlikeEvent].
   ///
-  /// Throws [NotDownvotedException] if the event is not downvoted.
+  /// Pass [addressableId] when the target is addressable: an edit mints a new
+  /// event id under the same coordinate, so the coordinate is the only durable
+  /// way to find the reaction afterwards. When the in-memory cache holds
+  /// nothing, the relay copy is consulted before giving up.
+  ///
+  /// Throws [NotDownvotedException] when neither the cache nor the relay has a
+  /// live downvote for the target.
   /// Throws [UnlikeFailedException] if the deletion publish fails.
   Future<void> removeDownvote(String eventId, {String? addressableId}) async {
     await _ensureInitialized();

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -213,7 +213,11 @@ class LikesRepository {
     final record = _likeRecords.remove(targetEventId);
     final addressableId = record?.addressableId;
     if (addressableId != null && addressableId.isNotEmpty) {
-      _likeRecordsByAddressableId.remove(addressableId);
+      final indexed = _likeRecordsByAddressableId[addressableId];
+      if (indexed?.reactionEventId == record?.reactionEventId &&
+          indexed?.targetEventId == record?.targetEventId) {
+        _likeRecordsByAddressableId.remove(addressableId);
+      }
     }
   }
 
@@ -232,7 +236,11 @@ class LikesRepository {
     final record = _downvoteRecords.remove(targetEventId);
     final addressableId = record?.addressableId;
     if (addressableId != null && addressableId.isNotEmpty) {
-      _downvoteRecordsByAddressableId.remove(addressableId);
+      final indexed = _downvoteRecordsByAddressableId[addressableId];
+      if (indexed?.reactionEventId == record?.reactionEventId &&
+          indexed?.targetEventId == record?.targetEventId) {
+        _downvoteRecordsByAddressableId.remove(addressableId);
+      }
     }
   }
 
@@ -1033,14 +1041,10 @@ class LikesRepository {
       addressableIds,
     );
 
-    final events = await _nostrClient.queryEvents([
-      Filter(kinds: const [EventKind.reaction], e: eventIds),
-      if (eventIdByCoordinate.isNotEmpty)
-        Filter(
-          kinds: const [EventKind.reaction],
-          a: eventIdByCoordinate.keys.toList(),
-        ),
-    ]);
+    final events = await _queryVoteTargetReactions(
+      eventIds: eventIds,
+      eventIdByCoordinate: eventIdByCoordinate,
+    );
 
     final upvotes = <String, int>{};
     final downvotes = <String, int>{};
@@ -1050,9 +1054,6 @@ class LikesRepository {
     }
 
     final knownEventIds = eventIds.toSet();
-    // A multi-filter REQ emits one frame per matching filter, so a reaction
-    // carrying both the `e` and the `a` tag arrives twice — count each
-    // reaction once.
     final counted = <String>{};
     for (final event in events) {
       if (!counted.add(event.id)) continue;
@@ -1095,19 +1096,11 @@ class LikesRepository {
       addressableIds,
     );
 
-    final events = await _nostrClient.queryEvents([
-      Filter(
-        kinds: const [EventKind.reaction],
-        authors: [_nostrClient.publicKey],
-        e: eventIds,
-      ),
-      if (eventIdByCoordinate.isNotEmpty)
-        Filter(
-          kinds: const [EventKind.reaction],
-          authors: [_nostrClient.publicKey],
-          a: eventIdByCoordinate.keys.toList(),
-        ),
-    ]);
+    final events = await _queryVoteTargetReactions(
+      eventIds: eventIds,
+      eventIdByCoordinate: eventIdByCoordinate,
+      authors: [_nostrClient.publicKey],
+    );
 
     // Also fetch deletions to exclude deleted votes
     final deletionFilter = Filter(
@@ -1147,6 +1140,32 @@ class LikesRepository {
     }
 
     return (upvotedIds: upvotedIds, downvotedIds: downvotedIds);
+  }
+
+  Future<List<Event>> _queryVoteTargetReactions({
+    required List<String> eventIds,
+    required Map<String, String> eventIdByCoordinate,
+    List<String>? authors,
+  }) async {
+    final eEventsFuture = _nostrClient.queryEvents([
+      Filter(kinds: const [EventKind.reaction], authors: authors, e: eventIds),
+    ]);
+    final aEventsFuture = eventIdByCoordinate.isEmpty
+        ? Future<List<Event>>.value(const <Event>[])
+        : _nostrClient.queryEvents([
+            Filter(
+              kinds: const [EventKind.reaction],
+              authors: authors,
+              a: eventIdByCoordinate.keys.toList(),
+            ),
+          ]);
+    final results = await Future.wait([eEventsFuture, aEventsFuture]);
+
+    final eventsById = <String, Event>{};
+    for (final event in [...results[0], ...results[1]]) {
+      eventsById[event.id] = event;
+    }
+    return eventsById.values.toList();
   }
 
   /// Inverts [addressableIds] into a coordinate → event-id lookup, limited to
@@ -1215,6 +1234,17 @@ class LikesRepository {
 
     if (_lookupDownvoteRecord(eventId, addressableId) != null) {
       throw AlreadyDownvotedException(eventId);
+    }
+    if (addressableId != null && addressableId.isNotEmpty) {
+      final remoteRecord = await _resolveRemoteDownvoteRecord(
+        eventId,
+        addressableId: addressableId,
+      );
+      if (remoteRecord != null) {
+        _indexDownvoteRecord(remoteRecord);
+        _emitDownvotedIds();
+        throw AlreadyDownvotedException(eventId);
+      }
     }
 
     // 1. Optimistic-first: write to memory + tick the stream BEFORE any
@@ -2032,24 +2062,14 @@ class LikesRepository {
     String? addressableId,
   }) async {
     final hasCoordinate = addressableId != null && addressableId.isNotEmpty;
-    final reactions = await _nostrClient.queryEvents([
-      Filter(
-        kinds: const [EventKind.reaction],
-        authors: [_nostrClient.publicKey],
-        e: [eventId],
-      ),
-      // An edited addressable target answers to a new event id, so the
-      // pre-edit reaction is only reachable by coordinate (#6124).
-      if (hasCoordinate)
-        Filter(
-          kinds: const [EventKind.reaction],
-          authors: [_nostrClient.publicKey],
-          a: [addressableId],
-        ),
-    ]);
+    final reactions = await _queryVoteTargetReactions(
+      eventIds: [eventId],
+      eventIdByCoordinate: hasCoordinate
+          ? {addressableId: eventId}
+          : const <String, String>{},
+      authors: [_nostrClient.publicKey],
+    );
 
-    // A multi-filter REQ emits one frame per matching filter, so a reaction
-    // carrying both the `e` and the `a` tag arrives twice — dedupe by id.
     final candidatesById = <String, Event>{};
     for (final event in reactions) {
       if (event.content != _downvoteContent) continue;

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -127,6 +127,17 @@ class LikesRepository {
   /// [syncUserReactions] / [getVoteCounts] on next fetch.
   final Map<String, LikeRecord> _downvoteRecords = {};
 
+  /// Companion index of [_downvoteRecords] keyed by addressable coordinate.
+  ///
+  /// Mirror of [_likeRecordsByAddressableId] for the downvote side. An edit of
+  /// an addressable target mints a new event id under the same coordinate, so
+  /// an id-only index loses the downvote the moment the target is edited
+  /// (#6124). Unlike the like side there is no persisted companion column:
+  /// `personal_reactions` has no reaction-content discriminator and is keyed
+  /// `{targetEventId, userPubkey}`, so it cannot represent a like and a
+  /// downvote on the same target. Downvotes stay in-memory only, as in v1.
+  final Map<String, LikeRecord> _downvoteRecordsByAddressableId = {};
+
   /// In-memory cache of global like counts keyed by event ID.
   ///
   /// Prevents redundant relay queries when the same video is scrolled
@@ -204,6 +215,37 @@ class LikesRepository {
     if (addressableId != null && addressableId.isNotEmpty) {
       _likeRecordsByAddressableId.remove(addressableId);
     }
+  }
+
+  /// Indexes [record] into [_downvoteRecords] and, when it carries a
+  /// coordinate, [_downvoteRecordsByAddressableId].
+  void _indexDownvoteRecord(LikeRecord record) {
+    _downvoteRecords[record.targetEventId] = record;
+    final addressableId = record.addressableId;
+    if (addressableId != null && addressableId.isNotEmpty) {
+      _downvoteRecordsByAddressableId[addressableId] = record;
+    }
+  }
+
+  /// Removes any downvote record for [targetEventId] from both indexes.
+  void _deindexDownvoteRecord(String targetEventId) {
+    final record = _downvoteRecords.remove(targetEventId);
+    final addressableId = record?.addressableId;
+    if (addressableId != null && addressableId.isNotEmpty) {
+      _downvoteRecordsByAddressableId.remove(addressableId);
+    }
+  }
+
+  /// Resolves a downvote record by target event id, falling back to
+  /// [addressableId] when the id-keyed lookup misses.
+  ///
+  /// An addressable target that has been edited answers to a new event id but
+  /// the same coordinate, so the coordinate is the durable key (#6124).
+  LikeRecord? _lookupDownvoteRecord(String eventId, String? addressableId) {
+    final byId = _downvoteRecords[eventId];
+    if (byId != null) return byId;
+    if (addressableId == null || addressableId.isEmpty) return null;
+    return _downvoteRecordsByAddressableId[addressableId];
   }
 
   /// Emits the current liked event IDs ordered by recency (most recent
@@ -1076,10 +1118,11 @@ class LikesRepository {
     required String eventId,
     required String authorPubkey,
     int? targetKind,
+    String? addressableId,
   }) async {
     await _ensureInitialized();
 
-    if (_downvoteRecords.containsKey(eventId)) {
+    if (_lookupDownvoteRecord(eventId, addressableId) != null) {
       throw AlreadyDownvotedException(eventId);
     }
 
@@ -1090,8 +1133,9 @@ class LikesRepository {
       targetEventId: eventId,
       reactionEventId: placeholderId,
       createdAt: DateTime.now(),
+      addressableId: addressableId,
     );
-    _downvoteRecords[eventId] = placeholder;
+    _indexDownvoteRecord(placeholder);
     _emitDownvotedIds();
 
     // 2. Online → publish kind 7 with '-'; on success swap the placeholder
@@ -1100,6 +1144,7 @@ class LikesRepository {
       final reactionEvent = await _nostrClient.sendLike(
         eventId,
         content: _downvoteContent,
+        addressableId: addressableId,
         targetAuthorPubkey: authorPubkey,
         targetKind: targetKind,
       );
@@ -1108,15 +1153,18 @@ class LikesRepository {
         throw const LikeFailedException('Failed to publish downvote reaction');
       }
 
-      _downvoteRecords[eventId] = LikeRecord(
-        targetEventId: eventId,
-        reactionEventId: reactionEvent.id,
-        createdAt: placeholder.createdAt,
+      _indexDownvoteRecord(
+        LikeRecord(
+          targetEventId: eventId,
+          reactionEventId: reactionEvent.id,
+          createdAt: placeholder.createdAt,
+          addressableId: addressableId,
+        ),
       );
 
       return reactionEvent.id;
     } catch (_) {
-      _downvoteRecords.remove(eventId);
+      _deindexDownvoteRecord(eventId);
       _emitDownvotedIds();
       rethrow;
     }
@@ -1130,7 +1178,7 @@ class LikesRepository {
   ///
   /// Throws [NotDownvotedException] if the event is not downvoted.
   /// Throws [UnlikeFailedException] if the deletion publish fails.
-  Future<void> removeDownvote(String eventId) async {
+  Future<void> removeDownvote(String eventId, {String? addressableId}) async {
     await _ensureInitialized();
 
     // [_downvoteRecords] is in-memory only in v1, so a cold start leaves it
@@ -1139,16 +1187,21 @@ class LikesRepository {
     // [NotDownvotedException], the caller clears its UI, and the downvote
     // survives untouched and reappears on the next fetch (#6124).
     final record =
-        _downvoteRecords[eventId] ??
-        await _resolveRemoteDownvoteRecord(eventId);
+        _lookupDownvoteRecord(eventId, addressableId) ??
+        await _resolveRemoteDownvoteRecord(
+          eventId,
+          addressableId: addressableId,
+        );
     if (record == null) {
       throw NotDownvotedException(eventId);
     }
 
     final snapshotRecord = record;
 
-    // 1. Optimistic-first: remove from memory and tick the stream.
-    _downvoteRecords.remove(eventId);
+    // 1. Optimistic-first: remove from memory and tick the stream. Deindex by
+    // the record's own target id: a coordinate hit can resolve to a record
+    // filed under a superseded event id.
+    _deindexDownvoteRecord(snapshotRecord.targetEventId);
     _emitDownvotedIds();
 
     // 2. Skip publishing deletion for placeholders that never reached the
@@ -1168,7 +1221,7 @@ class LikesRepository {
         );
       }
     } catch (_) {
-      _downvoteRecords[eventId] = snapshotRecord;
+      _indexDownvoteRecord(snapshotRecord);
       _emitDownvotedIds();
       rethrow;
     }
@@ -1183,11 +1236,12 @@ class LikesRepository {
     required String eventId,
     required String authorPubkey,
     int? targetKind,
+    String? addressableId,
   }) async {
     await _ensureInitialized();
 
-    if (_downvoteRecords.containsKey(eventId)) {
-      await removeDownvote(eventId);
+    if (_lookupDownvoteRecord(eventId, addressableId) != null) {
+      await removeDownvote(eventId, addressableId: addressableId);
       return false;
     }
 
@@ -1195,6 +1249,7 @@ class LikesRepository {
       eventId: eventId,
       authorPubkey: authorPubkey,
       targetKind: targetKind,
+      addressableId: addressableId,
     );
     return true;
   }
@@ -1329,14 +1384,16 @@ class LikesRepository {
             createdAt: DateTime.fromMillisecondsSinceEpoch(
               event.createdAt * 1000,
             ),
+            addressableId: _extractAddressableId(event),
           );
 
           // Mirror the upvote freshness check; downvotes aren't persisted
-          // in v1 so there's no batch save.
+          // in v1 so there's no batch save. The coordinate is indexed
+          // alongside the id so an edited target still resolves (#6124).
           final existing = _downvoteRecords[targetId];
           if (existing == null ||
               record.createdAt.isAfter(existing.createdAt)) {
-            _downvoteRecords[targetId] = record;
+            _indexDownvoteRecord(record);
             downvoteCacheChanged = true;
           }
         }
@@ -1350,7 +1407,7 @@ class LikesRepository {
 
       // Remove deleted downvotes from in-memory cache (no local storage in v1)
       for (final targetId in deletedDownvoteTargetIds) {
-        _downvoteRecords.remove(targetId);
+        _deindexDownvoteRecord(targetId);
         downvoteCacheChanged = true;
       }
 
@@ -1730,10 +1787,13 @@ class LikesRepository {
       final existing = _downvoteRecords[targetId];
       if (existing != null && !createdAt.isAfter(existing.createdAt)) return;
 
-      _downvoteRecords[targetId] = LikeRecord(
-        targetEventId: targetId,
-        reactionEventId: event.id,
-        createdAt: createdAt,
+      _indexDownvoteRecord(
+        LikeRecord(
+          targetEventId: targetId,
+          reactionEventId: event.id,
+          createdAt: createdAt,
+          addressableId: _extractAddressableId(event),
+        ),
       );
       _emitDownvotedIds();
     }
@@ -1798,6 +1858,7 @@ class LikesRepository {
     _likeRecords.clear();
     _likeRecordsByAddressableId.clear();
     _downvoteRecords.clear();
+    _downvoteRecordsByAddressableId.clear();
     _likeCountCache.clear();
     _likeCountCacheByAddressableId.clear();
     await _localStorage?.clearAll();
@@ -1869,19 +1930,38 @@ class LikesRepository {
   /// against [eventId], or `null` when there is none. Used by
   /// [removeDownvote] to recover from an empty in-memory cache after a cold
   /// start, since downvotes are not persisted locally in v1.
-  Future<LikeRecord?> _resolveRemoteDownvoteRecord(String eventId) async {
+  Future<LikeRecord?> _resolveRemoteDownvoteRecord(
+    String eventId, {
+    String? addressableId,
+  }) async {
+    final hasCoordinate = addressableId != null && addressableId.isNotEmpty;
     final reactions = await _nostrClient.queryEvents([
       Filter(
         kinds: const [EventKind.reaction],
         authors: [_nostrClient.publicKey],
         e: [eventId],
       ),
+      // An edited addressable target answers to a new event id, so the
+      // pre-edit reaction is only reachable by coordinate (#6124).
+      if (hasCoordinate)
+        Filter(
+          kinds: const [EventKind.reaction],
+          authors: [_nostrClient.publicKey],
+          a: [addressableId],
+        ),
     ]);
 
-    final candidates = reactions
-        .where((event) => event.content == _downvoteContent)
-        .where((event) => _extractTargetEventId(event) == eventId)
-        .toList();
+    // A multi-filter REQ emits one frame per matching filter, so a reaction
+    // carrying both the `e` and the `a` tag arrives twice — dedupe by id.
+    final candidatesById = <String, Event>{};
+    for (final event in reactions) {
+      if (event.content != _downvoteContent) continue;
+      final matches =
+          _extractTargetEventId(event) == eventId ||
+          (hasCoordinate && _extractAddressableId(event) == addressableId);
+      if (matches) candidatesById[event.id] = event;
+    }
+    final candidates = candidatesById.values.toList();
     if (candidates.isEmpty) return null;
 
     final deletions = await _nostrClient.queryEvents([

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -1012,16 +1012,35 @@ class LikesRepository {
   /// Queries relays for Kind 7 reactions on each event, differentiating
   /// between `+` (upvote) and `-` (downvote) content.
   ///
+  /// Pass [addressableIds] — event id to `kind:pubkey:d-tag` coordinate — for
+  /// targets that are addressable. An edit republishes such a target under a
+  /// new event id, so every vote cast against the previous revision is only
+  /// reachable by coordinate; an `e`-only query reports zero and the score
+  /// vanishes for every viewer the moment the target is edited (#6124).
+  ///
   /// Returns a record of upvote and downvote count maps.
   Future<({Map<String, int> upvotes, Map<String, int> downvotes})>
-  getVoteCounts(List<String> eventIds) async {
+  getVoteCounts(
+    List<String> eventIds, {
+    Map<String, String> addressableIds = const {},
+  }) async {
     if (eventIds.isEmpty) {
       return (upvotes: <String, int>{}, downvotes: <String, int>{});
     }
 
-    final filter = Filter(kinds: const [EventKind.reaction], e: eventIds);
+    final eventIdByCoordinate = _voteTargetsByCoordinate(
+      eventIds,
+      addressableIds,
+    );
 
-    final events = await _nostrClient.queryEvents([filter]);
+    final events = await _nostrClient.queryEvents([
+      Filter(kinds: const [EventKind.reaction], e: eventIds),
+      if (eventIdByCoordinate.isNotEmpty)
+        Filter(
+          kinds: const [EventKind.reaction],
+          a: eventIdByCoordinate.keys.toList(),
+        ),
+    ]);
 
     final upvotes = <String, int>{};
     final downvotes = <String, int>{};
@@ -1030,19 +1049,25 @@ class LikesRepository {
       downvotes[eventId] = 0;
     }
 
+    final knownEventIds = eventIds.toSet();
+    // A multi-filter REQ emits one frame per matching filter, so a reaction
+    // carrying both the `e` and the `a` tag arrives twice — count each
+    // reaction once.
+    final counted = <String>{};
     for (final event in events) {
-      for (final tag in event.tags) {
-        if (tag.isNotEmpty && tag[0] == 'e' && tag.length > 1) {
-          final targetId = tag[1];
-          if (upvotes.containsKey(targetId)) {
-            if (event.content == _downvoteContent) {
-              downvotes[targetId] = downvotes[targetId]! + 1;
-            } else {
-              // '+' and any other content counts as upvote
-              upvotes[targetId] = upvotes[targetId]! + 1;
-            }
-          }
-        }
+      if (!counted.add(event.id)) continue;
+      final targetId = _resolveVoteTarget(
+        event,
+        knownEventIds,
+        eventIdByCoordinate,
+      );
+      if (targetId == null) continue;
+
+      if (event.content == _downvoteContent) {
+        downvotes[targetId] = downvotes[targetId]! + 1;
+      } else {
+        // '+' and any other content counts as upvote
+        upvotes[targetId] = upvotes[targetId]! + 1;
       }
     }
 
@@ -1051,20 +1076,38 @@ class LikesRepository {
 
   /// Get the user's current vote status for multiple events.
   ///
+  /// Pass [addressableIds] for addressable targets, for the same reason
+  /// [getVoteCounts] needs it: without the coordinate the voter's own arrow
+  /// silently un-fills after the target is edited (#6124).
+  ///
   /// Returns maps of event IDs the user has upvoted or downvoted.
   Future<({Set<String> upvotedIds, Set<String> downvotedIds})>
-  getUserVoteStatuses(List<String> eventIds) async {
+  getUserVoteStatuses(
+    List<String> eventIds, {
+    Map<String, String> addressableIds = const {},
+  }) async {
     if (eventIds.isEmpty) {
       return (upvotedIds: <String>{}, downvotedIds: <String>{});
     }
 
-    final filter = Filter(
-      kinds: const [EventKind.reaction],
-      authors: [_nostrClient.publicKey],
-      e: eventIds,
+    final eventIdByCoordinate = _voteTargetsByCoordinate(
+      eventIds,
+      addressableIds,
     );
 
-    final events = await _nostrClient.queryEvents([filter]);
+    final events = await _nostrClient.queryEvents([
+      Filter(
+        kinds: const [EventKind.reaction],
+        authors: [_nostrClient.publicKey],
+        e: eventIds,
+      ),
+      if (eventIdByCoordinate.isNotEmpty)
+        Filter(
+          kinds: const [EventKind.reaction],
+          authors: [_nostrClient.publicKey],
+          a: eventIdByCoordinate.keys.toList(),
+        ),
+    ]);
 
     // Also fetch deletions to exclude deleted votes
     final deletionFilter = Filter(
@@ -1084,12 +1127,17 @@ class LikesRepository {
 
     final upvotedIds = <String>{};
     final downvotedIds = <String>{};
+    final knownEventIds = eventIds.toSet();
 
     for (final event in events) {
       if (deletedIds.contains(event.id)) continue;
 
-      final targetId = _extractTargetEventId(event);
-      if (targetId == null || !eventIds.contains(targetId)) continue;
+      final targetId = _resolveVoteTarget(
+        event,
+        knownEventIds,
+        eventIdByCoordinate,
+      );
+      if (targetId == null) continue;
 
       if (event.content == _downvoteContent) {
         downvotedIds.add(targetId);
@@ -1099,6 +1147,45 @@ class LikesRepository {
     }
 
     return (upvotedIds: upvotedIds, downvotedIds: downvotedIds);
+  }
+
+  /// Inverts [addressableIds] into a coordinate → event-id lookup, limited to
+  /// the ids actually being queried and skipping blank coordinates.
+  Map<String, String> _voteTargetsByCoordinate(
+    List<String> eventIds,
+    Map<String, String> addressableIds,
+  ) {
+    final byCoordinate = <String, String>{};
+    for (final eventId in eventIds) {
+      final coordinate = addressableIds[eventId];
+      if (coordinate != null && coordinate.isNotEmpty) {
+        byCoordinate[coordinate] = eventId;
+      }
+    }
+    return byCoordinate;
+  }
+
+  /// Resolves which queried target a reaction belongs to.
+  ///
+  /// Matches the `e` tag first, then falls back to the `a` tag so a reaction
+  /// cast against a superseded revision of an addressable target still lands
+  /// on the revision the caller is currently showing (#6124). Returns `null`
+  /// when the reaction targets nothing in the queried set.
+  String? _resolveVoteTarget(
+    Event event,
+    Set<String> knownEventIds,
+    Map<String, String> eventIdByCoordinate,
+  ) {
+    for (final tag in event.tags) {
+      if (tag.isNotEmpty && tag[0] == 'e' && tag.length > 1) {
+        final targetId = tag[1];
+        if (knownEventIds.contains(targetId)) return targetId;
+      }
+    }
+    if (eventIdByCoordinate.isEmpty) return null;
+    final coordinate = _extractAddressableId(event);
+    if (coordinate == null) return null;
+    return eventIdByCoordinate[coordinate];
   }
 
   /// Publish a downvote (Kind 7 reaction with content '-').

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -1049,6 +1049,50 @@ void main() {
         );
       });
 
+      test('throws AlreadyDownvotedException when relay has coordinate '
+          'downvote after cold start (#6124)', () async {
+        const supersededId = 'superseded_reply_id_1234567890abcdef';
+        const editedId = 'edited_reply_id_1234567890abcdef';
+        const coordinate = '34236:$testAuthorPubkey:reply-d-tag';
+        mockQueryEventsSequence([
+          <Event>[],
+          [
+            createMockReaction(
+              id: testReactionEventId,
+              targetEventId: supersededId,
+              content: '-',
+              tags: [
+                ['e', supersededId],
+                ['a', coordinate],
+              ],
+            ),
+          ],
+          <Event>[],
+        ]);
+
+        repository = createRepository(withLocalStorage: false);
+
+        await expectLater(
+          repository.downvoteEvent(
+            eventId: editedId,
+            authorPubkey: testAuthorPubkey,
+            addressableId: coordinate,
+            targetKind: 34236,
+          ),
+          throwsA(isA<AlreadyDownvotedException>()),
+        );
+
+        verifyNever(
+          () => mockNostrClient.sendLike(
+            any(),
+            content: any(named: 'content'),
+            addressableId: any(named: 'addressableId'),
+            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+            targetKind: any(named: 'targetKind'),
+          ),
+        );
+      });
+
       test('rolls back record + stream when publish returns null', () async {
         when(
           () => mockNostrClient.sendLike(
@@ -1144,6 +1188,7 @@ void main() {
         const editedId = 'edited_event_id_1234567890abcdef';
 
         repository = createRepository(withLocalStorage: false);
+        mockQueryEventsSequence([<Event>[], <Event>[], <Event>[]]);
         when(
           () => mockNostrClient.sendLike(
             any(),
@@ -1180,6 +1225,7 @@ void main() {
       test('passes the coordinate through to sendLike (#6124)', () async {
         const coordinate = '34236:$testAuthorPubkey:reply-d-tag';
         repository = createRepository(withLocalStorage: false);
+        mockQueryEventsSequence([<Event>[], <Event>[], <Event>[]]);
         when(
           () => mockNostrClient.sendLike(
             any(),
@@ -4279,9 +4325,10 @@ void main() {
             ['a', coordinate],
           ],
         );
-        when(
-          () => mockNostrClient.queryEvents(any()),
-        ).thenAnswer((_) async => [reaction]);
+        mockQueryEventsSequence([
+          <Event>[],
+          [reaction],
+        ]);
 
         repository = createRepository(withLocalStorage: false);
 
@@ -4298,34 +4345,45 @@ void main() {
         );
       });
 
-      test('getVoteCounts counts a dual-tagged reaction only once', () async {
-        // A multi-filter REQ emits one frame per matching filter, so the same
-        // reaction arrives on both the e-filter and the a-filter.
-        final reaction = createMockReaction(
-          id: 'voter_reaction',
-          targetEventId: editedId,
-          authorPubkey: 'some_voter_pubkey_1234567890abcdef',
-          tags: [
-            ['e', editedId],
-            ['a', coordinate],
-          ],
-        );
-        when(
-          () => mockNostrClient.queryEvents(any()),
-        ).thenAnswer((_) async => [reaction, reaction]);
+      test(
+        'getVoteCounts queries e and a separately so cache stays active',
+        () async {
+          final reaction = createMockReaction(
+            id: 'voter_reaction',
+            targetEventId: editedId,
+            authorPubkey: 'some_voter_pubkey_1234567890abcdef',
+            tags: [
+              ['e', editedId],
+              ['a', coordinate],
+            ],
+          );
+          mockQueryEventsSequence([
+            [reaction],
+            [reaction],
+          ]);
 
-        repository = createRepository(withLocalStorage: false);
+          repository = createRepository(withLocalStorage: false);
 
-        final counts = await repository.getVoteCounts(
-          [editedId],
-          addressableIds: const {editedId: coordinate},
-        );
+          final counts = await repository.getVoteCounts(
+            [editedId],
+            addressableIds: const {editedId: coordinate},
+          );
 
-        expect(counts.upvotes[editedId], equals(1));
-      });
+          expect(counts.upvotes[editedId], equals(1));
+
+          final captured = verify(
+            () => mockNostrClient.queryEvents(captureAny()),
+          ).captured.cast<List<Filter>>();
+          expect(captured, hasLength(2));
+          expect(captured.every((filters) => filters.length == 1), isTrue);
+          expect(captured[0].single.e, equals([editedId]));
+          expect(captured[1].single.a, equals([coordinate]));
+        },
+      );
 
       test('getUserVoteStatuses resolves the own vote by coordinate', () async {
         mockQueryEventsSequence([
+          <Event>[],
           [
             createMockReaction(
               id: 'own_downvote',
@@ -4355,6 +4413,7 @@ void main() {
       test('getUserVoteStatuses still excludes a deleted coordinate '
           'vote', () async {
         mockQueryEventsSequence([
+          <Event>[],
           [
             createMockReaction(
               id: 'own_downvote',
@@ -4391,9 +4450,10 @@ void main() {
             ['a', '34236:$testAuthorPubkey:some-other-d-tag'],
           ],
         );
-        when(
-          () => mockNostrClient.queryEvents(any()),
-        ).thenAnswer((_) async => [reaction]);
+        mockQueryEventsSequence([
+          <Event>[],
+          [reaction],
+        ]);
 
         repository = createRepository(withLocalStorage: false);
 
@@ -4403,6 +4463,54 @@ void main() {
         );
 
         expect(counts.upvotes[editedId], equals(0));
+      });
+
+      test('deleting an older revision keeps the newer coordinate downvote '
+          'indexed (#6124)', () async {
+        const coordinate = '34236:$testAuthorPubkey:reply-d-tag';
+        const oldId = 'old_reply_id_1234567890abcdef';
+        const newId = 'new_reply_id_1234567890abcdef';
+        const oldReactionId = 'old_downvote_reaction_id_1234567890abcdef';
+        const newReactionId = 'new_downvote_reaction_id_1234567890abcdef';
+        final oldReaction = createMockReaction(
+          id: oldReactionId,
+          targetEventId: oldId,
+          content: '-',
+          tags: [
+            ['e', oldId],
+            ['a', coordinate],
+          ],
+        );
+        final newReaction = createMockReaction(
+          id: newReactionId,
+          targetEventId: newId,
+          content: '-',
+          createdAt: defaultTimestamp + 1,
+          tags: [
+            ['e', newId],
+            ['a', coordinate],
+          ],
+        );
+
+        mockQueryEventsSequence([
+          [oldReaction, newReaction],
+          <Event>[],
+          [oldReaction, newReaction],
+          [
+            createMockDeletion([oldReactionId]),
+          ],
+        ]);
+        when(
+          () => mockNostrClient.deleteEvent(any()),
+        ).thenAnswer((_) async => MockEvent());
+
+        repository = createRepository(withLocalStorage: false);
+
+        await repository.syncUserReactions();
+        await repository.syncUserReactions();
+        await repository.removeDownvote(newId, addressableId: coordinate);
+
+        verify(() => mockNostrClient.deleteEvent(newReactionId)).called(1);
       });
     });
   });

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -1134,14 +1134,73 @@ void main() {
         ).called(1);
       });
 
-      test('throws NotDownvotedException when not downvoted', () async {
-        repository = createRepository(withLocalStorage: false);
+      test(
+        'throws NotDownvotedException when neither cache nor relay has one',
+        () async {
+          repository = createRepository(withLocalStorage: false);
+          // Relay reports no reaction and no deletion.
+          mockQueryEventsSequence([<Event>[], <Event>[]]);
 
-        await expectLater(
-          repository.removeDownvote(testEventId),
-          throwsA(isA<NotDownvotedException>()),
-        );
-      });
+          await expectLater(
+            repository.removeDownvote(testEventId),
+            throwsA(isA<NotDownvotedException>()),
+          );
+        },
+      );
+
+      test(
+        'deletes the relay copy when the in-memory cache is cold (#6124)',
+        () async {
+          // Downvotes are never persisted, so a cold start leaves the cache
+          // empty while the kind-7 is still live. Without the relay fallback
+          // this threw and the deletion was never published.
+          repository = createRepository(withLocalStorage: false);
+          mockQueryEventsSequence([
+            [
+              createMockReaction(
+                id: testReactionEventId,
+                targetEventId: testEventId,
+                content: '-',
+              ),
+            ],
+            <Event>[],
+          ]);
+          when(
+            () => mockNostrClient.deleteEvent(any()),
+          ).thenAnswer((_) async => MockEvent());
+
+          await repository.removeDownvote(testEventId);
+
+          verify(
+            () => mockNostrClient.deleteEvent(testReactionEventId),
+          ).called(1);
+        },
+      );
+
+      test(
+        'does not delete a relay downvote that was already deleted (#6124)',
+        () async {
+          repository = createRepository(withLocalStorage: false);
+          mockQueryEventsSequence([
+            [
+              createMockReaction(
+                id: testReactionEventId,
+                targetEventId: testEventId,
+                content: '-',
+              ),
+            ],
+            [
+              createMockDeletion([testReactionEventId]),
+            ],
+          ]);
+
+          await expectLater(
+            repository.removeDownvote(testEventId),
+            throwsA(isA<NotDownvotedException>()),
+          );
+          verifyNever(() => mockNostrClient.deleteEvent(any()));
+        },
+      );
 
       test('rolls back record + stream when deletion returns null', () async {
         when(

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -1134,6 +1134,86 @@ void main() {
         ).called(1);
       });
 
+      test('resolves a downvote by coordinate after the target is edited '
+          '(#6124)', () async {
+        // An edit mints a new event id under the same coordinate. Without the
+        // coordinate companion index the pre-edit downvote is unreachable, so
+        // the deletion is never published and re-tapping mints a duplicate.
+        const coordinate = '34236:$testAuthorPubkey:reply-d-tag';
+        const supersededId = 'superseded_event_id_1234567890abcdef';
+        const editedId = 'edited_event_id_1234567890abcdef';
+
+        repository = createRepository(withLocalStorage: false);
+        when(
+          () => mockNostrClient.sendLike(
+            any(),
+            content: any(named: 'content'),
+            addressableId: any(named: 'addressableId'),
+            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+            targetKind: any(named: 'targetKind'),
+          ),
+        ).thenAnswer(
+          (_) async => createMockReaction(
+            id: testReactionEventId,
+            targetEventId: supersededId,
+            content: '-',
+          ),
+        );
+        when(
+          () => mockNostrClient.deleteEvent(any()),
+        ).thenAnswer((_) async => MockEvent());
+
+        await repository.downvoteEvent(
+          eventId: supersededId,
+          authorPubkey: testAuthorPubkey,
+          addressableId: coordinate,
+        );
+
+        // The edited revision answers to a different id, same coordinate.
+        await repository.removeDownvote(editedId, addressableId: coordinate);
+
+        verify(
+          () => mockNostrClient.deleteEvent(testReactionEventId),
+        ).called(1);
+      });
+
+      test('passes the coordinate through to sendLike (#6124)', () async {
+        const coordinate = '34236:$testAuthorPubkey:reply-d-tag';
+        repository = createRepository(withLocalStorage: false);
+        when(
+          () => mockNostrClient.sendLike(
+            any(),
+            content: any(named: 'content'),
+            addressableId: any(named: 'addressableId'),
+            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+            targetKind: any(named: 'targetKind'),
+          ),
+        ).thenAnswer(
+          (_) async => createMockReaction(
+            id: testReactionEventId,
+            targetEventId: testEventId,
+            content: '-',
+          ),
+        );
+
+        await repository.downvoteEvent(
+          eventId: testEventId,
+          authorPubkey: testAuthorPubkey,
+          targetKind: 34236,
+          addressableId: coordinate,
+        );
+
+        verify(
+          () => mockNostrClient.sendLike(
+            testEventId,
+            content: '-',
+            addressableId: coordinate,
+            targetAuthorPubkey: testAuthorPubkey,
+            targetKind: 34236,
+          ),
+        ).called(1);
+      });
+
       test(
         'throws NotDownvotedException when neither cache nor relay has one',
         () async {

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -62,8 +62,12 @@ void main() {
     }
 
     // Helper to create a mock deletion event
-    MockEvent createMockDeletion(List<String> deletedEventIds) {
+    MockEvent createMockDeletion(
+      List<String> deletedEventIds, {
+      String authorPubkey = 'reaction_author_pubkey_1234567890abcdef',
+    }) {
       final event = MockEvent();
+      when(() => event.pubkey).thenReturn(authorPubkey);
       when(
         () => event.tags,
       ).thenReturn(deletedEventIds.map((id) => ['e', id]).toList());
@@ -4360,6 +4364,7 @@ void main() {
           mockQueryEventsSequence([
             [reaction],
             [reaction],
+            <Event>[], // no deletions
           ]);
 
           repository = createRepository(withLocalStorage: false);
@@ -4371,13 +4376,21 @@ void main() {
 
           expect(counts.upvotes[editedId], equals(1));
 
+          // Three single-filter requests: by `e`, by `a`, then the Kind 5
+          // sweep over the reactions those returned. Every one has to stay
+          // single-filter — NostrClient skips the local event cache the
+          // moment a call carries more than one.
           final captured = verify(
             () => mockNostrClient.queryEvents(captureAny()),
           ).captured.cast<List<Filter>>();
-          expect(captured, hasLength(2));
+          expect(captured, hasLength(3));
           expect(captured.every((filters) => filters.length == 1), isTrue);
           expect(captured[0].single.e, equals([editedId]));
           expect(captured[1].single.a, equals([coordinate]));
+          expect(
+            captured[2].single.kinds,
+            equals([EventKind.eventDeletion]),
+          );
         },
       );
 
@@ -4471,6 +4484,87 @@ void main() {
 
         expect(counts.upvotes[editedId], equals(1));
         expect(counts.upvotes[rootCommentId], equals(0));
+      });
+
+      test('getVoteCounts excludes a vote retracted on an earlier '
+          'revision', () async {
+        // Switching an upvote to a downvote on an edited reply publishes a
+        // Kind 5 for the pre-edit reaction and a new downvote on the current
+        // one. The coordinate leg reaches both, so counting the retracted
+        // upvote would leave netScore 0 — which comment_item renders by
+        // hiding the score entirely.
+        const voter = 'some_voter_pubkey_1234567890abcdef';
+        final retractedUpvote = createMockReaction(
+          id: 'retracted_upvote',
+          targetEventId: supersededId,
+          authorPubkey: voter,
+          tags: [
+            ['e', supersededId],
+            ['a', coordinate],
+          ],
+        );
+        final liveDownvote = createMockReaction(
+          id: 'live_downvote',
+          targetEventId: editedId,
+          authorPubkey: voter,
+          content: '-',
+          tags: [
+            ['e', editedId],
+            ['a', coordinate],
+          ],
+        );
+        mockQueryEventsSequence([
+          [liveDownvote],
+          [retractedUpvote, liveDownvote],
+          [
+            createMockDeletion(['retracted_upvote'], authorPubkey: voter),
+          ],
+        ]);
+
+        repository = createRepository(withLocalStorage: false);
+
+        final counts = await repository.getVoteCounts(
+          [editedId],
+          addressableIds: const {editedId: coordinate},
+        );
+
+        expect(counts.upvotes[editedId], equals(0));
+        expect(counts.downvotes[editedId], equals(1));
+      });
+
+      test('getVoteCounts ignores a deletion published by someone other than '
+          'the voter', () async {
+        // Otherwise anyone could suppress another user's vote by referencing
+        // its reaction id.
+        const voter = 'some_voter_pubkey_1234567890abcdef';
+        final upvote = createMockReaction(
+          id: 'honest_upvote',
+          targetEventId: editedId,
+          authorPubkey: voter,
+          tags: [
+            ['e', editedId],
+            ['a', coordinate],
+          ],
+        );
+        mockQueryEventsSequence([
+          [upvote],
+          [upvote],
+          [
+            createMockDeletion(
+              ['honest_upvote'],
+              authorPubkey: 'an_impostor_pubkey_1234567890abcdef',
+            ),
+          ],
+        ]);
+
+        repository = createRepository(withLocalStorage: false);
+
+        final counts = await repository.getVoteCounts(
+          [editedId],
+          addressableIds: const {editedId: coordinate},
+        );
+
+        expect(counts.upvotes[editedId], equals(1));
       });
 
       test('getVoteCounts ignores an unrelated coordinate', () async {

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -4441,6 +4441,38 @@ void main() {
         expect(statuses.downvotedIds, isEmpty);
       });
 
+      test('getVoteCounts credits the last `e` tag when a reaction carries '
+          'several', () async {
+        // NIP-25: "the target event `id` should be last of the `e` tags".
+        // A client that copies the thread's ancestor tags would otherwise
+        // have its vote credited to the root comment instead of the reply.
+        const rootCommentId = 'root_comment_id_1234567890abcdef';
+        final reaction = createMockReaction(
+          id: 'ancestor_tagged_reaction',
+          targetEventId: editedId,
+          authorPubkey: 'some_voter_pubkey_1234567890abcdef',
+          tags: [
+            ['e', rootCommentId],
+            ['e', editedId],
+          ],
+        );
+        mockQueryEventsSequence([
+          [reaction],
+          <Event>[],
+          <Event>[],
+        ]);
+
+        repository = createRepository(withLocalStorage: false);
+
+        final counts = await repository.getVoteCounts([
+          rootCommentId,
+          editedId,
+        ]);
+
+        expect(counts.upvotes[editedId], equals(1));
+        expect(counts.upvotes[rootCommentId], equals(0));
+      });
+
       test('getVoteCounts ignores an unrelated coordinate', () async {
         final reaction = createMockReaction(
           id: 'other_reaction',

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -4260,5 +4260,150 @@ void main() {
         },
       );
     });
+
+    group('coordinate-aware vote reads (#6124)', () {
+      const supersededId = 'superseded_reply_id_1234567890abcdef';
+      const editedId = 'edited_reply_id_1234567890abcdef';
+      const coordinate = '34236:$testAuthorPubkey:reply-d-tag';
+
+      test('getVoteCounts counts a vote cast before the target was edited', () {
+        // The reaction names the pre-edit id in its `e` tag, so an `e`-only
+        // query against the current id returns nothing and the score
+        // disappears for every viewer.
+        final reaction = createMockReaction(
+          id: 'voter_reaction',
+          targetEventId: supersededId,
+          authorPubkey: 'some_voter_pubkey_1234567890abcdef',
+          tags: [
+            ['e', supersededId],
+            ['a', coordinate],
+          ],
+        );
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [reaction]);
+
+        repository = createRepository(withLocalStorage: false);
+
+        return expectLater(
+          repository.getVoteCounts(
+            [editedId],
+            addressableIds: const {editedId: coordinate},
+          ),
+          completion(
+            isA<({Map<String, int> upvotes, Map<String, int> downvotes})>()
+                .having((r) => r.upvotes[editedId], 'upvotes', 1)
+                .having((r) => r.downvotes[editedId], 'downvotes', 0),
+          ),
+        );
+      });
+
+      test('getVoteCounts counts a dual-tagged reaction only once', () async {
+        // A multi-filter REQ emits one frame per matching filter, so the same
+        // reaction arrives on both the e-filter and the a-filter.
+        final reaction = createMockReaction(
+          id: 'voter_reaction',
+          targetEventId: editedId,
+          authorPubkey: 'some_voter_pubkey_1234567890abcdef',
+          tags: [
+            ['e', editedId],
+            ['a', coordinate],
+          ],
+        );
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [reaction, reaction]);
+
+        repository = createRepository(withLocalStorage: false);
+
+        final counts = await repository.getVoteCounts(
+          [editedId],
+          addressableIds: const {editedId: coordinate},
+        );
+
+        expect(counts.upvotes[editedId], equals(1));
+      });
+
+      test('getUserVoteStatuses resolves the own vote by coordinate', () async {
+        mockQueryEventsSequence([
+          [
+            createMockReaction(
+              id: 'own_downvote',
+              targetEventId: supersededId,
+              authorPubkey: testUserPubkey,
+              content: '-',
+              tags: [
+                ['e', supersededId],
+                ['a', coordinate],
+              ],
+            ),
+          ],
+          <Event>[], // no deletions
+        ]);
+
+        repository = createRepository(withLocalStorage: false);
+
+        final statuses = await repository.getUserVoteStatuses(
+          [editedId],
+          addressableIds: const {editedId: coordinate},
+        );
+
+        expect(statuses.downvotedIds, contains(editedId));
+        expect(statuses.upvotedIds, isEmpty);
+      });
+
+      test('getUserVoteStatuses still excludes a deleted coordinate '
+          'vote', () async {
+        mockQueryEventsSequence([
+          [
+            createMockReaction(
+              id: 'own_downvote',
+              targetEventId: supersededId,
+              authorPubkey: testUserPubkey,
+              content: '-',
+              tags: [
+                ['e', supersededId],
+                ['a', coordinate],
+              ],
+            ),
+          ],
+          [
+            createMockDeletion(['own_downvote']),
+          ],
+        ]);
+
+        repository = createRepository(withLocalStorage: false);
+
+        final statuses = await repository.getUserVoteStatuses(
+          [editedId],
+          addressableIds: const {editedId: coordinate},
+        );
+
+        expect(statuses.downvotedIds, isEmpty);
+      });
+
+      test('getVoteCounts ignores an unrelated coordinate', () async {
+        final reaction = createMockReaction(
+          id: 'other_reaction',
+          targetEventId: 'unrelated_event_id_1234567890abcdef',
+          authorPubkey: 'some_voter_pubkey_1234567890abcdef',
+          tags: [
+            ['a', '34236:$testAuthorPubkey:some-other-d-tag'],
+          ],
+        );
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [reaction]);
+
+        repository = createRepository(withLocalStorage: false);
+
+        final counts = await repository.getVoteCounts(
+          [editedId],
+          addressableIds: const {editedId: coordinate},
+        );
+
+        expect(counts.upvotes[editedId], equals(0));
+      });
+    });
   });
 }

--- a/mobile/test/blocs/comments/comment_reactions/comment_reactions_bloc_test.dart
+++ b/mobile/test/blocs/comments/comment_reactions/comment_reactions_bloc_test.dart
@@ -101,16 +101,12 @@ void main() {
         'populates counts and statuses from likes repo',
         setUp: () {
           when(() => mockLikesRepository.getVoteCounts(any())).thenAnswer(
-            (_) async => (
-              upvotes: {validId('c1'): 5},
-              downvotes: {validId('c1'): 1},
-            ),
+            (_) async =>
+                (upvotes: {validId('c1'): 5}, downvotes: {validId('c1'): 1}),
           );
           when(() => mockLikesRepository.getUserVoteStatuses(any())).thenAnswer(
-            (_) async => (
-              upvotedIds: {validId('c1')},
-              downvotedIds: <String>{},
-            ),
+            (_) async =>
+                (upvotedIds: {validId('c1')}, downvotedIds: <String>{}),
           );
         },
         build: createBloc,
@@ -184,9 +180,7 @@ void main() {
               authorPubkey: any(named: 'authorPubkey'),
               targetKind: any(named: 'targetKind'),
             ),
-          ).thenThrow(
-            const LikesRepositoryException('publish failed'),
-          );
+          ).thenThrow(const LikesRepositoryException('publish failed'));
         },
         build: createBloc,
         act: (b) => b.add(
@@ -354,6 +348,52 @@ void main() {
               eventId: validId('c1'),
               authorPubkey: validId('author1'),
               targetKind: 34236,
+              addressableId: '34236:${validId('author1')}:reply-d',
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<CommentReactionsBloc, CommentReactionsState>(
+        'tears down an upvote by coordinate when switching to a downvote '
+        '(#6124)',
+        setUp: () {
+          when(
+            () => mockLikesRepository.unlikeEvent(
+              any(),
+              addressableId: any(named: 'addressableId'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockLikesRepository.downvoteEvent(
+              eventId: any(named: 'eventId'),
+              authorPubkey: any(named: 'authorPubkey'),
+              targetKind: any(named: 'targetKind'),
+              addressableId: any(named: 'addressableId'),
+            ),
+          ).thenAnswer((_) async => 'downvote-event-id');
+        },
+        build: createBloc,
+        seed: () => CommentReactionsState(
+          upvotedCommentIds: {validId('c1')},
+          commentUpvoteCounts: {validId('c1'): 3},
+        ),
+        act: (b) => b.add(
+          CommentVoteToggled(
+            commentId: validId('c1'),
+            authorPubkey: validId('author1'),
+            vote: Vote.down,
+            addressableId: '34236:${validId('author1')}:reply-d',
+            targetKind: 34236,
+          ),
+        ),
+        verify: (_) {
+          // Symmetric with removeDownvote: an edited target answers to a new
+          // event id, so an id-only teardown throws NotLikedException and
+          // strands the upvote reaction.
+          verify(
+            () => mockLikesRepository.unlikeEvent(
+              validId('c1'),
               addressableId: '34236:${validId('author1')}:reply-d',
             ),
           ).called(1);

--- a/mobile/test/blocs/comments/comment_reactions/comment_reactions_bloc_test.dart
+++ b/mobile/test/blocs/comments/comment_reactions/comment_reactions_bloc_test.dart
@@ -124,6 +124,56 @@ void main() {
       );
 
       blocTest<CommentReactionsBloc, CommentReactionsState>(
+        'forwards the coordinates to both read paths (#6124)',
+        setUp: () {
+          when(
+            () => mockLikesRepository.getVoteCounts(
+              any(),
+              addressableIds: any(named: 'addressableIds'),
+            ),
+          ).thenAnswer(
+            (_) async => (upvotes: <String, int>{}, downvotes: <String, int>{}),
+          );
+          when(
+            () => mockLikesRepository.getUserVoteStatuses(
+              any(),
+              addressableIds: any(named: 'addressableIds'),
+            ),
+          ).thenAnswer(
+            (_) async => (upvotedIds: <String>{}, downvotedIds: <String>{}),
+          );
+        },
+        build: createBloc,
+        act: (b) => b.add(
+          CommentVoteCountsFetchRequested(
+            [validId('c1')],
+            addressableIdsByCommentId: {
+              validId('c1'): '34236:${validId('author1')}:reply-d',
+            },
+          ),
+        ),
+        verify: (_) {
+          // Both reads are e-only without this; a vote on an edited video
+          // reply then reads as zero for the counts and unvoted for the arrow.
+          final expected = {
+            validId('c1'): '34236:${validId('author1')}:reply-d',
+          };
+          verify(
+            () => mockLikesRepository.getVoteCounts(
+              [validId('c1')],
+              addressableIds: expected,
+            ),
+          ).called(1);
+          verify(
+            () => mockLikesRepository.getUserVoteStatuses(
+              [validId('c1')],
+              addressableIds: expected,
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<CommentReactionsBloc, CommentReactionsState>(
         'no-ops when commentIds is empty',
         build: createBloc,
         act: (b) => b.add(const CommentVoteCountsFetchRequested([])),

--- a/mobile/test/blocs/comments/comment_reactions/comment_reactions_bloc_test.dart
+++ b/mobile/test/blocs/comments/comment_reactions/comment_reactions_bloc_test.dart
@@ -321,6 +321,51 @@ void main() {
           ).called(1);
         },
       );
+
+      blocTest<CommentReactionsBloc, CommentReactionsState>(
+        'still publishes the upvote when the downvote teardown reports none '
+        '(#6124)',
+        setUp: () {
+          // Downvotes live only in memory, so after a cold start the teardown
+          // of a pre-restart downvote reports "not downvoted". That must not
+          // abort the upvote — previously it threw past the likeEvent call and
+          // the UI showed an upvote that was never published.
+          when(
+            () => mockLikesRepository.removeDownvote(any()),
+          ).thenThrow(NotDownvotedException(validId('c1')));
+          when(
+            () => mockLikesRepository.likeEvent(
+              eventId: any(named: 'eventId'),
+              authorPubkey: any(named: 'authorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer((_) async => 'like-event-id');
+        },
+        build: createBloc,
+        seed: () => CommentReactionsState(
+          downvotedCommentIds: {validId('c1')},
+          commentDownvoteCounts: {validId('c1'): 2},
+        ),
+        act: (b) => b.add(
+          CommentVoteToggled(
+            commentId: validId('c1'),
+            authorPubkey: validId('author1'),
+            vote: Vote.up,
+          ),
+        ),
+        verify: (b) {
+          verify(
+            () => mockLikesRepository.likeEvent(
+              eventId: validId('c1'),
+              authorPubkey: validId('author1'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).called(1);
+          expect(b.state.upvotedCommentIds.contains(validId('c1')), isTrue);
+          expect(b.state.downvotedCommentIds.contains(validId('c1')), isFalse);
+          expect(b.state.error, isNull);
+        },
+      );
     });
 
     group('CommentReportRequested', () {

--- a/mobile/test/blocs/comments/comment_reactions/comment_reactions_bloc_test.dart
+++ b/mobile/test/blocs/comments/comment_reactions/comment_reactions_bloc_test.dart
@@ -323,6 +323,82 @@ void main() {
       );
 
       blocTest<CommentReactionsBloc, CommentReactionsState>(
+        'tags a video-reply vote with its OWN coordinate and real kind '
+        '(#6124)',
+        setUp: () {
+          when(
+            () => mockLikesRepository.downvoteEvent(
+              eventId: any(named: 'eventId'),
+              authorPubkey: any(named: 'authorPubkey'),
+              targetKind: any(named: 'targetKind'),
+              addressableId: any(named: 'addressableId'),
+            ),
+          ).thenAnswer((_) async => 'downvote-event-id');
+        },
+        build: createBloc,
+        act: (b) => b.add(
+          CommentVoteToggled(
+            commentId: validId('c1'),
+            authorPubkey: validId('author1'),
+            vote: Vote.down,
+            addressableId: '34236:${validId('author1')}:reply-d',
+            targetKind: 34236,
+          ),
+        ),
+        verify: (_) {
+          // The parent video's coordinate must never be used here: funnelcake
+          // counts kind-7 by a-tag with no content filter, so it would inflate
+          // the parent's public reaction_count.
+          verify(
+            () => mockLikesRepository.downvoteEvent(
+              eventId: validId('c1'),
+              authorPubkey: validId('author1'),
+              targetKind: 34236,
+              addressableId: '34236:${validId('author1')}:reply-d',
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<CommentReactionsBloc, CommentReactionsState>(
+        'falls back to kind 1111 and no coordinate for a plain comment '
+        '(#6124)',
+        setUp: () {
+          when(
+            () => mockLikesRepository.likeEvent(
+              eventId: any(named: 'eventId'),
+              authorPubkey: any(named: 'authorPubkey'),
+              targetKind: any(named: 'targetKind'),
+              addressableId: any(named: 'addressableId'),
+            ),
+          ).thenAnswer((_) async => 'like-event-id');
+        },
+        build: createBloc,
+        act: (b) => b.add(
+          CommentVoteToggled(
+            commentId: validId('c1'),
+            authorPubkey: validId('author1'),
+            vote: Vote.up,
+          ),
+        ),
+        verify: (_) {
+          // Captured rather than matched inline: passing `addressableId: null`
+          // to verify() reads as a redundant default, but the null IS the
+          // assertion — a Kind 1111 comment has no coordinate to send.
+          final captured = verify(
+            () => mockLikesRepository.likeEvent(
+              eventId: validId('c1'),
+              authorPubkey: validId('author1'),
+              targetKind: 1111,
+              addressableId: captureAny(named: 'addressableId'),
+            ),
+          ).captured;
+          expect(captured, hasLength(1));
+          expect(captured.single, isNull);
+        },
+      );
+
+      blocTest<CommentReactionsBloc, CommentReactionsState>(
         'still publishes the upvote when the downvote teardown reports none '
         '(#6124)',
         setUp: () {

--- a/mobile/test/builders/comment_builder.dart
+++ b/mobile/test/builders/comment_builder.dart
@@ -26,6 +26,8 @@ class CommentBuilder {
       'd4e5f6789012345678901234567890abcdef123456789012345678901234abc';
   String? _replyToEventId;
   String? _replyToAuthorPubkey;
+  int? _eventKind;
+  String? _addressableId;
 
   /// Set the comment ID.
   CommentBuilder withId(String id) {
@@ -97,6 +99,16 @@ class CommentBuilder {
     return this;
   }
 
+  /// Make this comment an addressable Kind 34236 video reply.
+  ///
+  /// [ownCoordinate] is the reply's **own** `kind:pubkey:d-tag`, not the
+  /// parent video's — that distinction is what #6124 turns on.
+  CommentBuilder asVideoReply({required String ownCoordinate}) {
+    _eventKind = 34236;
+    _addressableId = ownCoordinate;
+    return this;
+  }
+
   /// Build the Comment instance.
   Comment build() => Comment(
     id: _id,
@@ -107,6 +119,8 @@ class CommentBuilder {
     rootAuthorPubkey: _rootAuthorPubkey,
     replyToEventId: _replyToEventId,
     replyToAuthorPubkey: _replyToAuthorPubkey,
+    eventKind: _eventKind,
+    addressableId: _addressableId,
   );
 }
 

--- a/mobile/test/screens/comments/comment_item_test.dart
+++ b/mobile/test/screens/comments/comment_item_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: CommentReactionsBloc provider tree.
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:comments_repository/comments_repository.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -72,8 +73,9 @@ void main() {
     String content, {
     required _MockComposerBloc composerBloc,
     required _MockReactionsBloc reactionsBloc,
+    Comment? comment,
   }) {
-    final comment = CommentBuilder()
+    comment ??= CommentBuilder()
         .withAuthorPubkey(_testHexPubkey)
         .withRootEventId(_testRootEventId)
         .withRootAuthorPubkey(_testRootAuthorPubkey)
@@ -108,6 +110,46 @@ void main() {
       ),
     );
   }
+
+  testWidgets('votes a video reply with its own coordinate and kind, not the '
+      "parent video's (#6124)", (tester) async {
+    // The reply's own coordinate is deliberate: funnelcake's
+    // engagement_counts_by_coordinate_a_mv counts kind-7 `a` tags with no
+    // content filter, so sending the parent video's coordinate would make
+    // every comment vote inflate that video's public reaction_count.
+    const ownCoordinate = '34236:$_testHexPubkey:reply-d-tag';
+    final mocks = buildMocks();
+    final reply = CommentBuilder()
+        .withAuthorPubkey(_testHexPubkey)
+        .withRootEventId(_testRootEventId)
+        .withRootAuthorPubkey(_testRootAuthorPubkey)
+        .withContent('a video reply')
+        .asVideoReply(ownCoordinate: ownCoordinate)
+        .build();
+
+    await tester.pumpWidget(
+      buildTestWidget(
+        'a video reply',
+        composerBloc: mocks.composer,
+        reactionsBloc: mocks.reactions,
+        comment: reply,
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.bySemanticsIdentifier('upvote_button'));
+    await tester.pump();
+
+    final dispatched = verify(
+      () => mocks.reactions.add(captureAny()),
+    ).captured.whereType<CommentVoteToggled>().single;
+
+    expect(dispatched.addressableId, equals(ownCoordinate));
+    expect(dispatched.targetKind, equals(34236));
+    expect(dispatched.commentId, equals(reply.id));
+    // The root event is the parent video; its id must not leak into the vote.
+    expect(dispatched.addressableId, isNot(contains(_testRootEventId)));
+  });
 
   testWidgets('renders bare npub mentions as interactive profile links', (
     tester,


### PR DESCRIPTION
## Description

Comment votes are published against whatever event id a `Comment` wraps. When `FeatureFlag.videoReplies` is on that can be an **addressable Kind 34236 video reply** — `_threadKinds` requests `[1111, 34236]` and `_eventToComment` has no kind guard — so the emitted kind-7 carried `['e', <34236 id>]`, `['k','1111']` (wrong; the target kind is 34236) and **no** `['a', coordinate]`.

`VideoMetadataUpdateService` is reply-aware and republishes under the same `d` tag with a new event id, and both vote read paths are `#e`-only. So after an edit:

1. The voter's arrow silently un-fills; the a11y label reverts to "Upvote comment".
2. The score **disappears** rather than showing `0` (`comment_item.dart` guards the widget on `netScore != 0`).
3. **Every viewer** loses the count — `getVoteCounts` has no `authors:` constraint, so it is the public aggregate.
4. Re-tapping mints a **duplicate** kind-7; #6123's `alreadyLikedByCoordinate` guard cannot fire with a null coordinate.
5. The original reaction becomes **undeletable through the UI**.

This affects the **upvote path identically** — #6123 shipped `addressableId` on `likeEvent`, but this call site never adopted it.

Closes #6124, which was filed as downvote-only with "zero blast radius". The evidence for that premise being false is in [this comment](https://github.com/divinevideo/divine-mobile/issues/6124#issuecomment-5191603296).

## Commits

1. **`stop losing downvote deletions after a cold start`** — reachable with the flag *off*, so it affects the most users. `_downvoteRecords` is in-memory only, so after a cold start `removeDownvote` threw `NotDownvotedException`; the bloc swallowed it as a silent sentinel, cleared the UI, and never published the kind-5, leaving the downvote live. The same throw also aborted the handler, so a downvote→upvote switch skipped `likeEvent` entirely — the UI showed an upvote that was never sent. The repository now falls back to the relay copy, and the bloc scopes teardown failures so they cannot abort vote placement.
2. **`thread addressableId through the downvote family`** — the parameter on all three mutators, passed to the internal `sendLike`, plus a coordinate companion index so guards and teardown resolve by coordinate. Sync and realtime ingest now extract the `a` tag for downvote records.
3. **`give Comment its own coordinate and event kind`** — two nullable fields parsed from the event.
4. **`vote with the target's own coordinate and real kind`** — threads both through `CommentVoteToggled` for *both* vote directions.

## Two things worth a reviewer's attention

**The coordinate is deliberately the comment's own, never `rootAddressableId`.** funnelcake's `engagement_counts_by_coordinate_a_mv` counts `kind = 7 AND tag[1] IN ('a','A')` with **no content filter**, keyed on the coordinate parsed from the `a` tag. Using the parent video's coordinate would make every comment vote inflate that video's public `reaction_count`, while `/api/videos/{id}/likers` keeps filtering `content != '-'`. Using the target's own coordinate is count-neutral — `uniqStateIf(id, …)` dedupes across the e-path and a-path.

**A missing `d` tag yields a null coordinate**, deliberately *not* falling back to the event id the way `VideoEvent` does — that fallback produces a well-formed coordinate addressing nothing.

## No persistence

`personal_reactions` has no reaction-content discriminator and is keyed `{targetEventId, userPubkey}`, so it cannot represent a like and a downvote on the same target. Downvotes stay in-memory only, as in v1. No schema change, no migration, no codegen, no backend change.

## Testing

The existing vote tests used `any(named: 'targetKind')` matchers that passed no matter what was sent, and mocktail matches a null `addressableId` — so this fix would otherwise have shipped green and unguarded. Those are replaced with value assertions.

Every new test was run against the previous implementation to confirm it fails there. The bloc coordinate test reports the defect directly:

```
No matching calls. All calls: downvoteEvent({..., targetKind: 1111, addressableId: null})
```

- `flutter analyze lib test integration_test` — no issues
- `likes_repository` 193 tests, coverage 90.87% (gate 62%)
- `comments_repository` 144 tests
- `test/screens/comments` + `test/blocs/comments` — 215 tests

## Out of scope

- **Already-cast votes are not healed.** Reactions already published without a coordinate stay stranded; resolving them needs revision history, which is what #6711 is adding (`VideoRevisionsResolver`). That is a follow-on once #6711 lands — its port is optional, so this PR does not depend on it.
- Downvotes already inflate a reply's `reaction_count` via the e-tag path today. Pre-existing, same class as funnelcake #626.
- `commentsById` does not dedupe by coordinate, so an edited revision arriving on an open sheet lands as an additional row beside the stale one. Separate defect.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
