### PR TITLE
fix(feed): record skipped videos as seen impressions

### DIFF
--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -117,7 +117,7 @@ PersonalEventCacheService personalEventCacheService(Ref ref) {
 SeenVideosService seenVideosService(Ref ref) {
   final service = SeenVideosService();
   unawaited(service.initialize());
-  ref.onDispose(service.dispose);
+  ref.onDispose(() => unawaited(service.dispose()));
   return service;
 }
 

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -164,7 +164,7 @@ final class SeenVideosServiceProvider
   }
 }
 
-String _$seenVideosServiceHash() => r'933e55ea8a18eee2890da07089a3164a8ec424de';
+String _$seenVideosServiceHash() => r'b980fc7c86abd4229783e3c7066c8883d4d56558';
 
 /// Subscription manager for centralized subscription management
 

--- a/mobile/lib/services/seen_videos_service.dart
+++ b/mobile/lib/services/seen_videos_service.dart
@@ -74,11 +74,14 @@ class SeenVideosService {
   static const String _seenVideosMetricsKey = 'seen_video_metrics'; // New key
   static const int _maxSeenVideos =
       1000; // Limit storage to prevent unbounded growth
+  static const Duration _saveDebounceDuration = Duration(milliseconds: 100);
 
   final Map<String, SeenVideoMetrics> _seenVideos = {};
   SharedPreferences? _prefs;
   bool _isInitialized = false;
   Future<void>? _initializeFuture;
+  Timer? _saveDebounceTimer;
+  Completer<void>? _pendingSaveCompleter;
 
   /// Whether the service has been initialized
   bool get isInitialized => _isInitialized;
@@ -164,7 +167,7 @@ class SeenVideosService {
         );
 
         // Save in new format and remove legacy key
-        await _saveSeenVideos();
+        await _saveSeenVideosNow();
         await _prefs!.remove(_seenVideosKey);
       }
     } catch (e) {
@@ -177,7 +180,7 @@ class SeenVideosService {
   }
 
   /// Save seen videos to persistent storage
-  Future<void> _saveSeenVideos() async {
+  Future<void> _saveSeenVideosNow() async {
     if (_prefs == null) return;
 
     try {
@@ -213,6 +216,36 @@ class SeenVideosService {
         name: 'SeenVideosService',
         category: LogCategory.system,
       );
+    }
+  }
+
+  Future<void> _scheduleSeenVideosSave() {
+    if (_prefs == null) return Future.value();
+
+    _saveDebounceTimer?.cancel();
+    final completer = _pendingSaveCompleter ??= Completer<void>();
+    _saveDebounceTimer = Timer(
+      _saveDebounceDuration,
+      () => unawaited(_flushPendingSeenVideosSave()),
+    );
+    return completer.future;
+  }
+
+  Future<void> _flushPendingSeenVideosSave() async {
+    _saveDebounceTimer?.cancel();
+    _saveDebounceTimer = null;
+
+    final completer = _pendingSaveCompleter;
+    if (completer == null) return;
+    _pendingSaveCompleter = null;
+
+    try {
+      await _saveSeenVideosNow();
+      if (!completer.isCompleted) completer.complete();
+    } catch (error, stackTrace) {
+      if (!completer.isCompleted) {
+        completer.completeError(error, stackTrace);
+      }
     }
   }
 
@@ -268,8 +301,7 @@ class SeenVideosService {
       );
     }
 
-    // Save to storage asynchronously
-    await _saveSeenVideos();
+    await _scheduleSeenVideosSave();
   }
 
   /// Mark multiple videos as seen (batch operation)
@@ -289,7 +321,7 @@ class SeenVideosService {
     }
 
     if (hasChanges) {
-      await _saveSeenVideos();
+      await _scheduleSeenVideosSave();
     }
   }
 
@@ -331,6 +363,7 @@ class SeenVideosService {
       category: LogCategory.system,
     );
     _seenVideos.clear();
+    await _flushPendingSeenVideosSave();
 
     if (_prefs != null) {
       await _prefs!.remove(_seenVideosMetricsKey);
@@ -351,7 +384,7 @@ class SeenVideosService {
     );
     _seenVideos.remove(videoId);
 
-    await _saveSeenVideos();
+    await _scheduleSeenVideosSave();
   }
 
   /// Get statistics about seen videos
@@ -378,8 +411,5 @@ class SeenVideosService {
     };
   }
 
-  void dispose() {
-    // Save any pending changes before disposing
-    _saveSeenVideos();
-  }
+  Future<void> dispose() => _flushPendingSeenVideosSave();
 }

--- a/mobile/lib/services/seen_videos_service.dart
+++ b/mobile/lib/services/seen_videos_service.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:meta/meta.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -70,13 +71,18 @@ class SeenVideoMetrics {
 /// Service for tracking seen videos with engagement metrics
 /// REFACTORED: Extended to store timestamps, loop counts, and watch duration
 class SeenVideosService {
+  SeenVideosService({
+    @visibleForTesting Duration? saveDebounceDuration,
+  }) : _saveDebounceDuration =
+           saveDebounceDuration ?? const Duration(milliseconds: 100);
+
   static const String _seenVideosKey = 'seen_video_ids'; // Legacy key
   static const String _seenVideosMetricsKey = 'seen_video_metrics'; // New key
   static const int _maxSeenVideos =
       1000; // Limit storage to prevent unbounded growth
-  static const Duration _saveDebounceDuration = Duration(milliseconds: 100);
 
   final Map<String, SeenVideoMetrics> _seenVideos = {};
+  final Duration _saveDebounceDuration;
   SharedPreferences? _prefs;
   bool _isInitialized = false;
   Future<void>? _initializeFuture;

--- a/mobile/lib/widgets/divine_video_metrics_tracker.dart
+++ b/mobile/lib/widgets/divine_video_metrics_tracker.dart
@@ -51,7 +51,8 @@ class _DivineVideoMetricsTrackerState
   Duration? _lastPosition;
   int _loopCount = 0;
   bool _hasTrackedView = false;
-  bool _hasFinalizedView = false;
+  bool _hasSentEndEvent = false;
+  bool _hasRecordedImpression = false;
   bool _isPlaying = false;
   StreamSubscription<DivineVideoPlayerState>? _stateSubscription;
 
@@ -163,7 +164,8 @@ class _DivineVideoMetricsTrackerState
   void _trackViewStart() {
     _viewStartTime = widget._clock();
     _hasTrackedView = true;
-    _hasFinalizedView = false;
+    _hasSentEndEvent = false;
+    _hasRecordedImpression = false;
 
     _analyticsService.trackDetailedVideoViewWithUser(
       widget.video,
@@ -174,7 +176,8 @@ class _DivineVideoMetricsTrackerState
   }
 
   void _finalizeAndPublish({VideoEvent? finalizedVideo}) {
-    if (!_hasTrackedView || _hasFinalizedView) return;
+    if (!_hasTrackedView) return;
+    if (_hasSentEndEvent && _hasRecordedImpression) return;
     final viewStartTime = _viewStartTime;
     if (viewStartTime == null) return;
 
@@ -190,9 +193,6 @@ class _DivineVideoMetricsTrackerState
   }
 
   void _publishEvents(VideoEvent video, {required Duration activeDuration}) {
-    if (_hasFinalizedView) return;
-    _hasFinalizedView = true;
-
     Duration? totalDuration;
     try {
       totalDuration = widget.controller?.state.duration;
@@ -200,7 +200,8 @@ class _DivineVideoMetricsTrackerState
       totalDuration = null;
     }
 
-    if (_totalWatchDuration >= _minimumViewEndWatchDuration) {
+    if (!_hasSentEndEvent &&
+        _totalWatchDuration >= _minimumViewEndWatchDuration) {
       try {
         _analyticsService.trackDetailedVideoViewWithUser(
           video,
@@ -219,6 +220,8 @@ class _DivineVideoMetricsTrackerState
           trafficSource: widget.trafficSource,
           sourceDetail: widget.sourceDetail,
         );
+
+        _hasSentEndEvent = true;
       } catch (e) {
         Log.warning(
           'Failed to send video end event: $e',
@@ -228,7 +231,9 @@ class _DivineVideoMetricsTrackerState
       }
     }
 
-    if (activeDuration >= _minimumImpressionDuration) {
+    if (!_hasRecordedImpression &&
+        activeDuration >= _minimumImpressionDuration) {
+      _hasRecordedImpression = true;
       unawaited(
         _seenVideosService.recordVideoView(
           video.id,
@@ -246,7 +251,8 @@ class _DivineVideoMetricsTrackerState
     _lastPosition = null;
     _loopCount = 0;
     _hasTrackedView = false;
-    _hasFinalizedView = false;
+    _hasSentEndEvent = false;
+    _hasRecordedImpression = false;
     _isPlaying = false;
   }
 

--- a/mobile/lib/widgets/divine_video_metrics_tracker.dart
+++ b/mobile/lib/widgets/divine_video_metrics_tracker.dart
@@ -43,7 +43,6 @@ class DivineVideoMetricsTracker extends ConsumerStatefulWidget {
 class _DivineVideoMetricsTrackerState
     extends ConsumerState<DivineVideoMetricsTracker> {
   static const _minimumViewEndWatchDuration = Duration(seconds: 1);
-  static const _minimumImpressionDuration = Duration(milliseconds: 500);
 
   DateTime? _viewStartTime;
   DateTime? _lastPlayStartTime;
@@ -231,8 +230,7 @@ class _DivineVideoMetricsTrackerState
       }
     }
 
-    if (!_hasRecordedImpression &&
-        activeDuration >= _minimumImpressionDuration) {
+    if (!_hasRecordedImpression && activeDuration > Duration.zero) {
       _hasRecordedImpression = true;
       unawaited(
         _seenVideosService.recordVideoView(

--- a/mobile/lib/widgets/divine_video_metrics_tracker.dart
+++ b/mobile/lib/widgets/divine_video_metrics_tracker.dart
@@ -42,13 +42,16 @@ class DivineVideoMetricsTracker extends ConsumerStatefulWidget {
 
 class _DivineVideoMetricsTrackerState
     extends ConsumerState<DivineVideoMetricsTracker> {
+  static const _minimumViewEndWatchDuration = Duration(seconds: 1);
+  static const _minimumImpressionDuration = Duration(milliseconds: 500);
+
   DateTime? _viewStartTime;
   DateTime? _lastPlayStartTime;
   Duration _totalWatchDuration = Duration.zero;
   Duration? _lastPosition;
   int _loopCount = 0;
   bool _hasTrackedView = false;
-  bool _hasSentEndEvent = false;
+  bool _hasFinalizedView = false;
   bool _isPlaying = false;
   StreamSubscription<DivineVideoPlayerState>? _stateSubscription;
 
@@ -160,7 +163,7 @@ class _DivineVideoMetricsTrackerState
   void _trackViewStart() {
     _viewStartTime = widget._clock();
     _hasTrackedView = true;
-    _hasSentEndEvent = false;
+    _hasFinalizedView = false;
 
     _analyticsService.trackDetailedVideoViewWithUser(
       widget.video,
@@ -171,8 +174,9 @@ class _DivineVideoMetricsTrackerState
   }
 
   void _finalizeAndPublish({VideoEvent? finalizedVideo}) {
-    if (!_hasTrackedView || _hasSentEndEvent) return;
-    if (_viewStartTime == null) return;
+    if (!_hasTrackedView || _hasFinalizedView) return;
+    final viewStartTime = _viewStartTime;
+    if (viewStartTime == null) return;
 
     if (_isPlaying && _lastPlayStartTime != null) {
       _totalWatchDuration += widget._clock().difference(_lastPlayStartTime!);
@@ -181,12 +185,13 @@ class _DivineVideoMetricsTrackerState
     _isPlaying = false;
 
     final video = finalizedVideo ?? widget.video;
-    _publishEvents(video);
+    final activeDuration = widget._clock().difference(viewStartTime);
+    _publishEvents(video, activeDuration: activeDuration);
   }
 
-  void _publishEvents(VideoEvent video) {
-    if (_hasSentEndEvent) return;
-    if (_totalWatchDuration.inSeconds < 1) return;
+  void _publishEvents(VideoEvent video, {required Duration activeDuration}) {
+    if (_hasFinalizedView) return;
+    _hasFinalizedView = true;
 
     Duration? totalDuration;
     try {
@@ -195,37 +200,41 @@ class _DivineVideoMetricsTrackerState
       totalDuration = null;
     }
 
-    try {
-      _analyticsService.trackDetailedVideoViewWithUser(
-        video,
-        userId: _authService.currentPublicKeyHex,
-        source: 'mobile',
-        eventType: 'view_end',
-        watchDuration: _totalWatchDuration,
-        totalDuration: totalDuration,
-        loopCount: _loopCount,
-        completedVideo:
-            _loopCount > 0 ||
-            (totalDuration != null &&
-                totalDuration > Duration.zero &&
-                _totalWatchDuration.inMilliseconds >=
-                    totalDuration.inMilliseconds * 0.9),
-        trafficSource: widget.trafficSource,
-        sourceDetail: widget.sourceDetail,
-      );
+    if (_totalWatchDuration >= _minimumViewEndWatchDuration) {
+      try {
+        _analyticsService.trackDetailedVideoViewWithUser(
+          video,
+          userId: _authService.currentPublicKeyHex,
+          source: 'mobile',
+          eventType: 'view_end',
+          watchDuration: _totalWatchDuration,
+          totalDuration: totalDuration,
+          loopCount: _loopCount,
+          completedVideo:
+              _loopCount > 0 ||
+              (totalDuration != null &&
+                  totalDuration > Duration.zero &&
+                  _totalWatchDuration.inMilliseconds >=
+                      totalDuration.inMilliseconds * 0.9),
+          trafficSource: widget.trafficSource,
+          sourceDetail: widget.sourceDetail,
+        );
+      } catch (e) {
+        Log.warning(
+          'Failed to send video end event: $e',
+          name: 'DivineVideoMetricsTracker',
+          category: LogCategory.video,
+        );
+      }
+    }
 
-      _seenVideosService.recordVideoView(
-        video.id,
-        loopCount: _loopCount,
-        watchDuration: _totalWatchDuration,
-      );
-
-      _hasSentEndEvent = true;
-    } catch (e) {
-      Log.warning(
-        'Failed to send video end event: $e',
-        name: 'DivineVideoMetricsTracker',
-        category: LogCategory.video,
+    if (activeDuration >= _minimumImpressionDuration) {
+      unawaited(
+        _seenVideosService.recordVideoView(
+          video.id,
+          loopCount: _loopCount,
+          watchDuration: _totalWatchDuration,
+        ),
       );
     }
   }
@@ -237,7 +246,7 @@ class _DivineVideoMetricsTrackerState
     _lastPosition = null;
     _loopCount = 0;
     _hasTrackedView = false;
-    _hasSentEndEvent = false;
+    _hasFinalizedView = false;
     _isPlaying = false;
   }
 

--- a/mobile/test/services/seen_videos_service_test.dart
+++ b/mobile/test/services/seen_videos_service_test.dart
@@ -15,8 +15,8 @@ void main() {
       await service.initialize();
     });
 
-    tearDown(() {
-      service.dispose();
+    tearDown(() async {
+      await service.dispose();
     });
 
     test('initializes with empty seen videos', () {
@@ -174,7 +174,43 @@ void main() {
       final metrics = newService.getVideoMetrics(videoId);
       expect(metrics?.loopCount, 2);
 
-      newService.dispose();
+      await newService.dispose();
+    });
+
+    test('coalesces rapid records while keeping memory current', () async {
+      final firstSave = service.recordVideoView('video1');
+      final secondSave = service.recordVideoView('video2');
+
+      expect(service.hasSeenVideo('video1'), isTrue);
+      expect(service.hasSeenVideo('video2'), isTrue);
+
+      final beforeFlush = SeenVideosService();
+      await beforeFlush.initialize();
+      expect(beforeFlush.hasSeenVideo('video1'), isFalse);
+      expect(beforeFlush.hasSeenVideo('video2'), isFalse);
+      await beforeFlush.dispose();
+
+      await Future.wait([firstSave, secondSave]);
+
+      final afterFlush = SeenVideosService();
+      await afterFlush.initialize();
+      expect(afterFlush.hasSeenVideo('video1'), isTrue);
+      expect(afterFlush.hasSeenVideo('video2'), isTrue);
+      await afterFlush.dispose();
+    });
+
+    test('dispose flushes pending seen video writes', () async {
+      final pendingSave = service.recordVideoView('dispose_video');
+
+      await service.dispose();
+      await pendingSave;
+
+      final newService = SeenVideosService();
+      await newService.initialize();
+
+      expect(newService.hasSeenVideo('dispose_video'), isTrue);
+
+      await newService.dispose();
     });
   });
 }

--- a/mobile/test/services/seen_videos_service_test.dart
+++ b/mobile/test/services/seen_videos_service_test.dart
@@ -178,6 +178,12 @@ void main() {
     });
 
     test('coalesces rapid records while keeping memory current', () async {
+      await service.dispose();
+      service = SeenVideosService(
+        saveDebounceDuration: const Duration(days: 1),
+      );
+      await service.initialize();
+
       final firstSave = service.recordVideoView('video1');
       final secondSave = service.recordVideoView('video2');
 
@@ -190,6 +196,7 @@ void main() {
       expect(beforeFlush.hasSeenVideo('video2'), isFalse);
       await beforeFlush.dispose();
 
+      await service.dispose();
       await Future.wait([firstSave, secondSave]);
 
       final afterFlush = SeenVideosService();

--- a/mobile/test/widgets/divine_video_metrics_tracker_test.dart
+++ b/mobile/test/widgets/divine_video_metrics_tracker_test.dart
@@ -226,7 +226,7 @@ void main() {
       await controller.close();
     });
 
-    testWidgets('fling-speed active session records nothing', (tester) async {
+    testWidgets('fling-speed active session records seen only', (tester) async {
       final isActive = ValueNotifier(true);
       final video = ValueNotifier(_video);
       final controller = _stubController(isPlaying: true);
@@ -248,7 +248,12 @@ void main() {
       await tester.pump();
 
       expect(_viewEndEvents(analyticsService), isEmpty);
-      expect(seenVideosService.records, isEmpty);
+      expect(seenVideosService.records, hasLength(1));
+      expect(seenVideosService.records.single.videoId, equals('video_id'));
+      expect(
+        seenVideosService.records.single.watchDuration,
+        const Duration(milliseconds: 400),
+      );
 
       isActive.dispose();
       video.dispose();
@@ -395,14 +400,18 @@ void main() {
         ),
       );
 
-      // Glance too short for either threshold, then the feed goes inactive
+      // Glance too short for view_end, then the feed goes inactive
       // (app backgrounded, route pushed, or swiped past within the pool).
       now = now.add(const Duration(milliseconds: 300));
       isActive.value = false;
       await tester.pump();
 
       expect(_viewEndEvents(analyticsService), isEmpty);
-      expect(seenVideosService.records, isEmpty);
+      expect(seenVideosService.records, hasLength(1));
+      expect(
+        seenVideosService.records.single.watchDuration,
+        const Duration(milliseconds: 300),
+      );
 
       // The same tracker becomes active again and is actually watched.
       isActive.value = true;

--- a/mobile/test/widgets/divine_video_metrics_tracker_test.dart
+++ b/mobile/test/widgets/divine_video_metrics_tracker_test.dart
@@ -376,6 +376,102 @@ void main() {
       await controller.close();
     });
 
+    testWidgets('reactivation after a skipped glance still finalizes', (
+      tester,
+    ) async {
+      final isActive = ValueNotifier(true);
+      final video = ValueNotifier(_video);
+      final controller = _stubController(isPlaying: true);
+
+      await tester.pumpWidget(
+        _buildTrackerHarness(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          controller: controller.controller,
+          video: video,
+          isActive: isActive,
+          clock: () => now,
+        ),
+      );
+
+      // Glance too short for either threshold, then the feed goes inactive
+      // (app backgrounded, route pushed, or swiped past within the pool).
+      now = now.add(const Duration(milliseconds: 300));
+      isActive.value = false;
+      await tester.pump();
+
+      expect(_viewEndEvents(analyticsService), isEmpty);
+      expect(seenVideosService.records, isEmpty);
+
+      // The same tracker becomes active again and is actually watched.
+      isActive.value = true;
+      await tester.pump();
+      now = now.add(const Duration(seconds: 5));
+      isActive.value = false;
+      await tester.pump();
+
+      final viewEndEvents = _viewEndEvents(analyticsService);
+      expect(viewEndEvents, hasLength(1));
+      expect(
+        viewEndEvents.single.watchDuration,
+        const Duration(milliseconds: 5300),
+      );
+      expect(seenVideosService.records, hasLength(1));
+      expect(seenVideosService.records.single.videoId, equals('video_id'));
+
+      isActive.dispose();
+      video.dispose();
+      await controller.close();
+    });
+
+    testWidgets('reactivation after a recorded impression sends view_end', (
+      tester,
+    ) async {
+      final isActive = ValueNotifier(true);
+      final video = ValueNotifier(_video);
+      final controller = _stubController(isPlaying: true);
+
+      await tester.pumpWidget(
+        _buildTrackerHarness(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          controller: controller.controller,
+          video: video,
+          isActive: isActive,
+          clock: () => now,
+        ),
+      );
+
+      // Long enough to record a seen impression, too short for view_end.
+      now = now.add(const Duration(milliseconds: 700));
+      isActive.value = false;
+      await tester.pump();
+
+      expect(_viewEndEvents(analyticsService), isEmpty);
+      expect(seenVideosService.records, hasLength(1));
+
+      isActive.value = true;
+      await tester.pump();
+      now = now.add(const Duration(seconds: 5));
+      isActive.value = false;
+      await tester.pump();
+
+      final viewEndEvents = _viewEndEvents(analyticsService);
+      expect(viewEndEvents, hasLength(1));
+      expect(
+        viewEndEvents.single.watchDuration,
+        const Duration(milliseconds: 5700),
+      );
+      // The impression is not recorded twice for one view session.
+      expect(seenVideosService.records, hasLength(1));
+
+      isActive.dispose();
+      video.dispose();
+      await controller.close();
+    });
+
     testWidgets('video id change finalizes old video and starts new one', (
       tester,
     ) async {

--- a/mobile/test/widgets/divine_video_metrics_tracker_test.dart
+++ b/mobile/test/widgets/divine_video_metrics_tracker_test.dart
@@ -260,6 +260,34 @@ void main() {
       await controller.close();
     });
 
+    testWidgets('zero-duration active session records nothing', (tester) async {
+      final isActive = ValueNotifier(true);
+      final video = ValueNotifier(_video);
+      final controller = _stubController(isPlaying: true);
+
+      await tester.pumpWidget(
+        _buildTrackerHarness(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          controller: controller.controller,
+          video: video,
+          isActive: isActive,
+          clock: () => now,
+        ),
+      );
+
+      isActive.value = false;
+      await tester.pump();
+
+      expect(_viewEndEvents(analyticsService), isEmpty);
+      expect(seenVideosService.records, isEmpty);
+
+      isActive.dispose();
+      video.dispose();
+      await controller.close();
+    });
+
     testWidgets('dispose under one second records seen once', (tester) async {
       final controller = _stubController(isPlaying: true);
 

--- a/mobile/test/widgets/divine_video_metrics_tracker_test.dart
+++ b/mobile/test/widgets/divine_video_metrics_tracker_test.dart
@@ -250,6 +250,7 @@ void main() {
       expect(_viewEndEvents(analyticsService), isEmpty);
       expect(seenVideosService.records, hasLength(1));
       expect(seenVideosService.records.single.videoId, equals('video_id'));
+      expect(seenVideosService.records.single.loopCount, equals(0));
       expect(
         seenVideosService.records.single.watchDuration,
         const Duration(milliseconds: 400),

--- a/mobile/test/widgets/divine_video_metrics_tracker_test.dart
+++ b/mobile/test/widgets/divine_video_metrics_tracker_test.dart
@@ -190,7 +190,7 @@ void main() {
       await controller.close();
     });
 
-    testWidgets('active to inactive under one second omits view_end', (
+    testWidgets('active to inactive under one second records seen only', (
       tester,
     ) async {
       final isActive = ValueNotifier(true);
@@ -214,10 +214,72 @@ void main() {
       await tester.pump();
 
       expect(_viewEndEvents(analyticsService), isEmpty);
+      expect(seenVideosService.records, hasLength(1));
+      expect(seenVideosService.records.single.videoId, equals('video_id'));
+      expect(
+        seenVideosService.records.single.watchDuration,
+        const Duration(milliseconds: 900),
+      );
+
+      isActive.dispose();
+      video.dispose();
+      await controller.close();
+    });
+
+    testWidgets('fling-speed active session records nothing', (tester) async {
+      final isActive = ValueNotifier(true);
+      final video = ValueNotifier(_video);
+      final controller = _stubController(isPlaying: true);
+
+      await tester.pumpWidget(
+        _buildTrackerHarness(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          controller: controller.controller,
+          video: video,
+          isActive: isActive,
+          clock: () => now,
+        ),
+      );
+
+      now = now.add(const Duration(milliseconds: 400));
+      isActive.value = false;
+      await tester.pump();
+
+      expect(_viewEndEvents(analyticsService), isEmpty);
       expect(seenVideosService.records, isEmpty);
 
       isActive.dispose();
       video.dispose();
+      await controller.close();
+    });
+
+    testWidgets('dispose under one second records seen once', (tester) async {
+      final controller = _stubController(isPlaying: true);
+
+      await tester.pumpWidget(
+        _buildTracker(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          controller: controller.controller,
+          isActive: true,
+          clock: () => now,
+        ),
+      );
+
+      now = now.add(const Duration(milliseconds: 900));
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpWidget(const SizedBox.shrink());
+
+      expect(_viewEndEvents(analyticsService), isEmpty);
+      expect(seenVideosService.records, hasLength(1));
+      expect(
+        seenVideosService.records.single.watchDuration,
+        const Duration(milliseconds: 900),
+      );
+
       await controller.close();
     });
 
@@ -246,6 +308,39 @@ void main() {
       );
       expect(seenVideosService.records, hasLength(1));
 
+      await controller.close();
+    });
+
+    testWidgets('active video that never plays still records seen', (
+      tester,
+    ) async {
+      final isActive = ValueNotifier(true);
+      final video = ValueNotifier(_video);
+      final controller = _stubController(isPlaying: false);
+
+      await tester.pumpWidget(
+        _buildTrackerHarness(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          controller: controller.controller,
+          video: video,
+          isActive: isActive,
+          clock: () => now,
+        ),
+      );
+
+      now = now.add(const Duration(milliseconds: 900));
+      isActive.value = false;
+      await tester.pump();
+
+      expect(_viewEndEvents(analyticsService), isEmpty);
+      expect(seenVideosService.records, hasLength(1));
+      expect(seenVideosService.records.single.videoId, equals('video_id'));
+      expect(seenVideosService.records.single.watchDuration, Duration.zero);
+
+      isActive.dispose();
+      video.dispose();
       await controller.close();
     });
 


### PR DESCRIPTION
## Description

Split DivineVideoMetricsTracker finalization so local seen impressions are recorded separately from analytics view_end events. Analytics still requires at least 1 second of watch time, while local seen persistence now records any active session with positive on-screen time, including videos that were visible but never started playing.

SeenVideosService now coalesces rapid persistence writes and flushes pending writes on disposal, avoiding a full SharedPreferences rewrite on every swipe while keeping in-memory seen state current.

**Related Issue:** Closes #6752

## Out of Scope

The separate feedDedupKey versus video.id seen-key migration is intentionally not included here because it changes persisted identity semantics and should be handled in a focused follow-up.

## Verification

- `flutter test test/widgets/divine_video_metrics_tracker_test.dart test/services/seen_videos_service_test.dart`
- `flutter analyze lib test integration_test`
- pre-push checks: analyzer, generated-file verification, changed-file tests

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
