### PR TITLE
fix(explore): drop the status-bar gap above Lists and Apps tabs

### DIFF
--- a/mobile/lib/screens/apps/apps_directory_screen.dart
+++ b/mobile/lib/screens/apps/apps_directory_screen.dart
@@ -86,6 +86,10 @@ class _AppsDirectoryContent extends StatelessWidget {
                   onRefresh: () =>
                       context.read<AppsDirectoryCubit>().refreshApps(),
                   child: ListView.builder(
+                    // Explicit padding: without it Flutter inserts
+                    // MediaQuery.padding, which adds a status-bar-sized gap
+                    // above the intro card when embedded in Explore.
+                    padding: EdgeInsets.zero,
                     itemCount: state.apps.length + 1,
                     itemBuilder: (context, index) {
                       if (index == 0) {

--- a/mobile/lib/screens/apps/apps_directory_screen.dart
+++ b/mobile/lib/screens/apps/apps_directory_screen.dart
@@ -86,10 +86,16 @@ class _AppsDirectoryContent extends StatelessWidget {
                   onRefresh: () =>
                       context.read<AppsDirectoryCubit>().refreshApps(),
                   child: ListView.builder(
-                    // Explicit padding: without it Flutter inserts
-                    // MediaQuery.padding, which adds a status-bar-sized gap
-                    // above the intro card when embedded in Explore.
-                    padding: EdgeInsets.zero,
+                    // A null padding makes Flutter fall back to the vertical
+                    // MediaQuery.padding — both insets. Embedded in Explore
+                    // there is no app bar above, so the top inset is still
+                    // the status bar and would gap the intro card; standalone
+                    // the bottom inset is real (no bottom nav) and has to stay
+                    // so the last card clears the gesture bar. Resolved here,
+                    // below the Scaffold: 0 embedded, the inset standalone.
+                    padding: EdgeInsets.only(
+                      bottom: MediaQuery.paddingOf(context).bottom,
+                    ),
                     itemCount: state.apps.length + 1,
                     itemBuilder: (context, index) {
                       if (index == 0) {

--- a/mobile/lib/screens/explore/tabs/explore_lists_tab.dart
+++ b/mobile/lib/screens/explore/tabs/explore_lists_tab.dart
@@ -39,6 +39,9 @@ class ExploreListsTab extends ConsumerWidget {
       },
       child: ListView(
         key: const Key('lists-tab-content'),
+        // Explicit padding: without it Flutter inserts MediaQuery.padding,
+        // which adds a status-bar-sized gap above the first card.
+        padding: EdgeInsets.zero,
         children: [
           // Discover Lists button - ALWAYS VISIBLE
           Padding(

--- a/mobile/test/screens/apps/apps_directory_screen_test.dart
+++ b/mobile/test/screens/apps/apps_directory_screen_test.dart
@@ -126,6 +126,32 @@ void main() {
       expect(find.text('Primal'), findsOneWidget);
     });
 
+    testWidgets('embedded drops the status-bar inset above the first card', (
+      tester,
+    ) async {
+      // 120 physical px / 3.0 test devicePixelRatio = 40 logical px of status
+      // bar. Embedded in Explore nothing above this list consumes the top
+      // inset, so a null padding would push the intro card down by exactly
+      // that much — the gap reported in #6797.
+      tester.view.padding = const FakeViewPadding(top: 120);
+      addTearDown(tester.view.resetPadding);
+
+      when(
+        () => mockDirectoryService.fetchApprovedApps(),
+      ).thenAnswer((_) async => [_fixture()]);
+
+      await tester.pumpWidget(buildEmbeddedSubject());
+      await tester.pumpAndSettle();
+
+      // _AppsDirectoryIntro's own EdgeInsets.fromLTRB(16, 16, 16, 8) is the
+      // only offset that may sit between the viewport top and the card.
+      expect(
+        tester.getRect(find.byType(DivineInfoCard)).top -
+            tester.getRect(find.byType(ListView)).top,
+        moreOrLessEquals(16, epsilon: 0.5),
+      );
+    });
+
     testWidgets('standalone keeps the last card clear of the bottom inset', (
       tester,
     ) async {

--- a/mobile/test/screens/apps/apps_directory_screen_test.dart
+++ b/mobile/test/screens/apps/apps_directory_screen_test.dart
@@ -126,6 +126,45 @@ void main() {
       expect(find.text('Primal'), findsOneWidget);
     });
 
+    testWidgets('standalone keeps the last card clear of the bottom inset', (
+      tester,
+    ) async {
+      // 102 physical px / 3.0 test devicePixelRatio = 34 logical px, i.e. a
+      // home indicator or gesture bar. The standalone route has no bottom
+      // nav, so Scaffold leaves this inset in the body's MediaQuery and the
+      // list has to reserve it itself.
+      tester.view.padding = const FakeViewPadding(bottom: 102);
+      addTearDown(tester.view.resetPadding);
+
+      when(
+        () => mockDirectoryService.fetchApprovedApps(),
+      ).thenAnswer((_) async => List.generate(12, _numberedFixture));
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      // A lazily-built list only reports its true extent once the last item
+      // has been laid out, so jump until the extent stops moving.
+      final position = tester
+          .state<ScrollableState>(find.byType(Scrollable))
+          .position;
+      double previousExtent;
+      do {
+        previousExtent = position.maxScrollExtent;
+        position.jumpTo(previousExtent);
+        await tester.pumpAndSettle();
+      } while (position.maxScrollExtent != previousExtent);
+
+      final lastCard = find.ancestor(
+        of: find.text('App 11'),
+        matching: find.byType(Ink),
+      );
+      expect(
+        tester.getRect(lastCard).bottom,
+        lessThanOrEqualTo(tester.getRect(find.byType(ListView)).bottom - 34),
+      );
+    });
+
     testWidgets('tapping an app opens its integration route', (tester) async {
       final mockGoRouter = MockGoRouter();
       when(
@@ -295,6 +334,26 @@ NostrAppDirectoryEntry _verifierFixtureWithUrl(String launchUrl) {
     promptRequiredFor: const [],
     status: 'approved',
     sortOrder: 16,
+    createdAt: null,
+    updatedAt: null,
+  );
+}
+
+NostrAppDirectoryEntry _numberedFixture(int index) {
+  return NostrAppDirectoryEntry(
+    id: 'app-$index',
+    slug: 'app-$index',
+    name: 'App $index',
+    tagline: 'Tagline $index',
+    description: 'Description $index',
+    iconUrl: '',
+    launchUrl: 'https://app$index.example',
+    allowedOrigins: ['https://app$index.example'],
+    allowedMethods: const ['getPublicKey'],
+    allowedSignEventKinds: const [1],
+    promptRequiredFor: const [],
+    status: 'approved',
+    sortOrder: index,
     createdAt: null,
     updatedAt: null,
   );

--- a/mobile/test/screens/explore/tabs/explore_lists_tab_test.dart
+++ b/mobile/test/screens/explore/tabs/explore_lists_tab_test.dart
@@ -1,0 +1,64 @@
+// ABOUTME: Regression test for the Explore Lists tab's top inset (#6797).
+// ABOUTME: Pins that the tab's ListView carries an explicit padding, so the
+// ABOUTME: status-bar inset never reappears as a gap above the first button.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/list_providers.dart';
+import 'package:openvine/providers/repository_providers.dart';
+import 'package:openvine/screens/explore/tabs/explore_lists_tab.dart';
+import 'package:openvine/services/curated_list_service.dart';
+
+import '../../../helpers/test_provider_overrides.dart';
+
+class _FakeCuratedListsState extends CuratedListsState {
+  @override
+  CuratedListService? get service => null;
+
+  @override
+  Future<List<CuratedList>> build() async => const [];
+}
+
+void main() {
+  group(ExploreListsTab, () {
+    testWidgets('drops the status-bar inset above the first button', (
+      tester,
+    ) async {
+      // 120 physical px / 3.0 test devicePixelRatio = 40 logical px of status
+      // bar. The tab renders inside Explore, whose shell Scaffold has no app
+      // bar, so the top inset is still in MediaQuery here. Without an explicit
+      // padding BoxScrollView would fall back to it and gap the first button.
+      tester.view.padding = const FakeViewPadding(top: 120);
+      addTearDown(tester.view.resetPadding);
+
+      await tester.pumpWidget(
+        testProviderScope(
+          additionalOverrides: [
+            allListsProvider.overrideWith(
+              (ref) async =>
+                  (userLists: <UserList>[], curatedLists: <CuratedList>[]),
+            ),
+            curatedListsStateProvider.overrideWith(_FakeCuratedListsState.new),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: ExploreListsTab()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The Discover Lists button's own EdgeInsets.all(16) is the only offset
+      // that may sit between the viewport top and the button.
+      expect(
+        tester.getRect(find.byType(DivineButton).first).top -
+            tester.getRect(find.byType(ListView)).top,
+        moreOrLessEquals(16, epsilon: 0.5),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #6797

## What

The Explore **Lists** and **Apps** tabs rendered a visible gap above their first card, even though nothing sits above them inside the tab view.

## Why

Both tabs build a `ListView` without an explicit `padding`. In that case `BoxScrollView.buildSlivers` falls back to inserting `MediaQuery.padding` as sliver padding — with only left/right zeroed, so **both** vertical insets. Explore renders its own header instead of an `AppBar`, so `MediaQuery.padding.top` is still the full status-bar inset at that point in the tree, and the first card got pushed down by exactly that much. The remaining Explore tabs (New, Categories, …) already pass an explicit padding, which is why only these two were affected.

## Two commits

**1. `fix(explore): drop the status-bar gap above Lists and Apps tabs`** — `padding: EdgeInsets.zero` on both list views.

**2. `fix(apps): keep the bottom safe-area inset on the standalone apps list`** — zeroing *both* insets was wrong for `AppsDirectoryScreen`, because that widget renders in two places:

- embedded in Explore, where `AppShell`'s `bottomNavigationBar` has already removed the bottom inset, so zeroing it is a no-op;
- standalone at `/apps`, a top-level route whose own `Scaffold` has an app bar and **no** bottom nav — so Flutter removes only the top inset from the body and the bottom one survives all the way down to the `ListView`.

Measured on the standalone route with a 34 px bottom inset: `SliverPadding` went from `EdgeInsets(0, 0, 0, 34)` to `EdgeInsets.zero`, and since `_AppsDirectoryRow` has no bottom padding of its own the last card ended flush against the gesture bar at scroll end. The second commit resolves the inset inside `_AppsDirectoryContent` — below the `Scaffold`, so the same widget reads `0` embedded and the real inset standalone:

```dart
padding: EdgeInsets.only(bottom: MediaQuery.paddingOf(context).bottom),
```

`ExploreListsTab` needs no equivalent change: it only ever mounts inside the shell, where the bottom inset is already gone.

## Test plan

- New regression test in `apps_directory_screen_test.dart`: pumps the standalone mount under a 34 px bottom inset, scrolls to the true list end, asserts the last card clears the inset. Fails on commit 1 (last card bottom `600.0`, screen edge), passes on commit 2 (`≤ 566.0`).
- `flutter test test/screens/apps/` — 83/83 green, stable under `--test-randomize-ordering-seed random`
- `flutter analyze` on all three changed files — clean
- Manually verified on a real Samsung Galaxy: Lists and Apps tabs now start flush under the tab bar; standalone Apps directory route (`/apps`) unchanged at the top.
