### PR TITLE
refactor(auth): reuse the QR layout as the nostr-connect loading state

### DIFF
--- a/mobile/lib/screens/auth/nostr_connect_screen.dart
+++ b/mobile/lib/screens/auth/nostr_connect_screen.dart
@@ -492,8 +492,11 @@ class _QrContent extends StatelessWidget {
   final VoidCallback onShareUrl;
   final VoidCallback onAddBunker;
 
-  /// Whether the session payload is still pending. Skeletonizes — and, via
-  /// its default `ignorePointers`, disables — the QR code and action bar.
+  /// Whether the session payload is still pending. Skeletonizes the QR code
+  /// and action bar. [Skeletonizer]'s `ignorePointers` blocks touch but not
+  /// the semantics tree, so the action bar is also disabled for screen
+  /// readers by nulling its callbacks (see [_ActionBar.isLoading]) — otherwise
+  /// a double-tap could open the bunker sheet and drop the live session.
   final bool isLoading;
 
   @override
@@ -544,6 +547,7 @@ class _QrContent extends StatelessWidget {
 
                 // Action bar
                 _ActionBar(
+                  isLoading: isLoading,
                   onCopyUrl: onCopyUrl,
                   onShareUrl: onShareUrl,
                   onAddBunker: onAddBunker,
@@ -591,8 +595,10 @@ class _QrCodeCard extends StatelessWidget {
             color: VineTheme.whiteText,
             borderRadius: BorderRadius.circular(12),
           ),
-          // Replaced rather than skeletonized in place: the encoder would
-          // otherwise render a QR for a placeholder payload.
+          // Replaced rather than skeletonized in place: in the steady loading
+          // state the encoder never runs over the placeholder payload. (The
+          // switch animation still builds one throwaway `QrImageView('')`
+          // mid-transition; harmless — an empty payload encodes fine.)
           child: Skeleton.replace(
             replace: isLoading,
             width: 200,
@@ -658,11 +664,18 @@ class _ActionBar extends StatelessWidget {
     required this.onCopyUrl,
     required this.onShareUrl,
     required this.onAddBunker,
+    this.isLoading = false,
   });
 
   final VoidCallback onCopyUrl;
   final VoidCallback onShareUrl;
   final VoidCallback onAddBunker;
+
+  /// While loading, the buttons are handed `null` callbacks so they publish
+  /// no tap action — inert to both touch and screen readers. [Skeletonizer]'s
+  /// `ignorePointers` only blocks touch, so nulling here is what keeps a
+  /// double-tap from activating a bone.
+  final bool isLoading;
 
   @override
   Widget build(BuildContext context) {
@@ -689,7 +702,7 @@ class _ActionBar extends StatelessWidget {
                     size: MediaQuery.textScalerOf(context).scale(24),
                   ),
                   label: context.l10n.authCopyUrl,
-                  onTap: onCopyUrl,
+                  onTap: isLoading ? null : onCopyUrl,
                 ),
                 _ActionButton(
                   icon: DivineIcon(
@@ -698,7 +711,7 @@ class _ActionBar extends StatelessWidget {
                     size: MediaQuery.textScalerOf(context).scale(24),
                   ),
                   label: context.l10n.authShare,
-                  onTap: onShareUrl,
+                  onTap: isLoading ? null : onShareUrl,
                 ),
                 _ActionButton(
                   icon: DivineIcon(
@@ -707,7 +720,7 @@ class _ActionBar extends StatelessWidget {
                     size: MediaQuery.textScalerOf(context).scale(24),
                   ),
                   label: context.l10n.authAddBunker,
-                  onTap: onAddBunker,
+                  onTap: isLoading ? null : onAddBunker,
                 ),
               ],
             ),
@@ -728,7 +741,10 @@ class _ActionButton extends StatelessWidget {
 
   final Widget icon;
   final String label;
-  final VoidCallback onTap;
+
+  /// `null` while the session is loading, so the button is inert to both
+  /// touch and screen-reader activation.
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {

--- a/mobile/lib/screens/auth/nostr_connect_screen.dart
+++ b/mobile/lib/screens/auth/nostr_connect_screen.dart
@@ -16,6 +16,7 @@ import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/widgets/auth_back_button.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Screen for NIP-46 client-initiated connections via nostrconnect:// URL.
@@ -388,18 +389,33 @@ class _NostrConnectScreenState extends ConsumerState<NostrConnectScreen> {
       backgroundColor: context.vineColors.background,
       body: SafeArea(
         child: switch (_sessionState) {
-          NostrConnectState.idle || NostrConnectState.generating =>
-            _LoadingContent(message: context.l10n.authGeneratingConnection),
-          NostrConnectState.listening => _QrContent(
-            connectUrl: _connectUrl ?? '',
-            elapsedSeconds: _elapsedTimer.elapsed.inSeconds,
+          NostrConnectState.idle || NostrConnectState.generating => _QrContent(
+            connectUrl: '',
+            statusMessage: context.l10n.authGeneratingConnection,
+            isLoading: true,
             onBack: () => context.pop(),
             onCopyUrl: _copyUrl,
             onShareUrl: _shareUrl,
             onAddBunker: _showPasteBunkerDialog,
           ),
-          NostrConnectState.connected => _LoadingContent(
-            message: context.l10n.authConnectedAuthenticating,
+          NostrConnectState.listening => _QrContent(
+            connectUrl: _connectUrl ?? '',
+            statusMessage: context.l10n.authWaitingForConnection(
+              _elapsedTimer.elapsed.inSeconds,
+            ),
+            onBack: () => context.pop(),
+            onCopyUrl: _copyUrl,
+            onShareUrl: _shareUrl,
+            onAddBunker: _showPasteBunkerDialog,
+          ),
+          NostrConnectState.connected => _QrContent(
+            connectUrl: _connectUrl ?? '',
+            statusMessage: context.l10n.authConnectedAuthenticating,
+            isLoading: true,
+            onBack: () => context.pop(),
+            onCopyUrl: _copyUrl,
+            onShareUrl: _shareUrl,
+            onAddBunker: _showPasteBunkerDialog,
           ),
           NostrConnectState.timeout => _ErrorContent(
             title: context.l10n.authConnectionTimedOut,
@@ -452,59 +468,33 @@ String resolveNostrConnectFailureMessage(
   };
 }
 
-/// Loading state with spinner and message.
-class _LoadingContent extends StatelessWidget {
-  const _LoadingContent({required this.message});
-
-  final String message;
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Space for close button overlay
-          const SizedBox(height: 72),
-          Text(
-            context.l10n.authScanSignerApp,
-            style: VineTheme.headlineLargeFont(
-              color: context.vineColors.primaryText,
-            ),
-          ),
-          const Spacer(),
-          const CircularProgressIndicator(color: VineTheme.vineGreen),
-          const SizedBox(height: 24),
-          Text(
-            message,
-            style: TextStyle(
-              color: context.vineColors.secondaryText,
-              fontSize: 16,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
 /// Main QR code content with actions and compatibility table.
+///
+/// The same layout backs the generating and authenticating states: instead of
+/// a separate spinner screen, the payload-dependent parts (QR code and action
+/// bar) shimmer via [Skeletonizer] while [isLoading] is `true`, so the chrome
+/// never shifts between states.
 class _QrContent extends StatelessWidget {
   const _QrContent({
     required this.connectUrl,
-    required this.elapsedSeconds,
+    required this.statusMessage,
     required this.onBack,
     required this.onCopyUrl,
     required this.onShareUrl,
     required this.onAddBunker,
+    this.isLoading = false,
   });
 
   final String connectUrl;
-  final int elapsedSeconds;
+  final String statusMessage;
   final VoidCallback onBack;
   final VoidCallback onCopyUrl;
   final VoidCallback onShareUrl;
   final VoidCallback onAddBunker;
+
+  /// Whether the session payload is still pending. Skeletonizes — and, via
+  /// its default `ignorePointers`, disables — the QR code and action bar.
+  final bool isLoading;
 
   @override
   Widget build(BuildContext context) {
@@ -515,7 +505,8 @@ class _QrContent extends StatelessWidget {
         children: [
           const SizedBox(height: 8),
 
-          // Back button
+          // Back button — outside the skeleton so it stays tappable while
+          // the session is still generating.
           AuthBackButton(onPressed: onBack),
 
           const SizedBox(height: 32),
@@ -533,21 +524,32 @@ class _QrContent extends StatelessWidget {
 
           const SizedBox(height: 32),
 
-          // QR code card
-          _QrCodeCard(connectUrl: connectUrl),
+          Skeletonizer(
+            enabled: isLoading,
+            enableSwitchAnimation: true,
+            effect: vineSkeletonEffectOf(context),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // QR code card
+                _QrCodeCard(connectUrl: connectUrl, isLoading: isLoading),
 
-          const SizedBox(height: 20),
+                const SizedBox(height: 20),
 
-          // Waiting indicator
-          _WaitingIndicator(elapsedSeconds: elapsedSeconds),
+                // Status indicator — the message is real copy in every state,
+                // so it is kept rather than turned into a text bone.
+                Skeleton.keep(child: _StatusIndicator(message: statusMessage)),
 
-          const SizedBox(height: 32),
+                const SizedBox(height: 32),
 
-          // Action bar
-          _ActionBar(
-            onCopyUrl: onCopyUrl,
-            onShareUrl: onShareUrl,
-            onAddBunker: onAddBunker,
+                // Action bar
+                _ActionBar(
+                  onCopyUrl: onCopyUrl,
+                  onShareUrl: onShareUrl,
+                  onAddBunker: onAddBunker,
+                ),
+              ],
+            ),
           ),
 
           const SizedBox(height: 24),
@@ -564,9 +566,10 @@ class _QrContent extends StatelessWidget {
 
 /// QR code displayed in a rounded card.
 class _QrCodeCard extends StatelessWidget {
-  const _QrCodeCard({required this.connectUrl});
+  const _QrCodeCard({required this.connectUrl, required this.isLoading});
 
   final String connectUrl;
+  final bool isLoading;
 
   @override
   Widget build(BuildContext context) {
@@ -588,11 +591,26 @@ class _QrCodeCard extends StatelessWidget {
             color: VineTheme.whiteText,
             borderRadius: BorderRadius.circular(12),
           ),
-          child: QrImageView(
-            data: connectUrl,
-            size: 200,
-            backgroundColor: VineTheme.whiteText,
-            errorCorrectionLevel: QrErrorCorrectLevel.M,
+          // Replaced rather than skeletonized in place: the encoder would
+          // otherwise render a QR for a placeholder payload.
+          child: Skeleton.replace(
+            replace: isLoading,
+            width: 200,
+            height: 200,
+            replacement: Skeleton.leaf(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  color: context.vineColors.skeleton,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+            ),
+            child: QrImageView(
+              data: connectUrl,
+              size: 200,
+              backgroundColor: VineTheme.whiteText,
+              errorCorrectionLevel: QrErrorCorrectLevel.M,
+            ),
           ),
         ),
       ),
@@ -600,11 +618,11 @@ class _QrCodeCard extends StatelessWidget {
   }
 }
 
-/// Waiting spinner with elapsed time.
-class _WaitingIndicator extends StatelessWidget {
-  const _WaitingIndicator({required this.elapsedSeconds});
+/// Spinner with the current session status message.
+class _StatusIndicator extends StatelessWidget {
+  const _StatusIndicator({required this.message});
 
-  final int elapsedSeconds;
+  final String message;
 
   @override
   Widget build(BuildContext context) {
@@ -621,7 +639,8 @@ class _WaitingIndicator extends StatelessWidget {
           ),
           const SizedBox(height: 12),
           Text(
-            context.l10n.authWaitingForConnection(elapsedSeconds),
+            message,
+            textAlign: TextAlign.center,
             style: TextStyle(
               color: context.vineColors.secondaryText,
               fontSize: 14,

--- a/mobile/test/screens/auth/nostr_connect_screen_test.dart
+++ b/mobile/test/screens/auth/nostr_connect_screen_test.dart
@@ -20,6 +20,17 @@ import '../../helpers/test_provider_overrides.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
 
+/// The [GestureDetector] wrapping the action-bar button labelled [label].
+/// `onTap` is `null` while the session is loading, so this reads the fix that
+/// keeps the button inert to both touch and screen readers.
+GestureDetector _actionButton(WidgetTester tester, String label) {
+  return tester.widget<GestureDetector>(
+    find
+        .ancestor(of: find.text(label), matching: find.byType(GestureDetector))
+        .first,
+  );
+}
+
 void main() {
   group('NostrConnectScreen route constants', () {
     test('has correct path', () {
@@ -89,11 +100,17 @@ void main() {
       );
       expect(find.text(l10n.authGeneratingConnection), findsOneWidget);
 
+      // The action bar is inert: skeletonizer's ignorePointers stops touch,
+      // and the null callbacks stop screen-reader taps.
+      expect(_actionButton(tester, l10n.authCopyUrl).onTap, isNull);
+      expect(_actionButton(tester, l10n.authShare).onTap, isNull);
+      expect(_actionButton(tester, l10n.authAddBunker).onTap, isNull);
+
       // Unmount to run dispose() and cancel any pending timers.
       await tester.pumpWidget(const SizedBox());
     });
 
-    testWidgets('listening state renders the real QR for the connect URL', (
+    testWidgets('listening state renders the real QR and a live action bar', (
       tester,
     ) async {
       const connectUrl =
@@ -110,6 +127,8 @@ void main() {
       await tester.pumpWidget(createTestWidget());
       await tester.pump();
 
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
       // Skeleton.replace is off, so the real QR encoder is built (not the
       // shimmer placeholder shown while generating).
       expect(find.byType(QrImageView), findsOneWidget);
@@ -117,6 +136,86 @@ void main() {
         tester.widget<Skeletonizer>(find.bySubtype<Skeletonizer>()).enabled,
         isFalse,
       );
+      // The action bar is live again once loaded.
+      expect(_actionButton(tester, l10n.authCopyUrl).onTap, isNotNull);
+      expect(_actionButton(tester, l10n.authAddBunker).onTap, isNotNull);
+
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('connected state stays skeletonized with an inert action bar', (
+      tester,
+    ) async {
+      const connectUrl =
+          'nostrconnect://abc123?relay=wss://relay.example.com&secret=xyz';
+      when(() => mockAuthService.nostrConnectUrl).thenReturn(connectUrl);
+      when(
+        () => mockAuthService.nostrConnectState,
+      ).thenReturn(NostrConnectState.listening);
+      // Resume subscribes to this stream; emitting `connected` drives the
+      // screen into the authenticating branch this PR converted.
+      when(() => mockAuthService.nostrConnectStateStream).thenAnswer(
+        (_) => Stream<NostrConnectState>.value(NostrConnectState.connected),
+      );
+      when(
+        () => mockAuthService.waitForNostrConnectResponse(),
+      ).thenAnswer((_) => Completer<AuthResult>().future);
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pump(); // resume -> listening
+      await tester.pump(); // stream emits connected -> rebuild
+      await tester.pump(const Duration(seconds: 1)); // finish skeleton switch
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      // The authenticating branch must keep isLoading: true — otherwise the
+      // screen paints a live QR (and a tappable action bar) for a session that
+      // has already been consumed.
+      expect(find.text(l10n.authConnectedAuthenticating), findsOneWidget);
+      expect(
+        tester.widget<Skeletonizer>(find.bySubtype<Skeletonizer>()).enabled,
+        isTrue,
+      );
+      expect(find.byType(QrImageView), findsNothing);
+      // The dangerous one: a screen-reader tap here runs cancelNostrConnect().
+      expect(_actionButton(tester, l10n.authAddBunker).onTap, isNull);
+
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('chrome does not shift between loading and loaded', (
+      tester,
+    ) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      final header = find.text(l10n.authCompatibleSignerApps);
+
+      // Generating (loading): record the compatibility header offset.
+      when(() => mockAuthService.nostrConnectUrl).thenReturn(null);
+      when(() => mockAuthService.nostrConnectState).thenReturn(null);
+      when(
+        () => mockAuthService.initiateNostrConnect(),
+      ).thenAnswer((_) => Completer<NostrConnectSession>().future);
+      await tester.pumpWidget(createTestWidget());
+      await tester.pump();
+      final loadingOffset = tester.getTopLeft(header);
+      await tester.pumpWidget(const SizedBox());
+
+      // Listening (loaded): the same header must sit at the same offset —
+      // the whole point of reusing one layout instead of two.
+      when(() => mockAuthService.nostrConnectUrl).thenReturn(
+        'nostrconnect://abc123?relay=wss://relay.example.com&secret=xyz',
+      );
+      when(
+        () => mockAuthService.nostrConnectState,
+      ).thenReturn(NostrConnectState.listening);
+      when(
+        () => mockAuthService.waitForNostrConnectResponse(),
+      ).thenAnswer((_) => Completer<AuthResult>().future);
+      await tester.pumpWidget(createTestWidget());
+      await tester.pump();
+      final loadedOffset = tester.getTopLeft(header);
+
+      expect(loadedOffset, loadingOffset);
 
       await tester.pumpWidget(const SizedBox());
     });

--- a/mobile/test/screens/auth/nostr_connect_screen_test.dart
+++ b/mobile/test/screens/auth/nostr_connect_screen_test.dart
@@ -1,8 +1,24 @@
-// ABOUTME: Widget tests for NostrConnectScreen
-// ABOUTME: Tests route constants and basic structure
+// ABOUTME: Widget tests for NostrConnectScreen.
+// ABOUTME: Route constants plus the skeleton-loading vs real-QR state contract.
 
+import 'dart:async';
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/screens/auth/nostr_connect_screen.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+
+import '../../helpers/test_provider_overrides.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
 
 void main() {
   group('NostrConnectScreen route constants', () {
@@ -15,9 +31,94 @@ void main() {
     });
   });
 
-  // Note: Full widget tests require complex mocking of AuthService,
-  // NostrConnectSession, timers, and clipboard. The core logic is tested
-  // via unit tests in nostr_connect_session_test.dart.
-  // Integration testing is recommended via manual smoke testing with
-  // actual signer apps (Amber, nsecBunker).
+  group('NostrConnectScreen loading contract', () {
+    late _MockAuthService mockAuthService;
+
+    setUp(() {
+      mockAuthService = _MockAuthService();
+      // dispose() reads this before deciding whether to cancel the session.
+      when(
+        () => mockAuthService.isNostrConnectCallbackHandoffActive,
+      ).thenReturn(false);
+    });
+
+    Widget createTestWidget() {
+      return ProviderScope(
+        overrides: [
+          ...getStandardTestOverrides(mockAuthService: mockAuthService),
+        ],
+        child: MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: VineTheme.theme,
+          routerConfig: GoRouter(
+            initialLocation: NostrConnectScreen.path,
+            routes: [
+              GoRoute(path: '/', builder: (_, _) => const Scaffold()),
+              GoRoute(
+                path: NostrConnectScreen.path,
+                builder: (_, _) => const NostrConnectScreen(),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    testWidgets('generating state skeletonizes and omits the real QR encoder', (
+      tester,
+    ) async {
+      when(() => mockAuthService.nostrConnectUrl).thenReturn(null);
+      when(() => mockAuthService.nostrConnectState).thenReturn(null);
+      // Never resolves, so the screen stays in the generating state.
+      when(
+        () => mockAuthService.initiateNostrConnect(),
+      ).thenAnswer((_) => Completer<NostrConnectSession>().future);
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pump();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      // Skeleton.replace must swap the QR out entirely — otherwise the
+      // encoder would run over the empty placeholder payload.
+      expect(find.byType(QrImageView), findsNothing);
+      expect(
+        tester.widget<Skeletonizer>(find.bySubtype<Skeletonizer>()).enabled,
+        isTrue,
+      );
+      expect(find.text(l10n.authGeneratingConnection), findsOneWidget);
+
+      // Unmount to run dispose() and cancel any pending timers.
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('listening state renders the real QR for the connect URL', (
+      tester,
+    ) async {
+      const connectUrl =
+          'nostrconnect://abc123?relay=wss://relay.example.com&secret=xyz';
+      when(() => mockAuthService.nostrConnectUrl).thenReturn(connectUrl);
+      when(
+        () => mockAuthService.nostrConnectState,
+      ).thenReturn(NostrConnectState.listening);
+      // Never resolves, so the screen stays in the listening state.
+      when(
+        () => mockAuthService.waitForNostrConnectResponse(),
+      ).thenAnswer((_) => Completer<AuthResult>().future);
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pump();
+
+      // Skeleton.replace is off, so the real QR encoder is built (not the
+      // shimmer placeholder shown while generating).
+      expect(find.byType(QrImageView), findsOneWidget);
+      expect(
+        tester.widget<Skeletonizer>(find.bySubtype<Skeletonizer>()).enabled,
+        isFalse,
+      );
+
+      await tester.pumpWidget(const SizedBox());
+    });
+  });
 }


### PR DESCRIPTION
Closes #6778

## Description

The nostr-connect screen had a dedicated `_LoadingContent` widget for the `generating` and `connected` states. It rendered its own layout — a centred `Column` with a `Spacer`, start-aligned text and no horizontal padding — so the screen visibly jumped when the session moved to `listening`, and the title sat flush against the screen edge with no inset.

Dropped it and skeletonized the real `_QrContent` instead. The two loading states now render the same widget as the loaded state, so the chrome matches by construction rather than by keeping two layouts in sync by hand.

Notes on the parts that weren't obvious:

- **Only the payload-dependent parts shimmer** — the QR card and the action bar. The back button, title and compatibility table stay *outside* the `Skeletonizer` because its default `ignorePointers: true` blocks hit testing for the entire subtree, `Skeleton.keep` included. Wrapping the back button would have left it visible but dead while the session generates.
- **The status line is `Skeleton.keep`.** It carries real copy in every state ("Generating connection…" / "Waiting for connection (Xs)" / "Connected, authenticating…"), so turning it into a text bone would hide information we already have. Its spinner keeps running on its own ticker.
- **The QR uses `Skeleton.replace`, not an in-place shimmer.** Skeletonizing it in place still builds the child, which would run the QR encoder over the empty placeholder payload. `Skeleton.replace` swaps the subtree at build time, so the encoder never sees it.
- `_QrContent` now takes a `statusMessage` string instead of `elapsedSeconds`. The screen owns the per-state copy, which keeps the component state-agnostic and avoids threading a `NostrConnectState` into the widget layer.

The shimmer comes from `vineSkeletonEffectOf(context)` and the bone from `context.vineColors.skeleton`, matching the existing skeleton pattern in `people_section.dart`.

**Related Issue:** 

## Out of Scope

The `connected` (authenticating) state also renders as a skeleton, even though the QR payload exists by then. That preserves the previous behaviour — that state was fully non-interactive before — and keeps the action bar from being tappable mid-authentication. Leaving the real QR visible there instead is a reasonable alternative if it reads better on device.

## Verification

- `dart format` — no changes
- `flutter analyze lib/screens/auth/nostr_connect_screen.dart` — no issues
- `flutter test test/screens/auth/nostr_connect_screen_test.dart test/screens/auth/nostr_connect_failure_message_test.dart` — 7 passing
- All four design-system ceiling ratchets (`raw_textstyle`, `raw_colors`, `material_button`, `raw_dialog`) — green
- Manual verification on a real Samsung Galaxy still pending — draft until the generating → listening transition is checked on device.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore