### PR TITLE
fix(notifications): tighten preview tokenizer cleanup

### DIFF
--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -2408,9 +2408,10 @@ class NotificationRepository {
           match.group(_bech32ReferenceGroup) != null ||
           match.group(_hexReferenceGroup) != null;
       if (!isReference) continue;
-      final startsBeforeOrAtLimit = match.start < limit;
-      final endsAfterLimit = match.end > limit;
-      if (!startsBeforeOrAtLimit || !endsAfterLimit) continue;
+      // The `break` above already guarantees `match.start < limit`, so
+      // ending after it is exactly the straddling case.
+      final straddlesLimit = match.end > limit;
+      if (!straddlesLimit) continue;
       final canKeepLeadingToken =
           match.end <= maxReferencePreviewLength &&
           _hasOnlyWhitespaceOrPunctuationBefore(content, match.start);

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -65,9 +65,10 @@ final RegExp _npubIdentifierPattern = RegExp(
 ///
 /// The UI's trailing `@([a-zA-Z][a-zA-Z0-9_]{0,30})` alternative is the one
 /// deliberate divergence. It wins over the bech32 alternative for `@npub1…`
-/// and truncates the token to 31 characters, so mirroring it would drop the
-/// protection #6346 added for that input. Whether the UI should tokenize
-/// `@npub1…` as a mention at all is a separate question from this cut.
+/// and over hex for `@<64-hex>`, so mirroring it would drop the protection
+/// #6346 added for `@npub1…` and keep `@<64-hex>` capped at the mention
+/// length. Whether the UI should tokenize those as mentions at all is a
+/// separate question from this cut.
 final RegExp _uiTokenPattern = RegExp(
   r'((?:[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})|(?:https?:\/\/[^\s]+|www\.[^\s]+|(?<![@\w])(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?))|#(\w+)|(?<![A-Za-z0-9])(?:nostr:)?((?:npub|nprofile|note|nevent|naddr)1[a-z0-9]+)\b|(?<![A-Fa-f0-9])([A-Fa-f0-9]{64})(?![A-Fa-f0-9])',
   caseSensitive: false,
@@ -2399,6 +2400,7 @@ class NotificationRepository {
   static int _referenceAwareCut(String content, int limit) {
     final maxReferencePreviewLength = limit * 4;
     for (final match in _uiTokenPattern.allMatches(content)) {
+      if (match.start >= limit) break;
       final isReference =
           match.group(_bech32ReferenceGroup) != null ||
           match.group(_hexReferenceGroup) != null;

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -64,11 +64,14 @@ final RegExp _npubIdentifierPattern = RegExp(
 /// their own text so a run buried inside them is not mistaken for one.
 ///
 /// The UI's trailing `@([a-zA-Z][a-zA-Z0-9_]{0,30})` alternative is the one
-/// deliberate divergence. It wins over the bech32 alternative for `@npub1…`
-/// and over hex for `@<64-hex>`, so mirroring it would drop the protection
-/// #6346 added for `@npub1…` and keep `@<64-hex>` capped at the mention
-/// length. Whether the UI should tokenize those as mentions at all is a
-/// separate question from this cut.
+/// deliberate divergence, and it only fires when a letter follows the `@`.
+/// It therefore always wins for `@npub1…` — every bech32 prefix starts with
+/// `n` — and wins over hex only for a letter-initial `@<64-hex>`, capping
+/// either at 31 characters. A digit-initial `@<64-hex>` starts with no
+/// letter to consume, so it falls through to the hex alternative in both
+/// patterns and does not diverge at all. Mirroring the alternative would
+/// drop the protection #6346 added for `@npub1…`. Whether the UI should
+/// tokenize these as mentions at all is a separate question from this cut.
 final RegExp _uiTokenPattern = RegExp(
   r'((?:[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})|(?:https?:\/\/[^\s]+|www\.[^\s]+|(?<![@\w])(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?))|#(\w+)|(?<![A-Za-z0-9])(?:nostr:)?((?:npub|nprofile|note|nevent|naddr)1[a-z0-9]+)\b|(?<![A-Fa-f0-9])([A-Fa-f0-9]{64})(?![A-Fa-f0-9])',
   caseSensitive: false,

--- a/mobile/test/widgets/linkified_text/linkified_text_span_builder_test.dart
+++ b/mobile/test/widgets/linkified_text/linkified_text_span_builder_test.dart
@@ -277,6 +277,59 @@ void main() {
       expect(spans.single.recognizer, isNull);
     });
 
+    // `@<64-hex>` resolves on the first character after the `@`. The trailing
+    // mention alternative opens with `[a-zA-Z]`, so a letter-initial hex is
+    // taken as a 31-character mention while a digit-initial one has no letter
+    // to consume and falls through to the hex reference alternative.
+    // `notification_repository` mirrors this tokenizer without the mention
+    // alternative and documents that divergence, so it is pinned here.
+    group('@-prefixed 64-hex references', () {
+      const letterInitialHex =
+          'a1b2c3d4e5f60718293a4b5c6d7e8f90'
+          'a1b2c3d4e5f60718293a4b5c6d7e8f90';
+      const digitInitialHex =
+          '01b2c3d4e5f60718293a4b5c6d7e8f90'
+          'a1b2c3d4e5f60718293a4b5c6d7e8f90';
+
+      test('truncates a letter-initial hex to a plain mention', () {
+        String? tappedMention;
+
+        final spans = LinkifiedTextSpanBuilder(
+          text: '@$letterInitialHex',
+          defaultStyle: defaultStyle,
+          linkStyle: linkStyle,
+          mentionStyle: mentionStyle,
+          onMentionTap: (username) => tappedMention = username,
+        ).build();
+
+        final mentionSpan = spans.tappableSpans.single;
+        expect(
+          mentionSpan.text,
+          equals('@${letterInitialHex.substring(0, 31)}'),
+        );
+        mentionSpan.tap();
+        expect(tappedMention, equals(letterInitialHex.substring(0, 31)));
+      });
+
+      test('keeps a digit-initial hex whole as a video reference', () {
+        String? tappedVideo;
+
+        final spans = LinkifiedTextSpanBuilder(
+          text: '@$digitInitialHex',
+          defaultStyle: defaultStyle,
+          linkStyle: linkStyle,
+          mentionStyle: mentionStyle,
+          videoLabel: 'View video',
+          onVideoTap: (routeReference) => tappedVideo = routeReference,
+        ).build();
+
+        final videoSpan = spans.tappableSpans.single;
+        expect(videoSpan.text, equals('View video'));
+        videoSpan.tap();
+        expect(tappedVideo, equals(digitInitialHex));
+      });
+    });
+
     // Unpaired UTF-16 surrogates make Flutter's paragraph builder throw
     // "string is not well-formed UTF-16" during layout, which is a crash
     // rather than a rendering glitch. They reach spans from two independent


### PR DESCRIPTION
## Description

Follow-up to merged #6839 with the two small review cleanups that did not land before the PR was merged:

- Document that the deliberate @mention tokenizer divergence also covers @<64-hex>, not only @npub1...
- Stop scanning tokenizer matches once match.start is at or beyond the preview limit, since later matches cannot affect the cut

This intentionally does not consolidate the shared tokenizer regex; that is larger than the cleanup and should be handled separately if we want to centralize parsing.

**Related Issue:** Relates to #6762, #6346

## Verification

- flutter test in mobile/packages/notification_repository — 172 pass
- flutter analyze lib test integration_test from mobile — no issues
