### PR TITLE
fix(video-editor): stop speed-render thrash stalling the encoder

### DIFF
--- a/mobile/lib/services/video_editor/clip_speed_render_service.dart
+++ b/mobile/lib/services/video_editor/clip_speed_render_service.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Pre-renders a clip's trimmed body at its playbackSpeed into a plain
 // ABOUTME: normal-rate file so the preview plays it at 1× instead of retiming live.
 
+import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 
@@ -84,6 +86,42 @@ class ClipSpeedRenderService {
     return speed > 0 && speed != 1.0 && clip.video?.file != null;
   }
 
+  /// How many speed bodies may encode natively at the same time.
+  ///
+  /// The canvas asks for a render per non-1× clip on every timeline change, so
+  /// a 28-clip draft would otherwise open 28 export sessions at once. Past a
+  /// couple of concurrent sessions the platform encoder stops making progress
+  /// and `pro_video_editor` fails them with a stall (`progress=0.00` after
+  /// 20s), which is slower *and* lossier than encoding them a few at a time.
+  static const _maxConcurrentRenders = 2;
+
+  int _activeRenders = 0;
+  final _waitingForSlot = Queue<Completer<void>>();
+
+  /// Resolves once a render slot is free. Slots are handed out FIFO so the
+  /// clips at the head of the timeline — the ones the user is most likely to
+  /// play first — finish first.
+  Future<void> _acquireRenderSlot() {
+    if (_activeRenders < _maxConcurrentRenders) {
+      _activeRenders++;
+      return Future<void>.value();
+    }
+    final waiter = Completer<void>();
+    _waitingForSlot.add(waiter);
+    return waiter.future;
+  }
+
+  /// Hands this slot straight to the next waiter, or gives it back to the pool
+  /// when nobody is queued. Passing it on keeps [_activeRenders] at the cap
+  /// instead of dipping below it between renders.
+  void _releaseRenderSlot() {
+    if (_waitingForSlot.isNotEmpty) {
+      _waitingForSlot.removeFirst().complete();
+      return;
+    }
+    _activeRenders--;
+  }
+
   Future<RenderedSpeedClip?> _render(DivineVideoClip clip, String key) async {
     // Reachable only via [render], which gates on [_needsRender] (video
     // non-null). Re-checked here so the type is provably non-null below.
@@ -122,23 +160,33 @@ class ClipSpeedRenderService {
       // Render only the trimmed body at the target speed, with no crop/transform
       // — the preview player crops the texture itself, exactly as it does for
       // the raw live-retimed clip, so nothing is double-cropped.
-      await VideoEditorRenderService.renderNativeVideoToFile(
-        tempOutput,
-        VideoRenderData(
-          id: 'speed_$hash',
-          videoSegments: [
-            VideoSegment(
-              video: video,
-              startTime: clip.trimStart == Duration.zero
-                  ? null
-                  : clip.trimStart,
-              endTime: clip.trimStart + clip.trimmedDuration,
-              playbackSpeed: clip.playbackSpeed,
-            ),
-          ],
-          shouldOptimizeForNetworkUse: true,
-        ),
-      );
+      await _acquireRenderSlot();
+      try {
+        // The editor may have closed, or this clip may have been edited again,
+        // while the request waited for a slot. Bailing here keeps a queued
+        // backlog from encoding bodies nobody will play — the case that kept
+        // the encoder busy for ~20s after the editor was torn down.
+        if (_isStale(renderGeneration)) return null;
+        await VideoEditorRenderService.renderNativeVideoToFile(
+          tempOutput,
+          VideoRenderData(
+            id: 'speed_$hash',
+            videoSegments: [
+              VideoSegment(
+                video: video,
+                startTime: clip.trimStart == Duration.zero
+                    ? null
+                    : clip.trimStart,
+                endTime: clip.trimStart + clip.trimmedDuration,
+                playbackSpeed: clip.playbackSpeed,
+              ),
+            ],
+            shouldOptimizeForNetworkUse: true,
+          ),
+        );
+      } finally {
+        _releaseRenderSlot();
+      }
       if (_isStale(renderGeneration)) {
         await _deleteQuietly(tempOutput);
         return null;
@@ -302,8 +350,14 @@ class ClipSpeedRenderService {
   /// instead of replayed stale if the OS keeps temp cache files around.
   static const _cacheVersion = 1;
 
+  /// Keyed by what the render actually bakes in — source file, trims and speed
+  /// — and deliberately **not** by [DivineVideoClip.id]. Duplicating a clip,
+  /// splitting one and undoing the split, or reopening a draft all mint fresh
+  /// ids for byte-identical bodies; keying on the id re-encoded every one of
+  /// them. Two clips that agree on all of these produce the same file, so they
+  /// can share a single render.
   String _key(DivineVideoClip clip) =>
-      'v$_cacheVersion|${clip.id}:${clip.video?.file?.path}:'
+      'v$_cacheVersion|${clip.video?.file?.path}:'
       '${clip.duration.inMicroseconds}:${clip.trimStart.inMicroseconds}:'
       '${clip.trimEnd.inMicroseconds}:${clip.playbackSpeed ?? 1.0}';
 

--- a/mobile/test/services/video_editor/clip_speed_render_service_test.dart
+++ b/mobile/test/services/video_editor/clip_speed_render_service_test.dart
@@ -207,6 +207,92 @@ void main() {
         expect(service.render(clip('a')), completion(isNull));
         expect(service.isRendering(clip('a')), isFalse);
       });
+
+      test('reuses one render for clips that differ only by id', () async {
+        final native = _FakeProVideoEditor();
+        editor.ProVideoEditor.instance = native;
+        final service = ClipSpeedRenderService();
+
+        // A duplicated / re-split clip: fresh id, byte-identical body.
+        final original = clip('a', playbackSpeed: 2);
+        final duplicate = clip(
+          'a_copy_123',
+          playbackSpeed: 2,
+          path: '/tmp/a.mp4',
+        );
+
+        final first = service.render(original);
+        await pumpEventQueue();
+        native.allowRenderToFinishAt(0).complete();
+        await first;
+
+        expect(service.cached(duplicate), isNotNull);
+        await expectLater(service.render(duplicate), completes);
+        expect(
+          native.renderCount,
+          1,
+          reason: 'the duplicate must reuse the original body, not re-encode',
+        );
+      });
+
+      test(
+        'caps concurrent native renders so the encoder does not stall',
+        () async {
+          final native = _FakeProVideoEditor();
+          editor.ProVideoEditor.instance = native;
+          final service = ClipSpeedRenderService();
+
+          final pending = [
+            for (var i = 0; i < 3; i++)
+              service.render(clip('a$i', playbackSpeed: 2)),
+          ];
+          await pumpEventQueue();
+
+          expect(
+            native.renderCount,
+            2,
+            reason:
+                'the third clip must queue instead of opening a 3rd session',
+          );
+
+          // Freeing one slot lets exactly one queued clip through.
+          native.allowRenderToFinishAt(0).complete();
+          await pumpEventQueue();
+          expect(native.renderCount, 3);
+
+          native
+            ..allowRenderToFinishAt(1).complete()
+            ..allowRenderToFinishAt(2).complete();
+          await Future.wait(pending);
+        },
+      );
+
+      test('drops queued renders once the editor closes', () async {
+        final native = _FakeProVideoEditor();
+        editor.ProVideoEditor.instance = native;
+        final service = ClipSpeedRenderService();
+
+        final pending = [
+          for (var i = 0; i < 3; i++)
+            service.render(clip('a$i', playbackSpeed: 2)),
+        ];
+        await pumpEventQueue();
+        expect(native.renderCount, 2);
+
+        // Closing the editor must not let the backlog keep encoding.
+        service.clear();
+        native
+          ..allowRenderToFinishAt(0).complete()
+          ..allowRenderToFinishAt(1).complete();
+        await Future.wait(pending);
+        await pumpEventQueue();
+
+        expect(
+          native.renderCount,
+          2,
+          reason: 'the queued third clip must be abandoned, not encoded',
+        );
+      });
     });
 
     group('clear', () {


### PR DESCRIPTION
Closes #6818

## Description

Device logs from a 28-clip draft (iPad13,17, iOS 18.7.8) showed 14 failed speed renders in an 11-minute editing session — 6 × `Render export stalled after 20s with no progress [progress=0.00 mode=AVAssetExportPresetHighestQuality]` and 8 × `Swift.CancellationError`, alongside RSS climbing from 284 MB to a 640 MB peak.

Two root causes, both in `ClipSpeedRenderService`:

**1. Unbounded render fan-out.** `_ensureSpeedClipsRendered` in `video_editor_canvas.dart` requests a speed body for every non-1× clip on *every* timeline change, so a 28-clip draft opened 28 native export sessions simultaneously. Past a couple of concurrent sessions the platform encoder stops making progress entirely and `pro_video_editor` fails the session with a 20s stall. Individual renders that did complete took 66–991 ms, so serialising them is both faster and more reliable than letting them contend.

This PR caps concurrent speed renders at 2 and queues the rest FIFO (head-of-timeline clips finish first, since those are the ones most likely to be played first).

The cap deliberately lives in `ClipSpeedRenderService`, **not** in `VideoEditorRenderService.renderNativeVideoToFile`. The latter looks like the natural choke point, but `renderVideo` (used by `TransitionSeamRenderService`) re-enters it several times per seam — a semaphore there would let an outer call hold a slot while waiting for its own inner calls, and deadlock.

A stale check *after* acquiring a slot drops the queued backlog when the editor closes. That backlog is what previously kept the encoder busy for ~20s after teardown and produced the `CancellationError` renders logged well after the user had left the editor.

**2. Cache key included `clip.id`.** The class doc already described the key as "the clip's file, trims and speed" — the id had drifted in and was never part of the documented intent. Because duplicating a clip, splitting one, or reopening a draft all mint fresh ids for byte-identical bodies, the id forced a full re-encode of identical material. The render output is fully determined by (source file, trims, speed), so clips agreeing on those now share one render. Visible in the logs as e.g. `1786035685738183_start_copy_...` re-encoding a body already rendered moments earlier.

**Related Issue:** 

## Out of Scope

Three findings from the same log deliberately left for separate PRs:

- `clear()` deletes the on-disk speed bodies when the editor closes, so reopening a draft still re-renders everything from scratch. Keeping them is a trade-off against temp-dir disk usage and wants its own decision.
- Duplicating a draft logs `Draft not found: draft_...` 1 ms after `Saving draft: draft_...` — a read-before-write race in the duplicate flow.
- `ClipEditorBloc` logs its init twice after the editor has been reopened several times, suggesting a second subscription. Unconfirmed; needs a reproduction first.

## Verification

- `flutter test test/services/video_editor/` — 290 passed
- `flutter test test/widgets/video_editor/` — 813 passed
- `flutter analyze lib/services/video_editor/ test/services/video_editor/` — no issues
- Both suites re-run after rebasing onto current `main`

Three regression tests added, each verified to fail without its fix:

| Test | Without the fix |
|---|---|
| `caps concurrent native renders so the encoder does not stall` | `Expected: <2> Actual: <3>` |
| `drops queued renders once the editor closes` | `Expected: <2> Actual: <3>` |
| `reuses one render for clips that differ only by id` | `Expected: not null Actual: <null>` |

Manual: reproduced and confirmed fixed on the iPad the original logs came from, using the same 28-clip draft. Not yet re-verified on a Samsung Galaxy.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore