### PR TITLE
fix(nostr): bound and validate relay-list admission

### DIFF
--- a/mobile/integration_test/e2e/dm_inbox_relay_admission_test.dart
+++ b/mobile/integration_test/e2e/dm_inbox_relay_admission_test.dart
@@ -65,6 +65,7 @@ final List<String> _surplusTargets = [
   for (var i = 0; i < 10; i++) 'wss://surplus-$i.example',
 ];
 
+@Tags(['service'])
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 

--- a/mobile/integration_test/e2e/dm_inbox_relay_admission_test.dart
+++ b/mobile/integration_test/e2e/dm_inbox_relay_admission_test.dart
@@ -1,0 +1,245 @@
+// ABOUTME: E2E for #6585 — a DM is routed only to the relays admitted from
+// ABOUTME: the recipient's kind-10050, and still sends. Drives a real
+// ABOUTME: DmRepository + NostrClient over real sockets.
+// ABOUTME: Requires: NO Docker stack — every dependency here is local.
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/nostr.dart';
+import 'package:nostr_sdk/relay/relay_base.dart';
+import 'package:nostr_sdk/relay/relay_status.dart';
+import 'package:nostr_sdk/relay/web_socket_connection_manager.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+import 'package:nostr_sdk/utils/relay_addr_util.dart';
+import 'package:nostr_sdk/utils/relay_url_policy.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../helpers/fake_relay.dart';
+
+/// Redirects the public hostnames a relay list advertises onto the in-process
+/// relay, and records every address it was asked to open.
+///
+/// Both halves matter. The redirect is what makes an end-to-end test possible
+/// at all: `isRemoteSuppliedRelayUrlAllowed` refuses private and loopback
+/// hosts by design, so a `ws://127.0.0.1` relay can never *be* an admitted
+/// target — it has to be reached through one. And the recording is the
+/// assertion: "this host was never dialed" is then something the test
+/// observes directly, rather than infers from a publish result.
+class _RecordingRedirectFactory implements WebSocketChannelFactory {
+  _RecordingRedirectFactory(this.port);
+
+  final int port;
+  final List<String> requested = [];
+
+  @override
+  WebSocketChannel create(Uri uri) {
+    requested.add(uri.toString());
+    return WebSocketChannel.connect(
+      Uri.parse('ws://127.0.0.1:$port${uri.path}'),
+    );
+  }
+}
+
+/// Hosts a counterparty must never be able to point this device at.
+const _hostileTargets = <String>[
+  'wss://192.168.1.50',
+  'wss://127.0.0.1',
+  'wss://169.254.169.254',
+  'wss://nas.local',
+  'ws://cleartext.example',
+];
+
+const _admittedTargets = <String>[
+  'wss://admitted-1.example',
+  'wss://admitted-2.example',
+];
+
+/// Surplus legitimate hosts, so the total exceeds [RelayListCaps.dmInbox].
+final List<String> _surplusTargets = [
+  for (var i = 0; i < 10; i++) 'wss://surplus-$i.example',
+];
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const senderKey =
+      '1111111111111111111111111111111111111111111111111111111111111111';
+  const recipientKey =
+      '2222222222222222222222222222222222222222222222222222222222222222';
+  final senderPubkey = getPublicKey(senderKey);
+  final recipientPubkey = getPublicKey(recipientKey);
+
+  /// The recipient's kind-10050, signed by them, ordered so the admitted
+  /// hosts come first and the cap is provably first-N in tag order.
+  Map<String, dynamic> recipientInbox() {
+    final event = Event(
+      recipientPubkey,
+      10050,
+      [
+        for (final url in [
+          ..._admittedTargets,
+          ..._hostileTargets,
+          ..._surplusTargets,
+        ])
+          ['relay', url],
+      ],
+      '',
+      createdAt: 1700000000,
+    )..sign(recipientKey);
+    return event.toJson();
+  }
+
+  /// Builds the real stack: Nostr → RelayPool → RelayManager → NostrClient →
+  /// NIP17MessageService → DmRepository, with every socket landing on [relay].
+  Future<
+    ({DmRepository repository, Nostr nostr, _RecordingRedirectFactory factory})
+  >
+  buildStack(FakeRelay relay) async {
+    final factory = _RecordingRedirectFactory(relay.port);
+    final signer = LocalNostrSigner(senderKey);
+
+    RelayBase gen(String url) =>
+        RelayBase(url, RelayStatus(url), channelFactory: factory);
+    final nostr = Nostr(signer, [], gen, channelFactory: factory);
+
+    final relayManager = RelayManager(
+      config: RelayManagerConfig(
+        defaultRelayUrl: relay.url,
+        storage: InMemoryRelayStorage(),
+        // Without this, a relay that drops at teardown keeps retrying and
+        // the failure surfaces against whichever test is running next.
+        autoReconnect: false,
+        // Deliberately unset: this is the production shape, and setting it
+        // would filter every `*.example` target away — `_allowedRelays`
+        // collapses an all-filtered list to null, which falls back to the
+        // whole pool and would quietly hide what this test is measuring.
+      ),
+      relayPool: nostr.relayPool,
+    );
+    final client = NostrClient.forTesting(
+      nostr: nostr,
+      relayManager: relayManager,
+    );
+
+    final db = AppDatabase.test(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    final repository = DmRepository(
+      nostrClient: client,
+      directMessagesDao: db.directMessagesDao,
+      conversationsDao: db.conversationsDao,
+      outgoingDmsDao: db.outgoingDmsDao,
+      userPubkey: senderPubkey,
+      signer: signer,
+      messageService: NIP17MessageService(
+        signer: signer,
+        senderPublicKey: senderPubkey,
+        nostrService: client,
+      ),
+    );
+    addTearDown(repository.stopListening);
+    // Close every socket before the fake relay goes away. `addTearDown` is
+    // LIFO and `relay.stop` was registered first, so this runs ahead of it —
+    // otherwise in-flight connects fail after the test has completed and get
+    // attributed to it.
+    addTearDown(nostr.relayPool.removeAll);
+
+    // Through the manager, not RelayPool.add: a publish with no explicit
+    // targets checks `connectedRelays`, which only the manager populates.
+    await client.initialize();
+
+    return (repository: repository, nostr: nostr, factory: factory);
+  }
+
+  group('#6585 DM inbox relay admission', () {
+    testWidgets('resolves only the admitted subset of a kind-10050', (
+      tester,
+    ) async {
+      final relay = await FakeRelay.start(reply: recipientInbox());
+      addTearDown(relay.stop);
+      final stack = await buildStack(relay);
+
+      final resolved = await stack.repository.resolveDmInboxRelays(
+        recipientPubkey,
+      );
+
+      expect(resolved, hasLength(RelayListCaps.dmInbox));
+      // First-N in tag order: the two admitted hosts, then surplus.
+      expect(resolved!.take(2), _admittedTargets);
+      for (final hostile in _hostileTargets) {
+        expect(resolved, isNot(contains(hostile)), reason: hostile);
+      }
+    });
+
+    testWidgets('never dials a host the recipient should not reach', (
+      tester,
+    ) async {
+      final relay = await FakeRelay.start(reply: recipientInbox());
+      addTearDown(relay.stop);
+      final stack = await buildStack(relay);
+
+      final result = await stack.repository.sendMessage(
+        recipientPubkey: recipientPubkey,
+        content: 'admission probe',
+      );
+
+      // Positive control. If the send did not succeed the harness is wrong,
+      // and every "was not dialed" assertion below would pass for that reason
+      // rather than because the filter worked.
+      expect(result.success, isTrue, reason: result.toString());
+
+      for (final hostile in _hostileTargets) {
+        final host = Uri.parse(hostile).host;
+        expect(
+          stack.factory.requested.where((u) => u.contains(host)),
+          isEmpty,
+          reason: 'dialed $hostile',
+        );
+      }
+
+      // Connection-level witness. Temp relays are keyed by the normalised
+      // address, so comparing raw URLs here would silently match nothing.
+      // `_sendCollect` does not normalise `tempRelays` while `subscribe`
+      // does, so the same host can be keyed either way. Accept both rather
+      // than pinning the inconsistency.
+      final admitted = {
+        for (final url in [..._admittedTargets, ..._surplusTargets]) ...[
+          url,
+          RelayAddrUtil.handle(url),
+        ],
+      };
+      for (final dialed in stack.nostr.relayPool.tempRelayUrls) {
+        expect(admitted, contains(dialed), reason: dialed);
+      }
+    });
+
+    testWidgets('still delivers when the recipient advertises no inbox', (
+      tester,
+    ) async {
+      // The `absent` fallback predates #6585 and must survive it: a recipient
+      // with no kind-10050 is still reachable via the default pool.
+      final relay = await FakeRelay.start();
+      addTearDown(relay.stop);
+      final stack = await buildStack(relay);
+
+      expect(
+        await stack.repository.resolveDmInboxRelays(recipientPubkey),
+        isNull,
+      );
+
+      final result = await stack.repository.sendMessage(
+        recipientPubkey: recipientPubkey,
+        content: 'fallback probe',
+      );
+
+      expect(result.success, isTrue, reason: result.toString());
+      expect(relay.publishedEventIds, isNotEmpty);
+    });
+  });
+}

--- a/mobile/integration_test/e2e/dm_inbox_relay_admission_test.dart
+++ b/mobile/integration_test/e2e/dm_inbox_relay_admission_test.dart
@@ -3,6 +3,7 @@
 // ABOUTME: DmRepository + NostrClient over real sockets.
 // ABOUTME: Requires: NO Docker stack — every dependency here is local.
 
+@Tags(['service'])
 import 'package:db_client/db_client.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:drift/native.dart';
@@ -65,7 +66,6 @@ final List<String> _surplusTargets = [
   for (var i = 0; i < 10; i++) 'wss://surplus-$i.example',
 ];
 
-@Tags(['service'])
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 

