### PR TITLE
fix(profile): reject empty image-picker files before opening the crop editor

### DIFF
--- a/mobile/lib/screens/profile_setup/widgets/profile_avatar_section.dart
+++ b/mobile/lib/screens/profile_setup/widgets/profile_avatar_section.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -201,10 +199,9 @@ class _ProfileAvatarSectionState extends ConsumerState<ProfileAvatarSection> {
 
   /// Platform-aware image selection with an interactive crop step.
   ///
-  /// Native picks yield an [XFile] with a real filesystem path (wrapped in a
-  /// `dart:io File`); web picks yield blob bytes read eagerly before the URL
-  /// is revoked. Either way the image is handed to the Vine crop editor, and
-  /// the resulting cropped JPEG bytes are uploaded via
+  /// [resolveProfileImageSelection] validates the pick and resolves it to a
+  /// file (native) or bytes (web), so an empty pick never reaches the Vine
+  /// crop editor. The resulting cropped JPEG bytes are uploaded via
   /// `BlossomUploadService.uploadImageBytes`. The crop re-encode bounds the
   /// output dimensions and drops the original EXIF.
   Future<void> _pickImage(ImageSource source) async {
@@ -241,26 +238,22 @@ class _ProfileAvatarSectionState extends ConsumerState<ProfileAvatarSection> {
         return;
       }
 
-      final cropLauncher = ref.read(imageCropLauncherProvider);
-      Uint8List? cropped;
-      if (kIsWeb) {
-        // Resolve the blob synchronously here — once we navigate away from
-        // the picker the URL can be revoked.
-        final bytes = await picked.readAsBytes();
-        if (!mounted) return;
-        cropped = await cropLauncher(
-          context,
-          kind: ImageCropKind.avatar,
-          bytes: bytes,
-        );
-      } else {
-        if (!mounted) return;
-        cropped = await cropLauncher(
-          context,
-          kind: ImageCropKind.avatar,
-          file: File(picked.path),
-        );
+      // An empty pick would blow up inside the crop editor's image providers,
+      // so it is rejected here instead.
+      final selection = await resolveProfileImageSelection(picked);
+      if (!mounted) return;
+      if (selection == null) {
+        showProfileImageSelectionFailed(context);
+        return;
       }
+
+      final cropLauncher = ref.read(imageCropLauncherProvider);
+      final cropped = await cropLauncher(
+        context,
+        kind: ImageCropKind.avatar,
+        file: selection.file,
+        bytes: selection.bytes,
+      );
 
       if (cropped == null) {
         Log.info(

--- a/mobile/lib/screens/profile_setup/widgets/profile_header_preview.dart
+++ b/mobile/lib/screens/profile_setup/widgets/profile_header_preview.dart
@@ -1,7 +1,4 @@
-import 'dart:io';
-
 import 'package:divine_ui/divine_ui.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -15,6 +12,7 @@ import 'package:openvine/screens/profile_setup/widgets/banner_color_swatches.dar
 import 'package:openvine/screens/profile_setup/widgets/image_url_sheet.dart';
 import 'package:openvine/screens/profile_setup/widgets/profile_avatar_section.dart';
 import 'package:openvine/screens/profile_setup/widgets/profile_image_actions_sheet.dart';
+import 'package:openvine/screens/profile_setup/widgets/profile_image_picker.dart';
 import 'package:openvine/widgets/profile/profile_header_widget.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -229,24 +227,22 @@ class _BannerEditButton extends ConsumerWidget {
     }
     if (picked == null) return;
 
-    final cropLauncher = ref.read(imageCropLauncherProvider);
-    Uint8List? cropped;
-    if (kIsWeb) {
-      final bytes = await picked.readAsBytes();
-      if (!context.mounted) return;
-      cropped = await cropLauncher(
-        context,
-        kind: ImageCropKind.banner,
-        bytes: bytes,
-      );
-    } else {
-      if (!context.mounted) return;
-      cropped = await cropLauncher(
-        context,
-        kind: ImageCropKind.banner,
-        file: File(picked.path),
-      );
+    // An empty pick would blow up inside the crop editor's image providers,
+    // so it is rejected here instead.
+    final selection = await resolveProfileImageSelection(picked);
+    if (!context.mounted) return;
+    if (selection == null) {
+      showProfileImageSelectionFailed(context);
+      return;
     }
+
+    final cropLauncher = ref.read(imageCropLauncherProvider);
+    final cropped = await cropLauncher(
+      context,
+      kind: ImageCropKind.banner,
+      file: selection.file,
+      bytes: selection.bytes,
+    );
 
     if (cropped == null) return;
 

--- a/mobile/lib/screens/profile_setup/widgets/profile_image_picker.dart
+++ b/mobile/lib/screens/profile_setup/widgets/profile_image_picker.dart
@@ -1,6 +1,9 @@
+import 'dart:io';
+
+import 'package:divine_ui/divine_ui.dart';
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -51,6 +54,96 @@ Future<XFile?> pickProfileXFile(
     );
     rethrow;
   }
+}
+
+/// A picker result that has been checked for content and resolved into a
+/// source the crop editor can decode.
+///
+/// Exactly one of [file] / [bytes] is set: native picks stay a file, web picks
+/// are read eagerly because the blob URL can be revoked once the picker is
+/// left behind.
+@immutable
+class ProfileImageSelection {
+  /// Wraps a native file that exists and holds at least one byte.
+  const ProfileImageSelection.file(File this.file) : bytes = null;
+
+  /// Wraps non-empty bytes read from a web blob.
+  const ProfileImageSelection.bytes(Uint8List this.bytes) : file = null;
+
+  /// The native source file, or `null` on web.
+  final File? file;
+
+  /// The web blob's bytes, or `null` on native.
+  final Uint8List? bytes;
+}
+
+/// Validates [picked] and resolves it into a crop-editor source.
+///
+/// Returns `null` when the picker handed back nothing usable — a missing file,
+/// a zero-byte file (iOS occasionally returns an empty temporary JPEG), an
+/// empty web blob, or an I/O failure while checking. Callers must surface a
+/// recoverable selection failure instead: the crop editor decodes its source
+/// through image providers, so an empty source throws "file is empty" and
+/// "invalid image data" as fatal errors before the user can crop anything.
+Future<ProfileImageSelection?> resolveProfileImageSelection(
+  XFile picked,
+) async {
+  try {
+    if (kIsWeb) {
+      // Read the blob here — its URL can be revoked once we navigate away.
+      final bytes = await picked.readAsBytes();
+      if (bytes.isEmpty) {
+        _logEmptySelection();
+        return null;
+      }
+      return ProfileImageSelection.bytes(bytes);
+    }
+
+    final file = File(picked.path);
+    // Sync stat: one syscall on a local temp file, and it keeps the check off
+    // the event loop. It throws PathNotFoundException when the picker's
+    // temporary file is already gone, which lands in the rejection below.
+    if (file.lengthSync() == 0) {
+      _logEmptySelection();
+      return null;
+    }
+    return ProfileImageSelection.file(file);
+  } on PathNotFoundException {
+    _logEmptySelection();
+    return null;
+  } catch (e) {
+    // The message stays free of the path: it names a user's temporary file.
+    Log.error(
+      'Could not read the picked image (${e.runtimeType})',
+      name: 'ProfileSetupScreen',
+      category: LogCategory.ui,
+    );
+    return null;
+  }
+}
+
+/// Tells the user their pick could not be used and points at the URL sheet.
+///
+/// Shared by the avatar and banner flows so a rejected pick never looks like a
+/// silent no-op on either surface.
+void showProfileImageSelectionFailed(BuildContext context) {
+  ScaffoldMessenger.of(context).showSnackBar(
+    DivineSnackbarContainer.snackBar(
+      context.l10n.profileSetupImageSelectionFailed,
+      error: true,
+      duration: const Duration(seconds: 5),
+      actionLabel: context.l10n.profileSetupGotItButton,
+      onActionPressed: () {},
+    ),
+  );
+}
+
+void _logEmptySelection() {
+  Log.warning(
+    'Picked image is missing or empty; not opening the crop editor',
+    name: 'ProfileSetupScreen',
+    category: LogCategory.ui,
+  );
 }
 
 Future<XFile?> _pickXFileFromDesktop(BuildContext context) async {

--- a/mobile/test/helpers/image_picker_stub.dart
+++ b/mobile/test/helpers/image_picker_stub.dart
@@ -1,0 +1,27 @@
+// ABOUTME: Points the shared image_picker channel at a real file on disk.
+// ABOUTME: The canonical handler answers with a path that was never written,
+// ABOUTME: which flows validating the pick reject before any crop/upload runs.
+
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+import 'shared_channel_override.dart';
+
+const MethodChannel imagePickerChannel = MethodChannel(
+  'plugins.flutter.io/image_picker',
+);
+
+/// Writes [bytes] to `picked.jpg` inside [directory] and makes the mocked
+/// picker answer `pickImage` with its path.
+///
+/// Pass an empty list to reproduce the zero-byte pick iOS occasionally hands
+/// back, or `deleteSync()` the returned file to reproduce a pick whose file is
+/// already gone. The override auto-restores the canonical handler on teardown.
+File stubPickedImageFile(Directory directory, List<int> bytes) {
+  final file = File('${directory.path}/picked.jpg')..writeAsBytesSync(bytes);
+  overrideSharedChannel(imagePickerChannel, (call) async {
+    return call.method == 'pickImage' ? file.path : null;
+  });
+  return file;
+}

--- a/mobile/test/screens/profile_setup/profile_avatar_section_test.dart
+++ b/mobile/test/screens/profile_setup/profile_avatar_section_test.dart
@@ -8,7 +8,6 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -20,12 +19,8 @@ import 'package:openvine/screens/image_crop_editor/image_crop_editor.dart';
 import 'package:openvine/screens/profile_setup/widgets/profile_avatar_section.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 
-import '../../helpers/shared_channel_override.dart';
+import '../../helpers/image_picker_stub.dart';
 import '../../helpers/test_provider_overrides.dart';
-
-const MethodChannel _imagePickerChannel = MethodChannel(
-  'plugins.flutter.io/image_picker',
-);
 
 class _MockProfileEditorBloc
     extends MockBloc<ProfileEditorEvent, ProfileEditorState>
@@ -223,19 +218,8 @@ void main() {
         if (tempDir.existsSync()) await tempDir.delete(recursive: true);
       });
 
-      /// Points the mocked picker at a file holding [bytes], and returns it.
-      ///
-      /// The canonical handler answers with a path that was never written, so
-      /// a test that needs a pick to survive validation has to write real
-      /// bytes for it.
-      File stubPickedFile(List<int> bytes) {
-        final file = File('${tempDir.path}/picked.jpg')
-          ..writeAsBytesSync(bytes);
-        overrideSharedChannel(_imagePickerChannel, (call) async {
-          return call.method == 'pickImage' ? file.path : null;
-        });
-        return file;
-      }
+      File stubPickedFile(List<int> bytes) =>
+          stubPickedImageFile(tempDir, bytes);
 
       // Gallery picks route through file_selector on desktop and image_picker
       // on mobile; force a mobile platform so the mocked image_picker channel

--- a/mobile/test/screens/profile_setup/profile_avatar_section_test.dart
+++ b/mobile/test/screens/profile_setup/profile_avatar_section_test.dart
@@ -8,6 +8,7 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -19,7 +20,12 @@ import 'package:openvine/screens/image_crop_editor/image_crop_editor.dart';
 import 'package:openvine/screens/profile_setup/widgets/profile_avatar_section.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 
+import '../../helpers/shared_channel_override.dart';
 import '../../helpers/test_provider_overrides.dart';
+
+const MethodChannel _imagePickerChannel = MethodChannel(
+  'plugins.flutter.io/image_picker',
+);
 
 class _MockProfileEditorBloc
     extends MockBloc<ProfileEditorEvent, ProfileEditorState>
@@ -207,6 +213,30 @@ void main() {
     });
 
     group('pick → crop → dispatch', () {
+      late Directory tempDir;
+
+      setUp(() async {
+        tempDir = await Directory.systemTemp.createTemp('avatar_section_test');
+      });
+
+      tearDown(() async {
+        if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+      });
+
+      /// Points the mocked picker at a file holding [bytes], and returns it.
+      ///
+      /// The canonical handler answers with a path that was never written, so
+      /// a test that needs a pick to survive validation has to write real
+      /// bytes for it.
+      File stubPickedFile(List<int> bytes) {
+        final file = File('${tempDir.path}/picked.jpg')
+          ..writeAsBytesSync(bytes);
+        overrideSharedChannel(_imagePickerChannel, (call) async {
+          return call.method == 'pickImage' ? file.path : null;
+        });
+        return file;
+      }
+
       // Gallery picks route through file_selector on desktop and image_picker
       // on mobile; force a mobile platform so the mocked image_picker channel
       // is exercised. The sources moved behind the pencil, so each pick is now
@@ -225,6 +255,7 @@ void main() {
         (tester) async {
           debugDefaultTargetPlatformOverride = TargetPlatform.android;
           try {
+            stubPickedFile([9, 9, 9]);
             final croppedBytes = Uint8List.fromList([1, 2, 3, 4]);
             final launcher = _FakeCropLauncher(croppedBytes);
             await pump(tester, cropLauncher: launcher.launch);
@@ -254,6 +285,7 @@ void main() {
       ) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.android;
         try {
+          stubPickedFile([9, 9, 9]);
           final launcher = _FakeCropLauncher(null);
           await pump(tester, cropLauncher: launcher.launch);
 
@@ -261,6 +293,50 @@ void main() {
 
           expect(launcher.callCount, 1);
           verifyNever(() => bloc.add(any()));
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      });
+
+      testWidgets('rejects a zero-byte pick before opening the crop editor', (
+        tester,
+      ) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        try {
+          // iOS occasionally hands back an empty temporary JPEG; decoding it
+          // inside the crop editor is what crashed (#6276).
+          stubPickedFile([]);
+          final launcher = _FakeCropLauncher(Uint8List.fromList([1, 2, 3]));
+          await pump(tester, cropLauncher: launcher.launch);
+
+          await pickFromGallery(tester);
+
+          expect(launcher.callCount, 0);
+          verifyNever(() => bloc.add(any()));
+          expect(
+            find.text(l10n.profileSetupImageSelectionFailed),
+            findsOneWidget,
+          );
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      });
+
+      testWidgets('rejects a pick whose file is gone', (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        try {
+          stubPickedFile([9, 9, 9]).deleteSync();
+          final launcher = _FakeCropLauncher(Uint8List.fromList([1, 2, 3]));
+          await pump(tester, cropLauncher: launcher.launch);
+
+          await pickFromGallery(tester);
+
+          expect(launcher.callCount, 0);
+          verifyNever(() => bloc.add(any()));
+          expect(
+            find.text(l10n.profileSetupImageSelectionFailed),
+            findsOneWidget,
+          );
         } finally {
           debugDefaultTargetPlatformOverride = null;
         }

--- a/mobile/test/screens/profile_setup/profile_header_preview_test.dart
+++ b/mobile/test/screens/profile_setup/profile_header_preview_test.dart
@@ -6,8 +6,8 @@ import 'dart:io';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -18,12 +18,8 @@ import 'package:openvine/providers/image_crop_launcher_provider.dart';
 import 'package:openvine/screens/image_crop_editor/image_crop_editor.dart';
 import 'package:openvine/screens/profile_setup/widgets/profile_header_preview.dart';
 
-import '../../helpers/shared_channel_override.dart';
+import '../../helpers/image_picker_stub.dart';
 import '../../helpers/test_provider_overrides.dart';
-
-const MethodChannel _imagePickerChannel = MethodChannel(
-  'plugins.flutter.io/image_picker',
-);
 
 class _MockProfileEditorBloc
     extends MockBloc<ProfileEditorEvent, ProfileEditorState>
@@ -76,18 +72,7 @@ void main() {
       if (tempDir.existsSync()) await tempDir.delete(recursive: true);
     });
 
-    /// Points the mocked picker at a file holding [bytes], and returns it.
-    ///
-    /// The canonical handler answers with a path that was never written, so a
-    /// test that needs a pick to survive validation has to write real bytes
-    /// for it.
-    File stubPickedFile(List<int> bytes) {
-      final file = File('${tempDir.path}/picked.jpg')..writeAsBytesSync(bytes);
-      overrideSharedChannel(_imagePickerChannel, (call) async {
-        return call.method == 'pickImage' ? file.path : null;
-      });
-      return file;
-    }
+    File stubPickedFile(List<int> bytes) => stubPickedImageFile(tempDir, bytes);
 
     Future<void> pump(WidgetTester tester, ImageCropLauncher cropLauncher) {
       return tester.pumpWidget(

--- a/mobile/test/screens/profile_setup/profile_header_preview_test.dart
+++ b/mobile/test/screens/profile_setup/profile_header_preview_test.dart
@@ -1,0 +1,170 @@
+// ABOUTME: Widget tests for the banner half of ProfileHeaderPreview.
+// ABOUTME: Covers the pick → crop → dispatch path via the
+// ABOUTME: imageCropLauncherProvider seam, including rejected empty picks.
+
+import 'dart:io';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/profile_editor/profile_editor_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/image_crop_launcher_provider.dart';
+import 'package:openvine/screens/image_crop_editor/image_crop_editor.dart';
+import 'package:openvine/screens/profile_setup/widgets/profile_header_preview.dart';
+
+import '../../helpers/shared_channel_override.dart';
+import '../../helpers/test_provider_overrides.dart';
+
+const MethodChannel _imagePickerChannel = MethodChannel(
+  'plugins.flutter.io/image_picker',
+);
+
+class _MockProfileEditorBloc
+    extends MockBloc<ProfileEditorEvent, ProfileEditorState>
+    implements ProfileEditorBloc {}
+
+/// Fake crop launcher that records its invocation and returns a canned result
+/// without pumping the real editor (which needs a decodable image).
+class _FakeCropLauncher {
+  _FakeCropLauncher(this.result);
+
+  final Uint8List? result;
+  int callCount = 0;
+  ImageCropKind? lastKind;
+
+  Future<Uint8List?> launch(
+    BuildContext context, {
+    required ImageCropKind kind,
+    File? file,
+    Uint8List? bytes,
+  }) async {
+    callCount++;
+    lastKind = kind;
+    return result;
+  }
+}
+
+void main() {
+  final l10n = lookupAppLocalizations(const Locale('en'));
+
+  group(ProfileHeaderPreview, () {
+    const testPubkeyHex =
+        'a1b2c3d4e5f6789012345678901234567890abcdef1234567890123456789012';
+
+    late MockAuthService mockAuthService;
+    late _MockProfileEditorBloc bloc;
+    late TextEditingController nameController;
+    late Directory tempDir;
+
+    setUp(() async {
+      mockAuthService = createMockAuthService();
+      when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPubkeyHex);
+      bloc = _MockProfileEditorBloc();
+      when(() => bloc.state).thenReturn(const ProfileEditorState());
+      nameController = TextEditingController();
+      tempDir = await Directory.systemTemp.createTemp('header_preview_test');
+    });
+
+    tearDown(() async {
+      nameController.dispose();
+      if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+    });
+
+    /// Points the mocked picker at a file holding [bytes], and returns it.
+    ///
+    /// The canonical handler answers with a path that was never written, so a
+    /// test that needs a pick to survive validation has to write real bytes
+    /// for it.
+    File stubPickedFile(List<int> bytes) {
+      final file = File('${tempDir.path}/picked.jpg')..writeAsBytesSync(bytes);
+      overrideSharedChannel(_imagePickerChannel, (call) async {
+        return call.method == 'pickImage' ? file.path : null;
+      });
+      return file;
+    }
+
+    Future<void> pump(WidgetTester tester, ImageCropLauncher cropLauncher) {
+      return tester.pumpWidget(
+        testProviderScope(
+          additionalOverrides: [
+            authServiceProvider.overrideWithValue(mockAuthService),
+            imageCropLauncherProvider.overrideWithValue(cropLauncher),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            theme: VineTheme.theme,
+            home: Scaffold(
+              body: BlocProvider<ProfileEditorBloc>.value(
+                value: bloc,
+                child: ProfileHeaderPreview(nameController: nameController),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    /// Opens the banner sheet from its own pencil — the avatar has one too —
+    /// and picks the gallery row.
+    Future<void> pickBannerFromGallery(WidgetTester tester) async {
+      await tester.tap(find.byTooltip(l10n.profileSetupEditBannerLabel));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(l10n.profileSetupImageUploadFromCameraRoll));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('dispatches $ProfileBannerUploadRequested with the cropped '
+        'bytes', (tester) async {
+      stubPickedFile([9, 9, 9]);
+      final croppedBytes = Uint8List.fromList([1, 2, 3, 4]);
+      final launcher = _FakeCropLauncher(croppedBytes);
+      await pump(tester, launcher.launch);
+
+      await pickBannerFromGallery(tester);
+
+      expect(launcher.callCount, 1);
+      expect(launcher.lastKind, ImageCropKind.banner);
+
+      final captured = verify(() => bloc.add(captureAny())).captured;
+      final uploads = captured.whereType<ProfileBannerUploadRequested>();
+      expect(uploads, hasLength(1));
+      expect(uploads.single.pubkey, testPubkeyHex);
+      expect(uploads.single.bytes, equals(croppedBytes));
+    });
+
+    testWidgets('rejects a zero-byte pick before opening the crop editor', (
+      tester,
+    ) async {
+      // iOS occasionally hands back an empty temporary JPEG; decoding it
+      // inside the crop editor is what crashed (#6276).
+      stubPickedFile([]);
+      final launcher = _FakeCropLauncher(Uint8List.fromList([1, 2, 3]));
+      await pump(tester, launcher.launch);
+
+      await pickBannerFromGallery(tester);
+
+      expect(launcher.callCount, 0);
+      verifyNever(() => bloc.add(any()));
+      expect(find.text(l10n.profileSetupImageSelectionFailed), findsOneWidget);
+    });
+
+    testWidgets('rejects a pick whose file is gone', (tester) async {
+      stubPickedFile([9, 9, 9]).deleteSync();
+      final launcher = _FakeCropLauncher(Uint8List.fromList([1, 2, 3]));
+      await pump(tester, launcher.launch);
+
+      await pickBannerFromGallery(tester);
+
+      expect(launcher.callCount, 0);
+      verifyNever(() => bloc.add(any()));
+      expect(find.text(l10n.profileSetupImageSelectionFailed), findsOneWidget);
+    });
+  });
+}

--- a/mobile/test/screens/profile_setup/profile_image_picker_test.dart
+++ b/mobile/test/screens/profile_setup/profile_image_picker_test.dart
@@ -1,7 +1,11 @@
-// ABOUTME: Unit tests for the profile image-picker platform routing helper.
+// ABOUTME: Unit tests for the profile image-picker platform routing helper and
+// ABOUTME: the pre-crop validation that rejects missing/empty picker output.
+
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:openvine/screens/profile_setup/widgets/profile_image_picker.dart';
 
 void main() {
@@ -24,6 +28,48 @@ void main() {
         debugDefaultTargetPlatformOverride = platform;
         expect(isDesktopImagePickerPlatform(), isTrue, reason: '$platform');
       }
+    });
+  });
+
+  group('resolveProfileImageSelection', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('profile_image_picker');
+    });
+
+    tearDown(() async {
+      if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+    });
+
+    test('resolves an existing non-empty file', () async {
+      final file = File('${tempDir.path}/picked.jpg')
+        ..writeAsBytesSync([1, 2, 3, 4]);
+
+      final selection = await resolveProfileImageSelection(XFile(file.path));
+
+      expect(selection, isNotNull);
+      expect(selection!.file?.path, file.path);
+      expect(selection.bytes, isNull);
+    });
+
+    test('rejects a file the picker never wrote', () async {
+      // Stat throws for a missing path; the caller must still get a
+      // recoverable null rather than an uncaught exception.
+      final selection = await resolveProfileImageSelection(
+        XFile('${tempDir.path}/gone.jpg'),
+      );
+
+      expect(selection, isNull);
+    });
+
+    test('rejects a zero-byte file', () async {
+      // The iOS crash: image_picker hands back a temporary JPEG with no bytes.
+      final file = File('${tempDir.path}/empty.jpg')..writeAsBytesSync([]);
+
+      final selection = await resolveProfileImageSelection(XFile(file.path));
+
+      expect(selection, isNull);
     });
   });
 }

--- a/mobile/test/screens/profile_setup/profile_image_picker_test.dart
+++ b/mobile/test/screens/profile_setup/profile_image_picker_test.dart
@@ -71,5 +71,19 @@ void main() {
 
       expect(selection, isNull);
     });
+
+    test('maps an I/O failure to null rather than throwing', () async {
+      // Traversing through a regular file fails with ENOTDIR on every POSIX
+      // platform — a FileSystemException that is *not* PathNotFoundException,
+      // so it exercises the catch-all rather than the missing-file branch.
+      final file = File('${tempDir.path}/not_a_dir.jpg')
+        ..writeAsBytesSync([1, 2, 3]);
+
+      final selection = await resolveProfileImageSelection(
+        XFile('${file.path}/picked.jpg'),
+      );
+
+      expect(selection, isNull);
+    });
   });
 }

--- a/mobile/test/test_setup.dart
+++ b/mobile/test/test_setup.dart
@@ -232,8 +232,10 @@ void _setupPlatformChannelMocks() {
 void _setupImagePickerMock() {
   // image_picker plugin: return a synthetic file path so widget tests that
   // exercise the picker entry point can proceed without a real platform
-  // implementation. The path does not need to point at a real file because
-  // upload-service mocks intercept the bytes before any I/O happens.
+  // implementation. The path is never written, so a flow that stats or reads
+  // the pick (e.g. the profile image-selection boundary) sees it as invalid.
+  // Tests needing a pick to survive that check must point the channel at a
+  // real file — see `stubPickedImageFile` in helpers/image_picker_stub.dart.
   _installShared(
     const MethodChannel(_imagePickerChannelName),
     _imagePickerHandler,


### PR DESCRIPTION
## Description

The avatar and banner flows passed the image-picker result straight to the crop editor, which decodes its source through `FileImage` / `MemoryImage`. When iOS returned a zero-byte temporary JPEG, that decode threw two paired fatal errors before the user could crop anything. The existing `croppedBytesOrNull` check only validates crop *output*, so it can never prevent a bad *source* from being decoded.

Both Crashlytics signatures are grouped here because they fire in the same session at the same timestamp from one missing source-validation boundary:

- [Invalid image bytes — `instantiateImageCodecWithSize` / invalid image data](https://console.firebase.google.com/v1/appid/project/openvine-co/crashlytics/app/1:972941478875:ios:f61272b3cf485df244b5fe/issues/4800cfba8e6f2b43a75afa8de5e20ed1) (`4800cfba8e6f2b43a75afa8de5e20ed1`)
- [Empty image-picker file — `FileImage._loadAsync` / file is empty](https://console.firebase.google.com/v1/appid/project/openvine-co/crashlytics/app/1:972941478875:ios:f61272b3cf485df244b5fe/issues/8421aca7ecc9b84b6f8a830aecc50e1f) (`8421aca7ecc9b84b6f8a830aecc50e1f`)

**Related Issue:** Closes #6276

### What changed

`resolveProfileImageSelection(XFile)` in `profile_image_picker.dart` is the new shared boundary. It validates the pick and resolves it into a `ProfileImageSelection` — a file on native, eagerly-read bytes on web — or `null` when the picker handed back nothing usable. Both entry points (`ProfileAvatarSection._pickImage` and `_BannerEditButton._pickBannerImage`) now go through it and show the existing localized snackbar on `null`, so neither surface opens the crop editor or dispatches an upload event for an unusable pick.

Design notes for the non-obvious bits:

- **Resolver returns the source, not just a bool.** Both call sites had their own `kIsWeb` branch (read blob bytes vs. wrap a `File`); folding that into the validator removes the duplication and guarantees a surface cannot be validated but then constructed differently. On web the bytes are read once and reused, exactly as before.
- **`lengthSync()` rather than `await file.length()`.** It is one stat syscall on a local temp file right after the user returned from a heavyweight picker, and `avoid_slow_async_io` prefers the sync form. It also keeps the check off the event loop, which matters for widget tests: real async file I/O does not complete inside `pumpAndSettle`'s fake-async zone.
- **A missing file rides the same `PathNotFoundException` path as an empty one.** `lengthSync()` throws for a path that is already gone, and both cases mean the same thing to the user, so they share one rejection and one warning-level log.
- **No new Crashlytics noise.** An empty pick is expected platform input, so it is logged at warning level and never wrapped in `Reportable`. The log message deliberately omits the path — it names a user's temporary file.
- **No ARB change.** `profileSetupImageSelectionFailed` ("Image selection failed. Please paste an image URL below instead.") already exists in all 17 locales and describes this failure accurately, so no copy was touched and no translation debt was added.

The banner path previously failed silently on a bad pick; it now gets the same snackbar as the avatar, from a shared `showProfileImageSelectionFailed(context)` helper.

## Out of Scope

- Defense-in-depth validation inside `ImageCropEditorScreen` itself. The boundary fix removes the reachable path; adding a second check there would duplicate the rule without a caller that can trigger it.
- The banner path still returns silently when `ImagePicker` itself throws (e.g. a denied permission). That is pre-existing behaviour and a different failure class from an empty result.

## Verification

- `flutter test test/screens` — 1726 passed, 62 skipped (skips pre-existing)
- `flutter test test/screens/profile_setup` — 63 passed, including the new cases
- `flutter analyze lib test integration_test` — clean
- `dart format` — no changes
- All four design-system ceiling ratchets, `check_test_unit_structure.sh`, `check_untested_services_floor.sh` — pass
- Manually verified on a real Samsung Galaxy device: avatar and banner picks from camera and gallery still crop and upload as before

New regression coverage:

- `profile_image_picker_test.dart` — non-empty file resolves; a never-written file resolves to `null` instead of throwing; a zero-byte file resolves to `null`
- `profile_avatar_section_test.dart` and the new `profile_header_preview_test.dart` — zero-byte and deleted picks launch no crop editor, dispatch no upload event, and surface the localized snackbar; a valid pick still crops and dispatches

The canonical test image-picker channel answers with a path that was never written, so the happy-path tests now stub it to a real temp file via the sanctioned `overrideSharedChannel` helper.

The web rule (empty blob bytes rejected) is implemented but not covered by the VM test run, since `kIsWeb` is a compile-time `false` there. I did not add an `isWeb` seam just to reach it.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
