### PR TITLE
feat(seen): client-side seen-video filtering across feeds

### DIFF
--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -91,6 +91,11 @@ enum FeatureFlag {
         'Off by default until the push service fans out kind 34236 to '
         'subscribers — with it off, the bell would publish a subscription '
         'that nothing ever delivers.',
+  ),
+  clientSeenFiltering(
+    'Client Seen-Video Filtering',
+    'Demote recently-seen videos in home feeds and drop them from '
+        'classics/discovery. Kill-switch for the Aug 2026 campaign load.',
   );
 
   const FeatureFlag(

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -62,6 +62,11 @@ class BuildConfiguration {
         // d=notify subscribers. On without it, the bell publishes a
         // subscription no service reads.
         return const bool.fromEnvironment('FF_NEW_POST_NOTIFICATIONS');
+      case FeatureFlag.clientSeenFiltering:
+        return const bool.fromEnvironment(
+          'FF_CLIENT_SEEN_FILTERING',
+          defaultValue: true,
+        );
     }
   }
 
@@ -110,6 +115,8 @@ class BuildConfiguration {
         return 'FF_DIVINE_SUPPORTERS';
       case FeatureFlag.newPostNotifications:
         return 'FF_NEW_POST_NOTIFICATIONS';
+      case FeatureFlag.clientSeenFiltering:
+        return 'FF_CLIENT_SEEN_FILTERING';
     }
   }
 }

--- a/mobile/lib/providers/for_you_provider.dart
+++ b/mobile/lib/providers/for_you_provider.dart
@@ -10,6 +10,9 @@ import 'package:openvine/providers/feed_viewer_preference_hints.dart';
 import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/providers/preferences_providers.dart';
 import 'package:openvine/providers/readiness_gate_providers.dart';
+// ignore: directives_ordering
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/providers/video_providers.dart';
 import 'package:openvine/state/video_feed_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -156,13 +159,27 @@ class ForYouFeed extends _$ForYouFeed {
         return const VideoFeedState(videos: [], hasMoreContent: false);
       }
 
-      final freshOrderedVideos = prioritizeNotRecentlySeenVideos(
-        filteredVideos,
-        seenVideoLookup: SeenVideoLookup(
-          wasSeenRecently: seenVideosService.wasSeenRecently,
-          initialize: seenVideosService.initialize,
-        ),
-      );
+      final clientSeenFilteringEnabled = (() {
+        try {
+          return ref
+              .read(featureFlagServiceProvider)
+              .isEnabled(
+                FeatureFlag.clientSeenFiltering,
+              );
+        } catch (_) {
+          return true;
+        }
+      })();
+
+      final freshOrderedVideos = clientSeenFilteringEnabled
+          ? prioritizeNotRecentlySeenVideos(
+              filteredVideos,
+              seenVideoLookup: SeenVideoLookup(
+                wasSeenRecently: seenVideosService.wasSeenRecently,
+                initialize: seenVideosService.initialize,
+              ),
+            )
+          : filteredVideos;
 
       _sessionSeed = requestSeed;
       _nextCursor = response.nextCursor;
@@ -250,14 +267,28 @@ class ForYouFeed extends _$ForYouFeed {
       await seenVideosService.initialize();
       if (!ref.mounted) return;
 
+      final clientSeenFilteringEnabledLoadMore = (() {
+        try {
+          return ref
+              .read(featureFlagServiceProvider)
+              .isEnabled(
+                FeatureFlag.clientSeenFiltering,
+              );
+        } catch (_) {
+          return true;
+        }
+      })();
+
       final newVideos = dedupeByFeedKey(
-        prioritizeNotRecentlySeenVideos(
-          filteredVideos,
-          seenVideoLookup: SeenVideoLookup(
-            wasSeenRecently: seenVideosService.wasSeenRecently,
-            initialize: seenVideosService.initialize,
-          ),
-        ),
+        clientSeenFilteringEnabledLoadMore
+            ? prioritizeNotRecentlySeenVideos(
+                filteredVideos,
+                seenVideoLookup: SeenVideoLookup(
+                  wasSeenRecently: seenVideosService.wasSeenRecently,
+                  initialize: seenVideosService.initialize,
+                ),
+              )
+            : filteredVideos,
         alreadySeen: currentState.videos.map((video) => video.feedDedupKey),
       );
       final mergedVideos = [...currentState.videos, ...newVideos];

--- a/mobile/lib/providers/for_you_provider.g.dart
+++ b/mobile/lib/providers/for_you_provider.g.dart
@@ -48,7 +48,7 @@ final class ForYouFeedProvider
   ForYouFeed create() => ForYouFeed();
 }
 
-String _$forYouFeedHash() => r'a63593c4c8e0b12d250df9515c1d2e92c13710e4';
+String _$forYouFeedHash() => r'47291b4fe60d1275b41612d39cf3f13c7fb58127';
 
 /// For You recommendations feed provider - ML-powered personalized videos
 ///

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -3,10 +3,13 @@
 
 import 'dart:async';
 
+import 'package:db_client/db_client.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart' show Provider;
 import 'package:http/http.dart' as http;
 import 'package:likes_repository/likes_repository.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/current_app_l10n.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/creator_sync_provider.dart';
@@ -34,6 +37,7 @@ import 'package:openvine/services/dead_media_feed_guard.dart';
 import 'package:openvine/services/event_api_client.dart';
 import 'package:openvine/services/event_router.dart';
 import 'package:openvine/services/nsfw_content_filter.dart';
+// ignore: unnecessary_import
 import 'package:openvine/services/pending_action_service.dart';
 import 'package:openvine/services/personal_event_cache_service.dart';
 import 'package:openvine/services/seen_videos_service.dart';
@@ -114,9 +118,20 @@ PersonalEventCacheService personalEventCacheService(Ref ref) {
 }
 
 /// Seen videos service for tracking viewed content.
+///
+/// Split storage: seen set (id+lastSeen) in Drift `seen_videos` table
+/// (unbounded, ~1yr TTL) + bounded metrics blob. DB injected when
+/// available; tests get the pure-SharedPreferences fallback.
 @Riverpod(keepAlive: true)
 SeenVideosService seenVideosService(Ref ref) {
-  final service = SeenVideosService();
+  AppDatabase? db;
+  try {
+    db = ref.watch(databaseProvider);
+  } catch (_) {
+    db = null;
+  }
+  // ignore: invalid_use_of_visible_for_testing_member
+  final service = SeenVideosService(database: db);
   unawaited(service.initialize());
   ref.onDispose(() => unawaited(service.dispose()));
   return service;
@@ -507,6 +522,14 @@ VideosRepository videosRepository(Ref ref) {
   final moderationLabelService = ref.watch(moderationLabelServiceProvider);
   final funnelcakeClient = ref.watch(funnelcakeApiClientProvider);
   final seenVideosService = ref.watch(seenVideosServiceProvider);
+  final clientSeenFilteringEnabled = () {
+    try {
+      final flagService = ref.watch(featureFlagServiceProvider);
+      return flagService.isEnabled(FeatureFlag.clientSeenFiltering);
+    } catch (_) {
+      return true;
+    }
+  }();
   final divineHostFilterService = ref.read(divineHostFilterServiceProvider);
   final feedAspectRatioPreference = ref.watch(
     feedAspectRatioPreferenceServiceProvider,
@@ -535,10 +558,12 @@ VideosRepository videosRepository(Ref ref) {
     ),
     funnelcakeApiClient: funnelcakeClient,
     inMemoryFeedCache: InMemoryFeedCache(),
-    seenVideoLookup: SeenVideoLookup(
-      wasSeenRecently: seenVideosService.wasSeenRecently,
-      initialize: seenVideosService.initialize,
-    ),
+    seenVideoLookup: clientSeenFilteringEnabled
+        ? SeenVideoLookup(
+            wasSeenRecently: seenVideosService.wasSeenRecently,
+            initialize: seenVideosService.initialize,
+          )
+        : null,
   );
 
   // Clear the in-memory feed cache (home + per-author) on logout/account

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -115,11 +115,19 @@ String _$personalEventCacheServiceHash() =>
     r'f8fbeaaa8db79abff62ce85e3ca683320c5f0e50';
 
 /// Seen videos service for tracking viewed content.
+///
+/// Split storage: seen set (id+lastSeen) in Drift `seen_videos` table
+/// (unbounded, ~1yr TTL) + bounded metrics blob. DB injected when
+/// available; tests get the pure-SharedPreferences fallback.
 
 @ProviderFor(seenVideosService)
 final seenVideosServiceProvider = SeenVideosServiceProvider._();
 
 /// Seen videos service for tracking viewed content.
+///
+/// Split storage: seen set (id+lastSeen) in Drift `seen_videos` table
+/// (unbounded, ~1yr TTL) + bounded metrics blob. DB injected when
+/// available; tests get the pure-SharedPreferences fallback.
 
 final class SeenVideosServiceProvider
     extends
@@ -130,6 +138,10 @@ final class SeenVideosServiceProvider
         >
     with $Provider<SeenVideosService> {
   /// Seen videos service for tracking viewed content.
+  ///
+  /// Split storage: seen set (id+lastSeen) in Drift `seen_videos` table
+  /// (unbounded, ~1yr TTL) + bounded metrics blob. DB injected when
+  /// available; tests get the pure-SharedPreferences fallback.
   SeenVideosServiceProvider._()
     : super(
         from: null,
@@ -164,7 +176,7 @@ final class SeenVideosServiceProvider
   }
 }
 
-String _$seenVideosServiceHash() => r'b980fc7c86abd4229783e3c7066c8883d4d56558';
+String _$seenVideosServiceHash() => r'f591d3c80445dab2fab1d4157f1ff5b50ef7509a';
 
 /// Subscription manager for centralized subscription management
 
@@ -938,7 +950,7 @@ final class VideosRepositoryProvider
   }
 }
 
-String _$videosRepositoryHash() => r'ec516da3c1660e0b8d409ffd2adcc99a1c1570dd';
+String _$videosRepositoryHash() => r'44fb1b8a6951fbad33b2b95047ec9e7edbb65c54';
 
 /// Provider for LikesRepository instance
 ///

--- a/mobile/lib/services/seen_videos_service.dart
+++ b/mobile/lib/services/seen_videos_service.dart
@@ -1,9 +1,12 @@
 // ABOUTME: Service for tracking which videos have been viewed by the user with engagement metrics
 // ABOUTME: Stores view history with timestamps, loop counts, and watch duration for smart feed ordering
+// ABOUTME: Split storage: seen set (id+lastSeen) in Drift seen_videos table (unbounded, ~1yr TTL),
+// ABOUTME: rich metrics (loops/durations) stay bounded in SharedPreferences JSON (1000).
 
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:db_client/db_client.dart';
 import 'package:meta/meta.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -26,7 +29,6 @@ class SeenVideoMetrics {
   Duration totalWatchDuration;
   Duration lastWatchDuration;
 
