### PR TITLE
fix(video-detail): give the dead-end states the TV-static look

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4537,7 +4537,7 @@
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "ቪዲዮ መጫን አልተሳካም",
     "videoDetailLoadErrorBody": "እዚህ ሲደርስ የሆነ ችግር ተፈጥሯል። እንደገና ሞክር።",
-    "videoDetailNotFoundBody": "ወይ ተሰርዟል፣ ወይም ልንደርስበት በማንችልበት ቦታ ተደብቋል።",
+    "videoDetailNotFoundBody": "ተሰርዞ ሊሆን ይችላል፣ ከአቅም ውጭ ሊሆን ይችላል፣ ወይም በቅንብሮችህ ተደብቆ ሊሆን ይችላል።",
     "databaseCorruptionTitle": "የአካባቢዎ ውሂብ ተበላሽቷል",
     "databaseCorruptionBody": "Divine ን ዘግተው እንደገና ይክፈቱት — በራስ-ሰር እናስተካክለዋለን። የቻልነውን ያህል ረቂቆችዎን እና ክሊፖችዎን እናስቀራለን፣ የቀረው እንደገና ይጫናል።",
     "databaseCorruptionCloseButton": "Divine ን ዝጋ",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4536,6 +4536,8 @@
     "videoErrorAdultContentHidden": "የአዋቂዎች ይዘት ጠፍቷል። በቅንብሮች → የይዘት ማጣሪያዎች ውስጥ ማብራት ይችላሉ።",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "ቪዲዮ መጫን አልተሳካም",
+    "videoDetailLoadErrorBody": "እዚህ ሲደርስ የሆነ ችግር ተፈጥሯል። እንደገና ሞክር።",
+    "videoDetailNotFoundBody": "ወይ ተሰርዟል፣ ወይም ልንደርስበት በማንችልበት ቦታ ተደብቋል።",
     "databaseCorruptionTitle": "የአካባቢዎ ውሂብ ተበላሽቷል",
     "databaseCorruptionBody": "Divine ን ዘግተው እንደገና ይክፈቱት — በራስ-ሰር እናስተካክለዋለን። የቻልነውን ያህል ረቂቆችዎን እና ክሊፖችዎን እናስቀራለን፣ የቀረው እንደገና ይጫናል።",
     "databaseCorruptionCloseButton": "Divine ን ዝጋ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4412,7 +4412,7 @@
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "فشل تحميل الفيديو",
     "videoDetailLoadErrorBody": "حدث خطأ ما في الطريق. جرّب مرة أخرى.",
-    "videoDetailNotFoundBody": "إمّا أنه حُذف أو أنه مخبّأ في مكان لا نصل إليه.",
+    "videoDetailNotFoundBody": "قد يكون محذوفًا، أو بعيدًا عن متناولنا، أو مخفيًا بواسطة إعداداتك.",
     "databaseCorruptionTitle": "بياناتك المحلية تعرضت للتلف",
     "databaseCorruptionBody": "أغلق Divine وافتحه من جديد — سنصلح ذلك تلقائيًا. سنحفظ ما نستطيع من مسوداتك ومقاطعك، وسيُعاد تحميل الباقي.",
     "databaseCorruptionCloseButton": "إغلاق Divine",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4411,6 +4411,8 @@
     "videoErrorAdultContentHidden": "المحتوى للبالغين مُعطَّل. يمكنك تفعيله من الإعدادات ← مرشّحات المحتوى.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "فشل تحميل الفيديو",
+    "videoDetailLoadErrorBody": "حدث خطأ ما في الطريق. جرّب مرة أخرى.",
+    "videoDetailNotFoundBody": "إمّا أنه حُذف أو أنه مخبّأ في مكان لا نصل إليه.",
     "databaseCorruptionTitle": "بياناتك المحلية تعرضت للتلف",
     "databaseCorruptionBody": "أغلق Divine وافتحه من جديد — سنصلح ذلك تلقائيًا. سنحفظ ما نستطيع من مسوداتك ومقاطعك، وسيُعاد تحميل الباقي.",
     "databaseCorruptionCloseButton": "إغلاق Divine",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4542,6 +4542,8 @@
     "videoErrorAdultContentHidden": "Съдържанието за възрастни е изключено. Можеш да го включиш от Настройки → Филтри за съдържание.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Неуспешно зареждане на видеото",
+    "videoDetailLoadErrorBody": "Нещо се обърка по пътя. Опитай пак.",
+    "videoDetailNotFoundBody": "Или е изтрито, или се крие някъде, докъдето не стигаме.",
     "databaseCorruptionTitle": "Локалните ти данни се повредиха",
     "databaseCorruptionBody": "Затвори Divine и го отвори пак — ще го поправим автоматично. Ще запазим каквото можем от черновите и клиповете ти, останалото се презарежда.",
     "databaseCorruptionCloseButton": "Затвори Divine",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4543,7 +4543,7 @@
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Неуспешно зареждане на видеото",
     "videoDetailLoadErrorBody": "Нещо се обърка по пътя. Опитай пак.",
-    "videoDetailNotFoundBody": "Или е изтрито, или се крие някъде, докъдето не стигаме.",
+    "videoDetailNotFoundBody": "Може да е изтрито, да е извън обсега ни или да е скрито от твоите настройки.",
     "databaseCorruptionTitle": "Локалните ти данни се повредиха",
     "databaseCorruptionBody": "Затвори Divine и го отвори пак — ще го поправим автоматично. Ще запазим каквото можем от черновите и клиповете ти, останалото се презарежда.",
     "databaseCorruptionCloseButton": "Затвори Divine",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4412,7 +4412,7 @@
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Video konnte nicht geladen werden",
     "videoDetailLoadErrorBody": "Auf dem Weg hierher ist was schiefgelaufen. Probier's nochmal.",
-    "videoDetailNotFoundBody": "Es wurde entweder gelöscht oder versteckt sich irgendwo, wo wir nicht rankommen.",
+    "videoDetailNotFoundBody": "Vielleicht ist es gelöscht, gerade nicht erreichbar oder durch deine Einstellungen ausgeblendet.",
     "databaseCorruptionTitle": "Deine lokalen Daten sind beschädigt",
     "databaseCorruptionBody": "Schließ Divine und öffne es neu — wir reparieren das automatisch. Wir retten so viel wie möglich von deinen Entwürfen und Clips, alles andere lädt neu.",
     "databaseCorruptionCloseButton": "Divine schließen",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4411,6 +4411,8 @@
     "videoErrorAdultContentHidden": "Inhalte für Erwachsene sind ausgeschaltet. Du kannst sie unter Einstellungen → Inhaltsfilter aktivieren.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Video konnte nicht geladen werden",
+    "videoDetailLoadErrorBody": "Auf dem Weg hierher ist was schiefgelaufen. Probier's nochmal.",
+    "videoDetailNotFoundBody": "Es wurde entweder gelöscht oder versteckt sich irgendwo, wo wir nicht rankommen.",
     "databaseCorruptionTitle": "Deine lokalen Daten sind beschädigt",
     "databaseCorruptionBody": "Schließ Divine und öffne es neu — wir reparieren das automatisch. Wir retten so viel wie möglich von deinen Entwürfen und Clips, alles andere lädt neu.",
     "databaseCorruptionCloseButton": "Divine schließen",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -809,7 +809,7 @@
   "@videoDetailLoadErrorBody": {
     "description": "Supporting copy under the 'Failed to load video' title on the shared-link video screen, shown next to a Retry button. Deliberately vague about the cause because the failure can be network, relay, or parsing."
   },
-  "videoDetailNotFoundBody": "It was either deleted, or it's hiding somewhere we can't reach.",
+  "videoDetailNotFoundBody": "It could be gone, out of reach, or hidden by your settings.",
   "@videoDetailNotFoundBody": {
     "description": "Supporting copy under the 'Video not found' title on the shared-link video screen. The screen shows this for three different causes it cannot tell apart: the video was deleted, it cannot be fetched from any connected relay, or it is hidden by a filter (a blocked or muted author, or the default-on Divine-hosted-only setting). It must not promise the video is gone for good, and it must not be read as covering only the first two."
   },

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -811,7 +811,7 @@
   },
   "videoDetailNotFoundBody": "It was either deleted, or it's hiding somewhere we can't reach.",
   "@videoDetailNotFoundBody": {
-    "description": "Supporting copy under the 'Video not found' title on the shared-link video screen. Covers both a deleted video and one we simply cannot fetch from any connected relay, so it must not promise the video is gone for good."
+    "description": "Supporting copy under the 'Video not found' title on the shared-link video screen. The screen shows this for three different causes it cannot tell apart: the video was deleted, it cannot be fetched from any connected relay, or it is hidden by a filter (a blocked or muted author, or the default-on Divine-hosted-only setting). It must not promise the video is gone for good, and it must not be read as covering only the first two."
   },
   "databaseCorruptionTitle": "Your local data got scrambled",
   "@databaseCorruptionTitle": {

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -805,6 +805,14 @@
     "description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."
   },
   "videoDetailLoadError": "Failed to load video",
+  "videoDetailLoadErrorBody": "Something went sideways on the way here. Give it another try.",
+  "@videoDetailLoadErrorBody": {
+    "description": "Supporting copy under the 'Failed to load video' title on the shared-link video screen, shown next to a Retry button. Deliberately vague about the cause because the failure can be network, relay, or parsing."
+  },
+  "videoDetailNotFoundBody": "It was either deleted, or it's hiding somewhere we can't reach.",
+  "@videoDetailNotFoundBody": {
+    "description": "Supporting copy under the 'Video not found' title on the shared-link video screen. Covers both a deleted video and one we simply cannot fetch from any connected relay, so it must not promise the video is gone for good."
+  },
   "databaseCorruptionTitle": "Your local data got scrambled",
   "@databaseCorruptionTitle": {
     "description": "Title of the full-screen takeover shown when the local database reports on-disk corruption at runtime. 'Scrambled' is deliberately non-technical: the user did nothing wrong and cannot act on the real cause."

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4411,6 +4411,8 @@
     "videoErrorAdultContentHidden": "El contenido para adultos está desactivado. Podés activarlo en Ajustes → Filtros de contenido.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Error al cargar el video",
+    "videoDetailLoadErrorBody": "Algo se torció por el camino. Inténtalo otra vez.",
+    "videoDetailNotFoundBody": "O lo han borrado, o está escondido en algún sitio al que no llegamos.",
     "databaseCorruptionTitle": "Tus datos locales se estropearon",
     "databaseCorruptionBody": "Cierra Divine y ábrelo de nuevo: lo arreglamos automáticamente. Guardamos los borradores y clips que podamos, lo demás se recarga.",
     "databaseCorruptionCloseButton": "Cerrar Divine",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4412,7 +4412,7 @@
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Error al cargar el video",
     "videoDetailLoadErrorBody": "Algo se torció por el camino. Inténtalo otra vez.",
-    "videoDetailNotFoundBody": "O lo han borrado, o está escondido en algún sitio al que no llegamos.",
+    "videoDetailNotFoundBody": "Puede que se haya borrado, que esté fuera de nuestro alcance o que lo oculten tus ajustes.",
     "databaseCorruptionTitle": "Tus datos locales se estropearon",
     "databaseCorruptionBody": "Cierra Divine y ábrelo de nuevo: lo arreglamos automáticamente. Guardamos los borradores y clips que podamos, lo demás se recarga.",
     "databaseCorruptionCloseButton": "Cerrar Divine",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2998,7 +2998,7 @@
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Hindi ma-load ang video",
     "videoDetailLoadErrorBody": "May sumablay sa daan. Subukan ulit.",
-    "videoDetailNotFoundBody": "Baka nabura na, o nagtatago sa lugar na hindi namin maabot.",
+    "videoDetailNotFoundBody": "Baka nabura na, wala sa abot, o nakatago dahil sa mga setting mo.",
     "databaseCorruptionTitle": "Nasira ang local data mo",
     "databaseCorruptionBody": "Isara ang Divine at buksan ulit — awtomatiko naming aayusin. Ise-save namin ang makakaya sa mga draft at clip mo, mag-reload na lang ang iba.",
     "databaseCorruptionCloseButton": "Isara ang Divine",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2997,6 +2997,8 @@
     "videoErrorAdultContentHidden": "Naka-off ang adult content. Puwede mong i-on sa Settings → Content Filters.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Hindi ma-load ang video",
+    "videoDetailLoadErrorBody": "May sumablay sa daan. Subukan ulit.",
+    "videoDetailNotFoundBody": "Baka nabura na, o nagtatago sa lugar na hindi namin maabot.",
     "databaseCorruptionTitle": "Nasira ang local data mo",
     "databaseCorruptionBody": "Isara ang Divine at buksan ulit — awtomatiko naming aayusin. Ise-save namin ang makakaya sa mga draft at clip mo, mag-reload na lang ang iba.",
     "databaseCorruptionCloseButton": "Isara ang Divine",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4411,6 +4411,8 @@
     "videoErrorAdultContentHidden": "Le contenu pour adultes est désactivé. Tu peux l'activer dans Réglages → Filtres de contenu.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Échec du chargement de la vidéo",
+    "videoDetailLoadErrorBody": "Quelque chose a déraillé en chemin. Réessaie.",
+    "videoDetailNotFoundBody": "Soit elle a été supprimée, soit elle se cache là où on ne peut pas aller.",
     "databaseCorruptionTitle": "Tes données locales sont abîmées",
     "databaseCorruptionBody": "Ferme Divine et rouvre-la : on répare ça automatiquement. On sauve ce qu'on peut de tes brouillons et clips, le reste se recharge.",
     "databaseCorruptionCloseButton": "Fermer Divine",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4412,7 +4412,7 @@
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Échec du chargement de la vidéo",
     "videoDetailLoadErrorBody": "Quelque chose a déraillé en chemin. Réessaie.",
-    "videoDetailNotFoundBody": "Soit elle a été supprimée, soit elle se cache là où on ne peut pas aller.",
+    "videoDetailNotFoundBody": "Elle a peut-être été supprimée, elle est hors de portée, ou tes réglages la masquent.",
     "databaseCorruptionTitle": "Tes données locales sont abîmées",
     "databaseCorruptionBody": "Ferme Divine et rouvre-la : on répare ça automatiquement. On sauve ce qu'on peut de tes brouillons et clips, le reste se recharge.",
     "databaseCorruptionCloseButton": "Fermer Divine",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4411,6 +4411,8 @@
     "videoErrorAdultContentHidden": "Konten dewasa sedang dimatikan. Kamu bisa mengaktifkannya di Pengaturan → Filter Konten.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Gagal memuat video",
+    "videoDetailLoadErrorBody": "Ada yang meleset di jalan. Coba lagi, ya.",
+    "videoDetailNotFoundBody": "Mungkin sudah dihapus, atau ngumpet di tempat yang nggak bisa kami jangkau.",
     "databaseCorruptionTitle": "Data lokalmu rusak",
     "databaseCorruptionBody": "Tutup Divine lalu buka lagi — kami perbaiki otomatis. Kami simpan draf dan klipmu semampu kami, sisanya dimuat ulang.",
     "databaseCorruptionCloseButton": "Tutup Divine",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4412,7 +4412,7 @@
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Gagal memuat video",
     "videoDetailLoadErrorBody": "Ada yang meleset di jalan. Coba lagi, ya.",
-    "videoDetailNotFoundBody": "Mungkin sudah dihapus, atau ngumpet di tempat yang nggak bisa kami jangkau.",
+    "videoDetailNotFoundBody": "Mungkin sudah dihapus, di luar jangkauan, atau disembunyikan sama pengaturanmu.",
     "databaseCorruptionTitle": "Data lokalmu rusak",
     "databaseCorruptionBody": "Tutup Divine lalu buka lagi — kami perbaiki otomatis. Kami simpan draf dan klipmu semampu kami, sisanya dimuat ulang.",
     "databaseCorruptionCloseButton": "Tutup Divine",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4412,7 +4412,7 @@
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Impossibile caricare il video",
     "videoDetailLoadErrorBody": "Qualcosa è andato storto lungo la strada. Riprova.",
-    "videoDetailNotFoundBody": "O è stato eliminato, o si nasconde dove non riusciamo ad arrivare.",
+    "videoDetailNotFoundBody": "Forse è stato eliminato, non è raggiungibile o è nascosto dalle tue impostazioni.",
     "databaseCorruptionTitle": "I tuoi dati locali si sono rovinati",
     "databaseCorruptionBody": "Chiudi Divine e riaprila: sistemiamo tutto in automatico. Salviamo quello che possiamo delle tue bozze e clip, il resto si ricarica.",
     "databaseCorruptionCloseButton": "Chiudi Divine",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4411,6 +4411,8 @@
     "videoErrorAdultContentHidden": "I contenuti per adulti sono disattivati. Puoi attivarli in Impostazioni → Filtri contenuti.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Impossibile caricare il video",
+    "videoDetailLoadErrorBody": "Qualcosa è andato storto lungo la strada. Riprova.",
+    "videoDetailNotFoundBody": "O è stato eliminato, o si nasconde dove non riusciamo ad arrivare.",
     "databaseCorruptionTitle": "I tuoi dati locali si sono rovinati",
     "databaseCorruptionBody": "Chiudi Divine e riaprila: sistemiamo tutto in automatico. Salviamo quello che possiamo delle tue bozze e clip, il resto si ricarica.",
     "databaseCorruptionCloseButton": "Chiudi Divine",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4412,7 +4412,7 @@
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "動画の読み込みに失敗したよ",
     "videoDetailLoadErrorBody": "途中で何かがうまくいきませんでした。もう一度お試しください。",
-    "videoDetailNotFoundBody": "削除されたか、こちらから届かない場所に隠れているみたいです。",
+    "videoDetailNotFoundBody": "削除されたか、こちらから届かないか、設定で非表示になっているのかもしれません。",
     "databaseCorruptionTitle": "ローカルデータが壊れちゃった",
     "databaseCorruptionBody": "Divine を閉じてもう一度開いてね。自動で直すよ。下書きとクリップはできるだけ残すよ。ほかは読み込み直すよ。",
     "databaseCorruptionCloseButton": "Divine を閉じる",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4411,6 +4411,8 @@
     "videoErrorAdultContentHidden": "アダルトコンテンツはオフになってるよ。[設定]→[コンテンツフィルター]でオンにできるよ。",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "動画の読み込みに失敗したよ",
+    "videoDetailLoadErrorBody": "途中で何かがうまくいきませんでした。もう一度お試しください。",
+    "videoDetailNotFoundBody": "削除されたか、こちらから届かない場所に隠れているみたいです。",
     "databaseCorruptionTitle": "ローカルデータが壊れちゃった",
     "databaseCorruptionBody": "Divine を閉じてもう一度開いてね。自動で直すよ。下書きとクリップはできるだけ残すよ。ほかは読み込み直すよ。",
     "databaseCorruptionCloseButton": "Divine を閉じる",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3743,7 +3743,7 @@
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "영상을 불러오지 못했어요",
     "videoDetailLoadErrorBody": "오는 길에 뭔가 어긋났어요. 다시 시도해 보세요.",
-    "videoDetailNotFoundBody": "삭제됐거나, 우리가 닿을 수 없는 곳에 숨어 있어요.",
+    "videoDetailNotFoundBody": "삭제됐거나, 닿을 수 없는 곳에 있거나, 설정 때문에 숨겨진 걸 수도 있어요.",
     "databaseCorruptionTitle": "로컬 데이터가 손상됐어요",
     "databaseCorruptionBody": "Divine을 껐다가 다시 열어주세요. 자동으로 고쳐드릴게요. 초안과 클립은 최대한 살려볼게요. 나머지는 다시 불러와요.",
     "databaseCorruptionCloseButton": "Divine 닫기",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3742,6 +3742,8 @@
     "videoErrorAdultContentHidden": "성인 콘텐츠가 꺼져 있어요. 설정 → 콘텐츠 필터에서 켤 수 있어요.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "영상을 불러오지 못했어요",
+    "videoDetailLoadErrorBody": "오는 길에 뭔가 어긋났어요. 다시 시도해 보세요.",
+    "videoDetailNotFoundBody": "삭제됐거나, 우리가 닿을 수 없는 곳에 숨어 있어요.",
     "databaseCorruptionTitle": "로컬 데이터가 손상됐어요",
     "databaseCorruptionBody": "Divine을 껐다가 다시 열어주세요. 자동으로 고쳐드릴게요. 초안과 클립은 최대한 살려볼게요. 나머지는 다시 불러와요.",
     "databaseCorruptionCloseButton": "Divine 닫기",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -738,7 +738,7 @@
   },
   "videoDetailLoadError": "Gagal memuatkan video",
   "videoDetailLoadErrorBody": "Ada yang tak kena dalam perjalanan. Cuba lagi.",
-  "videoDetailNotFoundBody": "Mungkin ia dipadam, atau tersembunyi di tempat yang kami tak dapat capai.",
+  "videoDetailNotFoundBody": "Mungkin ia dipadam, di luar capaian, atau disembunyikan oleh tetapan anda.",
   "databaseCorruptionTitle": "Data setempat anda bercelaru",
   "@databaseCorruptionTitle": {
     "description": "Title of the full-screen takeover shown when the local database reports on-disk corruption at runtime. 'Scrambled' is deliberately non-technical: the user did nothing wrong and cannot act on the real cause."

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -737,6 +737,8 @@
     "description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."
   },
   "videoDetailLoadError": "Gagal memuatkan video",
