### PR TITLE
fix(lists): dismiss editor before relay acknowledgement

### DIFF
--- a/mobile/lib/widgets/add_to_list_dialog.dart
+++ b/mobile/lib/widgets/add_to_list_dialog.dart
@@ -244,17 +244,31 @@ class _CreateListDialogState extends ConsumerState<CreateListDialog> {
             !await _confirmVisibilityChange(existingList.isPublic)) {
           return;
         }
-        final updated = await listService?.updateList(
+        if (!mounted) return;
+        if (listService == null) {
+          _showSaveFailed();
+          return;
+        }
+
+        final messenger = ScaffoldMessenger.of(context);
+        final failureMessage = context.l10n.listUpdateFailed;
+        final updateFuture = listService.updateList(
           listId: existingList.id,
           name: name,
           description: _descriptionController.text.trim(),
           isPublic: _isPublic,
         );
-        if (!mounted) return;
-        if (updated ?? false) {
-          context.pop();
-        } else {
-          _showSaveFailed();
+
+        // updateList applies local fields before waiting for the relay, and a
+        // visibility change can wait through the relay deadline. Close the
+        // editor now so a slow relay does not make the save look unresponsive.
+        Navigator.of(context).pop();
+
+        if (!await updateFuture && messenger.mounted) {
+          _showSaveFailed(
+            messenger: messenger,
+            failureMessage: failureMessage,
+          );
         }
         return;
       }
@@ -334,14 +348,18 @@ class _CreateListDialogState extends ConsumerState<CreateListDialog> {
     return confirmed ?? false;
   }
 
-  // Keeps the dialog open so the typed name and description survive a retry.
-  void _showSaveFailed() {
-    ScaffoldMessenger.of(context).showSnackBar(
+  // A retained messenger lets an edit report relay failure after dismissing.
+  void _showSaveFailed({
+    ScaffoldMessengerState? messenger,
+    String? failureMessage,
+  }) {
+    (messenger ?? ScaffoldMessenger.of(context)).showSnackBar(
       SnackBar(
         content: Text(
-          _isEditing
-              ? context.l10n.listUpdateFailed
-              : context.l10n.listCreateFailed,
+          failureMessage ??
+              (_isEditing
+                  ? context.l10n.listUpdateFailed
+                  : context.l10n.listCreateFailed),
         ),
         duration: const Duration(seconds: 2),
       ),

--- a/mobile/lib/widgets/add_to_list_dialog.dart
+++ b/mobile/lib/widgets/add_to_list_dialog.dart
@@ -4,7 +4,6 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -101,7 +100,10 @@ class SelectListDialog extends StatelessWidget {
                 },
                 child: Text(l10n.listNewList),
               ),
-              TextButton(onPressed: context.pop, child: Text(l10n.listDone)),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: Text(l10n.listDone),
+              ),
             ],
           );
         },
@@ -147,6 +149,11 @@ class SelectListDialog extends StatelessWidget {
 }
 
 /// Dialog for creating a new curated list, optionally adding [video] to it.
+///
+/// Like [SelectListDialog] this is always presented with `showDialog` and is
+/// never registered as a `go_router` route, so every dismissal here goes
+/// through [Navigator] — the navigator that owns the dialog route — rather
+/// than `context.pop`.
 class CreateListDialog extends ConsumerStatefulWidget {
   const CreateListDialog({this.video, this.existingList, super.key});
   final VideoEvent? video;
@@ -223,7 +230,10 @@ class _CreateListDialogState extends ConsumerState<CreateListDialog> {
         ],
       ),
       actions: [
-        TextButton(onPressed: context.pop, child: Text(l10n.listCancel)),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(l10n.listCancel),
+        ),
         TextButton(
           onPressed: _saveList,
           child: Text(_isEditing ? l10n.listSave : l10n.listCreate),
@@ -265,14 +275,14 @@ class _CreateListDialogState extends ConsumerState<CreateListDialog> {
         Navigator.of(context).pop();
 
         if (!await updateFuture && messenger.mounted) {
-          _showSaveFailed(
-            messenger: messenger,
-            failureMessage: failureMessage,
-          );
+          _showSaveFailedDetached(messenger, failureMessage);
         }
         return;
       }
 
+      // The create path cannot dismiss early the way the edit path does:
+      // createList rolls the new list back out of local storage when the relay
+      // rejects it, and its generated ID is only known once it returns.
       final newList = await listService?.createList(
         name: name,
         description: _descriptionController.text.trim().isEmpty
@@ -296,7 +306,7 @@ class _CreateListDialogState extends ConsumerState<CreateListDialog> {
       }
 
       if (mounted) {
-        context.pop();
+        Navigator.of(context).pop();
       }
     } catch (e) {
       Log.error(
@@ -348,21 +358,23 @@ class _CreateListDialogState extends ConsumerState<CreateListDialog> {
     return confirmed ?? false;
   }
 
-  // A retained messenger lets an edit report relay failure after dismissing.
-  void _showSaveFailed({
-    ScaffoldMessengerState? messenger,
-    String? failureMessage,
-  }) {
-    (messenger ?? ScaffoldMessenger.of(context)).showSnackBar(
-      SnackBar(
-        content: Text(
-          failureMessage ??
-              (_isEditing
-                  ? context.l10n.listUpdateFailed
-                  : context.l10n.listCreateFailed),
-        ),
-        duration: const Duration(seconds: 2),
-      ),
+  /// Reports a failure while this dialog is still on screen.
+  void _showSaveFailed() => _showSaveFailedDetached(
+    ScaffoldMessenger.of(context),
+    _isEditing ? context.l10n.listUpdateFailed : context.l10n.listCreateFailed,
+  );
+
+  /// Reports a failure once the dialog may already be gone.
+  ///
+  /// Both arguments must be resolved before the async gap: after the pop this
+  /// State can be unmounted, so neither the messenger nor the message can be
+  /// recovered from [context].
+  void _showSaveFailedDetached(
+    ScaffoldMessengerState messenger,
+    String message,
+  ) {
+    messenger.showSnackBar(
+      SnackBar(content: Text(message), duration: const Duration(seconds: 2)),
     );
   }
 

--- a/mobile/lib/widgets/add_to_list_dialog.dart
+++ b/mobile/lib/widgets/add_to_list_dialog.dart
@@ -250,7 +250,8 @@ class _CreateListDialogState extends ConsumerState<CreateListDialog> {
       final listService = ref.read(curatedListsStateProvider.notifier).service;
       final existingList = widget.existingList;
       if (existingList != null) {
-        if (existingList.isPublic != _isPublic &&
+        final visibilityChanged = existingList.isPublic != _isPublic;
+        if (visibilityChanged &&
             !await _confirmVisibilityChange(existingList.isPublic)) {
           return;
         }
@@ -260,8 +261,6 @@ class _CreateListDialogState extends ConsumerState<CreateListDialog> {
           return;
         }
 
-        final messenger = ScaffoldMessenger.of(context);
-        final failureMessage = context.l10n.listUpdateFailed;
         final updateFuture = listService.updateList(
           listId: existingList.id,
           name: name,
@@ -269,9 +268,28 @@ class _CreateListDialogState extends ConsumerState<CreateListDialog> {
           isPublic: _isPublic,
         );
 
-        // updateList applies local fields before waiting for the relay, and a
-        // visibility change can wait through the relay deadline. Close the
-        // editor now so a slow relay does not make the save look unresponsive.
+        // Visibility is the one field updateList holds back until a relay
+        // accepts the change, so a rejection means the switch the user flipped
+        // did not take. Wait for the answer and keep the editor open on
+        // failure, so that flip survives a retry.
+        if (visibilityChanged) {
+          final updated = await updateFuture;
+          if (!mounted) return;
+          if (updated) {
+            Navigator.of(context).pop();
+          } else {
+            _showSaveFailed();
+          }
+          return;
+        }
+
+        // Name and description are already stored locally before updateList
+        // awaits the relay, so nothing the user typed is riding on the answer.
+        // Close now rather than let a slow relay make the save look
+        // unresponsive; the messenger and message have to be resolved first
+        // because the pop can unmount this State.
+        final messenger = ScaffoldMessenger.of(context);
+        final failureMessage = context.l10n.listUpdateFailed;
         Navigator.of(context).pop();
 
         if (!await updateFuture && messenger.mounted) {

--- a/mobile/test/widgets/add_to_list_dialog_test.dart
+++ b/mobile/test/widgets/add_to_list_dialog_test.dart
@@ -13,7 +13,6 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/curated_list_service.dart';
 import 'package:openvine/widgets/add_to_list_dialog.dart';
 
-import '../helpers/go_router.dart';
 import '../helpers/test_provider_overrides.dart';
 
 class _MockCuratedListService extends Mock implements CuratedListService {}
@@ -285,32 +284,26 @@ void main() {
       updatedAt: DateTime.now(),
     );
 
-    Widget buildSubject({
+    Widget buildSubject({VideoEvent? video, CuratedList? existingList}) =>
+        testProviderScope(
+          additionalOverrides: [
+            curatedListsStateProvider.overrideWith(_FakeCuratedListsState.new),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: CreateListDialog(video: video, existingList: existingList),
+            ),
+          ),
+        );
+
+    /// Hosts the dialog on a real dialog route so dismissal — and the snackbar
+    /// that has to outlive it — can be asserted the way a user sees them.
+    Widget buildDialogLauncher({
       VideoEvent? video,
       CuratedList? existingList,
-      MockGoRouter? goRouter,
-    }) {
-      final dialog = CreateListDialog(
-        video: video,
-        existingList: existingList,
-      );
-      return testProviderScope(
-        additionalOverrides: [
-          curatedListsStateProvider.overrideWith(_FakeCuratedListsState.new),
-        ],
-        child: MaterialApp(
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: Scaffold(
-            body: goRouter == null
-                ? dialog
-                : MockGoRouterProvider(goRouter: goRouter, child: dialog),
-          ),
-        ),
-      );
-    }
-
-    Widget buildDialogLauncher(CuratedList existingList) => testProviderScope(
+    }) => testProviderScope(
       additionalOverrides: [
         curatedListsStateProvider.overrideWith(_FakeCuratedListsState.new),
       ],
@@ -322,7 +315,8 @@ void main() {
             body: TextButton(
               onPressed: () => showDialog<void>(
                 context: context,
-                builder: (_) => CreateListDialog(existingList: existingList),
+                builder: (_) =>
+                    CreateListDialog(video: video, existingList: existingList),
               ),
               child: const Text('Open list editor'),
             ),
@@ -388,9 +382,6 @@ void main() {
 
     testWidgets('confirms before publishing a private list', (tester) async {
       final list = createdList('Puppets').copyWith(isPublic: false);
-      final goRouter = MockGoRouter();
-      when(goRouter.canPop).thenReturn(true);
-      when(() => goRouter.pop<Object?>()).thenReturn(null);
       when(
         () => mockListService.updateList(
           listId: any(named: 'listId'),
@@ -400,9 +391,9 @@ void main() {
         ),
       ).thenAnswer((_) async => true);
 
-      await tester.pumpWidget(
-        buildSubject(existingList: list, goRouter: goRouter),
-      );
+      await tester.pumpWidget(buildDialogLauncher(existingList: list));
+      await tester.tap(find.text('Open list editor'));
+      await tester.pumpAndSettle();
       await tester.tap(find.byType(SwitchListTile));
       await tester.tap(find.text('Save'));
       await tester.pumpAndSettle();
@@ -447,7 +438,7 @@ void main() {
         ),
       ).thenAnswer((_) => updateCompleter.future);
 
-      await tester.pumpWidget(buildDialogLauncher(list));
+      await tester.pumpWidget(buildDialogLauncher(existingList: list));
       await tester.tap(find.text('Open list editor'));
       await tester.pumpAndSettle();
       await tester.enterText(find.byType(TextField).first, 'Marionettes');
@@ -489,7 +480,7 @@ void main() {
           ),
         ).thenAnswer((_) => updateCompleter.future);
 
-        await tester.pumpWidget(buildDialogLauncher(list));
+        await tester.pumpWidget(buildDialogLauncher(existingList: list));
         await tester.tap(find.text('Open list editor'));
         await tester.pumpAndSettle();
         await tester.tap(find.byType(SwitchListTile));
@@ -510,6 +501,53 @@ void main() {
 
         updateCompleter.complete(true);
         await tester.pump();
+      },
+    );
+
+    testWidgets(
+      'drops the pending edit when publishing a private list is rejected',
+      (tester) async {
+        final list = createdList('Puppets').copyWith(isPublic: false);
+        final updateCompleter = Completer<bool>();
+        addTearDown(() {
+          if (!updateCompleter.isCompleted) updateCompleter.complete(true);
+        });
+        when(
+          () => mockListService.updateList(
+            listId: any(named: 'listId'),
+            name: any(named: 'name'),
+            description: any(named: 'description'),
+            isPublic: any(named: 'isPublic'),
+          ),
+        ).thenAnswer((_) => updateCompleter.future);
+
+        await tester.pumpWidget(buildDialogLauncher(existingList: list));
+        await tester.tap(find.text('Open list editor'));
+        await tester.pumpAndSettle();
+        await tester.enterText(find.byType(TextField).first, 'Marionettes');
+        await tester.tap(find.byType(SwitchListTile));
+        await tester.tap(find.text(l10n.listSave));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(l10n.listContinue));
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.listEditTitle), findsNothing);
+
+        updateCompleter.complete(false);
+        await tester.pumpAndSettle();
+
+        // The messenger captured before the pop belongs to the host scaffold,
+        // so the failure still reaches the user once the editor route is gone.
+        expect(find.text(l10n.listUpdateFailed), findsOneWidget);
+
+        // Nothing is left to retry from. The editor did not reopen, the typed
+        // name went with it, and the visibility switch the user flipped is no
+        // longer on screen — the service leaves isPublic at its old value on a
+        // rejected publish (curated_list_service_crud_test.dart, "keeps a list
+        // private when publication is rejected"), so that flip is lost too.
+        expect(find.text(l10n.listEditTitle), findsNothing);
+        expect(find.text('Marionettes'), findsNothing);
+        expect(find.byType(SwitchListTile), findsNothing);
       },
     );
 
@@ -534,9 +572,6 @@ void main() {
 
     testWidgets('creates list and pops without adding video when no video '
         'is provided', (tester) async {
-      final goRouter = MockGoRouter();
-      when(goRouter.canPop).thenReturn(true);
-      when(() => goRouter.pop<Object?>()).thenReturn(null);
       when(
         () => mockListService.createList(
           name: any(named: 'name'),
@@ -545,7 +580,9 @@ void main() {
         ),
       ).thenAnswer((_) async => createdList('Fresh List'));
 
-      await tester.pumpWidget(buildSubject(goRouter: goRouter));
+      await tester.pumpWidget(buildDialogLauncher());
+      await tester.tap(find.text('Open list editor'));
+      await tester.pumpAndSettle();
       await tester.enterText(find.byType(TextField).first, 'Fresh List');
       await tester.tap(find.text(l10n.listCreate));
       await tester.pumpAndSettle();
@@ -558,15 +595,12 @@ void main() {
         ),
       ).called(1);
       verifyNever(() => mockListService.addVideoToList(any(), any()));
-      verify(() => goRouter.pop<Object?>()).called(1);
+      expect(find.text(l10n.listCreateNewList), findsNothing);
     });
 
     testWidgets('creates list and adds video when a video is provided', (
       tester,
     ) async {
-      final goRouter = MockGoRouter();
-      when(goRouter.canPop).thenReturn(true);
-      when(() => goRouter.pop<Object?>()).thenReturn(null);
       final newList = createdList('Video List');
       when(
         () => mockListService.createList(
@@ -579,9 +613,9 @@ void main() {
         () => mockListService.addVideoToList(any(), any()),
       ).thenAnswer((_) async => true);
 
-      await tester.pumpWidget(
-        buildSubject(video: testVideo, goRouter: goRouter),
-      );
+      await tester.pumpWidget(buildDialogLauncher(video: testVideo));
+      await tester.tap(find.text('Open list editor'));
+      await tester.pumpAndSettle();
       await tester.enterText(find.byType(TextField).first, 'Video List');
       await tester.tap(find.text(l10n.listCreate));
       await tester.pumpAndSettle();
@@ -589,13 +623,11 @@ void main() {
       verify(
         () => mockListService.addVideoToList(newList.id, testVideo.id),
       ).called(1);
-      verify(() => goRouter.pop<Object?>()).called(1);
+      expect(find.text(l10n.listCreateNewList), findsNothing);
     });
 
     testWidgets('shows failure snackbar and keeps dialog open when '
         'createList returns null', (tester) async {
-      final goRouter = MockGoRouter();
-      when(goRouter.canPop).thenReturn(true);
       when(
         () => mockListService.createList(
           name: any(named: 'name'),
@@ -604,7 +636,9 @@ void main() {
         ),
       ).thenAnswer((_) async => null);
 
-      await tester.pumpWidget(buildSubject(goRouter: goRouter));
+      await tester.pumpWidget(buildDialogLauncher());
+      await tester.tap(find.text('Open list editor'));
+      await tester.pumpAndSettle();
       await tester.enterText(find.byType(TextField).first, 'Doomed List');
       await tester.tap(find.text(l10n.listCreate));
       await tester.pumpAndSettle();
@@ -612,7 +646,6 @@ void main() {
       expect(find.text(l10n.listCreateFailed), findsOneWidget);
       expect(find.text(l10n.listCreateNewList), findsOneWidget);
       verifyNever(() => mockListService.addVideoToList(any(), any()));
-      verifyNever(() => goRouter.pop<Object?>());
     });
   });
 }

--- a/mobile/test/widgets/add_to_list_dialog_test.dart
+++ b/mobile/test/widgets/add_to_list_dialog_test.dart
@@ -462,7 +462,7 @@ void main() {
     });
 
     testWidgets(
-      'dismisses while publishing a private list with a pending relay update',
+      'waits on the relay before dismissing a visibility change',
       (
         tester,
       ) async {
@@ -497,15 +497,17 @@ void main() {
             isPublic: true,
           ),
         ).called(1);
-        expect(find.text(l10n.listEditTitle), findsNothing);
+        expect(find.text(l10n.listEditTitle), findsOneWidget);
 
         updateCompleter.complete(true);
-        await tester.pump();
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.listEditTitle), findsNothing);
       },
     );
 
     testWidgets(
-      'drops the pending edit when publishing a private list is rejected',
+      'keeps a rejected visibility change on screen for a retry',
       (tester) async {
         final list = createdList('Puppets').copyWith(isPublic: false);
         final updateCompleter = Completer<bool>();
@@ -531,23 +533,21 @@ void main() {
         await tester.tap(find.text(l10n.listContinue));
         await tester.pumpAndSettle();
 
-        expect(find.text(l10n.listEditTitle), findsNothing);
-
         updateCompleter.complete(false);
         await tester.pumpAndSettle();
 
-        // The messenger captured before the pop belongs to the host scaffold,
-        // so the failure still reaches the user once the editor route is gone.
         expect(find.text(l10n.listUpdateFailed), findsOneWidget);
 
-        // Nothing is left to retry from. The editor did not reopen, the typed
-        // name went with it, and the visibility switch the user flipped is no
-        // longer on screen — the service leaves isPublic at its old value on a
-        // rejected publish (curated_list_service_crud_test.dart, "keeps a list
-        // private when publication is rejected"), so that flip is lost too.
-        expect(find.text(l10n.listEditTitle), findsNothing);
-        expect(find.text('Marionettes'), findsNothing);
-        expect(find.byType(SwitchListTile), findsNothing);
+        // The service leaves isPublic at its old value on a rejected publish
+        // (curated_list_service_crud_test.dart, "keeps a list private when
+        // publication is rejected"), so the flip only survives if the editor
+        // holding it is still on screen with the typed name intact.
+        expect(find.text(l10n.listEditTitle), findsOneWidget);
+        expect(find.text('Marionettes'), findsOneWidget);
+        expect(
+          tester.widget<SwitchListTile>(find.byType(SwitchListTile)).value,
+          isTrue,
+        );
       },
     );
 

--- a/mobile/test/widgets/add_to_list_dialog_test.dart
+++ b/mobile/test/widgets/add_to_list_dialog_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for SelectListDialog and CreateListDialog widgets
 // ABOUTME: Verifies list selection, list item interactions, and list creation form
 
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -308,6 +310,27 @@ void main() {
       );
     }
 
+    Widget buildDialogLauncher(CuratedList existingList) => testProviderScope(
+      additionalOverrides: [
+        curatedListsStateProvider.overrideWith(_FakeCuratedListsState.new),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: TextButton(
+              onPressed: () => showDialog<void>(
+                context: context,
+                builder: (_) => CreateListDialog(existingList: existingList),
+              ),
+              child: const Text('Open list editor'),
+            ),
+          ),
+        ),
+      ),
+    );
+
     testWidgets('renders Create New List form', (tester) async {
       await tester.pumpWidget(buildSubject());
 
@@ -406,6 +429,89 @@ void main() {
         ),
       ).called(1);
     });
+
+    testWidgets('dismisses a renamed list before reporting relay failure', (
+      tester,
+    ) async {
+      final list = createdList('Puppets');
+      final updateCompleter = Completer<bool>();
+      addTearDown(() {
+        if (!updateCompleter.isCompleted) updateCompleter.complete(true);
+      });
+      when(
+        () => mockListService.updateList(
+          listId: any(named: 'listId'),
+          name: any(named: 'name'),
+          description: any(named: 'description'),
+          isPublic: any(named: 'isPublic'),
+        ),
+      ).thenAnswer((_) => updateCompleter.future);
+
+      await tester.pumpWidget(buildDialogLauncher(list));
+      await tester.tap(find.text('Open list editor'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField).first, 'Marionettes');
+      await tester.tap(find.text(l10n.listSave));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => mockListService.updateList(
+          listId: list.id,
+          name: 'Marionettes',
+          description: '',
+          isPublic: true,
+        ),
+      ).called(1);
+      expect(find.text(l10n.listEditTitle), findsNothing);
+
+      updateCompleter.complete(false);
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n.listUpdateFailed), findsOneWidget);
+    });
+
+    testWidgets(
+      'dismisses while publishing a private list with a pending relay update',
+      (
+        tester,
+      ) async {
+        final list = createdList('Puppets').copyWith(isPublic: false);
+        final updateCompleter = Completer<bool>();
+        addTearDown(() {
+          if (!updateCompleter.isCompleted) updateCompleter.complete(true);
+        });
+        when(
+          () => mockListService.updateList(
+            listId: any(named: 'listId'),
+            name: any(named: 'name'),
+            description: any(named: 'description'),
+            isPublic: any(named: 'isPublic'),
+          ),
+        ).thenAnswer((_) => updateCompleter.future);
+
+        await tester.pumpWidget(buildDialogLauncher(list));
+        await tester.tap(find.text('Open list editor'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byType(SwitchListTile));
+        await tester.tap(find.text(l10n.listSave));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(l10n.listContinue));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => mockListService.updateList(
+            listId: list.id,
+            name: 'Puppets',
+            description: '',
+            isPublic: true,
+          ),
+        ).called(1);
+        expect(find.text(l10n.listEditTitle), findsNothing);
+
+        updateCompleter.complete(true);
+        await tester.pump();
+      },
+    );
 
     testWidgets('Create button does nothing when name is empty', (
       tester,


### PR DESCRIPTION
Closes #6862

## Summary

- dismiss list settings after the local update begins instead of waiting for relay acknowledgement
- preserve relay failure feedback on the underlying screen after dismissal
- cover rename and private-to-public saves while relay work is pending

## Testing

- flutter test test/widgets/add_to_list_dialog_test.dart
- flutter analyze