### PR TITLE
fix(video-metadata): frame the post preview like the feed

### DIFF
--- a/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
@@ -9,6 +9,7 @@ import 'package:go_router/go_router.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
@@ -187,12 +188,19 @@ class _PreviewStage extends StatelessWidget {
 
 /// Container widget that wraps the video player in a hero transition.
 ///
-/// Frames the clip exactly the way the feed will: non-square clips fill the
-/// preview edge to edge and crop like `VideoItemWidget`'s cover branch, square
-/// clips stay contain-fit on the blurred poster backdrop the feed paints in
-/// their letterbox bars. Without that mirroring the preview showed more of the
-/// frame than the feed does, so the metadata overlay sat over a different crop
-/// than the published post.
+/// Frames the clip to match the feed: non-square clips fill the preview edge to
+/// edge and crop like `VideoItemWidget`'s cover branch, square clips stay
+/// contain-fit on the blurred poster backdrop the feed paints in their
+/// letterbox bars. Without that mirroring the preview showed more of the frame
+/// than the feed does, so the metadata overlay sat over a different crop than
+/// the published post.
+///
+/// The video surface is sized from [DivineVideoClip.targetAspectRatio], not the
+/// live decoded ratio the feed uses. For a square target whose source is still
+/// uncropped (the crop is applied at publish) the video is fitted to the target
+/// box rather than center-cropped the way the feed shows the published file;
+/// matching that exactly would mean sizing from the decoded ratio like
+/// `video_metadata_cover_screen`.
 class _VideoPreviewContent extends StatelessWidget {
   /// Creates the video preview content wrapper.
   const _VideoPreviewContent({
@@ -230,13 +238,10 @@ class _VideoPreviewContent extends StatelessWidget {
               videoAspectRatio: aspectRatio,
             ),
           if (stopMotionFrames != null)
-            StopMotionPlayer(
+            _FittedStopMotion(
               frames: stopMotionFrames,
-              fit: fit,
-              cacheHeight:
-                  (MediaQuery.sizeOf(context).height *
-                          MediaQuery.devicePixelRatioOf(context))
-                      .round(),
+              aspectRatio: aspectRatio,
+              coversViewport: coversViewport,
             )
           else
             _FittedVideoSurface(
@@ -254,8 +259,10 @@ class _VideoPreviewContent extends StatelessWidget {
 /// Inscribes the player surface into the preview the way the feed does.
 ///
 /// The native surface has no intrinsic size and stretches to whatever box it
-/// gets, so the video is laid out at its own aspect ratio inside a
-/// [FittedBox] — the same construction `VideoItemWidget` uses in the feed.
+/// gets, so the video is laid out at [aspectRatio] inside a [FittedBox] — the
+/// same construction `VideoItemWidget` uses in the feed. Here [aspectRatio] is
+/// the clip's target ratio; see [_VideoPreviewContent] for the square-source
+/// caveat.
 class _FittedVideoSurface extends StatelessWidget {
   const _FittedVideoSurface({
     required this.clip,
@@ -283,6 +290,43 @@ class _FittedVideoSurface extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+/// Frames a stop-motion clip the way the feed and the export do.
+///
+/// Export center-crops the raw stills to the target box (`StopMotionFit.cover`
+/// in `StopMotionRenderService`) and the feed then fits that already-cropped
+/// mp4 per cover/contain. Reproduce both from the stills: [StopMotionPlayer]
+/// cover-crops them, and for the letterboxed (square) case they are constrained
+/// to the target-ratio box so the blurred backdrop fills the bars — instead of
+/// contain-fitting the whole non-square still, which showed more frame than the
+/// published post.
+class _FittedStopMotion extends StatelessWidget {
+  const _FittedStopMotion({
+    required this.frames,
+    required this.aspectRatio,
+    required this.coversViewport,
+  });
+
+  final List<StopMotionClipFrame> frames;
+  final double aspectRatio;
+  final bool coversViewport;
+
+  @override
+  Widget build(BuildContext context) {
+    // Default fit is BoxFit.cover — the centered crop the export bakes in.
+    final player = StopMotionPlayer(
+      frames: frames,
+      cacheHeight:
+          (MediaQuery.sizeOf(context).height *
+                  MediaQuery.devicePixelRatioOf(context))
+              .round(),
+    );
+    if (coversViewport) return player;
+    return Center(
+      child: AspectRatio(aspectRatio: aspectRatio, child: player),
     );
   }
 }

--- a/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
@@ -92,9 +92,7 @@ class _VideoMetadataPreviewScreenState
     _controller = DivineVideoPlayerController(useTexture: true);
     if (mounted) await _controller!.initialize();
     if (mounted) {
-      await _controller!.setSource(
-        VideoClip.file(await video.safeFilePath()),
-      );
+      await _controller!.setSource(VideoClip.file(await video.safeFilePath()));
     }
     if (mounted) await _controller!.setLooping(looping: true);
     if (mounted) await _controller!.play();
@@ -167,7 +165,7 @@ class _VideoMetadataPreviewScreenState
 /// behind them.
 ///
 /// The preview-only route has no bottom chrome to seam into and stays edge to
-/// edge — the same call the fullscreen feed makes in `_MaybeRoundFeedBottom`.
+/// edge — the same branch the fullscreen feed takes in `_MaybeRoundFeedBottom`.
 class _PreviewStage extends StatelessWidget {
   const _PreviewStage({required this.roundBottom, required this.child});
 
@@ -195,18 +193,14 @@ class _PreviewStage extends StatelessWidget {
 /// than the feed does, so the metadata overlay sat over a different crop than
 /// the published post.
 ///
-/// The video surface is sized from [DivineVideoClip.targetAspectRatio], not the
-/// live decoded ratio the feed uses. For a square target whose source is still
-/// uncropped (the crop is applied at publish) the video is fitted to the target
-/// box rather than center-cropped the way the feed shows the published file;
-/// matching that exactly would mean sizing from the decoded ratio like
-/// `video_metadata_cover_screen`.
+/// The video surface is sized from the live decoded ratio when the native
+/// player has reported dimensions, with [DivineVideoClip.targetAspectRatio] as
+/// the pre-decode fallback. That keeps raw draft previews from squeezing an
+/// uncropped source into the target-ratio box while still matching the rendered
+/// post path once the render has baked the target crop into the file.
 class _VideoPreviewContent extends StatelessWidget {
   /// Creates the video preview content wrapper.
-  const _VideoPreviewContent({
-    required this.clip,
-    required this.controller,
-  });
+  const _VideoPreviewContent({required this.clip, required this.controller});
 
   final DivineVideoClip clip;
   final DivineVideoPlayerController? controller;
@@ -259,11 +253,9 @@ class _VideoPreviewContent extends StatelessWidget {
 /// Inscribes the player surface into the preview the way the feed does.
 ///
 /// The native surface has no intrinsic size and stretches to whatever box it
-/// gets, so the video is laid out at [aspectRatio] inside a [FittedBox] — the
-/// same construction `VideoItemWidget` uses in the feed. Here [aspectRatio] is
-/// the clip's target ratio; see [_VideoPreviewContent] for the square-source
-/// caveat.
-class _FittedVideoSurface extends StatelessWidget {
+/// gets, so the video is laid out at the decoded video ratio inside a
+/// [FittedBox] — the same construction `VideoItemWidget` uses in the feed.
+class _FittedVideoSurface extends StatefulWidget {
   const _FittedVideoSurface({
     required this.clip,
     required this.controller,
@@ -277,16 +269,60 @@ class _FittedVideoSurface extends StatelessWidget {
   final BoxFit fit;
 
   @override
+  State<_FittedVideoSurface> createState() => _FittedVideoSurfaceState();
+}
+
+class _FittedVideoSurfaceState extends State<_FittedVideoSurface> {
+  StreamSubscription<DivineVideoPlayerState>? _sub;
+  double _videoAspectRatio = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _subscribeToController(widget.controller);
+  }
+
+  @override
+  void didUpdateWidget(_FittedVideoSurface oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      unawaited(_sub?.cancel());
+      _subscribeToController(widget.controller);
+    }
+  }
+
+  void _subscribeToController(DivineVideoPlayerController? controller) {
+    _videoAspectRatio = controller?.state.aspectRatio ?? 0;
+    _sub = controller?.stateStream.listen((state) {
+      final aspectRatio = state.aspectRatio;
+      if (aspectRatio > 0 && aspectRatio != _videoAspectRatio) {
+        setState(() => _videoAspectRatio = aspectRatio);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    unawaited(_sub?.cancel());
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final videoAspectRatio = _videoAspectRatio > 0
+        ? _videoAspectRatio
+        : widget.aspectRatio;
     return ClipRect(
       child: FittedBox(
-        fit: fit,
+        fit: widget.fit,
         child: SizedBox(
-          width: aspectRatio * 100,
+          width: videoAspectRatio * 100,
           height: 100,
           child: DivineVideoPlayer(
-            controller: controller,
-            placeholder: VideoMetadataCapturePreviewThumbnail(clip: clip),
+            controller: widget.controller,
+            placeholder: VideoMetadataCapturePreviewThumbnail(
+              clip: widget.clip,
+            ),
           ),
         ),
       ),

--- a/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
@@ -14,6 +14,7 @@ import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/screens/feed/feed_mode_switch.dart';
 import 'package:openvine/widgets/stop_motion/stop_motion_player.dart';
+import 'package:openvine/widgets/video_feed_item/blurred_video_backdrop.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:openvine/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar.dart';
 import 'package:openvine/widgets/video_metadata/modes/capture/video_metadata_capture_preview_thumbnail.dart';
@@ -118,17 +119,31 @@ class _VideoMetadataPreviewScreenState
           children: [
             // Video preview area with close button
             Expanded(
-              child: Stack(
-                fit: .expand,
-                children: [
-                  _VideoPreviewContent(
-                    clip: widget.clip,
-                    controller: _controller,
-                  ),
-                  if (!widget.previewOnly)
-                    _PreviewOverlay(isPreviewReady: _isPreviewReady),
-                  const _CloseButton(),
-                ],
+              child: _PreviewStage(
+                roundBottom: !widget.previewOnly,
+                child: Stack(
+                  fit: .expand,
+                  children: [
+                    _VideoPreviewContent(
+                      clip: widget.clip,
+                      controller: _controller,
+                    ),
+                    if (!widget.previewOnly)
+                      // The overlay offsets its caption and action column
+                      // above the system bottom inset for the feed, where it
+                      // spans the whole screen. Here the stage already ends
+                      // above the post bar's [SafeArea], so that inset would
+                      // be counted twice and float the buttons off the bottom
+                      // edge. Same removal the fullscreen feed applies around
+                      // its own [FeedVideos].
+                      MediaQuery.removePadding(
+                        context: context,
+                        removeBottom: true,
+                        child: _PreviewOverlay(isPreviewReady: _isPreviewReady),
+                      ),
+                    const _CloseButton(),
+                  ],
+                ),
               ),
             ),
             // Post button at bottom
@@ -144,8 +159,41 @@ class _VideoMetadataPreviewScreenState
   }
 }
 
+/// Rounds the bottom corners of the preview area so it seams into the post
+/// bar the way the feed seams into the bottom nav
+/// ([VineTheme.shellCornerRadius], via `NavRoundedShell`). The corners reveal
+/// the scaffold surface the post bar sits on, so no extra fill is painted
+/// behind them.
+///
+/// The preview-only route has no bottom chrome to seam into and stays edge to
+/// edge — the same call the fullscreen feed makes in `_MaybeRoundFeedBottom`.
+class _PreviewStage extends StatelessWidget {
+  const _PreviewStage({required this.roundBottom, required this.child});
+
+  final bool roundBottom;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!roundBottom) return child;
+    return ClipRRect(
+      borderRadius: const BorderRadius.vertical(
+        bottom: Radius.circular(VineTheme.shellCornerRadius),
+      ),
+      child: child,
+    );
+  }
+}
+
 /// Container widget that wraps the video player in a hero transition.
-class _VideoPreviewContent extends ConsumerWidget {
+///
+/// Frames the clip exactly the way the feed will: non-square clips fill the
+/// preview edge to edge and crop like `VideoItemWidget`'s cover branch, square
+/// clips stay contain-fit on the blurred poster backdrop the feed paints in
+/// their letterbox bars. Without that mirroring the preview showed more of the
+/// frame than the feed does, so the metadata overlay sat over a different crop
+/// than the published post.
+class _VideoPreviewContent extends StatelessWidget {
   /// Creates the video preview content wrapper.
   const _VideoPreviewContent({
     required this.clip,
@@ -156,8 +204,16 @@ class _VideoPreviewContent extends ConsumerWidget {
   final DivineVideoPlayerController? controller;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final aspectRatio = clip.targetAspectRatio.value;
+    // The feed leaves portrait expansion on (FeedVideos defaults it to true
+    // and no caller overrides it), so the preview mirrors that branch.
+    final coversViewport = videoCoversFeedViewport(
+      aspectRatio: aspectRatio,
+      shouldPortraitExpand: true,
+    );
+    final fit = coversViewport ? BoxFit.cover : BoxFit.contain;
+    final thumbnailPath = clip.thumbnailPath;
     final stopMotionFrames = clip.stopMotionFrames;
 
     // Hero animation from metadata screen
@@ -165,25 +221,65 @@ class _VideoPreviewContent extends ConsumerWidget {
       tag: VideoEditorConstants.heroMetaPreviewId,
       // Use linear flight path instead of curved arc
       createRectTween: (begin, end) => RectTween(begin: begin, end: end),
-      child: Center(
-        child: AspectRatio(
-          aspectRatio: aspectRatio,
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(16),
-            child: stopMotionFrames != null
-                ? StopMotionPlayer(
-                    frames: stopMotionFrames,
-                    cacheHeight:
-                        (MediaQuery.sizeOf(context).height *
-                                MediaQuery.devicePixelRatioOf(context))
-                            .round(),
-                  )
-                : DivineVideoPlayer(
-                    controller: controller,
-                    placeholder: VideoMetadataCapturePreviewThumbnail(
-                      clip: clip,
-                    ),
-                  ),
+      child: Stack(
+        fit: .expand,
+        children: [
+          if (!coversViewport && thumbnailPath != null)
+            BlurredVideoBackdrop(
+              filePath: thumbnailPath,
+              videoAspectRatio: aspectRatio,
+            ),
+          if (stopMotionFrames != null)
+            StopMotionPlayer(
+              frames: stopMotionFrames,
+              fit: fit,
+              cacheHeight:
+                  (MediaQuery.sizeOf(context).height *
+                          MediaQuery.devicePixelRatioOf(context))
+                      .round(),
+            )
+          else
+            _FittedVideoSurface(
+              clip: clip,
+              controller: controller,
+              aspectRatio: aspectRatio,
+              fit: fit,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Inscribes the player surface into the preview the way the feed does.
+///
+/// The native surface has no intrinsic size and stretches to whatever box it
+/// gets, so the video is laid out at its own aspect ratio inside a
+/// [FittedBox] — the same construction `VideoItemWidget` uses in the feed.
+class _FittedVideoSurface extends StatelessWidget {
+  const _FittedVideoSurface({
+    required this.clip,
+    required this.controller,
+    required this.aspectRatio,
+    required this.fit,
+  });
+
+  final DivineVideoClip clip;
+  final DivineVideoPlayerController? controller;
+  final double aspectRatio;
+  final BoxFit fit;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRect(
+      child: FittedBox(
+        fit: fit,
+        child: SizedBox(
+          width: aspectRatio * 100,
+          height: 100,
+          child: DivineVideoPlayer(
+            controller: controller,
+            placeholder: VideoMetadataCapturePreviewThumbnail(clip: clip),
           ),
         ),
       ),

--- a/mobile/lib/widgets/video_feed_item/blurred_video_backdrop.dart
+++ b/mobile/lib/widgets/video_feed_item/blurred_video_backdrop.dart
@@ -2,6 +2,7 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/widgets.dart';
 import 'package:openvine/widgets/blurhash_display.dart';
+import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 
 /// Diffused colour cloud derived from a video's own first frame,
@@ -29,17 +30,24 @@ class BlurredVideoBackdrop extends StatelessWidget {
   /// Creates a blurred backdrop for a video poster.
   ///
   /// [blurhash] is preferred when non-empty. [url] is the HTTPS poster
-  /// thumbnail used for the runtime-blur fallback; when neither is
-  /// available, or the image fails to load, the widget renders as empty
-  /// ([SizedBox.shrink]) and lets the parent background show through.
+  /// thumbnail used for the runtime-blur fallback, [filePath] the local
+  /// poster of a clip that has not been published yet (the pre-publish
+  /// preview). When none is available, or the image fails to load, the
+  /// widget renders as empty ([SizedBox.shrink]) and lets the parent
+  /// background show through.
   const BlurredVideoBackdrop({
     super.key,
     this.url,
+    this.filePath,
     this.blurhash,
     this.videoAspectRatio,
   });
 
   final String? url;
+
+  /// Absolute path of a local poster file, used when no [url] is available.
+  final String? filePath;
+
   final String? blurhash;
 
   /// Intrinsic aspect ratio (width / height) of the video sitting on this
@@ -51,7 +59,11 @@ class BlurredVideoBackdrop extends StatelessWidget {
   Widget build(BuildContext context) {
     final aspectRatio = videoAspectRatio;
     if (aspectRatio == null) {
-      return _BackdropContent(url: url, blurhash: blurhash);
+      return _BackdropContent(
+        url: url,
+        filePath: filePath,
+        blurhash: blurhash,
+      );
     }
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -71,7 +83,11 @@ class BlurredVideoBackdrop extends StatelessWidget {
                 // the video area, so there is no occluded fullscreen overdraw
                 // (PR #5957).
                 child: RepaintBoundary(
-                  child: _BackdropContent(url: url, blurhash: blurhash),
+                  child: _BackdropContent(
+                    url: url,
+                    filePath: filePath,
+                    blurhash: blurhash,
+                  ),
                 ),
               ),
           ],
@@ -84,9 +100,10 @@ class BlurredVideoBackdrop extends StatelessWidget {
 /// The blurred fill itself, without any letterbox clip. Prefers the cheap
 /// stretched-blurhash path and falls back to a runtime gaussian of the poster.
 class _BackdropContent extends StatelessWidget {
-  const _BackdropContent({this.url, this.blurhash});
+  const _BackdropContent({this.url, this.filePath, this.blurhash});
 
   final String? url;
+  final String? filePath;
   final String? blurhash;
 
   @override
@@ -97,7 +114,23 @@ class _BackdropContent extends StatelessWidget {
       return BlurhashDisplay(blurhash: hash, opacity: 0.5);
     }
     final posterUrl = url;
-    if (posterUrl == null || posterUrl.isEmpty) {
+    final posterPath = filePath;
+    final Widget poster;
+    if (posterUrl != null && posterUrl.isNotEmpty) {
+      poster = VineCachedImage(
+        imageUrl: posterUrl,
+        // Fall back to nothing on error — the parent
+        // [ColoredBox(VineTheme.surfaceContainerHigh)] shows through.
+        errorWidget: (_, _, _) => const SizedBox.shrink(),
+      );
+    } else if (posterPath != null && posterPath.isNotEmpty) {
+      poster = ClipThumbnailImage(
+        path: posterPath,
+        fit: BoxFit.cover,
+        excludeFromSemantics: true,
+        placeholder: const SizedBox.shrink(),
+      );
+    } else {
       return const SizedBox.shrink();
     }
     return ClipRect(
@@ -106,15 +139,7 @@ class _BackdropContent extends StatelessWidget {
       // outside the widget's box and over the surrounding chrome.
       child: ImageFiltered(
         imageFilter: ui.ImageFilter.blur(sigmaX: 30, sigmaY: 30),
-        child: Opacity(
-          opacity: 0.5,
-          child: VineCachedImage(
-            imageUrl: posterUrl,
-            // Fall back to nothing on error — the parent
-            // [ColoredBox(VineTheme.surfaceContainerHigh)] shows through.
-            errorWidget: (_, _, _) => const SizedBox.shrink(),
-          ),
-        ),
+        child: Opacity(opacity: 0.5, child: poster),
       ),
     );
   }

--- a/mobile/test/screens/video_metadata_preview_screen_test.dart
+++ b/mobile/test/screens/video_metadata_preview_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as models;
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/models/video_publish/video_publish_provider_state.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -17,6 +18,7 @@ import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_preview_screen.dart';
+import 'package:openvine/widgets/stop_motion/stop_motion_player.dart';
 import 'package:openvine/widgets/video_feed_item/blurred_video_backdrop.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -53,42 +55,84 @@ DivineVideoClip _createTestClip({
   String id = 'test-clip',
   models.AspectRatio targetAspectRatio = models.AspectRatio.square,
   String? thumbnailPath,
+  List<StopMotionClipFrame>? stopMotionFrames,
 }) {
   return DivineVideoClip(
     id: id,
-    video: EditorVideo.file('test.mp4'),
+    video: stopMotionFrames == null ? EditorVideo.file('test.mp4') : null,
     duration: const Duration(seconds: 10),
     recordedAt: DateTime.now(),
     targetAspectRatio: targetAspectRatio,
     originalAspectRatio: 9 / 16,
     thumbnailPath: thumbnailPath,
+    stopMotionFrames: stopMotionFrames,
   );
+}
+
+class _PlayerEventsStreamHandler extends MockStreamHandler {
+  MockStreamHandlerEventSink? _events;
+
+  void addState(Map<Object?, Object?> state) => _events?.success(state);
+
+  @override
+  void onListen(Object? arguments, MockStreamHandlerEventSink events) {
+    _events = events;
+  }
+
+  @override
+  void onCancel(Object? arguments) {
+    _events = null;
+  }
 }
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late SharedPreferences prefs;
+  late _PlayerEventsStreamHandler playerEvents;
 
   setUp(() async {
     SharedPreferences.setMockInitialValues({});
     prefs = await SharedPreferences.getInstance();
+    playerEvents = _PlayerEventsStreamHandler();
     DivineVideoPlayerController.resetIdCounterForTesting();
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(const MethodChannel('divine_video_player'), (
           call,
         ) async {
           if (call.method == 'create') {
+            final args = call.arguments! as Map<Object?, Object?>;
+            final id = args['id']! as int;
+            TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+                .setMockMethodCallHandler(
+                  MethodChannel('divine_video_player/player_$id'),
+                  (call) async => null,
+                );
+            TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+                .setMockStreamHandler(
+                  EventChannel('divine_video_player/player_$id/events'),
+                  playerEvents,
+                );
             return <String, Object?>{'textureId': 1};
           }
           return null;
         });
   });
 
-  tearDown(() {
+  tearDown(() async {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(
           const MethodChannel('divine_video_player'),
+          null,
+        );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('divine_video_player/player_0'),
+          null,
+        );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockStreamHandler(
+          const EventChannel('divine_video_player/player_0/events'),
           null,
         );
   });
@@ -157,19 +201,6 @@ void main() {
     testWidgets('renders $VideoMetadataPreviewScreen with scaffold', (
       tester,
     ) async {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-            const MethodChannel('divine_video_player/player_0'),
-            (call) async => null,
-          );
-      addTearDown(() {
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-              const MethodChannel('divine_video_player/player_0'),
-              null,
-            );
-      });
-
       await tester.pumpWidget(buildTestWidget());
       // Pump past the 350ms hero animation timer in initState
       await tester.pump(const Duration(milliseconds: 400));
@@ -179,19 +210,6 @@ void main() {
     });
 
     testWidgets('renders $DivineVideoPlayer widget', (tester) async {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-            const MethodChannel('divine_video_player/player_0'),
-            (call) async => null,
-          );
-      addTearDown(() {
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-              const MethodChannel('divine_video_player/player_0'),
-              null,
-            );
-      });
-
       await tester.pumpWidget(buildTestWidget());
       await tester.pump(const Duration(milliseconds: 400));
 
@@ -201,19 +219,6 @@ void main() {
     testWidgets('cover-fits a non-square clip like the feed does', (
       tester,
     ) async {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-            const MethodChannel('divine_video_player/player_0'),
-            (call) async => null,
-          );
-      addTearDown(() {
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-              const MethodChannel('divine_video_player/player_0'),
-              null,
-            );
-      });
-
       await tester.pumpWidget(
         buildTestWidget(
           clip: _createTestClip(
@@ -237,22 +242,48 @@ void main() {
       expect(find.byType(BlurredVideoBackdrop), findsNothing);
     });
 
+    testWidgets('sizes the fitted video from decoded source dimensions', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          clip: _createTestClip(thumbnailPath: '/tmp/poster.jpg'),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 400));
+
+      playerEvents.addState(<Object?, Object?>{
+        'status': 'playing',
+        'positionMs': 0,
+        'durationMs': 1000,
+        'bufferedPositionMs': 1000,
+        'currentClipIndex': 0,
+        'clipCount': 1,
+        'isLooping': true,
+        'volume': 1.0,
+        'playbackSpeed': 1.0,
+        'isFirstFrameRendered': true,
+        'videoWidth': 1080,
+        'videoHeight': 1920,
+      });
+      await tester.pump();
+      await tester.pump();
+
+      final surfaceBox = tester.widget<SizedBox>(
+        find
+            .ancestor(
+              of: find.byType(DivineVideoPlayer),
+              matching: find.byType(SizedBox),
+            )
+            .first,
+      );
+      expect(surfaceBox.width, equals(56.25));
+      expect(surfaceBox.height, equals(100));
+    });
+
     testWidgets('letterboxes a square clip on the blurred poster backdrop', (
       tester,
     ) async {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-            const MethodChannel('divine_video_player/player_0'),
-            (call) async => null,
-          );
-      addTearDown(() {
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-              const MethodChannel('divine_video_player/player_0'),
-              null,
-            );
-      });
-
       await tester.pumpWidget(
         buildTestWidget(
           clip: _createTestClip(thumbnailPath: '/tmp/poster.jpg'),
@@ -277,19 +308,6 @@ void main() {
     });
 
     testWidgets('renders close button', (tester) async {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-            const MethodChannel('divine_video_player/player_0'),
-            (call) async => null,
-          );
-      addTearDown(() {
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-              const MethodChannel('divine_video_player/player_0'),
-              null,
-            );
-      });
-
       await tester.pumpWidget(buildTestWidget());
       await tester.pump(const Duration(milliseconds: 400));
 
@@ -297,19 +315,6 @@ void main() {
     });
 
     testWidgets('stays edge to edge in preview-only mode', (tester) async {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-            const MethodChannel('divine_video_player/player_0'),
-            (call) async => null,
-          );
-      addTearDown(() {
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-              const MethodChannel('divine_video_player/player_0'),
-              null,
-            );
-      });
-
       await tester.pumpWidget(buildTestWidget());
       await tester.pump(const Duration(milliseconds: 400));
 
@@ -329,19 +334,6 @@ void main() {
     });
 
     testWidgets('rounds the bottom corners in the post flow', (tester) async {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-            const MethodChannel('divine_video_player/player_0'),
-            (call) async => null,
-          );
-      addTearDown(() {
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-              const MethodChannel('divine_video_player/player_0'),
-              null,
-            );
-      });
-
       // The post flow (previewOnly: false, the default) mounts the metadata
       // overlay, so its editor/nostr dependencies are stubbed here. The stage
       // seams into the post bar with rounded bottom corners.
@@ -378,22 +370,64 @@ void main() {
       );
     });
 
+    testWidgets('constrains square stop-motion clips to the target box', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          clip: _createTestClip(
+            stopMotionFrames: const <StopMotionClipFrame>[],
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(find.byType(StopMotionPlayer), findsOneWidget);
+      final targetBox = tester.widget<AspectRatio>(
+        find
+            .ancestor(
+              of: find.byType(StopMotionPlayer),
+              matching: find.byType(AspectRatio),
+            )
+            .first,
+      );
+      expect(targetBox.aspectRatio, equals(1.0));
+      expect(
+        find.ancestor(
+          of: find.byType(StopMotionPlayer),
+          matching: find.byType(Center),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('cover-fills vertical stop-motion clips edge to edge', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          clip: _createTestClip(
+            targetAspectRatio: models.AspectRatio.vertical,
+            stopMotionFrames: const <StopMotionClipFrame>[],
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(find.byType(StopMotionPlayer), findsOneWidget);
+      expect(
+        find.ancestor(
+          of: find.byType(StopMotionPlayer),
+          matching: find.byType(AspectRatio),
+        ),
+        findsNothing,
+      );
+      expect(find.byType(BlurredVideoBackdrop), findsNothing);
+    });
+
     testWidgets('hides bottom bar and overlay in preview-only mode', (
       tester,
     ) async {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-            const MethodChannel('divine_video_player/player_0'),
-            (call) async => null,
-          );
-      addTearDown(() {
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-              const MethodChannel('divine_video_player/player_0'),
-              null,
-            );
-      });
-
       await tester.pumpWidget(buildTestWidget());
       await tester.pump(const Duration(milliseconds: 400));
 

--- a/mobile/test/screens/video_metadata_preview_screen_test.dart
+++ b/mobile/test/screens/video_metadata_preview_screen_test.dart
@@ -14,6 +14,7 @@ import 'package:openvine/models/video_publish/video_publish_provider_state.dart'
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_preview_screen.dart';
+import 'package:openvine/widgets/video_feed_item/blurred_video_backdrop.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -27,14 +28,19 @@ class _MockVideoPublishNotifier extends VideoPublishNotifier {
   VideoPublishProviderState build() => _initialState;
 }
 
-DivineVideoClip _createTestClip({String id = 'test-clip'}) {
+DivineVideoClip _createTestClip({
+  String id = 'test-clip',
+  models.AspectRatio targetAspectRatio = models.AspectRatio.square,
+  String? thumbnailPath,
+}) {
   return DivineVideoClip(
     id: id,
     video: EditorVideo.file('test.mp4'),
     duration: const Duration(seconds: 10),
     recordedAt: DateTime.now(),
-    targetAspectRatio: models.AspectRatio.square,
+    targetAspectRatio: targetAspectRatio,
     originalAspectRatio: 9 / 16,
+    thumbnailPath: thumbnailPath,
   );
 }
 
@@ -171,6 +177,84 @@ void main() {
       expect(find.byType(DivineVideoPlayer), findsOneWidget);
     });
 
+    testWidgets('cover-fits a non-square clip like the feed does', (
+      tester,
+    ) async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('divine_video_player/player_0'),
+            (call) async => null,
+          );
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              const MethodChannel('divine_video_player/player_0'),
+              null,
+            );
+      });
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          clip: _createTestClip(
+            targetAspectRatio: models.AspectRatio.vertical,
+            thumbnailPath: '/tmp/poster.jpg',
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final fittedBox = tester.widget<FittedBox>(
+        find
+            .ancestor(
+              of: find.byType(DivineVideoPlayer),
+              matching: find.byType(FittedBox),
+            )
+            .first,
+      );
+      expect(fittedBox.fit, equals(BoxFit.cover));
+      // A cover-fit video occludes the backdrop, so the feed never mounts it.
+      expect(find.byType(BlurredVideoBackdrop), findsNothing);
+    });
+
+    testWidgets('letterboxes a square clip on the blurred poster backdrop', (
+      tester,
+    ) async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('divine_video_player/player_0'),
+            (call) async => null,
+          );
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              const MethodChannel('divine_video_player/player_0'),
+              null,
+            );
+      });
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          clip: _createTestClip(thumbnailPath: '/tmp/poster.jpg'),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final fittedBox = tester.widget<FittedBox>(
+        find
+            .ancestor(
+              of: find.byType(DivineVideoPlayer),
+              matching: find.byType(FittedBox),
+            )
+            .first,
+      );
+      expect(fittedBox.fit, equals(BoxFit.contain));
+      final backdrop = tester.widget<BlurredVideoBackdrop>(
+        find.byType(BlurredVideoBackdrop),
+      );
+      expect(backdrop.filePath, equals('/tmp/poster.jpg'));
+      expect(backdrop.videoAspectRatio, equals(1.0));
+    });
+
     testWidgets('renders close button', (tester) async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(
@@ -189,6 +273,38 @@ void main() {
       await tester.pump(const Duration(milliseconds: 400));
 
       expect(find.byType(DivineIconButton), findsOneWidget);
+    });
+
+    testWidgets('stays edge to edge in preview-only mode', (tester) async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('divine_video_player/player_0'),
+            (call) async => null,
+          );
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              const MethodChannel('divine_video_player/player_0'),
+              null,
+            );
+      });
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pump(const Duration(milliseconds: 400));
+
+      // The rounded bottom corners seam into the post bar; without a post
+      // bar there is nothing to seam into, so the preview fills the screen.
+      final rounded = tester.widgetList<ClipRRect>(find.byType(ClipRRect));
+      expect(
+        rounded.any(
+          (clip) =>
+              clip.borderRadius ==
+              const BorderRadius.vertical(
+                bottom: Radius.circular(VineTheme.shellCornerRadius),
+              ),
+        ),
+        isFalse,
+      );
     });
 
     testWidgets('hides bottom bar and overlay in preview-only mode', (

--- a/mobile/test/screens/video_metadata_preview_screen_test.dart
+++ b/mobile/test/screens/video_metadata_preview_screen_test.dart
@@ -10,14 +10,19 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as models;
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/models/video_publish/video_publish_provider_state.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_preview_screen.dart';
 import 'package:openvine/widgets/video_feed_item/blurred_video_backdrop.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+import '../mocks/mock_nostr_service.dart';
 
 class _MockVideoPublishNotifier extends VideoPublishNotifier {
   _MockVideoPublishNotifier(this._initialState);
@@ -26,6 +31,22 @@ class _MockVideoPublishNotifier extends VideoPublishNotifier {
 
   @override
   VideoPublishProviderState build() => _initialState;
+}
+
+/// Returns a default editor state so the post-mode overlay can render without
+/// the real editor's dependency chain.
+class _MockVideoEditorNotifier extends VideoEditorNotifier {
+  @override
+  VideoEditorProviderState build() => VideoEditorProviderState();
+}
+
+/// Supplies a stable public key so the post-mode overlay can resolve the author
+/// pubkey without a real nostr session. [NostrClient.publicKey] is non-null, so
+/// the base mock's `noSuchMethod` (which returns null) is not enough here.
+class _FakeNostrClient extends MockNostrService {
+  @override
+  String get publicKey =>
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 }
 
 DivineVideoClip _createTestClip({
@@ -304,6 +325,56 @@ void main() {
               ),
         ),
         isFalse,
+      );
+    });
+
+    testWidgets('rounds the bottom corners in the post flow', (tester) async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('divine_video_player/player_0'),
+            (call) async => null,
+          );
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              const MethodChannel('divine_video_player/player_0'),
+              null,
+            );
+      });
+
+      // The post flow (previewOnly: false, the default) mounts the metadata
+      // overlay, so its editor/nostr dependencies are stubbed here. The stage
+      // seams into the post bar with rounded bottom corners.
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            videoPublishProvider.overrideWith(
+              () =>
+                  _MockVideoPublishNotifier(const VideoPublishProviderState()),
+            ),
+            videoEditorProvider.overrideWith(_MockVideoEditorNotifier.new),
+            nostrServiceProvider.overrideWithValue(_FakeNostrClient()),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: VideoMetadataPreviewScreen(clip: _createTestClip()),
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final rounded = tester.widgetList<ClipRRect>(find.byType(ClipRRect));
+      expect(
+        rounded.any(
+          (clip) =>
+              clip.borderRadius ==
+              const BorderRadius.vertical(
+                bottom: Radius.circular(VineTheme.shellCornerRadius),
+              ),
+        ),
+        isTrue,
       );
     });
 

--- a/mobile/test/widgets/video_feed_item/blurred_video_backdrop_test.dart
+++ b/mobile/test/widgets/video_feed_item/blurred_video_backdrop_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/widgets/blurhash_display.dart';
+import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
 import 'package:openvine/widgets/video_feed_item/blurred_video_backdrop.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 
@@ -98,6 +99,31 @@ void main() {
 
         expect(find.byType(BlurhashDisplay), findsNothing);
         expect(find.byType(ImageFiltered), findsNothing);
+        expect(find.byType(VineCachedImage), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'blurs the local poster file when no url is available',
+      (tester) async {
+        // The pre-publish preview has a local thumbnail, never a poster URL.
+        await tester.pumpWidget(
+          WidgetsApp(
+            color: const Color(0xFF000000),
+            builder: (_, _) => const SizedBox(
+              width: 400,
+              height: 800,
+              child: BlurredVideoBackdrop(filePath: '/tmp/poster.jpg'),
+            ),
+          ),
+        );
+
+        final image = tester.widget<ClipThumbnailImage>(
+          find.byType(ClipThumbnailImage),
+        );
+        expect(image.path, equals('/tmp/poster.jpg'));
+        expect(image.fit, equals(BoxFit.cover));
+        expect(find.byType(ImageFiltered), findsOneWidget);
         expect(find.byType(VineCachedImage), findsNothing);
       },
     );


### PR DESCRIPTION
Closes #6783

## Description

The post preview inscribed the clip with `AspectRatio(clip.targetAspectRatio)` inside a rounded card, so it showed the whole frame letterboxed. The feed does the opposite: `VideoItemWidget` cover-fits every non-square video and crops its sides, and letterboxes square clips on a blurred poster backdrop. The metadata overlay was drawn full-bleed over that different crop, so the preview did not represent the published post.

The preview now mirrors the feed's framing:

- The fit decision reuses `videoCoversFeedViewport` - the same helper the feed uses for its backdrop gate - instead of a second copy of the square/non-square rule.
- Non-square clips cover-fit edge to edge through the same `FittedBox` construction `VideoItemWidget` uses. The native surface has no intrinsic size, so it is laid out at the decoded video ratio when dimensions are available, falling back to the target ratio before decode.
- Square clips stay contain-fit on `BlurredVideoBackdrop`. The backdrop gained an optional local poster path: a clip that is not published yet has a thumbnail file, never a URL or a blurhash. Reusing the widget keeps one implementation of the letterbox-band geometry instead of a preview-only copy that would drift from the feed.
- Stop-motion preview routes through `_FittedStopMotion` so square targets are constrained to the target-ratio box while the stills remain cover-cropped like the export.
- The stage's bottom corners are rounded with `VineTheme.shellCornerRadius`, the radius the feed uses via `NavRoundedShell` where the video meets the bottom nav. Preview-only mode (upload failure sheet) has no bottom chrome to seam into and stays edge to edge, mirroring the feed's `_MaybeRoundFeedBottom` branch.
- The system bottom inset is removed around the overlay. `VideoOverlayActions` offsets its caption and action column by `14 + viewPadding.bottom` because in the feed it spans the whole screen; here the stage already ends above the post bar's `SafeArea`, so that inset was counted twice and floated the action column about 34-48 px off the bottom edge. This is the same `MediaQuery.removePadding(removeBottom: true)` the fullscreen feed applies around its own `FeedVideos`.

## Out of Scope

The preview area sits above the post bar, so its viewport is slightly shorter than the feed's. The side crop is therefore marginally smaller than in the feed. Making it pixel-identical would mean moving the post bar on top of the video, which is a layout change beyond this fix.

## Verification

- `flutter analyze lib/screens/video_metadata lib/widgets/video_feed_item test/screens/video_metadata_preview_screen_test.dart test/widgets/video_feed_item/blurred_video_backdrop_test.dart` - clean
- `flutter test test/screens/video_metadata_preview_screen_test.dart test/widgets/video_feed_item/blurred_video_backdrop_test.dart` - green
- `flutter test test/widgets/stop_motion/stop_motion_player_test.dart` - green
- Pre-push hook - green, including changed-file analyze/tests
- Manually verified by the author on a real Samsung Galaxy device before takeover: 9:16 preview matches the feed crop, square clip letterboxes on the blurred poster, bottom corners round into the post bar, action buttons sit at the bottom edge

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Review Follow-Ups

- **Stop-motion parity fix.** A square-target stop-motion clip was contain-fit across the whole non-square still, showing more frame than the published post. Stop-motion now routes through `_FittedStopMotion`, which cover-crops the stills and constrains the square case to the target-ratio box; the vertical case still cover-fills the viewport.
- **Rounding test gap.** Added a positive-path test that the post flow (`previewOnly: false`) rounds the stage's bottom corners.
- **Decoded-ratio sizing.** The fitted video surface now listens to the native controller's decoded aspect ratio and uses the target ratio only as a pre-decode fallback, preventing raw draft previews from squeezing uncropped sources into the target box.
- **Test debt cleanup.** The repeated `divine_video_player/player_0` channel mock is hoisted into shared setup, and preview tests now cover decoded-ratio sizing plus the square/vertical stop-motion wrapper branches.
