### PR TITLE
fix(for-you): rebuild the algorithm header and explainer on the design system

### DIFF
--- a/mobile/lib/widgets/for_you_tab.dart
+++ b/mobile/lib/widgets/for_you_tab.dart
@@ -153,14 +153,11 @@ class _ForYouContent extends ConsumerStatefulWidget {
 class _ForYouContentState extends ConsumerState<_ForYouContent>
     with ScrollToHideMixin {
   void _showAlgorithmExplainer(BuildContext context) {
-    showModalBottomSheet<void>(
+    VineBottomSheet.show(
       context: context,
-      isScrollControlled: true,
-      backgroundColor: context.vineColors.card,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      buildScrollBody: (scrollController) => _AlgorithmExplainerSheet(
+        scrollController: scrollController,
       ),
-      builder: (context) => const _AlgorithmExplainerSheet(),
     );
   }
 
@@ -240,32 +237,37 @@ class _ForYouContentState extends ConsumerState<_ForYouContent>
           child: GestureDetector(
             key: headerKey,
             onTap: () => _showAlgorithmExplainer(context),
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: ColoredBox(
               color: context.vineColors.background,
-              child: Row(
-                children: [
-                  const DivineIcon(
-                    icon: DivineIconName.sparkle,
-                    color: VineTheme.vineGreen,
-                    size: 20,
-                  ),
-                  const SizedBox(width: 8),
-                  Text(
-                    context.l10n.forYouAlgorithmTitle,
-                    style: const TextStyle(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Row(
+                  children: [
+                    const DivineIcon(
+                      icon: DivineIconName.sparkle,
                       color: VineTheme.vineGreen,
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
+                      size: 20,
                     ),
-                  ),
-                  const SizedBox(width: 4),
-                  DivineIcon(
-                    icon: DivineIconName.info,
-                    color: context.vineColors.secondaryText,
-                    size: 16,
-                  ),
-                ],
+                    const SizedBox(width: 8),
+                    Text(
+                      context.l10n.forYouAlgorithmTitle,
+                      style: VineTheme.labelLargeFont(
+                        color: VineTheme.vineGreen,
+                      ),
+                    ),
+                    DivineIconButton(
+                      icon: DivineIconName.info,
+                      size: DivineIconButtonSize.small,
+                      backgroundColor: VineTheme.transparent,
+                      foregroundColor: context.vineColors.secondaryText,
+                      showShadow: false,
+                      tooltip: context.l10n.forYouAlgorithmHowItWorksTitle,
+                      semanticLabel:
+                          context.l10n.forYouAlgorithmHowItWorksTitle,
+                      onPressed: () => _showAlgorithmExplainer(context),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
@@ -277,190 +279,162 @@ class _ForYouContentState extends ConsumerState<_ForYouContent>
 
 /// Bottom sheet explaining how the Divine Algorithm works
 class _AlgorithmExplainerSheet extends StatelessWidget {
-  const _AlgorithmExplainerSheet();
+  const _AlgorithmExplainerSheet({
+    required this.scrollController,
+  });
+
+  final ScrollController scrollController;
 
   @override
   Widget build(BuildContext context) {
-    return DraggableScrollableSheet(
-      initialChildSize: 0.85,
-      minChildSize: 0.5,
-      maxChildSize: 0.95,
-      expand: false,
-      builder: (context, scrollController) {
-        return Container(
-          padding: const EdgeInsets.fromLTRB(20, 8, 20, 20),
-          child: ListView(
-            controller: scrollController,
-            children: [
-              // Drag handle
-              Center(
-                child: Container(
-                  width: 40,
-                  height: 4,
-                  margin: const EdgeInsets.only(bottom: 20),
-                  decoration: BoxDecoration(
-                    color: context.vineColors.secondaryText.withValues(
-                      alpha: 0.3,
-                    ),
-                    borderRadius: BorderRadius.circular(2),
-                  ),
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(20, 8, 20, 20),
+      controller: scrollController,
+      children: [
+        // Title
+        Row(
+          spacing: 12,
+          children: [
+            const DivineIcon(
+              icon: DivineIconName.sparkle,
+              color: VineTheme.vineGreen,
+              size: 28,
+            ),
+            Expanded(
+              child: Text(
+                context.l10n.forYouAlgorithmTitle,
+                style: VineTheme.titleLargeFont(
+                  color: context.vineColors.primaryText,
                 ),
               ),
-              // Title
-              Row(
-                children: [
-                  const DivineIcon(
-                    icon: DivineIconName.sparkle,
-                    color: VineTheme.vineGreen,
-                    size: 28,
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Text(
-                      context.l10n.forYouAlgorithmTitle,
-                      style: TextStyle(
-                        color: context.vineColors.primaryText,
-                        fontSize: 22,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 8),
-              Text(
-                context.l10n.forYouAlgorithmSubtitle,
-                style: const TextStyle(
-                  color: VineTheme.vineGreen,
-                  fontSize: 13,
-                  fontStyle: FontStyle.italic,
-                ),
-              ),
-              const SizedBox(height: 24),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Text(
+          context.l10n.forYouAlgorithmSubtitle,
+          style: VineTheme.bodySmallFont(
+            color: VineTheme.vineGreen,
+          ).copyWith(fontStyle: FontStyle.italic),
+        ),
+        const SizedBox(height: 24),
 
-              // Section: How it works
-              _buildSectionTitle(
-                context,
-                context.l10n.forYouAlgorithmHowItWorksTitle,
-              ),
-              const SizedBox(height: 12),
-              Text(
-                context.l10n.forYouAlgorithmHowItWorksBody,
-                style: _bodyTextStyleOf(context),
-              ),
-              const SizedBox(height: 16),
-              Text(
-                context.l10n.forYouAlgorithmInteractionsIntro,
-                style: _bodyTextStyleOf(context),
-              ),
-              const SizedBox(height: 12),
+        // Section: How it works
+        _buildSectionTitle(
+          context,
+          context.l10n.forYouAlgorithmHowItWorksTitle,
+        ),
+        const SizedBox(height: 12),
+        Text(
+          context.l10n.forYouAlgorithmHowItWorksBody,
+          style: _bodyTextStyleOf(context),
+        ),
+        const SizedBox(height: 16),
+        Text(
+          context.l10n.forYouAlgorithmInteractionsIntro,
+          style: _bodyTextStyleOf(context),
+        ),
+        const SizedBox(height: 12),
 
-              // Interaction weights
-              _buildInteractionItem(
-                context,
-                Icons.repeat,
-                context.l10n.metadataRepostsLabel,
-                context.l10n.forYouAlgorithmRepostsDescription,
-              ),
-              _buildInteractionItem(
-                context,
-                Icons.chat_bubble_outline,
-                context.l10n.profileCommentsSection,
-                context.l10n.forYouAlgorithmCommentsDescription,
-              ),
-              _buildInteractionItem(
-                context,
-                Icons.favorite_outline,
-                context.l10n.forYouAlgorithmReactionsTitle,
-                context.l10n.forYouAlgorithmReactionsDescription,
-              ),
-              _buildInteractionItem(
-                context,
-                Icons.play_circle_outline,
-                context.l10n.analyticsViews,
-                context.l10n.forYouAlgorithmViewsDescription,
-              ),
-              const SizedBox(height: 24),
+        // Interaction weights
+        _buildInteractionItem(
+          context,
+          DivineIconName.repeat,
+          context.l10n.metadataRepostsLabel,
+          context.l10n.forYouAlgorithmRepostsDescription,
+        ),
+        _buildInteractionItem(
+          context,
+          DivineIconName.chat,
+          context.l10n.profileCommentsSection,
+          context.l10n.forYouAlgorithmCommentsDescription,
+        ),
+        _buildInteractionItem(
+          context,
+          DivineIconName.heart,
+          context.l10n.forYouAlgorithmReactionsTitle,
+          context.l10n.forYouAlgorithmReactionsDescription,
+        ),
+        _buildInteractionItem(
+          context,
+          DivineIconName.playCircle,
+          context.l10n.analyticsViews,
+          context.l10n.forYouAlgorithmViewsDescription,
+        ),
+        const SizedBox(height: 24),
 
-              // Section: Cold start
-              _buildSectionTitle(
-                context,
-                context.l10n.forYouAlgorithmNewToDivineTitle,
-              ),
-              const SizedBox(height: 12),
-              Text(
-                context.l10n.forYouAlgorithmNewToDivineBody1,
-                style: _bodyTextStyleOf(context),
-              ),
-              const SizedBox(height: 12),
-              Text(
-                context.l10n.forYouAlgorithmNewToDivineBody2,
-                style: _bodyTextStyleOf(context),
-              ),
-              const SizedBox(height: 24),
+        // Section: Cold start
+        _buildSectionTitle(
+          context,
+          context.l10n.forYouAlgorithmNewToDivineTitle,
+        ),
+        const SizedBox(height: 12),
+        Text(
+          context.l10n.forYouAlgorithmNewToDivineBody1,
+          style: _bodyTextStyleOf(context),
+        ),
+        const SizedBox(height: 12),
+        Text(
+          context.l10n.forYouAlgorithmNewToDivineBody2,
+          style: _bodyTextStyleOf(context),
+        ),
+        const SizedBox(height: 24),
 
-              // Section: Future vision
-              _buildSectionTitle(
-                context,
-                context.l10n.forYouAlgorithmChoiceTitle,
-              ),
-              const SizedBox(height: 12),
-              Text(
-                context.l10n.forYouAlgorithmChoiceBody,
-                style: _bodyTextStyleOf(context),
-              ),
-              const SizedBox(height: 12),
-              _buildFutureFeatureItem(
-                context,
-                context.l10n.forYouAlgorithmChoicePersonalizedFeed,
-              ),
-              _buildFutureFeatureItem(
-                context,
-                context.l10n.forYouAlgorithmChoiceChronological,
-              ),
-              _buildFutureFeatureItem(
-                context,
-                context.l10n.forYouAlgorithmChoiceTrending,
-              ),
-              _buildFutureFeatureItem(
-                context,
-                context.l10n.forYouAlgorithmChoiceCustomFeeds,
-              ),
-              const SizedBox(height: 16),
-              Text(
-                context.l10n.forYouAlgorithmChoiceClosing,
-                style: _bodyTextStyleOf(context),
-              ),
-              const SizedBox(height: 24),
+        // Section: Future vision
+        _buildSectionTitle(
+          context,
+          context.l10n.forYouAlgorithmChoiceTitle,
+        ),
+        const SizedBox(height: 12),
+        Text(
+          context.l10n.forYouAlgorithmChoiceBody,
+          style: _bodyTextStyleOf(context),
+        ),
+        const SizedBox(height: 12),
+        _buildFutureFeatureItem(
+          context,
+          context.l10n.forYouAlgorithmChoicePersonalizedFeed,
+        ),
+        _buildFutureFeatureItem(
+          context,
+          context.l10n.forYouAlgorithmChoiceChronological,
+        ),
+        _buildFutureFeatureItem(
+          context,
+          context.l10n.forYouAlgorithmChoiceTrending,
+        ),
+        _buildFutureFeatureItem(
+          context,
+          context.l10n.forYouAlgorithmChoiceCustomFeeds,
+        ),
+        const SizedBox(height: 16),
+        Text(
+          context.l10n.forYouAlgorithmChoiceClosing,
+          style: _bodyTextStyleOf(context),
+        ),
+        const SizedBox(height: 24),
 
-              DivineInfoCard(
-                icon: DivineIconName.bracketsAngle,
-                compact: true,
-                title: context.l10n.forYouAlgorithmOpenSourceTitle,
-                message: context.l10n.forYouAlgorithmOpenSourceBody,
-              ),
-              const SizedBox(height: 32),
-            ],
-          ),
-        );
-      },
+        DivineInfoCard(
+          icon: DivineIconName.bracketsAngle,
+          compact: true,
+          title: context.l10n.forYouAlgorithmOpenSourceTitle,
+          message: context.l10n.forYouAlgorithmOpenSourceBody,
+        ),
+        const SizedBox(height: 32),
+      ],
     );
   }
 
   Widget _buildSectionTitle(BuildContext context, String title) {
     return Text(
       title,
-      style: TextStyle(
-        color: context.vineColors.primaryText,
-        fontSize: 17,
-        fontWeight: FontWeight.w600,
-      ),
+      style: VineTheme.titleMediumFont(color: context.vineColors.primaryText),
     );
   }
 
   Widget _buildInteractionItem(
     BuildContext context,
-    IconData icon,
+    DivineIconName icon,
     String title,
     String description,
   ) {
@@ -475,7 +449,7 @@ class _AlgorithmExplainerSheet extends StatelessWidget {
               color: context.vineColors.card,
               borderRadius: BorderRadius.circular(8),
             ),
-            child: Icon(icon, color: VineTheme.vineGreen, size: 18),
+            child: DivineIcon(icon: icon, color: VineTheme.vineGreen, size: 18),
           ),
           const SizedBox(width: 12),
           Expanded(
@@ -484,19 +458,15 @@ class _AlgorithmExplainerSheet extends StatelessWidget {
               children: [
                 Text(
                   title,
-                  style: TextStyle(
+                  style: VineTheme.labelLargeFont(
                     color: context.vineColors.primaryText,
-                    fontSize: 14,
-                    fontWeight: FontWeight.w500,
                   ),
                 ),
                 const SizedBox(height: 2),
                 Text(
                   description,
-                  style: TextStyle(
+                  style: VineTheme.bodySmallFont(
                     color: context.vineColors.secondaryText,
-                    fontSize: 13,
-                    height: 1.3,
                   ),
                 ),
               ],
@@ -512,24 +482,21 @@ class _AlgorithmExplainerSheet extends StatelessWidget {
       padding: const EdgeInsetsDirectional.only(start: 8, bottom: 8),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: 8,
         children: [
           const DivineIcon(
             icon: DivineIconName.checkCircle,
             color: VineTheme.vineGreen,
             size: 18,
           ),
-          const SizedBox(width: 8),
           Expanded(child: Text(text, style: _bodyTextStyleOf(context))),
         ],
       ),
     );
   }
 
-  static TextStyle _bodyTextStyleOf(BuildContext context) => TextStyle(
-    color: context.vineColors.primaryText,
-    fontSize: 14,
-    height: 1.5,
-  );
+  static TextStyle _bodyTextStyleOf(BuildContext context) =>
+      VineTheme.bodyMediumFont(color: context.vineColors.primaryText);
 }
 
 /// Unavailable state when recommendations are not available
@@ -552,20 +519,16 @@ class _ForYouUnavailableState extends StatelessWidget {
             const SizedBox(height: 16),
             Text(
               context.l10n.forYouUnavailableTitle,
-              style: TextStyle(
+              style: VineTheme.titleMediumFont(
                 color: context.vineColors.primaryText,
-                fontSize: 18,
-                fontWeight: FontWeight.w500,
               ),
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 12),
             Text(
               context.l10n.forYouUnavailableDescription,
-              style: TextStyle(
+              style: VineTheme.bodyMediumFont(
                 color: context.vineColors.secondaryText,
-                fontSize: 14,
-                height: 1.4,
               ),
               textAlign: TextAlign.center,
             ),
@@ -594,10 +557,8 @@ class _ForYouEmptyState extends StatelessWidget {
           const SizedBox(height: 16),
           Text(
             context.l10n.forYouEmptyTitle,
-            style: TextStyle(
+            style: VineTheme.titleMediumFont(
               color: context.vineColors.primaryText,
-              fontSize: 18,
-              fontWeight: FontWeight.w500,
             ),
           ),
           const SizedBox(height: 8),
@@ -605,9 +566,8 @@ class _ForYouEmptyState extends StatelessWidget {
             padding: const EdgeInsets.symmetric(horizontal: 32),
             child: Text(
               context.l10n.forYouEmptyDescription,
-              style: TextStyle(
+              style: VineTheme.bodyMediumFont(
                 color: context.vineColors.secondaryText,
-                fontSize: 14,
               ),
               textAlign: TextAlign.center,
             ),
@@ -634,16 +594,15 @@ class _ForYouErrorState extends StatelessWidget {
           const SizedBox(height: 16),
           Text(
             context.l10n.forYouErrorTitle,
-            style: const TextStyle(color: VineTheme.likeRed, fontSize: 18),
+            style: VineTheme.titleMediumFont(color: VineTheme.likeRed),
           ),
           const SizedBox(height: 8),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 32),
             child: Text(
               error,
-              style: TextStyle(
+              style: VineTheme.bodySmallFont(
                 color: context.vineColors.secondaryText,
-                fontSize: 12,
               ),
               textAlign: TextAlign.center,
             ),

--- a/mobile/lib/widgets/for_you_tab.dart
+++ b/mobile/lib/widgets/for_you_tab.dart
@@ -155,6 +155,11 @@ class _ForYouContentState extends ConsumerState<_ForYouContent>
   void _showAlgorithmExplainer(BuildContext context) {
     VineBottomSheet.show(
       context: context,
+      // Long-form content: keep the pre-design-system sizing so the explainer
+      // still opens nearly full-height instead of the 0.6 default.
+      initialChildSize: 0.85,
+      minChildSize: 0.5,
+      maxChildSize: 0.95,
       buildScrollBody: (scrollController) => _AlgorithmExplainerSheet(
         scrollController: scrollController,
       ),
@@ -246,7 +251,6 @@ class _ForYouContentState extends ConsumerState<_ForYouContent>
                     const DivineIcon(
                       icon: DivineIconName.sparkle,
                       color: VineTheme.vineGreen,
-                      size: 20,
                     ),
                     const SizedBox(width: 8),
                     Text(

--- a/mobile/lib/widgets/for_you_tab.dart
+++ b/mobile/lib/widgets/for_you_tab.dart
@@ -160,9 +160,8 @@ class _ForYouContentState extends ConsumerState<_ForYouContent>
       initialChildSize: 0.85,
       minChildSize: 0.5,
       maxChildSize: 0.95,
-      buildScrollBody: (scrollController) => _AlgorithmExplainerSheet(
-        scrollController: scrollController,
-      ),
+      buildScrollBody: (scrollController) =>
+          _AlgorithmExplainerSheet(scrollController: scrollController),
     );
   }
 
@@ -239,38 +238,50 @@ class _ForYouContentState extends ConsumerState<_ForYouContent>
           top: headerOffset,
           left: 0,
           right: 0,
-          child: GestureDetector(
-            key: headerKey,
-            onTap: () => _showAlgorithmExplainer(context),
-            child: ColoredBox(
-              color: context.vineColors.background,
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Row(
-                  children: [
-                    const DivineIcon(
-                      icon: DivineIconName.sparkle,
-                      color: VineTheme.vineGreen,
-                    ),
-                    const SizedBox(width: 8),
-                    Text(
-                      context.l10n.forYouAlgorithmTitle,
-                      style: VineTheme.labelLargeFont(
+          child: Semantics(
+            button: true,
+            // The visible title is the button's name; the hint says what
+            // activating it does.
+            hint: context.l10n.forYouAlgorithmHowItWorksTitle,
+            child: GestureDetector(
+              key: headerKey,
+              onTap: () => _showAlgorithmExplainer(context),
+              child: ColoredBox(
+                color: context.vineColors.background,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Row(
+                    children: [
+                      const DivineIcon(
+                        icon: DivineIconName.sparkle,
                         color: VineTheme.vineGreen,
+                        size: 20,
                       ),
-                    ),
-                    DivineIconButton(
-                      icon: DivineIconName.info,
-                      size: DivineIconButtonSize.small,
-                      backgroundColor: VineTheme.transparent,
-                      foregroundColor: context.vineColors.secondaryText,
-                      showShadow: false,
-                      tooltip: context.l10n.forYouAlgorithmHowItWorksTitle,
-                      semanticLabel:
-                          context.l10n.forYouAlgorithmHowItWorksTitle,
-                      onPressed: () => _showAlgorithmExplainer(context),
-                    ),
-                  ],
+                      const SizedBox(width: 8),
+                      Flexible(
+                        child: Text(
+                          context.l10n.forYouAlgorithmTitle,
+                          style: VineTheme.labelLargeFont(
+                            color: VineTheme.vineGreen,
+                          ),
+                        ),
+                      ),
+                      // The row and the button open the same sheet, so the row
+                      // owns the semantics — otherwise a screen reader
+                      // announces one action twice.
+                      ExcludeSemantics(
+                        child: DivineIconButton(
+                          icon: DivineIconName.info,
+                          size: DivineIconButtonSize.small,
+                          backgroundColor: VineTheme.transparent,
+                          foregroundColor: context.vineColors.secondaryText,
+                          showShadow: false,
+                          tooltip: context.l10n.forYouAlgorithmHowItWorksTitle,
+                          onPressed: () => _showAlgorithmExplainer(context),
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -283,9 +294,7 @@ class _ForYouContentState extends ConsumerState<_ForYouContent>
 
 /// Bottom sheet explaining how the Divine Algorithm works
 class _AlgorithmExplainerSheet extends StatelessWidget {
-  const _AlgorithmExplainerSheet({
-    required this.scrollController,
-  });
+  const _AlgorithmExplainerSheet({required this.scrollController});
 
   final ScrollController scrollController;
 
@@ -324,10 +333,7 @@ class _AlgorithmExplainerSheet extends StatelessWidget {
         const SizedBox(height: 24),
 
         // Section: How it works
-        _buildSectionTitle(
-          context,
-          context.l10n.forYouAlgorithmHowItWorksTitle,
-        ),
+        _SectionTitle(context.l10n.forYouAlgorithmHowItWorksTitle),
         const SizedBox(height: 12),
         Text(
           context.l10n.forYouAlgorithmHowItWorksBody,
@@ -341,37 +347,30 @@ class _AlgorithmExplainerSheet extends StatelessWidget {
         const SizedBox(height: 12),
 
         // Interaction weights
-        _buildInteractionItem(
-          context,
-          DivineIconName.repeat,
-          context.l10n.metadataRepostsLabel,
-          context.l10n.forYouAlgorithmRepostsDescription,
+        _InteractionItem(
+          icon: DivineIconName.repeat,
+          title: context.l10n.metadataRepostsLabel,
+          description: context.l10n.forYouAlgorithmRepostsDescription,
         ),
-        _buildInteractionItem(
-          context,
-          DivineIconName.chat,
-          context.l10n.profileCommentsSection,
-          context.l10n.forYouAlgorithmCommentsDescription,
+        _InteractionItem(
+          icon: DivineIconName.chat,
+          title: context.l10n.profileCommentsSection,
+          description: context.l10n.forYouAlgorithmCommentsDescription,
         ),
-        _buildInteractionItem(
-          context,
-          DivineIconName.heart,
-          context.l10n.forYouAlgorithmReactionsTitle,
-          context.l10n.forYouAlgorithmReactionsDescription,
+        _InteractionItem(
+          icon: DivineIconName.heart,
+          title: context.l10n.forYouAlgorithmReactionsTitle,
+          description: context.l10n.forYouAlgorithmReactionsDescription,
         ),
-        _buildInteractionItem(
-          context,
-          DivineIconName.playCircle,
-          context.l10n.analyticsViews,
-          context.l10n.forYouAlgorithmViewsDescription,
+        _InteractionItem(
+          icon: DivineIconName.playCircle,
+          title: context.l10n.analyticsViews,
+          description: context.l10n.forYouAlgorithmViewsDescription,
         ),
         const SizedBox(height: 24),
 
         // Section: Cold start
-        _buildSectionTitle(
-          context,
-          context.l10n.forYouAlgorithmNewToDivineTitle,
-        ),
+        _SectionTitle(context.l10n.forYouAlgorithmNewToDivineTitle),
         const SizedBox(height: 12),
         Text(
           context.l10n.forYouAlgorithmNewToDivineBody1,
@@ -385,32 +384,17 @@ class _AlgorithmExplainerSheet extends StatelessWidget {
         const SizedBox(height: 24),
 
         // Section: Future vision
-        _buildSectionTitle(
-          context,
-          context.l10n.forYouAlgorithmChoiceTitle,
-        ),
+        _SectionTitle(context.l10n.forYouAlgorithmChoiceTitle),
         const SizedBox(height: 12),
         Text(
           context.l10n.forYouAlgorithmChoiceBody,
           style: _bodyTextStyleOf(context),
         ),
         const SizedBox(height: 12),
-        _buildFutureFeatureItem(
-          context,
-          context.l10n.forYouAlgorithmChoicePersonalizedFeed,
-        ),
-        _buildFutureFeatureItem(
-          context,
-          context.l10n.forYouAlgorithmChoiceChronological,
-        ),
-        _buildFutureFeatureItem(
-          context,
-          context.l10n.forYouAlgorithmChoiceTrending,
-        ),
-        _buildFutureFeatureItem(
-          context,
-          context.l10n.forYouAlgorithmChoiceCustomFeeds,
-        ),
+        _FutureFeatureItem(context.l10n.forYouAlgorithmChoicePersonalizedFeed),
+        _FutureFeatureItem(context.l10n.forYouAlgorithmChoiceChronological),
+        _FutureFeatureItem(context.l10n.forYouAlgorithmChoiceTrending),
+        _FutureFeatureItem(context.l10n.forYouAlgorithmChoiceCustomFeeds),
         const SizedBox(height: 16),
         Text(
           context.l10n.forYouAlgorithmChoiceClosing,
@@ -428,24 +412,45 @@ class _AlgorithmExplainerSheet extends StatelessWidget {
       ],
     );
   }
+}
 
-  Widget _buildSectionTitle(BuildContext context, String title) {
+TextStyle _bodyTextStyleOf(BuildContext context) =>
+    VineTheme.bodyMediumFont(color: context.vineColors.primaryText);
+
+/// Heading for one section of the algorithm explainer.
+class _SectionTitle extends StatelessWidget {
+  const _SectionTitle(this.title);
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
     return Text(
       title,
       style: VineTheme.titleMediumFont(color: context.vineColors.primaryText),
     );
   }
+}
 
-  Widget _buildInteractionItem(
-    BuildContext context,
-    DivineIconName icon,
-    String title,
-    String description,
-  ) {
+/// One interaction weight row: badge icon, label and description.
+class _InteractionItem extends StatelessWidget {
+  const _InteractionItem({
+    required this.icon,
+    required this.title,
+    required this.description,
+  });
+
+  final DivineIconName icon;
+  final String title;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: 12,
         children: [
           Container(
             padding: const EdgeInsets.all(8),
@@ -455,7 +460,6 @@ class _AlgorithmExplainerSheet extends StatelessWidget {
             ),
             child: DivineIcon(icon: icon, color: VineTheme.vineGreen, size: 18),
           ),
-          const SizedBox(width: 12),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -480,8 +484,16 @@ class _AlgorithmExplainerSheet extends StatelessWidget {
       ),
     );
   }
+}
 
-  Widget _buildFutureFeatureItem(BuildContext context, String text) {
+/// One bullet in the "what's coming" list.
+class _FutureFeatureItem extends StatelessWidget {
+  const _FutureFeatureItem(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsetsDirectional.only(start: 8, bottom: 8),
       child: Row(
@@ -498,9 +510,6 @@ class _AlgorithmExplainerSheet extends StatelessWidget {
       ),
     );
   }
-
-  static TextStyle _bodyTextStyleOf(BuildContext context) =>
-      VineTheme.bodyMediumFont(color: context.vineColors.primaryText);
 }
 
 /// Unavailable state when recommendations are not available

--- a/mobile/scripts/baseline/raw_dialogs.txt
+++ b/mobile/scripts/baseline/raw_dialogs.txt
@@ -25,7 +25,6 @@ lib/utils/pause_aware_modals.dart	2
 lib/widgets/add_to_list_dialog.dart	1
 lib/widgets/age_verification_dialog.dart	1
 lib/widgets/composable_video_grid.dart	1
-lib/widgets/for_you_tab.dart	1
 lib/widgets/library/drafts_tab.dart	1
 lib/widgets/owner_video_delete_confirmation_dialog.dart	1
 lib/widgets/profile_editor/username_status_indicator.dart	1

--- a/mobile/scripts/baseline/raw_icons.txt
+++ b/mobile/scripts/baseline/raw_icons.txt
@@ -24,7 +24,7 @@ lib/widgets/auth/forgot_password_dialog.dart	1
 lib/widgets/classic_viners_slider.dart	1
 lib/widgets/classic_vines_tab.dart	2
 lib/widgets/composable_video_grid.dart	2
-lib/widgets/for_you_tab.dart	6
+lib/widgets/for_you_tab.dart	2
 lib/widgets/library/sounds_tab.dart	3
 lib/widgets/list_card.dart	1
 lib/widgets/new_videos_tab.dart	1

--- a/mobile/scripts/baseline/raw_textstyle.txt
+++ b/mobile/scripts/baseline/raw_textstyle.txt
@@ -59,7 +59,6 @@ lib/widgets/composable_video_grid.dart	8
 lib/widgets/content_warning.dart	11
 lib/widgets/environment_indicator.dart	1
 lib/widgets/error_message.dart	1
-lib/widgets/for_you_tab.dart	13
 lib/widgets/global_error_widget.dart	7
 lib/widgets/library/sounds_tab.dart	7
 lib/widgets/linkified_text/linkified_text.dart	2

--- a/mobile/test/widgets/for_you_tab_test.dart
+++ b/mobile/test/widgets/for_you_tab_test.dart
@@ -1,0 +1,86 @@
+// Pins the For You header's accessibility contract (#6852): the header strip
+// is a single labelled button rather than a silent tap region wrapped around a
+// second labelled button, and activating it opens the algorithm explainer.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/curation_providers.dart';
+import 'package:openvine/providers/for_you_provider.dart';
+import 'package:openvine/state/video_feed_state.dart';
+import 'package:openvine/widgets/for_you_tab.dart';
+
+class _AvailableFunnelcake extends FunnelcakeAvailable {
+  @override
+  Future<bool> build() async => true;
+}
+
+class _EmptyForYouFeed extends ForYouFeed {
+  @override
+  Future<VideoFeedState> build() async =>
+      const VideoFeedState(videos: [], hasMoreContent: false);
+}
+
+Widget _host() => ProviderScope(
+  overrides: [
+    funnelcakeAvailableProvider.overrideWith(_AvailableFunnelcake.new),
+    forYouFeedProvider.overrideWith(_EmptyForYouFeed.new),
+  ],
+  child: const MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(body: ForYouTab()),
+  ),
+);
+
+void main() {
+  final l10n = lookupAppLocalizations(const Locale('en'));
+
+  group(ForYouTab, () {
+    testWidgets('header is one button named by its visible title', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(_host());
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.getSemantics(find.text(l10n.forYouAlgorithmTitle)),
+        isSemantics(
+          isButton: true,
+          label: l10n.forYouAlgorithmTitle,
+          hint: l10n.forYouAlgorithmHowItWorksTitle,
+        ),
+      );
+
+      // The info icon opens the same sheet as the row, so it contributes no
+      // node of its own — walking up from it lands on the header's button
+      // rather than a second one announcing the same action.
+      expect(
+        tester.getSemantics(find.byType(DivineIconButton)),
+        isSemantics(label: l10n.forYouAlgorithmTitle),
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('tapping the header opens the algorithm explainer', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_host());
+      await tester.pumpAndSettle();
+
+      // The subtitle renders only inside the explainer sheet, so it proves the
+      // sheet opened instead of matching something in the header strip.
+      expect(find.text(l10n.forYouAlgorithmSubtitle), findsNothing);
+
+      await tester.tap(find.text(l10n.forYouAlgorithmTitle));
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n.forYouAlgorithmSubtitle), findsOneWidget);
+    });
+  });
+}

--- a/mobile/test/widgets/for_you_tab_test.dart
+++ b/mobile/test/widgets/for_you_tab_test.dart
@@ -23,17 +23,34 @@ class _EmptyForYouFeed extends ForYouFeed {
       const VideoFeedState(videos: [], hasMoreContent: false);
 }
 
-Widget _host() => ProviderScope(
+Widget _host({double textScale = 1}) => ProviderScope(
   overrides: [
     funnelcakeAvailableProvider.overrideWith(_AvailableFunnelcake.new),
     forYouFeedProvider.overrideWith(_EmptyForYouFeed.new),
   ],
-  child: const MaterialApp(
+  child: MaterialApp(
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
-    home: Scaffold(body: ForYouTab()),
+    home: Builder(
+      builder: (context) => MediaQuery(
+        data: MediaQuery.of(
+          context,
+        ).copyWith(textScaler: TextScaler.linear(textScale)),
+        child: const Scaffold(body: ForYouTab()),
+      ),
+    ),
   ),
 );
+
+/// Narrowest screen the app targets, where the header has the least room.
+const _narrowWidth = 320.0;
+
+void _useNarrowScreen(WidgetTester tester) {
+  tester.view.physicalSize = const Size(_narrowWidth, 640);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+}
 
 void main() {
   final l10n = lookupAppLocalizations(const Locale('en'));
@@ -81,6 +98,24 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text(l10n.forYouAlgorithmSubtitle), findsOneWidget);
+    });
+
+    // The largest scale is deliberate: at the default scale the title's
+    // measured width depends on which font resolves in the test environment,
+    // so that case would report on font loading rather than on layout.
+    // Asserting geometry rather than a caught overflow exception keeps this
+    // independent of the debug-only overflow reporter.
+    testWidgets('header keeps the info button on screen at the largest text '
+        'scale', (tester) async {
+      _useNarrowScreen(tester);
+
+      await tester.pumpWidget(_host(textScale: 3));
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.getRect(find.byType(DivineIconButton)).right,
+        lessThanOrEqualTo(_narrowWidth),
+      );
     });
   });
 }


### PR DESCRIPTION
Closes #6852

## Description

The For You header and its algorithm explainer sheet were the last hand-rolled corner of the discovery tab: a bare `DivineIcon` as the info affordance, a hand-built `DraggableScrollableSheet` with its own drag handle, thirteen inline `TextStyle`s and four raw Material icons. None of that picks up theme or accessibility changes coming out of `divine_ui`.

**Sheet → `VineBottomSheet`.** `VineBottomSheet` owns the drag handle, sizing and surface, so `_AlgorithmExplainerSheet` is reduced to content plus the scroll controller handed in by the host. The hand-drawn handle is gone. The `0.85 / 0.5 / 0.95` sizing is kept deliberately and passed explicitly, because `VineBottomSheet.show` defaults to `0.6 / 0.3 / 0.9` and this is long-form content that should open nearly full-height.

**Info icon → `DivineIconButton`.** Previously a 16px glyph with no semantics inside a bare `GestureDetector` — invisible to screen readers as an action. It now carries a 48px tap target and a tooltip. The semantics ended up on the header row rather than on the button: review pointed out the row was still a silent tap region wrapped around a labelled button, so the row now owns `Semantics(button: true, hint: ...)` and the button is wrapped in `ExcludeSemantics` — one action announced once, named by its visible title. The hint reuses the existing `forYouAlgorithmHowItWorksTitle` key rather than adding a new one that would need 17 locale translations. The whole header row stays tappable as before, so the discoverability of the explainer does not shrink.

**Inline styles → `VineTheme`.** All thirteen raw `TextStyle`s map onto the closest point of the design-system scale. Where no exact match existed I rounded to the scale rather than adding a new `VineTheme` helper for a one-off, so a few tokens shift: section titles 17 → 16, state titles 18 → 16, secondary text 13 → 12. Weight and family move with them — section titles w600 → w800, state titles w500 → w800, interaction labels w500 → w600, and the title styles into Bricolage, the app's title family (the sheet title keeps 22px but goes w700 → w800). Body line-height goes 1.5 → 1.43. The ad-hoc values were never design tokens to begin with.

**Material icons → `DivineIcon`.** The four interaction-weight icons become `repeat` / `chat` / `heart` / `playCircle`. `chat` over `chatCircle` because it is the more common variant elsewhere in the app (5 call sites vs 2).

Both ceiling baselines are regenerated: the file drops to zero raw `TextStyle`s and zero raw sheet calls, and the ratchets require a file falling to zero to be locked in explicitly. Only the `for_you_tab.dart` line is removed from each baseline — a full regeneration would have swept in unrelated drift from three other files.

**Related Issue:** 

## Out of Scope

- `Icons.cloud_off` and `Icons.error` in the unavailable / error states still use raw Material icons. Converting them would drop the file to zero raw icons and pull the `raw_icons` baseline into this diff for two 64px placeholder glyphs that carry no design intent.
- `DivineButton` has no `foregroundColor` override, so the whole header could not become a single `DivineButton` without either losing the green title or restyling the strip into a chip. Left as is deliberately.

## Verification

- `flutter analyze lib test integration_test` — clean
- `dart format` — clean
- Design-system ceilings: `raw_textstyle`, `raw_colors`, `material_button`, `raw_icons` green. `raw_dialog` now fails on the un-merged branch because `main` has since shrunk `composable_video_grid.dart` from 2 to 1 — base staleness on a file this PR does not touch, not this diff. It is green on the merge, which is what CI runs.
- `mobile/test/widgets/for_you_tab_test.dart` pins the header's accessibility contract: one button named by its visible title, and tapping it opens the explainer
- Device verification on a real Samsung Galaxy still pending; holding merge on it

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
