### PR TITLE
fix(library): animate the clip preview hero back on dismiss

### DIFF
--- a/mobile/lib/widgets/video_clip/video_clip_hero.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_hero.dart
@@ -1,0 +1,20 @@
+// ABOUTME: Shared Hero helpers for video clip grid-to-preview transitions
+// ABOUTME: Keeps tags and decorative fallback thumbnails consistent
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+
+String videoClipPreviewHeroTag(String clipId) => 'Video-Clip-Preview-$clipId';
+
+class VideoClipThumbnailPlaceholder extends StatelessWidget {
+  const VideoClipThumbnailPlaceholder({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return DivineIcon(
+      icon: DivineIconName.videoCamera,
+      color: context.vineColors.mutedText,
+      size: 32,
+    );
+  }
+}

--- a/mobile/lib/widgets/video_clip/video_clip_preview.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_preview.dart
@@ -197,62 +197,12 @@ class _VideoClipPreviewSheetState extends ConsumerState<VideoClipPreview> {
                       aspectRatio: widget.clip.targetAspectRatio.value,
                       child: ClipRRect(
                         borderRadius: .circular(16),
-                        child: Builder(
-                          builder: (context) {
-                            if (widget.clip.stopMotionFrames
-                                case final frames?) {
-                              return StopMotionPlayer(
-                                frames: frames,
-                                cacheHeight:
-                                    (MediaQuery.sizeOf(context).height *
-                                            MediaQuery.devicePixelRatioOf(
-                                              context,
-                                            ))
-                                        .round(),
-                              );
-                            }
-
-                            final vw = _controller?.state.videoWidth ?? 0;
-                            final vh = _controller?.state.videoHeight ?? 0;
-
-                            final player = DivineVideoPlayer(
-                              controller: _controller,
-                              placeholder: Stack(
-                                fit: .expand,
-                                children: [
-                                  // Thumbnail
-                                  if (widget.clip.thumbnailPath != null)
-                                    Hero(
-                                      tag:
-                                          'Video-Clip-Preview-${widget.clip.id}',
-                                      child: ClipThumbnailImage(
-                                        path: widget.clip.thumbnailPath!,
-                                        fit: BoxFit.cover,
-                                      ),
-                                    ),
-
-                                  // Progress-indicator
-                                  const Center(
-                                    child: CircularProgressIndicator(
-                                      color: VineTheme.vineGreen,
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            );
-
-                            if (vw == 0 || vh == 0) return player;
-
-                            return FittedBox(
-                              fit: BoxFit.cover,
-                              clipBehavior: Clip.hardEdge,
-                              child: SizedBox(
-                                width: vw.toDouble(),
-                                height: vh.toDouble(),
-                                child: player,
-                              ),
-                            );
-                          },
+                        child: _ClipHero(
+                          clip: widget.clip,
+                          child: _ClipMedia(
+                            clip: widget.clip,
+                            controller: _controller,
+                          ),
                         ),
                       ),
                     ),
@@ -280,6 +230,85 @@ class _VideoClipPreviewSheetState extends ConsumerState<VideoClipPreview> {
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// Keeps the grid → preview [Hero] mounted for the preview's whole lifetime.
+///
+/// The hero used to sit inside [DivineVideoPlayer]'s placeholder, which is
+/// dropped from the tree once the first video frame renders — so by the time
+/// the user closed the preview there was no hero left to fly back from. The
+/// shuttle renders the still thumbnail in both directions, which also keeps
+/// the native video surface out of the hero overlay.
+class _ClipHero extends StatelessWidget {
+  const _ClipHero({required this.clip, required this.child});
+
+  final DivineVideoClip clip;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final thumbnailPath = clip.thumbnailPath;
+    if (thumbnailPath == null) return child;
+
+    return Hero(
+      tag: 'Video-Clip-Preview-${clip.id}',
+      flightShuttleBuilder: (_, _, _, _, _) =>
+          ClipThumbnailImage(path: thumbnailPath, fit: BoxFit.cover),
+      child: child,
+    );
+  }
+}
+
+/// The clip itself: stop-motion stills, or the video surface with a thumbnail
+/// placeholder bridging the decode gap.
+class _ClipMedia extends StatelessWidget {
+  const _ClipMedia({required this.clip, required this.controller});
+
+  final DivineVideoClip clip;
+
+  /// `null` until the player has been created and initialized.
+  final DivineVideoPlayerController? controller;
+
+  @override
+  Widget build(BuildContext context) {
+    if (clip.stopMotionFrames case final frames?) {
+      return StopMotionPlayer(
+        frames: frames,
+        cacheHeight:
+            (MediaQuery.sizeOf(context).height *
+                    MediaQuery.devicePixelRatioOf(context))
+                .round(),
+      );
+    }
+
+    final player = DivineVideoPlayer(
+      controller: controller,
+      placeholder: Stack(
+        fit: .expand,
+        children: [
+          if (clip.thumbnailPath case final thumbnailPath?)
+            ClipThumbnailImage(path: thumbnailPath, fit: BoxFit.cover),
+          const Center(
+            child: CircularProgressIndicator(color: VineTheme.vineGreen),
+          ),
+        ],
+      ),
+    );
+
+    final vw = controller?.state.videoWidth ?? 0;
+    final vh = controller?.state.videoHeight ?? 0;
+    if (vw == 0 || vh == 0) return player;
+
+    return FittedBox(
+      fit: BoxFit.cover,
+      clipBehavior: Clip.hardEdge,
+      child: SizedBox(
+        width: vw.toDouble(),
+        height: vh.toDouble(),
+        child: player,
       ),
     );
   }

--- a/mobile/lib/widgets/video_clip/video_clip_preview.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_preview.dart
@@ -110,9 +110,7 @@ class _VideoClipPreviewSheetState extends ConsumerState<VideoClipPreview> {
       final gallerySaveService = ref.read(gallerySaveServiceProvider);
       // Stop-motion clips render their mp4 on demand; a normal clip passes
       // through unchanged.
-      materialized = await StopMotionRenderService.materialize(
-        widget.clip,
-      );
+      materialized = await StopMotionRenderService.materialize(widget.clip);
       if (!mounted) return;
       if (materialized == null) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -253,14 +251,28 @@ class _ClipHero extends StatelessWidget {
     final thumbnailPath = clip.thumbnailPath;
     if (thumbnailPath == null) return child;
 
+    final cacheHeight = _stillCacheHeight(context);
     return Hero(
       tag: 'Video-Clip-Preview-${clip.id}',
-      flightShuttleBuilder: (_, _, _, _, _) =>
-          ClipThumbnailImage(path: thumbnailPath, fit: BoxFit.cover),
+      flightShuttleBuilder: (_, _, _, _, _) => ClipThumbnailImage(
+        path: thumbnailPath,
+        fit: BoxFit.cover,
+        cacheHeight: cacheHeight,
+      ),
       child: child,
     );
   }
 }
+
+/// Decode bound (physical pixels) for every still the preview renders.
+///
+/// A stop-motion clip's thumbnail is a full-resolution camera frame; decoded
+/// unbounded it costs tens of MB and evicts the rest of the image cache. The
+/// shuttle, the video placeholder and [StopMotionPlayer] all share this bound
+/// so they resolve to one cache entry instead of three.
+int _stillCacheHeight(BuildContext context) =>
+    (MediaQuery.sizeOf(context).height * MediaQuery.devicePixelRatioOf(context))
+        .round();
 
 /// The clip itself: stop-motion stills, or the video surface with a thumbnail
 /// placeholder bridging the decode gap.
@@ -274,14 +286,9 @@ class _ClipMedia extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final cacheHeight = _stillCacheHeight(context);
     if (clip.stopMotionFrames case final frames?) {
-      return StopMotionPlayer(
-        frames: frames,
-        cacheHeight:
-            (MediaQuery.sizeOf(context).height *
-                    MediaQuery.devicePixelRatioOf(context))
-                .round(),
-      );
+      return StopMotionPlayer(frames: frames, cacheHeight: cacheHeight);
     }
 
     final player = DivineVideoPlayer(
@@ -290,7 +297,11 @@ class _ClipMedia extends StatelessWidget {
         fit: .expand,
         children: [
           if (clip.thumbnailPath case final thumbnailPath?)
-            ClipThumbnailImage(path: thumbnailPath, fit: BoxFit.cover),
+            ClipThumbnailImage(
+              path: thumbnailPath,
+              fit: BoxFit.cover,
+              cacheHeight: cacheHeight,
+            ),
           const Center(
             child: CircularProgressIndicator(color: VineTheme.vineGreen),
           ),

--- a/mobile/lib/widgets/video_clip/video_clip_preview.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_preview.dart
@@ -17,6 +17,7 @@ import 'package:openvine/services/gallery_save_service.dart';
 import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
 import 'package:openvine/widgets/stop_motion/stop_motion_player.dart';
 import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
+import 'package:openvine/widgets/video_clip/video_clip_hero.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 class VideoClipPreview extends ConsumerStatefulWidget {
@@ -253,11 +254,13 @@ class _ClipHero extends StatelessWidget {
 
     final cacheHeight = _stillCacheHeight(context);
     return Hero(
-      tag: 'Video-Clip-Preview-${clip.id}',
+      tag: videoClipPreviewHeroTag(clip.id),
       flightShuttleBuilder: (_, _, _, _, _) => ClipThumbnailImage(
         path: thumbnailPath,
         fit: BoxFit.cover,
         cacheHeight: cacheHeight,
+        excludeFromSemantics: true,
+        placeholder: const VideoClipThumbnailPlaceholder(),
       ),
       child: child,
     );

--- a/mobile/lib/widgets/video_clip/video_clip_thumbnail_card.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_thumbnail_card.dart
@@ -7,6 +7,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/utils/video_editor_utils.dart';
 import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
+import 'package:openvine/widgets/video_clip/video_clip_hero.dart';
 
 /// Thumbnail card for a single clip in the grid.
 ///
@@ -150,7 +151,7 @@ class _Thumbnail extends StatelessWidget {
     final thumbnailPath = clip.thumbnailPath;
     if (thumbnailPath != null) {
       return Hero(
-        tag: 'Video-Clip-Preview-${clip.id}',
+        tag: videoClipPreviewHeroTag(clip.id),
         // Stop-motion clips use a full-resolution still as their thumbnail;
         // bound the decode to the grid cell so it doesn't cost tens of MB.
         child: ClipThumbnailImage(
@@ -161,20 +162,12 @@ class _Thumbnail extends StatelessWidget {
                       MediaQuery.devicePixelRatioOf(context) /
                       2)
                   .round(),
-          placeholder: DivineIcon(
-            icon: DivineIconName.videoCamera,
-            color: context.vineColors.mutedText,
-            size: 32,
-          ),
+          placeholder: const VideoClipThumbnailPlaceholder(),
         ),
       );
     }
 
-    return DivineIcon(
-      icon: DivineIconName.videoCamera,
-      color: context.vineColors.mutedText,
-      size: 32,
-    );
+    return const VideoClipThumbnailPlaceholder();
   }
 }
 
@@ -278,9 +271,9 @@ class _DurationBadge extends StatelessWidget {
         ),
         child: Text(
           clip.durationInSeconds.toStringAsFixed(2),
-          style: VineTheme.labelSmallFont(color: VineTheme.whiteText).copyWith(
-            fontFeatures: [const .tabularFigures()],
-          ),
+          style: VineTheme.labelSmallFont(
+            color: VineTheme.whiteText,
+          ).copyWith(fontFeatures: [const .tabularFigures()]),
         ),
       ),
     );

--- a/mobile/test/widgets/video_clip/video_clip_preview_test.dart
+++ b/mobile/test/widgets/video_clip/video_clip_preview_test.dart
@@ -12,8 +12,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/gallery_save_service.dart';
+import 'package:openvine/widgets/stop_motion/stop_motion_player.dart';
+import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
+import 'package:openvine/widgets/video_clip/video_clip_hero.dart';
 import 'package:openvine/widgets/video_clip/video_clip_preview.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
@@ -93,7 +97,7 @@ void main() {
       originalAspectRatio: 9 / 16,
     );
 
-    Widget buildTestWidget({VoidCallback? onDelete}) {
+    Widget buildTestWidget({DivineVideoClip? clip, VoidCallback? onDelete}) {
       return ProviderScope(
         overrides: [
           gallerySaveServiceProvider.overrideWithValue(mockGallerySaveService),
@@ -104,7 +108,10 @@ void main() {
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(
-              body: VideoClipPreview(clip: testClip, onDelete: onDelete),
+              body: VideoClipPreview(
+                clip: clip ?? testClip,
+                onDelete: onDelete,
+              ),
             ),
           ),
         ),
@@ -228,7 +235,7 @@ void main() {
       final videoFile = File('${tempDir.path}/video.mp4')
         ..writeAsBytesSync(const [0]);
       final thumbnailFile = File('${tempDir.path}/thumbnail.jpg')
-        ..writeAsBytesSync(const [0]);
+        ..writeAsBytesSync(_transparentPngBytes);
 
       final messenger =
           TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
@@ -257,23 +264,9 @@ void main() {
         thumbnailPath: thumbnailFile.path,
       );
 
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            gallerySaveServiceProvider.overrideWithValue(
-              mockGallerySaveService,
-            ),
-          ],
-          child: MockGoRouterProvider(
-            goRouter: mockGoRouter,
-            child: MaterialApp(
-              localizationsDelegates: AppLocalizations.localizationsDelegates,
-              supportedLocales: AppLocalizations.supportedLocales,
-              home: Scaffold(body: VideoClipPreview(clip: clip)),
-            ),
-          ),
-        ),
-      );
+      await tester.pumpWidget(buildTestWidget(clip: clip));
+      // pumpAndSettle cannot be used here because the pre-fix placeholder owns
+      // a CircularProgressIndicator that never settles.
       for (var i = 0; i < 5; i++) {
         await tester.pump(const Duration(milliseconds: 100));
       }
@@ -284,10 +277,60 @@ void main() {
       expect(find.byType(CircularProgressIndicator), findsNothing);
       expect(
         find.byWidgetPredicate(
-          (w) => w is Hero && w.tag == 'Video-Clip-Preview-${clip.id}',
+          (w) => w is Hero && w.tag == videoClipPreviewHeroTag(clip.id),
         ),
         findsOneWidget,
       );
+    });
+
+    testWidgets('builds a decorative thumbnail shuttle for stop-motion clips', (
+      tester,
+    ) async {
+      final tempDir = Directory.systemTemp.createTempSync(
+        'clip_preview_stop_motion_hero',
+      );
+      addTearDown(() => tempDir.deleteSync(recursive: true));
+      final frameFile = File('${tempDir.path}/frame.png')
+        ..writeAsBytesSync(_transparentPngBytes);
+
+      final clip = DivineVideoClip(
+        id: 'stop-motion-clip-1',
+        stopMotionFrames: [
+          StopMotionClipFrame(
+            path: frameFile.path,
+            duration: const Duration(milliseconds: 83),
+          ),
+        ],
+        thumbnailPath: frameFile.path,
+        libraryTitle: 'Tiny jump',
+        duration: const Duration(milliseconds: 83),
+        recordedAt: DateTime(2026),
+        targetAspectRatio: .vertical,
+        originalAspectRatio: 9 / 16,
+      );
+
+      await tester.pumpWidget(buildTestWidget(clip: clip));
+
+      expect(find.byType(StopMotionPlayer), findsOneWidget);
+
+      final heroFinder = find.byWidgetPredicate(
+        (w) => w is Hero && w.tag == videoClipPreviewHeroTag(clip.id),
+      );
+      final hero = tester.widget<Hero>(heroFinder);
+      final shuttle = hero.flightShuttleBuilder!(
+        tester.element(find.byType(VideoClipPreview)),
+        const AlwaysStoppedAnimation<double>(0),
+        HeroFlightDirection.push,
+        tester.element(heroFinder),
+        tester.element(heroFinder),
+      );
+
+      final thumbnail = shuttle as ClipThumbnailImage;
+      expect(thumbnail.path, frameFile.path);
+      expect(thumbnail.fit, BoxFit.cover);
+      expect(thumbnail.cacheHeight, tester.view.physicalSize.height.round());
+      expect(thumbnail.excludeFromSemantics, isTrue);
+      expect(thumbnail.placeholder, isA<VideoClipThumbnailPlaceholder>());
     });
 
     group('save result snackbar', () {
@@ -336,17 +379,16 @@ void main() {
         );
       });
 
-      testWidgets(
-        'shows permission message on $GallerySavePermissionDenied',
-        (tester) async {
-          await pumpAndSave(tester, const GallerySavePermissionDenied());
+      testWidgets('shows permission message on $GallerySavePermissionDenied', (
+        tester,
+      ) async {
+        await pumpAndSave(tester, const GallerySavePermissionDenied());
 
-          expect(
-            find.text(l10n.libraryGalleryPermissionDenied(destination)),
-            findsOneWidget,
-          );
-        },
-      );
+        expect(
+          find.text(l10n.libraryGalleryPermissionDenied(destination)),
+          findsOneWidget,
+        );
+      });
 
       testWidgets('shows failure message on $GallerySaveFailure', (
         tester,
@@ -358,3 +400,73 @@ void main() {
     });
   });
 }
+
+const _transparentPngBytes = <int>[
+  0x89,
+  0x50,
+  0x4e,
+  0x47,
+  0x0d,
+  0x0a,
+  0x1a,
+  0x0a,
+  0x00,
+  0x00,
+  0x00,
+  0x0d,
+  0x49,
+  0x48,
+  0x44,
+  0x52,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x08,
+  0x06,
+  0x00,
+  0x00,
+  0x00,
+  0x1f,
+  0x15,
+  0xc4,
+  0x89,
+  0x00,
+  0x00,
+  0x00,
+  0x0d,
+  0x49,
+  0x44,
+  0x41,
+  0x54,
+  0x78,
+  0x9c,
+  0x63,
+  0x60,
+  0x00,
+  0x00,
+  0x00,
+  0x02,
+  0x00,
+  0x01,
+  0xe2,
+  0x21,
+  0xbc,
+  0x33,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x49,
+  0x45,
+  0x4e,
+  0x44,
+  0xae,
+  0x42,
+  0x60,
+  0x82,
+];

--- a/mobile/test/widgets/video_clip/video_clip_preview_test.dart
+++ b/mobile/test/widgets/video_clip/video_clip_preview_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for VideoClipPreview widget
 // ABOUTME: Verifies rendering, DivineVideoPlayer integration, and button layout
 
+import 'dart:io';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:divine_video_player/divine_video_player.dart';
 import 'package:flutter/material.dart';
@@ -18,6 +20,31 @@ import 'package:pro_video_editor/pro_video_editor.dart';
 import '../../helpers/go_router.dart';
 
 class _MockGallerySaveService extends Mock implements GallerySaveService {}
+
+/// Reports a decoded first frame as soon as the controller subscribes, which
+/// is what drops [DivineVideoPlayer]'s placeholder from the tree.
+class _FirstFrameStreamHandler extends MockStreamHandler {
+  @override
+  void onListen(Object? arguments, MockStreamHandlerEventSink events) {
+    events.success(<Object?, Object?>{
+      'status': 'playing',
+      'positionMs': 0,
+      'durationMs': 1000,
+      'bufferedPositionMs': 500,
+      'currentClipIndex': 0,
+      'clipCount': 1,
+      'isLooping': true,
+      'volume': 1.0,
+      'playbackSpeed': 1.0,
+      'isFirstFrameRendered': true,
+      'videoWidth': 1080,
+      'videoHeight': 1920,
+    });
+  }
+
+  @override
+  void onCancel(Object? arguments) {}
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -192,6 +219,75 @@ void main() {
       await tester.pump(const Duration(milliseconds: 100));
 
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('keeps the hero mounted once the video replaces the '
+        'placeholder', (tester) async {
+      final tempDir = Directory.systemTemp.createTempSync('clip_preview_hero');
+      addTearDown(() => tempDir.deleteSync(recursive: true));
+      final videoFile = File('${tempDir.path}/video.mp4')
+        ..writeAsBytesSync(const [0]);
+      final thumbnailFile = File('${tempDir.path}/thumbnail.jpg')
+        ..writeAsBytesSync(const [0]);
+
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            ..setMockMethodCallHandler(
+              const MethodChannel('divine_video_player/player_0'),
+              (call) async => null,
+            )
+            ..setMockStreamHandler(
+              const EventChannel('divine_video_player/player_0/events'),
+              _FirstFrameStreamHandler(),
+            );
+      addTearDown(() {
+        messenger
+          ..setMockMethodCallHandler(
+            const MethodChannel('divine_video_player/player_0'),
+            null,
+          )
+          ..setMockStreamHandler(
+            const EventChannel('divine_video_player/player_0/events'),
+            null,
+          );
+      });
+
+      final clip = testClip.copyWith(
+        video: EditorVideo.file(videoFile.path),
+        thumbnailPath: thumbnailFile.path,
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gallerySaveServiceProvider.overrideWithValue(
+              mockGallerySaveService,
+            ),
+          ],
+          child: MockGoRouterProvider(
+            goRouter: mockGoRouter,
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(body: VideoClipPreview(clip: clip)),
+            ),
+          ),
+        ),
+      );
+      for (var i = 0; i < 5; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+
+      // The placeholder — which used to own the hero — is gone once the first
+      // frame is up, so a hero living inside it would be unmounted here and
+      // the dismiss animation would have nothing to fly back from.
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(
+        find.byWidgetPredicate(
+          (w) => w is Hero && w.tag == 'Video-Clip-Preview-${clip.id}',
+        ),
+        findsOneWidget,
+      );
     });
 
     group('save result snackbar', () {


### PR DESCRIPTION
Closes #6801

## Description

Closing the clip preview no longer animated the thumbnail back into the library grid — the overlay just faded out.

The `Hero` was rendered inside `DivineVideoPlayer`'s `placeholder`, and that placeholder is removed from the tree (`SizedBox.shrink()`) once the first video frame is decoded. Opening still animated because the placeholder is up while the player initializes; by the time the user dismissed the preview there was no hero left to fly back from. It also sat below the `FittedBox`, so even while mounted its rect was the video's native pixel size instead of the visible preview box. Regression from #2691, which moved the hero into the placeholder when the preview was ported to `DivineVideoPlayer`.

The hero now wraps the media directly under the preview's `ClipRRect`, where it stays mounted for the preview's whole lifetime and measures the box the user actually sees. A `flightShuttleBuilder` renders the still thumbnail for both directions — otherwise the push flight would reparent the live platform view / texture into the hero overlay, which is exactly where native surfaces misbehave.

Player construction moved into a `_ClipMedia` widget: keeping it inline under the extra hero level pushed the tree past readable nesting, and it follows the repo's prefer-widget-classes-over-inline-builders rule.

Stop-motion clips get the animation too. They render through `StopMotionPlayer` and never reached the placeholder branch, so the preview had no hero at all even though the grid card sets one.

The still decode is bounded because a stop-motion clip's thumbnail is `frames.first.path` — a full-resolution camera still. The shuttle, the video placeholder and `StopMotionPlayer` now share one bound, so the preview resolves to a single cache entry instead of three. `ResizeImage` never upscales, so small video thumbnails are unaffected.

Takeover follow-up centralized the grid/preview hero tag, made the shuttle decorative for semantics, and reused the grid card's missing-thumbnail placeholder so the fallback icon stays stable during the flight.

## Verification

- `flutter analyze lib/widgets/video_clip test/widgets/video_clip` — clean
- `flutter test test/widgets/video_clip/ test/widgets/library/clips_tab_test.dart test/widgets/stop_motion` — 43 passed
- New regression test verified to fail without the fix (finds 0 heroes once the first frame renders) and pass with it
- Stop-motion preview test asserts the hero shuttle uses the bounded thumbnail, excludes semantics, and preserves the missing-thumbnail placeholder
- Manually tested on a real Samsung Galaxy: open a clip from the library grid, let the video start playing, dismiss — thumbnail flies back into its grid cell. Checked both tap and long-press entry, and a stop-motion clip.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
