### PR TITLE
fix(library): move clip selection into a sheet footer

### DIFF
--- a/mobile/lib/screens/library_screen.dart
+++ b/mobile/lib/screens/library_screen.dart
@@ -619,59 +619,67 @@ class _LibraryContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final content = Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (!isClipsOnlyMode) const SizedBox(height: 12),
+        if (!isClipsOnlyMode)
+          TabBar(
+            controller: tabController,
+            isScrollable: true,
+            tabAlignment: TabAlignment.start,
+            padding: const EdgeInsetsDirectional.only(start: 16),
+            indicatorColor: VineTheme.tabIndicatorGreen,
+            indicatorWeight: 4,
+            indicatorSize: TabBarIndicatorSize.tab,
+            dividerColor: VineTheme.transparent,
+            labelColor: context.vineColors.primaryText,
+            unselectedLabelColor: context.vineColors.onSurfaceMuted,
+            labelPadding: const EdgeInsets.symmetric(horizontal: 14),
+            labelStyle: VineTheme.titleMediumFont(
+              color: context.vineColors.primaryText,
+            ),
+            unselectedLabelStyle: VineTheme.titleMediumFont(
+              color: context.vineColors.onSurfaceMuted,
+            ),
+            tabs: [
+              Tab(text: context.l10n.libraryTabDrafts),
+              Tab(text: context.l10n.libraryTabClips),
+              Tab(text: context.l10n.soundsTitle),
+            ],
+          ),
+        if (!isClipsOnlyMode) const SizedBox(height: 2),
+        Expanded(
+          child: selectionMode
+              ? _SelectionBody(
+                  scrollController: scrollController,
+                  targetAspectRatio: targetAspectRatio,
+                  onCreate: onCreateVideo,
+                )
+              : _TabBody(
+                  clips: sortedClips,
+                  selectionEnabled: selectionEnabled,
+                  isClipsOnlyMode: isClipsOnlyMode,
+                  tabController: tabController,
+                  targetAspectRatio: targetAspectRatio,
+                ),
+        ),
+      ],
+    );
+
+    // Selection mode renders inside a bottom sheet, which brings its own
+    // surface and rounded corners. Skipping the shell here keeps the sheet's
+    // colour showing through and stops the 32px corner radius from slicing
+    // the top row of thumbnails.
+    if (selectionMode) return content;
+
     return ClipRRect(
       borderRadius: const BorderRadius.all(
         Radius.circular(VineTheme.shellInnerCornerRadius),
       ),
       child: ColoredBox(
         color: context.vineColors.surfaceContainerHigh,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            if (!isClipsOnlyMode) const SizedBox(height: 12),
-            if (!isClipsOnlyMode)
-              TabBar(
-                controller: tabController,
-                isScrollable: true,
-                tabAlignment: TabAlignment.start,
-                padding: const EdgeInsetsDirectional.only(start: 16),
-                indicatorColor: VineTheme.tabIndicatorGreen,
-                indicatorWeight: 4,
-                indicatorSize: TabBarIndicatorSize.tab,
-                dividerColor: VineTheme.transparent,
-                labelColor: context.vineColors.primaryText,
-                unselectedLabelColor: context.vineColors.onSurfaceMuted,
-                labelPadding: const EdgeInsets.symmetric(horizontal: 14),
-                labelStyle: VineTheme.titleMediumFont(
-                  color: context.vineColors.primaryText,
-                ),
-                unselectedLabelStyle: VineTheme.titleMediumFont(
-                  color: context.vineColors.onSurfaceMuted,
-                ),
-                tabs: [
-                  Tab(text: context.l10n.libraryTabDrafts),
-                  Tab(text: context.l10n.libraryTabClips),
-                  Tab(text: context.l10n.soundsTitle),
-                ],
-              ),
-            if (!isClipsOnlyMode) const SizedBox(height: 2),
-            Expanded(
-              child: selectionMode
-                  ? _SelectionBody(
-                      scrollController: scrollController,
-                      targetAspectRatio: targetAspectRatio,
-                      onCreate: onCreateVideo,
-                    )
-                  : _TabBody(
-                      clips: sortedClips,
-                      selectionEnabled: selectionEnabled,
-                      isClipsOnlyMode: isClipsOnlyMode,
-                      tabController: tabController,
-                      targetAspectRatio: targetAspectRatio,
-                    ),
-            ),
-          ],
-        ),
+        child: content,
       ),
     );
   }
@@ -785,14 +793,15 @@ class _SelectionBody extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        ClipSelectionHeader(onCreate: onCreate),
         Expanded(
           child: ClipsTab(
             targetAspectRatio: targetAspectRatio,
             showRecordButton: true,
             scrollController: scrollController,
+            gridTopPadding: 8,
           ),
         ),
