### PR TITLE
fix(engagement): resolve the author key before querying likes, votes and reposts

### DIFF
--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -549,8 +549,8 @@ VideosRepository videosRepository(Ref ref) {
 
 /// Provider for LikesRepository instance
 ///
-/// Creates a LikesRepository when the user is authenticated.
-/// Returns null when user is not authenticated.
+/// Creates a LikesRepository. Local storage is attached when the user is
+/// authenticated; signed-out relay queries are guarded by the repository.
 ///
 /// Uses:
 /// - NostrClient from nostrServiceProvider (for relay communication)

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -942,8 +942,8 @@ String _$videosRepositoryHash() => r'f98257a666f2fede19dd41cbc4e5dca57ae65328';
 
 /// Provider for LikesRepository instance
 ///
-/// Creates a LikesRepository when the user is authenticated.
-/// Returns null when user is not authenticated.
+/// Creates a LikesRepository. Local storage is attached when the user is
+/// authenticated; signed-out relay queries are guarded by the repository.
 ///
 /// Uses:
 /// - NostrClient from nostrServiceProvider (for relay communication)
@@ -954,8 +954,8 @@ final likesRepositoryProvider = LikesRepositoryProvider._();
 
 /// Provider for LikesRepository instance
 ///
-/// Creates a LikesRepository when the user is authenticated.
-/// Returns null when user is not authenticated.
+/// Creates a LikesRepository. Local storage is attached when the user is
+/// authenticated; signed-out relay queries are guarded by the repository.
 ///
 /// Uses:
 /// - NostrClient from nostrServiceProvider (for relay communication)
@@ -967,8 +967,8 @@ final class LikesRepositoryProvider
     with $Provider<LikesRepository> {
   /// Provider for LikesRepository instance
   ///
-  /// Creates a LikesRepository when the user is authenticated.
-  /// Returns null when user is not authenticated.
+  /// Creates a LikesRepository. Local storage is attached when the user is
+  /// authenticated; signed-out relay queries are guarded by the repository.
   ///
   /// Uses:
   /// - NostrClient from nostrServiceProvider (for relay communication)

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -1439,32 +1439,32 @@ class LikesRepository {
       _emitLikedIds();
     }
 
-    // Signed out: keep whatever local storage gave us rather than throwing —
-    // there is nothing to reconcile against, which is not a sync failure.
-    final pubkey = await _currentUserPubkey();
-    if (pubkey == null) {
-      Log.warning(
-        'Skipping reaction sync: signer has no public key',
-        name: 'LikesRepository',
-      );
-      _isInitialized = true;
-      return _buildSyncResult();
-    }
-
-    // Fetch both reactions and deletions from relays (authoritative)
-    final reactionsFilter = Filter(
-      kinds: const [EventKind.reaction],
-      authors: [pubkey],
-      limit: _defaultReactionFetchLimit,
-    );
-
-    final deletionsFilter = Filter(
-      kinds: const [EventKind.eventDeletion],
-      authors: [pubkey],
-      limit: _defaultReactionFetchLimit,
-    );
-
     try {
+      // Signed out: keep whatever local storage gave us rather than throwing —
+      // there is nothing to reconcile against, which is not a sync failure.
+      final pubkey = await _currentUserPubkey();
+      if (pubkey == null) {
+        Log.warning(
+          'Skipping reaction sync: signer has no public key',
+          name: 'LikesRepository',
+        );
+        _isInitialized = true;
+        return _buildSyncResult();
+      }
+
+      // Fetch both reactions and deletions from relays (authoritative)
+      final reactionsFilter = Filter(
+        kinds: const [EventKind.reaction],
+        authors: [pubkey],
+        limit: _defaultReactionFetchLimit,
+      );
+
+      final deletionsFilter = Filter(
+        kinds: const [EventKind.eventDeletion],
+        authors: [pubkey],
+        limit: _defaultReactionFetchLimit,
+      );
+
       // Fetch reactions and deletions in parallel
       final results = await Future.wait([
         _nostrClient.queryEvents([reactionsFilter]),
@@ -1870,16 +1870,16 @@ class LikesRepository {
       _emitLikedIds();
     }
 
-    // Subscribe to reactions for real-time sync and cross-device updates
-    if (_nostrClient.hasKeys) {
-      _subscribeToReactions();
+    final pubkey = await _currentUserPubkey();
+    if (pubkey != null) {
+      _subscribeToReactions(pubkey);
     }
 
     // Flip the flag before the backfill sync so _ensureInitialized callers
     // aren't blocked on a relay round-trip.
     _isInitialized = true;
 
-    if (hasCoordinatelessRecords && _nostrClient.hasKeys) {
+    if (hasCoordinatelessRecords && pubkey != null) {
       try {
         await syncUserReactions();
       } on Exception catch (_) {
@@ -1895,10 +1895,7 @@ class LikesRepository {
   /// Creates a long-running subscription to the current user's Kind 7 events.
   /// When a newer reaction arrives (from another device or this one),
   /// updates the local cache.
-  void _subscribeToReactions() {
-    final currentUserPubkey = _nostrClient.publicKey;
-    if (currentUserPubkey.isEmpty) return;
-
+  void _subscribeToReactions(String currentUserPubkey) {
     // Use a deterministic subscription ID so we can unsubscribe later
     _reactionSubscriptionId = 'likes_repo_reactions_$currentUserPubkey';
 

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -1099,6 +1099,13 @@ class LikesRepository {
       return (upvotedIds: <String>{}, downvotedIds: <String>{});
     }
 
+    // Signed out: both queries below are author-scoped, and a null author
+    // would widen them to every user's votes rather than narrowing to none.
+    final pubkey = await _currentUserPubkey();
+    if (pubkey == null) {
+      return (upvotedIds: <String>{}, downvotedIds: <String>{});
+    }
+
     final eventIdByCoordinate = _voteTargetsByCoordinate(
       eventIds,
       addressableIds,
@@ -1107,13 +1114,13 @@ class LikesRepository {
     final events = await _queryVoteTargetReactions(
       eventIds: eventIds,
       eventIdByCoordinate: eventIdByCoordinate,
-      authors: [_nostrClient.publicKey],
+      authors: [pubkey],
     );
 
     // Also fetch deletions to exclude deleted votes
     final deletionFilter = Filter(
       kinds: const [EventKind.eventDeletion],
-      authors: [_nostrClient.publicKey],
+      authors: [pubkey],
     );
     final deletions = await _nostrClient.queryEvents([deletionFilter]);
 
@@ -1432,16 +1439,28 @@ class LikesRepository {
       _emitLikedIds();
     }
 
+    // Signed out: keep whatever local storage gave us rather than throwing —
+    // there is nothing to reconcile against, which is not a sync failure.
+    final pubkey = await _currentUserPubkey();
+    if (pubkey == null) {
+      Log.warning(
+        'Skipping reaction sync: signer has no public key',
+        name: 'LikesRepository',
+      );
+      _isInitialized = true;
+      return _buildSyncResult();
+    }
+
     // Fetch both reactions and deletions from relays (authoritative)
     final reactionsFilter = Filter(
       kinds: const [EventKind.reaction],
-      authors: [_nostrClient.publicKey],
+      authors: [pubkey],
       limit: _defaultReactionFetchLimit,
     );
 
     final deletionsFilter = Filter(
       kinds: const [EventKind.eventDeletion],
-      authors: [_nostrClient.publicKey],
+      authors: [pubkey],
       limit: _defaultReactionFetchLimit,
     );
 
@@ -2033,6 +2052,14 @@ class LikesRepository {
     unawaited(_downvotedIdsController.close());
   }
 
+  /// The signed-in user's pubkey, or `null` when the signer has no key.
+  ///
+  /// Resolves through [NostrClient.resolvePublicKey] rather than reading
+  /// `publicKey` directly, so a signer that acquired its key after the client
+  /// initialized is picked up here instead of leaving every author-scoped
+  /// query below filtering on an empty author (#6813).
+  Future<String?> _currentUserPubkey() => _nostrClient.resolvePublicKey();
+
   /// Ensures the repository is initialized with data from storage.
   Future<void> _ensureInitialized() async {
     if (_isInitialized) return;
@@ -2084,13 +2111,16 @@ class LikesRepository {
     String eventId, {
     String? addressableId,
   }) async {
+    final pubkey = await _currentUserPubkey();
+    if (pubkey == null) return null;
+
     final hasCoordinate = addressableId != null && addressableId.isNotEmpty;
     final reactions = await _queryVoteTargetReactions(
       eventIds: [eventId],
       eventIdByCoordinate: hasCoordinate
           ? {addressableId: eventId}
           : const <String, String>{},
-      authors: [_nostrClient.publicKey],
+      authors: [pubkey],
     );
 
     final candidatesById = <String, Event>{};
@@ -2107,7 +2137,7 @@ class LikesRepository {
     final deletions = await _nostrClient.queryEvents([
       Filter(
         kinds: const [EventKind.eventDeletion],
-        authors: [_nostrClient.publicKey],
+        authors: [pubkey],
         e: candidates.map((event) => event.id).toList(),
       ),
     ]);

--- a/mobile/packages/likes_repository/test/src/likes_repository_pre_column_db_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_pre_column_db_test.dart
@@ -70,6 +70,7 @@ void main() {
     MockNostrClient createClient() {
       final client = MockNostrClient();
       when(() => client.publicKey).thenReturn(testUserPubkey);
+      when(client.resolvePublicKey).thenAnswer((_) async => testUserPubkey);
       when(() => client.hasKeys).thenReturn(true);
       when(() => client.unsubscribe(any())).thenAnswer((_) async {});
       when(

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -117,6 +117,12 @@ void main() {
       when(() => mockNostrClient.hasKeys).thenReturn(false);
       when(() => mockNostrClient.unsubscribe(any())).thenAnswer((_) async {});
       when(
+        () => mockNostrClient.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+        ),
+      ).thenAnswer((_) => const Stream.empty());
+      when(
         () => mockLocalStorage.getAllLikeRecords(),
       ).thenAnswer((_) async => []);
       when(
@@ -2230,6 +2236,24 @@ void main() {
       );
 
       test(
+        'syncUserReactions keeps local data when key resolution throws',
+        () async {
+          when(
+            () => mockNostrClient.resolvePublicKey(),
+          ).thenThrow(StateError('signer unavailable'));
+          when(() => mockLocalStorage.getAllLikeRecords()).thenAnswer(
+            (_) async => [createLikeRecord()],
+          );
+
+          repository = createRepository();
+          final result = await repository.syncUserReactions();
+
+          verifyNever(() => mockNostrClient.queryEvents(any()));
+          expect(result.orderedEventIds, contains(testEventId));
+        },
+      );
+
+      test(
         'getUserVoteStatuses returns empty without querying with no key',
         () async {
           when(
@@ -3158,7 +3182,9 @@ void main() {
 
     group('initialize', () {
       test('loads records from local storage', () async {
-        when(() => mockNostrClient.hasKeys).thenReturn(false);
+        when(
+          () => mockNostrClient.resolvePublicKey(),
+        ).thenAnswer((_) async => null);
         when(() => mockLocalStorage.getAllLikeRecords()).thenAnswer(
           (_) async => [
             createLikeRecord(
@@ -3174,8 +3200,7 @@ void main() {
         expect(await repository.isLiked('event_a_1234567890abcdef'), isTrue);
       });
 
-      test('sets up subscription when client has keys', () async {
-        when(() => mockNostrClient.hasKeys).thenReturn(true);
+      test('sets up subscription when the client resolves a key', () async {
         when(
           () => mockNostrClient.subscribe(
             any(),
@@ -3195,7 +3220,9 @@ void main() {
       });
 
       test('skips subscription when client has no keys', () async {
-        when(() => mockNostrClient.hasKeys).thenReturn(false);
+        when(
+          () => mockNostrClient.resolvePublicKey(),
+        ).thenAnswer((_) async => null);
 
         repository = createRepository();
         await repository.initialize();
@@ -3208,8 +3235,39 @@ void main() {
         );
       });
 
+      test(
+        'subscribes with the resolved key when the publicKey cache is stale',
+        () async {
+          when(() => mockNostrClient.publicKey).thenReturn('');
+          when(
+            () => mockNostrClient.resolvePublicKey(),
+          ).thenAnswer((_) async => testUserPubkey);
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => const Stream.empty());
+
+          repository = createRepository();
+          await repository.initialize();
+
+          final captured =
+              verify(
+                    () => mockNostrClient.subscribe(
+                      captureAny(),
+                      subscriptionId: any(named: 'subscriptionId'),
+                    ),
+                  ).captured.single
+                  as List<Filter>;
+          expect(captured.single.authors, equals([testUserPubkey]));
+        },
+      );
+
       test('is idempotent', () async {
-        when(() => mockNostrClient.hasKeys).thenReturn(false);
+        when(
+          () => mockNostrClient.resolvePublicKey(),
+        ).thenAnswer((_) async => null);
 
         repository = createRepository();
         await repository.initialize();

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -111,6 +111,9 @@ void main() {
 
       // Default mock behaviors
       when(() => mockNostrClient.publicKey).thenReturn(testUserPubkey);
+      when(
+        () => mockNostrClient.resolvePublicKey(),
+      ).thenAnswer((_) async => testUserPubkey);
       when(() => mockNostrClient.hasKeys).thenReturn(false);
       when(() => mockNostrClient.unsubscribe(any())).thenAnswer((_) async {});
       when(
@@ -2177,6 +2180,70 @@ void main() {
         verify(() => mockNostrClient.countEvents(any())).called(1);
         verify(() => mockNostrClient.queryEvents(any())).called(1);
       });
+    });
+
+    group('signer readiness (#6813)', () {
+      test(
+        'syncUserReactions filters on the resolved key, not the stale cache',
+        () async {
+          // The cache stays empty when the signer acquired its key after the
+          // client initialized. Reading it directly would query
+          // authors: [''], which matches no event.
+          when(() => mockNostrClient.publicKey).thenReturn('');
+          when(
+            () => mockNostrClient.resolvePublicKey(),
+          ).thenAnswer((_) async => testUserPubkey);
+          mockQueryEventsSequence([
+            [],
+            [],
+          ]);
+
+          repository = createRepository();
+          await repository.syncUserReactions();
+
+          final captured = verify(
+            () => mockNostrClient.queryEvents(captureAny()),
+          ).captured.cast<List<Filter>>();
+          expect(captured, isNotEmpty);
+          for (final filters in captured) {
+            expect(filters.single.authors, equals([testUserPubkey]));
+          }
+        },
+      );
+
+      test(
+        'syncUserReactions keeps local data and skips relays with no key',
+        () async {
+          when(
+            () => mockNostrClient.resolvePublicKey(),
+          ).thenAnswer((_) async => null);
+          when(() => mockLocalStorage.getAllLikeRecords()).thenAnswer(
+            (_) async => [createLikeRecord()],
+          );
+
+          repository = createRepository();
+          final result = await repository.syncUserReactions();
+
+          verifyNever(() => mockNostrClient.queryEvents(any()));
+          expect(result.orderedEventIds, contains(testEventId));
+        },
+      );
+
+      test(
+        'getUserVoteStatuses returns empty without querying with no key',
+        () async {
+          when(
+            () => mockNostrClient.resolvePublicKey(),
+          ).thenAnswer((_) async => null);
+
+          repository = createRepository();
+          final statuses = await repository.getUserVoteStatuses([testEventId]);
+
+          verifyNever(() => mockNostrClient.queryEvents(any()));
+          expect(statuses.upvotedIds, isEmpty);
+          expect(statuses.downvotedIds, isEmpty);
+        },
+      );
     });
 
     group('syncUserReactions', () {

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -507,17 +507,24 @@ class NostrClient {
     final cached = _nostr.publicKey;
     if (cached.isNotEmpty) return cached;
 
-    final refresh = _pendingPublicKeyRefresh ??= _nostr
-        .refreshPublicKey()
-        .whenComplete(() => _pendingPublicKeyRefresh = null);
-    await refresh;
+    try {
+      await _refreshPublicKeyFromSigner();
+    } on Object {
+      return null;
+    }
 
     final key = _nostr.publicKey;
     return key.isEmpty ? null : key;
   }
 
-  /// In-flight [resolvePublicKey] signer refresh, shared by concurrent callers.
+  /// In-flight signer refresh, shared by initialize and resolving callers.
   Future<void>? _pendingPublicKeyRefresh;
+
+  Future<void> _refreshPublicKeyFromSigner() {
+    return _pendingPublicKeyRefresh ??= _nostr.refreshPublicKey().whenComplete(
+      () => _pendingPublicKeyRefresh = null,
+    );
+  }
 
   /// Whether the client has been initialized
   ///
@@ -548,7 +555,7 @@ class NostrClient {
       _reportInitializationStage(
         NostrClientInitializationStage.refreshingPublicKey,
       );
-      await _nostr.refreshPublicKey();
+      await _refreshPublicKeyFromSigner();
       // Seed the already-verified set before relays connect, so re-sent
       // events skip re-verification during the cold-start flood.
       _reportInitializationStage(

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -509,7 +509,16 @@ class NostrClient {
 
     try {
       await _refreshPublicKeyFromSigner();
-    } on Object {
+    } on Object catch (e, st) {
+      // Non-fatal: the caller skips its author-scoped query. Logged so a
+      // failed signer stays distinguishable from a signed-out session —
+      // callers report both as "no public key".
+      log(
+        'Signer refresh failed while resolving the public key',
+        name: 'NostrClient',
+        error: e,
+        stackTrace: st,
+      );
       return null;
     }
 

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -486,6 +486,39 @@ class NostrClient {
   /// Public key of the client
   String get publicKey => _nostr.publicKey;
 
+  /// The signed-in user's public key, or `null` when the signer has none.
+  ///
+  /// [publicKey] is a plain cache read, and the cache stays empty when the
+  /// signer had no key at [initialize] time but acquired one afterwards —
+  /// nothing re-runs the refresh on its own. Resolving through here retries
+  /// the signer on a cache miss, so a late signer is picked up on the next
+  /// call instead of leaving author-scoped queries filtering on an empty
+  /// author for the rest of the session (#6813).
+  ///
+  /// Returns `null` rather than throwing, for callers that should skip their
+  /// query when signed out. Use [Nostr.ensurePublicKey] when the absence of a
+  /// key is a programming error instead.
+  ///
+  /// Concurrent callers share one refresh. A cache miss reaches the signer,
+  /// and for NIP-55 that is an Amber intent — a user-visible prompt — so the
+  /// several repositories that resolve the key at startup must not each raise
+  /// their own.
+  Future<String?> resolvePublicKey() async {
+    final cached = _nostr.publicKey;
+    if (cached.isNotEmpty) return cached;
+
+    final refresh = _pendingPublicKeyRefresh ??= _nostr
+        .refreshPublicKey()
+        .whenComplete(() => _pendingPublicKeyRefresh = null);
+    await refresh;
+
+    final key = _nostr.publicKey;
+    return key.isEmpty ? null : key;
+  }
+
+  /// In-flight [resolvePublicKey] signer refresh, shared by concurrent callers.
+  Future<void>? _pendingPublicKeyRefresh;
+
   /// Whether the client has been initialized
   ///
   /// Returns true if the relay manager is initialized

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -161,6 +161,69 @@ void main() {
         );
         expect(clientWithoutDb.publicKey, equals(testPublicKey));
       });
+
+      group('resolvePublicKey (#6813)', () {
+        test('returns the cached key without asking the signer', () async {
+          expect(await client.resolvePublicKey(), equals(testPublicKey));
+          verifyNever(() => mockNostr.refreshPublicKey());
+        });
+
+        test('refreshes from the signer when the cache is empty', () async {
+          // The signer acquired its key after the client initialized, so the
+          // cache is stale — the refresh is what makes it visible.
+          var cached = '';
+          when(() => mockNostr.publicKey).thenAnswer((_) => cached);
+          when(() => mockNostr.refreshPublicKey()).thenAnswer((_) async {
+            cached = testPublicKey;
+          });
+
+          expect(await client.resolvePublicKey(), equals(testPublicKey));
+          verify(() => mockNostr.refreshPublicKey()).called(1);
+        });
+
+        test('returns null when the signer still has no key', () async {
+          when(() => mockNostr.publicKey).thenReturn('');
+          when(() => mockNostr.refreshPublicKey()).thenAnswer((_) async {});
+
+          expect(await client.resolvePublicKey(), isNull);
+        });
+
+        test('concurrent callers share a single signer refresh', () async {
+          // A cache miss reaches the signer, and under NIP-55 that is a
+          // user-visible Amber prompt — three repositories resolving the key
+          // at startup must not raise three of them.
+          var cached = '';
+          final gate = Completer<void>();
+          when(() => mockNostr.publicKey).thenAnswer((_) => cached);
+          when(() => mockNostr.refreshPublicKey()).thenAnswer((_) async {
+            await gate.future;
+            cached = testPublicKey;
+          });
+
+          final calls = Future.wait([
+            client.resolvePublicKey(),
+            client.resolvePublicKey(),
+            client.resolvePublicKey(),
+          ]);
+          gate.complete();
+
+          expect(await calls, everyElement(equals(testPublicKey)));
+          verify(() => mockNostr.refreshPublicKey()).called(1);
+        });
+
+        test(
+          'a later miss refreshes again once the first has settled',
+          () async {
+            when(() => mockNostr.publicKey).thenReturn('');
+            when(() => mockNostr.refreshPublicKey()).thenAnswer((_) async {});
+
+            expect(await client.resolvePublicKey(), isNull);
+            expect(await client.resolvePublicKey(), isNull);
+
+            verify(() => mockNostr.refreshPublicKey()).called(2);
+          },
+        );
+      });
     });
 
     group('initialize seeds known-verified event ids', () {

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -188,6 +188,15 @@ void main() {
           expect(await client.resolvePublicKey(), isNull);
         });
 
+        test('returns null when the signer refresh throws', () async {
+          when(() => mockNostr.publicKey).thenReturn('');
+          when(
+            () => mockNostr.refreshPublicKey(),
+          ).thenThrow(StateError('refresh failed'));
+
+          expect(await client.resolvePublicKey(), isNull);
+        });
+
         test('concurrent callers share a single signer refresh', () async {
           // A cache miss reaches the signer, and under NIP-55 that is a
           // user-visible Amber prompt — three repositories resolving the key
@@ -221,6 +230,28 @@ void main() {
             expect(await client.resolvePublicKey(), isNull);
 
             verify(() => mockNostr.refreshPublicKey()).called(2);
+          },
+        );
+
+        test(
+          'shares an initialize refresh with concurrent resolvers',
+          () async {
+            var cached = '';
+            final gate = Completer<void>();
+            when(() => mockNostr.publicKey).thenAnswer((_) => cached);
+            when(() => mockNostr.refreshPublicKey()).thenAnswer((_) async {
+              await gate.future;
+              cached = testPublicKey;
+            });
+            when(() => mockRelayManager.initialize()).thenAnswer((_) async {});
+
+            final initialization = client.initialize();
+            final resolved = client.resolvePublicKey();
+            gate.complete();
+
+            await initialization;
+            expect(await resolved, equals(testPublicKey));
+            verify(() => mockNostr.refreshPublicKey()).called(1);
           },
         );
       });

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
@@ -596,26 +596,26 @@ class RepostsRepository {
       _emitRepostedIds();
     }
 
-    // Signed out: keep whatever local storage gave us rather than throwing —
-    // there is nothing to reconcile against, which is not a sync failure.
-    final pubkey = await _currentUserPubkey();
-    if (pubkey == null) {
-      Log.warning(
-        'Skipping repost sync: signer has no public key',
-        name: 'RepostsRepository',
-      );
-      _isInitialized = true;
-      return _buildSyncResult();
-    }
-
-    // Then, fetch from relays (authoritative)
-    final filter = Filter(
-      kinds: const [EventKind.genericRepost],
-      authors: [pubkey],
-      limit: _defaultRepostFetchLimit,
-    );
-
     try {
+      // Signed out: keep whatever local storage gave us rather than throwing —
+      // there is nothing to reconcile against, which is not a sync failure.
+      final pubkey = await _currentUserPubkey();
+      if (pubkey == null) {
+        Log.warning(
+          'Skipping repost sync: signer has no public key',
+          name: 'RepostsRepository',
+        );
+        _isInitialized = true;
+        return _buildSyncResult();
+      }
+
+      // Then, fetch from relays (authoritative)
+      final filter = Filter(
+        kinds: const [EventKind.genericRepost],
+        authors: [pubkey],
+        limit: _defaultRepostFetchLimit,
+      );
+
       final events = await _nostrClient.queryEvents([filter]);
       final newRecords = <RepostRecord>[];
 
@@ -899,9 +899,9 @@ class RepostsRepository {
       _emitRepostedIds();
     }
 
-    // Subscribe to reposts for real-time sync and cross-device updates
-    if (_nostrClient.hasKeys) {
-      _subscribeToReposts();
+    final pubkey = await _currentUserPubkey();
+    if (pubkey != null) {
+      _subscribeToReposts(pubkey);
     }
 
     _isInitialized = true;
@@ -912,10 +912,7 @@ class RepostsRepository {
   /// Creates a long-running subscription to the current user's Kind 16 events.
   /// When a newer repost arrives (from another device or this one),
   /// updates the local cache.
-  void _subscribeToReposts() {
-    final currentUserPubkey = _nostrClient.publicKey;
-    if (currentUserPubkey.isEmpty) return;
-
+  void _subscribeToReposts(String currentUserPubkey) {
     // Use a deterministic subscription ID so we can unsubscribe later
     _repostSubscriptionId = 'reposts_repo_reposts_$currentUserPubkey';
 

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
@@ -596,10 +596,22 @@ class RepostsRepository {
       _emitRepostedIds();
     }
 
+    // Signed out: keep whatever local storage gave us rather than throwing —
+    // there is nothing to reconcile against, which is not a sync failure.
+    final pubkey = await _currentUserPubkey();
+    if (pubkey == null) {
+      Log.warning(
+        'Skipping repost sync: signer has no public key',
+        name: 'RepostsRepository',
+      );
+      _isInitialized = true;
+      return _buildSyncResult();
+    }
+
     // Then, fetch from relays (authoritative)
     final filter = Filter(
       kinds: const [EventKind.genericRepost],
-      authors: [_nostrClient.publicKey],
+      authors: [pubkey],
       limit: _defaultRepostFetchLimit,
     );
 
@@ -988,6 +1000,14 @@ class RepostsRepository {
     }
     unawaited(_repostedIdsController.close());
   }
+
+  /// The signed-in user's pubkey, or `null` when the signer has no key.
+  ///
+  /// Resolves through [NostrClient.resolvePublicKey] rather than reading
+  /// `publicKey` directly, so a signer that acquired its key after the client
+  /// initialized is picked up here instead of leaving the author-scoped sync
+  /// query filtering on an empty author (#6813).
+  Future<String?> _currentUserPubkey() => _nostrClient.resolvePublicKey();
 
   /// Ensures the repository is initialized with data from storage.
   Future<void> _ensureInitialized() async {

--- a/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
+++ b/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
@@ -67,6 +67,9 @@ void main() {
       mockLocalStorage = MockRepostsLocalStorage();
 
       when(() => mockNostrClient.publicKey).thenReturn(testPubkey);
+      when(
+        () => mockNostrClient.resolvePublicKey(),
+      ).thenAnswer((_) async => testPubkey);
 
       // Default sendGenericRepost mock - returns a valid event
       when(
@@ -1124,6 +1127,65 @@ void main() {
         expect(record.repostEventId, equals(testRepostEventId));
         expect(record.originalAuthorPubkey, equals(testAuthorPubkey));
       });
+    });
+
+    group('signer readiness (#6813)', () {
+      test(
+        'syncUserReposts filters on the resolved key, not the stale cache',
+        () async {
+          // The cache stays empty when the signer acquired its key after the
+          // client initialized. Reading it directly would query
+          // authors: [''], which matches no event.
+          when(() => mockNostrClient.publicKey).thenReturn('');
+          when(
+            () => mockNostrClient.resolvePublicKey(),
+          ).thenAnswer((_) async => testPubkey);
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => []);
+
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+          );
+          await repository.syncUserReposts();
+
+          final captured = verify(
+            () => mockNostrClient.queryEvents(captureAny()),
+          ).captured.cast<List<Filter>>();
+          expect(captured, isNotEmpty);
+          for (final filters in captured) {
+            expect(filters.single.authors, equals([testPubkey]));
+          }
+        },
+      );
+
+      test(
+        'syncUserReposts keeps local data and skips relays with no key',
+        () async {
+          final record = RepostRecord(
+            addressableId: testAddressableId,
+            repostEventId: testRepostEventId,
+            originalAuthorPubkey: testAuthorPubkey,
+            createdAt: DateTime.now(),
+          );
+          when(
+            () => mockNostrClient.resolvePublicKey(),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockLocalStorage.getAllRepostRecords(),
+          ).thenAnswer((_) async => [record]);
+
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+          );
+          final result = await repository.syncUserReposts();
+
+          verifyNever(() => mockNostrClient.queryEvents(any()));
+          expect(result.orderedAddressableIds, contains(testAddressableId));
+        },
+      );
     });
 
     group('syncUserReposts', () {

--- a/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
+++ b/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
@@ -70,6 +70,12 @@ void main() {
       when(
         () => mockNostrClient.resolvePublicKey(),
       ).thenAnswer((_) async => testPubkey);
+      when(
+        () => mockNostrClient.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+        ),
+      ).thenAnswer((_) => const Stream.empty());
 
       // Default sendGenericRepost mock - returns a valid event
       when(
@@ -1186,6 +1192,33 @@ void main() {
           expect(result.orderedAddressableIds, contains(testAddressableId));
         },
       );
+
+      test(
+        'syncUserReposts keeps local data when key resolution throws',
+        () async {
+          final record = RepostRecord(
+            addressableId: testAddressableId,
+            repostEventId: testRepostEventId,
+            originalAuthorPubkey: testAuthorPubkey,
+            createdAt: DateTime.now(),
+          );
+          when(
+            () => mockNostrClient.resolvePublicKey(),
+          ).thenThrow(StateError('signer unavailable'));
+          when(
+            () => mockLocalStorage.getAllRepostRecords(),
+          ).thenAnswer((_) async => [record]);
+
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+          );
+          final result = await repository.syncUserReposts();
+
+          verifyNever(() => mockNostrClient.queryEvents(any()));
+          expect(result.orderedAddressableIds, contains(testAddressableId));
+        },
+      );
     });
 
     group('syncUserReposts', () {
@@ -1938,7 +1971,9 @@ void main() {
 
     group('initialize', () {
       test('loads records from local storage', () async {
-        when(() => mockNostrClient.hasKeys).thenReturn(false);
+        when(
+          () => mockNostrClient.resolvePublicKey(),
+        ).thenAnswer((_) async => null);
         when(() => mockLocalStorage.getAllRepostRecords()).thenAnswer(
           (_) async => [
             RepostRecord(
@@ -1960,8 +1995,7 @@ void main() {
         expect(await repository.isReposted(testAddressableId), isTrue);
       });
 
-      test('sets up subscription when client has keys', () async {
-        when(() => mockNostrClient.hasKeys).thenReturn(true);
+      test('sets up subscription when the client resolves a key', () async {
         when(
           () => mockNostrClient.subscribe(
             any(),
@@ -1984,7 +2018,9 @@ void main() {
       });
 
       test('skips subscription when client has no keys', () async {
-        when(() => mockNostrClient.hasKeys).thenReturn(false);
+        when(
+          () => mockNostrClient.resolvePublicKey(),
+        ).thenAnswer((_) async => null);
 
         final repository = RepostsRepository(
           nostrClient: mockNostrClient,
@@ -2001,7 +2037,9 @@ void main() {
       });
 
       test('is idempotent', () async {
-        when(() => mockNostrClient.hasKeys).thenReturn(false);
+        when(
+          () => mockNostrClient.resolvePublicKey(),
+        ).thenAnswer((_) async => null);
 
         final repository = RepostsRepository(
           nostrClient: mockNostrClient,
@@ -2012,6 +2050,38 @@ void main() {
 
         verify(() => mockLocalStorage.getAllRepostRecords()).called(1);
       });
+
+      test(
+        'subscribes with the resolved key when the publicKey cache is stale',
+        () async {
+          when(() => mockNostrClient.publicKey).thenReturn('');
+          when(
+            () => mockNostrClient.resolvePublicKey(),
+          ).thenAnswer((_) async => testPubkey);
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => const Stream.empty());
+
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+          );
+          await repository.initialize();
+
+          final captured =
+              verify(
+                    () => mockNostrClient.subscribe(
+                      captureAny(),
+                      subscriptionId: any(named: 'subscriptionId'),
+                    ),
+                  ).captured.single
+                  as List<Filter>;
+          expect(captured.single.authors, equals([testPubkey]));
+        },
+      );
     });
 
     group('real-time sync', () {


### PR DESCRIPTION
## Description

Seven relay queries in `likes_repository` and `reposts_repository` built their filter as `authors: [_nostrClient.publicKey]` with no check that the key was populated. `publicKey` is a plain read of `Nostr._cachedPublicKey`, which starts empty. No event has an empty pubkey, so a conformant relay matched nothing and the query returned empty — not an error, just no results.

All four affected methods are cold-start recovery paths, so the window in which the key is unset is the window in which they run:

| Method | Symptom |
|---|---|
| `syncUserReactions` | documented "called on startup to reconcile against relay state" — reconciles nothing |
| `syncUserReposts` | same |
| `getUserVoteStatuses` | the user's own arrows render unfilled on content they voted on |
| `_resolveRemoteDownvoteRecord` | exists to recover an empty downvote cache after a cold start — finds no record |

None surfaces an error; each degrades to a silently empty result.

### Why the guard alone wasn't enough

`hasKeys` was already the predicate in both classes (`likes_repository.dart:1855,1863`, `reposts_repository.dart:891`) — but on one *caller* rather than the method, so `profile_liked_videos_bloc`, `profile_reposted_videos_bloc` and `comment_reactions_bloc` all called straight past it.

Adding a fourth caller-side guard would not have fixed the symptom either. The real sequence is: `initialize()` runs → signer still empty → cache stays `''` → the signer acquires its key moments later → **nothing re-runs `refreshPublicKey()`**. A guard would turn "malformed query returns nothing" into "explicitly skipped, still nothing."

So this adds `NostrClient.resolvePublicKey()`, which retries the signer on a cache miss and returns `null` instead of throwing. `Nostr.ensurePublicKey()` stays the right call where the absence of a key is a programming error — the client already documents this exact "ready resolved but `hasKeys` still false" case at `isReadyResolved`.

### Notes for review

- **Concurrent callers share one refresh.** A cache miss reaches the signer, and under NIP-55 `AndroidNostrSigner.getPublicKey()` launches an Amber intent — a user-visible prompt. Three repositories resolving the key at startup must not raise three of them. Pinned by a test, and by a sibling test asserting a *later* miss does refresh again.
- **Initialization shares the same refresh gate.** `NostrClient.initialize()` now routes through the same in-flight refresh, so a startup repository resolve cannot trigger a second signer prompt while initialization is still refreshing the key.
- **Startup subscriptions also resolve the key.** Likes/reposts Kind 7 / Kind 16 subscriptions no longer rely on the stale synchronous cache, so late signer resolution does not leave cross-device updates unsubscribed for the session.
- **`getUserVoteStatuses` returns empty rather than passing a null author.** `_queryVoteTargetReactions` takes `List<String>?`, so a null there would widen the query to every user's votes instead of narrowing it to none.
- **The sync methods keep whatever local storage returned** rather than throwing, matching how they already treat a failed relay fetch. They do not return `.empty()`, which would contradict the in-memory index.
- **A failed signer is logged, not just skipped.** `resolvePublicKey()` returns `null` both when the session is signed out and when the signer refresh threw, and the callers report both as "signer has no public key". The swallow logs the error so a denied or crashed NIP-55 prompt stays distinguishable from a signed-out session — the same non-fatal-swallow shape already used twice in this file.
- **Not a regression.** A conformant relay has always returned nothing for `authors: ['']`; these queries have been malformed on this path the whole time.

## Out of Scope

The sync methods are still not re-driven automatically when the signer resolves *after* a sync already ran and returned early — the next call picks the key up, but nothing schedules that call. Tracked in #6838; it needs a readiness signal these repositories do not currently observe.

## Verification

Each of the original guards is mutation-checked — reverting it turns its own test red, verified individually rather than as a batch.

Post-takeover verification, on the rebased branch (author):

- Full `flutter test` per package after the rebase onto `origin/main` — `nostr_client` 330, `likes_repository` 208, `reposts_repository` 129, all passing
- Bare `flutter analyze` (so `lib` + `test`) clean in all three packages, plus `flutter analyze lib/providers/video_providers.dart` in `mobile`
- Rebase touches nothing shared: `origin/main` gained 10 commits, none of which change `mobile/packages` or `mobile/lib/providers`

Takeover verification:

- `flutter test test/src/nostr_client_test.dart` in `mobile/packages/nostr_client`
- `flutter test test/src/likes_repository_test.dart` in `mobile/packages/likes_repository`
- `flutter test test/src/reposts_repository_test.dart` in `mobile/packages/reposts_repository`
- `flutter analyze` in `mobile/packages/nostr_client`
- `flutter analyze` in `mobile/packages/likes_repository`
- `flutter analyze` in `mobile/packages/reposts_repository`
- `flutter analyze lib/providers/video_providers.dart` in `mobile`

Original author verification:

- `flutter analyze` clean (bare, so `lib` + `test`) in `nostr_client`, `likes_repository`, `reposts_repository`
- `flutter analyze lib test integration_test` clean in `mobile`
- `flutter test` — `nostr_client` 328, `likes_repository` 206, `reposts_repository` 127, all passing
- App-level consumers of these paths: `comment_reactions_bloc_test`, `profile_liked_videos_bloc_test`, `profile_reposted_videos_bloc_test`, `profile_grid_test` — 108 passing
- Coverage above gate: `nostr_client` 87.63% (gate 82), `likes_repository` 97.00% (gate 62)
- Checked that all 8 hand-written `implements NostrClient` fakes declare `noSuchMethod`, so the new member does not break them

**Related Issue:** Closes #6813

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)

