### PR TITLE
feat(feed): add immersive video viewing mode

### DIFF
--- a/mobile/lib/screens/feed/feed_immersive_cubit.dart
+++ b/mobile/lib/screens/feed/feed_immersive_cubit.dart
@@ -29,14 +29,16 @@ class FeedImmersiveState extends Equatable {
 class FeedImmersiveCubit extends Cubit<FeedImmersiveState> {
   FeedImmersiveCubit() : super(const FeedImmersiveState());
 
-  /// Hides the chrome. Idempotent, so the several exit paths that guard
-  /// against a stuck overlay can all call it unconditionally.
-  void enter() {
-    if (state.isImmersive) return;
-    emit(const FeedImmersiveState(isImmersive: true));
-  }
+  /// Hides the chrome. Idempotent — `emit` already drops a state equal to the
+  /// current one once anything has been emitted.
+  void enter() => emit(const FeedImmersiveState(isImmersive: true));
 
-  /// Restores the chrome. Idempotent — see [enter].
+  /// Restores the chrome. Idempotent, so the several exit paths that guard
+  /// against a stuck overlay can all call it unconditionally.
+  ///
+  /// The guard is load-bearing here in a way it is not in [enter]: `emit`
+  /// only suppresses an equal state after the first emission, so without it
+  /// an `exit()` on an untouched cubit would emit the initial state.
   void exit() {
     if (!state.isImmersive) return;
     emit(const FeedImmersiveState());

--- a/mobile/lib/screens/feed/feed_immersive_cubit.dart
+++ b/mobile/lib/screens/feed/feed_immersive_cubit.dart
@@ -1,0 +1,44 @@
+// ABOUTME: Feed-scoped state for immersive (hold-to-peek) video viewing.
+// ABOUTME: While held, every chrome layer over the video fades out so the
+// ABOUTME: frame can be seen unobstructed; releasing brings it straight back.
+
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+/// Feed-scoped runtime state for immersive viewing.
+///
+/// Owned per feed surface (home feed page / fullscreen feed) and provided
+/// down the tree via `BlocProvider`, so the page-level chrome (feed mode
+/// header, app bar) and the per-item overlay chrome all fade against the
+/// same signal.
+class FeedImmersiveState extends Equatable {
+  const FeedImmersiveState({this.isImmersive = false});
+
+  /// Whether the chrome over the video is currently hidden.
+  final bool isImmersive;
+
+  @override
+  List<Object?> get props => [isImmersive];
+}
+
+/// Feed-scoped Cubit that owns the immersive-viewing flag.
+///
+/// The flag is transient by design — it is raised while the viewer holds a
+/// finger on the video and lowered the moment they let go, so it is never
+/// persisted and never survives leaving the feed.
+class FeedImmersiveCubit extends Cubit<FeedImmersiveState> {
+  FeedImmersiveCubit() : super(const FeedImmersiveState());
+
+  /// Hides the chrome. Idempotent, so the several exit paths that guard
+  /// against a stuck overlay can all call it unconditionally.
+  void enter() {
+    if (state.isImmersive) return;
+    emit(const FeedImmersiveState(isImmersive: true));
+  }
+
+  /// Restores the chrome. Idempotent — see [enter].
+  void exit() {
+    if (!state.isImmersive) return;
+    emit(const FeedImmersiveState());
+  }
+}

--- a/mobile/lib/screens/feed/feed_mode_switch.dart
+++ b/mobile/lib/screens/feed/feed_mode_switch.dart
@@ -9,6 +9,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/screens/feed/feed_settings_menu.dart';
+import 'package:openvine/widgets/video_feed_item/feed_immersive_chrome.dart';
 
 /// Feed mode picker overlay that displays the current feed mode
 /// and allows users to switch between modes via a bottom sheet.
@@ -29,40 +30,45 @@ class FeedModeSwitch extends StatelessWidget {
       top: 0,
       left: 0,
       right: 0,
-      child: Container(
-        decoration: isPreviewMode
-            ? null
-            : const BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [VineTheme.innerShadowPressed, VineTheme.transparent],
-                ),
-              ),
-        child: SafeArea(
-          bottom: false,
-          child: Padding(
-            // Left padding (16) matches the video metadata container's
-            // `start: 16` on the overlay below, so the feed-mode label
-            // lines up with the avatar.
-            // Right padding (12) gives the trailing More popover a hair
-            // more breathing room from the screen edge — matches the
-            // fullscreen app bar and the profile screen's nav-button row.
-            padding: const EdgeInsetsDirectional.fromSTEB(16, 16, 12, 16),
-            child: isPreviewMode
-                ? _FeedModeContent(
-                    label: _labelForMode(FeedMode.forYou, context.l10n),
-                  )
-                : BlocBuilder<VideoFeedBloc, VideoFeedBlocState>(
-                    buildWhen: (prev, curr) =>
-                        prev.source != curr.source ||
-                        prev.subscribedLists != curr.subscribedLists,
-                    builder: (context, state) => _FeedModeContent(
-                      onTap: () => _showFeedModeBottomSheet(context, state),
-                      label: _labelForSource(state, context.l10n),
-                      trailing: const FeedSettingsMenu(),
-                    ),
+      child: FeedImmersiveChrome(
+        child: Container(
+          decoration: isPreviewMode
+              ? null
+              : const BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: [
+                      VineTheme.innerShadowPressed,
+                      VineTheme.transparent,
+                    ],
                   ),
+                ),
+          child: SafeArea(
+            bottom: false,
+            child: Padding(
+              // Left padding (16) matches the video metadata container's
+              // `start: 16` on the overlay below, so the feed-mode label
+              // lines up with the avatar.
+              // Right padding (12) gives the trailing More popover a hair
+              // more breathing room from the screen edge — matches the
+              // fullscreen app bar and the profile screen's nav-button row.
+              padding: const EdgeInsetsDirectional.fromSTEB(16, 16, 12, 16),
+              child: isPreviewMode
+                  ? _FeedModeContent(
+                      label: _labelForMode(FeedMode.forYou, context.l10n),
+                    )
+                  : BlocBuilder<VideoFeedBloc, VideoFeedBlocState>(
+                      buildWhen: (prev, curr) =>
+                          prev.source != curr.source ||
+                          prev.subscribedLists != curr.subscribedLists,
+                      builder: (context, state) => _FeedModeContent(
+                        onTap: () => _showFeedModeBottomSheet(context, state),
+                        label: _labelForSource(state, context.l10n),
+                        trailing: const FeedSettingsMenu(),
+                      ),
+                    ),
+            ),
           ),
         ),
       ),

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -28,6 +28,7 @@ import 'package:openvine/screens/comments/comments_screen.dart';
 import 'package:openvine/screens/feed/dm_reply_context.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_coordinator.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
+import 'package:openvine/screens/feed/feed_immersive_cubit.dart';
 import 'package:openvine/screens/feed/feed_settings_menu.dart';
 import 'package:openvine/screens/feed/feed_tuning_snackbar.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
@@ -35,6 +36,7 @@ import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/feed_tuning/feed_tuning_swipe_overlay.dart';
 import 'package:openvine/widgets/nav_rounded_shell.dart';
+import 'package:openvine/widgets/video_feed_item/feed_immersive_chrome.dart';
 import 'package:openvine/widgets/video_feed_item/feed_videos.dart';
 import 'package:openvine/widgets/video_feed_item/inline_comment_composer_bar.dart';
 import 'package:openvine/widgets/video_feed_item/reaction_overlay.dart';
@@ -419,6 +421,11 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
   /// `BlocProvider.value` in [build].
   final FeedAutoAdvanceCubit _autoAdvanceCubit = FeedAutoAdvanceCubit();
 
+  /// Feed-scoped immersive (hold-to-peek) state. Owned here so it sits above
+  /// both [FeedVideos] — which raises it on a long press — and this screen's
+  /// app bar, which fades out against it.
+  final FeedImmersiveCubit _immersiveCubit = FeedImmersiveCubit();
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
@@ -443,6 +450,7 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
     routeObserver.unsubscribe(this);
     _pagePosition.dispose();
     unawaited(_autoAdvanceCubit.close());
+    unawaited(_immersiveCubit.close());
     super.dispose();
   }
 
@@ -607,8 +615,11 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
       key: ValueKey(commentsRepository),
       create: (_) =>
           InlineCommentComposerCubit(commentsRepository: commentsRepository),
-      child: BlocProvider.value(
-        value: _autoAdvanceCubit,
+      child: MultiBlocProvider(
+        providers: [
+          BlocProvider.value(value: _autoAdvanceCubit),
+          BlocProvider.value(value: _immersiveCubit),
+        ],
         child: MultiBlocListener(
           listeners: [
             BlocListener<FullscreenFeedBloc, FullscreenFeedState>(
@@ -836,9 +847,15 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                 // [TextFieldTapRegion] inside [_FeedSettingsOverlay] so
                 // taps on the playback controls (which render outside
                 // this widget tree via [OverlayPortal]) are covered too.
+                // [FeedImmersiveChrome] fades the bar out while the viewer
+                // holds the video, matching the per-item overlay below. The
+                // slot keeps its height either way, which is what the
+                // already-`extendBodyBehindAppBar` body expects.
                 appBar: PreferredSize(
                   preferredSize: appBar.preferredSize,
-                  child: TextFieldTapRegion(child: appBar),
+                  child: FeedImmersiveChrome(
+                    child: TextFieldTapRegion(child: appBar),
+                  ),
                 ),
                 body: Stack(
                   children: [

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -22,6 +22,7 @@ import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/shell_obscured_provider.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
+import 'package:openvine/screens/feed/feed_immersive_cubit.dart';
 import 'package:openvine/screens/feed/feed_mode_switch.dart';
 import 'package:openvine/screens/feed/feed_tuning_snackbar.dart';
 import 'package:openvine/screens/feed/home_feed_retap_cubit.dart';
@@ -164,6 +165,11 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
   /// can observe/read it.
   final FeedAutoAdvanceCubit _autoAdvanceCubit = FeedAutoAdvanceCubit();
 
+  /// Feed-scoped immersive (hold-to-peek) state. Owned here so it sits above
+  /// both [FeedVideos] — which raises it on a long press — and
+  /// [FeedModeSwitch], which fades out against it.
+  final FeedImmersiveCubit _immersiveCubit = FeedImmersiveCubit();
+
   @override
   void initState() {
     super.initState();
@@ -185,6 +191,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
   void dispose() {
     _pagePosition.dispose();
     unawaited(_autoAdvanceCubit.close());
+    unawaited(_immersiveCubit.close());
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
@@ -331,8 +338,11 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
       // light in both appearance modes — the app-level style in main.dart
       // follows the palette and would turn them dark on a light theme.
       value: VineTheme.statusBarStyle,
-      child: BlocProvider.value(
-        value: _autoAdvanceCubit,
+      child: MultiBlocProvider(
+        providers: [
+          BlocProvider.value(value: _autoAdvanceCubit),
+          BlocProvider.value(value: _immersiveCubit),
+        ],
         child: NavRoundedShell(
           innerColor: context.vineColors.background,
           child: MultiBlocListener(

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -201,6 +201,12 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
     if (state == AppLifecycleState.paused ||
         state == AppLifecycleState.hidden) {
       _wasBackgrounded = true;
+      // A hold in progress ends here whether or not the platform delivers a
+      // pointer cancel. Without this, a touch lost to backgrounding leaves
+      // the item's pointer set non-empty, and that item can never lower the
+      // flag again — the header and app bar would stay hidden for the life
+      // of the page.
+      _immersiveCubit.exit();
       return;
     }
     // Only auto-refresh on a genuine background → foreground transition. The

--- a/mobile/lib/services/haptic_service.dart
+++ b/mobile/lib/services/haptic_service.dart
@@ -31,6 +31,12 @@ abstract class HapticService {
   /// Haptic feedback when a layer snaps to a helper line.
   static Future<void> snapFeedback() => lightImpact();
 
+  /// Haptic feedback when a press-and-hold enters immersive viewing.
+  ///
+  /// The gesture hides the chrome rather than showing anything new, so this
+  /// is the only confirmation that the hold registered.
+  static Future<void> immersiveModeFeedback() => lightImpact();
+
   /// Haptic feedback when entering a destructive zone.
   ///
   /// Triggered when dragging a layer or clip over a delete/remove area

--- a/mobile/lib/widgets/video_feed_item/feed_immersive_chrome.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_immersive_chrome.dart
@@ -1,0 +1,47 @@
+// ABOUTME: Fades a chrome layer out while the feed is in immersive mode.
+// ABOUTME: Wraps the feed-mode header, the fullscreen app bar, and the
+// ABOUTME: per-item overlay so they all disappear on the same signal.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/screens/feed/feed_immersive_cubit.dart';
+
+/// How long the chrome takes to fade out and back in.
+///
+/// Short enough that releasing feels immediate, long enough that the chrome
+/// doesn't pop.
+const Duration kFeedImmersiveFadeDuration = Duration(milliseconds: 180);
+
+/// Hides [child] while [FeedImmersiveCubit] reports immersive viewing.
+///
+/// The cubit is looked up nullably, so surfaces that render feed chrome
+/// outside a feed page — the video-editor preview's [FeedModeSwitch], widget
+/// tests pumping a single overlay — simply never go immersive instead of
+/// throwing for a missing provider.
+///
+/// [child] is passed through untouched on every rebuild, so a fade toggle
+/// re-runs only this widget's build, not the (expensive) chrome subtree.
+class FeedImmersiveChrome extends StatelessWidget {
+  const FeedImmersiveChrome({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final isImmersive = context.select<FeedImmersiveCubit?, bool>(
+      (cubit) => cubit?.state.isImmersive ?? false,
+    );
+    return IgnorePointer(
+      ignoring: isImmersive,
+      child: AnimatedOpacity(
+        opacity: isImmersive ? 0.0 : 1.0,
+        // Reduced motion gets the same end state without the cross-fade.
+        duration: MediaQuery.disableAnimationsOf(context)
+            ? Duration.zero
+            : kFeedImmersiveFadeDuration,
+        curve: Curves.easeOut,
+        child: child,
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/video_feed_item/feed_immersive_chrome.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_immersive_chrome.dart
@@ -21,10 +21,25 @@ const Duration kFeedImmersiveFadeDuration = Duration(milliseconds: 180);
 ///
 /// [child] is passed through untouched on every rebuild, so a fade toggle
 /// re-runs only this widget's build, not the (expensive) chrome subtree.
-class FeedImmersiveChrome extends StatelessWidget {
+class FeedImmersiveChrome extends StatefulWidget {
   const FeedImmersiveChrome({required this.child, super.key});
 
   final Widget child;
+
+  @override
+  State<FeedImmersiveChrome> createState() => _FeedImmersiveChromeState();
+}
+
+class _FeedImmersiveChromeState extends State<FeedImmersiveChrome> {
+  /// Whether the chrome has finished fading back in.
+  ///
+  /// Pointers stay blocked until this is true. Blocking is driven off the
+  /// fade rather than off the flag alone because the flag drops the instant
+  /// the viewer lifts, while the chrome needs
+  /// [kFeedImmersiveFadeDuration] to become visible again — and a control
+  /// that accepts a tap before the viewer can see it publishes a like or
+  /// opens a report they never chose.
+  bool _fullyVisible = true;
 
   @override
   Widget build(BuildContext context) {
@@ -32,7 +47,9 @@ class FeedImmersiveChrome extends StatelessWidget {
       (cubit) => cubit?.state.isImmersive ?? false,
     );
     return IgnorePointer(
-      ignoring: isImmersive,
+      // Blocked immediately on the way out, and until the fade completes on
+      // the way back in — the chrome is never tappable while invisible.
+      ignoring: isImmersive || !_fullyVisible,
       child: AnimatedOpacity(
         opacity: isImmersive ? 0.0 : 1.0,
         // Reduced motion gets the same end state without the cross-fade.
@@ -40,7 +57,13 @@ class FeedImmersiveChrome extends StatelessWidget {
             ? Duration.zero
             : kFeedImmersiveFadeDuration,
         curve: Curves.easeOut,
-        child: child,
+        onEnd: () {
+          final visible = !isImmersive;
+          if (visible != _fullyVisible) {
+            setState(() => _fullyVisible = visible);
+          }
+        },
+        child: widget.child,
       ),
     );
   }

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -1019,6 +1019,17 @@ class __OverlayState extends ConsumerState<_Overlay> {
                               // like, while this only hides chrome, which is
                               // just as valid over a still-loading frame.
                               //
+                              // Excluded from semantics, and kept on its own
+                              // detector so the tap action above still is
+                              // published. A `GestureDetector` publishes
+                              // `SemanticsAction.longPress` for ANY long-press
+                              // callback, `onLongPressStart` included — and
+                              // firing that action delivers no pointer events,
+                              // so the release path below would never run and
+                              // a screen-reader user would be left with every
+                              // control hidden and pointer-blocked until the
+                              // item was disposed.
+                              excludeFromSemantics: true,
                               onLongPressStart: (_) => _enterImmersive(),
                               child: const SizedBox.expand(),
                             ),

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -651,6 +651,9 @@ class __OverlayState extends ConsumerState<_Overlay> {
     // The cubit outlives this overlay, so the flag has to come down here or
     // the surface would be left with permanently hidden chrome.
     _exitImmersive();
+    // [didUpdateWidget] re-points this State at a different video, so the
+    // pointer set must not outlive the item that filled it.
+    _immersivePointers.clear();
     _heartTrigger.dispose();
     super.dispose();
   }

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -600,9 +600,14 @@ class __OverlayState extends ConsumerState<_Overlay> {
   /// without reaching through a deactivated [BuildContext].
   FeedImmersiveCubit? _immersiveCubit;
 
-  /// Whether *this* item raised the immersive flag. Guards every exit path
-  /// so releasing an unrelated pointer can't clear a hold we never started.
+  /// Whether *this* item raised the immersive flag. Guards enter/exit so an
+  /// unrelated pointer can't clear a hold we never started.
   bool _isHoldingForImmersive = false;
+
+  /// Pointers currently down over this item. The peek ends only when the last
+  /// one lifts, so an incidental second finger (a resting thumb, a pinch
+  /// attempt) can't restore the chrome while the hold finger is still down.
+  final Set<int> _immersivePointers = <int>{};
 
   @override
   void initState() {
@@ -660,12 +665,22 @@ class __OverlayState extends ConsumerState<_Overlay> {
     cubit.enter();
   }
 
-  /// Brings the chrome back.
+  /// Drops a lifted/cancelled pointer and, once none remain, brings the chrome
+  /// back.
   ///
-  /// Reached from three directions because `LongPressGestureRecognizer` only
-  /// reports `onLongPressEnd` for a clean lift: a `PointerCancelEvent` after
-  /// the press was accepted fires neither `onLongPressEnd` nor
-  /// `onLongPressCancel`, which would otherwise strand the chrome hidden.
+  /// Driven off the raw [Listener] rather than the gesture callbacks:
+  /// `LongPressGestureRecognizer` reports neither `onLongPressEnd` nor
+  /// `onLongPressCancel` for a pointer cancelled after the press was accepted,
+  /// which would otherwise strand the chrome hidden. Flutter still delivers the
+  /// terminal event to the down-time hit path even after the [Listener] has
+  /// unmounted (a mode flip mid-hold), so this stays the reliable exit.
+  void _handleImmersivePointerEnd(int pointer) {
+    _immersivePointers.remove(pointer);
+    if (_immersivePointers.isEmpty) _exitImmersive();
+  }
+
+  /// Brings the chrome back. Idempotent — the no-op guard lets [dispose] and
+  /// the last-pointer-up path both call it unconditionally.
   void _exitImmersive() {
     if (!_isHoldingForImmersive) return;
     _isHoldingForImmersive = false;
@@ -945,19 +960,25 @@ class __OverlayState extends ConsumerState<_Overlay> {
                   button: true,
                   label: context.l10n.videoPlayerPlayVideo,
                   hint: isOwnVideo ? null : context.l10n.videoPlayerTapHint,
-                  // The raw [Listener] is the backstop for immersive mode: a
-                  // cancelled pointer never reaches the long-press callbacks
-                  // below (see [_exitImmersive]), and a Listener sits outside
+                  // The raw [Listener] owns immersive mode's release: it counts
+                  // the pointers over the item and exits once the last lifts,
+                  // because a pointer cancelled after the press was accepted
+                  // reaches neither long-press callback (see
+                  // [_handleImmersivePointerEnd]), and a Listener sits outside
                   // the gesture arena so it can't steal the press either.
                   child: Listener(
                     // Must match the translucent child below: with
                     // `deferToChild` a press on empty video area never adds
                     // this Listener to the hit-test path (the translucent
                     // GestureDetector adds itself but still reports a miss),
-                    // so the cancel event would never arrive.
+                    // so the pointer events would never arrive.
                     behavior: HitTestBehavior.translucent,
-                    onPointerUp: (_) => _exitImmersive(),
-                    onPointerCancel: (_) => _exitImmersive(),
+                    onPointerDown: (event) =>
+                        _immersivePointers.add(event.pointer),
+                    onPointerUp: (event) =>
+                        _handleImmersivePointerEnd(event.pointer),
+                    onPointerCancel: (event) =>
+                        _handleImmersivePointerEnd(event.pointer),
                     child: GestureDetector(
                       behavior: .translucent,
                       onTap: interactiveReady ? _handlePlayerTap : null,
@@ -974,12 +995,13 @@ class __OverlayState extends ConsumerState<_Overlay> {
                       // publish a like, while this only hides chrome, which
                       // is just as valid over a still-loading frame.
                       //
-                      // Only `onLongPressStart` / `onLongPressEnd` are wired
-                      // (never `onLongPress`), so no long-press semantics
-                      // action is published — the peek would be meaningless
-                      // to a screen reader, which needs the chrome it hides.
+                      // Only `onLongPressStart` is wired (never `onLongPress`),
+                      // so no long-press semantics action is published — the
+                      // peek would be meaningless to a screen reader, which
+                      // needs the chrome it hides. The release runs through the
+                      // [Listener] above, not `onLongPressEnd`, so an incidental
+                      // second finger can't cut the hold short.
                       onLongPressStart: (_) => _enterImmersive(),
-                      onLongPressEnd: (_) => _exitImmersive(),
                       child: Stack(
                         children: [
                           if (widget.controller != null)

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -1064,6 +1064,12 @@ class __OverlayState extends ConsumerState<_Overlay> {
                           effectiveAutoEnabled: effectiveAutoEnabled,
                           onToggleAutoAdvance: widget.onToggleAutoAdvance,
                           onSuppressAutoAdvance: widget.onSuppressAutoAdvance,
+                          // Captions fade with the rest of the chrome, by
+                          // design: the hold reveals the frame the UI covers,
+                          // and the caption is an overlay over that same frame,
+                          // so keeping it up would re-cover exactly what the
+                          // peek exposes. It is gone only while the viewer
+                          // holds, and returns the instant they release.
                           subtitleLayer:
                               video.hasSubtitles && widget.controller != null
                               ? _SubtitleLayer(

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -27,8 +27,10 @@ import 'package:openvine/router/app_router.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_coordinator.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_error_listener.dart';
+import 'package:openvine/screens/feed/feed_immersive_cubit.dart';
 import 'package:openvine/screens/feed/pooled_age_restricted_retry.dart';
 import 'package:openvine/services/community_content_label_service.dart';
+import 'package:openvine/services/haptic_service.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
 import 'package:openvine/services/view_event_publisher.dart'
@@ -39,6 +41,7 @@ import 'package:openvine/widgets/video_feed_item/blurred_video_backdrop.dart';
 import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/double_tap_heart_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/double_tap_like_helpers.dart';
+import 'package:openvine/widgets/video_feed_item/feed_immersive_chrome.dart';
 import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/paused_video_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/subtitle_overlay.dart';
@@ -593,6 +596,14 @@ class __OverlayState extends ConsumerState<_Overlay> {
   InfiniteVideoFeedState? _feedState;
   ValueListenable<double>? _pagePositionListenable;
 
+  /// Page-scoped immersive state, cached so [dispose] can lower the flag
+  /// without reaching through a deactivated [BuildContext].
+  FeedImmersiveCubit? _immersiveCubit;
+
+  /// Whether *this* item raised the immersive flag. Guards every exit path
+  /// so releasing an unrelated pointer can't clear a hold we never started.
+  bool _isHoldingForImmersive = false;
+
   @override
   void initState() {
     super.initState();
@@ -626,12 +637,41 @@ class __OverlayState extends ConsumerState<_Overlay> {
     super.didChangeDependencies();
     _feedState = context.findAncestorStateOfType<InfiniteVideoFeedState>();
     _pagePositionListenable = _feedState?.pagePositionListenable;
+    _immersiveCubit = context.read<FeedImmersiveCubit?>();
   }
 
   @override
   void dispose() {
+    // An item can be torn down mid-hold (feed rebuild, route replacement).
+    // The cubit outlives this overlay, so the flag has to come down here or
+    // the surface would be left with permanently hidden chrome.
+    _exitImmersive();
     _heartTrigger.dispose();
     super.dispose();
+  }
+
+  /// Hides the chrome for as long as the viewer keeps their finger down.
+  void _enterImmersive() {
+    final cubit = _immersiveCubit;
+    if (cubit == null || cubit.isClosed || _isHoldingForImmersive) return;
+    _isHoldingForImmersive = true;
+    // Confirms the hold registered — the gesture has no other affordance.
+    unawaited(HapticService.immersiveModeFeedback());
+    cubit.enter();
+  }
+
+  /// Brings the chrome back.
+  ///
+  /// Reached from three directions because `LongPressGestureRecognizer` only
+  /// reports `onLongPressEnd` for a clean lift: a `PointerCancelEvent` after
+  /// the press was accepted fires neither `onLongPressEnd` nor
+  /// `onLongPressCancel`, which would otherwise strand the chrome hidden.
+  void _exitImmersive() {
+    if (!_isHoldingForImmersive) return;
+    _isHoldingForImmersive = false;
+    final cubit = _immersiveCubit;
+    if (cubit == null || cubit.isClosed) return;
+    cubit.exit();
   }
 
   // Single definition of "what counts as warned" for this overlay: the
@@ -905,45 +945,77 @@ class __OverlayState extends ConsumerState<_Overlay> {
                   button: true,
                   label: context.l10n.videoPlayerPlayVideo,
                   hint: isOwnVideo ? null : context.l10n.videoPlayerTapHint,
-                  child: GestureDetector(
-                    behavior: .translucent,
-                    onTap: interactiveReady ? _handlePlayerTap : null,
-                    onDoubleTapDown: interactiveReady
-                        ? (details) => _handleDoubleTapLike(
-                            context,
-                            details,
-                            isOwnVideo: isOwnVideo,
-                          )
-                        : null,
-                    child: Stack(
-                      children: [
-                        if (widget.controller != null)
-                          PausedVideoOverlay(
-                            controller: widget.controller!,
-                            isVisible: widget.isActive,
+                  // The raw [Listener] is the backstop for immersive mode: a
+                  // cancelled pointer never reaches the long-press callbacks
+                  // below (see [_exitImmersive]), and a Listener sits outside
+                  // the gesture arena so it can't steal the press either.
+                  child: Listener(
+                    // Must match the translucent child below: with
+                    // `deferToChild` a press on empty video area never adds
+                    // this Listener to the hit-test path (the translucent
+                    // GestureDetector adds itself but still reports a miss),
+                    // so the cancel event would never arrive.
+                    behavior: HitTestBehavior.translucent,
+                    onPointerUp: (_) => _exitImmersive(),
+                    onPointerCancel: (_) => _exitImmersive(),
+                    child: GestureDetector(
+                      behavior: .translucent,
+                      onTap: interactiveReady ? _handlePlayerTap : null,
+                      onDoubleTapDown: interactiveReady
+                          ? (details) => _handleDoubleTapLike(
+                              context,
+                              details,
+                              isOwnVideo: isOwnVideo,
+                            )
+                          : null,
+                      // Press and hold to peek at the unobstructed frame.
+                      // Deliberately not gated on [interactiveReady] the way
+                      // tap and double-tap are: those mutate the player or
+                      // publish a like, while this only hides chrome, which
+                      // is just as valid over a still-loading frame.
+                      //
+                      // Only `onLongPressStart` / `onLongPressEnd` are wired
+                      // (never `onLongPress`), so no long-press semantics
+                      // action is published — the peek would be meaningless
+                      // to a screen reader, which needs the chrome it hides.
+                      onLongPressStart: (_) => _enterImmersive(),
+                      onLongPressEnd: (_) => _exitImmersive(),
+                      child: Stack(
+                        children: [
+                          if (widget.controller != null)
+                            PausedVideoOverlay(
+                              controller: widget.controller!,
+                              isVisible: widget.isActive,
+                            ),
+                          FeedImmersiveChrome(
+                            child: _FeedItemActions(
+                              video: video,
+                              index: widget.index,
+                              contextTitle: widget.contextTitle,
+                              isOwnVideo: isOwnVideo,
+                              autoAdvanceAvailable: autoAdvanceAvailable,
+                              effectiveAutoEnabled: effectiveAutoEnabled,
+                              onToggleAutoAdvance: widget.onToggleAutoAdvance,
+                              onSuppressAutoAdvance:
+                                  widget.onSuppressAutoAdvance,
+                              subtitleLayer:
+                                  video.hasSubtitles &&
+                                      widget.controller != null
+                                  ? _SubtitleLayer(
+                                      video: video,
+                                      controller: widget.controller!,
+                                    )
+                                  : null,
+                              pagePositionListenable: pagePositionListenable,
+                            ),
                           ),
-                        _FeedItemActions(
-                          video: video,
-                          index: widget.index,
-                          contextTitle: widget.contextTitle,
-                          isOwnVideo: isOwnVideo,
-                          autoAdvanceAvailable: autoAdvanceAvailable,
-                          effectiveAutoEnabled: effectiveAutoEnabled,
-                          onToggleAutoAdvance: widget.onToggleAutoAdvance,
-                          onSuppressAutoAdvance: widget.onSuppressAutoAdvance,
-                          subtitleLayer:
-                              video.hasSubtitles && widget.controller != null
-                              ? _SubtitleLayer(
-                                  video: video,
-                                  controller: widget.controller!,
-                                )
-                              : null,
-                          pagePositionListenable: pagePositionListenable,
-                        ),
-                        Positioned.fill(
-                          child: DoubleTapHeartOverlay(trigger: _heartTrigger),
-                        ),
-                      ],
+                          Positioned.fill(
+                            child: DoubleTapHeartOverlay(
+                              trigger: _heartTrigger,
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 );

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -983,9 +983,15 @@ class __OverlayState extends ConsumerState<_Overlay> {
                       child: Stack(
                         children: [
                           if (widget.controller != null)
-                            PausedVideoOverlay(
-                              controller: widget.controller!,
-                              isVisible: widget.isActive,
+                            // The paused play indicator is chrome too — it
+                            // covers the frame the peek is meant to reveal,
+                            // and holding never resumes playback, so leaving
+                            // it up would contradict the gesture.
+                            FeedImmersiveChrome(
+                              child: PausedVideoOverlay(
+                                controller: widget.controller!,
+                                isVisible: widget.isActive,
+                              ),
                             ),
                           FeedImmersiveChrome(
                             child: _FeedItemActions(

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -668,12 +668,14 @@ class __OverlayState extends ConsumerState<_Overlay> {
   /// Drops a lifted/cancelled pointer and, once none remain, brings the chrome
   /// back.
   ///
-  /// Driven off the raw [Listener] rather than the gesture callbacks:
-  /// `LongPressGestureRecognizer` reports neither `onLongPressEnd` nor
-  /// `onLongPressCancel` for a pointer cancelled after the press was accepted,
-  /// which would otherwise strand the chrome hidden. Flutter still delivers the
-  /// terminal event to the down-time hit path even after the [Listener] has
-  /// unmounted (a mode flip mid-hold), so this stays the reliable exit.
+  /// Driven off the raw [Listener] rather than the gesture callbacks.
+  /// `LongPressGestureRecognizer` does not report `onLongPressEnd` for a
+  /// pointer cancelled after the press was accepted (`onLongPressCancel`
+  /// does fire), and neither callback can distinguish an incidental second
+  /// finger lifting from the hold finger lifting — only counting pointers
+  /// can. Flutter still delivers the terminal event to the down-time hit
+  /// path even after the [Listener] has unmounted (a mode flip mid-hold),
+  /// so this stays the reliable exit.
   void _handleImmersivePointerEnd(int pointer) {
     _immersivePointers.remove(pointer);
     if (_immersivePointers.isEmpty) _exitImmersive();

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -965,91 +965,101 @@ class __OverlayState extends ConsumerState<_Overlay> {
                   button: true,
                   label: context.l10n.videoPlayerPlayVideo,
                   hint: isOwnVideo ? null : context.l10n.videoPlayerTapHint,
-                  // The raw [Listener] owns immersive mode's release: it counts
-                  // the pointers over the item and exits once the last lifts,
-                  // because a pointer cancelled after the press was accepted
-                  // reaches neither long-press callback (see
-                  // [_handleImmersivePointerEnd]), and a Listener sits outside
-                  // the gesture arena so it can't steal the press either.
-                  child: Listener(
-                    // Must match the translucent child below: with
-                    // `deferToChild` a press on empty video area never adds
-                    // this Listener to the hit-test path (the translucent
-                    // GestureDetector adds itself but still reports a miss),
-                    // so the pointer events would never arrive.
-                    behavior: HitTestBehavior.translucent,
-                    onPointerDown: (event) =>
-                        _immersivePointers.add(event.pointer),
-                    onPointerUp: (event) =>
-                        _handleImmersivePointerEnd(event.pointer),
-                    onPointerCancel: (event) =>
-                        _handleImmersivePointerEnd(event.pointer),
-                    child: GestureDetector(
-                      behavior: .translucent,
-                      onTap: interactiveReady ? _handlePlayerTap : null,
-                      onDoubleTapDown: interactiveReady
-                          ? (details) => _handleDoubleTapLike(
-                              context,
-                              details,
-                              isOwnVideo: isOwnVideo,
-                            )
-                          : null,
-                      // Press and hold to peek at the unobstructed frame.
-                      // Deliberately not gated on [interactiveReady] the way
-                      // tap and double-tap are: those mutate the player or
-                      // publish a like, while this only hides chrome, which
-                      // is just as valid over a still-loading frame.
-                      //
-                      // Only `onLongPressStart` is wired (never `onLongPress`),
-                      // so no long-press semantics action is published — the
-                      // peek would be meaningless to a screen reader, which
-                      // needs the chrome it hides. The release runs through the
-                      // [Listener] above, not `onLongPressEnd`, so an incidental
-                      // second finger can't cut the hold short.
-                      onLongPressStart: (_) => _enterImmersive(),
-                      child: Stack(
-                        children: [
-                          if (widget.controller != null)
-                            // The paused play indicator is chrome too — it
-                            // covers the frame the peek is meant to reveal,
-                            // and holding never resumes playback, so leaving
-                            // it up would contradict the gesture.
-                            FeedImmersiveChrome(
-                              child: PausedVideoOverlay(
-                                controller: widget.controller!,
-                                isVisible: widget.isActive,
-                              ),
-                            ),
-                          FeedImmersiveChrome(
-                            child: _FeedItemActions(
-                              video: video,
-                              index: widget.index,
-                              contextTitle: widget.contextTitle,
-                              isOwnVideo: isOwnVideo,
-                              autoAdvanceAvailable: autoAdvanceAvailable,
-                              effectiveAutoEnabled: effectiveAutoEnabled,
-                              onToggleAutoAdvance: widget.onToggleAutoAdvance,
-                              onSuppressAutoAdvance:
-                                  widget.onSuppressAutoAdvance,
-                              subtitleLayer:
-                                  video.hasSubtitles &&
-                                      widget.controller != null
-                                  ? _SubtitleLayer(
-                                      video: video,
-                                      controller: widget.controller!,
-                                    )
-                                  : null,
-                              pagePositionListenable: pagePositionListenable,
+                  // The chrome layers are SIBLINGS above the gesture surface,
+                  // never descendants of it. As descendants, any press held
+                  // past `kLongPressTimeout` anywhere on the action rail was
+                  // claimed by the video's long-press: the rail's own tap
+                  // recognizer only accepts on pointer-up, so it lost the
+                  // arena, and Report/More/Share swallowed the tap and faded
+                  // out under the viewer's finger. Keeping them siblings lets
+                  // an opaque button win the hit test outright, so the peek
+                  // never sees that pointer.
+                  child: Stack(
+                    children: [
+                      // The raw [Listener] owns immersive mode's release: it
+                      // counts the pointers over the item and exits once the
+                      // last lifts. `onLongPressEnd` alone would not do —
+                      // it does not fire for a pointer cancelled after the
+                      // press was accepted (`onLongPressCancel` does), and
+                      // neither callback can tell an incidental second finger
+                      // lifting from the hold finger lifting. A Listener also
+                      // sits outside the gesture arena, so it can't steal the
+                      // press.
+                      Positioned.fill(
+                        child: Listener(
+                          // Must match the translucent child below: with
+                          // `deferToChild` a press on empty video area never
+                          // adds this Listener to the hit-test path (the
+                          // translucent GestureDetector adds itself but still
+                          // reports a miss), so the pointer events would never
+                          // arrive.
+                          behavior: HitTestBehavior.translucent,
+                          onPointerDown: (event) =>
+                              _immersivePointers.add(event.pointer),
+                          onPointerUp: (event) =>
+                              _handleImmersivePointerEnd(event.pointer),
+                          onPointerCancel: (event) =>
+                              _handleImmersivePointerEnd(event.pointer),
+                          child: GestureDetector(
+                            behavior: .translucent,
+                            onTap: interactiveReady ? _handlePlayerTap : null,
+                            onDoubleTapDown: interactiveReady
+                                ? (details) => _handleDoubleTapLike(
+                                    context,
+                                    details,
+                                    isOwnVideo: isOwnVideo,
+                                  )
+                                : null,
+                            child: GestureDetector(
+                              behavior: .translucent,
+                              // Press and hold to peek at the unobstructed
+                              // frame. Deliberately not gated on
+                              // [interactiveReady] the way tap and double-tap
+                              // are: those mutate the player or publish a
+                              // like, while this only hides chrome, which is
+                              // just as valid over a still-loading frame.
+                              //
+                              onLongPressStart: (_) => _enterImmersive(),
+                              child: const SizedBox.expand(),
                             ),
                           ),
-                          Positioned.fill(
-                            child: DoubleTapHeartOverlay(
-                              trigger: _heartTrigger,
-                            ),
-                          ),
-                        ],
+                        ),
                       ),
-                    ),
+                      if (widget.controller != null)
+                        // The paused play indicator is chrome too — it
+                        // covers the frame the peek is meant to reveal,
+                        // and holding never resumes playback, so leaving
+                        // it up would contradict the gesture.
+                        FeedImmersiveChrome(
+                          child: PausedVideoOverlay(
+                            controller: widget.controller!,
+                            isVisible: widget.isActive,
+                          ),
+                        ),
+                      FeedImmersiveChrome(
+                        child: _FeedItemActions(
+                          video: video,
+                          index: widget.index,
+                          contextTitle: widget.contextTitle,
+                          isOwnVideo: isOwnVideo,
+                          autoAdvanceAvailable: autoAdvanceAvailable,
+                          effectiveAutoEnabled: effectiveAutoEnabled,
+                          onToggleAutoAdvance: widget.onToggleAutoAdvance,
+                          onSuppressAutoAdvance: widget.onSuppressAutoAdvance,
+                          subtitleLayer:
+                              video.hasSubtitles && widget.controller != null
+                              ? _SubtitleLayer(
+                                  video: video,
+                                  controller: widget.controller!,
+                                )
+                              : null,
+                          pagePositionListenable: pagePositionListenable,
+                        ),
+                      ),
+                      Positioned.fill(
+                        child: DoubleTapHeartOverlay(trigger: _heartTrigger),
+                      ),
+                    ],
                   ),
                 );
               },

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -994,8 +994,15 @@ class __OverlayState extends ConsumerState<_Overlay> {
                           // reports a miss), so the pointer events would never
                           // arrive.
                           behavior: HitTestBehavior.translucent,
-                          onPointerDown: (event) =>
-                              _immersivePointers.add(event.pointer),
+                          onPointerDown: (event) {
+                            // An empty set means nothing is down, so any hold
+                            // this item still believes it owns is stale — its
+                            // terminal event was lost (a touch dropped on
+                            // backgrounding, a platform view taking over).
+                            // Without this the item could never peek again.
+                            if (_immersivePointers.isEmpty) _exitImmersive();
+                            _immersivePointers.add(event.pointer);
+                          },
                           onPointerUp: (event) =>
                               _handleImmersivePointerEnd(event.pointer),
                           onPointerCancel: (event) =>

--- a/mobile/test/screens/feed/feed_immersive_cubit_test.dart
+++ b/mobile/test/screens/feed/feed_immersive_cubit_test.dart
@@ -1,0 +1,53 @@
+// ABOUTME: Unit tests for FeedImmersiveCubit.
+// ABOUTME: Pins the idempotent enter/exit contract the several hold-release
+// ABOUTME: paths in the feed rely on.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/screens/feed/feed_immersive_cubit.dart';
+
+void main() {
+  group(FeedImmersiveCubit, () {
+    test('starts with the chrome visible', () {
+      final cubit = FeedImmersiveCubit();
+      addTearDown(cubit.close);
+
+      expect(cubit.state.isImmersive, isFalse);
+    });
+
+    blocTest<FeedImmersiveCubit, FeedImmersiveState>(
+      'enter hides the chrome',
+      build: FeedImmersiveCubit.new,
+      act: (cubit) => cubit.enter(),
+      expect: () => const [FeedImmersiveState(isImmersive: true)],
+    );
+
+    blocTest<FeedImmersiveCubit, FeedImmersiveState>(
+      'exit restores the chrome',
+      build: FeedImmersiveCubit.new,
+      act: (cubit) => cubit
+        ..enter()
+        ..exit(),
+      expect: () => const [
+        FeedImmersiveState(isImmersive: true),
+        FeedImmersiveState(),
+      ],
+    );
+
+    blocTest<FeedImmersiveCubit, FeedImmersiveState>(
+      'repeated enter does not re-emit',
+      build: FeedImmersiveCubit.new,
+      act: (cubit) => cubit
+        ..enter()
+        ..enter(),
+      expect: () => const [FeedImmersiveState(isImmersive: true)],
+    );
+
+    blocTest<FeedImmersiveCubit, FeedImmersiveState>(
+      'exit without a preceding enter emits nothing',
+      build: FeedImmersiveCubit.new,
+      act: (cubit) => cubit.exit(),
+      expect: () => const <FeedImmersiveState>[],
+    );
+  });
+}

--- a/mobile/test/screens/feed/feed_mode_switch_test.dart
+++ b/mobile/test/screens/feed/feed_mode_switch_test.dart
@@ -11,7 +11,9 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/screens/feed/feed_immersive_cubit.dart';
 import 'package:openvine/screens/feed/feed_mode_switch.dart';
+import 'package:openvine/widgets/video_feed_item/feed_immersive_chrome.dart';
 
 class _MockVideoFeedBloc extends MockBloc<VideoFeedEvent, VideoFeedBlocState>
     implements VideoFeedBloc {}
@@ -372,6 +374,64 @@ void main() {
           expect(find.byType(VineBottomSheet), findsOneWidget);
         },
       );
+    });
+
+    group('Immersive mode', () {
+      testWidgets('fades the header out while the viewer holds the video', (
+        tester,
+      ) async {
+        when(() => mockBloc.state).thenReturn(
+          const VideoFeedBlocState(
+            status: VideoFeedStatus.success,
+            source: VideoFeedSource.forYou(),
+          ),
+        );
+        final immersiveCubit = FeedImmersiveCubit();
+        addTearDown(immersiveCubit.close);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: Stack(
+                  children: [
+                    MultiBlocProvider(
+                      providers: [
+                        BlocProvider<VideoFeedBloc>.value(value: mockBloc),
+                        BlocProvider<FeedImmersiveCubit>.value(
+                          value: immersiveCubit,
+                        ),
+                      ],
+                      child: const FeedModeSwitch(),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        double headerOpacity() => tester
+            .widget<AnimatedOpacity>(
+              find
+                  .descendant(
+                    of: find.byType(FeedImmersiveChrome),
+                    matching: find.byType(AnimatedOpacity),
+                  )
+                  .first,
+            )
+            .opacity;
+
+        expect(headerOpacity(), equals(1.0));
+
+        immersiveCubit.enter();
+        await tester.pumpAndSettle();
+
+        expect(headerOpacity(), equals(0.0));
+      });
     });
 
     group('Accessibility', () {

--- a/mobile/test/services/haptic_service_test.dart
+++ b/mobile/test/services/haptic_service_test.dart
@@ -61,5 +61,11 @@ void main() {
 
       expect(hapticCalls, equals(['HapticFeedbackType.heavyImpact']));
     });
+
+    test('immersiveModeFeedback delegates to lightImpact', () async {
+      await HapticService.immersiveModeFeedback();
+
+      expect(hapticCalls, equals(['HapticFeedbackType.lightImpact']));
+    });
   });
 }

--- a/mobile/test/widgets/video_feed_item/feed_immersive_chrome_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_immersive_chrome_test.dart
@@ -98,6 +98,45 @@ void main() {
       expect(_ignoringPointer(tester), isFalse);
     });
 
+    testWidgets('keeps blocking taps until the chrome is visible again', (
+      tester,
+    ) async {
+      final cubit = FeedImmersiveCubit();
+      addTearDown(cubit.close);
+      var taps = 0;
+
+      await _pumpChrome(tester, cubit: cubit, onTap: () => taps++);
+      cubit.enter();
+      await tester.pumpAndSettle();
+
+      // Release the hold, then stop part-way through the fade back in.
+      cubit.exit();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 20));
+
+      expect(
+        _ignoringPointer(tester),
+        isTrue,
+        reason: 'chrome is still invisible here — it must not accept taps',
+      );
+
+      await tester.tap(find.text('chrome'), warnIfMissed: false);
+      await tester.pump();
+
+      expect(
+        taps,
+        isZero,
+        reason: 'a tap must never land on a control the viewer cannot see',
+      );
+
+      // Once the fade completes the chrome is tappable again.
+      await tester.pumpAndSettle();
+      expect(_ignoringPointer(tester), isFalse);
+      await tester.tap(find.text('chrome'));
+      await tester.pump();
+      expect(taps, equals(1));
+    });
+
     testWidgets('stays visible when no cubit is provided', (tester) async {
       await _pumpChrome(tester);
 

--- a/mobile/test/widgets/video_feed_item/feed_immersive_chrome_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_immersive_chrome_test.dart
@@ -1,0 +1,120 @@
+// ABOUTME: Widget tests for FeedImmersiveChrome.
+// ABOUTME: Covers fading + pointer-blocking against the cubit, the
+// ABOUTME: no-provider fallback, and the reduced-motion instant switch.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/screens/feed/feed_immersive_cubit.dart';
+import 'package:openvine/widgets/video_feed_item/feed_immersive_chrome.dart';
+
+Future<void> _pumpChrome(
+  WidgetTester tester, {
+  FeedImmersiveCubit? cubit,
+  bool disableAnimations = false,
+  VoidCallback? onTap,
+}) async {
+  final chrome = FeedImmersiveChrome(
+    child: GestureDetector(
+      onTap: onTap,
+      child: const SizedBox.expand(child: Text('chrome')),
+    ),
+  );
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: MediaQuery(
+        data: MediaQueryData(disableAnimations: disableAnimations),
+        child: cubit == null
+            ? chrome
+            : BlocProvider<FeedImmersiveCubit>.value(
+                value: cubit,
+                child: chrome,
+              ),
+      ),
+    ),
+  );
+}
+
+double _opacityOf(WidgetTester tester) =>
+    tester.widget<AnimatedOpacity>(find.byType(AnimatedOpacity)).opacity;
+
+bool _ignoringPointer(WidgetTester tester) => tester
+    .widget<IgnorePointer>(
+      find.descendant(
+        of: find.byType(FeedImmersiveChrome),
+        matching: find.byType(IgnorePointer),
+      ),
+    )
+    .ignoring;
+
+void main() {
+  group(FeedImmersiveChrome, () {
+    testWidgets('shows the chrome while not immersive', (tester) async {
+      final cubit = FeedImmersiveCubit();
+      addTearDown(cubit.close);
+
+      await _pumpChrome(tester, cubit: cubit);
+
+      expect(_opacityOf(tester), equals(1.0));
+      expect(_ignoringPointer(tester), isFalse);
+    });
+
+    testWidgets('hides the chrome and blocks taps once immersive', (
+      tester,
+    ) async {
+      final cubit = FeedImmersiveCubit();
+      addTearDown(cubit.close);
+      var taps = 0;
+
+      await _pumpChrome(tester, cubit: cubit, onTap: () => taps++);
+      cubit.enter();
+      await tester.pumpAndSettle();
+
+      expect(_opacityOf(tester), equals(0.0));
+      expect(_ignoringPointer(tester), isTrue);
+
+      await tester.tap(find.text('chrome'), warnIfMissed: false);
+      await tester.pump();
+
+      expect(
+        taps,
+        isZero,
+        reason: 'hidden chrome must not swallow taps meant for the video',
+      );
+    });
+
+    testWidgets('restores the chrome when the hold ends', (tester) async {
+      final cubit = FeedImmersiveCubit();
+      addTearDown(cubit.close);
+
+      await _pumpChrome(tester, cubit: cubit);
+      cubit.enter();
+      await tester.pumpAndSettle();
+      cubit.exit();
+      await tester.pumpAndSettle();
+
+      expect(_opacityOf(tester), equals(1.0));
+      expect(_ignoringPointer(tester), isFalse);
+    });
+
+    testWidgets('stays visible when no cubit is provided', (tester) async {
+      await _pumpChrome(tester);
+
+      expect(_opacityOf(tester), equals(1.0));
+      expect(_ignoringPointer(tester), isFalse);
+    });
+
+    testWidgets('skips the cross-fade under reduced motion', (tester) async {
+      final cubit = FeedImmersiveCubit();
+      addTearDown(cubit.close);
+
+      await _pumpChrome(tester, cubit: cubit, disableAnimations: true);
+
+      expect(
+        tester.widget<AnimatedOpacity>(find.byType(AnimatedOpacity)).duration,
+        equals(Duration.zero),
+      );
+    });
+  });
+}

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -1261,6 +1261,48 @@ void main() {
       expect(chromeOpacity(tester, of: VideoOverlayActions), equals(1.0));
     });
 
+    testWidgets('a second finger lifting mid-hold does not end the peek', (
+      tester,
+    ) async {
+      final video = _makeVideo();
+      final immersiveCubit = FeedImmersiveCubit();
+
+      await _pumpFeedVideos(
+        tester,
+        videos: [video],
+        feedImmersiveCubit: immersiveCubit,
+      );
+      await tester.pump();
+
+      final center = tester.getCenter(find.byType(InfiniteVideoFeed));
+      final holdFinger = await tester.startGesture(center, pointer: 1);
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+      await pumpFade(tester);
+
+      expect(immersiveCubit.state.isImmersive, isTrue);
+
+      // A second finger touches down and lifts while the first still holds.
+      final secondFinger = await tester.startGesture(
+        center + const Offset(24, 24),
+        pointer: 2,
+      );
+      await secondFinger.up();
+      await pumpFade(tester);
+
+      expect(
+        immersiveCubit.state.isImmersive,
+        isTrue,
+        reason: 'a second finger must not cut a hold the first finger keeps',
+      );
+      expect(chromeOpacity(tester, of: VideoOverlayActions), equals(0.0));
+
+      await holdFinger.up();
+      await pumpFade(tester);
+
+      expect(immersiveCubit.state.isImmersive, isFalse);
+      expect(chromeOpacity(tester, of: VideoOverlayActions), equals(1.0));
+    });
+
     testWidgets('hides the paused play indicator too', (tester) async {
       // The play indicator only mounts once a controller exists.
       InfiniteVideoFeed.debugIsSupportedOverride = true;

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -6,6 +6,7 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:comments_repository/comments_repository.dart';
 import 'package:flutter/gestures.dart' show kLongPressTimeout;
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -1421,6 +1422,35 @@ void main() {
         );
       },
     );
+
+    testWidgets('publishes no long-press semantics action', (tester) async {
+      // A semantics long-press delivers no pointer events, so the release
+      // path could never run and a screen-reader user would be stranded
+      // with every control hidden and pointer-blocked.
+      final handle = tester.ensureSemantics();
+      final video = _makeVideo();
+      final immersiveCubit = FeedImmersiveCubit();
+      addTearDown(immersiveCubit.close);
+
+      await _pumpFeedVideos(
+        tester,
+        videos: [video],
+        feedImmersiveCubit: immersiveCubit,
+      );
+      await tester.pump();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      final node = tester.getSemantics(
+        find.bySemanticsLabel(l10n.videoPlayerPlayVideo).first,
+      );
+
+      expect(
+        node.getSemanticsData().hasAction(SemanticsAction.longPress),
+        isFalse,
+        reason: 'the peek must not be reachable from a screen reader',
+      );
+      handle.dispose();
+    });
 
     testWidgets('caps InfiniteVideoFeed playback at the feed cap', (
       tester,

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:comments_repository/comments_repository.dart';
+import 'package:flutter/gestures.dart' show kLongPressTimeout;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -34,6 +35,7 @@ import 'package:openvine/providers/subtitle_providers.dart';
 import 'package:openvine/repositories/community_content_label_repository.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
+import 'package:openvine/screens/feed/feed_immersive_cubit.dart';
 import 'package:openvine/services/analytics_service.dart';
 import 'package:openvine/services/community_content_label_service.dart';
 import 'package:openvine/services/connection_status_service.dart';
@@ -46,6 +48,7 @@ import 'package:openvine/services/view_event_publisher.dart'
 import 'package:openvine/widgets/divine_video_metrics_tracker.dart';
 import 'package:openvine/widgets/video_feed_item/actions/help_classify_action_button.dart';
 import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
+import 'package:openvine/widgets/video_feed_item/feed_immersive_chrome.dart';
 import 'package:openvine/widgets/video_feed_item/feed_videos.dart';
 import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/pooled_video_error_overlay.dart';
@@ -288,6 +291,7 @@ Future<void> _pumpFeedVideos(
   required List<VideoEvent> videos,
   _MockVideoPlaybackStatusCubit? videoPlaybackStatusCubit,
   _MockFeedAutoAdvanceCubit? feedAutoAdvanceCubit,
+  FeedImmersiveCubit? feedImmersiveCubit,
   _MockVideoVolumeCubit? videoVolumeCubit,
   VideoModerationStatusService? moderationService,
   MediaAuthInterceptor? mediaAuthInterceptor,
@@ -313,6 +317,10 @@ Future<void> _pumpFeedVideos(
       feedAutoAdvanceCubit ??
       (_MockFeedAutoAdvanceCubit()..stub(const FeedAutoAdvanceState()));
   final mockVolumeCubit = videoVolumeCubit ?? (_MockVideoVolumeCubit()..stub());
+  // Real cubit rather than a mock: it holds one bool and the hold-to-peek
+  // tests assert the chrome that reacts to it.
+  final immersiveCubit = feedImmersiveCubit ?? FeedImmersiveCubit();
+  addTearDown(immersiveCubit.close);
   final container = ProviderContainer(
     overrides: [
       ..._buildOverrides(
@@ -345,6 +353,7 @@ Future<void> _pumpFeedVideos(
               value: mockPlaybackCubit,
             ),
             BlocProvider<VideoVolumeCubit>.value(value: mockVolumeCubit),
+            BlocProvider<FeedImmersiveCubit>.value(value: immersiveCubit),
           ],
           child: Scaffold(
             body: FeedVideos(
@@ -1163,6 +1172,140 @@ void main() {
         ).called(1);
       },
     );
+  });
+
+  // -------------------------------------------------------------------------
+  // Immersive (hold-to-peek) viewing — #6234
+  // -------------------------------------------------------------------------
+  group('hold to peek', () {
+    // The overlay's author block has an AnimatedOpacity of its own, so take
+    // the outermost one — the wrapper's.
+    double chromeOpacity(WidgetTester tester) => tester
+        .widget<AnimatedOpacity>(
+          find
+              .descendant(
+                of: find.byType(FeedImmersiveChrome),
+                matching: find.byType(AnimatedOpacity),
+              )
+              .first,
+        )
+        .opacity;
+
+    // pumpAndSettle can't be used here: InfiniteVideoFeed keeps its own
+    // timers running, so settle never arrives. The fade is a fixed duration.
+    Future<void> pumpFade(WidgetTester tester) => tester.pump(
+      kFeedImmersiveFadeDuration + const Duration(milliseconds: 50),
+    );
+
+    testWidgets('hides the overlay chrome while held and restores on release', (
+      tester,
+    ) async {
+      final video = _makeVideo();
+      final immersiveCubit = FeedImmersiveCubit();
+
+      await _pumpFeedVideos(
+        tester,
+        videos: [video],
+        feedImmersiveCubit: immersiveCubit,
+      );
+      await tester.pump();
+
+      expect(chromeOpacity(tester), equals(1.0));
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byType(InfiniteVideoFeed)),
+      );
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+      await pumpFade(tester);
+
+      expect(immersiveCubit.state.isImmersive, isTrue);
+      expect(chromeOpacity(tester), equals(0.0));
+
+      await gesture.up();
+      await pumpFade(tester);
+
+      expect(immersiveCubit.state.isImmersive, isFalse);
+      expect(chromeOpacity(tester), equals(1.0));
+    });
+
+    testWidgets('restores the chrome when the pointer is cancelled', (
+      tester,
+    ) async {
+      final video = _makeVideo();
+      final immersiveCubit = FeedImmersiveCubit();
+
+      await _pumpFeedVideos(
+        tester,
+        videos: [video],
+        feedImmersiveCubit: immersiveCubit,
+      );
+      await tester.pump();
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byType(InfiniteVideoFeed)),
+      );
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+      expect(immersiveCubit.state.isImmersive, isTrue);
+
+      // LongPressGestureRecognizer reports neither onLongPressEnd nor
+      // onLongPressCancel for a pointer cancelled after acceptance, so
+      // without the raw Listener backstop the chrome would stay hidden.
+      await gesture.cancel();
+      await pumpFade(tester);
+
+      expect(immersiveCubit.state.isImmersive, isFalse);
+      expect(chromeOpacity(tester), equals(1.0));
+    });
+
+    testWidgets('a short tap leaves the chrome alone', (tester) async {
+      final video = _makeVideo();
+      final immersiveCubit = FeedImmersiveCubit();
+
+      await _pumpFeedVideos(
+        tester,
+        videos: [video],
+        feedImmersiveCubit: immersiveCubit,
+      );
+      await tester.pump();
+
+      await tester.tap(find.byType(InfiniteVideoFeed));
+      await pumpFade(tester);
+
+      expect(immersiveCubit.state.isImmersive, isFalse);
+      expect(chromeOpacity(tester), equals(1.0));
+    });
+
+    testWidgets('lowers the flag when the feed is torn down mid-hold', (
+      tester,
+    ) async {
+      final video = _makeVideo();
+      final immersiveCubit = FeedImmersiveCubit();
+      addTearDown(immersiveCubit.close);
+
+      await _pumpFeedVideos(
+        tester,
+        videos: [video],
+        feedImmersiveCubit: immersiveCubit,
+      );
+      await tester.pump();
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byType(InfiniteVideoFeed)),
+      );
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+      expect(immersiveCubit.state.isImmersive, isTrue);
+
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump(const Duration(seconds: 4));
+
+      expect(
+        immersiveCubit.state.isImmersive,
+        isFalse,
+        reason: 'a cubit outliving the overlay must not stay immersive',
+      );
+
+      await gesture.cancel();
+    });
   });
 
   group('playback length cap', () {

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -2,6 +2,8 @@
 // ABOUTME: overlay mode switching (forbidden/ageRestricted/contentWarning/interactive),
 // ABOUTME: effective isActive propagation, route-aware pausing, and pagination flush.
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:comments_repository/comments_repository.dart';
 import 'package:flutter/gestures.dart' show kLongPressTimeout;
@@ -1452,6 +1454,106 @@ void main() {
       handle.dispose();
     });
 
+    testWidgets('cannot peek past a content warning gate', (tester) async {
+      // The gate modes are early returns in _resolveOverlayMode, so the
+      // gesture does not exist in that subtree. Nothing else enforces it —
+      // if the blur ever becomes a sibling in the interactive Stack, a hold
+      // would silently reveal warned content.
+      final video = _makeVideo(warnLabels: ['nudity']);
+      final immersiveCubit = FeedImmersiveCubit();
+      addTearDown(immersiveCubit.close);
+
+      await _pumpFeedVideos(
+        tester,
+        videos: [video],
+        feedImmersiveCubit: immersiveCubit,
+      );
+      await tester.pump();
+
+      expect(find.byType(ContentWarningBlurOverlay), findsOneWidget);
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byType(InfiniteVideoFeed)),
+      );
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+      await pumpFade(tester);
+
+      expect(
+        immersiveCubit.state.isImmersive,
+        isFalse,
+        reason: 'a hold must never uncover gated content',
+      );
+      expect(find.byType(ContentWarningBlurOverlay), findsOneWidget);
+
+      await gesture.up();
+    });
+
+    testWidgets(
+      'restores the chrome when the overlay mode flips mid-hold',
+      (tester) async {
+        // The one release path `dispose()` cannot cover: a community label
+        // resolving mid-hold swaps the interactive subtree — and with it the
+        // Listener — for the blur overlay, while __OverlayState itself
+        // survives. The exit then depends on Flutter still delivering the
+        // terminal pointer event to the hit path captured at pointer-down.
+        final video = _makeVideo(); // no creator/trusted warn labels
+        final labels = Completer<Set<String>>();
+        final repository = _MockCommunityContentLabelRepository();
+        when(
+          () => repository.communityLabelsForVideo(video),
+        ).thenAnswer((_) => labels.future);
+        final filter = _MockContentFilterService();
+        when(
+          () => filter.getPreference(ContentLabel.gambling),
+        ).thenReturn(ContentFilterPreference.warn);
+        final service = CommunityContentLabelService(
+          repository: repository,
+          contentFilterService: filter,
+        );
+        final immersiveCubit = FeedImmersiveCubit();
+        addTearDown(immersiveCubit.close);
+
+        await _pumpFeedVideos(
+          tester,
+          videos: [video],
+          feedImmersiveCubit: immersiveCubit,
+          additionalOverrides: [
+            communityContentLabelServiceProvider.overrideWith((ref) => service),
+            featureFlagServiceProvider.overrideWithValue(_communityFlagsOn()),
+          ],
+        );
+        await tester.pump();
+
+        // Hold while the item is still interactive.
+        final gesture = await tester.startGesture(
+          tester.getCenter(find.byType(InfiniteVideoFeed)),
+        );
+        await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+        expect(immersiveCubit.state.isImmersive, isTrue);
+
+        // The label lands mid-hold and unmounts the Listener.
+        labels.complete({'gambling'});
+        await tester.pump();
+        await tester.pump();
+        expect(
+          find.byType(ContentWarningBlurOverlay),
+          findsOneWidget,
+          reason: 'the flip must actually replace the interactive subtree',
+        );
+
+        await gesture.up();
+        await pumpFade(tester);
+
+        expect(
+          immersiveCubit.state.isImmersive,
+          isFalse,
+          reason: 'releasing after a mid-hold mode flip must restore chrome',
+        );
+      },
+    );
+  });
+
+  group('playback length cap', () {
     testWidgets('caps InfiniteVideoFeed playback at the feed cap', (
       tester,
     ) async {

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -51,7 +51,9 @@ import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/feed_immersive_chrome.dart';
 import 'package:openvine/widgets/video_feed_item/feed_videos.dart';
 import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
+import 'package:openvine/widgets/video_feed_item/paused_video_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/pooled_video_error_overlay.dart';
+import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:openvine/widgets/video_feed_item/video_loading_placeholder.dart';
 import 'package:reposts_repository/reposts_repository.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -1178,13 +1180,15 @@ void main() {
   // Immersive (hold-to-peek) viewing — #6234
   // -------------------------------------------------------------------------
   group('hold to peek', () {
-    // The overlay's author block has an AnimatedOpacity of its own, so take
-    // the outermost one — the wrapper's.
-    double chromeOpacity(WidgetTester tester) => tester
+    // Reads the fade the [FeedImmersiveChrome] around [of] applies. Anchored
+    // on the wrapped widget rather than on FeedImmersiveChrome itself: each
+    // chrome layer has its own wrapper, and the overlay actions carry an
+    // unrelated AnimatedOpacity of their own further down.
+    double chromeOpacity(WidgetTester tester, {required Type of}) => tester
         .widget<AnimatedOpacity>(
           find
-              .descendant(
-                of: find.byType(FeedImmersiveChrome),
+              .ancestor(
+                of: find.byType(of),
                 matching: find.byType(AnimatedOpacity),
               )
               .first,
@@ -1210,7 +1214,7 @@ void main() {
       );
       await tester.pump();
 
-      expect(chromeOpacity(tester), equals(1.0));
+      expect(chromeOpacity(tester, of: VideoOverlayActions), equals(1.0));
 
       final gesture = await tester.startGesture(
         tester.getCenter(find.byType(InfiniteVideoFeed)),
@@ -1219,13 +1223,13 @@ void main() {
       await pumpFade(tester);
 
       expect(immersiveCubit.state.isImmersive, isTrue);
-      expect(chromeOpacity(tester), equals(0.0));
+      expect(chromeOpacity(tester, of: VideoOverlayActions), equals(0.0));
 
       await gesture.up();
       await pumpFade(tester);
 
       expect(immersiveCubit.state.isImmersive, isFalse);
-      expect(chromeOpacity(tester), equals(1.0));
+      expect(chromeOpacity(tester, of: VideoOverlayActions), equals(1.0));
     });
 
     testWidgets('restores the chrome when the pointer is cancelled', (
@@ -1254,7 +1258,41 @@ void main() {
       await pumpFade(tester);
 
       expect(immersiveCubit.state.isImmersive, isFalse);
-      expect(chromeOpacity(tester), equals(1.0));
+      expect(chromeOpacity(tester, of: VideoOverlayActions), equals(1.0));
+    });
+
+    testWidgets('hides the paused play indicator too', (tester) async {
+      // The play indicator only mounts once a controller exists.
+      InfiniteVideoFeed.debugIsSupportedOverride = true;
+      final video = _makeVideo();
+      final immersiveCubit = FeedImmersiveCubit();
+
+      await _pumpFeedVideos(
+        tester,
+        videos: [video],
+        feedImmersiveCubit: immersiveCubit,
+      );
+      await tester.pump(const Duration(seconds: 4));
+
+      expect(find.byType(PausedVideoOverlay), findsOneWidget);
+      expect(chromeOpacity(tester, of: PausedVideoOverlay), equals(1.0));
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byType(InfiniteVideoFeed)),
+      );
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+      await pumpFade(tester);
+
+      expect(
+        chromeOpacity(tester, of: PausedVideoOverlay),
+        equals(0.0),
+        reason: 'the play indicator covers the frame the peek reveals',
+      );
+
+      await gesture.up();
+      await pumpFade(tester);
+
+      expect(chromeOpacity(tester, of: PausedVideoOverlay), equals(1.0));
     });
 
     testWidgets('a short tap leaves the chrome alone', (tester) async {
@@ -1272,7 +1310,7 @@ void main() {
       await pumpFade(tester);
 
       expect(immersiveCubit.state.isImmersive, isFalse);
-      expect(chromeOpacity(tester), equals(1.0));
+      expect(chromeOpacity(tester, of: VideoOverlayActions), equals(1.0));
     });
 
     testWidgets('lowers the flag when the feed is torn down mid-hold', (

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -1386,9 +1386,42 @@ void main() {
 
       await gesture.cancel();
     });
-  });
 
-  group('playback length cap', () {
+    testWidgets(
+      'keeps the action rail out from under the peek gesture',
+      (tester) async {
+        // When the rail sat *inside* the long-press detector, any press held
+        // past kLongPressTimeout anywhere on Report/More/Share was claimed by
+        // the video's long-press: the button's tap recognizer only accepts on
+        // pointer-up, so it lost the arena, the tap was swallowed and the
+        // control faded out under the viewer's finger.
+        //
+        // Asserted structurally rather than by pressing a button: the action
+        // icons are SVG-backed and lay out at zero size under `flutter test`,
+        // so there is no button rect to press. Ancestry is the invariant that
+        // actually matters — a sibling rail cannot lose the arena.
+        final video = _makeVideo();
+
+        await _pumpFeedVideos(tester, videos: [video]);
+        await tester.pump();
+
+        final longPressAncestors = tester
+            .widgetList<GestureDetector>(
+              find.ancestor(
+                of: find.byType(VideoOverlayActions),
+                matching: find.byType(GestureDetector),
+              ),
+            )
+            .where((detector) => detector.onLongPressStart != null);
+
+        expect(
+          longPressAncestors,
+          isEmpty,
+          reason: 'the peek gesture must not sit above the action rail',
+        );
+      },
+    );
+
     testWidgets('caps InfiniteVideoFeed playback at the feed cap', (
       tester,
     ) async {


### PR DESCRIPTION
## Description

Adds an immersive viewing mode to the feed: **press and hold anywhere on a video** and every chrome layer over it cross-fades out (180 ms), so the frame can be seen unobstructed. Release and it all comes straight back.

Hidden while held: the feed-mode header (`For You` + `⋯`), the author block, caption, action rail, both gradients, and the paused play indicator — plus the fullscreen reel's app bar. The shell's bottom nav intentionally stays.

Each chrome layer carries its own `FeedImmersiveChrome` wrapper rather than sharing one, so the double-tap heart animation stays independent of the fade.

**Related Issue:** Closes #6234

### Why hold-to-peek and not a toggle

The issue leaves the interaction open and lists pinch, long-press and a menu toggle as community suggestions. It also asks for a way to focus on a video *"without permanently changing the viewing experience"*, and describes the mode as temporarily hiding the UI — which is what a transient hold gives you, and a sticky toggle does not.

Practical consequences that made this the safer of the three:

- Nothing is persisted, and there is no state the UI can get stuck in. A sticky toggle needs an exit affordance, and the obvious one (single tap) is already play/pause.
- No gesture conflicts. A short press rejects the long-press recognizer so tap-to-pause is untouched; a completed hold suppresses the tap, so releasing does not pause the video. Double-tap-to-like is unaffected — the first tap's release lands well inside the 500 ms long-press deadline.

### Why a raw `Listener` backstops the release

`LongPressGestureRecognizer` fires **neither** `onLongPressEnd` nor `onLongPressCancel` when a pointer is cancelled *after* the press was accepted (`handlePrimaryPointer` routes `PointerCancelEvent` to `_checkLongPressCancel`, which no-ops once the recognizer has left `possible`). Without a backstop, an incoming call or a system gesture mid-hold would leave the chrome permanently hidden. `dispose()` covers the third case — the item being torn down mid-hold.

That `Listener` needs `behavior: HitTestBehavior.translucent`. With the default `deferToChild` it never enters the hit-test path over empty video area at all: the translucent `GestureDetector` beneath it adds *itself* to the hit-test result but still returns `false`, so a `deferToChild` parent concludes it was missed. This was caught by the pointer-cancel test, which failed before the fix.

### Why the hold is not gated on player readiness

Tap and double-tap are gated on `interactiveReady` because they mutate the player or publish a like. Hiding chrome has neither effect and is just as valid over a still-loading or letterboxed frame, so the hold works immediately.

### Architecture

A page-scoped `FeedImmersiveCubit` (one idempotent bool) is owned by `VideoFeedView` and `_FullscreenFeedContentState`, alongside the existing `FeedAutoAdvanceCubit` — it has to sit above both `FeedVideos`, which raises the flag, and the page-level header/app bar, which fade against it. `FeedImmersiveChrome` wraps each chrome layer in `AnimatedOpacity` + `IgnorePointer` and looks the cubit up **nullably**, so surfaces that render feed chrome outside a feed page (the video-editor preview's `FeedModeSwitch`, isolated widget tests) simply never go immersive instead of throwing. Reduced motion (`MediaQuery.disableAnimationsOf`) gets the same end state with `Duration.zero`.

No new user-facing strings, so no ARB changes. Only `onLongPressStart` / `onLongPressEnd` are wired — never `onLongPress` — so no long-press semantics action is published: the peek would be meaningless to a screen reader, which needs the chrome it hides.

## Out of Scope

- **Discoverability.** No coach-mark or first-run hint. The issue carries `needs design` with @Chardot and @NotThatKindOfDrLiz assigned; this ships the interaction, not their sign-off on how it is surfaced.
- **Bottom navigation bar.** Deliberately left visible — hiding it means a cross-cutting signal into `AppShell`'s `Scaffold`, which is a bigger change than this feature warrants.
- **Captions.** `subtitleLayer` lives inside `VideoOverlayActions`' author Column, so it fades with the rest of the block. Separating it means restructuring that widget; the hold is user-initiated and momentary, so it was not worth the churn here.

## Verification

- `dart format` — clean
- `flutter analyze lib test integration_test` — no issues
- `flutter test test/widgets/video_feed_item/ test/screens/feed/ test/services/haptic_service_test.dart test/screens/explore` — 493 passed
- `flutter test` on the other suites that mount these screens (hashtag feed ×3, notifications view, profile videos grid, fullscreen feed redirect, foreground idle warmup) — 84 passed
- All four design-system ceilings (`raw_textstyle`, `raw_colors`, `material_button`, `raw_dialog`), `check_untested_services_floor.sh`, `check_test_unit_structure.sh` — pass
- No goldens cover feed chrome, and `Opacity` at 1.0 is a no-op paint, so nothing shifts at rest

New/extended coverage:

- `feed_immersive_cubit_test.dart` — idempotent enter/exit contract
- `feed_immersive_chrome_test.dart` — fade + pointer blocking, no-provider fallback, reduced-motion instant switch
- `feed_videos_test.dart` → `hold to peek` — hides on hold and restores on release, hides the paused play indicator, restores on pointer **cancel**, a short tap leaves the chrome alone, and the flag lowers when the feed is torn down mid-hold
- `feed_mode_switch_test.dart` → `Immersive mode` — the header fades with the cubit

Manually verified on a real Samsung Galaxy device.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
