### PR TITLE
fix(repositories): stop an unreadable local cache from blocking relay publishes

### DIFF
--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -28,6 +28,7 @@ import 'package:openvine/services/auth_service.dart' show AuthState;
 import 'package:openvine/services/broken_video_tracker.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/services/content_deletion_service.dart';
+import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/dead_media_feed_guard.dart';
 import 'package:openvine/services/event_api_client.dart';
 import 'package:openvine/services/event_router.dart';
@@ -589,6 +590,15 @@ LikesRepository likesRepository(Ref ref) {
     nostrClient: nostrClient,
     localStorage: localStorage,
     blockFilter: createBlockedAuthorFilter(ref),
+    errorReporter: (error, stackTrace, {required site}) {
+      unawaited(
+        CrashReportingService.instance.recordError(
+          error,
+          stackTrace,
+          reason: 'LikesRepository.$site',
+        ),
+      );
+    },
     isOnline: () =>
         connectionStatus.isOnline && authService.canPublishNostrWritesNow,
     queueOfflineAction: pendingActionService != null
@@ -685,6 +695,15 @@ RepostsRepository repostsRepository(Ref ref) {
     nostrClient: nostrClient,
     localStorage: localStorage,
     blockFilter: createBlockedAuthorFilter(ref),
+    errorReporter: (error, stackTrace, {required site}) {
+      unawaited(
+        CrashReportingService.instance.recordError(
+          error,
+          stackTrace,
+          reason: 'RepostsRepository.$site',
+        ),
+      );
+    },
     isOnline: () =>
         connectionStatus.isOnline && authService.canPublishNostrWritesNow,
     queueOfflineAction: pendingActionService != null

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -1006,4 +1006,4 @@ final class LikesRepositoryProvider
   }
 }
 
-String _$likesRepositoryHash() => r'441c473c923ad75405f4ab0a650e0f5716894fa1';
+String _$likesRepositoryHash() => r'd8126449ef36a6be85a7a2bb01f052f0ccb1f315';

--- a/mobile/packages/likes_repository/lib/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/likes_repository.dart
@@ -13,4 +13,5 @@ export 'src/db_likes_local_storage.dart';
 export 'src/exceptions.dart';
 export 'src/likes_local_storage.dart';
 export 'src/likes_repository.dart';
