### PR TITLE
fix(l10n): select the list-add plural in ICU, not in Dart

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3448,21 +3448,9 @@
             }
         }
     },
-    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3323,21 +3323,9 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "عرض الملفات الشخصية",
-    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3051,21 +3051,9 @@
             }
         }
     },
-    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3330,21 +3330,9 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Profile öffnen",
-    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4720,21 +4720,9 @@
       }
     }
   },
-  "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3338,21 +3338,9 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Ver perfiles",
-    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2271,21 +2271,9 @@
     "nostrAppPermissionTitle": "Hinihingi ng {appName} ang pag-apruba mo",
     "notificationAndConnector": "at",
     "notificationOthersCount": "{count, plural, =1{1 iba pa} other{{count} iba pa}}",
-    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3330,21 +3330,9 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Voir les profils",
-    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3330,21 +3330,9 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Lihat profil",
-    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3330,21 +3330,9 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Vedi profili",
-    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3323,21 +3323,9 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "プロフィールを開く",
-    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2661,21 +2661,9 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "프로필 보기",
-    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -4818,21 +4818,9 @@
     }
   },
   "notificationPostedNewVine": "{actorName} menyiarkan vine baharu",
-  "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3330,21 +3330,9 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Profielen bekijken",
-    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3330,21 +3330,9 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Zobacz profile",
-    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3330,21 +3330,9 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Ver perfis",
-    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3330,21 +3330,9 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Vezi profilurile",
-    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3330,21 +3330,9 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Visa profiler",
-    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3330,21 +3330,9 @@
         }
     },
     "notificationsViewProfilesSemanticLabel": "Profilleri görüntüle",
-    "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -4818,21 +4818,9 @@
     }
   },
   "notificationPostedNewVine": "{actorName} نے نئی ویڈیو پوسٹ کی",
-  "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -4818,21 +4818,9 @@
     }
   },
   "notificationPostedNewVine": "{actorName} đã đăng một vine mới",
-  "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -4818,21 +4818,9 @@
     }
   },
   "notificationPostedNewVine": "{actorName} 发布了新视频",
-  "notificationAddedYourVideoToList": "{actorName} added your vine to {listName}",
-  "@notificationAddedYourVideoToList": {
-    "description": "Shown when someone adds one of the user's videos to a public curated list.",
-    "placeholders": {
-      "actorName": {
-        "type": "String"
-      },
-      "listName": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationAddedYourVideosToList": "{actorName} added {count} of your vines to {listName}",
+  "notificationAddedYourVideosToList": "{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}",
   "@notificationAddedYourVideosToList": {
-    "description": "Shown when someone adds multiple of the user's videos to the same public curated list.",
+    "description": "Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.",
     "placeholders": {
       "actorName": {
         "type": "String"

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -13970,16 +13970,10 @@ abstract class AppLocalizations {
   /// **'{actorName} posted a new vine'**
   String notificationPostedNewVine(String actorName);
 
-  /// Shown when someone adds one of the user's videos to a public curated list.
+  /// Shown when someone adds the user's videos to a public curated list. Uses an ICU plural so locales with more than two plural categories can inflect correctly.
   ///
   /// In en, this message translates to:
-  /// **'{actorName} added your vine to {listName}'**
-  String notificationAddedYourVideoToList(String actorName, String listName);
-
-  /// Shown when someone adds multiple of the user's videos to the same public curated list.
-  ///
-  /// In en, this message translates to:
-  /// **'{actorName} added {count} of your vines to {listName}'**
+  /// **'{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}'**
   String notificationAddedYourVideosToList(
     String actorName,
     int count,

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7920,17 +7920,18 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -8033,17 +8033,18 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -8161,17 +8161,18 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -8185,17 +8185,18 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -8075,17 +8075,18 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -8164,17 +8164,18 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -8183,17 +8183,18 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -8193,17 +8193,18 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -8047,17 +8047,18 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -8167,17 +8167,18 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7738,17 +7738,18 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -7762,17 +7762,18 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -8137,17 +8137,18 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -8123,17 +8123,18 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -8264,17 +8264,18 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -8144,17 +8144,18 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -8263,17 +8263,18 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -8081,17 +8081,18 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -8046,17 +8046,18 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -8091,17 +8091,18 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -8094,17 +8094,18 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -7684,17 +7684,18 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String notificationAddedYourVideoToList(String actorName, String listName) {
-    return '$actorName added your vine to $listName';
-  }
-
-  @override
   String notificationAddedYourVideosToList(
     String actorName,
     int count,
     String listName,
   ) {
-    return '$actorName added $count of your vines to $listName';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count of your vines',
+      one: 'your vine',
+    );
+    return '$actorName added $_temp0 to $listName';
   }
 
   @override

--- a/mobile/lib/notifications/widgets/video_notification_row.dart
+++ b/mobile/lib/notifications/widgets/video_notification_row.dart
@@ -200,16 +200,11 @@ class _MessageText extends StatelessWidget {
       final listName = notification.listTitle?.isNotEmpty == true
           ? notification.listTitle!
           : l10n.routeDefaultListName;
-      final fullText = notification.totalCount > 1
-          ? l10n.notificationAddedYourVideosToList(
-              actors.first.displayName,
-              notification.totalCount,
-              listName,
-            )
-          : l10n.notificationAddedYourVideoToList(
-              actors.first.displayName,
-              listName,
-            );
+      final fullText = l10n.notificationAddedYourVideosToList(
+        actors.first.displayName,
+        notification.totalCount,
+        listName,
+      );
       spans.addAll(
         _localizedActorAndListSentenceSpans(
           fullText: fullText,

--- a/mobile/test/notifications/widgets/video_notification_row_test.dart
+++ b/mobile/test/notifications/widgets/video_notification_row_test.dart
@@ -189,10 +189,12 @@ void main() {
 
         expect(
           find.textContaining(
-            _l10n.notificationAddedYourVideoToList('Alice', 'Literature'),
+            _l10n.notificationAddedYourVideosToList('Alice', 1, 'Literature'),
           ),
           findsOneWidget,
         );
+        // The `=1` arm must not leak the count into the sentence.
+        expect(find.textContaining('1 of your vines'), findsNothing);
       });
 
       testWidgets('grouped listAdd counts videos, not other actors', (


### PR DESCRIPTION
## Summary

The list-add notification chose between two ARB keys with `totalCount > 1` inside the widget, and the plural key took a bare `{count}` placeholder. That hard-codes a two-form plural in Dart.

It cannot be correct for every locale we ship. Arabic has six plural categories and Polish four; a `> 1` branch in Dart can express neither, so counts like 2, 5 and 22 read wrong in those locales regardless of translation quality. `.claude/rules/localization.md` states the rule directly: *"Plurals use ICU syntax in ARB files, not conditional logic in Dart."*

Follow-up to #6729.

## What changed

- Collapsed `notificationAddedYourVideoToList` and `notificationAddedYourVideosToList` into a single ICU `plural` on `count`.
- Dropped the `totalCount > 1` branch in `_MessageText`; the widget now makes one call.
- Mirrored the new shape into all 22 `app_*.arb` locales and committed the regenerated `lib/l10n/generated/`.

```
"{actorName} added {count, plural, =1{your vine} other{{count} of your vines}} to {listName}"
```

**English output is unchanged.** `=1` renders "Alice added your vine to Literature" and `other` renders "Alice added 3 of your vines to Literature" — byte-identical to the two keys they replace. What changes is that selection now runs through `Intl.pluralLogic` against the viewer's locale.

## On the other locales

All 22 locales carried the untranslated English string for **both** keys, so no translated copy was lost — each locale keeps the same English text in its new ICU shape, and the untranslated-message counts are unchanged.

Locales needing more than `one`/`other` still fall back to `other` until those arms are written. The point of this change is that they are now *expressible*: a translator can add `few`/`many` per locale in the ARB with no Dart change and no new key. Before, the categories had nowhere to live.

## Verification

- `flutter test test/l10n/arb_consistency_test.dart` — 8 passing, including `every locale keeps the placeholders app_en.arb interpolates`, which is the one that matters here since the placeholder structure changed
- `flutter test test/notifications test/goldens/widgets/notification_rows_golden_test.dart` — 209 passing, goldens unchanged
- `flutter analyze lib test` — no issues
- `dart format` — clean
- Confirmed `app_localizations_pl.dart` now routes through `Intl.pluralLogic(count, locale: localeName, ...)` rather than a fixed string

The singular test now asserts on the `=1` arm and adds `expect(find.textContaining('1 of your vines'), findsNothing)`, so a regression that drops the `=1` arm and lets `other` handle 1 fails loudly instead of silently rendering "1 of your vines".

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
