### PR TITLE
fix(lists): show creator on subscribed curated lists

### DIFF
--- a/mobile/lib/screens/curated_list_feed_screen.dart
+++ b/mobile/lib/screens/curated_list_feed_screen.dart
@@ -298,7 +298,9 @@ class _CuratedListFeedScreenState extends ConsumerState<CuratedListFeedScreen> {
     final videoCount =
         widget.videoIds?.length ?? localList?.videoEventIds.length ?? 0;
     final videoText = context.l10n.listVideoCount(videoCount);
-    final authorPubkey = widget.authorPubkey;
+    final authorPubkey = _isOwnedList()
+        ? null
+        : widget.authorPubkey ?? localList?.pubkey;
 
     if (authorPubkey != null) {
       return GestureDetector(
@@ -319,7 +321,7 @@ class _CuratedListFeedScreenState extends ConsumerState<CuratedListFeedScreen> {
             Flexible(
               flex: 0,
               child: UserName.fromPubKey(
-                widget.authorPubkey!,
+                authorPubkey,
                 style: TextStyle(
                   color: context.vineColors.primaryText,
                   fontSize: 12,
@@ -488,9 +490,9 @@ class _CuratedListFeedScreenState extends ConsumerState<CuratedListFeedScreen> {
         stackTrace: stackTrace,
       );
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(context.l10n.listShareFailed)),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(context.l10n.listShareFailed)));
       }
     }
   }

--- a/mobile/lib/widgets/list_card.dart
+++ b/mobile/lib/widgets/list_card.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
+import 'package:openvine/widgets/user_name.dart';
 
 /// Card for displaying a user list (kind 30000 - people list)
 class UserListCard extends StatelessWidget {
@@ -186,6 +187,10 @@ class CuratedListCard extends StatelessWidget {
                   ],
                 ],
               ),
+              if (curatedList.pubkey != null) ...[
+                const SizedBox(height: 8),
+                _CuratedListAuthor(pubkey: curatedList.pubkey!),
+              ],
               if (showVisibility) ...[
                 const SizedBox(height: 8),
                 _ListVisibilityBadge(isPublic: curatedList.isPublic),
@@ -194,6 +199,37 @@ class CuratedListCard extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _CuratedListAuthor extends StatelessWidget {
+  const _CuratedListAuthor({required this.pubkey});
+
+  final String pubkey;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          context.l10n.listByAuthorPrefix,
+          style: VineTheme.labelSmallFont(
+            color: context.vineColors.secondaryText,
+          ),
+        ),
+        Flexible(
+          child: UserName.fromPubKey(
+            pubkey,
+            style: VineTheme.labelSmallFont(
+              color: context.vineColors.primaryText,
+            ),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/mobile/lib/widgets/list_card.dart
+++ b/mobile/lib/widgets/list_card.dart
@@ -90,12 +90,20 @@ class CuratedListCard extends StatelessWidget {
     required this.curatedList,
     required this.onTap,
     this.showVisibility = false,
+    this.showAuthor = true,
     super.key,
   });
 
   final CuratedList curatedList;
   final VoidCallback onTap;
   final bool showVisibility;
+
+  /// Whether to credit the list's creator.
+  ///
+  /// Off for the viewer's own lists: every list they create is stamped with
+  /// their pubkey, so the row would credit them to themselves. The curated
+  /// list feed screen suppresses its own creator row for the same reason.
+  final bool showAuthor;
 
   @override
   Widget build(BuildContext context) {
@@ -187,7 +195,7 @@ class CuratedListCard extends StatelessWidget {
                   ],
                 ],
               ),
-              if (curatedList.pubkey != null) ...[
+              if (showAuthor && curatedList.pubkey != null) ...[
                 const SizedBox(height: 8),
                 _CuratedListAuthor(pubkey: curatedList.pubkey!),
               ],

--- a/mobile/lib/widgets/owned_list_card.dart
+++ b/mobile/lib/widgets/owned_list_card.dart
@@ -29,6 +29,7 @@ class OwnedListCard extends StatelessWidget {
     return CuratedListCard(
       curatedList: curatedList,
       showVisibility: true,
+      showAuthor: false,
       onTap: () {
         onTap?.call();
         context.push(

--- a/mobile/test/screens/curated_list_feed_screen_test.dart
+++ b/mobile/test/screens/curated_list_feed_screen_test.dart
@@ -251,6 +251,71 @@ void main() {
       },
     );
 
+    testWidgets('route without extras shows stored author and video count', (
+      tester,
+    ) async {
+      when(() => mockService.isOwnedList('external-list')).thenReturn(false);
+      when(() => mockService.getListById('external-list')).thenReturn(
+        CuratedList(
+          id: 'external-list',
+          name: 'Subscribed List',
+          pubkey:
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          videoEventIds: const ['one', 'two', 'three'],
+          createdAt: DateTime(2026),
+          updatedAt: DateTime(2026),
+        ),
+      );
+
+      await tester.pumpWidget(
+        buildSubject(
+          listName: 'Subscribed List',
+          authorPubkey: null,
+          videoIds: null,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text(l10n.listByAuthorPrefix), findsOneWidget);
+      expect(find.text(' • ${l10n.listVideoCount(3)}'), findsOneWidget);
+    });
+
+    testWidgets('owned list suppresses author attribution', (tester) async {
+      when(() => mockService.isOwnedList('owned-list')).thenReturn(true);
+      when(
+        () => mockService.isSubscribedToList('owned-list'),
+      ).thenReturn(false);
+      when(() => mockService.getListById('owned-list')).thenReturn(
+        CuratedList(
+          id: 'owned-list',
+          name: 'Puppets',
+          pubkey:
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          videoEventIds: const ['one', 'two', 'three'],
+          createdAt: DateTime(2026),
+          updatedAt: DateTime(2026),
+        ),
+      );
+
+      await tester.pumpWidget(
+        buildSubject(
+          listId: 'owned-list',
+          listName: 'Puppets',
+          authorPubkey: null,
+          videoIds: null,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text(l10n.listByAuthorPrefix), findsNothing);
+      expect(
+        find.text(
+          '${l10n.listVideoCount(3)} • ${l10n.listVisibilityPublic}',
+        ),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('owned public list offers edit, share, and delete', (
       tester,
     ) async {

--- a/mobile/test/widgets/list_card_test.dart
+++ b/mobile/test/widgets/list_card_test.dart
@@ -3,33 +3,40 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/list_card.dart';
 
+import '../helpers/test_provider_overrides.dart';
+
 void main() {
   group(CuratedListCard, () {
     final l10n = lookupAppLocalizations(const Locale('en'));
 
-    Widget buildSubject({required bool isPublic}) {
+    Widget buildSubject({required bool isPublic, String? pubkey}) {
       final now = DateTime(2026);
-      return MaterialApp(
-        theme: VineTheme.theme,
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        home: Scaffold(
-          body: CuratedListCard(
-            curatedList: CuratedList(
-              id: 'puppets',
-              name: 'Puppets',
-              videoEventIds: const [],
-              createdAt: now,
-              updatedAt: now,
-              isPublic: isPublic,
+      return ProviderScope(
+        overrides: [...getStandardTestOverrides()],
+        child: MaterialApp(
+          theme: VineTheme.theme,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: CuratedListCard(
+              curatedList: CuratedList(
+                id: 'puppets',
+                name: 'Puppets',
+                pubkey: pubkey,
+                videoEventIds: const [],
+                createdAt: now,
+                updatedAt: now,
+                isPublic: isPublic,
+              ),
+              showVisibility: true,
+              onTap: () {},
             ),
-            showVisibility: true,
-            onTap: () {},
           ),
         ),
       );
@@ -45,6 +52,24 @@ void main() {
       await tester.pumpWidget(buildSubject(isPublic: false));
 
       expect(find.text(l10n.listVisibilityPrivateDevice), findsOneWidget);
+    });
+
+    testWidgets('shows the list author when available', (tester) async {
+      await tester.pumpWidget(
+        buildSubject(
+          isPublic: true,
+          pubkey:
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        ),
+      );
+
+      expect(find.text(l10n.listByAuthorPrefix), findsOneWidget);
+    });
+
+    testWidgets('omits the list author when unavailable', (tester) async {
+      await tester.pumpWidget(buildSubject(isPublic: true));
+
+      expect(find.text(l10n.listByAuthorPrefix), findsNothing);
     });
   });
 }

--- a/mobile/test/widgets/owned_list_card_test.dart
+++ b/mobile/test/widgets/owned_list_card_test.dart
@@ -30,6 +30,10 @@ void main() {
       return CuratedList(
         id: 'puppets',
         name: 'Puppets',
+        // Owned lists always carry the owner's pubkey — CuratedListService
+        // stamps it at creation — so the fixture must too.
+        pubkey:
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
         videoEventIds: const [],
         createdAt: now,
         updatedAt: now,
@@ -96,6 +100,12 @@ void main() {
       await tester.pumpWidget(buildSubject(isPublic: false));
 
       expect(find.text(l10n.listVisibilityPrivateDevice), findsOneWidget);
+    });
+
+    testWidgets('does not credit the owner as the list author', (tester) async {
+      await tester.pumpWidget(buildSubject());
+
+      expect(find.text(l10n.listByAuthorPrefix), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## Summary

- show curated-list creators on shared list cards when the list has a creator pubkey
- resolve creator attribution on the curated-list detail screen from stored list data when route extras are missing
- keep owned-list detail views focused on count/visibility instead of showing a creator row for the current user

## Root cause

Search and discovery routes passed richer curated-list extras, but subscribed, owned, and deep-link paths can arrive with only the list ID/name. The stored subscribed list already has the creator pubkey and video IDs, so the detail screen should not depend on route extras for those fields.

Closes #6757.
Related to #6749, which should stay open for the broader route-payload consolidation.

## Verification

- `flutter test test/screens/curated_list_feed_screen_test.dart test/widgets/list_card_test.dart`
- `flutter analyze lib/screens/curated_list_feed_screen.dart lib/widgets/list_card.dart test/screens/curated_list_feed_screen_test.dart test/widgets/list_card_test.dart`
- `flutter analyze lib test integration_test`
- pre-push hook reran analyzer and changed-file tests successfully