--- a/mobile/integration_test/e2e/relay_list_admission_test.dart
+++ b/mobile/integration_test/e2e/relay_list_admission_test.dart
@@ -207,7 +207,6 @@ void main() {
       await pool.sendEventAwaitOk(
         ['EVENT', wrap.toJson()],
         eventId: wrap.id,
-        eventKind: wrap.kind,
         tempRelays: urls,
         targetRelays: urls,
         timeout: const Duration(seconds: 2),

--- a/mobile/integration_test/e2e/relay_list_admission_test.dart
+++ b/mobile/integration_test/e2e/relay_list_admission_test.dart
@@ -3,6 +3,7 @@
 // ABOUTME: released. Runs on-device against local WebSocket relays.
 // ABOUTME: Requires: NO Docker stack — every dependency here is local.
 
+@Tags(['service'])
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -37,7 +38,6 @@ Map<String, dynamic> _signedRelayList({
   return event.toJson();
 }
 
-@Tags(['service'])
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 

--- a/mobile/integration_test/e2e/relay_list_admission_test.dart
+++ b/mobile/integration_test/e2e/relay_list_admission_test.dart
@@ -4,7 +4,6 @@
 // ABOUTME: Requires: NO Docker stack — every dependency here is local.
 
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -19,83 +18,7 @@ import 'package:nostr_sdk/utils/relay_url_policy.dart';
 import 'package:openvine/services/relay_discovery_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-/// A relay that answers every REQ with one chosen frame.
-///
-/// Stands in for an indexer. The point of #6585 is that an indexer is a
-/// third-party server, so what it returns is untrusted input no matter that
-/// we were the ones who asked.
-class _StubIndexer {
-  _StubIndexer(this._server, this._reply);
-
-  final HttpServer _server;
-  final Map<String, dynamic>? _reply;
-
-  String get url => 'ws://127.0.0.1:${_server.port}';
-
-  static Future<_StubIndexer> start(Map<String, dynamic>? reply) async {
-    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
-    final indexer = _StubIndexer(server, reply);
-    server.listen((req) async {
-      // Anything that is not a WebSocket upgrade (a NIP-11 capability probe,
-      // a health check) must be answered rather than thrown out of the
-      // listener — an async throw here fails the surrounding test.
-      if (!WebSocketTransformer.isUpgradeRequest(req)) {
-        req.response.statusCode = HttpStatus.badRequest;
-        await req.response.close();
-        return;
-      }
-      final socket = await WebSocketTransformer.upgrade(req);
-      socket.listen((raw) {
-        final frame = jsonDecode(raw as String) as List<dynamic>;
-        if (frame.isEmpty || frame[0] != 'REQ') return;
-        final subId = frame[1] as String;
-        if (indexer._reply != null) {
-          socket.add(jsonEncode(<dynamic>['EVENT', subId, indexer._reply]));
-        }
-        socket.add(jsonEncode(<dynamic>['EOSE', subId]));
-      }, onError: (_) {});
-    });
-    return indexer;
-  }
-
-  Future<void> stop() => _server.close(force: true);
-}
-
-/// A relay that accepts the connection and then says nothing — the shape a
-/// listener takes when its only purpose is to be connected to.
-class _SilentRelay {
-  _SilentRelay(this._server);
-
-  final HttpServer _server;
-  final List<WebSocket> _sockets = [];
-
-  String get url => 'ws://127.0.0.1:${_server.port}';
-  int get openSockets =>
-      _sockets.where((s) => s.readyState == WebSocket.open).length;
-
-  static Future<_SilentRelay> start() async {
-    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
-    final relay = _SilentRelay(server);
-    server.listen((req) async {
-      if (!WebSocketTransformer.isUpgradeRequest(req)) {
-        req.response.statusCode = HttpStatus.badRequest;
-        await req.response.close();
-        return;
-      }
-      final socket = await WebSocketTransformer.upgrade(req);
-      relay._sockets.add(socket);
-      socket.listen((_) {}, onError: (_) {});
-    });
-    return relay;
-  }
-
-  Future<void> stop() async {
-    for (final socket in _sockets) {
-      await socket.close().catchError((_) => null);
-    }
-    await _server.close(force: true);
-  }
-}
+import '../helpers/fake_relay.dart';
 
 Map<String, dynamic> _signedRelayList({
   required String privateKey,
@@ -114,6 +37,7 @@ Map<String, dynamic> _signedRelayList({
   return event.toJson();
 }
 
+@Tags(['service'])
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -123,8 +47,8 @@ void main() {
 
   group('#6585 relay-list admission', () {
     testWidgets('a correctly signed kind-10002 is admitted', (tester) async {
-      final indexer = await _StubIndexer.start(
-        _signedRelayList(privateKey: authorKey),
+      final indexer = await FakeRelay.start(
+        reply: _signedRelayList(privateKey: authorKey),
       );
       addTearDown(indexer.stop);
 
@@ -160,7 +84,7 @@ void main() {
       };
 
       for (final entry in cases.entries) {
-        final indexer = await _StubIndexer.start(entry.value);
+        final indexer = await FakeRelay.start(reply: entry.value);
         addTearDown(indexer.stop);
         final relays = await RelayDiscoveryService(
           indexerRelays: [indexer.url],
@@ -172,8 +96,8 @@ void main() {
     testWidgets("an admitted list cannot name this device's own network", (
       tester,
     ) async {
-      final indexer = await _StubIndexer.start(
-        _signedRelayList(
+      final indexer = await FakeRelay.start(
+        reply: _signedRelayList(
           privateKey: authorKey,
           tags: const [
             ['r', 'wss://public.example'],
@@ -200,8 +124,8 @@ void main() {
     testWidgets('one relay list cannot inject an unbounded set', (
       tester,
     ) async {
-      final indexer = await _StubIndexer.start(
-        _signedRelayList(
+      final indexer = await FakeRelay.start(
+        reply: _signedRelayList(
           privateKey: authorKey,
           tags: [
             for (var i = 0; i < 200; i++) ['r', 'wss://flood-$i.example'],
@@ -261,7 +185,7 @@ void main() {
     testWidgets('sockets opened for a publish are released once idle', (
       tester,
     ) async {
-      final targets = [for (var i = 0; i < 4; i++) await _SilentRelay.start()];
+      final targets = [for (var i = 0; i < 4; i++) await FakeRelay.start()];
       addTearDown(() async {
         for (final relay in targets) {
           await relay.stop();

--- a/mobile/integration_test/e2e/relay_list_admission_test.dart
+++ b/mobile/integration_test/e2e/relay_list_admission_test.dart
@@ -1,0 +1,306 @@
+// ABOUTME: E2E for #6585 — relay lists arriving from the network are
+// ABOUTME: authenticated, host-filtered, count-capped, and their sockets
+// ABOUTME: released. Runs on-device against local WebSocket relays.
+// ABOUTME: Requires: NO Docker stack — every dependency here is local.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/nostr.dart';
+import 'package:nostr_sdk/relay/relay_base.dart';
+import 'package:nostr_sdk/relay/relay_pool.dart';
+import 'package:nostr_sdk/relay/relay_status.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+import 'package:nostr_sdk/utils/relay_url_policy.dart';
+import 'package:openvine/services/relay_discovery_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// A relay that answers every REQ with one chosen frame.
+///
+/// Stands in for an indexer. The point of #6585 is that an indexer is a
+/// third-party server, so what it returns is untrusted input no matter that
+/// we were the ones who asked.
+class _StubIndexer {
+  _StubIndexer(this._server, this._reply);
+
+  final HttpServer _server;
+  final Map<String, dynamic>? _reply;
+
+  String get url => 'ws://127.0.0.1:${_server.port}';
+
+  static Future<_StubIndexer> start(Map<String, dynamic>? reply) async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final indexer = _StubIndexer(server, reply);
+    server.listen((req) async {
+      // Anything that is not a WebSocket upgrade (a NIP-11 capability probe,
+      // a health check) must be answered rather than thrown out of the
+      // listener — an async throw here fails the surrounding test.
+      if (!WebSocketTransformer.isUpgradeRequest(req)) {
+        req.response.statusCode = HttpStatus.badRequest;
+        await req.response.close();
+        return;
+      }
+      final socket = await WebSocketTransformer.upgrade(req);
+      socket.listen((raw) {
+        final frame = jsonDecode(raw as String) as List<dynamic>;
+        if (frame.isEmpty || frame[0] != 'REQ') return;
+        final subId = frame[1] as String;
+        if (indexer._reply != null) {
+          socket.add(jsonEncode(<dynamic>['EVENT', subId, indexer._reply]));
+        }
+        socket.add(jsonEncode(<dynamic>['EOSE', subId]));
+      }, onError: (_) {});
+    });
+    return indexer;
+  }
+
+  Future<void> stop() => _server.close(force: true);
+}
+
+/// A relay that accepts the connection and then says nothing — the shape a
+/// listener takes when its only purpose is to be connected to.
+class _SilentRelay {
+  _SilentRelay(this._server);
+
+  final HttpServer _server;
+  final List<WebSocket> _sockets = [];
+
+  String get url => 'ws://127.0.0.1:${_server.port}';
+  int get openSockets =>
+      _sockets.where((s) => s.readyState == WebSocket.open).length;
+
+  static Future<_SilentRelay> start() async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final relay = _SilentRelay(server);
+    server.listen((req) async {
+      if (!WebSocketTransformer.isUpgradeRequest(req)) {
+        req.response.statusCode = HttpStatus.badRequest;
+        await req.response.close();
+        return;
+      }
+      final socket = await WebSocketTransformer.upgrade(req);
+      relay._sockets.add(socket);
+      socket.listen((_) {}, onError: (_) {});
+    });
+    return relay;
+  }
+
+  Future<void> stop() async {
+    for (final socket in _sockets) {
+      await socket.close().catchError((_) => null);
+    }
+    await _server.close(force: true);
+  }
+}
+
+Map<String, dynamic> _signedRelayList({
+  required String privateKey,
+  List<List<String>> tags = const [
+    ['r', 'wss://legit.example'],
+  ],
+  int kind = 10002,
+}) {
+  final event = Event(
+    getPublicKey(privateKey),
+    kind,
+    tags,
+    '',
+    createdAt: 1700000000,
+  )..sign(privateKey);
+  return event.toJson();
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const authorKey =
+      '1111111111111111111111111111111111111111111111111111111111111111';
+  final authorPubkey = getPublicKey(authorKey);
+
+  group('#6585 relay-list admission', () {
+    testWidgets('a correctly signed kind-10002 is admitted', (tester) async {
+      final indexer = await _StubIndexer.start(
+        _signedRelayList(privateKey: authorKey),
+      );
+      addTearDown(indexer.stop);
+
+      final relays = await RelayDiscoveryService(
+        indexerRelays: [indexer.url],
+      ).queryIndexerDirect(indexer.url, authorPubkey);
+
+      // Positive control: without this, every rejection below could be
+      // passing because nothing was ever delivered.
+      expect(relays.map((r) => r.url), ['wss://legit.example']);
+    });
+
+    testWidgets("a frame that is not the author's kind-10002 is refused", (
+      tester,
+    ) async {
+      const otherKey =
+          '2222222222222222222222222222222222222222222222222222222222222222';
+
+      final cases = <String, Map<String, dynamic>>{
+        'no signature': _signedRelayList(privateKey: authorKey)..['sig'] = '',
+        'signed by someone else': _signedRelayList(privateKey: otherKey),
+        'wrong kind': _signedRelayList(privateKey: authorKey, kind: 1),
+        'id does not match its contents':
+            _signedRelayList(privateKey: authorKey)
+              ..['tags'] = [
+                ['r', 'wss://swapped-in.example'],
+              ],
+        'not an event at all': {
+          'tags': [
+            ['r', 'wss://bare-tags.example'],
+          ],
+        },
+      };
+
+      for (final entry in cases.entries) {
+        final indexer = await _StubIndexer.start(entry.value);
+        addTearDown(indexer.stop);
+        final relays = await RelayDiscoveryService(
+          indexerRelays: [indexer.url],
+        ).queryIndexerDirect(indexer.url, authorPubkey);
+        expect(relays, isEmpty, reason: entry.key);
+      }
+    });
+
+    testWidgets("an admitted list cannot name this device's own network", (
+      tester,
+    ) async {
+      final indexer = await _StubIndexer.start(
+        _signedRelayList(
+          privateKey: authorKey,
+          tags: const [
+            ['r', 'wss://public.example'],
+            ['r', 'wss://192.168.1.50'],
+            ['r', 'wss://10.1.2.3'],
+            ['r', 'wss://127.0.0.1'],
+            ['r', 'wss://169.254.169.254'],
+            ['r', 'wss://[fe80::1]'],
+            ['r', 'wss://2130706433'],
+            ['r', 'wss://nas.local'],
+            ['r', 'ws://cleartext.example'],
+          ],
+        ),
+      );
+      addTearDown(indexer.stop);
+
+      final relays = await RelayDiscoveryService(
+        indexerRelays: [indexer.url],
+      ).queryIndexerDirect(indexer.url, authorPubkey);
+
+      expect(relays.map((r) => r.url), ['wss://public.example']);
+    });
+
+    testWidgets('one relay list cannot inject an unbounded set', (
+      tester,
+    ) async {
+      final indexer = await _StubIndexer.start(
+        _signedRelayList(
+          privateKey: authorKey,
+          tags: [
+            for (var i = 0; i < 200; i++) ['r', 'wss://flood-$i.example'],
+          ],
+        ),
+      );
+      addTearDown(indexer.stop);
+
+      final relays = await RelayDiscoveryService(
+        indexerRelays: [indexer.url],
+      ).queryIndexerDirect(indexer.url, authorPubkey);
+
+      expect(relays, hasLength(RelayListCaps.nip65));
+      expect(relays.first.url, 'wss://flood-0.example');
+    });
+
+    testWidgets('a cached list is re-admitted on read, not just on write', (
+      tester,
+    ) async {
+      // The cache outlives the write by 24h, so an entry persisted by an
+      // older build must not be adopted unchecked.
+      const npub = 'npub1e2eadmissiontest';
+      SharedPreferences.setMockInitialValues({
+        'relay_discovery_$npub': jsonEncode({
+          'timestamp': DateTime.now().millisecondsSinceEpoch,
+          'relays': [
+            {'url': 'wss://public.example', 'read': true, 'write': true},
+            {'url': 'wss://192.168.1.50', 'read': true, 'write': true},
+            {'url': 'wss://127.0.0.1', 'read': true, 'write': true},
+            {'url': 'wss://169.254.169.254', 'read': true, 'write': true},
+            {'url': 'ws://cleartext.example', 'read': true, 'write': true},
+            for (var i = 0; i < 40; i++)
+              {'url': 'wss://cached-$i.example', 'read': true, 'write': true},
+          ],
+        }),
+      });
+
+      final result = await RelayDiscoveryService(
+        indexerRelays: const ['ws://127.0.0.1:1'],
+      ).discoverRelays(npub);
+
+      expect(result.relays, hasLength(RelayListCaps.nip65));
+      expect(
+        result.relays.map((r) => r.url),
+        isNot(anyElement(contains('192.168'))),
+      );
+      expect(
+        result.relays.map((r) => r.url),
+        isNot(anyElement(contains('127.0.0.1'))),
+      );
+      expect(
+        result.relays.map((r) => r.url),
+        isNot(anyElement(contains('169.254'))),
+      );
+    });
+
+    testWidgets('sockets opened for a publish are released once idle', (
+      tester,
+    ) async {
+      final targets = [for (var i = 0; i < 4; i++) await _SilentRelay.start()];
+      addTearDown(() async {
+        for (final relay in targets) {
+          await relay.stop();
+        }
+      });
+      final urls = [for (final relay in targets) relay.url];
+
+      final signer = LocalNostrSigner(authorKey);
+      RelayBase gen(String url) => RelayBase(url, RelayStatus(url));
+      final pool = RelayPool(
+        Nostr(signer, [], gen),
+        [],
+        gen,
+        tempRelayIdleTimeout: Duration.zero,
+        tempRelaySweepInterval: const Duration(hours: 1),
+      );
+
+      final wrap = Event(authorPubkey, 1059, [], 'probe')..sign(authorKey);
+      await pool.sendEventAwaitOk(
+        ['EVENT', wrap.toJson()],
+        eventId: wrap.id,
+        eventKind: wrap.kind,
+        tempRelays: urls,
+        targetRelays: urls,
+        timeout: const Duration(seconds: 2),
+      );
+
+      // NIP-17 requires publishing to the relays the recipient named, so the
+      // connections are expected — what #6585 changes is that they end.
+      expect(pool.tempRelayUrls, hasLength(4));
+      expect(targets.every((r) => r.openSockets > 0), isTrue);
+
+      pool.sweepIdleTempRelays();
+      await Future<void>.delayed(const Duration(milliseconds: 400));
+
+      expect(pool.tempRelayUrls, isEmpty);
+      for (final relay in targets) {
+        expect(relay.openSockets, isZero, reason: relay.url);
+      }
+    });
+  });
+}

--- a/mobile/integration_test/helpers/fake_relay.dart
+++ b/mobile/integration_test/helpers/fake_relay.dart
@@ -1,0 +1,117 @@
+// ABOUTME: In-process WebSocket relay for integration tests that need to
+// ABOUTME: control exactly what a relay says, without the Docker stack.
+// ABOUTME: Answers REQ with a chosen EVENT, OK-confirms inbound EVENTs, and
+// ABOUTME: records what it was sent.
+
+import 'dart:convert';
+import 'dart:io';
+
+/// A Nostr relay that runs inside the test process.
+///
+/// Exists because the local Docker relay cannot serve the kinds these tests
+/// need (see #6594 — the pinned funnelcake images predate gift-wrap support),
+/// and because a test that asserts *which* relays were dialed has to own both
+/// ends of the connection.
+///
+/// Speaks only the subset of the protocol these tests exercise:
+/// - `REQ` → the configured [reply] event (if any), then `EOSE`
+/// - `EVENT` → `["OK", <id>, true, ""]`, so an OK-confirmed publish settles
+///   instead of timing out into `retryablePending`
+class FakeRelay {
+  FakeRelay._(this._server, this.reply, this.okConfirms);
+
+  /// Starts a relay on an ephemeral loopback port.
+  ///
+  /// [reply] is the event served for any `REQ`; null answers `EOSE` only.
+  /// Set [okConfirms] false to model a relay that accepts the frame but never
+  /// confirms it.
+  static Future<FakeRelay> start({
+    Map<String, dynamic>? reply,
+    bool okConfirms = true,
+  }) async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final relay = FakeRelay._(server, reply, okConfirms);
+    server.listen(relay._handle, onError: (_) {});
+    return relay;
+  }
+
+  final HttpServer _server;
+  final List<WebSocket> _sockets = [];
+
+  /// The event served in response to any `REQ`, or null for `EOSE` only.
+  final Map<String, dynamic>? reply;
+
+  /// Whether an inbound `EVENT` is answered with `OK … true`.
+  final bool okConfirms;
+
+  /// Every frame this relay received, in arrival order.
+  final List<List<dynamic>> receivedFrames = [];
+
+  /// The `ws://` address of this relay.
+  String get url => 'ws://127.0.0.1:${_server.port}';
+
+  /// The port, for a channel factory that redirects other hosts here.
+  int get port => _server.port;
+
+  /// Sockets still open from the server's point of view.
+  int get openSockets =>
+      _sockets.where((s) => s.readyState == WebSocket.open).length;
+
+  /// Event ids this relay was asked to store.
+  List<String> get publishedEventIds => [
+    for (final frame in receivedFrames)
+      if (frame.isNotEmpty &&
+          frame[0] == 'EVENT' &&
+          frame.length >= 2 &&
+          frame[1] is Map)
+        (frame[1] as Map)['id'] as String,
+  ];
+
+  Future<void> _handle(HttpRequest req) async {
+    // `RelayBase.doConnect` probes NIP-11 over plain HTTP before upgrading.
+    // Answering rather than throwing matters: an async throw out of this
+    // listener fails whatever test happens to be running.
+    if (!WebSocketTransformer.isUpgradeRequest(req)) {
+      req.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType('application', 'nostr+json')
+        ..write(jsonEncode({'name': 'fake-relay', 'supported_nips': <int>[]}));
+      await req.response.close();
+      return;
+    }
+
+    final socket = await WebSocketTransformer.upgrade(req);
+    _sockets.add(socket);
+    socket.listen(
+      (raw) {
+        final List<dynamic> frame;
+        try {
+          frame = jsonDecode(raw as String) as List<dynamic>;
+        } on Object {
+          return;
+        }
+        receivedFrames.add(frame);
+        if (frame.isEmpty) return;
+
+        if (frame[0] == 'REQ' && frame.length >= 2) {
+          final subId = frame[1] as String;
+          if (reply != null) {
+            socket.add(jsonEncode(<dynamic>['EVENT', subId, reply]));
+          }
+          socket.add(jsonEncode(<dynamic>['EOSE', subId]));
+        } else if (frame[0] == 'EVENT' && frame.length >= 2 && okConfirms) {
+          final event = frame[1] as Map<String, dynamic>;
+          socket.add(jsonEncode(<dynamic>['OK', event['id'], true, '']));
+        }
+      },
+      onError: (_) {},
+    );
+  }
+
+  Future<void> stop() async {
+    for (final socket in _sockets) {
+      await socket.close().catchError((_) => null);
+    }
+    await _server.close(force: true);
+  }
+}

--- a/mobile/lib/providers/nostr_client_provider.dart
+++ b/mobile/lib/providers/nostr_client_provider.dart
@@ -721,10 +721,10 @@ class NostrService extends _$NostrService {
       if (targetPubkey == null || pubkey != targetPubkey || relayUrls.isEmpty) {
         return;
       }
-      // Last gate before these become permanent pool members. Discovery
-      // already applies the same rule, but this is the boundary every path
-      // into the pool crosses, and the cost of getting it wrong here is a
-      // relay the user never chose serving all their reads and writes (#6585).
+      // Last gate before this callback's discovered relays become permanent
+      // pool members. Discovery already applies the same rule; keeping it
+      // here protects the late-add path if a future caller hands the callback
+      // a list that did not come straight from discovery (#6585).
       final admitted = admitRemoteSuppliedRelays(
         relayUrls,
         cap: RelayListCaps.nip65,

--- a/mobile/lib/providers/nostr_client_provider.dart
+++ b/mobile/lib/providers/nostr_client_provider.dart
@@ -721,6 +721,25 @@ class NostrService extends _$NostrService {
       if (targetPubkey == null || pubkey != targetPubkey || relayUrls.isEmpty) {
         return;
       }
+      // Last gate before these become permanent pool members. Discovery
+      // already applies the same rule, but this is the boundary every path
+      // into the pool crosses, and the cost of getting it wrong here is a
+      // relay the user never chose serving all their reads and writes (#6585).
+      final admitted = admitRemoteSuppliedRelays(
+        relayUrls,
+        cap: RelayListCaps.nip65,
+        onRejected: (url) => Log.warning(
+          '[NostrService] Refusing discovered relay: $url',
+          name: 'NostrService',
+          category: LogCategory.system,
+        ),
+        onTruncated: (kept, total) => Log.warning(
+          '[NostrService] Discovery returned $total relays; adding $kept',
+          name: 'NostrService',
+          category: LogCategory.system,
+        ),
+      );
+      if (admitted.isEmpty) return;
       Future.microtask(() async {
         try {
           if (!_isCurrentClientForPubkey(
@@ -730,7 +749,7 @@ class NostrService extends _$NostrService {
           )) {
             return;
           }
-          final added = await client.addRelays(relayUrls);
+          final added = await client.addRelays(admitted);
           if (added > 0) {
             Log.info(
               '[NostrService] Added $added discovered relay(s) after NIP-65 discovery',

--- a/mobile/lib/providers/nostr_client_provider.g.dart
+++ b/mobile/lib/providers/nostr_client_provider.g.dart
@@ -109,7 +109,7 @@ final class NostrServiceProvider
   }
 }
 
-String _$nostrServiceHash() => r'43e4f95c9c8108962707d675a4d81200e4edd083';
+String _$nostrServiceHash() => r'eadbbe3f376aa1b94a263bbd724397146bdd7178';
 
 /// Core Nostr service via NostrClient for relay communication
 /// Uses a Notifier to react to auth state changes and recreate the client

--- a/mobile/lib/services/relay_discovery_service.dart
+++ b/mobile/lib/services/relay_discovery_service.dart
@@ -339,8 +339,14 @@ class RelayDiscoveryService {
         },
       );
 
-      // Send CLOSE before disconnecting
-      await relay.send(<dynamic>['CLOSE', subscriptionId]);
+      // Send CLOSE before disconnecting. skipReconnect because the socket is
+      // about to be torn down either way: without it, a CLOSE sent after the
+      // indexer already dropped the connection walks the reconnect backoff,
+      // holding this method — and the relay it owns — open for minutes.
+      await relay.send(<dynamic>[
+        'CLOSE',
+        subscriptionId,
+      ], skipReconnect: true);
 
       Log.info(
         '  Got ${result.length} relays from $indexerUrl',
@@ -359,6 +365,10 @@ class RelayDiscoveryService {
     } finally {
       try {
         await relay.disconnect();
+      } catch (_) {}
+      // Its own guard: a throw from disconnect must not skip the dispose,
+      // which is what releases the socket's stream subscriptions.
+      try {
         relay.dispose();
       } catch (_) {}
     }

--- a/mobile/lib/services/relay_discovery_service.dart
+++ b/mobile/lib/services/relay_discovery_service.dart
@@ -543,13 +543,15 @@ class RelayDiscoveryService {
         cached.map((r) => r.url),
         cap: RelayListCaps.nip65,
       );
-      final cachedByUrl = {
-        for (final relay in cached.reversed) relay.url: relay,
-      };
+      // Filter the cached entries rather than rebuilding one per admitted URL:
+      // a kind-10002 may list the same host twice to carry a `read` and a
+      // `write` marker, and the fresh parse keeps both. Keying by URL would
+      // drop the second, so the same event would answer differently depending
+      // on which path served it. The record cap matches the fresh parse.
       return [
-        for (final url in admitted)
-          if (cachedByUrl[url] != null) cachedByUrl[url]!,
-      ];
+        for (final relay in cached)
+          if (admitted.contains(relay.url)) relay,
+      ].take(RelayListCaps.nip65).toList();
     } catch (e) {
       Log.warning(
         'Failed to read cached relays: $e',

--- a/mobile/lib/services/relay_discovery_service.dart
+++ b/mobile/lib/services/relay_discovery_service.dart
@@ -526,10 +526,22 @@ class RelayDiscoveryService {
       }
 
       final relaysList = cacheData['relays'] as List<dynamic>;
-      return relaysList
+      final cached = relaysList
           .map((r) => DiscoveredRelay.fromJson(r as Map<String, dynamic>))
-          .where((r) => isRelayUrlAllowed(r.url))
           .toList();
+      // Re-admit on read, on the same remote-supplied terms as a fresh
+      // discovery. The cache holds a list that arrived over the network and
+      // survives for 24h, so filtering only on write would leave a day-long
+      // window in which an entry written by an older build — or by a build
+      // before this rule existed — is adopted unchecked (#6585).
+      final admitted = admitRemoteSuppliedRelays(
+        cached.map((r) => r.url),
+        cap: RelayListCaps.nip65,
+      );
+      return [
+        for (final relay in cached)
+          if (admitted.contains(relay.url)) relay,
+      ];
     } catch (e) {
       Log.warning(
         'Failed to read cached relays: $e',

--- a/mobile/lib/services/relay_discovery_service.dart
+++ b/mobile/lib/services/relay_discovery_service.dart
@@ -7,7 +7,6 @@ import 'dart:convert';
 
 import 'package:meta/meta.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
-import 'package:openvine/utils/relay_url_utils.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 

--- a/mobile/lib/services/relay_discovery_service.dart
+++ b/mobile/lib/services/relay_discovery_service.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 
 import 'package:meta/meta.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:openvine/utils/relay_url_utils.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -450,18 +451,27 @@ class RelayDiscoveryService {
   List<DiscoveredRelay> _parseRelayListFromEvent(Event event) =>
       _parseRelayListFromTags(event.tags);
 
-  List<DiscoveredRelay> _parseRelayListFromTags(List<List<String>> eventTags) {
-    final relays = <DiscoveredRelay>[];
+  /// Admits a kind-10002's relays: host policy, duplicate collapse, then cap.
+  ///
+  /// The list belongs to the user but reaches us through a third-party
+  /// indexer, so it is admitted on remote-supplied terms: `wss://` only, and
+  /// never a private, loopback or link-local target (#3362, #6585).
+  ///
+  /// Duplicates collapse before the cap is counted, or a host named
+  /// [RelayListCaps.nip65] times would spend the whole budget and drop every
+  /// genuine relay after it. Markers are OR-ed rather than first-wins: NIP-65
+  /// marks a relay per `r` tag, so a host carrying a `read` row and a `write`
+  /// row is read *and* write. Keeping the pair instead would be lossy anyway —
+  /// `RelayListRepository._markerFor` takes the first match and republishes
+  /// the host as `read`-only, and the app bridge takes the last.
+  ///
+  /// Both the fresh parse and the cached read go through here, so the same
+  /// event cannot answer differently depending on which one served it.
+  List<DiscoveredRelay> _admitRelayList(Iterable<DiscoveredRelay> candidates) {
+    final byHost = <String, DiscoveredRelay>{};
 
-    for (final tag in eventTags) {
-      if (tag.isEmpty || tag[0] != 'r') continue;
-      if (tag.length < 2) continue;
-
-      final url = tag[1];
-
-      // The list belongs to the user but reaches us through a third-party
-      // indexer, so it is admitted on remote-supplied terms: `wss://` only,
-      // and never a private, loopback or link-local target (#3362, #6585).
+    for (final candidate in candidates) {
+      final url = candidate.url;
       if (!isRemoteSuppliedRelayUrlAllowed(url)) {
         Log.warning(
           '  Skipping disallowed relay URL: $url',
@@ -471,7 +481,20 @@ class RelayDiscoveryService {
         continue;
       }
 
-      if (relays.length >= RelayListCaps.nip65) {
+      // Compare hosts the way the rest of the app does, so `wss://a.example`
+      // and `wss://a.example/` are one relay rather than two cap slots.
+      final key = normalizeRelayUrlForComparison(url) ?? url;
+      final existing = byHost[key];
+      if (existing != null) {
+        byHost[key] = DiscoveredRelay(
+          url: existing.url,
+          read: existing.read || candidate.read,
+          write: existing.write || candidate.write,
+        );
+        continue;
+      }
+
+      if (byHost.length >= RelayListCaps.nip65) {
         Log.warning(
           '  kind-10002 lists more than ${RelayListCaps.nip65} relays; '
           'ignoring the rest',
@@ -481,16 +504,22 @@ class RelayDiscoveryService {
         break;
       }
 
-      final permission = tag.length > 2 ? tag[2] as String? : null;
-
-      final relay = DiscoveredRelay(
-        url: url,
-        read: permission == null || permission == 'read',
-        write: permission == null || permission == 'write',
-      );
-
-      relays.add(relay);
+      byHost[key] = candidate;
     }
+
+    return byHost.values.toList();
+  }
+
+  List<DiscoveredRelay> _parseRelayListFromTags(List<List<String>> eventTags) {
+    final relays = _admitRelayList([
+      for (final tag in eventTags)
+        if (tag.length >= 2 && tag[0] == 'r')
+          DiscoveredRelay(
+            url: tag[1],
+            read: tag.length <= 2 || tag[2] == 'read',
+            write: tag.length <= 2 || tag[2] == 'write',
+          ),
+    ]);
 
     Log.info(
       '  Parsed ${relays.length} relays from kind 10002 event',
@@ -548,20 +577,10 @@ class RelayDiscoveryService {
       // discovery. The cache holds a list that arrived over the network and
       // survives for 24h, so filtering only on write would leave a day-long
       // window in which an entry written by an older build — or by a build
-      // before this rule existed — is adopted unchecked (#6585).
-      final admitted = admitRemoteSuppliedRelays(
-        cached.map((r) => r.url),
-        cap: RelayListCaps.nip65,
-      );
-      // Filter the cached entries rather than rebuilding one per admitted URL:
-      // a kind-10002 may list the same host twice to carry a `read` and a
-      // `write` marker, and the fresh parse keeps both. Keying by URL would
-      // drop the second, so the same event would answer differently depending
-      // on which path served it. The record cap matches the fresh parse.
-      return [
-        for (final relay in cached)
-          if (admitted.contains(relay.url)) relay,
-      ].take(RelayListCaps.nip65).toList();
+      // before this rule existed — is adopted unchecked (#6585). A pre-#6585
+      // build wrote under this same key with no author check and no cap, so
+      // these rows can still be an unauthenticated indexer's.
+      return _admitRelayList(cached);
     } catch (e) {
       Log.warning(
         'Failed to read cached relays: $e',

--- a/mobile/lib/services/relay_discovery_service.dart
+++ b/mobile/lib/services/relay_discovery_service.dart
@@ -268,7 +268,7 @@ class RelayDiscoveryService {
     final relayStatus = RelayStatus(indexerUrl);
     final relay = RelayBase(indexerUrl, relayStatus);
     final completer = Completer<List<DiscoveredRelay>>();
-    final events = <Map<String, dynamic>>[];
+    final events = <Event>[];
     final subscriptionId = 'rd_${DateTime.now().millisecondsSinceEpoch}';
 
     // Set up message handler before connecting
@@ -278,18 +278,20 @@ class RelayDiscoveryService {
       final messageType = json[0] as String;
 
       if (messageType == 'EVENT' && json.length >= 3) {
-        // Collect the raw event JSON
         final eventJson = json[2] as Map<String, dynamic>;
-        events.add(eventJson);
+        final event = _authenticRelayList(eventJson, indexerUrl, pubkeyHex);
+        if (event != null) events.add(event);
       } else if (messageType == 'EOSE') {
         // All stored events received - parse and complete
         if (!completer.isCompleted) {
           if (events.isEmpty) {
             completer.complete(<DiscoveredRelay>[]);
           } else {
-            // Parse the most recent event's relay list
-            final relays = _parseRelayListFromJson(events.first);
-            completer.complete(relays);
+            // Newest wins. Frames arrive in whatever order the indexer feels
+            // like sending them, so the first one through the socket is not
+            // the current relay list.
+            events.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+            completer.complete(_parseRelayListFromEvent(events.first));
           }
         }
       } else if (messageType == 'NOTICE') {
@@ -358,33 +360,110 @@ class RelayDiscoveryService {
     }
   }
 
+  /// Returns [eventJson] as an [Event] when it is genuinely [pubkeyHex]'s
+  /// kind-10002, and null otherwise.
+  ///
+  /// This query runs on a bare [RelayBase] with its own `onMessage`, so the
+  /// frame never passes through `RelayPool`, which is the only place inbound
+  /// events are checked. Nothing else stands between an indexer and the relay
+  /// pool: what comes back here is adopted via `NostrClient.addRelays` and
+  /// then used for every subsequent read and write. The indexers queried are
+  /// third-party public relays, so "it answered our REQ" is not evidence the
+  /// answer is the list we asked for — the id, the signature, the author and
+  /// the kind all have to be checked here (#6585).
+  ///
+  /// A frame that fails is logged and dropped, not reported: a broken or
+  /// hostile indexer is not something the user can act on, and routing it to
+  /// Crashlytics would bury real defects (see `error_handling.md`).
+  Event? _authenticRelayList(
+    Map<String, dynamic> eventJson,
+    String indexerUrl,
+    String pubkeyHex,
+  ) {
+    void reject(String reason) {
+      Log.warning(
+        '  Rejecting kind-10002 frame from $indexerUrl: $reason',
+        name: 'RelayDiscoveryService',
+        category: LogCategory.auth,
+      );
+    }
+
+    final Event event;
+    try {
+      event = Event.fromJson(eventJson);
+    } on Object catch (e) {
+      reject('unparseable ($e)');
+      return null;
+    }
+
+    if (event.kind != 10002) {
+      reject('kind ${event.kind}, expected 10002');
+      return null;
+    }
+    if (event.pubkey != pubkeyHex) {
+      reject('authored by ${event.pubkey}, asked for $pubkeyHex');
+      return null;
+    }
+    // `isValid` recomputes the id; `isSigned` verifies the Schnorr signature.
+    // Both are needed — the id check alone only proves internal consistency,
+    // which anyone can produce.
+    if (!event.isValid) {
+      reject('event id does not match its contents');
+      return null;
+    }
+    if (!event.isSigned) {
+      reject('missing or invalid signature');
+      return null;
+    }
+    return event;
+  }
+
   /// Parse relay list from kind 10002 event JSON.
   ///
   /// NIP-65 format:
   /// Tags: [["r", "<relay-url>"], ["r", "<relay-url>", "read"],
   ///        ["r", "<relay-url>", "write"]]
   @visibleForTesting
-  List<DiscoveredRelay> parseRelayListFromJson(Map<String, dynamic> json) =>
-      _parseRelayListFromJson(json);
+  List<DiscoveredRelay> parseRelayListFromJson(Map<String, dynamic> json) {
+    final tags = json['tags'] as List<dynamic>? ?? const [];
+    return _parseRelayListFromTags([
+      for (final tag in tags)
+        if (tag is List) [for (final value in tag) value.toString()],
+    ]);
+  }
 
-  List<DiscoveredRelay> _parseRelayListFromJson(Map<String, dynamic> json) {
+  List<DiscoveredRelay> _parseRelayListFromEvent(Event event) =>
+      _parseRelayListFromTags(event.tags);
+
+  List<DiscoveredRelay> _parseRelayListFromTags(List<List<String>> eventTags) {
     final relays = <DiscoveredRelay>[];
-    final tags = json['tags'] as List<dynamic>? ?? [];
 
-    for (final tag in tags) {
-      if (tag is! List || tag.isEmpty || tag[0] != 'r') continue;
+    for (final tag in eventTags) {
+      if (tag.isEmpty || tag[0] != 'r') continue;
       if (tag.length < 2) continue;
 
-      final url = tag[1] as String;
+      final url = tag[1];
 
-      // Accept wss:// for any host, ws:// only for loopback (#3362).
-      if (!isRelayUrlAllowed(url)) {
+      // The list belongs to the user but reaches us through a third-party
+      // indexer, so it is admitted on remote-supplied terms: `wss://` only,
+      // and never a private, loopback or link-local target (#3362, #6585).
+      if (!isRemoteSuppliedRelayUrlAllowed(url)) {
         Log.warning(
           '  Skipping disallowed relay URL: $url',
           name: 'RelayDiscoveryService',
           category: LogCategory.auth,
         );
         continue;
+      }
+
+      if (relays.length >= RelayListCaps.nip65) {
+        Log.warning(
+          '  kind-10002 lists more than ${RelayListCaps.nip65} relays; '
+          'ignoring the rest',
+          name: 'RelayDiscoveryService',
+          category: LogCategory.auth,
+        );
+        break;
       }
 
       final permission = tag.length > 2 ? tag[2] as String? : null;

--- a/mobile/lib/services/relay_discovery_service.dart
+++ b/mobile/lib/services/relay_discovery_service.dart
@@ -210,9 +210,9 @@ class RelayDiscoveryService {
   /// rather than waiting for all indexers to finish. If all indexers return
   /// empty or fail, returns null.
   ///
-  // TODO: cancel remaining WebSocket connections on first success. Currently
-  // losing queries complete naturally (EOSE or 10s timeout) which is harmless
-  // but wastes resources.
+  // Losing queries complete naturally (EOSE or 10s timeout). Each direct
+  // query owns and disposes its RelayBase, so no connection survives that
+  // bound.
   Future<(List<DiscoveredRelay>, String)?> _queryFirstSuccess(
     String pubkeyHex,
   ) async {
@@ -268,7 +268,7 @@ class RelayDiscoveryService {
     final relayStatus = RelayStatus(indexerUrl);
     final relay = RelayBase(indexerUrl, relayStatus);
     final completer = Completer<List<DiscoveredRelay>>();
-    final events = <Event>[];
+    Event? newestEvent;
     final subscriptionId = 'rd_${DateTime.now().millisecondsSinceEpoch}';
 
     // Set up message handler before connecting
@@ -280,18 +280,21 @@ class RelayDiscoveryService {
       if (messageType == 'EVENT' && json.length >= 3) {
         final eventJson = json[2] as Map<String, dynamic>;
         final event = _authenticRelayList(eventJson, indexerUrl, pubkeyHex);
-        if (event != null) events.add(event);
+        if (event != null &&
+            (newestEvent == null || event.createdAt > newestEvent!.createdAt)) {
+          newestEvent = event;
+        }
       } else if (messageType == 'EOSE') {
         // All stored events received - parse and complete
         if (!completer.isCompleted) {
-          if (events.isEmpty) {
+          final event = newestEvent;
+          if (event == null) {
             completer.complete(<DiscoveredRelay>[]);
           } else {
             // Newest wins. Frames arrive in whatever order the indexer feels
             // like sending them, so the first one through the socket is not
             // the current relay list.
-            events.sort((a, b) => b.createdAt.compareTo(a.createdAt));
-            completer.complete(_parseRelayListFromEvent(events.first));
+            completer.complete(_parseRelayListFromEvent(event));
           }
         }
       } else if (messageType == 'NOTICE') {
@@ -356,6 +359,7 @@ class RelayDiscoveryService {
     } finally {
       try {
         await relay.disconnect();
+        relay.dispose();
       } catch (_) {}
     }
   }
@@ -364,9 +368,10 @@ class RelayDiscoveryService {
   /// kind-10002, and null otherwise.
   ///
   /// This query runs on a bare [RelayBase] with its own `onMessage`, so the
-  /// frame never passes through `RelayPool`, which is the only place inbound
-  /// events are checked. Nothing else stands between an indexer and the relay
-  /// pool: what comes back here is adopted via `NostrClient.addRelays` and
+  /// frame never passes through `RelayPool`, so it bypasses the normal
+  /// subscription filter and signature checks. Nothing else stands between an
+  /// indexer and the relay pool: what comes back here is adopted via
+  /// `NostrClient.addRelays` and
   /// then used for every subsequent read and write. The indexers queried are
   /// third-party public relays, so "it answered our REQ" is not evidence the
   /// answer is the list we asked for — the id, the signature, the author and
@@ -538,9 +543,12 @@ class RelayDiscoveryService {
         cached.map((r) => r.url),
         cap: RelayListCaps.nip65,
       );
+      final cachedByUrl = {
+        for (final relay in cached.reversed) relay.url: relay,
+      };
       return [
-        for (final relay in cached)
-          if (admitted.contains(relay.url)) relay,
+        for (final url in admitted)
+          if (cachedByUrl[url] != null) cachedByUrl[url]!,
       ];
     } catch (e) {
       Log.warning(

--- a/mobile/lib/services/relay_discovery_service.dart
+++ b/mobile/lib/services/relay_discovery_service.dart
@@ -469,6 +469,7 @@ class RelayDiscoveryService {
   /// event cannot answer differently depending on which one served it.
   List<DiscoveredRelay> _admitRelayList(Iterable<DiscoveredRelay> candidates) {
     final byHost = <String, DiscoveredRelay>{};
+    var loggedCap = false;
 
     for (final candidate in candidates) {
       final url = candidate.url;
@@ -495,13 +496,16 @@ class RelayDiscoveryService {
       }
 
       if (byHost.length >= RelayListCaps.nip65) {
-        Log.warning(
-          '  kind-10002 lists more than ${RelayListCaps.nip65} relays; '
-          'ignoring the rest',
-          name: 'RelayDiscoveryService',
-          category: LogCategory.auth,
-        );
-        break;
+        if (!loggedCap) {
+          Log.warning(
+            '  kind-10002 lists more than ${RelayListCaps.nip65} relays; '
+            'ignoring additional hosts',
+            name: 'RelayDiscoveryService',
+            category: LogCategory.auth,
+          );
+          loggedCap = true;
+        }
+        continue;
       }
 
       byHost[key] = candidate;

--- a/mobile/lib/utils/relay_url_utils.dart
+++ b/mobile/lib/utils/relay_url_utils.dart
@@ -4,20 +4,29 @@
 import 'package:nostr_client/nostr_client.dart' as nostr_client;
 import 'package:nostr_sdk/nostr_sdk.dart' as nostr_sdk;
 
+/// The relay-URL admission policy lives in `nostr_sdk` so package-layer
+/// callers can share it without importing app code, and is re-exported here
+/// so app-layer callers keep a single import.
+///
+/// These are re-exports, not wrappers: a wrapper would be a second
+/// declaration of the same name, and any library importing both this file and
+/// the `nostr_sdk` barrel would fail with `ambiguous_import`.
+export 'package:nostr_sdk/nostr_sdk.dart'
+    show
+        RelayListCaps,
+        admitRemoteSuppliedRelays,
+        isLoopbackHost,
+        isPrivateOrLinkLocalHost,
+        isRelayUrlAllowed,
+        isRemoteSuppliedRelayUrlAllowed;
+
 const _divineRelayHost = 'relay.divine.video';
 const _divineApiBaseUrl = 'https://api.divine.video';
-
-/// True if [host] is a recognized loopback address that may be reached over
-/// cleartext (`ws://` / `http://`).
-///
-/// Delegates to the package-level source of truth in `nostr_sdk`; native
-/// cleartext transport config must mirror that predicate.
-bool isLoopbackHost(String host) => nostr_sdk.isLoopbackHost(host);
 
 /// Relay hosts operated by Divine across all environments.
 ///
 /// Matches the `EnvironmentConfig.relayUrl` hosts. Loopback (the `local`
-/// environment relay) is covered separately via [isLoopbackHost].
+/// environment relay) is covered separately via `isLoopbackHost`.
 const _divineHostedRelayHosts = <String>{
   'relay.divine.video',
   'relay.staging.divine.video',
@@ -30,7 +39,8 @@ const _divineHostedRelayHosts = <String>{
 bool isDivineHostedRelayUrl(String url) {
   final host = Uri.tryParse(url)?.host.toLowerCase();
   if (host == null || host.isEmpty) return false;
-  return _divineHostedRelayHosts.contains(host) || isLoopbackHost(host);
+  return _divineHostedRelayHosts.contains(host) ||
+      nostr_sdk.isLoopbackHost(host);
 }
 
 /// True if [configuredRelays] includes a relay the user added beyond the
@@ -55,35 +65,11 @@ bool usesUserChosenRelay(
   return configuredRelays.any((url) {
     final host = Uri.tryParse(url)?.host.toLowerCase();
     if (host == null || host.isEmpty) return false;
-    if (allowedHosts.contains(host) || isLoopbackHost(host)) return false;
+    if (allowedHosts.contains(host) || nostr_sdk.isLoopbackHost(host)) {
+      return false;
+    }
     return true;
   });
-}
-
-/// True if [url] is a relay URL the app is allowed to connect to.
-///
-/// Nostr relays speak WebSocket only — `wss://` is accepted for any host,
-/// and `ws://` is accepted only for a recognized loopback host. Any other
-/// scheme (`https://`, `http://`, `ftp://`, …), a malformed URL, or a missing
-/// host is rejected. Unlike `normalizeRelayUrl` in `nostr_client`, this
-/// requires an explicit scheme and rejects bare hosts because it validates
-/// user/app-layer input before the connection layer canonicalizes identity.
-///
-/// This predicate is the single source of truth for the application-layer
-/// relay URL allowlist. The loopback host predicate itself lives in
-/// `nostr_sdk` so package-layer callers can share it without importing app
-/// code.
-bool isRelayUrlAllowed(String url) {
-  final uri = Uri.tryParse(url.trim());
-  if (uri == null || !uri.hasAuthority || uri.host.isEmpty) return false;
-  // `wss://http://x` parses as host=`http` and path=`//x`; reject so a
-  // mis-nested URL in a NIP-65 tag or capability-service input cannot
-  // pass the allowlist and target the wrong host downstream.
-  if (uri.path.startsWith('//')) return false;
-  final scheme = uri.scheme.toLowerCase();
-  if (scheme == 'wss') return true;
-  if (scheme == 'ws') return isLoopbackHost(uri.host);
-  return false;
 }
 
 /// Normalizes a relay URL for identity comparison in UI state.

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -32,6 +32,7 @@ import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
 import 'package:nostr_sdk/nostr.dart';
 import 'package:nostr_sdk/signer/isolate_decrypt_signer.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
+import 'package:nostr_sdk/utils/relay_url_policy.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Decrypts a gift-wrapped event (kind 1059) through the NIP-17 layers
@@ -127,13 +128,6 @@ abstract class DmHistoryDrainConfig {
   static const int unwrapBatchSize = 100;
 }
 
-const _relayLoopbackHosts = <String>{
-  'localhost',
-  '127.0.0.1',
-  '10.0.2.2',
-  '::1',
-};
-
 /// Compile-time gate for temporary per-conversation classification
 /// diagnostics. Off by default and structurally disabled in release builds:
 /// the `!kReleaseMode` term folds the constant to `false` under AOT product
@@ -187,16 +181,16 @@ enum _OwnDmInboxState {
   failed,
 }
 
-bool _isAllowedDmRelayUrl(String url) {
-  final uri = Uri.tryParse(url.trim());
-  if (uri == null || !uri.hasAuthority || uri.host.isEmpty) return false;
-  if (uri.path.startsWith('//')) return false;
-  final scheme = uri.scheme.toLowerCase();
-  if (scheme == 'wss') return true;
-  if (scheme == 'ws') {
-    return _relayLoopbackHosts.contains(uri.host.toLowerCase());
-  }
-  return false;
+/// Who authored the kind-10050 a relay list is being read out of.
+///
+/// The two are admitted on different terms. Our own list may name the local
+/// stack; a counterparty's may not name anything on this device's network.
+enum DmRelayListSource {
+  /// The signed-in user's own kind-10050.
+  selfAuthored,
+
+  /// A counterparty's kind-10050, resolved to route a gift wrap to them.
+  remote,
 }
 
 /// Repository for NIP-17 direct message operations.
@@ -879,7 +873,10 @@ class DmRepository {
   _resolveOwnDmInbox() {
     final cached = _ownInboxFuture;
     if (cached != null) return cached;
-    final future = _queryOwnDmInbox(_userPubkey);
+    final future = _queryOwnDmInbox(
+      _userPubkey,
+      source: DmRelayListSource.selfAuthored,
+    );
     _ownInboxFuture = future;
     unawaited(
       future.then((res) {
@@ -2580,6 +2577,52 @@ class DmRepository {
     return (await _queryOwnDmInbox(pubkey)).relays;
   }
 
+  /// Filters and bounds the relay URLs advertised in a kind-10050.
+  ///
+  /// A relay list is untrusted input and nothing in the protocol bounds its
+  /// length, so the client bounds it. When [source] is
+  /// [DmRelayListSource.remote] the URLs came from the person being messaged,
+  /// and each one becomes an outbound connection from this device carrying
+  /// the gift wrap — so private, loopback and link-local targets are refused
+  /// on top of the usual scheme rule. Our own list keeps the loopback
+  /// allowance the local Docker stack needs.
+  ///
+  /// The cap is well above NIP-17's own "keep it to 1-3 relays" guidance:
+  /// the point is to turn unbounded into a small constant, not to be tight,
+  /// because truncating a real user silently costs them reachability.
+  List<String> _admitDmRelays(
+    Iterable<String> urls,
+    String pubkey,
+    DmRelayListSource source,
+  ) {
+    if (source == DmRelayListSource.selfAuthored) {
+      final admitted = <String>{
+        for (final url in urls)
+          if (isRelayUrlAllowed(url)) url,
+      };
+      if (admitted.length <= RelayListCaps.dmInbox) return admitted.toList();
+      Log.warning(
+        'Own kind-10050 lists ${admitted.length} relays; using the first '
+        '${RelayListCaps.dmInbox}',
+        category: LogCategory.system,
+      );
+      return admitted.take(RelayListCaps.dmInbox).toList();
+    }
+    return admitRemoteSuppliedRelays(
+      urls,
+      cap: RelayListCaps.dmInbox,
+      onRejected: (url) => Log.warning(
+        'Refusing DM inbox relay advertised by $pubkey: $url',
+        category: LogCategory.system,
+      ),
+      onTruncated: (kept, total) => Log.warning(
+        'kind-10050 for $pubkey lists $total relays; routing to the first '
+        '$kept',
+        category: LogCategory.system,
+      ),
+    );
+  }
+
   /// Queries [pubkey]'s kind-10050 DM inbox relay list and reports a
   /// found / absent / failed outcome (#4974).
   ///
@@ -2588,8 +2631,12 @@ class DmRepository {
   /// read (both fall back to the default pool either way), but RC3 must tell
   /// them apart — see [ensureDmRelayListPublished].
   Future<({_OwnDmInboxState state, List<String>? relays})> _queryOwnDmInbox(
-    String pubkey,
-  ) async {
+    String pubkey, {
+    // Defaults to the strict reading so a call site added later fails closed.
+    // Every path here except the signed-in user's own inbox is resolving
+    // somebody else's list.
+    DmRelayListSource source = DmRelayListSource.remote,
+  }) async {
     try {
       final events = await _nostrClient.queryEvents([
         nostr_filter.Filter(
@@ -2609,17 +2656,20 @@ class DmRepository {
       // kind-10050 event both unambiguously denote DM inbox relays. Matches
       // divine-web's resolveDmReadRelays. Shared with the send path via
       // resolveDmInboxRelays, so it also widens recipient resolution there.
-      final relays = <String>{
-        for (final tag in events.first.tags)
-          if (tag.length >= 2 &&
-              (tag[0] == 'relay' || tag[0] == 'r') &&
-              tag[1].isNotEmpty &&
-              _isAllowedDmRelayUrl(tag[1]))
-            tag[1],
-      };
+      final relays = _admitDmRelays(
+        [
+          for (final tag in events.first.tags)
+            if (tag.length >= 2 &&
+                (tag[0] == 'relay' || tag[0] == 'r') &&
+                tag[1].isNotEmpty)
+              tag[1],
+        ],
+        pubkey,
+        source,
+      );
       return relays.isEmpty
           ? (state: _OwnDmInboxState.absent, relays: null)
-          : (state: _OwnDmInboxState.found, relays: relays.toList());
+          : (state: _OwnDmInboxState.found, relays: relays);
     } on Object catch (e) {
       Log.warning(
         'Failed to resolve DM inbox relays for $pubkey: $e',
@@ -2658,7 +2708,7 @@ class DmRepository {
     final signer = _signer;
     final relayUrl = _dmInboxRelayUrl;
     if (syncState == null || signer == null) return;
-    if (relayUrl == null || !_isAllowedDmRelayUrl(relayUrl)) return;
+    if (relayUrl == null || !isRelayUrlAllowed(relayUrl)) return;
     final pubkey = _userPubkey;
     // Session-identity token: bail after any await if an account switch /
     // logout (or other teardown) bumped it while we were in flight.

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -2654,8 +2654,20 @@ class DmRepository {
       if (events.isEmpty) {
         return (state: _OwnDmInboxState.absent, relays: null);
       }
+      final matchingEvents = [
+        for (final event in events)
+          if (event.kind == EventKind.dmRelaysList && event.pubkey == pubkey)
+            event,
+      ];
+      if (matchingEvents.isEmpty) {
+        Log.warning(
+          'Ignoring off-filter DM inbox relay response for $pubkey',
+          category: LogCategory.system,
+        );
+        return (state: _OwnDmInboxState.absent, relays: null);
+      }
       // Newest wins for a replaceable event served from multiple relays.
-      events.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+      matchingEvents.sort((a, b) => b.createdAt.compareTo(a.createdAt));
       // Accept both `relay` (the kind-10050 spec tag) and `r` tags. The
       // whole point of #4974 is reading a 10050 a user advertised from
       // ANOTHER client, and some clients write `r` tags; within a
@@ -2664,7 +2676,7 @@ class DmRepository {
       // resolveDmInboxRelays, so it also widens recipient resolution there.
       final relays = _admitDmRelays(
         [
-          for (final tag in events.first.tags)
+          for (final tag in matchingEvents.first.tags)
             if (tag.length >= 2 &&
                 (tag[0] == 'relay' || tag[0] == 'r') &&
                 tag[1].isNotEmpty)

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -185,7 +185,7 @@ enum _OwnDmInboxState {
 ///
 /// The two are admitted on different terms. Our own list may name the local
 /// stack; a counterparty's may not name anything on this device's network.
-enum DmRelayListSource {
+enum _DmRelayListSource {
   /// The signed-in user's own kind-10050.
   selfAuthored,
 
@@ -875,7 +875,7 @@ class DmRepository {
     if (cached != null) return cached;
     final future = _queryOwnDmInbox(
       _userPubkey,
-      source: DmRelayListSource.selfAuthored,
+      source: _DmRelayListSource.selfAuthored,
     );
     _ownInboxFuture = future;
     unawaited(
@@ -2573,6 +2573,12 @@ class DmRepository {
   /// the default relay pool so reachability is preserved for recipients
   /// who have not advertised a DM inbox. Resolution failures degrade to
   /// `null` rather than throwing, so a relay hiccup never blocks a send.
+  ///
+  /// The list is admitted on remote-supplied terms and capped at
+  /// [RelayListCaps.dmInbox]: each entry becomes an outbound connection from
+  /// this device carrying the gift wrap, so a counterparty decides neither
+  /// how many hosts we dial nor whether any of them sit on the sender's own
+  /// network (#6585).
   Future<List<String>?> resolveDmInboxRelays(String pubkey) async {
     return (await _queryOwnDmInbox(pubkey)).relays;
   }
@@ -2581,7 +2587,7 @@ class DmRepository {
   ///
   /// A relay list is untrusted input and nothing in the protocol bounds its
   /// length, so the client bounds it. When [source] is
-  /// [DmRelayListSource.remote] the URLs came from the person being messaged,
+  /// [_DmRelayListSource.remote] the URLs came from the person being messaged,
   /// and each one becomes an outbound connection from this device carrying
   /// the gift wrap — so private, loopback and link-local targets are refused
   /// on top of the usual scheme rule. Our own list keeps the loopback
@@ -2593,9 +2599,9 @@ class DmRepository {
   List<String> _admitDmRelays(
     Iterable<String> urls,
     String pubkey,
-    DmRelayListSource source,
+    _DmRelayListSource source,
   ) {
-    if (source == DmRelayListSource.selfAuthored) {
+    if (source == _DmRelayListSource.selfAuthored) {
       final admitted = <String>{
         for (final url in urls)
           if (isRelayUrlAllowed(url)) url,
@@ -2635,7 +2641,7 @@ class DmRepository {
     // Defaults to the strict reading so a call site added later fails closed.
     // Every path here except the signed-in user's own inbox is resolving
     // somebody else's list.
-    DmRelayListSource source = DmRelayListSource.remote,
+    _DmRelayListSource source = _DmRelayListSource.remote,
   }) async {
     try {
       final events = await _nostrClient.queryEvents([

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -2602,10 +2602,19 @@ class DmRepository {
     _DmRelayListSource source,
   ) {
     if (source == _DmRelayListSource.selfAuthored) {
-      final admitted = <String>{
-        for (final url in urls)
-          if (isRelayUrlAllowed(url)) url,
-      };
+      final admitted = <String>{};
+      for (final url in urls) {
+        if (isRelayUrlAllowed(url)) {
+          admitted.add(url);
+          continue;
+        }
+        // Their own list, so a rejection is a typo they can fix — say so
+        // rather than dropping the entry the way the remote branch does.
+        Log.warning(
+          'Ignoring unusable relay in own kind-10050: $url',
+          category: LogCategory.system,
+        );
+      }
       if (admitted.length <= RelayListCaps.dmInbox) return admitted.toList();
       Log.warning(
         'Own kind-10050 lists ${admitted.length} relays; using the first '

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -17,6 +17,7 @@ import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/event_kind.dart';
 import 'package:nostr_sdk/filter.dart' as nostr_filter;
 import 'package:nostr_sdk/nip44/nip44_v2.dart';
+import 'package:nostr_sdk/utils/relay_url_policy.dart';
 import 'package:nostr_sdk/nip59/gift_wrap_batch_unwrap.dart';
 import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
 import 'package:nostr_sdk/relay/publish_outcome.dart';
@@ -3859,8 +3860,6 @@ void main() {
         stubQuery([
           kind10050Event([
             'wss://valid.example',
-            'ws://localhost:7777',
-            'ws://10.0.2.2:7777',
             'ws://attacker.example',
             'http://attacker.example',
             'https://attacker.example',
@@ -3869,13 +3868,54 @@ void main() {
           ]),
         ]);
         final repository = createRepository();
-        expect(
-          await repository.resolveDmInboxRelays(_validPubkeyB),
-          [
+        expect(await repository.resolveDmInboxRelays(_validPubkeyB), [
+          'wss://valid.example',
+        ]);
+      });
+
+      // #6585: every entry here becomes an outbound connection from this
+      // device carrying the gift wrap, to an address the *recipient* chose.
+      // Pointing that at the sender's own network is never legitimate, and
+      // the local-stack loopback allowance does not extend to a list somebody
+      // else authored.
+      test('refuses private, loopback and link-local targets', () async {
+        stubQuery([
+          kind10050Event([
             'wss://valid.example',
             'ws://localhost:7777',
             'ws://10.0.2.2:7777',
-          ],
+            'wss://127.0.0.1',
+            'wss://localhost',
+            'wss://192.168.1.10',
+            'wss://10.1.2.3',
+            'wss://172.16.0.9',
+            'wss://169.254.169.254',
+            'wss://[fe80::1]',
+            'wss://2130706433',
+            'wss://printer.local',
+          ]),
+        ]);
+        final repository = createRepository();
+        expect(await repository.resolveDmInboxRelays(_validPubkeyB), [
+          'wss://valid.example',
+        ]);
+      });
+
+      test('caps how many relays one kind-10050 can point us at', () async {
+        stubQuery([
+          kind10050Event([
+            for (var i = 0; i < 50; i++) 'wss://relay-$i.example',
+          ]),
+        ]);
+        final repository = createRepository();
+        final resolved = await repository.resolveDmInboxRelays(_validPubkeyB);
+
+        expect(resolved, hasLength(RelayListCaps.dmInbox));
+        // Deterministic: first-N in tag order, not an arbitrary subset.
+        expect(resolved!.first, 'wss://relay-0.example');
+        expect(
+          resolved.last,
+          'wss://relay-${RelayListCaps.dmInbox - 1}.example',
         );
       });
 
@@ -3887,6 +3927,7 @@ void main() {
               'ws://attacker.example',
               'http://attacker.example',
               'wss://https://attacker.example',
+              'wss://192.168.0.1',
             ]),
           ]);
           final repository = createRepository();

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -3800,10 +3800,15 @@ void main() {
     });
 
     group('resolveDmInboxRelays', () {
-      Event kind10050Event(List<String> relays, {int createdAt = 1700000000}) {
+      Event kind10050Event(
+        List<String> relays, {
+        int createdAt = 1700000000,
+        String pubkey = _validPubkeyB,
+        int kind = EventKind.dmRelaysList,
+      }) {
         return Event(
-          _validPubkeyB,
-          EventKind.dmRelaysList,
+          pubkey,
+          kind,
           [
             for (final r in relays) ['relay', r],
           ],
@@ -3844,6 +3849,25 @@ void main() {
         final repository = createRepository();
         expect(await repository.resolveDmInboxRelays(_validPubkeyB), isNull);
       });
+
+      test(
+        'ignores relay-returned events that do not match the requested '
+        'kind-10050 author',
+        () async {
+          stubQuery([
+            kind10050Event(
+              ['wss://attacker-selected.example'],
+              pubkey: _validPubkeyC,
+            ),
+            kind10050Event(
+              ['wss://wrong-kind.example'],
+              kind: EventKind.textNote,
+            ),
+          ]);
+          final repository = createRepository();
+          expect(await repository.resolveDmInboxRelays(_validPubkeyB), isNull);
+        },
+      );
 
       test('de-duplicates relay urls', () async {
         stubQuery([
@@ -15125,10 +15149,14 @@ void main() {
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
             ),
-          ).thenAnswer(
-            (_) async => [
+          ).thenAnswer((invocation) async {
+            final filters =
+                invocation.positionalArguments.first
+                    as List<nostr_filter.Filter>;
+            final recipient = filters.single.authors!.single;
+            return [
               Event(
-                _validPubkeyB,
+                recipient,
                 EventKind.dmRelaysList,
                 [
                   ['relay', 'wss://inbox.example'],
@@ -15136,8 +15164,8 @@ void main() {
                 '',
                 createdAt: 1700000000,
               ),
-            ],
-          );
+            ];
+          });
           stubSendRumor((_, recipient) async {
             return NIP17SendResult.success(
               rumorEventId: 'rumor-$recipient',

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -17,13 +17,13 @@ import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/event_kind.dart';
 import 'package:nostr_sdk/filter.dart' as nostr_filter;
 import 'package:nostr_sdk/nip44/nip44_v2.dart';
-import 'package:nostr_sdk/utils/relay_url_policy.dart';
 import 'package:nostr_sdk/nip59/gift_wrap_batch_unwrap.dart';
 import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
 import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:nostr_sdk/signer/isolate_decrypt_signer.dart';
 import 'package:nostr_sdk/signer/local_nostr_signer.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
+import 'package:nostr_sdk/utils/relay_url_policy.dart';
 
 class _MockOutgoingDmsDao extends Mock implements OutgoingDmsDao {}
 

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -849,7 +849,10 @@ class NostrClient {
           ? await _queryPool.withResource(runWebSocketQuery)
           : await runWebSocketQuery();
     }
-    final websocketEvents = websocketResult.events;
+    final websocketEvents = _eventsMatchingAnyFilter(
+      websocketResult.events,
+      filters,
+    );
 
     // Cache websocket results (fire-and-forget)
     if (websocketEvents.isNotEmpty) {
@@ -1684,6 +1687,16 @@ class NostrClient {
     final bytes = utf8.encode(jsonString);
     final digest = sha256.convert(bytes);
     return digest.toString().substring(0, 16);
+  }
+
+  List<Event> _eventsMatchingAnyFilter(
+    List<Event> events,
+    List<Filter> filters,
+  ) {
+    return [
+      for (final event in events)
+        if (filters.any((filter) => filter.checkEvent(event))) event,
+    ];
   }
 
   /// Merges cached and network events, deduplicating by event ID.

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -799,9 +799,23 @@ class NostrClient {
     final cacheResults = <Event>[];
 
     // 1. Get cache results (don't return early - we'll merge with network)
+    //
+    // Held to the same filter as the network leg. The local store is not an
+    // admission oracle: its rows are remote-sourced, several writers put them
+    // there without ever seeing this filter, and rows written by a build that
+    // predates the gate are still inside the cache TTL. The DAO's SQL narrows
+    // on most dimensions but not all — an empty-but-non-null list emits no
+    // condition at all, where `checkEvent` matches nothing — so relying on
+    // SQL/`checkEvent` parity would rest a boundary on a cross-package
+    // coincidence neither side declares.
     final dao = _nostrEventsDao;
     if (useCache && dao != null && filters.length == 1) {
-      cacheResults.addAll(await dao.getEventsByFilter(filters.first));
+      cacheResults.addAll(
+        _eventsMatchingAnyFilter(
+          await dao.getEventsByFilter(filters.first),
+          filters,
+        ),
+      );
     }
 
     // 2. Query via WebSocket.

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -1436,6 +1436,44 @@ void main() {
           expect(result.events, [matching]);
         },
       );
+
+      test(
+        'drops cached events that do not match the requested filter',
+        () async {
+          final mockDbClient = _MockAppDbClient();
+          final mockDatabase = _MockAppDatabase();
+          final dao = _MockNostrEventsDao();
+          when(() => mockDbClient.database).thenReturn(mockDatabase);
+          when(() => mockDatabase.nostrEventsDao).thenReturn(dao);
+
+          final matching = _createTestEvent(kind: EventKind.textNote);
+          final offFilter = _createTestEvent(kind: EventKind.relayListMetadata);
+          // A row the cache holds but this query did not ask for — what an
+          // older build persisted before the gate existed, or what one of the
+          // other writers into this table put there.
+          when(
+            () => dao.getEventsByFilter(any()),
+          ).thenAnswer((_) async => [offFilter, matching]);
+
+          final clientWithCache = NostrClient.forTesting(
+            nostr: mockNostr,
+            relayManager: mockRelayManager,
+            dbClient: mockDbClient,
+          );
+          stubWebSocketEvents([]);
+
+          final result = await clientWithCache.queryEventsDetailed([
+            textNoteFilter(),
+          ]);
+
+          expect(
+            result.events,
+            [matching],
+            reason:
+                'the cache leg is held to the same filter as the network leg',
+          );
+        },
+      );
     });
 
     group('fetchEventById', () {

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -274,7 +274,9 @@ void main() {
         expect(pendingQueries, hasLength(2));
         expect(activeQueries, 2);
 
-        pendingQueries.removeFirst().complete([_createTestEvent(id: 'one')]);
+        pendingQueries.removeFirst().complete([
+          _createTestEvent(id: 'one', kind: 1059),
+        ]);
         await pumpEventQueue();
 
         expect(pendingQueries, hasLength(2));
@@ -286,8 +288,12 @@ void main() {
         expect(pendingQueries, hasLength(2));
         expect(activeQueries, 2);
 
-        pendingQueries.removeFirst().complete([_createTestEvent(id: 'three')]);
-        pendingQueries.removeFirst().complete([_createTestEvent(id: 'four')]);
+        pendingQueries.removeFirst().complete([
+          _createTestEvent(id: 'three', kind: 1059),
+        ]);
+        pendingQueries.removeFirst().complete([
+          _createTestEvent(id: 'four', kind: 1059),
+        ]);
 
         await expectLater(
           Future.wait(results),
@@ -1415,6 +1421,19 @@ void main() {
           // The simple form drops the timeout signal, but must not drop the
           // events that arrived before it.
           expect(await client.queryEvents([textNoteFilter()]), equals(events));
+        },
+      );
+
+      test(
+        'drops websocket events that do not match any requested filter',
+        () async {
+          final matching = _createTestEvent(kind: EventKind.textNote);
+          final offFilter = _createTestEvent(kind: EventKind.relayListMetadata);
+          stubWebSocketEvents([offFilter, matching]);
+
+          final result = await client.queryEventsDetailed([textNoteFilter()]);
+
+          expect(result.events, [matching]);
         },
       );
     });

--- a/mobile/packages/nostr_sdk/lib/filter.dart
+++ b/mobile/packages/nostr_sdk/lib/filter.dart
@@ -2,10 +2,11 @@ import 'package:nostr_sdk/event.dart';
 
 /// filter is a JSON object that determines what events will be sent in that subscription
 class Filter {
-  /// a list of event ids or prefixes
+  /// a list of event ids, each an exact 64-character lowercase hex value
   List<String>? ids;
 
-  /// a list of pubkeys or prefixes, the pubkey of an event must be one of these
+  /// a list of pubkeys, each an exact 64-character lowercase hex value; the
+  /// pubkey of an event must be one of these
   List<String>? authors;
 
   /// a list of a kind numbers
@@ -149,10 +150,14 @@ class Filter {
   }
 
   bool checkEvent(Event event) {
-    if (ids != null && !_matchesAnyPrefix(ids!, event.id)) {
+    // Exact, not prefix. NIP-01: "The `ids`, `authors`, `#e` and `#p` filter
+    // lists MUST contain exact 64-character lowercase hex values." A prefix
+    // compare would also make a single `''` entry match every event, turning
+    // the admission gates built on checkEvent into pass-throughs.
+    if (ids != null && (!ids!.contains(event.id))) {
       return false;
     }
-    if (authors != null && !_matchesAnyPrefix(authors!, event.pubkey)) {
+    if (authors != null && (!authors!.contains(event.pubkey))) {
       return false;
     }
     if (kinds != null && (!kinds!.contains(event.kind))) {
@@ -265,9 +270,5 @@ class Filter {
     }
 
     return true;
-  }
-
-  bool _matchesAnyPrefix(List<String> prefixes, String value) {
-    return prefixes.any(value.startsWith);
   }
 }

--- a/mobile/packages/nostr_sdk/lib/filter.dart
+++ b/mobile/packages/nostr_sdk/lib/filter.dart
@@ -149,10 +149,10 @@ class Filter {
   }
 
   bool checkEvent(Event event) {
-    if (ids != null && (!ids!.contains(event.id))) {
+    if (ids != null && !_matchesAnyPrefix(ids!, event.id)) {
       return false;
     }
-    if (authors != null && (!authors!.contains(event.pubkey))) {
+    if (authors != null && !_matchesAnyPrefix(authors!, event.pubkey)) {
       return false;
     }
     if (kinds != null && (!kinds!.contains(event.kind))) {
@@ -265,5 +265,9 @@ class Filter {
     }
 
     return true;
+  }
+
+  bool _matchesAnyPrefix(List<String> prefixes, String value) {
+    return prefixes.any(value.startsWith);
   }
 }

--- a/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
@@ -70,6 +70,7 @@ export 'upload/upload_util.dart';
 export 'utils/date_format_util.dart';
 export 'utils/loopback_host.dart';
 export 'utils/redact_http_headers_for_logs.dart';
+export 'utils/relay_url_policy.dart';
 export 'utils/string_util.dart';
 export 'zap/lnurl_response.dart';
 export 'zap/zap.dart';

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1637,7 +1637,11 @@ class RelayPool {
     String? id,
     Function? onComplete,
   }) {
-    if (filtersMap.isEmpty) {
+    if (filtersMap.isEmpty ||
+        filtersMap.values.any((filters) => filters.isEmpty)) {
+      // A per-relay entry with no filters would build a Subscription that
+      // matches nothing, so every event it received would be dropped by the
+      // admission gate. The sibling entry points reject this the same way.
       throw ArgumentError("No filters given", "filters");
     }
     id ??= StringUtil.rndNameStr(16);

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -5,7 +5,7 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:developer';
 
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 import 'package:nostr_sdk/utils/relay_addr_util.dart';
 
 import '../count_response.dart';
@@ -1126,6 +1126,24 @@ class RelayPool {
           _verifiesSkippedByPolicy++;
         }
 
+        final poolSubscription = _subscriptions[subId];
+        final querySubscription = poolSubscription == null
+            ? relay.getRequestSubscription(subId)
+            : null;
+        final subscription = poolSubscription ?? querySubscription;
+
+        if (subscription == null) {
+          return;
+        }
+
+        if (!subscription.matchesEvent(event)) {
+          log(
+            'Dropping relay event that does not match subscription filter '
+            'from ${relay.url}: eventId=${event.id}, subId=$subId',
+          );
+          return;
+        }
+
         if ((relay.relayStatus.relayType != RelayType.cache)) {
           var event = Map<String, dynamic>.from(eventJson);
           var kind = event["kind"];
@@ -1158,20 +1176,13 @@ class RelayPool {
         } else {
           event.sources.add(relay.url);
         }
-        var subscription = _subscriptions[subId];
-
-        if (subscription != null) {
-          subscription.onEvent(event);
-        } else {
-          subscription = relay.getRequestSubscription(subId);
-          if (subscription != null) {
-            // The relay is mid-answer for this one-shot query, so it has not
-            // gone silent — restart the grace period rather than cut its
-            // result set off part-way through.
-            _restartQuerySettleWindow(subId);
-            subscription.onEvent(event);
-          }
+        if (querySubscription != null) {
+          // The relay is mid-answer for this one-shot query, so it has not
+          // gone silent. Restart the grace period rather than cutting its
+          // result set off part-way through.
+          _restartQuerySettleWindow(subId);
         }
+        subscription.onEvent(event);
       } catch (err) {
         log(err.toString());
       }
@@ -2352,6 +2363,7 @@ class RelayPool {
     var relay = _tempRelays.remove(addr);
     if (relay != null) {
       relay.disconnect();
+      relay.dispose();
     }
     _forgetRelayBookkeeping(addr);
   }

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:developer';
 
+import 'package:flutter/foundation.dart';
 import 'package:nostr_sdk/utils/relay_addr_util.dart';
 
 import '../count_response.dart';
@@ -198,7 +199,31 @@ class RelayPool {
     this.onNotice,
     this.signatureVerificationPolicy = SignatureVerificationPolicy.all,
     this.silentRepairCooldown = const Duration(seconds: 60),
+    this.tempRelayIdleTimeout = const Duration(seconds: 120),
+    this.tempRelaySweepInterval = const Duration(seconds: 60),
   });
+
+  /// How long a temp relay may sit with no inbound traffic before the sweep
+  /// closes it. Injectable so tests need no wall-clock wait.
+  ///
+  /// A temp relay is created per entry in a caller's `tempRelays` list, and
+  /// before #6585 nothing ever closed one: [_sendCollect] only tore a temp
+  /// relay down when the publish deadline had *already* expired, so any
+  /// address that answered in time kept its socket for the life of the
+  /// process. That matters most where the addresses are not ours to choose —
+  /// a NIP-17 gift wrap goes to the relays the *recipient* advertised, so an
+  /// unbounded, immortal set of connections was reachable from a counterparty
+  /// simply by listing hosts in their kind-10050.
+  ///
+  /// NIP-17's kind-10050 description says as much directly: "After sending,
+  /// disconnect from these relays unless further messages are expected."
+  final Duration tempRelayIdleTimeout;
+
+  /// How often the idle sweep runs while any temp relay exists.
+  final Duration tempRelaySweepInterval;
+
+  /// Periodic idle sweep over [_tempRelays]; null while none exist.
+  Timer? _tempRelaySweepTimer;
 
   /// Minimum gap between two silent-socket repairs of the *same* relay.
   ///
@@ -449,6 +474,11 @@ class RelayPool {
       _forgetRelayBookkeeping(url);
     }
     _relays.clear();
+    for (final url in _tempRelays.keys.toList(growable: false)) {
+      removeTempRelay(url);
+    }
+    _tempRelaySweepTimer?.cancel();
+    _tempRelaySweepTimer = null;
   }
 
   /// Drops the pool-side state keyed by [url] so a relay that comes back is
@@ -1780,6 +1810,12 @@ class RelayPool {
       return deadline != null && !DateTime.now().isBefore(deadline);
     }
 
+    // Only tears down a temp relay once the publish deadline has passed —
+    // before that the relay may still be carrying a concurrent publish or
+    // query, since temp relays are keyed by URL and therefore shared. The
+    // sockets this deliberately leaves behind are reclaimed by
+    // [sweepIdleTempRelays] once they go quiet, which is safe precisely
+    // because it judges idleness rather than guessing at ownership.
     void removeExpiredTempRelay(Relay relay) {
       if (!deadlineExpired()) return;
       unawaited(relay.disconnect());
@@ -2212,9 +2248,64 @@ class RelayPool {
       _observeRelayStatus(tempRelay);
       tempRelay.connect();
       _tempRelays[addr] = tempRelay;
+      _ensureTempRelaySweepScheduled();
     }
 
     return tempRelay;
+  }
+
+  void _ensureTempRelaySweepScheduled() {
+    if (_tempRelaySweepTimer != null) return;
+    _tempRelaySweepTimer = Timer.periodic(
+      tempRelaySweepInterval,
+      (_) => sweepIdleTempRelays(),
+    );
+  }
+
+  /// Closes temp relays that have gone quiet and are not serving anything.
+  ///
+  /// A temp relay exists to carry one publish or one targeted query. Once that
+  /// is done the socket is pure liability: it holds a connection open to an
+  /// address the caller may not control, and it keeps the pool paying for a
+  /// peer nothing is waiting on. This is the teardown NIP-17 asks for on the
+  /// DM path, applied uniformly so every `tempRelays` caller inherits it.
+  ///
+  /// A relay is closed only when it is **both** silent for
+  /// [tempRelayIdleTimeout] **and** holds no live subscription or unanswered
+  /// query. Temp relays are keyed by URL and therefore shared — a second
+  /// publish, or a query naming the same address, reuses the same entry — so
+  /// closing on "this publish finished" would cut a socket out from under a
+  /// concurrent caller. Idleness is the only condition that is safe to judge
+  /// without tracking ownership.
+  @visibleForTesting
+  void sweepIdleTempRelays() {
+    final idleSince = DateTime.now().subtract(tempRelayIdleTimeout);
+    for (final entry in _tempRelayEntriesSnapshot()) {
+      if (!_isTempRelayReapable(entry.value, idleSince)) continue;
+      log('Closing idle temp relay ${entry.key}');
+      removeTempRelay(entry.key);
+    }
+    if (_tempRelays.isEmpty) {
+      _tempRelaySweepTimer?.cancel();
+      _tempRelaySweepTimer = null;
+    }
+  }
+
+  bool _isTempRelayReapable(Relay relay, DateTime idleSince) {
+    // Still carrying work for somebody — never reap.
+    if (relay.hasSubscription() || relay.getQueries().isNotEmpty) return false;
+
+    // A relay that failed to connect, or has since dropped, is doing nothing
+    // for anyone. [RelayBase.isSilentSince] deliberately answers false for a
+    // socket that is not connected — it exists to spot *live* zombie sockets —
+    // so the disconnected case has to be caught separately or those entries
+    // would accumulate forever, which is the half of the leak that a failed
+    // send used to produce.
+    if (relay.relayStatus.connected == ClientConnected.disconnect) return true;
+
+    // Connected: reap only once genuinely quiet. The connection stamps its
+    // activity clock on connect, so a freshly opened socket is never silent.
+    return relay is RelayBase && relay.isSilentSince(idleSince);
   }
 
   bool _shouldReplaceTempRelay(Relay relay) {
@@ -2268,6 +2359,14 @@ class RelayPool {
   Relay? getTempRelay(String url) {
     return _tempRelays[url];
   }
+
+  /// Addresses currently holding a temp-relay connection.
+  ///
+  /// Keys are normalised by [RelayAddrUtil.handle], so tests assert on this
+  /// rather than on the raw URL they passed in — a raw-URL lookup misses and
+  /// would make an "it was cleaned up" assertion pass vacuously.
+  @visibleForTesting
+  List<String> get tempRelayUrls => _tempRelays.keys.toList(growable: false);
 
   bool readable() {
     for (final relay in _relaysSnapshot()) {

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -2302,10 +2302,6 @@ class RelayPool {
       log('Closing idle temp relay ${entry.key}');
       removeTempRelay(entry.key);
     }
-    if (_tempRelays.isEmpty) {
-      _tempRelaySweepTimer?.cancel();
-      _tempRelaySweepTimer = null;
-    }
   }
 
   bool _isTempRelayReapable(Relay relay, DateTime idleSince) {
@@ -2393,6 +2389,13 @@ class RelayPool {
       relay.dispose();
     }
     _forgetRelayBookkeeping(addr);
+    // Pairs with the arm in [checkAndGenTempRelay]: the sweep exists only to
+    // serve entries in [_tempRelays], so it stops with the last one rather
+    // than waiting for a tick to notice the map is empty.
+    if (_tempRelays.isEmpty) {
+      _tempRelaySweepTimer?.cancel();
+      _tempRelaySweepTimer = null;
+    }
   }
 
   Relay? getTempRelay(String url) {

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -2312,13 +2312,34 @@ class RelayPool {
     // Still carrying work for somebody — never reap.
     if (relay.hasSubscription() || relay.getQueries().isNotEmpty) return false;
 
+    // Queued frames are work too. A disconnected relay replays these the
+    // moment it reconnects (`Relay.onConnected`), and `pendingAuthedMessages`
+    // is specifically a publish parked behind a NIP-42 handshake. Reaping
+    // disconnects and disposes, which clears `_shouldReconnect` — so without
+    // this the sweep would cancel the very reconnect the caller is waiting on
+    // and the publish would be reported unanswered instead of being resent.
+    if (relay.pendingMessages.isNotEmpty ||
+        relay.pendingAuthedMessages.isNotEmpty) {
+      return false;
+    }
+
     // A relay that failed to connect, or has since dropped, is doing nothing
     // for anyone. [RelayBase.isSilentSince] deliberately answers false for a
     // socket that is not connected — it exists to spot *live* zombie sockets —
     // so the disconnected case has to be caught separately or those entries
     // would accumulate forever, which is the half of the leak that a failed
     // send used to produce.
-    if (relay.relayStatus.connected == ClientConnected.disconnect) return true;
+    //
+    // Give it one idle window first. `connect()` is async, so an entry is in
+    // the map before its socket opens; `RelayStatus.connectTime` is stamped
+    // when the status is built and never reset, which for a temp relay is its
+    // creation time. Without this the branch depends on every `Relay`
+    // implementation advancing to `connecting` before the first sweep can
+    // observe it — true for the ones here, but by scheduler accident rather
+    // than by contract, and not true of a manually driven sweep.
+    if (relay.relayStatus.connected == ClientConnected.disconnect) {
+      return relay.relayStatus.connectTime.isBefore(idleSince);
+    }
 
     // Connected: reap only once genuinely quiet. The connection stamps its
     // activity clock on connect, so a freshly opened socket is never silent.

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1136,6 +1136,17 @@ class RelayPool {
           return;
         }
 
+        // Liveness before admission: a frame arriving is progress whether or
+        // not we wanted its contents. Both of these say "this relay is still
+        // working", which is a property of the socket, not of the payload.
+        relay.relayStatus.noteReceive();
+        if (querySubscription != null) {
+          // The relay is mid-answer for this one-shot query, so it has not
+          // gone silent. Restart the grace period rather than cutting its
+          // result set off part-way through.
+          _restartQuerySettleWindow(subId);
+        }
+
         if (!subscription.matchesEvent(event)) {
           log(
             'Dropping relay event that does not match subscription filter '
@@ -1152,9 +1163,6 @@ class RelayPool {
             _broadcaseToCache(event);
           }
         }
-
-        // add some statistics
-        relay.relayStatus.noteReceive();
 
         // check block pubkey
         for (var eventFilter in eventFilters) {
@@ -1175,12 +1183,6 @@ class RelayPool {
           event.cacheEvent = true;
         } else {
           event.sources.add(relay.url);
-        }
-        if (querySubscription != null) {
-          // The relay is mid-answer for this one-shot query, so it has not
-          // gone silent. Restart the grace period rather than cutting its
-          // result set off part-way through.
-          _restartQuerySettleWindow(subId);
         }
         subscription.onEvent(event);
       } catch (err) {

--- a/mobile/packages/nostr_sdk/lib/subscription.dart
+++ b/mobile/packages/nostr_sdk/lib/subscription.dart
@@ -1,3 +1,5 @@
+import 'event.dart';
+import 'filter.dart';
 import 'utils/string_util.dart';
 
 /// Representation of a Nostr event subscription.
@@ -15,6 +17,14 @@ class Subscription {
 
   Subscription(this.filters, this.onEvent, {String? id, this.onEose})
     : _id = id ?? StringUtil.rndNameStr(16);
+
+  /// Whether [event] satisfies at least one filter in this subscription.
+  bool matchesEvent(Event event) {
+    for (final filterJson in filters) {
+      if (Filter.fromJson(filterJson).checkEvent(event)) return true;
+    }
+    return false;
+  }
 
   /// Returns the subscription as a Nostr subscription request in JSON format
   List<dynamic> toJson() {

--- a/mobile/packages/nostr_sdk/lib/subscription.dart
+++ b/mobile/packages/nostr_sdk/lib/subscription.dart
@@ -5,26 +5,35 @@ import 'utils/string_util.dart';
 /// Representation of a Nostr event subscription.
 class Subscription {
   final String _id;
-  List<Map<String, dynamic>> filters;
+  final List<Map<String, dynamic>> filters;
   Function onEvent;
 
   /// Callback invoked when EOSE (End of Stored Events) is received from all
   /// relays for this subscription.
   void Function()? onEose;
 
+  /// [filters] parsed once at construction.
+  ///
+  /// [matchesEvent] runs on every inbound frame, and `Filter.fromJson` copies
+  /// each id/author list it is handed — parsing per event would make the
+  /// receive path scale with the size of the author set. Parsing here also
+  /// means a malformed filter throws at subscribe time rather than being
+  /// swallowed per-event by the frame handler's catch-all.
+  final List<Filter> _parsedFilters;
+
   /// Subscription ID
   String get id => _id;
 
   Subscription(this.filters, this.onEvent, {String? id, this.onEose})
-    : _id = id ?? StringUtil.rndNameStr(16);
+    : _id = id ?? StringUtil.rndNameStr(16),
+      _parsedFilters = [for (final filter in filters) Filter.fromJson(filter)];
 
   /// Whether [event] satisfies at least one filter in this subscription.
-  bool matchesEvent(Event event) {
-    for (final filterJson in filters) {
-      if (Filter.fromJson(filterJson).checkEvent(event)) return true;
-    }
-    return false;
-  }
+  ///
+  /// A subscription carrying no filters matches nothing; the pool's entry
+  /// points reject an empty filter list before one can be constructed.
+  bool matchesEvent(Event event) =>
+      _parsedFilters.any((filter) => filter.checkEvent(event));
 
   /// Returns the subscription as a Nostr subscription request in JSON format
   List<dynamic> toJson() {

--- a/mobile/packages/nostr_sdk/lib/utils/loopback_host.dart
+++ b/mobile/packages/nostr_sdk/lib/utils/loopback_host.dart
@@ -131,6 +131,12 @@ List<int>? _tryParseIPv6(String host) {
   }
 }
 
+/// Whether [b] is outside the globally routable unicast space.
+///
+/// Tracks the IANA IPv4 Special-Purpose Address Registry rather than only the
+/// reachable-LAN set: a relay list a stranger wrote has no business naming any
+/// of these, and "not globally routable" is a rule that can be checked against
+/// a published registry instead of re-argued per range.
 bool _isPrivateIPv4(List<int> b) {
   if (b[0] == 10) return true; // 10.0.0.0/8 private
   if (b[0] == 127) return true; // 127.0.0.0/8 loopback
@@ -140,6 +146,14 @@ bool _isPrivateIPv4(List<int> b) {
   if (b[0] == 192 && b[1] == 168) return true; // 192.168.0.0/16
   if (b[0] == 100 && b[1] >= 64 && b[1] <= 127) return true; // 100.64/10 CGNAT
   if (b[0] >= 224) return true; // 224.0.0.0/4 multicast + 240/4 reserved
+  // 192.0.0.0/24 IETF protocol assignments.
+  if (b[0] == 192 && b[1] == 0 && b[2] == 0) return true;
+  // 198.18.0.0/15 benchmarking (RFC 2544).
+  if (b[0] == 198 && (b[1] == 18 || b[1] == 19)) return true;
+  // RFC 5737 documentation ranges: TEST-NET-1/2/3.
+  if (b[0] == 192 && b[1] == 0 && b[2] == 2) return true;
+  if (b[0] == 198 && b[1] == 51 && b[2] == 100) return true;
+  if (b[0] == 203 && b[1] == 0 && b[2] == 113) return true;
   return false;
 }
 
@@ -158,5 +172,7 @@ bool _isPrivateIPv6(List<int> b) {
   // fe80::/10 link-local.
   if (b[0] == 0xfe && (b[1] & 0xc0) == 0x80) return true;
   if (b[0] == 0xff) return true; // ff00::/8 multicast
+  // 2001:db8::/32 documentation (RFC 3849) — the v6 twin of TEST-NET.
+  if (b[0] == 0x20 && b[1] == 0x01 && b[2] == 0x0d && b[3] == 0xb8) return true;
   return false;
 }

--- a/mobile/packages/nostr_sdk/lib/utils/loopback_host.dart
+++ b/mobile/packages/nostr_sdk/lib/utils/loopback_host.dart
@@ -28,3 +28,135 @@ bool isLoopbackHost(String host) => _loopbackHosts.contains(host.toLowerCase());
 /// cleartext (`ws://` / `http://`) loopback, not self-signed TLS.
 bool allowsLocalBadCertificateHost(String host) =>
     kDebugMode && isLoopbackHost(host);
+
+/// Hostname suffixes that resolve only inside a private network.
+const Set<String> _privateHostSuffixes = {'.local', '.internal', '.home.arpa'};
+
+/// Whether [host] names a private, loopback, or link-local endpoint — an
+/// address that is only meaningful inside the device's own network.
+///
+/// Used to refuse relay URLs supplied by a *remote* party. A counterparty
+/// choosing which hosts this device dials must not be able to point it at the
+/// user's LAN, VPN, or loopback interface. Self-authored and app-configured
+/// URLs are not filtered by this (the local stack legitimately runs on
+/// loopback) — see `isRemoteSuppliedRelayUrlAllowed` in `relay_url_policy.dart`.
+///
+/// Resolves [host] to an IP address before testing, so alternate literal
+/// encodings (`0x7f.0.0.1`, `2130706433`, `::ffff:192.168.0.1`) are judged by
+/// the address they denote rather than slipping past a string comparison.
+/// A host that is not an IP literal is matched on name: [isLoopbackHost]
+/// members plus [_privateHostSuffixes].
+///
+/// This does **not** resolve DNS — `wss://evil.example` that happens to
+/// resolve to `192.168.1.1` is not caught here. Doing so would need async
+/// resolution on the admission path and would still be racable via short TTLs,
+/// so the filter deliberately stops at literals and known-private names.
+///
+/// Deliberately free of `dart:io`: `nostr_sdk` builds for web, where
+/// `InternetAddress` does not exist. Parsing is `dart:core` only.
+bool isPrivateOrLinkLocalHost(String host) {
+  final normalized = host.toLowerCase().trim();
+  if (normalized.isEmpty) return true;
+  // A bracketed IPv6 literal arrives with its brackets when read off a URI.
+  final bare = normalized.startsWith('[') && normalized.endsWith(']')
+      ? normalized.substring(1, normalized.length - 1)
+      : normalized;
+
+  final ipv4 = _tryParseIPv4(bare);
+  if (ipv4 != null) return _isPrivateIPv4(ipv4);
+
+  final ipv6 = _tryParseIPv6(bare);
+  if (ipv6 != null) return _isPrivateIPv6(ipv6);
+
+  if (isLoopbackHost(bare)) return true;
+  return _privateHostSuffixes.any(bare.endsWith);
+}
+
+/// Parses the `inet_aton` family of IPv4 literals into four octets.
+///
+/// Accepts 1–4 dot-separated parts, each decimal, octal (`0…`), or hex
+/// (`0x…`) — the same shapes the platform resolver accepts. The trailing part
+/// absorbs the remaining octets, so `127.1` is `127.0.0.1` and `2130706433`
+/// is `127.0.0.1`. Returns null when [host] is not an IPv4 literal at all.
+List<int>? _tryParseIPv4(String host) {
+  final parts = host.split('.');
+  if (parts.isEmpty || parts.length > 4) return null;
+  final values = <int>[];
+  for (final part in parts) {
+    final value = _parseUnsignedRadixAware(part);
+    if (value == null) return null;
+    values.add(value);
+  }
+  // Every leading part is a single octet; the last absorbs what remains.
+  final octetsLeft = 4 - (values.length - 1);
+  if (values.take(values.length - 1).any((v) => v > 0xff)) return null;
+  final maxTail = octetsLeft == 4 ? 0xffffffff : (1 << (8 * octetsLeft)) - 1;
+  if (values.last > maxTail) return null;
+
+  var packed = 0;
+  for (var i = 0; i < values.length - 1; i++) {
+    packed = (packed << 8) | values[i];
+  }
+  packed = (packed << (8 * octetsLeft)) | values.last;
+  return [
+    (packed >> 24) & 0xff,
+    (packed >> 16) & 0xff,
+    (packed >> 8) & 0xff,
+    packed & 0xff,
+  ];
+}
+
+int? _parseUnsignedRadixAware(String raw) {
+  if (raw.isEmpty) return null;
+  if (raw.startsWith('0x')) {
+    if (raw.length == 2) return null;
+    return int.tryParse(raw.substring(2), radix: 16);
+  }
+  if (raw.length > 1 && raw.startsWith('0')) {
+    return int.tryParse(raw.substring(1), radix: 8);
+  }
+  return int.tryParse(raw);
+}
+
+/// Parses an IPv6 literal into 16 bytes, or null when [host] is not one.
+///
+/// `Uri.parseIPv6Address` is `dart:core` and handles `::` compression and the
+/// embedded-IPv4 tail, so there is no hand-rolled IPv6 parsing here.
+List<int>? _tryParseIPv6(String host) {
+  if (!host.contains(':')) return null;
+  try {
+    return Uri.parseIPv6Address(host);
+  } on FormatException {
+    return null;
+  }
+}
+
+bool _isPrivateIPv4(List<int> b) {
+  if (b[0] == 10) return true; // 10.0.0.0/8 private
+  if (b[0] == 127) return true; // 127.0.0.0/8 loopback
+  if (b[0] == 0) return true; // 0.0.0.0/8 "this network"
+  if (b[0] == 169 && b[1] == 254) return true; // 169.254.0.0/16 link-local
+  if (b[0] == 172 && b[1] >= 16 && b[1] <= 31) return true; // 172.16.0.0/12
+  if (b[0] == 192 && b[1] == 168) return true; // 192.168.0.0/16
+  if (b[0] == 100 && b[1] >= 64 && b[1] <= 127) return true; // 100.64/10 CGNAT
+  if (b[0] >= 224) return true; // 224.0.0.0/4 multicast + 240/4 reserved
+  return false;
+}
+
+bool _isPrivateIPv6(List<int> b) {
+  if (b.length != 16) return true;
+  // IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible (::a.b.c.d) carry the v4
+  // address in the last four bytes; judge those by the v4 rules so a mapped
+  // LAN address cannot dodge the filter.
+  final prefixIsZero = b.take(10).every((byte) => byte == 0);
+  if (prefixIsZero) {
+    final mapped = b[10] == 0xff && b[11] == 0xff;
+    final compatible = b[10] == 0 && b[11] == 0;
+    if (mapped || compatible) return _isPrivateIPv4(b.sublist(12));
+  }
+  if ((b[0] & 0xfe) == 0xfc) return true; // fc00::/7 unique local
+  // fe80::/10 link-local.
+  if (b[0] == 0xfe && (b[1] & 0xc0) == 0x80) return true;
+  if (b[0] == 0xff) return true; // ff00::/8 multicast
+  return false;
+}

--- a/mobile/packages/nostr_sdk/lib/utils/relay_url_policy.dart
+++ b/mobile/packages/nostr_sdk/lib/utils/relay_url_policy.dart
@@ -75,6 +75,18 @@ Uri? _tryParseRelayUri(String url) {
   return uri;
 }
 
+String? _remoteRelayIdentityKey(String url) {
+  final uri = _tryParseRelayUri(url);
+  if (uri == null) return null;
+  return uri
+      .replace(
+        scheme: uri.scheme.toLowerCase(),
+        host: uri.host.toLowerCase(),
+        path: uri.path == '/' ? '' : uri.path,
+      )
+      .toString();
+}
+
 /// Filters [urls] to those a remote party may legitimately point us at, and
 /// truncates the result to [cap], preserving order.
 ///
@@ -86,15 +98,16 @@ List<String> admitRemoteSuppliedRelays(
   void Function(String url)? onRejected,
   void Function(int kept, int total)? onTruncated,
 }) {
-  final admitted = <String>{};
+  final admittedByKey = <String, String>{};
   for (final url in urls) {
     if (isRemoteSuppliedRelayUrlAllowed(url)) {
-      admitted.add(url);
+      final key = _remoteRelayIdentityKey(url) ?? url;
+      admittedByKey.putIfAbsent(key, () => url);
     } else {
       onRejected?.call(url);
     }
   }
-  if (admitted.length <= cap) return admitted.toList();
-  onTruncated?.call(cap, admitted.length);
-  return admitted.take(cap).toList();
+  if (admittedByKey.length <= cap) return admittedByKey.values.toList();
+  onTruncated?.call(cap, admittedByKey.length);
+  return admittedByKey.values.take(cap).toList();
 }

--- a/mobile/packages/nostr_sdk/lib/utils/relay_url_policy.dart
+++ b/mobile/packages/nostr_sdk/lib/utils/relay_url_policy.dart
@@ -60,10 +60,11 @@ bool isRelayUrlAllowed(String url) {
 /// has no legitimate reason to ask for cleartext.
 bool isRemoteSuppliedRelayUrlAllowed(String url) {
   final uri = _tryParseRelayUri(url);
-  if (uri == null) return false;
-  if (uri.scheme.toLowerCase() != 'wss') return false;
-  return !isPrivateOrLinkLocalHost(uri.host);
+  return uri != null && _isRemoteSuppliedUriAllowed(uri);
 }
+
+bool _isRemoteSuppliedUriAllowed(Uri uri) =>
+    uri.scheme.toLowerCase() == 'wss' && !isPrivateOrLinkLocalHost(uri.host);
 
 Uri? _tryParseRelayUri(String url) {
   final uri = Uri.tryParse(url.trim());
@@ -75,16 +76,23 @@ Uri? _tryParseRelayUri(String url) {
   return uri;
 }
 
-String? _remoteRelayIdentityKey(String url) {
+/// The identity [urls] entries are deduplicated under, or null when a remote
+/// party may not name this one at all.
+///
+/// Admitting and keying share a single parse: deciding twice would double the
+/// work done per entry on input that is untrusted and, before the cap applies,
+/// unbounded — and would let the two answers drift apart.
+///
+/// Only a bare root path is collapsed, so `wss://h.example` and
+/// `wss://h.example/` are one relay while `wss://h.example/a` and
+/// `wss://h.example/a/` stay two. That is the equivalence
+/// `RelayAddrUtil.handle` already applies to every address this package dials;
+/// a wider rule here would disagree with the pool it feeds. Scheme and host
+/// need no case folding — `Uri` canonicalizes both at parse.
+String? _admittedRemoteRelayKey(String url) {
   final uri = _tryParseRelayUri(url);
-  if (uri == null) return null;
-  return uri
-      .replace(
-        scheme: uri.scheme.toLowerCase(),
-        host: uri.host.toLowerCase(),
-        path: uri.path == '/' ? '' : uri.path,
-      )
-      .toString();
+  if (uri == null || !_isRemoteSuppliedUriAllowed(uri)) return null;
+  return uri.replace(path: uri.path == '/' ? '' : uri.path).toString();
 }
 
 /// Filters [urls] to those a remote party may legitimately point us at, and
@@ -100,12 +108,12 @@ List<String> admitRemoteSuppliedRelays(
 }) {
   final admittedByKey = <String, String>{};
   for (final url in urls) {
-    if (isRemoteSuppliedRelayUrlAllowed(url)) {
-      final key = _remoteRelayIdentityKey(url) ?? url;
-      admittedByKey.putIfAbsent(key, () => url);
-    } else {
+    final key = _admittedRemoteRelayKey(url);
+    if (key == null) {
       onRejected?.call(url);
+      continue;
     }
+    admittedByKey.putIfAbsent(key, () => url);
   }
   if (admittedByKey.length <= cap) return admittedByKey.values.toList();
   onTruncated?.call(cap, admittedByKey.length);

--- a/mobile/packages/nostr_sdk/lib/utils/relay_url_policy.dart
+++ b/mobile/packages/nostr_sdk/lib/utils/relay_url_policy.dart
@@ -1,0 +1,100 @@
+// ABOUTME: Single source of truth for which relay URLs the client may dial.
+// ABOUTME: Distinguishes self/app-supplied URLs from ones a remote party chose.
+
+import 'package:nostr_sdk/utils/loopback_host.dart';
+
+/// Upper bounds on how many relays the client will adopt from a single
+/// advertised relay list.
+///
+/// A relay list arriving from the network is untrusted input, and nothing in
+/// the protocol bounds its length — so the client bounds it. Both values sit
+/// well above the sizing the NIPs themselves recommend, because the point is
+/// to turn "unbounded" into a small constant, not to be tight: a cap that
+/// bites a legitimate user silently reduces their reachability.
+abstract final class RelayListCaps {
+  /// Cap for a NIP-17 kind-10050 DM inbox relay list.
+  ///
+  /// NIP-17: "Clients SHOULD guide users to keep `kind:10050` lists small
+  /// (1-3 relays)."
+  static const int dmInbox = 8;
+
+  /// Cap for a NIP-65 kind-10002 relay list metadata event.
+  ///
+  /// NIP-65: "Clients SHOULD guide users to keep `kind:10002` lists small
+  /// (2-4 relays of each category)" — read and write, hence the larger bound.
+  static const int nip65 = 16;
+}
+
+/// Whether [url] is a relay URL the app may connect to.
+///
+/// Nostr relays speak WebSocket only — `wss://` is accepted for any host, and
+/// `ws://` only for a recognized loopback host (the local Docker stack). Any
+/// other scheme, a malformed URL, or a missing host is rejected.
+///
+/// Use this for URLs the app itself configured or the user authored. For a
+/// list a *remote* party controls, use [isRemoteSuppliedRelayUrlAllowed].
+///
+/// This is the single source of truth for the rule; `mobile/lib`,
+/// `nostr_client`, and `dm_repository` all delegate here rather than
+/// re-implementing it (see #3362 / PR #3806, and #6585 which removed the last
+/// drifted copy).
+bool isRelayUrlAllowed(String url) {
+  final uri = _tryParseRelayUri(url);
+  if (uri == null) return false;
+  final scheme = uri.scheme.toLowerCase();
+  if (scheme == 'wss') return true;
+  if (scheme == 'ws') return isLoopbackHost(uri.host);
+  return false;
+}
+
+/// Whether [url] may be dialed when a *remote* party chose it.
+///
+/// Adds a host restriction on top of [isRelayUrlAllowed]: private, loopback,
+/// and link-local addresses are refused. A counterparty's kind-10050 or an
+/// indexer's kind-10002 must not be able to point this device at the user's
+/// LAN, VPN, or loopback interface — neither to reach a service there nor to
+/// learn, from how the connection behaves, whether one exists.
+///
+/// Note this makes `ws://` unreachable by construction: its only allowance was
+/// loopback, which this predicate refuses. That is intended — a remote party
+/// has no legitimate reason to ask for cleartext.
+bool isRemoteSuppliedRelayUrlAllowed(String url) {
+  final uri = _tryParseRelayUri(url);
+  if (uri == null) return false;
+  if (uri.scheme.toLowerCase() != 'wss') return false;
+  return !isPrivateOrLinkLocalHost(uri.host);
+}
+
+Uri? _tryParseRelayUri(String url) {
+  final uri = Uri.tryParse(url.trim());
+  if (uri == null || !uri.hasAuthority || uri.host.isEmpty) return null;
+  // `wss://http://x` parses as host=`http` with path=`//x`; reject so a
+  // mis-nested URL in a relay-list tag cannot pass and then target a
+  // different host once the connection layer re-parses it.
+  if (uri.path.startsWith('//')) return null;
+  return uri;
+}
+
+/// Filters [urls] to those a remote party may legitimately point us at, and
+/// truncates the result to [cap], preserving order.
+///
+/// Duplicates are collapsed. [onRejected] and [onTruncated] let the caller log
+/// at its own layer, so this stays free of any logging dependency.
+List<String> admitRemoteSuppliedRelays(
+  Iterable<String> urls, {
+  required int cap,
+  void Function(String url)? onRejected,
+  void Function(int kept, int total)? onTruncated,
+}) {
+  final admitted = <String>{};
+  for (final url in urls) {
+    if (isRemoteSuppliedRelayUrlAllowed(url)) {
+      admitted.add(url);
+    } else {
+      onRejected?.call(url);
+    }
+  }
+  if (admitted.length <= cap) return admitted.toList();
+  onTruncated?.call(cap, admitted.length);
+  return admitted.take(cap).toList();
+}

--- a/mobile/packages/nostr_sdk/pubspec.yaml
+++ b/mobile/packages/nostr_sdk/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   clock: ^1.1.2
   http: ^1.4.0
   http_parser: ^4.1.2
+  meta: ^1.18.0
 dependency_overrides:
   meta: ^1.18.0
 

--- a/mobile/packages/nostr_sdk/test/integration/temp_relay_lifetime_test.dart
+++ b/mobile/packages/nostr_sdk/test/integration/temp_relay_lifetime_test.dart
@@ -1,0 +1,201 @@
+// ABOUTME: Pins that temp relays opened for a publish are closed once idle.
+// ABOUTME: Before #6585 nothing ever closed them, so a publish to addresses a
+// ABOUTME: counterparty chose left a socket open per address for the session.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:nostr_sdk/nostr.dart';
+import 'package:nostr_sdk/relay/relay_base.dart';
+import 'package:nostr_sdk/relay/relay_pool.dart';
+import 'package:nostr_sdk/relay/relay_status.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+import 'package:nostr_sdk/utils/relay_addr_util.dart';
+
+/// A relay that accepts the upgrade and then stays silent — the worst case a
+/// listener can present, and the one that used to keep its socket forever.
+class _SilentRelay {
+  _SilentRelay(this._server);
+
+  final HttpServer _server;
+  final List<WebSocket> _sockets = [];
+
+  String get url => 'ws://127.0.0.1:${_server.port}';
+
+  /// The key a *subscribe* stores this relay under.
+  ///
+  /// `subscribe` normalises its `tempRelays` through [RelayAddrUtil.handle]
+  /// (which appends a trailing slash) while the publish path does not, so the
+  /// two enter `_tempRelays` under different keys for the same host. Tests
+  /// assert on [RelayPool.tempRelayUrls] rather than guessing, because a
+  /// lookup with the wrong key misses and makes a cleanup assertion vacuous.
+  String get subscribeKey => RelayAddrUtil.handle(url);
+
+  /// Sockets this listener still has open, from the *server's* point of view.
+  int get openSockets =>
+      _sockets.where((s) => s.readyState == WebSocket.open).length;
+
+  static Future<_SilentRelay> start() async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final relay = _SilentRelay(server);
+    server.listen((req) async {
+      if (!WebSocketTransformer.isUpgradeRequest(req)) {
+        req.response.statusCode = 400;
+        await req.response.close();
+        return;
+      }
+      final socket = await WebSocketTransformer.upgrade(req);
+      relay._sockets.add(socket);
+      socket.listen((_) {}, onError: (_) {});
+    });
+    return relay;
+  }
+
+  Future<void> stop() async {
+    for (final socket in _sockets) {
+      await socket.close().catchError((_) => null);
+    }
+    await _server.close(force: true);
+  }
+}
+
+void main() {
+  late List<_SilentRelay> relays;
+
+  setUp(() => relays = []);
+
+  tearDown(() async {
+    for (final relay in relays) {
+      await relay.stop();
+    }
+  });
+
+  Future<_SilentRelay> startRelay() async {
+    final relay = await _SilentRelay.start();
+    relays.add(relay);
+    return relay;
+  }
+
+  /// Builds a pool with a short idle window so the sweep is observable
+  /// without a wall-clock wait. The sweep is driven manually in these tests.
+  RelayPool buildPool() {
+    final signer = LocalNostrSigner(
+      '0000000000000000000000000000000000000000000000000000000000000001',
+    );
+    final nostr = Nostr(signer, [], (url) => RelayBase(url, RelayStatus(url)));
+    return RelayPool(
+      nostr,
+      [],
+      (url) => RelayBase(url, RelayStatus(url)),
+      tempRelayIdleTimeout: Duration.zero,
+      tempRelaySweepInterval: const Duration(hours: 1),
+    );
+  }
+
+  Future<Event> signedGiftWrap(RelayPool pool) async {
+    final signer = pool.localNostr.nostrSigner;
+    final pubkey = await signer.getPublicKey();
+    final event = Event(pubkey!, 1059, [], 'probe');
+    final signed = await signer.signEvent(event);
+    return signed!;
+  }
+
+  test(
+    'closes the temp relays a publish opened once they go idle',
+    () async {
+      final targets = [for (var i = 0; i < 5; i++) await startRelay()];
+      final urls = [for (final relay in targets) relay.url];
+      final pool = buildPool();
+      final event = await signedGiftWrap(pool);
+
+      await pool.sendEventAwaitOk(
+        ['EVENT', event.toJson()],
+        eventId: event.id,
+        eventKind: event.kind,
+        tempRelays: urls,
+        targetRelays: urls,
+        timeout: const Duration(seconds: 2),
+      );
+
+      // Every address got a socket — that is the behaviour #6585 bounds, not
+      // removes: NIP-17 requires publishing to the recipient's own relays.
+      expect(
+        targets.every((relay) => relay.openSockets > 0),
+        isTrue,
+        reason: 'publish should reach every target',
+      );
+      expect(pool.tempRelayUrls, hasLength(5));
+
+      pool.sweepIdleTempRelays();
+      // Let the close frames land on the listeners.
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      for (final relay in targets) {
+        expect(
+          relay.openSockets,
+          isZero,
+          reason: 'idle temp relay ${relay.url} should have been closed',
+        );
+      }
+      expect(pool.tempRelayUrls, isEmpty);
+    },
+    timeout: const Timeout(Duration(minutes: 2)),
+  );
+
+  test(
+    'leaves a temp relay alone while it is still serving a subscription',
+    () async {
+      final target = await startRelay();
+      final pool = buildPool();
+
+      pool.subscribe(
+        [
+          Filter(kinds: [1], limit: 1).toJson(),
+        ],
+        (_) {},
+        tempRelays: [target.url],
+        id: 'sub-under-sweep',
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      pool.sweepIdleTempRelays();
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(
+        pool.tempRelayUrls,
+        contains(target.subscribeKey),
+        reason: 'a relay carrying a live subscription must not be swept',
+      );
+      expect(target.openSockets, greaterThan(0));
+    },
+    timeout: const Timeout(Duration(minutes: 2)),
+  );
+
+  test(
+    'removeAll closes temp relays and stops the sweep',
+    () async {
+      final target = await startRelay();
+      final pool = buildPool();
+      final event = await signedGiftWrap(pool);
+
+      await pool.sendEventAwaitOk(
+        ['EVENT', event.toJson()],
+        eventId: event.id,
+        eventKind: event.kind,
+        tempRelays: [target.url],
+        targetRelays: [target.url],
+        timeout: const Duration(seconds: 2),
+      );
+      expect(pool.tempRelayUrls, hasLength(1));
+
+      pool.removeAll();
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      expect(pool.tempRelayUrls, isEmpty);
+      expect(target.openSockets, isZero);
+    },
+    timeout: const Timeout(Duration(minutes: 2)),
+  );
+}

--- a/mobile/packages/nostr_sdk/test/integration/temp_relay_lifetime_test.dart
+++ b/mobile/packages/nostr_sdk/test/integration/temp_relay_lifetime_test.dart
@@ -61,6 +61,26 @@ class _SilentRelay {
   }
 }
 
+/// Polls [condition] until it holds, failing after [timeout].
+///
+/// Loopback sockets close in a couple of milliseconds, but a fixed sleep has
+/// to pick a side of that: too short flakes under CI load, too long taxes
+/// every green run. Mirrors `_waitUntil` in
+/// `test/unit/nostr_connect_session_test.dart`.
+Future<void> _waitUntil(
+  bool Function() condition, {
+  required String Function() describe,
+  Duration timeout = const Duration(seconds: 5),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (!condition()) {
+    if (DateTime.now().isAfter(deadline)) {
+      fail('${describe()} (waited $timeout)');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+}
+
 void main() {
   late List<_SilentRelay> relays;
 
@@ -85,13 +105,18 @@ void main() {
       '0000000000000000000000000000000000000000000000000000000000000001',
     );
     final nostr = Nostr(signer, [], (url) => RelayBase(url, RelayStatus(url)));
-    return RelayPool(
+    final pool = RelayPool(
       nostr,
       [],
       (url) => RelayBase(url, RelayStatus(url)),
       tempRelayIdleTimeout: Duration.zero,
       tempRelaySweepInterval: const Duration(hours: 1),
     );
+    // A test that leaves temp relays behind also leaves the sweep timer
+    // armed, and these files share one isolate under `very_good test
+    // --optimization` — so the pool must not outlive the test that built it.
+    addTearDown(pool.removeAll);
+    return pool;
   }
 
   Future<Event> signedGiftWrap(RelayPool pool) async {
@@ -129,8 +154,12 @@ void main() {
       expect(pool.tempRelayUrls, hasLength(5));
 
       pool.sweepIdleTempRelays();
-      // Let the close frames land on the listeners.
-      await Future<void>.delayed(const Duration(milliseconds: 300));
+      await _waitUntil(
+        () => targets.every((relay) => relay.openSockets == 0),
+        describe: () =>
+            'idle temp relays still open: '
+            '${targets.where((r) => r.openSockets > 0).map((r) => r.url)}',
+      );
 
       for (final relay in targets) {
         expect(
@@ -158,10 +187,15 @@ void main() {
         tempRelays: [target.url],
         id: 'sub-under-sweep',
       );
-      await Future<void>.delayed(const Duration(milliseconds: 300));
+      await _waitUntil(
+        () => target.openSockets > 0,
+        describe: () => 'subscribe never opened a socket on ${target.url}',
+      );
 
+      // No settling wait afterwards: `removeTempRelay` drops the map key
+      // before it disconnects, so a wrongly swept relay is already missing
+      // from `tempRelayUrls` by the time the sweep returns.
       pool.sweepIdleTempRelays();
-      await Future<void>.delayed(const Duration(milliseconds: 200));
 
       expect(
         pool.tempRelayUrls,
@@ -191,7 +225,10 @@ void main() {
       expect(pool.tempRelayUrls, hasLength(1));
 
       pool.removeAll();
-      await Future<void>.delayed(const Duration(milliseconds: 300));
+      await _waitUntil(
+        () => target.openSockets == 0,
+        describe: () => 'removeAll left ${target.url} open',
+      );
 
       expect(pool.tempRelayUrls, isEmpty);
       expect(target.openSockets, isZero);

--- a/mobile/packages/nostr_sdk/test/integration/temp_relay_lifetime_test.dart
+++ b/mobile/packages/nostr_sdk/test/integration/temp_relay_lifetime_test.dart
@@ -138,7 +138,6 @@ void main() {
       await pool.sendEventAwaitOk(
         ['EVENT', event.toJson()],
         eventId: event.id,
-        eventKind: event.kind,
         tempRelays: urls,
         targetRelays: urls,
         timeout: const Duration(seconds: 2),
@@ -217,7 +216,6 @@ void main() {
       await pool.sendEventAwaitOk(
         ['EVENT', event.toJson()],
         eventId: event.id,
-        eventKind: event.kind,
         tempRelays: [target.url],
         targetRelays: [target.url],
         timeout: const Duration(seconds: 2),

--- a/mobile/packages/nostr_sdk/test/unit/filter_search_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/filter_search_test.dart
@@ -1,5 +1,6 @@
-// ABOUTME: Unit tests for NIP-50 search field in Filter class
-// ABOUTME: Tests serialization and deserialization of search parameter
+// ABOUTME: Unit tests for Filter's NIP-50 search field and for checkEvent,
+// ABOUTME: which backs the RelayPool and NostrClient inbound admission gates.
+// ABOUTME: Covers search serialization plus id/author/kind matching rules.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';

--- a/mobile/packages/nostr_sdk/test/unit/filter_search_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/filter_search_test.dart
@@ -6,22 +6,31 @@ import 'package:nostr_sdk/nostr_sdk.dart';
 
 void main() {
   group('Filter event matching', () {
-    test('matches event id and author prefixes', () {
-      const pubkey =
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const pubkey =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+    test('matches an event by exact id and author', () {
       final event = Event(pubkey, 1, const [], 'hello', createdAt: 1);
 
-      final filter = Filter(
-        ids: [event.id.substring(0, 12)],
-        authors: [pubkey.substring(0, 12)],
-      );
+      final filter = Filter(ids: [event.id], authors: const [pubkey]);
 
       expect(filter.checkEvent(event), isTrue);
     });
 
-    test('rejects non-matching event id and author prefixes', () {
-      const pubkey =
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    test('a blank id or author entry matches nothing', () {
+      final event = Event(pubkey, 1, const [], 'hello', createdAt: 1);
+
+      // The discriminator against prefix matching. NIP-01 requires exact
+      // 64-character lowercase hex and dropped prefixes from the spec, and
+      // every string starts with '' — so under a prefix compare one blank
+      // entry silently turns the constraint, and the RelayPool and
+      // NostrClient gates built on checkEvent, into pass-throughs. Filter
+      // admits whatever it is handed, so this is where that is caught.
+      expect(Filter(ids: const ['']).checkEvent(event), isFalse);
+      expect(Filter(authors: const ['']).checkEvent(event), isFalse);
+    });
+
+    test('rejects a non-matching event id and author', () {
       final event = Event(pubkey, 1, const [], 'hello', createdAt: 1);
 
       final filter = Filter(ids: const ['bbbb'], authors: const ['cccc']);

--- a/mobile/packages/nostr_sdk/test/unit/filter_search_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/filter_search_test.dart
@@ -5,6 +5,31 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 
 void main() {
+  group('Filter event matching', () {
+    test('matches event id and author prefixes', () {
+      const pubkey =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      final event = Event(pubkey, 1, const [], 'hello', createdAt: 1);
+
+      final filter = Filter(
+        ids: [event.id.substring(0, 12)],
+        authors: [pubkey.substring(0, 12)],
+      );
+
+      expect(filter.checkEvent(event), isTrue);
+    });
+
+    test('rejects non-matching event id and author prefixes', () {
+      const pubkey =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      final event = Event(pubkey, 1, const [], 'hello', createdAt: 1);
+
+      final filter = Filter(ids: const ['bbbb'], authors: const ['cccc']);
+
+      expect(filter.checkEvent(event), isFalse);
+    });
+  });
+
   group('Filter Search Tests', () {
     test('Should serialize search field to JSON', () {
       final filter = Filter(kinds: [1], limit: 10, search: 'bitcoin');

--- a/mobile/packages/nostr_sdk/test/unit/filter_search_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/filter_search_test.dart
@@ -38,6 +38,32 @@ void main() {
 
       expect(filter.checkEvent(event), isFalse);
     });
+
+    test('matches #t tags exactly and case-sensitively', () {
+      final lowercaseEvent = Event(
+        pubkey,
+        1,
+        const [
+          ['t', 'skateboarding'],
+        ],
+        'hello',
+        createdAt: 1,
+      );
+      final mixedCaseEvent = Event(
+        pubkey,
+        1,
+        const [
+          ['t', 'Skateboarding'],
+        ],
+        'hello',
+        createdAt: 1,
+      );
+
+      final filter = Filter(t: const ['skateboarding']);
+
+      expect(filter.checkEvent(lowercaseEvent), isTrue);
+      expect(filter.checkEvent(mixedCaseEvent), isFalse);
+    });
   });
 
   group('Filter Search Tests', () {

--- a/mobile/packages/nostr_sdk/test/unit/loopback_host_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/loopback_host_test.dart
@@ -54,6 +54,40 @@ void main() {
     });
   });
 
+  group('isPrivateOrLinkLocalHost', () {
+    test('covers every loopback host the local stack uses', () {
+      for (final host in ['localhost', '127.0.0.1', '10.0.2.2', '::1']) {
+        expect(isPrivateOrLinkLocalHost(host), isTrue, reason: host);
+      }
+    });
+
+    test('treats an empty or unparseable host as private', () {
+      expect(isPrivateOrLinkLocalHost(''), isTrue);
+      expect(isPrivateOrLinkLocalHost('   '), isTrue);
+    });
+
+    test('strips brackets from an IPv6 literal read off a URI', () {
+      expect(isPrivateOrLinkLocalHost('[fe80::1]'), isTrue);
+      expect(isPrivateOrLinkLocalHost('[2606:4700::1111]'), isFalse);
+    });
+
+    test('is case-insensitive', () {
+      expect(isPrivateOrLinkLocalHost('LOCALHOST'), isTrue);
+      expect(isPrivateOrLinkLocalHost('Printer.LOCAL'), isTrue);
+    });
+
+    test('leaves ordinary public hosts alone', () {
+      for (final host in [
+        'relay.divine.video',
+        'inbox.nostr.wine',
+        '8.8.8.8',
+        '2606:4700:4700::1111',
+      ]) {
+        expect(isPrivateOrLinkLocalHost(host), isFalse, reason: host);
+      }
+    });
+  });
+
   group('allowsLocalBadCertificateHost', () {
     test('allows loopback hosts only in debug builds', () {
       expect(allowsLocalBadCertificateHost('localhost'), kDebugMode);

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_malformed_frame_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_malformed_frame_test.dart
@@ -8,6 +8,8 @@ import 'package:nostr_sdk/relay/client_connected.dart';
 class _MalformedFrameRelay extends Relay {
   _MalformedFrameRelay(String url) : super(url, RelayStatus(url));
 
+  String? capturedSubId;
+
   @override
   Future<bool> doConnect() async {
     relayStatus.connected = ClientConnected.connected;
@@ -27,6 +29,9 @@ class _MalformedFrameRelay extends Relay {
     bool skipReconnect = false,
     DateTime? deadline,
   }) async {
+    if (message.isNotEmpty && message[0] == 'REQ' && message.length > 1) {
+      capturedSubId = message[1] as String;
+    }
     return true;
   }
 
@@ -81,6 +86,46 @@ void main() {
           reason: 'malformed relay frame should be dropped: $frame',
         );
       }
+    });
+
+    test('drops signed events that do not match the query filter', () async {
+      const privateKey =
+          '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12';
+      final signer = LocalNostrSigner(privateKey);
+      final nostr = Nostr(signer, [], dummyTempRelay);
+      final relay = _MalformedFrameRelay('wss://off-filter.example');
+
+      expect(await nostr.relayPool.add(relay), isTrue);
+
+      final pending = nostr.queryEventsDetailed([
+        {
+          'authors': [getPublicKey(privateKey)],
+          'kinds': [EventKind.relayListMetadata],
+        },
+      ], timeout: const Duration(seconds: 2));
+
+      for (var i = 0; i < 1000 && relay.capturedSubId == null; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      final subId = relay.capturedSubId;
+      expect(subId, isNotNull);
+
+      final offFilterEvent = Event(
+        getPublicKey(privateKey),
+        EventKind.textNote,
+        [
+          ['r', 'wss://attacker-selected.example'],
+        ],
+        '',
+        createdAt: 1700000000,
+      )..sign(privateKey);
+
+      await relay.deliver(['EVENT', subId, offFilterEvent.toJson()]);
+      await relay.deliver(['EOSE', subId]);
+
+      final result = await pending;
+      expect(result.events, isEmpty);
+      expect(result.timedOut, isFalse);
     });
   });
 }

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_by_filters_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_by_filters_test.dart
@@ -1,0 +1,42 @@
+// ABOUTME: Tests RelayPool.queryByFilters' argument validation.
+// ABOUTME: A per-relay entry with no filters would build a subscription that
+// ABOUTME: matches nothing, so every event it received would be dropped.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+void main() {
+  group('RelayPool.queryByFilters', () {
+    Relay dummyTempRelay(String url) => RelayBase(url, RelayStatus(url));
+
+    late RelayPool pool;
+
+    setUp(() {
+      final signer = LocalNostrSigner(
+        '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+      );
+      pool = Nostr(signer, [], dummyTempRelay).relayPool;
+    });
+
+    test('rejects an empty map', () {
+      expect(
+        () => pool.queryByFilters(const {}, (_) {}),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects a relay entry carrying no filters', () {
+      // The sibling entry points (subscribe, query, addInitQuery) all reject
+      // an empty filter list. queryByFilters checked only the outer map, so
+      // this built a Subscription with nothing to match against — it sends a
+      // filterless REQ, which many relays answer with everything, and then
+      // drops every frame at the admission gate.
+      expect(
+        () => pool.queryByFilters(const {
+          'wss://relay.example': <Map<String, dynamic>>[],
+        }, (_) {}),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+}

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
@@ -443,6 +443,56 @@ void main() {
       );
     });
 
+    test('events the subscription filter rejects still prove the relay has '
+        'not gone silent', () async {
+      final nostr = _newNostr();
+      final fast = _SilentRelay('wss://fast.example');
+      final streaming = _SilentRelay('wss://streams-slowly.example');
+      expect(await nostr.relayPool.add(fast), isTrue);
+      expect(await nostr.relayPool.add(streaming), isTrue);
+      final pubkey = await nostr.ensurePublicKey();
+
+      final pending = nostr.queryEventsDetailed([
+        {
+          'kinds': [EventKind.textNote],
+        },
+      ], timeout: _timeout);
+
+      final subId = await fast.awaitPendingQuery();
+      await streaming.awaitPendingQuery();
+      await fast.deliver(['EOSE', subId]);
+
+      // The relay leads with events this subscription did not ask for. They
+      // are dropped at the admission gate, but arriving at all is what proves
+      // the socket is still working — the settle window bounds silence, and a
+      // relay sending the wrong events is not silent. Before #6585's gate the
+      // window expired under this and the caller was handed a truncated set
+      // with `timedOut: false`, which reads exactly like a complete one.
+      for (var i = 0; i < 5; i++) {
+        await Future<void>.delayed(RelayPool.querySettleWindow ~/ 2);
+        final unwanted = await nostr.nostrSigner.signEvent(
+          Event(pubkey, EventKind.reaction, const [], '+'),
+        );
+        await streaming.deliver(['EVENT', subId, unwanted!.toJson()]);
+      }
+
+      final wanted = await nostr.nostrSigner.signEvent(
+        Event(pubkey, EventKind.textNote, const [], 'the tail'),
+      );
+      await streaming.deliver(['EVENT', subId, wanted!.toJson()]);
+      await streaming.deliver(['EOSE', subId]);
+
+      final result = await pending;
+      expect(result.timedOut, isFalse);
+      expect(
+        result.events.map((e) => e.content),
+        ['the tail'],
+        reason:
+            'the matching tail must survive: rejected events are dropped '
+            'from the result set, not treated as the relay falling silent',
+      );
+    });
+
     test(
       'an outstanding NIP-42 handshake survives the settle window',
       () async {

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_temp_relay_reap_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_temp_relay_reap_test.dart
@@ -1,0 +1,103 @@
+// ABOUTME: Pins which disconnected temp relays the idle sweep may reap.
+// ABOUTME: Reaping disposes the relay, so it must not cut off a reconnect a
+// ABOUTME: caller is still waiting on, nor a socket that never got to open.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:nostr_sdk/relay/client_connected.dart';
+
+/// A relay that never manages to connect — the shape of an entry sitting in
+/// reconnect backoff, or one whose first `connect()` has not landed yet.
+class _NeverConnectsRelay extends Relay {
+  _NeverConnectsRelay(String url) : super(url, RelayStatus(url));
+
+  @override
+  Future<bool> doConnect() async => false;
+
+  @override
+  Future<void> disconnect() async {
+    relayStatus.connected = ClientConnected.disconnect;
+  }
+
+  @override
+  Future<bool> send(
+    List<dynamic> message, {
+    bool? forceSend,
+    bool queueIfFailed = true,
+    bool skipReconnect = false,
+    DateTime? deadline,
+  }) async => false;
+}
+
+void main() {
+  group('RelayPool temp relay reaping', () {
+    RelayPool buildPool({required Duration idleTimeout}) {
+      final signer = LocalNostrSigner(
+        '0000000000000000000000000000000000000000000000000000000000000001',
+      );
+      Relay gener(String url) => _NeverConnectsRelay(url);
+      final nostr = Nostr(signer, [], gener);
+      return RelayPool(
+        nostr,
+        [],
+        gener,
+        tempRelayIdleTimeout: idleTimeout,
+        tempRelaySweepInterval: const Duration(hours: 1),
+      );
+    }
+
+    test('reaps a disconnected temp relay that is holding nothing', () async {
+      final pool = buildPool(idleTimeout: Duration.zero);
+      pool.checkAndGenTempRelay('wss://idle.example');
+      expect(pool.tempRelayUrls, hasLength(1));
+
+      pool.sweepIdleTempRelays();
+
+      // Positive control: without this the two tests below would pass
+      // vacuously, because nothing would ever be reaped.
+      expect(pool.tempRelayUrls, isEmpty);
+    });
+
+    test('spares a disconnected temp relay with a publish queued behind '
+        'its reconnect', () async {
+      final pool = buildPool(idleTimeout: Duration.zero);
+      final relay = pool.checkAndGenTempRelay('wss://parked.example');
+      // What a gift wrap parked behind a NIP-42 handshake looks like: the
+      // caller is waiting for the reconnect to replay it.
+      relay.pendingAuthedMessages.add(['EVENT', <String, dynamic>{}]);
+
+      pool.sweepIdleTempRelays();
+
+      expect(
+        pool.tempRelayUrls,
+        hasLength(1),
+        reason:
+            'reaping disposes the relay and cancels the reconnect that '
+            'would have flushed the queued publish',
+      );
+    });
+
+    test(
+      'spares a temp relay whose first connect has not landed yet',
+      () async {
+        final pool = buildPool(idleTimeout: const Duration(milliseconds: 200));
+        pool.checkAndGenTempRelay('wss://still-dialing.example');
+
+        pool.sweepIdleTempRelays();
+        expect(
+          pool.tempRelayUrls,
+          hasLength(1),
+          reason: 'an entry younger than one idle window is still dialing',
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 250));
+        pool.sweepIdleTempRelays();
+        expect(
+          pool.tempRelayUrls,
+          isEmpty,
+          reason: 'once the window has passed a dead entry must be reclaimed',
+        );
+      },
+    );
+  });
+}

--- a/mobile/packages/nostr_sdk/test/unit/relay_url_policy_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_url_policy_test.dart
@@ -218,6 +218,17 @@ void main() {
 
       expect(admitted, equals(['wss://same.example']));
     });
+
+    test('collapses equivalent relay URLs before applying the cap', () {
+      final admitted = admitRemoteSuppliedRelays([
+        'wss://same.example',
+        'WSS://same.example/',
+        'wss://same.example/',
+        'wss://other.example',
+      ], cap: RelayListCaps.dmInbox);
+
+      expect(admitted, equals(['wss://same.example', 'wss://other.example']));
+    });
   });
 
   group('RelayListCaps', () {

--- a/mobile/packages/nostr_sdk/test/unit/relay_url_policy_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_url_policy_test.dart
@@ -1,0 +1,210 @@
+// ABOUTME: Tests for the relay-URL admission policy shared across packages.
+// ABOUTME: Covers the self-supplied rule, the remote-supplied host filter,
+// ABOUTME: and the cap applied to untrusted relay lists (#6585).
+
+import 'package:nostr_sdk/utils/relay_url_policy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('isRelayUrlAllowed', () {
+    test('accepts wss:// for any host', () {
+      expect(isRelayUrlAllowed('wss://relay.divine.video'), isTrue);
+      expect(isRelayUrlAllowed('wss://relay.example.com:4848'), isTrue);
+    });
+
+    test('accepts ws:// only for local-stack loopback hosts', () {
+      expect(isRelayUrlAllowed('ws://localhost:7777'), isTrue);
+      expect(isRelayUrlAllowed('ws://127.0.0.1:7777'), isTrue);
+      expect(isRelayUrlAllowed('ws://10.0.2.2:7777'), isTrue);
+      expect(isRelayUrlAllowed('ws://relay.example.com'), isFalse);
+    });
+
+    test('rejects non-WebSocket schemes', () {
+      for (final url in [
+        'https://relay.example.com',
+        'http://localhost',
+        'ftp://relay.example.com',
+        'relay.example.com',
+      ]) {
+        expect(isRelayUrlAllowed(url), isFalse, reason: url);
+      }
+    });
+
+    test('rejects malformed and mis-nested URLs', () {
+      expect(isRelayUrlAllowed(''), isFalse);
+      expect(isRelayUrlAllowed('wss://'), isFalse);
+      expect(isRelayUrlAllowed('wss://http://evil.example'), isFalse);
+    });
+  });
+
+  group('isRemoteSuppliedRelayUrlAllowed', () {
+    test('accepts an ordinary public wss relay', () {
+      expect(isRemoteSuppliedRelayUrlAllowed('wss://inbox.nostr.wine'), isTrue);
+      expect(
+        isRemoteSuppliedRelayUrlAllowed('wss://relay.example.com:4848/path'),
+        isTrue,
+      );
+    });
+
+    test('refuses loopback even over wss, unlike the self-supplied rule', () {
+      for (final url in [
+        'wss://localhost',
+        'wss://127.0.0.1',
+        'wss://10.0.2.2',
+        'wss://[::1]',
+      ]) {
+        expect(isRelayUrlAllowed(url), isTrue, reason: '$url self-supplied');
+        expect(
+          isRemoteSuppliedRelayUrlAllowed(url),
+          isFalse,
+          reason: '$url remote-supplied',
+        );
+      }
+    });
+
+    test('refuses RFC1918, CGNAT, link-local and multicast targets', () {
+      for (final url in [
+        'wss://10.1.2.3',
+        'wss://172.16.5.5',
+        'wss://172.31.255.254',
+        'wss://192.168.1.1',
+        'wss://169.254.169.254', // cloud metadata
+        'wss://100.64.0.1', // CGNAT / Tailscale range
+        'wss://0.0.0.0',
+        'wss://239.1.1.1', // multicast
+      ]) {
+        expect(isRemoteSuppliedRelayUrlAllowed(url), isFalse, reason: url);
+      }
+    });
+
+    test('refuses IPv6 private, link-local and mapped-IPv4 forms', () {
+      for (final url in [
+        'wss://[fe80::1]',
+        'wss://[fc00::1]',
+        'wss://[fd12:3456::1]',
+        'wss://[::ffff:192.168.0.1]',
+        'wss://[::ffff:127.0.0.1]',
+        'wss://[ff02::1]',
+      ]) {
+        expect(isRemoteSuppliedRelayUrlAllowed(url), isFalse, reason: url);
+      }
+    });
+
+    test('refuses alternate IPv4 literal encodings of private space', () {
+      for (final url in [
+        'wss://2130706433', // 127.0.0.1 as a single integer
+        'wss://0x7f.0.0.1', // hex first octet
+        'wss://127.1', // inet_aton short form
+        'wss://0300.0250.0.1', // octal 192.168.0.1
+      ]) {
+        expect(isRemoteSuppliedRelayUrlAllowed(url), isFalse, reason: url);
+      }
+    });
+
+    test('refuses private-network hostname suffixes', () {
+      for (final url in [
+        'wss://printer.local',
+        'wss://db.internal',
+        'wss://router.home.arpa',
+      ]) {
+        expect(isRemoteSuppliedRelayUrlAllowed(url), isFalse, reason: url);
+      }
+    });
+
+    test('refuses ws:// outright — cleartext is never remote-legitimate', () {
+      expect(isRemoteSuppliedRelayUrlAllowed('ws://localhost'), isFalse);
+      expect(
+        isRemoteSuppliedRelayUrlAllowed('ws://relay.example.com'),
+        isFalse,
+      );
+    });
+
+    test(
+      'does not refuse ordinary public addresses that merely look close',
+      () {
+        for (final url in [
+          'wss://11.0.0.1', // adjacent to 10/8
+          'wss://172.15.0.1', // just below 172.16/12
+          'wss://172.32.0.1', // just above 172.16/12
+          'wss://192.169.0.1', // adjacent to 192.168/16
+          'wss://100.63.0.1', // just below CGNAT
+          'wss://8.8.8.8',
+        ]) {
+          expect(isRemoteSuppliedRelayUrlAllowed(url), isTrue, reason: url);
+        }
+      },
+    );
+  });
+
+  group('admitRemoteSuppliedRelays', () {
+    test('caps the list and reports the truncation', () {
+      final urls = [for (var i = 0; i < 50; i++) 'wss://relay-$i.example'];
+      int? keptReported;
+      int? totalReported;
+
+      final admitted = admitRemoteSuppliedRelays(
+        urls,
+        cap: RelayListCaps.dmInbox,
+        onTruncated: (kept, total) {
+          keptReported = kept;
+          totalReported = total;
+        },
+      );
+
+      expect(admitted, hasLength(RelayListCaps.dmInbox));
+      expect(admitted.first, equals('wss://relay-0.example'));
+      expect(keptReported, equals(RelayListCaps.dmInbox));
+      expect(totalReported, equals(50));
+    });
+
+    test('does not report truncation when the list fits', () {
+      var truncated = false;
+      final admitted = admitRemoteSuppliedRelays(
+        ['wss://a.example', 'wss://b.example'],
+        cap: RelayListCaps.dmInbox,
+        onTruncated: (_, _) => truncated = true,
+      );
+
+      expect(admitted, hasLength(2));
+      expect(truncated, isFalse);
+    });
+
+    test('drops disallowed entries and reports each one', () {
+      final rejected = <String>[];
+      final admitted = admitRemoteSuppliedRelays(
+        [
+          'wss://good.example',
+          'wss://192.168.1.1',
+          'ws://localhost',
+          'wss://also-good.example',
+        ],
+        cap: RelayListCaps.dmInbox,
+        onRejected: rejected.add,
+      );
+
+      expect(
+        admitted,
+        equals(['wss://good.example', 'wss://also-good.example']),
+      );
+      expect(rejected, equals(['wss://192.168.1.1', 'ws://localhost']));
+    });
+
+    test('collapses duplicates before applying the cap', () {
+      final admitted = admitRemoteSuppliedRelays(
+        List<String>.filled(20, 'wss://same.example'),
+        cap: RelayListCaps.dmInbox,
+      );
+
+      expect(admitted, equals(['wss://same.example']));
+    });
+  });
+
+  group('RelayListCaps', () {
+    test('sits above the sizing the NIPs recommend', () {
+      // NIP-17 recommends 1-3 kind-10050 relays; NIP-65 recommends 2-4 of
+      // each category. The caps bound abuse without truncating real users.
+      expect(RelayListCaps.dmInbox, greaterThan(3));
+      expect(RelayListCaps.nip65, greaterThan(8));
+    });
+  });
+}

--- a/mobile/packages/nostr_sdk/test/unit/relay_url_policy_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_url_policy_test.dart
@@ -119,6 +119,20 @@ void main() {
       );
     });
 
+    test('refuses the remaining non-globally-routable ranges', () {
+      for (final url in [
+        'wss://192.0.0.1', // 192.0.0.0/24 IETF protocol assignments
+        'wss://198.18.0.1', // 198.18.0.0/15 benchmarking
+        'wss://198.19.255.254', // top of the benchmarking block
+        'wss://192.0.2.1', // TEST-NET-1
+        'wss://198.51.100.1', // TEST-NET-2
+        'wss://203.0.113.1', // TEST-NET-3
+        'wss://[2001:db8::1]', // RFC 3849 documentation prefix
+      ]) {
+        expect(isRemoteSuppliedRelayUrlAllowed(url), isFalse, reason: url);
+      }
+    });
+
     test(
       'does not refuse ordinary public addresses that merely look close',
       () {
@@ -129,6 +143,13 @@ void main() {
           'wss://192.169.0.1', // adjacent to 192.168/16
           'wss://100.63.0.1', // just below CGNAT
           'wss://8.8.8.8',
+          'wss://192.0.1.1', // just above 192.0.0.0/24
+          'wss://192.0.3.1', // just above TEST-NET-1
+          'wss://198.17.255.254', // just below the benchmarking block
+          'wss://198.20.0.1', // just above the benchmarking block
+          'wss://198.51.99.1', // just below TEST-NET-2
+          'wss://203.0.114.1', // just above TEST-NET-3
+          'wss://[2001:db9::1]', // adjacent to the documentation prefix
         ]) {
           expect(isRemoteSuppliedRelayUrlAllowed(url), isTrue, reason: url);
         }

--- a/mobile/packages/nostr_sdk/test/unit/subscription_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/subscription_test.dart
@@ -1,0 +1,53 @@
+// ABOUTME: Tests that Subscription parses its filters once, at construction.
+// ABOUTME: matchesEvent gates every inbound frame, so an unparseable filter
+// ABOUTME: must fail loudly at subscribe time rather than per event.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+void main() {
+  group(Subscription, () {
+    const pubkey =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const otherPubkey =
+        'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+    test('rejects an unparseable filter at construction', () {
+      // `kinds` holding strings is the shape a hand-built filter map takes
+      // when it skips Filter.toJson. Parsing per event instead would push the
+      // TypeError inside RelayPool's frame handler, whose catch-all would
+      // swallow it — every event on the subscription silently dropped, no
+      // error anywhere. Failing here names the offending caller instead.
+      expect(
+        () => Subscription([
+          {
+            'kinds': ['1'],
+          },
+        ], (_) {}),
+        throwsA(isA<TypeError>()),
+      );
+    });
+
+    test('matches on any one of several filters', () {
+      final event = Event(pubkey, 7, const [], '+', createdAt: 1);
+
+      final subscription = Subscription([
+        Filter(kinds: const [1]).toJson(),
+        Filter(kinds: const [7], authors: const [pubkey]).toJson(),
+      ], (_) {});
+
+      expect(subscription.matchesEvent(event), isTrue);
+    });
+
+    test('does not match an event outside every filter', () {
+      final event = Event(pubkey, 7, const [], '+', createdAt: 1);
+
+      final subscription = Subscription([
+        Filter(kinds: const [1]).toJson(),
+        Filter(kinds: const [7], authors: const [otherPubkey]).toJson(),
+      ], (_) {});
+
+      expect(subscription.matchesEvent(event), isFalse);
+    });
+  });
+}

--- a/mobile/test/services/relay_discovery_service_test.dart
+++ b/mobile/test/services/relay_discovery_service_test.dart
@@ -245,6 +245,7 @@ void main() {
   });
 
   _authenticityTests();
+  _cacheAdmissionTests();
 
   group('parseRelayListFromJson (#3362 insecure URL filtering)', () {
     late RelayDiscoveryService service;
@@ -531,4 +532,51 @@ class _HostileIndexer {
   }
 
   Future<void> stop() => _server.close(force: true);
+}
+
+/// #6585 — the discovery cache holds a list that arrived over the network and
+/// survives for 24h, so it is re-admitted on read. Filtering only on write
+/// would leave a day-long window in which an entry persisted by an older
+/// build is adopted unchecked.
+void _cacheAdmissionTests() {
+  group('cached relay admission (#6585)', () {
+    const npub = 'npub1cachetest';
+
+    Future<List<DiscoveredRelay>> discoverFromCache(
+      List<String> cachedUrls,
+    ) async {
+      SharedPreferences.setMockInitialValues({
+        'relay_discovery_$npub': jsonEncode({
+          'timestamp': DateTime.now().millisecondsSinceEpoch,
+          'relays': [
+            for (final url in cachedUrls)
+              {'url': url, 'read': true, 'write': true},
+          ],
+        }),
+      });
+      final service = RelayDiscoveryService(indexerRelays: const ['wss://a']);
+      final result = await service.discoverRelays(npub);
+      return result.relays;
+    }
+
+    test(
+      'drops a cached private or loopback relay written by an old build',
+      () async {
+        final relays = await discoverFromCache([
+          'wss://good.example',
+          'wss://192.168.1.10',
+          'ws://localhost:47777',
+          'wss://169.254.169.254',
+        ]);
+        expect(relays.map((r) => r.url), ['wss://good.example']);
+      },
+    );
+
+    test('caps an oversized cached list', () async {
+      final relays = await discoverFromCache([
+        for (var i = 0; i < 100; i++) 'wss://cached-$i.example',
+      ]);
+      expect(relays, hasLength(RelayListCaps.nip65));
+    });
+  });
 }

--- a/mobile/test/services/relay_discovery_service_test.dart
+++ b/mobile/test/services/relay_discovery_service_test.dart
@@ -576,13 +576,11 @@ void _cacheAdmissionTests() {
       expect(relays, hasLength(RelayListCaps.nip65));
     });
 
-    test('keeps both marker rows when one host is cached twice', () async {
-      // A kind-10002 may name the same host twice to carry a `read` and a
-      // `write` marker, and the fresh parse keeps both rows. Re-admission
-      // works on a deduplicated URL set, so rebuilding the result from that
-      // set instead of filtering the cached rows drops the second marker —
-      // the same event would then answer differently depending on whether
-      // discovery or the cache served it.
+    test('merges a host cached twice into one read-and-write relay', () async {
+      // NIP-65 marks a relay per `r` tag, so a host carrying a `read` row and
+      // a `write` row is both. Keeping the pair is lossy downstream anyway:
+      // `RelayListRepository._markerFor` takes the first match and would
+      // republish this host as `read`-only.
       SharedPreferences.setMockInitialValues({
         'relay_discovery_$npub': jsonEncode({
           'timestamp': DateTime.now().millisecondsSinceEpoch,
@@ -596,11 +594,53 @@ void _cacheAdmissionTests() {
 
       final result = await service.discoverRelays(npub);
 
+      expect(result.relays.map((r) => r.url), ['wss://both.example']);
+      expect(result.relays.single.read, isTrue);
+      expect(result.relays.single.write, isTrue);
+    });
+
+    test('a repeated host does not spend the whole cap', () async {
+      // Duplicates used to be counted against the cap, so a list naming one
+      // host RelayListCaps.nip65 times dropped every genuine relay after it.
+      SharedPreferences.setMockInitialValues({
+        'relay_discovery_$npub': jsonEncode({
+          'timestamp': DateTime.now().millisecondsSinceEpoch,
+          'relays': [
+            for (var i = 0; i < RelayListCaps.nip65; i++)
+              {'url': 'wss://loud.example', 'read': true, 'write': true},
+            {'url': 'wss://genuine-one.example', 'read': true, 'write': true},
+            {'url': 'wss://genuine-two.example', 'read': true, 'write': true},
+          ],
+        }),
+      });
+      final service = RelayDiscoveryService(indexerRelays: const ['wss://a']);
+
+      final result = await service.discoverRelays(npub);
+
       expect(result.relays.map((r) => r.url), [
-        'wss://both.example',
-        'wss://both.example',
+        'wss://loud.example',
+        'wss://genuine-one.example',
+        'wss://genuine-two.example',
       ]);
-      expect(result.relays.map((r) => r.write), [false, true]);
+    });
+
+    test('collapses hosts that differ only by trailing slash', () async {
+      SharedPreferences.setMockInitialValues({
+        'relay_discovery_$npub': jsonEncode({
+          'timestamp': DateTime.now().millisecondsSinceEpoch,
+          'relays': [
+            {'url': 'wss://same.example', 'read': true, 'write': false},
+            {'url': 'wss://same.example/', 'read': false, 'write': true},
+          ],
+        }),
+      });
+      final service = RelayDiscoveryService(indexerRelays: const ['wss://a']);
+
+      final result = await service.discoverRelays(npub);
+
+      expect(result.relays, hasLength(1));
+      expect(result.relays.single.read, isTrue);
+      expect(result.relays.single.write, isTrue);
     });
   });
 }

--- a/mobile/test/services/relay_discovery_service_test.dart
+++ b/mobile/test/services/relay_discovery_service_test.dart
@@ -3,8 +3,11 @@
 // ABOUTME: succeeds, rather than waiting for all indexers to complete
 
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/services/relay_discovery_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -241,6 +244,8 @@ void main() {
     });
   });
 
+  _authenticityTests();
+
   group('parseRelayListFromJson (#3362 insecure URL filtering)', () {
     late RelayDiscoveryService service;
 
@@ -260,13 +265,42 @@ void main() {
       expect(relays.first.url, equals('wss://relay.example.com'));
     });
 
-    test('keeps ws://localhost relays', () {
+    // #6585: a kind-10002 reaches us through a third-party indexer, so it is
+    // admitted on remote-supplied terms. The local-stack loopback allowance
+    // does not extend to a list that arrived over the network.
+    test('drops ws://localhost relays', () {
       final relays = service.parseRelayListFromJson(
         tagsJson([
           ['r', 'ws://localhost:47777'],
         ]),
       );
-      expect(relays, hasLength(1));
+      expect(relays, isEmpty);
+    });
+
+    test('drops private, loopback and link-local targets (#6585)', () {
+      final relays = service.parseRelayListFromJson(
+        tagsJson([
+          ['r', 'wss://127.0.0.1'],
+          ['r', 'wss://localhost'],
+          ['r', 'wss://10.0.2.2'],
+          ['r', 'wss://192.168.1.10'],
+          ['r', 'wss://169.254.169.254'],
+          ['r', 'wss://[fe80::1]'],
+          ['r', 'wss://2130706433'],
+          ['r', 'wss://nas.local'],
+        ]),
+      );
+      expect(relays, isEmpty);
+    });
+
+    test('caps how many relays one kind-10002 can inject (#6585)', () {
+      final relays = service.parseRelayListFromJson(
+        tagsJson([
+          for (var i = 0; i < 200; i++) ['r', 'wss://flood-$i.example'],
+        ]),
+      );
+      expect(relays, hasLength(RelayListCaps.nip65));
+      expect(relays.first.url, 'wss://flood-0.example');
     });
 
     test('drops ws:// non-loopback relays', () {
@@ -314,11 +348,8 @@ void main() {
           ['r', 'http://localhost:47777'],
         ]),
       );
-      expect(relays, hasLength(2));
-      expect(
-        relays.map((r) => r.url),
-        containsAll(['wss://good.example.com', 'ws://localhost:8080']),
-      );
+      expect(relays, hasLength(1));
+      expect(relays.single.url, 'wss://good.example.com');
     });
 
     test(
@@ -369,4 +400,135 @@ void main() {
       });
     });
   });
+}
+
+/// #6585 — the indexer query runs on a bare `RelayBase` with its own
+/// `onMessage`, so the frame never passes through `RelayPool`, which is the
+/// only place inbound events are checked. Whatever survives here is adopted
+/// into the persistent relay pool via `NostrClient.addRelays`, and the
+/// indexers queried are third-party public relays — so "it answered our REQ"
+/// is not evidence the answer is the list we asked for.
+void _authenticityTests() {
+  group('queryIndexerDirect authenticity (#6585)', () {
+    const victim =
+        '0000000000000000000000000000000000000000000000000000000000000abc';
+    late _HostileIndexer indexer;
+    late RelayDiscoveryService service;
+
+    Future<List<DiscoveredRelay>> query(Map<String, dynamic> reply) async {
+      indexer = await _HostileIndexer.start(reply);
+      addTearDown(indexer.stop);
+      service = RelayDiscoveryService(indexerRelays: [indexer.url]);
+      return service.queryIndexerDirect(indexer.url, victim);
+    }
+
+    /// A genuinely signed kind-10002 for [author].
+    Map<String, dynamic> signedRelayList({
+      required String privateKey,
+      List<List<String>> tags = const [
+        ['r', 'wss://legit.example'],
+      ],
+      int kind = 10002,
+      int createdAt = 1700000000,
+    }) {
+      final event = Event(
+        getPublicKey(privateKey),
+        kind,
+        tags,
+        '',
+        createdAt: createdAt,
+      )..sign(privateKey);
+      return event.toJson();
+    }
+
+    const victimKey =
+        '1111111111111111111111111111111111111111111111111111111111111111';
+    final victimPubkey = getPublicKey(victimKey);
+
+    // Positive control. Without this, every rejection below could be passing
+    // because the harness never delivers anything, not because the checks work.
+    test(
+      'accepts a correctly signed kind-10002 from the author asked for',
+      () async {
+        indexer = await _HostileIndexer.start(
+          signedRelayList(privateKey: victimKey),
+        );
+        addTearDown(indexer.stop);
+        service = RelayDiscoveryService(indexerRelays: [indexer.url]);
+
+        final relays = await service.queryIndexerDirect(
+          indexer.url,
+          victimPubkey,
+        );
+        expect(relays.map((r) => r.url), ['wss://legit.example']);
+      },
+    );
+
+    test('rejects a frame with no signature', () async {
+      final unsigned = signedRelayList(privateKey: victimKey)
+        ..['sig'] = ''
+        ..['pubkey'] = victim;
+      expect(await query(unsigned), isEmpty);
+    });
+
+    test('rejects a frame signed by somebody else', () async {
+      const otherKey =
+          '2222222222222222222222222222222222222222222222222222222222222222';
+      expect(await query(signedRelayList(privateKey: otherKey)), isEmpty);
+    });
+
+    test('rejects a frame whose id does not match its contents', () async {
+      final tampered = signedRelayList(privateKey: victimKey)
+        ..['pubkey'] = victim
+        ..['tags'] = [
+          ['r', 'wss://attacker-controlled.example'],
+        ];
+      expect(await query(tampered), isEmpty);
+    });
+
+    test('rejects a frame of the wrong kind', () async {
+      final wrongKind = signedRelayList(privateKey: victimKey, kind: 1);
+      expect(await query(wrongKind), isEmpty);
+    });
+
+    test('rejects a bare tags blob that is not an event at all', () async {
+      expect(
+        await query({
+          'tags': [
+            ['r', 'wss://attacker-controlled.example'],
+          ],
+        }),
+        isEmpty,
+      );
+    });
+  });
+}
+
+/// An "indexer" that answers any REQ with whatever it was constructed with.
+class _HostileIndexer {
+  _HostileIndexer(this._server, this._reply);
+
+  final HttpServer _server;
+  final Map<String, dynamic> _reply;
+
+  String get url => 'ws://127.0.0.1:${_server.port}';
+
+  static Future<_HostileIndexer> start(Map<String, dynamic> reply) async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final indexer = _HostileIndexer(server, reply);
+    server.listen((req) async {
+      final socket = await WebSocketTransformer.upgrade(req);
+      socket.listen((raw) {
+        final frame = jsonDecode(raw as String) as List<dynamic>;
+        if (frame.isEmpty || frame[0] != 'REQ') return;
+        final subId = frame[1] as String;
+        socket
+          ..add(jsonEncode(<dynamic>['EVENT', subId, indexer._reply]))
+          ..add(jsonEncode(<dynamic>['EOSE', subId]));
+      });
+    });
+    return indexer;
+  }
+
+  Future<void> stop() => _server.close(force: true);
 }

--- a/mobile/test/services/relay_discovery_service_test.dart
+++ b/mobile/test/services/relay_discovery_service_test.dart
@@ -353,26 +353,23 @@ void main() {
       expect(relays.single.url, 'wss://good.example.com');
     });
 
-    test(
-      'drops mis-nested wss://http:// tags (#3362 review follow-up)',
-      () {
-        // `wss://http://attacker` parses with host=`http` and path=`//attacker…`.
-        // Without the `path.startsWith('//')` guard in `isRelayUrlAllowed`,
-        // the predicate would accept it (scheme=wss) and discovery would
-        // surface a relay pointing at host `http`. `normalizeRelayUrl`
-        // would also reject it downstream, but we don't want
-        // discovery's `hasRelays` to flip true on a malformed tag — that
-        // would suppress the safe-fallback bootstrap (#2931).
-        final relays = service.parseRelayListFromJson(
-          tagsJson([
-            ['r', 'wss://http://attacker.example.com'],
-            ['r', 'wss://https://attacker.example.com'],
-            ['r', 'wss://wss://relay.example.com'],
-          ]),
-        );
-        expect(relays, isEmpty);
-      },
-    );
+    test('drops mis-nested wss://http:// tags (#3362 review follow-up)', () {
+      // `wss://http://attacker` parses with host=`http` and path=`//attacker…`.
+      // Without the `path.startsWith('//')` guard in `isRelayUrlAllowed`,
+      // the predicate would accept it (scheme=wss) and discovery would
+      // surface a relay pointing at host `http`. `normalizeRelayUrl`
+      // would also reject it downstream, but we don't want
+      // discovery's `hasRelays` to flip true on a malformed tag — that
+      // would suppress the safe-fallback bootstrap (#2931).
+      final relays = service.parseRelayListFromJson(
+        tagsJson([
+          ['r', 'wss://http://attacker.example.com'],
+          ['r', 'wss://https://attacker.example.com'],
+          ['r', 'wss://wss://relay.example.com'],
+        ]),
+      );
+      expect(relays, isEmpty);
+    });
   });
 
   group(IndexerRelayConfig, () {
@@ -411,8 +408,9 @@ void main() {
 /// is not evidence the answer is the list we asked for.
 void _authenticityTests() {
   group('queryIndexerDirect authenticity (#6585)', () {
-    const victim =
-        '0000000000000000000000000000000000000000000000000000000000000abc';
+    const victimKey =
+        '1111111111111111111111111111111111111111111111111111111111111111';
+    final victimPubkey = getPublicKey(victimKey);
     late _HostileIndexer indexer;
     late RelayDiscoveryService service;
 
@@ -420,7 +418,7 @@ void _authenticityTests() {
       indexer = await _HostileIndexer.start(reply);
       addTearDown(indexer.stop);
       service = RelayDiscoveryService(indexerRelays: [indexer.url]);
-      return service.queryIndexerDirect(indexer.url, victim);
+      return service.queryIndexerDirect(indexer.url, victimPubkey);
     }
 
     /// A genuinely signed kind-10002 for [author].
@@ -442,10 +440,6 @@ void _authenticityTests() {
       return event.toJson();
     }
 
-    const victimKey =
-        '1111111111111111111111111111111111111111111111111111111111111111';
-    final victimPubkey = getPublicKey(victimKey);
-
     // Positive control. Without this, every rejection below could be passing
     // because the harness never delivers anything, not because the checks work.
     test(
@@ -466,10 +460,14 @@ void _authenticityTests() {
     );
 
     test('rejects a frame with no signature', () async {
-      final unsigned = signedRelayList(privateKey: victimKey)
-        ..['sig'] = ''
-        ..['pubkey'] = victim;
+      final unsigned = signedRelayList(privateKey: victimKey)..['sig'] = '';
       expect(await query(unsigned), isEmpty);
+    });
+
+    test('rejects a frame with an invalid signature', () async {
+      final badSignature = signedRelayList(privateKey: victimKey);
+      badSignature['sig'] = '00${(badSignature['sig'] as String).substring(2)}';
+      expect(await query(badSignature), isEmpty);
     });
 
     test('rejects a frame signed by somebody else', () async {
@@ -480,7 +478,6 @@ void _authenticityTests() {
 
     test('rejects a frame whose id does not match its contents', () async {
       final tampered = signedRelayList(privateKey: victimKey)
-        ..['pubkey'] = victim
         ..['tags'] = [
           ['r', 'wss://attacker-controlled.example'],
         ];

--- a/mobile/test/services/relay_discovery_service_test.dart
+++ b/mobile/test/services/relay_discovery_service_test.dart
@@ -575,5 +575,32 @@ void _cacheAdmissionTests() {
       ]);
       expect(relays, hasLength(RelayListCaps.nip65));
     });
+
+    test('keeps both marker rows when one host is cached twice', () async {
+      // A kind-10002 may name the same host twice to carry a `read` and a
+      // `write` marker, and the fresh parse keeps both rows. Re-admission
+      // works on a deduplicated URL set, so rebuilding the result from that
+      // set instead of filtering the cached rows drops the second marker —
+      // the same event would then answer differently depending on whether
+      // discovery or the cache served it.
+      SharedPreferences.setMockInitialValues({
+        'relay_discovery_$npub': jsonEncode({
+          'timestamp': DateTime.now().millisecondsSinceEpoch,
+          'relays': [
+            {'url': 'wss://both.example', 'read': true, 'write': false},
+            {'url': 'wss://both.example', 'read': false, 'write': true},
+          ],
+        }),
+      });
+      final service = RelayDiscoveryService(indexerRelays: const ['wss://a']);
+
+      final result = await service.discoverRelays(npub);
+
+      expect(result.relays.map((r) => r.url), [
+        'wss://both.example',
+        'wss://both.example',
+      ]);
+      expect(result.relays.map((r) => r.write), [false, true]);
+    });
   });
 }

--- a/mobile/test/services/relay_discovery_service_test.dart
+++ b/mobile/test/services/relay_discovery_service_test.dart
@@ -304,6 +304,27 @@ void main() {
       expect(relays.first.url, 'wss://flood-0.example');
     });
 
+    test('keeps merging markers for admitted relays after the cap', () {
+      final relays = service.parseRelayListFromJson(
+        tagsJson([
+          ['r', 'wss://relay-0.example', 'read'],
+          for (var i = 1; i < RelayListCaps.nip65; i++)
+            ['r', 'wss://relay-$i.example'],
+          ['r', 'wss://overflow.example'],
+          ['r', 'wss://relay-0.example', 'write'],
+        ]),
+      );
+
+      expect(relays, hasLength(RelayListCaps.nip65));
+      expect(
+        relays.map((relay) => relay.url),
+        isNot(contains('wss://overflow.example')),
+      );
+      expect(relays.first.url, 'wss://relay-0.example');
+      expect(relays.first.read, isTrue);
+      expect(relays.first.write, isTrue);
+    });
+
     test('drops ws:// non-loopback relays', () {
       final relays = service.parseRelayListFromJson(
         tagsJson([


### PR DESCRIPTION
## Description

Relay URLs reach the client from three trust levels — app config, the signed-in user, and a
remote party's advertised relay list — but only one predicate has ever guarded them, checking
the scheme and nothing else. So a list somebody else controls was admitted on the same terms
as our own configuration: no host policy, no count limit, and on the NIP-65 path no
authenticity check at all.

Two admission paths are affected, fixed together because they share the predicate.

**DM inbox lists (kind 10050).** `_queryOwnDmInbox` read every `relay`/`r` tag into an
unbounded set. On the send path that list belongs to the person being messaged, and each
entry becomes an outbound WebSocket connection from this device carrying the gift wrap — so
a counterparty decided both how many hosts we dial and which, including addresses on the
sender's own network. Admission now depends on who authored the list: our own keeps the
loopback allowance the local Docker stack needs, a counterparty's is refused private,
loopback and link-local targets, and both are capped. The reply is also checked to be the
kind and author we asked for before any tag is read.

**NIP-65 relay lists (kind 10002).** The indexer query runs on a bare `RelayBase` with its own
`onMessage`, so the frame never passes through `RelayPool` — the one place inbound events are
checked. The parser read `tags` and nothing else, and the result is adopted through
`addRelays` into the persistent pool that serves every subsequent read and write. A frame now
has to parse as an event, carry kind 10002, be authored by the pubkey we asked for, hash to
its own id, and verify its signature. The 24h cache is re-admitted on read too, so filtering
only on write can't leave a day-long gap.

**Temp relay lifetime.** Nothing ever closed a temp relay: `_sendCollect` tore one down only
when the publish deadline had *already* expired, so any address that answered in time kept its
socket for the life of the process. A periodic sweep now closes them once idle and carrying no
subscription. Idleness rather than "this publish finished" is what makes it safe — temp relays
are keyed by URL and therefore shared, so per-publish teardown could cut a socket out from
under a concurrent caller. The indexer query likewise now bounds its own teardown.

**Inbound events are checked against the filter that asked for them.** `RelayPool` verified an
EVENT frame's id and signature and then handed it to whichever subscription carried the id,
without ever comparing it to the REQ's filter — `Filter.checkEvent` existed with zero callers
on the inbound path. A signed event is only evidence that *someone* wrote it, so an
author-scoped filter was not a boundary: any relay could answer any open subscription with
anything. Frames matching no filter on their subscription are now dropped before delivery and
before the cache fanout, and `NostrClient` applies the same check to query results before they
are cached.

That last part is broader than relay-list admission and is what a reviewer should look at
hardest — it changes what every subscription in the app receives, not just the two paths
above. It arrived via @NotThatKindOfDrLiz's takeover commit 4450dbfd6; the commits after it
correct three things in that change and re-verify the rest.

### Notes for review

- **Honouring recipient relays is required, not optional.** NIP-17: *"Clients MUST only publish
  events to the relays listed in the recipient's kind 10050 event."* So this bounds the
  behaviour rather than removing it. `tempRelays` is likewise load-bearing — PR #1396 added it
  because `targetRelays` alone only *filters* the pool, leaving a targeted publish reaching
  zero relays.
- **The caps are deliberately generous** — 8 for kind 10050 against the NIP's own "1-3 relays"
  guidance, 16 for kind 10002 against "2-4 of each category". The win is turning unbounded into
  a small constant; a tight cap would silently cost a real user reachability. Every rejection
  and truncation is logged.
- **Caps are applied at admission only**, not pool-wide. Every current `tempRelays` caller
  passes at most three app-controlled relays, so a pool-wide cap would add silent-truncation
  risk for no gain.
- **`checkEvent` matches ids and authors exactly, not by prefix.** The takeover had switched
  both to `startsWith`. Current NIP-01 says the opposite — *"The `ids`, `authors`, `#e` and
  `#p` filter lists MUST contain exact 64-character lowercase hex values"* — prefix matching
  was removed from the spec, and nothing here ever passes a short prefix. The sharp edge is
  that every string starts with `''`, so one blank entry made the constraint vacuous and the
  new gate a pass-through; `Nostr.publicKey` returns `''` until `refreshPublicKey` lands, so a
  cold-start `Filter(authors: [publicKey])` reaches exactly that shape. A test pins it.
- **A subscription parses its filters once, at construction.** `matchesEvent` runs per inbound
  frame and `Filter.fromJson` copies the whole id/author list, so parsing per event made the
  receive path scale with the size of the author set. Parsing up front also turns a malformed
  filter from a silent per-event drop — the parse sat inside `RelayPool`'s frame-handler
  catch-all — into a loud failure at subscribe time that names the caller.
- **Verification failures are logged and dropped, not `Reportable`** — a broken or hostile
  indexer isn't something the user can act on, and `error_handling.md`'s matrix defaults to
  not-reportable.
- **One drifted copy of the URL rule is deleted.** `dm_repository` carried its own predicate and
  its own loopback-host set; the rule now lives once in `nostr_sdk`, which already owned
  `isLoopbackHost`. This follows the "one predicate" direction taken in #3806.
- **Three existing assertions are inverted** — they asserted that a list arriving over the
  network could name `ws://localhost` or `ws://10.0.2.2`. The local-stack loopback allowance
  doesn't extend to a list somebody else authored.

**Related Issue:** Closes #6585

## Out of Scope

- Routing discovery through `RelayPool` to remove the `onMessage` bypass class entirely —
  architecturally cleaner but needs an auth-bootstrap rework. Worth its own issue. The new
  filter check does not cover it: discovery still owns its own `onMessage`, which is why the
  kind-10002 authenticity check is written there by hand.
- NIP-17 says a client "shouldn't try" when a recipient advertises no kind-10050;
  `resolveDmInboxRelays` returns null and callers fall back to the default pool. Pre-existing,
  and a behaviour change rather than a hardening one.
- `_sendCollect` doesn't normalise `tempRelays` through `RelayAddrUtil.handle` while
  `subscribe` does, so the same host can occupy two `_tempRelays` entries. Pre-existing; the
  new sweep reclaims both. Noted while writing the lifetime test.
- Seven call sites in `likes_repository` and `reposts_repository` build
  `Filter(authors: [_nostrClient.publicKey])` with no guard against the pre-auth `''`. The
  filter is meaningless either way and relays match nothing on it, so this wants its own fix
  rather than a relaxed predicate to paper over it.
- The sibling web client has the same class of gap; tracking separately.

## Verification

- `flutter analyze lib test integration_test` — clean; bare `flutter analyze` clean in
  `nostr_sdk`, `nostr_client` and `dm_repository`
- `nostr_sdk` — 478 tests, `dm_repository` — 562, `nostr_client` — 325
- `mobile/test/services` — 3736; with `test/repositories` and `test/providers` — 4439
- New tests were mutation-checked rather than assumed: the sweep guard, the sweep itself, the
  cache admission, the exact-match rule, the filter precompute, the `queryByFilters` guard and
  the cached-list shape were each reverted in turn to confirm the corresponding test goes red.
  Two assertions were found vacuous this way — they looked up temp relays by raw URL when the
  pool keys them differently — and were rewritten.
- The two new `integration_test/e2e` files carry `@Tags(['service'])` above the first import.
  Placed below the imports the runner never reads it — `package:test` takes suite metadata only
  from the first directive — so the files were silently untagged. Checked by discriminator:
  `--exclude-tags service` ran all six tests before the move and reports "No tests ran" after.
- End-to-end verification against the local relay isn't possible today (#6594 — the pinned
  funnelcake images predate gift-wrap support), so the socket-lifetime test drives the real
  `RelayPool` against local WebSocket listeners instead.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor


- Service integration workflow tracker: #4239


