### PR TITLE
fix(video-metadata): settle the cover picker's entrance

### DIFF
--- a/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
@@ -874,10 +874,7 @@ class _ThumbnailStripState extends State<_ThumbnailStrip> {
                   Positioned(
                     top: 0,
                     bottom: 0,
-                    left: (cursorDx - _cursorWidth / 2).clamp(
-                      0,
-                      stripWidth - _cursorWidth,
-                    ),
+                    left: cursorLeft,
                     child: IgnorePointer(
                       child: Container(
                         width: _cursorWidth,

--- a/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
@@ -108,8 +108,15 @@ class _VideoMetadataCoverScreenState
         await controller.dispose();
         return;
       }
-      await controller.setSource(VideoClip.file(localPath));
-      if (mounted) await controller.seekTo(_selectedPosition);
+      // Prepare directly at the cover position instead of loading at 0 and
+      // seeking afterwards: the decoder's very first frame is then already
+      // the selected one. Loading-then-seeking renders frame 0 first, which
+      // flashed the wrong frame for the length of the seek right after the
+      // hero landed.
+      await controller.setClips(
+        [VideoClip.file(localPath)],
+        startPosition: _selectedPosition,
+      );
       if (mounted) {
         setState(() {
           _controller = controller;
@@ -472,6 +479,11 @@ class _VideoAreaState extends State<_VideoArea> {
           child: DivineVideoPlayer(
             controller: widget.controller,
             placeholder: _buildPlaceholder(),
+            // The thumbnail is already on screen (it is what the hero flew
+            // in) and the player is swapped in only once its first frame is
+            // decoded. Without this the widget hard-cuts thumbnail→texture,
+            // which reads as a flicker; cross-fade instead.
+            crossFadePlaceholder: true,
           ),
         ),
       ),
@@ -487,8 +499,109 @@ class _VideoAreaState extends State<_VideoArea> {
   }
 }
 
-class _TopBar extends StatelessWidget {
+/// Controls overlaying the preview, held back until the route transition has
+/// settled.
+///
+/// The hero flies in the navigator's overlay, which sits above everything the
+/// route itself paints. A bar rendered from the first frame is therefore
+/// covered by the flying video for the length of the flight and only pops in
+/// front once the hero lands — so it fades in on arrival instead.
+class _TopBar extends StatefulWidget {
   const _TopBar({
+    required this.isConfirming,
+    required this.onClose,
+    required this.onConfirm,
+  });
+
+  static const _fadeDuration = Duration(milliseconds: 180);
+
+  final bool isConfirming;
+  final VoidCallback onClose;
+  final VoidCallback onConfirm;
+
+  @override
+  State<_TopBar> createState() => _TopBarState();
+}
+
+class _TopBarState extends State<_TopBar> {
+  Animation<double>? _entranceAnimation;
+  bool _entered = false;
+
+  /// Only a bar that actually waited for a flight has something to fade in
+  /// from. Shown without a transition it just belongs on screen.
+  bool _fadeIn = false;
+
+  @override
+  void initState() {
+    super.initState();
+    // Armed from a post-frame callback, the same shape
+    // [CodecHeavySurfaceGuard] uses. Reading the route during the first build
+    // is unreliable — it still resolves to the route being pushed *from*,
+    // whose transition has long completed, so the bar would decide it had
+    // nothing to wait for.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _armAfterEntrance();
+    });
+  }
+
+  void _armAfterEntrance() {
+    final animation = ModalRoute.of(context)?.animation;
+    if (animation == null || animation.isCompleted) {
+      _reveal(fadeIn: false);
+      return;
+    }
+    _entranceAnimation = animation..addStatusListener(_onEntranceStatus);
+  }
+
+  void _onEntranceStatus(AnimationStatus status) {
+    if (status != AnimationStatus.completed) return;
+    _detachEntranceListener();
+    if (mounted) _reveal(fadeIn: true);
+  }
+
+  void _reveal({required bool fadeIn}) {
+    if (_entered) return;
+    setState(() {
+      _entered = true;
+      _fadeIn = fadeIn;
+    });
+  }
+
+  void _detachEntranceListener() {
+    _entranceAnimation?.removeStatusListener(_onEntranceStatus);
+    _entranceAnimation = null;
+  }
+
+  @override
+  void dispose() {
+    _detachEntranceListener();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      // Opacity 0 drops the buttons from the semantics tree but still hit
+      // tests, so taps have to be blocked separately.
+      ignoring: !_entered,
+      child: AnimatedOpacity(
+        opacity: _entered ? 1 : 0,
+        duration: _fadeIn && !MediaQuery.disableAnimationsOf(context)
+            ? _TopBar._fadeDuration
+            : Duration.zero,
+        curve: Curves.easeOut,
+        child: _TopBarContent(
+          isConfirming: widget.isConfirming,
+          onClose: widget.onClose,
+          onConfirm: widget.onConfirm,
+        ),
+      ),
+    );
+  }
+}
+
+class _TopBarContent extends StatelessWidget {
+  const _TopBarContent({
     required this.isConfirming,
     required this.onClose,
     required this.onConfirm,
@@ -532,20 +645,7 @@ class _TopBar extends StatelessWidget {
                 label: context.l10n.videoMetadataEditCoverConfirmSemanticLabel,
                 button: true,
                 child: isConfirming
-                    ? const SizedBox(
-                        width: 40,
-                        height: 40,
-                        child: Center(
-                          child: SizedBox(
-                            width: 20,
-                            height: 20,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                              color: VineTheme.primary,
-                            ),
-                          ),
-                        ),
-                      )
+                    ? const BrandedLoadingIndicator(size: 44)
                     : DivineIconButton(
                         icon: .check,
                         size: .small,
@@ -720,6 +820,10 @@ class _ThumbnailStripState extends State<_ThumbnailStrip> {
           _updateSlotCache(count);
           final slotWidth = stripWidth / count;
           final cursorDx = _dxFromPosition(widget.selectedPosition, stripWidth);
+          final cursorLeft = (cursorDx - _cursorWidth / 2).clamp(
+            0.0,
+            stripWidth - _cursorWidth,
+          );
 
           return GestureDetector(
             behavior: HitTestBehavior.opaque,
@@ -747,6 +851,24 @@ class _ThumbnailStripState extends State<_ThumbnailStrip> {
                             ),
                           ),
                       ],
+                    ),
+                  ),
+                  Positioned(
+                    top: 0,
+                    bottom: 0,
+                    left: 0,
+                    width: cursorLeft,
+                    child: const IgnorePointer(
+                      child: ColoredBox(color: VineTheme.scrim35),
+                    ),
+                  ),
+                  Positioned(
+                    top: 0,
+                    bottom: 0,
+                    left: cursorLeft + _cursorWidth,
+                    right: 0,
+                    child: const IgnorePointer(
+                      child: ColoredBox(color: VineTheme.scrim35),
                     ),
                   ),
                   Positioned(
@@ -810,14 +932,66 @@ class _SlotImage extends StatelessWidget {
           )
         : ColoredBox(color: context.vineColors.surfaceContainerHigh);
 
-    if (stripThumbnailPath == null) return fallback;
+    final path = stripThumbnailPath;
+    if (path == null) return fallback;
 
-    return ClipThumbnailImage(
-      path: stripThumbnailPath!,
-      fit: BoxFit.cover,
-      gaplessPlayback: true,
-      excludeFromSemantics: true,
-      placeholder: fallback,
+    return _FadingSlotImage(path: path, fallback: fallback);
+  }
+}
+
+/// Fades an extracted strip frame in over [fallback] instead of swapping it
+/// in the moment it decodes.
+///
+/// The priority timestamps cover every slot, so the first batch fills the
+/// whole strip at once — a hard swap flips all tiles from the stretched
+/// cover thumbnail to their real frames on a single frame boundary, which
+/// reads as a jolt.
+class _FadingSlotImage extends StatefulWidget {
+  const _FadingSlotImage({required this.path, required this.fallback});
+
+  /// Absolute path of the extracted strip frame.
+  final String path;
+
+  /// Painted underneath until the frame has faded in, and on the error path.
+  final Widget fallback;
+
+  @override
+  State<_FadingSlotImage> createState() => _FadingSlotImageState();
+}
+
+class _FadingSlotImageState extends State<_FadingSlotImage> {
+  static const _fadeDuration = Duration(milliseconds: 220);
+
+  /// Sticky once a frame has been painted: a later batch reassigning this
+  /// slot keeps the previous frame up (via `gaplessPlayback`) rather than
+  /// dipping back to the fallback while the new file decodes.
+  bool _hasFrame = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      fit: .expand,
+      children: [
+        widget.fallback,
+        ClipThumbnailImage(
+          path: widget.path,
+          fit: .cover,
+          gaplessPlayback: true,
+          excludeFromSemantics: true,
+          placeholder: widget.fallback,
+          frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
+            if (frame != null || wasSynchronouslyLoaded) _hasFrame = true;
+            return AnimatedOpacity(
+              opacity: _hasFrame ? 1 : 0,
+              // A cache hit paints on the first build; fading in from
+              // nothing there would invent a transition nobody asked for.
+              duration: wasSynchronouslyLoaded ? Duration.zero : _fadeDuration,
+              curve: Curves.easeOut,
+              child: child,
+            );
+          },
+        ),
+      ],
     );
   }
 }

--- a/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
@@ -117,15 +117,20 @@ class _VideoMetadataCoverScreenState
         [VideoClip.file(localPath)],
         startPosition: _selectedPosition,
       );
-      if (mounted) {
-        setState(() {
-          _controller = controller;
-          _playerReady = true;
-          _seekEpoch++;
-          _isSeeking = false;
-          _pendingSeekPosition = null;
-        });
+      // Unmounting during the await leaves the controller unreachable but
+      // still registered, so dispose() has already run against a null
+      // _controller and nothing else will release the decoder.
+      if (!mounted) {
+        await controller.dispose();
+        return;
       }
+      setState(() {
+        _controller = controller;
+        _playerReady = true;
+        _seekEpoch++;
+        _isSeeking = false;
+        _pendingSeekPosition = null;
+      });
     } catch (e, stackTrace) {
       // A dead preview must not take the cover picker down with it — the
       // strip below still lets the user scrub and confirm a frame.

--- a/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
@@ -964,12 +964,25 @@ class _FadingSlotImageState extends State<_FadingSlotImage> {
   /// dipping back to the fallback while the new file decodes.
   bool _hasFrame = false;
 
+  /// Set once the frame is fully opaque, from where the layer underneath is
+  /// a second full-size image painted behind an opaque one — on every frame,
+  /// for every slot, for as long as the picker is open. The error path keeps
+  /// its own copy via [ClipThumbnailImage.placeholder], and a reassigned slot
+  /// holds its previous frame through `gaplessPlayback`, so nothing still
+  /// needs it.
+  bool _covered = false;
+
+  void _dropFallback() {
+    if (_covered || !_hasFrame || !mounted) return;
+    setState(() => _covered = true);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Stack(
       fit: .expand,
       children: [
-        widget.fallback,
+        if (_covered) const SizedBox.shrink() else widget.fallback,
         ClipThumbnailImage(
           path: widget.path,
           fit: .cover,
@@ -978,12 +991,20 @@ class _FadingSlotImageState extends State<_FadingSlotImage> {
           placeholder: widget.fallback,
           frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
             if (frame != null || wasSynchronouslyLoaded) _hasFrame = true;
+            if (wasSynchronouslyLoaded && !_covered) {
+              // Painted opaque on this very build, so there is no transition
+              // for `onEnd` to report — drop the layer on the next frame.
+              WidgetsBinding.instance.addPostFrameCallback(
+                (_) => _dropFallback(),
+              );
+            }
             return AnimatedOpacity(
               opacity: _hasFrame ? 1 : 0,
               // A cache hit paints on the first build; fading in from
               // nothing there would invent a transition nobody asked for.
               duration: wasSynchronouslyLoaded ? Duration.zero : _fadeDuration,
               curve: Curves.easeOut,
+              onEnd: _dropFallback,
               child: child,
             );
           },

--- a/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
@@ -969,17 +969,25 @@ class _FadingSlotImageState extends State<_FadingSlotImage> {
   /// dipping back to the fallback while the new file decodes.
   bool _hasFrame = false;
 
-  /// Set once the frame is fully opaque, from where the layer underneath is
-  /// a second full-size image painted behind an opaque one — on every frame,
-  /// for every slot, for as long as the picker is open. The error path keeps
-  /// its own copy via [ClipThumbnailImage.placeholder], and a reassigned slot
-  /// holds its previous frame through `gaplessPlayback`, so nothing still
-  /// needs it.
+  /// Set once the frame is fully opaque, at which point the fallback beneath
+  /// it is nothing but a second full-size image painted behind an opaque one
+  /// — on every frame, for every slot, for as long as the picker is open.
+  /// Dropping it is safe because both paths that could still want it are
+  /// covered: the error path keeps its own copy via
+  /// [ClipThumbnailImage.placeholder], and a reassigned slot holds its
+  /// previous frame through `gaplessPlayback`.
   bool _covered = false;
 
+  /// Always deferred to the next frame: [AnimatedOpacity] fires `onEnd`
+  /// synchronously when its duration is zero and the target changed, which
+  /// lands mid-build and would mark this ancestor dirty while the [Image]
+  /// below is still building.
   void _dropFallback() {
     if (_covered || !_hasFrame || !mounted) return;
-    setState(() => _covered = true);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _covered || !_hasFrame) return;
+      setState(() => _covered = true);
+    });
   }
 
   @override
@@ -996,12 +1004,10 @@ class _FadingSlotImageState extends State<_FadingSlotImage> {
           placeholder: widget.fallback,
           frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
             if (frame != null || wasSynchronouslyLoaded) _hasFrame = true;
-            if (wasSynchronouslyLoaded && !_covered) {
+            if (wasSynchronouslyLoaded) {
               // Painted opaque on this very build, so there is no transition
               // for `onEnd` to report — drop the layer on the next frame.
-              WidgetsBinding.instance.addPostFrameCallback(
-                (_) => _dropFallback(),
-              );
+              _dropFallback();
             }
             return AnimatedOpacity(
               opacity: _hasFrame ? 1 : 0,

--- a/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
@@ -653,7 +653,12 @@ class _TopBarContent extends StatelessWidget {
                 label: context.l10n.videoMetadataEditCoverConfirmSemanticLabel,
                 button: true,
                 child: isConfirming
-                    ? const BrandedLoadingIndicator(size: 44)
+                    // The indicator is an Image.asset that is not excluded
+                    // from semantics, so without this the confirm node
+                    // announces as an image as well as a button.
+                    ? const ExcludeSemantics(
+                        child: BrandedLoadingIndicator(size: 44),
+                      )
                     : DivineIconButton(
                         icon: .check,
                         size: .small,

--- a/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
@@ -540,10 +540,13 @@ class _TopBarState extends State<_TopBar> {
   void initState() {
     super.initState();
     // Armed from a post-frame callback, the same shape
-    // [CodecHeavySurfaceGuard] uses. Reading the route during the first build
-    // is unreliable — it still resolves to the route being pushed *from*,
-    // whose transition has long completed, so the bar would decide it had
-    // nothing to wait for.
+    // [CodecHeavySurfaceGuard] uses, for two independent reasons. Reading the
+    // route in initState throws outright, and reading it during the first
+    // build resolves the right route but the wrong animation: Navigator
+    // renders a newly pushed route offstage on its first frame so heroes can
+    // be measured, and ModalRoute swaps in kAlwaysCompleteAnimation while
+    // offstage. The bar would see `completed` and decide it had nothing to
+    // wait for.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) _armAfterEntrance();
     });
@@ -1013,7 +1016,11 @@ class _FadingSlotImageState extends State<_FadingSlotImage> {
               opacity: _hasFrame ? 1 : 0,
               // A cache hit paints on the first build; fading in from
               // nothing there would invent a transition nobody asked for.
-              duration: wasSynchronouslyLoaded ? Duration.zero : _fadeDuration,
+              duration:
+                  wasSynchronouslyLoaded ||
+                      MediaQuery.disableAnimationsOf(context)
+                  ? Duration.zero
+                  : _fadeDuration,
               curve: Curves.easeOut,
               onEnd: _dropFallback,
               child: child,

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -18,6 +18,7 @@ import 'package:openvine/services/native_proofmode_service.dart';
 import 'package:openvine/services/video_editor/native_render_task_registry.dart';
 import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
 import 'package:openvine/services/video_editor/video_editor_audio_render.dart';
+import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
@@ -503,6 +504,17 @@ class VideoEditorRenderService {
         );
       }
 
+      // The cover must come from the rendered file, not from the first source
+      // clip: the render trims, re-times, crops and filters, so an inherited
+      // frame has no matching position in the output. That mismatch is visible
+      // in the cover picker, which opens the preview at the clip's
+      // thumbnailTimestamp and would land on a different frame than the cover
+      // it just showed. Falling back to the source thumbnail keeps a render
+      // whose extraction failed from losing its preview entirely.
+      final cover = await VideoThumbnailService.extractThumbnail(
+        videoPath: outputPath,
+      );
+
       final clip = DivineVideoClip(
         id: 'clip-${DateTime.now().millisecondsSinceEpoch}',
         video: EditorVideo.file(outputPath),
@@ -510,7 +522,8 @@ class VideoEditorRenderService {
         recordedAt: DateTime.now(),
         originalAspectRatio: clips.first.originalAspectRatio,
         targetAspectRatio: clips.first.targetAspectRatio,
-        thumbnailPath: clips.first.thumbnailPath,
+        thumbnailPath: cover?.path ?? clips.first.thumbnailPath,
+        thumbnailTimestamp: cover?.timestamp,
       );
 
       return (clip, proofManifestJson);

--- a/mobile/lib/widgets/video_clip/clip_thumbnail_image.dart
+++ b/mobile/lib/widgets/video_clip/clip_thumbnail_image.dart
@@ -27,6 +27,7 @@ class ClipThumbnailImage extends StatelessWidget {
     this.gaplessPlayback = false,
     this.excludeFromSemantics = false,
     this.placeholder,
+    this.frameBuilder,
   });
 
   /// Absolute path of the thumbnail/ghost file.
@@ -44,6 +45,11 @@ class ClipThumbnailImage extends StatelessWidget {
   /// the drafts list uses for a clip with no thumbnail).
   final Widget? placeholder;
 
+  /// Wraps the decoded image, e.g. to fade it in once the first frame
+  /// lands. Forwarded verbatim to [Image.file]; not called on the error
+  /// path, where [placeholder] replaces the image outright.
+  final ImageFrameBuilder? frameBuilder;
+
   @override
   Widget build(BuildContext context) {
     return Image.file(
@@ -54,6 +60,7 @@ class ClipThumbnailImage extends StatelessWidget {
       cacheHeight: cacheHeight,
       gaplessPlayback: gaplessPlayback,
       excludeFromSemantics: excludeFromSemantics,
+      frameBuilder: frameBuilder,
       errorBuilder: (context, error, stackTrace) =>
           placeholder ?? const _MissingThumbnailPlaceholder(),
     );

--- a/mobile/test/screens/video_metadata_cover_screen_test.dart
+++ b/mobile/test/screens/video_metadata_cover_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' as models;
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
@@ -127,6 +128,51 @@ void main() {
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: VideoMetadataCoverScreen(clip: clip ?? _createTestClip()),
+          ),
+        ),
+      );
+    }
+
+    /// Wraps the screen behind a push so the route transition — and with it
+    /// the hero flight — actually runs. Pumped directly as `home:` the route
+    /// animation is already completed and never animates.
+    Widget buildPushableApp(DivineVideoClip clip) {
+      return ProviderScope(
+        overrides: [
+          videoEditorProvider.overrideWith(
+            () => _MockVideoEditorNotifier(VideoEditorProviderState()),
+          ),
+        ],
+        child: MockGoRouterProvider(
+          goRouter: mockGoRouter,
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Builder(
+              builder: (context) => Center(
+                // A matching hero on the source side, so the push runs a real
+                // flight through the navigator overlay rather than a bare
+                // route transition.
+                child: Hero(
+                  tag: VideoEditorConstants.heroMetaPreviewId,
+                  child: SizedBox(
+                    width: 200,
+                    height: 200,
+                    child: TextButton(
+                      // Mirrors the production push in
+                      // video_metadata_capture_clip_preview.dart.
+                      onPressed: () => Navigator.of(context).push(
+                        PageRouteBuilder<void>(
+                          pageBuilder: (_, _, _) =>
+                              VideoMetadataCoverScreen(clip: clip),
+                        ),
+                      ),
+                      child: const Text('open'),
+                    ),
+                  ),
+                ),
+              ),
+            ),
           ),
         ),
       );
@@ -330,6 +376,68 @@ void main() {
         findsOneWidget,
       );
     });
+
+    testWidgets('keeps the top bar hidden until the route transition lands', (
+      tester,
+    ) async {
+      setUpPlayerChannel();
+      addTearDown(tearDownPlayerChannel);
+
+      await tester.pumpWidget(buildPushableApp(_createTestClip()));
+      await tester.tap(find.text('open'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      final topBar = find.ancestor(
+        of: find.text(l10n.videoMetadataEditCoverTitle),
+        matching: find.byType(AnimatedOpacity),
+      );
+
+      // Mid-flight the hero is painted by the navigator overlay, on top of
+      // anything the route draws — the bar must stay out of the way.
+      expect(tester.widget<AnimatedOpacity>(topBar).opacity, equals(0.0));
+
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(tester.widget<AnimatedOpacity>(topBar).opacity, equals(1.0));
+    });
+
+    testWidgets(
+      'loads the preview at the cover position instead of seeking after '
+      'load',
+      (tester) async {
+        addTearDown(tearDownPlayerChannel);
+        final calls = <MethodCall>[];
+        _setHandler(const MethodChannel('divine_video_player/player_0'), (
+          call,
+        ) async {
+          calls.add(call);
+          return null;
+        });
+        _setHandler(
+          const MethodChannel('divine_video_player/player_0/events'),
+          (call) async => null,
+        );
+
+        await tester.pumpWidget(
+          buildWidget(
+            clip: _createTestClip().copyWith(
+              thumbnailTimestamp: const Duration(milliseconds: 1500),
+            ),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 400));
+
+        final setClips = calls.singleWhere((c) => c.method == 'setClips');
+        expect(
+          (setClips.arguments as Map)['startPositionMs'],
+          equals(1500),
+          reason: 'the first decoded frame must already be the cover frame',
+        );
+        expect(calls.where((c) => c.method == 'seekTo'), isEmpty);
+      },
+    );
 
     testWidgets(
       'a permanently failed preview still generates the cover strip, hides '

--- a/mobile/test/screens/video_metadata_cover_screen_test.dart
+++ b/mobile/test/screens/video_metadata_cover_screen_test.dart
@@ -429,7 +429,9 @@ void main() {
         );
         await tester.pump(const Duration(milliseconds: 400));
 
-        final setClips = calls.singleWhere((c) => c.method == 'setClips');
+        final setClipsCalls = calls.where((c) => c.method == 'setClips');
+        expect(setClipsCalls, hasLength(1));
+        final setClips = setClipsCalls.first;
         expect(
           (setClips.arguments as Map)['startPositionMs'],
           equals(1500),

--- a/mobile/test/screens/video_metadata_cover_screen_test.dart
+++ b/mobile/test/screens/video_metadata_cover_screen_test.dart
@@ -377,6 +377,59 @@ void main() {
       );
     });
 
+    testWidgets('dims the strip either side of the selection cursor', (
+      tester,
+    ) async {
+      setUpPlayerChannel();
+      addTearDown(tearDownPlayerChannel);
+
+      await tester.pumpWidget(buildWidget());
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final dimFinder = find.byWidgetPredicate(
+        (w) => w is ColoredBox && w.color == VineTheme.scrim35,
+      );
+      expect(dimFinder, findsNWidgets(2));
+
+      Rect leftDim() => tester.getRect(dimFinder.first);
+      Rect rightDim() => tester.getRect(dimFinder.last);
+
+      // The dims span the strip between them, flanking the cursor.
+      final stripLeft = leftDim().left;
+      final stripRight = rightDim().right;
+      expect(rightDim().left - leftDim().right, equals(36.0));
+
+      // The default cover sits inside the cursor's own width, so the clamp
+      // collapses the leading dim rather than giving it a negative width.
+      expect(leftDim().width, equals(0.0));
+
+      final midY = leftDim().center.dy;
+      await tester.tapAt(
+        Offset(stripLeft + (stripRight - stripLeft) * 0.6, midY),
+      );
+      await tester.pump();
+
+      // Moving the selection later widens the dim behind it. The strip's own
+      // bounds do not move, and the cursor-sized gap is preserved.
+      expect(leftDim().width, greaterThan(0));
+      expect(leftDim().left, equals(stripLeft));
+      expect(rightDim().right, equals(stripRight));
+      expect(rightDim().left - leftDim().right, equals(36.0));
+
+      // Clamped at the far end too: the trailing dim collapses rather than
+      // running past the strip.
+      await tester.tapAt(Offset(stripRight - 1, midY));
+      await tester.pump();
+      expect(rightDim().width, equals(0.0));
+      expect(stripRight - leftDim().right, equals(36.0));
+
+      // And back to the start.
+      await tester.tapAt(Offset(stripLeft + 1, midY));
+      await tester.pump();
+      expect(leftDim().width, equals(0.0));
+      expect(rightDim().left - stripLeft, equals(36.0));
+    });
+
     testWidgets('keeps the top bar hidden until the route transition lands', (
       tester,
     ) async {

--- a/mobile/test/screens/video_metadata_cover_screen_test.dart
+++ b/mobile/test/screens/video_metadata_cover_screen_test.dart
@@ -355,7 +355,7 @@ void main() {
           find.text(l10n.videoMetadataEditCoverFailedSnackbar),
           findsOneWidget,
         );
-        expect(find.byType(CircularProgressIndicator), findsNothing);
+        expect(find.byType(BrandedLoadingIndicator), findsNothing);
       },
     );
 
@@ -368,7 +368,7 @@ void main() {
       await tester.pumpWidget(buildWidget());
       await tester.pump(const Duration(milliseconds: 400));
 
-      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.byType(BrandedLoadingIndicator), findsNothing);
       expect(
         find.byWidgetPredicate(
           (w) => w is DivineIconButton && w.icon == DivineIconName.check,

--- a/mobile/test/services/video_editor/video_editor_render_service_progress_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_progress_test.dart
@@ -134,6 +134,7 @@ DivineVideoClip _createClip(int index) {
     recordedAt: DateTime(2026, 6, 5, 12, index),
     targetAspectRatio: model.AspectRatio.vertical,
     originalAspectRatio: 9 / 16,
+    thumbnailPath: '${Directory.systemTemp.path}/clip-$index-thumb.jpg',
   );
 }
 
@@ -264,6 +265,13 @@ void main() {
 
         expect(result, isNotNull);
         expect(result?.$2, isNotNull);
+        // Cover extraction cannot succeed here (the render output is never
+        // written), so the clip must fall back to the first source clip's
+        // thumbnail rather than being left without a preview.
+        expect(
+          result?.$1.thumbnailPath,
+          equals('${Directory.systemTemp.path}/clip-0-thumb.jpg'),
+        );
         expect(
           proofCallClipCounts,
           equals([null, null, null, 3]),

--- a/mobile/test/widgets/video_clip/clip_thumbnail_image_test.dart
+++ b/mobile/test/widgets/video_clip/clip_thumbnail_image_test.dart
@@ -8,6 +8,16 @@ import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
 
 void main() {
   group(ClipThumbnailImage, () {
+    // Every test here resolves a deliberately missing file, and a failed
+    // resolution stays in the process-global cache. Under the merged-isolate
+    // test run that entry would outlive this file and deliver the error
+    // before the first build of any later test using the same path.
+    tearDown(() {
+      PaintingBinding.instance.imageCache
+        ..clear()
+        ..clearLiveImages();
+    });
+
     Future<void> pumpMissingThumbnail(
       WidgetTester tester, {
       Widget? placeholder,
@@ -70,9 +80,6 @@ void main() {
                 width: 120,
                 height: 120,
                 child: ClipThumbnailImage(
-                  // A path of its own: the sibling tests leave a failed
-                  // entry for theirs in the process-global image cache,
-                  // which would deliver the error before the first build.
                   path: '/nonexistent/container/frame_builder_probe.jpg',
                   placeholder: const SizedBox.shrink(),
                   frameBuilder: (context, child, frame, _) =>

--- a/mobile/test/widgets/video_clip/clip_thumbnail_image_test.dart
+++ b/mobile/test/widgets/video_clip/clip_thumbnail_image_test.dart
@@ -56,5 +56,43 @@ void main() {
       expect(find.byKey(marker), findsOneWidget);
       expect(find.byType(DivineIcon), findsNothing);
     });
+
+    testWidgets(
+      'wraps the image with frameBuilder while decoding, and drops it for '
+      'the placeholder once decoding fails',
+      (tester) async {
+        const marker = Key('frame-builder');
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 120,
+                height: 120,
+                child: ClipThumbnailImage(
+                  // A path of its own: the sibling tests leave a failed
+                  // entry for theirs in the process-global image cache,
+                  // which would deliver the error before the first build.
+                  path: '/nonexistent/container/frame_builder_probe.jpg',
+                  placeholder: const SizedBox.shrink(),
+                  frameBuilder: (context, child, frame, _) =>
+                      SizedBox(key: marker, child: child),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byKey(marker), findsOneWidget);
+
+        await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 100)),
+        );
+        await tester.pump();
+
+        expect(tester.takeException(), isNull);
+        expect(find.byKey(marker), findsNothing);
+      },
+    );
   });
 }


### PR DESCRIPTION
Closes #6828

## Description

Opening the cover picker flashed in four distinct ways. Each had its own cause, so they are separated into two commits.

**The cover the picker opens on was a frame of a different file.** The rendered clip inherited `thumbnailPath` from the first source clip and carried no `thumbnailTimestamp`, so its cover was a frame of the raw recording — before trim, speed, crop and filters — while the fallback timestamp pointed 210 ms into the *rendered* file. The picker showed the inherited thumbnail via the hero and then jumped to whatever sits at 210 ms. With a trim this stopped being cosmetic: the published cover could be a frame the video no longer contains. The cover is now extracted from the render output, which pairs path and timestamp by construction — the same thing the picker already does when the user confirms a frame by hand. If extraction fails it falls back to the inherited thumbnail, so a render is never left without a preview.

**The preview loaded at 0 and seeked afterwards.** `setSource` prepares at position 0, so the decoder's first frame — and `firstFrameRendered` with it — landed on frame 0, and the seek to the cover position only moved it after the texture was already on screen. `setClips` takes a `startPosition` that both platforms honour before reporting ready (Android `setMediaItems(items, startIndex, startLocalMs)` before `prepare()`, iOS seek + `forceRefresh` + preroll before `"ready"`), so the first decoded frame is the selected one.

**The player was hard-cut in over the hero's thumbnail.** `DivineVideoPlayer` skips its placeholder entirely when the first frame is already decoded at mount, which is exactly the case here — the thumbnail was already on screen because the hero flew it in. `crossFadePlaceholder: true` keeps it for the hand-off, the same reason the video editor sets it.

**The strip flipped in one frame.** The priority timestamps cover every slot, so the first batch replaces the stretched cover thumbnail in every tile at once. Tiles now fade their frame in over that fallback. The fade flag is sticky on purpose: a later batch reassigning a slot keeps the previous frame up via `gaplessPlayback` instead of dipping back to the fallback while the new file decodes. This needed a `frameBuilder` passthrough on `ClipThumbnailImage` — its `placeholder` is an error path, not a loading state, so there was no hook for a fade.

**The top bar was painted over by the flying video** and popped back in front when the hero landed, because the hero flies in the navigator's overlay, above everything the route itself paints. The bar now waits for the entrance transition and fades in. It follows `CodecHeavySurfaceGuard`: the route is read from a post-frame callback, not during build, because on the first build `ModalRoute.of` still resolves to the route being pushed *from*, whose transition has long completed — verified on device, where the first reading reported `completed` before the second reported `forward`. Opacity 0 already drops the buttons from the semantics tree, but it still hit tests, so taps are blocked separately.

Smaller: the areas either side of the strip selection are dimmed, and the confirm spinner is `BrandedLoadingIndicator` instead of a raw `CircularProgressIndicator`.

**Related Issue:** 

## Out of Scope

The page cross-fade on both push sites stays as it is. While the incoming page is translucent the screen underneath shows through, and its header sits at the same position as the cover screen's, so buttons are briefly visible there too. Removing the cross-fade fixes that (both screens share `surfaceContainerHigh`, so the swap would be invisible), but it changes the feel of the transition and was not part of what was verified here.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test test/screens/video_metadata_cover_screen_test.dart test/widgets/video_clip test/widgets/video_metadata test/services/video_editor/video_editor_render_service_test.dart test/services/video_editor/video_editor_render_service_progress_test.dart test/providers/video_editor_provider_test.dart test/models/divine_video_draft_cover_thumbnail_test.dart` — 354 passing
- New tests: `setClips` carries `startPositionMs` and no separate `seekTo` fires on init; the top bar is at opacity 0 mid-push and 1 after the transition lands (pushed through a real route with a matching source hero, so an actual flight runs); `ClipThumbnailImage` wraps the image with `frameBuilder` while decoding and drops it for the placeholder when decoding fails.
- No test for `renderVideoToClip` — it sits behind ProofMode and the native renderer, so a test there would be mock scaffolding rather than evidence.
- Manually verified on a real Samsung Galaxy: open the picker from the metadata screen with and without a manually chosen cover, scrub the strip, confirm, reopen.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore