### PR TITLE
test(personal-event-cache): bound provider waits on wall-clock time

### DIFF
--- a/mobile/test/helpers/test_helpers.dart
+++ b/mobile/test/helpers/test_helpers.dart
@@ -257,6 +257,7 @@ class TestHelpers {
     bool Function() condition, {
     Duration timeout = const Duration(seconds: 5),
     Duration checkInterval = const Duration(milliseconds: 100),
+    String description = 'condition',
   }) async {
     final stopwatch = Stopwatch()..start();
 
@@ -266,7 +267,7 @@ class TestHelpers {
 
     if (!condition()) {
       throw TimeoutException(
-        'Condition not met within ${timeout.inSeconds} seconds',
+        'Timed out after ${timeout.inSeconds}s waiting for $description.',
         timeout,
       );
     }

--- a/mobile/test/providers/personal_event_cache_service_provider_test.dart
+++ b/mobile/test/providers/personal_event_cache_service_provider_test.dart
@@ -13,6 +13,8 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/personal_event_cache_service.dart';
 
+import '../helpers/test_helpers.dart';
+
 class _MockAuthService extends Mock implements AuthService {}
 
 const String _userPubkey =
@@ -130,32 +132,19 @@ void main() {
       authStateController.add(AuthState.checking);
     }
 
-    /// Pumps the event queue until [isSatisfied] holds, failing with
-    /// [description] once [_settleTimeout] elapses.
-    ///
-    /// The bound has to be wall-clock, not a fixed number of pumps: the work
-    /// being waited on completes on real Hive file I/O, while `pumpEventQueue`
-    /// only spins event-loop turns. A turn-bounded poll can burn its whole
-    /// budget in microseconds with the I/O still outstanding, which is how a
-    /// loaded CI isolate flaked this suite (run 31199721092, shard 3/4).
-    Future<void> waitFor(
+    /// Waits on wall-clock time rather than a fixed pump count because the
+    /// condition depends on real Hive file I/O.
+    Future<void> waitForPersonalCache(
       String description,
       bool Function() isSatisfied,
-    ) async {
-      final stopwatch = Stopwatch()..start();
-      while (!isSatisfied()) {
-        if (stopwatch.elapsed > _settleTimeout) {
-          fail(
-            'Timed out after ${_settleTimeout.inSeconds}s waiting for '
-            '$description.',
-          );
-        }
-        await pumpEventQueue();
-      }
-    }
+    ) => TestHelpers.waitForCondition(
+      isSatisfied,
+      timeout: _settleTimeout,
+      description: description,
+    );
 
     Future<void> waitForInitialized(PersonalEventCacheService service) =>
-        waitFor(
+        waitForPersonalCache(
           'PersonalEventCacheService to finish initializing',
           () => service.isInitialized,
         );
@@ -163,7 +152,7 @@ void main() {
     Future<void> waitForCachedEvent(
       PersonalEventCacheService service,
       Event event,
-    ) => waitFor(
+    ) => waitForPersonalCache(
       'event ${event.id} to be added to the kind ${event.kind} index',
       () => service
           .getEventsByKind(event.kind)
@@ -218,29 +207,26 @@ void main() {
       },
     );
 
-    test(
-      'keeps queued events through transient non-auth states',
-      () async {
-        final container = buildContainer();
-        final subscription = container.listen(
-          personalEventCacheServiceProvider,
-          (_, _) {},
-          fireImmediately: true,
-        );
-        addTearDown(subscription.close);
-        final ownEvent = _createEvent(pubkey: _userPubkey, id: _hexId(3));
+    test('keeps queued events through transient non-auth states', () async {
+      final container = buildContainer();
+      final subscription = container.listen(
+        personalEventCacheServiceProvider,
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+      final ownEvent = _createEvent(pubkey: _userPubkey, id: _hexId(3));
 
-        final service = subscription.read();
-        service.cacheUserEvent(ownEvent);
+      final service = subscription.read();
+      service.cacheUserEvent(ownEvent);
 
-        emitChecking();
-        await authenticate();
-        await waitForInitialized(service);
+      emitChecking();
+      await authenticate();
+      await waitForInitialized(service);
 
-        expect(service.hasEvent(ownEvent.id), isTrue);
-        expect(service.getEventById(ownEvent.id)?.id, ownEvent.id);
-      },
-    );
+      expect(service.hasEvent(ownEvent.id), isTrue);
+      expect(service.getEventById(ownEvent.id)?.id, ownEvent.id);
+    });
 
     test(
       'resets active cache session when auth becomes unauthenticated',

--- a/mobile/test/providers/personal_event_cache_service_provider_test.dart
+++ b/mobile/test/providers/personal_event_cache_service_provider_test.dart
@@ -20,6 +20,12 @@ const String _userPubkey =
 const String _otherPubkey =
     'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 
+/// Wall-clock budget for the async-settling helpers in this suite.
+///
+/// Generous enough to absorb a loaded CI isolate, and well inside the 30s
+/// per-test default so an expiry reports itself instead of hanging the shard.
+const Duration _settleTimeout = Duration(seconds: 10);
+
 String _hexId(int index) => index.toRadixString(16).padLeft(64, '0');
 
 Event _createEvent({required String pubkey, required String id}) {
@@ -124,29 +130,45 @@ void main() {
       authStateController.add(AuthState.checking);
     }
 
-    Future<void> waitForInitialized(PersonalEventCacheService service) async {
-      for (var attempt = 0; attempt < 20; attempt++) {
-        await pumpEventQueue();
-        if (service.isInitialized) {
-          return;
+    /// Pumps the event queue until [isSatisfied] holds, failing with
+    /// [description] once [_settleTimeout] elapses.
+    ///
+    /// The bound has to be wall-clock, not a fixed number of pumps: the work
+    /// being waited on completes on real Hive file I/O, while `pumpEventQueue`
+    /// only spins event-loop turns. A turn-bounded poll can burn its whole
+    /// budget in microseconds with the I/O still outstanding, which is how a
+    /// loaded CI isolate flaked this suite (run 31199721092, shard 3/4).
+    Future<void> waitFor(
+      String description,
+      bool Function() isSatisfied,
+    ) async {
+      final stopwatch = Stopwatch()..start();
+      while (!isSatisfied()) {
+        if (stopwatch.elapsed > _settleTimeout) {
+          fail(
+            'Timed out after ${_settleTimeout.inSeconds}s waiting for '
+            '$description.',
+          );
         }
+        await pumpEventQueue();
       }
     }
+
+    Future<void> waitForInitialized(PersonalEventCacheService service) =>
+        waitFor(
+          'PersonalEventCacheService to finish initializing',
+          () => service.isInitialized,
+        );
 
     Future<void> waitForCachedEvent(
       PersonalEventCacheService service,
       Event event,
-    ) async {
-      for (var attempt = 0; attempt < 20; attempt++) {
-        await pumpEventQueue();
-        if (service
-            .getEventsByKind(event.kind)
-            .any((cachedEvent) => cachedEvent.id == event.id)) {
-          return;
-        }
-      }
-      fail('Event ${event.id} was not added to kind ${event.kind} index');
-    }
+    ) => waitFor(
+      'event ${event.id} to be added to the kind ${event.kind} index',
+      () => service
+          .getEventsByKind(event.kind)
+          .any((cachedEvent) => cachedEvent.id == event.id),
+    );
 
     test(
       'initializes when auth becomes ready after provider construction',

--- a/mobile/test/services/personal_event_cache_service_test.dart
+++ b/mobile/test/services/personal_event_cache_service_test.dart
@@ -8,6 +8,11 @@ import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:openvine/services/personal_event_cache_service.dart';
 
+import '../helpers/test_helpers.dart';
+
+/// Wall-clock budget for waits that depend on Hive file I/O.
+const Duration _settleTimeout = Duration(seconds: 10);
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -43,15 +48,13 @@ void main() {
     // cacheUserEvent is fire-and-forget: the event record is written before
     // its kind index. Wait for the index entry instead of assuming that one
     // event-loop pump means both Hive writes have completed.
-    for (var attempt = 0; attempt < 20; attempt++) {
-      await pumpEventQueue();
-      if (service
+    await TestHelpers.waitForCondition(
+      () => service
           .getEventsByKind(event.kind)
-          .any((cachedEvent) => cachedEvent.id == event.id)) {
-        return;
-      }
-    }
-    fail('Event ${event.id} was not added to kind ${event.kind} index');
+          .any((cachedEvent) => cachedEvent.id == event.id),
+      timeout: _settleTimeout,
+      description: 'event ${event.id} to be added to kind ${event.kind} index',
+    );
   }
 
   setUp(() async {


### PR DESCRIPTION
Closes #6850

## Description

`personal_event_cache_service_provider_test.dart` flaked on CI because its settling helpers polled `pumpEventQueue()` a fixed number of times while the work being awaited depended on real Hive file I/O: `PersonalEventCacheService.initialize()` opens Hive boxes, and later cache writes update Hive metadata. Event-loop-turn budgets can burn down before file I/O completes under CI load, producing misleading downstream assertion failures.

This PR now moves those waits onto a wall-clock timeout with descriptive failure messages:

- `TestHelpers.waitForCondition` accepts an optional `description` for named timeout failures.
- The provider suite reuses that shared helper instead of a local poller.
- The sibling `personal_event_cache_service_test.dart` kind-index helper now uses the same 10s wall-clock wait, closing the adjacent latent flake.

Awaiting a real provider initialization future was considered but is not currently exposed: `video_providers.dart` starts initialization with `unawaited(...)`, and adding production API surface only for this test would be the wrong layer for this fix.

## Verification

- `flutter test test/providers/personal_event_cache_service_provider_test.dart test/services/personal_event_cache_service_test.dart` — 12/12 passed locally
- `flutter analyze lib test integration_test` — No issues found locally
- `mise exec -- dart format lib test integration_test` — 0 files changed locally
- Pre-push hook reran analysis and the changed test files before push — passed

Not verified on a physical device: this is a test-only change with no app-visible behavior.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore