### PR TITLE
feat(analytics): attribute home-feed views to the feed mode that served them

### DIFF
--- a/mobile/lib/blocs/video_feed/video_feed_state.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_state.dart
@@ -36,6 +36,27 @@ enum VideoFeedSourceType {
   classic,
 }
 
+extension VideoFeedSourceTypeAnalytics on VideoFeedSourceType {
+  /// Stable analytics tag for this source type.
+  ///
+  /// Published as the third element of the kind-22236 `source` tag, which
+  /// funnelcake stores in `view_traffic_sources.source_detail`. The `source`
+  /// itself stays `home` for every mode, because a single feed page renders
+  /// all of them — without this detail every mode collapses into one `home`
+  /// bucket and re-serve rates cannot be attributed to a specific feed.
+  ///
+  /// These values are persisted analytics data. Renaming one silently splits
+  /// its history in two, so add new values rather than repurposing existing
+  /// ones.
+  String get analyticsTag => switch (this) {
+    VideoFeedSourceType.forYou => 'foryou',
+    VideoFeedSourceType.following => 'following',
+    VideoFeedSourceType.subscribedList => 'list',
+    VideoFeedSourceType.newVideos => 'new',
+    VideoFeedSourceType.classic => 'classic',
+  };
+}
+
 /// Source selection for [VideoFeedBloc].
 final class VideoFeedSource extends Equatable {
   /// Personalized recommended videos.

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -502,6 +502,11 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                             hasMore: state.hasMore,
                             isLoadingMore: state.isLoadingMore,
                             trafficSource: ViewTrafficSource.home,
+                            // Every feed mode renders through this one page and
+                            // reports source=home, so without this detail the
+                            // For You, following, list, new and classic feeds
+                            // are indistinguishable in view_traffic_sources.
+                            sourceDetail: state.source.type.analyticsTag,
                             onActiveVideoChanged: (video, index) {
                               final isTuningAutoAdvance =
                                   _pendingTuningAutoAdvanceIndex == index;

--- a/mobile/test/blocs/video_feed/video_feed_source_analytics_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_source_analytics_test.dart
@@ -1,0 +1,53 @@
+// ABOUTME: Locks the analytics tags published as view_traffic_sources.source_detail
+// ABOUTME: so renaming one cannot silently split its history in the funnelcake data
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
+
+void main() {
+  group('VideoFeedSourceTypeAnalytics', () {
+    test('every source type has a distinct, stable tag', () {
+      // These strings are written to funnelcake's
+      // view_traffic_sources.source_detail and queried historically. Renaming
+      // one splits its history in two, so this asserts the exact values rather
+      // than merely that a tag exists.
+      expect(VideoFeedSourceType.forYou.analyticsTag, 'foryou');
+      expect(VideoFeedSourceType.following.analyticsTag, 'following');
+      expect(VideoFeedSourceType.subscribedList.analyticsTag, 'list');
+      expect(VideoFeedSourceType.newVideos.analyticsTag, 'new');
+      expect(VideoFeedSourceType.classic.analyticsTag, 'classic');
+    });
+
+    test('tags are unique across all source types', () {
+      // A duplicate tag would silently merge two feeds into one bucket, which
+      // is the exact problem this detail field exists to solve.
+      final tags = VideoFeedSourceType.values
+          .map((type) => type.analyticsTag)
+          .toList();
+
+      expect(tags.toSet().length, tags.length, reason: 'tags must be unique');
+    });
+
+    test('a new source type must be given a tag', () {
+      // The switch in analyticsTag is exhaustive, so adding an enum value
+      // without a tag is a compile error. This asserts the count so the intent
+      // is visible at review time when someone adds a feed mode.
+      expect(
+        VideoFeedSourceType.values.length,
+        5,
+        reason:
+            'new feed mode added: give it an analyticsTag and update this '
+            'test, otherwise its views land in an unattributed bucket',
+      );
+    });
+
+    test('no tag is empty or whitespace', () {
+      for (final type in VideoFeedSourceType.values) {
+        expect(type.analyticsTag.trim(), isNotEmpty, reason: '$type');
+        // The publisher omits the detail element entirely when it is empty,
+        // which would collapse the mode back into the bare `home` bucket.
+        expect(type.analyticsTag, isNot(contains(' ')), reason: '$type');
+      }
+    });
+  });
+}


### PR DESCRIPTION
Closes #6866

## Problem

`home` accounts for **28.7% of measured feed re-serves** — and it is currently impossible to tell which feed is responsible.

`VideoFeedPage` renders **five different feed modes** and reports `source=home` for every one of them:

| Mode | Backing call |
|---|---|
| For You | `getRecommendedVideos` → `/api/users/{pubkey}/recommendations` |
| Following | `getHomeFeedVideos` |
| Subscribed list | `_mergeListVideos` |
| New | chronological |
| Classic | `getClassicVideos` |

They all collapse into one `home` bucket in funnelcake's `view_traffic_sources`. The daily re-serve monitor therefore cannot attribute a rate to a specific feed and — more importantly right now — **cannot show whether a fix to one of them worked**. Backend fixes just landed for the recommendations path (divinevideo/divine-funnelcake#843, #858); without this, their effect is invisible because it is averaged with four untouched feeds.

## Change

Publish the bloc's current source type as the **source detail**.

This only populates plumbing that already exists end to end:

- The kind-22236 `source` tag already carries an optional third element (`['source', <source>, <detail>]`)
- funnelcake's view handler already parses `tag[2]` into `view_traffic_sources.source_detail`
- `ViewEventPublisher` already accepts `sourceDetail`, already threaded through `FeedVideos` → `DivineVideoMetricsTracker`

Only the value was missing.

## Compatibility

**Purely additive.** `source` stays `home` for every mode, so existing queries and dashboards filtering on it are unaffected — including funnelcake's `"home" => home_views += row.views` aggregation. No funnelcake change, no migration, no schema change.

## Tags

`foryou` · `following` · `list` · `new` · `classic`

These become persisted analytics values, so the test asserts the **exact strings** rather than merely that a tag exists — renaming one silently splits its history in two. It also asserts uniqueness (a duplicate would merge two feeds back into one bucket) and the enum arity, so adding a feed mode surfaces the decision at review time instead of quietly landing views in an unattributed bucket.

## Validation

- `flutter analyze lib test integration_test` ✅ No issues found
- `flutter test test/blocs/video_feed/` ✅ 120 passed
- `video_feed_page_test.dart` ✅ 34 passed (covers the changed call site)
- New test ✅ 4 passed

## After this ships

The daily re-serve monitor can group by `source_detail` and answer what is currently unanswerable: which of the five home feeds is re-serving, and whether the recommendations fixes moved their slice. Worth having before the 2026-08-18 campaign — it is the difference between measuring the feed and guessing at it.

Note this is instrumentation only: it changes no feed behaviour and carries no rollout risk.
