### PR TITLE
fix(notifications): protect every UI-decodable reference in previews

### DIFF
--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -46,16 +46,30 @@ final RegExp _npubIdentifierPattern = RegExp(
   caseSensitive: false,
 );
 
-/// A bech32 Nostr reference embedded in note content, e.g. `npub1...` or
-/// `nostr:nprofile1...`.
+/// A Nostr reference embedded in note content that the UI can decode: either
+/// bech32 (`npub1...`, `nostr:nprofile1...`) or a bare 64-char hex pubkey /
+/// event id.
 ///
-/// Keep this boundary rule aligned with
-/// `LinkifiedTextSpanBuilder._combinedRegex` so the repository only protects
-/// token spans the UI can decode.
-final RegExp _bech32ReferencePattern = RegExp(
-  r'(?<![A-Za-z0-9])(?:nostr:)?(?:npub|nprofile|note|nevent|naddr)1[a-z0-9]+\b',
+/// Keep both boundary rules aligned with
+/// `LinkifiedTextSpanBuilder._combinedRegex` so the repository protects
+/// exactly the token spans the UI can decode — no more, no less. A hex
+/// reference is 64 characters, so it always exceeds the preview cap; leaving
+/// it unprotected guaranteed a sliced fragment that the UI then rendered as
+/// raw hex, which is the same defect bech32 slicing caused.
+final RegExp _decodableReferencePattern = RegExp(
+  r'(?<![A-Za-z0-9])(?:nostr:)?(?:npub|nprofile|note|nevent|naddr)1[a-z0-9]+\b'
+  '|(?<![A-Fa-f0-9])[A-Fa-f0-9]{64}(?![A-Fa-f0-9])',
   caseSensitive: false,
 );
+
+/// Any letter or digit in any script.
+///
+/// The preview's "is this token the leading content?" test must treat
+/// Cyrillic, CJK, and accented text as content. Testing only ASCII
+/// `[0-9A-Za-z]` classified every non-Latin script as punctuation, which let
+/// a straddling token qualify as leading and silently raised the preview cap
+/// from [_maxCommentLength] to four times that for most locales.
+final RegExp _letterOrDigitPattern = RegExp(r'[\p{L}\p{N}]', unicode: true);
 
 /// Retry policy for the first-page notifications fetch.
 ///
@@ -2335,12 +2349,12 @@ class NotificationRepository {
   ///
   /// Only applies to comment and reply notifications.
   ///
-  /// The cut avoids splitting a bech32 Nostr reference (`npub1...`,
-  /// `nprofile1...`, `note1...`, `nevent1...`, `naddr1...`) mid-token. A
-  /// sliced token can no longer be decoded, so the row widget falls back to
-  /// rendering the raw `npub1...` string verbatim instead of resolving it.
-  /// Keeping a bounded leading token intact lets the UI linkifier resolve it to
-  /// `@<name>`.
+  /// The cut avoids splitting a Nostr reference the UI can decode — bech32
+  /// (`npub1...`, `nprofile1...`, `note1...`, `nevent1...`, `naddr1...`) or a
+  /// bare 64-char hex pubkey / event id — mid-token. A sliced token can no
+  /// longer be decoded, so the row widget falls back to rendering the raw
+  /// string verbatim instead of resolving it. Keeping a bounded leading token
+  /// intact lets the UI linkifier resolve it to `@<name>`.
   static String? _truncateComment(String? content, NotificationKind kind) {
     if (content == null) return null;
     if (kind != NotificationKind.comment && kind != NotificationKind.reply) {
@@ -2348,26 +2362,27 @@ class NotificationRepository {
     }
     if (content.length <= _maxCommentLength) return content;
 
-    final cut = _bech32AwareCut(content, _maxCommentLength);
+    final cut = _referenceAwareCut(content, _maxCommentLength);
     if (cut >= content.length) return content;
     return '${content.substring(0, cut).trimRight()}...';
   }
 
-  /// Returns a bounded cut index that does not split a bech32 Nostr reference.
+  /// Returns a bounded cut index that does not split a decodable Nostr
+  /// reference — bech32 or bare 64-char hex.
   ///
   /// If a reference straddles [limit], the cut is pulled back to the
   /// reference's start so the token is omitted from the preview rather than
   /// split. If the content before that token is only whitespace or
   /// punctuation, and keeping the full token stays within the preview bound,
   /// the token's end is returned so the UI can resolve it.
-  static int _bech32AwareCut(String content, int limit) {
-    final maxBech32PreviewLength = limit * 4;
-    for (final match in _bech32ReferencePattern.allMatches(content)) {
+  static int _referenceAwareCut(String content, int limit) {
+    final maxReferencePreviewLength = limit * 4;
+    for (final match in _decodableReferencePattern.allMatches(content)) {
       final startsBeforeOrAtLimit = match.start < limit;
       final endsAfterLimit = match.end > limit;
       if (!startsBeforeOrAtLimit || !endsAfterLimit) continue;
       final canKeepLeadingToken =
-          match.end <= maxBech32PreviewLength &&
+          match.end <= maxReferencePreviewLength &&
           _hasOnlyWhitespaceOrPunctuationBefore(content, match.start);
       if (canKeepLeadingToken) return match.end;
       return match.start;
@@ -2375,16 +2390,8 @@ class NotificationRepository {
     return limit;
   }
 
-  static bool _hasOnlyWhitespaceOrPunctuationBefore(String content, int end) {
-    for (var index = 0; index < end; index += 1) {
-      final codeUnit = content.codeUnitAt(index);
-      final isAsciiDigit = codeUnit >= 0x30 && codeUnit <= 0x39;
-      final isAsciiUppercase = codeUnit >= 0x41 && codeUnit <= 0x5A;
-      final isAsciiLowercase = codeUnit >= 0x61 && codeUnit <= 0x7A;
-      if (isAsciiDigit || isAsciiUppercase || isAsciiLowercase) return false;
-    }
-    return true;
-  }
+  static bool _hasOnlyWhitespaceOrPunctuationBefore(String content, int end) =>
+      !_letterOrDigitPattern.hasMatch(content.substring(0, end));
 }
 
 @immutable

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -46,21 +46,38 @@ final RegExp _npubIdentifierPattern = RegExp(
   caseSensitive: false,
 );
 
-/// A Nostr reference embedded in note content that the UI can decode: either
-/// bech32 (`npub1...`, `nostr:nprofile1...`) or a bare 64-char hex pubkey /
-/// event id.
+/// Mirror of `LinkifiedTextSpanBuilder._combinedRegex`
+/// (`mobile/lib/widgets/linkified_text/linkified_text_span_builder.dart`),
+/// alternative for alternative and in the same order.
 ///
-/// Keep both boundary rules aligned with
-/// `LinkifiedTextSpanBuilder._combinedRegex` so the repository protects
-/// exactly the token spans the UI can decode — no more, no less. A hex
-/// reference is 64 characters, so it always exceeds the preview cap; leaving
-/// it unprotected guaranteed a sliced fragment that the UI then rendered as
-/// raw hex, which is the same defect bech32 slicing caused.
-final RegExp _decodableReferencePattern = RegExp(
-  r'(?<![A-Za-z0-9])(?:nostr:)?(?:npub|nprofile|note|nevent|naddr)1[a-z0-9]+\b'
-  '|(?<![A-Fa-f0-9])[A-Fa-f0-9]{64}(?![A-Fa-f0-9])',
+/// The surrounding alternatives are mirrored too, not just the two reference
+/// ones, because alternation resolves per start position: a URL or hashtag
+/// that *contains* a bech32 or hex run starts earlier and wins there. In the
+/// UI `https://host/<64-hex>` is a single URL token and the hex inside it is
+/// never a reference. A pattern holding only the reference alternatives
+/// cannot see that and pulls the preview cut back for a span the UI never
+/// links — Blossom and CDN media URLs are exactly that shape.
+///
+/// Group 3 is a bech32 reference and group 4 a bare 64-char hex pubkey /
+/// event id; those are the spans [NotificationRepository._referenceAwareCut]
+/// protects. Groups 1 and 2 (URL/email, hashtag) are here only to consume
+/// their own text so a run buried inside them is not mistaken for one.
+///
+/// The UI's trailing `@([a-zA-Z][a-zA-Z0-9_]{0,30})` alternative is the one
+/// deliberate divergence. It wins over the bech32 alternative for `@npub1…`
+/// and truncates the token to 31 characters, so mirroring it would drop the
+/// protection #6346 added for that input. Whether the UI should tokenize
+/// `@npub1…` as a mention at all is a separate question from this cut.
+final RegExp _uiTokenPattern = RegExp(
+  r'((?:[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})|(?:https?:\/\/[^\s]+|www\.[^\s]+|(?<![@\w])(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?))|#(\w+)|(?<![A-Za-z0-9])(?:nostr:)?((?:npub|nprofile|note|nevent|naddr)1[a-z0-9]+)\b|(?<![A-Fa-f0-9])([A-Fa-f0-9]{64})(?![A-Fa-f0-9])',
   caseSensitive: false,
 );
+
+/// [_uiTokenPattern] group holding a bech32 Nostr reference.
+const _bech32ReferenceGroup = 3;
+
+/// [_uiTokenPattern] group holding a bare 64-char hex pubkey / event id.
+const _hexReferenceGroup = 4;
 
 /// Any letter or digit in any script.
 ///
@@ -2375,9 +2392,17 @@ class NotificationRepository {
   /// split. If the content before that token is only whitespace or
   /// punctuation, and keeping the full token stays within the preview bound,
   /// the token's end is returned so the UI can resolve it.
+  ///
+  /// A token the UI resolves as a URL or hashtag is skipped even when a
+  /// bech32 or hex run sits inside it — the UI does not link that run, so
+  /// pulling the cut back to it only shortens the preview.
   static int _referenceAwareCut(String content, int limit) {
     final maxReferencePreviewLength = limit * 4;
-    for (final match in _decodableReferencePattern.allMatches(content)) {
+    for (final match in _uiTokenPattern.allMatches(content)) {
+      final isReference =
+          match.group(_bech32ReferenceGroup) != null ||
+          match.group(_hexReferenceGroup) != null;
+      if (!isReference) continue;
       final startsBeforeOrAtLimit = match.start < limit;
       final endsAfterLimit = match.end > limit;
       if (!startsBeforeOrAtLimit || !endsAfterLimit) continue;

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -3030,6 +3030,82 @@ void main() {
         },
       );
 
+      test('leaves a hex run inside a URL to the plain cut', () async {
+        // The UI's URL alternative starts earlier than the hex one and wins,
+        // so https://host/<64-hex> is a single URL token and the hex inside
+        // it is never linked. Pulling the cut back to it would shorten the
+        // preview for a span the UI never resolves. Blossom and CDN media
+        // URLs are exactly this shape, so this is the common case, not an
+        // edge case.
+        const hex64 =
+            'a1b2c3d4e5f60718293a4b5c6d7e8f90'
+            'a1b2c3d4e5f60718293a4b5c6d7e8f90';
+        const content =
+            'Look at this https://blossom.divine.video/$hex64.mp4 great stuff';
+        stubNotifications([
+          makeNotification(
+            notificationType: 'comment',
+            sourceKind: 1,
+            content: content,
+          ),
+        ]);
+        stubProfiles({});
+
+        final page = await repository.getNotifications();
+        final item = page.items.single as VideoNotification;
+        expect(
+          item.commentText,
+          equals('Look at this https://blossom.divine.video/a1b2c3d4...'),
+        );
+      });
+
+      test('leaves a bech32 token inside a URL to the plain cut', () async {
+        // Same rule as the hex case: a share link is one URL token in the UI,
+        // so the npub in its path is not a reference either.
+        const npub =
+            'npub180cvv07tjdrrgpa9jzd0cdkej42kwsaxq9rz7gvdpjx6nz004f9uulstw6';
+        const content = 'Follow https://divine.video/$npub please';
+        stubNotifications([
+          makeNotification(
+            notificationType: 'comment',
+            sourceKind: 1,
+            content: content,
+          ),
+        ]);
+        stubProfiles({});
+
+        final page = await repository.getNotifications();
+        final item = page.items.single as VideoNotification;
+        expect(item.commentText, equals('${content.substring(0, 50)}...'));
+        expect(
+          item.commentText,
+          startsWith('Follow https://divine.video/npub1'),
+        );
+      });
+
+      test('leaves a hex run behind a hashtag to the plain cut', () async {
+        // The hashtag alternative also starts earlier and swallows the run.
+        const hex64 =
+            'a1b2c3d4e5f60718293a4b5c6d7e8f90'
+            'a1b2c3d4e5f60718293a4b5c6d7e8f90';
+        const content = 'nice one #$hex64 keep going with more words here';
+        stubNotifications([
+          makeNotification(
+            notificationType: 'comment',
+            sourceKind: 1,
+            content: content,
+          ),
+        ]);
+        stubProfiles({});
+
+        final page = await repository.getNotifications();
+        final item = page.items.single as VideoNotification;
+        expect(
+          item.commentText,
+          equals('nice one #a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4...'),
+        );
+      });
+
       test(
         'like / repost on video leaves commentText null (no body text)',
         () async {

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -2933,6 +2933,103 @@ void main() {
         },
       );
 
+      test('keeps a bounded leading 64-hex reference intact', () async {
+        // LinkifiedTextSpanBuilder decodes a bare 64-char hex pubkey / event
+        // id the same way it decodes bech32. A hex reference is always
+        // longer than the 50-char cap, so before it was protected the cut
+        // sliced it every time and the row rendered raw hex.
+        const hex64 =
+            'a1b2c3d4e5f60718293a4b5c6d7e8f90'
+            'a1b2c3d4e5f60718293a4b5c6d7e8f90';
+        const content = '$hex64 and some trailing words';
+        stubNotifications([
+          makeNotification(
+            notificationType: 'comment',
+            sourceKind: 1,
+            content: content,
+          ),
+        ]);
+        stubProfiles({});
+
+        final page = await repository.getNotifications();
+        final item = page.items.single as VideoNotification;
+        expect(item.commentText, equals('$hex64...'));
+      });
+
+      test(
+        'omits a 64-hex reference straddling the cut instead of splitting it',
+        () async {
+          const hex64 =
+              'a1b2c3d4e5f60718293a4b5c6d7e8f90'
+              'a1b2c3d4e5f60718293a4b5c6d7e8f90';
+          const content = 'Reply to $hex64 more';
+          stubNotifications([
+            makeNotification(
+              notificationType: 'comment',
+              sourceKind: 1,
+              content: content,
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as VideoNotification;
+          expect(item.commentText, equals('Reply to...'));
+          expect(item.commentText, isNot(contains(hex64.substring(0, 16))));
+        },
+      );
+
+      test('applies the preview cap to non-Latin lead-in text', () async {
+        // The leading-token allowance is bounded at four times the cap, and
+        // is only meant to fire when nothing but whitespace or punctuation
+        // precedes the token. Testing only ASCII letters classified every
+        // non-Latin script as punctuation, so Cyrillic / CJK / accented
+        // lead-ins silently got a 200-char preview of remote-controlled
+        // content while the Latin equivalent got 50.
+        const npub =
+            'npub180cvv07tjdrrgpa9jzd0cdkej42kwsaxq9rz7gvdpjx6nz004f9uulstw6';
+        const cyrillic = 'Привет всем друзьям сегодня';
+        const content = '$cyrillic nostr:$npub и ещё немного текста';
+        stubNotifications([
+          makeNotification(
+            notificationType: 'comment',
+            sourceKind: 1,
+            content: content,
+          ),
+        ]);
+        stubProfiles({});
+
+        final page = await repository.getNotifications();
+        final item = page.items.single as VideoNotification;
+        expect(item.commentText, equals('$cyrillic...'));
+        expect(item.commentText!.length, lessThanOrEqualTo(53));
+        expect(item.commentText, isNot(contains('npub1')));
+      });
+
+      test(
+        'still treats punctuation-only lead-in as leading for a bech32 token',
+        () async {
+          // Guards the other side of the non-Latin fix: real punctuation and
+          // whitespace must keep qualifying as "leading", including
+          // non-ASCII punctuation such as guillemets and an em dash.
+          const npub =
+              'npub180cvv07tjdrrgpa9jzd0cdkej42kwsaxq9rz7gvdpjx6nz004f9uulstw6';
+          const content = '«— » $npub';
+          stubNotifications([
+            makeNotification(
+              notificationType: 'comment',
+              sourceKind: 1,
+              content: content,
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as VideoNotification;
+          expect(item.commentText, equals(content));
+        },
+      );
+
       test(
         'like / repost on video leaves commentText null (no body text)',
         () async {

--- a/mobile/test/notifications/widgets/notification_comment_quote_test.dart
+++ b/mobile/test/notifications/widgets/notification_comment_quote_test.dart
@@ -7,9 +7,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/notifications/widgets/notification_comment_quote.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
+
+final AppLocalizations _l10n = lookupAppLocalizations(const Locale('en'));
 
 Future<void> _pump(
   WidgetTester tester, {
@@ -27,6 +30,11 @@ Future<void> _pump(
           ).overrideWith((ref) => Stream.value(profile)),
       ],
       child: MaterialApp(
+        // The widget reads AppLocalizations for the video-reference label;
+        // without the delegates it silently falls back to rendering the raw
+        // reference, which masks link regressions.
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
           body: NotificationCommentQuote(text: text, timestamp: timestamp),
         ),
@@ -138,6 +146,66 @@ void main() {
       );
       expect(profileSpan, isNotNull);
       expect(profileSpan!.recognizer, isA<TapGestureRecognizer>());
+    });
+
+    testWidgets('renders an undecodable npub as raw text (#6346 mode)', (
+      tester,
+    ) async {
+      // The symptom users reported: a bech32 token whose checksum does not
+      // verify — which is what slicing one produces — cannot be decoded, so
+      // the linkifier leaves it as literal text. This pins *why*
+      // NotificationRepository must never split a reference; without it,
+      // nothing at this layer fails when truncation regresses.
+      final malformed = 'npub1${'q' * 40}';
+
+      await _pump(tester, text: 'hey nostr:$malformed');
+
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      final rootSpan = richText.text as TextSpan;
+      expect(rootSpan.toPlainText(), contains(malformed));
+      expect(rootSpan.toPlainText(), isNot(contains('@')));
+    });
+
+    testWidgets('renders an intact 64-hex reference as a tappable link', (
+      tester,
+    ) async {
+      // The linkifier decodes a bare 64-char hex reference as well as bech32,
+      // resolving it to a labelled video link. This is why
+      // NotificationRepository must protect hex from the preview cut: a hex
+      // reference is 64 chars, so an unprotected one was always sliced.
+      await _pump(tester, text: 'hey $profileHex thanks');
+
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      final rootSpan = richText.text as TextSpan;
+      expect(
+        rootSpan.toPlainText(),
+        equals('“hey ${_l10n.clickableTextViewVideoLink} thanks”'),
+      );
+      expect(rootSpan.toPlainText(), isNot(contains(profileHex)));
+
+      final linkSpan = _findSpan(
+        rootSpan,
+        matching: (span) => span.text == _l10n.clickableTextViewVideoLink,
+      );
+      expect(linkSpan, isNotNull);
+      expect(linkSpan!.recognizer, isA<TapGestureRecognizer>());
+    });
+
+    testWidgets('renders a partial hex reference as raw text', (tester) async {
+      // The other half of the pair above: anything short of 64 hex chars is
+      // not a reference, so a sliced one is dumped verbatim into the row.
+      // That is the user-visible damage the repository cut used to cause.
+      final partialHex = 'a1b2c3d4e5' * 5; // 50 chars — below the 64 needed
+
+      await _pump(tester, text: 'hey $partialHex thanks');
+
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      final rootSpan = richText.text as TextSpan;
+      expect(rootSpan.toPlainText(), contains(partialHex));
+      expect(
+        rootSpan.toPlainText(),
+        isNot(contains(_l10n.clickableTextViewVideoLink)),
+      );
     });
 
     testWidgets('uses cached profile names for nostr profile references', (


### PR DESCRIPTION
## Description

#6345 made the notification comment preview stop slicing bech32 tokens. While verifying that fix for #6762 I found the preview cut is still wrong in two other ways, and review found a third. All three are the same underlying mistake — the repository's idea of "a reference the UI can decode" does not match what `LinkifiedTextSpanBuilder` actually decodes.

**1. A bare 64-char hex reference was never protected.**

`LinkifiedTextSpanBuilder._combinedRegex` decodes a bare 64-char hex pubkey / event id and renders it as a tappable "View video" link. The repository's `_bech32ReferencePattern` covered only the bech32 alternative. A hex reference is 64 characters, so it *always* exceeded the 50-char cap and was *always* sliced — and anything shorter than 64 hex chars is not a reference, so the row rendered 50 raw hex characters instead of a link. Same defect class as #6346, different token type.

Before / after, from the repository tests:

```
before:  "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f6071829..."
after:   "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90..."
```

**2. The preview cap did not apply to non-Latin scripts.**

`_hasOnlyWhitespaceOrPunctuationBefore` rejected only ASCII `[0-9A-Za-z]`, so Cyrillic, CJK, and accented lead-in text counted as punctuation. A straddling token then qualified as "leading", and the cut returned the token's *end* — bounded only by `limit * 4`. The 50-char cap silently became 200 for most locales, persisting four times the intended amount of remote-controlled notification content:

```
Cyrillic lead-in (before):  100 chars — "Привет всем друзьям сегодня nostr:npub1…uulstw6..."
Latin lead-in    (before):   32 chars — "Hello everyone my friends tod..."
Cyrillic lead-in (after):    30 chars — "Привет всем друзьям сегодня..."
```

Non-ASCII *punctuation* (guillemets, em dash) still correctly counts as a leading-token prefix; there is a test for that direction too.

**3. A hex or bech32 run inside a URL or hashtag was protected as if the UI decoded it.**

Found in review by @hm21 and fixed in a11bde3a4 — a regression introduced by fix 1 above. Adding the hex alternative gave the repository a pattern that could match a hex run *anywhere*, including inside a span the UI never links. `LinkifiedTextSpanBuilder` resolves alternation per start position, so a URL or hashtag containing a hex run starts earlier and wins: `https://host/<64-hex>` is a single URL token and the hex inside it is never a reference. The cut was pulled back to it anyway, shortening the preview for a span the UI does not resolve. Blossom and CDN media URLs are exactly `https://host/<sha256>`, so this is the common shape rather than an edge case:

```
before this PR:  "Look at this https://blossom.divine.video/a1b2c3d4..."  (53)
on b09b6e7ac:    "Look at this https://blossom.divine.video/..."          (45)
after a11bde3a4: "Look at this https://blossom.divine.video/a1b2c3d4..."  (53)
```

`#<64-hex>` was worse, collapsing the preview to `nice one #...` (13 chars of a 50-char budget).

The fix mirrors `_combinedRegex` alternative for alternative and protects only the bech32 and hex capture groups, so the surrounding alternatives consume their own text and a run buried inside them is not mistaken for a reference. Two consequences worth naming:

- The UI's trailing `@([a-zA-Z][a-zA-Z0-9_]{0,30})` alternative is deliberately **not** mirrored. It beats bech32 for `@npub1…` and truncates the token to 31 characters, so mirroring it would drop the protection #6346 added for that input. Whether the UI should tokenize `@npub1…` as a mention at all is a separate question from this cut, and is not decided here.
- A bech32 token inside a URL path is no longer pulled back either, because the UI reads that as a URL too. This is a deliberate behaviour change relative to `main` and is pinned by a test. It is not separable from the fix: bech32-in-URL and hex-in-URL are the same alternative, so keeping the old behaviour there would reintroduce the hex-in-URL regression that is the common case.

The fix replaces the ASCII loop with `RegExp(r'[\p{L}\p{N}]', unicode: true)`, adds the hex alternative to the reference pattern, and mirrors the surrounding UI alternatives so the "exactly what the UI can decode" rule holds, renaming to drop the now-inaccurate `bech32` prefix.

**Related Issue:** Relates to #6762, #6346, #6763

## Out of Scope

- The mid-sentence mention loss tracked in #6763. Note for that issue: this change makes the behaviour *consistent* across locales — previously Cyrillic lead-ins accidentally kept the mention while Latin ones dropped it. #6763 remains the fix for preserving it everywhere.
- Sharing one token regex between `notification_repository` and `LinkifiedTextSpanBuilder`. They are kept in sync by comment and by the tests here; a shared source would mean extracting a new package, since a pure-Dart package cannot depend on the app layer.
- Whether the UI should tokenize `@npub1…` as a 31-char mention instead of a bech32 reference. Pre-existing, unchanged here.

## Verification

- `flutter test` in `mobile/packages/notification_repository` — **172 pass**
- `flutter test --coverage` in that package — **95.68%**, above its `min_coverage: 94` gate
- `flutter test test/notifications/` — **210 pass**
- `flutter analyze` in the package — no issues
- `flutter analyze lib test integration_test` in `mobile/` — no issues
- `dart format --set-exit-if-changed` — clean

Red/green status per test, re-checked against `origin/main` and against `b09b6e7ac` rather than asserted:

- Tests 1, 2, 3 fail against `origin/main` and pass after — the "before" numbers above are captured output from that run, not estimates.
- Tests 8, 9, 10 fail against `b09b6e7ac` and pass after; the numbers in defect 3 are captured from that run.
- Tests 4, 5, 7 are **guard tests that also pass against pre-fix code**. They pin behaviour that must not regress (the other side of the non-Latin fix, and the render-layer failure modes that give the repository cut its reason to exist) rather than demonstrating a fixed defect. An earlier revision of this description claimed every test was red first; that was wrong for these three.

### Tests added

`notification_repository`:
1. Keeps a bounded leading 64-hex reference intact.
2. Omits a straddling 64-hex reference rather than slicing it.
3. Applies the 50-char cap to non-Latin lead-in text.
4. Still treats punctuation-only lead-in (including non-ASCII punctuation) as leading.
8. Leaves a hex run inside a URL to the plain cut.
9. Leaves a bech32 token inside a URL to the plain cut.
10. Leaves a hex run behind a hashtag to the plain cut.

`notification_comment_quote`:
5. An undecodable npub renders as raw text — pins the #6346 failure mode at the render layer, which previously had no guard.
6. An intact 64-hex reference renders as a tappable link.
7. A partial hex reference renders as raw text.

Test 6 also required adding `AppLocalizations.localizationsDelegates` / `supportedLocales` to this file's `_pump` helper, which was missing them. Without the delegates `videoLabel` resolved to `null` and the widget silently fell back to rendering the raw reference — so the harness would have reported a broken link as passing.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