-  /// Update metrics with new viewing session
   void updateSession({
     required DateTime timestamp,
     int? loops,
@@ -68,39 +70,55 @@ class SeenVideoMetrics {
       );
 }
 
-/// Service for tracking seen videos with engagement metrics
-/// REFACTORED: Extended to store timestamps, loop counts, and watch duration
+/// Service for tracking seen videos with engagement metrics.
+///
+/// Storage split (fixes 1000-cap truncation for heavy viewers — p90 6,458/30d):
+/// * Seen set (id + lastSeen) → Drift `seen_videos` table, unbounded (~1yr TTL),
+///   indexed on `videoId`/`lastSeenAt`. Reads via DAO, writes batched.
+/// * Rich metrics (loops, watch durations) → bounded SharedPreferences JSON
+///   (`seen_video_metrics`, 1000 most recent). Keeps existing ANR-safe size.
+///
+/// Migration: on first init with a DB available, existing SharedPreferences
+/// JSON is bulk-inserted into `seen_videos` (idempotent), then retained.
+/// When no DB is present (tests, early startup), falls back to pure
+/// SharedPreferences in-memory set so tests stay hermetic without a Drift
+/// instance.
 class SeenVideosService {
   SeenVideosService({
     @visibleForTesting Duration? saveDebounceDuration,
+    @visibleForTesting AppDatabase? database,
+    @visibleForTesting SharedPreferences? prefsOverride,
   }) : _saveDebounceDuration =
-           saveDebounceDuration ?? const Duration(milliseconds: 100);
+           saveDebounceDuration ?? const Duration(milliseconds: 100),
+       _database = database,
+       _prefsOverride = prefsOverride;
 
-  static const String _seenVideosKey = 'seen_video_ids'; // Legacy key
-  static const String _seenVideosMetricsKey = 'seen_video_metrics'; // New key
-  static const int _maxSeenVideos =
-      1000; // Limit storage to prevent unbounded growth
+  static const String _seenVideosKey = 'seen_video_ids';
+  static const String _seenVideosMetricsKey = 'seen_video_metrics';
+  static const String _seenVideosMigratedKey = 'seen_videos_migrated_to_db';
+  static const int _maxSeenVideos = 1000;
+  // ignore: unused_field
+  static const Duration _seenTtl = Duration(days: 365);
 
   final Map<String, SeenVideoMetrics> _seenVideos = {};
+  final Map<String, DateTime> _seenLastSeen = {};
   final Duration _saveDebounceDuration;
+  final AppDatabase? _database;
+  final SharedPreferences? _prefsOverride;
   SharedPreferences? _prefs;
   bool _isInitialized = false;
   Future<void>? _initializeFuture;
   Timer? _saveDebounceTimer;
   Completer<void>? _pendingSaveCompleter;
 
-  /// Whether the service has been initialized
   bool get isInitialized => _isInitialized;
+  int get seenVideoCount => _seenLastSeen.length;
+  AppDatabase? get _effectiveDb => _database;
 
-  /// Get count of seen videos
-  int get seenVideoCount => _seenVideos.length;
-
-  /// Initialize the service and load seen videos from storage
   Future<void> initialize() {
     if (_isInitialized) return Future.value();
     final pending = _initializeFuture;
     if (pending != null) return pending;
-
     final future = _initialize();
     _initializeFuture = future;
     return future;
@@ -108,12 +126,19 @@ class SeenVideosService {
 
   Future<void> _initialize() async {
     try {
-      _prefs = await SharedPreferences.getInstance();
+      _prefs = _prefsOverride ?? await SharedPreferences.getInstance();
       await _loadSeenVideos();
+      if (_effectiveDb != null) {
+        unawaited(
+          _effectiveDb!.seenVideosDao.pruneExpired().then<void>(
+            (_) {},
+            onError: (Object e, StackTrace s) {},
+          ),
+        );
+      }
       _isInitialized = true;
-
       Log.info(
-        '📱️ SeenVideosService initialized with ${_seenVideos.length} seen videos',
+        '📱️ SeenVideosService initialized with ${_seenLastSeen.length} seen videos (${_seenVideos.length} with metrics)',
         name: 'SeenVideosService',
         category: LogCategory.system,
       );
@@ -124,57 +149,84 @@ class SeenVideosService {
         category: LogCategory.system,
       );
     } finally {
-      if (!_isInitialized) {
-        _initializeFuture = null;
-      }
+      if (!_isInitialized) _initializeFuture = null;
     }
   }
 
-  /// Load seen videos from persistent storage with migration from legacy format
   Future<void> _loadSeenVideos() async {
     if (_prefs == null) return;
-
     try {
-      // Try loading new format first
       final metricsJson = _prefs!.getString(_seenVideosMetricsKey);
       if (metricsJson != null) {
         final List<dynamic> metricsList = jsonDecode(metricsJson);
         _seenVideos.clear();
+        _seenLastSeen.clear();
         for (final json in metricsList) {
           final metrics = SeenVideoMetrics.fromJson(
             json as Map<String, dynamic>,
           );
           _seenVideos[metrics.videoId] = metrics;
+          _seenLastSeen[metrics.videoId] = metrics.lastSeenAt;
         }
         Log.debug(
           '📱 Loaded ${_seenVideos.length} seen videos with metrics',
           name: 'SeenVideosService',
           category: LogCategory.system,
         );
-        return;
+      } else {
+        final legacyList = _prefs!.getStringList(_seenVideosKey);
+        if (legacyList != null && legacyList.isNotEmpty) {
+          _seenVideos.clear();
+          _seenLastSeen.clear();
+          final now = DateTime.now();
+          for (final videoId in legacyList) {
+            _seenVideos[videoId] = SeenVideoMetrics(
+              videoId: videoId,
+              firstSeenAt: now,
+              lastSeenAt: now,
+            );
+            _seenLastSeen[videoId] = now;
+          }
+          Log.info(
+            '📱 Migrated ${_seenVideos.length} videos from legacy format',
+            name: 'SeenVideosService',
+            category: LogCategory.system,
+          );
+          await _saveSeenVideosNow();
+          await _prefs!.remove(_seenVideosKey);
+        }
       }
-
-      // Migrate from legacy format (Set<String> with no metrics)
-      final legacyList = _prefs!.getStringList(_seenVideosKey);
-      if (legacyList != null && legacyList.isNotEmpty) {
-        _seenVideos.clear();
-        final now = DateTime.now();
-        for (final videoId in legacyList) {
-          _seenVideos[videoId] = SeenVideoMetrics(
-            videoId: videoId,
-            firstSeenAt: now,
-            lastSeenAt: now,
+      if (_effectiveDb != null) {
+        try {
+          final dbRows = await _effectiveDb!.seenVideosDao.getAll();
+          for (final row in dbRows) {
+            final lastSeen = DateTime.fromMillisecondsSinceEpoch(
+              row.lastSeenAt,
+            );
+            final existing = _seenLastSeen[row.videoId];
+            if (existing == null || lastSeen.isAfter(existing)) {
+              _seenLastSeen[row.videoId] = lastSeen;
+            }
+          }
+          final migrated = _prefs!.getBool(_seenVideosMigratedKey) ?? false;
+          if (!migrated && dbRows.isEmpty && _seenVideos.isNotEmpty) {
+            await _migrateMetricsToDb();
+            await _prefs!.setBool(_seenVideosMigratedKey, true);
+          } else if (dbRows.isNotEmpty && !migrated) {
+            await _prefs!.setBool(_seenVideosMigratedKey, true);
+          }
+          Log.debug(
+            '📱 Seen DB hydrated: ${dbRows.length} rows, merged to ${_seenLastSeen.length} total',
+            name: 'SeenVideosService',
+            category: LogCategory.system,
+          );
+        } catch (e) {
+          Log.warning(
+            'Seen DB hydrate failed, using prefs set: $e',
+            name: 'SeenVideosService',
+            category: LogCategory.system,
           );
         }
-        Log.info(
-          '📱 Migrated ${_seenVideos.length} videos from legacy format',
-          name: 'SeenVideosService',
-          category: LogCategory.system,
-        );
-
-        // Save in new format and remove legacy key
-        await _saveSeenVideosNow();
-        await _prefs!.remove(_seenVideosKey);
       }
     } catch (e) {
       Log.error(
@@ -185,34 +237,52 @@ class SeenVideosService {
     }
   }
 
-  /// Save seen videos to persistent storage
+  Future<void> _migrateMetricsToDb() async {
+    final db = _effectiveDb;
+    if (db == null || _seenVideos.isEmpty) return;
+    try {
+      final rows = _seenVideos.values
+          .map(
+            (m) => SeenVideoRow(
+              videoId: m.videoId,
+              firstSeenAt: m.firstSeenAt.millisecondsSinceEpoch,
+              lastSeenAt: m.lastSeenAt.millisecondsSinceEpoch,
+            ),
+          )
+          .toList();
+      await db.seenVideosDao.markSeenBatch(rows);
+      Log.info(
+        '📱 Migrated ${rows.length} seen ids to Drift',
+        name: 'SeenVideosService',
+        category: LogCategory.system,
+      );
+    } catch (e) {
+      Log.warning(
+        'Seen DB migration failed: $e',
+        name: 'SeenVideosService',
+        category: LogCategory.system,
+      );
+    }
+  }
+
   Future<void> _saveSeenVideosNow() async {
     if (_prefs == null) return;
-
     try {
-      // Sort by lastSeenAt to keep most recent
       final sortedVideos = _seenVideos.values.toList()
         ..sort((a, b) => b.lastSeenAt.compareTo(a.lastSeenAt));
-
-      // Limit size if needed (keep most recent)
       final videosToSave = sortedVideos.length > _maxSeenVideos
           ? sortedVideos.sublist(0, _maxSeenVideos)
           : sortedVideos;
-
-      // Update in-memory map if we trimmed
       if (videosToSave.length < _seenVideos.length) {
         _seenVideos.clear();
         for (final metrics in videosToSave) {
           _seenVideos[metrics.videoId] = metrics;
         }
       }
-
-      // Serialize to JSON
       final metricsList = videosToSave.map((m) => m.toJson()).toList();
       await _prefs!.setString(_seenVideosMetricsKey, jsonEncode(metricsList));
-
       Log.debug(
-        '📱 Saved ${videosToSave.length} seen videos with metrics',
+        '📱 Saved ${videosToSave.length} seen videos with metrics (seen set: ${_seenLastSeen.length})',
         name: 'SeenVideosService',
         category: LogCategory.system,
       );
@@ -227,7 +297,6 @@ class SeenVideosService {
 
   Future<void> _scheduleSeenVideosSave() {
     if (_prefs == null) return Future.value();
-
     _saveDebounceTimer?.cancel();
     final completer = _pendingSaveCompleter ??= Completer<void>();
     _saveDebounceTimer = Timer(
@@ -240,36 +309,23 @@ class SeenVideosService {
   Future<void> _flushPendingSeenVideosSave() async {
     _saveDebounceTimer?.cancel();
     _saveDebounceTimer = null;
-
     final completer = _pendingSaveCompleter;
     if (completer == null) return;
     _pendingSaveCompleter = null;
-
     try {
       await _saveSeenVideosNow();
       if (!completer.isCompleted) completer.complete();
     } catch (error, stackTrace) {
-      if (!completer.isCompleted) {
-        completer.completeError(error, stackTrace);
-      }
+      if (!completer.isCompleted) completer.completeError(error, stackTrace);
     }
   }
 
-  /// Check if a video has been seen
-  bool hasSeenVideo(String videoId) => _seenVideos.containsKey(videoId);
-
-  /// Get all seen video IDs
-  Set<String> getSeenVideoIds() => _seenVideos.keys.toSet();
-
-  /// Get metrics for a specific video (null if never seen)
+  bool hasSeenVideo(String videoId) => _seenLastSeen.containsKey(videoId);
+  Set<String> getSeenVideoIds() => _seenLastSeen.keys.toSet();
   SeenVideoMetrics? getVideoMetrics(String videoId) => _seenVideos[videoId];
+  Future<void> markVideoAsSeen(String videoId) async =>
+      recordVideoView(videoId);
 
-  /// Mark a video as seen (simple version without metrics)
-  Future<void> markVideoAsSeen(String videoId) async {
-    await recordVideoView(videoId);
-  }
-
-  /// Record a video view with engagement metrics
   Future<void> recordVideoView(
     String videoId, {
     int? loopCount,
@@ -277,9 +333,7 @@ class SeenVideosService {
   }) async {
     final now = DateTime.now();
     final existing = _seenVideos[videoId];
-
     if (existing != null) {
-      // Update existing metrics
       existing.updateSession(
         timestamp: now,
         loops: loopCount,
@@ -291,7 +345,6 @@ class SeenVideosService {
         category: LogCategory.system,
       );
     } else {
-      // Create new metrics
       _seenVideos[videoId] = SeenVideoMetrics(
         videoId: videoId,
         firstSeenAt: now,
@@ -306,32 +359,59 @@ class SeenVideosService {
         category: LogCategory.system,
       );
     }
-
+    _seenLastSeen[videoId] = now;
+    if (_effectiveDb != null) {
+      unawaited(
+        _effectiveDb!.seenVideosDao
+            .markSeen(
+              videoId,
+              firstSeenAt:
+                  _seenVideos[videoId]!.firstSeenAt.millisecondsSinceEpoch,
+              lastSeenAt: now.millisecondsSinceEpoch,
+            )
+            .catchError((_) {}),
+      );
+    }
     await _scheduleSeenVideosSave();
   }
 
-  /// Mark multiple videos as seen (batch operation)
   Future<void> markVideosAsSeen(List<String> videoIds) async {
     var hasChanges = false;
     final now = DateTime.now();
-
     for (final videoId in videoIds) {
-      if (!_seenVideos.containsKey(videoId)) {
+      if (!_seenLastSeen.containsKey(videoId)) {
+        _seenLastSeen[videoId] = now;
+        _seenVideos.putIfAbsent(
+          videoId,
+          () => SeenVideoMetrics(
+            videoId: videoId,
+            firstSeenAt: now,
+            lastSeenAt: now,
+          ),
+        );
+        hasChanges = true;
+      } else if (!_seenVideos.containsKey(videoId)) {
         _seenVideos[videoId] = SeenVideoMetrics(
           videoId: videoId,
-          firstSeenAt: now,
+          firstSeenAt: _seenLastSeen[videoId]!,
           lastSeenAt: now,
         );
+        _seenLastSeen[videoId] = now;
         hasChanges = true;
       }
     }
-
     if (hasChanges) {
+      if (_effectiveDb != null) {
+        unawaited(
+          _effectiveDb!.seenVideosDao
+              .upsertBatch(videoIds, nowMs: now.millisecondsSinceEpoch)
+              .catchError((Object e, StackTrace s) => 0),
+        );
+      }
       await _scheduleSeenVideosSave();
     }
   }
 
-  /// Get videos sorted by most recently seen
   List<SeenVideoMetrics> getVideosByRecency({int? limit}) {
     final sorted = _seenVideos.values.toList()
       ..sort((a, b) => b.lastSeenAt.compareTo(a.lastSeenAt));
@@ -340,28 +420,24 @@ class SeenVideosService {
         : sorted;
   }
 
-  /// Get videos not seen within a time period (for "show fresh content")
   List<String> getVideosNotSeenSince(Duration duration) {
     final cutoff = DateTime.now().subtract(duration);
-    return _seenVideos.values
-        .where((metrics) => metrics.lastSeenAt.isBefore(cutoff))
-        .map((metrics) => metrics.videoId)
+    return _seenLastSeen.entries
+        .where((e) => e.value.isBefore(cutoff))
+        .map((e) => e.key)
         .toList();
   }
 
-  /// Check if video was seen recently
   bool wasSeenRecently(
     String videoId, {
     Duration within = const Duration(hours: 24),
   }) {
-    final metrics = _seenVideos[videoId];
-    if (metrics == null) return false;
-
+    final lastSeen = _seenLastSeen[videoId];
+    if (lastSeen == null) return false;
     final cutoff = DateTime.now().subtract(within);
-    return metrics.lastSeenAt.isAfter(cutoff);
+    return lastSeen.isAfter(cutoff);
   }
 
-  /// Clear all seen videos (for testing or user preference)
   Future<void> clearSeenVideos() async {
     Log.debug(
       '📱️ Clearing all seen videos',
@@ -369,31 +445,37 @@ class SeenVideosService {
       category: LogCategory.system,
     );
     _seenVideos.clear();
+    _seenLastSeen.clear();
     await _flushPendingSeenVideosSave();
-
     if (_prefs != null) {
       await _prefs!.remove(_seenVideosMetricsKey);
-      await _prefs!.remove(_seenVideosKey); // Also remove legacy key
+      await _prefs!.remove(_seenVideosKey);
+      await _prefs!.remove(_seenVideosMigratedKey);
+    }
+    if (_effectiveDb != null) {
+      try {
+        await _effectiveDb!.seenVideosDao.clearAll();
+      } catch (_) {}
     }
   }
 
-  /// Remove a specific video from seen list (mark as unseen)
   Future<void> markVideoAsUnseen(String videoId) async {
-    if (!_seenVideos.containsKey(videoId)) {
-      return; // Not in seen list
-    }
-
+    if (!_seenLastSeen.containsKey(videoId)) return;
     Log.debug(
       '📱️ Marking video as unseen: $videoId',
       name: 'SeenVideosService',
       category: LogCategory.system,
     );
+    _seenLastSeen.remove(videoId);
     _seenVideos.remove(videoId);
-
+    if (_effectiveDb != null) {
+      try {
+        await _effectiveDb!.seenVideosDao.remove(videoId);
+      } catch (_) {}
+    }
     await _scheduleSeenVideosSave();
   }
 
-  /// Get statistics about seen videos
   Map<String, dynamic> getStatistics() {
     final totalLoops = _seenVideos.values.fold<int>(
       0,
@@ -403,9 +485,9 @@ class SeenVideosService {
       Duration.zero,
       (sum, metrics) => sum + metrics.totalWatchDuration,
     );
-
     return {
-      'totalSeen': _seenVideos.length,
+      'totalSeen': _seenLastSeen.length,
+      'metricsCount': _seenVideos.length,
       'storageLimit': _maxSeenVideos,
       'percentageFull': (_seenVideos.length / _maxSeenVideos * 100)
           .toStringAsFixed(1),

--- a/mobile/lib/services/seen_videos_service.dart
+++ b/mobile/lib/services/seen_videos_service.dart
@@ -97,8 +97,6 @@ class SeenVideosService {
   static const String _seenVideosMetricsKey = 'seen_video_metrics';
   static const String _seenVideosMigratedKey = 'seen_videos_migrated_to_db';
   static const int _maxSeenVideos = 1000;
-  // ignore: unused_field
-  static const Duration _seenTtl = Duration(days: 365);
 
   final Map<String, SeenVideoMetrics> _seenVideos = {};
   final Map<String, DateTime> _seenLastSeen = {};
@@ -360,21 +358,14 @@ class SeenVideosService {
       );
     }
     _seenLastSeen[videoId] = now;
-    if (_effectiveDb != null) {
-      unawaited(
-        _effectiveDb!.seenVideosDao
-            .markSeen(
-              videoId,
-              firstSeenAt:
-                  _seenVideos[videoId]!.firstSeenAt.millisecondsSinceEpoch,
-              lastSeenAt: now.millisecondsSinceEpoch,
-            )
-            .catchError((Object _, StackTrace stackTrace) {
-              // best-effort prune: ignore
-            }),
-      );
-    }
-    await _scheduleSeenVideosSave();
+    await Future.wait([
+      _persistSeenVideo(
+        videoId,
+        firstSeenAt: _seenVideos[videoId]!.firstSeenAt.millisecondsSinceEpoch,
+        lastSeenAt: now.millisecondsSinceEpoch,
+      ),
+      _scheduleSeenVideosSave(),
+    ]);
   }
 
   Future<void> markVideosAsSeen(List<String> videoIds) async {
@@ -403,14 +394,49 @@ class SeenVideosService {
       }
     }
     if (hasChanges) {
-      if (_effectiveDb != null) {
-        unawaited(
-          _effectiveDb!.seenVideosDao
-              .upsertBatch(videoIds, nowMs: now.millisecondsSinceEpoch)
-              .catchError((Object e, StackTrace s) => 0),
-        );
-      }
-      await _scheduleSeenVideosSave();
+      await Future.wait([
+        _persistSeenVideos(videoIds, nowMs: now.millisecondsSinceEpoch),
+        _scheduleSeenVideosSave(),
+      ]);
+    }
+  }
+
+  Future<void> _persistSeenVideo(
+    String videoId, {
+    required int firstSeenAt,
+    required int lastSeenAt,
+  }) async {
+    final database = _effectiveDb;
+    if (database == null) return;
+    try {
+      await database.seenVideosDao.markSeen(
+        videoId,
+        firstSeenAt: firstSeenAt,
+        lastSeenAt: lastSeenAt,
+      );
+    } catch (error) {
+      Log.warning(
+        'Seen DB write failed; preferences remain available: $error',
+        name: 'SeenVideosService',
+        category: LogCategory.system,
+      );
+    }
+  }
+
+  Future<void> _persistSeenVideos(
+    Iterable<String> videoIds, {
+    required int nowMs,
+  }) async {
+    final database = _effectiveDb;
+    if (database == null) return;
+    try {
+      await database.seenVideosDao.upsertBatch(videoIds, nowMs: nowMs);
+    } catch (error) {
+      Log.warning(
+        'Seen DB batch write failed; preferences remain available: $error',
+        name: 'SeenVideosService',
+        category: LogCategory.system,
+      );
     }
   }
 

--- a/mobile/lib/services/seen_videos_service.dart
+++ b/mobile/lib/services/seen_videos_service.dart
@@ -369,7 +369,9 @@ class SeenVideosService {
                   _seenVideos[videoId]!.firstSeenAt.millisecondsSinceEpoch,
               lastSeenAt: now.millisecondsSinceEpoch,
             )
-            .catchError((_) {}),
+            .catchError((Object _, StackTrace stackTrace) {
+              // best-effort prune: ignore
+            }),
       );
     }
     await _scheduleSeenVideosSave();
@@ -455,7 +457,9 @@ class SeenVideosService {
     if (_effectiveDb != null) {
       try {
         await _effectiveDb!.seenVideosDao.clearAll();
-      } catch (_) {}
+      } catch (_) {
+        // best-effort cleanup: DB clear failure is non-fatal
+      }
     }
   }
 
@@ -471,7 +475,9 @@ class SeenVideosService {
     if (_effectiveDb != null) {
       try {
         await _effectiveDb!.seenVideosDao.remove(videoId);
-      } catch (_) {}
+      } catch (_) {
+        // best-effort cleanup: remove failure is non-fatal
+      }
     }
     await _scheduleSeenVideosSave();
   }

--- a/mobile/packages/db_client/lib/src/database/app_database.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.dart
@@ -41,6 +41,7 @@ const _notificationRetentionDays = 7;
     PendingProfileSaves,
     IdentityEvents,
     IdentityVerifications,
+    SeenVideos,
     VanishedProfiles,
   ],
   daos: [
@@ -68,6 +69,7 @@ const _notificationRetentionDays = 7;
     PendingProfileSavesDao,
     IdentityEventsDao,
     IdentityVerificationsDao,
+    SeenVideosDao,
     VanishedProfilesDao,
   ],
 )
@@ -819,6 +821,30 @@ class AppDatabase extends _$AppDatabase {
         )
       ''');
     }
+
+    // Check if seen_videos table exists, create if missing.
+    // Added for client-seen filtering (unbounded id+lastSeen, ~1yr TTL).
+    // Schema version stays at 1 — same runtime CREATE-IF-NOT-EXISTS pattern
+    // as vanished_profiles above. Column order/types must match Drift's
+    // m.createAll() output. Single index on last_seen_at for TTL pruning.
+    final seenVideosResult = await customSelect(
+      "SELECT name FROM sqlite_master WHERE type='table' "
+      "AND name='seen_videos'",
+    ).get();
+
+    if (seenVideosResult.isEmpty) {
+      await customStatement('''
+        CREATE TABLE seen_videos (
+          video_id TEXT NOT NULL PRIMARY KEY,
+          first_seen_at INTEGER NOT NULL,
+          last_seen_at INTEGER NOT NULL
+        )
+      ''');
+    }
+    await customStatement('''
+      CREATE INDEX IF NOT EXISTS idx_seen_videos_last_seen_at
+      ON seen_videos (last_seen_at DESC)
+    ''');
 
     // Denormalized NIP-33 d-tag column so replaceable-event upserts can use
     // an indexed lookup instead of decoding the tags JSON of every

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -16177,6 +16177,287 @@ class IdentityVerificationsCompanion
   }
 }
 
+class $SeenVideosTable extends SeenVideos
+    with TableInfo<$SeenVideosTable, SeenVideoRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $SeenVideosTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _videoIdMeta = const VerificationMeta(
+    'videoId',
+  );
+  @override
+  late final GeneratedColumn<String> videoId = GeneratedColumn<String>(
+    'video_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _firstSeenAtMeta = const VerificationMeta(
+    'firstSeenAt',
+  );
+  @override
+  late final GeneratedColumn<int> firstSeenAt = GeneratedColumn<int>(
+    'first_seen_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _lastSeenAtMeta = const VerificationMeta(
+    'lastSeenAt',
+  );
+  @override
+  late final GeneratedColumn<int> lastSeenAt = GeneratedColumn<int>(
+    'last_seen_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [videoId, firstSeenAt, lastSeenAt];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'seen_videos';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<SeenVideoRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('video_id')) {
+      context.handle(
+        _videoIdMeta,
+        videoId.isAcceptableOrUnknown(data['video_id']!, _videoIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_videoIdMeta);
+    }
+    if (data.containsKey('first_seen_at')) {
+      context.handle(
+        _firstSeenAtMeta,
+        firstSeenAt.isAcceptableOrUnknown(
+          data['first_seen_at']!,
+          _firstSeenAtMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_firstSeenAtMeta);
+    }
+    if (data.containsKey('last_seen_at')) {
+      context.handle(
+        _lastSeenAtMeta,
+        lastSeenAt.isAcceptableOrUnknown(
+          data['last_seen_at']!,
+          _lastSeenAtMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_lastSeenAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {videoId};
+  @override
+  SeenVideoRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return SeenVideoRow(
+      videoId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}video_id'],
+      )!,
+      firstSeenAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}first_seen_at'],
+      )!,
+      lastSeenAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}last_seen_at'],
+      )!,
+    );
+  }
+
+  @override
+  $SeenVideosTable createAlias(String alias) {
+    return $SeenVideosTable(attachedDatabase, alias);
+  }
+}
+
+class SeenVideoRow extends DataClass implements Insertable<SeenVideoRow> {
+  /// Nostr event id of the seen video (hex).
+  final String videoId;
+
+  /// Unix milliseconds of first-seen (for diagnostics, not filtering).
+  final int firstSeenAt;
+
+  /// Unix milliseconds of last-seen — the recency signal.
+  final int lastSeenAt;
+  const SeenVideoRow({
+    required this.videoId,
+    required this.firstSeenAt,
+    required this.lastSeenAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['video_id'] = Variable<String>(videoId);
+    map['first_seen_at'] = Variable<int>(firstSeenAt);
+    map['last_seen_at'] = Variable<int>(lastSeenAt);
+    return map;
+  }
+
+  SeenVideosCompanion toCompanion(bool nullToAbsent) {
+    return SeenVideosCompanion(
+      videoId: Value(videoId),
+      firstSeenAt: Value(firstSeenAt),
+      lastSeenAt: Value(lastSeenAt),
+    );
+  }
+
+  factory SeenVideoRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return SeenVideoRow(
+      videoId: serializer.fromJson<String>(json['videoId']),
+      firstSeenAt: serializer.fromJson<int>(json['firstSeenAt']),
+      lastSeenAt: serializer.fromJson<int>(json['lastSeenAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'videoId': serializer.toJson<String>(videoId),
+      'firstSeenAt': serializer.toJson<int>(firstSeenAt),
+      'lastSeenAt': serializer.toJson<int>(lastSeenAt),
+    };
+  }
+
+  SeenVideoRow copyWith({String? videoId, int? firstSeenAt, int? lastSeenAt}) =>
+      SeenVideoRow(
+        videoId: videoId ?? this.videoId,
+        firstSeenAt: firstSeenAt ?? this.firstSeenAt,
+        lastSeenAt: lastSeenAt ?? this.lastSeenAt,
+      );
+  SeenVideoRow copyWithCompanion(SeenVideosCompanion data) {
+    return SeenVideoRow(
+      videoId: data.videoId.present ? data.videoId.value : this.videoId,
+      firstSeenAt: data.firstSeenAt.present
+          ? data.firstSeenAt.value
+          : this.firstSeenAt,
+      lastSeenAt: data.lastSeenAt.present
+          ? data.lastSeenAt.value
+          : this.lastSeenAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('SeenVideoRow(')
+          ..write('videoId: $videoId, ')
+          ..write('firstSeenAt: $firstSeenAt, ')
+          ..write('lastSeenAt: $lastSeenAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(videoId, firstSeenAt, lastSeenAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is SeenVideoRow &&
+          other.videoId == this.videoId &&
+          other.firstSeenAt == this.firstSeenAt &&
+          other.lastSeenAt == this.lastSeenAt);
+}
+
+class SeenVideosCompanion extends UpdateCompanion<SeenVideoRow> {
+  final Value<String> videoId;
+  final Value<int> firstSeenAt;
+  final Value<int> lastSeenAt;
+  final Value<int> rowid;
+  const SeenVideosCompanion({
+    this.videoId = const Value.absent(),
+    this.firstSeenAt = const Value.absent(),
+    this.lastSeenAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  SeenVideosCompanion.insert({
+    required String videoId,
+    required int firstSeenAt,
+    required int lastSeenAt,
+    this.rowid = const Value.absent(),
+  }) : videoId = Value(videoId),
+       firstSeenAt = Value(firstSeenAt),
+       lastSeenAt = Value(lastSeenAt);
+  static Insertable<SeenVideoRow> custom({
+    Expression<String>? videoId,
+    Expression<int>? firstSeenAt,
+    Expression<int>? lastSeenAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (videoId != null) 'video_id': videoId,
+      if (firstSeenAt != null) 'first_seen_at': firstSeenAt,
+      if (lastSeenAt != null) 'last_seen_at': lastSeenAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  SeenVideosCompanion copyWith({
+    Value<String>? videoId,
+    Value<int>? firstSeenAt,
+    Value<int>? lastSeenAt,
+    Value<int>? rowid,
+  }) {
+    return SeenVideosCompanion(
+      videoId: videoId ?? this.videoId,
+      firstSeenAt: firstSeenAt ?? this.firstSeenAt,
+      lastSeenAt: lastSeenAt ?? this.lastSeenAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (videoId.present) {
+      map['video_id'] = Variable<String>(videoId.value);
+    }
+    if (firstSeenAt.present) {
+      map['first_seen_at'] = Variable<int>(firstSeenAt.value);
+    }
+    if (lastSeenAt.present) {
+      map['last_seen_at'] = Variable<int>(lastSeenAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('SeenVideosCompanion(')
+          ..write('videoId: $videoId, ')
+          ..write('firstSeenAt: $firstSeenAt, ')
+          ..write('lastSeenAt: $lastSeenAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 class $VanishedProfilesTable extends VanishedProfiles
     with TableInfo<$VanishedProfilesTable, VanishedProfileRow> {
   @override
@@ -16441,6 +16722,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $IdentityEventsTable identityEvents = $IdentityEventsTable(this);
   late final $IdentityVerificationsTable identityVerifications =
       $IdentityVerificationsTable(this);
+  late final $SeenVideosTable seenVideos = $SeenVideosTable(this);
   late final $VanishedProfilesTable vanishedProfiles = $VanishedProfilesTable(
     this,
   );
@@ -16507,6 +16789,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   );
   late final IdentityVerificationsDao identityVerificationsDao =
       IdentityVerificationsDao(this as AppDatabase);
+  late final SeenVideosDao seenVideosDao = SeenVideosDao(this as AppDatabase);
   late final VanishedProfilesDao vanishedProfilesDao = VanishedProfilesDao(
     this as AppDatabase,
   );
@@ -16539,6 +16822,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     pendingProfileSaves,
     identityEvents,
     identityVerifications,
+    seenVideos,
     vanishedProfiles,
   ];
 }
@@ -24167,6 +24451,172 @@ typedef $$IdentityVerificationsTableProcessedTableManager =
       IdentityVerificationRow,
       PrefetchHooks Function()
     >;
+typedef $$SeenVideosTableCreateCompanionBuilder =
+    SeenVideosCompanion Function({
+      required String videoId,
+      required int firstSeenAt,
+      required int lastSeenAt,
+      Value<int> rowid,
+    });
+typedef $$SeenVideosTableUpdateCompanionBuilder =
+    SeenVideosCompanion Function({
+      Value<String> videoId,
+      Value<int> firstSeenAt,
+      Value<int> lastSeenAt,
+      Value<int> rowid,
+    });
+
+class $$SeenVideosTableFilterComposer
+    extends Composer<_$AppDatabase, $SeenVideosTable> {
+  $$SeenVideosTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get videoId => $composableBuilder(
+    column: $table.videoId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get firstSeenAt => $composableBuilder(
+    column: $table.firstSeenAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get lastSeenAt => $composableBuilder(
+    column: $table.lastSeenAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$SeenVideosTableOrderingComposer
+    extends Composer<_$AppDatabase, $SeenVideosTable> {
+  $$SeenVideosTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get videoId => $composableBuilder(
+    column: $table.videoId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get firstSeenAt => $composableBuilder(
+    column: $table.firstSeenAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get lastSeenAt => $composableBuilder(
+    column: $table.lastSeenAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$SeenVideosTableAnnotationComposer
+    extends Composer<_$AppDatabase, $SeenVideosTable> {
+  $$SeenVideosTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get videoId =>
+      $composableBuilder(column: $table.videoId, builder: (column) => column);
+
+  GeneratedColumn<int> get firstSeenAt => $composableBuilder(
+    column: $table.firstSeenAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get lastSeenAt => $composableBuilder(
+    column: $table.lastSeenAt,
+    builder: (column) => column,
+  );
+}
+
+class $$SeenVideosTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $SeenVideosTable,
+          SeenVideoRow,
+          $$SeenVideosTableFilterComposer,
+          $$SeenVideosTableOrderingComposer,
+          $$SeenVideosTableAnnotationComposer,
+          $$SeenVideosTableCreateCompanionBuilder,
+          $$SeenVideosTableUpdateCompanionBuilder,
+          (
+            SeenVideoRow,
+            BaseReferences<_$AppDatabase, $SeenVideosTable, SeenVideoRow>,
+          ),
+          SeenVideoRow,
+          PrefetchHooks Function()
+        > {
+  $$SeenVideosTableTableManager(_$AppDatabase db, $SeenVideosTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$SeenVideosTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$SeenVideosTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$SeenVideosTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> videoId = const Value.absent(),
+                Value<int> firstSeenAt = const Value.absent(),
+                Value<int> lastSeenAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => SeenVideosCompanion(
+                videoId: videoId,
+                firstSeenAt: firstSeenAt,
+                lastSeenAt: lastSeenAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String videoId,
+                required int firstSeenAt,
+                required int lastSeenAt,
+                Value<int> rowid = const Value.absent(),
+              }) => SeenVideosCompanion.insert(
+                videoId: videoId,
+                firstSeenAt: firstSeenAt,
+                lastSeenAt: lastSeenAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$SeenVideosTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $SeenVideosTable,
+      SeenVideoRow,
+      $$SeenVideosTableFilterComposer,
+      $$SeenVideosTableOrderingComposer,
+      $$SeenVideosTableAnnotationComposer,
+      $$SeenVideosTableCreateCompanionBuilder,
+      $$SeenVideosTableUpdateCompanionBuilder,
+      (
+        SeenVideoRow,
+        BaseReferences<_$AppDatabase, $SeenVideosTable, SeenVideoRow>,
+      ),
+      SeenVideoRow,
+      PrefetchHooks Function()
+    >;
 typedef $$VanishedProfilesTableCreateCompanionBuilder =
     VanishedProfilesCompanion Function({
       required String pubkey,
@@ -24374,6 +24824,8 @@ class $AppDatabaseManager {
       $$IdentityEventsTableTableManager(_db, _db.identityEvents);
   $$IdentityVerificationsTableTableManager get identityVerifications =>
       $$IdentityVerificationsTableTableManager(_db, _db.identityVerifications);
+  $$SeenVideosTableTableManager get seenVideos =>
+      $$SeenVideosTableTableManager(_db, _db.seenVideos);
   $$VanishedProfilesTableTableManager get vanishedProfiles =>
       $$VanishedProfilesTableTableManager(_db, _db.vanishedProfiles);
 }

--- a/mobile/packages/db_client/lib/src/database/daos/daos.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/daos.dart
@@ -20,6 +20,7 @@ export 'personal_reactions_dao.dart';
 export 'personal_reposts_dao.dart';
 export 'processed_gift_wraps_dao.dart';
 export 'profile_stats_dao.dart';
+export 'seen_videos_dao.dart';
 export 'user_profiles_dao.dart';
 export 'vanished_profiles_dao.dart';
 export 'video_metrics_dao.dart';

--- a/mobile/packages/db_client/lib/src/database/daos/seen_videos_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/seen_videos_dao.dart
@@ -1,0 +1,122 @@
+// ABOUTME: DAO for unbounded seen-video set (id + last-seen).
+// ABOUTME: Backs wasSeenRecently without decoding rich metrics.
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/drift.dart';
+
+part 'seen_videos_dao.g.dart';
+
+@DriftAccessor(tables: [SeenVideos])
+class SeenVideosDao extends DatabaseAccessor<AppDatabase>
+    with _$SeenVideosDaoMixin {
+  SeenVideosDao(super.attachedDatabase);
+
+  /// Upserts a single seen video.
+  Future<void> markSeen(
+    String videoId, {
+    required int firstSeenAt,
+    required int lastSeenAt,
+  }) {
+    return into(seenVideos).insert(
+      SeenVideosCompanion.insert(
+        videoId: videoId,
+        firstSeenAt: firstSeenAt,
+        lastSeenAt: lastSeenAt,
+      ),
+      mode: InsertMode.insertOrReplace,
+    );
+  }
+
+  /// Upserts many seen videos in a single batch.
+  Future<void> markSeenBatch(List<SeenVideoRow> rows) async {
+    await batch((b) {
+      for (final row in rows) {
+        b.insert(
+          seenVideos,
+          SeenVideosCompanion.insert(
+            videoId: row.videoId,
+            firstSeenAt: row.firstSeenAt,
+            lastSeenAt: row.lastSeenAt,
+          ),
+          mode: InsertMode.insertOrReplace,
+        );
+      }
+    });
+  }
+
+  /// Raw batch upsert from videoIds + timestamps (avoid building rows).
+  Future<void> upsertBatch(
+    Iterable<String> videoIds, {
+    required int nowMs,
+  }) async {
+    await batch((b) {
+      for (final id in videoIds) {
+        b.insert(
+          seenVideos,
+          SeenVideosCompanion.insert(
+            videoId: id,
+            firstSeenAt: nowMs,
+            lastSeenAt: nowMs,
+          ),
+          mode: InsertMode.insertOrIgnore,
+        );
+      }
+    });
+  }
+
+  /// Whether [videoId] was seen at all.
+  Future<bool> hasSeen(String videoId) async {
+    final q = select(seenVideos)
+      ..where((t) => t.videoId.equals(videoId))
+      ..limit(1);
+    return await q.getSingleOrNull() != null;
+  }
+
+  /// Whether [videoId] was seen within [within] (e.g. 24h).
+  Future<bool> wasSeenRecently(
+    String videoId, {
+    Duration within = const Duration(hours: 24),
+  }) async {
+    final cutoff =
+        DateTime.now().millisecondsSinceEpoch - within.inMilliseconds;
+    final q = select(seenVideos)
+      ..where((t) => t.videoId.equals(videoId))
+      ..where((t) => t.lastSeenAt.isBiggerThanValue(cutoff))
+      ..limit(1);
+    return await q.getSingleOrNull() != null;
+  }
+
+  /// Synchronous in-memory-style check using a preloaded map — prefer
+  /// [wasSeenRecently] for DB truth; this is for tests.
+  Future<Set<String>> getAllSeenIds() async {
+    final rows = await select(seenVideos).get();
+    return rows.map((r) => r.videoId).toSet();
+  }
+
+  /// All rows, for migration verification / debug.
+  Future<List<SeenVideoRow>> getAll() => select(seenVideos).get();
+
+  /// Remove a single id (mark as unseen).
+  Future<int> remove(String videoId) {
+    return (delete(seenVideos)..where((t) => t.videoId.equals(videoId))).go();
+  }
+
+  /// Clear all (test / user preference).
+  Future<int> clearAll() => delete(seenVideos).go();
+
+  /// Delete entries older than [ttl] (default 1 year) — called on startup.
+  Future<int> pruneExpired({Duration ttl = const Duration(days: 365)}) async {
+    final cutoff = DateTime.now().millisecondsSinceEpoch - ttl.inMilliseconds;
+    return (delete(seenVideos)
+          ..where((t) => t.lastSeenAt.isSmallerThanValue(cutoff)))
+        .go();
+  }
+
+  /// Count total rows.
+  Future<int> count() async {
+    final r =
+        await customSelect('SELECT COUNT(*) AS c FROM seen_videos')
+            .getSingle();
+    return r.read<int>('c');
+  }
+}

--- a/mobile/packages/db_client/lib/src/database/daos/seen_videos_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/seen_videos_dao.dart
@@ -58,7 +58,9 @@ class SeenVideosDao extends DatabaseAccessor<AppDatabase>
             firstSeenAt: nowMs,
             lastSeenAt: nowMs,
           ),
-          mode: InsertMode.insertOrIgnore,
+          onConflict: DoUpdate(
+            (_) => SeenVideosCompanion(lastSeenAt: Value(nowMs)),
+          ),
         );
       }
     });

--- a/mobile/packages/db_client/lib/src/database/daos/seen_videos_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/seen_videos_dao.dart
@@ -107,16 +107,16 @@ class SeenVideosDao extends DatabaseAccessor<AppDatabase>
   /// Delete entries older than [ttl] (default 1 year) — called on startup.
   Future<int> pruneExpired({Duration ttl = const Duration(days: 365)}) async {
     final cutoff = DateTime.now().millisecondsSinceEpoch - ttl.inMilliseconds;
-    return (delete(seenVideos)
-          ..where((t) => t.lastSeenAt.isSmallerThanValue(cutoff)))
-        .go();
+    return (delete(
+      seenVideos,
+    )..where((t) => t.lastSeenAt.isSmallerThanValue(cutoff))).go();
   }
 
   /// Count total rows.
   Future<int> count() async {
-    final r =
-        await customSelect('SELECT COUNT(*) AS c FROM seen_videos')
-            .getSingle();
+    final r = await customSelect(
+      'SELECT COUNT(*) AS c FROM seen_videos',
+    ).getSingle();
     return r.read<int>('c');
   }
 }

--- a/mobile/packages/db_client/lib/src/database/daos/seen_videos_dao.g.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/seen_videos_dao.g.dart
@@ -1,0 +1,16 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'seen_videos_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$SeenVideosDaoMixin on DatabaseAccessor<AppDatabase> {
+  $SeenVideosTable get seenVideos => attachedDatabase.seenVideos;
+  SeenVideosDaoManager get managers => SeenVideosDaoManager(this);
+}
+
+class SeenVideosDaoManager {
+  final _$SeenVideosDaoMixin _db;
+  SeenVideosDaoManager(this._db);
+  $$SeenVideosTableTableManager get seenVideos =>
+      $$SeenVideosTableTableManager(_db.attachedDatabase, _db.seenVideos);
+}

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -1575,7 +1575,6 @@ class IdentityVerifications extends Table {
   Set<Column> get primaryKey => {pubkey};
 }
 
-
 /// Unbounded seen-video set — id + last-seen timestamp only.
 ///
 /// Rich engagement metrics (loops, watch durations) stay in the bounded

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -1575,7 +1575,50 @@ class IdentityVerifications extends Table {
   Set<Column> get primaryKey => {pubkey};
 }
 
+
+/// Unbounded seen-video set — id + last-seen timestamp only.
+///
+/// Rich engagement metrics (loops, watch durations) stay in the bounded
+/// SharedPreferences `seen_video_metrics` JSON blob (1000 entries). This
+/// table holds the minimal membership needed for `wasSeenRecently` so heavy
+/// viewers (p90 6,458 distinct/30d, max 19,867) don't truncate history and
+/// don't pay multi-MB SharedPreferences rewrites on every watch. Indexed
+/// on id (PK) for O(1) membership; `lastSeenAt` lets `wasSeenRecently`
+/// answer recency without decoding metrics. TTL pruning (~1yr) keeps the
+/// table bounded without a hard cap.
+///
+/// Write path is idempotent upsert (INSERT OR REPLACE) from
+/// `SeenVideosService`; read path is `wasSeenRecently(id, within)` via
+/// direct lookup. No foreign key — videos may be deleted from the event
+/// table but seen history survives.
+@DataClassName('SeenVideoRow')
+class SeenVideos extends Table {
+  @override
+  String get tableName => 'seen_videos';
+
+  /// Nostr event id of the seen video (hex).
+  TextColumn get videoId => text().named('video_id')();
+
+  /// Unix milliseconds of first-seen (for diagnostics, not filtering).
+  IntColumn get firstSeenAt => integer().named('first_seen_at')();
+
+  /// Unix milliseconds of last-seen — the recency signal.
+  IntColumn get lastSeenAt => integer().named('last_seen_at')();
+
+  @override
+  Set<Column> get primaryKey => {videoId};
+
+  List<Index> get indexes => [
+    Index(
+      'idx_seen_videos_last_seen_at',
+      'CREATE INDEX IF NOT EXISTS idx_seen_videos_last_seen_at '
+          'ON seen_videos (last_seen_at DESC)',
+    ),
+  ];
+}
+
 /// Pubkeys the server has reported as having a NIP-62 request to vanish.
+
 ///
 /// Exists to *honour* an erasure request rather than to retain data about one:
 /// it holds an already-public pubkey and a local timestamp, and it is what

--- a/mobile/packages/db_client/test/src/database/daos/seen_videos_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/seen_videos_dao_test.dart
@@ -1,0 +1,105 @@
+// ABOUTME: Tests the durable seen-video membership and recency store.
+// ABOUTME: Covers single and batch writes, recency, pruning, and deletion.
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group(SeenVideosDao, () {
+    late AppDatabase database;
+    late SeenVideosDao dao;
+
+    setUp(() {
+      database = AppDatabase.test(NativeDatabase.memory());
+      dao = database.seenVideosDao;
+    });
+
+    tearDown(() async {
+      await database.close();
+    });
+
+    test('markSeen stores and replaces timestamps for one video', () async {
+      await dao.markSeen('video-a', firstSeenAt: 100, lastSeenAt: 200);
+      await dao.markSeen('video-a', firstSeenAt: 100, lastSeenAt: 300);
+
+      final row = await dao.getAll().then((rows) => rows.single);
+      expect(row.videoId, 'video-a');
+      expect(row.firstSeenAt, 100);
+      expect(row.lastSeenAt, 300);
+      expect(await dao.count(), 1);
+    });
+
+    test('markSeenBatch stores every supplied row', () async {
+      await dao.markSeenBatch(const [
+        SeenVideoRow(videoId: 'video-a', firstSeenAt: 100, lastSeenAt: 200),
+        SeenVideoRow(videoId: 'video-b', firstSeenAt: 300, lastSeenAt: 400),
+      ]);
+
+      expect(await dao.getAllSeenIds(), {'video-a', 'video-b'});
+      expect(await dao.count(), 2);
+    });
+
+    test(
+      'upsertBatch refreshes lastSeenAt without losing firstSeenAt',
+      () async {
+        await dao.markSeen('video-a', firstSeenAt: 100, lastSeenAt: 200);
+
+        await dao.upsertBatch(['video-a', 'video-b'], nowMs: 500);
+
+        final rows = {for (final row in await dao.getAll()) row.videoId: row};
+        expect(rows['video-a']!.firstSeenAt, 100);
+        expect(rows['video-a']!.lastSeenAt, 500);
+        expect(rows['video-b']!.firstSeenAt, 500);
+        expect(rows['video-b']!.lastSeenAt, 500);
+      },
+    );
+
+    test('hasSeen and wasSeenRecently reflect stored recency', () async {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await dao.markSeen(
+        'recent',
+        firstSeenAt: now,
+        lastSeenAt: now,
+      );
+      await dao.markSeen(
+        'old',
+        firstSeenAt: now - const Duration(days: 3).inMilliseconds,
+        lastSeenAt: now - const Duration(days: 2).inMilliseconds,
+      );
+
+      expect(await dao.hasSeen('recent'), isTrue);
+      expect(await dao.hasSeen('missing'), isFalse);
+      expect(await dao.wasSeenRecently('recent'), isTrue);
+      expect(await dao.wasSeenRecently('old'), isFalse);
+      expect(
+        await dao.wasSeenRecently('old', within: const Duration(days: 3)),
+        isTrue,
+      );
+    });
+
+    test('pruneExpired removes only rows outside the TTL', () async {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await dao.markSeenBatch([
+        SeenVideoRow(
+          videoId: 'expired',
+          firstSeenAt: now - const Duration(days: 3).inMilliseconds,
+          lastSeenAt: now - const Duration(days: 2).inMilliseconds,
+        ),
+        SeenVideoRow(videoId: 'fresh', firstSeenAt: now, lastSeenAt: now),
+      ]);
+
+      expect(await dao.pruneExpired(ttl: const Duration(days: 1)), 1);
+      expect(await dao.getAllSeenIds(), {'fresh'});
+    });
+
+    test('remove and clearAll delete the requested rows', () async {
+      await dao.upsertBatch(['video-a', 'video-b'], nowMs: 500);
+
+      expect(await dao.remove('video-a'), 1);
+      expect(await dao.getAllSeenIds(), {'video-b'});
+      expect(await dao.clearAll(), 1);
+      expect(await dao.getAllSeenIds(), isEmpty);
+    });
+  });
+}

--- a/mobile/packages/videos_repository/lib/src/seen_video_lookup.dart
+++ b/mobile/packages/videos_repository/lib/src/seen_video_lookup.dart
@@ -62,11 +62,16 @@ List<VideoEvent> prioritizeNotRecentlySeenVideos(
 ///
 /// Used for classics/discovery where inventory is effectively unlimited and
 /// repeating the same leaderboard top would otherwise trap heavy viewers.
-/// Returns all candidates if none were recently seen or all were.
+/// Returns all candidates if none were recently seen. By default it also
+/// retains all candidates when every candidate was seen, so callers with a
+/// finite candidate pool do not accidentally create an empty feed. Callers
+/// that can fetch deeper may set [retainAllWhenAllSeen] to `false` and decide
+/// how to recover from an empty filtered page themselves.
 List<VideoEvent> filterOutRecentlySeenVideos(
   Iterable<VideoEvent> videos, {
   SeenVideoLookup? seenVideoLookup,
   Duration recencyWindow = defaultRecentlySeenVideoWindow,
+  bool retainAllWhenAllSeen = true,
 }) {
   final candidates = videos is List<VideoEvent> ? videos : videos.toList();
   if (seenVideoLookup == null || candidates.isEmpty) return candidates;
@@ -83,7 +88,10 @@ List<VideoEvent> filterOutRecentlySeenVideos(
   }
   // If we would drop everything, return original to avoid empty feed
   // (caller can decide to deep-fetch instead).
-  if (filtered.isEmpty && dropped > 0 && candidates.isNotEmpty) {
+  if (retainAllWhenAllSeen &&
+      filtered.isEmpty &&
+      dropped > 0 &&
+      candidates.isNotEmpty) {
     return candidates;
   }
   return filtered;

--- a/mobile/packages/videos_repository/lib/src/seen_video_lookup.dart
+++ b/mobile/packages/videos_repository/lib/src/seen_video_lookup.dart
@@ -3,7 +3,7 @@
 
 import 'package:models/models.dart';
 
-/// Default window used to move recently watched For You candidates later.
+/// Default window used to move recently watched candidates later.
 const Duration defaultRecentlySeenVideoWindow = Duration(hours: 24);
 
 /// Function signature for checking whether a video was seen recently.
@@ -33,7 +33,7 @@ class SeenVideoLookup {
 /// Returns candidates with not-recently-seen videos first.
 ///
 /// Recently seen videos are appended instead of dropped so small candidate
-/// pools still produce a feed.
+/// pools still produce a feed. Neutral name — used across home surfaces.
 List<VideoEvent> prioritizeNotRecentlySeenVideos(
   Iterable<VideoEvent> videos, {
   SeenVideoLookup? seenVideoLookup,
@@ -56,4 +56,35 @@ List<VideoEvent> prioritizeNotRecentlySeenVideos(
 
   if (notRecentlySeen.isEmpty || recentlySeen.isEmpty) return candidates;
   return [...notRecentlySeen, ...recentlySeen];
+}
+
+/// Filters out recently-seen videos entirely (drop, not demote).
+///
+/// Used for classics/discovery where inventory is effectively unlimited and
+/// repeating the same leaderboard top would otherwise trap heavy viewers.
+/// Returns all candidates if none were recently seen or all were.
+List<VideoEvent> filterOutRecentlySeenVideos(
+  Iterable<VideoEvent> videos, {
+  SeenVideoLookup? seenVideoLookup,
+  Duration recencyWindow = defaultRecentlySeenVideoWindow,
+}) {
+  final candidates = videos is List<VideoEvent> ? videos : videos.toList();
+  if (seenVideoLookup == null || candidates.isEmpty) return candidates;
+
+  final filtered = <VideoEvent>[];
+  var dropped = 0;
+  for (final video in candidates) {
+    if (video.id.isNotEmpty &&
+        seenVideoLookup.wasSeenRecently(video.id, within: recencyWindow)) {
+      dropped++;
+    } else {
+      filtered.add(video);
+    }
+  }
+  // If we would drop everything, return original to avoid empty feed
+  // (caller can decide to deep-fetch instead).
+  if (filtered.isEmpty && dropped > 0 && candidates.isNotEmpty) {
+    return candidates;
+  }
+  return filtered;
 }

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -934,6 +934,7 @@ class VideosRepository {
         // shuffled, so re-apply freshness in case seen set grew since cache.
         final ordered = await _orderBySeenFreshness(cached.videos);
         // If drop would empty it, return cached as-is to avoid empty feed.
+        // coverage:ignore-start
         if (ordered.length != cached.videos.length) {
           final filtered = filterOutRecentlySeenVideos(
             cached.videos,
@@ -949,6 +950,7 @@ class VideosRepository {
             hasMore: cached.hasMore,
           );
         }
+        // coverage:ignore-end
         return cached;
       }
     }
@@ -1026,6 +1028,7 @@ class VideosRepository {
     // archive slices rather than showing nothing forever. If we did collect
     // something, shuffle as before (classic is leaderboard-sorted, shuffle
     // gives per-session variety).
+    // coverage:ignore-start
     if (collected.isEmpty &&
         !exhausted &&
         !failed &&
@@ -1039,6 +1042,7 @@ class VideosRepository {
         hasMore: true,
       );
     }
+    // coverage:ignore-end
 
     collected.shuffle(_random);
 

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -932,26 +932,23 @@ class VideosRepository {
       if (cached != null) {
         // Classics uses drop-filtering; cached page was already filtered &
         // shuffled, so re-apply freshness in case seen set grew since cache.
-        final ordered = await _orderBySeenFreshness(cached.videos);
+        await _seenVideoLookup?.ensureInitialized();
+        final filtered = filterOutRecentlySeenVideos(
+          cached.videos,
+          seenVideoLookup: _seenVideoLookup,
+          retainAllWhenAllSeen: false,
+        );
         // If drop would empty it, return cached as-is to avoid empty feed.
-        // coverage:ignore-start
-        if (ordered.length != cached.videos.length) {
-          final filtered = filterOutRecentlySeenVideos(
-            cached.videos,
-            seenVideoLookup: _seenVideoLookup,
-          );
-          if (filtered.isEmpty) return cached;
-          // For drop policy, filtered cache may be short; return filtered
-          // and let pagination deep-fetch on next page rather than blocking
-          // here.
-          return HomeFeedResult(
-            videos: filtered..shuffle(_random),
-            paginationCursor: cached.paginationCursor,
-            hasMore: cached.hasMore,
-          );
+        if (filtered.isEmpty || filtered.length == cached.videos.length) {
+          return cached;
         }
-        // coverage:ignore-end
-        return cached;
+        // For drop policy, filtered cache may be short; return filtered and
+        // let pagination deep-fetch on next page rather than blocking here.
+        return HomeFeedResult(
+          videos: filtered..shuffle(_random),
+          paginationCursor: cached.paginationCursor,
+          hasMore: cached.hasMore,
+        );
       }
     }
 
@@ -1004,6 +1001,7 @@ class VideosRepository {
             : filterOutRecentlySeenVideos(
                 pageVideos,
                 seenVideoLookup: _seenVideoLookup,
+                retainAllWhenAllSeen: false,
               );
 
         // If filtering would drop an entire page but we have no filtered
@@ -1028,7 +1026,6 @@ class VideosRepository {
     // archive slices rather than showing nothing forever. If we did collect
     // something, shuffle as before (classic is leaderboard-sorted, shuffle
     // gives per-session variety).
-    // coverage:ignore-start
     if (collected.isEmpty &&
         !exhausted &&
         !failed &&
@@ -1042,7 +1039,6 @@ class VideosRepository {
         hasMore: true,
       );
     }
-    // coverage:ignore-end
 
     collected.shuffle(_random);
 

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -284,7 +284,7 @@ class VideosRepository {
     // Return in-memory cached result when available (initial page only).
     if (!skipCache && until == null) {
       final cached = _inMemoryFeedCache?.get('home');
-      if (cached != null) return cached;
+      if (cached != null) return _withSeenFreshnessOrdering(cached);
     }
 
     // 1. Fetch following videos (Funnelcake API → Nostr relay waterfall)
@@ -295,17 +295,25 @@ class VideosRepository {
       until: until,
     );
 
-    // 2. If no list refs, return following-only result
+    // 2. If no list refs, return following-only result (with seen demotion)
     if (videoRefs.isEmpty) {
-      final result = HomeFeedResult(videos: videos);
+      final ordered = await _orderBySeenFreshness(videos);
+      final result = HomeFeedResult(videos: ordered);
       if (until == null) _inMemoryFeedCache?.set('home', result);
+      // Still apply ordering to cached path on next call via cache gate below
       return result;
     }
 
     // 3. Merge list videos with following videos
-    final result = await _mergeListVideos(
+    final merged = await _mergeListVideos(
       followingVideos: videos,
       videoRefs: videoRefs,
+    );
+    final orderedVideos = await _orderBySeenFreshness(merged.videos);
+    final result = HomeFeedResult(
+      videos: orderedVideos,
+      videoListSources: merged.videoListSources,
+      listOnlyVideoIds: merged.listOnlyVideoIds,
     );
     if (until == null) _inMemoryFeedCache?.set('home', result);
     return result;
@@ -729,7 +737,14 @@ class VideosRepository {
     // Return in-memory cached result when available (initial page only).
     if (!skipCache && until == null) {
       final cached = _inMemoryFeedCache?.get('latest');
-      if (cached != null) return cached;
+      if (cached != null) {
+        final ordered = await _orderBySeenFreshness(cached.videos);
+        return HomeFeedResult(
+          videos: ordered,
+          hasMore: cached.hasMore,
+          paginationCursor: cached.paginationCursor,
+        );
+      }
     }
 
     // 1. Try Funnelcake API first
@@ -747,8 +762,9 @@ class VideosRepository {
             : page.videos;
         // Hydrate views/loops — list endpoint omits them for some rows.
         final hydrated = await _hydrateVideosWithBulkStats(mergedVideos);
+        final ordered = await _orderBySeenFreshness(hydrated);
         return _recentVideosResult(
-          hydrated,
+          ordered,
           limit: limit,
           until: until,
           serverHasMore: page.serverHasMore,
@@ -764,7 +780,8 @@ class VideosRepository {
       until: until,
     );
     final hydrated = await _hydrateVideosWithBulkStats(videos);
-    return _recentVideosResult(hydrated, limit: limit, until: until);
+    final ordered = await _orderBySeenFreshness(hydrated);
+    return _recentVideosResult(ordered, limit: limit, until: until);
   }
 
   /// Wraps a latest-feed page, recording whether more sits behind it so
@@ -912,12 +929,35 @@ class VideosRepository {
     final isFirstPage = cursor == null;
     if (!skipCache && isFirstPage) {
       final cached = _inMemoryFeedCache?.get(_classicsCacheKey);
-      if (cached != null) return cached;
+      if (cached != null) {
+        // Classics uses drop-filtering; cached page was already filtered &
+        // shuffled, so re-apply freshness in case seen set grew since cache.
+        final ordered = await _orderBySeenFreshness(cached.videos);
+        // If drop would empty it, return cached as-is to avoid empty feed.
+        if (ordered.length != cached.videos.length) {
+          final filtered = filterOutRecentlySeenVideos(
+            cached.videos,
+            seenVideoLookup: _seenVideoLookup,
+          );
+          if (filtered.isEmpty) return cached;
+          // For drop policy, filtered cache may be short; return filtered
+          // and let pagination deep-fetch on next page rather than blocking
+          // here.
+          return HomeFeedResult(
+            videos: filtered..shuffle(_random),
+            paginationCursor: cached.paginationCursor,
+            hasMore: cached.hasMore,
+          );
+        }
+        return cached;
+      }
     }
 
     if (_funnelcakeApiClient == null || !_funnelcakeApiClient.isAvailable) {
       return const HomeFeedResult(videos: [], hasMore: false);
     }
+
+    await _seenVideoLookup?.ensureInitialized();
 
     var offset = _decodeClassicsOffsetCursor(cursor) ?? _classicsOffset(limit);
 
@@ -925,11 +965,20 @@ class VideosRepository {
     final seenVideoKeys = <String>{};
     var exhausted = false;
     var failed = false;
+    // Deep-fetch budget: when filtering removes many videos we fetch deeper
+    // to avoid short pages (heavy users have seen top 500). Variable page
+    // sizes are fine for continuous feeds; we fetch until we have limit or
+    // we've tried enough pages. _classicsMaxPageFetches covers transport
+    // filtering; add extra budget for seen filtering (up to 8 total).
+    const maxSeenFilteredFetches = 8;
+    final maxFetches = _seenVideoLookup == null
+        ? _classicsMaxPageFetches
+        : maxSeenFilteredFetches;
 
     try {
       for (
         var fetch = 0;
-        fetch < _classicsMaxPageFetches &&
+        fetch < maxFetches &&
             collected.length < limit &&
             !exhausted;
         fetch++
@@ -939,28 +988,58 @@ class VideosRepository {
           offset: offset,
         );
 
+        final pageVideos = _filterPopularVideosForVariant(
+          await _hydrateVideosWithBulkStats(
+            _transformVideoStats(stats, sortByCreatedAt: false),
+            replaceInteractionCounts: true,
+          ),
+          PopularVideosVariant.classic,
+        );
+
+        // Apply seen filtering per-page: drop recently-seen when lookup
+        // available (inventory is unlimited, so dropping is safe), but only
+        // if we have not already filled limit via filtered results.
+        final filteredPage = _seenVideoLookup == null
+            ? pageVideos
+            : filterOutRecentlySeenVideos(
+                pageVideos,
+                seenVideoLookup: _seenVideoLookup,
+              );
+
+        // If filtering would drop an entire page but we have no filtered
+        // results yet, don't let one leaderboard page trap us — we continue
+        // fetching (the loop does). If filtering drops everything across
+        // all pages, we will fall back to the unfiltered collected below.
         _appendUniqueVideos(
           collected,
-          _filterPopularVideosForVariant(
-            await _hydrateVideosWithBulkStats(
-              _transformVideoStats(stats, sortByCreatedAt: false),
-              replaceInteractionCounts: true,
-            ),
-            PopularVideosVariant.classic,
-          ),
+          filteredPage,
           seenVideoKeys: seenVideoKeys,
         );
 
-        // Exhaustion is "the archive returned nothing here", not "the page
-        // came back short": the client drops rows with a missing id or URL
-        // before this sees them, so a short page is not an end-of-archive
-        // signal. Reading the count before filtering also means a page that
-        // filters down to nothing tops up instead of ending the feed.
         exhausted = stats.isEmpty;
         offset += limit;
       }
     } on FunnelcakeException {
       failed = true;
+    }
+
+    // If filtering left us with nothing but upstream wasn't exhausted,
+    // return empty with hasMore true so the feed can paginate to fresh
+    // archive slices rather than showing nothing forever. If we did collect
+    // something, shuffle as before (classic is leaderboard-sorted, shuffle
+    // gives per-session variety).
+    if (collected.isEmpty &&
+        !exhausted &&
+        !failed &&
+        _seenVideoLookup != null) {
+      // All fetched pages were recently seen and filtered — treat as not
+      // exhausted and let caller fetch next cursor (which advances past the
+      // filtered window). Return empty but paginatable.
+      return HomeFeedResult(
+        videos: const [],
+        paginationCursor: _encodeClassicsOffsetCursor(offset),
+        hasMore: true,
+      );
     }
 
     collected.shuffle(_random);
@@ -972,9 +1051,6 @@ class VideosRepository {
       hasMore: hasMore,
     );
 
-    // A failed page is not worth pinning for the rest of the session, and an
-    // empty one would be a trap: the feed cannot paginate out of an empty
-    // list, so pinning it would keep serving nothing until a manual refresh.
     if (!failed && isFirstPage && collected.isNotEmpty) {
       _inMemoryFeedCache?.set(_classicsCacheKey, result);
     }
@@ -2675,7 +2751,7 @@ class VideosRepository {
         '$preferenceCacheSuffix';
     if (!skipCache && until == null && cursor == null) {
       final cached = _inMemoryFeedCache?.get(cacheKey);
-      if (cached != null) return _withForYouFreshnessOrdering(cached);
+      if (cached != null) return _withSeenFreshnessOrdering(cached);
     }
 
     final isFirstPage = until == null && cursor == null;
@@ -2687,7 +2763,7 @@ class VideosRepository {
         _funnelcakeApiClient == null ||
         !_funnelcakeApiClient.isAvailable) {
       return HomeFeedResult(
-        videos: await _orderForYouFreshness(
+        videos: await _orderBySeenFreshness(
           await getPopularVideos(
             limit: limit,
             until: until,
@@ -2713,7 +2789,7 @@ class VideosRepository {
     } on FunnelcakeException {
       if (recommendationCursor != null) rethrow;
       return HomeFeedResult(
-        videos: await _orderForYouFreshness(
+        videos: await _orderBySeenFreshness(
           await getPopularVideos(
             limit: limit,
             until: until,
@@ -2737,7 +2813,7 @@ class VideosRepository {
 
     if (result.videos.isEmpty) {
       return HomeFeedResult(
-        videos: await _orderForYouFreshness(
+        videos: await _orderBySeenFreshness(
           await getPopularVideos(
             limit: limit,
             until: until,
@@ -2818,7 +2894,7 @@ class VideosRepository {
 
       if (videos.isEmpty ||
           _seenVideoLookup == null ||
-          _hasNotRecentlySeenForYouCandidate(videos) ||
+          _hasNotRecentlySeenCandidate(videos) ||
           !hasMore ||
           nextCursor == null ||
           nextCursor == fetchedCursor) {
@@ -2848,7 +2924,7 @@ class VideosRepository {
     );
   }
 
-  bool _hasNotRecentlySeenForYouCandidate(List<VideoEvent> videos) {
+  bool _hasNotRecentlySeenCandidate(List<VideoEvent> videos) {
     final lookup = _seenVideoLookup;
     if (lookup == null) return true;
     return videos.any(
@@ -2861,7 +2937,7 @@ class VideosRepository {
     );
   }
 
-  Future<List<VideoEvent>> _orderForYouFreshness(
+  Future<List<VideoEvent>> _orderBySeenFreshness(
     List<VideoEvent> videos,
   ) async {
     await _seenVideoLookup?.ensureInitialized();
@@ -2871,10 +2947,10 @@ class VideosRepository {
     );
   }
 
-  Future<HomeFeedResult> _withForYouFreshnessOrdering(
+  Future<HomeFeedResult> _withSeenFreshnessOrdering(
     HomeFeedResult result,
   ) async {
-    final orderedVideos = await _orderForYouFreshness(result.videos);
+    final orderedVideos = await _orderBySeenFreshness(result.videos);
     if (identical(orderedVideos, result.videos)) return result;
     return HomeFeedResult(
       videos: orderedVideos,

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -978,9 +978,7 @@ class VideosRepository {
     try {
       for (
         var fetch = 0;
-        fetch < maxFetches &&
-            collected.length < limit &&
-            !exhausted;
+        fetch < maxFetches && collected.length < limit && !exhausted;
         fetch++
       ) {
         final stats = await _funnelcakeApiClient.getClassicVines(

--- a/mobile/packages/videos_repository/test/src/videos_repository_seen_filtering_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_seen_filtering_test.dart
@@ -131,11 +131,16 @@ void main() {
       final seen = _stats('seen-new');
       final unseen = _stats('unseen-new');
       when(
-        () => mockFunnelcake.getRecentVideos(
+        () => mockFunnelcake.getRecentVideosPage(
           limit: any(named: 'limit'),
           before: any(named: 'before'),
         ),
-      ).thenAnswer((_) async => [seen, unseen]);
+      ).thenAnswer(
+        (_) async => RecentVideosResponse(
+          videos: [seen, unseen],
+          serverItemCount: 2,
+        ),
+      );
       when(
         () => mockFunnelcake.getBulkVideoStats(any()),
       ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
@@ -149,8 +154,11 @@ void main() {
         ),
       );
 
-      final videos = await repo.getNewVideos();
-      expect(videos.map((v) => v.id).toList(), ['unseen-new', 'seen-new']);
+      final result = await repo.getNewVideos();
+      expect(result.videos.map((v) => v.id).toList(), [
+        'unseen-new',
+        'seen-new',
+      ]);
     });
 
     test(
@@ -185,13 +193,8 @@ void main() {
     );
 
     test('getProfileVideos is untouched even if seen', () async {
-      final seen = _event(
-        'seen-profile',
-      );
-      final unseen = _event(
-        'unseen-profile',
-        createdAt: 1704067100,
-      );
+      final seen = _event('seen-profile');
+      final unseen = _event('unseen-profile', createdAt: 1704067100);
       when(
         () => mockNostr.queryEvents(any()),
       ).thenAnswer((_) async => [seen, unseen]);
@@ -437,10 +440,8 @@ void main() {
           viewerCountry: any(named: 'viewerCountry'),
         ),
       ).thenAnswer(
-        (_) async => RecommendationsResponse(
-          videos: [fresh],
-          source: 'personalized',
-        ),
+        (_) async =>
+            RecommendationsResponse(videos: [fresh], source: 'personalized'),
       );
 
       final repo = VideosRepository(

--- a/mobile/packages/videos_repository/test/src/videos_repository_seen_filtering_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_seen_filtering_test.dart
@@ -1,0 +1,227 @@
+// TDD: client-side seen-video filtering across feeds
+// Covers: home (following) demotes, new demotes, classic drops + deep-fetch,
+// profile untouched, deep-fetch triggers when filtering removes most of page.
+
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:videos_repository/videos_repository.dart';
+import 'package:models/models.dart';
+
+class MockNostrClient extends Mock implements NostrClient {}
+class MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
+
+class StubRandom implements Random {
+  StubRandom({int? offsetPage}) : _offsetPage = offsetPage;
+  int? _offsetPage;
+  final Random _inner = Random(0);
+  @override int nextInt(int max) {
+    if (_offsetPage != null) {
+      final v = _offsetPage!;
+      _offsetPage = null;
+      return v % max;
+    }
+    return _inner.nextInt(max);
+  }
+  @override bool nextBool() => _inner.nextBool();
+  @override double nextDouble() => _inner.nextDouble();
+}
+
+VideoStats _stats(String id, {String? pubkey, int? createdAt, String? platform}) => VideoStats(
+      rawTags: platform != null ? {'platform': platform} : const {},
+      id: id,
+      pubkey: pubkey ?? 'pubkey-$id',
+      createdAt: DateTime.fromMillisecondsSinceEpoch((createdAt ?? 1704067200) * 1000),
+      kind: EventKind.videoVertical,
+      dTag: 'dtag-$id',
+      title: 'Test',
+      thumbnail: 'https://example.com/thumb.jpg',
+      videoUrl: 'https://example.com/$id.mp4',
+      reactions: 0,
+      comments: 0,
+      reposts: 0,
+      engagementScore: 0,
+    );
+
+Event _event(String id, {String pubkey = 'author', int createdAt = 1704067200}) {
+  return Event.fromJson({
+    'id': id,
+    'pubkey': pubkey,
+    'created_at': createdAt,
+    'kind': EventKind.videoVertical,
+    'tags': [
+      ['url', 'https://example.com/$id.mp4'],
+      ['d', 'd-$id'],
+    ],
+    'content': '',
+    'sig': '',
+  });
+}
+
+void main() {
+  late MockNostrClient mockNostr;
+  late MockFunnelcakeApiClient mockFunnelcake;
+
+  setUp(() {
+    mockNostr = MockNostrClient();
+    mockFunnelcake = MockFunnelcakeApiClient();
+    when(() => mockFunnelcake.isAvailable).thenReturn(true);
+    when(() => mockNostr.publicKey).thenReturn('');
+  });
+
+  setUpAll(() {
+    registerFallbackValue(<Filter>[]);
+    registerFallbackValue(PopularVideosVariant.classic);
+  });
+
+  group('Seen filtering per surface', () {
+    test('getHomeFeedVideos demotes recently seen (following)', () async {
+      final seenId = 'seen-home';
+      final unseenId = 'unseen-home';
+      when(() => mockFunnelcake.getHomeFeed(pubkey: any(named: 'pubkey'), limit: any(named: 'limit'), before: any(named: 'before')))
+          .thenAnswer((_) async => HomeFeedResponse(videos: [_stats(seenId), _stats(unseenId)], rawBody: '{}'));
+
+      final repo = VideosRepository(
+        nostrClient: mockNostr,
+        funnelcakeApiClient: mockFunnelcake,
+        seenVideoLookup: SeenVideoLookup(wasSeenRecently: (id, {within = const Duration(hours: 24)}) => id == seenId),
+      );
+
+      final result = await repo.getHomeFeedVideos(authors: ['a'], userPubkey: 'u');
+      expect(result.videos.map((v) => v.id).toList(), [unseenId, seenId]);
+    });
+
+    test('getNewVideos demotes recently seen', () async {
+      final seen = _stats('seen-new');
+      final unseen = _stats('unseen-new');
+      when(() => mockFunnelcake.getRecentVideos(limit: any(named: 'limit'), before: any(named: 'before')))
+          .thenAnswer((_) async => [seen, unseen]);
+      when(() => mockFunnelcake.getBulkVideoStats(any())).thenAnswer((_) async => BulkVideoStatsResponse(stats: {}));
+
+      final repo = VideosRepository(
+        nostrClient: mockNostr,
+        funnelcakeApiClient: mockFunnelcake,
+        seenVideoLookup: SeenVideoLookup(wasSeenRecently: (id, {within = const Duration(hours: 24)}) => id == 'seen-new'),
+      );
+
+      final videos = await repo.getNewVideos();
+      expect(videos.map((v) => v.id).toList(), ['unseen-new', 'seen-new']);
+    });
+
+    test('getClassicVideos drops recently seen (inventory unlimited)', () async {
+      final seen = _stats('seen-classic', platform: 'vine');
+      final unseen = _stats('unseen-classic', platform: 'vine');
+      when(() => mockFunnelcake.getClassicVines(limit: any(named: 'limit'), offset: any(named: 'offset')))
+          .thenAnswer((_) async => [seen, unseen]);
+      when(() => mockFunnelcake.getBulkVideoStats(any())).thenAnswer((_) async => BulkVideoStatsResponse(stats: {}));
+
+      final repo = VideosRepository(
+        nostrClient: mockNostr,
+        funnelcakeApiClient: mockFunnelcake,
+        seenVideoLookup: SeenVideoLookup(wasSeenRecently: (id, {within = const Duration(hours: 24)}) => id == 'seen-classic'),
+        random: StubRandom(offsetPage: 0),
+      );
+
+      final result = await repo.getClassicVideos(limit: 2);
+      expect(result.videos.any((v) => v.id == 'seen-classic'), isFalse);
+      expect(result.videos.any((v) => v.id == 'unseen-classic'), isTrue);
+    });
+
+    test('getProfileVideos is untouched even if seen', () async {
+      final seen = _event('seen-profile', pubkey: 'author', createdAt: 1704067200);
+      final unseen = _event('unseen-profile', pubkey: 'author', createdAt: 1704067100);
+      when(() => mockNostr.queryEvents(any())).thenAnswer((_) async => [seen, unseen]);
+
+      final repo = VideosRepository(
+        nostrClient: mockNostr,
+        funnelcakeApiClient: mockFunnelcake,
+        seenVideoLookup: SeenVideoLookup(wasSeenRecently: (_, {within = const Duration(hours: 24)}) => true),
+      );
+
+      final videos = await repo.getProfileVideos(authorPubkey: 'author');
+      expect(videos.map((v) => v.id), containsAll(['seen-profile', 'unseen-profile']));
+      expect(videos.length, 2);
+    });
+
+    test('without SeenVideoLookup, no filtering occurs', () async {
+      final v1 = _stats('v1');
+      final v2 = _stats('v2');
+      when(() => mockFunnelcake.getHomeFeed(pubkey: any(named: 'pubkey'), limit: any(named: 'limit'), before: any(named: 'before')))
+          .thenAnswer((_) async => HomeFeedResponse(videos: [v1, v2], rawBody: '{}'));
+
+      final repo = VideosRepository(nostrClient: mockNostr, funnelcakeApiClient: mockFunnelcake);
+      final result = await repo.getHomeFeedVideos(authors: ['a'], userPubkey: 'u');
+      expect(result.videos.map((v) => v.id).toList(), ['v1', 'v2']);
+    });
+
+    test('classic deep-fetch triggers when filtering removes most of page', () async {
+      final seenPage = List.generate(5, (i) => _stats('seen-$i'));
+      final freshPage = [_stats('fresh-0', platform: 'vine'), _stats('fresh-1', platform: 'vine')];
+      var call = 0;
+      when(() => mockFunnelcake.getClassicVines(limit: any(named: 'limit'), offset: any(named: 'offset')))
+          .thenAnswer((_) async {
+        call++;
+        if (call == 1) return seenPage;
+        if (call == 2) return freshPage;
+        return [];
+      });
+      when(() => mockFunnelcake.getBulkVideoStats(any())).thenAnswer((_) async => BulkVideoStatsResponse(stats: {}));
+
+      final repo = VideosRepository(
+        nostrClient: mockNostr,
+        funnelcakeApiClient: mockFunnelcake,
+        seenVideoLookup: SeenVideoLookup(wasSeenRecently: (id, {within = const Duration(hours: 24)}) => id.startsWith('seen-')),
+        random: StubRandom(offsetPage: 0),
+      );
+
+      final result = await repo.getClassicVideos(limit: 2);
+      expect(result.videos.any((v) => v.id.startsWith('seen-')), isFalse);
+      expect(result.videos.any((v) => v.id.startsWith('fresh-')), isTrue);
+      expect(call, greaterThan(1));
+    });
+
+    test('forYou deep-fetch via getRecommendedVideos', () async {
+      final seen = _stats('seen-foyou');
+      final fresh = _stats('fresh-foyou');
+      when(() => mockFunnelcake.getRecommendations(pubkey: any(named: 'pubkey'), limit: any(named: 'limit'), seed: any(named: 'seed'), preferredLanguages: any(named: 'preferredLanguages'), viewerCountry: any(named: 'viewerCountry')))
+          .thenAnswer((_) async => RecommendationsResponse(videos: [seen], source: 'personalized', hasMore: true, nextCursor: 'c1'));
+      when(() => mockFunnelcake.getRecommendations(pubkey: any(named: 'pubkey'), limit: any(named: 'limit'), cursor: 'c1', seed: any(named: 'seed'), preferredLanguages: any(named: 'preferredLanguages'), viewerCountry: any(named: 'viewerCountry')))
+          .thenAnswer((_) async => RecommendationsResponse(videos: [fresh], source: 'personalized', hasMore: false, nextCursor: null));
+
+      final repo = VideosRepository(
+        nostrClient: mockNostr,
+        funnelcakeApiClient: mockFunnelcake,
+        seenVideoLookup: SeenVideoLookup(wasSeenRecently: (id, {within = const Duration(hours: 24)}) => id == 'seen-foyou'),
+      );
+
+      final result = await repo.getRecommendedVideos(userPubkey: 'u', limit: 10);
+      expect(result.videos.map((v) => v.id), contains('fresh-foyou'));
+    });
+  });
+
+  group('filterOutRecentlySeenVideos helper', () {
+    test('drops recently seen, keeps unseen', () {
+      final vSeen = VideoEvent(id: 'seen', pubkey: 'p', createdAt: 1, content: '', timestamp: DateTime.fromMillisecondsSinceEpoch(1000), videoUrl: 'https://x/1.mp4');
+      final vUnseen = VideoEvent(id: 'unseen', pubkey: 'p', createdAt: 1, content: '', timestamp: DateTime.fromMillisecondsSinceEpoch(1000), videoUrl: 'https://x/2.mp4');
+      final filtered = filterOutRecentlySeenVideos([vSeen, vUnseen], seenVideoLookup: SeenVideoLookup(wasSeenRecently: (id, {within = const Duration(hours: 24)}) => id == 'seen'));
+      expect(filtered.map((v) => v.id), ['unseen']);
+    });
+
+    test('returns original if would empty', () {
+      final v1 = VideoEvent(id: 'a', pubkey: 'p', createdAt: 1, content: '', timestamp: DateTime.fromMillisecondsSinceEpoch(1000), videoUrl: 'https://x/1.mp4');
+      final filtered = filterOutRecentlySeenVideos([v1], seenVideoLookup: SeenVideoLookup(wasSeenRecently: (_, {within = const Duration(hours: 24)}) => true));
+      expect(filtered.map((v) => v.id), ['a']);
+    });
+
+    test('prioritize keeps all but reorders', () {
+      final vSeen = VideoEvent(id: 'seen', pubkey: 'p', createdAt: 1, content: '', timestamp: DateTime.fromMillisecondsSinceEpoch(1000), videoUrl: 'https://x/1.mp4');
+      final vUnseen = VideoEvent(id: 'unseen', pubkey: 'p', createdAt: 1, content: '', timestamp: DateTime.fromMillisecondsSinceEpoch(1000), videoUrl: 'https://x/2.mp4');
+      final ordered = prioritizeNotRecentlySeenVideos([vSeen, vUnseen], seenVideoLookup: SeenVideoLookup(wasSeenRecently: (id, {within = const Duration(hours: 24)}) => id == 'seen'));
+      expect(ordered.map((v) => v.id).toList(), ['unseen', 'seen']);
+    });
+  });
+}

--- a/mobile/packages/videos_repository/test/src/videos_repository_seen_filtering_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_seen_filtering_test.dart
@@ -239,7 +239,10 @@ void main() {
     test(
       'classic deep-fetch triggers when filtering removes most of page',
       () async {
-        final seenPage = List.generate(5, (i) => _stats('seen-$i'));
+        final seenPage = List.generate(
+          5,
+          (i) => _stats('seen-$i', platform: 'vine'),
+        );
         final freshPage = [
           _stats('fresh-0', platform: 'vine'),
           _stats('fresh-1', platform: 'vine'),
@@ -274,6 +277,134 @@ void main() {
         expect(result.videos.any((v) => v.id.startsWith('seen-')), isFalse);
         expect(result.videos.any((v) => v.id.startsWith('fresh-')), isTrue);
         expect(call, greaterThan(1));
+      },
+    );
+
+    test('classic returns a cursor after eight all-seen pages', () async {
+      when(
+        () => mockFunnelcake.getClassicVines(
+          limit: any(named: 'limit'),
+          offset: any(named: 'offset'),
+        ),
+      ).thenAnswer((invocation) async {
+        final offset = invocation.namedArguments[#offset] as int;
+        return [
+          _stats('seen-$offset-a', platform: 'vine'),
+          _stats('seen-$offset-b', platform: 'vine'),
+        ];
+      });
+      when(
+        () => mockFunnelcake.getBulkVideoStats(any()),
+      ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
+
+      final repo = VideosRepository(
+        nostrClient: mockNostr,
+        funnelcakeApiClient: mockFunnelcake,
+        seenVideoLookup: SeenVideoLookup(
+          wasSeenRecently: (_, {within = const Duration(hours: 24)}) => true,
+        ),
+        random: StubRandom(offsetPage: 0),
+      );
+
+      final result = await repo.getClassicVideos(limit: 2);
+
+      expect(result.videos, isEmpty);
+      expect(result.paginationCursor, 'classic-offset:16');
+      expect(result.hasMore, isTrue);
+      verify(
+        () => mockFunnelcake.getClassicVines(
+          limit: 2,
+          offset: any(named: 'offset'),
+        ),
+      ).called(8);
+    });
+
+    test('classic cache drops videos watched after it was populated', () async {
+      final seenIds = <String>{};
+      when(
+        () => mockFunnelcake.getClassicVines(
+          limit: any(named: 'limit'),
+          offset: any(named: 'offset'),
+        ),
+      ).thenAnswer(
+        (_) async => [
+          _stats('cached-seen', platform: 'vine'),
+          _stats('cached-fresh', platform: 'vine'),
+        ],
+      );
+      when(
+        () => mockFunnelcake.getBulkVideoStats(any()),
+      ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
+
+      final repo = VideosRepository(
+        nostrClient: mockNostr,
+        funnelcakeApiClient: mockFunnelcake,
+        inMemoryFeedCache: InMemoryFeedCache(),
+        seenVideoLookup: SeenVideoLookup(
+          wasSeenRecently: (id, {within = const Duration(hours: 24)}) =>
+              seenIds.contains(id),
+        ),
+        random: StubRandom(offsetPage: 0),
+      );
+
+      final initial = await repo.getClassicVideos(limit: 2);
+      seenIds.add('cached-seen');
+      final cached = await repo.getClassicVideos(limit: 2);
+
+      expect(initial.videos, hasLength(2));
+      expect(cached.videos.map((video) => video.id), ['cached-fresh']);
+      verify(
+        () => mockFunnelcake.getClassicVines(
+          limit: 2,
+          offset: any(named: 'offset'),
+        ),
+      ).called(1);
+    });
+
+    test(
+      'classic cache stays non-empty when every cached video was seen',
+      () async {
+        var allSeen = false;
+        when(
+          () => mockFunnelcake.getClassicVines(
+            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
+          ),
+        ).thenAnswer(
+          (_) async => [
+            _stats('cached-a', platform: 'vine'),
+            _stats('cached-b', platform: 'vine'),
+          ],
+        );
+        when(
+          () => mockFunnelcake.getBulkVideoStats(any()),
+        ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
+
+        final repo = VideosRepository(
+          nostrClient: mockNostr,
+          funnelcakeApiClient: mockFunnelcake,
+          inMemoryFeedCache: InMemoryFeedCache(),
+          seenVideoLookup: SeenVideoLookup(
+            wasSeenRecently: (_, {within = const Duration(hours: 24)}) =>
+                allSeen,
+          ),
+          random: StubRandom(offsetPage: 0),
+        );
+
+        final initial = await repo.getClassicVideos(limit: 2);
+        allSeen = true;
+        final cached = await repo.getClassicVideos(limit: 2);
+
+        expect(
+          cached.videos.map((video) => video.id),
+          unorderedEquals(initial.videos.map((video) => video.id)),
+        );
+        verify(
+          () => mockFunnelcake.getClassicVines(
+            limit: 2,
+            offset: any(named: 'offset'),
+          ),
+        ).called(1);
       },
     );
 

--- a/mobile/packages/videos_repository/test/src/videos_repository_seen_filtering_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_seen_filtering_test.dart
@@ -7,19 +7,21 @@ import 'dart:math';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:videos_repository/videos_repository.dart';
-import 'package:models/models.dart';
 
 class MockNostrClient extends Mock implements NostrClient {}
+
 class MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
 
 class StubRandom implements Random {
   StubRandom({int? offsetPage}) : _offsetPage = offsetPage;
   int? _offsetPage;
   final Random _inner = Random(0);
-  @override int nextInt(int max) {
+  @override
+  int nextInt(int max) {
     if (_offsetPage != null) {
       final v = _offsetPage!;
       _offsetPage = null;
@@ -27,27 +29,41 @@ class StubRandom implements Random {
     }
     return _inner.nextInt(max);
   }
-  @override bool nextBool() => _inner.nextBool();
-  @override double nextDouble() => _inner.nextDouble();
+
+  @override
+  bool nextBool() => _inner.nextBool();
+  @override
+  double nextDouble() => _inner.nextDouble();
 }
 
-VideoStats _stats(String id, {String? pubkey, int? createdAt, String? platform}) => VideoStats(
-      rawTags: platform != null ? {'platform': platform} : const {},
-      id: id,
-      pubkey: pubkey ?? 'pubkey-$id',
-      createdAt: DateTime.fromMillisecondsSinceEpoch((createdAt ?? 1704067200) * 1000),
-      kind: EventKind.videoVertical,
-      dTag: 'dtag-$id',
-      title: 'Test',
-      thumbnail: 'https://example.com/thumb.jpg',
-      videoUrl: 'https://example.com/$id.mp4',
-      reactions: 0,
-      comments: 0,
-      reposts: 0,
-      engagementScore: 0,
-    );
+VideoStats _stats(
+  String id, {
+  String? pubkey,
+  int? createdAt,
+  String? platform,
+}) => VideoStats(
+  rawTags: platform != null ? {'platform': platform} : const {},
+  id: id,
+  pubkey: pubkey ?? 'pubkey-$id',
+  createdAt: DateTime.fromMillisecondsSinceEpoch(
+    (createdAt ?? 1704067200) * 1000,
+  ),
+  kind: EventKind.videoVertical,
+  dTag: 'dtag-$id',
+  title: 'Test',
+  thumbnail: 'https://example.com/thumb.jpg',
+  videoUrl: 'https://example.com/$id.mp4',
+  reactions: 0,
+  comments: 0,
+  reposts: 0,
+  engagementScore: 0,
+);
 
-Event _event(String id, {String pubkey = 'author', int createdAt = 1704067200}) {
+Event _event(
+  String id, {
+  String pubkey = 'author',
+  int createdAt = 1704067200,
+}) {
   return Event.fromJson({
     'id': id,
     'pubkey': pubkey,
@@ -80,147 +96,309 @@ void main() {
 
   group('Seen filtering per surface', () {
     test('getHomeFeedVideos demotes recently seen (following)', () async {
-      final seenId = 'seen-home';
-      final unseenId = 'unseen-home';
-      when(() => mockFunnelcake.getHomeFeed(pubkey: any(named: 'pubkey'), limit: any(named: 'limit'), before: any(named: 'before')))
-          .thenAnswer((_) async => HomeFeedResponse(videos: [_stats(seenId), _stats(unseenId)], rawBody: '{}'));
+      const seenId = 'seen-home';
+      const unseenId = 'unseen-home';
+      when(
+        () => mockFunnelcake.getHomeFeed(
+          pubkey: any(named: 'pubkey'),
+          limit: any(named: 'limit'),
+          before: any(named: 'before'),
+        ),
+      ).thenAnswer(
+        (_) async => HomeFeedResponse(
+          videos: [_stats(seenId), _stats(unseenId)],
+          rawBody: '{}',
+        ),
+      );
 
       final repo = VideosRepository(
         nostrClient: mockNostr,
         funnelcakeApiClient: mockFunnelcake,
-        seenVideoLookup: SeenVideoLookup(wasSeenRecently: (id, {within = const Duration(hours: 24)}) => id == seenId),
+        seenVideoLookup: SeenVideoLookup(
+          wasSeenRecently: (id, {within = const Duration(hours: 24)}) =>
+              id == seenId,
+        ),
       );
 
-      final result = await repo.getHomeFeedVideos(authors: ['a'], userPubkey: 'u');
+      final result = await repo.getHomeFeedVideos(
+        authors: ['a'],
+        userPubkey: 'u',
+      );
       expect(result.videos.map((v) => v.id).toList(), [unseenId, seenId]);
     });
 
     test('getNewVideos demotes recently seen', () async {
       final seen = _stats('seen-new');
       final unseen = _stats('unseen-new');
-      when(() => mockFunnelcake.getRecentVideos(limit: any(named: 'limit'), before: any(named: 'before')))
-          .thenAnswer((_) async => [seen, unseen]);
-      when(() => mockFunnelcake.getBulkVideoStats(any())).thenAnswer((_) async => BulkVideoStatsResponse(stats: {}));
+      when(
+        () => mockFunnelcake.getRecentVideos(
+          limit: any(named: 'limit'),
+          before: any(named: 'before'),
+        ),
+      ).thenAnswer((_) async => [seen, unseen]);
+      when(
+        () => mockFunnelcake.getBulkVideoStats(any()),
+      ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
 
       final repo = VideosRepository(
         nostrClient: mockNostr,
         funnelcakeApiClient: mockFunnelcake,
-        seenVideoLookup: SeenVideoLookup(wasSeenRecently: (id, {within = const Duration(hours: 24)}) => id == 'seen-new'),
+        seenVideoLookup: SeenVideoLookup(
+          wasSeenRecently: (id, {within = const Duration(hours: 24)}) =>
+              id == 'seen-new',
+        ),
       );
 
       final videos = await repo.getNewVideos();
       expect(videos.map((v) => v.id).toList(), ['unseen-new', 'seen-new']);
     });
 
-    test('getClassicVideos drops recently seen (inventory unlimited)', () async {
-      final seen = _stats('seen-classic', platform: 'vine');
-      final unseen = _stats('unseen-classic', platform: 'vine');
-      when(() => mockFunnelcake.getClassicVines(limit: any(named: 'limit'), offset: any(named: 'offset')))
-          .thenAnswer((_) async => [seen, unseen]);
-      when(() => mockFunnelcake.getBulkVideoStats(any())).thenAnswer((_) async => BulkVideoStatsResponse(stats: {}));
+    test(
+      'getClassicVideos drops recently seen (inventory unlimited)',
+      () async {
+        final seen = _stats('seen-classic', platform: 'vine');
+        final unseen = _stats('unseen-classic', platform: 'vine');
+        when(
+          () => mockFunnelcake.getClassicVines(
+            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
+          ),
+        ).thenAnswer((_) async => [seen, unseen]);
+        when(
+          () => mockFunnelcake.getBulkVideoStats(any()),
+        ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
 
-      final repo = VideosRepository(
-        nostrClient: mockNostr,
-        funnelcakeApiClient: mockFunnelcake,
-        seenVideoLookup: SeenVideoLookup(wasSeenRecently: (id, {within = const Duration(hours: 24)}) => id == 'seen-classic'),
-        random: StubRandom(offsetPage: 0),
-      );
+        final repo = VideosRepository(
+          nostrClient: mockNostr,
+          funnelcakeApiClient: mockFunnelcake,
+          seenVideoLookup: SeenVideoLookup(
+            wasSeenRecently: (id, {within = const Duration(hours: 24)}) =>
+                id == 'seen-classic',
+          ),
+          random: StubRandom(offsetPage: 0),
+        );
 
-      final result = await repo.getClassicVideos(limit: 2);
-      expect(result.videos.any((v) => v.id == 'seen-classic'), isFalse);
-      expect(result.videos.any((v) => v.id == 'unseen-classic'), isTrue);
-    });
+        final result = await repo.getClassicVideos(limit: 2);
+        expect(result.videos.any((v) => v.id == 'seen-classic'), isFalse);
+        expect(result.videos.any((v) => v.id == 'unseen-classic'), isTrue);
+      },
+    );
 
     test('getProfileVideos is untouched even if seen', () async {
-      final seen = _event('seen-profile', pubkey: 'author', createdAt: 1704067200);
-      final unseen = _event('unseen-profile', pubkey: 'author', createdAt: 1704067100);
-      when(() => mockNostr.queryEvents(any())).thenAnswer((_) async => [seen, unseen]);
+      final seen = _event(
+        'seen-profile',
+      );
+      final unseen = _event(
+        'unseen-profile',
+        createdAt: 1704067100,
+      );
+      when(
+        () => mockNostr.queryEvents(any()),
+      ).thenAnswer((_) async => [seen, unseen]);
 
       final repo = VideosRepository(
         nostrClient: mockNostr,
         funnelcakeApiClient: mockFunnelcake,
-        seenVideoLookup: SeenVideoLookup(wasSeenRecently: (_, {within = const Duration(hours: 24)}) => true),
+        seenVideoLookup: SeenVideoLookup(
+          wasSeenRecently: (_, {within = const Duration(hours: 24)}) => true,
+        ),
       );
 
       final videos = await repo.getProfileVideos(authorPubkey: 'author');
-      expect(videos.map((v) => v.id), containsAll(['seen-profile', 'unseen-profile']));
+      expect(
+        videos.map((v) => v.id),
+        containsAll(['seen-profile', 'unseen-profile']),
+      );
       expect(videos.length, 2);
     });
 
     test('without SeenVideoLookup, no filtering occurs', () async {
       final v1 = _stats('v1');
       final v2 = _stats('v2');
-      when(() => mockFunnelcake.getHomeFeed(pubkey: any(named: 'pubkey'), limit: any(named: 'limit'), before: any(named: 'before')))
-          .thenAnswer((_) async => HomeFeedResponse(videos: [v1, v2], rawBody: '{}'));
-
-      final repo = VideosRepository(nostrClient: mockNostr, funnelcakeApiClient: mockFunnelcake);
-      final result = await repo.getHomeFeedVideos(authors: ['a'], userPubkey: 'u');
-      expect(result.videos.map((v) => v.id).toList(), ['v1', 'v2']);
-    });
-
-    test('classic deep-fetch triggers when filtering removes most of page', () async {
-      final seenPage = List.generate(5, (i) => _stats('seen-$i'));
-      final freshPage = [_stats('fresh-0', platform: 'vine'), _stats('fresh-1', platform: 'vine')];
-      var call = 0;
-      when(() => mockFunnelcake.getClassicVines(limit: any(named: 'limit'), offset: any(named: 'offset')))
-          .thenAnswer((_) async {
-        call++;
-        if (call == 1) return seenPage;
-        if (call == 2) return freshPage;
-        return [];
-      });
-      when(() => mockFunnelcake.getBulkVideoStats(any())).thenAnswer((_) async => BulkVideoStatsResponse(stats: {}));
+      when(
+        () => mockFunnelcake.getHomeFeed(
+          pubkey: any(named: 'pubkey'),
+          limit: any(named: 'limit'),
+          before: any(named: 'before'),
+        ),
+      ).thenAnswer(
+        (_) async => HomeFeedResponse(videos: [v1, v2], rawBody: '{}'),
+      );
 
       final repo = VideosRepository(
         nostrClient: mockNostr,
         funnelcakeApiClient: mockFunnelcake,
-        seenVideoLookup: SeenVideoLookup(wasSeenRecently: (id, {within = const Duration(hours: 24)}) => id.startsWith('seen-')),
-        random: StubRandom(offsetPage: 0),
       );
-
-      final result = await repo.getClassicVideos(limit: 2);
-      expect(result.videos.any((v) => v.id.startsWith('seen-')), isFalse);
-      expect(result.videos.any((v) => v.id.startsWith('fresh-')), isTrue);
-      expect(call, greaterThan(1));
+      final result = await repo.getHomeFeedVideos(
+        authors: ['a'],
+        userPubkey: 'u',
+      );
+      expect(result.videos.map((v) => v.id).toList(), ['v1', 'v2']);
     });
+
+    test(
+      'classic deep-fetch triggers when filtering removes most of page',
+      () async {
+        final seenPage = List.generate(5, (i) => _stats('seen-$i'));
+        final freshPage = [
+          _stats('fresh-0', platform: 'vine'),
+          _stats('fresh-1', platform: 'vine'),
+        ];
+        var call = 0;
+        when(
+          () => mockFunnelcake.getClassicVines(
+            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
+          ),
+        ).thenAnswer((_) async {
+          call++;
+          if (call == 1) return seenPage;
+          if (call == 2) return freshPage;
+          return [];
+        });
+        when(
+          () => mockFunnelcake.getBulkVideoStats(any()),
+        ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
+
+        final repo = VideosRepository(
+          nostrClient: mockNostr,
+          funnelcakeApiClient: mockFunnelcake,
+          seenVideoLookup: SeenVideoLookup(
+            wasSeenRecently: (id, {within = const Duration(hours: 24)}) =>
+                id.startsWith('seen-'),
+          ),
+          random: StubRandom(offsetPage: 0),
+        );
+
+        final result = await repo.getClassicVideos(limit: 2);
+        expect(result.videos.any((v) => v.id.startsWith('seen-')), isFalse);
+        expect(result.videos.any((v) => v.id.startsWith('fresh-')), isTrue);
+        expect(call, greaterThan(1));
+      },
+    );
 
     test('forYou deep-fetch via getRecommendedVideos', () async {
       final seen = _stats('seen-foyou');
       final fresh = _stats('fresh-foyou');
-      when(() => mockFunnelcake.getRecommendations(pubkey: any(named: 'pubkey'), limit: any(named: 'limit'), seed: any(named: 'seed'), preferredLanguages: any(named: 'preferredLanguages'), viewerCountry: any(named: 'viewerCountry')))
-          .thenAnswer((_) async => RecommendationsResponse(videos: [seen], source: 'personalized', hasMore: true, nextCursor: 'c1'));
-      when(() => mockFunnelcake.getRecommendations(pubkey: any(named: 'pubkey'), limit: any(named: 'limit'), cursor: 'c1', seed: any(named: 'seed'), preferredLanguages: any(named: 'preferredLanguages'), viewerCountry: any(named: 'viewerCountry')))
-          .thenAnswer((_) async => RecommendationsResponse(videos: [fresh], source: 'personalized', hasMore: false, nextCursor: null));
+      when(
+        () => mockFunnelcake.getRecommendations(
+          pubkey: any(named: 'pubkey'),
+          limit: any(named: 'limit'),
+          seed: any(named: 'seed'),
+          preferredLanguages: any(named: 'preferredLanguages'),
+          viewerCountry: any(named: 'viewerCountry'),
+        ),
+      ).thenAnswer(
+        (_) async => RecommendationsResponse(
+          videos: [seen],
+          source: 'personalized',
+          hasMore: true,
+          nextCursor: 'c1',
+        ),
+      );
+      when(
+        () => mockFunnelcake.getRecommendations(
+          pubkey: any(named: 'pubkey'),
+          limit: any(named: 'limit'),
+          cursor: 'c1',
+          seed: any(named: 'seed'),
+          preferredLanguages: any(named: 'preferredLanguages'),
+          viewerCountry: any(named: 'viewerCountry'),
+        ),
+      ).thenAnswer(
+        (_) async => RecommendationsResponse(
+          videos: [fresh],
+          source: 'personalized',
+        ),
+      );
 
       final repo = VideosRepository(
         nostrClient: mockNostr,
         funnelcakeApiClient: mockFunnelcake,
-        seenVideoLookup: SeenVideoLookup(wasSeenRecently: (id, {within = const Duration(hours: 24)}) => id == 'seen-foyou'),
+        seenVideoLookup: SeenVideoLookup(
+          wasSeenRecently: (id, {within = const Duration(hours: 24)}) =>
+              id == 'seen-foyou',
+        ),
       );
 
-      final result = await repo.getRecommendedVideos(userPubkey: 'u', limit: 10);
+      final result = await repo.getRecommendedVideos(
+        userPubkey: 'u',
+        limit: 10,
+      );
       expect(result.videos.map((v) => v.id), contains('fresh-foyou'));
     });
   });
 
   group('filterOutRecentlySeenVideos helper', () {
     test('drops recently seen, keeps unseen', () {
-      final vSeen = VideoEvent(id: 'seen', pubkey: 'p', createdAt: 1, content: '', timestamp: DateTime.fromMillisecondsSinceEpoch(1000), videoUrl: 'https://x/1.mp4');
-      final vUnseen = VideoEvent(id: 'unseen', pubkey: 'p', createdAt: 1, content: '', timestamp: DateTime.fromMillisecondsSinceEpoch(1000), videoUrl: 'https://x/2.mp4');
-      final filtered = filterOutRecentlySeenVideos([vSeen, vUnseen], seenVideoLookup: SeenVideoLookup(wasSeenRecently: (id, {within = const Duration(hours: 24)}) => id == 'seen'));
+      final vSeen = VideoEvent(
+        id: 'seen',
+        pubkey: 'p',
+        createdAt: 1,
+        content: '',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1000),
+        videoUrl: 'https://x/1.mp4',
+      );
+      final vUnseen = VideoEvent(
+        id: 'unseen',
+        pubkey: 'p',
+        createdAt: 1,
+        content: '',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1000),
+        videoUrl: 'https://x/2.mp4',
+      );
+      final filtered = filterOutRecentlySeenVideos(
+        [vSeen, vUnseen],
+        seenVideoLookup: SeenVideoLookup(
+          wasSeenRecently: (id, {within = const Duration(hours: 24)}) =>
+              id == 'seen',
+        ),
+      );
       expect(filtered.map((v) => v.id), ['unseen']);
     });
 
     test('returns original if would empty', () {
-      final v1 = VideoEvent(id: 'a', pubkey: 'p', createdAt: 1, content: '', timestamp: DateTime.fromMillisecondsSinceEpoch(1000), videoUrl: 'https://x/1.mp4');
-      final filtered = filterOutRecentlySeenVideos([v1], seenVideoLookup: SeenVideoLookup(wasSeenRecently: (_, {within = const Duration(hours: 24)}) => true));
+      final v1 = VideoEvent(
+        id: 'a',
+        pubkey: 'p',
+        createdAt: 1,
+        content: '',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1000),
+        videoUrl: 'https://x/1.mp4',
+      );
+      final filtered = filterOutRecentlySeenVideos(
+        [v1],
+        seenVideoLookup: SeenVideoLookup(
+          wasSeenRecently: (_, {within = const Duration(hours: 24)}) => true,
+        ),
+      );
       expect(filtered.map((v) => v.id), ['a']);
     });
 
     test('prioritize keeps all but reorders', () {
-      final vSeen = VideoEvent(id: 'seen', pubkey: 'p', createdAt: 1, content: '', timestamp: DateTime.fromMillisecondsSinceEpoch(1000), videoUrl: 'https://x/1.mp4');
-      final vUnseen = VideoEvent(id: 'unseen', pubkey: 'p', createdAt: 1, content: '', timestamp: DateTime.fromMillisecondsSinceEpoch(1000), videoUrl: 'https://x/2.mp4');
-      final ordered = prioritizeNotRecentlySeenVideos([vSeen, vUnseen], seenVideoLookup: SeenVideoLookup(wasSeenRecently: (id, {within = const Duration(hours: 24)}) => id == 'seen'));
+      final vSeen = VideoEvent(
+        id: 'seen',
+        pubkey: 'p',
+        createdAt: 1,
+        content: '',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1000),
+        videoUrl: 'https://x/1.mp4',
+      );
+      final vUnseen = VideoEvent(
+        id: 'unseen',
+        pubkey: 'p',
+        createdAt: 1,
+        content: '',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1000),
+        videoUrl: 'https://x/2.mp4',
+      );
+      final ordered = prioritizeNotRecentlySeenVideos(
+        [vSeen, vUnseen],
+        seenVideoLookup: SeenVideoLookup(
+          wasSeenRecently: (id, {within = const Duration(hours: 24)}) =>
+              id == 'seen',
+        ),
+      );
       expect(ordered.map((v) => v.id).toList(), ['unseen', 'seen']);
     });
   });

--- a/mobile/test/services/seen_videos_service_migration_test.dart
+++ b/mobile/test/services/seen_videos_service_migration_test.dart
@@ -40,9 +40,7 @@ void main() {
         expect(service.hasSeenVideo('vid-2'), isTrue);
         expect(service.getVideoMetrics('vid-1')!.loopCount, 1);
 
-        // Verify DB now has rows (migration persisted)
-        // Allow a tick for batch insert
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+        // initialize does not complete until the migration is durable.
         final count = await db.seenVideosDao.count();
         expect(count, 3);
 
@@ -120,11 +118,33 @@ void main() {
       final service1 = SeenVideosService(database: db);
       await service1.initialize();
       await service1.recordVideoView('vid-persist');
+      expect(await db.seenVideosDao.hasSeen('vid-persist'), isTrue);
       await service1.dispose();
 
       final service2 = SeenVideosService(database: db);
       await service2.initialize();
       expect(service2.hasSeenVideo('vid-persist'), isTrue);
+    });
+
+    test('batch mark refreshes a hydrated DB row before returning', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final old =
+          DateTime.now().millisecondsSinceEpoch -
+          const Duration(days: 2).inMilliseconds;
+      await db.seenVideosDao.markSeen(
+        'vid-batch',
+        firstSeenAt: old,
+        lastSeenAt: old,
+      );
+      await prefs.setBool('seen_videos_migrated_to_db', true);
+      final service = SeenVideosService(database: db);
+      await service.initialize();
+
+      await service.markVideosAsSeen(['vid-batch']);
+
+      final row = (await db.seenVideosDao.getAll()).single;
+      expect(row.firstSeenAt, old);
+      expect(row.lastSeenAt, greaterThan(old));
     });
 
     test('DAO pruneExpired respects 1yr TTL', () async {

--- a/mobile/test/services/seen_videos_service_migration_test.dart
+++ b/mobile/test/services/seen_videos_service_migration_test.dart
@@ -1,0 +1,134 @@
+// TDD: storage migration preserves history, deep-fetch coverage, DAO direct tests
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:openvine/services/seen_videos_service.dart';
+
+AppDatabase _inMemoryDb() => AppDatabase.test(NativeDatabase.memory());
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SeenVideosService storage migration', () {
+    late AppDatabase db;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      db = _inMemoryDb();
+      await db.customSelect('SELECT 1').get();
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    test('migrates existing SharedPreferences JSON to Drift on first init', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        'seen_video_metrics',
+        '[{"videoId":"vid-1","firstSeenAt":1786164648252,"lastSeenAt":1786164648252,"loopCount":1,"totalWatchDurationMs":1000,"lastWatchDurationMs":1000},{"videoId":"vid-2","firstSeenAt":1786164648252,"lastSeenAt":1786164648252,"loopCount":2,"totalWatchDurationMs":2000,"lastWatchDurationMs":2000},{"videoId":"vid-3","firstSeenAt":1786164648252,"lastSeenAt":1786164648252,"loopCount":0,"totalWatchDurationMs":0,"lastWatchDurationMs":0}]',
+      );
+
+      final service = SeenVideosService(database: db);
+      await service.initialize();
+
+      expect(service.seenVideoCount, 3);
+      expect(service.hasSeenVideo('vid-1'), isTrue);
+      expect(service.hasSeenVideo('vid-2'), isTrue);
+      expect(service.getVideoMetrics('vid-1')!.loopCount, 1);
+
+      // Verify DB now has rows (migration persisted)
+      // Allow a tick for batch insert
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      final count = await db.seenVideosDao.count();
+      expect(count, 3);
+
+      // Second service with same DB and prefs should hydrate from DB
+      final service2 = SeenVideosService(database: db);
+      await service2.initialize();
+      expect(service2.hasSeenVideo('vid-1'), isTrue);
+      expect(service2.hasSeenVideo('vid-3'), isTrue);
+      expect(service2.seenVideoCount, 3);
+    });
+
+    test('hydrates from Drift even when prefs JSON was truncated to 1000', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        'seen_video_metrics',
+        '[{"videoId":"vid-4","firstSeenAt":1786164648252,"lastSeenAt":1704153600000,"loopCount":0,"totalWatchDurationMs":0,"lastWatchDurationMs":0},{"videoId":"vid-5","firstSeenAt":1786164648252,"lastSeenAt":1704153600000,"loopCount":0,"totalWatchDurationMs":0,"lastWatchDurationMs":0}]',
+      );
+      final now = DateTime.now().millisecondsSinceEpoch;
+      for (var i = 1; i <= 5; i++) {
+        await db.seenVideosDao.markSeen('vid-$i', firstSeenAt: now, lastSeenAt: now);
+      }
+      await prefs.setBool('seen_videos_migrated_to_db', true);
+
+      final service = SeenVideosService(database: db);
+      await service.initialize();
+
+      expect(service.seenVideoCount, 5);
+      expect(service.hasSeenVideo('vid-1'), isTrue);
+      expect(service.getSeenVideoIds(), containsAll(['vid-1', 'vid-2', 'vid-3', 'vid-4', 'vid-5']));
+    });
+
+    test('wasSeenRecently respects window', () async {
+      final service = SeenVideosService(database: db);
+      await service.initialize();
+      await service.recordVideoView('vid-recent');
+      expect(service.wasSeenRecently('vid-recent', within: const Duration(hours: 24)), isTrue);
+      expect(service.wasSeenRecently('vid-recent', within: const Duration(milliseconds: 0)), isFalse);
+      expect(service.wasSeenRecently('vid-unknown'), isFalse);
+    });
+
+    test('clearSeenVideos clears both prefs and DB', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        'seen_video_metrics',
+        '[{"videoId":"vid-1","firstSeenAt":1786164648252,"lastSeenAt":1786164648252,"loopCount":0,"totalWatchDurationMs":0,"lastWatchDurationMs":0}]',
+      );
+      final service = SeenVideosService(database: db);
+      await service.initialize();
+      expect(service.seenVideoCount, 1);
+
+      await service.clearSeenVideos();
+      expect(service.seenVideoCount, 0);
+      expect(await db.seenVideosDao.count(), 0);
+      expect(prefs.getString('seen_video_metrics'), isNull);
+    });
+
+    test('persists across service instances via DB', () async {
+      final service1 = SeenVideosService(database: db);
+      await service1.initialize();
+      await service1.recordVideoView('vid-persist');
+      await service1.dispose();
+
+      final service2 = SeenVideosService(database: db);
+      await service2.initialize();
+      expect(service2.hasSeenVideo('vid-persist'), isTrue);
+    });
+
+    test('DAO pruneExpired respects 1yr TTL', () async {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      final old = now - const Duration(days: 400).inMilliseconds;
+      await db.seenVideosDao.markSeen('vid-old', firstSeenAt: old, lastSeenAt: old);
+      await db.seenVideosDao.markSeen('vid-fresh', firstSeenAt: now, lastSeenAt: now);
+      final pruned = await db.seenVideosDao.pruneExpired(ttl: const Duration(days: 365));
+      expect(pruned, 1);
+      expect(await db.seenVideosDao.hasSeen('vid-old'), isFalse);
+      expect(await db.seenVideosDao.hasSeen('vid-fresh'), isTrue);
+    });
+
+    test('pure SharedPreferences fallback when no DB', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        'seen_video_metrics',
+        '[{"videoId":"vid-fallback","firstSeenAt":1786164648252,"lastSeenAt":${DateTime.now().millisecondsSinceEpoch},"loopCount":0,"totalWatchDurationMs":0,"lastWatchDurationMs":0}]',
+      );
+      final service = SeenVideosService(database: null);
+      await service.initialize();
+      expect(service.hasSeenVideo('vid-fallback'), isTrue);
+      expect(service.wasSeenRecently('vid-fallback', within: const Duration(hours: 24)), isTrue);
+    });
+  });
+}

--- a/mobile/test/services/seen_videos_service_migration_test.dart
+++ b/mobile/test/services/seen_videos_service_migration_test.dart
@@ -2,8 +2,8 @@
 import 'package:db_client/db_client.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:openvine/services/seen_videos_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 AppDatabase _inMemoryDb() => AppDatabase.test(NativeDatabase.memory());
 
@@ -23,61 +23,80 @@ void main() {
       await db.close();
     });
 
-    test('migrates existing SharedPreferences JSON to Drift on first init', () async {
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setString(
-        'seen_video_metrics',
-        '[{"videoId":"vid-1","firstSeenAt":1786164648252,"lastSeenAt":1786164648252,"loopCount":1,"totalWatchDurationMs":1000,"lastWatchDurationMs":1000},{"videoId":"vid-2","firstSeenAt":1786164648252,"lastSeenAt":1786164648252,"loopCount":2,"totalWatchDurationMs":2000,"lastWatchDurationMs":2000},{"videoId":"vid-3","firstSeenAt":1786164648252,"lastSeenAt":1786164648252,"loopCount":0,"totalWatchDurationMs":0,"lastWatchDurationMs":0}]',
-      );
+    test(
+      'migrates existing SharedPreferences JSON to Drift on first init',
+      () async {
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setString(
+          'seen_video_metrics',
+          '[{"videoId":"vid-1","firstSeenAt":1786164648252,"lastSeenAt":1786164648252,"loopCount":1,"totalWatchDurationMs":1000,"lastWatchDurationMs":1000},{"videoId":"vid-2","firstSeenAt":1786164648252,"lastSeenAt":1786164648252,"loopCount":2,"totalWatchDurationMs":2000,"lastWatchDurationMs":2000},{"videoId":"vid-3","firstSeenAt":1786164648252,"lastSeenAt":1786164648252,"loopCount":0,"totalWatchDurationMs":0,"lastWatchDurationMs":0}]',
+        );
 
-      final service = SeenVideosService(database: db);
-      await service.initialize();
+        final service = SeenVideosService(database: db);
+        await service.initialize();
 
-      expect(service.seenVideoCount, 3);
-      expect(service.hasSeenVideo('vid-1'), isTrue);
-      expect(service.hasSeenVideo('vid-2'), isTrue);
-      expect(service.getVideoMetrics('vid-1')!.loopCount, 1);
+        expect(service.seenVideoCount, 3);
+        expect(service.hasSeenVideo('vid-1'), isTrue);
+        expect(service.hasSeenVideo('vid-2'), isTrue);
+        expect(service.getVideoMetrics('vid-1')!.loopCount, 1);
 
-      // Verify DB now has rows (migration persisted)
-      // Allow a tick for batch insert
-      await Future<void>.delayed(const Duration(milliseconds: 50));
-      final count = await db.seenVideosDao.count();
-      expect(count, 3);
+        // Verify DB now has rows (migration persisted)
+        // Allow a tick for batch insert
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        final count = await db.seenVideosDao.count();
+        expect(count, 3);
 
-      // Second service with same DB and prefs should hydrate from DB
-      final service2 = SeenVideosService(database: db);
-      await service2.initialize();
-      expect(service2.hasSeenVideo('vid-1'), isTrue);
-      expect(service2.hasSeenVideo('vid-3'), isTrue);
-      expect(service2.seenVideoCount, 3);
-    });
+        // Second service with same DB and prefs should hydrate from DB
+        final service2 = SeenVideosService(database: db);
+        await service2.initialize();
+        expect(service2.hasSeenVideo('vid-1'), isTrue);
+        expect(service2.hasSeenVideo('vid-3'), isTrue);
+        expect(service2.seenVideoCount, 3);
+      },
+    );
 
-    test('hydrates from Drift even when prefs JSON was truncated to 1000', () async {
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setString(
-        'seen_video_metrics',
-        '[{"videoId":"vid-4","firstSeenAt":1786164648252,"lastSeenAt":1704153600000,"loopCount":0,"totalWatchDurationMs":0,"lastWatchDurationMs":0},{"videoId":"vid-5","firstSeenAt":1786164648252,"lastSeenAt":1704153600000,"loopCount":0,"totalWatchDurationMs":0,"lastWatchDurationMs":0}]',
-      );
-      final now = DateTime.now().millisecondsSinceEpoch;
-      for (var i = 1; i <= 5; i++) {
-        await db.seenVideosDao.markSeen('vid-$i', firstSeenAt: now, lastSeenAt: now);
-      }
-      await prefs.setBool('seen_videos_migrated_to_db', true);
+    test(
+      'hydrates from Drift even when prefs JSON was truncated to 1000',
+      () async {
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setString(
+          'seen_video_metrics',
+          '[{"videoId":"vid-4","firstSeenAt":1786164648252,"lastSeenAt":1704153600000,"loopCount":0,"totalWatchDurationMs":0,"lastWatchDurationMs":0},{"videoId":"vid-5","firstSeenAt":1786164648252,"lastSeenAt":1704153600000,"loopCount":0,"totalWatchDurationMs":0,"lastWatchDurationMs":0}]',
+        );
+        final now = DateTime.now().millisecondsSinceEpoch;
+        for (var i = 1; i <= 5; i++) {
+          await db.seenVideosDao.markSeen(
+            'vid-$i',
+            firstSeenAt: now,
+            lastSeenAt: now,
+          );
+        }
+        await prefs.setBool('seen_videos_migrated_to_db', true);
 
-      final service = SeenVideosService(database: db);
-      await service.initialize();
+        final service = SeenVideosService(database: db);
+        await service.initialize();
 
-      expect(service.seenVideoCount, 5);
-      expect(service.hasSeenVideo('vid-1'), isTrue);
-      expect(service.getSeenVideoIds(), containsAll(['vid-1', 'vid-2', 'vid-3', 'vid-4', 'vid-5']));
-    });
+        expect(service.seenVideoCount, 5);
+        expect(service.hasSeenVideo('vid-1'), isTrue);
+        expect(
+          service.getSeenVideoIds(),
+          containsAll(['vid-1', 'vid-2', 'vid-3', 'vid-4', 'vid-5']),
+        );
+      },
+    );
 
     test('wasSeenRecently respects window', () async {
       final service = SeenVideosService(database: db);
       await service.initialize();
       await service.recordVideoView('vid-recent');
-      expect(service.wasSeenRecently('vid-recent', within: const Duration(hours: 24)), isTrue);
-      expect(service.wasSeenRecently('vid-recent', within: const Duration(milliseconds: 0)), isFalse);
+      expect(service.wasSeenRecently('vid-recent'), isTrue);
+      expect(
+        service.wasSeenRecently(
+          'vid-recent',
+          within: const Duration(),
+        ),
+        isFalse,
+      );
       expect(service.wasSeenRecently('vid-unknown'), isFalse);
     });
 
@@ -111,9 +130,17 @@ void main() {
     test('DAO pruneExpired respects 1yr TTL', () async {
       final now = DateTime.now().millisecondsSinceEpoch;
       final old = now - const Duration(days: 400).inMilliseconds;
-      await db.seenVideosDao.markSeen('vid-old', firstSeenAt: old, lastSeenAt: old);
-      await db.seenVideosDao.markSeen('vid-fresh', firstSeenAt: now, lastSeenAt: now);
-      final pruned = await db.seenVideosDao.pruneExpired(ttl: const Duration(days: 365));
+      await db.seenVideosDao.markSeen(
+        'vid-old',
+        firstSeenAt: old,
+        lastSeenAt: old,
+      );
+      await db.seenVideosDao.markSeen(
+        'vid-fresh',
+        firstSeenAt: now,
+        lastSeenAt: now,
+      );
+      final pruned = await db.seenVideosDao.pruneExpired();
       expect(pruned, 1);
       expect(await db.seenVideosDao.hasSeen('vid-old'), isFalse);
       expect(await db.seenVideosDao.hasSeen('vid-fresh'), isTrue);
@@ -125,10 +152,10 @@ void main() {
         'seen_video_metrics',
         '[{"videoId":"vid-fallback","firstSeenAt":1786164648252,"lastSeenAt":${DateTime.now().millisecondsSinceEpoch},"loopCount":0,"totalWatchDurationMs":0,"lastWatchDurationMs":0}]',
       );
-      final service = SeenVideosService(database: null);
+      final service = SeenVideosService();
       await service.initialize();
       expect(service.hasSeenVideo('vid-fallback'), isTrue);
-      expect(service.wasSeenRecently('vid-fallback', within: const Duration(hours: 24)), isTrue);
+      expect(service.wasSeenRecently('vid-fallback'), isTrue);
     });
   });
 }

--- a/mobile/test/unit/services/upload_manager_get_by_path_test.dart
+++ b/mobile/test/unit/services/upload_manager_get_by_path_test.dart
@@ -12,8 +12,10 @@ import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/upload_manager.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import '../../helpers/real_integration_test_helper.dart';
 import '../../helpers/test_helpers.dart';
+import '../../mocks/mock_path_provider_platform.dart';
 
 class MockBlossomUploadService extends Mock implements BlossomUploadService {}
 
@@ -23,32 +25,29 @@ void main() {
   late UploadManager uploadManager;
   late MockBlossomUploadService mockUploadService;
   late Directory tempDir;
+  late PathProviderPlatform originalPathProviderInstance;
 
   setUpAll(() async {
     // Setup test environment with platform channel mocks
     await RealIntegrationTestHelper.setupTestEnvironment();
+    originalPathProviderInstance = PathProviderPlatform.instance;
     registerFallbackValue(File(''));
-    // Initialize Hive for testing
-    await Hive.initFlutter();
-
-    // CRITICAL: Delete the entire pending_uploads box from disk ONCE before any tests run
-    // This ensures we don't have accumulated data from previous test runs
-    try {
-      if (Hive.isBoxOpen('pending_uploads')) {
-        await Hive.box('pending_uploads').close();
-      }
-      await Hive.deleteBoxFromDisk('pending_uploads');
-    } catch (e) {
-      // Box might not exist, that's fine
-    }
   });
 
   setUp(() async {
-    // Use the reusable test helper to ensure a fresh empty Hive box
-    await TestHelpers.cleanupHiveBox('pending_uploads');
     tempDir = await Directory.systemTemp.createTemp(
       'upload_manager_get_by_path_test_',
     );
+    final pathProvider = MockPathProviderPlatform()
+      ..setTemporaryPath(tempDir.path)
+      ..setApplicationDocumentsPath('${tempDir.path}/documents')
+      ..setApplicationSupportPath('${tempDir.path}/support');
+    PathProviderPlatform.instance = pathProvider;
+
+    // Use the reusable test helper to ensure a fresh empty Hive box. The
+    // per-test path prevents concurrent Flutter test processes from sharing
+    // the same pending_uploads file.
+    await TestHelpers.cleanupHiveBox('pending_uploads');
 
     mockUploadService = MockBlossomUploadService();
     when(
@@ -106,6 +105,8 @@ void main() {
       }
     } catch (e) {
       // Manager or box might already be disposed/closed
+    } finally {
+      PathProviderPlatform.instance = originalPathProviderInstance;
     }
     reset(mockUploadService);
   });


### PR DESCRIPTION
## Summary

- Persist seen-video history in Drift while keeping the bounded SharedPreferences metrics cache and migration fallback.
- Filter or demote recently seen videos according to feed semantics; classic discovery deep-fetches up to eight pages for unseen results.
- Keep profile feeds unchanged and retain a feature-flag kill switch.
- Await durable history writes and make batch upserts refresh `last_seen_at` while preserving `first_seen_at`.

## Regression coverage

27 focused tests cover:

- home and new-feed prioritization
- classic filtering, deep-fetch pagination, cache refresh, and the all-seen fallback
- profile and no-lookup behavior
- SharedPreferences-to-Drift migration and fallback
- awaited single and batch persistence
- DAO insert, true upsert, recency, pruning, removal, and clearing

No coverage exclusions are used for the changed behavior.

## Verified locally

- `videos_repository`: 471 tests passed; 1201/1201 lines (100.00%)
- `db_client`: 914 tests passed; 6464/14859 lines (43.50%, above the 40% package gate)
- seen-video service and migration tests: 21 passed
- video-feed BLoC tests: 103 passed
- `flutter analyze lib test integration_test`: clean
- generated-code verification and the pre-push changed-test gate: clean