### PR TITLE
fix(c2pa): validate signing endpoint and stop blaming the user's connection

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -38,6 +38,13 @@ definitions:
     - &check_ios_extension_signing_contract
       name: Check iOS extension signing contract
       script: ./scripts/check_ios_extension_signing_contract.sh
+    - &check_signing_endpoint
+      name: Check C2PA signing endpoint
+      script: |
+        # Every build step below interpolates this variable unconditionally, so
+        # an unset variable ships an empty --dart-define that overrides the
+        # in-app default and breaks signing on every capture. Require it here.
+        REQUIRE_SIGNING_ENDPOINT=1 ./scripts/check_signing_endpoint.sh
     - &clean_ios_workspace_state
       name: Clean stale Xcode/SPM workspace state
       script: |
@@ -482,6 +489,7 @@ workflows:
     triggering:
       events: []
     scripts:
+      - *check_signing_endpoint
       - *check_ios_extension_signing_contract
       - *setup_code_signing_xcode
       - *clean_ios_workspace_state
@@ -536,6 +544,7 @@ workflows:
     triggering:
       events: []
     scripts:
+      - *check_signing_endpoint
       - *clean_ios_workspace_state
       - *enable_spm
       - *flutter_pub_get
@@ -586,6 +595,7 @@ workflows:
     triggering:
       events: []
     scripts:
+      - *check_signing_endpoint
       - *enable_spm
       - *setup_local_properties
       - *configure_gradle_memory
@@ -644,6 +654,7 @@ workflows:
     triggering:
       events: []
     scripts:
+      - *check_signing_endpoint
       - *install_flutterfire
       - *enable_spm
       - *flutter_pub_get
@@ -677,6 +688,7 @@ workflows:
     triggering:
       events: []
     scripts:
+      - *check_signing_endpoint
       - *clean_ios_workspace_state
       - *enable_spm
       - *flutter_pub_get
@@ -712,6 +724,7 @@ workflows:
     triggering:
       events: []
     scripts:
+      - *check_signing_endpoint
       - *flutter_pub_get
       - *setup_local_properties
       - *build_android_e2e

--- a/mobile/build_android.sh
+++ b/mobile/build_android.sh
@@ -4,6 +4,11 @@
 
 set -e
 