+  "videoDetailLoadErrorBody": "Ada yang tak kena dalam perjalanan. Cuba lagi.",
+  "videoDetailNotFoundBody": "Mungkin ia dipadam, atau tersembunyi di tempat yang kami tak dapat capai.",
   "databaseCorruptionTitle": "Data setempat anda bercelaru",
   "@databaseCorruptionTitle": {
     "description": "Title of the full-screen takeover shown when the local database reports on-disk corruption at runtime. 'Scrambled' is deliberately non-technical: the user did nothing wrong and cannot act on the real cause."

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4412,7 +4412,7 @@
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Video laden mislukt",
     "videoDetailLoadErrorBody": "Er ging onderweg iets mis. Probeer het nog eens.",
-    "videoDetailNotFoundBody": "Hij is verwijderd, of hij verstopt zich ergens waar we niet bij kunnen.",
+    "videoDetailNotFoundBody": "Misschien is hij verwijderd, buiten bereik, of verborgen door je instellingen.",
     "databaseCorruptionTitle": "Je lokale gegevens zijn beschadigd",
     "databaseCorruptionBody": "Sluit Divine en open het opnieuw — we repareren het automatisch. We redden wat we kunnen van je concepten en clips, de rest laadt opnieuw.",
     "databaseCorruptionCloseButton": "Divine sluiten",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4411,6 +4411,8 @@
     "videoErrorAdultContentHidden": "Inhoud voor volwassenen staat uit. Je kunt dit aanzetten via Instellingen → Inhoudsfilters.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Video laden mislukt",
+    "videoDetailLoadErrorBody": "Er ging onderweg iets mis. Probeer het nog eens.",
+    "videoDetailNotFoundBody": "Hij is verwijderd, of hij verstopt zich ergens waar we niet bij kunnen.",
     "databaseCorruptionTitle": "Je lokale gegevens zijn beschadigd",
     "databaseCorruptionBody": "Sluit Divine en open het opnieuw — we repareren het automatisch. We redden wat we kunnen van je concepten en clips, de rest laadt opnieuw.",
     "databaseCorruptionCloseButton": "Divine sluiten",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4412,7 +4412,7 @@
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Nie udało się wczytać filmu",
     "videoDetailLoadErrorBody": "Coś poszło nie tak po drodze. Spróbuj jeszcze raz.",
-    "videoDetailNotFoundBody": "Albo został usunięty, albo ukrywa się tam, gdzie nie sięgamy.",
+    "videoDetailNotFoundBody": "Mógł zostać usunięty, być poza zasięgiem albo ukryty przez twoje ustawienia.",
     "databaseCorruptionTitle": "Twoje lokalne dane się uszkodziły",
     "databaseCorruptionBody": "Zamknij Divine i otwórz ponownie — naprawimy to automatycznie. Zachowamy tyle Twoich szkiców i klipów, ile się da, reszta wczyta się na nowo.",
     "databaseCorruptionCloseButton": "Zamknij Divine",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4411,6 +4411,8 @@
     "videoErrorAdultContentHidden": "Treści dla dorosłych są wyłączone. Możesz je włączyć w Ustawienia → Filtry treści.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Nie udało się wczytać filmu",
+    "videoDetailLoadErrorBody": "Coś poszło nie tak po drodze. Spróbuj jeszcze raz.",
+    "videoDetailNotFoundBody": "Albo został usunięty, albo ukrywa się tam, gdzie nie sięgamy.",
     "databaseCorruptionTitle": "Twoje lokalne dane się uszkodziły",
     "databaseCorruptionBody": "Zamknij Divine i otwórz ponownie — naprawimy to automatycznie. Zachowamy tyle Twoich szkiców i klipów, ile się da, reszta wczyta się na nowo.",
     "databaseCorruptionCloseButton": "Zamknij Divine",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4411,6 +4411,8 @@
     "videoErrorAdultContentHidden": "O conteúdo adulto está desativado. Você pode ativá-lo em Configurações → Filtros de conteúdo.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Falha ao carregar o vídeo",
+    "videoDetailLoadErrorBody": "Alguma coisa deu errado no caminho. Tenta de novo.",
+    "videoDetailNotFoundBody": "Ou foi apagado, ou está escondido num lugar que não alcançamos.",
     "databaseCorruptionTitle": "Seus dados locais foram corrompidos",
     "databaseCorruptionBody": "Feche o Divine e abra de novo — a gente conserta automaticamente. A gente salva o que der dos seus rascunhos e clipes, o resto recarrega.",
     "databaseCorruptionCloseButton": "Fechar o Divine",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4412,7 +4412,7 @@
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Falha ao carregar o vídeo",
     "videoDetailLoadErrorBody": "Alguma coisa deu errado no caminho. Tenta de novo.",
-    "videoDetailNotFoundBody": "Ou foi apagado, ou está escondido num lugar que não alcançamos.",
+    "videoDetailNotFoundBody": "Pode ter sido apagado, estar fora de alcance ou escondido pelas tuas definições.",
     "databaseCorruptionTitle": "Seus dados locais foram corrompidos",
     "databaseCorruptionBody": "Feche o Divine e abra de novo — a gente conserta automaticamente. A gente salva o que der dos seus rascunhos e clipes, o resto recarrega.",
     "databaseCorruptionCloseButton": "Fechar o Divine",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4411,6 +4411,8 @@
     "videoErrorAdultContentHidden": "Conținutul pentru adulți este dezactivat. Îl poți activa în Setări → Filtre de conținut.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "N-am putut încărca videoclipul",
+    "videoDetailLoadErrorBody": "Ceva a mers prost pe drum. Mai încearcă o dată.",
+    "videoDetailNotFoundBody": "Ori a fost șters, ori se ascunde undeva unde nu ajungem.",
     "databaseCorruptionTitle": "Datele tale locale s-au deteriorat",
     "databaseCorruptionBody": "Închide Divine și deschide-l din nou — reparăm automat. Salvăm ce putem din ciornele și clipurile tale, restul se reîncarcă.",
     "databaseCorruptionCloseButton": "Închide Divine",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4412,7 +4412,7 @@
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "N-am putut încărca videoclipul",
     "videoDetailLoadErrorBody": "Ceva a mers prost pe drum. Mai încearcă o dată.",
-    "videoDetailNotFoundBody": "Ori a fost șters, ori se ascunde undeva unde nu ajungem.",
+    "videoDetailNotFoundBody": "Poate a fost șters, e în afara razei noastre sau ascuns de setările tale.",
     "databaseCorruptionTitle": "Datele tale locale s-au deteriorat",
     "databaseCorruptionBody": "Închide Divine și deschide-l din nou — reparăm automat. Salvăm ce putem din ciornele și clipurile tale, restul se reîncarcă.",
     "databaseCorruptionCloseButton": "Închide Divine",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4412,7 +4412,7 @@
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Kunde inte läsa in videon",
     "videoDetailLoadErrorBody": "Något gick snett på vägen hit. Testa igen.",
-    "videoDetailNotFoundBody": "Antingen är den raderad, eller så gömmer den sig där vi inte når.",
+    "videoDetailNotFoundBody": "Den kan vara borttagen, utom räckhåll eller dold av dina inställningar.",
     "databaseCorruptionTitle": "Dina lokala data har skadats",
     "databaseCorruptionBody": "Stäng Divine och öppna appen igen – vi fixar det automatiskt. Vi räddar så mycket vi kan av dina utkast och klipp, resten laddas om.",
     "databaseCorruptionCloseButton": "Stäng Divine",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4411,6 +4411,8 @@
     "videoErrorAdultContentHidden": "Innehåll för vuxna är avstängt. Du kan slå på det i Inställningar → Innehållsfilter.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Kunde inte läsa in videon",
+    "videoDetailLoadErrorBody": "Något gick snett på vägen hit. Testa igen.",
+    "videoDetailNotFoundBody": "Antingen är den raderad, eller så gömmer den sig där vi inte når.",
     "databaseCorruptionTitle": "Dina lokala data har skadats",
     "databaseCorruptionBody": "Stäng Divine och öppna appen igen – vi fixar det automatiskt. Vi räddar så mycket vi kan av dina utkast och klipp, resten laddas om.",
     "databaseCorruptionCloseButton": "Stäng Divine",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4411,6 +4411,8 @@
     "videoErrorAdultContentHidden": "Yetişkin içeriği kapalı. Ayarlar → İçerik Filtreleri'nden açabilirsin.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Video yüklenemedi",
+    "videoDetailLoadErrorBody": "Yolda bir şeyler ters gitti. Bir daha dene.",
+    "videoDetailNotFoundBody": "Ya silinmiş ya da ulaşamadığımız bir yerde saklanıyor.",
     "databaseCorruptionTitle": "Yerel verilerin bozuldu",
     "databaseCorruptionBody": "Divine'ı kapatıp yeniden aç — bunu otomatik olarak onarıyoruz. Taslaklarından ve kliplerinden kurtarabildiğimizi saklıyoruz, gerisi yeniden yükleniyor.",
     "databaseCorruptionCloseButton": "Divine'ı kapat",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4412,7 +4412,7 @@
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Video yüklenemedi",
     "videoDetailLoadErrorBody": "Yolda bir şeyler ters gitti. Bir daha dene.",
-    "videoDetailNotFoundBody": "Ya silinmiş ya da ulaşamadığımız bir yerde saklanıyor.",
+    "videoDetailNotFoundBody": "Silinmiş, ulaşılamıyor ya da ayarların yüzünden gizlenmiş olabilir.",
     "databaseCorruptionTitle": "Yerel verilerin bozuldu",
     "databaseCorruptionBody": "Divine'ı kapatıp yeniden aç — bunu otomatik olarak onarıyoruz. Taslaklarından ve kliplerinden kurtarabildiğimizi saklıyoruz, gerisi yeniden yükleniyor.",
     "databaseCorruptionCloseButton": "Divine'ı kapat",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -738,7 +738,7 @@
   },
   "videoDetailLoadError": "ویڈیو لوڈ نہیں ہو سکی",
   "videoDetailLoadErrorBody": "یہاں پہنچتے پہنچتے کچھ گڑبڑ ہو گئی۔ دوبارہ کوشش کریں۔",
-  "videoDetailNotFoundBody": "یا تو یہ حذف ہو چکی ہے، یا کہیں ایسی جگہ چھپی ہے جہاں ہم نہیں پہنچ سکتے۔",
+  "videoDetailNotFoundBody": "ہو سکتا ہے یہ حذف ہو چکی ہو، ہماری پہنچ سے باہر ہو، یا آپ کی ترتیبات نے اسے چھپا دیا ہو۔",
   "databaseCorruptionTitle": "آپ کا مقامی ڈیٹا بگڑ گیا",
   "@databaseCorruptionTitle": {
     "description": "Title of the full-screen takeover shown when the local database reports on-disk corruption at runtime. 'Scrambled' is deliberately non-technical: the user did nothing wrong and cannot act on the real cause."

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -737,6 +737,8 @@
     "description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."
   },
   "videoDetailLoadError": "ویڈیو لوڈ نہیں ہو سکی",
+  "videoDetailLoadErrorBody": "یہاں پہنچتے پہنچتے کچھ گڑبڑ ہو گئی۔ دوبارہ کوشش کریں۔",
+  "videoDetailNotFoundBody": "یا تو یہ حذف ہو چکی ہے، یا کہیں ایسی جگہ چھپی ہے جہاں ہم نہیں پہنچ سکتے۔",
   "databaseCorruptionTitle": "آپ کا مقامی ڈیٹا بگڑ گیا",
   "@databaseCorruptionTitle": {
     "description": "Title of the full-screen takeover shown when the local database reports on-disk corruption at runtime. 'Scrambled' is deliberately non-technical: the user did nothing wrong and cannot act on the real cause."

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -738,7 +738,7 @@
   },
   "videoDetailLoadError": "Không thể tải video",
   "videoDetailLoadErrorBody": "Có gì đó trục trặc trên đường tới đây. Thử lại nhé.",
-  "videoDetailNotFoundBody": "Có thể nó đã bị xoá, hoặc đang trốn ở nơi chúng tôi không với tới.",
+  "videoDetailNotFoundBody": "Có thể nó đã bị xoá, ngoài tầm với, hoặc bị ẩn bởi cài đặt của bạn.",
   "databaseCorruptionTitle": "Dữ liệu cục bộ của bạn bị rối tung",
   "@databaseCorruptionTitle": {
     "description": "Title of the full-screen takeover shown when the local database reports on-disk corruption at runtime. 'Scrambled' is deliberately non-technical: the user did nothing wrong and cannot act on the real cause."

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -737,6 +737,8 @@
     "description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."
   },
   "videoDetailLoadError": "Không thể tải video",
+  "videoDetailLoadErrorBody": "Có gì đó trục trặc trên đường tới đây. Thử lại nhé.",
+  "videoDetailNotFoundBody": "Có thể nó đã bị xoá, hoặc đang trốn ở nơi chúng tôi không với tới.",
   "databaseCorruptionTitle": "Dữ liệu cục bộ của bạn bị rối tung",
   "@databaseCorruptionTitle": {
     "description": "Title of the full-screen takeover shown when the local database reports on-disk corruption at runtime. 'Scrambled' is deliberately non-technical: the user did nothing wrong and cannot act on the real cause."

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -738,7 +738,7 @@
   },
   "videoDetailLoadError": "视频加载失败",
   "videoDetailLoadErrorBody": "路上出了点岔子，再试一次吧。",
-  "videoDetailNotFoundBody": "要么被删了，要么藏在我们够不到的地方。",
+  "videoDetailNotFoundBody": "可能被删了，可能够不到，也可能被你的设置隐藏了。",
   "databaseCorruptionTitle": "你的本地数据乱套了",
   "@databaseCorruptionTitle": {
     "description": "Title of the full-screen takeover shown when the local database reports on-disk corruption at runtime. 'Scrambled' is deliberately non-technical: the user did nothing wrong and cannot act on the real cause."

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -737,6 +737,8 @@
     "description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."
   },
   "videoDetailLoadError": "视频加载失败",
