### PR TITLE
fix(feed): pause playback for the mode and classify sheets

### DIFF
--- a/mobile/lib/screens/feed/feed_mode_switch.dart
+++ b/mobile/lib/screens/feed/feed_mode_switch.dart
@@ -9,6 +9,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/screens/feed/feed_settings_menu.dart';
+import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:openvine/widgets/video_feed_item/feed_immersive_chrome.dart';
 
 /// Feed mode picker overlay that displays the current feed mode
@@ -80,8 +81,7 @@ class FeedModeSwitch extends StatelessWidget {
     VideoFeedBlocState state,
   ) async {
     final l10n = context.l10n;
-    final selected = await VineBottomSheetSelectionMenu.show(
-      context: context,
+    final selected = await context.showVideoPausingSelectionMenu(
       selectedValue: state.source.persistenceValue,
       options: [
         VineBottomSheetSelectionOptionData(

--- a/mobile/lib/utils/pause_aware_modals.dart
+++ b/mobile/lib/utils/pause_aware_modals.dart
@@ -110,6 +110,7 @@ extension PauseAwareModals on BuildContext {
     Widget? bottomInput,
     bool expanded = true,
     bool showHeaderDivider = true,
+    bool showDragHandle = true,
     bool? isScrollControlled,
     double initialChildSize = 0.6,
     double minChildSize = 0.3,
@@ -164,6 +165,7 @@ extension PauseAwareModals on BuildContext {
       bottomInput: bottomInput,
       expanded: expanded,
       showHeaderDivider: showHeaderDivider,
+      showDragHandle: showDragHandle,
       isScrollControlled: isScrollControlled,
       initialChildSize: initialChildSize,
       minChildSize: minChildSize,
@@ -177,5 +179,37 @@ extension PauseAwareModals on BuildContext {
       onShow: () => overlayNotifier.setBottomSheetOpen(true),
       onDismiss: () => overlayNotifier.setBottomSheetOpen(false),
     );
+  }
+
+  /// Shows a [VineBottomSheetSelectionMenu] that automatically pauses video
+  /// playback.
+  ///
+  /// [VineBottomSheetSelectionMenu.show] does not expose
+  /// `onShow`/`onDismiss`, so the overlay flag is toggled here around the
+  /// returned future. Uses `setBottomSheetOpen` — same semantics as
+  /// [showVideoPausingVineBottomSheet], so the current player is paused but
+  /// retained for instant resume.
+  Future<String?> showVideoPausingSelectionMenu({
+    required List<VineBottomSheetSelectionOptionData> options,
+    Widget? title,
+    String? selectedValue,
+    EdgeInsetsGeometry? headerPadding,
+    DivineIconButton? headerLeadingAction,
+    DivineIconButton? headerTrailingAction,
+  }) {
+    final container = ProviderScope.containerOf(this, listen: false);
+    final overlayNotifier = container.read(overlayVisibilityProvider.notifier);
+
+    overlayNotifier.setBottomSheetOpen(true);
+
+    return VineBottomSheetSelectionMenu.show(
+      context: this,
+      options: options,
+      title: title,
+      selectedValue: selectedValue,
+      headerPadding: headerPadding,
+      headerLeadingAction: headerLeadingAction,
+      headerTrailingAction: headerTrailingAction,
+    ).whenComplete(() => overlayNotifier.setBottomSheetOpen(false));
   }
 }

--- a/mobile/lib/widgets/community_suggest/community_suggest_sheet.dart
+++ b/mobile/lib/widgets/community_suggest/community_suggest_sheet.dart
@@ -12,6 +12,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_content_label_name.dart';
 import 'package:openvine/models/content_label.dart';
 import 'package:openvine/repositories/community_content_label_repository.dart';
+import 'package:openvine/utils/pause_aware_modals.dart';
 
 /// The "Help classify this" content-warning suggestion sheet.
 class CommunitySuggestSheet {
@@ -24,13 +25,15 @@ class CommunitySuggestSheet {
     required CommunityContentLabelRepository repository,
     required String myPubkey,
   }) {
-    return VineBottomSheet.show<void>(
-      context: context,
+    return context.showVideoPausingVineBottomSheet<void>(
       maxChildSize: 1,
       initialChildSize: 0.9,
       minChildSize: 0.7,
       showHeader: false,
       showDragHandle: false,
+      // Preserves the pre-pause-integration presentation: the sheet stays in
+      // the shell navigator rather than covering the tab bar.
+      useRootNavigator: false,
       buildScrollBody: (scrollController) => BlocProvider(
         create: (_) => CommunitySuggestCubit(
           repository: repository,

--- a/mobile/test/screens/feed/feed_mode_switch_test.dart
+++ b/mobile/test/screens/feed/feed_mode_switch_test.dart
@@ -11,6 +11,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/overlay_visibility_provider.dart';
 import 'package:openvine/screens/feed/feed_immersive_cubit.dart';
 import 'package:openvine/screens/feed/feed_mode_switch.dart';
 import 'package:openvine/widgets/video_feed_item/feed_immersive_chrome.dart';
@@ -298,6 +299,41 @@ void main() {
         await tester.pumpAndSettle();
 
         verifyNever(() => mockBloc.add(any()));
+      });
+
+      testWidgets('pauses video playback while the mode sheet is open', (
+        tester,
+      ) async {
+        // Regression: the mode sheet used to bypass the overlay-visibility
+        // integration, so the video behind it kept playing.
+        when(() => mockBloc.state).thenReturn(
+          const VideoFeedBlocState(
+            status: VideoFeedStatus.success,
+            source: VideoFeedSource.forYou(),
+          ),
+        );
+        await tester.pumpWidget(createTestWidget());
+
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(FeedModeSwitch)),
+          listen: false,
+        );
+
+        await tester.tap(find.text(l10n.feedModeForYou));
+        await tester.pumpAndSettle();
+
+        expect(
+          container.read(overlayVisibilityProvider).isBottomSheetOpen,
+          isTrue,
+        );
+
+        await tester.tap(find.text(l10n.feedModeFollowing));
+        await tester.pumpAndSettle();
+
+        expect(
+          container.read(overlayVisibilityProvider).isBottomSheetOpen,
+          isFalse,
+        );
       });
     });
 

--- a/mobile/test/screens/feed/feed_mode_switch_test.dart
+++ b/mobile/test/screens/feed/feed_mode_switch_test.dart
@@ -335,6 +335,45 @@ void main() {
           isFalse,
         );
       });
+
+      testWidgets(
+        'clears the pause flag when the mode sheet is dismissed without a '
+        'selection',
+        (tester) async {
+          // Regression guard: dismissing via the scrim (no option tapped)
+          // must still resume playback. The clear lives in the extension's
+          // whenComplete, so it fires on cancel too — this pins that path.
+          when(() => mockBloc.state).thenReturn(
+            const VideoFeedBlocState(
+              status: VideoFeedStatus.success,
+              source: VideoFeedSource.forYou(),
+            ),
+          );
+          await tester.pumpWidget(createTestWidget());
+
+          final container = ProviderScope.containerOf(
+            tester.element(find.byType(FeedModeSwitch)),
+            listen: false,
+          );
+
+          await tester.tap(find.text(l10n.feedModeForYou));
+          await tester.pumpAndSettle();
+
+          expect(
+            container.read(overlayVisibilityProvider).isBottomSheetOpen,
+            isTrue,
+          );
+
+          // Dismiss by tapping outside (on the barrier), no option selected.
+          await tester.tapAt(const Offset(10, 10));
+          await tester.pumpAndSettle();
+
+          expect(
+            container.read(overlayVisibilityProvider).isBottomSheetOpen,
+            isFalse,
+          );
+        },
+      );
     });
 
     group('Tap Area Coverage', () {

--- a/mobile/test/utils/pause_aware_modals_test.dart
+++ b/mobile/test/utils/pause_aware_modals_test.dart
@@ -3,6 +3,7 @@
 // ABOUTME: Comments after migration) rely on for tap-outside dismissal
 // ABOUTME: and overlay-visibility integration.
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -145,6 +146,65 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text('Pinned Body'), findsOneWidget);
+      },
+    );
+  });
+
+  group('showVideoPausingSelectionMenu', () {
+    testWidgets(
+      'sets and clears isBottomSheetOpen on the overlay visibility provider',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(800, 1200));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          ProviderScope(
+            child: MaterialApp(
+              home: Scaffold(
+                body: Builder(
+                  builder: (context) => ElevatedButton(
+                    onPressed: () {
+                      context.showVideoPausingSelectionMenu(
+                        options: const [
+                          VineBottomSheetSelectionOptionData(
+                            label: 'Option A',
+                            value: 'a',
+                          ),
+                        ],
+                      );
+                    },
+                    child: const Text('Open'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final container = ProviderScope.containerOf(
+          tester.element(find.text('Open')),
+          listen: false,
+        );
+        expect(
+          container.read(overlayVisibilityProvider).isBottomSheetOpen,
+          isFalse,
+        );
+
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        expect(
+          container.read(overlayVisibilityProvider).isBottomSheetOpen,
+          isTrue,
+        );
+
+        await tester.tap(find.text('Option A'));
+        await tester.pumpAndSettle();
+
+        expect(
+          container.read(overlayVisibilityProvider).isBottomSheetOpen,
+          isFalse,
+        );
       },
     );
   });

--- a/mobile/test/widgets/video_feed_item/actions/help_classify_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/help_classify_action_button_test.dart
@@ -11,6 +11,7 @@ import 'package:openvine/features/feature_flags/services/feature_flag_service.da
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/community_content_label_provider.dart';
+import 'package:openvine/providers/overlay_visibility_provider.dart';
 import 'package:openvine/repositories/community_content_label_repository.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/widgets/video_feed_item/actions/help_classify_action_button.dart';
@@ -159,6 +160,38 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text(l10n.communitySuggestTitle), findsOneWidget);
+    });
+
+    testWidgets('pauses video playback while the suggestion sheet is open', (
+      tester,
+    ) async {
+      // Regression: the suggestion sheet used to bypass the
+      // overlay-visibility integration, so the video behind it kept playing.
+      await tester.pumpWidget(wrap(repo: repository));
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(HelpClassifyActionButton)),
+        listen: false,
+      );
+
+      await tester.tap(find.byType(VideoActionButton));
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(overlayVisibilityProvider).isBottomSheetOpen,
+        isTrue,
+      );
+
+      Navigator.of(
+        tester.element(find.text(l10n.communitySuggestTitle)),
+      ).pop();
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(overlayVisibilityProvider).isBottomSheetOpen,
+        isFalse,
+      );
     });
   });
 }


### PR DESCRIPTION
Closes #6789

## Description

Tapping the feed-mode picker ("For You ▾") or the "Help classify this" action left the video behind the sheet playing. The comments and share sheets pause it.

Both opened `VineBottomSheetSelectionMenu.show` / `VineBottomSheet.show` directly, bypassing the `PauseAwareModals` extension. That extension is what flips `overlayVisibilityProvider.isBottomSheetOpen`, which `VideoFeedPage` listens to in order to deactivate the feed — without it nothing pauses.

Both now route through `PauseAwareModals`, using `setBottomSheetOpen` (not `setPageOpen`), so the current player is paused but retained for instant resume — identical to comments and share.

Two supporting changes in `pause_aware_modals.dart`:

- New `showVideoPausingSelectionMenu`. `VineBottomSheetSelectionMenu.show` exposes no `onShow`/`onDismiss` hooks, so the flag is toggled around the returned future rather than adding parameters to `divine_ui` for one call site.
- `showDragHandle` passthrough on `showVideoPausingVineBottomSheet`, which the classify sheet needs (`showDragHandle: false`).

The classify sheet passes `useRootNavigator: false` explicitly. The extension defaults to `true`, which would newly make the sheet cover the tab bar — a visual change unrelated to the pause fix, so the current presentation is preserved.

**Related Issue:** 

## Out of Scope

Whether the classify sheet *should* cover the tab bar like the comments sheet does. That is a design call, not part of this fix.

The other `VineBottomSheetSelectionMenu` call sites (library, search filters, recorder, metadata expiration) are not over a playing feed video and are left alone.

## Verification

- `flutter analyze lib test` — clean
- `flutter test test/utils/pause_aware_modals_test.dart test/screens/feed/feed_mode_switch_test.dart test/widgets/video_feed_item/actions/help_classify_action_button_test.dart test/widgets/community_suggest/community_suggest_sheet_test.dart` — 33 passed
- Both new call-site regression tests were confirmed to fail against the pre-fix code (`+23 -2`) and pass after, so they can catch the regression coming back.
- Manually verified on a real Samsung Galaxy device: opening the mode picker and the classify sheet stops playback, closing either resumes it from where it was.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore