### PR TITLE
fix(report): attach machine-readable NIP-17 tags to the moderation DM

### DIFF
--- a/mobile/lib/services/content_moderation_types.dart
+++ b/mobile/lib/services/content_moderation_types.dart
@@ -18,6 +18,30 @@ enum ContentFilterReason {
   other,
 }
 
+/// Maps a [ContentFilterReason] to the canonical NIP-56 (kind 1984)
+/// report type strings: nudity, malware, profanity, illegal, spam,
+/// impersonation, other.
+///
+/// Shared by [ContentFilterReason]'s two report channels so they stay in
+/// sync: the kind-1984 `e`/`p` tag's 3rd element (NIP-56), and the
+/// moderation-DM's `report_type` tag (a divine-moderation-service-specific
+/// convention — see `divine-mobile#6593`).
+String contentFilterReasonToNip56Type(ContentFilterReason reason) {
+  return switch (reason) {
+    ContentFilterReason.spam => 'spam',
+    ContentFilterReason.harassment => 'profanity',
+    ContentFilterReason.violence => 'illegal',
+    ContentFilterReason.sexualContent => 'nudity',
+    ContentFilterReason.copyright => 'illegal',
+    ContentFilterReason.falseInformation => 'other',
+    ContentFilterReason.childSafety => 'other',
+    ContentFilterReason.csam => 'illegal',
+    ContentFilterReason.underageUser => 'other',
+    ContentFilterReason.aiGenerated => 'other',
+    ContentFilterReason.other => 'other',
+  };
+}
+
 /// Content severity levels for filtering
 enum ContentSeverity {
   info, // Informational only

--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -454,7 +454,7 @@ class ContentReportingService {
       }
 
       // NIP-56 requires the report type as the 3rd element of the e/p tags.
-      final nip56Type = _toNip56ReportType(reason);
+      final nip56Type = contentFilterReasonToNip56Type(reason);
       // Filter at the construction boundary so every report path avoids
       // emitting synthetic or malformed e tags, not just reportUser().
       final eventTagIds = (nip56EventIds ?? [eventId])
@@ -527,25 +527,6 @@ class ContentReportingService {
       );
       return null;
     }
-  }
-
-  /// Maps app-level [ContentFilterReason] to one of the NIP-56 standard
-  /// report type strings: nudity, malware, profanity, illegal, spam,
-  /// impersonation, other.
-  String _toNip56ReportType(ContentFilterReason reason) {
-    return switch (reason) {
-      ContentFilterReason.spam => 'spam',
-      ContentFilterReason.harassment => 'profanity',
-      ContentFilterReason.violence => 'illegal',
-      ContentFilterReason.sexualContent => 'nudity',
-      ContentFilterReason.copyright => 'illegal',
-      ContentFilterReason.falseInformation => 'other',
-      ContentFilterReason.childSafety => 'other',
-      ContentFilterReason.csam => 'illegal',
-      ContentFilterReason.underageUser => 'other',
-      ContentFilterReason.aiGenerated => 'other',
-      ContentFilterReason.other => 'other',
-    };
   }
 
   static bool _isValidEventId(String eventId) =>

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -524,6 +524,7 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
           // never let them degrade to a metadata-leaking NIP-04
           // plaintext duplicate. NIP-17 gift wrap only.
           skipNip04Fallback: true,
+          additionalTags: _reportDmTags(),
         );
       } else {
         try {
@@ -617,6 +618,26 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
       buffer.writeln('Details: $details');
     }
     return buffer.toString().trimRight();
+  }
+
+  /// Machine-readable data for divine-moderation-service's dm-reader to
+  /// classify this report, attached as NIP-17 tags on the rumor rather
+  /// than folded into [_formatReportDm]'s content — the DM stays plain,
+  /// human-readable prose (see divine-mobile#6593).
+  ///
+  /// `sha256` is only present for content reports where the reported
+  /// video has a resolvable Blossom blob hash — [VideoEvent.sha256] is
+  /// nullable (a video published without an `imeta` `x` value has none),
+  /// and user reports / DM-message reports never have one at all. The
+  /// backend's `user_reports` table is `sha256 NOT NULL`, so it can only
+  /// ever record content reports; this tag intentionally never covers the
+  /// other two report variants.
+  List<List<String>> _reportDmTags() {
+    final sha256 = widget.video?.sha256;
+    return [
+      ['report_type', contentFilterReasonToNip56Type(_selectedReason!)],
+      if (sha256 != null && sha256.isNotEmpty) ['sha256', sha256],
+    ];
   }
 
   @override