+  "videoDetailLoadErrorBody": "路上出了点岔子，再试一次吧。",
+  "videoDetailNotFoundBody": "要么被删了，要么藏在我们够不到的地方。",
   "databaseCorruptionTitle": "你的本地数据乱套了",
   "@databaseCorruptionTitle": {
     "description": "Title of the full-screen takeover shown when the local database reports on-disk corruption at runtime. 'Scrambled' is deliberately non-technical: the user did nothing wrong and cannot act on the real cause."

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -2736,6 +2736,18 @@ abstract class AppLocalizations {
   /// **'Failed to load video'**
   String get videoDetailLoadError;
 
+  /// Supporting copy under the 'Failed to load video' title on the shared-link video screen, shown next to a Retry button. Deliberately vague about the cause because the failure can be network, relay, or parsing.
+  ///
+  /// In en, this message translates to:
+  /// **'Something went sideways on the way here. Give it another try.'**
+  String get videoDetailLoadErrorBody;
+
+  /// Supporting copy under the 'Video not found' title on the shared-link video screen. Covers both a deleted video and one we simply cannot fetch from any connected relay, so it must not promise the video is gone for good.
+  ///
+  /// In en, this message translates to:
+  /// **'It was either deleted, or it\'s hiding somewhere we can\'t reach.'**
+  String get videoDetailNotFoundBody;
+
   /// Title of the full-screen takeover shown when the local database reports on-disk corruption at runtime. 'Scrambled' is deliberately non-technical: the user did nothing wrong and cannot act on the real cause.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -2742,7 +2742,7 @@ abstract class AppLocalizations {
   /// **'Something went sideways on the way here. Give it another try.'**
   String get videoDetailLoadErrorBody;
 
-  /// Supporting copy under the 'Video not found' title on the shared-link video screen. Covers both a deleted video and one we simply cannot fetch from any connected relay, so it must not promise the video is gone for good.
+  /// Supporting copy under the 'Video not found' title on the shared-link video screen. The screen shows this for three different causes it cannot tell apart: the video was deleted, it cannot be fetched from any connected relay, or it is hidden by a filter (a blocked or muted author, or the default-on Divine-hosted-only setting). It must not promise the video is gone for good, and it must not be read as covering only the first two.
   ///
   /// In en, this message translates to:
   /// **'It was either deleted, or it\'s hiding somewhere we can\'t reach.'**

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -2745,7 +2745,7 @@ abstract class AppLocalizations {
   /// Supporting copy under the 'Video not found' title on the shared-link video screen. The screen shows this for three different causes it cannot tell apart: the video was deleted, it cannot be fetched from any connected relay, or it is hidden by a filter (a blocked or muted author, or the default-on Divine-hosted-only setting). It must not promise the video is gone for good, and it must not be read as covering only the first two.
   ///
   /// In en, this message translates to:
-  /// **'It was either deleted, or it\'s hiding somewhere we can\'t reach.'**
+  /// **'It could be gone, out of reach, or hidden by your settings.'**
   String get videoDetailNotFoundBody;
 
   /// Title of the full-screen takeover shown when the local database reports on-disk corruption at runtime. 'Scrambled' is deliberately non-technical: the user did nothing wrong and cannot act on the real cause.

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1508,7 +1508,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get videoDetailNotFoundBody =>
-      'ወይ ተሰርዟል፣ ወይም ልንደርስበት በማንችልበት ቦታ ተደብቋል።';
+      'ተሰርዞ ሊሆን ይችላል፣ ከአቅም ውጭ ሊሆን ይችላል፣ ወይም በቅንብሮችህ ተደብቆ ሊሆን ይችላል።';
 
   @override
   String get databaseCorruptionTitle => 'የአካባቢዎ ውሂብ ተበላሽቷል';

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1504,6 +1504,13 @@ class AppLocalizationsAm extends AppLocalizations {
   String get videoDetailLoadError => 'ቪዲዮ መጫን አልተሳካም';
 
   @override
+  String get videoDetailLoadErrorBody => 'እዚህ ሲደርስ የሆነ ችግር ተፈጥሯል። እንደገና ሞክር።';
+
+  @override
+  String get videoDetailNotFoundBody =>
+      'ወይ ተሰርዟል፣ ወይም ልንደርስበት በማንችልበት ቦታ ተደብቋል።';
+
+  @override
   String get databaseCorruptionTitle => 'የአካባቢዎ ውሂብ ተበላሽቷል';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1525,7 +1525,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get videoDetailNotFoundBody =>
-      'إمّا أنه حُذف أو أنه مخبّأ في مكان لا نصل إليه.';
+      'قد يكون محذوفًا، أو بعيدًا عن متناولنا، أو مخفيًا بواسطة إعداداتك.';
 
   @override
   String get databaseCorruptionTitle => 'بياناتك المحلية تعرضت للتلف';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1521,6 +1521,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoDetailLoadError => 'فشل تحميل الفيديو';
 
   @override
+  String get videoDetailLoadErrorBody => 'حدث خطأ ما في الطريق. جرّب مرة أخرى.';
+
+  @override
+  String get videoDetailNotFoundBody =>
+      'إمّا أنه حُذف أو أنه مخبّأ في مكان لا نصل إليه.';
+
+  @override
   String get databaseCorruptionTitle => 'بياناتك المحلية تعرضت للتلف';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -1558,6 +1558,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get videoDetailLoadError => 'Неуспешно зареждане на видеото';
 
   @override
+  String get videoDetailLoadErrorBody => 'Нещо се обърка по пътя. Опитай пак.';
+
+  @override
+  String get videoDetailNotFoundBody =>
+      'Или е изтрито, или се крие някъде, докъдето не стигаме.';
+
+  @override
   String get databaseCorruptionTitle => 'Локалните ти данни се повредиха';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -1562,7 +1562,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get videoDetailNotFoundBody =>
-      'Или е изтрито, или се крие някъде, докъдето не стигаме.';
+      'Може да е изтрито, да е извън обсега ни или да е скрито от твоите настройки.';
 
   @override
   String get databaseCorruptionTitle => 'Локалните ти данни се повредиха';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -1561,7 +1561,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get videoDetailNotFoundBody =>
-      'Es wurde entweder gelöscht oder versteckt sich irgendwo, wo wir nicht rankommen.';
+      'Vielleicht ist es gelöscht, gerade nicht erreichbar oder durch deine Einstellungen ausgeblendet.';
 
   @override
   String get databaseCorruptionTitle => 'Deine lokalen Daten sind beschädigt';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -1556,6 +1556,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get videoDetailLoadError => 'Video konnte nicht geladen werden';
 
   @override
+  String get videoDetailLoadErrorBody =>
+      'Auf dem Weg hierher ist was schiefgelaufen. Probier\'s nochmal.';
+
+  @override
+  String get videoDetailNotFoundBody =>
+      'Es wurde entweder gelöscht oder versteckt sich irgendwo, wo wir nicht rankommen.';
+
+  @override
   String get databaseCorruptionTitle => 'Deine lokalen Daten sind beschädigt';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1542,7 +1542,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get videoDetailNotFoundBody =>
-      'It was either deleted, or it\'s hiding somewhere we can\'t reach.';
+      'It could be gone, out of reach, or hidden by your settings.';
 
   @override
   String get databaseCorruptionTitle => 'Your local data got scrambled';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1537,6 +1537,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get videoDetailLoadError => 'Failed to load video';
 
   @override
+  String get videoDetailLoadErrorBody =>
+      'Something went sideways on the way here. Give it another try.';
+
+  @override
+  String get videoDetailNotFoundBody =>
+      'It was either deleted, or it\'s hiding somewhere we can\'t reach.';
+
+  @override
   String get databaseCorruptionTitle => 'Your local data got scrambled';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -1558,6 +1558,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String get videoDetailLoadError => 'Error al cargar el video';
 
   @override
+  String get videoDetailLoadErrorBody =>
+      'Algo se torció por el camino. Inténtalo otra vez.';
+
+  @override
+  String get videoDetailNotFoundBody =>
+      'O lo han borrado, o está escondido en algún sitio al que no llegamos.';
+
+  @override
   String get databaseCorruptionTitle => 'Tus datos locales se estropearon';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -1563,7 +1563,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get videoDetailNotFoundBody =>
-      'O lo han borrado, o está escondido en algún sitio al que no llegamos.';
+      'Puede que se haya borrado, que esté fuera de nuestro alcance o que lo oculten tus ajustes.';
 
   @override
   String get databaseCorruptionTitle => 'Tus datos locales se estropearon';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -1568,6 +1568,13 @@ class AppLocalizationsFil extends AppLocalizations {
   String get videoDetailLoadError => 'Hindi ma-load ang video';
 
   @override
+  String get videoDetailLoadErrorBody => 'May sumablay sa daan. Subukan ulit.';
+
+  @override
+  String get videoDetailNotFoundBody =>
+      'Baka nabura na, o nagtatago sa lugar na hindi namin maabot.';
+
+  @override
   String get databaseCorruptionTitle => 'Nasira ang local data mo';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -1572,7 +1572,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get videoDetailNotFoundBody =>
-      'Baka nabura na, o nagtatago sa lugar na hindi namin maabot.';
+      'Baka nabura na, wala sa abot, o nakatago dahil sa mga setting mo.';
 
   @override
   String get databaseCorruptionTitle => 'Nasira ang local data mo';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -1566,6 +1566,14 @@ class AppLocalizationsFr extends AppLocalizations {
   String get videoDetailLoadError => 'Échec du chargement de la vidéo';
 
   @override
+  String get videoDetailLoadErrorBody =>
+      'Quelque chose a déraillé en chemin. Réessaie.';
+
+  @override
+  String get videoDetailNotFoundBody =>
+      'Soit elle a été supprimée, soit elle se cache là où on ne peut pas aller.';
+
+  @override
   String get databaseCorruptionTitle => 'Tes données locales sont abîmées';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -1571,7 +1571,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get videoDetailNotFoundBody =>
-      'Soit elle a été supprimée, soit elle se cache là où on ne peut pas aller.';
+      'Elle a peut-être été supprimée, elle est hors de portée, ou tes réglages la masquent.';
 
   @override
   String get databaseCorruptionTitle => 'Tes données locales sont abîmées';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1507,7 +1507,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get videoDetailNotFoundBody =>
-      'Mungkin sudah dihapus, atau ngumpet di tempat yang nggak bisa kami jangkau.';
+      'Mungkin sudah dihapus, di luar jangkauan, atau disembunyikan sama pengaturanmu.';
 
   @override
   String get databaseCorruptionTitle => 'Data lokalmu rusak';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1502,6 +1502,14 @@ class AppLocalizationsId extends AppLocalizations {
   String get videoDetailLoadError => 'Gagal memuat video';
 
   @override
+  String get videoDetailLoadErrorBody =>
+      'Ada yang meleset di jalan. Coba lagi, ya.';
+
+  @override
+  String get videoDetailNotFoundBody =>
+      'Mungkin sudah dihapus, atau ngumpet di tempat yang nggak bisa kami jangkau.';
+
+  @override
   String get databaseCorruptionTitle => 'Data lokalmu rusak';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -1566,7 +1566,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get videoDetailNotFoundBody =>
-      'O è stato eliminato, o si nasconde dove non riusciamo ad arrivare.';
+      'Forse è stato eliminato, non è raggiungibile o è nascosto dalle tue impostazioni.';
 
   @override
   String get databaseCorruptionTitle => 'I tuoi dati locali si sono rovinati';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -1561,6 +1561,14 @@ class AppLocalizationsIt extends AppLocalizations {
   String get videoDetailLoadError => 'Impossibile caricare il video';
 
   @override
+  String get videoDetailLoadErrorBody =>
+      'Qualcosa è andato storto lungo la strada. Riprova.';
+
+  @override
+  String get videoDetailNotFoundBody =>
+      'O è stato eliminato, o si nasconde dove non riusciamo ad arrivare.';
+
+  @override
   String get databaseCorruptionTitle => 'I tuoi dati locali si sono rovinati';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1434,7 +1434,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoDetailLoadErrorBody => '途中で何かがうまくいきませんでした。もう一度お試しください。';
 
   @override
-  String get videoDetailNotFoundBody => '削除されたか、こちらから届かない場所に隠れているみたいです。';
+  String get videoDetailNotFoundBody =>
+      '削除されたか、こちらから届かないか、設定で非表示になっているのかもしれません。';
 
   @override
   String get databaseCorruptionTitle => 'ローカルデータが壊れちゃった';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1431,6 +1431,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoDetailLoadError => '動画の読み込みに失敗したよ';
 
   @override
+  String get videoDetailLoadErrorBody => '途中で何かがうまくいきませんでした。もう一度お試しください。';
+
+  @override
+  String get videoDetailNotFoundBody => '削除されたか、こちらから届かない場所に隠れているみたいです。';
+
+  @override
   String get databaseCorruptionTitle => 'ローカルデータが壊れちゃった';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1441,6 +1441,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoDetailLoadError => '영상을 불러오지 못했어요';
 
   @override
+  String get videoDetailLoadErrorBody => '오는 길에 뭔가 어긋났어요. 다시 시도해 보세요.';
+
+  @override
+  String get videoDetailNotFoundBody => '삭제됐거나, 우리가 닿을 수 없는 곳에 숨어 있어요.';
+
+  @override
   String get databaseCorruptionTitle => '로컬 데이터가 손상됐어요';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1444,7 +1444,8 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoDetailLoadErrorBody => '오는 길에 뭔가 어긋났어요. 다시 시도해 보세요.';
 
   @override
-  String get videoDetailNotFoundBody => '삭제됐거나, 우리가 닿을 수 없는 곳에 숨어 있어요.';
+  String get videoDetailNotFoundBody =>
+      '삭제됐거나, 닿을 수 없는 곳에 있거나, 설정 때문에 숨겨진 걸 수도 있어요.';
 
   @override
   String get databaseCorruptionTitle => '로컬 데이터가 손상됐어요';

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -1549,6 +1549,14 @@ class AppLocalizationsMs extends AppLocalizations {
   String get videoDetailLoadError => 'Gagal memuatkan video';
 
   @override
+  String get videoDetailLoadErrorBody =>
+      'Ada yang tak kena dalam perjalanan. Cuba lagi.';
+
+  @override
+  String get videoDetailNotFoundBody =>
+      'Mungkin ia dipadam, atau tersembunyi di tempat yang kami tak dapat capai.';
+
+  @override
   String get databaseCorruptionTitle => 'Data setempat anda bercelaru';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -1554,7 +1554,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get videoDetailNotFoundBody =>
-      'Mungkin ia dipadam, atau tersembunyi di tempat yang kami tak dapat capai.';
+      'Mungkin ia dipadam, di luar capaian, atau disembunyikan oleh tetapan anda.';
 
   @override
   String get databaseCorruptionTitle => 'Data setempat anda bercelaru';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -1546,6 +1546,14 @@ class AppLocalizationsNl extends AppLocalizations {
   String get videoDetailLoadError => 'Video laden mislukt';
 
   @override
+  String get videoDetailLoadErrorBody =>
+      'Er ging onderweg iets mis. Probeer het nog eens.';
+
+  @override
+  String get videoDetailNotFoundBody =>
+      'Hij is verwijderd, of hij verstopt zich ergens waar we niet bij kunnen.';
+
+  @override
   String get databaseCorruptionTitle => 'Je lokale gegevens zijn beschadigd';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -1551,7 +1551,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get videoDetailNotFoundBody =>
-      'Hij is verwijderd, of hij verstopt zich ergens waar we niet bij kunnen.';
+      'Misschien is hij verwijderd, buiten bereik, of verborgen door je instellingen.';
 
   @override
   String get databaseCorruptionTitle => 'Je lokale gegevens zijn beschadigd';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -1569,7 +1569,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get videoDetailNotFoundBody =>
-      'Albo został usunięty, albo ukrywa się tam, gdzie nie sięgamy.';
+      'Mógł zostać usunięty, być poza zasięgiem albo ukryty przez twoje ustawienia.';
 
   @override
   String get databaseCorruptionTitle => 'Twoje lokalne dane się uszkodziły';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -1564,6 +1564,14 @@ class AppLocalizationsPl extends AppLocalizations {
   String get videoDetailLoadError => 'Nie udało się wczytać filmu';
 
   @override
+  String get videoDetailLoadErrorBody =>
+      'Coś poszło nie tak po drodze. Spróbuj jeszcze raz.';
+
+  @override
+  String get videoDetailNotFoundBody =>
+      'Albo został usunięty, albo ukrywa się tam, gdzie nie sięgamy.';
+
+  @override
   String get databaseCorruptionTitle => 'Twoje lokalne dane się uszkodziły';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -1560,7 +1560,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get videoDetailNotFoundBody =>
-      'Ou foi apagado, ou está escondido num lugar que não alcançamos.';
+      'Pode ter sido apagado, estar fora de alcance ou escondido pelas tuas definições.';
 
   @override
   String get databaseCorruptionTitle => 'Seus dados locais foram corrompidos';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -1555,6 +1555,14 @@ class AppLocalizationsPt extends AppLocalizations {
   String get videoDetailLoadError => 'Falha ao carregar o vídeo';
 
   @override
+  String get videoDetailLoadErrorBody =>
+      'Alguma coisa deu errado no caminho. Tenta de novo.';
+
+  @override
+  String get videoDetailNotFoundBody =>
+      'Ou foi apagado, ou está escondido num lugar que não alcançamos.';
+
+  @override
   String get databaseCorruptionTitle => 'Seus dados locais foram corrompidos';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -1579,6 +1579,14 @@ class AppLocalizationsRo extends AppLocalizations {
   String get videoDetailLoadError => 'N-am putut încărca videoclipul';
 
   @override
+  String get videoDetailLoadErrorBody =>
+      'Ceva a mers prost pe drum. Mai încearcă o dată.';
+
+  @override
+  String get videoDetailNotFoundBody =>
+      'Ori a fost șters, ori se ascunde undeva unde nu ajungem.';
+
+  @override
   String get databaseCorruptionTitle => 'Datele tale locale s-au deteriorat';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -1584,7 +1584,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get videoDetailNotFoundBody =>
-      'Ori a fost șters, ori se ascunde undeva unde nu ajungem.';
+      'Poate a fost șters, e în afara razei noastre sau ascuns de setările tale.';
 
   @override
   String get databaseCorruptionTitle => 'Datele tale locale s-au deteriorat';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1539,7 +1539,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get videoDetailNotFoundBody =>
-      'Antingen är den raderad, eller så gömmer den sig där vi inte når.';
+      'Den kan vara borttagen, utom räckhåll eller dold av dina inställningar.';
 
   @override
   String get databaseCorruptionTitle => 'Dina lokala data har skadats';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1534,6 +1534,14 @@ class AppLocalizationsSv extends AppLocalizations {
   String get videoDetailLoadError => 'Kunde inte läsa in videon';
 
   @override
+  String get videoDetailLoadErrorBody =>
+      'Något gick snett på vägen hit. Testa igen.';
+
+  @override
+  String get videoDetailNotFoundBody =>
+      'Antingen är den raderad, eller så gömmer den sig där vi inte når.';
+
+  @override
   String get databaseCorruptionTitle => 'Dina lokala data har skadats';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1510,7 +1510,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get videoDetailNotFoundBody =>
-      'Ya silinmiş ya da ulaşamadığımız bir yerde saklanıyor.';
+      'Silinmiş, ulaşılamıyor ya da ayarların yüzünden gizlenmiş olabilir.';
 
   @override
   String get databaseCorruptionTitle => 'Yerel verilerin bozuldu';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1505,6 +1505,14 @@ class AppLocalizationsTr extends AppLocalizations {
   String get videoDetailLoadError => 'Video yüklenemedi';
 
   @override
+  String get videoDetailLoadErrorBody =>
+      'Yolda bir şeyler ters gitti. Bir daha dene.';
+
+  @override
+  String get videoDetailNotFoundBody =>
+      'Ya silinmiş ya da ulaşamadığımız bir yerde saklanıyor.';
+
+  @override
   String get databaseCorruptionTitle => 'Yerel verilerin bozuldu';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -1545,7 +1545,7 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get videoDetailNotFoundBody =>
-      'یا تو یہ حذف ہو چکی ہے، یا کہیں ایسی جگہ چھپی ہے جہاں ہم نہیں پہنچ سکتے۔';
+      'ہو سکتا ہے یہ حذف ہو چکی ہو، ہماری پہنچ سے باہر ہو، یا آپ کی ترتیبات نے اسے چھپا دیا ہو۔';
 
   @override
   String get databaseCorruptionTitle => 'آپ کا مقامی ڈیٹا بگڑ گیا';

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -1540,6 +1540,14 @@ class AppLocalizationsUr extends AppLocalizations {
   String get videoDetailLoadError => 'ویڈیو لوڈ نہیں ہو سکی';
 
   @override
+  String get videoDetailLoadErrorBody =>
+      'یہاں پہنچتے پہنچتے کچھ گڑبڑ ہو گئی۔ دوبارہ کوشش کریں۔';
+
+  @override
+  String get videoDetailNotFoundBody =>
+      'یا تو یہ حذف ہو چکی ہے، یا کہیں ایسی جگہ چھپی ہے جہاں ہم نہیں پہنچ سکتے۔';
+
+  @override
   String get databaseCorruptionTitle => 'آپ کا مقامی ڈیٹا بگڑ گیا';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -1544,6 +1544,14 @@ class AppLocalizationsVi extends AppLocalizations {
   String get videoDetailLoadError => 'Không thể tải video';
 
   @override
+  String get videoDetailLoadErrorBody =>
+      'Có gì đó trục trặc trên đường tới đây. Thử lại nhé.';
+
+  @override
+  String get videoDetailNotFoundBody =>
+      'Có thể nó đã bị xoá, hoặc đang trốn ở nơi chúng tôi không với tới.';
+
+  @override
   String get databaseCorruptionTitle => 'Dữ liệu cục bộ của bạn bị rối tung';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -1549,7 +1549,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get videoDetailNotFoundBody =>
-      'Có thể nó đã bị xoá, hoặc đang trốn ở nơi chúng tôi không với tới.';
+      'Có thể nó đã bị xoá, ngoài tầm với, hoặc bị ẩn bởi cài đặt của bạn.';
 
   @override
   String get databaseCorruptionTitle => 'Dữ liệu cục bộ của bạn bị rối tung';

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -1447,6 +1447,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get videoDetailLoadError => '视频加载失败';
 
   @override
+  String get videoDetailLoadErrorBody => '路上出了点岔子，再试一次吧。';
+
+  @override
+  String get videoDetailNotFoundBody => '要么被删了，要么藏在我们够不到的地方。';
+
+  @override
   String get databaseCorruptionTitle => '你的本地数据乱套了';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -1450,7 +1450,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get videoDetailLoadErrorBody => '路上出了点岔子，再试一次吧。';
 
   @override
-  String get videoDetailNotFoundBody => '要么被删了，要么藏在我们够不到的地方。';
+  String get videoDetailNotFoundBody => '可能被删了，可能够不到，也可能被你的设置隐藏了。';
 
   @override
   String get databaseCorruptionTitle => '你的本地数据乱套了';

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -20,6 +20,7 @@ import 'package:openvine/screens/feed/dm_reply_context.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
+import 'package:openvine/widgets/takeover_close_button.dart';
 import 'package:openvine/widgets/tv_static_message_screen.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -361,18 +362,9 @@ class _LoadingScreen extends StatelessWidget {
             ),
           ),
           SafeArea(
-            child: Align(
-              alignment: .topLeft,
-              child: Padding(
-                padding: const .fromLTRB(16, 16, 0, 8),
-                child: DivineIconButton(
-                  icon: .x,
-                  onPressed: onClose,
-                  size: .small,
-                  type: .ghost,
-                  semanticLabel: context.l10n.videoDetailCloseSemanticLabel,
-                ),
-              ),
+            child: TakeoverCloseButton(
+              onPressed: onClose,
+              semanticLabel: context.l10n.videoDetailCloseSemanticLabel,
             ),
           ),
         ],

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -20,6 +20,7 @@ import 'package:openvine/screens/feed/dm_reply_context.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
+import 'package:openvine/widgets/tv_static_message_screen.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 class VideoDetailRouteExtra {
@@ -281,52 +282,27 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
       );
     }
 
-    if (_error != null) {
-      final message = switch (_error!) {
-        _VideoDetailError.notFound => context.l10n.videoErrorNotFound,
-        _VideoDetailError.loadFailed => context.l10n.videoDetailLoadError,
-      };
-      return Scaffold(
-        backgroundColor: context.vineColors.background,
-        appBar: _buildExitAppBar(context),
-        body: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const DivineIcon(
-                icon: DivineIconName.warningCircle,
-                color: VineTheme.error,
-                size: 64,
-              ),
-              const SizedBox(height: 16),
-              Text(
-                message,
-                style: VineTheme.bodyLargeFont(
-                  color: context.vineColors.primaryText,
-                ),
-                textAlign: TextAlign.center,
-              ),
-            ],
-          ),
+    if (_error case final error?) {
+      return switch (error) {
+        _VideoDetailError.notFound => _NotFoundScreen(
+          onClose: () => _handleExit(context),
         ),
-      );
+        _VideoDetailError.loadFailed => TvStaticMessageScreen(
+          sticker: .alert,
+          title: context.l10n.videoDetailLoadError,
+          description: context.l10n.videoDetailLoadErrorBody,
+          actionLabel: context.l10n.videoErrorRetry,
+          onAction: _retry,
+          onClose: () => _handleExit(context),
+          closeSemanticLabel: context.l10n.videoDetailCloseSemanticLabel,
+        ),
+      };
     }
 
     if (_video == null ||
         videoEventService.shouldHideVideo(_video!) ||
         videoEventService.isVideoEventKnownDeleted(_video!)) {
-      return Scaffold(
-        backgroundColor: context.vineColors.background,
-        appBar: _buildExitAppBar(context),
-        body: Center(
-          child: Text(
-            context.l10n.videoErrorNotFound,
-            style: VineTheme.bodyMediumFont(
-              color: context.vineColors.primaryText,
-            ),
-          ),
-        ),
-      );
+      return _NotFoundScreen(onClose: () => _handleExit(context));
     }
 
     // Display video in full-screen pooled player
@@ -342,14 +318,12 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
         );
   }
 
-  DiVineAppBar _buildExitAppBar(BuildContext context) {
-    return DiVineAppBar(
-      title: '',
-      showBackButton: true,
-      onBackPressed: () => _handleExit(context),
-      backButtonSemanticLabel: context.l10n.videoDetailCloseSemanticLabel,
-      backgroundMode: DiVineAppBarBackgroundMode.transparent,
-    );
+  void _retry() {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+    unawaited(_loadVideo());
   }
 
   void _handleExit(BuildContext context) {
@@ -358,6 +332,25 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
       return;
     }
     context.go('/');
+  }
+}
+
+/// Shown when the route's video cannot be resolved, is hidden by a filter, or
+/// was deleted — the three ways a shared link lands on nothing to play.
+class _NotFoundScreen extends StatelessWidget {
+  const _NotFoundScreen({required this.onClose});
+
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return TvStaticMessageScreen(
+      sticker: .alert,
+      title: context.l10n.videoErrorNotFound,
+      description: context.l10n.videoDetailNotFoundBody,
+      onClose: onClose,
+      closeSemanticLabel: context.l10n.videoDetailCloseSemanticLabel,
+    );
   }
 }
 

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -315,7 +315,11 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
       _isLoading = true;
       _error = null;
     });
-    unawaited(_loadVideo());
+    // A user-initiated retry must end in a definite state. Deferring to the
+    // relay-ready listener would swallow the failure and park the screen on an
+    // unbounded spinner with the Retry button gone; the user can always tap
+    // again once they are back online.
+    unawaited(_loadVideo(allowRelayReadyRetry: false));
   }
 
   void _handleExit(BuildContext context) {

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -271,15 +271,7 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
     final videoEventService = ref.read(videoEventServiceProvider);
 
     if (_isLoading) {
-      return Scaffold(
-        backgroundColor: context.vineColors.background,
-        body: Center(
-          child: Semantics(
-            identifier: SemanticIds.videoDetailLoading,
-            child: const BrandedLoadingIndicator(),
-          ),
-        ),
-      );
+      return _LoadingScreen(onClose: () => _handleExit(context));
     }
 
     if (_error case final error?) {
@@ -332,6 +324,49 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
       return;
     }
     context.go('/');
+  }
+}
+
+/// Shown while the route's video is still being resolved.
+///
+/// Carries the same top-left close affordance as the dead-end states, so a slow
+/// or relay-stalled lookup never strands the user on a spinner with no way out.
+class _LoadingScreen extends StatelessWidget {
+  const _LoadingScreen({required this.onClose});
+
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: context.vineColors.background,
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          Center(
+            child: Semantics(
+              identifier: SemanticIds.videoDetailLoading,
+              child: const BrandedLoadingIndicator(),
+            ),
+          ),
+          SafeArea(
+            child: Align(
+              alignment: .topLeft,
+              child: Padding(
+                padding: const .fromLTRB(16, 16, 0, 8),
+                child: DivineIconButton(
+                  icon: .x,
+                  onPressed: onClose,
+                  size: .small,
+                  type: .ghost,
+                  semanticLabel: context.l10n.videoDetailCloseSemanticLabel,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -323,6 +323,13 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
   }
 
   void _handleExit(BuildContext context) {
+    // The loading state can now be dismissed mid-fetch. Without this, a relay
+    // connecting during the pop transition would restart the lookup for a
+    // screen the user has already left.
+    _relayReadySubscription?.cancel();
+    _relayReadySubscription = null;
+    _retryScheduled = false;
+
     if (context.canPop()) {
       context.pop();
       return;

--- a/mobile/lib/widgets/camera_permission_gate.dart
+++ b/mobile/lib/widgets/camera_permission_gate.dart
@@ -11,8 +11,8 @@ import 'package:openvine/blocs/camera_permission/camera_permission_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
+import 'package:openvine/widgets/tv_static_message_screen.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_bottom_bar.dart';
-import 'package:tv_static_effect/tv_static_effect.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// A declarative gate widget that handles camera/microphone permissions.
@@ -274,75 +274,22 @@ class _PermissionScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: VideoEditorConstants.uiOverlayStyleFor(context.vineColors),
-      child: Scaffold(
-        backgroundColor: context.vineColors.background,
-        body: Stack(
-          fit: StackFit.expand,
-          children: [
-            const TvStaticNoise(),
-            Column(
-              children: [
-                Align(
-                  alignment: .centerLeft,
-                  child: SafeArea(
-                    bottom: false,
-                    child: Padding(
-                      padding: const .fromLTRB(16, 16, 0, 8),
-                      child: DivineIconButton(
-                        icon: .x,
-                        onPressed: onClose,
-                        size: .small,
-                        type: .ghost,
-                      ),
-                    ),
-                  ),
-                ),
-
-                Expanded(
-                  child: Center(
-                    child: SingleChildScrollView(
-                      padding: const .symmetric(horizontal: 48),
-                      child: Column(
-                        mainAxisAlignment: .center,
-                        children: [
-                          const DivineSticker(sticker: .alert, size: 154),
-                          const SizedBox(height: 19),
-                          Text(
-                            title,
-                            style: VineTheme.titleMediumFont(
-                              color: context.vineColors.onSurfaceMuted,
-                            ),
-                            textAlign: .center,
-                          ),
-                          const SizedBox(height: 8),
-                          Text(
-                            description,
-                            style: VineTheme.bodyMediumFont(
-                              color: context.vineColors.onSurfaceMuted,
-                            ),
-                            textAlign: .center,
-                          ),
-                          const SizedBox(height: 32),
-                          DivineButton(label: buttonLabel, onPressed: onAction),
-                        ],
-                      ),
-                    ),
-                  ),
-                ),
-
-                IgnorePointer(
-                  child: Container(
-                    padding: const .only(top: 8),
-                    color: context.vineColors.surfaceContainerHigh,
-                    child: const Opacity(
-                      opacity: 0.25,
-                      child: VideoRecorderBottomBar(),
-                    ),
-                  ),
-                ),
-              ],
+      child: TvStaticMessageScreen(
+        sticker: .alert,
+        title: title,
+        description: description,
+        actionLabel: buttonLabel,
+        onAction: onAction,
+        onClose: onClose,
+        footer: IgnorePointer(
+          child: Container(
+            padding: const .only(top: 8),
+            color: context.vineColors.surfaceContainerHigh,
+            child: const Opacity(
+              opacity: 0.25,
+              child: VideoRecorderBottomBar(),
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/widgets/camera_permission_gate.dart
+++ b/mobile/lib/widgets/camera_permission_gate.dart
@@ -4,13 +4,12 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/camera_permission/camera_permission_bloc.dart';
-import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
+import 'package:openvine/widgets/takeover_close_button.dart';
 import 'package:openvine/widgets/tv_static_message_screen.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_bottom_bar.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -232,19 +231,11 @@ class _LoadingIndicator extends StatelessWidget {
             child: CircularProgressIndicator(color: VineTheme.vineGreen),
           ),
           if (onClose case final onClose?)
-            Align(
-              alignment: .topLeft,
-              child: SafeArea(
-                bottom: false,
-                child: Padding(
-                  padding: const .fromLTRB(16, 16, 0, 8),
-                  child: DivineIconButton(
-                    icon: .x,
-                    onPressed: onClose,
-                    size: .small,
-                    type: .ghost,
-                  ),
-                ),
+            SafeArea(
+              bottom: false,
+              child: TakeoverCloseButton(
+                onPressed: onClose,
+                semanticLabel: context.l10n.videoRecorderCloseLabel,
               ),
             ),
         ],
@@ -272,23 +263,21 @@ class _PermissionScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AnnotatedRegion<SystemUiOverlayStyle>(
-      value: VideoEditorConstants.uiOverlayStyleFor(context.vineColors),
-      child: TvStaticMessageScreen(
-        sticker: .alert,
-        title: title,
-        description: description,
-        actionLabel: buttonLabel,
-        onAction: onAction,
-        onClose: onClose,
-        footer: IgnorePointer(
-          child: Container(
-            padding: const .only(top: 8),
-            color: context.vineColors.surfaceContainerHigh,
-            child: const Opacity(
-              opacity: 0.25,
-              child: VideoRecorderBottomBar(),
-            ),
+    return TvStaticMessageScreen(
+      sticker: .alert,
+      title: title,
+      description: description,
+      actionLabel: buttonLabel,
+      onAction: onAction,
+      onClose: onClose,
+      closeSemanticLabel: context.l10n.videoRecorderCloseLabel,
+      footer: IgnorePointer(
+        child: Container(
+          padding: const .only(top: 8),
+          color: context.vineColors.surfaceContainerHigh,
+          child: const Opacity(
+            opacity: 0.25,
+            child: VideoRecorderBottomBar(),
           ),
         ),
       ),

--- a/mobile/lib/widgets/takeover_close_button.dart
+++ b/mobile/lib/widgets/takeover_close_button.dart
@@ -1,0 +1,43 @@
+// ABOUTME: Top-left close affordance shared by the full-screen takeovers
+// ABOUTME: Keeps the TV-static, loading, and permission screens in step
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+
+/// The top-left X that dismisses a full-screen takeover.
+///
+/// Lives in one place so the TV-static dead ends, the video-detail spinner,
+/// and the camera permission gate cannot drift apart on the next design tweak.
+class TakeoverCloseButton extends StatelessWidget {
+  const TakeoverCloseButton({
+    required this.onPressed,
+    this.semanticLabel,
+    super.key,
+  });
+
+  final VoidCallback onPressed;
+
+  /// Accessibility label. Screens that name the thing being closed should
+  /// pass one; the button is unlabelled without it.
+  final String? semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    // topLeft, not centerLeft: inside a Column the two are identical, but
+    // these screens also place the button directly in an expanded Stack,
+    // where centerLeft would drop it to the middle of the screen.
+    return Align(
+      alignment: .topLeft,
+      child: Padding(
+        padding: const .fromLTRB(16, 16, 0, 8),
+        child: DivineIconButton(
+          icon: .x,
+          onPressed: onPressed,
+          size: .small,
+          type: .ghost,
+          semanticLabel: semanticLabel,
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/tv_static_message_screen.dart
+++ b/mobile/lib/widgets/tv_static_message_screen.dart
@@ -1,0 +1,149 @@
+// ABOUTME: Full-screen takeover that renders a message over TV static noise
+// ABOUTME: Shared retro "no signal" look for permission and video dead ends
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:tv_static_effect/tv_static_effect.dart';
+
+/// Full-screen takeover that renders a message over animated TV static.
+///
+/// The retro "no signal" look the camera permission screen introduced, reused
+/// wherever the app has nothing to play: a missing video, a failed load, a
+/// denied permission. A close affordance sits in the top-left corner; the
+/// primary action and the [footer] chrome are optional.
+class TvStaticMessageScreen extends StatelessWidget {
+  const TvStaticMessageScreen({
+    required this.sticker,
+    required this.title,
+    required this.onClose,
+    this.description,
+    this.actionLabel,
+    this.onAction,
+    this.closeSemanticLabel,
+    this.footer,
+    super.key,
+  });
+
+  /// Sticker shown above the title.
+  final DivineStickerName sticker;
+
+  final String title;
+
+  /// Optional supporting copy below the title.
+  final String? description;
+
+  /// Label of the primary action. Rendered only alongside [onAction].
+  final String? actionLabel;
+
+  /// Primary action. Rendered only alongside [actionLabel].
+  final VoidCallback? onAction;
+
+  /// Invoked by the top-left close button.
+  final VoidCallback onClose;
+
+  /// Accessibility label for the close button.
+  final String? closeSemanticLabel;
+
+  /// Optional chrome pinned to the bottom edge, below the message.
+  final Widget? footer;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: context.vineColors.background,
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          const TvStaticNoise(),
+          SafeArea(
+            child: Column(
+              children: [
+                Align(
+                  alignment: .centerLeft,
+                  child: SafeArea(
+                    bottom: false,
+                    child: Padding(
+                      padding: const .fromLTRB(16, 16, 0, 8),
+                      child: DivineIconButton(
+                        icon: .x,
+                        onPressed: onClose,
+                        size: .small,
+                        type: .ghost,
+                        semanticLabel: closeSemanticLabel,
+                      ),
+                    ),
+                  ),
+                ),
+
+                Expanded(
+                  child: Center(
+                    child: SingleChildScrollView(
+                      padding: const .symmetric(horizontal: 48),
+                      child: _TvStaticMessage(
+                        sticker: sticker,
+                        title: title,
+                        description: description,
+                        actionLabel: actionLabel,
+                        onAction: onAction,
+                      ),
+                    ),
+                  ),
+                ),
+
+                ?footer,
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TvStaticMessage extends StatelessWidget {
+  const _TvStaticMessage({
+    required this.sticker,
+    required this.title,
+    required this.description,
+    required this.actionLabel,
+    required this.onAction,
+  });
+
+  final DivineStickerName sticker;
+  final String title;
+  final String? description;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: .center,
+      children: [
+        DivineSticker(sticker: sticker, size: 154),
+        const SizedBox(height: 20),
+        Text(
+          title,
+          style: VineTheme.titleMediumFont(
+            color: context.vineColors.onSurfaceMuted,
+          ),
+          textAlign: .center,
+        ),
+        if (description case final description?) ...[
+          const SizedBox(height: 8),
+          Text(
+            description,
+            style: VineTheme.bodyMediumFont(
+              color: context.vineColors.onSurfaceMuted,
+            ),
+            textAlign: .center,
+          ),
+        ],
+        if ((actionLabel, onAction) case (final label?, final onAction?)) ...[
+          const SizedBox(height: 32),
+          DivineButton(label: label, onPressed: onAction),
+        ],
+      ],
+    );
+  }
+}

--- a/mobile/lib/widgets/tv_static_message_screen.dart
+++ b/mobile/lib/widgets/tv_static_message_screen.dart
@@ -60,17 +60,14 @@ class TvStaticMessageScreen extends StatelessWidget {
               children: [
                 Align(
                   alignment: .centerLeft,
-                  child: SafeArea(
-                    bottom: false,
-                    child: Padding(
-                      padding: const .fromLTRB(16, 16, 0, 8),
-                      child: DivineIconButton(
-                        icon: .x,
-                        onPressed: onClose,
-                        size: .small,
-                        type: .ghost,
-                        semanticLabel: closeSemanticLabel,
-                      ),
+                  child: Padding(
+                    padding: const .fromLTRB(16, 16, 0, 8),
+                    child: DivineIconButton(
+                      icon: .x,
+                      onPressed: onClose,
+                      size: .small,
+                      type: .ghost,
+                      semanticLabel: closeSemanticLabel,
                     ),
                   ),
                 ),

--- a/mobile/lib/widgets/tv_static_message_screen.dart
+++ b/mobile/lib/widgets/tv_static_message_screen.dart
@@ -45,6 +45,9 @@ class TvStaticMessageScreen extends StatelessWidget {
   final String? closeSemanticLabel;
 
   /// Optional chrome pinned to the bottom edge, below the message.
+  ///
+  /// A footer owns its own bottom inset — [SafeArea] here stops at the
+  /// message column so the footer can paint all the way to the screen edge.
   final Widget? footer;
 
   @override
@@ -56,6 +59,7 @@ class TvStaticMessageScreen extends StatelessWidget {
         children: [
           const TvStaticNoise(),
           SafeArea(
+            bottom: footer == null,
             child: Column(
               children: [
                 Align(

--- a/mobile/lib/widgets/tv_static_message_screen.dart
+++ b/mobile/lib/widgets/tv_static_message_screen.dart
@@ -3,6 +3,9 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/widgets/takeover_close_button.dart';
 import 'package:tv_static_effect/tv_static_effect.dart';
 
 /// Full-screen takeover that renders a message over animated TV static.
@@ -52,50 +55,46 @@ class TvStaticMessageScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: context.vineColors.background,
-      body: Stack(
-        fit: StackFit.expand,
-        children: [
-          const TvStaticNoise(),
-          SafeArea(
-            bottom: footer == null,
-            child: Column(
-              children: [
-                Align(
-                  alignment: .centerLeft,
-                  child: Padding(
-                    padding: const .fromLTRB(16, 16, 0, 8),
-                    child: DivineIconButton(
-                      icon: .x,
-                      onPressed: onClose,
-                      size: .small,
-                      type: .ghost,
-                      semanticLabel: closeSemanticLabel,
-                    ),
+    // The takeover replaces the whole screen, so it owns the status-bar tint
+    // rather than inheriting whatever route it covered.
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+      value: VideoEditorConstants.uiOverlayStyleFor(context.vineColors),
+      child: Scaffold(
+        backgroundColor: context.vineColors.background,
+        body: Stack(
+          fit: StackFit.expand,
+          children: [
+            const TvStaticNoise(),
+            SafeArea(
+              bottom: footer == null,
+              child: Column(
+                children: [
+                  TakeoverCloseButton(
+                    onPressed: onClose,
+                    semanticLabel: closeSemanticLabel,
                   ),
-                ),
 
-                Expanded(
-                  child: Center(
-                    child: SingleChildScrollView(
-                      padding: const .symmetric(horizontal: 48),
-                      child: _TvStaticMessage(
-                        sticker: sticker,
-                        title: title,
-                        description: description,
-                        actionLabel: actionLabel,
-                        onAction: onAction,
+                  Expanded(
+                    child: Center(
+                      child: SingleChildScrollView(
+                        padding: const .symmetric(horizontal: 48),
+                        child: _TvStaticMessage(
+                          sticker: sticker,
+                          title: title,
+                          description: description,
+                          actionLabel: actionLabel,
+                          onAction: onAction,
+                        ),
                       ),
                     ),
                   ),
-                ),
 
-                ?footer,
-              ],
+                  ?footer,
+                ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -639,6 +639,67 @@ void main() {
         expect(find.byKey(const Key('video-feed-placeholder')), findsOneWidget);
         expect(attempts, equals(2));
       });
+
+      testWidgets('shows the loading state while the retry is in flight', (
+        tester,
+      ) async {
+        final refetch = Completer<VideoEvent?>();
+        var attempts = 0;
+        when(
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(any()),
+        ).thenAnswer((_) {
+          attempts++;
+          return attempts == 1
+              ? Future<VideoEvent?>.error(Exception('Network error'))
+              : refetch.future;
+        });
+        addTearDown(() => refetch.complete(null));
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pump();
+
+        expect(find.text(l10n.videoDetailLoadError), findsOneWidget);
+
+        await tester.tap(find.text(l10n.videoErrorRetry));
+        await tester.pump();
+
+        // The error takeover must give way to the spinner immediately, rather
+        // than sitting there unchanged for the length of the refetch.
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
+        expect(find.text(l10n.videoDetailLoadError), findsNothing);
+      });
+
+      testWidgets(
+        'retry surfaces the error again when the relays are unreachable',
+        (tester) async {
+          // Regression: a retry that deferred to the relay-ready listener left
+          // the user on an unbounded spinner with no way back to Retry.
+          var attempts = 0;
+          when(
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(any()),
+          ).thenAnswer((_) {
+            attempts++;
+            return Future<VideoEvent?>.error(Exception('Network error'));
+          });
+
+          await tester.pumpWidget(buildSubject());
+          await tester.pump();
+
+          expect(find.text(l10n.videoErrorRetry), findsOneWidget);
+
+          // The last relay drops while the user sits on the error screen.
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(0);
+
+          await tester.tap(find.text(l10n.videoErrorRetry));
+          await tester.pump();
+          await tester.pump();
+
+          expect(attempts, equals(2));
+          expect(find.byType(BrandedLoadingIndicator), findsNothing);
+          expect(find.text(l10n.videoDetailLoadError), findsOneWidget);
+          expect(find.text(l10n.videoErrorRetry), findsOneWidget);
+        },
+      );
     });
 
     group('explicit route block filtering', () {

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -540,6 +540,7 @@ void main() {
           await tester.pump();
 
           expect(find.text(l10n.videoErrorNotFound), findsOneWidget);
+          expect(find.text(l10n.videoDetailNotFoundBody), findsOneWidget);
           // Prove the copy resolves through l10n rather than a hardcoded
           // English string (#5125).
           expect(
@@ -548,10 +549,7 @@ void main() {
             ),
             findsNothing,
           );
-          expect(
-            _divineSticker(DivineStickerName.alert),
-            findsOneWidget,
-          );
+          expect(_divineSticker(DivineStickerName.alert), findsOneWidget);
           expect(
             find.bySemanticsLabel(l10n.videoDetailCloseSemanticLabel),
             findsOneWidget,
@@ -580,10 +578,8 @@ void main() {
           await tester.pump();
 
           expect(find.text(l10n.videoErrorNotFound), findsOneWidget);
-          expect(
-            _divineSticker(DivineStickerName.alert),
-            findsOneWidget,
-          );
+          expect(find.text(l10n.videoDetailNotFoundBody), findsOneWidget);
+          expect(_divineSticker(DivineStickerName.alert), findsOneWidget);
           expect(
             find.bySemanticsLabel(l10n.videoDetailCloseSemanticLabel),
             findsOneWidget,

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -203,6 +203,85 @@ void main() {
           expect(find.text('caller screen'), findsOneWidget);
         },
       );
+
+      testWidgets(
+        'does not resume the lookup after leaving a deferred cold start',
+        (tester) async {
+          // Cold start: no relay is queryable yet, so the first lookup defers
+          // until one connects. The user leaves before that happens.
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(0);
+          var attempts = 0;
+          when(
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(any()),
+          ).thenAnswer((_) async {
+            attempts++;
+            return null;
+          });
+
+          final router = GoRouter(
+            routes: [
+              GoRoute(
+                path: '/',
+                builder: (_, _) => const Scaffold(body: Text('caller screen')),
+              ),
+              GoRoute(
+                path: VideoDetailScreen.path,
+                builder: (_, state) => VideoDetailScreen(
+                  videoId: state.pathParameters['id']!,
+                ),
+              ),
+            ],
+          );
+          addTearDown(router.dispose);
+
+          await tester.pumpWidget(
+            testProviderScope(
+              mockNostrService: mockNostrClient,
+              mockFollowRepository: mockFollowRepository,
+              additionalOverrides: [
+                videoEventServiceProvider.overrideWithValue(
+                  mockVideoEventService,
+                ),
+                contentBlocklistRepositoryProvider.overrideWithValue(
+                  mockBlocklistRepository,
+                ),
+                videosRepositoryProvider.overrideWithValue(
+                  mockVideosRepository,
+                ),
+              ],
+              child: MaterialApp.router(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                routerConfig: router,
+              ),
+            ),
+          );
+
+          unawaited(router.push(VideoDetailScreen.pathForId('test_video_id')));
+          await tester.pump();
+          await tester.pump(const Duration(seconds: 1));
+
+          expect(attempts, equals(1));
+
+          await tester.tap(
+            find.bySemanticsLabel(l10n.videoDetailCloseSemanticLabel),
+          );
+          // A relay comes up mid-transition, while the popped route's State is
+          // still alive and its listener has not yet been disposed.
+          await tester.pump();
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(1);
+          relayStatusController.add({
+            'wss://relay.divine.video': RelayConnectionStatus.connected(
+              'wss://relay.divine.video',
+            ),
+          });
+          await tester.pump();
+          await tester.pump(const Duration(seconds: 1));
+
+          expect(attempts, equals(1));
+          expect(find.text('caller screen'), findsOneWidget);
+        },
+      );
     });
 
     group('video found', () {

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
@@ -134,6 +135,74 @@ void main() {
         expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
         expect(find.byType(CircularProgressIndicator), findsNothing);
       });
+
+      testWidgets(
+        'leaves the screen via the close button while still fetching',
+        (tester) async {
+          // A lookup that never resolves — cold start before the relays are
+          // queryable — used to strand the user on the spinner with no exit.
+          final completer = Completer<VideoEvent?>();
+          when(
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(any()),
+          ).thenAnswer((_) => completer.future);
+          addTearDown(() => completer.complete(null));
+
+          final router = GoRouter(
+            routes: [
+              GoRoute(
+                path: '/',
+                builder: (_, _) => const Scaffold(body: Text('caller screen')),
+              ),
+              GoRoute(
+                path: VideoDetailScreen.path,
+                builder: (_, state) => VideoDetailScreen(
+                  videoId: state.pathParameters['id']!,
+                ),
+              ),
+            ],
+          );
+          addTearDown(router.dispose);
+
+          await tester.pumpWidget(
+            testProviderScope(
+              mockNostrService: mockNostrClient,
+              mockFollowRepository: mockFollowRepository,
+              additionalOverrides: [
+                videoEventServiceProvider.overrideWithValue(
+                  mockVideoEventService,
+                ),
+                contentBlocklistRepositoryProvider.overrideWithValue(
+                  mockBlocklistRepository,
+                ),
+                videosRepositoryProvider.overrideWithValue(
+                  mockVideosRepository,
+                ),
+              ],
+              child: MaterialApp.router(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                routerConfig: router,
+              ),
+            ),
+          );
+
+          unawaited(router.push(VideoDetailScreen.pathForId('test_video_id')));
+          // The branded indicator animates forever, so settle would time out.
+          await tester.pump();
+          await tester.pump(const Duration(seconds: 1));
+
+          expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
+
+          await tester.tap(
+            find.bySemanticsLabel(l10n.videoDetailCloseSemanticLabel),
+          );
+          await tester.pump();
+          await tester.pump(const Duration(seconds: 1));
+
+          expect(find.byType(BrandedLoadingIndicator), findsNothing);
+          expect(find.text('caller screen'), findsOneWidget);
+        },
+      );
     });
 
     group('video found', () {

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -33,8 +33,8 @@ class _MockContentBlocklistRepository extends Mock
 
 class _MockVideosRepository extends Mock implements VideosRepository {}
 
-Finder _divineIcon(DivineIconName name) =>
-    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
+Finder _divineSticker(DivineStickerName name) =>
+    find.byWidgetPredicate((w) => w is DivineSticker && w.sticker == name);
 
 void main() {
   final l10n = lookupAppLocalizations(const Locale('en'));
@@ -400,7 +400,10 @@ void main() {
             ),
             findsNothing,
           );
-          expect(_divineIcon(DivineIconName.warningCircle), findsOneWidget);
+          expect(
+            _divineSticker(DivineStickerName.alert),
+            findsOneWidget,
+          );
           expect(
             find.bySemanticsLabel(l10n.videoDetailCloseSemanticLabel),
             findsOneWidget,
@@ -429,7 +432,10 @@ void main() {
           await tester.pump();
 
           expect(find.text(l10n.videoErrorNotFound), findsOneWidget);
-          expect(_divineIcon(DivineIconName.warningCircle), findsOneWidget);
+          expect(
+            _divineSticker(DivineStickerName.alert),
+            findsOneWidget,
+          );
           expect(
             find.bySemanticsLabel(l10n.videoDetailCloseSemanticLabel),
             findsOneWidget,
@@ -503,7 +509,8 @@ void main() {
           await tester.pump();
 
           expect(find.text(l10n.videoDetailLoadError), findsOneWidget);
-          expect(_divineIcon(DivineIconName.warningCircle), findsOneWidget);
+          expect(find.text(l10n.videoDetailLoadErrorBody), findsOneWidget);
+          expect(_divineSticker(DivineStickerName.alert), findsOneWidget);
           expect(
             find.bySemanticsLabel(l10n.videoDetailCloseSemanticLabel),
             findsOneWidget,
@@ -533,6 +540,35 @@ void main() {
         expect(find.text(l10n.videoDetailLoadError), findsOneWidget);
         expect(find.textContaining('SqliteException'), findsNothing);
         expect(find.textContaining('SELECT'), findsNothing);
+      });
+
+      testWidgets('refetches the video when retry is tapped', (tester) async {
+        final video = createTestVideoEvent(
+          id: 'test_video_id',
+          pubkey: 'test_pubkey',
+          title: 'Deep Link Video',
+        );
+        var attempts = 0;
+        when(
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(any()),
+        ).thenAnswer((_) {
+          attempts++;
+          return attempts == 1
+              ? Future<VideoEvent?>.error(Exception('Network error'))
+              : Future<VideoEvent?>.value(video);
+        });
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pump();
+
+        expect(find.text(l10n.videoDetailLoadError), findsOneWidget);
+
+        await tester.tap(find.text(l10n.videoErrorRetry));
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.byKey(const Key('video-feed-placeholder')), findsOneWidget);
+        expect(attempts, equals(2));
       });
     });
 

--- a/mobile/test/widgets/camera_permission_gate_test.dart
+++ b/mobile/test/widgets/camera_permission_gate_test.dart
@@ -215,6 +215,29 @@ void main() {
       expect(bloc.addedEvents.last, isA<CameraPermissionRefresh>());
     });
 
+    testWidgets('the permission prompt closes via its labelled X', (
+      tester,
+    ) async {
+      // The prompt renders through the shared TvStaticMessageScreen, so its
+      // close wiring and label have to survive that hop.
+      final bloc = _FakeCameraPermissionBloc(
+        const CameraPermissionLoaded(CameraPermissionStatus.requiresSettings),
+      );
+      addTearDown(bloc.close);
+      final goRouter = MockGoRouter();
+      when(goRouter.canPop).thenReturn(true);
+
+      await tester.pumpWidget(buildSubject(bloc, goRouter));
+      await tester.pump();
+
+      await tester.tap(
+        find.bySemanticsLabel(l10n.videoRecorderCloseLabel),
+      );
+      await tester.pump();
+
+      verify(goRouter.pop).called(1);
+    });
+
     testWidgets('a stuck loading state offers a close affordance to bail out', (
       tester,
     ) async {

--- a/mobile/test/widgets/tv_static_message_screen_test.dart
+++ b/mobile/test/widgets/tv_static_message_screen_test.dart
@@ -1,0 +1,112 @@
+// ABOUTME: Widget tests for the shared TV-static message takeover
+// ABOUTME: Covers optional description, optional action, close, and footer
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/widgets/tv_static_message_screen.dart';
+
+void main() {
+  group(TvStaticMessageScreen, () {
+    testWidgets('renders the sticker, title, and description', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: TvStaticMessageScreen(
+            sticker: DivineStickerName.vintageTvTestPattern,
+            title: 'Video not found',
+            description: 'It was either deleted, or it is hiding.',
+            onClose: () {},
+          ),
+        ),
+      );
+
+      expect(
+        find.byWidgetPredicate(
+          (w) =>
+              w is DivineSticker &&
+              w.sticker == DivineStickerName.vintageTvTestPattern,
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('Video not found'), findsOneWidget);
+      expect(
+        find.text('It was either deleted, or it is hiding.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('omits the action button when no action is supplied', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: TvStaticMessageScreen(
+            sticker: DivineStickerName.alert,
+            title: 'Video not found',
+            onClose: () {},
+          ),
+        ),
+      );
+
+      expect(find.byType(DivineButton), findsNothing);
+    });
+
+    testWidgets('invokes the action when the button is tapped', (tester) async {
+      var actionCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: TvStaticMessageScreen(
+            sticker: DivineStickerName.alert,
+            title: 'Failed to load video',
+            actionLabel: 'Retry',
+            onAction: () => actionCount++,
+            onClose: () {},
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Retry'));
+      await tester.pump();
+
+      expect(actionCount, equals(1));
+    });
+
+    testWidgets('invokes onClose from the labelled close button', (
+      tester,
+    ) async {
+      var closeCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: TvStaticMessageScreen(
+            sticker: DivineStickerName.alert,
+            title: 'Failed to load video',
+            onClose: () => closeCount++,
+            closeSemanticLabel: 'Close video player',
+          ),
+        ),
+      );
+
+      await tester.tap(find.bySemanticsLabel('Close video player'));
+      await tester.pump();
+
+      expect(closeCount, equals(1));
+    });
+
+    testWidgets('renders the footer chrome when supplied', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: TvStaticMessageScreen(
+            sticker: DivineStickerName.alert,
+            title: 'Allow camera access',
+            onClose: () {},
+            footer: const SizedBox(key: Key('footer'), height: 48),
+          ),
+        ),
+      );
+
+      expect(find.byKey(const Key('footer')), findsOneWidget);
+    });
+  });
+}

--- a/mobile/test/widgets/tv_static_message_screen_test.dart
+++ b/mobile/test/widgets/tv_static_message_screen_test.dart
@@ -108,5 +108,70 @@ void main() {
 
       expect(find.byKey(const Key('footer')), findsOneWidget);
     });
+
+    testWidgets('lets the footer paint to the bottom screen edge', (
+      tester,
+    ) async {
+      // A footer carries its own SafeArea. If this screen also consumed the
+      // bottom inset, the footer's background would stop short of the edge
+      // and the animated static behind it would show through the gap.
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        const MediaQuery(
+          data: MediaQueryData(padding: EdgeInsets.only(bottom: 48)),
+          child: MaterialApp(
+            home: TvStaticMessageScreen(
+              sticker: DivineStickerName.alert,
+              title: 'Allow camera access',
+              onClose: _noop,
+              footer: SizedBox(key: Key('footer'), height: 60),
+            ),
+          ),
+        ),
+      );
+
+      final footer = tester.getRect(find.byKey(const Key('footer')));
+      final screen = tester.getRect(find.byType(Scaffold));
+
+      expect(footer.bottom, equals(screen.bottom));
+    });
+
+    testWidgets('keeps the bottom inset when there is no footer', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        const MediaQuery(
+          data: MediaQueryData(padding: EdgeInsets.only(bottom: 48)),
+          child: MaterialApp(
+            home: TvStaticMessageScreen(
+              sticker: DivineStickerName.alert,
+              title: 'Video not found',
+              onClose: _noop,
+            ),
+          ),
+        ),
+      );
+
+      final column = tester.getRect(
+        find
+            .descendant(
+              of: find.byType(SafeArea),
+              matching: find.byType(Column),
+            )
+            .first,
+      );
+      final screen = tester.getRect(find.byType(Scaffold));
+
+      expect(column.bottom, equals(screen.bottom - 48));
+    });
   });
 }
+
+void _noop() {}


### PR DESCRIPTION
Closes #6787

## Description

The shared-link video screen (`/video/:id`) rendered its dead ends as a red warning icon on a flat background — it read like a crash report, not a state, and it was the first thing anyone opening a Divine link to a deleted video saw.

Those states now use the retro "no signal" takeover the camera permission screen already had: animated TV static, a sticker, title, and supporting copy.

- **Video not found** (also covers filtered and locally deleted videos): sticker + "Video not found" + new body copy. The copy deliberately covers both "deleted" and "we just can't fetch it from any connected relay", because the screen cannot tell those apart.
- **Failed to load**: same treatment plus a **Retry** button. Until now a transient network error was a dead end — the only recovery was leaving the screen and re-opening the link.
- **Still loading**: the bare spinner now carries the same top-left X, wired to the existing exit handler. A cold-start deep link parks on the first relay connection with no timeout, so without this an unresolved lookup could sit on the spinner with no way out.

The layout was extracted into `TvStaticMessageScreen` and the camera permission screen was moved onto it (–85 lines there). Rationale: two screens rendering the same takeover by hand drift apart on the first design tweak, and the camera gate keeps its specific chrome (dimmed recorder bottom bar, overlay style) through the widget's `footer` slot rather than by duplicating the whole stack.

The old `DiVineAppBar` on these states is gone; the close affordance is now the same top-left X the camera screen uses, carrying the existing `videoDetailCloseSemanticLabel`.

### Intended design adjustments

The shared `TvStaticMessageScreen` wraps its whole column in a single `SafeArea`. This is deliberate: it fixes the camera permission screen's content not being vertically centered on Android, where the system navigation bar was not previously accounted for. Two camera-screen deltas follow from the extraction and are intentional, not drift — the dimmed recorder bottom bar now sits inside the safe area, and the sticker→title gap is normalized to 20px.

## Out of Scope

Other error surfaces that still use the icon-on-flat-background pattern (e.g. the in-feed `PooledVideoErrorOverlay`) are untouched — those sit over a video frame, not on an empty screen, so the takeover treatment does not apply.

## Verification

- `flutter analyze lib test` — clean
- `flutter test test/screens/video_detail_screen_test.dart test/widgets/tv_static_message_screen_test.dart test/widgets/camera_permission_gate_test.dart` — 28 passing, including tests that the Retry button refetches, that the loading state can be dismissed mid-fetch, and a suite for `TvStaticMessageScreen`
- `flutter test test/l10n/arb_consistency_test.dart` — clean (2 new keys mirrored into all 21 non-English locales, `flutter gen-l10n` output committed)
- All four design-system ceiling ratchets (`raw_textstyle`, `raw_colors`, `material_button`, `raw_dialog`) — clean
- Manually verified on a real Samsung Galaxy: opened a link to a deleted video, opened a link while offline and used Retry to recover, dismissed a stalled cold-start loading state via the X, and re-checked the camera permission screen for regressions after the refactor

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor
