### PR TITLE
fix(video-editor): shoot green-screen backgrounds with the camera only

### DIFF
--- a/mobile/lib/screens/video_editor/video_clip_chroma_key_screen.dart
+++ b/mobile/lib/screens/video_editor/video_clip_chroma_key_screen.dart
@@ -201,19 +201,24 @@ class _VideoClipChromaKeyScreenState extends State<VideoClipChromaKeyScreen> {
     }
   }
 
+  /// Shoots a photo to sit behind the keyed subject.
+  ///
+  /// Camera only, deliberately: the gallery is a route for AI-generated
+  /// imagery to enter a Divine video, and a backdrop the user photographs on
+  /// the spot cannot be one.
   Future<void> _pickImageBackground() async {
-    final picked = await ImagePicker().pickImage(source: ImageSource.gallery);
-    if (picked == null) return;
     try {
+      final picked = await ImagePicker().pickImage(source: ImageSource.camera);
+      if (picked == null) return;
       // `image_picker` hands back a cache path the OS may prune, while clip
       // state persists as a documents-relative basename — so take a copy we
       // own before pointing the key at it.
       //
-      // The copy is normalized rather than byte-for-byte: a portrait photo is
-      // usually stored as landscape pixels plus an EXIF orientation tag, and
-      // the renderer decodes raw bytes, so it would show the backdrop rotated.
-      // Baking the rotation in also caps the photo to a sane size for a
-      // backdrop that is stretched to the video frame anyway.
+      // The copy is normalized rather than byte-for-byte: a photo shot in
+      // portrait is stored as landscape pixels plus an EXIF orientation tag,
+      // and the renderer decodes raw bytes, so it would show the backdrop
+      // rotated. Baking the rotation in also caps the photo to a sane size for
+      // a backdrop that is stretched to the video frame anyway.
       final documentsPath = await getDocumentsPath();
       final target = p.join(
         documentsPath,
@@ -235,7 +240,7 @@ class _VideoClipChromaKeyScreenState extends State<VideoClipChromaKeyScreen> {
       unawaited(_pruneCreatedImages(keep: target));
     } catch (error, stackTrace) {
       Log.error(
-        'Failed to copy the chroma-key background image',
+        'Failed to capture the chroma-key background image',
         name: 'VideoClipChromaKeyScreen',
         error: error,
         stackTrace: stackTrace,

--- a/mobile/lib/widgets/video_editor/chroma_key/chroma_key_controls.dart
+++ b/mobile/lib/widgets/video_editor/chroma_key/chroma_key_controls.dart
@@ -14,8 +14,8 @@ import 'package:openvine/widgets/video_editor/video_editor_color_picker_sheet.da
 class ChromaKeyControls extends StatelessWidget {
   const ChromaKeyControls({required this.onPickBackground, super.key});
 
-  /// Opens the picker for [type]. Owned by the screen because an image comes
-  /// from the photo library and a video from the clip library.
+  /// Opens the picker for [type]. Owned by the screen because an image is shot
+  /// with the camera and a video comes from the clip library.
   final ValueChanged<ClipChromaKeyBackgroundType> onPickBackground;
 
   @override

--- a/mobile/test/screens/video_editor/video_clip_chroma_key_screen_test.dart
+++ b/mobile/test/screens/video_editor/video_clip_chroma_key_screen_test.dart
@@ -1,0 +1,97 @@
+// ABOUTME: Pins the green-screen background photo to the camera — the gallery
+// ABOUTME: is how an AI-generated image would get into a Divine video.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' as model;
+import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/screens/video_editor/video_clip_chroma_key_screen.dart';
+import 'package:pro_video_editor/pro_video_editor.dart' show EditorVideo;
+
+import '../../helpers/shared_channel_override.dart';
+
+class _MockClipEditorBloc extends MockBloc<ClipEditorEvent, ClipEditorState>
+    implements ClipEditorBloc {}
+
+void main() {
+  group(VideoClipChromaKeyScreen, () {
+    late _MockClipEditorBloc bloc;
+    late List<MethodCall> pickerCalls;
+
+    setUp(() {
+      bloc = _MockClipEditorBloc();
+      when(() => bloc.state).thenReturn(const ClipEditorState());
+      when(
+        () => bloc.stream,
+      ).thenAnswer((_) => const Stream<ClipEditorState>.empty());
+
+      pickerCalls = <MethodCall>[];
+      overrideSharedChannel(
+        const MethodChannel('plugins.flutter.io/image_picker'),
+        (call) async {
+          pickerCalls.add(call);
+          // Null reads as "user backed out", which stops the screen before it
+          // touches the filesystem.
+          return null;
+        },
+      );
+    });
+
+    // An empty video path keeps the preview player out of the test: the screen
+    // skips initialization rather than reaching for a native plugin.
+    final clip = DivineVideoClip(
+      id: 'clip-1',
+      video: EditorVideo.file(''),
+      duration: const Duration(seconds: 3),
+      recordedAt: DateTime(2025),
+      targetAspectRatio: model.AspectRatio.vertical,
+      originalAspectRatio: 9 / 16,
+    );
+
+    Future<void> pump(WidgetTester tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: BlocProvider<ClipEditorBloc>.value(
+              value: bloc,
+              child: VideoClipChromaKeyScreen(
+                clip: clip,
+                detectOnOpen: false,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+    }
+
+    testWidgets('shoots the background photo instead of opening the gallery', (
+      tester,
+    ) async {
+      await pump(tester);
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      final imageChip = find.text(l10n.videoEditorChromaKeyBackgroundImage);
+      await tester.ensureVisible(imageChip);
+      await tester.tap(imageChip);
+      await tester.pump();
+
+      expect(pickerCalls, hasLength(1));
+      expect(pickerCalls.single.method, equals('pickImage'));
+      expect(
+        (pickerCalls.single.arguments as Map)['source'],
+        equals(ImageSource.camera.index),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #6776

## Description

The green-screen editor's **Image** backdrop opened the phone's photo gallery. That is exactly the route an AI-generated picture takes into a Divine video, so the picker is now camera-only — a photo the user shoots on the spot cannot be AI.

The `pickImage` call also moves inside the existing `try`. It used to sit outside it, which was harmless with a gallery source but not with a camera one: a denied permission or a device without a camera would escape as an unhandled exception instead of the screen's "Couldn't load that image" snackbar.

The **Clip** backdrop is unaffected and was never a gap — it reads the app's own clip library (clips recorded in Divine), and there is no `pickVideo` call anywhere in `mobile/lib`.

**Related Issue:** 

## Out of Scope

The chip is still labelled **Image**. Now that it opens the camera directly, "Camera" or "Photo" would read better, but that is a copy change across 17 ARB locales and a product call — left out deliberately.

## Verification

- Manually verified on a real Samsung Galaxy (SM-S942B): green-screen editor → Replace with → **Image** opens the camera directly, and the photo lands as the backdrop.
- `flutter analyze lib/screens/video_editor lib/widgets/video_editor/chroma_key test/screens/video_editor` — clean
- `flutter test test/screens/video_editor test/widgets/video_editor/chroma_key` — green
- New regression test `video_clip_chroma_key_screen_test.dart` asserts the image_picker channel receives `source: camera`. Counter-checked: flipping the source back to `gallery` fails it.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)