### PR TITLE
perf(collabs): render mutual follows as each follower source answers

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2262,6 +2262,7 @@
     "userPickerSearchByName": "በስም ፈልግ",
     "userPickerFilterByNameHint": "በስም አጣራ...",
     "userPickerSearchByNameHint": "በስም ፈልግ...",
+    "userPickerClearSearchSemantics": "ፍለጋን አጽዳ",
     "userPickerAlreadyAddedSemantics": "{name} አስቀድሞ ታክሏል።",
     "@userPickerAlreadyAddedSemantics": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1865,6 +1865,7 @@
     "userPickerSearchByName": "İsme göre ara",
     "userPickerFilterByNameHint": "İsme göre filtrele...",
     "userPickerSearchByNameHint": "İsme göre ara...",
+    "userPickerClearSearchSemantics": "مسح البحث",
     "userPickerAlreadyAddedSemantics": "{name} zaten eklendi",
     "@userPickerAlreadyAddedSemantics": {
         "placeholders": {

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2075,6 +2075,7 @@
     "userPickerSearchByName": "Търсене по име",
     "userPickerFilterByNameHint": "Филтриране по име...",
     "userPickerSearchByNameHint": "Търсене по име...",
+    "userPickerClearSearchSemantics": "Изчистване на търсенето",
     "userPickerAlreadyAddedSemantics": "{name} вече е добавен",
     "@userPickerAlreadyAddedSemantics": {
         "placeholders": {

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1875,6 +1875,7 @@
     "userPickerSearchByName": "Nach Namen suchen",
     "userPickerFilterByNameHint": "Nach Namen filtern...",
     "userPickerSearchByNameHint": "Nach Namen suchen...",
+    "userPickerClearSearchSemantics": "Suche löschen",
     "userPickerAlreadyAddedSemantics": "{name} bereits hinzugefügt",
     "@userPickerAlreadyAddedSemantics": {
         "placeholders": {

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2761,6 +2761,10 @@
   "userPickerSearchByName": "Search by name",
   "userPickerFilterByNameHint": "Filter by name...",
   "userPickerSearchByNameHint": "Search by name...",
+  "userPickerClearSearchSemantics": "Clear search",
+  "@userPickerClearSearchSemantics": {
+    "description": "Semantic label for the button that clears the text in the user picker search field."
+  },
   "userPickerAlreadyAddedSemantics": "{name} already added",
   "@userPickerAlreadyAddedSemantics": {
     "placeholders": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1879,6 +1879,7 @@
     "userPickerSearchByName": "Buscar por nombre",
     "userPickerFilterByNameHint": "Filtrar por nombre...",
     "userPickerSearchByNameHint": "Buscar por nombre...",
+    "userPickerClearSearchSemantics": "Borrar búsqueda",
     "userPickerAlreadyAddedSemantics": "{name} ya fue agregado",
     "@userPickerAlreadyAddedSemantics": {
         "placeholders": {

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1217,6 +1217,7 @@
     "userPickerSearchByName": "Hanapin ayon sa pangalan",
     "userPickerFilterByNameHint": "I-filter ayon sa pangalan...",
     "userPickerSearchByNameHint": "Hanapin ayon sa pangalan...",
+    "userPickerClearSearchSemantics": "I-clear ang paghahanap",
     "userPickerAlreadyAddedSemantics": "Naidagdag na si {name}",
     "userPickerSelectSemantics": "Piliin si {name}",
     "userPickerEmptyFollowListTitle": "Naghihintay sa iyo ang crew mo",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1875,6 +1875,7 @@
     "userPickerSearchByName": "Rechercher par nom",
     "userPickerFilterByNameHint": "Filtrer par nom...",
     "userPickerSearchByNameHint": "Rechercher par nom...",
+    "userPickerClearSearchSemantics": "Effacer la recherche",
     "userPickerAlreadyAddedSemantics": "{name} déjà ajouté",
     "@userPickerAlreadyAddedSemantics": {
         "placeholders": {

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1872,6 +1872,7 @@
     "userPickerSearchByName": "Cari berdasarkan nama",
     "userPickerFilterByNameHint": "Filter berdasarkan nama...",
     "userPickerSearchByNameHint": "Cari berdasarkan nama...",
+    "userPickerClearSearchSemantics": "Hapus pencarian",
     "userPickerAlreadyAddedSemantics": "{name} sudah ditambahkan",
     "@userPickerAlreadyAddedSemantics": {
         "placeholders": {

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1875,6 +1875,7 @@
     "userPickerSearchByName": "Cerca per nome",
     "userPickerFilterByNameHint": "Filtra per nome...",
     "userPickerSearchByNameHint": "Cerca per nome...",
+    "userPickerClearSearchSemantics": "Cancella ricerca",
     "userPickerAlreadyAddedSemantics": "{name} già aggiunto",
     "@userPickerAlreadyAddedSemantics": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1865,6 +1865,7 @@
     "userPickerSearchByName": "名前で検索",
     "userPickerFilterByNameHint": "名前で絞り込み...",
     "userPickerSearchByNameHint": "名前で検索...",
+    "userPickerClearSearchSemantics": "検索をクリア",
     "userPickerAlreadyAddedSemantics": "{name} はすでに追加済みです",
     "@userPickerAlreadyAddedSemantics": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1203,6 +1203,7 @@
     "userPickerSearchByName": "이름으로 검색",
     "userPickerFilterByNameHint": "이름으로 필터링...",
     "userPickerSearchByNameHint": "이름으로 검색...",
+    "userPickerClearSearchSemantics": "검색 지우기",
     "userPickerAlreadyAddedSemantics": "{name} 이미 추가됨",
     "@userPickerAlreadyAddedSemantics": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -2606,6 +2606,7 @@
   "userPickerSearchByName": "Cari mengikut nama",
   "userPickerFilterByNameHint": "Tapis mengikut nama...",
   "userPickerSearchByNameHint": "Cari mengikut nama...",
+  "userPickerClearSearchSemantics": "Kosongkan carian",
   "userPickerAlreadyAddedSemantics": "{name} sudah ditambah",
   "@userPickerAlreadyAddedSemantics": {
     "placeholders": {

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1875,6 +1875,7 @@
     "userPickerSearchByName": "Zoeken op naam",
     "userPickerFilterByNameHint": "Filteren op naam...",
     "userPickerSearchByNameHint": "Zoeken op naam...",
+    "userPickerClearSearchSemantics": "Zoekopdracht wissen",
     "userPickerAlreadyAddedSemantics": "{name} al toegevoegd",
     "@userPickerAlreadyAddedSemantics": {
         "placeholders": {

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1875,6 +1875,7 @@
     "userPickerSearchByName": "Szukaj po nazwie",
     "userPickerFilterByNameHint": "Filtruj po nazwie...",
     "userPickerSearchByNameHint": "Szukaj po nazwie...",
+    "userPickerClearSearchSemantics": "Wyczyść wyszukiwanie",
     "userPickerAlreadyAddedSemantics": "{name} już dodano",
     "@userPickerAlreadyAddedSemantics": {
         "placeholders": {

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1875,6 +1875,7 @@
     "userPickerSearchByName": "Pesquisar por nome",
     "userPickerFilterByNameHint": "Filtrar por nome...",
     "userPickerSearchByNameHint": "Pesquisar por nome...",
+    "userPickerClearSearchSemantics": "Limpar pesquisa",
     "userPickerAlreadyAddedSemantics": "{name} já adicionado",
     "@userPickerAlreadyAddedSemantics": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1875,6 +1875,7 @@
     "userPickerSearchByName": "Caută după nume",
     "userPickerFilterByNameHint": "Filtrează după nume...",
     "userPickerSearchByNameHint": "Caută după nume...",
+    "userPickerClearSearchSemantics": "Șterge căutarea",
     "userPickerAlreadyAddedSemantics": "{name} este deja adăugat",
     "@userPickerAlreadyAddedSemantics": {
         "placeholders": {

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1875,6 +1875,7 @@
     "userPickerSearchByName": "Sök efter namn",
     "userPickerFilterByNameHint": "Filtrera efter namn...",
     "userPickerSearchByNameHint": "Sök efter namn...",
+    "userPickerClearSearchSemantics": "Rensa sökning",
     "userPickerAlreadyAddedSemantics": "{name} har redan lagts till",
     "@userPickerAlreadyAddedSemantics": {
         "placeholders": {

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1872,6 +1872,7 @@
     "userPickerSearchByName": "Ada göre ara",
     "userPickerFilterByNameHint": "Ada göre filtrele...",
     "userPickerSearchByNameHint": "Ada göre ara...",
+    "userPickerClearSearchSemantics": "Aramayı temizle",
     "userPickerAlreadyAddedSemantics": "{name} zaten eklendi",
     "@userPickerAlreadyAddedSemantics": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -2606,6 +2606,7 @@
   "userPickerSearchByName": "نام سے تلاش کریں",
   "userPickerFilterByNameHint": "نام سے فلٹر کریں...",
   "userPickerSearchByNameHint": "نام سے تلاش کریں...",
+  "userPickerClearSearchSemantics": "تلاش صاف کریں",
   "userPickerAlreadyAddedSemantics": "{name} پہلے سے شامل ہے",
   "@userPickerAlreadyAddedSemantics": {
     "placeholders": {

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -2606,6 +2606,7 @@
   "userPickerSearchByName": "Tìm theo tên",
   "userPickerFilterByNameHint": "Lọc theo tên...",
   "userPickerSearchByNameHint": "Tìm theo tên...",
+  "userPickerClearSearchSemantics": "Xóa tìm kiếm",
   "userPickerAlreadyAddedSemantics": "{name} đã được thêm",
   "@userPickerAlreadyAddedSemantics": {
     "placeholders": {

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -2606,6 +2606,7 @@
   "userPickerSearchByName": "按名字搜索",
   "userPickerFilterByNameHint": "按名字筛选...",
   "userPickerSearchByNameHint": "按名字搜索...",
+  "userPickerClearSearchSemantics": "清除搜索",
   "userPickerAlreadyAddedSemantics": "{name} 已添加",
   "@userPickerAlreadyAddedSemantics": {
     "placeholders": {

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -8066,6 +8066,12 @@ abstract class AppLocalizations {
   /// **'Search by name...'**
   String get userPickerSearchByNameHint;
 
+  /// Semantic label for the button that clears the text in the user picker search field.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear search'**
+  String get userPickerClearSearchSemantics;
+
   /// No description provided for @userPickerAlreadyAddedSemantics.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4560,6 +4560,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get userPickerSearchByNameHint => 'በስም ፈልግ...';
 
   @override
+  String get userPickerClearSearchSemantics => 'ፍለጋን አጽዳ';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return '$name አስቀድሞ ታክሏል።';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4614,6 +4614,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get userPickerSearchByNameHint => 'İsme göre ara...';
 
   @override
+  String get userPickerClearSearchSemantics => 'مسح البحث';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return '$name zaten eklendi';
   }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4700,6 +4700,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get userPickerSearchByNameHint => 'Търсене по име...';
 
   @override
+  String get userPickerClearSearchSemantics => 'Изчистване на търсенето';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return '$name вече е добавен';
   }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4708,6 +4708,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get userPickerSearchByNameHint => 'Nach Namen suchen...';
 
   @override
+  String get userPickerClearSearchSemantics => 'Suche löschen';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return '$name bereits hinzugefügt';
   }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4651,6 +4651,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get userPickerSearchByNameHint => 'Search by name...';
 
   @override
+  String get userPickerClearSearchSemantics => 'Clear search';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return '$name already added';
   }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4699,6 +4699,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get userPickerSearchByNameHint => 'Buscar por nombre...';
 
   @override
+  String get userPickerClearSearchSemantics => 'Borrar búsqueda';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return '$name ya fue agregado';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4716,6 +4716,9 @@ class AppLocalizationsFil extends AppLocalizations {
   String get userPickerSearchByNameHint => 'Hanapin ayon sa pangalan...';
 
   @override
+  String get userPickerClearSearchSemantics => 'I-clear ang paghahanap';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return 'Naidagdag na si $name';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4722,6 +4722,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get userPickerSearchByNameHint => 'Rechercher par nom...';
 
   @override
+  String get userPickerClearSearchSemantics => 'Effacer la recherche';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return '$name déjà ajouté';
   }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4611,6 +4611,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get userPickerSearchByNameHint => 'Cari berdasarkan nama...';
 
   @override
+  String get userPickerClearSearchSemantics => 'Hapus pencarian';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return '$name sudah ditambahkan';
   }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4705,6 +4705,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get userPickerSearchByNameHint => 'Cerca per nome...';
 
   @override
+  String get userPickerClearSearchSemantics => 'Cancella ricerca';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return '$name già aggiunto';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4420,6 +4420,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get userPickerSearchByNameHint => '名前で検索...';
 
   @override
+  String get userPickerClearSearchSemantics => '検索をクリア';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return '$name はすでに追加済みです';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4440,6 +4440,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get userPickerSearchByNameHint => '이름으로 검색...';
 
   @override
+  String get userPickerClearSearchSemantics => '검색 지우기';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return '$name 이미 추가됨';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -4687,6 +4687,9 @@ class AppLocalizationsMs extends AppLocalizations {
   String get userPickerSearchByNameHint => 'Cari mengikut nama...';
 
   @override
+  String get userPickerClearSearchSemantics => 'Kosongkan carian';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return '$name sudah ditambah';
   }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4671,6 +4671,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get userPickerSearchByNameHint => 'Zoeken op naam...';
 
   @override
+  String get userPickerClearSearchSemantics => 'Zoekopdracht wissen';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return '$name al toegevoegd';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4771,6 +4771,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get userPickerSearchByNameHint => 'Szukaj po nazwie...';
 
   @override
+  String get userPickerClearSearchSemantics => 'Wyczyść wyszukiwanie';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return '$name już dodano';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4683,6 +4683,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get userPickerSearchByNameHint => 'Pesquisar por nome...';
 
   @override
+  String get userPickerClearSearchSemantics => 'Limpar pesquisa';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return '$name já adicionado';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4786,6 +4786,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get userPickerSearchByNameHint => 'Caută după nume...';
 
   @override
+  String get userPickerClearSearchSemantics => 'Șterge căutarea';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return '$name este deja adăugat';
   }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4649,6 +4649,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get userPickerSearchByNameHint => 'Sök efter namn...';
 
   @override
+  String get userPickerClearSearchSemantics => 'Rensa sökning';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return '$name har redan lagts till';
   }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4621,6 +4621,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get userPickerSearchByNameHint => 'Ada göre ara...';
 
   @override
+  String get userPickerClearSearchSemantics => 'Aramayı temizle';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return '$name zaten eklendi';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -4659,6 +4659,9 @@ class AppLocalizationsUr extends AppLocalizations {
   String get userPickerSearchByNameHint => 'نام سے تلاش کریں...';
 
   @override
+  String get userPickerClearSearchSemantics => 'تلاش صاف کریں';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return '$name پہلے سے شامل ہے';
   }

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -4656,6 +4656,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get userPickerSearchByNameHint => 'Tìm theo tên...';
 
   @override
+  String get userPickerClearSearchSemantics => 'Xóa tìm kiếm';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return '$name đã được thêm';
   }

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -4408,6 +4408,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get userPickerSearchByNameHint => '按名字搜索...';
 
   @override
+  String get userPickerClearSearchSemantics => '清除搜索';
+
+  @override
   String userPickerAlreadyAddedSemantics(String name) {
     return '$name 已添加';
   }

--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Supports filtering by mutual follows (fast local search)
 // ABOUTME: or all users (network search) with mute-check validation
 
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -11,6 +13,7 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/user_search/user_search_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 
 /// Filter mode for user search in [UserPickerSheet].
@@ -123,6 +126,7 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
   List<UserProfile> _followProfiles = [];
   List<UserProfile> _filteredFollowProfiles = [];
   bool _followListLoaded = false;
+  StreamSubscription<List<String>>? _followersSubscription;
   final _selectedProfiles = <UserProfile>[];
 
   /// Whether the profile repository was unavailable at init time.
@@ -161,7 +165,16 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
     }
   }
 
-  /// Loads followed profiles and fetches followers in parallel for mutual mode.
+  /// Loads followed profiles, then narrows them to mutuals as each follower
+  /// source answers.
+  ///
+  /// The follower sources differ by an order of magnitude in latency (REST
+  /// ~150ms, indexer relays up to ~2s) while the slow ones rarely add anyone.
+  /// Rendering each emission as it arrives shows the bulk of the list roughly
+  /// ten times sooner. Emissions only ever grow
+  /// ([FollowRepository.streamMyFollowers]), so everyone on screen is a
+  /// mutual confirmed by a live source — a late source can add rows, never
+  /// invalidate one already shown.
   Future<void> _loadFollowProfiles() async {
     final followRepo = ref.read(followRepositoryProvider);
     final profileRepo = ref.read(profileRepositoryProvider);
@@ -173,54 +186,23 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
     final followingPubkeys = followRepo.followingPubkeys;
     final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
 
-    final profilesFuture = Future.wait(
-      followingPubkeys.map((pk) => profileRepo.getCachedProfile(pubkey: pk)),
-    );
+    final List<UserProfile> candidates;
     try {
-      final myFollowersFuture =
-          widget.filterMode == UserPickerFilterMode.mutualFollowsOnly
-          ? followRepo
-                .getMyFollowers()
-                .then<Set<String>?>((followers) => followers.toSet())
-                // Relay/network failures should not block sheet loading.
-                .catchError((Object _, StackTrace _) => null)
-          : Future<Set<String>?>.value(const <String>{});
-
-      final (rawProfiles, myFollowersSet) = await (
-        profilesFuture,
-        myFollowersFuture,
-      ).wait;
-
-      var profiles = rawProfiles.whereType<UserProfile>().toList();
-      profiles = profiles
-          .where(
-            (profile) =>
-                !blocklistRepository.shouldFilterFromFeeds(profile.pubkey),
-          )
-          .toList();
-
-      // When mutual-follow fetch fails, fall back to local follows so the
-      // picker remains usable instead of hanging in loading.
-      if (widget.filterMode == UserPickerFilterMode.mutualFollowsOnly &&
-          myFollowersSet != null) {
-        profiles = profiles
-            .where((p) => myFollowersSet.contains(p.pubkey))
-            .toList();
-      }
-
-      profiles.sort(
-        (a, b) => a.bestDisplayName.toLowerCase().compareTo(
-          b.bestDisplayName.toLowerCase(),
-        ),
+      final cached = await profileRepo.getCachedProfiles(
+        pubkeys: followingPubkeys,
       );
-
-      if (mounted) {
-        setState(() {
-          _followProfiles = profiles;
-          _filteredFollowProfiles = profiles;
-          _followListLoaded = true;
-        });
-      }
+      candidates =
+          cached
+              .where(
+                (profile) =>
+                    !blocklistRepository.shouldFilterFromFeeds(profile.pubkey),
+              )
+              .toList()
+            ..sort(
+              (a, b) => a.bestDisplayName.toLowerCase().compareTo(
+                b.bestDisplayName.toLowerCase(),
+              ),
+            );
     } catch (_) {
       if (mounted) {
         setState(() {
@@ -229,11 +211,59 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
           _followListLoaded = true;
         });
       }
+      return;
     }
+
+    if (!mounted) return;
+
+    if (candidates.isEmpty) {
+      setState(() => _followListLoaded = true);
+      return;
+    }
+
+    _followersSubscription = followRepo.streamMyFollowers().listen(
+      (followers) {
+        final followerSet = followers.toSet();
+        final mutuals = candidates
+            .where((profile) => followerSet.contains(profile.pubkey))
+            .toList();
+
+        // An early source can legitimately return nothing; showing the empty
+        // state before the slower ones answer would flash "you follow nobody".
+        if (mutuals.isEmpty && !_followListLoaded) return;
+
+        setState(() {
+          _followProfiles = mutuals;
+          _filteredFollowProfiles = _matchingFollowProfiles(
+            _searchController.text,
+            mutuals,
+          );
+          _followListLoaded = true;
+        });
+      },
+      // Every source failed. Fall back to local follows so the picker stays
+      // usable instead of hanging in loading.
+      onError: (Object _) {
+        if (!mounted) return;
+        setState(() {
+          _followProfiles = candidates;
+          _filteredFollowProfiles = _matchingFollowProfiles(
+            _searchController.text,
+            candidates,
+          );
+          _followListLoaded = true;
+        });
+      },
+      onDone: () {
+        if (!mounted || _followListLoaded) return;
+        setState(() => _followListLoaded = true);
+      },
+    );
   }
 
   @override
   void dispose() {
+    unawaited(_followersSubscription?.cancel());
     _searchController.dispose();
     _searchBloc?.close();
     super.dispose();
@@ -252,19 +282,27 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
   }
 
   void _filterFollowProfiles(String query) {
-    final trimmed = query.trim().toLowerCase();
-    if (trimmed.isEmpty) {
-      setState(() => _filteredFollowProfiles = _followProfiles);
-      return;
-    }
-
     setState(() {
-      _filteredFollowProfiles = _followProfiles.where((profile) {
-        final name = profile.bestDisplayName.toLowerCase();
-        final nip05 = (profile.nip05 ?? '').toLowerCase();
-        return name.contains(trimmed) || nip05.contains(trimmed);
-      }).toList();
+      _filteredFollowProfiles = _matchingFollowProfiles(query, _followProfiles);
     });
+  }
+
+  /// The subset of [profiles] matching [query] by display name or NIP-05.
+  ///
+  /// Kept separate from [_filterFollowProfiles] because the follower stream
+  /// re-applies the active query every time it adds rows.
+  List<UserProfile> _matchingFollowProfiles(
+    String query,
+    List<UserProfile> profiles,
+  ) {
+    final trimmed = query.trim().toLowerCase();
+    if (trimmed.isEmpty) return profiles;
+
+    return profiles.where((profile) {
+      final name = profile.bestDisplayName.toLowerCase();
+      final nip05 = (profile.nip05 ?? '').toLowerCase();
+      return name.contains(trimmed) || nip05.contains(trimmed);
+    }).toList();
   }
 
   void _onUserSelected(UserProfile profile) {
@@ -383,6 +421,20 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
                   child: DivineIcon(
                     icon: DivineIconName.search,
                     color: context.vineColors.onSurfaceMuted,
+                  ),
+                ),
+                suffixIcon: ValueListenableBuilder(
+                  valueListenable: _searchController,
+                  builder: (context, value, child) => AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 180),
+                    child: _searchController.text.isEmpty
+                        ? const SizedBox.shrink()
+                        : DivineIconButton(
+                            onPressed: _searchController.clear,
+                            icon: .x,
+                            backgroundColor: VineTheme.transparent,
+                            foregroundColor: context.vineColors.onSurfaceMuted,
+                          ),
                   ),
                 ),
                 border: .none,
@@ -769,7 +821,7 @@ class _NetworkResults extends StatelessWidget {
               hidePubkeys: hidePubkeys,
             ),
           UserSearchStatus.loading => const Center(
-            child: CircularProgressIndicator(color: VineTheme.vineGreen),
+            child: BrandedLoadingIndicator(),
           ),
           UserSearchStatus.failure => const _ErrorState(),
           UserSearchStatus.success when state.results.isEmpty =>
@@ -813,7 +865,7 @@ class _LocalResults extends StatelessWidget {
   Widget build(BuildContext context) {
     if (!followListLoaded) {
       return const Center(
-        child: CircularProgressIndicator(color: VineTheme.vineGreen),
+        child: BrandedLoadingIndicator(),
       );
     }
 

--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -223,6 +223,7 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
 
     _followersSubscription = followRepo.streamMyFollowers().listen(
       (followers) {
+        if (!mounted) return;
         final followerSet = followers.toSet();
         final mutuals = candidates
             .where((profile) => followerSet.contains(profile.pubkey))
@@ -876,9 +877,7 @@ class _LocalResults extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (!followListLoaded) {
-      return const Center(
-        child: BrandedLoadingIndicator(),
-      );
+      return const Center(child: BrandedLoadingIndicator());
     }
 
     if (followProfiles.isEmpty) {

--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -281,6 +281,16 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
     }
   }
 
+  /// Empties the search field and re-runs the search for the now-empty query.
+  ///
+  /// [TextEditingController.clear] does not fire [TextField.onChanged] — that
+  /// only runs for platform input — so the reset has to be dispatched by hand
+  /// or the results stay filtered under an empty field.
+  void _clearSearch() {
+    _searchController.clear();
+    _onSearchChanged('');
+  }
+
   void _filterFollowProfiles(String query) {
     setState(() {
       _filteredFollowProfiles = _matchingFollowProfiles(query, _followProfiles);
@@ -427,11 +437,13 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
                   valueListenable: _searchController,
                   builder: (context, value, child) => AnimatedSwitcher(
                     duration: const Duration(milliseconds: 180),
-                    child: _searchController.text.isEmpty
+                    child: value.text.isEmpty
                         ? const SizedBox.shrink()
                         : DivineIconButton(
-                            onPressed: _searchController.clear,
+                            onPressed: _clearSearch,
                             icon: .x,
+                            semanticLabel:
+                                context.l10n.userPickerClearSearchSemantics,
                             backgroundColor: VineTheme.transparent,
                             foregroundColor: context.vineColors.onSurfaceMuted,
                           ),

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -1032,23 +1032,13 @@ class FollowRepository {
       return [];
     }
 
-    // Run all three sources in parallel for best coverage
-    final apiFuture = (_funnelcakeApiClient?.isAvailable ?? false)
-        ? _funnelcakeApiClient!
-              .getFollowers(pubkey: pubkey, limit: 5000)
-              .then((r) => r.pubkeys)
-              .catchError((_) => <String>[])
-        : Future<List<String>>.value(const []);
-
-    final relayFuture = _fetchFollowersFromRelays(pubkey);
-    final indexerFuture = _fetchFollowerPubkeysFromIndexers(
-      pubkey,
-    ).catchError((_) => <String>[]);
-
+    // The API and indexer sources are best-effort here; a connected-relay
+    // failure still fails the whole call, as it always has.
+    final sources = _followerSources(pubkey);
     final results = await Future.wait<List<String>>([
-      apiFuture,
-      relayFuture,
-      indexerFuture,
+      sources[0].catchError((_) => <String>[]),
+      sources[1],
+      sources[2].catchError((_) => <String>[]),
     ]);
     final apiFollowers = results[0];
     final relayFollowers = results[1];
@@ -1072,6 +1062,93 @@ class FollowRepository {
     );
 
     return merged.toList();
+  }
+
+  /// The three follower sources, started in parallel.
+  ///
+  /// Order is fixed — `[REST API, connected relays, indexer relays]` — because
+  /// [_fetchFollowers] indexes into the results to log per-source counts.
+  /// Failures are *not* swallowed here; each caller applies its own policy.
+  List<Future<List<String>>> _followerSources(String pubkey) {
+    final apiFuture = (_funnelcakeApiClient?.isAvailable ?? false)
+        ? _funnelcakeApiClient!
+              .getFollowers(pubkey: pubkey, limit: 5000)
+              .then((r) => r.pubkeys)
+        : Future<List<String>>.value(const []);
+
+    return [
+      apiFuture,
+      _fetchFollowersFromRelays(pubkey),
+      _fetchFollowerPubkeysFromIndexers(pubkey),
+    ];
+  }
+
+  /// Streams the current user's followers as each source resolves.
+  ///
+  /// Every emission is the union of all sources that have answered so far, so
+  /// the list only ever grows and a pubkey that has been emitted is always
+  /// backed by a live source. Consumers that must not show a stale follower
+  /// (the mutual-follow user picker) can therefore render the first emission
+  /// immediately instead of waiting for the slowest relay.
+  ///
+  /// The REST API typically answers in ~150ms while indexer relays take up to
+  /// ~2s, so the first emission carries the large majority of the final list.
+  ///
+  /// A failing source is skipped — a working one still yields a usable list,
+  /// and a strict consumer keeps filtering rather than falling back. The
+  /// stream only emits an error when it ends up with *no* followers at all
+  /// and at least one source failed, which is the case where the caller
+  /// genuinely cannot tell "you have no followers" from "the lookup broke".
+  Stream<List<String>> streamMyFollowers() =>
+      _streamFollowers(_nostrClient.publicKey);
+
+  Stream<List<String>> _streamFollowers(String pubkey) async* {
+    if (pubkey.isEmpty) {
+      yield const [];
+      return;
+    }
+
+    final merged = <String>{};
+    Object? lastError;
+    StackTrace? lastStackTrace;
+
+    final guarded = _followerSources(pubkey).map(
+      (source) => source.then<(List<String>, Object?, StackTrace?)>(
+        (pubkeys) => (pubkeys, null, null),
+        onError: (Object error, StackTrace stackTrace) =>
+            (const <String>[], error, stackTrace),
+      ),
+    );
+
+    await for (final (pubkeys, error, stackTrace)
+        in Stream<(List<String>, Object?, StackTrace?)>.fromFutures(guarded)) {
+      if (error != null) {
+        lastError = error;
+        lastStackTrace = stackTrace;
+        Log.warning(
+          'Follower source failed: $error',
+          name: 'FollowRepository',
+          category: LogCategory.system,
+        );
+        continue;
+      }
+      final before = merged.length;
+      merged.addAll(pubkeys);
+      // The union only grows, so an unchanged size means this source added
+      // nobody — emitting again would just churn the consumer's UI.
+      if (merged.length != before) {
+        yield List<String>.unmodifiable(merged);
+      }
+    }
+
+    if (merged.isEmpty && lastError != null) {
+      Error.throwWithStackTrace(lastError, lastStackTrace ?? StackTrace.empty);
+    }
+
+    if (pubkey == _nostrClient.publicKey) {
+      _cachedMyFollowersPubkeys = merged.toList();
+      _hasMyFollowersCache = true;
+    }
   }
 
   /// Query connected relays for kind 3 events mentioning a pubkey.

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -1340,6 +1340,113 @@ void main() {
       });
     });
 
+    group('streamMyFollowers', () {
+      const follower1 =
+          'e5f6789012345678901234567890abcdef1234567890123456789012abcd1234';
+      const follower2 =
+          'f6789012345678901234567890abcdef1234567890123456789012abcde12345';
+
+      /// Builds a repository whose REST source answers immediately while the
+      /// connected-relay source stays pending until [relayResult] completes.
+      FollowRepository buildRepository({
+        required Future<List<Event>> Function() relayResult,
+        List<String> apiFollowers = const [],
+        bool apiAvailable = true,
+      }) {
+        final mockFunnelcakeClient = _MockFunnelcakeApiClient();
+        when(() => mockFunnelcakeClient.isAvailable).thenReturn(apiAvailable);
+        when(
+          () => mockFunnelcakeClient.getFollowers(
+            pubkey: any(named: 'pubkey'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) async => PaginatedPubkeys(pubkeys: apiFollowers));
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) => relayResult());
+
+        return FollowRepository(
+          nostrClient: mockNostrClient,
+          isCacheInitialized: () => cacheIsInitialized,
+          getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+          cacheUserEvent: cachedUserEvents.add,
+          funnelcakeApiClient: mockFunnelcakeClient,
+          indexerRelayUrls: const [],
+        );
+      }
+
+      Event contactListOf(String author) => Event(
+        author,
+        3,
+        [
+          ['p', testCurrentUserPubkey],
+        ],
+        '',
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      );
+
+      test('emits a growing union as each source answers', () async {
+        final slowRelay = Completer<List<Event>>();
+        repository = buildRepository(
+          relayResult: () => slowRelay.future,
+          apiFollowers: const [follower1],
+        );
+
+        final emissions = <List<String>>[];
+        final done = repository.streamMyFollowers().forEach(emissions.add);
+
+        // The fast REST source lands first, on its own.
+        await pumpEventQueue();
+        expect(emissions, [
+          [follower1],
+        ]);
+
+        slowRelay.complete([contactListOf(follower2)]);
+        await done;
+
+        // Later sources only add — the first emission stays a prefix.
+        expect(emissions.last, containsAll([follower1, follower2]));
+        expect(emissions.first, equals([follower1]));
+      });
+
+      test('keeps emitting when a single source fails', () async {
+        repository = buildRepository(
+          relayResult: () => Future<List<Event>>.error(Exception('relay down')),
+          apiFollowers: const [follower1],
+        );
+
+        final followers = await repository.streamMyFollowers().last;
+
+        expect(followers, equals([follower1]));
+      });
+
+      test(
+        'emits an error when a source fails and nothing was found',
+        () async {
+          repository = buildRepository(
+            relayResult: () => Future<List<Event>>.error(
+              Exception('relay down'),
+            ),
+            apiAvailable: false,
+          );
+
+          await expectLater(
+            repository.streamMyFollowers(),
+            emitsThrough(emitsError(isA<Exception>())),
+          );
+        },
+      );
+
+      test('emits an empty list when not authenticated', () async {
+        when(() => mockNostrClient.publicKey).thenReturn('');
+
+        final emissions = await repository.streamMyFollowers().toList();
+
+        expect(emissions, [<String>[]]);
+        verifyNever(() => mockNostrClient.queryEvents(any()));
+      });
+    });
+
     group('watchMyFollowers', () {
       const follower1 =
           'e5f6789012345678901234567890abcdef1234567890123456789012abcd1234';

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -341,6 +341,23 @@ class ProfileRepository implements ProfileReader {
     return _userProfilesDao.getProfile(pubkey);
   }
 
+  /// Returns the cached profiles for [pubkeys] in a single query.
+  ///
+  /// The batch counterpart to [getCachedProfile]: same local-storage-only
+  /// semantics, but one `WHERE pubkey IN (...)` round trip instead of one per
+  /// pubkey. Callers resolving a whole list (follow lists, pickers) should use
+  /// this — the per-pubkey variant costs a Drift round trip each.
+  ///
+  /// Pubkeys without a cached profile are absent from the result, so the
+  /// returned list may be shorter than [pubkeys] and is not order-aligned
+  /// with it.
+  Future<List<UserProfile>> getCachedProfiles({
+    required List<String> pubkeys,
+  }) async {
+    if (pubkeys.isEmpty) return const [];
+    return _userProfilesDao.getProfilesByPubkeys(pubkeys);
+  }
+
   /// Persists a profile to local storage (SQLite).
   ///
   /// Use this to cache profiles obtained from relay events or REST APIs.

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -190,6 +190,35 @@ void main() {
       });
     });
 
+    group('getCachedProfiles', () {
+      test('returns the cached profiles in a single query', () async {
+        final profile = UserProfile.fromNostrEvent(mockProfileEvent);
+        when(
+          () => mockUserProfilesDao.getProfilesByPubkeys(any()),
+        ).thenAnswer((_) async => [profile]);
+
+        final result = await profileRepository.getCachedProfiles(
+          pubkeys: [testPubkey, 'uncached-pubkey'],
+        );
+
+        expect(result, equals([profile]));
+        verify(
+          () => mockUserProfilesDao.getProfilesByPubkeys([
+            testPubkey,
+            'uncached-pubkey',
+          ]),
+        ).called(1);
+        verifyNever(() => mockNostrClient.fetchProfile(any()));
+      });
+
+      test('does not hit the database for an empty pubkey list', () async {
+        final result = await profileRepository.getCachedProfiles(pubkeys: []);
+
+        expect(result, isEmpty);
+        verifyNever(() => mockUserProfilesDao.getProfilesByPubkeys(any()));
+      });
+    });
+
     group('cacheProfile', () {
       test('delegates to userProfilesDao.upsertProfile', () async {
         final profile = UserProfile.fromNostrEvent(mockProfileEvent);

--- a/mobile/test/widgets/user_picker_sheet_test.dart
+++ b/mobile/test/widgets/user_picker_sheet_test.dart
@@ -618,6 +618,119 @@ void main() {
         expect(find.text('Your crew is out there'), findsNothing);
       });
 
+      testWidgets('clear button restores the unfiltered follow list', (
+        tester,
+      ) async {
+        final profiles = [
+          UserProfile(
+            pubkey: 'pubkey1',
+            name: 'Alpha',
+            rawData: const {'name': 'Alpha'},
+            createdAt: DateTime.now(),
+            eventId: 'event1',
+          ),
+          UserProfile(
+            pubkey: 'pubkey2',
+            name: 'Bravo',
+            rawData: const {'name': 'Bravo'},
+            createdAt: DateTime.now(),
+            eventId: 'event2',
+          ),
+        ];
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              profileRepositoryProvider.overrideWithValue(
+                _createMockProfileRepository(cachedProfiles: profiles),
+              ),
+              followRepositoryProvider.overrideWithValue(
+                _createMockFollowRepository(
+                  followingPubkeys: ['pubkey1', 'pubkey2'],
+                ),
+              ),
+              contentBlocklistRepositoryProvider.overrideWithValue(
+                _createMockContentBlocklistRepository(),
+              ),
+            ],
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: UserPickerSheet(
+                  title: 'Title',
+                  filterMode: UserPickerFilterMode.mutualFollowsOnly,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.enterText(find.byType(TextField), 'Alpha');
+        await tester.pumpAndSettle();
+        expect(find.text('Bravo'), findsNothing);
+
+        // TextEditingController.clear() alone does not fire onChanged, so the
+        // button has to dispatch the reset itself.
+        final clearButton = find.descendant(
+          of: find.byType(TextField),
+          matching: find.byType(DivineIconButton),
+        );
+        expect(clearButton, findsOneWidget);
+        await tester.tap(clearButton);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Alpha'), findsOneWidget);
+        expect(find.text('Bravo'), findsOneWidget);
+      });
+
+      testWidgets('clear button carries a semantic label', (tester) async {
+        final profile = UserProfile(
+          pubkey: 'pubkey1',
+          name: 'Alpha',
+          rawData: const {'name': 'Alpha'},
+          createdAt: DateTime.now(),
+          eventId: 'event1',
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              profileRepositoryProvider.overrideWithValue(
+                _createMockProfileRepository(cachedProfiles: [profile]),
+              ),
+              followRepositoryProvider.overrideWithValue(
+                _createMockFollowRepository(followingPubkeys: ['pubkey1']),
+              ),
+              contentBlocklistRepositoryProvider.overrideWithValue(
+                _createMockContentBlocklistRepository(),
+              ),
+            ],
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: UserPickerSheet(
+                  title: 'Title',
+                  filterMode: UserPickerFilterMode.mutualFollowsOnly,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.enterText(find.byType(TextField), 'Alpha');
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(
+          find.bySemanticsLabel(l10n.userPickerClearSearchSemantics),
+          findsOneWidget,
+        );
+      });
+
       testWidgets('filters blocked users from the follow list', (tester) async {
         final allowedProfile = UserProfile(
           pubkey: 'pubkey1',

--- a/mobile/test/widgets/user_picker_sheet_test.dart
+++ b/mobile/test/widgets/user_picker_sheet_test.dart
@@ -31,9 +31,7 @@ _MockContentBlocklistRepository _createMockContentBlocklistRepository({
   Set<String> blockedPubkeys = const {},
 }) {
   final mock = _MockContentBlocklistRepository();
-  when(
-    () => mock.shouldFilterFromFeeds(any()),
-  ).thenReturn(false);
+  when(() => mock.shouldFilterFromFeeds(any())).thenReturn(false);
   for (final pubkey in blockedPubkeys) {
     when(() => mock.shouldFilterFromFeeds(pubkey)).thenReturn(true);
   }
@@ -82,15 +80,15 @@ _MockProfileRepository _createMockProfileRepository({
 
   // The batch lookup answers from the same per-pubkey stubs, so a test that
   // stubs a single profile gets it back through either entry point.
-  when(
-    () => mock.getCachedProfiles(pubkeys: any(named: 'pubkeys')),
-  ).thenAnswer((invocation) async {
-    final pubkeys = invocation.namedArguments[#pubkeys] as List<String>;
-    final profiles = await Future.wait(
-      pubkeys.map((pubkey) => mock.getCachedProfile(pubkey: pubkey)),
-    );
-    return profiles.whereType<UserProfile>().toList();
-  });
+  when(() => mock.getCachedProfiles(pubkeys: any(named: 'pubkeys'))).thenAnswer(
+    (invocation) async {
+      final pubkeys = invocation.namedArguments[#pubkeys] as List<String>;
+      final profiles = await Future.wait(
+        pubkeys.map((pubkey) => mock.getCachedProfile(pubkey: pubkey)),
+      );
+      return profiles.whereType<UserProfile>().toList();
+    },
+  );
 
   return mock;
 }
@@ -377,9 +375,7 @@ void main() {
         final mockFollowRepo = _createMockFollowRepository(
           followingPubkeys: ['pubkey1'],
         );
-        when(
-          mockFollowRepo.streamMyFollowers,
-        ).thenAnswer(
+        when(mockFollowRepo.streamMyFollowers).thenAnswer(
           (_) => Stream<List<String>>.error(Exception('relay down')),
         );
 
@@ -493,6 +489,83 @@ void main() {
         expect(find.text('Slow User'), findsOneWidget);
       });
 
+      testWidgets(
+        'keeps the active filter when later follower sources add rows',
+        (tester) async {
+          final profiles = [
+            UserProfile(
+              pubkey: 'pubkey1',
+              name: 'Fast User',
+              rawData: const {'name': 'Fast User'},
+              createdAt: DateTime.now(),
+              eventId: 'event1',
+            ),
+            UserProfile(
+              pubkey: 'pubkey2',
+              name: 'Slow Match',
+              rawData: const {'name': 'Slow Match'},
+              createdAt: DateTime.now(),
+              eventId: 'event2',
+            ),
+          ];
+
+          final followers = StreamController<List<String>>();
+          addTearDown(() => unawaited(followers.close()));
+
+          final mockFollowRepo = _createMockFollowRepository(
+            followingPubkeys: ['pubkey1', 'pubkey2'],
+          );
+          when(
+            mockFollowRepo.streamMyFollowers,
+          ).thenAnswer((_) => followers.stream);
+
+          await tester.pumpWidget(
+            ProviderScope(
+              overrides: [
+                profileRepositoryProvider.overrideWithValue(
+                  _createMockProfileRepository(cachedProfiles: profiles),
+                ),
+                followRepositoryProvider.overrideWithValue(mockFollowRepo),
+                contentBlocklistRepositoryProvider.overrideWithValue(
+                  _createMockContentBlocklistRepository(),
+                ),
+              ],
+              child: const MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: Scaffold(
+                  body: UserPickerSheet(
+                    title: 'Title',
+                    filterMode: UserPickerFilterMode.mutualFollowsOnly,
+                  ),
+                ),
+              ),
+            ),
+          );
+          await tester.pump();
+
+          followers.add(['pubkey1']);
+          await tester.pump();
+          await tester.pump();
+
+          expect(find.text('Fast User'), findsOneWidget);
+          expect(find.text('Slow Match'), findsNothing);
+
+          await tester.enterText(find.byType(TextField), 'slow');
+          await tester.pumpAndSettle();
+
+          expect(find.text('Fast User'), findsNothing);
+          expect(find.text('Slow Match'), findsNothing);
+
+          followers.add(['pubkey1', 'pubkey2']);
+          await tester.pump();
+          await tester.pump();
+
+          expect(find.text('Fast User'), findsNothing);
+          expect(find.text('Slow Match'), findsOneWidget);
+        },
+      );
+
       testWidgets('keeps the spinner while an early source reports no '
           'followers', (tester) async {
         final profile = UserProfile(
@@ -581,13 +654,6 @@ void main() {
         final mockProfileRepo = _createMockProfileRepository(
           cachedProfiles: profiles,
         );
-
-        // Explicitly stub each pubkey
-        for (final profile in profiles) {
-          when(
-            () => mockProfileRepo.getCachedProfile(pubkey: profile.pubkey),
-          ).thenAnswer((_) async => profile);
-        }
 
         await tester.pumpWidget(
           ProviderScope(
@@ -753,16 +819,6 @@ void main() {
         final mockProfileRepo = _createMockProfileRepository(
           cachedProfiles: [allowedProfile, blockedProfile],
         );
-        when(
-          () => mockProfileRepo.getCachedProfile(
-            pubkey: allowedProfile.pubkey,
-          ),
-        ).thenAnswer((_) async => allowedProfile);
-        when(
-          () => mockProfileRepo.getCachedProfile(
-            pubkey: blockedProfile.pubkey,
-          ),
-        ).thenAnswer((_) async => blockedProfile);
         final mockBlocklistRepo = _createMockContentBlocklistRepository(
           blockedPubkeys: {blockedProfile.pubkey},
         );

--- a/mobile/test/widgets/user_picker_sheet_test.dart
+++ b/mobile/test/widgets/user_picker_sheet_test.dart
@@ -13,6 +13,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/user_picker_sheet.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:rxdart/rxdart.dart';
@@ -66,6 +67,12 @@ _MockProfileRepository _createMockProfileRepository({
     ),
   );
 
+  // Default for unknown pubkeys. Registered first so the per-profile stubs
+  // below win — mocktail resolves to the most recently registered match.
+  when(
+    () => mock.getCachedProfile(pubkey: any(named: 'pubkey')),
+  ).thenAnswer((_) async => null);
+
   // Mock getCachedProfile
   for (final profile in cachedProfiles) {
     when(
@@ -73,10 +80,17 @@ _MockProfileRepository _createMockProfileRepository({
     ).thenAnswer((_) async => profile);
   }
 
-  // Default for unknown pubkeys
+  // The batch lookup answers from the same per-pubkey stubs, so a test that
+  // stubs a single profile gets it back through either entry point.
   when(
-    () => mock.getCachedProfile(pubkey: any(named: 'pubkey')),
-  ).thenAnswer((_) async => null);
+    () => mock.getCachedProfiles(pubkeys: any(named: 'pubkeys')),
+  ).thenAnswer((invocation) async {
+    final pubkeys = invocation.namedArguments[#pubkeys] as List<String>;
+    final profiles = await Future.wait(
+      pubkeys.map((pubkey) => mock.getCachedProfile(pubkey: pubkey)),
+    );
+    return profiles.whereType<UserProfile>().toList();
+  });
 
   return mock;
 }
@@ -93,6 +107,9 @@ _MockFollowRepository _createMockFollowRepository({
   when(() => mock.isInitialized).thenReturn(true);
   when(() => mock.followingCount).thenReturn(followingPubkeys.length);
   when(mock.getMyFollowers).thenAnswer((_) async => followingPubkeys);
+  when(
+    mock.streamMyFollowers,
+  ).thenAnswer((_) => Stream.value(followingPubkeys));
   return mock;
 }
 
@@ -221,12 +238,31 @@ void main() {
     });
 
     group('mutualFollowsOnly mode', () {
-      testWidgets('shows loading indicator initially', (tester) async {
+      testWidgets('shows loading indicator until the first follower source '
+          'answers', (tester) async {
         final mockFollowRepo = _createMockFollowRepository(
           followingPubkeys: ['pubkey1'],
         );
+        // No source has answered yet.
+        final followers = StreamController<List<String>>();
+        // Not awaited: the widget is still listening at teardown, so the done
+        // event would never be delivered and the test would hang.
+        addTearDown(() => unawaited(followers.close()));
+        when(
+          mockFollowRepo.streamMyFollowers,
+        ).thenAnswer((_) => followers.stream);
 
-        final mockProfileRepo = _createMockProfileRepository();
+        final mockProfileRepo = _createMockProfileRepository(
+          cachedProfiles: [
+            UserProfile(
+              pubkey: 'pubkey1',
+              name: 'User One',
+              rawData: const {'name': 'User One'},
+              createdAt: DateTime.now(),
+              eventId: 'event1',
+            ),
+          ],
+        );
 
         await tester.pumpWidget(
           ProviderScope(
@@ -251,8 +287,12 @@ void main() {
           ),
         );
 
-        // Should show loading while follow profiles load
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        await tester.pump();
+
+        // Profiles are already resolved — the spinner is waiting on the
+        // mutual check, not on the profile lookup.
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
+        expect(find.text('User One'), findsNothing);
       });
 
       testWidgets('shows empty state when no follows exist', (tester) async {
@@ -324,9 +364,8 @@ void main() {
         expect(find.text('Go back'), findsOneWidget);
       });
 
-      testWidgets('falls back to local follows when getMyFollowers fails', (
-        tester,
-      ) async {
+      testWidgets('falls back to local follows when every follower source '
+          'fails', (tester) async {
         final profile = UserProfile(
           pubkey: 'pubkey1',
           name: 'User One',
@@ -339,8 +378,10 @@ void main() {
           followingPubkeys: ['pubkey1'],
         );
         when(
-          mockFollowRepo.getMyFollowers,
-        ).thenAnswer((_) async => throw Exception('relay down'));
+          mockFollowRepo.streamMyFollowers,
+        ).thenAnswer(
+          (_) => Stream<List<String>>.error(Exception('relay down')),
+        );
 
         final mockProfileRepo = _createMockProfileRepository();
         when(
@@ -372,9 +413,146 @@ void main() {
 
         await tester.pumpAndSettle();
 
-        expect(find.byType(CircularProgressIndicator), findsNothing);
+        expect(find.byType(BrandedLoadingIndicator), findsNothing);
         expect(find.text('User One'), findsOneWidget);
         expect(tester.takeException(), isNull);
+      });
+
+      testWidgets('renders mutuals from the first follower source and adds '
+          'later ones', (tester) async {
+        final profiles = [
+          UserProfile(
+            pubkey: 'pubkey1',
+            name: 'Fast User',
+            rawData: const {'name': 'Fast User'},
+            createdAt: DateTime.now(),
+            eventId: 'event1',
+          ),
+          UserProfile(
+            pubkey: 'pubkey2',
+            name: 'Slow User',
+            rawData: const {'name': 'Slow User'},
+            createdAt: DateTime.now(),
+            eventId: 'event2',
+          ),
+        ];
+
+        final followers = StreamController<List<String>>();
+        // Not awaited: the widget is still listening at teardown, so the done
+        // event would never be delivered and the test would hang.
+        addTearDown(() => unawaited(followers.close()));
+
+        final mockFollowRepo = _createMockFollowRepository(
+          followingPubkeys: ['pubkey1', 'pubkey2'],
+        );
+        when(
+          mockFollowRepo.streamMyFollowers,
+        ).thenAnswer((_) => followers.stream);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              profileRepositoryProvider.overrideWithValue(
+                _createMockProfileRepository(cachedProfiles: profiles),
+              ),
+              followRepositoryProvider.overrideWithValue(mockFollowRepo),
+              contentBlocklistRepositoryProvider.overrideWithValue(
+                _createMockContentBlocklistRepository(),
+              ),
+            ],
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: UserPickerSheet(
+                  title: 'Title',
+                  filterMode: UserPickerFilterMode.mutualFollowsOnly,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        // The fast source alone is enough to leave the spinner. Two pumps:
+        // one to deliver the stream event, one to render the rebuild.
+        followers.add(['pubkey1']);
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.byType(BrandedLoadingIndicator), findsNothing);
+        expect(find.text('Fast User'), findsOneWidget);
+        expect(find.text('Slow User'), findsNothing);
+
+        // A slower source only ever adds rows.
+        followers.add(['pubkey1', 'pubkey2']);
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.text('Fast User'), findsOneWidget);
+        expect(find.text('Slow User'), findsOneWidget);
+      });
+
+      testWidgets('keeps the spinner while an early source reports no '
+          'followers', (tester) async {
+        final profile = UserProfile(
+          pubkey: 'pubkey1',
+          name: 'Late Mutual',
+          rawData: const {'name': 'Late Mutual'},
+          createdAt: DateTime.now(),
+          eventId: 'event1',
+        );
+
+        final followers = StreamController<List<String>>();
+        // Not awaited: the widget is still listening at teardown, so the done
+        // event would never be delivered and the test would hang.
+        addTearDown(() => unawaited(followers.close()));
+
+        final mockFollowRepo = _createMockFollowRepository(
+          followingPubkeys: ['pubkey1'],
+        );
+        when(
+          mockFollowRepo.streamMyFollowers,
+        ).thenAnswer((_) => followers.stream);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              profileRepositoryProvider.overrideWithValue(
+                _createMockProfileRepository(cachedProfiles: [profile]),
+              ),
+              followRepositoryProvider.overrideWithValue(mockFollowRepo),
+              contentBlocklistRepositoryProvider.overrideWithValue(
+                _createMockContentBlocklistRepository(),
+              ),
+            ],
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: UserPickerSheet(
+                  title: 'Title',
+                  filterMode: UserPickerFilterMode.mutualFollowsOnly,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        // An empty first emission must not flash the "no follows" state.
+        followers.add(const []);
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
+        expect(find.text('Your crew is out there'), findsNothing);
+
+        followers.add(['pubkey1']);
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.text('Late Mutual'), findsOneWidget);
       });
 
       testWidgets('displays follow list after loading', (tester) async {


### PR DESCRIPTION
Closes #6835

## Description

Opening the collaborator picker took ~1.9s before a single row appeared. Instrumented on device, the follower lookup was **1847ms of the 1856ms total**, and the wait bought almost nothing:

| Source | Duration | Mutuals | of those **unique** |
|---|---|---|---|
| REST `getFollowers` | 151 ms | 35 | — (baseline) |
| `relay.nos.social` | 982 ms | 35 | +3 |
| connected relays `#p` | 1206 ms | 31 | 0 |
| `purplepag.es` | 1848 ms | 29 | 0 (subset of nos.social) |
| `user.kindpag.es` | 218 ms | 0 | 0 |

`getMyFollowers()` waits for the union of all of them, so the slowest source sets the latency while contributing nothing the fastest one had not already returned.

`FollowRepository.streamMyFollowers()` now emits the union as each source answers instead of only at the end, and the picker renders every emission. Because emissions only ever grow, each row on screen is backed by a live source: a late source can add people, never invalidate someone already shown. That keeps the picker's mutual-follow guarantee intact — the picker is the only gate before a collaborator lands in the published event, so a cached or stale follower list was not an option here.

Measured after the change: first rows at **101ms** instead of 1856ms, same 34 entries.

Two things this fixes along the way:

- **Partial failures no longer drop the filter.** A single failing source used to fail the whole lookup, and the picker responded by skipping the mutual filter entirely and offering *every* follow as a collaborator. The filter now survives on partial results; the fallback only triggers when no source returned anyone at all.
- **44 single Drift queries → 1.** Resolving the followed profiles ran one `getCachedProfile` per pubkey (231ms). The new `ProfileRepository.getCachedProfiles` batches them into a single `WHERE pubkey IN (...)` (21ms).

**Related Issue:** 

## Out of Scope

Two search-field changes predate the perf work on this branch and ride along in the same file:

- The loading indicator was swapped to `BrandedLoadingIndicator`.
- The search field got a ✕ clear button. Review caught that it was wired straight to `TextEditingController.clear`, which empties the field but never fires `TextField.onChanged` — that only runs for platform input. So the list stayed filtered under an empty field in mutual mode, and in allUsers mode the bloc never received `UserSearchCleared` and stale network results stayed on screen. The button now goes through `_clearSearch()`, which clears the controller and dispatches the empty query itself, and it carries the semantic label it was missing (new `userPickerClearSearchSemantics` key, translated into all 21 non-English locales).

## Verification

- `flutter analyze lib test packages/follow_repository packages/profile_repository` — clean
- `flutter test test/widgets/user_picker_sheet_test.dart` — 26/26, including new coverage for progressive rendering, the empty-first-emission case, the all-sources-failed fallback, and the clear button restoring the unfiltered list
- `flutter test test/l10n/arb_consistency_test.dart` — green after adding the clear-button semantic label to every locale
- `flutter test` in `packages/follow_repository` — 230/230, with new `streamMyFollowers` tests for the growing union, single-source failure, and total failure
- `flutter test --coverage` in `packages/profile_repository` — 346/346, with new `getCachedProfiles` tests
- Manually verified on a real Samsung Galaxy: timings above are from that device, before and after

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
