### PR TITLE
fix(feed): hide the paused affordance during a temporary pause

### DIFF
--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -495,6 +495,7 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
               video: video,
               index: index,
               isActive: isActive,
+              isFeedActive: isFeedActive,
               contextTitle: widget.contextTitle,
               contentWarningRevealed: _revealedContentWarningVideoIds.contains(
                 video.id,
@@ -517,6 +518,7 @@ class _Overlay extends ConsumerStatefulWidget {
     required this.video,
     required this.index,
     required this.isActive,
+    required this.isFeedActive,
     required this.contentWarningRevealed,
     required this.onContentWarningRevealed,
     this.onToggleAutoAdvance,
@@ -527,7 +529,15 @@ class _Overlay extends ConsumerStatefulWidget {
   final DivineVideoPlayerController? controller;
   final VideoEvent video;
   final int index;
+
+  /// Whether this item is the current page of the feed.
   final bool isActive;
+
+  /// Whether the feed itself may play: the home tab is current, no route or
+  /// overlay covers it, and the app is foregrounded. A paused player while
+  /// this is `false` is a temporary pause that resumes on its own, so the
+  /// paused affordance stays hidden.
+  final bool isFeedActive;
 
   /// Whether the user already dismissed this video's content warning.
   /// Owned by [FeedVideosState] so the autoplay gate can read it too.
@@ -920,7 +930,12 @@ class __OverlayState extends ConsumerState<_Overlay> {
                         if (widget.controller != null)
                           PausedVideoOverlay(
                             controller: widget.controller!,
-                            isVisible: widget.isActive,
+                            // Only a pause the user can undo gets the
+                            // affordance. A comments/share sheet, a pushed
+                            // route or a backgrounded app pauses the player
+                            // too, but resumes it on its own — showing a play
+                            // button behind the sheet just reads as broken.
+                            isVisible: widget.isActive && widget.isFeedActive,
                           ),
                         _FeedItemActions(
                           video: video,

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -1275,8 +1275,9 @@ void main() {
           isTrue,
         );
 
-        // A pushed route / opened sheet pauses the current player but resumes
-        // it on the way back, so the play affordance must stay hidden.
+        // Navigating away (a pushed route here; an opened comments/share
+        // sheet drives the same feed-inactive gate) pauses the player but
+        // resumes it on the way back, so the affordance must stay hidden.
         tester.state<FeedVideosState>(find.byType(FeedVideos)).didPushNext();
         await tester.pump();
         expect(
@@ -1285,6 +1286,45 @@ void main() {
         );
 
         tester.state<FeedVideosState>(find.byType(FeedVideos)).didPopNext();
+        await tester.pump();
+        expect(
+          tester.widget<PausedVideoOverlay>(overlayFinder).isVisible,
+          isTrue,
+        );
+      },
+    );
+
+    testWidgets(
+      'hides the paused affordance while the app is backgrounded',
+      (tester) async {
+        InfiniteVideoFeed.debugIsSupportedOverride = true;
+        final video = _makeVideo();
+
+        await _pumpFeedVideos(tester, videos: [video]);
+        await tester.pump(const Duration(seconds: 4));
+
+        final overlayFinder = find.byType(PausedVideoOverlay);
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(FeedVideos)),
+          listen: false,
+        );
+        expect(
+          tester.widget<PausedVideoOverlay>(overlayFinder).isVisible,
+          isTrue,
+        );
+
+        // Backgrounding pauses the player; foregrounding resumes it. The
+        // affordance must stay hidden while backgrounded. Guards the
+        // appForeground factor specifically: the route test above stays
+        // green if a refactor drops it, this one turns red.
+        container.read(appForegroundProvider.notifier).setForeground(false);
+        await tester.pump();
+        expect(
+          tester.widget<PausedVideoOverlay>(overlayFinder).isVisible,
+          isFalse,
+        );
+
+        container.read(appForegroundProvider.notifier).setForeground(true);
         await tester.pump();
         expect(
           tester.widget<PausedVideoOverlay>(overlayFinder).isVisible,

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -48,6 +48,7 @@ import 'package:openvine/widgets/video_feed_item/actions/help_classify_action_bu
 import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/feed_videos.dart';
 import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
+import 'package:openvine/widgets/video_feed_item/paused_video_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/pooled_video_error_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/video_loading_placeholder.dart';
 import 'package:reposts_repository/reposts_repository.dart';
@@ -1254,6 +1255,43 @@ void main() {
       await tester.pump();
       expect(tester.widget<InfiniteVideoFeed>(feedFinder).isActive, isTrue);
     });
+
+    testWidgets(
+      'hides the paused affordance while the feed itself is inactive',
+      (tester) async {
+        InfiniteVideoFeed.debugIsSupportedOverride = true;
+        final video = _makeVideo();
+
+        await _pumpFeedVideos(
+          tester,
+          videos: [video],
+          navigatorObservers: <NavigatorObserver>[routeObserver],
+        );
+        await tester.pump(const Duration(seconds: 4));
+
+        final overlayFinder = find.byType(PausedVideoOverlay);
+        expect(
+          tester.widget<PausedVideoOverlay>(overlayFinder).isVisible,
+          isTrue,
+        );
+
+        // A pushed route / opened sheet pauses the current player but resumes
+        // it on the way back, so the play affordance must stay hidden.
+        tester.state<FeedVideosState>(find.byType(FeedVideos)).didPushNext();
+        await tester.pump();
+        expect(
+          tester.widget<PausedVideoOverlay>(overlayFinder).isVisible,
+          isFalse,
+        );
+
+        tester.state<FeedVideosState>(find.byType(FeedVideos)).didPopNext();
+        await tester.pump();
+        expect(
+          tester.widget<PausedVideoOverlay>(overlayFinder).isVisible,
+          isTrue,
+        );
+      },
+    );
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
Closes #6785

## Description

Opening the comments (or share) sheet from the feed pauses the video — expected — but the paused affordance (play button + playback toggles pill) stayed on screen behind the sheet. Since that pause resumes on its own the moment the sheet closes, the play button is misleading: there is nothing for the viewer to undo.

`PausedVideoOverlay.isVisible` was gated on the per-page `isActive` flag, which only means "this is the current feed page". Whether the feed may play at all lives in `isFeedActive` (`FeedVideos.isActive && _routeAllowsPlayback && appForeground`). A bottom sheet flips the feed inactive via `showVideoPausingVineBottomSheet` → `setBottomSheetOpen(true)` → `_syncFeedActive()`, so the player pauses while the page stays current — and the overlay had no way to tell that apart from a tap-to-pause.

`_Overlay` now also receives `isFeedActive` and the affordance is gated on `isActive && isFeedActive`. That is the same composition `DivineVideoMetricsTracker` already uses one line above, so the two stay consistent. It covers every pause the app undoes by itself: comments/share sheet, a pushed route over the feed, and app backgrounding. A real tap-to-pause leaves `isFeedActive` untouched and still shows the full affordance.

When the sheet closes, `PausedVideoOverlay.didUpdateWidget` resets its `_hasStartedPlaying` latch; if the video does stay paused for some reason, the existing 300 ms `_stablePauseTimer` re-promotes it and the affordance comes back.

**Related Issue:** 

## Out of Scope

None.

## Verification

- New regression test `activity wiring > hides the paused affordance while the feed itself is inactive` in `feed_videos_test.dart`; verified it fails without the production change.
- `flutter test test/widgets/video_feed_item/` (feed_videos, paused_video_overlay, community pause, repo swap) — green.
- `flutter test test/screens/feed/video_feed_page_test.dart test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart` — 67 tests green.
- `dart format` + `flutter analyze lib/widgets/video_feed_item test/widgets/video_feed_item` — clean.
- Manually verified on a real Samsung Galaxy device: open the comment panel on a feed video → video pauses, no play indicator behind the sheet; close it → playback resumes without a flash. Tapping the video still shows the play button and the toggles pill.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)