### PR TITLE
fix(drafts): stop the library from restamping and hiding drafts

### DIFF
--- a/mobile/lib/models/divine_video_draft.dart
+++ b/mobile/lib/models/divine_video_draft.dart
@@ -222,12 +222,23 @@ class DivineVideoDraft {
     );
   }
 
+  /// Rebuilds a draft from its [row] and [clipRows].
+  ///
+  /// Publish bookkeeping is taken from the row columns, not the `data` blob.
+  /// `DraftsDao.updatePublishStatus` writes only the columns, so after a
+  /// background publish fails or parks a draft the blob still holds the status
+  /// from the last full save — and a draft stuck at `publishing` is filtered
+  /// out of the library, stranding the video (#6833).
   factory DivineVideoDraft.fromDriftRow({
     required DraftRow row,
     required List<ClipRow> clipRows,
     required String documentsPath,
   }) {
-    final draftJson = json.decode(row.data) as Map<String, dynamic>;
+    final draftJson = json.decode(row.data) as Map<String, dynamic>
+      ..['publishStatus'] = row.publishStatus
+      ..['publishError'] = row.publishError
+      ..['publishAttempts'] = row.publishAttempts
+      ..['lastModified'] = row.lastModified.toIso8601String();
 
     // Reconstruct clips from clip rows
     final clips = clipRows.map((clipRow) {

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -454,7 +454,9 @@ class DraftStorageService {
       );
     }
 
-    return _clearMissingFinalRenderedClip(draft.copyWith(clips: validClips));
+    return _clearMissingFinalRenderedClip(
+      draft.copyWith(clips: validClips, skipUpdateLastModified: true),
+    );
   }
 
   /// Get the autosaved draft with validation.
@@ -464,6 +466,9 @@ class DraftStorageService {
     return getValidatedDraftById(VideoEditorConstants.autoSaveId);
   }
 
+  /// Hides unusable clips from a loaded draft without counting as an edit:
+  /// the stored `lastModified` is kept, so reading the list can't restamp
+  /// every draft with the current time (and scramble its newest-first order).
   DivineVideoDraft? _validatedDraft(DivineVideoDraft draft) {
     final validClips = _filterValidClips(draft.clips);
     if (validClips.isEmpty) {
@@ -484,7 +489,9 @@ class DraftStorageService {
       );
     }
 
-    return _clearMissingFinalRenderedClip(draft.copyWith(clips: validClips));
+    return _clearMissingFinalRenderedClip(
+      draft.copyWith(clips: validClips, skipUpdateLastModified: true),
+    );
   }
 
   /// Filter clips to only those whose source media still exists.
@@ -516,7 +523,10 @@ class DraftStorageService {
       name: 'DraftStorageService',
       category: LogCategory.video,
     );
-    return draft.copyWith(clearFinalRenderedClip: true);
+    return draft.copyWith(
+      clearFinalRenderedClip: true,
+      skipUpdateLastModified: true,
+    );
   }
 
   /// Get all drafts from storage

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -1093,6 +1093,44 @@ void main() {
         expect(updated, isFalse);
       });
 
