### PR TITLE
fix(notifications): stop labelling video likes "liked your comment"

### DIFF
--- a/mobile/lib/notifications/widgets/actor_notification_row.dart
+++ b/mobile/lib/notifications/widgets/actor_notification_row.dart
@@ -14,7 +14,7 @@ import 'package:openvine/notifications/widgets/notification_leading_type_icon.da
 import 'package:openvine/widgets/user_avatar.dart';
 
 /// Displays a single actor-anchored notification row (follow / mention /
-/// likeComment / reply / system).
+/// like / likeComment / reply / system).
 class ActorNotificationRow extends StatelessWidget {
   /// Creates an [ActorNotificationRow].
   const ActorNotificationRow({
@@ -236,6 +236,7 @@ String _messageFor(
 ) {
   return switch (type) {
     NotificationKind.follow => l10n.notificationStartedFollowing(actorName),
+    NotificationKind.like => l10n.notificationLikedYourVideo(actorName),
     NotificationKind.mention => l10n.notificationMentionedYou(actorName),
     NotificationKind.likeComment => l10n.notificationLikedYourComment(
       actorName,
@@ -244,7 +245,6 @@ String _messageFor(
     // newPost is video-anchored and never renders through the actor row;
     // listed here for switch exhaustivity only.
     NotificationKind.system ||
-    NotificationKind.like ||
     NotificationKind.comment ||
     NotificationKind.repost ||
     NotificationKind.newPost ||

--- a/mobile/lib/services/notification_target_resolver.dart
+++ b/mobile/lib/services/notification_target_resolver.dart
@@ -37,6 +37,14 @@ class NotificationTargetResolver {
       }
     }
 
+    // NIP-25 reactions on addressable videos use a lowercase a tag. This path
+    // supports anchorless actor-like rows whose target is the reaction event.
+    for (final tag in event.tags) {
+      if (tag.length >= 2 && tag[0] == 'a' && _isVideoAddressableId(tag[1])) {
+        return tag[1];
+      }
+    }
+
     // NIP-22: uppercase E tag = root scope, points to root video event.
     for (final tag in event.tags) {
       if (tag.length >= 2 && tag[0] == 'E' && tag[1].isNotEmpty) {

--- a/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
@@ -24,6 +24,7 @@ class RelayNotification {
     this.rootDTag,
     this.rootAddressableId,
     this.targetCommentId,
+    this.commentContent,
     this.listTitle,
     this.listCoordinate,
   });
@@ -81,6 +82,7 @@ class RelayNotification {
       rootDTag: _nonEmpty(json['root_d_tag'] as String?),
       rootAddressableId: _nonEmpty(json['root_addressable_id'] as String?),
       targetCommentId: _nonEmpty(json['target_comment_id'] as String?),
+      commentContent: _nonEmpty(json['comment_content'] as String?),
       listTitle: _nonEmpty(json['list_title'] as String?),
       listCoordinate: _nonEmpty(json['list_coordinate'] as String?),
     );
@@ -175,6 +177,15 @@ class RelayNotification {
 
   /// Comment event ID included by Funnelcake for NIP-22 comment notifications.
   final String? targetCommentId;
+
+  /// Body of the comment identified by [targetCommentId], when Funnelcake
+  /// resolves it.
+  ///
+  /// For a reaction this is the *liked* comment's text — [content] carries
+  /// only the reaction emoji, so this is the sole source of context for a
+  /// "liked your comment" row. For a comment or reply notification it is
+  /// the source event's own body, which duplicates [content].
+  final String? commentContent;
 
   /// Curated-list title for `notification_type: "list_add"`.
   final String? listTitle;

--- a/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
@@ -115,9 +115,12 @@ class RelayNotification {
   /// Optional content from the source event (e.g. reaction emoji).
   final String? content;
 
-  /// Whether the referenced event is a video. Set when the API populates
-  /// `referenced_video` (only present for video kinds). Lets the client
-  /// distinguish a like on a video from a like on a comment.
+  /// Whether the API populated a `referenced_video` join result for the
+  /// notification's root video.
+  ///
+  /// This is enrichment metadata, not a reliable target-type signal: comment
+  /// likes can include it because their root is a video, and video likes can
+  /// omit it when that root video fails to resolve.
   final bool isReferencedVideo;
 
   /// Title of the referenced video, when the referenced event is a video

--- a/mobile/packages/funnelcake_api_client/test/src/models/relay_notification_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/models/relay_notification_test.dart
@@ -433,6 +433,61 @@ void main() {
         );
       });
 
+      test('parses comment_content as the liked comment body', () {
+        // A reaction on a comment: `content` is the reaction emoji, and
+        // `comment_content` carries the body of the comment that was
+        // liked — the only context a "liked your comment" row can show.
+        final json = {
+          'id': 'notif_123',
+          'source_pubkey': 'aabbccdd' * 8,
+          'source_event_id': '11223344' * 8,
+          'source_kind': 7,
+          'notification_type': 'reaction',
+          'created_at': 1712345678,
+          'read': false,
+          'content': '+',
+          'target_comment_id': '55667788' * 8,
+          'comment_content': 'this vine still holds up',
+        };
+
+        final notification = RelayNotification.fromJson(json);
+
+        expect(notification.content, equals('+'));
+        expect(
+          notification.commentContent,
+          equals('this vine still holds up'),
+        );
+      });
+
+      test('treats empty comment_content as null', () {
+        final json = {
+          'id': 'notif_123',
+          'source_pubkey': 'aabbccdd' * 8,
+          'source_event_id': '11223344' * 8,
+          'source_kind': 7,
+          'notification_type': 'reaction',
+          'created_at': 1712345678,
+          'read': false,
+          'comment_content': '',
+        };
+
+        expect(RelayNotification.fromJson(json).commentContent, isNull);
+      });
+
+      test('leaves comment_content null when the server omits it', () {
+        final json = {
+          'id': 'notif_123',
+          'source_pubkey': 'aabbccdd' * 8,
+          'source_event_id': '11223344' * 8,
+          'source_kind': 7,
+          'notification_type': 'reaction',
+          'created_at': 1712345678,
+          'read': false,
+        };
+
+        expect(RelayNotification.fromJson(json).commentContent, isNull);
+      });
+
       test('treats empty root coordinate fields as null', () {
         final json = {
           'id': 'notif_123',

--- a/mobile/packages/models/lib/src/actor_notification.dart
+++ b/mobile/packages/models/lib/src/actor_notification.dart
@@ -37,16 +37,19 @@ class ActorNotification extends NotificationItem {
   /// The actor who triggered this notification.
   final ActorInfo actor;
 
-  /// Optional text body (e.g. mention's surrounding text).
+  /// Optional row quote/context text.
+  ///
+  /// For comment-like rows this is the liked comment's body. For reply and
+  /// mention rows this is the source event's surrounding text/body.
   final String? commentText;
 
   /// Whether the current user already follows this actor back.
   final bool isFollowingBack;
 
-  /// Stable NIP-33 addressable ID (`34236:pubkey:d-tag`) of the video
-  /// context for [NotificationKind.likeComment] and
-  /// [NotificationKind.reply] notifications, when the server provided
-  /// the `d_tag` in the notification payload.
+  /// Stable NIP-33 addressable ID (`34236:pubkey:d-tag`) of the video context
+  /// for actor-anchored [NotificationKind.like],
+  /// [NotificationKind.likeComment], and [NotificationKind.reply]
+  /// notifications, when the server provided a usable root video coordinate.
   ///
   /// When set, the tap handler navigates directly to the video using
   /// this ID without a relay round-trip through the resolver.

--- a/mobile/packages/models/lib/src/actor_notification.dart
+++ b/mobile/packages/models/lib/src/actor_notification.dart
@@ -1,9 +1,10 @@
-// ABOUTME: Actor-anchored notification — follows, mentions, system. No
-// ABOUTME: video reference; one row per event.
+// ABOUTME: Actor-anchored notification — follows, mentions, system, and
+// ABOUTME: reactions without an event-id anchor. One row per event.
 
 part of 'notification_item.dart';
 
-/// A notification anchored to an actor (follow, mention, system).
+/// A notification anchored to an actor (follow, mention, system, or an
+/// addressable reaction without a concrete video event ID).
 ///
 /// No video reference; one row per event.
 @immutable
@@ -24,11 +25,12 @@ class ActorNotification extends NotificationItem {
     this.hasCommentTarget = false,
   }) : assert(
          type == NotificationKind.follow ||
+             type == NotificationKind.like ||
              type == NotificationKind.mention ||
              type == NotificationKind.system ||
              type == NotificationKind.likeComment ||
              type == NotificationKind.reply,
-         'ActorNotification only supports follow, mention, system, '
+         'ActorNotification only supports follow, like, mention, system, '
          'likeComment, reply',
        );
 

--- a/mobile/packages/models/test/src/actor_notification_test.dart
+++ b/mobile/packages/models/test/src/actor_notification_test.dart
@@ -31,6 +31,17 @@ void main() {
         );
       });
 
+      test('accepts an anchorless like as an actor-anchored kind', () {
+        // Should not throw the assert.
+        ActorNotification(
+          id: 'n1',
+          type: NotificationKind.like,
+          actor: actor,
+          timestamp: timestamp,
+          targetEventId: 'reaction-event',
+        );
+      });
+
       test('exposes targetEventId for likeComment', () {
         final notification = ActorNotification(
           id: 'n1',

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1962,8 +1962,8 @@ class NotificationRepository {
 
   /// Returns the `targetEventId` for an actor-anchored notification.
   ///
-  /// - anchorless `like` → the reaction event ID (resolver follows its
-  ///   address tag to the video).
+  /// - anchorless `like` → the reaction event ID (resolver follows its `a` tag
+  ///   to the video when no recipient-owned root coordinate is available).
   /// - `likeComment`/`reply` → the referenced comment event ID (resolver
   ///   walks its E-tags to reach the root video).
   /// - `mention` → the source event ID (the kind-1 event that mentioned
@@ -2079,9 +2079,12 @@ class NotificationRepository {
   /// Returns the stable NIP-33 addressable ID for an actor-anchored
   /// notification, when the server provided the root video's full coordinate.
   ///
-  /// Populated for anchorless `like`, `likeComment`, and `reply` rows — the
-  /// tap handler uses it to navigate directly to the video without a relay
-  /// round-trip.
+  /// Populated for actor-anchored rows only when the coordinate is usable for
+  /// that row's ownership claim. Anchorless `like` rows render "liked your
+  /// video", so their direct route must name the notification recipient's own
+  /// video. `likeComment` and `reply` rows may legitimately route to a foreign
+  /// root video because the notification is about the recipient's comment on
+  /// that video.
   ///
   /// Used by the page-load path ([_mapActorAnchored]).
   String? _actorVideoAddressableId(
@@ -2093,7 +2096,16 @@ class NotificationRepository {
         mapped != NotificationKind.reply) {
       return null;
     }
-    return _nonEmpty(notification.rootAddressableId);
+    final addressableId = _nonEmpty(notification.rootAddressableId);
+    if (addressableId == null) return null;
+    final parsed = _parseAddressableId(addressableId);
+    if (parsed == null) return null;
+    if (!NIP71VideoKinds.isVideoKind(parsed.kind)) return null;
+    if (parsed.pubkey.isEmpty || parsed.dTag.isEmpty) return null;
+    if (mapped == NotificationKind.like && parsed.pubkey != _userPubkey) {
+      return null;
+    }
+    return addressableId;
   }
 
   bool _hasKnownReferencedVideoOwnerMismatch({

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -776,8 +776,8 @@ class NotificationRepository {
       );
     }
 
-    // Actor-anchored kinds — `follow`, `mention`, `likeComment`, `reply`,
-    // `system` (and unknown future types fall through to `system`).
+    // Actor-anchored kinds — `follow`, `actorLike`, `mention`, `likeComment`,
+    // `reply`, `system` (and unknown future types fall through to `system`).
     return ActorNotification(
       id: row.id,
       type: _actorKindFromCachedType(row.type),
@@ -814,6 +814,7 @@ class NotificationRepository {
   static NotificationKind _actorKindFromCachedType(String type) =>
       switch (type) {
         'follow' => NotificationKind.follow,
+        'actorLike' => NotificationKind.like,
         'mention' => NotificationKind.mention,
         'likeComment' => NotificationKind.likeComment,
         'reply' => NotificationKind.reply,
@@ -917,6 +918,7 @@ class NotificationRepository {
   /// Inverse of [_videoKindFromCachedType] plus [_actorKindFromCachedType].
   static String _persistType(NotificationItem item) => switch (item) {
     VideoNotification(type: NotificationKind.mention) => 'videoMention',
+    ActorNotification(type: NotificationKind.like) => 'actorLike',
     NotificationItem(:final type) => _persistKind(type),
   };
 
@@ -1784,7 +1786,8 @@ class NotificationRepository {
     RelayNotification notification,
   ) => _isVideoAnchoredKind(kind) || _isVideoSourcedMention(notification);
 
-  /// Builds [ActorNotification]s for follow/mention/system kinds.
+  /// Builds [ActorNotification]s for follow/mention/system kinds and
+  /// reactions that have no concrete video event ID.
   ///
   /// `reply` and other unmapped kinds are also routed here as
   /// [ActorNotification] — they don't have a clean video anchor, so we
@@ -1796,14 +1799,21 @@ class NotificationRepository {
     final result = <ActorNotification>[];
     for (final n in raw) {
       final kind = _mapNotificationKind(n);
-      // Skip kinds that became VideoNotifications.
-      if (_isVideoAnchoredKind(kind) || _isVideoSourcedMention(n)) {
+      final isAnchorlessLike =
+          kind == NotificationKind.like &&
+          _nonEmpty(_videoAnchorEventId(kind, n)) == null;
+      // Skip kinds that became VideoNotifications. An a-tag-only reaction has
+      // no event ID to group on, so keep it as an actor-backed like instead of
+      // silently dropping it from both pipelines.
+      if ((_isVideoAnchoredKind(kind) && !isAnchorlessLike) ||
+          _isVideoSourcedMention(n)) {
         continue;
       }
-      // ActorNotification supports follow/mention/system/likeComment/reply;
-      // coerce any other kind to system.
+      // ActorNotification supports follow/like/mention/system/likeComment/
+      // reply; coerce any other kind to system.
       final mapped =
           (kind == NotificationKind.follow ||
+              kind == NotificationKind.like ||
               kind == NotificationKind.mention ||
               kind == NotificationKind.system ||
               kind == NotificationKind.likeComment ||
@@ -1952,6 +1962,8 @@ class NotificationRepository {
 
   /// Returns the `targetEventId` for an actor-anchored notification.
   ///
+  /// - anchorless `like` → the reaction event ID (resolver follows its
+  ///   address tag to the video).
   /// - `likeComment`/`reply` → the referenced comment event ID (resolver
   ///   walks its E-tags to reach the root video).
   /// - `mention` → the source event ID (the kind-1 event that mentioned
@@ -1963,6 +1975,8 @@ class NotificationRepository {
     NotificationKind mapped,
     RelayNotification n,
   ) => switch (mapped) {
+    NotificationKind.like =>
+      n.sourceEventId.isNotEmpty ? n.sourceEventId : null,
     NotificationKind.likeComment || NotificationKind.reply =>
       // Prefer the explicit parent comment ID. Some Funnelcake reply payloads
       // carry the root video in referenced_event_id and the actual parent
@@ -2065,15 +2079,17 @@ class NotificationRepository {
   /// Returns the stable NIP-33 addressable ID for an actor-anchored
   /// notification, when the server provided the root video's full coordinate.
   ///
-  /// Only populated for `likeComment` and `reply` — the tap handler uses
-  /// it to navigate directly to the video without a relay round-trip.
+  /// Populated for anchorless `like`, `likeComment`, and `reply` rows — the
+  /// tap handler uses it to navigate directly to the video without a relay
+  /// round-trip.
   ///
   /// Used by the page-load path ([_mapActorAnchored]).
   String? _actorVideoAddressableId(
     NotificationKind mapped,
     RelayNotification notification,
   ) {
-    if (mapped != NotificationKind.likeComment &&
+    if (mapped != NotificationKind.like &&
+        mapped != NotificationKind.likeComment &&
         mapped != NotificationKind.reply) {
       return null;
     }

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1868,13 +1868,17 @@ class NotificationRepository {
     NotificationKind? commentKind,
     String? targetEventId,
   }) {
+    final quoteKind = commentKind ?? type;
     return ActorNotification(
       id: notification.dedupeKey,
       type: type,
       actor: _buildActor(notification.sourcePubkey, profiles),
       timestamp: notification.createdAt,
       isRead: notification.read,
-      commentText: _truncateComment(notification.content, commentKind ?? type),
+      commentText: _truncateComment(
+        _commentQuoteSource(notification, quoteKind),
+        quoteKind,
+      ),
       targetEventId: targetEventId ?? _actorTargetEventId(type, notification),
       sourceEventIds: notification.sourceEventId.isNotEmpty
           ? [notification.sourceEventId]
@@ -1886,6 +1890,20 @@ class NotificationRepository {
       hasCommentTarget: _actorHasCommentTarget(type, notification),
     );
   }
+
+  /// Raw text a row quotes beneath its message, before truncation.
+  ///
+  /// `comment` and `reply` quote the source event's own body. A
+  /// `likeComment` row instead quotes the comment that was liked: its
+  /// source event is a kind 7 reaction whose `content` is just the emoji,
+  /// so without `comment_content` the row states that someone liked a
+  /// comment while naming neither the comment nor its video.
+  static String? _commentQuoteSource(
+    RelayNotification notification,
+    NotificationKind kind,
+  ) => kind == NotificationKind.likeComment
+      ? notification.commentContent
+      : notification.content;
 
   static bool _actorHasCommentTarget(
     NotificationKind type,
@@ -2263,10 +2281,24 @@ class NotificationRepository {
   /// so the UI can render "liked your comment" instead of "liked your
   /// video". A comment target is identified by a non-empty
   /// `targetCommentId`, which Funnelcake sets to the comment's event ID
-  /// for reactions on a kind 1111 comment. `isReferencedVideo` cannot be
-  /// used for this split: Funnelcake populates `referenced_video` from the
-  /// notification's root video, so it is set for a like on a comment (whose
-  /// root is that video) exactly as it is for a like on the video itself.
+  /// for reactions on a kind 1111 comment. That signal is the *only* one
+  /// used for the split.
+  ///
+  /// `isReferencedVideo` deliberately plays no part. It reports whether
+  /// Funnelcake managed to attach a `referenced_video` block, which it
+  /// builds from the notification's *root* video — so it is set for a like
+  /// on a comment (whose root is that video) exactly as it is for a like on
+  /// the video itself, and it is unset whenever the root video simply
+  /// failed to resolve. Treating its absence as evidence of a comment
+  /// target relabelled ordinary video likes as "liked your comment"
+  /// whenever the video was unindexed or deleted.
+  ///
+  /// A reaction on a comment that Funnelcake could not resolve leaves
+  /// `targetCommentId` empty and so lands here as [NotificationKind.like].
+  /// That residual case is caught downstream by
+  /// [_hasKnownReferencedVideoOwnerMismatch], which reclassifies it to
+  /// `likeComment` once a confirmed metadata 404 plus a foreign
+  /// `root_event_pubkey` prove the anchor is not the user's own video.
   ///
   /// Replies (kind 1111) split by the immediate target, not by whether the
   /// payload also carries root video metadata. A reply directly on a video
@@ -2283,10 +2315,9 @@ class NotificationRepository {
       final targetCommentId = n.targetCommentId;
       final targetsComment =
           targetCommentId != null && targetCommentId.isNotEmpty;
-      if (targetsComment) return NotificationKind.likeComment;
-      return n.isReferencedVideo
-          ? NotificationKind.like
-          : NotificationKind.likeComment;
+      return targetsComment
+          ? NotificationKind.likeComment
+          : NotificationKind.like;
     }
     if (_isNestedCommentReply(n)) {
       return NotificationKind.reply;
@@ -2420,7 +2451,9 @@ class NotificationRepository {
   /// Truncates comment text to [_maxCommentLength] characters, except for
   /// bounded leading Nostr references that the UI can resolve.
   ///
-  /// Only applies to comment and reply notifications.
+  /// Only applies to the kinds that render a quote: comment, reply, and
+  /// likeComment. Pair it with [_commentQuoteSource], which picks the text
+  /// each kind should quote.
   ///
   /// The cut avoids splitting a Nostr reference the UI can decode — bech32
   /// (`npub1...`, `nprofile1...`, `note1...`, `nevent1...`, `naddr1...`) or a
@@ -2430,7 +2463,9 @@ class NotificationRepository {
   /// intact lets the UI linkifier resolve it to `@<name>`.
   static String? _truncateComment(String? content, NotificationKind kind) {
     if (content == null) return null;
-    if (kind != NotificationKind.comment && kind != NotificationKind.reply) {
+    if (kind != NotificationKind.comment &&
+        kind != NotificationKind.reply &&
+        kind != NotificationKind.likeComment) {
       return null;
     }
     if (content.length <= _maxCommentLength) return content;

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -1371,16 +1371,40 @@ void main() {
       });
 
       test(
-        'video-anchored notification with null referencedEventId is dropped',
+        'a-tag-only reaction maps to an actor like instead of being dropped',
         () async {
+          const rootAddressableId =
+              '34236:user1234567890abcdef:addressable-video';
           stubNotifications([
-            makeNotification(sourcePubkey: 'pub_a', referencedEventId: null),
+            makeNotification(
+              sourcePubkey: 'pub_a',
+              sourceEventId: 'reaction_event',
+              referencedEventId: null,
+              rootAddressableId: rootAddressableId,
+            ),
           ]);
           stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
 
           final page = await repository.getNotifications();
 
-          expect(page.items, isEmpty);
+          expect(page.items, hasLength(1));
+          final item = page.items.single as ActorNotification;
+          expect(item.type, equals(NotificationKind.like));
+          expect(item.targetEventId, equals('reaction_event'));
+          expect(item.videoAddressableId, equals(rootAddressableId));
+
+          final rows =
+              verify(
+                    () => notificationsDao.replaceAll(
+                      captureAny(),
+                      ownerPubkey: any(named: 'ownerPubkey'),
+                    ),
+                  ).captured.single
+                  as List<NotificationCacheRow>;
+          final row = rows.singleWhere((r) => r.type != 'seen_marker');
+          expect(row.type, equals('actorLike'));
+          expect(row.targetEventId, equals('reaction_event'));
+          expect(row.videoAddressableId, equals(rootAddressableId));
         },
       );
 
@@ -3590,6 +3614,57 @@ void main() {
                     item.totalCount == 1 &&
                     item.commentText == null;
               }, 'placeholder is VideoNotification(like) keyed to video'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'cached "actorLike" row remains an anchorless actor like',
+        () async {
+          const rootAddressableId =
+              '34236:user1234567890abcdef:addressable-video';
+          when(
+            () => notificationsDao.getAllNotifications(
+              limit: any(named: 'limit'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              NotificationRow(
+                id: 'cached_actor_like',
+                type: 'actorLike',
+                fromPubkey: 'actor_pub',
+                timestamp: 1700000000,
+                targetEventId: 'reaction_event',
+                videoAddressableId: rootAddressableId,
+                hasCommentTarget: false,
+                isRead: false,
+                cachedAt: DateTime(2026),
+              ),
+            ],
+          );
+          final hydrated = NotificationRepository(
+            funnelcakeApiClient: funnelcakeApiClient,
+            profileRepository: profileRepository,
+            notificationsDao: notificationsDao,
+            userPubkey: userPubkey,
+          );
+          addTearDown(hydrated.close);
+
+          await expectLater(
+            hydrated.watchSnapshot(),
+            emitsThrough(
+              predicate<NotificationPage>((p) {
+                if (p.items.length != 1) return false;
+                final item = p.items.first;
+                return item is ActorNotification &&
+                    item.id == 'cached_actor_like' &&
+                    item.type == NotificationKind.like &&
+                    item.targetEventId == 'reaction_event' &&
+                    item.videoAddressableId == rootAddressableId &&
+                    item.actor.pubkey == 'actor_pub';
+              }, 'placeholder is ActorNotification(like)'),
             ),
           );
         },

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -1409,6 +1409,68 @@ void main() {
       );
 
       test(
+        'anchorless actor like does not trust a foreign root coordinate',
+        () async {
+          const foreignRootAddressableId =
+              '34236:other_owner:addressable-video';
+          stubNotifications([
+            makeNotification(
+              sourcePubkey: 'pub_a',
+              sourceEventId: 'reaction_event',
+              referencedEventId: null,
+              rootAddressableId: foreignRootAddressableId,
+            ),
+          ]);
+          stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+
+          final page = await repository.getNotifications();
+
+          expect(page.items, hasLength(1));
+          final item = page.items.single as ActorNotification;
+          expect(item.type, equals(NotificationKind.like));
+          expect(item.targetEventId, equals('reaction_event'));
+          expect(item.videoAddressableId, isNull);
+
+          final rows =
+              verify(
+                    () => notificationsDao.replaceAll(
+                      captureAny(),
+                      ownerPubkey: any(named: 'ownerPubkey'),
+                    ),
+                  ).captured.single
+                  as List<NotificationCacheRow>;
+          final row = rows.singleWhere((r) => r.type != 'seen_marker');
+          expect(row.type, equals('actorLike'));
+          expect(row.targetEventId, equals('reaction_event'));
+          expect(row.videoAddressableId, isNull);
+        },
+      );
+
+      test(
+        'likeComment can keep a foreign root coordinate for comment routing',
+        () async {
+          const foreignRootAddressableId =
+              '34236:other_owner:addressable-video';
+          stubNotifications([
+            makeNotification(
+              sourcePubkey: 'pub_a',
+              targetCommentId: 'comment_event',
+              rootAddressableId: foreignRootAddressableId,
+            ),
+          ]);
+          stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+
+          final page = await repository.getNotifications();
+
+          expect(page.items, hasLength(1));
+          final item = page.items.single as ActorNotification;
+          expect(item.type, equals(NotificationKind.likeComment));
+          expect(item.targetEventId, equals('comment_event'));
+          expect(item.videoAddressableId, equals(foreignRootAddressableId));
+        },
+      );
+
+      test(
         'getVideoStats throws → row still rendered with null thumbnail',
         () async {
           stubNotifications([

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -134,6 +134,7 @@ void main() {
     String? rootAddressableId,
     String? targetCommentId,
     String? content,
+    String? commentContent,
     bool isReferencedVideo = true,
     String? referencedVideoTitle,
     String? referencedVideoThumbnail,
@@ -157,6 +158,7 @@ void main() {
       rootAddressableId: rootAddressableId,
       targetCommentId: targetCommentId,
       content: content,
+      commentContent: commentContent,
       isReferencedVideo: isReferencedVideo,
       referencedVideoTitle: referencedVideoTitle,
       referencedVideoThumbnail: referencedVideoThumbnail,
@@ -2137,21 +2139,38 @@ void main() {
         expect(page.items, isEmpty);
       });
 
-      test('reaction on a non-video target maps to likeComment '
-          '($ActorNotification)', () async {
-        stubNotifications([makeNotification(isReferencedVideo: false)]);
-        stubProfiles({});
+      test(
+        'reaction without a target comment stays like when the referenced '
+        'video did not resolve',
+        () async {
+          // An unresolved root video leaves referenced_video absent, which is
+          // a Funnelcake join miss (unindexed / deleted video), not evidence
+          // of a comment target. Reading it as one relabelled ordinary video
+          // likes "liked your comment" — with no thumbnail and no quote, so
+          // the row named neither a comment nor a video.
+          stubNotifications([
+            makeNotification(
+              isReferencedVideo: false,
+              referencedEventId: 'my_video',
+            ),
+          ]);
+          stubProfiles({});
 
-        final page = await repository.getNotifications();
-        final item = page.items.single as ActorNotification;
-        expect(item.type, equals(NotificationKind.likeComment));
-      });
+          final page = await repository.getNotifications();
+          final item = page.items.single as VideoNotification;
+          expect(item.type, equals(NotificationKind.like));
+          expect(item.videoEventId, equals('my_video'));
+        },
+      );
 
-      test('likeComment carries referencedEventId as targetEventId', () async {
+      test('likeComment quotes the liked comment body', () async {
+        // The source event is a kind 7 reaction, so `content` is the emoji.
+        // Funnelcake resolves the liked comment's text into comment_content.
         stubNotifications([
           makeNotification(
-            isReferencedVideo: false,
-            referencedEventId: 'comment_event_xyz',
+            targetCommentId: 'comment_event_xyz',
+            content: '+',
+            commentContent: 'this vine still holds up',
           ),
         ]);
         stubProfiles({});
@@ -2159,8 +2178,44 @@ void main() {
         final page = await repository.getNotifications();
         final item = page.items.single as ActorNotification;
         expect(item.type, equals(NotificationKind.likeComment));
-        expect(item.targetEventId, equals('comment_event_xyz'));
+        expect(item.commentText, equals('this vine still holds up'));
       });
+
+      test('likeComment truncates a long liked comment body', () async {
+        final body = 'a' * 120;
+        stubNotifications([
+          makeNotification(
+            targetCommentId: 'comment_event_xyz',
+            content: '+',
+            commentContent: body,
+          ),
+        ]);
+        stubProfiles({});
+
+        final page = await repository.getNotifications();
+        final item = page.items.single as ActorNotification;
+        expect(item.commentText, equals('${'a' * 50}...'));
+      });
+
+      test(
+        'likeComment leaves commentText null when the server omits the body',
+        () async {
+          stubNotifications([
+            makeNotification(
+              targetCommentId: 'comment_event_xyz',
+              content: '+',
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as ActorNotification;
+          expect(item.type, equals(NotificationKind.likeComment));
+          // Never the reaction emoji — a row quoting "+" is worse than one
+          // quoting nothing.
+          expect(item.commentText, isNull);
+        },
+      );
 
       test(
         'likeComment carries root addressable id for direct video routing',
@@ -2169,8 +2224,7 @@ void main() {
               '${NIP71VideoKinds.addressableShortVideo}:other_owner:root-d-tag';
           stubNotifications([
             makeNotification(
-              isReferencedVideo: false,
-              referencedEventId: 'comment_event_xyz',
+              targetCommentId: 'comment_event_xyz',
               rootAddressableId: rootAddressableId,
             ),
           ]);
@@ -2189,8 +2243,7 @@ void main() {
         () async {
           stubNotifications([
             makeNotification(
-              isReferencedVideo: false,
-              referencedEventId: 'comment_event_xyz',
+              targetCommentId: 'comment_event_xyz',
               referencedDTag: 'vine-abc',
             ),
           ]);
@@ -2208,8 +2261,7 @@ void main() {
         () async {
           stubNotifications([
             makeNotification(
-              isReferencedVideo: false,
-              referencedEventId: 'comment_event_xyz',
+              targetCommentId: 'comment_event_xyz',
               // referencedDTag intentionally omitted
             ),
           ]);

--- a/mobile/test/notifications/widgets/actor_notification_row_test.dart
+++ b/mobile/test/notifications/widgets/actor_notification_row_test.dart
@@ -300,6 +300,30 @@ void main() {
         expect(find.byType(NotificationCommentQuote), findsOneWidget);
       });
 
+      testWidgets('quotes the liked comment beneath a likeComment message', (
+        tester,
+      ) async {
+        // Without the quote the row reads "Alice liked your comment" and
+        // names neither the comment nor the video it lives on.
+        await _pump(
+          tester,
+          notification: _actor(
+            type: NotificationKind.likeComment,
+            commentText: 'this vine still holds up',
+          ),
+        );
+
+        expect(
+          find.textContaining(_l10n.notificationLikedYourComment('Alice')),
+          findsOneWidget,
+        );
+        expect(find.byType(NotificationCommentQuote), findsOneWidget);
+        final quote = tester.widget<NotificationCommentQuote>(
+          find.byType(NotificationCommentQuote),
+        );
+        expect(quote.text, equals('this vine still holds up'));
+      });
+
       testWidgets('timestamp moves to the quote when commentText is present', (
         tester,
       ) async {

--- a/mobile/test/notifications/widgets/actor_notification_row_test.dart
+++ b/mobile/test/notifications/widgets/actor_notification_row_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for ActorNotificationRow — follow / mention / system /
-// ABOUTME: likeComment / reply rendering, follow-back button visibility,
+// ABOUTME: like / likeComment / reply rendering, follow-back button visibility,
 // ABOUTME: and tap callbacks.
 
 import 'package:divine_ui/divine_ui.dart';
@@ -131,6 +131,24 @@ void main() {
         expect(
           find.textContaining(_l10n.notificationLikedYourComment('Alice')),
           findsOneWidget,
+        );
+      });
+
+      testWidgets('"{actor} liked your video" for anchorless like', (
+        tester,
+      ) async {
+        await _pump(
+          tester,
+          notification: _actor(type: NotificationKind.like),
+        );
+
+        expect(
+          find.textContaining(_l10n.notificationLikedYourVideo('Alice')),
+          findsOneWidget,
+        );
+        expect(
+          find.textContaining(_l10n.notificationLikedYourComment('Alice')),
+          findsNothing,
         );
       });
 

--- a/mobile/test/services/notification_target_resolver_test.dart
+++ b/mobile/test/services/notification_target_resolver_test.dart
@@ -109,6 +109,31 @@ void main() {
     );
 
     test(
+      'resolves addressable video from NIP-25 lowercase a tag on reaction',
+      () async {
+        const rootAddressableId =
+            '34236:'
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+            ':vine-stable-id';
+
+        when(
+          () => videoEventService.getVideoById('reaction_with_a'),
+        ).thenReturn(null);
+        when(() => nostrClient.fetchEventById('reaction_with_a')).thenAnswer(
+          (_) async => Event('b' * 64, 7, const [
+            ['a', rootAddressableId],
+            ['k', '34236'],
+          ], '+'),
+        );
+
+        final resolved = await resolver
+            .resolveVideoEventIdFromNotificationTarget('reaction_with_a');
+
+        expect(resolved, equals(rootAddressableId));
+      },
+    );
+
+    test(
       'resolves root video from NIP-22 uppercase E tag on top-level comment',
       () async {
         const rootVideoId = 'root_video_toplevel';


### PR DESCRIPTION
Closes #6806

Notification rows read "X liked your comment" with no thumbnail, no quote, and no way to tell which comment — or, more often, which video. Two independent causes.

## 1. Video likes were classified as comment likes

`_mapNotificationKind` treated a missing `referenced_video` block as evidence of a comment target:

```dart
if (targetsComment) return NotificationKind.likeComment;
return n.isReferencedVideo
    ? NotificationKind.like
    : NotificationKind.likeComment;  // ← guess
```

`isReferencedVideo` is just `json['referenced_video'] != null` — whether Funnelcake managed to join the video row. It is absent whenever the root video fails to resolve (unindexed, deleted), and it is *present* for genuine comment likes too, because Funnelcake fills it from the root video either way. The function's own doc comment already said so: "`isReferencedVideo` cannot be used for this split".

Net effect: an ordinary like on your own video became "liked your comment", actor-anchored and therefore stripped of its thumbnail.

#5883 added `target_comment_id` as the positive comment signal but left the negative fallback in place. This drops it — a reaction without a target comment is a `like`.

The residual case (Funnelcake can't resolve the comment, so `target_comment_id` is empty on a real comment like) is still caught downstream by the owner-mismatch reclassification from #4813/#5634, which requires a confirmed metadata 404 *plus* a foreign `root_event_pubkey` before rewriting the row.

## 2. `likeComment` rows carried no context at all

Even when the classification was right, the row named nothing. The reaction's `content` is the emoji (`+`), and `_truncateComment` returned null for every kind that wasn't `comment` or `reply`.

Funnelcake already returns the liked comment's body as `comment_content` (`crates/clickhouse/src/queries.rs`, asserted in the OpenAPI schema) — the Flutter DTO simply never parsed it. Parsed now and threaded through as the quote source for `likeComment` rows, so the row renders:

> ❤️ **4th_Chaos** liked your comment
> "this vine still holds up" 9h

Server-side change: none. `NotificationCommentQuote` and the cache round-trip both work generically off `commentText`, so cold-start hydration keeps the quote.

## Testing

- `notification_repository`: new regression test that an unresolved referenced video stays `like`; three tests for the quote (body, truncation, null when the server omits it). Five existing tests that used `isReferencedVideo: false` as a stand-in for "comment like" now use `targetCommentId`, the actual signal. 167 pass, coverage 95.71% (gate 94%).
- `funnelcake_api_client`: three `comment_content` parse tests. 377 pass.
- `mobile/test/notifications`: widget test that a `likeComment` row renders the quote. 208 pass.
- `flutter analyze lib test integration_test` clean; adjacent notification/inbox suites (430 tests) pass.

Screenshots to follow once this is on a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Reviewer takeover follow-up

A reviewer follow-up preserves anchorless (`a`-tag-only) reactions as actor-backed likes while keeping the display invariant: a row that says "liked your video" only gets a direct `videoAddressableId` when the root coordinate is a video coordinate owned by the notification recipient. Foreign root coordinates are withheld and taps fall back to resolving the reaction event. `likeComment` and `reply` may still carry a foreign root video coordinate because those rows are about the recipient's comment on that video, not an ownership claim on the video itself.

The tap resolver now also follows lowercase `a` tags on NIP-25 reactions, so anchorless addressable-video likes can still open the video when Funnelcake omits `root_addressable_id`.

Additional verification: `flutter test --coverage` in `mobile/packages/notification_repository` passed at 95.77% line coverage, plus targeted resolver, DTO/model, widget, and analyzer checks.