+export 'src/likes_repository_reportable_sites.dart';
 export 'src/models/models.dart';

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -1502,11 +1502,20 @@ class LikesRepository {
   ///
   /// Throws `SyncFailedException` if syncing fails.
   Future<LikesSyncResult> syncUserReactions() async {
-    // First, load from local storage (fast)
-    if (_localStorage != null) {
-      final records = await _localStorage.getAllLikeRecords();
-      records.forEach(_indexLikeRecord);
-      _emitLikedIds();
+    // First, load from local storage (fast). Best-effort and deliberately
+    // outside the relay try/catch below: an unreadable cache must not skip
+    // the authoritative relay fetch, which is the whole point of a sync.
+    final localStorage = _localStorage;
+    if (localStorage != null) {
+      final records = await _bestEffortLocalStorage(
+        localStorage.getAllLikeRecords,
+        description: 'loading persisted reactions for sync',
+        site: LikesRepositoryReportableSites.syncUserReactionsLoadRecords,
+      );
+      if (records != null) {
+        records.forEach(_indexLikeRecord);
+        _emitLikedIds();
+      }
     }
 
     try {
@@ -1632,7 +1641,11 @@ class LikesRepository {
       // Remove deleted likes from cache and storage
       for (final targetId in deletedTargetIds) {
         _deindexLikeRecord(targetId);
-        await _localStorage?.deleteLikeRecord(targetId);
+        await _bestEffortLocalStorage(
+          () async => localStorage?.deleteLikeRecord(targetId),
+          description: 'dropping a deleted reaction',
+          site: LikesRepositoryReportableSites.syncUserReactionsDeleteRecord,
+        );
       }
 
       // Remove deleted downvotes from in-memory cache (no local storage in v1)
@@ -1642,8 +1655,12 @@ class LikesRepository {
       }
 
       // Batch save new records to storage
-      if (newRecords.isNotEmpty && _localStorage != null) {
-        await _localStorage.saveLikeRecordsBatch(newRecords);
+      if (newRecords.isNotEmpty && localStorage != null) {
+        await _bestEffortLocalStorage(
+          () => localStorage.saveLikeRecordsBatch(newRecords),
+          description: 'persisting the synced reactions',
+          site: LikesRepositoryReportableSites.syncUserReactionsSaveBatch,
+        );
       }
 
       _emitLikedIds();
@@ -1929,15 +1946,24 @@ class LikesRepository {
   Future<void> initialize() async {
     if (_isInitialized) return;
 
-    // Load from local storage first for immediate UI display
+    // Load from local storage first for immediate UI display. Best-effort:
+    // throwing here would skip _subscribeToReactions below, so an unreadable
+    // cache would also cost the session its cross-device sync.
     var hasCoordinatelessRecords = false;
-    if (_localStorage != null) {
-      final records = await _localStorage.getAllLikeRecords();
-      records.forEach(_indexLikeRecord);
-      hasCoordinatelessRecords = records.any(
-        (r) => r.addressableId == null || r.addressableId!.isEmpty,
+    final localStorage = _localStorage;
+    if (localStorage != null) {
+      final records = await _bestEffortLocalStorage(
+        localStorage.getAllLikeRecords,
+        description: 'loading persisted reactions at startup',
+        site: LikesRepositoryReportableSites.initializeLoadRecords,
       );
-      _emitLikedIds();
+      if (records != null) {
+        records.forEach(_indexLikeRecord);
+        hasCoordinatelessRecords = records.any(
+          (r) => r.addressableId == null || r.addressableId!.isEmpty,
+        );
+        _emitLikedIds();
+      }
     }
 
     final pubkey = await _currentUserPubkey();

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -2042,7 +2042,18 @@ class LikesRepository {
       );
 
       _indexLikeRecord(record);
-      unawaited(_localStorage?.saveLikeRecord(record));
+      // Best-effort: `unawaited` attaches no error handler, so a raw
+      // rejection here would surface as an uncaught async error in the app's
+      // zone guard and reach Crashlytics as exactly the expected-IO noise the
+      // decision matrix keeps out.
+      unawaited(
+        _bestEffortLocalStorage(
+          () async => _localStorage?.saveLikeRecord(record),
+          description: 'saving a reaction from the live subscription',
+          site:
+              LikesRepositoryReportableSites.processIncomingReactionSaveRecord,
+        ),
+      );
       _emitLikedIds();
     } else if (event.content == _downvoteContent) {
       // Deduplicate downvotes (in-memory only — no local persistence in v1)

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -483,7 +483,10 @@ class LikesRepository {
       addressableId: addressableId,
     );
     _indexLikeRecord(placeholder);
-    await _localStorage?.saveLikeRecord(placeholder);
+    await _bestEffortLocalStorage(
+      () async => _localStorage?.saveLikeRecord(placeholder),
+      description: 'saving the like placeholder',
+    );
     if (previousCount != null) {
       _writeCachedLikeCount(
         eventId,
@@ -533,7 +536,10 @@ class LikesRepository {
         addressableId: addressableId,
       );
       _indexLikeRecord(confirmed);
-      await _localStorage?.saveLikeRecord(confirmed);
+      await _bestEffortLocalStorage(
+        () async => _localStorage?.saveLikeRecord(confirmed),
+        description: 'saving the confirmed like',
+      );
 
       return reactionEvent.id;
     } catch (e, stackTrace) {
@@ -555,7 +561,10 @@ class LikesRepository {
         return placeholderId;
       }
       _deindexLikeRecord(eventId);
-      await _localStorage?.deleteLikeRecord(eventId);
+      await _bestEffortLocalStorage(
+        () async => _localStorage?.deleteLikeRecord(eventId),
+        description: 'rolling back the like placeholder',
+      );
       if (previousCount != null) {
         _writeCachedLikeCount(
           eventId,
@@ -671,13 +680,17 @@ class LikesRepository {
     if (record == null && addressableId != null && addressableId.isNotEmpty) {
       record = _likeRecordsByAddressableId[addressableId];
     }
-    if (record == null && _localStorage != null) {
-      record = await _localStorage.getLikeRecord(eventId);
-      if (record == null && addressableId != null && addressableId.isNotEmpty) {
-        record = await _localStorage.getLikeRecordByAddressableId(
-          addressableId,
-        );
-      }
+    final localStorage = _localStorage;
+    if (record == null && localStorage != null) {
+      record = await _bestEffortLocalStorage<LikeRecord?>(
+        () async {
+          final stored = await localStorage.getLikeRecord(eventId);
+          if (stored != null) return stored;
+          if (addressableId == null || addressableId.isEmpty) return null;
+          return localStorage.getLikeRecordByAddressableId(addressableId);
+        },
+        description: 'reading the like record',
+      );
     }
 
     if (record == null) {
@@ -699,7 +712,10 @@ class LikesRepository {
     // 1. Optimistic-first: remove from memory + local storage and tick the
     // watchLikedEventIds stream BEFORE any network I/O (mirror of likeEvent).
     _deindexLikeRecord(resolvedEventId);
-    await _localStorage?.deleteLikeRecord(resolvedEventId);
+    await _bestEffortLocalStorage(
+      () async => _localStorage?.deleteLikeRecord(resolvedEventId),
+      description: 'deleting the like record',
+    );
     _decrementLikeCountCache(eventId, addressableId: addressableId);
     _emitLikedIds();
 
@@ -747,7 +763,10 @@ class LikesRepository {
         return;
       }
       _indexLikeRecord(snapshotRecord);
-      await _localStorage?.saveLikeRecord(snapshotRecord);
+      await _bestEffortLocalStorage(
+        () async => _localStorage?.saveLikeRecord(snapshotRecord),
+        description: 'restoring the like record',
+      );
       if (previousCount != null) {
         _writeCachedLikeCount(
           eventId,
@@ -2061,12 +2080,52 @@ class LikesRepository {
   Future<void> _ensureInitialized() async {
     if (_isInitialized) return;
 
-    if (_localStorage != null) {
-      final records = await _localStorage.getAllLikeRecords();
-      records.forEach(_indexLikeRecord);
-      _emitLikedIds();
+    final localStorage = _localStorage;
+    if (localStorage != null) {
+      try {
+        final records = await localStorage.getAllLikeRecords();
+        records.forEach(_indexLikeRecord);
+        _emitLikedIds();
+      } on Object catch (e) {
+        // Degrade to an in-memory-only cache rather than failing the caller.
+        // Callers are publish paths: an unreadable cache costs a stale
+        // already-liked check, while throwing here costs the Kind 7.
+        Log.warning(
+          'Like cache unavailable; continuing without persisted records: $e',
+          name: 'LikesRepository',
+          category: LogCategory.system,
+        );
+      }
     }
+    // Latched on both paths: an unreadable database stays unreadable for the
+    // session, so retrying would re-throw on every call instead of degrading.
     _isInitialized = true;
+  }
+
+  /// Runs a local-storage side effect that must never block a relay publish.
+  ///
+  /// The local database is a cache. A reaction that reached relays survives
+  /// without its cache row; a reaction blocked by an unwritable cache is lost
+  /// outright. Storage failures are therefore logged and swallowed.
+  ///
+  /// Expected IO/corruption failures are not Crashlytics-reportable (see the
+  /// decision matrix in `.claude/rules/error_handling.md`); the unified log is
+  /// where a degraded cache surfaces.
+  Future<T?> _bestEffortLocalStorage<T>(
+    Future<T> Function() operation, {
+    required String description,
+  }) async {
+    try {
+      return await operation();
+    } on Object catch (e) {
+      Log.warning(
+        'Local like storage unavailable ($description); '
+        'continuing without it: $e',
+        name: 'LikesRepository',
+        category: LogCategory.system,
+      );
+      return null;
+    }
   }
 
   /// Extracts the target event ID from a reaction event's 'e' tag.

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -909,8 +909,16 @@ class LikesRepository {
     // than the one being toggled here (#6020) — without this check,
     // toggling the (correctly, post-fix) filled heart on the current
     // version would try to *like* again instead of unliking the original.
+    // Best-effort for the same reason [likeEvent]'s writes are: this is the
+    // only entry point the like button uses, so an unreadable cache throwing
+    // here costs the Kind 7 outright. A swallowed read falls back to the
+    // in-memory cache, which is what the null-storage branch already does.
     final likedByEventId =
-        await _localStorage?.isLiked(eventId) ??
+        await _bestEffortLocalStorage<bool?>(
+          () async => _localStorage?.isLiked(eventId),
+          description: 'checking the like state',
+          site: LikesRepositoryReportableSites.toggleLikeReadState,
+        ) ??
         _likeRecords.containsKey(eventId);
     final likedByCoordinate =
         addressableId != null &&

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -10,6 +10,7 @@ import 'dart:math';
 import 'package:likes_repository/src/blocked_liker_filter.dart';
 import 'package:likes_repository/src/exceptions.dart';
 import 'package:likes_repository/src/likes_local_storage.dart';
+import 'package:likes_repository/src/likes_repository_reportable_sites.dart';
 import 'package:likes_repository/src/models/like_record.dart';
 import 'package:likes_repository/src/models/likes_sync_result.dart';
 import 'package:nostr_client/nostr_client.dart';
@@ -51,6 +52,26 @@ typedef QueueOfflineActionCallback =
       int? targetKind,
     });
 
+/// Reporter port for programming-invariant violations swallowed by the
+/// best-effort local-storage paths.
+///
+/// The repository swallows local-storage failures so an unusable cache can
+/// never block a relay publish. Expected IO and corruption failures stay in
+/// the unified log, but an `Error` — `StateError`, `TypeError`,
+/// `RangeError` — means the storage layer itself is broken, and a swallowed
+/// bug is a bug nobody ever sees. Wiring an implementation routes that
+/// signal to Crashlytics without crossing the `likes_repository` → app
+/// package boundary.
+///
+/// [site] is one of `LikesRepositoryReportableSites`'s constants and is used
+/// as the Crashlytics `reason:` suffix so the dashboard aggregates per
+/// swallow site.
+///
+/// Implementations MUST NOT throw — the repository invokes this from inside
+/// the swallow and any throw would defeat it.
+typedef LikesRepositoryErrorReporter =
+    void Function(Object error, StackTrace stackTrace, {required String site});
+
 /// Repository for managing user likes (Kind 7 reactions) on Nostr events.
 ///
 /// This repository provides a unified interface for:
@@ -81,20 +102,30 @@ class LikesRepository {
   /// - [queueOfflineAction]: Optional callback to queue actions when offline
   /// - [blockFilter]: Optional callback to hide blocked/muted users from
   ///   engagement lists ([fetchEventLikers])
+  /// - [errorReporter]: Optional reporter invoked from the best-effort
+  ///   local-storage swallow sites when the swallowed failure is a
+  ///   programming-invariant violation (see [LikesRepositoryErrorReporter]).
+  ///   Defaults to `null` so test fixtures need no rewiring; production
+  ///   wires it through `likesRepositoryProvider` to forward to Crashlytics.
   LikesRepository({
     required NostrClient nostrClient,
     LikesLocalStorage? localStorage,
     IsOnlineCallback? isOnline,
     QueueOfflineActionCallback? queueOfflineAction,
     BlockedLikerFilter? blockFilter,
+    LikesRepositoryErrorReporter? errorReporter,
   }) : _nostrClient = nostrClient,
        _localStorage = localStorage,
        _isOnline = isOnline,
        _queueOfflineAction = queueOfflineAction,
-       _blockFilter = blockFilter;
+       _blockFilter = blockFilter,
+       _errorReporter = errorReporter;
 
   final NostrClient _nostrClient;
   final LikesLocalStorage? _localStorage;
+
+  /// Reporter for invariant violations swallowed by the storage paths.
+  final LikesRepositoryErrorReporter? _errorReporter;
 
   /// Callback to hide blocked/muted users from engagement lists
   final BlockedLikerFilter? _blockFilter;
@@ -486,6 +517,7 @@ class LikesRepository {
     await _bestEffortLocalStorage(
       () async => _localStorage?.saveLikeRecord(placeholder),
       description: 'saving the like placeholder',
+      site: LikesRepositoryReportableSites.likeEventSavePlaceholder,
     );
     if (previousCount != null) {
       _writeCachedLikeCount(
@@ -539,6 +571,7 @@ class LikesRepository {
       await _bestEffortLocalStorage(
         () async => _localStorage?.saveLikeRecord(confirmed),
         description: 'saving the confirmed like',
+        site: LikesRepositoryReportableSites.likeEventSaveConfirmed,
       );
 
       return reactionEvent.id;
@@ -564,6 +597,7 @@ class LikesRepository {
       await _bestEffortLocalStorage(
         () async => _localStorage?.deleteLikeRecord(eventId),
         description: 'rolling back the like placeholder',
+        site: LikesRepositoryReportableSites.likeEventRollbackPlaceholder,
       );
       if (previousCount != null) {
         _writeCachedLikeCount(
@@ -690,9 +724,16 @@ class LikesRepository {
           return localStorage.getLikeRecordByAddressableId(addressableId);
         },
         description: 'reading the like record',
+        site: LikesRepositoryReportableSites.unlikeEventReadRecord,
       );
     }
 
+    // A swallowed read failure is indistinguishable from "no such record"
+    // here, so a degraded store reports "not liked" when the truth is
+    // "cannot tell". Both answers end the same way — there is no reaction
+    // event id to reference in a Kind 5, so nothing can be published either
+    // way — and widening the contract with a second exception would push a
+    // distinction the UI has no recovery for onto every caller.
     if (record == null) {
       throw NotLikedException(eventId);
     }
@@ -715,6 +756,7 @@ class LikesRepository {
     await _bestEffortLocalStorage(
       () async => _localStorage?.deleteLikeRecord(resolvedEventId),
       description: 'deleting the like record',
+      site: LikesRepositoryReportableSites.unlikeEventDeleteRecord,
     );
     _decrementLikeCountCache(eventId, addressableId: addressableId);
     _emitLikedIds();
@@ -766,6 +808,7 @@ class LikesRepository {
       await _bestEffortLocalStorage(
         () async => _localStorage?.saveLikeRecord(snapshotRecord),
         description: 'restoring the like record',
+        site: LikesRepositoryReportableSites.unlikeEventRestoreRecord,
       );
       if (previousCount != null) {
         _writeCachedLikeCount(
@@ -2086,10 +2129,15 @@ class LikesRepository {
         final records = await localStorage.getAllLikeRecords();
         records.forEach(_indexLikeRecord);
         _emitLikedIds();
-      } on Object catch (e) {
+      } on Object catch (e, stackTrace) {
         // Degrade to an in-memory-only cache rather than failing the caller.
         // Callers are publish paths: an unreadable cache costs a stale
         // already-liked check, while throwing here costs the Kind 7.
+        _reportIfInvariantViolation(
+          e,
+          stackTrace,
+          site: LikesRepositoryReportableSites.ensureInitializedLoadRecords,
+        );
         Log.warning(
           'Like cache unavailable; continuing without persisted records: $e',
           name: 'LikesRepository',
@@ -2110,14 +2158,21 @@ class LikesRepository {
   ///
   /// Expected IO/corruption failures are not Crashlytics-reportable (see the
   /// decision matrix in `.claude/rules/error_handling.md`); the unified log is
-  /// where a degraded cache surfaces.
+  /// where a degraded cache surfaces. Programming-invariant violations are
+  /// routed to [_errorReporter] instead of vanishing — see
+  /// [_reportIfInvariantViolation].
+  ///
+  /// [site] is the stable `LikesRepositoryReportableSites` identifier for
+  /// this call site; [description] is the human phrasing used in the log.
   Future<T?> _bestEffortLocalStorage<T>(
     Future<T> Function() operation, {
     required String description,
+    required String site,
   }) async {
     try {
       return await operation();
-    } on Object catch (e) {
+    } on Object catch (e, stackTrace) {
+      _reportIfInvariantViolation(e, stackTrace, site: site);
       Log.warning(
         'Local like storage unavailable ($description); '
         'continuing without it: $e',
@@ -2126,6 +2181,23 @@ class LikesRepository {
       );
       return null;
     }
+  }
+
+  /// Reports [error] when it is a programming-invariant violation.
+  ///
+  /// Storage IO and corruption failures arrive as `Exception`s
+  /// (`SqliteException`, `IOException`) and are expected on a broken device,
+  /// so per the decision matrix in `.claude/rules/error_handling.md` they
+  /// stay out of Crashlytics. `Error` subtypes — `StateError`, `TypeError`,
+  /// `RangeError` — mean the storage layer itself is buggy; swallowing those
+  /// silently is how a real defect ships unnoticed behind a warning log.
+  void _reportIfInvariantViolation(
+    Object error,
+    StackTrace stackTrace, {
+    required String site,
+  }) {
+    if (error is! Error) return;
+    _errorReporter?.call(error, stackTrace, site: site);
   }
 
   /// Extracts the target event ID from a reaction event's 'e' tag.

--- a/mobile/packages/likes_repository/lib/src/likes_repository_reportable_sites.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository_reportable_sites.dart
@@ -59,4 +59,9 @@ abstract class LikesRepositoryReportableSites {
   /// `initialize`: the startup read of persisted records threw, so the
   /// session continues on an in-memory-only cache.
   static const String initializeLoadRecords = 'initialize.loadRecords';
+
+  /// `_processIncomingReaction`: persisting a reaction that arrived on the
+  /// live cross-device subscription threw.
+  static const String processIncomingReactionSaveRecord =
+      'processIncomingReaction.saveRecord';
 }

--- a/mobile/packages/likes_repository/lib/src/likes_repository_reportable_sites.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository_reportable_sites.dart
@@ -41,4 +41,22 @@ abstract class LikesRepositoryReportableSites {
   /// `toggleLike`: the authoritative already-liked read threw, so the toggle
   /// falls back to the in-memory cache to decide its direction.
   static const String toggleLikeReadState = 'toggleLike.readState';
+
+  /// `syncUserReactions`: the warm read of persisted records threw, so the
+  /// sync runs on relay data alone.
+  static const String syncUserReactionsLoadRecords =
+      'syncUserReactions.loadRecords';
+
+  /// `syncUserReactions`: dropping a record whose reaction was deleted on
+  /// the wire threw, so a stale row survives locally.
+  static const String syncUserReactionsDeleteRecord =
+      'syncUserReactions.deleteRecord';
+
+  /// `syncUserReactions`: persisting the freshly-synced relay records threw.
+  static const String syncUserReactionsSaveBatch =
+      'syncUserReactions.saveBatch';
+
+  /// `initialize`: the startup read of persisted records threw, so the
+  /// session continues on an in-memory-only cache.
+  static const String initializeLoadRecords = 'initialize.loadRecords';
 }

--- a/mobile/packages/likes_repository/lib/src/likes_repository_reportable_sites.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository_reportable_sites.dart
@@ -1,0 +1,40 @@
+// ABOUTME: Stable identifiers for the local-storage swallow sites in
+// ABOUTME: LikesRepository, used as the `site:` annotation on reporter calls.
+
+/// Stable site identifiers for the best-effort local-storage swallow
+/// points in `LikesRepository`. The wiring layer forwards each call to
+/// Crashlytics with `reason: 'LikesRepository.<site>'` so the dashboard
+/// aggregates per site.
+///
+/// Only programming-invariant violations (`Error` subtypes) reach the
+/// reporter; expected IO and corruption failures stay in the unified log
+/// per the decision matrix in `.claude/rules/error_handling.md`.
+abstract class LikesRepositoryReportableSites {
+  /// `_ensureInitialized`: reading the persisted like records threw, so the
+  /// session continues on an in-memory-only cache.
+  static const String ensureInitializedLoadRecords =
+      'ensureInitialized.loadRecords';
+
+  /// `likeEvent`: persisting the optimistic placeholder record threw.
+  static const String likeEventSavePlaceholder = 'likeEvent.savePlaceholder';
+
+  /// `likeEvent`: persisting the confirmed record (real reaction event id)
+  /// threw after the Kind 7 publish landed.
+  static const String likeEventSaveConfirmed = 'likeEvent.saveConfirmed';
+
+  /// `likeEvent`: rolling the placeholder back after a publish failure
+  /// threw, leaving a stale row behind.
+  static const String likeEventRollbackPlaceholder =
+      'likeEvent.rollbackPlaceholder';
+
+  /// `unlikeEvent`: the fallback read of the like record threw, so the
+  /// caller cannot tell "not liked" from "cannot tell".
+  static const String unlikeEventReadRecord = 'unlikeEvent.readRecord';
+
+  /// `unlikeEvent`: deleting the record ahead of the Kind 5 publish threw.
+  static const String unlikeEventDeleteRecord = 'unlikeEvent.deleteRecord';
+
+  /// `unlikeEvent`: restoring the record after a deletion-publish failure
+  /// threw, so the optimistic removal is not undone locally.
+  static const String unlikeEventRestoreRecord = 'unlikeEvent.restoreRecord';
+}

--- a/mobile/packages/likes_repository/lib/src/likes_repository_reportable_sites.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository_reportable_sites.dart
@@ -37,4 +37,8 @@ abstract class LikesRepositoryReportableSites {
   /// `unlikeEvent`: restoring the record after a deletion-publish failure
   /// threw, so the optimistic removal is not undone locally.
   static const String unlikeEventRestoreRecord = 'unlikeEvent.restoreRecord';
+
+  /// `toggleLike`: the authoritative already-liked read threw, so the toggle
+  /// falls back to the in-memory cache to decide its direction.
+  static const String toggleLikeReadState = 'toggleLike.readState';
 }

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -88,6 +88,7 @@ void main() {
       IsOnlineCallback? isOnline,
       QueueOfflineActionCallback? queueOfflineAction,
       BlockedLikerFilter? blockFilter,
+      LikesRepositoryErrorReporter? errorReporter,
     }) {
       return LikesRepository(
         nostrClient: mockNostrClient,
@@ -95,6 +96,7 @@ void main() {
         isOnline: isOnline,
         queueOfflineAction: queueOfflineAction,
         blockFilter: blockFilter,
+        errorReporter: errorReporter,
       );
     }
 
@@ -322,6 +324,94 @@ void main() {
           verify(() => mockLocalStorage.getAllLikeRecords()).called(1);
         },
       );
+
+      test(
+        'reports an invariant violation raised by a storage write',
+        () async {
+          // An Error from the storage layer means the storage layer itself is
+          // broken. Still swallowed so the Kind 7 goes out, but routed to the
+          // reporter — a swallowed bug nobody can see is how a real defect
+          // ships behind a warning log.
+          final mockEvent = MockEvent();
+          when(() => mockEvent.id).thenReturn(testReactionEventId);
+          stubSendLike(mockEvent);
+          final reported = <({Object error, String site})>[];
+          when(
+            () => mockLocalStorage.saveLikeRecord(any()),
+          ).thenThrow(StateError('storage invariant violated'));
+
+          repository = createRepository(
+            errorReporter: (error, stackTrace, {required site}) {
+              reported.add((error: error, site: site));
+            },
+          );
+          await repository.likeEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+
+          expect(reported.first.error, isA<StateError>());
+          expect(
+            reported.map((r) => r.site),
+            equals([
+              LikesRepositoryReportableSites.likeEventSavePlaceholder,
+              LikesRepositoryReportableSites.likeEventSaveConfirmed,
+            ]),
+          );
+        },
+      );
+
+      test(
+        'reports an invariant violation raised by the initial read',
+        () async {
+          final reported = <String>[];
+          when(
+            () => mockLocalStorage.getAllLikeRecords(),
+          ).thenThrow(TypeError());
+
+          repository = createRepository(
+            errorReporter: (error, stackTrace, {required site}) {
+              reported.add(site);
+            },
+          );
+          await repository.getLikedEventIds();
+
+          expect(
+            reported,
+            equals([
+              LikesRepositoryReportableSites.ensureInitializedLoadRecords,
+            ]),
+          );
+        },
+      );
+
+      test('does not report an expected storage failure', () async {
+        // SqliteException and friends are Exceptions, not Errors: expected on
+        // a broken device and explicitly not Crashlytics-reportable per the
+        // decision matrix in `.claude/rules/error_handling.md`.
+        final mockEvent = MockEvent();
+        when(() => mockEvent.id).thenReturn(testReactionEventId);
+        stubSendLike(mockEvent);
+        var reportCount = 0;
+        when(
+          () => mockLocalStorage.getAllLikeRecords(),
+        ).thenThrow(storageFailure);
+        when(
+          () => mockLocalStorage.saveLikeRecord(any()),
+        ).thenThrow(storageFailure);
+
+        repository = createRepository(
+          errorReporter: (error, stackTrace, {required site}) {
+            reportCount++;
+          },
+        );
+        await repository.likeEvent(
+          eventId: testEventId,
+          authorPubkey: testAuthorPubkey,
+        );
+
+        expect(reportCount, isZero);
+      });
     });
 
     group('likeEvent', () {

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -412,6 +412,69 @@ void main() {
 
         expect(reportCount, isZero);
       });
+
+      test('publishes the like when the toggle state read fails', () async {
+        // The like button only ever reaches the repository through
+        // toggleLike (video_interactions_bloc.dart), so a storage read that
+        // throws there costs the Kind 7 just as surely as one inside
+        // likeEvent. likeEvent's own guard never gets a chance to run.
+        final mockEvent = MockEvent();
+        when(() => mockEvent.id).thenReturn(testReactionEventId);
+        stubSendLike(mockEvent);
+        when(
+          () => mockLocalStorage.getAllLikeRecords(),
+        ).thenThrow(storageFailure);
+        when(() => mockLocalStorage.isLiked(any())).thenThrow(storageFailure);
+
+        repository = createRepository();
+        final isNowLiked = await repository.toggleLike(
+          eventId: testEventId,
+          authorPubkey: testAuthorPubkey,
+        );
+
+        expect(isNowLiked, isTrue);
+        verify(
+          () => mockNostrClient.sendLike(
+            testEventId,
+            content: '+',
+            targetAuthorPubkey: testAuthorPubkey,
+          ),
+        ).called(1);
+      });
+
+      test(
+        'unlikes from the in-memory cache when the state read fails',
+        () async {
+          // The swallowed read must fall back to the cache, not to "not
+          // liked" — otherwise the toggle publishes a duplicate reaction
+          // instead of deleting the live one.
+          final mockEvent = MockEvent();
+          when(() => mockEvent.id).thenReturn(testReactionEventId);
+          stubSendLike(mockEvent);
+          final deletionEvent = MockEvent();
+          when(() => deletionEvent.id).thenReturn('deletion_event_id');
+          when(
+            () => mockNostrClient.deleteEvent(any()),
+          ).thenAnswer((_) async => deletionEvent);
+
+          repository = createRepository();
+          await repository.likeEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+          when(() => mockLocalStorage.isLiked(any())).thenThrow(storageFailure);
+
+          final isNowLiked = await repository.toggleLike(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+
+          expect(isNowLiked, isFalse);
+          verify(
+            () => mockNostrClient.deleteEvent(testReactionEventId),
+          ).called(1);
+        },
+      );
     });
 
     group('likeEvent', () {

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -475,6 +475,95 @@ void main() {
           ).called(1);
         },
       );
+
+      test('syncs from relays when the persisted read fails', () async {
+        // The relay half is the authoritative one. A cache read that throws
+        // used to escape syncUserReactions before the fetch below ever ran,
+        // so the profile Likes tab errored while relays were reachable.
+        const targetId = 'sync_target_1234567890abcdef';
+        const reactionId = 'sync_reaction_1234567890abcdef';
+        when(
+          () => mockLocalStorage.getAllLikeRecords(),
+        ).thenThrow(storageFailure);
+        mockQueryEventsSequence([
+          [createMockReaction(id: reactionId, targetEventId: targetId)],
+          [],
+        ]);
+
+        repository = createRepository();
+        final result = await repository.syncUserReactions();
+
+        expect(result.orderedEventIds, contains(targetId));
+      });
+
+      test('completes the sync when the batch save fails', () async {
+        const targetId = 'batch_target_1234567890abcdef';
+        const reactionId = 'batch_reaction_1234567890abcdef';
+        when(
+          () => mockLocalStorage.saveLikeRecordsBatch(any()),
+        ).thenThrow(storageFailure);
+        mockQueryEventsSequence([
+          [createMockReaction(id: reactionId, targetEventId: targetId)],
+          [],
+        ]);
+
+        repository = createRepository();
+        final result = await repository.syncUserReactions();
+
+        expect(result.orderedEventIds, contains(targetId));
+      });
+
+      test('completes the sync when the deleted-record purge fails', () async {
+        const targetId = 'purge_target_1234567890abcdef';
+        const reactionId = 'purge_reaction_1234567890abcdef';
+        when(() => mockLocalStorage.getAllLikeRecords()).thenAnswer(
+          (_) async => [
+            createLikeRecord(
+              targetEventId: targetId,
+              reactionEventId: reactionId,
+            ),
+          ],
+        );
+        when(
+          () => mockLocalStorage.deleteLikeRecord(any()),
+        ).thenThrow(storageFailure);
+        mockQueryEventsSequence([
+          [createMockReaction(id: reactionId, targetEventId: targetId)],
+          [
+            createMockDeletion([reactionId]),
+          ],
+        ]);
+
+        repository = createRepository();
+        final result = await repository.syncUserReactions();
+
+        expect(result.orderedEventIds, isNot(contains(targetId)));
+      });
+
+      test('still subscribes when the startup read fails', () async {
+        // initialize() reads storage before _subscribeToReactions, so a
+        // throw there costs the session its cross-device sync too.
+        when(
+          () => mockLocalStorage.getAllLikeRecords(),
+        ).thenThrow(storageFailure);
+        when(() => mockNostrClient.hasKeys).thenReturn(true);
+        when(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+          ),
+        ).thenAnswer((_) => const Stream.empty());
+
+        repository = createRepository();
+        await repository.initialize();
+
+        verify(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+          ),
+        ).called(1);
+      });
     });
 
     group('likeEvent', () {

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -235,6 +235,95 @@ void main() {
       });
     });
 
+    group('unavailable local storage', () {
+      // The local database is a cache, not a precondition. When it is
+      // unreadable (at-rest cipher bootstrap left it unopenable, runtime
+      // corruption, disk full) the Kind 7 must still reach relays: the signed
+      // reaction is the irreplaceable half, the cache row is not. Mirrors the
+      // same guarantee in RepostsRepository.
+      final storageFailure = Exception('database is unavailable');
+
+      void stubSendLike(MockEvent event) {
+        when(
+          () => mockNostrClient.sendLike(
+            any(),
+            content: any(named: 'content'),
+            addressableId: any(named: 'addressableId'),
+            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+            targetKind: any(named: 'targetKind'),
+          ),
+        ).thenAnswer((_) async => event);
+      }
+
+      test('publishes the like when local storage cannot be read', () async {
+        final mockEvent = MockEvent();
+        when(() => mockEvent.id).thenReturn(testReactionEventId);
+        stubSendLike(mockEvent);
+        when(
+          () => mockLocalStorage.getAllLikeRecords(),
+        ).thenThrow(storageFailure);
+        when(
+          () => mockLocalStorage.saveLikeRecord(any()),
+        ).thenAnswer((_) async {});
+
+        repository = createRepository();
+        final result = await repository.likeEvent(
+          eventId: testEventId,
+          authorPubkey: testAuthorPubkey,
+        );
+
+        expect(result, equals(testReactionEventId));
+        verify(
+          () => mockNostrClient.sendLike(
+            testEventId,
+            content: '+',
+            targetAuthorPubkey: testAuthorPubkey,
+          ),
+        ).called(1);
+      });
+
+      test('publishes the like when the local write fails', () async {
+        final mockEvent = MockEvent();
+        when(() => mockEvent.id).thenReturn(testReactionEventId);
+        stubSendLike(mockEvent);
+        when(
+          () => mockLocalStorage.saveLikeRecord(any()),
+        ).thenThrow(storageFailure);
+
+        repository = createRepository();
+        final result = await repository.likeEvent(
+          eventId: testEventId,
+          authorPubkey: testAuthorPubkey,
+        );
+
+        expect(result, equals(testReactionEventId));
+        verify(
+          () => mockNostrClient.sendLike(
+            testEventId,
+            content: '+',
+            targetAuthorPubkey: testAuthorPubkey,
+          ),
+        ).called(1);
+      });
+
+      test(
+        'a failed read does not strand the repository uninitialized',
+        () async {
+          // Without the latch every call re-runs the throwing read instead of
+          // degrading once.
+          when(
+            () => mockLocalStorage.getAllLikeRecords(),
+          ).thenThrow(storageFailure);
+
+          repository = createRepository();
+          await repository.getLikedEventIds();
+          await repository.getLikedEventIds();
+
+          verify(() => mockLocalStorage.getAllLikeRecords()).called(1);
+        },
+      );
+    });
+
     group('likeEvent', () {
       test('publishes like reaction and stores record', () async {
         final mockEvent = MockEvent();

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -564,6 +564,38 @@ void main() {
           ),
         ).called(1);
       });
+
+      test('caches a subscription reaction when its write fails', () async {
+        // The write is fire-and-forget, so an unguarded rejection would be
+        // an uncaught async error rather than a swallowed cache miss.
+        const targetId = 'live_target_1234567890abcdef';
+        final controller = StreamController<Event>();
+        addTearDown(controller.close);
+        final reaction = createMockReaction(
+          id: 'live_reaction_1234567890abcdef',
+          targetEventId: targetId,
+          authorPubkey: testUserPubkey,
+        );
+        when(() => reaction.kind).thenReturn(EventKind.reaction);
+        when(
+          () => mockLocalStorage.saveLikeRecord(any()),
+        ).thenThrow(storageFailure);
+        when(() => mockNostrClient.hasKeys).thenReturn(true);
+        when(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+          ),
+        ).thenAnswer((_) => controller.stream);
+
+        repository = createRepository();
+        await repository.initialize();
+
+        controller.add(reaction);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(await repository.isLiked(targetId), isTrue);
+      });
     });
 
     group('likeEvent', () {

--- a/mobile/packages/reposts_repository/lib/reposts_repository.dart
+++ b/mobile/packages/reposts_repository/lib/reposts_repository.dart
@@ -7,3 +7,4 @@ export 'src/exceptions.dart';
 export 'src/models/models.dart';
 export 'src/reposts_local_storage.dart';
 export 'src/reposts_repository.dart';
+export 'src/reposts_repository_reportable_sites.dart';

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
@@ -678,13 +678,22 @@ class RepostsRepository {
   ///
   /// Throws `SyncFailedException` if syncing fails.
   Future<RepostsSyncResult> syncUserReposts() async {
-    // First, load from local storage (fast)
-    if (_localStorage != null) {
-      final records = await _localStorage.getAllRepostRecords();
-      for (final record in records) {
-        _repostRecords[record.addressableId] = record;
+    // First, load from local storage (fast). Best-effort and deliberately
+    // outside the relay try/catch below: an unreadable cache must not skip
+    // the authoritative relay fetch, which is the whole point of a sync.
+    final localStorage = _localStorage;
+    if (localStorage != null) {
+      final records = await _bestEffortLocalStorage(
+        localStorage.getAllRepostRecords,
+        description: 'loading persisted reposts for sync',
+        site: RepostsRepositoryReportableSites.syncUserRepostsLoadRecords,
+      );
+      if (records != null) {
+        for (final record in records) {
+          _repostRecords[record.addressableId] = record;
+        }
+        _emitRepostedIds();
       }
-      _emitRepostedIds();
     }
 
     try {
@@ -735,8 +744,12 @@ class RepostsRepository {
       }
 
       // Batch save new records to storage
-      if (newRecords.isNotEmpty && _localStorage != null) {
-        await _localStorage.saveRepostRecordsBatch(newRecords);
+      if (newRecords.isNotEmpty && localStorage != null) {
+        await _bestEffortLocalStorage(
+          () => localStorage.saveRepostRecordsBatch(newRecords),
+          description: 'persisting the synced reposts',
+          site: RepostsRepositoryReportableSites.syncUserRepostsSaveBatch,
+        );
       }
 
       _emitRepostedIds();
@@ -981,13 +994,22 @@ class RepostsRepository {
   Future<void> initialize() async {
     if (_isInitialized) return;
 
-    // Load from local storage first for immediate UI display
-    if (_localStorage != null) {
-      final records = await _localStorage.getAllRepostRecords();
-      for (final record in records) {
-        _repostRecords[record.addressableId] = record;
+    // Load from local storage first for immediate UI display. Best-effort:
+    // throwing here would skip _subscribeToReposts below, so an unreadable
+    // cache would also cost the session its cross-device sync.
+    final localStorage = _localStorage;
+    if (localStorage != null) {
+      final records = await _bestEffortLocalStorage(
+        localStorage.getAllRepostRecords,
+        description: 'loading persisted reposts at startup',
+        site: RepostsRepositoryReportableSites.initializeLoadRecords,
+      );
+      if (records != null) {
+        for (final record in records) {
+          _repostRecords[record.addressableId] = record;
+        }
+        _emitRepostedIds();
       }
-      _emitRepostedIds();
     }
 
     final pubkey = await _currentUserPubkey();

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
@@ -14,6 +14,7 @@ import 'package:reposts_repository/src/exceptions.dart';
 import 'package:reposts_repository/src/models/repost_record.dart';
 import 'package:reposts_repository/src/models/reposts_sync_result.dart';
 import 'package:reposts_repository/src/reposts_local_storage.dart';
+import 'package:reposts_repository/src/reposts_repository_reportable_sites.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -31,6 +32,26 @@ typedef QueueOfflineRepostCallback =
       required String originalAuthorPubkey,
       String? eventId,
     });
+
+/// Reporter port for programming-invariant violations swallowed by the
+/// best-effort local-storage paths.
+///
+/// The repository swallows local-storage failures so an unusable cache can
+/// never block a relay publish. Expected IO and corruption failures stay in
+/// the unified log, but an `Error` — `StateError`, `TypeError`,
+/// `RangeError` — means the storage layer itself is broken, and a swallowed
+/// bug is a bug nobody ever sees. Wiring an implementation routes that
+/// signal to Crashlytics without crossing the `reposts_repository` → app
+/// package boundary.
+///
+/// [site] is one of `RepostsRepositoryReportableSites`'s constants and is
+/// used as the Crashlytics `reason:` suffix so the dashboard aggregates per
+/// swallow site.
+///
+/// Implementations MUST NOT throw — the repository invokes this from inside
+/// the swallow and any throw would defeat it.
+typedef RepostsRepositoryErrorReporter =
+    void Function(Object error, StackTrace stackTrace, {required String site});
 
 /// Repository for managing user reposts (Kind 16 generic reposts) on videos.
 ///
@@ -62,20 +83,31 @@ class RepostsRepository {
   /// - [queueOfflineAction]: Optional callback to queue actions when offline
   /// - [blockFilter]: Optional callback to hide blocked/muted users from
   ///   engagement lists ([fetchEventReposters])
+  /// - [errorReporter]: Optional reporter invoked from the best-effort
+  ///   local-storage swallow sites when the swallowed failure is a
+  ///   programming-invariant violation (see
+  ///   [RepostsRepositoryErrorReporter]). Defaults to `null` so test
+  ///   fixtures need no rewiring; production wires it through
+  ///   `repostsRepositoryProvider` to forward to Crashlytics.
   RepostsRepository({
     required NostrClient nostrClient,
     RepostsLocalStorage? localStorage,
     IsOnlineCallback? isOnline,
     QueueOfflineRepostCallback? queueOfflineAction,
     BlockedReposterFilter? blockFilter,
+    RepostsRepositoryErrorReporter? errorReporter,
   }) : _nostrClient = nostrClient,
        _localStorage = localStorage,
        _isOnline = isOnline,
        _queueOfflineAction = queueOfflineAction,
-       _blockFilter = blockFilter;
+       _blockFilter = blockFilter,
+       _errorReporter = errorReporter;
 
   final NostrClient _nostrClient;
   final RepostsLocalStorage? _localStorage;
+
+  /// Reporter for invariant violations swallowed by the storage paths.
+  final RepostsRepositoryErrorReporter? _errorReporter;
 
   /// Callback to hide blocked/muted users from engagement lists
   final BlockedReposterFilter? _blockFilter;
@@ -104,6 +136,15 @@ class RepostsRepository {
   /// Whether the repository has been initialized with data from storage.
   bool _isInitialized = false;
 
+  /// Whether local storage has proven unusable during this session.
+  ///
+  /// Latched by any swallowed storage failure. A store that cannot answer a
+  /// read or a write also cannot serve a live query stream, so
+  /// [watchRepostedAddressableIds] must not hand the UI a stream backed by
+  /// it — see that method for why a dead stream costs the repost button its
+  /// state.
+  bool _storageDegraded = false;
+
   /// Whether [dispose] has been called.
   ///
   /// Once disposed, all stream emissions are no-ops.
@@ -127,12 +168,23 @@ class RepostsRepository {
   ///
   /// Emits a new set whenever the user's reposts change.
   /// This is useful for UI components that need to reactively update.
-  Stream<Set<String>> watchRepostedAddressableIds() {
-    // If we have local storage, delegate to its reactive stream
-    if (_localStorage != null) {
-      return _localStorage.watchRepostedAddressableIds();
+  ///
+  /// Backed by local storage's own query stream when storage is healthy, and
+  /// by the repository's in-memory cache when it is not. The fallback is what
+  /// keeps the repost button honest on a device whose database is present but
+  /// unreadable: storage's stream never emits there, while every mutation
+  /// still ticks [_repostedIdsController], so a UI wired to the dead stream
+  /// would show the publish succeed and the button never flip.
+  Stream<Set<String>> watchRepostedAddressableIds() async* {
+    // Initialize before choosing the source so a broken store has already
+    // been observed by the time the choice is made.
+    await _ensureInitialized();
+    final localStorage = _localStorage;
+    if (localStorage != null && !_storageDegraded) {
+      yield* localStorage.watchRepostedAddressableIds();
+    } else {
+      yield* _repostedIdsController.stream;
     }
-    return _repostedIdsController.stream;
   }
 
   /// Get the current set of reposted addressable IDs.
@@ -288,6 +340,7 @@ class RepostsRepository {
     await _bestEffortLocalStorage(
       () async => _localStorage?.saveRepostRecord(placeholder),
       description: 'saving the repost placeholder',
+      site: RepostsRepositoryReportableSites.repostVideoSavePlaceholder,
     );
     if (previousCount != null) {
       _cacheRepostCount(addressableId, previousCount + 1);
@@ -333,6 +386,7 @@ class RepostsRepository {
       await _bestEffortLocalStorage(
         () async => _localStorage?.saveRepostRecord(confirmed),
         description: 'saving the confirmed repost',
+        site: RepostsRepositoryReportableSites.repostVideoSaveConfirmed,
       );
 
       return sentEvent.id;
@@ -357,6 +411,7 @@ class RepostsRepository {
       await _bestEffortLocalStorage(
         () async => _localStorage?.deleteRepostRecord(addressableId),
         description: 'rolling back the repost placeholder',
+        site: RepostsRepositoryReportableSites.repostVideoRollbackPlaceholder,
       );
       if (previousCount != null) {
         _cacheRepostCount(addressableId, previousCount);
@@ -425,9 +480,16 @@ class RepostsRepository {
       record = await _bestEffortLocalStorage<RepostRecord?>(
         () => localStorage.getRepostRecord(addressableId),
         description: 'reading the repost record',
+        site: RepostsRepositoryReportableSites.unrepostVideoReadRecord,
       );
     }
 
+    // A swallowed read failure is indistinguishable from "no such record"
+    // here, so a degraded store reports "not reposted" when the truth is
+    // "cannot tell". Both answers end the same way — there is no repost
+    // event id to reference in a Kind 5, so nothing can be published either
+    // way — and widening the contract with a second exception would push a
+    // distinction the UI has no recovery for onto every caller.
     if (record == null) {
       throw NotRepostedException(addressableId);
     }
@@ -443,6 +505,7 @@ class RepostsRepository {
     await _bestEffortLocalStorage(
       () async => _localStorage?.deleteRepostRecord(addressableId),
       description: 'deleting the repost record',
+      site: RepostsRepositoryReportableSites.unrepostVideoDeleteRecord,
     );
     if (previousCount != null) {
       _cacheRepostCount(addressableId, previousCount - 1);
@@ -498,6 +561,7 @@ class RepostsRepository {
       await _bestEffortLocalStorage(
         () async => _localStorage?.saveRepostRecord(snapshotRecord),
         description: 'restoring the repost record',
+        site: RepostsRepositoryReportableSites.unrepostVideoRestoreRecord,
       );
       if (previousCount != null) {
         _cacheRepostCount(addressableId, previousCount);
@@ -1037,10 +1101,15 @@ class RepostsRepository {
           _repostRecords[record.addressableId] = record;
         }
         _emitRepostedIds();
-      } on Object catch (e) {
+      } on Object catch (e, stackTrace) {
         // Degrade to an in-memory-only cache rather than failing the caller.
         // Callers are publish paths: an unreadable cache costs a stale
         // already-reposted check, while throwing here costs the Kind 16.
+        _markStorageDegraded(
+          e,
+          stackTrace,
+          site: RepostsRepositoryReportableSites.ensureInitializedLoadRecords,
+        );
         Log.warning(
           'Repost cache unavailable; continuing without persisted records: $e',
           name: 'RepostsRepository',
@@ -1061,14 +1130,21 @@ class RepostsRepository {
   ///
   /// Expected IO/corruption failures are not Crashlytics-reportable (see the
   /// decision matrix in `.claude/rules/error_handling.md`); the unified log is
-  /// where a degraded cache surfaces.
+  /// where a degraded cache surfaces. Programming-invariant violations are
+  /// routed to [_errorReporter] instead of vanishing — see
+  /// [_markStorageDegraded].
+  ///
+  /// [site] is the stable `RepostsRepositoryReportableSites` identifier for
+  /// this call site; [description] is the human phrasing used in the log.
   Future<T?> _bestEffortLocalStorage<T>(
     Future<T> Function() operation, {
     required String description,
+    required String site,
   }) async {
     try {
       return await operation();
-    } on Object catch (e) {
+    } on Object catch (e, stackTrace) {
+      _markStorageDegraded(e, stackTrace, site: site);
       Log.warning(
         'Local repost storage unavailable ($description); '
         'continuing without it: $e',
@@ -1077,6 +1153,25 @@ class RepostsRepository {
       );
       return null;
     }
+  }
+
+  /// Latches [_storageDegraded] and reports [error] when it is a
+  /// programming-invariant violation.
+  ///
+  /// Storage IO and corruption failures arrive as `Exception`s
+  /// (`SqliteException`, `IOException`) and are expected on a broken device,
+  /// so per the decision matrix in `.claude/rules/error_handling.md` they
+  /// stay out of Crashlytics. `Error` subtypes — `StateError`, `TypeError`,
+  /// `RangeError` — mean the storage layer itself is buggy; swallowing those
+  /// silently is how a real defect ships unnoticed behind a warning log.
+  void _markStorageDegraded(
+    Object error,
+    StackTrace stackTrace, {
+    required String site,
+  }) {
+    _storageDegraded = true;
+    if (error is! Error) return;
+    _errorReporter?.call(error, stackTrace, site: site);
   }
 
   /// Extracts the addressable ID from a repost event's 'a' tag.

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
@@ -1078,7 +1078,17 @@ class RepostsRepository {
     );
 
     _repostRecords[addressableId] = record;
-    unawaited(_localStorage?.saveRepostRecord(record));
+    // Best-effort: `unawaited` attaches no error handler, so a raw rejection
+    // here would surface as an uncaught async error in the app's zone guard
+    // and reach Crashlytics as exactly the expected-IO noise the decision
+    // matrix keeps out.
+    unawaited(
+      _bestEffortLocalStorage(
+        () async => _localStorage?.saveRepostRecord(record),
+        description: 'saving a repost from the live subscription',
+        site: RepostsRepositoryReportableSites.processIncomingRepostSaveRecord,
+      ),
+    );
     _emitRepostedIds();
   }
 

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
@@ -633,9 +633,17 @@ class RepostsRepository {
     await _ensureInitialized();
 
     // Query the database directly as source of truth to avoid cache/db
-    // inconsistency after app restart
+    // inconsistency after app restart. Best-effort for the same reason
+    // [repostVideo]'s writes are: this is the only entry point the repost
+    // button uses, so an unreadable cache throwing here costs the Kind 16
+    // outright. A swallowed read falls back to the in-memory cache, which is
+    // exactly what the null-storage branch of the `??` already does.
     final isCurrentlyReposted =
-        await _localStorage?.isReposted(addressableId) ??
+        await _bestEffortLocalStorage<bool?>(
+          () async => _localStorage?.isReposted(addressableId),
+          description: 'checking the repost state',
+          site: RepostsRepositoryReportableSites.toggleRepostReadState,
+        ) ??
         _repostRecords.containsKey(addressableId);
 
     if (isCurrentlyReposted) {

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
@@ -285,7 +285,10 @@ class RepostsRepository {
       createdAt: DateTime.now(),
     );
     _repostRecords[addressableId] = placeholder;
-    await _localStorage?.saveRepostRecord(placeholder);
+    await _bestEffortLocalStorage(
+      () async => _localStorage?.saveRepostRecord(placeholder),
+      description: 'saving the repost placeholder',
+    );
     if (previousCount != null) {
       _cacheRepostCount(addressableId, previousCount + 1);
     }
@@ -327,7 +330,10 @@ class RepostsRepository {
         createdAt: placeholder.createdAt,
       );
       _repostRecords[addressableId] = confirmed;
-      await _localStorage?.saveRepostRecord(confirmed);
+      await _bestEffortLocalStorage(
+        () async => _localStorage?.saveRepostRecord(confirmed),
+        description: 'saving the confirmed repost',
+      );
 
       return sentEvent.id;
     } catch (e, stackTrace) {
@@ -348,7 +354,10 @@ class RepostsRepository {
         return placeholderId;
       }
       _repostRecords.remove(addressableId);
-      await _localStorage?.deleteRepostRecord(addressableId);
+      await _bestEffortLocalStorage(
+        () async => _localStorage?.deleteRepostRecord(addressableId),
+        description: 'rolling back the repost placeholder',
+      );
       if (previousCount != null) {
         _cacheRepostCount(addressableId, previousCount);
       }
@@ -411,8 +420,12 @@ class RepostsRepository {
     // Try in-memory cache first, then fall back to database.
     // This handles the case where the cache hasn't been populated yet.
     var record = _repostRecords[addressableId];
-    if (record == null && _localStorage != null) {
-      record = await _localStorage.getRepostRecord(addressableId);
+    final localStorage = _localStorage;
+    if (record == null && localStorage != null) {
+      record = await _bestEffortLocalStorage<RepostRecord?>(
+        () => localStorage.getRepostRecord(addressableId),
+        description: 'reading the repost record',
+      );
     }
 
     if (record == null) {
@@ -427,7 +440,10 @@ class RepostsRepository {
     // watchRepostedAddressableIds stream BEFORE any network I/O (mirror of
     // repostVideo).
     _repostRecords.remove(addressableId);
-    await _localStorage?.deleteRepostRecord(addressableId);
+    await _bestEffortLocalStorage(
+      () async => _localStorage?.deleteRepostRecord(addressableId),
+      description: 'deleting the repost record',
+    );
     if (previousCount != null) {
       _cacheRepostCount(addressableId, previousCount - 1);
     }
@@ -479,7 +495,10 @@ class RepostsRepository {
         return;
       }
       _repostRecords[addressableId] = snapshotRecord;
-      await _localStorage?.saveRepostRecord(snapshotRecord);
+      await _bestEffortLocalStorage(
+        () async => _localStorage?.saveRepostRecord(snapshotRecord),
+        description: 'restoring the repost record',
+      );
       if (previousCount != null) {
         _cacheRepostCount(addressableId, previousCount);
       }
@@ -1010,14 +1029,54 @@ class RepostsRepository {
   Future<void> _ensureInitialized() async {
     if (_isInitialized) return;
 
-    if (_localStorage != null) {
-      final records = await _localStorage.getAllRepostRecords();
-      for (final record in records) {
-        _repostRecords[record.addressableId] = record;
+    final localStorage = _localStorage;
+    if (localStorage != null) {
+      try {
+        final records = await localStorage.getAllRepostRecords();
+        for (final record in records) {
+          _repostRecords[record.addressableId] = record;
+        }
+        _emitRepostedIds();
+      } on Object catch (e) {
+        // Degrade to an in-memory-only cache rather than failing the caller.
+        // Callers are publish paths: an unreadable cache costs a stale
+        // already-reposted check, while throwing here costs the Kind 16.
+        Log.warning(
+          'Repost cache unavailable; continuing without persisted records: $e',
+          name: 'RepostsRepository',
+          category: LogCategory.system,
+        );
       }
-      _emitRepostedIds();
     }
+    // Latched on both paths: an unreadable database stays unreadable for the
+    // session, so retrying would re-throw on every call instead of degrading.
     _isInitialized = true;
+  }
+
+  /// Runs a local-storage side effect that must never block a relay publish.
+  ///
+  /// The local database is a cache. A repost that reached relays survives
+  /// without its cache row; a repost blocked by an unwritable cache is lost
+  /// outright. Storage failures are therefore logged and swallowed.
+  ///
+  /// Expected IO/corruption failures are not Crashlytics-reportable (see the
+  /// decision matrix in `.claude/rules/error_handling.md`); the unified log is
+  /// where a degraded cache surfaces.
+  Future<T?> _bestEffortLocalStorage<T>(
+    Future<T> Function() operation, {
+    required String description,
+  }) async {
+    try {
+      return await operation();
+    } on Object catch (e) {
+      Log.warning(
+        'Local repost storage unavailable ($description); '
+        'continuing without it: $e',
+        name: 'RepostsRepository',
+        category: LogCategory.system,
+      );
+      return null;
+    }
   }
 
   /// Extracts the addressable ID from a repost event's 'a' tag.

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository_reportable_sites.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository_reportable_sites.dart
@@ -55,4 +55,9 @@ abstract class RepostsRepositoryReportableSites {
   /// `initialize`: the startup read of persisted records threw, so the
   /// session continues on an in-memory-only cache.
   static const String initializeLoadRecords = 'initialize.loadRecords';
+
+  /// `_processIncomingRepost`: persisting a repost that arrived on the live
+  /// cross-device subscription threw.
+  static const String processIncomingRepostSaveRecord =
+      'processIncomingRepost.saveRecord';
 }

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository_reportable_sites.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository_reportable_sites.dart
@@ -39,4 +39,8 @@ abstract class RepostsRepositoryReportableSites {
   /// threw, so the optimistic removal is not undone locally.
   static const String unrepostVideoRestoreRecord =
       'unrepostVideo.restoreRecord';
+
+  /// `toggleRepost`: the authoritative already-reposted read threw, so the
+  /// toggle falls back to the in-memory cache to decide its direction.
+  static const String toggleRepostReadState = 'toggleRepost.readState';
 }

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository_reportable_sites.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository_reportable_sites.dart
@@ -1,0 +1,42 @@
+// ABOUTME: Stable identifiers for the local-storage swallow sites in
+// ABOUTME: RepostsRepository, used as the `site:` annotation on reporter calls.
+
+/// Stable site identifiers for the best-effort local-storage swallow
+/// points in `RepostsRepository`. The wiring layer forwards each call to
+/// Crashlytics with `reason: 'RepostsRepository.<site>'` so the dashboard
+/// aggregates per site.
+///
+/// Only programming-invariant violations (`Error` subtypes) reach the
+/// reporter; expected IO and corruption failures stay in the unified log
+/// per the decision matrix in `.claude/rules/error_handling.md`.
+abstract class RepostsRepositoryReportableSites {
+  /// `_ensureInitialized`: reading the persisted repost records threw, so
+  /// the session continues on an in-memory-only cache.
+  static const String ensureInitializedLoadRecords =
+      'ensureInitialized.loadRecords';
+
+  /// `repostVideo`: persisting the optimistic placeholder record threw.
+  static const String repostVideoSavePlaceholder =
+      'repostVideo.savePlaceholder';
+
+  /// `repostVideo`: persisting the confirmed record (real repost event id)
+  /// threw after the Kind 16 publish landed.
+  static const String repostVideoSaveConfirmed = 'repostVideo.saveConfirmed';
+
+  /// `repostVideo`: rolling the placeholder back after a publish failure
+  /// threw, leaving a stale row behind.
+  static const String repostVideoRollbackPlaceholder =
+      'repostVideo.rollbackPlaceholder';
+
+  /// `unrepostVideo`: the fallback read of the repost record threw, so the
+  /// caller cannot tell "not reposted" from "cannot tell".
+  static const String unrepostVideoReadRecord = 'unrepostVideo.readRecord';
+
+  /// `unrepostVideo`: deleting the record ahead of the Kind 5 publish threw.
+  static const String unrepostVideoDeleteRecord = 'unrepostVideo.deleteRecord';
+
+  /// `unrepostVideo`: restoring the record after a deletion-publish failure
+  /// threw, so the optimistic removal is not undone locally.
+  static const String unrepostVideoRestoreRecord =
+      'unrepostVideo.restoreRecord';
+}

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository_reportable_sites.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository_reportable_sites.dart
@@ -43,4 +43,16 @@ abstract class RepostsRepositoryReportableSites {
   /// `toggleRepost`: the authoritative already-reposted read threw, so the
   /// toggle falls back to the in-memory cache to decide its direction.
   static const String toggleRepostReadState = 'toggleRepost.readState';
+
+  /// `syncUserReposts`: the warm read of persisted records threw, so the
+  /// sync runs on relay data alone.
+  static const String syncUserRepostsLoadRecords =
+      'syncUserReposts.loadRecords';
+
+  /// `syncUserReposts`: persisting the freshly-synced relay records threw.
+  static const String syncUserRepostsSaveBatch = 'syncUserReposts.saveBatch';
+
+  /// `initialize`: the startup read of persisted records threw, so the
+  /// session continues on an in-memory-only cache.
+  static const String initializeLoadRecords = 'initialize.loadRecords';
 }

--- a/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
+++ b/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
@@ -379,6 +379,98 @@ void main() {
 
         verify(() => mockNostrClient.deleteEvent(testRepostEventId)).called(1);
       });
+
+      test(
+        'reports an invariant violation raised by a storage write',
+        () async {
+          // An Error from the storage layer means the storage layer itself is
+          // broken. Still swallowed so the Kind 16 goes out, but routed to the
+          // reporter — a swallowed bug nobody can see is how a real defect
+          // ships behind a warning log.
+          final reported = <({Object error, String site})>[];
+          when(
+            () => mockLocalStorage.saveRepostRecord(any()),
+          ).thenThrow(StateError('storage invariant violated'));
+
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+            errorReporter: (error, stackTrace, {required site}) {
+              reported.add((error: error, site: site));
+            },
+          );
+
+          await repository.repostVideo(
+            addressableId: testAddressableId,
+            originalAuthorPubkey: testAuthorPubkey,
+          );
+
+          expect(reported, hasLength(2));
+          expect(reported.first.error, isA<StateError>());
+          expect(
+            reported.map((r) => r.site),
+            equals([
+              RepostsRepositoryReportableSites.repostVideoSavePlaceholder,
+              RepostsRepositoryReportableSites.repostVideoSaveConfirmed,
+            ]),
+          );
+        },
+      );
+
+      test(
+        'reports an invariant violation raised by the initial read',
+        () async {
+          final reported = <String>[];
+          when(
+            () => mockLocalStorage.getAllRepostRecords(),
+          ).thenThrow(TypeError());
+
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+            errorReporter: (error, stackTrace, {required site}) {
+              reported.add(site);
+            },
+          );
+
+          await repository.getRepostedAddressableIds();
+
+          expect(
+            reported,
+            equals([
+              RepostsRepositoryReportableSites.ensureInitializedLoadRecords,
+            ]),
+          );
+        },
+      );
+
+      test('does not report an expected storage failure', () async {
+        // SqliteException and friends are Exceptions, not Errors: expected on
+        // a broken device and explicitly not Crashlytics-reportable per the
+        // decision matrix in `.claude/rules/error_handling.md`.
+        var reportCount = 0;
+        when(
+          () => mockLocalStorage.getAllRepostRecords(),
+        ).thenThrow(storageFailure);
+        when(
+          () => mockLocalStorage.saveRepostRecord(any()),
+        ).thenThrow(storageFailure);
+
+        final repository = RepostsRepository(
+          nostrClient: mockNostrClient,
+          localStorage: mockLocalStorage,
+          errorReporter: (error, stackTrace, {required site}) {
+            reportCount++;
+          },
+        );
+
+        await repository.repostVideo(
+          addressableId: testAddressableId,
+          originalAuthorPubkey: testAuthorPubkey,
+        );
+
+        expect(reportCount, isZero);
+      });
     });
 
     group('repostVideo', () {
@@ -2068,22 +2160,63 @@ void main() {
         await subscription.cancel();
       });
 
-      test('delegates to local storage when available', () {
-        final storageStream = Stream.value(<String>{'test-id'});
+      test('delegates to local storage when available', () async {
         when(
           () => mockLocalStorage.watchRepostedAddressableIds(),
-        ).thenAnswer((_) => storageStream);
+        ).thenAnswer((_) => Stream.value(<String>{'test-id'}));
 
         final repository = RepostsRepository(
           nostrClient: mockNostrClient,
           localStorage: mockLocalStorage,
         );
 
-        final stream = repository.watchRepostedAddressableIds();
-
-        expect(stream, equals(storageStream));
+        await expectLater(
+          repository.watchRepostedAddressableIds(),
+          emits(equals(<String>{'test-id'})),
+        );
         verify(() => mockLocalStorage.watchRepostedAddressableIds()).called(1);
       });
+
+      test(
+        'falls back to the in-memory cache when storage is degraded',
+        () async {
+          // The regression: on a device whose database is present but
+          // unreadable, storage's query stream never emits, so a UI wired to it
+          // watches the repost publish succeed and the button never flip. Every
+          // mutation still ticks the repository's own controller, so that is
+          // what the stream must follow once storage has proven unusable.
+          when(
+            () => mockLocalStorage.getAllRepostRecords(),
+          ).thenThrow(Exception('database is unavailable'));
+          when(
+            () => mockLocalStorage.watchRepostedAddressableIds(),
+          ).thenAnswer((_) => const Stream<Set<String>>.empty());
+
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+          );
+
+          final emittedValues = <Set<String>>[];
+          final subscription = repository.watchRepostedAddressableIds().listen(
+            emittedValues.add,
+          );
+
+          await Future<void>.delayed(Duration.zero);
+          expect(emittedValues.last, isEmpty);
+
+          await repository.repostVideo(
+            addressableId: testAddressableId,
+            originalAuthorPubkey: testAuthorPubkey,
+          );
+
+          await Future<void>.delayed(Duration.zero);
+          expect(emittedValues.last, contains(testAddressableId));
+          verifyNever(() => mockLocalStorage.watchRepostedAddressableIds());
+
+          await subscription.cancel();
+        },
+      );
     });
 
     group('initialize', () {

--- a/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
+++ b/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
@@ -264,6 +264,123 @@ void main() {
       });
     });
 
+    group('unavailable local storage', () {
+      // The local database is a cache, not a precondition. When it is
+      // unreadable (at-rest cipher bootstrap left it unopenable, runtime
+      // corruption, disk full) the Kind 16 must still reach relays: the signed
+      // event is the irreplaceable half of the operation, the cache row is not.
+      // Regression for the SQLITE_NOTADB launch where every repost threw
+      // before `sendGenericRepost` was ever called.
+      final storageFailure = Exception('database is unavailable');
+
+      test('publishes the repost when local storage cannot be read', () async {
+        when(
+          () => mockLocalStorage.getAllRepostRecords(),
+        ).thenThrow(storageFailure);
+
+        final repository = RepostsRepository(
+          nostrClient: mockNostrClient,
+          localStorage: mockLocalStorage,
+        );
+
+        final eventId = await repository.repostVideo(
+          addressableId: testAddressableId,
+          originalAuthorPubkey: testAuthorPubkey,
+        );
+
+        expect(eventId, equals(testRepostEventId));
+        verify(
+          () => mockNostrClient.sendGenericRepost(
+            addressableId: testAddressableId,
+            targetKind: EventKind.videoVertical,
+            authorPubkey: testAuthorPubkey,
+            content: any(named: 'content'),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(1);
+      });
+
+      test('publishes the repost when the local write fails', () async {
+        when(
+          () => mockLocalStorage.saveRepostRecord(any()),
+        ).thenThrow(storageFailure);
+
+        final repository = RepostsRepository(
+          nostrClient: mockNostrClient,
+          localStorage: mockLocalStorage,
+        );
+
+        final eventId = await repository.repostVideo(
+          addressableId: testAddressableId,
+          originalAuthorPubkey: testAuthorPubkey,
+        );
+
+        expect(eventId, equals(testRepostEventId));
+        verify(
+          () => mockNostrClient.sendGenericRepost(
+            addressableId: testAddressableId,
+            targetKind: EventKind.videoVertical,
+            authorPubkey: testAuthorPubkey,
+            content: any(named: 'content'),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(1);
+      });
+
+      test(
+        'a failed read does not strand the repository uninitialized',
+        () async {
+          // Without this the `_isInitialized` latch never flips and every call
+          // re-runs the throwing read — the retry storm that filled the report
+          // with 26 identical failures for two taps.
+          when(
+            () => mockLocalStorage.getAllRepostRecords(),
+          ).thenThrow(storageFailure);
+
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+          );
+
+          await repository.getRepostedAddressableIds();
+          await repository.getRepostedAddressableIds();
+
+          verify(() => mockLocalStorage.getAllRepostRecords()).called(1);
+        },
+      );
+
+      test('publishes the deletion when the local delete fails', () async {
+        when(
+          () => mockLocalStorage.deleteRepostRecord(any()),
+        ).thenThrow(storageFailure);
+        when(() => mockNostrClient.deleteEvent(any())).thenAnswer(
+          (_) async => createMockEvent(
+            id: 'deletion_event_id',
+            kind: EventKind.eventDeletion,
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          ),
+        );
+
+        final repository = RepostsRepository(
+          nostrClient: mockNostrClient,
+          localStorage: mockLocalStorage,
+        );
+
+        // Establish the record in memory so the deletion knows which event id
+        // to reference; an unknown repost still throws NotRepostedException.
+        await repository.repostVideo(
+          addressableId: testAddressableId,
+          originalAuthorPubkey: testAuthorPubkey,
+        );
+
+        await repository.unrepostVideo(testAddressableId);
+
+        verify(() => mockNostrClient.deleteEvent(testRepostEventId)).called(1);
+      });
+    });
+
     group('repostVideo', () {
       test('creates and publishes Kind 16 event', () async {
         final repository = RepostsRepository(nostrClient: mockNostrClient);

--- a/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
+++ b/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
@@ -471,6 +471,74 @@ void main() {
 
         expect(reportCount, isZero);
       });
+
+      test('publishes the repost when the toggle state read fails', () async {
+        // The repost button only ever reaches the repository through
+        // toggleRepost (video_interactions_bloc.dart), so a storage read
+        // that throws there costs the Kind 16 just as surely as one inside
+        // repostVideo. repostVideo's own guard never gets a chance to run.
+        when(
+          () => mockLocalStorage.getAllRepostRecords(),
+        ).thenThrow(storageFailure);
+        when(
+          () => mockLocalStorage.isReposted(any()),
+        ).thenThrow(storageFailure);
+
+        final repository = RepostsRepository(
+          nostrClient: mockNostrClient,
+          localStorage: mockLocalStorage,
+        );
+
+        final isNowReposted = await repository.toggleRepost(
+          addressableId: testAddressableId,
+          originalAuthorPubkey: testAuthorPubkey,
+        );
+
+        expect(isNowReposted, isTrue);
+        verify(
+          () => mockNostrClient.sendGenericRepost(
+            addressableId: testAddressableId,
+            targetKind: EventKind.videoVertical,
+            authorPubkey: testAuthorPubkey,
+            content: any(named: 'content'),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(1);
+      });
+
+      test('unreposts from the in-memory cache when the read fails', () async {
+        // The swallowed read must fall back to the cache, not to "not
+        // reposted" — otherwise the toggle publishes a duplicate Kind 16
+        // instead of deleting the live one.
+        when(() => mockNostrClient.deleteEvent(any())).thenAnswer(
+          (_) async => createMockEvent(
+            id: 'deletion_event_id',
+            kind: EventKind.eventDeletion,
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          ),
+        );
+
+        final repository = RepostsRepository(
+          nostrClient: mockNostrClient,
+          localStorage: mockLocalStorage,
+        );
+        await repository.repostVideo(
+          addressableId: testAddressableId,
+          originalAuthorPubkey: testAuthorPubkey,
+        );
+        when(
+          () => mockLocalStorage.isReposted(any()),
+        ).thenThrow(storageFailure);
+
+        final isNowReposted = await repository.toggleRepost(
+          addressableId: testAddressableId,
+          originalAuthorPubkey: testAuthorPubkey,
+        );
+
+        expect(isNowReposted, isFalse);
+        verify(() => mockNostrClient.deleteEvent(testRepostEventId)).called(1);
+      });
     });
 
     group('repostVideo', () {

--- a/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
+++ b/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
@@ -627,6 +627,44 @@ void main() {
           ),
         ).called(1);
       });
+
+      test('caches a subscription repost when its write fails', () async {
+        // The write is fire-and-forget, so an unguarded rejection would be
+        // an uncaught async error rather than a swallowed cache miss.
+        final controller = StreamController<Event>();
+        addTearDown(controller.close);
+        when(
+          () => mockLocalStorage.saveRepostRecord(any()),
+        ).thenThrow(storageFailure);
+        when(() => mockNostrClient.hasKeys).thenReturn(true);
+        when(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+          ),
+        ).thenAnswer((_) => controller.stream);
+
+        final repository = RepostsRepository(
+          nostrClient: mockNostrClient,
+          localStorage: mockLocalStorage,
+        );
+        await repository.initialize();
+
+        controller.add(
+          createMockEvent(
+            id: testRepostEventId,
+            kind: EventKind.genericRepost,
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+            tags: [
+              ['a', testAddressableId],
+              ['p', testAuthorPubkey],
+            ],
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(repository.isRepostedSync(testAddressableId), isTrue);
+      });
     });
 
     group('repostVideo', () {

--- a/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
+++ b/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
@@ -539,6 +539,94 @@ void main() {
         expect(isNowReposted, isFalse);
         verify(() => mockNostrClient.deleteEvent(testRepostEventId)).called(1);
       });
+
+      test('syncs from relays when the persisted read fails', () async {
+        // The relay half is the authoritative one. A cache read that throws
+        // used to escape syncUserReposts before the fetch below ever ran,
+        // so the profile Reposts tab errored while relays were reachable.
+        when(
+          () => mockLocalStorage.getAllRepostRecords(),
+        ).thenThrow(storageFailure);
+        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+          (_) async => [
+            createMockEvent(
+              id: testRepostEventId,
+              kind: EventKind.genericRepost,
+              createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+              tags: [
+                ['a', testAddressableId],
+                ['p', testAuthorPubkey],
+              ],
+            ),
+          ],
+        );
+
+        final repository = RepostsRepository(
+          nostrClient: mockNostrClient,
+          localStorage: mockLocalStorage,
+        );
+
+        final result = await repository.syncUserReposts();
+
+        expect(result.orderedAddressableIds, equals([testAddressableId]));
+      });
+
+      test('completes the sync when the batch save fails', () async {
+        when(
+          () => mockLocalStorage.saveRepostRecordsBatch(any()),
+        ).thenThrow(storageFailure);
+        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+          (_) async => [
+            createMockEvent(
+              id: testRepostEventId,
+              kind: EventKind.genericRepost,
+              createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+              tags: [
+                ['a', testAddressableId],
+                ['p', testAuthorPubkey],
+              ],
+            ),
+          ],
+        );
+
+        final repository = RepostsRepository(
+          nostrClient: mockNostrClient,
+          localStorage: mockLocalStorage,
+        );
+
+        final result = await repository.syncUserReposts();
+
+        expect(result.orderedAddressableIds, equals([testAddressableId]));
+      });
+
+      test('still subscribes when the startup read fails', () async {
+        // initialize() reads storage before _subscribeToReposts, so a throw
+        // there costs the session its cross-device sync too.
+        when(
+          () => mockLocalStorage.getAllRepostRecords(),
+        ).thenThrow(storageFailure);
+        when(() => mockNostrClient.hasKeys).thenReturn(true);
+        when(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+          ),
+        ).thenAnswer((_) => const Stream.empty());
+
+        final repository = RepostsRepository(
+          nostrClient: mockNostrClient,
+          localStorage: mockLocalStorage,
+        );
+
+        await repository.initialize();
+
+        verify(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+          ),
+        ).called(1);
+      });
     });
 
     group('repostVideo', () {


### PR DESCRIPTION
Closes #6868

## Description

A user on 1.0.19+832 could not repost. The report showed the Kind 16 was never
even attempted: `RepostsRepository.repostVideo` called `_ensureInitialized()`
(a local-storage read) and awaited a placeholder write **before** reaching
`sendGenericRepost`, so a storage failure threw before any network I/O. The
same shape existed in `LikesRepository.likeEvent` / `unlikeEvent`.

The trigger on that device was an unopenable Drift database — every statement
failed `SqliteException(26)` — but the coupling is the bug independent of what
breaks storage. A signed Nostr event that reaches relays is irreplaceable; a
local cache row is not. Sacrificing the former to protect the latter inverts
the priority.

Made worse by two amplifiers:

- `_isInitialized` never latched on the throwing path, so every tap re-ran the
  failing read (26 identical failures for two taps in the report).
- The designated fallback, `_queueOfflineAction` → `PendingActionService`, is
  backed by the *same* database, and its `try` only wrapped the network publish
  — so the recovery path was both unreachable and non-functional.

Storage side effects on the publish paths are now best-effort (logged and
swallowed via a shared `_bestEffortLocalStorage` helper), and
`_ensureInitialized` degrades to an in-memory-only cache and latches on both
paths. Expected IO/corruption failures stay out of Crashlytics per the decision
matrix in `.claude/rules/error_handling.md`.

`FollowRepository` already had the correct ordering — it broadcasts before
saving, and its storage layer swallows its own errors — so it needed no change
and served as the in-repo model.

**Related Issue:** Relates to #

## Out of Scope

- The startup bug that left the database unopenable in the first place
  (`DatabaseEncryptionBootstrap` hands back a `null` cipher key when
  `migratePlaintextToEncrypted` cannot classify the file, so an encrypted DB is
  opened as plaintext). That is a separate root cause with a separate fix and
  will be its own PR — it does not depend on this one, and this one does not
  depend on it.
- `executeLikeAction` / `executeRepostAction` (the PendingActionService replay
  paths). Those exist to drain a DB-backed queue, so a dead DB legitimately
  means there is nothing to replay.

## Verification

- `flutter test` in `mobile/packages/reposts_repository` — 129 passed
- `flutter test` in `mobile/packages/likes_repository` — 206 passed
- Coverage: reposts 100.00% (no `min_coverage` set, so the VeryGood 100%
  default applies); likes 96.89% against its gate of 62
- `flutter analyze lib test` clean in both packages
- App-layer tests depending on either repository (19 files) — 255 passed,
  4 skipped
- New tests fail against the pre-fix code at the exact lines named above
  (`reposts_repository.dart:263/288/430`, `likes_repository.dart:449/486`)

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)