--- a/mobile/test/services/content_moderation_types_test.dart
+++ b/mobile/test/services/content_moderation_types_test.dart
@@ -72,4 +72,41 @@ void main() {
       expect(ModerationResult.clean.warningMessage, isNull);
     });
   });
+
+  group(contentFilterReasonToNip56Type, () {
+    test('maps every reason to a canonical NIP-56 report type string', () {
+      const expected = {
+        ContentFilterReason.spam: 'spam',
+        ContentFilterReason.harassment: 'profanity',
+        ContentFilterReason.violence: 'illegal',
+        ContentFilterReason.sexualContent: 'nudity',
+        ContentFilterReason.copyright: 'illegal',
+        ContentFilterReason.falseInformation: 'other',
+        ContentFilterReason.childSafety: 'other',
+        ContentFilterReason.csam: 'illegal',
+        ContentFilterReason.underageUser: 'other',
+        ContentFilterReason.aiGenerated: 'other',
+        ContentFilterReason.other: 'other',
+      };
+
+      for (final entry in expected.entries) {
+        expect(
+          contentFilterReasonToNip56Type(entry.key),
+          entry.value,
+          reason: '${entry.key} should map to NIP-56 type "${entry.value}"',
+        );
+      }
+    });
+
+    test('covers every ContentFilterReason value', () {
+      // Guards against a new enum case silently falling through to a
+      // default -- the switch in contentFilterReasonToNip56Type is
+      // exhaustive (no default case), so this would be a compile error
+      // before it could ever be a runtime gap, but pinning the full
+      // enum set here keeps that guarantee visible in the test itself.
+      for (final reason in ContentFilterReason.values) {
+        expect(contentFilterReasonToNip56Type(reason), isNotEmpty);
+      }
+    });
+  });
 }

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -725,6 +725,7 @@ void main() {
           content: any(named: 'content'),
           replyToId: any(named: 'replyToId'),
           skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          additionalTags: any(named: 'additionalTags'),
         ),
       ).thenAnswer(
         (_) async => NIP17SendResult.success(
@@ -801,6 +802,7 @@ void main() {
           content: any(named: 'content'),
           replyToId: any(named: 'replyToId'),
           skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          additionalTags: any(named: 'additionalTags'),
         ),
       ).called(1);
     });
@@ -817,6 +819,7 @@ void main() {
           content: captureAny(named: 'content'),
           replyToId: any(named: 'replyToId'),
           skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          additionalTags: any(named: 'additionalTags'),
         ),
       ).captured;
 
@@ -838,6 +841,102 @@ void main() {
       );
     });
 
+    testWidgets('DM carries a report_type tag matching the selected reason', (
+      tester,
+    ) async {
+      await setLargeSurface(tester);
+      await openAndSubmitReport(tester);
+
+      final captured = verify(
+        () => mockDmRepository.sendMessage(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+          replyToId: any(named: 'replyToId'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          additionalTags: captureAny(named: 'additionalTags'),
+        ),
+      ).captured;
+
+      final tags = captured.single as List<List<String>>;
+      expect(
+        tags.any(
+          (t) => t.length == 2 && t[0] == 'report_type' && t[1] == 'spam',
+        ),
+        isTrue,
+        reason:
+            'divine-moderation-service classifies the DM off this tag, not '
+            'the prose content (#6593)',
+      );
+    });
+
+    testWidgets(
+      'DM carries a sha256 tag when the reported video has a resolvable hash',
+      (tester) async {
+        testVideo = testVideo.copyWith(
+          sha256:
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        );
+
+        await setLargeSurface(tester);
+        await openAndSubmitReport(tester);
+
+        final captured = verify(
+          () => mockDmRepository.sendMessage(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            content: any(named: 'content'),
+            replyToId: any(named: 'replyToId'),
+            skipNip04Fallback: any(named: 'skipNip04Fallback'),
+            additionalTags: captureAny(named: 'additionalTags'),
+          ),
+        ).captured;
+
+        final tags = captured.single as List<List<String>>;
+        expect(
+          tags.any(
+            (t) =>
+                t.length == 2 &&
+                t[0] == 'sha256' &&
+                t[1] ==
+                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    testWidgets(
+      'DM omits the sha256 tag when the reported video has no resolvable hash',
+      (tester) async {
+        // The default testVideo fixture's imeta tag has no x (sha256)
+        // sub-value -- VideoEvent.sha256 is null, matching a video
+        // published without one (see the plan's findings addendum).
+        expect(testVideo.sha256, isNull);
+
+        await setLargeSurface(tester);
+        await openAndSubmitReport(tester);
+
+        final captured = verify(
+          () => mockDmRepository.sendMessage(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            content: any(named: 'content'),
+            replyToId: any(named: 'replyToId'),
+            skipNip04Fallback: any(named: 'skipNip04Fallback'),
+            additionalTags: captureAny(named: 'additionalTags'),
+          ),
+        ).captured;
+
+        final tags = captured.single as List<List<String>>;
+        expect(
+          tags.where((t) => t.first == 'sha256'),
+          isEmpty,
+          reason:
+              'user_reports.sha256 is NOT NULL server-side; a blank tag '
+              'would let a malformed report through instead of degrading '
+              'cleanly to no report row',
+        );
+      },
+    );
+
     testWidgets('report succeeds even if moderation DM fails', (tester) async {
       when(
         () => mockDmRepository.sendMessage(
@@ -845,6 +944,7 @@ void main() {
           content: any(named: 'content'),
           replyToId: any(named: 'replyToId'),
           skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          additionalTags: any(named: 'additionalTags'),
         ),
       ).thenThrow(Exception('DM relay unreachable'));
 
@@ -875,6 +975,7 @@ void main() {
           content: any(named: 'content'),
           replyToId: any(named: 'replyToId'),
           skipNip04Fallback: true,
+          additionalTags: any(named: 'additionalTags'),
         ),
       ).called(1);
     });
@@ -899,6 +1000,7 @@ void main() {
           content: any(named: 'content'),
           replyToId: any(named: 'replyToId'),
           skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          additionalTags: any(named: 'additionalTags'),
         ),
       ).thenAnswer((_) async => result);
     }
@@ -1009,6 +1111,7 @@ void main() {
           content: any(named: 'content'),
           replyToId: any(named: 'replyToId'),
           skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          additionalTags: any(named: 'additionalTags'),
         ),
       ).called(1);
     });
@@ -1050,6 +1153,7 @@ void main() {
           content: any(named: 'content'),
           replyToId: any(named: 'replyToId'),
           skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          additionalTags: any(named: 'additionalTags'),
         ),
       );
     });
@@ -1098,6 +1202,7 @@ void main() {
           content: any(named: 'content'),
           replyToId: any(named: 'replyToId'),
           skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          additionalTags: any(named: 'additionalTags'),
         ),
       ).called(1);
     });
@@ -1165,6 +1270,7 @@ void main() {
           content: any(named: 'content'),
           replyToId: any(named: 'replyToId'),
           skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          additionalTags: any(named: 'additionalTags'),
         ),
       ).called(1);
       verify(
@@ -1223,6 +1329,7 @@ void main() {
             content: any(named: 'content'),
             replyToId: any(named: 'replyToId'),
             skipNip04Fallback: any(named: 'skipNip04Fallback'),
+            additionalTags: any(named: 'additionalTags'),
           ),
         ).called(1);
         expect(find.text(l10n.reportReceivedTitle), findsOneWidget);
@@ -1273,6 +1380,7 @@ void main() {
           content: any(named: 'content'),
           replyToId: any(named: 'replyToId'),
           skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          additionalTags: any(named: 'additionalTags'),
         ),
       ).called(1);
       // Coalescing spent the row, so the re-drive is not retried either.
@@ -1318,6 +1426,7 @@ void main() {
           content: any(named: 'content'),
           replyToId: any(named: 'replyToId'),
           skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          additionalTags: any(named: 'additionalTags'),
         ),
       ).called(1);
     });
@@ -1478,6 +1587,7 @@ void main() {
             content: any(named: 'content'),
             replyToId: any(named: 'replyToId'),
             skipNip04Fallback: any(named: 'skipNip04Fallback'),
+            additionalTags: any(named: 'additionalTags'),
           ),
         ).thenThrow(Exception('No keys available'));
 
@@ -1536,6 +1646,7 @@ void main() {
             content: any(named: 'content'),
             replyToId: any(named: 'replyToId'),
             skipNip04Fallback: any(named: 'skipNip04Fallback'),
+            additionalTags: any(named: 'additionalTags'),
           ),
         );
       },
@@ -1566,6 +1677,7 @@ void main() {
           content: any(named: 'content'),
           replyToId: any(named: 'replyToId'),
           skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          additionalTags: any(named: 'additionalTags'),
         ),
       ).thenAnswer(
         (_) async => NIP17SendResult.success(
@@ -1648,6 +1760,7 @@ void main() {
             content: captureAny(named: 'content'),
             replyToId: any(named: 'replyToId'),
             skipNip04Fallback: any(named: 'skipNip04Fallback'),
+            additionalTags: any(named: 'additionalTags'),
           ),
         ).captured;
 
@@ -1699,6 +1812,7 @@ void main() {
           content: any(named: 'content'),
           replyToId: any(named: 'replyToId'),
           skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          additionalTags: any(named: 'additionalTags'),
         ),
       ).thenAnswer(
         (_) async => NIP17SendResult.success(
@@ -1809,6 +1923,7 @@ void main() {
             content: captureAny(named: 'content'),
             replyToId: any(named: 'replyToId'),
             skipNip04Fallback: any(named: 'skipNip04Fallback'),
+            additionalTags: any(named: 'additionalTags'),
           ),
         ).captured;
 


### PR DESCRIPTION
Closes #6593

## Summary

Fixes the producer half of #6593 ("moderation DM intake is half-wired and its unread badge is dead code") — divine-moderation-service's `dm-reader.mjs` only ever promoted an incoming DM to a `user_reports` row when its content parsed as JSON `{type:'conversation_report', sha256}`, a shape this app has never produced.

The DM's content stays exactly the same human-readable prose (`_formatReportDm`, unchanged) — no moderator-facing UI change, no NIP-17 content-convention violation. Report data now also travels as NIP-17 tags on the same kind-14 rumor, via `dm_repository.sendMessage`'s existing (already-shipped, already-tested via `replyToId`) `additionalTags` parameter. The companion divine-moderation-service PR reads those tags instead of trying to `JSON.parse` the content.

- `report_type` is attached for every report variant (content, user, DM-message), mapped from the same `ContentFilterReason` → NIP-56 conversion already used for the kind-1984 report tags — lifted out of `ContentReportingService` into a shared `contentFilterReasonToNip56Type` so both channels can't drift out of sync.
- `sha256` is attached only for content reports where `VideoEvent.sha256` resolves to a non-empty value. User reports and DM-message reports have no Blossom blob hash and never carry it — this matches the backend's `user_reports.sha256 NOT NULL` schema, which has no user-only/message-only shape (see the linked plan's "Non-goals": this activates the backend's `user_reports` insert for content reports only, by design, not as a gap).

The retry path (`recoverFullSend`) replays the originally-queued rumor bytes rather than rebuilding the send, so tags attached on the first send are automatically preserved on retry with no separate plumbing needed.

## Test plan

- [x] `flutter analyze lib test integration_test` — clean
- [x] `flutter test test/widgets/report_content_dialog_test.dart` — 84/84 pass (3 new: `report_type` tag present for the selected reason, `sha256` tag present/absent based on `VideoEvent.sha256`)
- [x] `flutter test test/services/content_moderation_types_test.dart` — 7/7 pass (new coverage for the extracted `contentFilterReasonToNip56Type` mapping, including exhaustiveness over every `ContentFilterReason`)
- [x] `flutter test test/services/content_reporting_service_test.dart` — 27/27 pass (unaffected — same mapping, moved not changed)
- [x] Pre-push hook (format + analyze + affected tests) — all green

## Related

- #6593
- Companion PR in divine-moderation-service (reads these tags)