### PR TITLE
fix(video-metadata): keep the preview rounded and make the audio credit form readable

### DIFF
--- a/mobile/lib/constants/video_editor_constants.dart
+++ b/mobile/lib/constants/video_editor_constants.dart
@@ -247,9 +247,11 @@ class VideoEditorConstants {
   /// Hero animation tag for the final clip-preview in the video editor.
   static const heroMetaPreviewId = 'Video-metadata-clip-preview-video';
 
-  /// Corner radius of the clip-preview thumbnail the [heroMetaPreviewId] hero
-  /// flies from. The preview screen morphs its flight out of this shape into
-  /// the stage's rounded bottom, so both sides read the same value.
+  /// Corner radius of the clip-preview thumbnails that carry
+  /// [heroMetaPreviewId]. The preview screen morphs its flight out of this
+  /// shape into the stage's rounded bottom, so the thumbnails and the flight
+  /// cannot drift apart. The cover screen is the other destination on that
+  /// tag and keeps its own rounding.
   static const clipPreviewCornerRadius = 16.0;
 
   /// Hero animation tag for the audio-chip in the video editor.

--- a/mobile/lib/constants/video_editor_constants.dart
+++ b/mobile/lib/constants/video_editor_constants.dart
@@ -247,6 +247,11 @@ class VideoEditorConstants {
   /// Hero animation tag for the final clip-preview in the video editor.
   static const heroMetaPreviewId = 'Video-metadata-clip-preview-video';
 
+  /// Corner radius of the clip-preview thumbnail the [heroMetaPreviewId] hero
+  /// flies from. The preview screen morphs its flight out of this shape into
+  /// the stage's rounded bottom, so both sides read the same value.
+  static const clipPreviewCornerRadius = 16.0;
+
   /// Hero animation tag for the audio-chip in the video editor.
   static const heroAudioChipId = 'Video-Editor-Audio-Chip';
 

--- a/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
@@ -626,7 +626,7 @@ class _TopBarContent extends StatelessWidget {
       child: SafeArea(
         bottom: false,
         child: Padding(
-          padding: const .all(16),
+          padding: const .symmetric(horizontal: 16),
           child: Row(
             spacing: 16,
             children: [

--- a/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
@@ -625,7 +625,8 @@ class _TopBarContent extends StatelessWidget {
       alignment: .topCenter,
       child: SafeArea(
         bottom: false,
-        child: Padding(
+        child: Container(
+          height: kToolbarHeight,
           padding: const .symmetric(horizontal: 16),
           child: Row(
             spacing: 16,

--- a/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
@@ -15,6 +15,7 @@ import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
+import 'package:openvine/widgets/video_metadata/metadata_hero_corners.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:time_formatter/time_formatter.dart';
@@ -472,10 +473,11 @@ class _VideoAreaState extends State<_VideoArea> {
         ? _videoAR
         : widget.clip.targetAspectRatio.value;
     final isSquare = widget.clip.targetAspectRatio.value == 1.0;
+    final coverBorderRadius = isSquare
+        ? BorderRadius.circular(12)
+        : const BorderRadius.vertical(bottom: Radius.circular(32));
     final player = ClipRRect(
-      borderRadius: isSquare
-          ? .circular(12)
-          : const .vertical(bottom: .circular(32)),
+      borderRadius: coverBorderRadius,
       child: FittedBox(
         fit: isSquare ? BoxFit.contain : BoxFit.cover,
         child: SizedBox(
@@ -496,6 +498,14 @@ class _VideoAreaState extends State<_VideoArea> {
     return Hero(
       tag: VideoEditorConstants.heroMetaPreviewId,
       createRectTween: (begin, end) => RectTween(begin: begin, end: end),
+      // The thumbnails round themselves from outside their Hero, so on the way
+      // back the shuttle arrives with no rounding of its own.
+      flightShuttleBuilder: (_, animation, _, _, toHeroContext) =>
+          MetadataHeroCorners(
+            animation: animation,
+            destinationBorderRadius: coverBorderRadius,
+            child: (toHeroContext.widget as Hero).child,
+          ),
       child: AspectRatio(
         aspectRatio: widget.clip.targetAspectRatio.value,
         child: isSquare ? Center(child: player) : player,

--- a/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
@@ -109,6 +109,11 @@ class _VideoMetadataPreviewScreenState
 
   @override
   Widget build(BuildContext context) {
+    final stageBorderRadius = widget.previewOnly
+        ? BorderRadius.zero
+        : const BorderRadius.vertical(
+            bottom: Radius.circular(VineTheme.shellCornerRadius),
+          );
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: VideoEditorConstants.uiOverlayStyleFor(context.vineColors),
       child: Scaffold(
@@ -119,13 +124,14 @@ class _VideoMetadataPreviewScreenState
             // Video preview area with close button
             Expanded(
               child: _PreviewStage(
-                roundBottom: !widget.previewOnly,
+                borderRadius: stageBorderRadius,
                 child: Stack(
                   fit: .expand,
                   children: [
                     _VideoPreviewContent(
                       clip: widget.clip,
                       controller: _controller,
+                      stageBorderRadius: stageBorderRadius,
                     ),
                     if (!widget.previewOnly)
                       // The overlay offsets its caption and action column
@@ -167,20 +173,15 @@ class _VideoMetadataPreviewScreenState
 /// The preview-only route has no bottom chrome to seam into and stays edge to
 /// edge — the same branch the fullscreen feed takes in `_MaybeRoundFeedBottom`.
 class _PreviewStage extends StatelessWidget {
-  const _PreviewStage({required this.roundBottom, required this.child});
+  const _PreviewStage({required this.borderRadius, required this.child});
 
-  final bool roundBottom;
+  final BorderRadius borderRadius;
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
-    if (!roundBottom) return child;
-    return ClipRRect(
-      borderRadius: const BorderRadius.vertical(
-        bottom: Radius.circular(VineTheme.shellCornerRadius),
-      ),
-      child: child,
-    );
+    if (borderRadius == BorderRadius.zero) return child;
+    return ClipRRect(borderRadius: borderRadius, child: child);
   }
 }
 
@@ -200,10 +201,17 @@ class _PreviewStage extends StatelessWidget {
 /// post path once the render has baked the target crop into the file.
 class _VideoPreviewContent extends StatelessWidget {
   /// Creates the video preview content wrapper.
-  const _VideoPreviewContent({required this.clip, required this.controller});
+  const _VideoPreviewContent({
+    required this.clip,
+    required this.controller,
+    required this.stageBorderRadius,
+  });
 
   final DivineVideoClip clip;
   final DivineVideoPlayerController? controller;
+
+  /// Shape the stage rests at, which the hero flight morphs into.
+  final BorderRadius stageBorderRadius;
 
   @override
   Widget build(BuildContext context) {
@@ -223,6 +231,12 @@ class _VideoPreviewContent extends StatelessWidget {
       tag: VideoEditorConstants.heroMetaPreviewId,
       // Use linear flight path instead of curved arc
       createRectTween: (begin, end) => RectTween(begin: begin, end: end),
+      flightShuttleBuilder: (_, animation, _, _, toHeroContext) =>
+          _PreviewFlightCorners(
+            animation: animation,
+            stageBorderRadius: stageBorderRadius,
+            child: (toHeroContext.widget as Hero).child,
+          ),
       child: Stack(
         fit: .expand,
         children: [
@@ -245,6 +259,43 @@ class _VideoPreviewContent extends StatelessWidget {
               fit: fit,
             ),
         ],
+      ),
+    );
+  }
+}
+
+/// Carries the stage's rounded bottom through the hero flight.
+///
+/// The flying widget is lifted into the navigator overlay, above the
+/// [_PreviewStage] clip, so the stage's rounding cannot reach it — the corners
+/// only appeared once the flight landed. Clip the shuttle here instead, morphing
+/// out of the clip thumbnail's all-round corners into the stage's shape.
+///
+/// The flight animation runs 0 (metadata screen) to 1 (preview screen) in both
+/// directions, because a pop drives it from the popped route's animation.
+class _PreviewFlightCorners extends StatelessWidget {
+  const _PreviewFlightCorners({
+    required this.animation,
+    required this.stageBorderRadius,
+    required this.child,
+  });
+
+  final Animation<double> animation;
+  final BorderRadius stageBorderRadius;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: animation,
+      child: child,
+      builder: (context, child) => ClipRRect(
+        borderRadius: BorderRadius.lerp(
+          BorderRadius.circular(VideoEditorConstants.clipPreviewCornerRadius),
+          stageBorderRadius,
+          animation.value.clamp(0.0, 1.0),
+        )!,
+        child: child,
       ),
     );
   }

--- a/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
@@ -17,6 +17,7 @@ import 'package:openvine/screens/feed/feed_mode_switch.dart';
 import 'package:openvine/widgets/stop_motion/stop_motion_player.dart';
 import 'package:openvine/widgets/video_feed_item/blurred_video_backdrop.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
+import 'package:openvine/widgets/video_metadata/metadata_hero_corners.dart';
 import 'package:openvine/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar.dart';
 import 'package:openvine/widgets/video_metadata/modes/capture/video_metadata_capture_preview_thumbnail.dart';
 
@@ -232,9 +233,9 @@ class _VideoPreviewContent extends StatelessWidget {
       // Use linear flight path instead of curved arc
       createRectTween: (begin, end) => RectTween(begin: begin, end: end),
       flightShuttleBuilder: (_, animation, _, _, toHeroContext) =>
-          _PreviewFlightCorners(
+          MetadataHeroCorners(
             animation: animation,
-            stageBorderRadius: stageBorderRadius,
+            destinationBorderRadius: stageBorderRadius,
             child: (toHeroContext.widget as Hero).child,
           ),
       child: Stack(
@@ -259,48 +260,6 @@ class _VideoPreviewContent extends StatelessWidget {
               fit: fit,
             ),
         ],
-      ),
-    );
-  }
-}
-
-/// Carries the stage's rounded bottom through the hero flight.
-///
-/// The flying widget is lifted into the navigator overlay, above the
-/// [_PreviewStage] clip, so the stage's rounding cannot reach it — the corners
-/// only appeared once the flight landed. Clip the shuttle here instead, morphing
-/// out of the clip thumbnail's all-round corners into the stage's shape. The
-/// thumbnails round themselves from outside their Hero so this is the only clip
-/// on the shuttle; one inside the Hero child would ride along and pin the
-/// corners it is meant to be animating.
-///
-/// The animation's endpoints mean the same thing in both directions — 0 is the
-/// metadata screen, 1 is the preview — because a push drives it from the pushed
-/// route's animation and a pop from the popped one. A pop runs 1 to 0, so a
-/// single lerp covers the way back.
-class _PreviewFlightCorners extends StatelessWidget {
-  const _PreviewFlightCorners({
-    required this.animation,
-    required this.stageBorderRadius,
-    required this.child,
-  });
-
-  final Animation<double> animation;
-  final BorderRadius stageBorderRadius;
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    return AnimatedBuilder(
-      animation: animation,
-      child: child,
-      builder: (context, child) => ClipRRect(
-        borderRadius: BorderRadius.lerp(
-          BorderRadius.circular(VideoEditorConstants.clipPreviewCornerRadius),
-          stageBorderRadius,
-          animation.value,
-        )!,
-        child: child,
       ),
     );
   }

--- a/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
@@ -269,10 +269,15 @@ class _VideoPreviewContent extends StatelessWidget {
 /// The flying widget is lifted into the navigator overlay, above the
 /// [_PreviewStage] clip, so the stage's rounding cannot reach it — the corners
 /// only appeared once the flight landed. Clip the shuttle here instead, morphing
-/// out of the clip thumbnail's all-round corners into the stage's shape.
+/// out of the clip thumbnail's all-round corners into the stage's shape. The
+/// thumbnails round themselves from outside their Hero so this is the only clip
+/// on the shuttle; one inside the Hero child would ride along and pin the
+/// corners it is meant to be animating.
 ///
-/// The flight animation runs 0 (metadata screen) to 1 (preview screen) in both
-/// directions, because a pop drives it from the popped route's animation.
+/// The animation's endpoints mean the same thing in both directions — 0 is the
+/// metadata screen, 1 is the preview — because a push drives it from the pushed
+/// route's animation and a pop from the popped one. A pop runs 1 to 0, so a
+/// single lerp covers the way back.
 class _PreviewFlightCorners extends StatelessWidget {
   const _PreviewFlightCorners({
     required this.animation,

--- a/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
@@ -298,7 +298,7 @@ class _PreviewFlightCorners extends StatelessWidget {
         borderRadius: BorderRadius.lerp(
           BorderRadius.circular(VideoEditorConstants.clipPreviewCornerRadius),
           stageBorderRadius,
-          animation.value.clamp(0.0, 1.0),
+          animation.value,
         )!,
         child: child,
       ),

--- a/mobile/lib/widgets/video_metadata/metadata_hero_corners.dart
+++ b/mobile/lib/widgets/video_metadata/metadata_hero_corners.dart
@@ -1,0 +1,59 @@
+// ABOUTME: Rounds the metadata clip-preview hero while it is in flight.
+// ABOUTME: Both destinations on that tag wrap their shuttle in this.
+
+import 'package:flutter/material.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
+
+/// Carries a rounded shape through a [VideoEditorConstants.heroMetaPreviewId]
+/// flight.
+///
+/// The flying widget is lifted into the navigator overlay, above the
+/// destination screen's own clip, so that clip cannot reach it — the corners
+/// only appear once the flight lands. Clip the shuttle here instead, morphing
+/// out of the thumbnail's all-round
+/// [VideoEditorConstants.clipPreviewCornerRadius] into
+/// [destinationBorderRadius].
+///
+/// The animation's endpoints mean the same thing in both directions — 0 is the
+/// metadata screen, 1 is the destination — because a push drives it from the
+/// pushed route's animation and a pop from the popped one. A pop runs 1 to 0,
+/// so a single lerp covers the way back.
+///
+/// Set this from the *destination's* [Hero], not the thumbnail's: on a pop the
+/// destination is the thumbnail, which has no builder, so Flutter falls back to
+/// the route being left. A builder on the thumbnail would instead win over
+/// every destination's.
+class MetadataHeroCorners extends StatelessWidget {
+  /// Creates the flight clip for a metadata clip-preview hero.
+  const MetadataHeroCorners({
+    required this.animation,
+    required this.destinationBorderRadius,
+    required this.child,
+    super.key,
+  });
+
+  /// The flight's progress, 0 at the metadata screen and 1 at the destination.
+  final Animation<double> animation;
+
+  /// Shape the destination rests at, which the flight morphs into.
+  final BorderRadius destinationBorderRadius;
+
+  /// The flying hero's content.
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: animation,
+      child: child,
+      builder: (context, child) => ClipRRect(
+        borderRadius: BorderRadius.lerp(
+          BorderRadius.circular(VideoEditorConstants.clipPreviewCornerRadius),
+          destinationBorderRadius,
+          animation.value,
+        )!,
+        child: child,
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview.dart
+++ b/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview.dart
@@ -72,7 +72,9 @@ class VideoMetadataCaptureClipPreview extends ConsumerWidget {
           child: AspectRatio(
             aspectRatio: clip.targetAspectRatio.value,
             child: ClipRRect(
-              borderRadius: .circular(16),
+              borderRadius: .circular(
+                VideoEditorConstants.clipPreviewCornerRadius,
+              ),
               child: Semantics(
                 button: true,
                 enabled: isReady,

--- a/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview.dart
+++ b/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview.dart
@@ -64,17 +64,20 @@ class VideoMetadataCaptureClipPreview extends ConsumerWidget {
     return Center(
       child: SizedBox(
         height: 200,
-        // Hero animation to preview screen
-        child: Hero(
-          tag: VideoEditorConstants.heroMetaPreviewId,
-          // Use linear flight path instead of curved arc
-          createRectTween: (begin, end) => RectTween(begin: begin, end: end),
-          child: AspectRatio(
-            aspectRatio: clip.targetAspectRatio.value,
-            child: ClipRRect(
-              borderRadius: .circular(
-                VideoEditorConstants.clipPreviewCornerRadius,
-              ),
+        // Rounds the thumbnail from outside the Hero: a clip inside the Hero
+        // child rides into the flight shuttle and fights the shape the
+        // preview's flightShuttleBuilder is morphing towards.
+        child: ClipRRect(
+          borderRadius: .circular(
+            VideoEditorConstants.clipPreviewCornerRadius,
+          ),
+          // Hero animation to preview screen
+          child: Hero(
+            tag: VideoEditorConstants.heroMetaPreviewId,
+            // Use linear flight path instead of curved arc
+            createRectTween: (begin, end) => RectTween(begin: begin, end: end),
+            child: AspectRatio(
+              aspectRatio: clip.targetAspectRatio.value,
               child: Semantics(
                 button: true,
                 enabled: isReady,

--- a/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_stack.dart
+++ b/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_stack.dart
@@ -213,15 +213,18 @@ class _EditClipPreview extends StatelessWidget {
     final thumbnailUrl = video.thumbnailUrl;
     final ratio = _aspectRatio();
     return Center(
-      child: Hero(
-        tag: VideoEditorConstants.heroMetaPreviewId,
-        child: SizedBox(
-          height: 200,
-          width: 200 * ratio,
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(
-              VideoEditorConstants.clipPreviewCornerRadius,
-            ),
+      // Rounds the thumbnail from outside the Hero: a clip inside the Hero
+      // child rides into the flight shuttle and fights the shape the
+      // preview's flightShuttleBuilder is morphing towards.
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(
+          VideoEditorConstants.clipPreviewCornerRadius,
+        ),
+        child: Hero(
+          tag: VideoEditorConstants.heroMetaPreviewId,
+          child: SizedBox(
+            height: 200,
+            width: 200 * ratio,
             child: Stack(
               fit: StackFit.expand,
               children: [

--- a/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_stack.dart
+++ b/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_stack.dart
@@ -219,7 +219,9 @@ class _EditClipPreview extends StatelessWidget {
           height: 200,
           width: 200 * ratio,
           child: ClipRRect(
-            borderRadius: BorderRadius.circular(16),
+            borderRadius: BorderRadius.circular(
+              VideoEditorConstants.clipPreviewCornerRadius,
+            ),
             child: Stack(
               fit: StackFit.expand,
               children: [

--- a/mobile/lib/widgets/video_metadata/video_metadata_audio_sharing_section.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_audio_sharing_section.dart
@@ -357,6 +357,7 @@ class _PublicAudioCreditEditorState
             ),
           ),
           child: ListTile(
+            contentPadding: const .symmetric(horizontal: 16),
             title: Text(
               context.l10n.soundSharedAs,
               style: VineTheme.labelMediumFont(

--- a/mobile/lib/widgets/video_metadata/video_metadata_audio_sharing_section.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_audio_sharing_section.dart
@@ -84,7 +84,7 @@ class VideoMetadataAudioSharingSection extends ConsumerWidget {
               editorState.requiresPublicAudioAttribution &&
                   !editorState.hasValidPublicAudioAttribution
               ? Padding(
-                  padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
                   child: Text(
                     context.l10n.soundCreditRequired,
                     key: const Key('audio_credit_validation'),

--- a/mobile/lib/widgets/video_metadata/video_metadata_audio_sharing_section.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_audio_sharing_section.dart
@@ -244,9 +244,8 @@ class _PublicAudioCreditEditorState
       crossAxisAlignment: CrossAxisAlignment.stretch,
       spacing: 8,
       children: [
-        const SizedBox(height: 8),
         Padding(
-          padding: const .symmetric(horizontal: 16),
+          padding: const .fromLTRB(16, 16, 16, 0),
           child: Text(
             context.l10n.soundPublicCredit,
             style: VineTheme.titleSmallFont(

--- a/mobile/lib/widgets/video_metadata/video_metadata_audio_sharing_section.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_audio_sharing_section.dart
@@ -69,7 +69,7 @@ class VideoMetadataAudioSharingSection extends ConsumerWidget {
             onChanged: derivativesAllowed ? updateReuse : null,
           ),
         ),
-        _ExpandSwitcher(
+        AnimatedReveal(
           child: external != null
               ? _ProviderAudioCredit(sound: sound!)
               : allowAudioReuse
@@ -77,9 +77,9 @@ class VideoMetadataAudioSharingSection extends ConsumerWidget {
                   key: ValueKey(sound?.id ?? 'original-audio'),
                   sound: sound,
                 )
-              : const SizedBox.shrink(),
+              : null,
         ),
-        _ExpandSwitcher(
+        AnimatedReveal(
           child:
               editorState.requiresPublicAudioAttribution &&
                   !editorState.hasValidPublicAudioAttribution
@@ -91,7 +91,7 @@ class VideoMetadataAudioSharingSection extends ConsumerWidget {
                     style: VineTheme.bodySmallFont(color: VineTheme.error),
                   ),
                 )
-              : const SizedBox.shrink(),
+              : null,
         ),
       ],
     );
@@ -118,29 +118,6 @@ class VideoMetadataAudioSharingSection extends ConsumerWidget {
       title: title?.isNotEmpty == true ? title! : 'Original sound',
       publisherName: publisherName,
       publisherPubkey: pubkey,
-    );
-  }
-}
-
-/// Cross-fades between the section's optional rows, growing the incoming one
-/// out of the top edge so the card's height never jumps.
-class _ExpandSwitcher extends StatelessWidget {
-  const _ExpandSwitcher({required this.child});
-
-  final Widget child;
-
-  static const _duration = Duration(milliseconds: 180);
-
-  @override
-  Widget build(BuildContext context) {
-    return AnimatedSwitcher(
-      duration: _duration,
-      transitionBuilder: (child, animation) => SizeTransition(
-        sizeFactor: animation,
-        alignment: Alignment.topCenter,
-        child: FadeTransition(opacity: animation, child: child),
-      ),
-      child: child,
     );
   }
 }
@@ -317,9 +294,9 @@ class _PublicAudioCreditEditorState
                 onChanged: (value) => _update(confirmedOwnWork: value),
               ),
             ),
-            _ExpandSwitcher(
+            AnimatedReveal(
               child: ownWork
-                  ? const SizedBox.shrink()
+                  ? null
                   : Padding(
                       padding: const .fromLTRB(16, 8, 16, 0),
                       child: DivineTextField(

--- a/mobile/lib/widgets/video_metadata/video_metadata_audio_sharing_section.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_audio_sharing_section.dart
@@ -79,7 +79,6 @@ class VideoMetadataAudioSharingSection extends ConsumerWidget {
                 )
               : const SizedBox.shrink(),
         ),
-
         _ExpandSwitcher(
           child:
               editorState.requiresPublicAudioAttribution &&
@@ -304,31 +303,38 @@ class _PublicAudioCreditEditorState
             onChanged: (value) => _update(creatorName: value),
           ),
         ),
-        Material(
-          type: MaterialType.transparency,
-          child: DivineCheckboxTile(
-            value: ownWork,
-            title: context.l10n.soundOwnWork,
-            onChanged: (value) => _update(confirmedOwnWork: value),
-          ),
-        ),
-
-        _ExpandSwitcher(
-          child: ownWork
-              ? const SizedBox.shrink()
-              : Padding(
-                  padding: const .symmetric(horizontal: 16),
-                  child: DivineTextField(
-                    key: const Key('audio_credit_source'),
-                    controller: _sourceController,
-                    labelText: context.l10n.soundCreditSourceUrlLabel,
-                    keyboardType: TextInputType.url,
-                    filled: true,
-                    autocorrect: false,
-                    textInputAction: .next,
-                    onChanged: (value) => _update(sourceUrl: value),
-                  ),
-                ),
+        // The source field carries its own top gap so that collapsing it
+        // leaves the checkbox row a single [Column.spacing] away from the
+        // hashtags field, not two.
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Material(
+              type: MaterialType.transparency,
+              child: DivineCheckboxTile(
+                value: ownWork,
+                title: context.l10n.soundOwnWork,
+                onChanged: (value) => _update(confirmedOwnWork: value),
+              ),
+            ),
+            _ExpandSwitcher(
+              child: ownWork
+                  ? const SizedBox.shrink()
+                  : Padding(
+                      padding: const .fromLTRB(16, 8, 16, 0),
+                      child: DivineTextField(
+                        key: const Key('audio_credit_source'),
+                        controller: _sourceController,
+                        labelText: context.l10n.soundCreditSourceUrlLabel,
+                        keyboardType: TextInputType.url,
+                        filled: true,
+                        autocorrect: false,
+                        textInputAction: .next,
+                        onChanged: (value) => _update(sourceUrl: value),
+                      ),
+                    ),
+            ),
+          ],
         ),
         Padding(
           padding: const .symmetric(horizontal: 16),
@@ -343,7 +349,6 @@ class _PublicAudioCreditEditorState
                 _update(publicTags: value.split(RegExp(r'[,\s]+'))),
           ),
         ),
-
         Container(
           margin: const .symmetric(vertical: 8),
           decoration: BoxDecoration(

--- a/mobile/lib/widgets/video_metadata/video_metadata_audio_sharing_section.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_audio_sharing_section.dart
@@ -1,0 +1,377 @@
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:models/models.dart' show AudioEvent, UserProfile;
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/models/audio_share_attribution.dart';
+import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/providers/video_editor_provider.dart';
+
+/// Lets the creator offer the post's audio for reuse and edit the public
+/// credit that ships with it.
+///
+/// Audio pulled from an external provider carries that provider's credit and
+/// license instead, and drops the reuse toggle when the license forbids
+/// derivatives.
+class VideoMetadataAudioSharingSection extends ConsumerWidget {
+  /// Creates the audio sharing section.
+  const VideoMetadataAudioSharingSection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final editorState = ref.watch(videoEditorProvider);
+    final sound = editorState.audioForAttribution;
+    final external = sound?.externalSource;
+    final derivativesAllowed = external?.license.allowsDerivatives ?? true;
+    final allowAudioReuse = editorState.allowAudioReuse && derivativesAllowed;
+    final needsAttribution =
+        allowAudioReuse &&
+        external == null &&
+        editorState.audioShareAttribution == null;
+    if (needsAttribution) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        final current = ref.read(videoEditorProvider);
+        final currentSound = current.audioForAttribution;
+        if (!current.allowAudioReuse ||
+            current.audioShareAttribution != null ||
+            currentSound?.externalSource != null) {
+          return;
+        }
+        ref
+            .read(videoEditorProvider.notifier)
+            .setAudioShareAttribution(_initialAttribution(ref, currentSound));
+      });
+    }
+
+    void updateReuse(bool value) {
+      final notifier = ref.read(videoEditorProvider.notifier);
+      notifier.setAllowAudioReuse(value);
+      if (!value ||
+          external != null ||
+          editorState.audioShareAttribution != null) {
+        return;
+      }
+      notifier.setAudioShareAttribution(_initialAttribution(ref, sound));
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Material(
+          type: MaterialType.transparency,
+          child: DivineSwitchTile(
+            value: allowAudioReuse,
+            title: context.l10n.soundAllowRemix,
+            subtitle: derivativesAllowed
+                ? context.l10n.videoMetadataAudioReuseSubtitle
+                : context.l10n.soundCreditOnly,
+            onChanged: derivativesAllowed ? updateReuse : null,
+          ),
+        ),
+        _ExpandSwitcher(
+          child: external != null
+              ? _ProviderAudioCredit(sound: sound!)
+              : allowAudioReuse
+              ? _PublicAudioCreditEditor(
+                  key: ValueKey(sound?.id ?? 'original-audio'),
+                  sound: sound,
+                )
+              : const SizedBox.shrink(),
+        ),
+
+        _ExpandSwitcher(
+          child:
+              editorState.requiresPublicAudioAttribution &&
+                  !editorState.hasValidPublicAudioAttribution
+              ? Padding(
+                  padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+                  child: Text(
+                    context.l10n.soundCreditRequired,
+                    key: const Key('audio_credit_validation'),
+                    style: VineTheme.bodySmallFont(color: VineTheme.error),
+                  ),
+                )
+              : const SizedBox.shrink(),
+        ),
+      ],
+    );
+  }
+
+  AudioShareAttribution _initialAttribution(WidgetRef ref, AudioEvent? sound) {
+    final pubkey = ref.read(authServiceProvider).currentPublicKeyHex ?? '';
+    final profile = pubkey.isEmpty
+        ? null
+        : ref.read(userProfileReactiveProvider(pubkey)).value;
+    final publisherName =
+        profile?.bestDisplayName ??
+        (pubkey.isEmpty ? '' : UserProfile.defaultDisplayNameFor(pubkey));
+    final title = sound?.title?.trim();
+    if (sound?.isLocalImport == true) {
+      return AudioShareAttribution(
+        title: title?.isNotEmpty == true ? title! : '',
+        creatorName: '',
+        publicTags: const [],
+        confirmedOwnWork: false,
+      );
+    }
+    return AudioShareAttribution.forOwnedSound(
+      title: title?.isNotEmpty == true ? title! : 'Original sound',
+      publisherName: publisherName,
+      publisherPubkey: pubkey,
+    );
+  }
+}
+
+/// Cross-fades between the section's optional rows, growing the incoming one
+/// out of the top edge so the card's height never jumps.
+class _ExpandSwitcher extends StatelessWidget {
+  const _ExpandSwitcher({required this.child});
+
+  final Widget child;
+
+  static const _duration = Duration(milliseconds: 180);
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: _duration,
+      transitionBuilder: (child, animation) => SizeTransition(
+        sizeFactor: animation,
+        alignment: Alignment.topCenter,
+        child: FadeTransition(opacity: animation, child: child),
+      ),
+      child: child,
+    );
+  }
+}
+
+class _ProviderAudioCredit extends StatelessWidget {
+  const _ProviderAudioCredit({required this.sound});
+
+  final AudioEvent sound;
+
+  @override
+  Widget build(BuildContext context) {
+    final external = sound.externalSource!;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            context.l10n.soundPublicCredit,
+            style: VineTheme.titleSmallFont(
+              color: context.vineColors.onSurface,
+            ),
+          ),
+          Text(
+            sound.title ?? external.providerName,
+            style: VineTheme.bodyMediumFont(
+              color: context.vineColors.onSurface,
+            ),
+          ),
+          if (external.creatorName case final creator?)
+            Text(
+              context.l10n.soundCreatorBy(creator),
+              style: VineTheme.bodySmallFont(
+                color: context.vineColors.onSurfaceVariant,
+              ),
+            ),
+          Text(
+            external.license.name,
+            style: VineTheme.bodySmallFont(
+              color: context.vineColors.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PublicAudioCreditEditor extends ConsumerStatefulWidget {
+  const _PublicAudioCreditEditor({required this.sound, super.key});
+
+  final AudioEvent? sound;
+
+  @override
+  ConsumerState<_PublicAudioCreditEditor> createState() =>
+      _PublicAudioCreditEditorState();
+}
+
+class _PublicAudioCreditEditorState
+    extends ConsumerState<_PublicAudioCreditEditor> {
+  late final TextEditingController _titleController;
+  late final TextEditingController _creatorController;
+  late final TextEditingController _sourceController;
+  late final TextEditingController _tagsController;
+
+  AudioShareAttribution get _attribution =>
+      ref.read(videoEditorProvider).audioShareAttribution ??
+      AudioShareAttribution(
+        title: widget.sound?.title ?? '',
+        creatorName: '',
+        publicTags: const [],
+        confirmedOwnWork: false,
+      );
+
+  @override
+  void initState() {
+    super.initState();
+    final attribution = _attribution;
+    _titleController = TextEditingController(text: attribution.title);
+    _creatorController = TextEditingController(text: attribution.creatorName);
+    _sourceController = TextEditingController(text: attribution.sourceUrl);
+    _tagsController = TextEditingController(
+      text: attribution.publicTags.map((tag) => '#$tag').join(' '),
+    );
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _creatorController.dispose();
+    _sourceController.dispose();
+    _tagsController.dispose();
+    super.dispose();
+  }
+
+  void _update({
+    String? title,
+    String? creatorName,
+    String? sourceUrl,
+    List<String>? publicTags,
+    bool? confirmedOwnWork,
+  }) {
+    final current = _attribution;
+    ref
+        .read(videoEditorProvider.notifier)
+        .setAudioShareAttribution(
+          current.copyWith(
+            title: title,
+            creatorName: creatorName,
+            sourceUrl: sourceUrl,
+            publicTags: publicTags,
+            confirmedOwnWork: confirmedOwnWork,
+          ),
+        );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final attribution = ref.watch(
+      videoEditorProvider.select((state) => state.audioShareAttribution),
+    );
+    final ownWork = attribution?.confirmedOwnWork ?? false;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      spacing: 8,
+      children: [
+        const SizedBox(height: 8),
+        Padding(
+          padding: const .symmetric(horizontal: 16),
+          child: Text(
+            context.l10n.soundPublicCredit,
+            style: VineTheme.titleSmallFont(
+              color: context.vineColors.onSurface,
+            ),
+          ),
+        ),
+        // Filled: these sit inside the section's own card, so an unfilled
+        // field takes the card's color and reads as a label rather than an
+        // input.
+        Padding(
+          padding: const .symmetric(horizontal: 16),
+          child: DivineTextField(
+            key: const Key('audio_credit_title'),
+            controller: _titleController,
+            labelText: context.l10n.soundCreditTitleLabel,
+            filled: true,
+            textInputAction: .next,
+            onChanged: (value) => _update(title: value),
+          ),
+        ),
+        Padding(
+          padding: const .symmetric(horizontal: 16),
+          child: DivineTextField(
+            key: const Key('audio_credit_creator'),
+            controller: _creatorController,
+            labelText: context.l10n.soundCreditCreatorLabel,
+            filled: true,
+            keyboardType: .name,
+            textInputAction: .next,
+            onChanged: (value) => _update(creatorName: value),
+          ),
+        ),
+        Material(
+          type: MaterialType.transparency,
+          child: DivineCheckboxTile(
+            value: ownWork,
+            title: context.l10n.soundOwnWork,
+            onChanged: (value) => _update(confirmedOwnWork: value),
+          ),
+        ),
+
+        _ExpandSwitcher(
+          child: ownWork
+              ? const SizedBox.shrink()
+              : Padding(
+                  padding: const .symmetric(horizontal: 16),
+                  child: DivineTextField(
+                    key: const Key('audio_credit_source'),
+                    controller: _sourceController,
+                    labelText: context.l10n.soundCreditSourceUrlLabel,
+                    keyboardType: TextInputType.url,
+                    filled: true,
+                    autocorrect: false,
+                    textInputAction: .next,
+                    onChanged: (value) => _update(sourceUrl: value),
+                  ),
+                ),
+        ),
+        Padding(
+          padding: const .symmetric(horizontal: 16),
+          child: DivineTextField(
+            key: const Key('audio_credit_tags'),
+            controller: _tagsController,
+            labelText: context.l10n.soundCreditPublicHashtagsLabel,
+            filled: true,
+            autocorrect: false,
+            textInputAction: .done,
+            onChanged: (value) =>
+                _update(publicTags: value.split(RegExp(r'[,\s]+'))),
+          ),
+        ),
+
+        Container(
+          margin: const .symmetric(vertical: 8),
+          decoration: BoxDecoration(
+            border: Border(
+              top: BorderSide(color: context.vineColors.outlineMuted),
+            ),
+          ),
+          child: ListTile(
+            title: Text(
+              context.l10n.soundSharedAs,
+              style: VineTheme.labelMediumFont(
+                color: context.vineColors.onSurfaceVariant,
+              ),
+            ),
+            subtitle: Text(
+              [
+                _titleController.text.trim(),
+                if (_creatorController.text.trim().isNotEmpty)
+                  context.l10n.soundCreatorBy(_creatorController.text.trim()),
+              ].where((value) => value.isNotEmpty).join(' · '),
+              key: const Key('audio_credit_preview'),
+              style: VineTheme.bodySmallFont(
+                color: context.vineColors.onSurfaceVariant,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/widgets/video_metadata/video_metadata_audio_sharing_section.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_audio_sharing_section.dart
@@ -114,6 +114,10 @@ class VideoMetadataAudioSharingSection extends ConsumerWidget {
         confirmedOwnWork: false,
       );
     }
+    // Deliberately not localized: this title is published into the audio
+    // event, so translating it would make event data depend on the poster's
+    // locale — a German poster's sound would read "Originalton" to every
+    // viewer, whatever their own locale.
     return AudioShareAttribution.forOwnedSound(
       title: title?.isNotEmpty == true ? title! : 'Original sound',
       publisherName: publisherName,

--- a/mobile/lib/widgets/video_metadata/video_metadata_form_fields.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_form_fields.dart
@@ -220,7 +220,6 @@ class _InputWrapper extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ClipRRect(
-      clipBehavior: .hardEdge,
       borderRadius: .circular(_borderRadius),
       child: DecoratedBox(
         decoration: BoxDecoration(

--- a/mobile/lib/widgets/video_metadata/video_metadata_form_fields.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_form_fields.dart
@@ -2,14 +2,11 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:models/models.dart' show AudioEvent, UserProfile;
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
-import 'package:openvine/models/audio_share_attribution.dart';
-import 'package:openvine/providers/auth_providers.dart';
-import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_reply_context_provider.dart';
+import 'package:openvine/widgets/video_metadata/video_metadata_audio_sharing_section.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_collaborators_input.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_content_warning_selector.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_expiration_selector.dart';
@@ -175,7 +172,7 @@ class _VideoMetadataFormFieldsState
             const _InputWrapper(child: VideoMetadataContentWarningSelector()),
 
           if (widget.enableAudioReuse && !reusesExternalAudio)
-            const _InputWrapper(child: _VideoMetadataAudioSharingSection()),
+            const _InputWrapper(child: VideoMetadataAudioSharingSection()),
 
           if (widget.enableVideoReply)
             const _InputWrapper(child: _VideoReplyVisibilityToggle()),
@@ -199,339 +196,15 @@ class _VideoReplyVisibilityToggle extends ConsumerWidget {
       videoEditorProvider.select((state) => state.shareReplyToFeed),
     );
 
-    return Padding(
-      padding: const .symmetric(horizontal: 4),
-      child: Material(
-        type: MaterialType.transparency,
-        child: SwitchListTile(
-          value: shareReplyToFeed,
-          title: Text(
-            context.l10n.videoMetadataShareReplyToFeedTitle,
-            style: VineTheme.titleMediumFont(
-              color: context.vineColors.onSurface,
-            ),
-          ),
-          subtitle: Text(
-            context.l10n.videoMetadataShareReplyToFeedSubtitle,
-            style: VineTheme.bodySmallFont(
-              color: context.vineColors.onSurfaceVariant,
-            ),
-          ),
-          contentPadding: const .symmetric(horizontal: 12, vertical: 4),
-          activeThumbColor: VineTheme.vineGreen,
-          inactiveThumbColor: context.vineColors.mutedText,
-          onChanged: (value) {
-            ref.read(videoEditorProvider.notifier).setShareReplyToFeed(value);
-          },
-        ),
-      ),
-    );
-  }
-}
-
-class _VideoMetadataAudioSharingSection extends ConsumerWidget {
-  const _VideoMetadataAudioSharingSection();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final editorState = ref.watch(videoEditorProvider);
-    final sound = editorState.audioForAttribution;
-    final external = sound?.externalSource;
-    final derivativesAllowed = external?.license.allowsDerivatives ?? true;
-    final allowAudioReuse = editorState.allowAudioReuse && derivativesAllowed;
-    final needsAttribution =
-        allowAudioReuse &&
-        external == null &&
-        editorState.audioShareAttribution == null;
-    if (needsAttribution) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        final current = ref.read(videoEditorProvider);
-        final currentSound = current.audioForAttribution;
-        if (!current.allowAudioReuse ||
-            current.audioShareAttribution != null ||
-            currentSound?.externalSource != null) {
-          return;
-        }
-        ref
-            .read(videoEditorProvider.notifier)
-            .setAudioShareAttribution(_initialAttribution(ref, currentSound));
-      });
-    }
-
-    void updateReuse(bool value) {
-      final notifier = ref.read(videoEditorProvider.notifier);
-      notifier.setAllowAudioReuse(value);
-      if (!value ||
-          external != null ||
-          editorState.audioShareAttribution != null) {
-        return;
-      }
-      notifier.setAudioShareAttribution(_initialAttribution(ref, sound));
-    }
-
-    return Padding(
-      padding: const .symmetric(horizontal: 4),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Material(
-            type: MaterialType.transparency,
-            child: SwitchListTile(
-              value: allowAudioReuse,
-              title: Text(
-                context.l10n.soundAllowRemix,
-                style: VineTheme.titleMediumFont(
-                  color: context.vineColors.onSurface,
-                ),
-              ),
-              subtitle: Text(
-                derivativesAllowed
-                    ? context.l10n.videoMetadataAudioReuseSubtitle
-                    : context.l10n.soundCreditOnly,
-                style: VineTheme.bodySmallFont(
-                  color: context.vineColors.onSurfaceVariant,
-                ),
-              ),
-              contentPadding: const .symmetric(horizontal: 12, vertical: 4),
-              activeThumbColor: VineTheme.vineGreen,
-              inactiveThumbColor: context.vineColors.mutedText,
-              onChanged: derivativesAllowed ? updateReuse : null,
-            ),
-          ),
-          if (external != null)
-            _ProviderAudioCredit(sound: sound!)
-          else if (allowAudioReuse)
-            _PublicAudioCreditEditor(
-              key: ValueKey(sound?.id ?? 'original-audio'),
-              sound: sound,
-            ),
-          if (editorState.requiresPublicAudioAttribution &&
-              !editorState.hasValidPublicAudioAttribution)
-            Padding(
-              padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
-              child: Text(
-                context.l10n.soundCreditRequired,
-                key: const Key('audio_credit_validation'),
-                style: VineTheme.bodySmallFont(color: VineTheme.error),
-              ),
-            ),
-        ],
-      ),
-    );
-  }
-
-  AudioShareAttribution _initialAttribution(WidgetRef ref, AudioEvent? sound) {
-    final pubkey = ref.read(authServiceProvider).currentPublicKeyHex ?? '';
-    final profile = pubkey.isEmpty
-        ? null
-        : ref.read(userProfileReactiveProvider(pubkey)).value;
-    final publisherName =
-        profile?.bestDisplayName ??
-        (pubkey.isEmpty ? '' : UserProfile.defaultDisplayNameFor(pubkey));
-    final title = sound?.title?.trim();
-    if (sound?.isLocalImport == true) {
-      return AudioShareAttribution(
-        title: title?.isNotEmpty == true ? title! : '',
-        creatorName: '',
-        publicTags: const [],
-        confirmedOwnWork: false,
-      );
-    }
-    return AudioShareAttribution.forOwnedSound(
-      title: title?.isNotEmpty == true ? title! : 'Original sound',
-      publisherName: publisherName,
-      publisherPubkey: pubkey,
-    );
-  }
-}
-
-class _ProviderAudioCredit extends StatelessWidget {
-  const _ProviderAudioCredit({required this.sound});
-
-  final AudioEvent sound;
-
-  @override
-  Widget build(BuildContext context) {
-    final external = sound.externalSource!;
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            context.l10n.soundPublicCredit,
-            style: VineTheme.titleSmallFont(
-              color: context.vineColors.onSurface,
-            ),
-          ),
-          Text(
-            sound.title ?? external.providerName,
-            style: VineTheme.bodyMediumFont(
-              color: context.vineColors.onSurface,
-            ),
-          ),
-          if (external.creatorName case final creator?)
-            Text(
-              context.l10n.soundCreatorBy(creator),
-              style: VineTheme.bodySmallFont(
-                color: context.vineColors.onSurfaceVariant,
-              ),
-            ),
-          Text(
-            external.license.name,
-            style: VineTheme.bodySmallFont(
-              color: context.vineColors.onSurfaceVariant,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _PublicAudioCreditEditor extends ConsumerStatefulWidget {
-  const _PublicAudioCreditEditor({required this.sound, super.key});
-
-  final AudioEvent? sound;
-
-  @override
-  ConsumerState<_PublicAudioCreditEditor> createState() =>
-      _PublicAudioCreditEditorState();
-}
-
-class _PublicAudioCreditEditorState
-    extends ConsumerState<_PublicAudioCreditEditor> {
-  late final TextEditingController _titleController;
-  late final TextEditingController _creatorController;
-  late final TextEditingController _sourceController;
-  late final TextEditingController _tagsController;
-
-  AudioShareAttribution get _attribution =>
-      ref.read(videoEditorProvider).audioShareAttribution ??
-      AudioShareAttribution(
-        title: widget.sound?.title ?? '',
-        creatorName: '',
-        publicTags: const [],
-        confirmedOwnWork: false,
-      );
-
-  @override
-  void initState() {
-    super.initState();
-    final attribution = _attribution;
-    _titleController = TextEditingController(text: attribution.title);
-    _creatorController = TextEditingController(text: attribution.creatorName);
-    _sourceController = TextEditingController(text: attribution.sourceUrl);
-    _tagsController = TextEditingController(
-      text: attribution.publicTags.map((tag) => '#$tag').join(' '),
-    );
-  }
-
-  @override
-  void dispose() {
-    _titleController.dispose();
-    _creatorController.dispose();
-    _sourceController.dispose();
-    _tagsController.dispose();
-    super.dispose();
-  }
-
-  void _update({
-    String? title,
-    String? creatorName,
-    String? sourceUrl,
-    List<String>? publicTags,
-    bool? confirmedOwnWork,
-  }) {
-    final current = _attribution;
-    ref
-        .read(videoEditorProvider.notifier)
-        .setAudioShareAttribution(
-          current.copyWith(
-            title: title,
-            creatorName: creatorName,
-            sourceUrl: sourceUrl,
-            publicTags: publicTags,
-            confirmedOwnWork: confirmedOwnWork,
-          ),
-        );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final attribution = ref.watch(
-      videoEditorProvider.select((state) => state.audioShareAttribution),
-    );
-    final ownWork = attribution?.confirmedOwnWork ?? false;
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        spacing: 8,
-        children: [
-          Text(
-            context.l10n.soundPublicCredit,
-            style: VineTheme.titleSmallFont(
-              color: context.vineColors.onSurface,
-            ),
-          ),
-          DivineTextField(
-            key: const Key('audio_credit_title'),
-            controller: _titleController,
-            labelText: context.l10n.soundCreditTitleLabel,
-            onChanged: (value) => _update(title: value),
-          ),
-          DivineTextField(
-            key: const Key('audio_credit_creator'),
-            controller: _creatorController,
-            labelText: context.l10n.soundCreditCreatorLabel,
-            onChanged: (value) => _update(creatorName: value),
-          ),
-          Material(
-            type: MaterialType.transparency,
-            child: CheckboxListTile(
-              value: ownWork,
-              title: Text(context.l10n.soundOwnWork),
-              contentPadding: EdgeInsets.zero,
-              controlAffinity: ListTileControlAffinity.leading,
-              onChanged: (value) => _update(confirmedOwnWork: value ?? false),
-            ),
-          ),
-          if (!ownWork)
-            DivineTextField(
-              key: const Key('audio_credit_source'),
-              controller: _sourceController,
-              labelText: context.l10n.soundCreditSourceUrlLabel,
-              keyboardType: TextInputType.url,
-              autocorrect: false,
-              onChanged: (value) => _update(sourceUrl: value),
-            ),
-          DivineTextField(
-            key: const Key('audio_credit_tags'),
-            controller: _tagsController,
-            labelText: context.l10n.soundCreditPublicHashtagsLabel,
-            autocorrect: false,
-            onChanged: (value) =>
-                _update(publicTags: value.split(RegExp(r'[,\s]+'))),
-          ),
-          Text(
-            context.l10n.soundSharedAs,
-            style: VineTheme.labelMediumFont(
-              color: context.vineColors.onSurfaceVariant,
-            ),
-          ),
-          Text(
-            [
-              _titleController.text.trim(),
-              if (_creatorController.text.trim().isNotEmpty)
-                context.l10n.soundCreatorBy(_creatorController.text.trim()),
-            ].where((value) => value.isNotEmpty).join(' · '),
-            key: const Key('audio_credit_preview'),
-            style: VineTheme.bodySmallFont(
-              color: context.vineColors.onSurfaceVariant,
-            ),
-          ),
-        ],
+    return Material(
+      type: MaterialType.transparency,
+      child: DivineSwitchTile(
+        value: shareReplyToFeed,
+        title: context.l10n.videoMetadataShareReplyToFeedTitle,
+        subtitle: context.l10n.videoMetadataShareReplyToFeedSubtitle,
+        onChanged: (value) {
+          ref.read(videoEditorProvider.notifier).setShareReplyToFeed(value);
+        },
       ),
     );
   }
@@ -546,12 +219,16 @@ class _InputWrapper extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: context.vineColors.surface,
-        borderRadius: .circular(_borderRadius),
+    return ClipRRect(
+      clipBehavior: .hardEdge,
+      borderRadius: .circular(_borderRadius),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: context.vineColors.surface,
+          borderRadius: .circular(_borderRadius),
+        ),
+        child: child,
       ),
-      child: child,
     );
   }
 }

--- a/mobile/packages/divine_ui/lib/src/checkbox/divine_checkbox_tile.dart
+++ b/mobile/packages/divine_ui/lib/src/checkbox/divine_checkbox_tile.dart
@@ -49,6 +49,8 @@ class DivineCheckboxTile extends StatelessWidget {
           enabled: isEnabled,
           checked: value,
           child: ListTile(
+            // Symmetric 16, matching `DivineSwitchTile` — see the note there
+            // on why control rows and navigation rows differ.
             contentPadding: const .symmetric(horizontal: 16),
             enabled: isEnabled,
             leading: DivineSpriteCheckbox(

--- a/mobile/packages/divine_ui/lib/src/checkbox/divine_checkbox_tile.dart
+++ b/mobile/packages/divine_ui/lib/src/checkbox/divine_checkbox_tile.dart
@@ -49,6 +49,7 @@ class DivineCheckboxTile extends StatelessWidget {
           enabled: isEnabled,
           checked: value,
           child: ListTile(
+            contentPadding: const .symmetric(horizontal: 16),
             enabled: isEnabled,
             leading: DivineSpriteCheckbox(
               state: value

--- a/mobile/packages/divine_ui/lib/src/switch/divine_switch.dart
+++ b/mobile/packages/divine_ui/lib/src/switch/divine_switch.dart
@@ -115,6 +115,7 @@ class DivineSwitchTile extends StatelessWidget {
       opacity: isEnabled ? 1.0 : disabledOpacity,
       child: MergeSemantics(
         child: ListTile(
+          contentPadding: const .symmetric(horizontal: 16),
           enabled: isEnabled,
           leading:
               leading ??

--- a/mobile/packages/divine_ui/lib/src/switch/divine_switch.dart
+++ b/mobile/packages/divine_ui/lib/src/switch/divine_switch.dart
@@ -115,6 +115,9 @@ class DivineSwitchTile extends StatelessWidget {
       opacity: isEnabled ? 1.0 : disabledOpacity,
       child: MergeSemantics(
         child: ListTile(
+          // Symmetric 16 rather than Material 3's start 16 / end 24. Rows that
+          // carry a control sit at 16 on both edges; navigation rows keep the
+          // Material default, so the caret has room to breathe.
           contentPadding: const .symmetric(horizontal: 16),
           enabled: isEnabled,
           leading:

--- a/mobile/test/screens/video_metadata_cover_screen_test.dart
+++ b/mobile/test/screens/video_metadata_cover_screen_test.dart
@@ -44,13 +44,16 @@ class _NoopInitProVideoEditor extends MethodChannelProVideoEditor {
   Stream<dynamic> initializeStream() => const Stream.empty();
 }
 
-DivineVideoClip _createTestClip({String id = 'test-clip'}) {
+DivineVideoClip _createTestClip({
+  String id = 'test-clip',
+  models.AspectRatio aspectRatio = models.AspectRatio.square,
+}) {
   return DivineVideoClip(
     id: id,
     video: EditorVideo.file('test.mp4'),
     duration: const Duration(seconds: 10),
     recordedAt: DateTime.now(),
-    targetAspectRatio: models.AspectRatio.square,
+    targetAspectRatio: aspectRatio,
     originalAspectRatio: 9 / 16,
   );
 }
@@ -232,6 +235,102 @@ void main() {
 
       final l10n = lookupAppLocalizations(const Locale('en'));
       expect(find.text(l10n.videoMetadataEditCoverTitle), findsOneWidget);
+    });
+
+    testWidgets('morphs the hero flight corners on the way back', (
+      tester,
+    ) async {
+      setUpPlayerChannel();
+      addTearDown(tearDownPlayerChannel);
+
+      // The metadata thumbnail rounds itself from outside its Hero, so the
+      // shuttle arrives carrying no rounding of its own. Without a builder on
+      // this screen's Hero the whole flight back is square-cornered.
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            videoEditorProvider.overrideWith(
+              () => _MockVideoEditorNotifier(VideoEditorProviderState()),
+            ),
+          ],
+          child: MockGoRouterProvider(
+            goRouter: mockGoRouter,
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Builder(
+                builder: (context) => Scaffold(
+                  body: Center(
+                    child: SizedBox(
+                      height: 200,
+                      // Clip outside the Hero, the way both real thumbnails do.
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(
+                          VideoEditorConstants.clipPreviewCornerRadius,
+                        ),
+                        child: Hero(
+                          tag: VideoEditorConstants.heroMetaPreviewId,
+                          child: GestureDetector(
+                            onTap: () => Navigator.of(context).push(
+                              PageRouteBuilder<void>(
+                                pageBuilder: (_, _, _) =>
+                                    VideoMetadataCoverScreen(
+                                      clip: _createTestClip(
+                                        aspectRatio:
+                                            models.AspectRatio.vertical,
+                                      ),
+                                    ),
+                              ),
+                            ),
+                            child: const Text('open'),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Caught mid-lerp the shuttle is strictly inside both endpoints on both
+      // corners: the thumbnail's 16 all round and this screen's bottom-only 32.
+      // Neither resting shape satisfies that, so only the shuttle matches.
+      final shuttleClip = find.byWidgetPredicate((widget) {
+        if (widget is! ClipRRect) return false;
+        final radius = widget.borderRadius;
+        return radius is BorderRadius &&
+            radius.topLeft.x > 0 &&
+            radius.topLeft.x < VideoEditorConstants.clipPreviewCornerRadius &&
+            radius.bottomLeft.x >
+                VideoEditorConstants.clipPreviewCornerRadius &&
+            radius.bottomLeft.x < 32;
+      });
+      BorderRadius shuttleRadius() =>
+          tester.widget<ClipRRect>(shuttleClip).borderRadius as BorderRadius;
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      tester.state<NavigatorState>(find.byType(Navigator)).pop();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 40));
+
+      expect(shuttleClip, findsOneWidget);
+      final early = shuttleRadius();
+
+      await tester.pump(const Duration(milliseconds: 120));
+      final later = shuttleRadius();
+
+      // Travelling towards the thumbnail: the top tightens back to 16 as the
+      // bottom relaxes off 32. A single sample cannot tell that from a lerp
+      // running backwards or one pinned to a constant.
+      expect(later.topLeft.x, greaterThan(early.topLeft.x));
+      expect(later.bottomLeft.x, lessThan(early.bottomLeft.x));
+
+      await tester.pumpAndSettle();
     });
 
     testWidgets('shows DivineVideoPlayer', (tester) async {

--- a/mobile/test/screens/video_metadata_preview_screen_test.dart
+++ b/mobile/test/screens/video_metadata_preview_screen_test.dart
@@ -10,10 +10,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as models;
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/models/video_publish/video_publish_provider_state.dart';
+import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
@@ -22,6 +24,7 @@ import 'package:openvine/screens/video_metadata/video_metadata_preview_screen.da
 import 'package:openvine/widgets/stop_motion/stop_motion_player.dart';
 import 'package:openvine/widgets/video_feed_item/blurred_video_backdrop.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
+import 'package:openvine/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -41,6 +44,27 @@ class _MockVideoPublishNotifier extends VideoPublishNotifier {
 class _MockVideoEditorNotifier extends VideoEditorNotifier {
   @override
   VideoEditorProviderState build() => VideoEditorProviderState();
+}
+
+/// Reports a finished render so [VideoMetadataCaptureClipPreview] shows the
+/// thumbnail rather than its processing overlay.
+class _MockRenderedVideoEditorNotifier extends VideoEditorNotifier {
+  _MockRenderedVideoEditorNotifier(this._clip);
+
+  final DivineVideoClip _clip;
+
+  @override
+  VideoEditorProviderState build() =>
+      VideoEditorProviderState(finalRenderedClip: _clip);
+}
+
+class _MockClipManagerNotifier extends ClipManagerNotifier {
+  _MockClipManagerNotifier(this._clips);
+
+  final List<DivineVideoClip> _clips;
+
+  @override
+  ClipManagerState build() => ClipManagerState(clips: _clips);
 }
 
 /// Supplies a stable public key so the post-mode overlay can resolve the author
@@ -485,6 +509,92 @@ void main() {
       );
 
       // Settle the flight and the overlay timer the screen starts on mount.
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('the real capture thumbnail rounds itself outside its Hero', (
+      tester,
+    ) async {
+      // The test above flies from a Hero this file builds, so it pins the
+      // flight but not the shape the app actually hands it. Fly from the real
+      // thumbnail instead: on a pop the shuttle renders the destination Hero's
+      // child, so a rounding inside that Hero rides along and pins the corners
+      // the flight is morphing.
+      final clip = _createTestClip(thumbnailPath: 'test_thumbnail.jpg');
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            videoPublishProvider.overrideWith(
+              () =>
+                  _MockVideoPublishNotifier(const VideoPublishProviderState()),
+            ),
+            clipManagerProvider.overrideWith(
+              () => _MockClipManagerNotifier([clip]),
+            ),
+            videoEditorProvider.overrideWith(
+              () => _MockRenderedVideoEditorNotifier(clip),
+            ),
+            nostrServiceProvider.overrideWithValue(_FakeNostrClient()),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Builder(
+              builder: (context) => Scaffold(
+                body: Column(
+                  children: [
+                    const Expanded(child: VideoMetadataCaptureClipPreview()),
+                    GestureDetector(
+                      onTap: () => Navigator.of(context).push(
+                        PageRouteBuilder<void>(
+                          pageBuilder: (_, _, _) =>
+                              VideoMetadataPreviewScreen(clip: clip),
+                        ),
+                      ),
+                      child: const Text('open'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      tester.state<NavigatorState>(find.byType(Navigator)).pop();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      final shuttleClip = find.byWidgetPredicate((widget) {
+        if (widget is! ClipRRect) return false;
+        final radius = widget.borderRadius;
+        return radius is BorderRadius &&
+            radius.topLeft.x > 0 &&
+            radius.topLeft.x < VideoEditorConstants.clipPreviewCornerRadius &&
+            radius.bottomLeft.x >
+                VideoEditorConstants.clipPreviewCornerRadius &&
+            radius.bottomLeft.x < VineTheme.shellCornerRadius;
+      });
+      expect(shuttleClip, findsOneWidget);
+      expect(
+        find.descendant(
+          of: shuttleClip,
+          matching: find.byWidgetPredicate(
+            (widget) =>
+                widget is ClipRRect &&
+                widget.borderRadius ==
+                    BorderRadius.circular(
+                      VideoEditorConstants.clipPreviewCornerRadius,
+                    ),
+          ),
+        ),
+        findsNothing,
+      );
+
       await tester.pumpAndSettle();
     });
 

--- a/mobile/test/screens/video_metadata_preview_screen_test.dart
+++ b/mobile/test/screens/video_metadata_preview_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as models;
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/stop_motion_clip_frame.dart';
@@ -368,6 +369,83 @@ void main() {
         ),
         isTrue,
       );
+    });
+
+    testWidgets('rounds the bottom corners during the hero flight', (
+      tester,
+    ) async {
+      // The flying hero is lifted into the navigator overlay, above the stage's
+      // clip, so without its own rounding the preview arrived square-bottomed
+      // and only snapped into shape once the flight landed.
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            videoPublishProvider.overrideWith(
+              () =>
+                  _MockVideoPublishNotifier(const VideoPublishProviderState()),
+            ),
+            videoEditorProvider.overrideWith(_MockVideoEditorNotifier.new),
+            nostrServiceProvider.overrideWithValue(_FakeNostrClient()),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Builder(
+              builder: (context) => Scaffold(
+                body: Center(
+                  child: SizedBox.square(
+                    dimension: 200,
+                    child: Hero(
+                      tag: VideoEditorConstants.heroMetaPreviewId,
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(
+                          VideoEditorConstants.clipPreviewCornerRadius,
+                        ),
+                        child: GestureDetector(
+                          onTap: () => Navigator.of(context).push(
+                            PageRouteBuilder<void>(
+                              pageBuilder: (_, _, _) =>
+                                  VideoMetadataPreviewScreen(
+                                    clip: _createTestClip(),
+                                  ),
+                            ),
+                          ),
+                          child: const Text('open'),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 150));
+
+      // Mid-flight the shuttle sits between the thumbnail's all-round corners
+      // and the stage's bottom-only rounding.
+      final radii = tester
+          .widgetList<ClipRRect>(find.byType(ClipRRect))
+          .map((clip) => clip.borderRadius)
+          .whereType<BorderRadius>();
+      expect(
+        radii.any(
+          (radius) =>
+              radius.bottomLeft.x >
+                  VideoEditorConstants.clipPreviewCornerRadius &&
+              radius.bottomLeft.x < VineTheme.shellCornerRadius &&
+              radius.topLeft.x < VideoEditorConstants.clipPreviewCornerRadius,
+        ),
+        isTrue,
+      );
+
+      // Settle the flight and the overlay timer the screen starts on mount.
+      await tester.pump(const Duration(milliseconds: 400));
     });
 
     testWidgets('constrains square stop-motion clips to the target box', (

--- a/mobile/test/screens/video_metadata_preview_screen_test.dart
+++ b/mobile/test/screens/video_metadata_preview_screen_test.dart
@@ -371,7 +371,7 @@ void main() {
       );
     });
 
-    testWidgets('rounds the bottom corners during the hero flight', (
+    testWidgets('morphs the hero flight corners in both directions', (
       tester,
     ) async {
       // The flying hero is lifted into the navigator overlay, above the stage's
@@ -425,29 +425,67 @@ void main() {
         ),
       );
 
+      // The shuttle is the only clip caught mid-lerp: strictly inside both
+      // endpoints on both corners. The stage's own clip sits exactly on them.
+      final shuttleClip = find.byWidgetPredicate((widget) {
+        if (widget is! ClipRRect) return false;
+        final radius = widget.borderRadius;
+        return radius is BorderRadius &&
+            radius.topLeft.x > 0 &&
+            radius.topLeft.x < VideoEditorConstants.clipPreviewCornerRadius &&
+            radius.bottomLeft.x >
+                VideoEditorConstants.clipPreviewCornerRadius &&
+            radius.bottomLeft.x < VineTheme.shellCornerRadius;
+      });
+      BorderRadius shuttleRadius() =>
+          tester.widget<ClipRRect>(shuttleClip).borderRadius as BorderRadius;
+
       await tester.tap(find.text('open'));
       await tester.pump();
-      await tester.pump(const Duration(milliseconds: 150));
+      await tester.pump(const Duration(milliseconds: 20));
 
       // Mid-flight the shuttle sits between the thumbnail's all-round corners
       // and the stage's bottom-only rounding.
-      final radii = tester
-          .widgetList<ClipRRect>(find.byType(ClipRRect))
-          .map((clip) => clip.borderRadius)
-          .whereType<BorderRadius>();
+      expect(shuttleClip, findsOneWidget);
+      final early = shuttleRadius();
+
+      await tester.pump(const Duration(milliseconds: 130));
+      final mid = shuttleRadius();
+
+      // It morphs from the thumbnail's shape towards the stage's, so the top
+      // opens out as the bottom tightens. A single sample cannot tell that
+      // from a lerp running backwards, or from one pinned to a constant --
+      // both leave the preview in the wrong shape, which is the bug here.
+      expect(mid.topLeft.x, lessThan(early.topLeft.x));
+      expect(mid.bottomLeft.x, greaterThan(early.bottomLeft.x));
+
+      await tester.pumpAndSettle();
+
+      // Coming back, the shuttle carries the destination thumbnail -- so a
+      // rounding that lives inside that Hero rides along and pins the top
+      // corners at 16 for the whole flight, whatever the lerp is doing.
+      tester.state<NavigatorState>(find.byType(Navigator)).pop();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(shuttleClip, findsOneWidget);
       expect(
-        radii.any(
-          (radius) =>
-              radius.bottomLeft.x >
-                  VideoEditorConstants.clipPreviewCornerRadius &&
-              radius.bottomLeft.x < VineTheme.shellCornerRadius &&
-              radius.topLeft.x < VideoEditorConstants.clipPreviewCornerRadius,
+        find.descendant(
+          of: shuttleClip,
+          matching: find.byWidgetPredicate(
+            (widget) =>
+                widget is ClipRRect &&
+                widget.borderRadius ==
+                    BorderRadius.circular(
+                      VideoEditorConstants.clipPreviewCornerRadius,
+                    ),
+          ),
         ),
-        isTrue,
+        findsNothing,
       );
 
       // Settle the flight and the overlay timer the screen starts on mount.
-      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pumpAndSettle();
     });
 
     testWidgets('constrains square stop-motion clips to the target box', (

--- a/mobile/test/screens/video_metadata_preview_screen_test.dart
+++ b/mobile/test/screens/video_metadata_preview_screen_test.dart
@@ -396,12 +396,14 @@ void main() {
                 body: Center(
                   child: SizedBox.square(
                     dimension: 200,
-                    child: Hero(
-                      tag: VideoEditorConstants.heroMetaPreviewId,
-                      child: ClipRRect(
-                        borderRadius: BorderRadius.circular(
-                          VideoEditorConstants.clipPreviewCornerRadius,
-                        ),
+                    // Clip outside the Hero, the way both real thumbnails do:
+                    // inside, it rides into the shuttle and pins the corners.
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(
+                        VideoEditorConstants.clipPreviewCornerRadius,
+                      ),
+                      child: Hero(
+                        tag: VideoEditorConstants.heroMetaPreviewId,
                         child: GestureDetector(
                           onTap: () => Navigator.of(context).push(
                             PageRouteBuilder<void>(

--- a/mobile/test/screens/video_metadata_screen_test.dart
+++ b/mobile/test/screens/video_metadata_screen_test.dart
@@ -253,7 +253,9 @@ void main() {
           find.byKey(const Key('audio_credit_source')),
           'https://example.com/source',
         );
-        await tester.pump();
+        // Settle: the validation line fades out over the section's switcher
+        // rather than disappearing on the next frame.
+        await tester.pumpAndSettle();
 
         final credit = container
             .read(videoEditorProvider)

--- a/mobile/test/widgets/video_metadata/video_metadata_form_fields_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_form_fields_test.dart
@@ -206,11 +206,11 @@ void main() {
         tester.element(find.byType(VideoMetadataFormFields)),
       );
       final tile = find.widgetWithText(
-        SwitchListTile,
+        DivineSwitchTile,
         l10n.videoMetadataShareReplyToFeedTitle,
       );
       expect(tile, findsOneWidget);
-      expect(tester.widget<SwitchListTile>(tile).value, isFalse);
+      expect(tester.widget<DivineSwitchTile>(tile).value, isFalse);
 
       await tester.ensureVisible(tile);
       await tester.pumpAndSettle();
@@ -225,7 +225,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(mockNotifier.lastShareReplyToFeed, isTrue);
-      expect(tester.widget<SwitchListTile>(tile).value, isTrue);
+      expect(tester.widget<DivineSwitchTile>(tile).value, isTrue);
     });
 
     testWidgets("audio reuse toggle is shown for the user's own audio", (
@@ -239,7 +239,7 @@ void main() {
       );
       expect(
         find.widgetWithText(
-          SwitchListTile,
+          DivineSwitchTile,
           l10n.soundAllowRemix,
         ),
         findsOneWidget,
@@ -267,7 +267,7 @@ void main() {
         );
         expect(
           find.widgetWithText(
-            SwitchListTile,
+            DivineSwitchTile,
             l10n.soundAllowRemix,
           ),
           findsNothing,
@@ -299,7 +299,7 @@ void main() {
       );
       expect(
         find.widgetWithText(
-          SwitchListTile,
+          DivineSwitchTile,
           l10n.soundAllowRemix,
         ),
         findsOneWidget,


### PR DESCRIPTION
Closes #6830

## Description

Three design issues on the video metadata flow.

**The preview arrived square-bottomed.** Opening the full-screen preview showed no rounding along the bottom edge for a moment, then it snapped in. The stage's rounded bottom comes from a `ClipRRect` above the `Hero`, but a flying hero is lifted into the navigator overlay — outside that clip — so nothing rounded the preview for the whole ~300ms flight. The flight now clips itself via `flightShuttleBuilder`, morphing out of the clip thumbnail's all-round corners into the stage's bottom-only rounding. The flight animation runs 0 (metadata screen) → 1 (preview) in *both* directions, because a pop drives it from the popped route's animation, so one lerp covers the way back too. The thumbnail's radius moved into `VideoEditorConstants.clipPreviewCornerRadius` so the flight's start shape can't drift away from the shape it starts on.

**The audio credit fields didn't look like fields.** Title, creator, source URL and hashtags sit together inside a single `_InputWrapper` card. `DivineTextField` is transparent by default and takes the colour of whatever it sits on, so each one read as a label — unlike the title and description fields further up, where every field gets its own card and the card *is* the visible input surface. They're `filled: true` now, which is the case the widget's own API documents. The "shared as" preview is separated by a top border instead of floating in the same block, and the optional rows (provider credit vs public editor, the source field that appears when "own work" is off, the validation line) cross-fade through a shared `_ExpandSwitcher` rather than snapping the card's height.

**Inset drift.** Material 3 gives `ListTile` an asymmetric `contentPadding` — start 16, end 24 — and both `DivineSwitchTile` and `DivineCheckboxTile` were falling through to it. 16 on both edges is the value the design system wants, so both now pin `contentPadding` to a symmetric 16. The leading edge doesn't move; the trailing edge tightens by 8px, and it does so everywhere those tiles are used, not just here — 16 switch rows across Safety, Notification, General, Nostr, Bluesky, Content preferences, Monetization links and Blossom settings plus the metadata form, and 2 checkbox rows in Safety settings and the audio credit card. It's a design-system correction rather than a local one; it just surfaced here, where a switch row and a checkbox row sit in the same card and the mismatch is visible. The cover screen's top bar separately drops its vertical padding so its horizontal inset matches the form.

The audio sharing section also moved into its own file. It carried three classes and five imports that nothing else in `video_metadata_form_fields.dart` needed, and that file had grown past 500 lines.

**Related Issue:** 

## Out of Scope

None.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test` on `video_metadata_cover_screen_test.dart`, `video_metadata_preview_screen_test.dart`, `video_metadata_screen_test.dart`, `test/widgets/video_metadata/` — 202 passing
- `flutter test` on `packages/divine_ui` — 845 passing
- All four design-system ceiling ratchets, the untested-services floor and the `test/unit` structure guard — pass
- Flight tests: `morphs the hero flight corners in both directions` pins the lerp's direction against a reversed and a constant-pinned mutant; `the real capture thumbnail rounds itself outside its Hero` flies from the real thumbnail widget and pins the clip that a pop would otherwise drag into the shuttle
- Two existing tests adapted to the new behaviour, both still asserting the same user-visible outcome: `requires public creator and source for imported audio` now settles before asserting the validation line is gone (it fades out over the switcher instead of vanishing next frame), and the form-field toggle tests target `DivineSwitchTile` instead of Material's `SwitchListTile`
- Manual pass on a real Samsung Galaxy (SM-S942B): open metadata → preview (corners rounded from the first frame of the flight and on the way back), toggle "Allow others to remix", toggle "own work" on/off, fill the credit until the validation line clears — all good
- Settings screens that use the two tiles re-run after the padding change: `safety_settings_screen_test.dart`, `settings_screen_audio_sharing_test.dart`, `test/screens/settings/` — 339 passing together with the metadata suites

### Screens on device (SM-S942B, `f3f4747`)

General Settings, where the tile change lands outside the metadata flow. Rows carrying a control (the switches) sit at 16 on both edges; navigation rows keep Material's start 16 / end 24, which is the split this PR settles on rather than flattens.

<img width="322" alt="General Settings after the tile inset change" src="https://github.com/user-attachments/assets/db678bb4-5fb0-4101-a963-836095568424" />

The audio credit card, the surface the form changes target.

<img width="322" alt="Post details audio credit card after the form changes" src="https://github.com/user-attachments/assets/9ab29a58-3fa2-4ffb-a455-5fe6aa48f38c" />


## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor

