### PR TITLE
fix(metadata): hold user chip rows open with placeholders

### DIFF
--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
@@ -3,6 +3,7 @@
 // ABOUTME: using tappable chips that navigate to user profiles.
 
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:collaborator_repository/collaborator_repository.dart';
 import 'package:divine_ui/divine_ui.dart';
@@ -22,6 +23,7 @@ import 'package:openvine/utils/public_identifier_normalizer.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_section.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/video_reposters_cubit.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 /// Whether every chip in [pubkeys] already knows the name it will render.
 ///
@@ -62,7 +64,8 @@ class MetadataCreatorSection extends StatelessWidget {
 /// `ignored` for this video. Pending collaborator chips are dimmed when
 /// the current user is the video's creator.
 ///
-/// Renders nothing while the resulting list is empty.
+/// Shows placeholder chips while the names of the resulting list resolve,
+/// and renders nothing while that list is empty.
 class MetadataCollaboratorsSection extends ConsumerWidget {
   const MetadataCollaboratorsSection({required this.video, super.key});
 
@@ -168,25 +171,35 @@ class _MetadataCollaboratorsSectionBodyState
     // A tagged collaborator stays hidden until their confirmation status
     // resolves, so this section arrives late on videos that have one. Profile
     // names get a short grace window to avoid common label reflows without
-    // hiding the whole section behind network tails.
-    return AnimatedReveal(
-      child: canReveal
-          ? MetadataSection(
-              label: context.l10n.metadataCollaboratorsLabel,
-              child: Wrap(
-                spacing: 8,
-                runSpacing: 8,
-                children: [
-                  for (final pubkey in visible)
-                    _TappableUserChip(
-                      pubkey: pubkey,
-                      isPending: widget.visibility.isPendingForInviter(pubkey),
-                    ),
-                ],
+    // hiding the whole section behind network tails — the tagged list is
+    // known up front, so placeholders of the right count hold the row open
+    // meanwhile.
+    final Widget? content;
+    if (canReveal) {
+      content = MetadataSection(
+        label: context.l10n.metadataCollaboratorsLabel,
+        child: Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            for (final pubkey in visible)
+              _TappableUserChip(
+                pubkey: pubkey,
+                isPending: widget.visibility.isPendingForInviter(pubkey),
               ),
-            )
-          : null,
-    );
+          ],
+        ),
+      );
+    } else if (visible.isNotEmpty) {
+      content = _UserChipsSkeleton(
+        label: context.l10n.metadataCollaboratorsLabel,
+        chipCount: visible.length,
+      );
+    } else {
+      content = null;
+    }
+
+    return AnimatedReveal(child: content);
   }
 
   void _syncGraceTimer(List<String> visible, bool namesSettled) {
@@ -245,7 +258,8 @@ class MetadataInspiredBySection extends StatelessWidget {
 /// Reads reposter pubkeys from [VideoRepostersCubit] (provided by the
 /// metadata sheet) and merges with any pre-populated
 /// [VideoEvent.reposterPubkeys] from feed consolidation.
-/// Renders nothing while no reposters are found.
+/// Renders skeleton chips while the relay query runs and the feed's repost
+/// count promises at least one, and nothing once no reposters are found.
 class MetadataRepostedBySection extends StatelessWidget {
   const MetadataRepostedBySection({required this.video, super.key});
 
@@ -260,18 +274,25 @@ class MetadataRepostedBySection extends StatelessWidget {
           ...state.pubkeys,
         }.toList();
 
-        if (state.isLoading && allPubkeys.isEmpty) {
-          return _RepostedByContent(
-            pubkeys: video.reposterPubkeys ?? [],
-            video: video,
-          );
-        }
-
-        return _RepostedByContent(pubkeys: allPubkeys, video: video);
+        return _RepostedByContent(
+          pubkeys: allPubkeys,
+          video: video,
+          isLoading: state.isLoading,
+        );
       },
     );
   }
 }
+
+/// Reposter chips the feed payload already promises for [video].
+///
+/// The feed carries the video's Nostr repost count, so the row's size is
+/// known before the relay names anyone. Archival Vine reposts are left out —
+/// they carry no pubkey and never become a chip.
+int _promisedReposterCount(VideoEvent video) => math.max(
+  video.nostrRepostCount ?? 0,
+  video.reposterPubkeys?.length ?? 0,
+);
 
 /// Content widget for the Reposted-by section.
 ///
@@ -280,12 +301,18 @@ class MetadataRepostedBySection extends StatelessWidget {
 /// times, and every chip resolves its own profile — rendering the full set
 /// would fire a profile fetch per reposter and lay them all out at once.
 ///
-/// Renders nothing until the first capped set of chip names has resolved,
-/// and while [pubkeys] is empty. The reposters resolve from a relay
-/// round-trip, so the section is revealed through an [AnimatedReveal] rather
-/// than snapping the sections below it down on arrival.
+/// Holds the row open with placeholder chips until the first capped set of
+/// chip names has resolved: the feed already knows how many reposts the video
+/// has, so the section can take its final shape before the relay answers
+/// instead of appearing out of nowhere. Renders nothing while nothing is
+/// promised, and collapses through an [AnimatedReveal] when the relay
+/// contradicts the promise.
 class _RepostedByContent extends ConsumerStatefulWidget {
-  const _RepostedByContent({required this.pubkeys, required this.video});
+  const _RepostedByContent({
+    required this.pubkeys,
+    required this.video,
+    required this.isLoading,
+  });
 
   /// Roughly three rows of chips on a phone — nine came out at five.
   ///
@@ -295,6 +322,9 @@ class _RepostedByContent extends ConsumerStatefulWidget {
 
   final List<String> pubkeys;
   final VideoEvent video;
+
+  /// Whether the relay query behind [pubkeys] is still in flight.
+  final bool isLoading;
 
   @override
   ConsumerState<_RepostedByContent> createState() => _RepostedByContentState();
@@ -335,23 +365,46 @@ class _RepostedByContentState extends ConsumerState<_RepostedByContent> {
     final visible = _revealed;
     final hiddenCount = widget.pubkeys.length - candidate.length;
 
-    return AnimatedReveal(
-      child: visible.isEmpty
+    final Widget? content;
+    if (visible.isNotEmpty) {
+      content = MetadataSection(
+        label: context.l10n.metadataRepostedByLabel,
+        child: Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            for (final pubkey in visible) _TappableUserChip(pubkey: pubkey),
+            if (hiddenCount > 0)
+              _MoreRepostersChip(count: hiddenCount, video: widget.video),
+          ],
+        ),
+      );
+    } else {
+      final placeholderCount = _placeholderChipCount(candidate);
+      content = placeholderCount == 0
           ? null
-          : MetadataSection(
+          : _UserChipsSkeleton(
               label: context.l10n.metadataRepostedByLabel,
-              child: Wrap(
-                spacing: 8,
-                runSpacing: 8,
-                crossAxisAlignment: WrapCrossAlignment.center,
-                children: [
-                  for (final pubkey in visible)
-                    _TappableUserChip(pubkey: pubkey),
-                  if (hiddenCount > 0)
-                    _MoreRepostersChip(count: hiddenCount, video: widget.video),
-                ],
-              ),
-            ),
+              chipCount: placeholderCount,
+            );
+    }
+
+    return AnimatedReveal(child: content);
+  }
+
+  /// Placeholder chips to hold the row open with while nothing is revealed.
+  ///
+  /// Once the relay has named someone, that count is exact — only the labels
+  /// are still resolving. Before then the feed's repost count stands in.
+  /// Drops to zero when the relay has answered with nobody, so a stale feed
+  /// count cannot leave a shimmer on screen forever.
+  int _placeholderChipCount(List<String> candidate) {
+    if (candidate.isNotEmpty) return candidate.length;
+    if (!widget.isLoading) return 0;
+    return math.min(
+      _promisedReposterCount(widget.video),
+      _RepostedByContent._maxVisibleReposters,
     );
   }
 
@@ -383,6 +436,67 @@ class _RepostedByContentState extends ConsumerState<_RepostedByContent> {
   void _cancelGraceTimer() {
     _graceTimer?.cancel();
     _graceTimer = null;
+  }
+}
+
+/// Placeholder chip row shown while a section's chip names resolve.
+///
+/// Sized from the chip count the caller already knows, so the section
+/// reaches roughly its final height on first paint instead of dropping in
+/// and pushing everything below it down a round-trip later.
+class _UserChipsSkeleton extends StatelessWidget {
+  const _UserChipsSkeleton({required this.label, required this.chipCount});
+
+  /// Varied so the row reads as a set of names. No width can be truthful
+  /// here — the names that decide them are exactly what is still missing.
+  static const _chipWidths = [112.0, 88.0, 128.0, 96.0, 104.0];
+
+  /// Section header the placeholders sit under.
+  final String label;
+
+  final int chipCount;
+
+  @override
+  Widget build(BuildContext context) {
+    return MetadataSection(
+      label: label,
+      child: Semantics(
+        label: context.l10n.commonLoading,
+        child: Skeletonizer(
+          effect: vineSkeletonEffectOf(context),
+          child: Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              for (var i = 0; i < chipCount; i++)
+                _UserChipSkeleton(width: _chipWidths[i % _chipWidths.length]),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A single placeholder pill matching [_TappableUserChip]'s 40 px height and
+/// 16 px radius.
+class _UserChipSkeleton extends StatelessWidget {
+  const _UserChipSkeleton({required this.width});
+
+  final double width;
+
+  @override
+  Widget build(BuildContext context) {
+    return Skeleton.leaf(
+      child: Container(
+        width: width,
+        height: 40,
+        decoration: BoxDecoration(
+          color: context.vineColors.skeleton,
+          borderRadius: BorderRadius.circular(16),
+        ),
+      ),
+    );
   }
 }
 

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
@@ -284,16 +284,6 @@ class MetadataRepostedBySection extends StatelessWidget {
   }
 }
 
-/// Reposter chips the feed payload already promises for [video].
-///
-/// The feed carries the video's Nostr repost count, so the row's size is
-/// known before the relay names anyone. Archival Vine reposts are left out —
-/// they carry no pubkey and never become a chip.
-int _promisedReposterCount(VideoEvent video) => math.max(
-  video.nostrRepostCount ?? 0,
-  video.reposterPubkeys?.length ?? 0,
-);
-
 /// Content widget for the Reposted-by section.
 ///
 /// Shows at most [_maxVisibleReposters] chips and hands the rest to the
@@ -395,15 +385,18 @@ class _RepostedByContentState extends ConsumerState<_RepostedByContent> {
 
   /// Placeholder chips to hold the row open with while nothing is revealed.
   ///
-  /// Once the relay has named someone, that count is exact — only the labels
-  /// are still resolving. Before then the feed's repost count stands in.
-  /// Drops to zero when the relay has answered with nobody, so a stale feed
-  /// count cannot leave a shimmer on screen forever.
+  /// Once the relay has named someone — including a reposter the feed
+  /// pre-populated — that count is exact and only the labels are still
+  /// resolving. Before then the feed's Nostr repost count stands in, since it
+  /// arrives with the video. Archival Vine reposts are left out: they carry
+  /// no pubkey and never become a chip. Drops to zero when the relay has
+  /// answered with nobody, so a stale feed count cannot leave a shimmer on
+  /// screen forever.
   int _placeholderChipCount(List<String> candidate) {
     if (candidate.isNotEmpty) return candidate.length;
     if (!widget.isLoading) return 0;
     return math.min(
-      _promisedReposterCount(widget.video),
+      widget.video.nostrRepostCount ?? 0,
       _RepostedByContent._maxVisibleReposters,
     );
   }

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
@@ -372,7 +372,7 @@ class _RepostedByContentState extends ConsumerState<_RepostedByContent> {
       );
     } else {
       final placeholderCount = _placeholderChipCount(candidate);
-      content = placeholderCount == 0
+      content = placeholderCount <= 0
           ? null
           : _UserChipsSkeleton(
               label: context.l10n.metadataRepostedByLabel,
@@ -389,16 +389,24 @@ class _RepostedByContentState extends ConsumerState<_RepostedByContent> {
   /// pre-populated — that count is exact and only the labels are still
   /// resolving. Before then the feed's Nostr repost count stands in, since it
   /// arrives with the video. Archival Vine reposts are left out: they carry
-  /// no pubkey and never become a chip. Drops to zero when the relay has
-  /// answered with nobody, so a stale feed count cannot leave a shimmer on
-  /// screen forever.
+  /// no pubkey and never become a chip. When the eventual row includes the
+  /// "+N more" action, one extra placeholder reserves that chip too. Drops to
+  /// zero when the relay has answered with nobody, so a stale feed count cannot
+  /// leave a shimmer on screen forever.
   int _placeholderChipCount(List<String> candidate) {
-    if (candidate.isNotEmpty) return candidate.length;
+    if (candidate.isNotEmpty) {
+      return candidate.length +
+          (widget.pubkeys.length > candidate.length ? 1 : 0);
+    }
     if (!widget.isLoading) return 0;
-    return math.min(
-      widget.video.nostrRepostCount ?? 0,
+    final promisedCount = widget.video.nostrRepostCount ?? 0;
+    if (promisedCount <= 0) return 0;
+    final visibleCount = math.min(
+      promisedCount,
       _RepostedByContent._maxVisibleReposters,
     );
+    return visibleCount +
+        (promisedCount > _RepostedByContent._maxVisibleReposters ? 1 : 0);
   }
 
   void _syncGraceTimer(List<String> candidate, bool namesSettled) {

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -1222,7 +1222,10 @@ void main() {
         );
         await tester.pump();
 
-        expect(find.text('Reposted by'), findsOneWidget);
+        expect(
+          find.text(_l10n(tester).metadataRepostedByLabel),
+          findsOneWidget,
+        );
         expect(_skeletonChips(), findsNWidgets(3));
         expect(find.byType(UserAvatar), findsNothing);
       },
@@ -1256,7 +1259,7 @@ void main() {
         );
         await tester.pump();
 
-        expect(find.text('Reposted by'), findsNothing);
+        expect(find.text(_l10n(tester).metadataRepostedByLabel), findsNothing);
         expect(_skeletonChips(), findsNothing);
       },
     );
@@ -1274,7 +1277,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('Reposted by'), findsNothing);
+        expect(find.text(_l10n(tester).metadataRepostedByLabel), findsNothing);
         expect(_skeletonChips(), findsNothing);
       },
     );
@@ -1300,7 +1303,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.text('Reposted by'), findsOneWidget);
+      expect(find.text(_l10n(tester).metadataRepostedByLabel), findsOneWidget);
       expect(find.text('Improvising'), findsOneWidget);
     });
 
@@ -1321,7 +1324,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.text('Reposted by'), findsOneWidget);
+      expect(find.text(_l10n(tester).metadataRepostedByLabel), findsOneWidget);
       expect(find.text('Improvising'), findsOneWidget);
     });
 
@@ -1435,7 +1438,10 @@ void main() {
         await tester.pumpAndSettle();
 
         final moreLabel = _l10n(tester).metadataMoreReposters(7);
-        expect(find.text('Reposted by'), findsOneWidget);
+        expect(
+          find.text(_l10n(tester).metadataRepostedByLabel),
+          findsOneWidget,
+        );
 
         await tester.tap(find.text(moreLabel));
         await tester.pumpAndSettle();
@@ -1450,7 +1456,7 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text('open sheet'), findsOneWidget);
-        expect(find.text('Reposted by'), findsNothing);
+        expect(find.text(_l10n(tester).metadataRepostedByLabel), findsNothing);
       },
     );
 
@@ -1479,7 +1485,10 @@ void main() {
         // Showing the real chips first would swap every label a moment later
         // and reflow the rows around the new widths, so a placeholder of the
         // known size stands in.
-        expect(find.text('Reposted by'), findsOneWidget);
+        expect(
+          find.text(_l10n(tester).metadataRepostedByLabel),
+          findsOneWidget,
+        );
         expect(_skeletonChips(), findsNWidgets(1));
         expect(find.byType(UserAvatar), findsNothing);
 
@@ -1517,7 +1526,10 @@ void main() {
         await tester.pump(const Duration(seconds: 1));
         await tester.pumpAndSettle();
 
-        expect(find.text('Reposted by'), findsOneWidget);
+        expect(
+          find.text(_l10n(tester).metadataRepostedByLabel),
+          findsOneWidget,
+        );
         expect(_skeletonChips(), findsNothing);
         expect(find.byType(UserAvatar), findsOneWidget);
 
@@ -1562,7 +1574,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('Reposted by'), findsNothing);
+        expect(find.text(_l10n(tester).metadataRepostedByLabel), findsNothing);
       },
     );
 
@@ -1597,7 +1609,7 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      expect(find.text('Reposted by'), findsOneWidget);
+      expect(find.text(_l10n(tester).metadataRepostedByLabel), findsOneWidget);
       expect(revealingHeight, lessThan(tester.getSize(section).height));
     });
 
@@ -2047,9 +2059,12 @@ void main() {
         expect(find.text('hello'), findsOneWidget);
 
         // Absent
-        expect(find.text('Collaborators'), findsNothing);
+        expect(
+          find.text(_l10n(tester).metadataCollaboratorsLabel),
+          findsNothing,
+        );
         expect(find.text('Inspired by'), findsNothing);
-        expect(find.text('Reposted by'), findsNothing);
+        expect(find.text(_l10n(tester).metadataRepostedByLabel), findsNothing);
 
         // Sounds section is always present (shows "Original sound")
         // Scroll down to find it

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -1232,7 +1232,7 @@ void main() {
     );
 
     testWidgetsWithSurfaceSize(
-      'caps the placeholder chips at the visible chip limit',
+      'reserves the more button placeholder for popular videos',
       (tester) async {
         await tester.pumpWidget(
           buildSubject(
@@ -1244,7 +1244,38 @@ void main() {
         );
         await tester.pump();
 
-        expect(_skeletonChips(), findsNWidgets(5));
+        expect(_skeletonChips(), findsNWidgets(6));
+      },
+    );
+
+    testWidgetsWithSurfaceSize(
+      'keeps the more button space while fetched reposter names resolve',
+      (tester) async {
+        final reposterPubkeys = List.generate(
+          7,
+          (index) => (index + 1).toRadixString(16).padLeft(64, '0'),
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            repostersState: VideoRepostersState(pubkeys: reposterPubkeys),
+            providerOverrides: [
+              for (final pubkey in reposterPubkeys.take(5))
+                fetchUserProfileProvider(
+                  pubkey,
+                ).overrideWith((ref) => Completer<UserProfile?>().future),
+            ],
+            child: MetadataRepostedBySection(video: _makeVideo()),
+          ),
+        );
+        await tester.pump();
+
+        expect(
+          find.text(_l10n(tester).metadataRepostedByLabel),
+          findsOneWidget,
+        );
+        expect(_skeletonChips(), findsNWidgets(6));
+        expect(find.byType(UserAvatar), findsNothing);
       },
     );
 
@@ -1255,6 +1286,24 @@ void main() {
           buildSubject(
             repostersState: const VideoRepostersState(),
             child: MetadataRepostedBySection(video: _makeVideo()),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text(_l10n(tester).metadataRepostedByLabel), findsNothing);
+        expect(_skeletonChips(), findsNothing);
+      },
+    );
+
+    testWidgetsWithSurfaceSize(
+      'stays hidden when the promised repost count is negative',
+      (tester) async {
+        await tester.pumpWidget(
+          buildSubject(
+            repostersState: const VideoRepostersState(),
+            child: MetadataRepostedBySection(
+              video: _makeVideo(nostrRepostCount: -1),
+            ),
           ),
         );
         await tester.pump();

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -36,6 +36,7 @@ import 'package:openvine/widgets/video_feed_item/metadata/metadata_verification_
 import 'package:openvine/widgets/video_feed_item/metadata/video_reposters_cubit.dart';
 import 'package:openvine/widgets/video_recorder/modes/upload/upload_explainer_constants.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 import 'package:videos_repository/videos_repository.dart';
 
@@ -75,6 +76,10 @@ const _parentAddressableId =
 Finder _dimmed() =>
     find.byWidgetPredicate((widget) => widget is Opacity && widget.opacity < 1);
 
+/// Placeholder pills painted by `Skeletonizer` while chip names resolve.
+Finder _skeletonChips() =>
+    find.byWidgetPredicate((widget) => widget is Skeleton);
+
 AppLocalizations _l10n(WidgetTester tester) =>
     AppLocalizations.of(tester.element(find.byType(Scaffold).first));
 
@@ -95,6 +100,7 @@ VideoEvent _makeVideo({
   List<String> collaboratorPubkeys = const [],
   InspiredByInfo? inspiredByVideo,
   List<String>? reposterPubkeys,
+  int? nostrRepostCount,
   String? audioEventId,
   String? title,
   String content = '',
@@ -116,6 +122,7 @@ VideoEvent _makeVideo({
   collaboratorPubkeys: collaboratorPubkeys,
   inspiredByVideo: inspiredByVideo,
   reposterPubkeys: reposterPubkeys,
+  nostrRepostCount: nostrRepostCount,
   audioEventId: audioEventId,
   originalLoops: originalLoops,
   rawTags: rawTags,
@@ -1109,17 +1116,50 @@ void main() {
         await tester.pump();
 
         final l10n = _l10n(tester);
-        expect(find.text(l10n.metadataCollaboratorsLabel), findsNothing);
+        expect(_skeletonChips(), findsNWidgets(1));
+        expect(find.byType(UserAvatar), findsNothing);
 
         await tester.pump(const Duration(seconds: 1));
         await tester.pumpAndSettle();
 
         expect(find.text(l10n.metadataCollaboratorsLabel), findsOneWidget);
+        expect(_skeletonChips(), findsNothing);
 
         profile.complete(_makeProfile(_collaborator1, 'Alice'));
         await tester.pumpAndSettle();
 
         expect(find.text('Alice'), findsOneWidget);
+      },
+    );
+
+    testWidgetsWithSurfaceSize(
+      'holds the row open with one placeholder per tagged collaborator',
+      (tester) async {
+        await tester.pumpWidget(
+          buildSubject(
+            providerOverrides: [
+              for (final pubkey in [_collaborator1, _collaborator2])
+                fetchUserProfileProvider(
+                  pubkey,
+                ).overrideWith((ref) => Completer<UserProfile?>().future),
+            ],
+            child: const MetadataCollaboratorsSectionBody(
+              visibility: CollaboratorVisibility.fallback(
+                taggedPubkeys: [_collaborator1, _collaborator2],
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        // The tagged list is known synchronously, so the row can take its
+        // final size while only the names are still in flight.
+        expect(
+          find.text(_l10n(tester).metadataCollaboratorsLabel),
+          findsOneWidget,
+        );
+        expect(_skeletonChips(), findsNWidgets(2));
+        expect(find.byType(UserAvatar), findsNothing);
       },
     );
   });
@@ -1169,6 +1209,76 @@ void main() {
   // Reposted By section
   // ---------------------------------------------------------------------------
   group(MetadataRepostedBySection, () {
+    testWidgetsWithSurfaceSize(
+      'holds the row open with one chip per known repost while loading',
+      (tester) async {
+        await tester.pumpWidget(
+          buildSubject(
+            repostersState: const VideoRepostersState(),
+            child: MetadataRepostedBySection(
+              video: _makeVideo(nostrRepostCount: 3),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('Reposted by'), findsOneWidget);
+        expect(_skeletonChips(), findsNWidgets(3));
+        expect(find.byType(UserAvatar), findsNothing);
+      },
+    );
+
+    testWidgetsWithSurfaceSize(
+      'caps the placeholder chips at the visible chip limit',
+      (tester) async {
+        await tester.pumpWidget(
+          buildSubject(
+            repostersState: const VideoRepostersState(),
+            child: MetadataRepostedBySection(
+              video: _makeVideo(nostrRepostCount: 4200),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(_skeletonChips(), findsNWidgets(5));
+      },
+    );
+
+    testWidgetsWithSurfaceSize(
+      'stays hidden while loading when the feed knows of no reposts',
+      (tester) async {
+        await tester.pumpWidget(
+          buildSubject(
+            repostersState: const VideoRepostersState(),
+            child: MetadataRepostedBySection(video: _makeVideo()),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('Reposted by'), findsNothing);
+        expect(_skeletonChips(), findsNothing);
+      },
+    );
+
+    testWidgetsWithSurfaceSize(
+      'drops the placeholders when the relay finds no reposters',
+      (tester) async {
+        await tester.pumpWidget(
+          buildSubject(
+            repostersState: const VideoRepostersState(isLoading: false),
+            child: MetadataRepostedBySection(
+              video: _makeVideo(nostrRepostCount: 3),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Reposted by'), findsNothing);
+        expect(_skeletonChips(), findsNothing);
+      },
+    );
+
     testWidgetsWithSurfaceSize('renders reposters fetched from relay', (
       tester,
     ) async {
@@ -1345,7 +1455,7 @@ void main() {
     );
 
     testWidgetsWithSurfaceSize(
-      'waits for the chip names before revealing the section',
+      'waits for the chip names before swapping the placeholders out',
       (tester) async {
         final profile = Completer<UserProfile?>();
 
@@ -1366,14 +1476,18 @@ void main() {
         await tester.pump();
 
         // A chip falls back to a generated name while its profile loads.
-        // Showing the row first would swap every label a moment later and
-        // reflow the rows around the new widths.
-        expect(find.text('Reposted by'), findsNothing);
+        // Showing the real chips first would swap every label a moment later
+        // and reflow the rows around the new widths, so a placeholder of the
+        // known size stands in.
+        expect(find.text('Reposted by'), findsOneWidget);
+        expect(_skeletonChips(), findsNWidgets(1));
+        expect(find.byType(UserAvatar), findsNothing);
 
         profile.complete(_makeProfile(_reposterPubkey, 'Improvising'));
         await tester.pumpAndSettle();
 
         expect(find.text('Improvising'), findsOneWidget);
+        expect(_skeletonChips(), findsNothing);
       },
     );
 
@@ -1398,12 +1512,14 @@ void main() {
         );
         await tester.pump();
 
-        expect(find.text('Reposted by'), findsNothing);
+        expect(_skeletonChips(), findsNWidgets(1));
 
         await tester.pump(const Duration(seconds: 1));
         await tester.pumpAndSettle();
 
         expect(find.text('Reposted by'), findsOneWidget);
+        expect(_skeletonChips(), findsNothing);
+        expect(find.byType(UserAvatar), findsOneWidget);
 
         profile.complete(_makeProfile(_reposterPubkey, 'Improvising'));
         await tester.pumpAndSettle();


### PR DESCRIPTION
Closes #6791

## Description

The Reposted by and Collaborators sections in the metadata sheet now reserve chip-row space while async profile and relay data resolves, instead of rendering nothing and dropping into the sheet later.

- Reposted by uses the live Nostr repost count while the relay query is in flight, then switches to the fetched/pre-populated pubkey count while profile names resolve.
- Collaborators uses the tagged collaborator list, which is known synchronously.
- Popular repost rows reserve one extra placeholder for the eventual +N more action, so the resolved row does not grow when the action appears.
- Non-positive or stale repost counts stay hidden or collapse through the existing AnimatedReveal path.

Archival Vine reposts remain excluded because they have no pubkey and never become user chips.

## Out of Scope

Creator and Inspired by render single chips without this reveal gate. Broader skeleton consolidation into divine_ui is left out of this focused bug fix.

## Verification

- flutter test test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart — 66 tests passing.
- flutter analyze lib test integration_test — no issues found.
- Pre-push hook reran analyzer and the changed metadata widget test before pushing 96a0e1f05.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)