+      test('surfaces the new status to readers of the draft', () async {
+        final draft = DivineVideoDraft.create(
+          clips: [
+            DivineVideoClip(
+              id: 'test_clip',
+              video: EditorVideo.file('/path/to/video.mp4'),
+              duration: const Duration(seconds: 6),
+              recordedAt: DateTime.now(),
+              targetAspectRatio: AspectRatio.square,
+              originalAspectRatio: 9 / 16,
+            ),
+          ],
+          title: 'Test Vine',
+          description: '',
+          hashtags: {},
+          selectedApproach: 'hybrid',
+        );
+
+        // The publish flow writes `publishing` through a full save, then only
+        // ever touches the row columns.
+        await service.saveDraft(
+          draft.copyWith(publishStatus: PublishStatus.publishing),
+        );
+        await service.updatePublishStatus(
+          draftId: draft.id,
+          status: PublishStatus.failed,
+          publishError: 'Network error',
+          publishAttempts: 2,
+        );
+
+        // A `publishing` draft is filtered out of the library, so reading the
+        // stale blob strands the video: the user never sees it again.
+        final loaded = await service.getAllDrafts();
+        expect(loaded.single.publishStatus, PublishStatus.failed);
+        expect(loaded.single.publishError, 'Network error');
+        expect(loaded.single.publishAttempts, 2);
+      });
+
       test('should update publish status with error message', () async {
         final draft = DivineVideoDraft.create(
           clips: [

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -250,6 +250,36 @@ void main() {
         expect(drafts.length, 2);
       });
 
+      test('keeps each draft own lastModified when reading the list', () async {
+        final savedAt = DateTime(2026, 5, 4, 3, 2, 1);
+        final draft = DivineVideoDraft(
+          id: 'draft_old',
+          clips: [
+            DivineVideoClip(
+              id: 'clip_old',
+              video: EditorVideo.file('/path/to/old_video.mp4'),
+              duration: const Duration(seconds: 6),
+              recordedAt: savedAt,
+              targetAspectRatio: AspectRatio.square,
+              originalAspectRatio: 9 / 16,
+            ),
+          ],
+          title: 'Old draft',
+          description: '',
+          hashtags: {},
+          selectedApproach: 'hybrid',
+          createdAt: savedAt,
+          lastModified: savedAt,
+          publishStatus: PublishStatus.draft,
+          publishAttempts: 0,
+        );
+
+        await service.saveDraft(draft);
+
+        final drafts = await service.getAllDrafts();
+        expect(drafts.single.lastModified, savedAt);
+      });
+
       test('should return empty when database is empty', () async {
         final drafts = await service.getAllDrafts();
         expect(drafts, isEmpty);

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -429,7 +429,9 @@ void main() {
       });
 
       test('clears missing final rendered clip references', () async {
-        final draft = DivineVideoDraft.create(
+        final savedAt = DateTime(2026, 5, 4, 3, 2, 1);
+        final draft = DivineVideoDraft(
+          id: 'draft_rendered',
           clips: [
             DivineVideoClip(
               id: 'clip_1',
@@ -444,6 +446,10 @@ void main() {
           description: '',
           hashtags: {},
           selectedApproach: 'video',
+          createdAt: savedAt,
+          lastModified: savedAt,
+          publishStatus: PublishStatus.draft,
+          publishAttempts: 0,
           finalRenderedClip: DivineVideoClip(
             id: 'rendered_clip',
             video: EditorVideo.file('/path/to/missing-render.mp4'),
@@ -462,6 +468,8 @@ void main() {
         // Dropping the dangling render does not take the draft out of play:
         // publish re-renders it from its clips and editor state.
         expect(drafts.single.canPost, isTrue);
+        // ...and it is not an edit either, so the timestamp stays put.
+        expect(drafts.single.lastModified, savedAt);
       });
     });
 
@@ -507,6 +515,38 @@ void main() {
         );
 
         expect(await service.getDraftById('draft_corrupt'), isNull);
+      });
+    });
+
+    group('getValidatedDraftById', () {
+      test('keeps the stored lastModified', () async {
+        final savedAt = DateTime(2026, 5, 4, 3, 2, 1);
+        final draft = DivineVideoDraft(
+          id: 'draft_validated',
+          clips: [
+            DivineVideoClip(
+              id: 'clip_validated',
+              video: EditorVideo.file('/path/to/old_video.mp4'),
+              duration: const Duration(seconds: 6),
+              recordedAt: savedAt,
+              targetAspectRatio: AspectRatio.square,
+              originalAspectRatio: 9 / 16,
+            ),
+          ],
+          title: 'Validated draft',
+          description: '',
+          hashtags: {},
+          selectedApproach: 'hybrid',
+          createdAt: savedAt,
+          lastModified: savedAt,
+          publishStatus: PublishStatus.draft,
+          publishAttempts: 0,
+        );
+
+        await service.saveDraft(draft);
+
+        final loaded = await service.getValidatedDraftById('draft_validated');
+        expect(loaded?.lastModified, savedAt);
       });
     });
 


### PR DESCRIPTION
Closes #6833

## Description

Two bugs in the drafts library, both from the same root: the read path reconstructing a draft differently than the write path stored it.

### 1. Every draft in the list showed the current time

Saving one draft made every other draft show the current time as its last-modified date.

`DivineVideoDraft.copyWith` restamps `lastModified` with `DateTime.now()` unless `skipUpdateLastModified: true` is passed. `DraftStorageService` uses `copyWith` on its **read** paths to hide clips whose source files are gone (`_validatedDraft`, `getValidatedDraftById`, `_clearMissingFinalRenderedClip`) — so every draft came back from the database stamped with the moment the list was loaded. The drafts tab reloads after returning from the editor, which is why it surfaced right after a save.

A second, quieter symptom: `DraftsLibraryBloc` sorts newest-first on `lastModified`, and with every value restamped within the same load it had nothing left to order by — the list order was effectively the database's.

Reading a draft is not an edit, so the three read paths now opt out of the bump. The write paths (save, publish, duplicate) are untouched and still bump as before. This matches the invariant `restoreDraft` already follows — opening a draft to view it must not reorder it to the top of the list (#5956).

### 2. A draft whose publish failed disappeared from the tab

`DraftsDao.updatePublishStatus` writes only the row columns — it is the cheap path that skips re-serializing the whole draft. But `DivineVideoDraft.fromDriftRow` rebuilt the draft entirely from the `data` blob and ignored those columns, so every column-only write was invisible to the app: `publishStatus`, `publishError`, `publishAttempts` and `lastModified` all kept the values from the last full save.

What that cost:

- A background publish that fails writes `failed` to the column, but the blob still says `publishing` — and `DraftsLibraryBloc` filters `publishing` drafts out of the list. The draft vanished from the drafts tab.
- `BackgroundPublishBloc._park` exists specifically to hand a video back to the user as a draft instead of deleting it when the publish copy is the only surviving copy. It writes `draft` to the column, the blob still said `publishing`, and the parked video stayed hidden.
- The classified `publishError` that `_persistPublishStatus` writes "so resume re-localizes correctly" never reached the resume flow, which read the stale null from the blob.

The fix reads those four fields from the row columns. They are only ever written from the same draft object a full save serializes, so they can never be staler than the blob — overlaying them onto the decoded JSON before parsing is always correct, and is a smaller change than teaching the DAO to rewrite the blob (which would put the app's JSON field names into `db_client`).

## Out of Scope

Fix 2 is not covered by the linked issue. Happy to split it into its own PR or open a follow-up issue for the record if preferred — it is in here because it is the same read path and the same class of bug.

## Verification

- Three regression tests, each verified red before the corresponding fix and green after:
  - `getAllDrafts` keeps each draft's stored `lastModified` (`Expected: 2026-05-04 03:02:01 / Actual: 2026-08-07 15:18:53`)
  - `getValidatedDraftById` keeps it too, and `clears missing final rendered clip references` now asserts it as well — checked in isolation by reverting only that one `skipUpdateLastModified` and watching it fail
  - `updatePublishStatus` surfaces status, error and attempt count to `getAllDrafts` (`Expected: PublishStatus.failed / Actual: PublishStatus.publishing`)
- `flutter test test/services/draft_storage_service_test.dart` — 72 passed
- `flutter test test/models/ test/blocs/drafts_library/ test/blocs/background_publish_bloc/ test/providers/video_publish_provider_test.dart test/providers/video_editor_provider_test.dart test/services/video_publish/ test/widgets/library/drafts_tab_test.dart test/screens/video_recorder_screen_test.dart test/services/clip_library_service_test.dart` — 1063 passed
- `flutter test` in `packages/db_client` — 908 passed
- `flutter analyze lib test` and `dart format` clean
- Manually verified on a real Samsung Galaxy: saving a new draft leaves the existing drafts' timestamps untouched. The publish-state fix has not been device-verified yet — the interrupted-publish flow still needs a run on hardware.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