+        ClipSelectionFooter(onCreate: onCreate),
       ],
     );
   }

--- a/mobile/lib/widgets/library/clips_tab.dart
+++ b/mobile/lib/widgets/library/clips_tab.dart
@@ -46,8 +46,8 @@ class ClipsTab extends StatelessWidget {
 
   /// Padding above the first grid row.
   ///
-  /// The selection sheet sets this so the grid clears the sheet's drag
-  /// handle instead of butting straight up against it.
+  /// The selection sheet sets this so the first row clears the bottom
+  /// sheet header's divider instead of butting straight up against it.
   final double gridTopPadding;
 
   @override

--- a/mobile/lib/widgets/library/clips_tab.dart
+++ b/mobile/lib/widgets/library/clips_tab.dart
@@ -5,7 +5,6 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
-import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/clips_library/clips_library_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -26,6 +25,7 @@ class ClipsTab extends StatelessWidget {
     this.clips,
     this.targetAspectRatio,
     this.scrollController,
+    this.gridTopPadding = 0,
     super.key,
   });
 
@@ -43,6 +43,12 @@ class ClipsTab extends StatelessWidget {
 
   /// Optional scroll controller, e.g. from a parent bottom sheet.
   final ScrollController? scrollController;
+
+  /// Padding above the first grid row.
+  ///
+  /// The selection sheet sets this so the grid clears the sheet's drag
+  /// handle instead of butting straight up against it.
+  final double gridTopPadding;
 
   @override
   Widget build(BuildContext context) {
@@ -116,6 +122,7 @@ class ClipsTab extends StatelessWidget {
           selectedIsStopMotion: state.selectedIsStopMotion,
           scrollController: scrollController,
           targetAspectRatio: targetAspectRatio,
+          topPadding: gridTopPadding,
           onTapClip: (clip) {
             if (selectionEnabled) {
               context.read<ClipsLibraryBloc>().add(
@@ -179,60 +186,33 @@ class ClipsTab extends StatelessWidget {
   }
 }
 
-/// Header widget for clip selection mode.
-class ClipSelectionHeader extends StatelessWidget {
-  /// Creates a selection header.
-  const ClipSelectionHeader({required this.onCreate, super.key});
+/// Footer action bar for clip selection mode.
+///
+/// Sits below the clip grid and confirms the current selection. Renders no
+/// background of its own so the enclosing bottom sheet's surface shows
+/// through.
+class ClipSelectionFooter extends StatelessWidget {
+  /// Creates a selection footer.
+  const ClipSelectionFooter({required this.onCreate, super.key});
 
-  /// Callback when create button is tapped.
+  /// Callback when the select button is tapped.
   final VoidCallback onCreate;
 
   @override
   Widget build(BuildContext context) {
-    return BlocSelector<ClipsLibraryBloc, ClipsLibraryState, Set<String>>(
-      selector: (state) => state.selectedClipIds,
-      builder: (context, selectedClipIds) {
-        return Column(
-          children: [
-            Padding(
-              padding: const EdgeInsets.only(top: 8, bottom: 16),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                spacing: 4,
-                children: [
-                  const Spacer(),
-                  Column(
-                    mainAxisSize: MainAxisSize.min,
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text(
-                        context.l10n.libraryClipSelectionTitle,
-                        style: VineTheme.titleMediumFont(
-                          color: context.vineColors.onSurface,
-                        ),
-                      ),
-                    ],
-                  ),
-                  Expanded(
-                    child: Align(
-                      alignment: AlignmentDirectional.centerEnd,
-                      child: _AddClipButton(
-                        onTap: selectedClipIds.isNotEmpty
-                            ? onCreate
-                            : context.pop,
-                        enable: selectedClipIds.isNotEmpty,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
+    return BlocSelector<ClipsLibraryBloc, ClipsLibraryState, bool>(
+      selector: (state) => state.selectedClipIds.isNotEmpty,
+      builder: (context, hasSelection) {
+        return SafeArea(
+          top: false,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: DivineButton(
+              expanded: true,
+              label: context.l10n.librarySelect,
+              onPressed: hasSelection ? onCreate : null,
             ),
-            Divider(
-              height: 2,
-              thickness: 2,
-              color: context.vineColors.surfaceContainer,
-            ),
-          ],
+          ),
         );
       },
     );
@@ -250,6 +230,7 @@ class _MasonryLayout extends StatelessWidget {
     this.scrollController,
     this.targetAspectRatio,
     this.selectedIsStopMotion,
+    this.topPadding = 0,
   });
 
   final List<DivineVideoClip> clips;
@@ -260,6 +241,7 @@ class _MasonryLayout extends StatelessWidget {
   final ValueChanged<DivineVideoClip> onTapClip;
   final ValueChanged<DivineVideoClip> onLongPressClip;
   final double? targetAspectRatio;
+  final double topPadding;
 
   /// Type of the current selection (`true` = stop-motion). When set, clips of
   /// the other type are disabled so a selection can't mix stop-motion stills
@@ -276,7 +258,10 @@ class _MasonryLayout extends StatelessWidget {
     };
     return MasonryGridView.count(
       controller: scrollController,
-      padding: .only(bottom: MediaQuery.viewPaddingOf(context).bottom),
+      padding: .only(
+        top: topPadding,
+        bottom: MediaQuery.viewPaddingOf(context).bottom,
+      ),
       crossAxisCount: _columnCount,
       mainAxisSpacing: 4,
       crossAxisSpacing: 4,
@@ -300,42 +285,6 @@ class _MasonryLayout extends StatelessWidget {
           onLongPress: () => onLongPressClip(clip),
         );
       },
-    );
-  }
-}
-
-class _AddClipButton extends StatelessWidget {
-  const _AddClipButton({required this.onTap, this.enable = true});
-
-  final VoidCallback? onTap;
-  final bool enable;
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      button: true,
-      label: context.l10n.librarySelect,
-      child: GestureDetector(
-        onTap: enable ? onTap : null,
-        child: Opacity(
-          opacity: enable ? 1 : 0.32,
-          child: Container(
-            margin: const EdgeInsetsDirectional.only(end: 16),
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            decoration: ShapeDecoration(
-              color: VineTheme.tabIndicatorGreen,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(16),
-              ),
-            ),
-            child: Text(
-              context.l10n.librarySelect,
-              textAlign: .center,
-              style: VineTheme.titleMediumFont(color: VineTheme.onPrimary),
-            ),
-          ),
-        ),
-      ),
     );
   }
 }

--- a/mobile/test/screens/library_screen_test.dart
+++ b/mobile/test/screens/library_screen_test.dart
@@ -120,11 +120,11 @@ void main() {
         expect(find.byType(ClipsTab), findsOneWidget);
       });
 
-      testWidgets('$ClipSelectionHeader in selection mode', (tester) async {
+      testWidgets('$ClipSelectionFooter in selection mode', (tester) async {
         await tester.pumpWidget(buildWidget(selectionMode: true));
         await tester.pump();
 
-        expect(find.byType(ClipSelectionHeader), findsOneWidget);
+        expect(find.byType(ClipSelectionFooter), findsOneWidget);
       });
 
       testWidgets('no app bar in selection mode', (tester) async {
@@ -366,7 +366,7 @@ void main() {
           await tester.pumpAndSettle();
 
           // Clips tab should show the clip
-          expect(find.byType(ClipSelectionHeader), findsOneWidget);
+          expect(find.byType(ClipSelectionFooter), findsOneWidget);
 
           // Locate a clip thumbnail card and tap to select it
           final clipCard = find.byType(VideoClipThumbnailCard);
@@ -374,7 +374,7 @@ void main() {
           await tester.tap(clipCard);
           await tester.pumpAndSettle();
 
-          // Tap "Select" button (visible in the header)
+          // Tap "Select" button (visible in the footer)
           await tester.tap(find.text(en.librarySelect).first);
           await tester.pumpAndSettle();
 

--- a/mobile/test/widgets/library/clips_tab_test.dart
+++ b/mobile/test/widgets/library/clips_tab_test.dart
@@ -234,17 +234,14 @@ void main() {
     });
   });
 
-  group(ClipSelectionHeader, () {
+  group(ClipSelectionFooter, () {
     late _MockClipsLibraryBloc mockBloc;
 
     setUp(() {
       mockBloc = _MockClipsLibraryBloc();
     });
 
-    Widget buildWidget({
-      Duration remainingDuration = const Duration(seconds: 30),
-      VoidCallback? onCreate,
-    }) {
+    Widget buildWidget({VoidCallback? onCreate}) {
       return MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -252,26 +249,15 @@ void main() {
         home: Scaffold(
           body: BlocProvider<ClipsLibraryBloc>.value(
             value: mockBloc,
-            child: ClipSelectionHeader(onCreate: onCreate ?? () {}),
+            child: ClipSelectionFooter(onCreate: onCreate ?? () {}),
           ),
         ),
       );
     }
 
-    testWidgets('renders Clips title', (tester) async {
-      when(() => mockBloc.state).thenReturn(
-        const ClipsLibraryState(
-          status: ClipsLibraryStatus.loaded,
-          selectedClipIds: {'clip1', 'clip2'},
-        ),
-      );
-
-      await tester.pumpWidget(buildWidget());
-
-      expect(find.text('Clips'), findsOneWidget);
-    });
-
-    testWidgets('calls onCreate when Add button is tapped', (tester) async {
+    testWidgets('calls onCreate when the select button is tapped', (
+      tester,
+    ) async {
       when(() => mockBloc.state).thenReturn(
         const ClipsLibraryState(
           status: ClipsLibraryStatus.loaded,
@@ -282,11 +268,24 @@ void main() {
       var created = false;
       await tester.pumpWidget(buildWidget(onCreate: () => created = true));
 
-      // Find and tap the Select button
-      final selectButton = find.text('Select');
-      expect(selectButton, findsOneWidget);
-      await tester.tap(selectButton);
+      await tester.tap(find.text(en.librarySelect));
+
       expect(created, isTrue);
+    });
+
+    testWidgets('disables the select button without a selection', (
+      tester,
+    ) async {
+      when(() => mockBloc.state).thenReturn(
+        const ClipsLibraryState(status: ClipsLibraryStatus.loaded),
+      );
+
+      var created = false;
+      await tester.pumpWidget(buildWidget(onCreate: () => created = true));
+
+      await tester.tap(find.text(en.librarySelect));
+
+      expect(created, isFalse);
     });
   });
 }


### PR DESCRIPTION
Closes #6837

## Description

The clip picker that opens from the video editor is a `VineBottomSheet`, but its content re-stated chrome the sheet already provides:

- A second **"Clips"** title sat right under the sheet's own header.
- The library shell painted `surfaceContainerHigh` (`0xFF000A06`, near black) on top of the sheet's `surface` (`0xFF00150D`, dark green), so the sheet looked like a black panel inside a green frame.
- The confirm action was a custom green pill in the top-right corner. Without a selection it was fully inert — `enable: false` nulled the tap handler, which also made the `context.pop` fallback behind it unreachable dead code.

This reworks the selection mode:

- `ClipSelectionHeader` → **`ClipSelectionFooter`**: no title, no divider, just a full-width `DivineButton` at the bottom with `SafeArea(top: false)`. That mirrors `_CreateVideoBar`, the footer the same screen already uses for the non-selection "Create video" flow, so the two confirm affordances now look and sit the same. Disabled state comes from the design system via `onPressed: null` rather than an `Opacity(0.32)` wrapper.
- `_LibraryContent` skips the shell wrapper (`ClipRRect` + `ColoredBox`) entirely in selection mode. The sheet already supplies surface and rounded corners; stacking a second one was the source of the black panel.
- The grid gets 8px of top padding so the first row clears the sheet header's divider. (Not the drag handle — `VineBottomSheetHeader` is a sibling above the scroll body and already puts 20px plus that divider between the handle and the content.) That padding is also **why** the `ClipRRect` had to go rather than just turning transparent: `shellInnerCornerRadius` is 32px, so once the first row no longer starts at y=0 it lands mid-arc and the corner slices diagonally through the top thumbnails. Previously the arc happened to read as the tiles' own rounding.
- `gridTopPadding` is an explicit `ClipsTab` parameter defaulting to `0`, so the standalone library screen and clips-only mode are untouched.

`BlocSelector` in the footer now selects `selectedClipIds.isNotEmpty` instead of the whole `Set`, so it rebuilds on the empty↔non-empty edge rather than on every selection change.

**Related Issue:** 

## Out of Scope

- The ARB key `libraryClipSelectionTitle` is now unused in code but still defined in all 17 locales. Left in place — this repo tolerates defined-but-unused keys (see `.claude/rules/localization.md`), and removing it would churn 17 ARB files plus generated output for no behavioural gain.
- The grid keeps its `bottom: viewPadding.bottom` padding, which is now partly redundant under the footer's own `SafeArea`. It costs a few px of extra scroll overshoot in selection mode and is load-bearing for every other mode.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test test/widgets/library test/screens/library_screen_test.dart` — 88 passing
- Manually verified on a real Samsung Galaxy: opened the clip picker from the video editor, confirmed the sheet's green surface now runs edge to edge, the select button sits in the footer and is disabled until a clip is picked, and the top thumbnail row is no longer clipped.

Tests updated: `ClipSelectionHeader` → `ClipSelectionFooter` throughout; the `renders Clips title` case is gone with the title, replaced by one that pins the button as a no-op without a selection.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