+# Fail fast on a malformed C2PA signing endpoint. A bare host silently collapses
+# to the service root at call time and surfaces as an opaque signing error
+# during capture rather than a build failure.
+"$(dirname "${BASH_SOURCE[0]:-$0}")/scripts/check_signing_endpoint.sh"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/mobile/build_ios.sh
+++ b/mobile/build_ios.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+# Fail fast on a malformed C2PA signing endpoint. A bare host silently collapses
+# to the service root at call time and surfaces as an opaque signing error
+# during capture rather than a build failure.
+"$(dirname "${BASH_SOURCE[0]:-$0}")/scripts/check_signing_endpoint.sh"
+
 usage() {
     cat <<'EOF'
 Usage: ./build_ios.sh [debug|release] [options]

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3887,7 +3887,11 @@
   },
   "videoMetadataC2paMissingNote": "Content credentials need an internet connection.",
   "@videoMetadataC2paMissingNote": {
-    "description": "Small trailing note under the missing-content-credential bottom sheet, hinting that the (remote) content-credential signing step requires connectivity. Not phrased as the definitive cause, since signing can also fail for other reasons."
+    "description": "Small trailing note under the missing-content-credential bottom sheet, shown when the device is offline, where connectivity really is the likely cause. When the device is online, videoMetadataC2paMissingNoteServiceUnavailable is shown instead."
+  },
+  "videoMetadataC2paMissingNoteServiceUnavailable": "The content credential service didn't respond. This isn't your connection.",
+  "@videoMetadataC2paMissingNoteServiceUnavailable": {
+    "description": "Small trailing note under the missing-content-credential bottom sheet, shown when the device IS online, so signing failed on the service side (outage, misconfigured endpoint, rejected request). Explicitly rules out the user's connection, because the previous connectivity-only wording sent users to debug working wifi."
   },
   "videoMetadataC2paMissingRegenerate": "Regenerate",
   "@videoMetadataC2paMissingRegenerate": {

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -11054,11 +11054,17 @@ abstract class AppLocalizations {
   /// **'We couldn\'t add content credentials, so this video won\'t be confirmed as Human-Made. Regenerate to try again, or post it as-is.'**
   String get videoMetadataC2paMissingBody;
 
-  /// Small trailing note under the missing-content-credential bottom sheet, hinting that the (remote) content-credential signing step requires connectivity. Not phrased as the definitive cause, since signing can also fail for other reasons.
+  /// Small trailing note under the missing-content-credential bottom sheet, shown when the device is offline, where connectivity really is the likely cause. When the device is online, videoMetadataC2paMissingNoteServiceUnavailable is shown instead.
   ///
   /// In en, this message translates to:
   /// **'Content credentials need an internet connection.'**
   String get videoMetadataC2paMissingNote;
+
+  /// Small trailing note under the missing-content-credential bottom sheet, shown when the device IS online, so signing failed on the service side (outage, misconfigured endpoint, rejected request). Explicitly rules out the user's connection, because the previous connectivity-only wording sent users to debug working wifi.
+  ///
+  /// In en, this message translates to:
+  /// **'The content credential service didn\'t respond. This isn\'t your connection.'**
+  String get videoMetadataC2paMissingNoteServiceUnavailable;
 
   /// Primary button on the missing-content-credential bottom sheet. Re-renders the video to attempt the C2PA signature again.
   ///

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -6197,6 +6197,10 @@ class AppLocalizationsAm extends AppLocalizations {
       'የይዘት መታወቂያዎች የበይነመረብ ግንኙነት ያስፈልጋቸዋል።';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => 'እንደገና ፍጠር';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -6278,6 +6278,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'تتطلب بيانات اعتماد المحتوى اتصالاً بالإنترنت.';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => 'إعادة الإنشاء';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -6380,6 +6380,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Удостоверенията за съдържание изискват интернет връзка.';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => 'Генерирай отново';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -6401,6 +6401,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Content Credentials brauchen eine Internetverbindung.';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => 'Neu generieren';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -6321,6 +6321,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Content credentials need an internet connection.';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => 'Regenerate';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -6378,6 +6378,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Las credenciales de contenido necesitan conexión a internet.';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => 'Volver a generar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -6401,6 +6401,10 @@ class AppLocalizationsFil extends AppLocalizations {
       'Kailangan ng internet connection ang content credentials.';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => 'I-regenerate';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -6406,6 +6406,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Les informations d’authenticité nécessitent une connexion internet.';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => 'Régénérer';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -6287,6 +6287,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Kredensial konten memerlukan koneksi internet.';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => 'Buat ulang';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -6387,6 +6387,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Le credenziali di contenuto richiedono una connessione a internet.';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => 'Rigenera';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -6048,6 +6048,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoMetadataC2paMissingNote => 'コンテンツ認証情報にはインターネット接続が必要です。';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => '再生成';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -6070,6 +6070,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoMetadataC2paMissingNote => '콘텐츠 자격 증명에는 인터넷 연결이 필요합니다.';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => '재생성';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -6372,6 +6372,10 @@ class AppLocalizationsMs extends AppLocalizations {
       'Kelayakan kandungan memerlukan sambungan internet.';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => 'Jana semula';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -6353,6 +6353,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Content credentials hebben een internetverbinding nodig.';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => 'Opnieuw genereren';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6476,6 +6476,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Poświadczenia treści wymagają połączenia z internetem.';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => 'Wygeneruj ponownie';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -6368,6 +6368,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'As credenciais de conteúdo precisam de conexão com a internet.';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => 'Gerar novamente';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6483,6 +6483,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Acreditările de conținut necesită o conexiune la internet.';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => 'Regenerează';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -6321,6 +6321,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Innehållsuppgifter kräver en internetanslutning.';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => 'Generera om';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -6291,6 +6291,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'İçerik kimlik bilgileri internet bağlantısı gerektirir.';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => 'Yeniden oluştur';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -6330,6 +6330,10 @@ class AppLocalizationsUr extends AppLocalizations {
       'مواد اسناد کے لیے انٹرنیٹ کنکشن درکار ہے۔';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => 'دوبارہ بنائیں';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -6332,6 +6332,10 @@ class AppLocalizationsVi extends AppLocalizations {
       'Chứng nhận nội dung cần kết nối internet.';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => 'Tạo lại';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -6020,6 +6020,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get videoMetadataC2paMissingNote => '添加内容凭证需要网络连接。';
 
   @override
+  String get videoMetadataC2paMissingNoteServiceUnavailable =>
+      'The content credential service didn\'t respond. This isn\'t your connection.';
+
+  @override
   String get videoMetadataC2paMissingRegenerate => '重新生成';
 
   @override

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -93,6 +93,7 @@ import 'package:openvine/screens/video_recorder_screen.dart';
 import 'package:openvine/services/app_engagement_store.dart';
 import 'package:openvine/services/back_button_handler.dart';
 import 'package:openvine/services/bandwidth_tracker_service.dart';
+import 'package:openvine/services/c2pa_signing_service.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/services/corrupted_video_repair_service.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
@@ -834,6 +835,11 @@ Future<void> _startOpenVineApp() async {
 
   // Ensure bindings are initialized first (required for everything)
   final widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
+
+  // Fail the launch on a malformed C2PA signing endpoint rather than letting it
+  // surface mid-capture as an opaque "Signature: internal error", which reads
+  // as a server outage and sends users to debug their own connection.
+  C2paSigningService.assertSigningEndpointValid();
 
   // Register bundled OFL font licenses so they surface on the in-app
   // Open Source Licenses page (Settings → Legal). See #3659.

--- a/mobile/lib/screens/video_metadata/video_metadata_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
+import 'package:openvine/providers/relay_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
@@ -99,6 +100,13 @@ class _VideoMetadataScreenState extends ConsumerState<VideoMetadataScreen> {
 
   Future<void> _showC2paMissingPrompt() async {
     final l10n = context.l10n;
+    // Blaming connectivity for a service-side failure sends users to debug wifi
+    // that is working. Only claim the connection when the device is actually
+    // offline; otherwise say the service didn't respond.
+    final isOnline = ref.read(connectionStatusServiceProvider).isOnline;
+    final note = isOnline
+        ? l10n.videoMetadataC2paMissingNoteServiceUnavailable
+        : l10n.videoMetadataC2paMissingNote;
     // Non-dismissible: forfeiting the content credential is a provenance
     // decision, so require an explicit button rather than letting an accidental
     // barrier tap / swipe silently post without it (#6058).
@@ -107,7 +115,7 @@ class _VideoMetadataScreenState extends ConsumerState<VideoMetadataScreen> {
       sticker: .alert,
       title: l10n.videoMetadataC2paMissingTitle,
       subtitle: l10n.videoMetadataC2paMissingBody,
-      additionalText: l10n.videoMetadataC2paMissingNote,
+      additionalText: note,
       primaryButtonText: l10n.videoMetadataC2paMissingRegenerate,
       onPrimaryPressed: () =>
           Navigator.of(context).pop(_C2paMissingChoice.regenerate),

--- a/mobile/lib/services/c2pa_signing_service.dart
+++ b/mobile/lib/services/c2pa_signing_service.dart
@@ -98,12 +98,13 @@ class C2paSigningService {
 
   /// Whether the remote signing pipeline is configured for this build.
   ///
-  /// Signing is a network call to [SIGNING_SERVER_ENDPOINT], which is injected
-  /// as a `--dart-define` only in builds that opt in (see `build_*.sh` /
-  /// `run_dev.sh`). CI and unconfigured builds leave it empty, so a missing
-  /// C2PA signature there is expected and must never be surfaced to the user —
+  /// Signing is a network call to [SIGNING_SERVER_ENDPOINT]. The endpoint always
+  /// resolves to a usable URL — an override that is absent falls back to
+  /// [defaultSigningServerEndpoint] — so signing is configured unless a build
+  /// explicitly disables it with `PROOFMODE_SIGNING_SERVER_ENDPOINT=disabled`.
+  /// Builds that disable it never surface a missing C2PA signature to the user;
   /// callers gate the "sign or skip" prompt on this (#6058).
-  static bool get isSigningConfigured => SIGNING_SERVER_ENDPOINT.isNotEmpty;
+  static bool get isSigningConfigured => !_signingDisabled;
 
   /// Signs a video file with C2PA content credentials.
   ///
@@ -490,10 +491,81 @@ class C2paSigningService {
     );
   }
 
+  /// Path every signing endpoint must end in.
+  ///
+  /// [_createSigner] appends `?platform=...` to the endpoint, so a value that
+  /// stops at the host collapses to the service root. The root serves an HTML
+  /// landing page with HTTP 200, and the signer then reports a bare
+  /// "Signature: internal error" that reads like a server outage.
+  static const String signingConfigurationPath = '/api/v1/c2pa/configuration';
+
+  /// Endpoint used when a build does not override it.
+  static const String defaultSigningServerEndpoint =
+      'https://proofsign.divine.video$signingConfigurationPath';
+
+  /// Sentinel that turns signing off entirely, for CI and unconfigured builds.
+  static const String signingDisabledSentinel = 'disabled';
+
   // add ?platform=android or ios
   static const String SIGNING_SERVER_ENDPOINT = String.fromEnvironment(
     'PROOFMODE_SIGNING_SERVER_ENDPOINT',
+    defaultValue: defaultSigningServerEndpoint,
   );
+
+  static bool get _signingDisabled =>
+      SIGNING_SERVER_ENDPOINT.trim().toLowerCase() == signingDisabledSentinel;
+
+  /// Validates [SIGNING_SERVER_ENDPOINT], returning null when it is usable and
+  /// a human-readable reason when it is not.
+  ///
+  /// Exposed separately from [assertSigningEndpointValid] so tests can check
+  /// arbitrary values without tearing down the app.
+  static String? describeSigningEndpointProblem(String endpoint) {
+    if (endpoint.trim().toLowerCase() == signingDisabledSentinel) return null;
+
+    if (endpoint.isEmpty) {
+      return 'PROOFMODE_SIGNING_SERVER_ENDPOINT is empty. Pass '
+          '--dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT=<url> or leave it '
+          'unset to use $defaultSigningServerEndpoint.';
+    }
+
+    final uri = Uri.tryParse(endpoint);
+    if (uri == null || !uri.isAbsolute || uri.host.isEmpty) {
+      return 'PROOFMODE_SIGNING_SERVER_ENDPOINT ("$endpoint") is not an '
+          'absolute URL.';
+    }
+
+    if (uri.scheme != 'https') {
+      return 'PROOFMODE_SIGNING_SERVER_ENDPOINT ("$endpoint") must use https, '
+          'not "${uri.scheme}".';
+    }
+
+    if (uri.hasQuery) {
+      return 'PROOFMODE_SIGNING_SERVER_ENDPOINT ("$endpoint") must not carry a '
+          'query string; the platform parameter is appended at call time.';
+    }
+
+    if (uri.path != signingConfigurationPath) {
+      return 'PROOFMODE_SIGNING_SERVER_ENDPOINT ("$endpoint") must end in '
+          '$signingConfigurationPath. A bare host resolves to the service '
+          'root, which returns an HTML landing page instead of a signing '
+          'configuration.';
+    }
+
+    return null;
+  }
+
+  /// Fails the launch when the signing endpoint is malformed.
+  ///
+  /// A misconfigured endpoint does not fail loudly on its own: it surfaces much
+  /// later as an opaque signing error during capture, which reads as an outage
+  /// rather than a build problem. Called from app startup.
+  static void assertSigningEndpointValid() {
+    final problem = describeSigningEndpointProblem(SIGNING_SERVER_ENDPOINT);
+    if (problem != null) {
+      throw StateError('C2PA signing misconfigured: $problem');
+    }
+  }
 
   static const String SIGNING_SERVER_TOKEN = String.fromEnvironment(
     'PROOFMODE_SIGNING_SERVER_TOKEN',

--- a/mobile/lib/services/c2pa_signing_service.dart
+++ b/mobile/lib/services/c2pa_signing_service.dart
@@ -32,6 +32,9 @@ enum C2paSigningFailureReason {
   outputMissing,
   tls,
   network,
+
+  /// This build opted out of C2PA signing; nothing was attempted.
+  disabled,
   other,
 }
 
@@ -123,6 +126,17 @@ class C2paSigningService {
     bool enableAdvancedCawgEmbedding = false,
   }) async {
     try {
+      // Opted-out builds must not reach the signer: the endpoint is a sentinel,
+      // not a URL, so attempting the call would fail with a confusing error.
+      if (!isSigningConfigured) {
+        return C2paSigningResult(
+          signedFilePath: videoPath,
+          success: false,
+          error: 'C2PA signing is disabled for this build',
+          failureReason: C2paSigningFailureReason.disabled,
+        );
+      }
+
       Log.info(
         'Starting C2PA signing for video: $videoPath',
         name: 'C2paSigningService',

--- a/mobile/run_dev.sh
+++ b/mobile/run_dev.sh
@@ -4,6 +4,11 @@
 
 set -e
 
+# Fail fast on a malformed C2PA signing endpoint. A bare host silently collapses
+# to the service root at call time and surfaces as an opaque signing error
+# during capture rather than a build failure.
+"$(dirname "${BASH_SOURCE[0]:-$0}")/scripts/check_signing_endpoint.sh"
+
 # Default to Chrome if no device specified
 DEVICE_ARG="${1:-chrome}"
 BUILD_MODE="${2:-debug}"

--- a/mobile/scripts/check_signing_endpoint.sh
+++ b/mobile/scripts/check_signing_endpoint.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Fails a build whose PROOFMODE_SIGNING_SERVER_ENDPOINT is malformed.
+#
+# The signer appends "?platform=ios" / "?platform=android" to this value, so an
+# endpoint that stops at the host collapses to the service root. A service root
+# answers HTTP 200 with an HTML landing page, and the C2PA signer then reports a
+# bare "Signature: internal error" during capture — indistinguishable from a
+# server outage, and it sends users to debug their own connection.
+#
+# An UNSET variable is not an error by default: the app falls back to the
+# default endpoint in C2paSigningService.defaultSigningServerEndpoint. Only a
+# value that is set and wrong fails here, plus the literal "disabled", which
+# turns signing off for CI and unconfigured builds.
+#
+# Set REQUIRE_SIGNING_ENDPOINT=1 to also reject an unset/empty value. Codemagic
+# needs this: it interpolates the variable unconditionally, so an unset variable
+# emits `--dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT=` — a define that is
+# present but empty, which overrides the Dart-side defaultValue rather than
+# falling back to it.
+#
+# Portable: POSIX sh constructs + grep -E only, so it runs on CI ubuntu and on
+# the macOS pre-push hook.
+set -euo pipefail
+
+REQUIRED_PATH="/api/v1/c2pa/configuration"
+DISABLED_SENTINEL="disabled"
+
+endpoint="${PROOFMODE_SIGNING_SERVER_ENDPOINT:-}"
+
+# Unset: the Dart default applies, unless this build injects the value
+# unconditionally and would therefore ship an empty define.
+if [ -z "$endpoint" ]; then
+  if [ "${REQUIRE_SIGNING_ENDPOINT:-0}" = "1" ]; then
+    echo "ERROR: PROOFMODE_SIGNING_SERVER_ENDPOINT is unset or empty." >&2
+    echo "  This build injects the value unconditionally, so an unset variable" >&2
+    echo "  ships --dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT= (present but" >&2
+    echo "  empty), which overrides the in-app default instead of falling back" >&2
+    echo "  to it. C2PA signing would then fail on every capture." >&2
+    echo >&2
+    echo "  Set it in the Codemagic 'proofmode_credentials' environment variable" >&2
+    echo "  group to an absolute https URL ending in $REQUIRED_PATH," >&2
+    echo "  or to 'disabled' to build without C2PA signing." >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+# Explicitly disabled: signing is off for this build, by design.
+if [ "$(printf '%s' "$endpoint" | tr '[:upper:]' '[:lower:]')" = "$DISABLED_SENTINEL" ]; then
+  exit 0
+fi
+
+fail() {
+  echo "ERROR: PROOFMODE_SIGNING_SERVER_ENDPOINT is malformed." >&2
+  echo "  $1" >&2
+  echo >&2
+  echo "  Expected an absolute https URL ending in $REQUIRED_PATH," >&2
+  echo "  for example: https://proofsign.divine.video$REQUIRED_PATH" >&2
+  echo >&2
+  echo "  Set it in the Codemagic 'proofmode_credentials' environment variable" >&2
+  echo "  group, or unset it to use the in-app default. Use 'disabled' to build" >&2
+  echo "  without C2PA signing." >&2
+  exit 1
+}
+
+case "$endpoint" in
+  https://*) ;;
+  *) fail "It must use https. Got: $endpoint" ;;
+esac
+
+case "$endpoint" in
+  *\?*) fail "It must not carry a query string; the platform parameter is appended at call time. Got: $endpoint" ;;
+esac
+
+case "$endpoint" in
+  *"$REQUIRED_PATH") ;;
+  *) fail "It must end in $REQUIRED_PATH. A bare host resolves to the service root, which returns an HTML landing page instead of a signing configuration. Got: $endpoint" ;;
+esac
+
+echo "PROOFMODE_SIGNING_SERVER_ENDPOINT looks well-formed."

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -354,6 +354,11 @@ const _knownUntranslatedDebt = <String>{
   'soundCreditPublicHashtagsLabel',
   'soundsSaveFailed',
   'soundsRemoveFailed',
+  // Distinguishes a signing-service failure from a genuinely offline device on
+  // the missing-content-credential sheet. English-only until the next
+  // localization pass; offline devices still get the fully translated
+  // videoMetadataC2paMissingNote.
+  'videoMetadataC2paMissingNoteServiceUnavailable',
 };
 
 const _signatureVerificationKeys = <String>{

--- a/mobile/test/screens/video_metadata_screen_test.dart
+++ b/mobile/test/screens/video_metadata_screen_test.dart
@@ -16,10 +16,12 @@ import 'package:openvine/models/video_publish/video_publish_provider_state.dart'
 import 'package:openvine/models/video_publish/video_publish_state.dart';
 import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/relay_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_screen.dart';
+import 'package:openvine/services/connection_status_service.dart';
 import 'package:openvine/services/native_proofmode_service.dart';
 import 'package:openvine/widgets/video_metadata/modes/capture/video_metadata_capture_stack.dart';
 import 'package:openvine/widgets/video_metadata/modes/classic/video_metadata_classic_stack.dart';
@@ -414,6 +416,9 @@ void main() {
         final container = ProviderContainer(
           overrides: [
             sharedPreferencesProvider.overrideWithValue(prefs),
+            connectionStatusServiceProvider.overrideWithValue(
+              _StubConnectionStatusService(),
+            ),
             clipManagerProvider.overrideWith(
               () => _MockClipManagerNotifier([testClip]),
             ),
@@ -486,6 +491,9 @@ void main() {
           final container = ProviderContainer(
             overrides: [
               sharedPreferencesProvider.overrideWithValue(prefs),
+              connectionStatusServiceProvider.overrideWithValue(
+                _StubConnectionStatusService(),
+              ),
               clipManagerProvider.overrideWith(
                 () => _MockClipManagerNotifier([testClip]),
               ),
@@ -566,6 +574,9 @@ void main() {
           final container = ProviderContainer(
             overrides: [
               sharedPreferencesProvider.overrideWithValue(prefs),
+              connectionStatusServiceProvider.overrideWithValue(
+                _StubConnectionStatusService(),
+              ),
               clipManagerProvider.overrideWith(
                 () => _MockClipManagerNotifier([testClip]),
               ),
@@ -631,6 +642,9 @@ void main() {
           final container = ProviderContainer(
             overrides: [
               sharedPreferencesProvider.overrideWithValue(prefs),
+              connectionStatusServiceProvider.overrideWithValue(
+                _StubConnectionStatusService(),
+              ),
               clipManagerProvider.overrideWith(
                 () => _MockClipManagerNotifier([testClip]),
               ),
@@ -737,6 +751,16 @@ void main() {
 }
 
 /// Mock clip manager notifier for testing.
+/// [ConnectionStatusService] starts a `Timer.periodic` from its constructor,
+/// which survives the widget test and trips `!timersPending` at teardown. The
+/// C2PA prompt only reads `isOnline`, so cancelling the poll leaves the value
+/// under test intact.
+class _StubConnectionStatusService extends ConnectionStatusService {
+  _StubConnectionStatusService() {
+    stopMonitoring();
+  }
+}
+
 class _MockClipManagerNotifier extends ClipManagerNotifier {
   _MockClipManagerNotifier(this._clips);
 

--- a/mobile/test/services/c2pa_signing_endpoint_validation_test.dart
+++ b/mobile/test/services/c2pa_signing_endpoint_validation_test.dart
@@ -1,0 +1,95 @@
+// ABOUTME: Tests validation of the C2PA signing endpoint dart-define
+// ABOUTME: Covers the bare-host misconfiguration that reads as a server outage
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/c2pa_signing_service.dart';
+
+void main() {
+  group('describeSigningEndpointProblem', () {
+    test('accepts the default endpoint', () {
+      expect(
+        C2paSigningService.describeSigningEndpointProblem(
+          C2paSigningService.defaultSigningServerEndpoint,
+        ),
+        isNull,
+      );
+    });
+
+    test('accepts the disabled sentinel', () {
+      expect(
+        C2paSigningService.describeSigningEndpointProblem(
+          C2paSigningService.signingDisabledSentinel,
+        ),
+        isNull,
+      );
+    });
+
+    test('rejects an empty endpoint', () {
+      final problem = C2paSigningService.describeSigningEndpointProblem('');
+      expect(problem, isNotNull);
+      expect(problem, contains('is empty'));
+    });
+
+    // The reported outage: the endpoint stopped at the host, so appending
+    // "?platform=ios" resolved to the service root, which answers HTTP 200 with
+    // an HTML landing page.
+    test('rejects a bare host with no configuration path', () {
+      final problem = C2paSigningService.describeSigningEndpointProblem(
+        'https://proofsign.divine.video',
+      );
+      expect(problem, isNotNull);
+      expect(problem, contains('/api/v1/c2pa/configuration'));
+    });
+
+    test('rejects a host with a trailing slash only', () {
+      expect(
+        C2paSigningService.describeSigningEndpointProblem(
+          'https://proofsign.divine.video/',
+        ),
+        isNotNull,
+      );
+    });
+
+    test('rejects a relative value', () {
+      expect(
+        C2paSigningService.describeSigningEndpointProblem(
+          '/api/v1/c2pa/configuration',
+        ),
+        isNotNull,
+      );
+    });
+
+    test('rejects plaintext http', () {
+      final problem = C2paSigningService.describeSigningEndpointProblem(
+        'http://proofsign.divine.video/api/v1/c2pa/configuration',
+      );
+      expect(problem, isNotNull);
+      expect(problem, contains('https'));
+    });
+
+    // The signer appends its own ?platform=, so a pre-existing query string
+    // would produce two of them.
+    test('rejects an endpoint that already carries a query string', () {
+      final problem = C2paSigningService.describeSigningEndpointProblem(
+        'https://proofsign.divine.video/api/v1/c2pa/configuration?platform=ios',
+      );
+      expect(problem, isNotNull);
+      expect(problem, contains('query string'));
+    });
+
+    test('accepts a well-formed endpoint on another host', () {
+      expect(
+        C2paSigningService.describeSigningEndpointProblem(
+          'https://proofsign.proofmode.org/api/v1/c2pa/configuration',
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('assertSigningEndpointValid', () {
+    test('passes for the endpoint this build was compiled with', () {
+      expect(C2paSigningService.assertSigningEndpointValid, returnsNormally);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

A C2PA signing failure presented as a server outage but was a client-side
URL-construction bug. This makes a missing or malformed signing endpoint fail
loudly at build time and launch, and stops the failure UI from blaming the
user's connection.

## Motivation

`_createSigner()` builds its URL as `SIGNING_SERVER_ENDPOINT + "?platform=ios"`.
`PROOFMODE_SIGNING_SERVER_ENDPOINT` had no default, so a missing value — or one
that stopped at the host — collapsed the URL to the service root. A service root
answers HTTP 200 with an HTML landing page, and the signer surfaced that as:

```
C2PA API error: Signature: internal error
(service responded with an HTTP error (status = 200,
 content-type = Some("text/html; charset=utf-8")))
```

Nothing about that says "misconfigured build". The user was on working wifi, and
the in-app note told them content credentials need an internet connection, so
they went and debugged their network.

### The default alone would not have fixed CI

`codemagic.yaml` interpolates the variables **unconditionally**:

```
--dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT=$PROOFMODE_SIGNING_SERVER_ENDPOINT
--dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN
```

If a Codemagic variable is unset, that emits a define that is *present but
empty*, which overrides Dart's `defaultValue` rather than falling back to it.
So a build-time guard is required, not just a default. Required C2PA builds now
require both a valid endpoint and a non-empty token unless the endpoint is
explicitly `disabled`.

## Changes

- Default the endpoint to `https://proofsign.divine.video/api/v1/c2pa/configuration`.
- Validate at launch that the endpoint is an absolute `https` URL ending in the
  configuration path, with no query string. A malformed value now fails the
  launch instead of surfacing mid-capture.
- Add `mobile/scripts/check_signing_endpoint.sh`, wired into `build_ios.sh`,
  `build_android.sh`, `run_dev.sh`, and into `codemagic.yaml` with
  `REQUIRE_SIGNING_ENDPOINT=1` so unset required CI credentials fail the build.
- `PROOFMODE_SIGNING_SERVER_ENDPOINT=disabled` turns signing off, preserving the
  #6058 gate for CI and unconfigured builds now that the endpoint is never empty.
  `signVideo` returns a typed `disabled` result before attempting any network work.
- Show a service-failure note when the device has a network; keep the
  connectivity wording only for genuinely offline devices. The signal is
  `connectivity_plus`, via a `deviceIsOfflineProvider` seam over the existing
  `dmSendConnectivityIsOffline` predicate.
- Require a bearer token for `isSigningConfigured`, and pass
  `PROOFMODE_SIGNING_SERVER_ENDPOINT=disabled` in both web workflows.
- Make the signing endpoint and token injectable on `C2paSigningService` so the
  configured / opted-out branches are reachable from tests at all.
- Keep intentionally disabled signing builds out of warning logs, and align
  `mobile/.env.example` with the shipped `proofsign.divine.video` endpoint.

## Behaviour changes worth a close look

1. **`isSigningConfigured` means endpoint *plus* token.** Defaulting the endpoint
   decoupled the two: previously an unset-env build was unconfigured because both
   defines were empty, and after the default it would have counted as configured
   and called production `proofsign.divine.video` with `bearerToken: ''`. Requiring
   the token restores the coupling for local `flutter run` and for any workflow
   that passes neither define. Both web workflows now set `disabled` explicitly,
   so the opt-out has real callers rather than being a sentinel nothing sets.
2. **Malformed endpoint remains a launch-fail.** That is intentional option 1
   from review: a build with a malformed signing endpoint should not continue as
   if it can produce content credentials. The check now runs after crash reporting
   initialization, so the startup failure is reportable instead of being dropped
   before telemetry is ready.
3. **New string is English-only**, registered in `_knownUntranslatedDebt` and
   tracked by #6808. Offline devices still get the fully translated existing
   note — and that note is now actually reachable, which it was not in the first
   revision of this PR.

## Review takeover

@mbradley and @NotThatKindOfDrLiz pushed the mechanical fixes directly
(`942a341`, `0547da9`, `daf8eb2`, `b3669a6`, `21f5d481f`): the missing
`resignDerived` disabled-sentinel guard, the stale `isSigningConfigured` doc,
fragment-vs-absolute diagnostic ordering, guard-script header claims, local
guards running after `.env` is sourced, one shared exact-path rule across the
shell guard and the Dart validator, startup validation moved below crash-reporting
init, and the backend-host-default guard widened to cover the C2PA endpoint.

Two owner decisions were left open and are resolved here:

**The connectivity signal.** `ConnectionStatusService` is not a connectivity
check — `_isConnected` initialises `true`, its only mutator `updateRelayStatus()`
is never called anywhere in the repo, and `checkConnection()` is a stub that sets
no state. So `isOnline` was a constant `true`: the sheet always claimed the
service was unavailable, `videoMetadataC2paMissingNote` was unreachable in all 21
locales, and a genuinely offline user was told "this isn't your connection". It
also constructed the real service's 30s `Timer.periodic` inside the widget tree,
which is what left four tests failing with *"A Timer is still pending even after
the widget tree was disposed"*. Replaced with `connectivity_plus`.

**The token policy.** `isSigningConfigured` requires a token, the web workflows
opt out explicitly, and the required Codemagic guard now fails if a non-disabled
endpoint is present without a token.

## Test plan

- `flutter test test/services/c2pa_signing_endpoint_validation_test.dart` — covers
  the bare-host, empty, relative, http, query-string, guard/validator drift, and
  required-token cases.
- `flutter test test/screens/video_metadata_screen_test.dart` — 16 pass,
  including two new cases pinning that the sheet blames the connection only when
  the device is offline and the service otherwise. The four pending-`Timer`
  failures reported in review are gone; they were caused by the real
  `ConnectionStatusService` being constructed in the widget tree.
- `flutter test test/services/c2pa_signing_service_test.dart` — 12 pass,
  including two new cases pinning that an untokened build and a `disabled`
  endpoint both return `disabled` without reaching `signFile`.
- `dart test test/l10n/arb_consistency_test.dart` — passes.
- `flutter analyze` on changed files — no issues.
- Guard script exercised directly: unset → exit 0; bare host → exit 1 with the
  remediation message; valid URL → exit 0; `disabled` → exit 0; with
  `REQUIRE_SIGNING_ENDPOINT=1`, unset endpoint → exit 1, valid endpoint without
  token → exit 1, and valid endpoint with token → exit 0.

## Still open from review

The guard script's suffix match vs the Dart validator's exact-path compare was
reconciled by `21f5d481f` (both use the exact rule). The remaining question —
whether a subpath / reverse-proxied deployment should be legal at all — is a
deployment decision, not a code one, and the two sides now agree either way.

## Not covered here

The Codemagic `proofmode_credentials` values themselves are not readable from a
checkout, so which endpoint/token shipped builds actually use still needs to be
confirmed in the Codemagic UI. Related server-side hardening (returning JSON
instead of HTML to API clients) is a separate PR in `proofsign-server`.

No visual change beyond the one note string on the missing-content-credential
sheet.

Relates to #838
