### PR TITLE
docs(agents): gate PR takeovers on authorship and green CI

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,6 +17,7 @@ Generic Flutter and Dart standards live in `.claude/rules/`:
 
 - `rules/self_review_checklist.md`: consolidated pre-plan / pre-commit / pre-PR checklist
 - `rules/agent_workflow.md`: worktree-from-`origin/main`, rebase-at-boundaries, no-stacked-PRs, no-tech-debt, failing-tests-are-your-fault
+- `rules/pr_takeover.md`: check PR authorship *first*, takeover gates, answer every review item, never hand back before CI is green
 - `rules/architecture.md`: layered flow, package boundaries, barrel files
 - `rules/state_management.md`: BLoC-first UI, BlocProvider laziness, cross-route state persistence, Riverpod legacy rules, event transformers
 - `rules/code_style.md`: naming, widget composition, Effective Dart guidance

--- a/.claude/rules/agent_workflow.md
+++ b/.claude/rules/agent_workflow.md
@@ -158,9 +158,11 @@ inherit cold.
 assumption is that any failing test on a feature branch is caused by
 something in that branch's diff — start there every time.
 
-That default is a starting point, not an axiom. `main` is not
-protected by required status checks, so a red commit *can* land on it,
-and when one does, every open PR inherits the failure. Assume the
+That default is a starting point, not an axiom. Required checks can
+pass and still be **stale**: a PR tested days ago can merge into a
+`main` that has since gained a semantically conflicting change — no
+textual conflict, no re-run, green badge, broken `main`. When that
+happens every open PR behind it inherits the failure. Assume the
 failure is yours until you have positively proven otherwise, and prove
 it the specific way described in "When the failure is not yours"
 below. Never assert it from vibes.
@@ -200,9 +202,18 @@ the local environment differs from CI. Investigate the difference.
 
 ### When the failure is not yours
 
-Rare, but real — `main` has no required status checks, so a red commit
-can land and break every open PR behind it. Before you may say this,
-prove it. Two checks, both required:
+Rare, but real. The usual cause is a **stale-check merge**: PR A
+removes an API, PR B adds a caller, both go green independently, and
+whichever merges second lands without re-running against the other.
+Nothing conflicts textually, so `main` breaks and every open PR behind
+it inherits the failure.
+
+`origin/main` broke exactly this way on 2026-08-07: #6731 removed
+`diagnosticTag` / `eventKind` from `nostr_sdk` and merged with checks
+that had last run 46 hours earlier, by which point #6721 and #6617 had
+added callers.
+
+Before you may claim this, prove it. Two checks, both required:
 
 1. **The failing symbol is outside your diff.** Confirm the files and
    identifiers in the failure do not appear in

--- a/.claude/rules/agent_workflow.md
+++ b/.claude/rules/agent_workflow.md
@@ -230,10 +230,14 @@ Before you may claim this, prove it. Two checks, both required:
    branch. Different errors mean you have two problems, one of them
    yours.
 
-Then find what unblocks it — usually an open PR already fixing it:
+Then find what unblocks it — usually an open PR already fixing it. Do
+not trust PR prose search by itself: GitHub tokenizes terms and can
+return noisy matches. Start from the code history, then verify any
+candidate PR by reading its diff:
 
 ```bash
-gh pr list --state open --search "<failing symbol>"
+git log --oneline -S"<failing symbol>" origin/main
+gh pr list --state open --search "<failing symbol>"   # hint only
 ```
 
 Having proven it, **stop and report**. Do not patch around a broken

--- a/.claude/rules/agent_workflow.md
+++ b/.claude/rules/agent_workflow.md
@@ -154,8 +154,16 @@ inherit cold.
 
 ## 5. Failing tests are never acceptable, and always your fault
 
-**`origin/main` always passes.** Therefore any failing test on a feature
-branch is caused by something in that branch's diff. Full stop.
+**`origin/main` is supposed to always pass.** So your default
+assumption is that any failing test on a feature branch is caused by
+something in that branch's diff — start there every time.
+
+That default is a starting point, not an axiom. `main` is not
+protected by required status checks, so a red commit *can* land on it,
+and when one does, every open PR inherits the failure. Assume the
+failure is yours until you have positively proven otherwise, and prove
+it the specific way described in "When the failure is not yours"
+below. Never assert it from vibes.
 
 When an agent says *"this test is flaky"* or *"this was already broken
 on main"* or *"we'll fix it in a follow-up,"* it is almost always
@@ -190,11 +198,50 @@ the local environment differs from CI. Investigate the difference.
    pass unless the test was genuinely wrong (rare — be suspicious of
    yourself when you reach for this).
 
+### When the failure is not yours
+
+Rare, but real — `main` has no required status checks, so a red commit
+can land and break every open PR behind it. Before you may say this,
+prove it. Two checks, both required:
+
+1. **The failing symbol is outside your diff.** Confirm the files and
+   identifiers in the failure do not appear in
+   `git diff origin/main... --stat`.
+2. **`main` itself is red, at its own HEAD.** Not inferred — read it:
+
+   ```bash
+   gh run list --branch main --workflow "Mobile CI" --limit 5 \
+     --json conclusion,headSha,createdAt
+   gh run view <failing-run-id> --log-failed | grep -iE "error •"
+   ```
+
+   The errors on `main`'s run must be the *same* errors as on your
+   branch. Different errors mean you have two problems, one of them
+   yours.
+
+Then find what unblocks it — usually an open PR already fixing it:
+
+```bash
+gh pr list --state open --search "<failing symbol>"
+```
+
+Having proven it, **stop and report**. Do not patch around a broken
+`main` inside an unrelated PR: you would be shipping someone else's
+fix in a diff nobody expects it in, and it collides with the real fix
+when that merges. Name the breaking commit, name the fixing PR, and
+say the PR is blocked until it lands.
+
+If `main` is green and your branch is red, it is yours. Go back to
+step 1.
+
 ### Forbidden
 
 - *"Flaky, will retry"* — find the race or order-dependence and fix it.
 - `skip:` / `@Skip` / `xtest` to silence a failing test.
-- *"Already broken on main"* without verifying on `origin/main`.
+- *"Already broken on main"* without running both proof checks above
+  and naming the breaking commit.
+- Patching an unrelated broken-`main` failure inside your own PR
+  instead of reporting it.
 - Pushing with red local tests "to see what CI says."
 - Claiming "tests pass" without having actually run them — see
   `superpowers:verification-before-completion`.
@@ -208,3 +255,12 @@ the local environment differs from CI. Investigate the difference.
 - If this is a PR-review fix without a rebase, verify GitHub reports no
   merge conflicts before relying on that exception.
 - If anything is red, do not push. Fix it.
+
+### After every push
+
+Local green does not end the task — CI green does.
+
+- `gh pr checks <number> --watch`, then read the result.
+- Red → fix and push again, until green.
+- Only after checks have *finished* do you post the handback comment
+  or report the task complete. See `pr_takeover.md` §3.

--- a/.claude/rules/pr_takeover.md
+++ b/.claude/rules/pr_takeover.md
@@ -11,7 +11,10 @@ it lives outside this repo — loaded via a SessionStart hook for Claude
 Code and via `~/.codex/AGENTS.md` for Codex. **Do not depend on it
 being loaded.** The gates below are the repo-local minimum and apply
 whether or not the handbook is in context. Where the two overlap,
-`PR_REVIEW.md` is authoritative and this file is the floor.
+`PR_REVIEW.md` is authoritative and this file is the floor. If
+`PR_REVIEW.md` or its team mapping is unavailable, same-repo takeover
+must stop: leave the PR open and report the missing runbook as the
+blocker.
 
 ---
 
@@ -28,6 +31,8 @@ gh api user --jq .login   # who am I authenticated as?
 ```
 
 Compare `author.login` against the authenticated account.
+`maintainerCanModify` is meaningful only when `isCrossRepository` is
+true; same-repo PRs can report `false` even when you can push.
 
 | Case | What it means | Which rules apply |
 |---|---|---|

--- a/.claude/rules/pr_takeover.md
+++ b/.claude/rules/pr_takeover.md
@@ -1,0 +1,148 @@
+# Working on an existing PR
+
+This file covers the case where the branch already exists and a pull
+request is already open on it — you are pushing to someone's PR rather
+than starting fresh work. `agent_workflow.md` covers new work; this
+file covers everything that happens after a PR exists.
+
+The cross-repo runbook is `PR_REVIEW.md` in the `divine-context`
+handbook. That file is the source of truth for takeover authority, and
+it lives outside this repo — loaded via a SessionStart hook for Claude
+Code and via `~/.codex/AGENTS.md` for Codex. **Do not depend on it
+being loaded.** The gates below are the repo-local minimum and apply
+whether or not the handbook is in context. Where the two overlap,
+`PR_REVIEW.md` is authoritative and this file is the floor.
+
+---
+
+## 1. Establish authorship before you touch anything
+
+**This is the first step, before reading the diff, before running
+tests, before planning a fix.** Which of the three cases you are in
+changes every rule that follows.
+
+```bash
+gh pr view <number> --json number,author,headRefName,isCrossRepository,\
+state,isDraft,mergeStateStatus,maintainerCanModify
+gh api user --jq .login   # who am I authenticated as?
+```
+
+Compare `author.login` against the authenticated account.
+
+| Case | What it means | Which rules apply |
+|---|---|---|
+| `author.login` == you | **You are the author.** Not a takeover. | Author gates (§3, §4). Takeover gates do not apply — you cannot review or approve your own PR. |
+| `author.login` != you, `isCrossRepository` false | **Same-repo takeover.** | Every gate in `PR_REVIEW.md` §"Shared takeover gates", then §3, §4. |
+| `isCrossRepository` true | **Fork PR.** | Takeover gates *plus* `maintainerCanModify` must be true. If false, you cannot push — use suggested changes or a review comment. |
+
+Additional read-only cases, regardless of authorship:
+
+- `isDraft` true → read-only unless the author explicitly asked for
+  implementation.
+- The request was framed as feedback-only → read-only.
+
+**Never discover authorship by trial and error.** If your first
+signal that you are the author is GitHub rejecting the call —
+`Review Can not request changes on your own pull request`, or
+`Can not approve your own pull request` — you skipped this step and
+every downstream decision was made under the wrong model. Back up and
+redo the triage.
+
+### When you are the author
+
+Working as the author is not the relaxed path — it is the stricter one:
+
+- You cannot submit `APPROVED` or `CHANGES_REQUESTED` on your own PR.
+  Findings you cannot resolve go in a **regular issue comment**,
+  clearly labelled as a blocker or an open decision.
+- There is nobody downstream to catch a red build. §3 is unconditional.
+- "Escalate to the author for a judgment call" resolves to **escalate
+  to the human running the session**. Say so plainly and stop; do not
+  decide it yourself because you happen to hold the author's
+  credentials.
+
+---
+
+## 2. Answer every review item, or say why not
+
+Before pushing, enumerate the review items and decide each one. Fetch
+inline threads too — a PR can carry substantive findings with zero
+inline threads, or findings only in outdated threads:
+
+```bash
+gh pr view <number> --json reviews --jq '.reviews[] | "\(.author.login) \(.state)\n\(.body)"'
+gh api graphql -f query='
+{ repository(owner:"divinevideo",name:"divine-mobile"){ pullRequest(number:NNN){
+  reviewThreads(first:100){ nodes { isResolved isOutdated path line
+    comments(first:10){ nodes { author{login} body } } } } } } }'
+```
+
+Every item lands in exactly one bucket: **fixed**, **escalated**
+(needs product/architecture judgment — name the decision), or
+**declined** (say why). An item you silently skip reads to the
+reviewer as an item you fixed.
+
+State the buckets in the handback comment. A summary that lists four
+bullets of what you changed, when the review raised eight items, is a
+misleading handback even when every bullet is true.
+
+**Do not add unrequested changes without flagging them.** If you find
+a real bug the reviewer did not raise, that is worth fixing — but call
+it out separately as *not requested by the review*, especially when it
+carries user-visible blast radius (cache-key bumps that invalidate
+every device, migrations, schema changes, defaults). Bury it in a
+bullet list of review fixes and nobody signs off on it.
+
+---
+
+## 3. Do not hand back until checks are green
+
+**Pushing is not the end of the task. Green CI is.**
+
+After every push to a PR branch, wait for the checks to finish and
+read the result:
+
+```bash
+gh pr checks <number> --watch
+```
+
+Then, and only then, post the handback comment.
+
+**Forbidden:**
+
+- Posting "I pushed the fixes" before checks have completed. The
+  comment must be written *after* you have read the result, not
+  optimistically alongside the push.
+- Ending the turn with red checks and no explanation.
+- Reporting a subset of checks as "green" when others are red or
+  still running.
+
+If checks are red, fix them and push again. Repeat until green. A
+failure you introduced is yours to fix — see
+`agent_workflow.md` §5.
+
+The **only** acceptable red handback is a failure you have positively
+proven is not caused by your diff. Proving it means naming the actual
+cause — the commit, the PR, or the ref that broke it — following the
+procedure in `agent_workflow.md` §5 ("When the failure is not yours").
+"Looks unrelated" is not proof. When you do hand back red, the comment
+must state the blocking cause and what unblocks it.
+
+---
+
+## 4. Scope, commits, and history
+
+- Keep changes within the intent and reasonable scope of the PR.
+- Push each distinct finding as its own commit where practical, so the
+  author can revert one without losing the others.
+- Do not force-push someone else's branch unless a rebase is required
+  by merge conflicts or stale-base policy, or the author authorized
+  the rewrite. When you must, use `--force-with-lease`.
+- If GitHub reports no merge conflicts and your push only addresses
+  review feedback, do not rebase to refresh history — see
+  `agent_workflow.md` §2.
+- Never modify workflows, security-sensitive code, permission
+  boundaries, infrastructure, deploy config, or release automation
+  through takeover without separate explicit authorization.
+
+The author keeps the merge decision. Takeover never includes merging.

--- a/.claude/rules/self_review_checklist.md
+++ b/.claude/rules/self_review_checklist.md
@@ -169,9 +169,11 @@ Then:
 - [ ] No unused imports, unused locals, dead code from a removed
   approach.
 - [ ] Format, analyze, and scoped tests all pass locally. **Never push
-  red** — `origin/main` always passes, so any failing test on your
-  branch is caused by your diff. See
-  [`agent_workflow.md`](agent_workflow.md#5-failing-tests-are-never-acceptable-and-always-your-fault).
+  red** — assume any failing test on your branch is caused by your diff.
+  In the rare case it genuinely isn't, prove it both ways and report
+  rather than patch. See
+  [`agent_workflow.md`](agent_workflow.md#5-failing-tests-are-never-acceptable-and-always-your-fault)
+  and [when the failure is not yours](agent_workflow.md#when-the-failure-is-not-yours).
 - [ ] Generated files (Riverpod, Freezed, JSON, Mockito, Drift) are
   regenerated and staged if you touched inputs.
 - [ ] `pubspec.lock` churn from a different SDK/pub-resolver run is

--- a/.claude/rules/self_review_checklist.md
+++ b/.claude/rules/self_review_checklist.md
@@ -10,6 +10,26 @@ before continuing.
 
 ---
 
+## Before touching an existing PR
+
+Do this **first** — before reading the diff, running tests, or planning
+a fix. See [`pr_takeover.md`](pr_takeover.md).
+
+- [ ] **Whose PR is this?** `gh pr view <n> --json author,isCrossRepository,isDraft,maintainerCanModify`
+  vs `gh api user --jq .login`. Your own PR, a same-repo takeover, and
+  a fork PR each carry different gates. Learning the answer from a
+  GitHub API rejection means you skipped this and re-triage is required.
+- [ ] If it's **your own** PR: you cannot review or approve it, and no
+  reviewer is downstream to catch a red build. Blockers go in a regular
+  issue comment, clearly labelled.
+- [ ] If it's **someone else's**: every gate in `PR_REVIEW.md` clears
+  before you push. Draft or feedback-only ⇒ read-only.
+- [ ] Every review item sorted into fixed / escalated / declined —
+  including inline threads fetched via GraphQL, and outdated ones.
+- [ ] Unrequested changes called out separately from review fixes.
+
+---
+
 ## Before starting any task
 
 Branch hygiene (see [`agent_workflow.md`](agent_workflow.md)):
@@ -186,6 +206,12 @@ Then:
 - [ ] CI: `build / build` (divine_ui coverage), `Analyze`,
   `Tests (shard N/total)` for every shard, aggregate `Mobile CI`,
   `Format`, `Generated Files` all green before requesting review.
+- [ ] **Checks watched to completion after the push**
+  (`gh pr checks <n> --watch`), not merely launched. The handback
+  comment is written *after* reading the result — never alongside the
+  push. Red ⇒ fix and push again until green. The only acceptable red
+  handback names the breaking commit and the PR that unblocks it; see
+  [`agent_workflow.md`](agent_workflow.md#when-the-failure-is-not-yours).
 
 ## Responding to review
 

--- a/.claude/rules/self_review_checklist.md
+++ b/.claude/rules/self_review_checklist.md
@@ -17,8 +17,10 @@ a fix. See [`pr_takeover.md`](pr_takeover.md).
 
 - [ ] **Whose PR is this?** `gh pr view <n> --json author,isCrossRepository,isDraft,maintainerCanModify`
   vs `gh api user --jq .login`. Your own PR, a same-repo takeover, and
-  a fork PR each carry different gates. Learning the answer from a
-  GitHub API rejection means you skipped this and re-triage is required.
+  a fork PR each carry different gates. Treat `maintainerCanModify` as
+  fork-only; same-repo PRs can report `false` even when mutable.
+  Learning the answer from a GitHub API rejection means you skipped this
+  and re-triage is required.
 - [ ] If it's **your own** PR: you cannot review or approve it, and no
   reviewer is downstream to catch a red build. Blockers go in a regular
   issue comment, clearly labelled.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ If a Divine Brain search or ask tool is available, you may use it for company me
 > See `.claude/rules/pr_takeover.md` for the full gates. The bullets below are the operational summary. These apply whether or not the `divine-context` `PR_REVIEW.md` handbook is loaded — do not assume it is.
 
 - **Establish authorship first**, before reading the diff, running tests, or planning a fix: `gh pr view <n> --json author,isCrossRepository,isDraft,maintainerCanModify` compared against `gh api user --jq .login`.
+  `maintainerCanModify` is meaningful only for fork PRs; same-repo PRs can report `false` even when you can push.
   - **Your own PR** — not a takeover. You cannot review or approve it. Findings you can't resolve go in a regular issue comment, labelled as a blocker. There is no reviewer downstream to catch a red build.
   - **Someone else's PR, same repo** — a takeover. Clear every gate in `PR_REVIEW.md` before pushing.
   - **Fork PR** (`isCrossRepository` true) — takeover gates *plus* `maintainerCanModify`. If false, you cannot push: use suggested changes or a review comment.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ If a Divine Brain search or ask tool is available, you may use it for company me
 
 - Do not accumulate technical debt. Fix issues in the PR that touches them; do not defer with TODOs, follow-up issues, skipped tests, or commented-out code. The only acceptable TODO is a transitional-code TODO with a tracking-issue link (see `.claude/rules/code_style.md`).
 - **Assume any failing test on a feature branch is caused by that branch's diff.** Never claim flakiness, never `@Skip` to silence a failure, never push red "to see what CI says." Run affected tests + `flutter analyze` before every push. See `.claude/rules/agent_workflow.md` for the diagnostic recipe when a test fails.
-- `main` has no required status checks, so a red commit can occasionally land there and break every open PR behind it. That is rare and never your first hypothesis. Before claiming it, prove it: the failing symbol is outside your diff **and** `main`'s own latest run failed with the same errors (`gh run list --branch main --workflow "Mobile CI"`). Then report the breaking commit and the PR that unblocks it — do not patch someone else's fix into your PR.
+- A red commit can occasionally land on `main` anyway — required checks pass but go **stale**, so PR A removing an API and PR B adding a caller can both be green and still break `main` when the second merges without re-running. Every open PR behind it then inherits the failure. That is rare and never your first hypothesis. Before claiming it, prove it: the failing symbol is outside your diff **and** `main`'s own latest run failed with the same errors (`gh run list --branch main --workflow "Mobile CI"`). Then report the breaking commit and the PR that unblocks it — do not patch someone else's fix into your PR.
 
 ## Bug-Fix Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,10 +62,26 @@ If a Divine Brain search or ask tool is available, you may use it for company me
 - Open a pull request for that branch once the change is ready for review. Do not leave finished work sitting only in a local branch or worktree.
 - Keep PRs focused and reviewable. If two pieces of work are *truly independent*, split them into separate PRs each targeting `main`. If they depend on each other, **combine them into one PR** rather than splitting and stacking.
 
+## Working On An Existing PR
+
+> See `.claude/rules/pr_takeover.md` for the full gates. The bullets below are the operational summary. These apply whether or not the `divine-context` `PR_REVIEW.md` handbook is loaded — do not assume it is.
+
+- **Establish authorship first**, before reading the diff, running tests, or planning a fix: `gh pr view <n> --json author,isCrossRepository,isDraft,maintainerCanModify` compared against `gh api user --jq .login`.
+  - **Your own PR** — not a takeover. You cannot review or approve it. Findings you can't resolve go in a regular issue comment, labelled as a blocker. There is no reviewer downstream to catch a red build.
+  - **Someone else's PR, same repo** — a takeover. Clear every gate in `PR_REVIEW.md` before pushing.
+  - **Fork PR** (`isCrossRepository` true) — takeover gates *plus* `maintainerCanModify`. If false, you cannot push: use suggested changes or a review comment.
+  - Draft PRs and feedback-only requests are read-only unless the author explicitly asks for implementation.
+- Never discover authorship by trial and error. GitHub refusing the call with `Can not request changes on your own pull request` means the triage step was skipped and every decision after it was made under the wrong model.
+- **Answer every review item.** Sort each into fixed / escalated / declined and say which in the handback. An item you skip silently reads as an item you fixed. Fetch inline threads via GraphQL too — substantive findings can live entirely in the review body, or only in outdated threads.
+- Flag unrequested changes separately from review fixes, especially anything with user-visible blast radius (cache-key bumps, migrations, changed defaults).
+- **Do not hand back until checks are green.** After every push: `gh pr checks <n> --watch`, read the result, *then* comment. Posting "I pushed the fixes" before checks finish is forbidden. The only acceptable red handback is a failure positively proven not to come from your diff, with the breaking commit named — see the broken-`main` procedure in `.claude/rules/agent_workflow.md`.
+- The author keeps the merge decision. Takeover never includes merging.
+
 ## No Technical Debt, No Failing Tests
 
 - Do not accumulate technical debt. Fix issues in the PR that touches them; do not defer with TODOs, follow-up issues, skipped tests, or commented-out code. The only acceptable TODO is a transitional-code TODO with a tracking-issue link (see `.claude/rules/code_style.md`).
-- **`origin/main` always passes.** Any failing test on a feature branch is caused by that branch's diff. Never claim flakiness, never `@Skip` to silence a failure, never push red "to see what CI says." Run affected tests + `flutter analyze` before every push. See `.claude/rules/agent_workflow.md` for the diagnostic recipe when a test fails.
+- **Assume any failing test on a feature branch is caused by that branch's diff.** Never claim flakiness, never `@Skip` to silence a failure, never push red "to see what CI says." Run affected tests + `flutter analyze` before every push. See `.claude/rules/agent_workflow.md` for the diagnostic recipe when a test fails.
+- `main` has no required status checks, so a red commit can occasionally land there and break every open PR behind it. That is rare and never your first hypothesis. Before claiming it, prove it: the failing symbol is outside your diff **and** `main`'s own latest run failed with the same errors (`gh run list --branch main --workflow "Mobile CI"`). Then report the breaking commit and the PR that unblocks it — do not patch someone else's fix into your PR.
 
 ## Bug-Fix Workflow
 
@@ -140,7 +156,7 @@ If a Divine Brain search or ask tool is available, you may use it for company me
 - Delete temporary debugging artifacts before commit.
 - If a generated file must be committed, make sure it is reproducible and relevant to the change.
 - Before opening the PR, review the diff and remove stray edits, generated junk, logs, scratch files, and half-finished experiments.
-- After opening or updating a PR, inspect GitHub checks and rerun stale semantic jobs if needed.
+- After opening or updating a PR, wait for GitHub checks to finish (`gh pr checks <n> --watch`), fix anything red, and rerun stale semantic jobs if needed. Do not report the task complete while checks are red or still running.
 - After a branch is merged or abandoned, prune the worktree and branch so stale task state does not accumulate.
 
 ## metaswarm


### PR DESCRIPTION
## Description

Agents (Claude and Codex) have repeatedly pushed to open PRs without first establishing **whose PR it is**, and have posted "I pushed the fixes" handbacks *before* CI finished — leaving PRs red with no explanation and no owner.

The concrete case: on #6767 the agent ran the full review-then-takeover flow assuming it was a reviewer, and only discovered it was the **author** when GitHub rejected its review with `Review Can not request changes on your own pull request`. By then every decision had been made under the wrong model. It also posted its handback comment at 02:36:33Z — the CI run logged its first error at 02:37:18Z and failed at 02:39:16Z. The comment was written before the checks could possibly have reported.

Three structural gaps, addressed here:

**1. The takeover rules were not in this repo.** `PR_REVIEW.md` — the whole authorship/takeover runbook — lives in the `divine-context` handbook, loaded via a machine-local SessionStart hook for Claude Code and `~/.codex/AGENTS.md` for Codex. Neither `AGENTS.md` nor `.claude/rules/*` contained the word "takeover" or any instruction to check authorship. Any agent without that hook had no rule to follow. New `.claude/rules/pr_takeover.md` plus an `AGENTS.md` section give both toolchains a repo-local floor; `PR_REVIEW.md` stays authoritative where they overlap.

**2. "Inspect GitHub checks" was too weak, and buried.** It was the last bullet of *Clean Workspace Expectations*. "Inspect" is not "block until green," and nothing forbade posting the handback before checks completed. Now an explicit post-push gate: `gh pr checks <n> --watch`, read the result, *then* comment.

**3. `agent_workflow.md` §5 asserted something false.** It said *"`origin/main` always passes. Therefore any failing test on a feature branch is caused by that branch's diff. Full stop."* `main` is red right now, and the mechanism is worth naming because the rules should teach it: required checks are enforced but can go **stale**. #6731 removed `diagnosticTag`/`eventKind` from `nostr_sdk` and merged 2026-08-07T02:01Z with checks that had last run 2026-08-05T03:45Z — 46 hours earlier, by which point #6721 had added `diagnosticTag` callers and #6617 had added `eventKind` callers. Two independently-green PRs, no textual conflict, no re-run, broken `main`. The absolute framing left an agent hitting that with no procedure except to hunt a phantom bug in its own diff. This keeps *assume it's your fault* as the default and adds a two-step proof plus a **report, don't patch** rule for the rare genuine case.

**Related Issue:** Relates to #6767

## Out of Scope

- **`main` is currently red** and #6807 is the fix. Not touched here — patching it into an unrelated PR is exactly what the new rule forbids.
- **Nothing here prevents the next stale-check merge.** Enabling *Require branches to be up to date before merging* on `main` is the control that would have caught #6731; that is a repo-settings decision, not a docs one.
- No changes to `PR_REVIEW.md` in the `divine-context` handbook — that repo is separate.

## Verification

- Documentation only: `AGENTS.md`, `.claude/CLAUDE.md`, `.claude/rules/*.md`. No Dart, config, or workflow files touched.
- Cross-references checked to resolve: `pr_takeover.md` §3 → `agent_workflow.md#when-the-failure-is-not-yours`, and the checklist anchors.

All checks green. `Detect App CI Scope` path-filters this as docs-only, so `Analyze`, `Format`, `Generated Files`, `Tests`, and `VGV Tag Gate` skip rather than run — this branch does not inherit the currently-broken `main` (#6731 removed `diagnosticTag`/`eventKind` from `nostr_sdk` but left the callsites; #6807 is the fix). PRs that do touch Dart are inheriting it.

## Type of Change

- [x] 📝 Documentation
