### PR TITLE
fix(sounds): unblock legacy sound reuse and stop the blocked-tap toast queue

### DIFF
--- a/mobile/lib/providers/sounds_providers.dart
+++ b/mobile/lib/providers/sounds_providers.dart
@@ -161,7 +161,6 @@ Future<bool> audioReuseTerms(Ref ref, AudioEvent sound) {
   final knownTerms = audioReuseTermsFromEvent(sound);
   if (knownTerms != null) return Future.value(knownTerms);
   return AudioReuseConsentResolver(
-    soundsRepository: ref.watch(soundsRepositoryProvider),
     videosRepository: ref.watch(videosRepositoryProvider),
   ).verify(sound);
 }
@@ -184,7 +183,6 @@ Future<bool> audioReuseConsent(Ref ref, AudioEvent sound) {
   }
   if (knownTerms == false) return Future.value(false);
   return AudioReuseConsentResolver(
-    soundsRepository: ref.watch(soundsRepositoryProvider),
     videosRepository: ref.watch(videosRepositoryProvider),
   ).verify(sound);
 }

--- a/mobile/lib/providers/sounds_providers.g.dart
+++ b/mobile/lib/providers/sounds_providers.g.dart
@@ -651,7 +651,7 @@ final class AudioReuseTermsProvider
   }
 }
 
-String _$audioReuseTermsHash() => r'f8dde7271c3f3bf5f45dba9a5decbafd5785a33d';
+String _$audioReuseTermsHash() => r'29a3be9aebb039c124e6afc99f33c2492a55bc6a';
 
 /// Viewer-independent reuse terms for explicit and legacy audio events.
 
@@ -741,7 +741,7 @@ final class AudioReuseConsentProvider
   }
 }
 
-String _$audioReuseConsentHash() => r'71e983b97064d07c92e7fd97de594d14f4a4fb9b';
+String _$audioReuseConsentHash() => r'd1e80a3056b98eaab653f8708aeac735cd21d4e8';
 
 /// Fail-closed reuse consent for explicit and legacy audio events.
 ///

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -47,7 +47,6 @@ import 'package:openvine/services/video_sharing_service.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:reposts_repository/reposts_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:sounds_repository/sounds_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:videos_repository/videos_repository.dart';
 
@@ -239,12 +238,9 @@ VideoEventPublisher videoEventPublisher(Ref ref) {
   final profileRepository = ref.watch(profileRepositoryProvider);
   final profileStatsDao = ref.watch(databaseProvider).profileStatsDao;
   final savedSoundsService = ref.watch(savedSoundsServiceProvider);
-  final consentSoundsRepository = SoundsRepository(nostrClient: nostrService);
   final consentResolver = AudioReuseConsentResolver(
-    soundsRepository: consentSoundsRepository,
     videosRepository: ref.watch(videosRepositoryProvider),
   );
-  ref.onDispose(() => unawaited(consentSoundsRepository.dispose()));
 
   // REST-first publish: POST the signed event to {eventPublishBaseUrl}/api/events with
   // NIP-98 auth, falling back to the WebSocket relay pool on transient

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -322,7 +322,7 @@ final class VideoEventPublisherProvider
 }
 
 String _$videoEventPublisherHash() =>
-    r'4d47f884ee710aa88188341a4dfdfd499a14b005';
+    r'47ea7b9e40b7cd95eff972cdb2995d58279e372f';
 
 /// View event publisher for kind 22236 ephemeral analytics events
 ///

--- a/mobile/lib/services/audio_reuse_consent_resolver.dart
+++ b/mobile/lib/services/audio_reuse_consent_resolver.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Fails closed unless the sound's source video grants reuse.
 
 import 'package:models/models.dart';
+import 'package:unified_logger/unified_logger.dart';
 import 'package:videos_repository/videos_repository.dart';
 
 class AudioReuseConsentResolver {
@@ -34,11 +35,21 @@ class AudioReuseConsentResolver {
       // `allow_audio_reuse` is rebuilt on every edit — dropping the tag is how
       // a creator revokes consent — and an addressable read resolves to the
       // current revision, so this is the live answer. A revision predating the
-      // sound cannot speak for it.
+      // sound cannot speak for it. This does not lock out the legacy population:
+      // `VideoEventPublisher` publishes the Kind 1063 before the video event
+      // because the video needs the audio id for its `e` tag, so an unedited
+      // source is never older than its own sound.
       final source = matching.first;
       if (source.createdAt < sound.createdAt) return false;
       return source.allowAudioReuse;
-    } catch (_) {
+    } catch (error) {
+      // Fail closed, but leave a trace — otherwise "why is reuse blocked?" is
+      // unanswerable from a bug report.
+      Log.warning(
+        'Reuse consent lookup failed for source $sourceAddress: $error',
+        name: 'AudioReuseConsentResolver',
+        category: LogCategory.video,
+      );
       return false;
     }
   }

--- a/mobile/lib/services/audio_reuse_consent_resolver.dart
+++ b/mobile/lib/services/audio_reuse_consent_resolver.dart
@@ -1,29 +1,15 @@
 // ABOUTME: Verifies reuse consent for legacy audio events without consent tags.
-// ABOUTME: Answers false unless one unambiguous source-video event grants reuse.
+// ABOUTME: Fails closed unless the sound's source video grants reuse.
 
 import 'package:models/models.dart';
-import 'package:sounds_repository/sounds_repository.dart';
 import 'package:videos_repository/videos_repository.dart';
 
 class AudioReuseConsentResolver {
-  const AudioReuseConsentResolver({
-    required SoundsRepository soundsRepository,
-    required VideosRepository videosRepository,
-  }) : _soundsRepository = soundsRepository,
-       _videosRepository = videosRepository;
+  const AudioReuseConsentResolver({required VideosRepository videosRepository})
+    : _videosRepository = videosRepository;
 
-  final SoundsRepository _soundsRepository;
   final VideosRepository _videosRepository;
 
-  /// Whether [sound] may be reused, judged from its source video's current
-  /// `allow_audio_reuse` tag.
-  ///
-  /// Fails closed: `false` covers a confirmed revocation, missing or ambiguous
-  /// evidence, *and* a lookup that never completed. Those are not the same
-  /// fact, and this answer cannot tell them apart — an unreachable relay, a
-  /// source video outside the query window, and one the viewer's own filters
-  /// dropped all arrive as an empty list. Callers must therefore treat `false`
-  /// as "not verified", never as "the creator said no".
   Future<bool> verify(AudioEvent sound) async {
     if (sound.allowsReuse) return true;
     if (sound.hasExplicitReuseConsent) return false;
@@ -31,39 +17,27 @@ class AudioReuseConsentResolver {
     final sourceAddress = sound.sourceVideoReference;
     if (sourceAddress == null || sourceAddress.isEmpty) return false;
 
-    // Query the id reusing videos tag, not [AudioEvent.id]: an editor timeline
-    // track carries a `-<timestamp>` uniqueness suffix and an original sound a
-    // `video_` prefix, so the raw id matches no `["e", …, "audio"]` tag. Under
-    // that id every legacy sound failed closed the moment it reached the
-    // timeline — including ones the picker had already verified.
-    final audioEventId = sound.attributionEventId;
-    if (audioEventId == null) return false;
-
     try {
-      final ids = await _soundsRepository.fetchVideosUsingSound(audioEventId);
-      if (ids.isEmpty) return false;
-      final candidates = await _videosRepository.getVideosByIds(
-        ids,
-        hydrateBulkStats: false,
-      );
-      // `addressableId` is stable across edits, so several revisions of the
-      // same video can match. `allow_audio_reuse` is rebuilt on every edit —
-      // dropping the tag is how a creator revokes consent — so the newest
-      // revision is the current answer.
-      final matching =
-          candidates
-              .where((video) => video.addressableId == sourceAddress)
-              .where((video) => video.createdAt >= sound.createdAt)
-              .toList()
-            ..sort((left, right) => right.createdAt.compareTo(left.createdAt));
+      // Read the source video straight off the address the sound already
+      // carries. Resolving it the other way round — asking which videos
+      // reference this sound — only works once a video carries the
+      // `['e', <audioEventId>, <relay>, 'audio']` tag, which legacy videos
+      // predate. That is the same population this resolver exists to rescue,
+      // so the reverse lookup returned nothing for every one of them (#6769).
+      final candidates = await _videosRepository.getVideosByAddressableIds([
+        sourceAddress,
+      ]);
+      final matching = candidates
+          .where((video) => video.addressableId == sourceAddress)
+          .toList();
       if (matching.isEmpty) return false;
-      // Two revisions stamped the same second leave no way to tell which one
-      // is current, so fail closed rather than guess at the consent state.
-      if (matching.length > 1 &&
-          matching[0].createdAt == matching[1].createdAt) {
-        return false;
-      }
-      return matching.first.allowAudioReuse;
+      // `allow_audio_reuse` is rebuilt on every edit — dropping the tag is how
+      // a creator revokes consent — and an addressable read resolves to the
+      // current revision, so this is the live answer. A revision predating the
+      // sound cannot speak for it.
+      final source = matching.first;
+      if (source.createdAt < sound.createdAt) return false;
+      return source.allowAudioReuse;
     } catch (_) {
       return false;
     }

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
@@ -256,12 +256,17 @@ class _AudioSelectionBottomSheetState
         name: 'AudioSelectionBottomSheet',
         category: LogCategory.ui,
       );
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(context.l10n.soundReuseUnavailable),
-          duration: const Duration(seconds: 2),
-        ),
-      );
+      // Replace rather than enqueue: the messenger outlives this sheet, so a
+      // burst of blocked taps would otherwise leave a backlog of identical
+      // toasts trailing the user into the editor (#6769).
+      ScaffoldMessenger.of(context)
+        ..removeCurrentSnackBar()
+        ..showSnackBar(
+          SnackBar(
+            content: Text(context.l10n.soundReuseUnavailable),
+            duration: const Duration(seconds: 2),
+          ),
+        );
       return;
     }
 

--- a/mobile/test/services/audio_reuse_consent_resolver_test.dart
+++ b/mobile/test/services/audio_reuse_consent_resolver_test.dart
@@ -1,32 +1,26 @@
 // ABOUTME: Tests fail-closed consent verification for legacy Kind 1063 audio.
-// ABOUTME: Ensures only unambiguous matching source-video evidence permits reuse.
+// ABOUTME: Ensures only the sound's own source video can grant reuse.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/services/audio_reuse_consent_resolver.dart';
-import 'package:sounds_repository/sounds_repository.dart';
 import 'package:videos_repository/videos_repository.dart';
-
-class _MockSoundsRepository extends Mock implements SoundsRepository {}
 
 class _MockVideosRepository extends Mock implements VideosRepository {}
 
 const _pubkey =
     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
-/// A real Kind 1063 id: the lookup only matches a 32-byte-hex event id.
-const _audioEventId =
-    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const _sourceAddress = '34236:$_pubkey:source-video';
 
 AudioEvent _sound({
   bool allowsReuse = false,
   bool hasExplicitReuseConsent = false,
-  String? sourceVideoReference = '34236:$_pubkey:source-video',
-  String id = _audioEventId,
+  String? sourceVideoReference = _sourceAddress,
 }) {
   return AudioEvent(
-    id: id,
+    id: 'audio-event',
     pubkey: _pubkey,
     createdAt: 100,
     sourceVideoReference: sourceVideoReference,
@@ -59,29 +53,23 @@ VideoEvent _video({
 }
 
 void main() {
-  late _MockSoundsRepository soundsRepository;
   late _MockVideosRepository videosRepository;
   late AudioReuseConsentResolver resolver;
 
   setUp(() {
-    soundsRepository = _MockSoundsRepository();
     videosRepository = _MockVideosRepository();
-    resolver = AudioReuseConsentResolver(
-      soundsRepository: soundsRepository,
-      videosRepository: videosRepository,
-    );
+    resolver = AudioReuseConsentResolver(videosRepository: videosRepository);
   });
 
-  /// Stubs the sound lookup with [ids].
-  void stubLookup(List<String> ids) {
+  void stubSource(List<VideoEvent> videos) {
     when(
-      () => soundsRepository.fetchVideosUsingSound(_audioEventId),
-    ).thenAnswer((_) async => ids);
+      () => videosRepository.getVideosByAddressableIds([_sourceAddress]),
+    ).thenAnswer((_) async => videos);
   }
 
   test('accepts explicit true without a legacy lookup', () async {
     expect(await resolver.verify(_sound(allowsReuse: true)), isTrue);
-    verifyNever(() => soundsRepository.fetchVideosUsingSound(any()));
+    verifyNever(() => videosRepository.getVideosByAddressableIds(any()));
   });
 
   test('honors explicit false without a legacy lookup', () async {
@@ -89,130 +77,53 @@ void main() {
       await resolver.verify(_sound(hasExplicitReuseConsent: true)),
       isFalse,
     );
-    verifyNever(() => soundsRepository.fetchVideosUsingSound(any()));
+    verifyNever(() => videosRepository.getVideosByAddressableIds(any()));
   });
 
-  test('uses newest matching source video for a legacy event', () async {
-    stubLookup(['later', 'earliest', 'wrong']);
-    when(
-      () => videosRepository.getVideosByIds([
-        'later',
-        'earliest',
-        'wrong',
-      ], hydrateBulkStats: false),
-    ).thenAnswer(
-      (_) async => [
-        _video(id: 'later', createdAt: 120),
-        _video(id: 'earliest', createdAt: 110, allowsReuse: false),
-        _video(id: 'wrong', vineId: 'other-video', createdAt: 105),
-      ],
-    );
+  test('grants reuse from the source video the sound points at', () async {
+    // Regression (#6769): the old reverse lookup asked which videos carry an
+    // `['e', <audioEventId>, …, 'audio']` tag back to the sound. Legacy videos
+    // predate that tag, so it returned nothing for exactly the sounds this
+    // resolver exists to rescue and every one of them failed closed.
+    stubSource([_video()]);
 
     expect(await resolver.verify(_sound()), isTrue);
   });
 
-  test('honours a revocation on the newest revision', () async {
-    stubLookup(['revoked', 'original']);
-    when(
-      () => videosRepository.getVideosByIds([
-        'revoked',
-        'original',
-      ], hydrateBulkStats: false),
-    ).thenAnswer(
-      (_) async => [
-        _video(id: 'revoked', createdAt: 120, allowsReuse: false),
-        _video(id: 'original', createdAt: 110),
-      ],
-    );
+  test('honours a revocation on the current revision', () async {
+    stubSource([_video(createdAt: 120, allowsReuse: false)]);
 
     expect(await resolver.verify(_sound()), isFalse);
   });
 
-  test('fails closed on ambiguous newest source events', () async {
-    stubLookup(['first', 'second']);
-    when(
-      () => videosRepository.getVideosByIds([
-        'first',
-        'second',
-      ], hydrateBulkStats: false),
-    ).thenAnswer(
-      (_) async => [
-        _video(id: 'first', createdAt: 110),
-        _video(id: 'second', createdAt: 110),
-      ],
-    );
+  test('ignores a video at a different address', () async {
+    stubSource([_video(vineId: 'other-video')]);
 
     expect(await resolver.verify(_sound()), isFalse);
   });
 
-  test('answers false on missing, mismatched, or old evidence', () async {
+  test('fails closed when the source video predates the sound', () async {
+    stubSource([_video(createdAt: 99)]);
+
+    expect(await resolver.verify(_sound()), isFalse);
+  });
+
+  test('fails closed without a source address', () async {
     expect(await resolver.verify(_sound(sourceVideoReference: null)), isFalse);
+    verifyNever(() => videosRepository.getVideosByAddressableIds(any()));
+  });
 
-    stubLookup(['candidate']);
-    when(
-      () => videosRepository.getVideosByIds([
-        'candidate',
-      ], hydrateBulkStats: false),
-    ).thenAnswer((_) async => [_video(vineId: 'other-video', createdAt: 99)]);
+  test('fails closed when the source video is unreachable', () async {
+    stubSource(const []);
+
     expect(await resolver.verify(_sound()), isFalse);
   });
 
-  // Every way the lookup can come back without evidence — an unreachable
-  // relay answering empty, a named video that cannot be fetched, an outright
-  // error — is fail-closed rather than a verdict. `false` here means "not
-  // verified", which is why the publish path does not report it as a refusal.
-  test('answers false when the lookup yields no evidence', () async {
-    stubLookup([]);
-    expect(await resolver.verify(_sound()), isFalse);
-
-    stubLookup(['granting']);
+  test('fails closed when the lookup throws', () async {
     when(
-      () => videosRepository.getVideosByIds([
-        'granting',
-      ], hydrateBulkStats: false),
-    ).thenAnswer((_) async => []);
-    expect(await resolver.verify(_sound()), isFalse);
-
-    when(
-      () => soundsRepository.fetchVideosUsingSound(_audioEventId),
+      () => videosRepository.getVideosByAddressableIds([_sourceAddress]),
     ).thenThrow(StateError('relay unavailable'));
+
     expect(await resolver.verify(_sound()), isFalse);
-  });
-
-  // The editor stamps a `-<timestamp>` uniqueness suffix onto every timeline
-  // track, so the sound the publisher re-verifies is never the one the picker
-  // verified. Querying the raw id found no reusing videos and blocked a
-  // publish the creator had explicitly allowed.
-  test('looks past an editor timeline uniqueness suffix', () async {
-    stubLookup(['granting']);
-    when(
-      () => videosRepository.getVideosByIds([
-        'granting',
-      ], hydrateBulkStats: false),
-    ).thenAnswer((_) async => [_video(id: 'granting', createdAt: 120)]);
-
-    expect(
-      await resolver.verify(_sound(id: '$_audioEventId-1786032375630')),
-      isTrue,
-    );
-    verify(
-      () => soundsRepository.fetchVideosUsingSound(_audioEventId),
-    ).called(1);
-  });
-
-  test('resolves an original sound through its source video id', () async {
-    stubLookup(['granting']);
-    when(
-      () => videosRepository.getVideosByIds([
-        'granting',
-      ], hydrateBulkStats: false),
-    ).thenAnswer((_) async => [_video(id: 'granting', createdAt: 120)]);
-
-    expect(await resolver.verify(_sound(id: 'video_$_audioEventId')), isTrue);
-  });
-
-  test('fails closed when the sound has no referenceable event id', () async {
-    expect(await resolver.verify(_sound(id: 'not-a-nostr-event-id')), isFalse);
-    verifyNever(() => soundsRepository.fetchVideosUsingSound(any()));
   });
 }

--- a/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
+++ b/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
@@ -243,6 +243,43 @@ void main() {
         expect(find.byType(AudioEditorSelectionOverlay), findsNothing);
       });
 
+      testWidgets('collapses repeated reuse-blocked toasts into one', (
+        tester,
+      ) async {
+        // Regression (#6769): each blocked tap used to enqueue its own
+        // snackbar, so a burst of taps left ~20s of backlog that trailed the
+        // user out of the sheet and misattributed itself to whatever sound
+        // they picked next.
+        final explicitForbidden = _createTestAudioEvent(
+          id: 'forbidden-sound',
+          title: 'Credit only',
+        ).copyWith(allowsReuse: false, hasExplicitReuseConsent: true);
+
+        await tester.pumpWidget(
+          buildWidget(
+            trendingSoundsAsync: AsyncValue.data([explicitForbidden]),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(find.text(l10n.videoEditorAudioCategoryCommunity));
+        await tester.pumpAndSettle();
+
+        for (var i = 0; i < 3; i++) {
+          await tester.tap(find.text('Credit only'));
+          await tester.pump();
+        }
+        await tester.pumpAndSettle();
+        expect(find.text(l10n.soundReuseUnavailable), findsOneWidget);
+
+        // One toast's lifetime clears the whole burst rather than the first
+        // of three.
+        await tester.pump(const Duration(seconds: 2));
+        await tester.pumpAndSettle();
+        expect(find.text(l10n.soundReuseUnavailable), findsNothing);
+      });
+
       testWidgets("selects the creator's own legacy sound", (tester) async {
         const ownerPubkey = 'owner-pubkey-hex';
         final audioService = _MockAudioPlaybackService();


### PR DESCRIPTION
## Description

Two independent defects behind one field report, both in the audio picker's reuse gate. Delineated as one commit each.

**`fix(sounds): resolve reuse consent from the source video address`**

`AudioReuseConsentResolver` is the fallback for audio events with no `allow_audio_reuse` tag. It resolved consent backwards: ask which videos reference the sound (`fetchVideosUsingSound` → `Filter(kinds: [34236], e: [audioEventId])`), then filter those candidates for the one whose `addressableId` matches the sound's own `sourceVideoReference`. That only matches videos carrying an `['e', <audioEventId>, <relay>, 'audio']` tag, which legacy videos predate — the exact population the resolver exists to rescue. `ids.isEmpty` short-circuited and every legacy sound failed closed.

The source video's address is already on the sound. This reads it directly via `getVideosByAddressableIds` instead.

Because an addressable read resolves to the current revision, the newest-revision-wins sort and the tie-fails-closed branch no longer have anything to disambiguate — the query settles that ordering — so both come out rather than sitting unreachable. Everything else about the policy is untouched: no source video, an address mismatch, a source revision older than the sound, or a thrown lookup all still deny.

Also drops the now-unused `SoundsRepository` dependency, including the instance `video_providers` constructed solely to feed it (plus its `onDispose`).

**`fix(sounds): replace the reuse-blocked toast instead of queueing it`**

Each blocked tap called `showSnackBar` with no `removeCurrentSnackBar`, so the messenger queued them. Ten taps in three seconds — which is what the reporter did — is ~20s of identical toasts draining one after another. The `ScaffoldMessenger` outlives the picker sheet, so the backlog followed the user into the editor and read as an error about whichever sound they had since selected. That is why the original report blamed a bundled sound that was never blocked.

**Related Issue:** Closes #6769

## Out of Scope

- **Signing service returning HTML.** The same session shows C2PA signing failing three times with `Signature: internal error (service responded with an HTTP error (status = 200, content-type = Some("text/html; charset=utf-8")))`. Server-side, tracked separately.
- **Music picker append-vs-replace** (#6770) and **upload throughput** (#6771) from the same report — filed, not addressed here.
- **Stale-relay revision ordering.** `getVideosByAddressableIds` merges across relays with last-write-wins, so a lagging relay could in principle supply a superseded revision. That is shared by every addressable read in the app (repost tabs, lists), not specific to consent, and is not made worse by this change.

## Verification

- `flutter analyze lib test integration_test` — no issues
- `dart format --set-exit-if-changed` on all changed files — clean
- `flutter test test/services/audio_reuse_consent_resolver_test.dart` — 9/9
- `flutter test test/widgets/video_editor/audio_editor/` — 21/21
- Consumers of the changed providers: `test/providers/sounds_providers_test.dart`, `test/providers/sound_picker_provider_test.dart`, `test/screens/sound_detail_screen_test.dart`, `test/screens/original_sound_detail_screen_test.dart`, `test/widgets/metadata_sounds_section_test.dart` — 158 + 17 passing
- `dart run build_runner build --delete-conflicting-outputs` — regenerated `sounds_providers.g.dart` / `video_providers.g.dart` (provider hashes only), committed

Both fixes were written test-first; each test was confirmed red against the old behaviour before the fix landed. The consent test fails with `Expected: true / Actual: <false>`; the toast test fails with a queued toast still on screen one lifetime later.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
