### PR TITLE
fix(a11y): make icons and tight layouts survive system font scaling

### DIFF
--- a/mobile/lib/constants/text_scale_limits.dart
+++ b/mobile/lib/constants/text_scale_limits.dart
@@ -1,0 +1,41 @@
+// ABOUTME: Upper bounds on the system text scale for layouts whose size is
+// ABOUTME: fixed by something other than the text they contain.
+
+/// Caps applied via `MediaQuery.withClampedTextScaling` around subtrees that
+/// cannot absorb unbounded growth.
+///
+/// A cap still honours the user's font-size preference — it just stops
+/// where the layout breaks. Prefer one over `TextScaler.noScaling`, which
+/// ignores the preference outright.
+///
+/// Icons are capped separately and globally by `DivineIcon.maxScaleFactor`;
+/// the values here bound the *labels* those icons sit beside. Where both
+/// apply the tighter of the two wins, so a subtree capped below the icon
+/// bound scales its icons to the subtree's cap.
+library;
+
+/// Rows of fixed height whose width is shared between a label and
+/// fixed-size chrome: the bottom nav, content-filter rows, the trending
+/// hashtag strip, category tiles.
+///
+/// These have the least room — the height is set by the bar, not the text,
+/// so growth spills rather than pushing the row taller.
+const fixedRowTextScaleLimit = 1.25;
+
+/// Columns of icon-with-caption buttons overlaid on video.
+///
+/// Matches `DivineIcon.maxScaleFactor` so the caption and the icon above it
+/// stop growing together; past that the column starts overlapping the
+/// video's own controls.
+const overlayActionColumnTextScaleLimit = 1.3;
+
+/// Single-line labels inside a pill or chip that can grow somewhat before
+/// the surrounding controls collide.
+const chipLabelTextScaleLimit = 1.4;
+
+/// Numeric stats in a divided row.
+///
+/// The loosest bound here: the digits carry the meaning, each column is
+/// `Expanded` so growth is shared, and the label below fades rather than
+/// overflowing.
+const statColumnTextScaleLimit = 1.5;

--- a/mobile/lib/screens/auth/nostr_connect_screen.dart
+++ b/mobile/lib/screens/auth/nostr_connect_screen.dart
@@ -696,28 +696,25 @@ class _ActionBar extends StatelessWidget {
               spacing: 10,
               children: [
                 _ActionButton(
-                  icon: DivineIcon(
+                  icon: const DivineIcon(
                     icon: DivineIconName.linkSimple,
                     color: VineTheme.vineGreen,
-                    size: MediaQuery.textScalerOf(context).scale(24),
                   ),
                   label: context.l10n.authCopyUrl,
                   onTap: isLoading ? null : onCopyUrl,
                 ),
                 _ActionButton(
-                  icon: DivineIcon(
+                  icon: const DivineIcon(
                     icon: DivineIconName.shareFat,
                     color: VineTheme.vineGreen,
-                    size: MediaQuery.textScalerOf(context).scale(24),
                   ),
                   label: context.l10n.authShare,
                   onTap: isLoading ? null : onShareUrl,
                 ),
                 _ActionButton(
-                  icon: DivineIcon(
+                  icon: const DivineIcon(
                     icon: DivineIconName.plus,
                     color: VineTheme.vineGreen,
-                    size: MediaQuery.textScalerOf(context).scale(24),
                   ),
                   label: context.l10n.authAddBunker,
                   onTap: isLoading ? null : onAddBunker,
@@ -954,9 +951,9 @@ class _ErrorContent extends StatelessWidget {
                       ),
                       elevation: 0,
                     ),
-                    icon: DivineIcon(
+                    icon: const DivineIcon(
                       icon: DivineIconName.arrowClockwise,
-                      size: MediaQuery.textScalerOf(context).scale(16),
+                      size: 16,
                       color: VineTheme.onPrimary,
                     ),
                     label: Text(

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -116,15 +116,20 @@ class _CommentsTitle extends StatelessWidget {
 
         return Row(
           mainAxisSize: MainAxisSize.min,
+          spacing: 8,
           children: [
-            Text(
-              context.l10n.commentsHeaderCount(count),
-              style: VineTheme.titleMediumFont(
-                color: context.vineColors.onSurface,
+            Flexible(
+              child: Text(
+                context.l10n.commentsHeaderCount(count),
+                style: VineTheme.titleMediumFont(
+                  color: context.vineColors.onSurface,
+                ),
+                maxLines: 1,
+                softWrap: false,
+                overflow: .fade,
               ),
             ),
-            if (state.newCommentCount > 0) ...[
-              const SizedBox(width: 8),
+            if (state.newCommentCount > 0)
               NewCommentsPill(
                 count: state.newCommentCount,
                 onTap: () {
@@ -134,7 +139,6 @@ class _CommentsTitle extends StatelessWidget {
                   );
                 },
               ),
-            ],
           ],
         );
       },

--- a/mobile/lib/screens/comments/widgets/comment_input.dart
+++ b/mobile/lib/screens/comments/widgets/comment_input.dart
@@ -222,27 +222,30 @@ class _CommentInputState extends State<CommentInput> {
                 crossAxisAlignment: CrossAxisAlignment.end,
                 children: [
                   Expanded(
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Flexible(
-                          child: _CommentTextField(
-                            controller: widget.controller,
-                            focusNode: _focusNode,
-                            isReplying: isReplying,
-                            isEditing: isEditing,
-                            onSubmitted: widget.onSubmit,
-                            onChanged: _handleTextChanged,
+                    child: MediaQuery.withClampedTextScaling(
+                      maxScaleFactor: 1.25,
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Flexible(
+                            child: _CommentTextField(
+                              controller: widget.controller,
+                              focusNode: _focusNode,
+                              isReplying: isReplying,
+                              isEditing: isEditing,
+                              onSubmitted: widget.onSubmit,
+                              onChanged: _handleTextChanged,
+                            ),
                           ),
-                        ),
-                        if (isEditing)
-                          _EditIndicator(onCancel: widget.onCancelEdit!)
-                        else if (isReplying)
-                          _ReplyIndicator(
-                            displayName: widget.replyToDisplayName!,
-                            onCancel: widget.onCancelReply!,
-                          ),
-                      ],
+                          if (isEditing)
+                            _EditIndicator(onCancel: widget.onCancelEdit!)
+                          else if (isReplying)
+                            _ReplyIndicator(
+                              displayName: widget.replyToDisplayName!,
+                              onCancel: widget.onCancelReply!,
+                            ),
+                        ],
+                      ),
                     ),
                   ),
                   if (widget.onVideoReplyPressed != null ||
@@ -291,8 +294,8 @@ class _VideoReplyButton extends StatelessWidget {
         constraints: const BoxConstraints(minWidth: 48, minHeight: 48),
         child: Center(
           child: Container(
-            width: 40,
-            height: 40,
+            width: MediaQuery.textScalerOf(context).scale(40),
+            height: MediaQuery.textScalerOf(context).scale(40),
             margin: const EdgeInsets.only(bottom: 4),
             // The camera asset is 29x18, so `contain` sizes it off its height
             // and it renders 35px wide inside the 40px circle. The padding

--- a/mobile/lib/screens/comments/widgets/comment_input.dart
+++ b/mobile/lib/screens/comments/widgets/comment_input.dart
@@ -4,6 +4,7 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:openvine/blocs/comments/comment_composer/comment_composer_bloc.dart';
+import 'package:openvine/constants/text_scale_limits.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/screens/comments/widgets/mention_overlay.dart';
 
@@ -223,7 +224,7 @@ class _CommentInputState extends State<CommentInput> {
                 children: [
                   Expanded(
                     child: MediaQuery.withClampedTextScaling(
-                      maxScaleFactor: 1.25,
+                      maxScaleFactor: fixedRowTextScaleLimit,
                       child: Column(
                         mainAxisSize: MainAxisSize.min,
                         children: [
@@ -294,8 +295,8 @@ class _VideoReplyButton extends StatelessWidget {
         constraints: const BoxConstraints(minWidth: 48, minHeight: 48),
         child: Center(
           child: Container(
-            width: MediaQuery.textScalerOf(context).scale(40),
-            height: MediaQuery.textScalerOf(context).scale(40),
+            width: DivineIcon.scaleSize(context, 40),
+            height: DivineIcon.scaleSize(context, 40),
             margin: const EdgeInsets.only(bottom: 4),
             // The camera asset is 29x18, so `contain` sizes it off its height
             // and it renders 35px wide inside the 40px circle. The padding

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -512,7 +512,7 @@ class _ActionsRow extends StatelessWidget {
                 children: [
                   DivineIcon(
                     icon: DivineIconName.arrowBendDownRight,
-                    size: MediaQuery.textScalerOf(context).scale(11),
+                    size: 11,
                     color: context.vineColors.onSurface,
                   ),
                   const SizedBox(width: 8),
@@ -601,7 +601,7 @@ class _CommentVoteButtons extends StatelessWidget {
                   ),
                   child: DivineIcon(
                     icon: DivineIconName.arrowFatUp,
-                    size: MediaQuery.textScalerOf(context).scale(16),
+                    size: 16,
                     color: voteState.isUpvoted
                         ? VineTheme.vineGreen
                         : context.vineColors.onSurfaceMuted,
@@ -650,7 +650,7 @@ class _CommentVoteButtons extends StatelessWidget {
                   ),
                   child: DivineIcon(
                     icon: DivineIconName.arrowFatDown,
-                    size: MediaQuery.textScalerOf(context).scale(16),
+                    size: 16,
                     color: voteState.isDownvoted
                         ? VineTheme.likeRed
                         : context.vineColors.onSurfaceMuted,

--- a/mobile/lib/screens/content_filters_screen.dart
+++ b/mobile/lib/screens/content_filters_screen.dart
@@ -168,21 +168,24 @@ class _CategoryGroup extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        DivineSectionHeader(title),
-        ...labels.map(
-          (label) => _ContentFilterRow(
-            label: label,
-            preference: state.preferenceFor(label),
-            locked: state.isLabelLocked(label),
-            onChanged: (preference) {
-              onChanged(label, preference);
-            },
+    return MediaQuery.withClampedTextScaling(
+      maxScaleFactor: 1.25,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          DivineSectionHeader(title),
+          ...labels.map(
+            (label) => _ContentFilterRow(
+              label: label,
+              preference: state.preferenceFor(label),
+              locked: state.isLabelLocked(label),
+              onChanged: (preference) {
+                onChanged(label, preference);
+              },
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/mobile/lib/screens/content_filters_screen.dart
+++ b/mobile/lib/screens/content_filters_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/content_filters/content_filters_cubit.dart';
 import 'package:openvine/blocs/content_filters/content_filters_state.dart';
+import 'package:openvine/constants/text_scale_limits.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_content_label_name.dart';
 import 'package:openvine/models/content_label.dart';
@@ -169,7 +170,7 @@ class _CategoryGroup extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MediaQuery.withClampedTextScaling(
-      maxScaleFactor: 1.25,
+      maxScaleFactor: fixedRowTextScaleLimit,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/mobile/lib/screens/profile_screen_router.dart
+++ b/mobile/lib/screens/profile_screen_router.dart
@@ -7,7 +7,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
@@ -223,67 +222,21 @@ class _ProfileScreenRouterState extends ConsumerState<ProfileScreenRouter>
   }
 
   Future<void> _more(String userIdHex) async {
-    final result = await VineBottomSheet.show<String>(
+    await VineBottomSheetActionMenu.show(
       context: context,
-      scrollable: false,
-      children: [
-        InkWell(
-          onTap: () => Navigator.of(context).pop('copy_npub'),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
-            child: Row(
-              children: [
-                SvgPicture.asset(
-                  DivineIconName.copy.assetPath,
-                  width: 24,
-                  height: 24,
-                  colorFilter: ColorFilter.mode(
-                    context.vineColors.primaryText,
-                    BlendMode.srcIn,
-                  ),
-                ),
-                const SizedBox(width: 16),
-                Text(
-                  context.l10n.profileCopyPublicKey,
-                  style: VineTheme.titleMediumFont(
-                    color: context.vineColors.primaryText,
-                  ),
-                ),
-              ],
-            ),
-          ),
+      options: [
+        VineBottomSheetActionData(
+          iconPath: DivineIconName.copy.assetPath,
+          label: context.l10n.profileCopyPublicKey,
+          onTap: () => _copyNpub(userIdHex),
         ),
-        InkWell(
-          onTap: () => Navigator.of(context).pop('embed_code'),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
-            child: Row(
-              children: [
-                DivineIcon(
-                  icon: DivineIconName.bracketsAngle,
-                  color: context.vineColors.primaryText,
-                ),
-                const SizedBox(width: 16),
-                Text(
-                  context.l10n.profileGetEmbedCode,
-                  style: VineTheme.titleMediumFont(
-                    color: context.vineColors.primaryText,
-                  ),
-                ),
-              ],
-            ),
-          ),
+        VineBottomSheetActionData(
+          iconPath: DivineIconName.bracketsAngle.assetPath,
+          label: context.l10n.profileGetEmbedCode,
+          onTap: () => _copyEmbedCode(userIdHex),
         ),
       ],
     );
-
-    if (!mounted) return;
-
-    if (result == 'copy_npub') {
-      await _copyNpub(userIdHex);
-    } else if (result == 'embed_code') {
-      await _copyEmbedCode(userIdHex);
-    }
   }
 
   Future<void> _copyNpub(String userIdHex) async {

--- a/mobile/lib/screens/settings/legal_screen.dart
+++ b/mobile/lib/screens/settings/legal_screen.dart
@@ -31,7 +31,7 @@ class LegalScreen extends StatelessWidget {
               DivineListTile(
                 leading: Icon(
                   Icons.description,
-                  size: MediaQuery.textScalerOf(context).scale(24),
+                  size: DivineIcon.scaleSize(context, 24),
                   color: VineTheme.vineGreen,
                 ),
                 title: l10n.legalTermsOfService,
@@ -47,7 +47,7 @@ class LegalScreen extends StatelessWidget {
               DivineListTile(
                 leading: Icon(
                   Icons.privacy_tip,
-                  size: MediaQuery.textScalerOf(context).scale(24),
+                  size: DivineIcon.scaleSize(context, 24),
                   color: VineTheme.vineGreen,
                 ),
                 title: l10n.legalPrivacyPolicy,
@@ -76,7 +76,7 @@ class LegalScreen extends StatelessWidget {
               DivineListTile(
                 leading: Icon(
                   Icons.copyright,
-                  size: MediaQuery.textScalerOf(context).scale(24),
+                  size: DivineIcon.scaleSize(context, 24),
                   color: VineTheme.vineGreen,
                 ),
                 title: l10n.legalDmca,
@@ -92,7 +92,7 @@ class LegalScreen extends StatelessWidget {
               DivineListTile(
                 leading: Icon(
                   Icons.source,
-                  size: MediaQuery.textScalerOf(context).scale(24),
+                  size: DivineIcon.scaleSize(context, 24),
                   color: VineTheme.vineGreen,
                 ),
                 title: l10n.legalOpenSourceLicenses,

--- a/mobile/lib/screens/settings/legal_screen.dart
+++ b/mobile/lib/screens/settings/legal_screen.dart
@@ -29,8 +29,9 @@ class LegalScreen extends StatelessWidget {
           child: ListView(
             children: [
               DivineListTile(
-                leading: const Icon(
+                leading: Icon(
                   Icons.description,
+                  size: MediaQuery.textScalerOf(context).scale(24),
                   color: VineTheme.vineGreen,
                 ),
                 title: l10n.legalTermsOfService,
@@ -44,8 +45,9 @@ class LegalScreen extends StatelessWidget {
                 ),
               ),
               DivineListTile(
-                leading: const Icon(
+                leading: Icon(
                   Icons.privacy_tip,
+                  size: MediaQuery.textScalerOf(context).scale(24),
                   color: VineTheme.vineGreen,
                 ),
                 title: l10n.legalPrivacyPolicy,
@@ -72,8 +74,9 @@ class LegalScreen extends StatelessWidget {
                 ),
               ),
               DivineListTile(
-                leading: const Icon(
+                leading: Icon(
                   Icons.copyright,
+                  size: MediaQuery.textScalerOf(context).scale(24),
                   color: VineTheme.vineGreen,
                 ),
                 title: l10n.legalDmca,
@@ -87,7 +90,11 @@ class LegalScreen extends StatelessWidget {
                 ),
               ),
               DivineListTile(
-                leading: const Icon(Icons.source, color: VineTheme.vineGreen),
+                leading: Icon(
+                  Icons.source,
+                  size: MediaQuery.textScalerOf(context).scale(24),
+                  color: VineTheme.vineGreen,
+                ),
                 title: l10n.legalOpenSourceLicenses,
                 subtitle: l10n.legalOpenSourceLicensesSubtitle,
                 onTap: () => showLicensePage(

--- a/mobile/lib/screens/settings/nostr_settings_screen.dart
+++ b/mobile/lib/screens/settings/nostr_settings_screen.dart
@@ -68,14 +68,19 @@ class NostrSettingsScreen extends ConsumerWidget {
               DivineSectionHeader(context.l10n.nostrSettingsSectionNetwork),
               if (showAdvancedRelaySettings) ...[
                 DivineListTile(
-                  leading: const Icon(Icons.hub, color: VineTheme.vineGreen),
+                  leading: Icon(
+                    Icons.hub,
+                    size: MediaQuery.textScalerOf(context).scale(24),
+                    color: VineTheme.vineGreen,
+                  ),
                   title: context.l10n.nostrSettingsRelays,
                   subtitle: context.l10n.nostrSettingsRelaysSubtitle,
                   onTap: () => context.push(RelaySettingsScreen.path),
                 ),
                 DivineListTile(
-                  leading: const Icon(
+                  leading: Icon(
                     Icons.troubleshoot,
+                    size: MediaQuery.textScalerOf(context).scale(24),
                     color: VineTheme.vineGreen,
                   ),
                   title: context.l10n.nostrSettingsRelayDiagnostics,
@@ -84,8 +89,9 @@ class NostrSettingsScreen extends ConsumerWidget {
                 ),
               ],
               DivineListTile(
-                leading: const Icon(
+                leading: Icon(
                   Icons.cloud_upload,
+                  size: MediaQuery.textScalerOf(context).scale(24),
                   color: VineTheme.vineGreen,
                 ),
                 title: context.l10n.nostrSettingsMediaServers,
@@ -106,8 +112,9 @@ class NostrSettingsScreen extends ConsumerWidget {
                 ),
                 const _ClientAttributionToggle(),
                 DivineListTile(
-                  leading: const Icon(
+                  leading: Icon(
                     Icons.alternate_email,
+                    size: MediaQuery.textScalerOf(context).scale(24),
                     color: VineTheme.vineGreen,
                   ),
                   title: context.l10n.nostrSettingsNip05Address,
@@ -148,7 +155,11 @@ class _RemoveKeysTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DivineListTile(
-      leading: const Icon(Icons.key_off, color: VineTheme.warning),
+      leading: Icon(
+        Icons.key_off,
+        size: MediaQuery.textScalerOf(context).scale(24),
+        color: VineTheme.warning,
+      ),
       title: context.l10n.nostrSettingsRemoveKeys,
       subtitle: context.l10n.nostrSettingsRemoveKeysSubtitle,
       onTap: () => _handleRemoveLocalAccount(context, ref),

--- a/mobile/lib/screens/settings/nostr_settings_screen.dart
+++ b/mobile/lib/screens/settings/nostr_settings_screen.dart
@@ -70,7 +70,7 @@ class NostrSettingsScreen extends ConsumerWidget {
                 DivineListTile(
                   leading: Icon(
                     Icons.hub,
-                    size: MediaQuery.textScalerOf(context).scale(24),
+                    size: DivineIcon.scaleSize(context, 24),
                     color: VineTheme.vineGreen,
                   ),
                   title: context.l10n.nostrSettingsRelays,
@@ -80,7 +80,7 @@ class NostrSettingsScreen extends ConsumerWidget {
                 DivineListTile(
                   leading: Icon(
                     Icons.troubleshoot,
-                    size: MediaQuery.textScalerOf(context).scale(24),
+                    size: DivineIcon.scaleSize(context, 24),
                     color: VineTheme.vineGreen,
                   ),
                   title: context.l10n.nostrSettingsRelayDiagnostics,
@@ -91,7 +91,7 @@ class NostrSettingsScreen extends ConsumerWidget {
               DivineListTile(
                 leading: Icon(
                   Icons.cloud_upload,
-                  size: MediaQuery.textScalerOf(context).scale(24),
+                  size: DivineIcon.scaleSize(context, 24),
                   color: VineTheme.vineGreen,
                 ),
                 title: context.l10n.nostrSettingsMediaServers,
@@ -114,7 +114,7 @@ class NostrSettingsScreen extends ConsumerWidget {
                 DivineListTile(
                   leading: Icon(
                     Icons.alternate_email,
-                    size: MediaQuery.textScalerOf(context).scale(24),
+                    size: DivineIcon.scaleSize(context, 24),
                     color: VineTheme.vineGreen,
                   ),
                   title: context.l10n.nostrSettingsNip05Address,
@@ -157,7 +157,7 @@ class _RemoveKeysTile extends StatelessWidget {
     return DivineListTile(
       leading: Icon(
         Icons.key_off,
-        size: MediaQuery.textScalerOf(context).scale(24),
+        size: DivineIcon.scaleSize(context, 24),
         color: VineTheme.warning,
       ),
       title: context.l10n.nostrSettingsRemoveKeys,

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -431,24 +431,36 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 ),
                 if (nostrAppsSandboxSupported)
                   DivineListTile(
-                    leading: const Icon(Icons.apps),
+                    leading: Icon(
+                      Icons.apps,
+                      size: MediaQuery.textScalerOf(context).scale(24),
+                    ),
                     title: context.l10n.settingsIntegratedApps,
                     subtitle: context.l10n.settingsIntegratedAppsSubtitle,
                     onTap: () => context.push(AppsDirectoryScreen.path),
                   ),
                 DivineListTile(
                   title: context.l10n.settingsLegal,
-                  leading: const Icon(Icons.gavel),
+                  leading: Icon(
+                    Icons.gavel,
+                    size: MediaQuery.textScalerOf(context).scale(24),
+                  ),
                   onTap: () => context.push(LegalScreen.path),
                 ),
                 DivineListTile(
-                  leading: const Icon(Icons.lock_open),
+                  leading: Icon(
+                    Icons.lock_open,
+                    size: MediaQuery.textScalerOf(context).scale(24),
+                  ),
                   title: context.l10n.settingsIntegrationPermissions,
                   subtitle: context.l10n.settingsIntegrationPermissionsSubtitle,
                   onTap: () => context.push(AppsPermissionsScreen.path),
                 ),
                 DivineListTile(
-                  leading: const Icon(Icons.science),
+                  leading: Icon(
+                    Icons.science,
+                    size: MediaQuery.textScalerOf(context).scale(24),
+                  ),
                   title: context.l10n.settingsExperimentalFeatures,
                   subtitle: context.l10n.settingsExperimentalFeaturesSubtitle,
                   onTap: () => Navigator.push(

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -433,7 +433,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                   DivineListTile(
                     leading: Icon(
                       Icons.apps,
-                      size: MediaQuery.textScalerOf(context).scale(24),
+                      size: DivineIcon.scaleSize(context, 24),
                     ),
                     title: context.l10n.settingsIntegratedApps,
                     subtitle: context.l10n.settingsIntegratedAppsSubtitle,
@@ -443,14 +443,14 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                   title: context.l10n.settingsLegal,
                   leading: Icon(
                     Icons.gavel,
-                    size: MediaQuery.textScalerOf(context).scale(24),
+                    size: DivineIcon.scaleSize(context, 24),
                   ),
                   onTap: () => context.push(LegalScreen.path),
                 ),
                 DivineListTile(
                   leading: Icon(
                     Icons.lock_open,
-                    size: MediaQuery.textScalerOf(context).scale(24),
+                    size: DivineIcon.scaleSize(context, 24),
                   ),
                   title: context.l10n.settingsIntegrationPermissions,
                   subtitle: context.l10n.settingsIntegrationPermissionsSubtitle,
@@ -459,7 +459,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 DivineListTile(
                   leading: Icon(
                     Icons.science,
-                    size: MediaQuery.textScalerOf(context).scale(24),
+                    size: DivineIcon.scaleSize(context, 24),
                   ),
                   title: context.l10n.settingsExperimentalFeatures,
                   subtitle: context.l10n.settingsExperimentalFeaturesSubtitle,

--- a/mobile/lib/widgets/categories_tab.dart
+++ b/mobile/lib/widgets/categories_tab.dart
@@ -178,33 +178,31 @@ class _CategoryTile extends StatelessWidget {
                     horizontal: 24,
                     vertical: 16,
                   ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text(
-                        localizedName,
-                        style: TextStyle(
-                          color: visuals.foregroundColor,
-                          fontSize: 24,
-                          height: 32 / 24,
-                          fontWeight: FontWeight.w700,
+                  child: MediaQuery.withClampedTextScaling(
+                    maxScaleFactor: 1.25,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      spacing: 4,
+                      children: [
+                        Text(
+                          localizedName,
+                          style: VineTheme.headlineSmallFont(
+                            color: visuals.foregroundColor,
+                          ),
                         ),
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        context.l10n.categoryVideoCount(
-                          _formatCount(category.videoCount),
+                        Text(
+                          context.l10n.categoryVideoCount(
+                            _formatCount(category.videoCount),
+                          ),
+                          style: VineTheme.labelMediumFont(
+                            color: visuals.foregroundColor.withValues(
+                              alpha: 0.9,
+                            ),
+                          ),
                         ),
-                        style: TextStyle(
-                          color: visuals.foregroundColor.withValues(alpha: 0.9),
-                          fontSize: 12,
-                          height: 16 / 12,
-                          fontWeight: FontWeight.w600,
-                          letterSpacing: 0.5,
-                        ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ),
                 PositionedDirectional(

--- a/mobile/lib/widgets/categories_tab.dart
+++ b/mobile/lib/widgets/categories_tab.dart
@@ -9,6 +9,7 @@ import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' show VideoCategory;
 import 'package:openvine/blocs/categories/categories_bloc.dart';
 import 'package:openvine/constants/semantic_ids.dart';
+import 'package:openvine/constants/text_scale_limits.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_category_name.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -179,7 +180,7 @@ class _CategoryTile extends StatelessWidget {
                     vertical: 16,
                   ),
                   child: MediaQuery.withClampedTextScaling(
-                    maxScaleFactor: 1.25,
+                    maxScaleFactor: fixedRowTextScaleLimit,
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       mainAxisAlignment: MainAxisAlignment.center,

--- a/mobile/lib/widgets/classic_viners_slider.dart
+++ b/mobile/lib/widgets/classic_viners_slider.dart
@@ -36,9 +36,13 @@ class ClassicVinersSlider extends ConsumerWidget {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: Row(
+              spacing: 8,
               children: [
-                const Icon(Icons.star, color: VineTheme.vineGreen, size: 20),
-                const SizedBox(width: 8),
+                Icon(
+                  Icons.star,
+                  color: VineTheme.vineGreen,
+                  size: MediaQuery.textScalerOf(context).scale(20),
+                ),
                 Text(
                   context.l10n.classicVinersTitle,
                   style: VineTheme.titleSmallFont(

--- a/mobile/lib/widgets/classic_viners_slider.dart
+++ b/mobile/lib/widgets/classic_viners_slider.dart
@@ -41,7 +41,7 @@ class ClassicVinersSlider extends ConsumerWidget {
                 Icon(
                   Icons.star,
                   color: VineTheme.vineGreen,
-                  size: MediaQuery.textScalerOf(context).scale(20),
+                  size: DivineIcon.scaleSize(context, 20),
                 ),
                 Text(
                   context.l10n.classicVinersTitle,

--- a/mobile/lib/widgets/og_viner_badge.dart
+++ b/mobile/lib/widgets/og_viner_badge.dart
@@ -12,7 +12,7 @@ class OgVinerBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final dimension = MediaQuery.textScalerOf(context).scale(size);
+    final dimension = DivineIcon.scaleSize(context, size);
     return Semantics(
       label: context.l10n.ogVinerBadgeLabel,
       container: true,
@@ -25,10 +25,15 @@ class OgVinerBadge extends StatelessWidget {
           color: VineTheme.primary,
           shape: BoxShape.circle,
         ),
+        // The glyph is a logo mark sized off the circle, not readable text:
+        // `dimension` already carries the text scale, so scaling the font
+        // again would square the factor. `FittedBox` stays as a guard
+        // against font-fallback metrics overflowing the circle.
         child: FittedBox(
           child: Text(
             'V',
             textAlign: TextAlign.center,
+            textScaler: TextScaler.noScaling,
             style: TextStyle(
               color: VineTheme.onPrimary,
               fontFamily: 'Pacifico',

--- a/mobile/lib/widgets/og_viner_badge.dart
+++ b/mobile/lib/widgets/og_viner_badge.dart
@@ -12,26 +12,27 @@ class OgVinerBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final dimension = MediaQuery.textScalerOf(context).scale(size);
     return Semantics(
       label: context.l10n.ogVinerBadgeLabel,
       container: true,
-      child: Padding(
-        padding: const EdgeInsetsDirectional.only(start: 4),
-        child: Container(
-          width: size,
-          height: size,
-          alignment: Alignment.center,
-          decoration: const BoxDecoration(
-            color: VineTheme.primary,
-            shape: BoxShape.circle,
-          ),
+      child: Container(
+        margin: const EdgeInsetsDirectional.only(start: 4),
+        width: dimension,
+        height: dimension,
+        alignment: Alignment.center,
+        decoration: const BoxDecoration(
+          color: VineTheme.primary,
+          shape: BoxShape.circle,
+        ),
+        child: FittedBox(
           child: Text(
             'V',
             textAlign: TextAlign.center,
             style: TextStyle(
               color: VineTheme.onPrimary,
               fontFamily: 'Pacifico',
-              fontSize: size * 0.85,
+              fontSize: dimension * 0.85,
               height: 1,
             ),
           ),

--- a/mobile/lib/widgets/profile/profile_stats_row_widget.dart
+++ b/mobile/lib/widgets/profile/profile_stats_row_widget.dart
@@ -3,6 +3,7 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:openvine/constants/text_scale_limits.dart';
 import 'package:openvine/utils/string_utils.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
@@ -27,7 +28,7 @@ class ProfileStatColumn extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final column = MediaQuery.withClampedTextScaling(
-      maxScaleFactor: 1.5,
+      maxScaleFactor: statColumnTextScaleLimit,
       child: Padding(
         padding: const .symmetric(horizontal: 4),
         child: Column(

--- a/mobile/lib/widgets/profile/profile_stats_row_widget.dart
+++ b/mobile/lib/widgets/profile/profile_stats_row_widget.dart
@@ -26,32 +26,41 @@ class ProfileStatColumn extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final column = Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        AnimatedSwitcher(
-          duration: const Duration(milliseconds: 300),
-          child: Text(
-            isLoading || count == null
-                ? '—'
-                : StringUtils.formatCompactNumber(count!),
-            key: ValueKey(isLoading ? 'loading' : count),
-            style: VineTheme.statNumberFont(
-              color: isLoading || count == null
-                  ? context.vineColors.onSurfaceMuted
-                  : context.vineColors.primaryText,
+    final column = MediaQuery.withClampedTextScaling(
+      maxScaleFactor: 1.5,
+      child: Padding(
+        padding: const .symmetric(horizontal: 4),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            AnimatedSwitcher(
+              duration: const Duration(milliseconds: 300),
+              child: Text(
+                isLoading || count == null
+                    ? '—'
+                    : StringUtils.formatCompactNumber(count!),
+                key: ValueKey(isLoading ? 'loading' : count),
+                style: VineTheme.statNumberFont(
+                  color: isLoading || count == null
+                      ? context.vineColors.onSurfaceMuted
+                      : context.vineColors.primaryText,
+                ),
+              ),
             ),
-          ),
-        ),
-        Skeleton.keep(
-          child: Text(
-            label,
-            style: VineTheme.bodySmallFont(
-              color: context.vineColors.onSurfaceVariant,
+            Skeleton.keep(
+              child: Text(
+                label,
+                style: VineTheme.bodySmallFont(
+                  color: context.vineColors.onSurfaceVariant,
+                ),
+                softWrap: false,
+                maxLines: 1,
+                overflow: .fade,
+              ),
             ),
-          ),
+          ],
         ),
-      ],
+      ),
     );
 
     if (onTap != null) {

--- a/mobile/lib/widgets/trending_hashtags_section.dart
+++ b/mobile/lib/widgets/trending_hashtags_section.dart
@@ -39,23 +39,26 @@ class TrendingHashtagsSection extends StatelessWidget {
       color: context.vineColors.background,
       child: SizedBox(
         height: 52,
-        child: Row(
-          children: [
-            if (leading != null)
-              Padding(
-                padding: const EdgeInsetsDirectional.only(start: 12, end: 6),
-                child: Center(child: leading),
+        child: MediaQuery.withClampedTextScaling(
+          maxScaleFactor: 1.25,
+          child: Row(
+            children: [
+              if (leading != null)
+                Padding(
+                  padding: const EdgeInsetsDirectional.only(start: 12, end: 6),
+                  child: Center(child: leading),
+                ),
+              Expanded(
+                child: hashtags.isEmpty
+                    ? const _HashtagLoadingPlaceholder()
+                    : _HashtagChipList(
+                        hashtags: hashtags,
+                        leadingInset: leading == null ? 16 : 0,
+                        onHashtagTap: onHashtagTap,
+                      ),
               ),
-            Expanded(
-              child: hashtags.isEmpty
-                  ? const _HashtagLoadingPlaceholder()
-                  : _HashtagChipList(
-                      hashtags: hashtags,
-                      leadingInset: leading == null ? 16 : 0,
-                      onHashtagTap: onHashtagTap,
-                    ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/widgets/trending_hashtags_section.dart
+++ b/mobile/lib/widgets/trending_hashtags_section.dart
@@ -4,6 +4,7 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:openvine/constants/text_scale_limits.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
 
@@ -40,7 +41,7 @@ class TrendingHashtagsSection extends StatelessWidget {
       child: SizedBox(
         height: 52,
         child: MediaQuery.withClampedTextScaling(
-          maxScaleFactor: 1.25,
+          maxScaleFactor: fixedRowTextScaleLimit,
           child: Row(
             children: [
               if (leading != null)

--- a/mobile/lib/widgets/video_editor/audio_editor/video_editor_audio_chip.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/video_editor_audio_chip.dart
@@ -1,6 +1,7 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:models/models.dart' show AudioEvent;
+import 'package:openvine/constants/text_scale_limits.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/screens/video_editor/video_audio_editor_timing_screen.dart';
@@ -93,7 +94,7 @@ class VideoEditorAudioChip extends StatelessWidget {
       child: Material(
         type: .transparency,
         child: MediaQuery.withClampedTextScaling(
-          maxScaleFactor: 1.4,
+          maxScaleFactor: chipLabelTextScaleLimit,
           child: InkWell(
             onTap: () => _selectAudio(context),
             borderRadius: .circular(16),
@@ -108,26 +109,7 @@ class VideoEditorAudioChip extends StatelessWidget {
                 mainAxisSize: .min,
                 mainAxisAlignment: .center,
                 children: [
-                  Row(
-                    spacing: MediaQuery.textScalerOf(context).scale(1.5),
-                    children: [
-                      _AudioBar(
-                        height: MediaQuery.textScalerOf(context).scale(7),
-                      ),
-                      _AudioBar(
-                        height: MediaQuery.textScalerOf(context).scale(16),
-                      ),
-                      _AudioBar(
-                        height: MediaQuery.textScalerOf(context).scale(13),
-                      ),
-                      _AudioBar(
-                        height: MediaQuery.textScalerOf(context).scale(7),
-                      ),
-                      _AudioBar(
-                        height: MediaQuery.textScalerOf(context).scale(10),
-                      ),
-                    ],
-                  ),
+                  const _AudioBars(),
                   Flexible(
                     child: Padding(
                       padding: const .symmetric(horizontal: 8),
@@ -177,17 +159,43 @@ class VideoEditorAudioChip extends StatelessWidget {
   }
 }
 
+/// The five-bar waveform glyph that stands in for an icon on the chip.
+///
+/// Its own build context sits below the chip's
+/// [MediaQuery.withClampedTextScaling], so reading the scaler here — rather
+/// than in the chip's `build` — is what keeps the bars inside the clamp the
+/// label beside them obeys.
+class _AudioBars extends StatelessWidget {
+  const _AudioBars();
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      spacing: DivineIcon.scaleSize(context, 1.5),
+      children: const [
+        _AudioBar(height: 7),
+        _AudioBar(height: 16),
+        _AudioBar(height: 13),
+        _AudioBar(height: 7),
+        _AudioBar(height: 10),
+      ],
+    );
+  }
+}
+
 class _AudioBar extends StatelessWidget {
   const _AudioBar({required this.height});
 
+  /// Height at 1.0x text scale. Scaled here rather than by the caller so
+  /// the value stays inside the chip's clamped subtree.
   final double height;
 
   @override
   Widget build(BuildContext context) {
     return AnimatedContainer(
       duration: const Duration(milliseconds: 150),
-      width: 2,
-      height: height,
+      width: DivineIcon.scaleSize(context, 2),
+      height: DivineIcon.scaleSize(context, height),
       decoration: BoxDecoration(
         color: VineTheme.whiteText,
         borderRadius: .circular(2),

--- a/mobile/lib/widgets/video_editor/audio_editor/video_editor_audio_chip.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/video_editor_audio_chip.dart
@@ -92,72 +92,83 @@ class VideoEditorAudioChip extends StatelessWidget {
       tag: VideoEditorConstants.heroAudioChipId,
       child: Material(
         type: .transparency,
-        child: InkWell(
-          onTap: () => _selectAudio(context),
-          borderRadius: .circular(16),
-          child: Container(
-            constraints: const BoxConstraints(minHeight: 40),
-            padding: const .fromLTRB(16, 8, 8, 8),
-            decoration: ShapeDecoration(
-              color: VineTheme.scrim15,
-              shape: RoundedRectangleBorder(borderRadius: .circular(16)),
-            ),
-            child: Row(
-              mainAxisSize: .min,
-              mainAxisAlignment: .center,
-              children: [
-                const Row(
-                  spacing: 1.5,
-                  children: [
-                    _AudioBar(height: 7),
-                    _AudioBar(height: 16),
-                    _AudioBar(height: 13),
-                    _AudioBar(height: 7),
-                    _AudioBar(height: 10),
-                  ],
-                ),
-                Flexible(
-                  child: Padding(
-                    padding: const .symmetric(horizontal: 8),
-                    child: hasSelectedSound
-                        ? Text.rich(
-                            textScaler: TextScaler.noScaling,
-                            TextSpan(
-                              style: VineTheme.labelLargeFont(
+        child: MediaQuery.withClampedTextScaling(
+          maxScaleFactor: 1.4,
+          child: InkWell(
+            onTap: () => _selectAudio(context),
+            borderRadius: .circular(16),
+            child: Container(
+              constraints: const BoxConstraints(minHeight: 40),
+              padding: const .fromLTRB(16, 8, 8, 8),
+              decoration: ShapeDecoration(
+                color: VineTheme.scrim15,
+                shape: RoundedRectangleBorder(borderRadius: .circular(16)),
+              ),
+              child: Row(
+                mainAxisSize: .min,
+                mainAxisAlignment: .center,
+                children: [
+                  Row(
+                    spacing: MediaQuery.textScalerOf(context).scale(1.5),
+                    children: [
+                      _AudioBar(
+                        height: MediaQuery.textScalerOf(context).scale(7),
+                      ),
+                      _AudioBar(
+                        height: MediaQuery.textScalerOf(context).scale(16),
+                      ),
+                      _AudioBar(
+                        height: MediaQuery.textScalerOf(context).scale(13),
+                      ),
+                      _AudioBar(
+                        height: MediaQuery.textScalerOf(context).scale(7),
+                      ),
+                      _AudioBar(
+                        height: MediaQuery.textScalerOf(context).scale(10),
+                      ),
+                    ],
+                  ),
+                  Flexible(
+                    child: Padding(
+                      padding: const .symmetric(horizontal: 8),
+                      child: hasSelectedSound
+                          ? Text.rich(
+                              TextSpan(
+                                style: VineTheme.labelLargeFont(
+                                  color: VineTheme.whiteText,
+                                ),
+                                children: [
+                                  TextSpan(
+                                    text:
+                                        selectedSound?.title ??
+                                        context.l10n.videoEditorAudioUntitled,
+                                  ),
+                                  if (selectedSound?.source != null) ...[
+                                    const TextSpan(text: ' ∙ '),
+                                    TextSpan(
+                                      text: selectedSound!.source,
+                                      style: VineTheme.bodyMediumFont(
+                                        color: VineTheme.whiteText,
+                                      ),
+                                    ),
+                                  ],
+                                ],
+                              ),
+                              textAlign: .center,
+                              maxLines: 1,
+                              overflow: .ellipsis,
+                            )
+                          : Text(
+                              context.l10n.videoEditorAudioAddAudio,
+                              textAlign: .center,
+                              style: VineTheme.titleMediumFont(
                                 color: VineTheme.whiteText,
                               ),
-                              children: [
-                                TextSpan(
-                                  text:
-                                      selectedSound?.title ??
-                                      context.l10n.videoEditorAudioUntitled,
-                                ),
-                                if (selectedSound?.source != null) ...[
-                                  const TextSpan(text: ' ∙ '),
-                                  TextSpan(
-                                    text: selectedSound!.source,
-                                    style: VineTheme.bodyMediumFont(
-                                      color: VineTheme.whiteText,
-                                    ),
-                                  ),
-                                ],
-                              ],
                             ),
-                            textAlign: .center,
-                            maxLines: 1,
-                            overflow: .ellipsis,
-                          )
-                        : Text(
-                            context.l10n.videoEditorAudioAddAudio,
-                            textAlign: .center,
-                            textScaler: TextScaler.noScaling,
-                            style: VineTheme.titleMediumFont(
-                              color: VineTheme.whiteText,
-                            ),
-                          ),
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_main_actions_sheet.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_main_actions_sheet.dart
@@ -7,6 +7,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/blocs/video_editor/tune_editor/video_editor_tune_bloc.dart';
+import 'package:openvine/constants/text_scale_limits.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
@@ -251,7 +252,7 @@ class _ItemButton extends StatelessWidget {
         Semantics(
           excludeSemantics: true,
           child: MediaQuery.withClampedTextScaling(
-            maxScaleFactor: 1.4,
+            maxScaleFactor: chipLabelTextScaleLimit,
             child: Text(
               label,
               maxLines: 1,

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_main_actions_sheet.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_main_actions_sheet.dart
@@ -250,12 +250,15 @@ class _ItemButton extends StatelessWidget {
         ),
         Semantics(
           excludeSemantics: true,
-          child: Text(
-            label,
-            maxLines: 1,
-            textAlign: .center,
-            style: VineTheme.bodySmallFont(
-              color: context.vineColors.primaryText,
+          child: MediaQuery.withClampedTextScaling(
+            maxScaleFactor: 1.4,
+            child: Text(
+              label,
+              maxLines: 1,
+              textAlign: .center,
+              style: VineTheme.bodySmallFont(
+                color: context.vineColors.primaryText,
+              ),
             ),
           ),
         ),

--- a/mobile/lib/widgets/video_editor/text_editor/video_editor_text_style_bar.dart
+++ b/mobile/lib/widgets/video_editor/text_editor/video_editor_text_style_bar.dart
@@ -142,7 +142,7 @@ class _ColorSwatchButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final dimension = MediaQuery.textScalerOf(context).scale(20);
+    final dimension = DivineIcon.scaleSize(context, 20);
     return Semantics(
       label: semanticsLabel,
       button: true,

--- a/mobile/lib/widgets/video_editor/text_editor/video_editor_text_style_bar.dart
+++ b/mobile/lib/widgets/video_editor/text_editor/video_editor_text_style_bar.dart
@@ -142,6 +142,7 @@ class _ColorSwatchButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final dimension = MediaQuery.textScalerOf(context).scale(20);
     return Semantics(
       label: semanticsLabel,
       button: true,
@@ -162,8 +163,8 @@ class _ColorSwatchButton extends StatelessWidget {
           child: Padding(
             padding: const EdgeInsets.all(10),
             child: Container(
-              width: 20,
-              height: 20,
+              width: dimension,
+              height: dimension,
               decoration: BoxDecoration(color: color, shape: BoxShape.circle),
             ),
           ),

--- a/mobile/lib/widgets/video_feed_item/actions/video_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/video_action_button.dart
@@ -187,9 +187,12 @@ class _VideoActionCaption extends StatelessWidget {
           shadows: VineTheme.buttonShadows,
         ),
         textAlign: TextAlign.center,
+        // `softWrap: false` keeps a long count on one line so the width
+        // genuinely overflows; with the default the text wraps, is cut at
+        // one line, and ellipsizes off the wrap instead of the width.
         softWrap: false,
         maxLines: 1,
-        overflow: TextOverflow.fade,
+        overflow: TextOverflow.ellipsis,
       ),
     );
   }

--- a/mobile/lib/widgets/video_feed_item/actions/video_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/video_action_button.dart
@@ -187,8 +187,9 @@ class _VideoActionCaption extends StatelessWidget {
           shadows: VineTheme.buttonShadows,
         ),
         textAlign: TextAlign.center,
+        softWrap: false,
         maxLines: 1,
-        overflow: TextOverflow.ellipsis,
+        overflow: TextOverflow.fade,
       ),
     );
   }

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory, NIP71VideoKinds;
 import 'package:openvine/constants/semantic_ids.dart';
+import 'package:openvine/constants/text_scale_limits.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/l10n.dart';
@@ -675,7 +676,7 @@ class VideoOverlayActionColumn extends ConsumerWidget {
     final showEditButton = !isPreviewMode && isOwnVideo;
 
     return MediaQuery.withClampedTextScaling(
-      maxScaleFactor: 1.3,
+      maxScaleFactor: overlayActionColumnTextScaleLimit,
       child: Column(
         spacing: 20,
         children: [

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -674,42 +674,48 @@ class VideoOverlayActionColumn extends ConsumerWidget {
         currentUserPubkey != null && currentUserPubkey == video.pubkey;
     final showEditButton = !isPreviewMode && isOwnVideo;
 
-    return Column(
-      spacing: 20,
-      children: [
-        if (showEditButton)
-          EditActionButton(video: video, onInteracted: onInteracted),
-        LikeActionButton(
-          video: video,
-          isPreviewMode: isPreviewMode,
-          isOwnVideo: isOwnVideo,
-          onInteracted: onInteracted,
-        ),
-        CommentActionButton(
-          video: video,
-          isPreviewMode: isPreviewMode,
-          onInteracted: onInteracted,
-        ),
-        RepostActionButton(
-          video: video,
-          isPreviewMode: isPreviewMode,
-          isOwnVideo: isOwnVideo,
-          onInteracted: onInteracted,
-        ),
-        ShareActionButton(video: video, onInteracted: onInteracted),
-        if (!isOwnVideo) ...[
-          ReportActionButton(video: video, onInteracted: onInteracted),
-          // Gate the slot itself so a default-off build inserts no child
-          // into Column(spacing: 20) — a hidden SizedBox.shrink would still
-          // add a permanent gap between Report and More. The button keeps its
-          // own defensive checks for the repository/pubkey readiness case.
-          if (ref.watch(
-            isFeatureEnabledProvider(FeatureFlag.communityContentWarnings),
-          ))
-            HelpClassifyActionButton(video: video, onInteracted: onInteracted),
+    return MediaQuery.withClampedTextScaling(
+      maxScaleFactor: 1.3,
+      child: Column(
+        spacing: 20,
+        children: [
+          if (showEditButton)
+            EditActionButton(video: video, onInteracted: onInteracted),
+          LikeActionButton(
+            video: video,
+            isPreviewMode: isPreviewMode,
+            isOwnVideo: isOwnVideo,
+            onInteracted: onInteracted,
+          ),
+          CommentActionButton(
+            video: video,
+            isPreviewMode: isPreviewMode,
+            onInteracted: onInteracted,
+          ),
+          RepostActionButton(
+            video: video,
+            isPreviewMode: isPreviewMode,
+            isOwnVideo: isOwnVideo,
+            onInteracted: onInteracted,
+          ),
+          ShareActionButton(video: video, onInteracted: onInteracted),
+          if (!isOwnVideo) ...[
+            ReportActionButton(video: video, onInteracted: onInteracted),
+            // Gate the slot itself so a default-off build inserts no child
+            // into Column(spacing: 20) — a hidden SizedBox.shrink would still
+            // add a permanent gap between Report and More. The button keeps its
+            // own defensive checks for the repository/pubkey readiness case.
+            if (ref.watch(
+              isFeatureEnabledProvider(FeatureFlag.communityContentWarnings),
+            ))
+              HelpClassifyActionButton(
+                video: video,
+                onInteracted: onInteracted,
+              ),
+          ],
+          MoreActionButton(video: video, onInteracted: onInteracted),
         ],
-        MoreActionButton(video: video, onInteracted: onInteracted),
-      ],
+      ),
     );
   }
 }

--- a/mobile/lib/widgets/vine_bottom_nav.dart
+++ b/mobile/lib/widgets/vine_bottom_nav.dart
@@ -141,59 +141,62 @@ class VineBottomNav extends ConsumerWidget {
                 ((constraints.maxWidth - totalIconWidth - totalEdgePad) / 8)
                     .clamp(0.0, double.infinity);
 
-            return Row(
-              children: [
-                _HomeTabButton(
-                  semanticLabel: context.l10n.navHome,
-                  isSelected: currentIndex == 0,
-                  isRefreshing: isHomeRefreshing,
-                  onTap: () => _handleTabTap(context, ref, 0),
-                  tapTargetWidth: _kHorizontalEdgePad + iconWidth + halfGap,
-                  iconAlignment: AlignmentDirectional.centerStart,
-                  edgePadding: const EdgeInsetsDirectional.only(
-                    start: _kHorizontalEdgePad,
+            return MediaQuery.withClampedTextScaling(
+              maxScaleFactor: 1.25,
+              child: Row(
+                children: [
+                  _HomeTabButton(
+                    semanticLabel: context.l10n.navHome,
+                    isSelected: currentIndex == 0,
+                    isRefreshing: isHomeRefreshing,
+                    onTap: () => _handleTabTap(context, ref, 0),
+                    tapTargetWidth: _kHorizontalEdgePad + iconWidth + halfGap,
+                    iconAlignment: AlignmentDirectional.centerStart,
+                    edgePadding: const EdgeInsetsDirectional.only(
+                      start: _kHorizontalEdgePad,
+                    ),
                   ),
-                ),
-                _IconTabButton(
-                  semanticIdentifier: SemanticIds.exploreTab,
-                  semanticLabel: context.l10n.navExplore,
-                  icon: DivineIconName.search,
-                  isSelected: currentIndex == 1,
-                  onTap: () => _handleTabTap(context, ref, 1),
-                  tapTargetWidth: iconWidth + halfGap * 2,
-                ),
-                // Camera button in center of bottom nav
-                _CameraButton(
-                  tapTargetWidth: cameraWidth + halfGap * 2,
-                  onTap: () {
-                    Log.info(
-                      '👆 User tapped camera button',
-                      name: 'Navigation',
-                      category: LogCategory.ui,
-                    );
-                    context.pushToCameraWithPermission();
-                  },
-                ),
-                _IconTabButton(
-                  semanticIdentifier: 'inbox_tab',
-                  semanticLabel: context.l10n.navInbox,
-                  icon: DivineIconName.chat,
-                  isSelected: currentIndex == 2,
-                  onTap: () => _handleTabTap(context, ref, 2),
-                  tapTargetWidth: iconWidth + halfGap * 2,
-                  badgeCount: _inboxUnreadCount(context, ref),
-                ),
-                _ProfileTabButton(
-                  semanticLabel: context.l10n.navProfile,
-                  isSelected: currentIndex == 3,
-                  onTap: () => _handleTabTap(context, ref, 3),
-                  tapTargetWidth: iconWidth + halfGap + _kHorizontalEdgePad,
-                  iconAlignment: AlignmentDirectional.centerEnd,
-                  edgePadding: const EdgeInsetsDirectional.only(
-                    end: _kHorizontalEdgePad,
+                  _IconTabButton(
+                    semanticIdentifier: SemanticIds.exploreTab,
+                    semanticLabel: context.l10n.navExplore,
+                    icon: DivineIconName.search,
+                    isSelected: currentIndex == 1,
+                    onTap: () => _handleTabTap(context, ref, 1),
+                    tapTargetWidth: iconWidth + halfGap * 2,
                   ),
-                ),
-              ],
+                  // Camera button in center of bottom nav
+                  _CameraButton(
+                    tapTargetWidth: cameraWidth + halfGap * 2,
+                    onTap: () {
+                      Log.info(
+                        '👆 User tapped camera button',
+                        name: 'Navigation',
+                        category: LogCategory.ui,
+                      );
+                      context.pushToCameraWithPermission();
+                    },
+                  ),
+                  _IconTabButton(
+                    semanticIdentifier: 'inbox_tab',
+                    semanticLabel: context.l10n.navInbox,
+                    icon: DivineIconName.chat,
+                    isSelected: currentIndex == 2,
+                    onTap: () => _handleTabTap(context, ref, 2),
+                    tapTargetWidth: iconWidth + halfGap * 2,
+                    badgeCount: _inboxUnreadCount(context, ref),
+                  ),
+                  _ProfileTabButton(
+                    semanticLabel: context.l10n.navProfile,
+                    isSelected: currentIndex == 3,
+                    onTap: () => _handleTabTap(context, ref, 3),
+                    tapTargetWidth: iconWidth + halfGap + _kHorizontalEdgePad,
+                    iconAlignment: AlignmentDirectional.centerEnd,
+                    edgePadding: const EdgeInsetsDirectional.only(
+                      end: _kHorizontalEdgePad,
+                    ),
+                  ),
+                ],
+              ),
             );
           },
         ),

--- a/mobile/lib/widgets/vine_bottom_nav.dart
+++ b/mobile/lib/widgets/vine_bottom_nav.dart
@@ -12,6 +12,7 @@ import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
 import 'package:openvine/blocs/notifications/badge/notification_badge_cubit.dart';
 import 'package:openvine/constants/semantic_ids.dart';
+import 'package:openvine/constants/text_scale_limits.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
@@ -142,7 +143,7 @@ class VineBottomNav extends ConsumerWidget {
                     .clamp(0.0, double.infinity);
 
             return MediaQuery.withClampedTextScaling(
-              maxScaleFactor: 1.25,
+              maxScaleFactor: fixedRowTextScaleLimit,
               child: Row(
                 children: [
                   _HomeTabButton(

--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_action_menu.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_action_menu.dart
@@ -112,9 +112,8 @@ class _VineBottomSheetListTile extends StatelessWidget {
       child: ListTile(
         enabled: isEnabled,
         minTileHeight: 56,
-        leading: SizedBox(
-          height: 24,
-          width: 24,
+        leading: SizedBox.square(
+          dimension: DivineIcon.scaleSize(context, 24),
           child: SvgPicture.asset(
             data.iconPath,
             colorFilter: .mode(color, .srcIn),

--- a/mobile/packages/divine_ui/lib/src/button/divine_button.dart
+++ b/mobile/packages/divine_ui/lib/src/button/divine_button.dart
@@ -206,7 +206,10 @@ class _DivineButtonContent extends StatelessWidget {
   /// inside the 32px visible chip, small/base use 24px.
   ///
   /// Unscaled — [DivineIcon] applies the text scaler itself. The loading
-  /// spinner is not a [DivineIcon], so it scales this explicitly.
+  /// spinner is not a [DivineIcon], so it scales this through
+  /// [DivineIcon.scaleSize] to land on the same size as the icon it
+  /// replaces; otherwise the button resizes when it enters the loading
+  /// state.
   double get _iconSize => switch (size) {
     DivineButtonSize.tiny => 20,
     DivineButtonSize.small => 24,
@@ -345,7 +348,7 @@ class _DivineButtonContent extends StatelessWidget {
       children: [
         if (isLoading)
           SizedBox.square(
-            dimension: MediaQuery.textScalerOf(context).scale(_iconSize),
+            dimension: DivineIcon.scaleSize(context, _iconSize),
             child: CircularProgressIndicator(
               strokeWidth: 2,
               valueColor: AlwaysStoppedAnimation<Color>(foregroundColor),

--- a/mobile/packages/divine_ui/lib/src/button/divine_button.dart
+++ b/mobile/packages/divine_ui/lib/src/button/divine_button.dart
@@ -204,6 +204,9 @@ class _DivineButtonContent extends StatelessWidget {
 
   /// Icon size scales with [size]: tiny uses a smaller 20px icon to fit
   /// inside the 32px visible chip, small/base use 24px.
+  ///
+  /// Unscaled — [DivineIcon] applies the text scaler itself. The loading
+  /// spinner is not a [DivineIcon], so it scales this explicitly.
   double get _iconSize => switch (size) {
     DivineButtonSize.tiny => 20,
     DivineButtonSize.small => 24,
@@ -341,9 +344,8 @@ class _DivineButtonContent extends StatelessWidget {
       spacing: _noLabel ? 0 : 8,
       children: [
         if (isLoading)
-          SizedBox(
-            width: _iconSize,
-            height: _iconSize,
+          SizedBox.square(
+            dimension: MediaQuery.textScalerOf(context).scale(_iconSize),
             child: CircularProgressIndicator(
               strokeWidth: 2,
               valueColor: AlwaysStoppedAnimation<Color>(foregroundColor),

--- a/mobile/packages/divine_ui/lib/src/button/divine_icon_button.dart
+++ b/mobile/packages/divine_ui/lib/src/button/divine_icon_button.dart
@@ -309,14 +309,18 @@ class _DivineIconButtonContent extends StatelessWidget {
     return VineTheme.buttonBoxShadowsFor(colors);
   }
 
-  Widget _iconWidget(Color iconColor) {
+  Widget _iconWidget(BuildContext context, Color iconColor) {
     final source = iconSource;
+    // Raw SvgPicture / Icon need the scaler applied here; the DivineIcon
+    // fallback below applies it itself, so it stays on its 24px default.
+    final size = MediaQuery.textScalerOf(context).scale(24);
+
     if (source != null) {
       return switch (source) {
         SvgIconSource(:final assetPath) => SvgPicture.asset(
           assetPath,
-          width: 24,
-          height: 24,
+          width: size,
+          height: size,
           colorFilter: ColorFilter.mode(iconColor, BlendMode.srcIn),
         ),
         // Still rendered for existing deprecated MaterialIconSource call
@@ -326,7 +330,7 @@ class _DivineIconButtonContent extends StatelessWidget {
         MaterialIconSource(:final iconData) => Icon(
           iconData,
           color: iconColor,
-          size: 24,
+          size: size,
         ),
       };
     }
@@ -338,7 +342,7 @@ class _DivineIconButtonContent extends StatelessWidget {
     final colors = context.vineColors;
     final iconColor = _resolveIconColor(colors);
     final borderColor = _borderColor(colors);
-    var iconWidget = _iconWidget(iconColor);
+    var iconWidget = _iconWidget(context, iconColor);
     if (tooltip != null) {
       iconWidget = Tooltip(message: tooltip, child: iconWidget);
     }
@@ -365,7 +369,10 @@ class _DivineIconButtonContent extends StatelessWidget {
     // space — a `Padding` outside the InkWell only reserves space, it
     // doesn't capture taps.
     final tapTarget = size == DivineIconButtonSize.small
-        ? SizedBox(width: 48, height: 48, child: Center(child: inkBox))
+        ? SizedBox.square(
+            dimension: MediaQuery.textScalerOf(context).scale(48),
+            child: Center(child: inkBox),
+          )
         : inkBox;
 
     return Semantics(

--- a/mobile/packages/divine_ui/lib/src/button/divine_icon_button.dart
+++ b/mobile/packages/divine_ui/lib/src/button/divine_icon_button.dart
@@ -312,8 +312,9 @@ class _DivineIconButtonContent extends StatelessWidget {
   Widget _iconWidget(BuildContext context, Color iconColor) {
     final source = iconSource;
     // Raw SvgPicture / Icon need the scaler applied here; the DivineIcon
-    // fallback below applies it itself, so it stays on its 24px default.
-    final size = MediaQuery.textScalerOf(context).scale(24);
+    // fallback below applies the same one itself, so it stays on its 24px
+    // default. Both branches must land on the same rendered size.
+    final size = DivineIcon.scaleSize(context, 24);
 
     if (source != null) {
       return switch (source) {
@@ -370,7 +371,7 @@ class _DivineIconButtonContent extends StatelessWidget {
     // doesn't capture taps.
     final tapTarget = size == DivineIconButtonSize.small
         ? SizedBox.square(
-            dimension: MediaQuery.textScalerOf(context).scale(48),
+            dimension: DivineIcon.scaleSize(context, 48),
             child: Center(child: inkBox),
           )
         : inkBox;

--- a/mobile/packages/divine_ui/lib/src/icon/divine_icon.dart
+++ b/mobile/packages/divine_ui/lib/src/icon/divine_icon.dart
@@ -269,12 +269,24 @@ class DivineIcon extends StatelessWidget {
   /// avatar.
   final BoxFit fit;
 
+  /// Upper bound on how far [size] grows with the system text scale.
+  ///
+  /// Icons track the text scale so they stay proportional to the labels
+  /// they sit next to, but unbounded growth breaks tight layouts — at the
+  /// 2.0x platform maximum a 24px icon would render at 48px and overflow
+  /// narrow rows. Callers must not pre-scale [size]; this widget owns it.
+  static const _kMaxIconScaleFactor = 1.3;
+
   @override
   Widget build(BuildContext context) {
+    final dimension = MediaQuery.textScalerOf(
+      context,
+    ).clamp(maxScaleFactor: _kMaxIconScaleFactor).scale(size);
+
     return SvgPicture.asset(
       icon.assetPath,
-      width: size,
-      height: size,
+      width: dimension,
+      height: dimension,
       fit: fit,
       colorFilter: color != null
           ? ColorFilter.mode(color!, BlendMode.srcIn)

--- a/mobile/packages/divine_ui/lib/src/icon/divine_icon.dart
+++ b/mobile/packages/divine_ui/lib/src/icon/divine_icon.dart
@@ -275,13 +275,25 @@ class DivineIcon extends StatelessWidget {
   /// they sit next to, but unbounded growth breaks tight layouts — at the
   /// 2.0x platform maximum a 24px icon would render at 48px and overflow
   /// narrow rows. Callers must not pre-scale [size]; this widget owns it.
-  static const _kMaxIconScaleFactor = 1.3;
+  static const maxScaleFactor = 1.3;
+
+  /// Applies the system text scale to [size], capped at [maxScaleFactor].
+  ///
+  /// Use this for icon-sized chrome that [DivineIcon] does not render
+  /// itself — a raw [Icon] or `SvgPicture`, a spinner standing in for an
+  /// icon, or a tap target sized off one — so it grows on the same curve
+  /// and stops at the same bound as the icons beside it.
+  ///
+  /// Do **not** use it on a [size] passed to [DivineIcon]: that scales the
+  /// value twice, squaring the factor.
+  static double scaleSize(BuildContext context, double size) =>
+      MediaQuery.textScalerOf(
+        context,
+      ).clamp(maxScaleFactor: maxScaleFactor).scale(size);
 
   @override
   Widget build(BuildContext context) {
-    final dimension = MediaQuery.textScalerOf(
-      context,
-    ).clamp(maxScaleFactor: _kMaxIconScaleFactor).scale(size);
+    final dimension = scaleSize(context, size);
 
     return SvgPicture.asset(
       icon.assetPath,

--- a/mobile/packages/divine_ui/test/src/bottom_sheet/vine_bottom_sheet_action_menu_test.dart
+++ b/mobile/packages/divine_ui/test/src/bottom_sheet/vine_bottom_sheet_action_menu_test.dart
@@ -268,6 +268,53 @@ void main() {
 
       expect(find.text('Action'), findsNothing);
     });
+
+    testWidgets('leading icon grows with the system text scale', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          // Wraps the Navigator, so the sheet's own route inherits the
+          // scale too — a MediaQuery under `home` would not reach it.
+          builder: (context, child) => MediaQuery(
+            data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+            child: child!,
+          ),
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () => VineBottomSheetActionMenu.show(
+                  context: context,
+                  options: [
+                    VineBottomSheetActionData(
+                      iconPath: testIconPath,
+                      label: 'Edit',
+                      onTap: () {},
+                    ),
+                  ],
+                ),
+                child: const Text('Show Menu'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show Menu'));
+      await tester.pumpAndSettle();
+
+      final leading = tester.getSize(
+        find
+            .ancestor(
+              of: find.byType(SvgPicture),
+              matching: find.byType(SizedBox),
+            )
+            .first,
+      );
+
+      expect(leading.width, closeTo(24 * DivineIcon.maxScaleFactor, 0.001));
+      expect(leading.height, leading.width);
+    });
   });
 
   group('VineBottomSheetActionData', () {

--- a/mobile/packages/divine_ui/test/src/button/divine_button_test.dart
+++ b/mobile/packages/divine_ui/test/src/button/divine_button_test.dart
@@ -1296,6 +1296,40 @@ void main() {
         expect(spacers, isEmpty);
       });
     });
+
+    group('text scaling', () {
+      Widget buildAtScale({required bool isLoading}) {
+        return MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+            child: Scaffold(
+              body: Center(
+                child: DivineButton(
+                  label: 'Save',
+                  onPressed: _noop,
+                  leadingIcon: DivineIconName.check,
+                  isLoading: isLoading,
+                ),
+              ),
+            ),
+          ),
+        );
+      }
+
+      testWidgets('loading spinner occupies the same box as the icon it '
+          'replaces', (tester) async {
+        await tester.pumpWidget(buildAtScale(isLoading: false));
+        final iconSize = tester.getSize(find.byType(SvgPicture));
+
+        await tester.pumpWidget(buildAtScale(isLoading: true));
+        final spinnerSize = tester.getSize(
+          find.byType(CircularProgressIndicator),
+        );
+
+        expect(iconSize.width, closeTo(24 * DivineIcon.maxScaleFactor, 0.001));
+        expect(spinnerSize, iconSize);
+      });
+    });
   });
 
   group('DivineTextLink', () {

--- a/mobile/packages/divine_ui/test/src/button/divine_icon_button_test.dart
+++ b/mobile/packages/divine_ui/test/src/button/divine_icon_button_test.dart
@@ -774,5 +774,80 @@ void main() {
         expect(pressed, isTrue);
       });
     });
+
+    group('text scaling', () {
+      Widget buildAtScale(Widget button) {
+        return MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+            child: Scaffold(body: Center(child: button)),
+          ),
+        );
+      }
+
+      testWidgets('renders the same icon size whichever source it is built '
+          'from', (tester) async {
+        await tester.pumpWidget(
+          buildAtScale(
+            DivineIconButton(icon: DivineIconName.x, onPressed: () {}),
+          ),
+        );
+        final fromName = tester
+            .widget<SvgPicture>(find.byType(SvgPicture))
+            .width;
+
+        await tester.pumpWidget(
+          buildAtScale(
+            DivineIconButton.fromSource(
+              icon: SvgIconSource(DivineIconName.x.assetPath),
+              onPressed: () {},
+            ),
+          ),
+        );
+        final fromSvgSource = tester
+            .widget<SvgPicture>(find.byType(SvgPicture))
+            .width;
+
+        await tester.pumpWidget(
+          buildAtScale(
+            DivineIconButton.fromSource(
+              icon: const MaterialIconSource(Icons.close),
+              onPressed: () {},
+            ),
+          ),
+        );
+        final fromMaterialSource = tester.widget<Icon>(find.byType(Icon)).size;
+
+        expect(fromName, closeTo(24 * DivineIcon.maxScaleFactor, 0.001));
+        expect(fromSvgSource, fromName);
+        expect(fromMaterialSource, fromName);
+      });
+
+      testWidgets('caps the small variant tap target with the icon', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildAtScale(
+            DivineIconButton(
+              icon: DivineIconName.x,
+              size: DivineIconButtonSize.small,
+              onPressed: () {},
+            ),
+          ),
+        );
+
+        final tapTarget = tester.getSize(
+          find
+              .descendant(
+                of: find.byType(DivineIconButton),
+                matching: find.byType(SizedBox),
+              )
+              .first,
+        );
+
+        expect(tapTarget.width, closeTo(48 * DivineIcon.maxScaleFactor, 0.001));
+        expect(tapTarget.height, tapTarget.width);
+      });
+    });
   });
 }

--- a/mobile/packages/divine_ui/test/src/icon/divine_icon_test.dart
+++ b/mobile/packages/divine_ui/test/src/icon/divine_icon_test.dart
@@ -175,4 +175,74 @@ void main() {
       expect(find.byType(DivineIcon), findsOneWidget);
     });
   });
+
+  group('DivineIcon text scaling', () {
+    Widget buildSubject({required double textScale, double size = 24}) {
+      return MaterialApp(
+        home: MediaQuery(
+          data: MediaQueryData(textScaler: TextScaler.linear(textScale)),
+          child: Scaffold(
+            body: DivineIcon(icon: DivineIconName.arrowLeft, size: size),
+          ),
+        ),
+      );
+    }
+
+    double renderedSize(WidgetTester tester) =>
+        tester.widget<SvgPicture>(find.byType(SvgPicture)).width!;
+
+    testWidgets('grows with the system text scale', (tester) async {
+      await tester.pumpWidget(buildSubject(textScale: 1.2));
+
+      expect(renderedSize(tester), closeTo(24 * 1.2, 0.001));
+    });
+
+    testWidgets('stops growing at maxScaleFactor', (tester) async {
+      await tester.pumpWidget(buildSubject(textScale: 2));
+
+      expect(
+        renderedSize(tester),
+        closeTo(24 * DivineIcon.maxScaleFactor, 0.001),
+      );
+    });
+
+    testWidgets('scales width and height together', (tester) async {
+      await tester.pumpWidget(buildSubject(textScale: 2, size: 40));
+
+      final svg = tester.widget<SvgPicture>(find.byType(SvgPicture));
+      expect(svg.width, svg.height);
+      expect(svg.width, closeTo(40 * DivineIcon.maxScaleFactor, 0.001));
+    });
+
+    testWidgets('scaleSize caps at maxScaleFactor, and a tighter ambient '
+        'clamp wins over it', (tester) async {
+      late double outer;
+      late double inner;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+            child: Builder(
+              builder: (context) {
+                outer = DivineIcon.scaleSize(context, 48);
+                return MediaQuery.withClampedTextScaling(
+                  maxScaleFactor: 1.1,
+                  child: Builder(
+                    builder: (context) {
+                      inner = DivineIcon.scaleSize(context, 48);
+                      return const SizedBox.shrink();
+                    },
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(outer, closeTo(48 * DivineIcon.maxScaleFactor, 0.001));
+      expect(inner, closeTo(48 * 1.1, 0.001));
+    });
+  });
 }

--- a/mobile/scripts/baseline/raw_textstyle.txt
+++ b/mobile/scripts/baseline/raw_textstyle.txt
@@ -54,7 +54,6 @@ lib/widgets/auth/auth_form_scaffold.dart	1
 lib/widgets/auth/auth_hero_section.dart	2
 lib/widgets/auth/forgot_password_dialog.dart	4
 lib/widgets/categories/category_glyph.dart	1
-lib/widgets/categories_tab.dart	2
 lib/widgets/classic_vines_tab.dart	7
 lib/widgets/composable_video_grid.dart	8
 lib/widgets/content_warning.dart	11

--- a/mobile/test/widgets/video_editor/audio_editor/video_editor_audio_chip_test.dart
+++ b/mobile/test/widgets/video_editor/audio_editor/video_editor_audio_chip_test.dart
@@ -182,5 +182,57 @@ void main() {
         expect(VideoEditorAudioChip.shouldOpenTimingScreen(sound), isTrue);
       });
     });
+
+    group('Text scaling', () {
+      Widget buildAtScale(double scale) {
+        return ProviderScope(
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: MediaQuery(
+              data: MediaQueryData(textScaler: TextScaler.linear(scale)),
+              child: Scaffold(
+                body: Center(
+                  child: VideoEditorAudioChip(
+                    selectedSound: null,
+                    onSoundChanged: (_) {},
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      }
+
+      // The waveform bars sit inside the chip's clamped subtree but are
+      // sized from their own build context. Reading the scaler from the
+      // chip's `build` instead would let them grow to the raw 2.0x while
+      // the label beside them stopped at the clamp.
+      testWidgets('waveform bars stay inside the chip clamp', (tester) async {
+        await tester.pumpWidget(buildAtScale(2));
+        await tester.pumpAndSettle();
+
+        final tallest = tester
+            .widgetList<AnimatedContainer>(find.byType(AnimatedContainer))
+            .map((bar) => bar.constraints?.maxHeight ?? 0)
+            .reduce((a, b) => a > b ? a : b);
+
+        expect(tallest, closeTo(16 * DivineIcon.maxScaleFactor, 0.001));
+      });
+
+      testWidgets('waveform bars grow with a scale under the clamp', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildAtScale(1.1));
+        await tester.pumpAndSettle();
+
+        final tallest = tester
+            .widgetList<AnimatedContainer>(find.byType(AnimatedContainer))
+            .map((bar) => bar.constraints?.maxHeight ?? 0)
+            .reduce((a, b) => a > b ? a : b);
+
+        expect(tallest, closeTo(16 * 1.1, 0.001));
+      });
+    });
   });
 }


### PR DESCRIPTION
Closes #6845

## What

Icons and tight layouts now survive the system font-scale setting.

Icons stayed at their fixed pixel size while labels grew with the system text scale, so at large font settings the icons shrank visually relative to the text they sit next to and rows drifted out of proportion. Icon-sized chrome now tracks the text scale, under one shared cap.

## Why these specific choices

**Why one shared scaler, capped at 1.3x.** `DivineIcon.maxScaleFactor` and `DivineIcon.scaleSize(context, size)` are the single contract: `DivineIcon` applies it to its own `size`, and everything sized to *match* an icon calls `scaleSize` — both `DivineIconButton` icon branches, its small-variant tap target, the `DivineButton` loading spinner, the action-menu sheet's leading icon, the raw Material icons in the settings screens, the classic-viners star, the text-editor colour swatch, the video-reply circle and the audio chip's waveform bars. The cap is not arbitrary: uncapped, a 24px icon renders at 48px at the 2.0x platform maximum, which overflows narrow rows — `crossposting_settings_screen_test`'s "narrow viewport and enlarged text do not overflow" case (320pt, 2.0x) catches this and fails without the clamp.

One contract matters beyond tidiness. A cap that lives only inside `DivineIcon` leaves everything sized *against* an icon growing to the raw 2.0x: the same `DivineIconButton` would render a 31.2px glyph from a `DivineIconName` and a 48px one from an `SvgIconSource`, its tap target would reach 96px, and a `DivineButton` would change size when it swapped a 31.2px icon for a 48px spinner.

**Why nine call sites lost their `MediaQuery.textScalerOf(...).scale(...)`.** Once `DivineIcon` owns the scaling, a pre-scaled `size` is applied twice — factor-squared, so 4x at the platform maximum. Those call sites now pass the raw design size. The same trap applied to `OgVinerBadge`, which derived its glyph's font size from an already-scaled dimension and then let the ambient scaler apply again; the glyph is a logo mark sized to its circle, so it opts out of the second pass.

**Why some screens clamp locally instead of opting out.** Screens whose layout cannot absorb unbounded growth wrap their subtree in `MediaQuery.withClampedTextScaling` (bottom nav, feed action column, comment input, content filters, trending hashtags, profile stats, video-editor chips). They still respond to the user's font preference, just within a bound the layout can hold — preferable to `TextScaler.noScaling`, which ignores the preference outright. The four bounds are named constants in `lib/constants/text_scale_limits.dart`, each documenting the constraint it encodes, so the next clamp added has a basis for picking one rather than a fifth bare number.

**Why the audio chip's waveform is its own widget.** The five bars were sized from the chip's `build` context, which sits *above* the `withClampedTextScaling` wrapping the rest of the chip — so the clamp never reached them, and at 2.0x the tallest bar rendered at 32px while the label beside it stopped at 22.4px. `_AudioBars` gives them a context below the clamp.

**Why `softWrap: false` on single-line labels.** With `maxLines: 1` and the default `softWrap: true`, Flutter wraps the text, cuts it at one line, and sets `textDidExceedMaxLines`. `RenderParagraph` picks its fade direction as `didOverflowWidth ? horizontal : vertical`, so the wrapped-then-cut case renders a *bottom* fade. `softWrap: false` keeps the text on one line so the width genuinely overflows and truncation reads horizontally. It is the whole fix — the video action captions keep the ellipsis they shipped with, since swapping in a fade would be a separate visual decision.

## Also in this branch

Drive-by cleanups in files this change already touched:

- Profile more-sheet uses `VineBottomSheetActionMenu` instead of two hand-rolled `InkWell` rows (61 lines to 17, and both entries now render through one code path — previously one used `SvgPicture.asset` and the other `DivineIcon`). That sheet rendered its leading icon in a hard-coded 24px box, so it now scales through `scaleSize` like every other icon.
- Category tile reads `VineTheme.headlineSmallFont` / `labelMediumFont` instead of inline `TextStyle`. Metrics are identical; both font families change, since the raw styles set no `fontFamily` and fell through to the platform default — the title now renders in Bricolage Grotesque and the count in Inter.
- `ProfileStatColumn` gains 4px of horizontal padding, so a label that fades at its edge doesn't run flush into the column divider.
- `scripts/baseline/raw_textstyle.txt` shrinks by one entry, since `categories_tab.dart` drops to zero raw `TextStyle(`.

## Test plan

- [x] `flutter analyze lib test integration_test` — clean
- [x] `dart format --set-exit-if-changed` on every changed Dart file — clean
- [x] `divine_ui` package: 853 tests pass, 100% line coverage held on all four touched files
- [x] `test/widgets` + `test/screens` (4,776 tests) pass
- [x] All four design-system ceiling ratchets green, plus the untested-services and test-structure floors
- [x] 10 new tests pin the scaling contract: the icon cap and that a tighter ambient clamp beats it, both `DivineIconButton` icon sources landing on one size, the small-variant tap target, the spinner matching the icon box it replaces, the action-menu leading icon, and the waveform bars staying inside the chip clamp. Five of them are regression proofs — each was run against the pre-fix code and observed to fail (the waveform bar measures 32.0 where 20.8 is expected; the icon-source pair measures 48 vs 31.2). The other five guard behaviour that already held, so they stay green either way.
- [x] Manual verification on a real Samsung Galaxy at 1.0x / 1.5x / 2.0x system font size

## Notes for the reviewer

The branch is 9 commits behind `origin/main` and has not been rebased. One of those commits (#6794) does touch `video_feed_item.dart`, which this branch also changes, but the two edits are in different regions — `git merge-tree` merges cleanly and GitHub reports the PR mergeable. Worth a rebase before this leaves draft.
