### PR TITLE
fix(build): drop references to the deleted publish diagnostics

### DIFF
--- a/mobile/lib/repositories/relay_list_repository.dart
+++ b/mobile/lib/repositories/relay_list_repository.dart
@@ -176,7 +176,6 @@ class RelayListRepository {
       signed,
       targetRelays: targetRelays,
       timeout: _relayListPublishTimeout,
-      diagnosticTag: 'relay-list-kind-10002',
     );
     final acceptedByIndexer = outcome.acceptedBy.any(
       _environment.indexerRelays.contains,

--- a/mobile/test/repositories/relay_list_repository_test.dart
+++ b/mobile/test/repositories/relay_list_repository_test.dart
@@ -58,7 +58,6 @@ void main() {
         any(),
         targetRelays: any(named: 'targetRelays'),
         timeout: any(named: 'timeout'),
-        diagnosticTag: any(named: 'diagnosticTag'),
       ),
     ).thenAnswer((invocation) async {
       final event = invocation.positionalArguments.first as Event;
@@ -99,7 +98,6 @@ void main() {
           captureAny(),
           targetRelays: captureAny(named: 'targetRelays'),
           timeout: captureAny(named: 'timeout'),
-          diagnosticTag: 'relay-list-kind-10002',
         ),
       ).captured;
       // mocktail returns captures ordered by argument name, not call order.
@@ -139,7 +137,6 @@ void main() {
         any(),
         targetRelays: any(named: 'targetRelays'),
         timeout: any(named: 'timeout'),
-        diagnosticTag: any(named: 'diagnosticTag'),
       ),
     );
     expect(buildRepository().isDirty(pubkey), isFalse);
@@ -156,7 +153,6 @@ void main() {
         any(),
         targetRelays: any(named: 'targetRelays'),
         timeout: any(named: 'timeout'),
-        diagnosticTag: any(named: 'diagnosticTag'),
       ),
     );
     expect(buildRepository().isDirty(pubkey), isFalse);
@@ -170,7 +166,6 @@ void main() {
           any(),
           targetRelays: any(named: 'targetRelays'),
           timeout: any(named: 'timeout'),
-          diagnosticTag: any(named: 'diagnosticTag'),
         ),
       ).thenAnswer((invocation) async {
         final event = invocation.positionalArguments.first as Event;
@@ -211,7 +206,6 @@ void main() {
           any(),
           targetRelays: any(named: 'targetRelays'),
           timeout: any(named: 'timeout'),
-          diagnosticTag: any(named: 'diagnosticTag'),
         ),
       );
 
@@ -224,7 +218,6 @@ void main() {
           any(),
           targetRelays: any(named: 'targetRelays'),
           timeout: any(named: 'timeout'),
-          diagnosticTag: any(named: 'diagnosticTag'),
         ),
       ).called(1);
       expect(repository.isDirty(pubkey), isFalse);

--- a/mobile/test/services/curated_list_service_collaboration_test.dart
+++ b/mobile/test/services/curated_list_service_collaboration_test.dart
@@ -51,7 +51,6 @@ void main() {
         final event = invocation.positionalArguments[0] as Event;
         return PublishOutcome(
           eventId: event.id,
-          eventKind: event.kind,
           acceptedBy: const ['wss://relay.test'],
           rejectedBy: const {},
           noResponseFrom: const [],

--- a/mobile/test/services/curated_list_service_crud_test.dart
+++ b/mobile/test/services/curated_list_service_crud_test.dart
@@ -30,7 +30,6 @@ const _otherPubkey =
 /// An outcome one relay accepted — what [PublishOutcome.acceptedByAny] gates on.
 PublishOutcome _accepted(Event event) => PublishOutcome(
   eventId: event.id,
-  eventKind: event.kind,
   acceptedBy: const ['wss://relay.test'],
   rejectedBy: const {},
   noResponseFrom: const [],
@@ -39,7 +38,6 @@ PublishOutcome _accepted(Event event) => PublishOutcome(
 /// An outcome no relay accepted, so the caller may roll local state back.
 PublishOutcome _rejected(Event event) => PublishOutcome(
   eventId: event.id,
-  eventKind: event.kind,
   acceptedBy: const [],
   rejectedBy: const {'wss://relay.test': 'blocked'},
   noResponseFrom: const [],

--- a/mobile/test/services/curated_list_service_persistence_test.dart
+++ b/mobile/test/services/curated_list_service_persistence_test.dart
@@ -62,7 +62,6 @@ void main() {
         final event = invocation.positionalArguments[0] as Event;
         return PublishOutcome(
           eventId: event.id,
-          eventKind: event.kind,
           acceptedBy: const ['wss://relay.test'],
           rejectedBy: const {},
           noResponseFrom: const [],

--- a/mobile/test/services/curated_list_service_playlist_test.dart
+++ b/mobile/test/services/curated_list_service_playlist_test.dart
@@ -61,7 +61,6 @@ void main() {
         final event = invocation.positionalArguments[0] as Event;
         return PublishOutcome(
           eventId: event.id,
-          eventKind: event.kind,
           acceptedBy: const ['wss://relay.test'],
           rejectedBy: const {},
           noResponseFrom: const [],

--- a/mobile/test/services/curated_list_service_query_test.dart
+++ b/mobile/test/services/curated_list_service_query_test.dart
@@ -65,7 +65,6 @@ void main() {
         final event = invocation.positionalArguments[0] as Event;
         return PublishOutcome(
           eventId: event.id,
-          eventKind: event.kind,
           acceptedBy: const ['wss://relay.test'],
           rejectedBy: const {},
           noResponseFrom: const [],

--- a/mobile/test/services/curated_list_service_video_management_test.dart
+++ b/mobile/test/services/curated_list_service_video_management_test.dart
@@ -51,7 +51,6 @@ void main() {
         final event = invocation.positionalArguments[0] as Event;
         return PublishOutcome(
           eventId: event.id,
-          eventKind: event.kind,
           acceptedBy: const ['wss://relay.test'],
           rejectedBy: const {},
           noResponseFrom: const [],
@@ -87,7 +86,6 @@ void main() {
         final event = invocation.positionalArguments[0] as Event;
         return PublishOutcome(
           eventId: event.id,
-          eventKind: event.kind,
           acceptedBy: const ['wss://relay.test'],
           rejectedBy: const {},
           noResponseFrom: const [],


### PR DESCRIPTION
## Summary

`main` is currently red. `flutter analyze lib test integration_test` reports **16 `undefined_named_parameter` errors**, one of them in production code (`lib/repositories/relay_list_repository.dart:179`).

## Cause

A semantic conflict that no textual merge check could catch:

- **#6731** removed `diagnosticTag` from `NostrClient.publishEventAwaitOk` / `Nostr.sendEventAwaitOk` / `RelayPool`, and removed `eventKind` from `PublishOutcome` / `PublishTracker`.
- **#6721** (merged 2026-08-05, a day earlier) had already added a `diagnosticTag: 'relay-list-kind-10002'` caller in `RelayListRepository`.
- The curated-list service tests construct `PublishOutcome(... eventKind: event.kind ...)`.

Those files don't overlap with #6731's diff, so GitHub reported `MERGEABLE / CLEAN` for both and each side's CI was green against its own base. The breakage only exists in the *combination*.

## Fix

Drops the dead arguments rather than restoring the parameters — #6731's intent was to delete the rollout-only diagnostics, and nothing reads them.

| File | Removed |
|---|---|
| `lib/repositories/relay_list_repository.dart` | 1 × `diagnosticTag:` |
| `test/repositories/relay_list_repository_test.dart` | 7 × `diagnosticTag:` |
| `test/services/curated_list_service_*_test.dart` (6 files) | 8 × `eventKind: event.kind,` |

16 deletions, no behaviour change.

## Verification

- `flutter analyze lib test integration_test` — **No issues found** (was 16 errors)
- `flutter test` over all 7 affected suites — **192 passing**
- `dart format --set-exit-if-changed` — clean

## Note for #6746

`fix/6585-bound-relay-list-admission` passes `eventKind:` to `RelayPool.sendEventAwaitOk` in two new test files. It will hit the same wall on its next rebase; the fix there is dropping those two lines.