### PR TITLE
feat(analytics): instrument creator campaign funnel

### DIFF
--- a/docs/ANALYTICS_OBSERVABILITY.md
+++ b/docs/ANALYTICS_OBSERVABILITY.md
@@ -110,9 +110,11 @@ or `upload`.
 
 The tracker is app-scoped so recorder, editor, metadata, and publish routes
 contribute to one session. Creation metadata remains local analytics state and
-is not written into Nostr video events. `time_since_camera_open_ms` is `0` for
-an editor-only restored draft that did not open the camera in the active
-session.
+is not written into Nostr video events. `time_since_camera_open_ms` is
+**omitted entirely** — not sent as `0` — for an editor-only restored draft
+that did not open the camera in the active session, so those publishes cannot
+drag the timing distribution toward zero. Query it with `IS NOT NULL` rather
+than treating a missing value as instant.
 
 ## Post-Publish Experiment
 

--- a/docs/ANALYTICS_OBSERVABILITY.md
+++ b/docs/ANALYTICS_OBSERVABILITY.md
@@ -141,8 +141,10 @@ Events:
 
 After the invite service confirms redemption, the normalized code is set as
 the Firebase Analytics user property `invite_code`. Failed redemptions do not
-set it. Logout clears it so a second account on the device cannot inherit the
-first account's attribution.
+set it. Any change of authenticated identity clears it, so a second account on
+the device cannot inherit the first account's attribution. Logout is not the
+only such change: an in-place account switch never passes through an
+unauthenticated state.
 
 ## Required Firebase Admin Setup
 

--- a/docs/ANALYTICS_OBSERVABILITY.md
+++ b/docs/ANALYTICS_OBSERVABILITY.md
@@ -1,7 +1,8 @@
 # Analytics Observability
 
-Status: Current contract with semantic route screen views and comments sheet
-surface load instrumentation live.
+Status: Current contract with semantic route screen views, comments sheet
+surface load instrumentation, authenticated identity, and creator funnel
+instrumentation live.
 Baseline validated against: `mobile/lib/services/screen_analytics_service.dart`,
 `mobile/lib/services/page_load_observer.dart`,
 `mobile/lib/screens/comments/comments_screen.dart`.
@@ -38,6 +39,13 @@ Examples:
 
 Do not log Nostr event IDs, pubkeys, npubs, nsecs, user-entered search text,
 comment text, or raw URLs in analytics parameters.
+
+The reserved Firebase Analytics `user_id` field is the deliberate exception to
+the pubkey rule above. It is the authenticated account's exact 64-character hex
+pubkey, never an npub and never a hash. It is identity metadata, not a custom
+event parameter. Login and restored identity set the same value in Analytics
+and Crashlytics; logout clears both and clears account-scoped invite
+attribution.
 
 ## Core Events
 
@@ -82,6 +90,92 @@ The comments sheet measures:
 - count loaded
 - whether video replies were enabled
 - whether the user dismissed before data loaded
+
+## Creator Funnel
+
+Every creator-funnel event includes `mode`, using the stable
+`VideoRecorderMode.name` values `capture`, `stopMotion`, `lipSync`, `classic`,
+or `upload`.
+
+| Event | Additional parameters | Boundary |
+| --- | --- | --- |
+| `camera_opened` | `entry_point` | Recorder session opens |
+| `recording_started` | — | Native recording succeeds, or the first stop-motion frame lands |
+| `recording_completed` | `clip_count`, `duration_ms` | Creator continues from the recorder |
+| `editor_opened` | — | Editor or metadata route opens |
+| `publish_started` | `time_since_camera_open_ms` | Creator taps publish, before render/upload |
+| `publish_succeeded` | `time_since_camera_open_ms` | Publish service confirms success |
+| `publish_failed` | `reason` | Render, preparation, or publish fails |
+| `creation_abandoned` | `last_stage` | The creation flow closes before publish starts |
+
+The tracker is app-scoped so recorder, editor, metadata, and publish routes
+contribute to one session. Creation metadata remains local analytics state and
+is not written into Nostr video events. `time_since_camera_open_ms` is `0` for
+an editor-only restored draft that did not open the camera in the active
+session.
+
+## Post-Publish Experiment
+
+The existing profile destination and published-video confirmation remain the
+payoff. A deterministic 50/50 assignment from the authenticated hex pubkey
+adds a create-again action to that confirmation for the `create_again`
+variant. The control variant is unchanged.
+
+- Remote Config key: `post_publish_create_again_enabled`
+- In-app default: `true`
+- Kill switch: publish the key as `false`; real-time Remote Config updates are
+  activated while the app is running
+- Baseline second-post rate: 44.1%
+
+Events:
+
+- `post_publish_screen_shown`: `destination`, `variant`
+- `post_publish_create_again_tapped`: `seconds_since_publish`
+
+## Invite Attribution
+
+After the invite service confirms redemption, the normalized code is set as
+the Firebase Analytics user property `invite_code`. Failed redemptions do not
+set it. Logout clears it so a second account on the device cannot inherit the
+first account's attribution.
+
+## Required Firebase Admin Setup
+
+Complete this before campaign traffic. GA4 stores unregistered parameters but
+does not make them queryable as dimensions retroactively.
+
+1. Create an event-scoped custom dimension named `mode` for event parameter
+   `mode`.
+2. Create a user-scoped custom dimension named `invite_code` for user property
+   `invite_code`.
+3. Create and publish the Remote Config boolean
+   `post_publish_create_again_enabled = true`. Set it to `false` for an
+   immediate kill switch.
+
+The GA4 reporting identity setting does not gate the BigQuery `user_id` field;
+use BigQuery as the campaign source of truth.
+
+## Pre-Freeze End-To-End Check
+
+Publish from a test account and query the streaming export within minutes:
+
+```sql
+SELECT
+  event_timestamp,
+  event_name,
+  user_id,
+  (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'mode')
+    AS mode
+FROM `openvine-co.analytics_<property_id>.events_intraday_*`
+WHERE _TABLE_SUFFIX = FORMAT_DATE('%Y%m%d', CURRENT_DATE())
+  AND user_id = @pubkey_hex
+ORDER BY event_timestamp;
+```
+
+Verify that `user_id` is the exact 64-character hex pubkey, matches the same
+account in ClickHouse `nostr.events_local.pubkey`, and accompanies the complete
+creation funnel with non-null `mode`. A null or bech32 `user_id` is a release
+blocker for the campaign build.
 
 ## Firebase Console Checks
 

--- a/docs/ANALYTICS_OBSERVABILITY.md
+++ b/docs/ANALYTICS_OBSERVABILITY.md
@@ -45,7 +45,10 @@ the pubkey rule above. It is the authenticated account's exact 64-character hex
 pubkey, never an npub and never a hash. It is identity metadata, not a custom
 event parameter. Login and restored identity set the same value in Analytics
 and Crashlytics; logout clears both and clears account-scoped invite
-attribution.
+attribution. This is owned by `analyticsIdentitySync` in
+`mobile/lib/providers/auth_providers.dart`, kept deliberately independent of
+the Zendesk identity sync so the campaign's BigQuery/ClickHouse join cannot be
+broken by a change to the support-desk integration.
 
 ## Core Events
 

--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Cubit for managing Divine authentication flow
 // ABOUTME: Handles sign in, sign up, and email verification states
 
+import 'package:analytics/analytics.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:invite_api_client/invite_api_client.dart';
@@ -32,6 +33,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
     String? inviteCode,
     String? inviteSourceSlug,
     bool requirePasswordConfirmation = false,
+    AnalyticsEventSink analytics = const NoOpAnalyticsEventSink(),
   }) : _oauthClient = oauthClient,
        _authService = authService,
        _pendingVerificationService = pendingVerificationService,
@@ -42,6 +44,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
        _inviteSourceSlug = inviteSourceSlug,
        _validationMessages = validationMessages,
        _requirePasswordConfirmation = requirePasswordConfirmation,
+       _analytics = analytics,
        super(const DivineAuthInitial());
 
   final KeycastOAuth _oauthClient;
@@ -52,6 +55,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
   final String? _inviteSourceSlug;
   final AuthValidationMessages _validationMessages;
   final bool _requirePasswordConfirmation;
+  final AnalyticsEventSink _analytics;
 
   /// Initialize form with default state (sign up mode)
   void initialize({
@@ -483,6 +487,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
             code: inviteCode,
             keyContainer: pendingKey,
           );
+          await _setInviteCodeProperty(inviteCode);
           await _authService.createAnonymousAccountFromKeyContainer(pendingKey);
         } finally {
           pendingKey.dispose();
@@ -558,6 +563,22 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       oauthConfig: _oauthClient.config,
       session: session,
     );
+    await _setInviteCodeProperty(inviteCode);
+  }
+
+  Future<void> _setInviteCodeProperty(String inviteCode) async {
+    try {
+      await _analytics.setUserProperty(
+        name: AnalyticsUserProperty.inviteCode,
+        value: inviteCode,
+      );
+    } catch (error) {
+      Log.warning(
+        'Failed to set invite attribution: $error',
+        name: 'DivineAuthCubit',
+        category: LogCategory.auth,
+      );
+    }
   }
 
   /// Return to form from email verification state

--- a/mobile/lib/blocs/email_verification/email_verification_cubit.dart
+++ b/mobile/lib/blocs/email_verification/email_verification_cubit.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:analytics/analytics.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -57,14 +58,17 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
     required KeycastOAuth oauthClient,
     required AuthService authService,
     InviteApiClient? inviteApiClient,
+    AnalyticsEventSink analytics = const NoOpAnalyticsEventSink(),
   }) : _oauthClient = oauthClient,
        _authService = authService,
        _inviteApiClient = inviteApiClient,
+       _analytics = analytics,
        super(const EmailVerificationState());
 
   final KeycastOAuth _oauthClient;
   final AuthService _authService;
   final InviteApiClient? _inviteApiClient;
+  final AnalyticsEventSink _analytics;
 
   /// Tracks the device code that was already successfully exchanged.
   ///
@@ -1217,6 +1221,7 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
           oauthConfig: _oauthClient.config,
           session: session,
         );
+        await _setInviteCodeProperty(inviteCode);
         return;
       } on InviteApiException catch (e) {
         final isLastAttempt = attempt == _maxConsumeRetries;
@@ -1232,6 +1237,21 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
         );
         await Future<void>.delayed(_consumeRetryDelay);
       }
+    }
+  }
+
+  Future<void> _setInviteCodeProperty(String inviteCode) async {
+    try {
+      await _analytics.setUserProperty(
+        name: AnalyticsUserProperty.inviteCode,
+        value: inviteCode,
+      );
+    } catch (error) {
+      Log.warning(
+        'Failed to set invite attribution: $error',
+        name: 'EmailVerificationCubit',
+        category: LogCategory.auth,
+      );
     }
   }
 

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -85,6 +85,9 @@ typedef ReadVideoEditorState = VideoEditorProviderState Function();
 /// Accessor for the [SharedPreferences] instance.
 typedef ReadSharedPreferences = SharedPreferences Function();
 
+/// Reports the recorder mode only after media capture actually starts.
+typedef RecordingStartedCallback = void Function(VideoRecorderMode mode);
+
 /// Default [CountdownSoundService] factory.
 ///
 /// Forwards `handleAudioSessionActivation: false` to [JustAudioSimplePlayer]
@@ -155,6 +158,7 @@ class VideoRecorderBloc
     CountdownSoundServiceFactory? countdownSoundServiceFactory,
     AudioPlaybackServiceFactory? audioPlaybackServiceFactory,
     PerformanceTraceMonitor? performanceMonitor,
+    RecordingStartedCallback? onRecordingStarted,
   }) : _readClipManager = readClipManager,
        _readVideoEditor = readVideoEditor,
        _readVideoEditorState = readVideoEditorState,
@@ -166,6 +170,7 @@ class VideoRecorderBloc
            audioPlaybackServiceFactory ?? defaultAudioPlaybackServiceFactory,
        _performanceMonitor =
            performanceMonitor ?? const NoOpPerformanceTraceMonitor(),
+       _onRecordingStarted = onRecordingStarted,
        super(const VideoRecorderBlocState()) {
     _cameraService =
         _cameraServiceOverride ??
@@ -260,6 +265,7 @@ class VideoRecorderBloc
   final CountdownSoundServiceFactory _countdownSoundServiceFactory;
   final AudioPlaybackServiceFactory _audioPlaybackServiceFactory;
   final PerformanceTraceMonitor _performanceMonitor;
+  final RecordingStartedCallback? _onRecordingStarted;
 
   late final CameraService _cameraService;
   AudioPlaybackService? _audioPlaybackService;
@@ -865,6 +871,7 @@ class VideoRecorderBloc
         name: 'VideoRecorderBloc',
         category: LogCategory.video,
       );
+      _onRecordingStarted?.call(state.recorderMode);
       await WakelockPlus.enable();
       if (state.recordingLockedForNavigation) {
         // Navigation locked during the wakelock-enable await, after the native
@@ -1701,6 +1708,9 @@ class VideoRecorderBloc
     }
 
     final framePaths = [...state.stopMotionFrames, photo.filePath];
+    if (state.stopMotionFrames.isEmpty) {
+      _onRecordingStarted?.call(state.recorderMode);
+    }
     // Back to idle so a retry after a failed assemble re-emits the failure the
     // status listener only fires on transitions.
     emit(

--- a/mobile/lib/features/creation_analytics/creation_analytics_tracker.dart
+++ b/mobile/lib/features/creation_analytics/creation_analytics_tracker.dart
@@ -105,7 +105,7 @@ class CreationAnalyticsTracker {
       name: 'publish_started',
       parameters: {
         'mode': mode.name,
-        'time_since_camera_open_ms': _elapsedSinceCameraOpenMs,
+        'time_since_camera_open_ms': ?_elapsedSinceCameraOpenMs,
       },
     );
   }
@@ -117,7 +117,7 @@ class CreationAnalyticsTracker {
       name: 'publish_succeeded',
       parameters: {
         'mode': mode.name,
-        'time_since_camera_open_ms': _elapsedSinceCameraOpenMs,
+        'time_since_camera_open_ms': ?_elapsedSinceCameraOpenMs,
       },
     );
     _terminal = true;
@@ -146,9 +146,12 @@ class CreationAnalyticsTracker {
     _terminal = true;
   }
 
-  int get _elapsedSinceCameraOpenMs {
+  /// Null when the active session never opened the camera (an editor-only
+  /// restored draft). Reporting `0` there would be indistinguishable from an
+  /// instant publish and would drag the funnel's timing distribution down.
+  int? get _elapsedSinceCameraOpenMs {
     final openedAt = _cameraOpenedAt;
-    if (openedAt == null) return 0;
+    if (openedAt == null) return null;
     final elapsed = _now().difference(openedAt).inMilliseconds;
     return elapsed < 0 ? 0 : elapsed;
   }

--- a/mobile/lib/features/creation_analytics/creation_analytics_tracker.dart
+++ b/mobile/lib/features/creation_analytics/creation_analytics_tracker.dart
@@ -1,0 +1,194 @@
+// ABOUTME: Records one creation funnel from camera entry through publish.
+// ABOUTME: Keeps mode and elapsed-time attribution consistent across routes.
+
+import 'package:analytics/analytics.dart';
+import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+typedef CreationAnalyticsClock = DateTime Function();
+
+/// Stages used by the creation funnel and its abandonment event.
+enum CreationFunnelStage { camera, recording, editor, publishing }
+
+/// App-scoped tracker for the active creation session.
+///
+/// The tracker is deliberately stateful so recorder, editor, metadata, and
+/// publish routes all contribute to the same funnel without putting analytics
+/// metadata on the Nostr event.
+class CreationAnalyticsTracker {
+  CreationAnalyticsTracker({
+    required AnalyticsEventSink analytics,
+    CreationAnalyticsClock? now,
+  }) : _analytics = analytics,
+       _now = now ?? DateTime.now;
+
+  final AnalyticsEventSink _analytics;
+  final CreationAnalyticsClock _now;
+
+  VideoRecorderMode? _mode;
+  DateTime? _cameraOpenedAt;
+  CreationFunnelStage? _lastStage;
+  bool _cameraOpenedLogged = false;
+  bool _recordingStarted = false;
+  bool _recordingCompleted = false;
+  bool _editorOpened = false;
+  bool _publishStarted = false;
+  bool _terminal = false;
+
+  VideoRecorderMode? get activeMode => _terminal ? null : _mode;
+  DateTime? get cameraOpenedAt => _cameraOpenedAt;
+
+  Future<void> cameraOpened({
+    required VideoRecorderMode mode,
+    required String entryPoint,
+  }) async {
+    if (_mode != null && !_terminal) {
+      _mode = mode;
+      if (_cameraOpenedLogged) return;
+      _cameraOpenedAt = _now();
+      _cameraOpenedLogged = true;
+    } else {
+      _reset(mode: mode, openedAt: _now(), cameraOpenedLogged: true);
+    }
+
+    await _logEvent(
+      name: 'camera_opened',
+      parameters: {'mode': mode.name, 'entry_point': entryPoint},
+    );
+  }
+
+  void modeChanged(VideoRecorderMode mode) {
+    if (!_terminal) _mode = mode;
+  }
+
+  Future<void> recordingStarted(VideoRecorderMode mode) async {
+    _ensureSession(mode);
+    if (_recordingStarted || _terminal) return;
+    _recordingStarted = true;
+    _lastStage = CreationFunnelStage.recording;
+    await _logEvent(name: 'recording_started', parameters: {'mode': mode.name});
+  }
+
+  Future<void> recordingCompleted({
+    required VideoRecorderMode mode,
+    required int clipCount,
+    required Duration duration,
+  }) async {
+    _ensureSession(mode);
+    if (_recordingCompleted || _terminal) return;
+    _recordingCompleted = true;
+    _lastStage = CreationFunnelStage.recording;
+    await _logEvent(
+      name: 'recording_completed',
+      parameters: {
+        'mode': mode.name,
+        'clip_count': clipCount,
+        'duration_ms': duration.inMilliseconds,
+      },
+    );
+  }
+
+  Future<void> editorOpened(VideoRecorderMode mode) async {
+    _ensureSession(mode);
+    if (_editorOpened || _terminal) return;
+    _editorOpened = true;
+    _lastStage = CreationFunnelStage.editor;
+    await _logEvent(name: 'editor_opened', parameters: {'mode': mode.name});
+  }
+
+  Future<void> publishStarted(VideoRecorderMode mode) async {
+    _ensureSession(mode);
+    if (_terminal) return;
+    _publishStarted = true;
+    _lastStage = CreationFunnelStage.publishing;
+    await _logEvent(
+      name: 'publish_started',
+      parameters: {
+        'mode': mode.name,
+        'time_since_camera_open_ms': _elapsedSinceCameraOpenMs,
+      },
+    );
+  }
+
+  Future<void> publishSucceeded(VideoRecorderMode mode) async {
+    _ensureSession(mode);
+    if (_terminal) return;
+    await _logEvent(
+      name: 'publish_succeeded',
+      parameters: {
+        'mode': mode.name,
+        'time_since_camera_open_ms': _elapsedSinceCameraOpenMs,
+      },
+    );
+    _terminal = true;
+  }
+
+  Future<void> publishFailed({
+    required VideoRecorderMode mode,
+    required String reason,
+  }) async {
+    _ensureSession(mode);
+    if (_terminal) return;
+    await _logEvent(
+      name: 'publish_failed',
+      parameters: {'mode': mode.name, 'reason': reason},
+    );
+  }
+
+  Future<void> creationAbandoned() async {
+    if (_mode == null || _lastStage == null || _terminal || _publishStarted) {
+      return;
+    }
+    await _logEvent(
+      name: 'creation_abandoned',
+      parameters: {'mode': _mode!.name, 'last_stage': _lastStage!.name},
+    );
+    _terminal = true;
+  }
+
+  int get _elapsedSinceCameraOpenMs {
+    final openedAt = _cameraOpenedAt;
+    if (openedAt == null) return 0;
+    final elapsed = _now().difference(openedAt).inMilliseconds;
+    return elapsed < 0 ? 0 : elapsed;
+  }
+
+  void _ensureSession(VideoRecorderMode mode) {
+    if (_mode == null || _terminal) {
+      _reset(mode: mode, openedAt: null, cameraOpenedLogged: false);
+    } else {
+      _mode = mode;
+    }
+  }
+
+  void _reset({
+    required VideoRecorderMode mode,
+    required DateTime? openedAt,
+    required bool cameraOpenedLogged,
+  }) {
+    _mode = mode;
+    _cameraOpenedAt = openedAt;
+    _lastStage = CreationFunnelStage.camera;
+    _cameraOpenedLogged = cameraOpenedLogged;
+    _recordingStarted = false;
+    _recordingCompleted = false;
+    _editorOpened = false;
+    _publishStarted = false;
+    _terminal = false;
+  }
+
+  Future<void> _logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async {
+    try {
+      await _analytics.logEvent(name: name, parameters: parameters);
+    } catch (error) {
+      Log.warning(
+        'Creation analytics event $name failed: $error',
+        name: 'CreationAnalyticsTracker',
+        category: LogCategory.system,
+      );
+    }
+  }
+}

--- a/mobile/lib/features/post_publish/post_publish_experiment.dart
+++ b/mobile/lib/features/post_publish/post_publish_experiment.dart
@@ -119,7 +119,15 @@ class PostPublishExperiment {
   final PostPublishFlagClient _flags;
   final AnalyticsEventSink _analytics;
   final DateTime Function() _now;
+
+  /// Pending assignments, oldest first. A publish that neither succeeds nor
+  /// fails in this app session (a vanished background entry, a kill before
+  /// the upload resolves) never reaches [completed] or [failed], so the map
+  /// is capped and evicts its oldest entry instead of growing for the
+  /// lifetime of the process.
   final Map<String, PostPublishVariant> _publishVariants = {};
+
+  static const _maxPendingVariants = 32;
 
   Future<void> initialize() => _flags.initialize();
 
@@ -138,7 +146,12 @@ class PostPublishExperiment {
     required String destination,
     required PostPublishVariant variant,
   }) async {
-    _publishVariants[publishId] = variant;
+    _publishVariants
+      ..remove(publishId)
+      ..[publishId] = variant;
+    while (_publishVariants.length > _maxPendingVariants) {
+      _publishVariants.remove(_publishVariants.keys.first);
+    }
     await _logEvent(
       name: 'post_publish_screen_shown',
       parameters: {

--- a/mobile/lib/features/post_publish/post_publish_experiment.dart
+++ b/mobile/lib/features/post_publish/post_publish_experiment.dart
@@ -135,7 +135,12 @@ class PostPublishExperiment {
     if (!_flags.createAgainEnabled || pubkeyHex == null) {
       return PostPublishVariant.control;
     }
-    final assignmentByte = sha256.convert(utf8.encode(pubkeyHex)).bytes.first;
+    // Lowercased so a signer that returns uppercase hex cannot move the same
+    // account between buckets.
+    final assignmentByte = sha256
+        .convert(utf8.encode(pubkeyHex.toLowerCase()))
+        .bytes
+        .first;
     return assignmentByte < 128
         ? PostPublishVariant.control
         : PostPublishVariant.createAgain;

--- a/mobile/lib/features/post_publish/post_publish_experiment.dart
+++ b/mobile/lib/features/post_publish/post_publish_experiment.dart
@@ -1,0 +1,192 @@
+// ABOUTME: Deterministically assigns the post-publish create-again experiment.
+// ABOUTME: Uses Firebase Remote Config as a live kill switch.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:analytics/analytics.dart';
+import 'package:crypto/crypto.dart';
+import 'package:firebase_remote_config/firebase_remote_config.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+const postPublishCreateAgainRemoteConfigKey =
+    'post_publish_create_again_enabled';
+
+enum PostPublishVariant {
+  control('control'),
+  createAgain('create_again');
+
+  const PostPublishVariant(this.analyticsName);
+
+  final String analyticsName;
+}
+
+abstract interface class PostPublishFlagClient {
+  Future<void> initialize();
+  bool get createAgainEnabled;
+  void dispose();
+}
+
+class FirebasePostPublishFlagClient implements PostPublishFlagClient {
+  FirebasePostPublishFlagClient({this.defaultEnabled = true});
+
+  final bool defaultEnabled;
+  FirebaseRemoteConfig? _remoteConfig;
+  StreamSubscription<RemoteConfigUpdate>? _updates;
+  Future<void>? _initialization;
+  bool _defaultsReady = false;
+
+  @override
+  bool get createAgainEnabled {
+    if (!_defaultsReady) return defaultEnabled;
+    try {
+      return _remoteConfig?.getBool(postPublishCreateAgainRemoteConfigKey) ??
+          defaultEnabled;
+    } catch (_) {
+      return defaultEnabled;
+    }
+  }
+
+  @override
+  Future<void> initialize() => _initialization ??= _initialize();
+
+  Future<void> _initialize() async {
+    try {
+      final remoteConfig = FirebaseRemoteConfig.instance;
+      _remoteConfig = remoteConfig;
+      await remoteConfig.setConfigSettings(
+        RemoteConfigSettings(
+          fetchTimeout: const Duration(seconds: 10),
+          minimumFetchInterval: const Duration(hours: 1),
+        ),
+      );
+      await remoteConfig.setDefaults({
+        postPublishCreateAgainRemoteConfigKey: defaultEnabled,
+      });
+      _defaultsReady = true;
+
+      try {
+        await remoteConfig.fetchAndActivate();
+      } catch (error) {
+        Log.warning(
+          'Post-publish Remote Config fetch failed: $error',
+          name: 'FirebasePostPublishFlagClient',
+          category: LogCategory.system,
+        );
+      }
+
+      _updates = remoteConfig.onConfigUpdated.listen((_) async {
+        try {
+          await remoteConfig.activate();
+        } catch (error) {
+          Log.warning(
+            'Post-publish Remote Config activation failed: $error',
+            name: 'FirebasePostPublishFlagClient',
+            category: LogCategory.system,
+          );
+        }
+      });
+    } catch (error) {
+      Log.warning(
+        'Post-publish Remote Config unavailable: $error',
+        name: 'FirebasePostPublishFlagClient',
+        category: LogCategory.system,
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    unawaited(_updates?.cancel());
+  }
+}
+
+class PostPublishCreateAgainOffer {
+  const PostPublishCreateAgainOffer({required this.publishedAt});
+
+  final DateTime publishedAt;
+}
+
+class PostPublishExperiment {
+  PostPublishExperiment({
+    required PostPublishFlagClient flags,
+    required AnalyticsEventSink analytics,
+    DateTime Function()? now,
+  }) : _flags = flags,
+       _analytics = analytics,
+       _now = now ?? DateTime.now;
+
+  final PostPublishFlagClient _flags;
+  final AnalyticsEventSink _analytics;
+  final DateTime Function() _now;
+  final Map<String, PostPublishVariant> _publishVariants = {};
+
+  Future<void> initialize() => _flags.initialize();
+
+  PostPublishVariant variantForUser(String? pubkeyHex) {
+    if (!_flags.createAgainEnabled || pubkeyHex == null) {
+      return PostPublishVariant.control;
+    }
+    final assignmentByte = sha256.convert(utf8.encode(pubkeyHex)).bytes.first;
+    return assignmentByte < 128
+        ? PostPublishVariant.control
+        : PostPublishVariant.createAgain;
+  }
+
+  Future<void> screenShown({
+    required String publishId,
+    required String destination,
+    required PostPublishVariant variant,
+  }) async {
+    _publishVariants[publishId] = variant;
+    await _logEvent(
+      name: 'post_publish_screen_shown',
+      parameters: {
+        'destination': destination,
+        'variant': variant.analyticsName,
+      },
+    );
+  }
+
+  PostPublishCreateAgainOffer? completed(Set<String> publishIds) {
+    var showCreateAgain = false;
+    for (final publishId in publishIds) {
+      showCreateAgain =
+          _publishVariants.remove(publishId) ==
+              PostPublishVariant.createAgain ||
+          showCreateAgain;
+    }
+    return showCreateAgain
+        ? PostPublishCreateAgainOffer(publishedAt: _now())
+        : null;
+  }
+
+  void failed(Set<String> publishIds) {
+    for (final publishId in publishIds) {
+      _publishVariants.remove(publishId);
+    }
+  }
+
+  Future<void> createAgainTapped(PostPublishCreateAgainOffer offer) async {
+    final elapsed = _now().difference(offer.publishedAt).inSeconds;
+    await _logEvent(
+      name: 'post_publish_create_again_tapped',
+      parameters: {'seconds_since_publish': elapsed < 0 ? 0 : elapsed},
+    );
+  }
+
+  Future<void> _logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async {
+    try {
+      await _analytics.logEvent(name: name, parameters: parameters);
+    } catch (error) {
+      Log.warning(
+        'Post-publish analytics event $name failed: $error',
+        name: 'PostPublishExperiment',
+        category: LogCategory.system,
+      );
+    }
+  }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -53,6 +53,7 @@ import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/features/people_lists/curated_lists_gate.dart';
 import 'package:openvine/features/people_lists/people_lists.dart';
+import 'package:openvine/features/post_publish/post_publish_experiment.dart';
 import 'package:openvine/l10n/current_app_l10n.dart';
 import 'package:openvine/l10n/email_verification_error_l10n.dart';
 import 'package:openvine/l10n/l10n.dart';
@@ -62,6 +63,7 @@ import 'package:openvine/network/vine_cdn_http_overrides.dart'
 import 'package:openvine/notifications/routing/notification_tap_target.dart';
 import 'package:openvine/notifications/view/notifications_page.dart';
 import 'package:openvine/observability/divine_bloc_observer.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/classic_vines_provider.dart';
 import 'package:openvine/providers/container_swap_host.dart';
@@ -74,6 +76,7 @@ import 'package:openvine/providers/install_source_provider.dart';
 import 'package:openvine/providers/layer_rasterizer_provider.dart';
 import 'package:openvine/providers/list_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/post_publish_providers.dart';
 import 'package:openvine/providers/saved_sounds_provider.dart';
 import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
@@ -544,7 +547,9 @@ class _AppQuickActionsNavigator implements QuickActionsNavigator {
 
   @override
   void openCamera() {
-    _router.go(VideoRecorderScreen.path);
+    _router.go(
+      VideoRecorderScreen.pathForEntryPoint(CreationEntryPoint.quickAction),
+    );
   }
 
   @override
@@ -1904,6 +1909,7 @@ class _DivineAppState extends ConsumerState<DivineApp>
   }
 
   void _initializeDeferredStartup() {
+    unawaited(ref.read(postPublishExperimentProvider).initialize());
     unawaited(
       widget.startupCoordinator.initializeRemaining().catchError((
         Object error,
@@ -2749,6 +2755,7 @@ class _DivineAppState extends ConsumerState<DivineApp>
                   oauthClient: ref.read(oauthClientProvider),
                   authService: ref.read(authServiceProvider),
                   inviteApiClient: context.read<InviteApiClient>(),
+                  analytics: ref.read(analyticsEventSinkProvider),
                 ),
               ),
               BlocProvider(
@@ -2927,14 +2934,14 @@ class _UploadFailureListenerState extends State<UploadFailureListener> {
   var _lastKnownFailedIds = <String>{};
   var _lastKnownSucceededIds = <String>{};
   var _pendingSuccessCount = 0;
+  PostPublishCreateAgainOffer? _pendingCreateAgainOffer;
 
   @override
   Widget build(BuildContext context) {
     return BlocListener<BackgroundPublishBloc, BackgroundPublishState>(
       listener: (context, state) {
-        final authService = ProviderScope.containerOf(
-          context,
-        ).read(authServiceProvider);
+        final container = ProviderScope.containerOf(context);
+        final authService = container.read(authServiceProvider);
 
         // Use the bloc's own recentlySucceededIds so we never confuse a
         // BackgroundPublishVanished removal with a true publish success.
@@ -2943,18 +2950,27 @@ class _UploadFailureListenerState extends State<UploadFailureListener> {
         );
         _lastKnownSucceededIds = state.recentlySucceededIds;
         final succeededCount = succeededIds.length;
+        final createAgainOffer = container
+            .read(postPublishExperimentProvider)
+            .completed(succeededIds);
 
         if (succeededCount > 0) {
           if (authService.isAuthenticated) {
             // Show immediately — user is still in-app. If the root navigator
             // context is unavailable the snackbar would be silently dropped,
             // so buffer it and replay once the context is ready.
-            if (!_showPublishSuccessSnackbar(succeededCount)) {
+            if (!_showPublishSuccessSnackbar(
+              succeededCount,
+              createAgainOffer: createAgainOffer,
+              container: container,
+            )) {
               _pendingSuccessCount += succeededCount;
+              _pendingCreateAgainOffer ??= createAgainOffer;
             }
           } else {
             // Buffer for when auth is restored after re-auth redirect.
             _pendingSuccessCount += succeededCount;
+            _pendingCreateAgainOffer ??= createAgainOffer;
           }
         }
 
@@ -2973,11 +2989,17 @@ class _UploadFailureListenerState extends State<UploadFailureListener> {
 
         // Auth is now confirmed — flush buffered successes from re-auth window.
         if (_pendingSuccessCount > 0 &&
-            _showPublishSuccessSnackbar(_pendingSuccessCount)) {
+            _showPublishSuccessSnackbar(
+              _pendingSuccessCount,
+              createAgainOffer: _pendingCreateAgainOffer,
+              container: container,
+            )) {
           _pendingSuccessCount = 0;
+          _pendingCreateAgainOffer = null;
         }
 
         final newFailedIds = currentFailedIds.difference(_lastKnownFailedIds);
+        container.read(postPublishExperimentProvider).failed(newFailedIds);
         _lastKnownFailedIds = currentFailedIds;
 
         if (newFailedIds.isEmpty) return;
@@ -3004,7 +3026,11 @@ class _UploadFailureListenerState extends State<UploadFailureListener> {
 /// [ScaffoldMessenger] from inside the app tree. The listener itself is mounted
 /// above [MaterialApp], so its own [BuildContext] does not have localization or
 /// scaffold ancestors in production.
-bool _showPublishSuccessSnackbar(int count) {
+bool _showPublishSuccessSnackbar(
+  int count, {
+  required ProviderContainer container,
+  PostPublishCreateAgainOffer? createAgainOffer,
+}) {
   final navContext = NavigatorKeys.root.currentContext;
   if (navContext == null || !navContext.mounted) return false;
   final l10n = navContext.l10n;
@@ -3016,6 +3042,25 @@ bool _showPublishSuccessSnackbar(int count) {
       ),
       backgroundColor: navContext.vineColors.nav,
       behavior: SnackBarBehavior.floating,
+      action: createAgainOffer == null
+          ? null
+          : SnackBarAction(
+              label: l10n.libraryRecordVideo,
+              onPressed: () {
+                unawaited(
+                  container
+                      .read(postPublishExperimentProvider)
+                      .createAgainTapped(createAgainOffer),
+                );
+                container
+                    .read(goRouterProvider)
+                    .go(
+                      VideoRecorderScreen.pathForEntryPoint(
+                        CreationEntryPoint.postPublish,
+                      ),
+                    );
+              },
+            ),
     ),
   );
   return true;

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -3052,13 +3052,18 @@ bool _showPublishSuccessSnackbar(
                       .read(postPublishExperimentProvider)
                       .createAgainTapped(createAgainOffer),
                 );
-                container
-                    .read(goRouterProvider)
-                    .go(
-                      VideoRecorderScreen.pathForEntryPoint(
-                        CreationEntryPoint.postPublish,
+                // Push, not go: the payoff this experiment measures is the
+                // profile the user is standing on, so closing the recorder
+                // has to pop back to it instead of resetting to the feed.
+                unawaited(
+                  container
+                      .read(goRouterProvider)
+                      .push<void>(
+                        VideoRecorderScreen.pathForEntryPoint(
+                          CreationEntryPoint.postPublish,
+                        ),
                       ),
-                    );
+                );
               },
             ),
     ),

--- a/mobile/lib/providers/analytics_providers.dart
+++ b/mobile/lib/providers/analytics_providers.dart
@@ -2,6 +2,7 @@
 // ABOUTME: migrated off the factory-singleton pattern to constructor injection (#4743).
 
 import 'package:analytics/analytics.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/features/creation_analytics/creation_analytics_tracker.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
@@ -17,12 +18,24 @@ class AnalyticsIdentityCoordinator {
   }) : _analytics = analytics,
        _setCrashUserId = setCrashUserId;
 
+  static final _hexPubkey = RegExp(r'^[0-9a-fA-F]{64}$');
+
+  /// The identity this app process last applied to Firebase.
+  ///
+  /// Static because the Firebase identity is process-global while this
+  /// coordinator is not: an account switch builds a fresh [ProviderContainer],
+  /// so a per-instance field would start at `null` and read the switch as a
+  /// first login.
+  static String? _lastAppliedUserId;
+
+  @visibleForTesting
+  static void resetLastAppliedUserId() => _lastAppliedUserId = null;
+
   final AnalyticsEventSink _analytics;
   final CrashUserIdSetter _setCrashUserId;
 
-  Future<void> setUserId(String? pubkeyHex) async {
-    if (pubkeyHex != null &&
-        !RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(pubkeyHex)) {
+  Future<void> setUserId(String? rawPubkeyHex) async {
+    if (rawPubkeyHex != null && !_hexPubkey.hasMatch(rawPubkeyHex)) {
       Log.error(
         'Refusing to set a non-hex analytics user ID',
         name: 'AnalyticsIdentityCoordinator',
@@ -30,6 +43,20 @@ class AnalyticsIdentityCoordinator {
       );
       return;
     }
+
+    // An external signer can hand back uppercase hex. The campaign join is a
+    // string compare against the lowercase pubkey stored downstream, so the
+    // identity is lowercased rather than passed through as received.
+    final pubkeyHex = rawPubkeyHex?.toLowerCase();
+
+    // `invite_code` is user-scoped, so it outlives the identity it was
+    // recorded for unless every identity change clears it. Logout is not the
+    // only one: an in-place account switch swaps containers without ever
+    // passing through an unauthenticated state.
+    final previousUserId = _lastAppliedUserId;
+    final identityChanged =
+        previousUserId != null && previousUserId != pubkeyHex;
+    _lastAppliedUserId = pubkeyHex;
 
     try {
       await _analytics.setUserId(pubkeyHex);
@@ -41,7 +68,7 @@ class AnalyticsIdentityCoordinator {
       );
     }
 
-    if (pubkeyHex == null) {
+    if (pubkeyHex == null || identityChanged) {
       try {
         await _analytics.setUserProperty(
           name: AnalyticsUserProperty.inviteCode,

--- a/mobile/lib/providers/analytics_providers.dart
+++ b/mobile/lib/providers/analytics_providers.dart
@@ -3,11 +3,89 @@
 
 import 'package:analytics/analytics.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/features/creation_analytics/creation_analytics_tracker.dart';
+import 'package:openvine/services/crash_reporting_service.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+typedef CrashUserIdSetter = Future<void> Function(String? userId);
+
+/// Keeps Firebase Analytics and Crashlytics on the same authenticated identity.
+class AnalyticsIdentityCoordinator {
+  AnalyticsIdentityCoordinator({
+    required AnalyticsEventSink analytics,
+    required CrashUserIdSetter setCrashUserId,
+  }) : _analytics = analytics,
+       _setCrashUserId = setCrashUserId;
+
+  final AnalyticsEventSink _analytics;
+  final CrashUserIdSetter _setCrashUserId;
+
+  Future<void> setUserId(String? pubkeyHex) async {
+    if (pubkeyHex != null &&
+        !RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(pubkeyHex)) {
+      Log.error(
+        'Refusing to set a non-hex analytics user ID',
+        name: 'AnalyticsIdentityCoordinator',
+        category: LogCategory.auth,
+      );
+      return;
+    }
+
+    try {
+      await _analytics.setUserId(pubkeyHex);
+    } catch (error) {
+      Log.warning(
+        'Failed to update the Firebase Analytics identity: $error',
+        name: 'AnalyticsIdentityCoordinator',
+        category: LogCategory.auth,
+      );
+    }
+
+    if (pubkeyHex == null) {
+      try {
+        await _analytics.setUserProperty(
+          name: AnalyticsUserProperty.inviteCode,
+          value: null,
+        );
+      } catch (error) {
+        Log.warning(
+          'Failed to clear Firebase Analytics invite attribution: $error',
+          name: 'AnalyticsIdentityCoordinator',
+          category: LogCategory.auth,
+        );
+      }
+    }
+
+    try {
+      await _setCrashUserId(pubkeyHex);
+    } catch (error) {
+      Log.warning(
+        'Failed to update the Crashlytics identity: $error',
+        name: 'AnalyticsIdentityCoordinator',
+        category: LogCategory.auth,
+      );
+    }
+  }
+}
 
 /// Provides the low-level analytics event sink for feature-specific events.
 final analyticsEventSinkProvider = Provider<AnalyticsEventSink>(
   (ref) => FirebaseAnalyticsEventSink(),
 );
+
+final creationAnalyticsTrackerProvider = Provider<CreationAnalyticsTracker>(
+  (ref) => CreationAnalyticsTracker(
+    analytics: ref.watch(analyticsEventSinkProvider),
+  ),
+);
+
+final analyticsIdentityCoordinatorProvider =
+    Provider<AnalyticsIdentityCoordinator>(
+      (ref) => AnalyticsIdentityCoordinator(
+        analytics: ref.watch(analyticsEventSinkProvider),
+        setCrashUserId: CrashReportingService.instance.setUserId,
+      ),
+    );
 
 /// Provides the app's shared [SurfacePerformanceTracker].
 ///

--- a/mobile/lib/providers/auth_providers.dart
+++ b/mobile/lib/providers/auth_providers.dart
@@ -1,6 +1,6 @@
 // ABOUTME: Auth & identity Riverpod providers split from app_providers.dart
 // ABOUTME: Secure storage, OAuth/Keycast, AuthService keystone, NIP-98/CAWG/NIP-39,
-// ABOUTME: account deletion, Zendesk identity sync (eager)
+// ABOUTME: account deletion, Zendesk and analytics identity sync (eager)
 
 import 'dart:async';
 import 'dart:convert';
@@ -306,7 +306,6 @@ void zendeskIdentitySync(Ref ref) {
         await _setZendeskIdentity(pubkeyHex, profileRepository, ref);
       }
     } else if (authState == AuthState.unauthenticated) {
-      await ref.read(analyticsIdentityCoordinatorProvider).setUserId(null);
       await ZendeskSupportService.clearUserIdentity();
       Log.info(
         'Zendesk identity cleared on logout',
@@ -319,14 +318,40 @@ void zendeskIdentitySync(Ref ref) {
   ref.onDispose(subscription.cancel);
 }
 
+/// Provider that mirrors the authenticated identity into Firebase Analytics
+/// and Crashlytics.
+///
+/// Deliberately independent of [zendeskIdentitySync]: campaign attribution
+/// joins BigQuery `user_id` against the ClickHouse pubkey, so it must not be
+/// coupled to the lifetime of the support-desk integration. Watch this
+/// provider at app startup to keep the analytics identity in sync with auth.
+@Riverpod(keepAlive: true)
+void analyticsIdentitySync(Ref ref) {
+  final authService = ref.watch(authServiceProvider);
+  final coordinator = ref.read(analyticsIdentityCoordinatorProvider);
+
+  final restoredPubkeyHex = authService.currentPublicKeyHex;
+  if (authService.isAuthenticated && restoredPubkeyHex != null) {
+    unawaited(coordinator.setUserId(restoredPubkeyHex));
+  }
+
+  final subscription = authService.authStateStream.listen((authState) async {
+    if (authState == AuthState.authenticated) {
+      await coordinator.setUserId(authService.currentPublicKeyHex);
+    } else if (authState == AuthState.unauthenticated) {
+      await coordinator.setUserId(null);
+    }
+  });
+
+  ref.onDispose(subscription.cancel);
+}
+
 /// Helper to set Zendesk identity from pubkey
 Future<void> _setZendeskIdentity(
   String pubkeyHex,
   ProfileRepository? profileRepository,
   Ref ref,
 ) async {
-  await ref.read(analyticsIdentityCoordinatorProvider).setUserId(pubkeyHex);
-
   try {
     final npub = NostrKeyUtils.encodePubKey(pubkeyHex);
     final profile = await profileRepository?.getCachedProfile(

--- a/mobile/lib/providers/auth_providers.dart
+++ b/mobile/lib/providers/auth_providers.dart
@@ -13,6 +13,7 @@ import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:openvine/models/auth_rpc_capability.dart';
 import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/models/known_account.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -305,6 +306,7 @@ void zendeskIdentitySync(Ref ref) {
         await _setZendeskIdentity(pubkeyHex, profileRepository, ref);
       }
     } else if (authState == AuthState.unauthenticated) {
+      await ref.read(analyticsIdentityCoordinatorProvider).setUserId(null);
       await ZendeskSupportService.clearUserIdentity();
       Log.info(
         'Zendesk identity cleared on logout',
@@ -323,6 +325,8 @@ Future<void> _setZendeskIdentity(
   ProfileRepository? profileRepository,
   Ref ref,
 ) async {
+  await ref.read(analyticsIdentityCoordinatorProvider).setUserId(pubkeyHex);
+
   try {
     final npub = NostrKeyUtils.encodePubKey(pubkeyHex);
     final profile = await profileRepository?.getCachedProfile(

--- a/mobile/lib/providers/auth_providers.g.dart
+++ b/mobile/lib/providers/auth_providers.g.dart
@@ -688,7 +688,72 @@ final class ZendeskIdentitySyncProvider
 }
 
 String _$zendeskIdentitySyncHash() =>
-    r'536f40b1c768ff2922aac6b05adac94f81ef8c81';
+    r'e49d4f9cedf56ec4131b30a6f1d9d45dada68bed';
+
+/// Provider that mirrors the authenticated identity into Firebase Analytics
+/// and Crashlytics.
+///
+/// Deliberately independent of [zendeskIdentitySync]: campaign attribution
+/// joins BigQuery `user_id` against the ClickHouse pubkey, so it must not be
+/// coupled to the lifetime of the support-desk integration. Watch this
+/// provider at app startup to keep the analytics identity in sync with auth.
+
+@ProviderFor(analyticsIdentitySync)
+final analyticsIdentitySyncProvider = AnalyticsIdentitySyncProvider._();
+
+/// Provider that mirrors the authenticated identity into Firebase Analytics
+/// and Crashlytics.
+///
+/// Deliberately independent of [zendeskIdentitySync]: campaign attribution
+/// joins BigQuery `user_id` against the ClickHouse pubkey, so it must not be
+/// coupled to the lifetime of the support-desk integration. Watch this
+/// provider at app startup to keep the analytics identity in sync with auth.
+
+final class AnalyticsIdentitySyncProvider
+    extends $FunctionalProvider<void, void, void>
+    with $Provider<void> {
+  /// Provider that mirrors the authenticated identity into Firebase Analytics
+  /// and Crashlytics.
+  ///
+  /// Deliberately independent of [zendeskIdentitySync]: campaign attribution
+  /// joins BigQuery `user_id` against the ClickHouse pubkey, so it must not be
+  /// coupled to the lifetime of the support-desk integration. Watch this
+  /// provider at app startup to keep the analytics identity in sync with auth.
+  AnalyticsIdentitySyncProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'analyticsIdentitySyncProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$analyticsIdentitySyncHash();
+
+  @$internal
+  @override
+  $ProviderElement<void> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  void create(Ref ref) {
+    return analyticsIdentitySync(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(void value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<void>(value),
+    );
+  }
+}
+
+String _$analyticsIdentitySyncHash() =>
+    r'18eadd08461e9c7074095cc74e7c05f606566374';
 
 /// Provider for [VerifierClient] pointed at the current environment's
 /// verifier base URL. Stateless — every call hits the network.

--- a/mobile/lib/providers/auth_providers.g.dart
+++ b/mobile/lib/providers/auth_providers.g.dart
@@ -688,7 +688,7 @@ final class ZendeskIdentitySyncProvider
 }
 
 String _$zendeskIdentitySyncHash() =>
-    r'e49d4f9cedf56ec4131b30a6f1d9d45dada68bed';
+    r'536f40b1c768ff2922aac6b05adac94f81ef8c81';
 
 /// Provider for [VerifierClient] pointed at the current environment's
 /// verifier base URL. Stateless — every call hits the network.

--- a/mobile/lib/providers/post_publish_providers.dart
+++ b/mobile/lib/providers/post_publish_providers.dart
@@ -1,0 +1,18 @@
+// ABOUTME: Riverpod wiring for the remotely controlled post-publish experiment.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/features/post_publish/post_publish_experiment.dart';
+import 'package:openvine/providers/analytics_providers.dart';
+
+final postPublishFlagClientProvider = Provider<PostPublishFlagClient>((ref) {
+  final client = FirebasePostPublishFlagClient();
+  ref.onDispose(client.dispose);
+  return client;
+});
+
+final postPublishExperimentProvider = Provider<PostPublishExperiment>((ref) {
+  return PostPublishExperiment(
+    flags: ref.watch(postPublishFlagClientProvider),
+    analytics: ref.watch(analyticsEventSinkProvider),
+  );
+});

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -15,16 +15,20 @@ import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' show NativeProofData;
 import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/features/post_publish/post_publish_experiment.dart';
 import 'package:openvine/l10n/current_app_l10n.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/publish_error_kind_l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/video_publish/video_publish_provider_state.dart';
+import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
 import 'package:openvine/models/video_reply_context.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/layer_rasterizer_provider.dart';
+import 'package:openvine/providers/post_publish_providers.dart';
 import 'package:openvine/providers/preferences_providers.dart';
 import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/providers/service_providers.dart';
@@ -373,8 +377,20 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
 
     _inFlightSourceDraftIds.add(sourceDraftId);
     state = state.copyWith(publishState: .preparing);
+    final creationTracker = ref.read(creationAnalyticsTrackerProvider);
+    final recorderMode =
+        creationTracker.activeMode ?? VideoRecorderMode.capture;
 
     try {
+      await creationTracker.publishStarted(recorderMode);
+      if (!context.mounted) {
+        await creationTracker.publishFailed(
+          mode: recorderMode,
+          reason: 'context_unmounted',
+        );
+        return;
+      }
+
       Log.info(
         '📝 Starting video publish process',
         name: 'VideoPublishNotifier',
@@ -408,6 +424,10 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
         );
         if (materialized == null) {
           setError(stopMotionFailedMessage!);
+          await creationTracker.publishFailed(
+            mode: recorderMode,
+            reason: 'stop_motion_render_failed',
+          );
           return;
         }
         finalRenderedClip = materialized;
@@ -452,6 +472,10 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
           ).publishErrorOverlaysUnavailable;
           setError(message);
           _showPublishError(message);
+          await creationTracker.publishFailed(
+            mode: recorderMode,
+            reason: 'overlays_unavailable',
+          );
           return;
         }
 
@@ -474,6 +498,12 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
               ).publishErrorMessage(PublishErrorKind.generic);
           setError(message);
           _showPublishError(message);
+          await creationTracker.publishFailed(
+            mode: recorderMode,
+            reason: needsStopMotionRender
+                ? 'stop_motion_render_failed'
+                : 'render_failed',
+          );
           return;
         }
 
@@ -520,7 +550,13 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
         category: .video,
       );
 
-      if (!context.mounted) return;
+      if (!context.mounted) {
+        await creationTracker.publishFailed(
+          mode: recorderMode,
+          reason: 'context_unmounted',
+        );
+        return;
+      }
 
       final backgroundPublishBloc = context.read<BackgroundPublishBloc>();
       final publishService = await _createPublishService(
@@ -546,10 +582,18 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
         ),
       );
       var didNavigate = false;
+      final postPublishExperiment = ref.read(postPublishExperimentProvider);
 
       if (context.mounted && videoReplyContext != null) {
         final destination = videoReplyPublishDestinationFor(videoReplyContext);
         context.go(destination.path, extra: destination.extra);
+        unawaited(
+          postPublishExperiment.screenShown(
+            publishId: publishDraft.id,
+            destination: 'video_reply',
+            variant: PostPublishVariant.control,
+          ),
+        );
         didNavigate = true;
       } else {
         // Navigate to current user's profile
@@ -557,6 +601,16 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
         final currentNpub = authService.currentNpub;
         if (currentNpub != null && context.mounted) {
           context.go(ProfileScreenRouter.pathForNpub(currentNpub));
+          final variant = postPublishExperiment.variantForUser(
+            authService.currentPublicKeyHex,
+          );
+          unawaited(
+            postPublishExperiment.screenShown(
+              publishId: publishDraft.id,
+              destination: 'profile',
+              variant: variant,
+            ),
+          );
           didNavigate = true;
         }
       }
@@ -576,6 +630,7 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
       // Handle result
       switch (result) {
         case PublishSuccess():
+          await creationTracker.publishSucceeded(recorderMode);
           Log.info(
             '🎉 Video published successfully',
             name: 'VideoPublishNotifier',
@@ -594,6 +649,10 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
               rawFallback ??
               l10n.publishErrorMessage(kind, serverName: serverName);
           setError(message);
+          await creationTracker.publishFailed(
+            mode: recorderMode,
+            reason: kind.name,
+          );
           Log.error(
             '❌ Publish failed: $message',
             name: 'VideoPublishNotifier',
@@ -616,6 +675,10 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
       final message = l10n.publishErrorMessage(PublishErrorKind.generic);
       setError(message);
       _showPublishError(message);
+      await creationTracker.publishFailed(
+        mode: recorderMode,
+        reason: 'unexpected_error',
+      );
     } finally {
       _inFlightSourceDraftIds.remove(sourceDraftId);
       Log.info(
@@ -720,10 +783,7 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
     );
     final message = collaboratorInviteRetryResultMessage(l10n, summary);
     messenger.showSnackBar(
-      SnackBar(
-        content: Text(message),
-        behavior: SnackBarBehavior.floating,
-      ),
+      SnackBar(content: Text(message), behavior: SnackBarBehavior.floating),
     );
   }
 

--- a/mobile/lib/router/app_router_redirect.dart
+++ b/mobile/lib/router/app_router_redirect.dart
@@ -108,7 +108,8 @@ bool _isAuthEntryLocation(String location) {
 }
 
 bool _isPublicRecorderLocation(String location) =>
-    location == VideoRecorderScreen.path;
+    location == VideoRecorderScreen.path ||
+    location.startsWith('${VideoRecorderScreen.path}?');
 
 /// The slice of [MinorAccountReviewStatus] (plus its async loading shape)
 /// that [appRouterRedirect] actually branches on. Two emissions with an

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -324,6 +324,9 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
     // Initialize Zendesk identity sync to keep user identity in sync with auth
     ref.watch(zendeskIdentitySyncProvider);
 
+    // Mirrors the authenticated pubkey into Firebase Analytics + Crashlytics.
+    ref.watch(analyticsIdentitySyncProvider);
+
     // Transitional scaffold: syncs notification preferences on auth change.
     // TODO(#4338): remove when NotificationPreferencesCubit owns this lifecycle.
     ref.watch(notificationPreferencesDirtySyncBridgeProvider);

--- a/mobile/lib/router/routes/video_routes.dart
+++ b/mobile/lib/router/routes/video_routes.dart
@@ -30,8 +30,14 @@ List<RouteBase> videoRoutes() {
       name: VideoRecorderScreen.routeName,
       // The recorder is a modal creation mode, not the next screen in a
       // flow — open it with the fade-upwards transition.
-      pageBuilder: (_, state) =>
-          fadeUpwardsPage(state: state, child: const VideoRecorderRoute()),
+      pageBuilder: (_, state) => fadeUpwardsPage(
+        state: state,
+        child: VideoRecorderRoute(
+          entryPoint: CreationEntryPoint.fromName(
+            state.uri.queryParameters['entry_point'],
+          ),
+        ),
+      ),
     ),
     GoRoute(
       path: CreatorAnalyticsScreen.path,

--- a/mobile/lib/screens/auth/create_account_screen.dart
+++ b/mobile/lib/screens/auth/create_account_screen.dart
@@ -14,6 +14,7 @@ import 'package:openvine/blocs/divine_auth/divine_auth_cubit.dart';
 import 'package:openvine/blocs/invite_gate/invite_gate_bloc.dart';
 import 'package:openvine/blocs/invite_gate/invite_gate_event.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/auth/email_verification_screen.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
@@ -53,6 +54,7 @@ class CreateAccountScreen extends ConsumerWidget {
         inviteSourceSlug: inviteAccessGrant?.creatorSlug,
         validationMessages: AuthValidationMessages.fromL10n(l10n),
         requirePasswordConfirmation: true,
+        analytics: ref.read(analyticsEventSinkProvider),
       )..initialize(),
       child: _CreateAccountView(inviteAccessGrant: inviteAccessGrant),
     );

--- a/mobile/lib/screens/auth/login_options_screen.dart
+++ b/mobile/lib/screens/auth/login_options_screen.dart
@@ -15,6 +15,7 @@ import 'package:go_router/go_router.dart';
 import 'package:nostr_sdk/nostr_sdk.dart' show AndroidPlugin;
 import 'package:openvine/blocs/divine_auth/divine_auth_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/auth/email_verification_screen.dart';
 import 'package:openvine/screens/auth/nostr_connect_screen.dart';
@@ -57,6 +58,7 @@ class LoginOptionsScreen extends ConsumerWidget {
             authService: authService,
             pendingVerificationService: pendingVerificationService,
             validationMessages: AuthValidationMessages.fromL10n(l10n),
+            analytics: ref.read(analyticsEventSinkProvider),
           )..initialize(
             isSignIn: true,
             initialEmail: initialEmail,

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -1032,7 +1032,11 @@ class _MainCommentInputState extends ConsumerState<MainCommentInput> {
     );
     unawaited(
       context
-          .push(VideoRecorderScreen.path)
+          .push(
+            VideoRecorderScreen.pathForEntryPoint(
+              CreationEntryPoint.videoReply,
+            ),
+          )
           .then((_) => replyContextNotifier.clear()),
     );
   }

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -22,6 +22,7 @@ import 'package:openvine/blocs/video_editor/voice_over/voice_over_cubit.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/extensions/video_editor_extensions.dart';
 import 'package:openvine/extensions/video_editor_history_extensions.dart';
+import 'package:openvine/features/creation_analytics/creation_analytics_tracker.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/mixins/codec_heavy_surface_guard.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -29,7 +30,10 @@ import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/models/video_editor/caption_layer_mapping.dart';
 import 'package:openvine/models/video_editor/caption_style_preset.dart';
 import 'package:openvine/models/video_editor/caption_track.dart';
+import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/providers/upload_media_providers.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
@@ -104,6 +108,7 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
   /// Manually managed so [_extractWaveform] can dispatch events without
   /// needing a child context below [MultiBlocProvider].
   late final TimelineOverlayBloc _timelineOverlayBloc;
+  late final CreationAnalyticsTracker _creationAnalyticsTracker;
 
   /// Body size notifier, updated by [_CanvasFitter].
   final _bodySizeNotifier = ValueNotifier<Size>(Size.zero);
@@ -147,6 +152,7 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
   @override
   void initState() {
     super.initState();
+    _creationAnalyticsTracker = ref.read(creationAnalyticsTrackerProvider);
     Log.info(
       '🎬 Initialized (draftId: ${widget.draftId}, fromLibrary: ${widget.fromLibrary})',
       name: 'VideoEditorScreen',
@@ -221,6 +227,20 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
           .read(videoEditorProvider.notifier)
           .initialize(draftId: widget.draftId);
 
+      if (!mounted) return;
+      final clips = ref.read(clipManagerProvider).clips;
+      final tracker = _creationAnalyticsTracker;
+      final recorderMode =
+          tracker.activeMode ??
+          (isStopMotionComposition(clips)
+              ? VideoRecorderMode.stopMotion
+              : VideoRecorderMode.fromName(
+                  ref
+                      .read(sharedPreferencesProvider)
+                      .getString(VideoRecorderMode.persistenceKey),
+                ));
+      await tracker.editorOpened(recorderMode);
+
       Log.info(
         '🎬 Video editor initialized successfully',
         name: 'VideoEditorScreen',
@@ -258,6 +278,9 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
 
   @override
   void dispose() {
+    if (widget.fromLibrary || widget.draftId != null) {
+      unawaited(_creationAnalyticsTracker.creationAbandoned());
+    }
     Log.info(
       '🎨 Disposed',
       name: 'VideoEditorScreen',
@@ -323,7 +346,10 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
         opaque: false,
         barrierDismissible: true,
         barrierColor: VineTheme.transparent,
-        pageBuilder: (_, _, _) => const VideoRecorderScreen(fromEditor: true),
+        pageBuilder: (_, _, _) => const VideoRecorderScreen(
+          fromEditor: true,
+          entryPoint: CreationEntryPoint.editor,
+        ),
         transitionsBuilder: (_, animation, _, child) {
           return FadeTransition(opacity: animation, child: child);
         },
@@ -686,9 +712,7 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
     final editor = _editorKey.currentState;
     if (editor == null) return;
 
-    final audioDuration = Duration(
-      milliseconds: (durationSecs * 1000).toInt(),
-    );
+    final audioDuration = Duration(milliseconds: (durationSecs * 1000).toInt());
     final clipDuration = _clipEditorBloc.state.totalDuration;
     const maxDuration = VideoEditorConstants.maxDuration;
     final endTime = [

--- a/mobile/lib/screens/video_metadata/video_metadata_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/relay_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
@@ -78,6 +79,17 @@ class _VideoMetadataScreenState extends ConsumerState<VideoMetadataScreen> {
       // Clear any stale error/completed state from a previous publish attempt
       // so the overlay doesn't block the new publish flow.
       ref.read(videoPublishProvider.notifier).clearError();
+      final recorderMode =
+          widget.draftMode ??
+          ref.read(creationAnalyticsTrackerProvider).activeMode ??
+          VideoRecorderMode.fromName(
+            ref
+                .read(sharedPreferencesProvider)
+                .getString(VideoRecorderMode.persistenceKey),
+          );
+      unawaited(
+        ref.read(creationAnalyticsTrackerProvider).editorOpened(recorderMode),
+      );
       // `ref.listen` only fires on a *change*, so a render that already failed
       // signing before this screen mounted (resumed draft, or capture/lip-sync
       // where the render is kicked off before navigation) would never surface

--- a/mobile/lib/screens/video_recorder_screen.dart
+++ b/mobile/lib/screens/video_recorder_screen.dart
@@ -140,7 +140,12 @@ class _VideoRecorderBlocScope extends ConsumerWidget {
     );
 
     return BlocProvider<VideoRecorderBloc>(
-      key: ValueKey((clipManager, videoEditor, sharedPreferences)),
+      key: ValueKey((
+        clipManager,
+        videoEditor,
+        sharedPreferences,
+        creationAnalyticsTracker,
+      )),
       create: (_) => VideoRecorderBloc(
         readClipManager: () => ref.read(clipManagerProvider.notifier),
         readVideoEditor: () => ref.read(videoEditorProvider.notifier),

--- a/mobile/lib/screens/video_recorder_screen.dart
+++ b/mobile/lib/screens/video_recorder_screen.dart
@@ -14,9 +14,11 @@ import 'package:openvine/blocs/sound_waveform/sound_waveform_bloc.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/config/screenshot_mode.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/features/creation_analytics/creation_analytics_tracker.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/mixins/codec_heavy_surface_guard.dart';
 import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/overlay_visibility_provider.dart';
@@ -38,17 +40,47 @@ import 'package:unified_logger/unified_logger.dart';
 
 const _kWhySixSecondsShownKey = 'why_six_seconds_shown';
 
+abstract final class CreationEntryPoint {
+  static const direct = 'direct';
+  static const bottomNav = 'bottom_nav';
+  static const cameraFab = 'camera_fab';
+  static const library = 'library';
+  static const videoReply = 'video_reply';
+  static const quickAction = 'quick_action';
+  static const postPublish = 'post_publish';
+  static const editor = 'editor';
+
+  static String fromName(String? value) => switch (value) {
+    direct ||
+    bottomNav ||
+    cameraFab ||
+    library ||
+    videoReply ||
+    quickAction ||
+    postPublish ||
+    editor => value!,
+    _ => direct,
+  };
+}
+
 /// Route shell for the standalone recorder flow.
 ///
 /// The permission gate renders recorder chrome while permissions are pending,
 /// so the [VideoRecorderBloc] must sit above both the gate and recorder view.
 class VideoRecorderRoute extends ConsumerWidget {
-  const VideoRecorderRoute({super.key});
+  const VideoRecorderRoute({
+    super.key,
+    this.entryPoint = CreationEntryPoint.direct,
+  });
+
+  final String entryPoint;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return const _VideoRecorderBlocScope(
-      child: CameraPermissionGate(child: VideoRecorderView()),
+    return _VideoRecorderBlocScope(
+      child: CameraPermissionGate(
+        child: VideoRecorderView(entryPoint: entryPoint),
+      ),
     );
   }
 }
@@ -62,7 +94,11 @@ class VideoRecorderRoute extends ConsumerWidget {
 /// `state_management.md`).
 class VideoRecorderScreen extends ConsumerWidget {
   /// Creates a video recorder screen.
-  const VideoRecorderScreen({super.key, this.fromEditor = false});
+  const VideoRecorderScreen({
+    super.key,
+    this.fromEditor = false,
+    this.entryPoint = CreationEntryPoint.direct,
+  });
 
   /// Whether the screen is opened from the video editor.
   ///
@@ -70,16 +106,21 @@ class VideoRecorderScreen extends ConsumerWidget {
   /// instead of the standard recorder close flow.
   final bool fromEditor;
 
+  final String entryPoint;
+
   /// Route name for this screen.
   static const routeName = 'video-recorder';
 
   /// Path for this route.
   static const path = '/video-recorder';
 
+  static String pathForEntryPoint(String entryPoint) =>
+      Uri(path: path, queryParameters: {'entry_point': entryPoint}).toString();
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return _VideoRecorderBlocScope(
-      child: VideoRecorderView(fromEditor: fromEditor),
+      child: VideoRecorderView(fromEditor: fromEditor, entryPoint: entryPoint),
     );
   }
 }
@@ -94,6 +135,9 @@ class _VideoRecorderBlocScope extends ConsumerWidget {
     final clipManager = ref.watch(clipManagerProvider.notifier);
     final videoEditor = ref.watch(videoEditorProvider.notifier);
     final sharedPreferences = ref.watch(sharedPreferencesProvider);
+    final creationAnalyticsTracker = ref.watch(
+      creationAnalyticsTrackerProvider,
+    );
 
     return BlocProvider<VideoRecorderBloc>(
       key: ValueKey((clipManager, videoEditor, sharedPreferences)),
@@ -103,6 +147,9 @@ class _VideoRecorderBlocScope extends ConsumerWidget {
         readVideoEditorState: () => ref.read(videoEditorProvider),
         readSharedPreferences: () => ref.read(sharedPreferencesProvider),
         performanceMonitor: ref.read(performanceMonitoringServiceProvider),
+        onRecordingStarted: (mode) => unawaited(
+          creationAnalyticsTracker.recordingStarted(mode),
+        ),
       ),
       child: child,
     );
@@ -113,10 +160,16 @@ class _VideoRecorderBlocScope extends ConsumerWidget {
 /// pump it directly with a mock [VideoRecorderBloc].
 @visibleForTesting
 class VideoRecorderView extends ConsumerStatefulWidget {
-  const VideoRecorderView({super.key, this.fromEditor = false});
+  const VideoRecorderView({
+    super.key,
+    this.fromEditor = false,
+    this.entryPoint = CreationEntryPoint.direct,
+  });
 
   /// Whether the screen is opened from the video editor.
   final bool fromEditor;
+
+  final String entryPoint;
 
   @override
   ConsumerState<VideoRecorderView> createState() => _VideoRecorderViewState();
@@ -126,6 +179,7 @@ class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
     with WidgetsBindingObserver, CodecHeavySurfaceGuard {
   ProviderSubscription<AudioEvent?>? _soundSubscription;
   OverlayVisibility? _overlayVisibilityNotifier;
+  late final CreationAnalyticsTracker _creationAnalyticsTracker;
   VideoRecorderMode? _lastRecorderMode;
 
   bool get _isAutosavedDraft => ref.read(videoEditorProvider).isAutosavedDraft;
@@ -134,7 +188,28 @@ class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
   void initState() {
     super.initState();
 
-    _lastRecorderMode = context.read<VideoRecorderBloc>().state.recorderMode;
+    final initialBlocMode = context
+        .read<VideoRecorderBloc>()
+        .state
+        .recorderMode;
+    _lastRecorderMode = initialBlocMode;
+    final tracker = ref.read(creationAnalyticsTrackerProvider);
+    _creationAnalyticsTracker = tracker;
+    final openingMode =
+        tracker.activeMode ??
+        (widget.fromEditor
+            ? initialBlocMode
+            : VideoRecorderMode.fromName(
+                ref
+                    .read(sharedPreferencesProvider)
+                    .getString(VideoRecorderMode.persistenceKey),
+              ));
+    unawaited(
+      tracker.cameraOpened(
+        mode: openingMode,
+        entryPoint: widget.entryPoint,
+      ),
+    );
 
     WidgetsBinding.instance.addObserver(this);
     _pauseBackgroundPlayback();
@@ -349,6 +424,9 @@ class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
 
   @override
   void dispose() {
+    if (!widget.fromEditor) {
+      unawaited(_creationAnalyticsTracker.creationAbandoned());
+    }
     try {
       _overlayVisibilityNotifier?.setPageOpen(false);
     } catch (e) {
@@ -393,6 +471,9 @@ class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
         listener: (context, state) {
           final previous = _lastRecorderMode;
           _lastRecorderMode = state.recorderMode;
+          ref
+              .read(creationAnalyticsTrackerProvider)
+              .modeChanged(state.recorderMode);
           if (state.recorderMode == VideoRecorderMode.upload) {
             context.read<VideoRecorderBloc>().add(
               const VideoRecorderAppLifecycleChanged(AppLifecycleState.paused),

--- a/mobile/lib/services/crash_reporting_service.dart
+++ b/mobile/lib/services/crash_reporting_service.dart
@@ -144,11 +144,11 @@ class CrashReportingService {
   }
 
   /// Set user identifier for crash reports
-  Future<void> setUserId(String userId) async {
+  Future<void> setUserId(String? userId) async {
     if (!_initialized) return;
 
     try {
-      await FirebaseCrashlytics.instance.setUserIdentifier(userId);
+      await FirebaseCrashlytics.instance.setUserIdentifier(userId ?? '');
     } catch (e) {
       Log.error(
         'Failed to set user ID in Crashlytics: $e',

--- a/mobile/lib/utils/camera_permission_check.dart
+++ b/mobile/lib/utils/camera_permission_check.dart
@@ -29,11 +29,14 @@ extension CameraPermissionNavigation on BuildContext {
   /// the back button — keeps the user here so the next camera tap re-prompts.
   ///
   /// Returns `true` if navigation occurred.
-  Future<bool> pushToCameraWithPermission() async {
+  Future<bool> pushToCameraWithPermission({
+    String entryPoint = CreationEntryPoint.cameraFab,
+  }) async {
     final bloc = read<CameraPermissionBloc>();
+    final recorderPath = VideoRecorderScreen.pathForEntryPoint(entryPoint);
 
     if (kIsWeb) {
-      await pushWithVideoPause(VideoRecorderScreen.path);
+      await pushWithVideoPause(recorderPath);
       return true;
     }
 
@@ -56,7 +59,7 @@ extension CameraPermissionNavigation on BuildContext {
     // requiresSettings shows the settings prompt) or when the entry check
     // couldn't settle (`resolved == null`: an errored/stalled pre-nav check) so
     // the gate surfaces its Error + Retry screen instead of dead-waiting here.
-    await pushWithVideoPause(VideoRecorderScreen.path);
+    await pushWithVideoPause(recorderPath);
     return true;
   }
 }

--- a/mobile/lib/widgets/library/empty_library_state.dart
+++ b/mobile/lib/widgets/library/empty_library_state.dart
@@ -4,6 +4,7 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/screens/video_recorder_screen.dart';
 import 'package:openvine/utils/camera_permission_check.dart';
 
 /// Empty state widget for library tabs (clips, drafts).
@@ -73,7 +74,9 @@ class EmptyLibraryState extends StatelessWidget {
                 label: context.l10n.libraryRecordVideo,
                 leadingIcon: .videoCamera,
                 type: .secondary,
-                onPressed: () => context.pushToCameraWithPermission(),
+                onPressed: () => context.pushToCameraWithPermission(
+                  entryPoint: CreationEntryPoint.library,
+                ),
               ),
             ],
           ],

--- a/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
@@ -13,6 +13,7 @@ import 'package:openvine/blocs/clips_library/clips_library_bloc.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
@@ -51,6 +52,7 @@ Future<void> openVideoEditorFromRecorder(
 
   final bloc = context.read<VideoRecorderBloc>();
   final recorderMode = bloc.state.recorderMode;
+  final clipManager = ref.read(clipManagerProvider.notifier);
 
   // Both next steps snapshot the clip list right here (classic renders it
   // below, the editor seeds its session from it on init), so a clip-delete
@@ -61,6 +63,15 @@ Future<void> openVideoEditorFromRecorder(
     await ref.read(clipManagerProvider.notifier).commitPendingDeletion();
     if (!context.mounted) return;
   }
+
+  await ref
+      .read(creationAnalyticsTrackerProvider)
+      .recordingCompleted(
+        mode: recorderMode,
+        clipCount: clipManager.clips.length,
+        duration: clipManager.totalDuration,
+      );
+  if (!context.mounted) return;
 
   // Lip-sync records against a selected sound, so silence the clips before the
   // editor: only the chosen audio should be heard, with the clips muted and

--- a/mobile/lib/widgets/vine_bottom_nav.dart
+++ b/mobile/lib/widgets/vine_bottom_nav.dart
@@ -22,6 +22,7 @@ import 'package:openvine/screens/feed/home_feed_retap_cubit.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/inbox/inbox_page.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
+import 'package:openvine/screens/video_recorder_screen.dart';
 import 'package:openvine/utils/camera_permission_check.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/notification_badge.dart';
@@ -174,7 +175,9 @@ class VineBottomNav extends ConsumerWidget {
                         name: 'Navigation',
                         category: LogCategory.ui,
                       );
-                      context.pushToCameraWithPermission();
+                      context.pushToCameraWithPermission(
+                        entryPoint: CreationEntryPoint.bottomNav,
+                      );
                     },
                   ),
                   _IconTabButton(

--- a/mobile/packages/analytics/lib/src/analytics_event_sink.dart
+++ b/mobile/packages/analytics/lib/src/analytics_event_sink.dart
@@ -1,6 +1,10 @@
 // ABOUTME: Testable abstraction over analytics event delivery.
 
 abstract interface class AnalyticsEventSink {
+  Future<void> setUserId(String? userId);
+
+  Future<void> setUserProperty({required String name, required String? value});
+
   Future<void> logEvent({
     required String name,
     required Map<String, Object> parameters,
@@ -13,8 +17,21 @@ abstract interface class AnalyticsEventSink {
   });
 }
 
+abstract final class AnalyticsUserProperty {
+  static const inviteCode = 'invite_code';
+}
+
 class NoOpAnalyticsEventSink implements AnalyticsEventSink {
   const NoOpAnalyticsEventSink();
+
+  @override
+  Future<void> setUserId(String? userId) async {}
+
+  @override
+  Future<void> setUserProperty({
+    required String name,
+    required String? value,
+  }) async {}
 
   @override
   Future<void> logEvent({

--- a/mobile/packages/analytics/lib/src/firebase_analytics_event_sink.dart
+++ b/mobile/packages/analytics/lib/src/firebase_analytics_event_sink.dart
@@ -34,6 +34,19 @@ class FirebaseAnalyticsEventSink implements AnalyticsEventSink {
   }
 
   @override
+  Future<void> setUserId(String? userId) async {
+    await _analytics?.setUserId(id: userId);
+  }
+
+  @override
+  Future<void> setUserProperty({
+    required String name,
+    required String? value,
+  }) async {
+    await _analytics?.setUserProperty(name: name, value: value);
+  }
+
+  @override
   Future<void> logEvent({
     required String name,
     required Map<String, Object> parameters,

--- a/mobile/packages/analytics/test/analytics_event_sink_test.dart
+++ b/mobile/packages/analytics/test/analytics_event_sink_test.dart
@@ -6,6 +6,12 @@ void main() {
     test('accepts event and screen view calls without side effects', () async {
       const sink = NoOpAnalyticsEventSink();
 
+      await sink.setUserId(
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      );
+      await sink.setUserId(null);
+      await sink.setUserProperty(name: 'invite_code', value: 'ABCD-EFGH');
+      await sink.setUserProperty(name: 'invite_code', value: null);
       await sink.logEvent(
         name: 'surface_load',
         parameters: const {'surface_name': 'comments_sheet'},

--- a/mobile/packages/analytics/test/error_analytics_tracker_test.dart
+++ b/mobile/packages/analytics/test/error_analytics_tracker_test.dart
@@ -8,6 +8,15 @@ class _RecordingAnalyticsEventSink implements AnalyticsEventSink {
   final events = <({String name, Map<String, Object> parameters})>[];
 
   @override
+  Future<void> setUserId(String? userId) async {}
+
+  @override
+  Future<void> setUserProperty({
+    required String name,
+    required String? value,
+  }) async {}
+
+  @override
   Future<void> logEvent({
     required String name,
     required Map<String, Object> parameters,

--- a/mobile/packages/analytics/test/firebase_analytics_event_sink_test.dart
+++ b/mobile/packages/analytics/test/firebase_analytics_event_sink_test.dart
@@ -15,25 +15,54 @@ void main() {
       sink = FirebaseAnalyticsEventSink(analytics: analytics);
     });
 
+    test(
+      'forwards user IDs to Firebase Analytics without transforming them',
+      () async {
+        const pubkeyHex =
+            '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+        when(() => analytics.setUserId(id: pubkeyHex)).thenAnswer((_) async {});
+
+        await sink.setUserId(pubkeyHex);
+
+        verify(() => analytics.setUserId(id: pubkeyHex)).called(1);
+      },
+    );
+
+    test('clears the Firebase Analytics user ID', () async {
+      when(() => analytics.setUserId()).thenAnswer((_) async {});
+
+      await sink.setUserId(null);
+
+      verify(() => analytics.setUserId()).called(1);
+    });
+
+    test('forwards user properties to Firebase Analytics', () async {
+      when(
+        () =>
+            analytics.setUserProperty(name: 'invite_code', value: 'ABCD-EFGH'),
+      ).thenAnswer((_) async {});
+
+      await sink.setUserProperty(name: 'invite_code', value: 'ABCD-EFGH');
+
+      verify(
+        () =>
+            analytics.setUserProperty(name: 'invite_code', value: 'ABCD-EFGH'),
+      ).called(1);
+    });
+
     test('forwards custom events to Firebase Analytics', () async {
       const parameters = <String, Object>{
         'surface_name': 'comments_sheet',
         'total_ms': 3250,
       };
       when(
-        () => analytics.logEvent(
-          name: 'surface_load',
-          parameters: parameters,
-        ),
+        () => analytics.logEvent(name: 'surface_load', parameters: parameters),
       ).thenAnswer((_) async {});
 
       await sink.logEvent(name: 'surface_load', parameters: parameters);
 
       verify(
-        () => analytics.logEvent(
-          name: 'surface_load',
-          parameters: parameters,
-        ),
+        () => analytics.logEvent(name: 'surface_load', parameters: parameters),
       ).called(1);
     });
 

--- a/mobile/packages/analytics/test/screen_analytics_service_test.dart
+++ b/mobile/packages/analytics/test/screen_analytics_service_test.dart
@@ -17,6 +17,15 @@ class RecordingAnalyticsEventSink implements AnalyticsEventSink {
       >[];
 
   @override
+  Future<void> setUserId(String? userId) async {}
+
+  @override
+  Future<void> setUserProperty({
+    required String name,
+    required String? value,
+  }) async {}
+
+  @override
   Future<void> logEvent({
     required String name,
     required Map<String, Object> parameters,

--- a/mobile/packages/analytics/test/surface_performance_tracker_test.dart
+++ b/mobile/packages/analytics/test/surface_performance_tracker_test.dart
@@ -8,6 +8,15 @@ class RecordingAnalyticsEventSink implements AnalyticsEventSink {
   final events = <({String name, Map<String, Object> parameters})>[];
 
   @override
+  Future<void> setUserId(String? userId) async {}
+
+  @override
+  Future<void> setUserProperty({
+    required String name,
+    required String? value,
+  }) async {}
+
+  @override
   Future<void> logEvent({
     required String name,
     required Map<String, Object> parameters,
@@ -37,10 +46,7 @@ void main() {
       PageLoadHistory().clear();
       sink = RecordingAnalyticsEventSink();
       now = DateTime(2026, 6, 12, 12);
-      tracker = SurfacePerformanceTracker(
-        sink: sink,
-        now: () => now,
-      );
+      tracker = SurfacePerformanceTracker(sink: sink, now: () => now);
     });
 
     tearDown(() {
@@ -164,24 +170,15 @@ void main() {
         expect(sink.events, hasLength(1));
         expect(
           sink.events.single.parameters,
-          containsPair(
-            AnalyticsParam.visibleMs,
-            40,
-          ),
+          containsPair(AnalyticsParam.visibleMs, 40),
         );
         expect(
           sink.events.single.parameters,
-          containsPair(
-            AnalyticsParam.dataMs,
-            -1,
-          ),
+          containsPair(AnalyticsParam.dataMs, -1),
         );
         expect(
           sink.events.single.parameters,
-          containsPair(
-            AnalyticsParam.totalMs,
-            130,
-          ),
+          containsPair(AnalyticsParam.totalMs, 130),
         );
       },
     );

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -761,6 +761,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.8+2"
+  firebase_remote_config:
+    dependency: "direct main"
+    description:
+      name: firebase_remote_config
+      sha256: "5d23c7021e69fbc9ef489ebcf4b1b941575e34ebacc7f20173c2a97f37f45b74"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.2"
+  firebase_remote_config_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_remote_config_platform_interface
+      sha256: f895915923bebb9e8b36a6387fac31a9dd36fbb63fa2ee1ea2cbe309634eecdf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.7"
+  firebase_remote_config_web:
+    dependency: transitive
+    description:
+      name: firebase_remote_config_web
+      sha256: a4de6b86e5eb0416a46948dcb1fa9fce6a71d41f80fa107f6e202ae579ec81b2
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.10.3"
   fixnum:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -303,6 +303,8 @@ dependencies:
   window_manager: ^0.5.1
   firebase_core: ^4.4.0
   firebase_crashlytics: ^5.0.7
+  # Pinned to the Firebase Core 4.4-compatible FlutterFire release family.
+  firebase_remote_config: 6.1.2
   go_router: ^16.2.4
   # Runtime splash-screen control via FlutterNativeSplash.preserve/remove.
   # Used ONLY for the runtime API — do NOT add a flutter_native_splash:

--- a/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
+++ b/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:analytics/analytics.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -24,6 +25,32 @@ class _MockPendingVerificationService extends Mock
     implements PendingVerificationService {}
 
 class _MockInviteApiClient extends Mock implements InviteApiClient {}
+
+class _RecordingAnalytics implements AnalyticsEventSink {
+  final properties = <({String name, String? value})>[];
+
+  @override
+  Future<void> setUserProperty({
+    required String name,
+    required String? value,
+  }) async => properties.add((name: name, value: value));
+
+  @override
+  Future<void> setUserId(String? userId) async {}
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async {}
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) async {}
+}
 
 class _FakeKeycastSession extends Fake implements KeycastSession {}
 
@@ -61,6 +88,7 @@ void main() {
     late _MockAuthService mockAuthService;
     late _MockPendingVerificationService mockPendingVerification;
     late _MockInviteApiClient mockInviteApiClient;
+    late _RecordingAnalytics analytics;
 
     const testEmail = 'test@example.com';
     const testPassword = 'password123';
@@ -74,6 +102,7 @@ void main() {
       mockAuthService = _MockAuthService();
       mockPendingVerification = _MockPendingVerificationService();
       mockInviteApiClient = _MockInviteApiClient();
+      analytics = _RecordingAnalytics();
       when(
         () => mockAuthService.clearPendingDivineOAuthSession(),
       ).thenAnswer((_) async {});
@@ -94,6 +123,7 @@ void main() {
         inviteApiClient: mockInviteApiClient,
         inviteCode: inviteCode,
         validationMessages: AuthValidationMessages.englishDefaults,
+        analytics: analytics,
       );
     }
 
@@ -477,6 +507,9 @@ void main() {
                 session: any(named: 'session'),
               ),
               () => mockAuthService.signInWithDivineOAuth(any()),
+            ]);
+            expect(analytics.properties, [
+              (name: AnalyticsUserProperty.inviteCode, value: 'AB12-EF34'),
             ]);
           },
         );

--- a/mobile/test/blocs/email_verification/email_verification_cubit_test.dart
+++ b/mobile/test/blocs/email_verification/email_verification_cubit_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:analytics/analytics.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -18,6 +19,32 @@ class _MockKeycastOAuth extends Mock implements KeycastOAuth {}
 class _MockAuthService extends Mock implements AuthService {}
 
 class _MockInviteApiClient extends Mock implements InviteApiClient {}
+
+class _RecordingAnalytics implements AnalyticsEventSink {
+  final properties = <({String name, String? value})>[];
+
+  @override
+  Future<void> setUserProperty({
+    required String name,
+    required String? value,
+  }) async => properties.add((name: name, value: value));
+
+  @override
+  Future<void> setUserId(String? userId) async {}
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async {}
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) async {}
+}
 
 class _FakeKeycastSession extends Fake implements KeycastSession {}
 
@@ -37,6 +64,7 @@ void main() {
     late _MockKeycastOAuth mockOAuth;
     late _MockAuthService mockAuthService;
     late _MockInviteApiClient mockInviteApiClient;
+    late _RecordingAnalytics analytics;
 
     const testDeviceCode = 'test-device-code-abc123';
     const testVerifier = 'test-verifier-xyz789';
@@ -47,6 +75,7 @@ void main() {
       mockOAuth = _MockKeycastOAuth();
       mockAuthService = _MockAuthService();
       mockInviteApiClient = _MockInviteApiClient();
+      analytics = _RecordingAnalytics();
       when(
         () => mockAuthService.clearPendingDivineOAuthSession(),
       ).thenAnswer((_) async {});
@@ -59,6 +88,7 @@ void main() {
         oauthClient: mockOAuth,
         authService: mockAuthService,
         inviteApiClient: mockInviteApiClient,
+        analytics: analytics,
       );
     }
 
@@ -440,6 +470,9 @@ void main() {
             () => mockAuthService.signInWithDivineOAuth(any()),
           ]);
           verifyNever(() => mockAuthService.clearPendingDivineOAuthSession());
+          expect(analytics.properties, [
+            (name: AnalyticsUserProperty.inviteCode, value: 'AB12-EF34'),
+          ]);
 
           cubit.close();
           fake.flushMicrotasks();

--- a/mobile/test/blocs/explore_tabs/explore_tabs_cubit_test.dart
+++ b/mobile/test/blocs/explore_tabs/explore_tabs_cubit_test.dart
@@ -13,6 +13,15 @@ class _RecordingAnalyticsSink implements AnalyticsEventSink {
   final events = <({String name, Map<String, Object> parameters})>[];
 
   @override
+  Future<void> setUserId(String? userId) async {}
+
+  @override
+  Future<void> setUserProperty({
+    required String name,
+    required String? value,
+  }) async {}
+
+  @override
   Future<void> logEvent({
     required String name,
     required Map<String, Object> parameters,

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -242,13 +242,16 @@ void main() {
   });
 
   /// Builds a bloc with all dependencies wired to the mocks.
-  VideoRecorderBloc buildBloc() {
+  VideoRecorderBloc buildBloc({
+    RecordingStartedCallback? onRecordingStarted,
+  }) {
     return VideoRecorderBloc(
       readClipManager: () => clipManager,
       readVideoEditor: () => videoEditor,
       readVideoEditorState: VideoEditorProviderState.new,
       readSharedPreferences: () => prefs,
       cameraService: cameraService,
+      onRecordingStarted: onRecordingStarted,
     );
   }
 
@@ -1184,6 +1187,46 @@ void main() {
     });
 
     group('RecordingStartRequested → flags-in-state migration', () {
+      test('reports analytics only after native recording succeeds', () async {
+        final reportedModes = <VideoRecorderMode>[];
+        when(
+          () => cameraService.startRecording(
+            maxDuration: any(named: 'maxDuration'),
+          ),
+        ).thenAnswer((_) async => true);
+        final bloc = buildBloc(onRecordingStarted: reportedModes.add);
+        addTearDown(bloc.close);
+
+        bloc.add(const VideoRecorderRecordingStartRequested());
+        await bloc.stream.firstWhere(
+          (state) =>
+              state.recordingState == VideoRecorderState.recording &&
+              !state.isStartingRecording,
+        );
+
+        expect(reportedModes, [VideoRecorderMode.capture]);
+      });
+
+      test('does not report analytics when native recording fails', () async {
+        final reportedModes = <VideoRecorderMode>[];
+        when(
+          () => cameraService.startRecording(
+            maxDuration: any(named: 'maxDuration'),
+          ),
+        ).thenAnswer((_) async => false);
+        final bloc = buildBloc(onRecordingStarted: reportedModes.add);
+        addTearDown(bloc.close);
+
+        bloc.add(const VideoRecorderRecordingStartRequested());
+        await bloc.stream.firstWhere(
+          (state) =>
+              state.recordingState == VideoRecorderState.idle &&
+              !state.isStartingRecording,
+        );
+
+        expect(reportedModes, isEmpty);
+      });
+
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'sets isStartingRecording true before the camera call and false '
         'after, with recordingState transitioning to recording',

--- a/mobile/test/features/app_review/app_review_analytics_test.dart
+++ b/mobile/test/features/app_review/app_review_analytics_test.dart
@@ -12,6 +12,15 @@ class _RecordingSink implements AnalyticsEventSink {
   final List<({String name, Map<String, Object> parameters})> events = [];
 
   @override
+  Future<void> setUserId(String? userId) async {}
+
+  @override
+  Future<void> setUserProperty({
+    required String name,
+    required String? value,
+  }) async {}
+
+  @override
   Future<void> logEvent({
     required String name,
     required Map<String, Object> parameters,

--- a/mobile/test/features/app_review/app_review_coordinator_cubit_test.dart
+++ b/mobile/test/features/app_review/app_review_coordinator_cubit_test.dart
@@ -14,6 +14,15 @@ class _RecordingSink implements AnalyticsEventSink {
   final List<({String name, Map<String, Object> parameters})> events = [];
 
   @override
+  Future<void> setUserId(String? userId) async {}
+
+  @override
+  Future<void> setUserProperty({
+    required String name,
+    required String? value,
+  }) async {}
+
+  @override
   Future<void> logEvent({
     required String name,
     required Map<String, Object> parameters,
@@ -121,10 +130,7 @@ void main() {
     test('does not burn cooldown when native review is unavailable', () async {
       platform.available = false;
 
-      final evaluation = cubit.evaluate(
-        inputs: inputs(),
-        isActive: () => true,
-      );
+      final evaluation = cubit.evaluate(inputs: inputs(), isActive: () => true);
       frameScheduler.complete();
       await evaluation;
 
@@ -135,10 +141,7 @@ void main() {
     });
 
     test('does not burn cooldown when the frame wait fails', () async {
-      final evaluation = cubit.evaluate(
-        inputs: inputs(),
-        isActive: () => true,
-      );
+      final evaluation = cubit.evaluate(inputs: inputs(), isActive: () => true);
       frameScheduler.complete(false);
       await evaluation;
 
@@ -200,10 +203,7 @@ void main() {
         expect(prefs.getInt('review_prompt_attempted_at_$pubkey'), isNotNull);
       };
 
-      final evaluation = cubit.evaluate(
-        inputs: inputs(),
-        isActive: () => true,
-      );
+      final evaluation = cubit.evaluate(inputs: inputs(), isActive: () => true);
       frameScheduler.complete();
       await evaluation;
 
@@ -248,10 +248,7 @@ void main() {
     });
 
     test('stops cleanly when closed during frame wait', () async {
-      final evaluation = cubit.evaluate(
-        inputs: inputs(),
-        isActive: () => true,
-      );
+      final evaluation = cubit.evaluate(inputs: inputs(), isActive: () => true);
 
       await cubit.close();
       frameScheduler.complete();

--- a/mobile/test/features/app_review/app_review_coordinator_test.dart
+++ b/mobile/test/features/app_review/app_review_coordinator_test.dart
@@ -50,6 +50,15 @@ class _ImmediateFrameScheduler implements AppReviewFrameScheduler {
 
 class _NoopAnalytics implements AnalyticsEventSink {
   @override
+  Future<void> setUserId(String? userId) async {}
+
+  @override
+  Future<void> setUserProperty({
+    required String name,
+    required String? value,
+  }) async {}
+
+  @override
   Future<void> logEvent({
     required String name,
     required Map<String, Object> parameters,
@@ -75,9 +84,7 @@ void main() {
     String? activePubkey = pubkey;
     final authService = _MockAuthService();
     when(() => authService.authState).thenAnswer((_) => authState);
-    when(
-      () => authService.currentPublicKeyHex,
-    ).thenAnswer((_) => activePubkey);
+    when(() => authService.currentPublicKeyHex).thenAnswer((_) => activePubkey);
 
     final statsController = StreamController<ProfileStats?>();
     addTearDown(statsController.close);

--- a/mobile/test/features/creation_analytics/creation_analytics_tracker_test.dart
+++ b/mobile/test/features/creation_analytics/creation_analytics_tracker_test.dart
@@ -135,19 +135,30 @@ void main() {
     });
   });
 
-  test(
-    'does not invent camera elapsed time for an editor-only draft',
-    () async {
-      final sink = _RecordingSink();
-      var now = DateTime.utc(2026, 8, 8, 12);
-      final tracker = CreationAnalyticsTracker(analytics: sink, now: () => now);
+  test('omits camera elapsed time entirely for an editor-only draft', () async {
+    final sink = _RecordingSink();
+    var now = DateTime.utc(2026, 8, 8, 12);
+    final tracker = CreationAnalyticsTracker(analytics: sink, now: () => now);
 
-      await tracker.editorOpened(VideoRecorderMode.upload);
-      now = now.add(const Duration(minutes: 2));
-      await tracker.publishStarted(VideoRecorderMode.upload);
+    await tracker.editorOpened(VideoRecorderMode.upload);
+    now = now.add(const Duration(minutes: 2));
+    await tracker.publishStarted(VideoRecorderMode.upload);
+    await tracker.publishSucceeded(VideoRecorderMode.upload);
 
-      expect(sink.events.last.name, 'publish_started');
-      expect(sink.events.last.parameters['time_since_camera_open_ms'], 0);
-    },
-  );
+    // A `0` here would be indistinguishable from an instant publish and
+    // would drag the campaign's timing distribution down.
+    expect(sink.events.map((event) => event.name), [
+      'editor_opened',
+      'publish_started',
+      'publish_succeeded',
+    ]);
+    expect(
+      sink.events[1].parameters,
+      isNot(contains('time_since_camera_open_ms')),
+    );
+    expect(
+      sink.events[2].parameters,
+      isNot(contains('time_since_camera_open_ms')),
+    );
+  });
 }

--- a/mobile/test/features/creation_analytics/creation_analytics_tracker_test.dart
+++ b/mobile/test/features/creation_analytics/creation_analytics_tracker_test.dart
@@ -1,0 +1,153 @@
+// ABOUTME: Tests creation funnel ordering, dimensions, timing, and abandonment.
+
+import 'package:analytics/analytics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/features/creation_analytics/creation_analytics_tracker.dart';
+import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
+
+class _RecordingSink implements AnalyticsEventSink {
+  final events = <({String name, Map<String, Object> parameters})>[];
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async => events.add((name: name, parameters: parameters));
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) async {}
+
+  @override
+  Future<void> setUserId(String? userId) async {}
+
+  @override
+  Future<void> setUserProperty({
+    required String name,
+    required String? value,
+  }) async {}
+}
+
+void main() {
+  test('records a complete funnel with mode and elapsed time', () async {
+    final sink = _RecordingSink();
+    var now = DateTime.utc(2026, 8, 8, 12);
+    final tracker = CreationAnalyticsTracker(analytics: sink, now: () => now);
+
+    await tracker.cameraOpened(
+      mode: VideoRecorderMode.capture,
+      entryPoint: 'bottom_nav',
+    );
+    await tracker.recordingStarted(VideoRecorderMode.capture);
+    await tracker.recordingStarted(VideoRecorderMode.capture);
+    await tracker.recordingCompleted(
+      mode: VideoRecorderMode.capture,
+      clipCount: 2,
+      duration: const Duration(milliseconds: 6500),
+    );
+    await tracker.editorOpened(VideoRecorderMode.capture);
+    now = now.add(const Duration(seconds: 30));
+    await tracker.publishStarted(VideoRecorderMode.capture);
+    now = now.add(const Duration(seconds: 5));
+    await tracker.publishSucceeded(VideoRecorderMode.capture);
+
+    expect(sink.events.map((event) => event.name), [
+      'camera_opened',
+      'recording_started',
+      'recording_completed',
+      'editor_opened',
+      'publish_started',
+      'publish_succeeded',
+    ]);
+    for (final event in sink.events) {
+      expect(event.parameters['mode'], 'capture');
+    }
+    expect(sink.events[0].parameters['entry_point'], 'bottom_nav');
+    expect(sink.events[2].parameters, containsPair('clip_count', 2));
+    expect(sink.events[2].parameters, containsPair('duration_ms', 6500));
+    expect(sink.events[4].parameters['time_since_camera_open_ms'], 30000);
+    expect(sink.events[5].parameters['time_since_camera_open_ms'], 35000);
+    expect(tracker.activeMode, isNull);
+  });
+
+  test('records abandonment at the deepest reached stage', () async {
+    final sink = _RecordingSink();
+    final tracker = CreationAnalyticsTracker(analytics: sink);
+
+    await tracker.cameraOpened(
+      mode: VideoRecorderMode.stopMotion,
+      entryPoint: 'camera_fab',
+    );
+    await tracker.recordingStarted(VideoRecorderMode.stopMotion);
+    await tracker.creationAbandoned();
+    await tracker.creationAbandoned();
+
+    expect(sink.events.last.name, 'creation_abandoned');
+    expect(sink.events.last.parameters, {
+      'mode': 'stopMotion',
+      'last_stage': 'recording',
+    });
+  });
+
+  test('records publish failure without misclassifying disposal', () async {
+    final sink = _RecordingSink();
+    final tracker = CreationAnalyticsTracker(analytics: sink);
+
+    await tracker.cameraOpened(
+      mode: VideoRecorderMode.classic,
+      entryPoint: 'direct',
+    );
+    await tracker.publishStarted(VideoRecorderMode.classic);
+    await tracker.publishFailed(
+      mode: VideoRecorderMode.classic,
+      reason: 'relay_publish_failed',
+    );
+    await tracker.creationAbandoned();
+
+    expect(sink.events.last.name, 'publish_failed');
+    expect(sink.events.last.parameters['reason'], 'relay_publish_failed');
+    expect(
+      sink.events.where((event) => event.name == 'creation_abandoned'),
+      isEmpty,
+    );
+  });
+
+  test('records camera when a draft editor opens the recorder later', () async {
+    final sink = _RecordingSink();
+    final tracker = CreationAnalyticsTracker(analytics: sink);
+
+    await tracker.editorOpened(VideoRecorderMode.stopMotion);
+    await tracker.cameraOpened(
+      mode: VideoRecorderMode.stopMotion,
+      entryPoint: 'editor',
+    );
+
+    expect(sink.events.map((event) => event.name), [
+      'editor_opened',
+      'camera_opened',
+    ]);
+    expect(sink.events.last.parameters, {
+      'mode': 'stopMotion',
+      'entry_point': 'editor',
+    });
+  });
+
+  test(
+    'does not invent camera elapsed time for an editor-only draft',
+    () async {
+      final sink = _RecordingSink();
+      var now = DateTime.utc(2026, 8, 8, 12);
+      final tracker = CreationAnalyticsTracker(analytics: sink, now: () => now);
+
+      await tracker.editorOpened(VideoRecorderMode.upload);
+      now = now.add(const Duration(minutes: 2));
+      await tracker.publishStarted(VideoRecorderMode.upload);
+
+      expect(sink.events.last.name, 'publish_started');
+      expect(sink.events.last.parameters['time_since_camera_open_ms'], 0);
+    },
+  );
+}

--- a/mobile/test/features/post_publish/post_publish_experiment_test.dart
+++ b/mobile/test/features/post_publish/post_publish_experiment_test.dart
@@ -1,0 +1,129 @@
+// ABOUTME: Tests deterministic post-publish assignment and CTA analytics.
+
+import 'package:analytics/analytics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/features/post_publish/post_publish_experiment.dart';
+
+class _FakeFlags implements PostPublishFlagClient {
+  _FakeFlags(this.createAgainEnabled);
+
+  @override
+  bool createAgainEnabled;
+
+  @override
+  void dispose() {}
+
+  @override
+  Future<void> initialize() async {}
+}
+
+class _RecordingSink implements AnalyticsEventSink {
+  final events = <({String name, Map<String, Object> parameters})>[];
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async => events.add((name: name, parameters: parameters));
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) async {}
+
+  @override
+  Future<void> setUserId(String? userId) async {}
+
+  @override
+  Future<void> setUserProperty({
+    required String name,
+    required String? value,
+  }) async {}
+}
+
+void main() {
+  const controlPubkey =
+      '0000000000000000000000000000000000000000000000000000000000000000';
+  const treatmentPubkey =
+      'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+
+  test('assigns the same user deterministically across calls', () {
+    final experiment = PostPublishExperiment(
+      flags: _FakeFlags(true),
+      analytics: _RecordingSink(),
+    );
+
+    expect(
+      experiment.variantForUser(controlPubkey),
+      PostPublishVariant.control,
+    );
+    expect(
+      experiment.variantForUser(treatmentPubkey),
+      PostPublishVariant.createAgain,
+    );
+    expect(
+      experiment.variantForUser(treatmentPubkey),
+      PostPublishVariant.createAgain,
+    );
+  });
+
+  test('remote flag forces every user into control', () {
+    final experiment = PostPublishExperiment(
+      flags: _FakeFlags(false),
+      analytics: _RecordingSink(),
+    );
+
+    expect(
+      experiment.variantForUser(treatmentPubkey),
+      PostPublishVariant.control,
+    );
+  });
+
+  test('records destination, variant, and seconds to create again', () async {
+    final sink = _RecordingSink();
+    var now = DateTime.utc(2026, 8, 8, 12);
+    final experiment = PostPublishExperiment(
+      flags: _FakeFlags(true),
+      analytics: sink,
+      now: () => now,
+    );
+
+    await experiment.screenShown(
+      publishId: 'publish-1',
+      destination: 'profile',
+      variant: PostPublishVariant.createAgain,
+    );
+    final offer = experiment.completed({'publish-1'});
+    expect(offer, isNotNull);
+    now = now.add(const Duration(seconds: 17));
+    await experiment.createAgainTapped(offer!);
+
+    expect(sink.events.map((event) => event.name), [
+      'post_publish_screen_shown',
+      'post_publish_create_again_tapped',
+    ]);
+    expect(sink.events.first.parameters, {
+      'destination': 'profile',
+      'variant': 'create_again',
+    });
+    expect(sink.events.last.parameters, {'seconds_since_publish': 17});
+  });
+
+  test('drops treatment state when a publish fails', () async {
+    final experiment = PostPublishExperiment(
+      flags: _FakeFlags(true),
+      analytics: _RecordingSink(),
+    );
+
+    await experiment.screenShown(
+      publishId: 'publish-failed',
+      destination: 'profile',
+      variant: PostPublishVariant.createAgain,
+    );
+    experiment.failed({'publish-failed'});
+
+    expect(experiment.completed({'publish-failed'}), isNull);
+  });
+}

--- a/mobile/test/features/post_publish/post_publish_experiment_test.dart
+++ b/mobile/test/features/post_publish/post_publish_experiment_test.dart
@@ -69,6 +69,18 @@ void main() {
     );
   });
 
+  test('assigns the same bucket regardless of hex casing', () {
+    final experiment = PostPublishExperiment(
+      flags: _FakeFlags(true),
+      analytics: _RecordingSink(),
+    );
+
+    expect(
+      experiment.variantForUser(treatmentPubkey.toUpperCase()),
+      experiment.variantForUser(treatmentPubkey),
+    );
+  });
+
   test('remote flag forces every user into control', () {
     final experiment = PostPublishExperiment(
       flags: _FakeFlags(false),

--- a/mobile/test/features/post_publish/post_publish_experiment_test.dart
+++ b/mobile/test/features/post_publish/post_publish_experiment_test.dart
@@ -111,6 +111,30 @@ void main() {
     expect(sink.events.last.parameters, {'seconds_since_publish': 17});
   });
 
+  test('bounds pending assignments that never resolve', () async {
+    final experiment = PostPublishExperiment(
+      flags: _FakeFlags(true),
+      analytics: _RecordingSink(),
+    );
+
+    await experiment.screenShown(
+      publishId: 'stranded',
+      destination: 'profile',
+      variant: PostPublishVariant.createAgain,
+    );
+    for (var i = 0; i < 32; i++) {
+      await experiment.screenShown(
+        publishId: 'publish-$i',
+        destination: 'profile',
+        variant: PostPublishVariant.createAgain,
+      );
+    }
+
+    // The oldest stranded entry is evicted; the newest 32 still resolve.
+    expect(experiment.completed({'stranded'}), isNull);
+    expect(experiment.completed({'publish-31'}), isNotNull);
+  });
+
   test('drops treatment state when a publish fails', () async {
     final experiment = PostPublishExperiment(
       flags: _FakeFlags(true),

--- a/mobile/test/providers/analytics_providers_test.dart
+++ b/mobile/test/providers/analytics_providers_test.dart
@@ -34,6 +34,13 @@ class _RecordingSink implements AnalyticsEventSink {
 void main() {
   const pubkey =
       '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+  const otherPubkey =
+      'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+
+  // The last applied identity is process-scoped, so it has to be reset between
+  // tests for the suite to be order-independent.
+  setUp(AnalyticsIdentityCoordinator.resetLastAppliedUserId);
+  tearDown(AnalyticsIdentityCoordinator.resetLastAppliedUserId);
 
   test('fans out the exact 64-character hex identity', () async {
     final sink = _RecordingSink();
@@ -64,6 +71,59 @@ void main() {
       (name: AnalyticsUserProperty.inviteCode, value: null),
     ]);
     expect(crashIds, [null]);
+  });
+
+  test('clears invite attribution when the account changes', () async {
+    final sink = _RecordingSink();
+    final coordinator = AnalyticsIdentityCoordinator(
+      analytics: sink,
+      setCrashUserId: (_) async {},
+    );
+
+    await coordinator.setUserId(pubkey);
+    expect(sink.properties, isEmpty);
+
+    // An account switch builds a fresh container, so the incoming account gets
+    // its own coordinator without ever passing through logout.
+    final switched = AnalyticsIdentityCoordinator(
+      analytics: sink,
+      setCrashUserId: (_) async {},
+    );
+    await switched.setUserId(otherPubkey);
+
+    expect(sink.userIds, [pubkey, otherPubkey]);
+    expect(sink.properties, [
+      (name: AnalyticsUserProperty.inviteCode, value: null),
+    ]);
+  });
+
+  test('keeps invite attribution set during the redeeming login', () async {
+    final sink = _RecordingSink();
+    final coordinator = AnalyticsIdentityCoordinator(
+      analytics: sink,
+      setCrashUserId: (_) async {},
+    );
+
+    // Redemption sets the property before the new account authenticates, and
+    // the sync provider can re-apply the same identity on a rebuild.
+    await coordinator.setUserId(pubkey);
+    await coordinator.setUserId(pubkey);
+
+    expect(sink.properties, isEmpty);
+  });
+
+  test('lowercases identities so the campaign join stays exact', () async {
+    final sink = _RecordingSink();
+    final crashIds = <String?>[];
+    final coordinator = AnalyticsIdentityCoordinator(
+      analytics: sink,
+      setCrashUserId: (userId) async => crashIds.add(userId),
+    );
+
+    await coordinator.setUserId(pubkey.toUpperCase());
+
+    expect(sink.userIds, [pubkey]);
+    expect(crashIds, [pubkey]);
   });
 
   test('refuses bech32 and malformed identities', () async {

--- a/mobile/test/providers/analytics_providers_test.dart
+++ b/mobile/test/providers/analytics_providers_test.dart
@@ -1,0 +1,82 @@
+// ABOUTME: Tests authenticated identity fan-out to Analytics and Crashlytics.
+
+import 'package:analytics/analytics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/providers/analytics_providers.dart';
+
+class _RecordingSink implements AnalyticsEventSink {
+  final userIds = <String?>[];
+  final properties = <({String name, String? value})>[];
+
+  @override
+  Future<void> setUserId(String? userId) async => userIds.add(userId);
+
+  @override
+  Future<void> setUserProperty({
+    required String name,
+    required String? value,
+  }) async => properties.add((name: name, value: value));
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async {}
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) async {}
+}
+
+void main() {
+  const pubkey =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+  test('fans out the exact 64-character hex identity', () async {
+    final sink = _RecordingSink();
+    final crashIds = <String?>[];
+    final coordinator = AnalyticsIdentityCoordinator(
+      analytics: sink,
+      setCrashUserId: (userId) async => crashIds.add(userId),
+    );
+
+    await coordinator.setUserId(pubkey);
+
+    expect(sink.userIds, [pubkey]);
+    expect(crashIds, [pubkey]);
+  });
+
+  test('clears user identity and invite attribution on logout', () async {
+    final sink = _RecordingSink();
+    final crashIds = <String?>[];
+    final coordinator = AnalyticsIdentityCoordinator(
+      analytics: sink,
+      setCrashUserId: (userId) async => crashIds.add(userId),
+    );
+
+    await coordinator.setUserId(null);
+
+    expect(sink.userIds, [null]);
+    expect(sink.properties, [
+      (name: AnalyticsUserProperty.inviteCode, value: null),
+    ]);
+    expect(crashIds, [null]);
+  });
+
+  test('refuses bech32 and malformed identities', () async {
+    final sink = _RecordingSink();
+    final crashIds = <String?>[];
+    final coordinator = AnalyticsIdentityCoordinator(
+      analytics: sink,
+      setCrashUserId: (userId) async => crashIds.add(userId),
+    );
+
+    await coordinator.setUserId('npub1not-a-hex-key');
+
+    expect(sink.userIds, isEmpty);
+    expect(crashIds, isEmpty);
+  });
+}

--- a/mobile/test/providers/auth_providers_test.dart
+++ b/mobile/test/providers/auth_providers_test.dart
@@ -54,7 +54,7 @@ void main() {
     });
   });
 
-  group('zendeskIdentitySyncProvider', () {
+  group('analyticsIdentitySyncProvider', () {
     const pubkey =
         '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
@@ -85,7 +85,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      container.read(zendeskIdentitySyncProvider);
+      container.read(analyticsIdentitySyncProvider);
       await Future<void>.delayed(Duration.zero);
 
       expect(analytics.userIds, [pubkey]);
@@ -96,6 +96,40 @@ void main() {
 
       expect(analytics.userIds, [pubkey, null]);
       expect(crashUserIds, [pubkey, null]);
+    });
+
+    test('does not depend on the Zendesk identity sync being read', () async {
+      final authStateController = StreamController<AuthState>.broadcast();
+      addTearDown(authStateController.close);
+      final authService = _MockAuthService();
+      when(() => authService.isAuthenticated).thenReturn(false);
+      when(() => authService.currentPublicKeyHex).thenReturn(null);
+      when(
+        () => authService.authStateStream,
+      ).thenAnswer((_) => authStateController.stream);
+
+      final analytics = _RecordingAnalytics();
+      final container = ProviderContainer(
+        overrides: [
+          authServiceProvider.overrideWithValue(authService),
+          profileRepositoryProvider.overrideWithValue(null),
+          analyticsIdentityCoordinatorProvider.overrideWithValue(
+            AnalyticsIdentityCoordinator(
+              analytics: analytics,
+              setCrashUserId: (_) async {},
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Only the analytics sync is read — the Zendesk provider stays cold.
+      container.read(analyticsIdentitySyncProvider);
+      when(() => authService.currentPublicKeyHex).thenReturn(pubkey);
+      authStateController.add(AuthState.authenticated);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(analytics.userIds, [pubkey]);
     });
   });
 }

--- a/mobile/test/providers/auth_providers_test.dart
+++ b/mobile/test/providers/auth_providers_test.dart
@@ -1,9 +1,44 @@
 // ABOUTME: Tests for authentication provider wiring.
 // ABOUTME: Guards secure storage options that affect session persistence.
 
+import 'dart:async';
+
+import 'package:analytics/analytics.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/repository_providers.dart';
+import 'package:openvine/services/auth_service.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _RecordingAnalytics implements AnalyticsEventSink {
+  final userIds = <String?>[];
+
+  @override
+  Future<void> setUserId(String? userId) async => userIds.add(userId);
+
+  @override
+  Future<void> setUserProperty({
+    required String name,
+    required String? value,
+  }) async {}
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async {}
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) async {}
+}
 
 void main() {
   group('flutterSecureStorageProvider', () {
@@ -16,6 +51,51 @@ void main() {
 
       expect(androidOptions['encryptedSharedPreferences'], 'true');
       expect(androidOptions['resetOnError'], 'false');
+    });
+  });
+
+  group('zendeskIdentitySyncProvider', () {
+    const pubkey =
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+    test('fans restored login identity out and clears it on logout', () async {
+      final authStateController = StreamController<AuthState>.broadcast();
+      addTearDown(authStateController.close);
+      final authService = _MockAuthService();
+      when(() => authService.isAuthenticated).thenReturn(true);
+      when(() => authService.currentPublicKeyHex).thenReturn(pubkey);
+      when(
+        () => authService.authStateStream,
+      ).thenAnswer((_) => authStateController.stream);
+
+      final analytics = _RecordingAnalytics();
+      final crashUserIds = <String?>[];
+      final identityCoordinator = AnalyticsIdentityCoordinator(
+        analytics: analytics,
+        setCrashUserId: (userId) async => crashUserIds.add(userId),
+      );
+      final container = ProviderContainer(
+        overrides: [
+          authServiceProvider.overrideWithValue(authService),
+          profileRepositoryProvider.overrideWithValue(null),
+          analyticsIdentityCoordinatorProvider.overrideWithValue(
+            identityCoordinator,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      container.read(zendeskIdentitySyncProvider);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(analytics.userIds, [pubkey]);
+      expect(crashUserIds, [pubkey]);
+
+      authStateController.add(AuthState.unauthenticated);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(analytics.userIds, [pubkey, null]);
+      expect(crashUserIds, [pubkey, null]);
     });
   });
 }

--- a/mobile/test/router/app_shell_chrome_freeze_test.dart
+++ b/mobile/test/router/app_shell_chrome_freeze_test.dart
@@ -44,6 +44,7 @@ List<Override> _overrides({
   relayStatisticsBridgeProvider.overrideWithValue(null),
   relaySetChangeBridgeProvider.overrideWithValue(null),
   zendeskIdentitySyncProvider.overrideWithValue(null),
+  analyticsIdentitySyncProvider.overrideWithValue(null),
   pushNotificationSyncProvider.overrideWithValue(null),
   blocklistSyncBridgeProvider.overrideWithValue(null),
   authServiceProvider.overrideWithValue(mockAuthService),

--- a/mobile/test/router/app_shell_notification_badge_test.dart
+++ b/mobile/test/router/app_shell_notification_badge_test.dart
@@ -62,6 +62,7 @@ Widget _buildSubject({
         relayStatisticsBridgeProvider.overrideWithValue(null),
         relaySetChangeBridgeProvider.overrideWithValue(null),
         zendeskIdentitySyncProvider.overrideWithValue(null),
+        analyticsIdentitySyncProvider.overrideWithValue(null),
         pushNotificationSyncProvider.overrideWithValue(null),
         blocklistSyncBridgeProvider.overrideWithValue(null),
         authServiceProvider.overrideWithValue(mockAuthService),

--- a/mobile/test/router/app_shell_obscured_test.dart
+++ b/mobile/test/router/app_shell_obscured_test.dart
@@ -48,6 +48,7 @@ List<Override> _overrides({
   relayStatisticsBridgeProvider.overrideWithValue(null),
   relaySetChangeBridgeProvider.overrideWithValue(null),
   zendeskIdentitySyncProvider.overrideWithValue(null),
+  analyticsIdentitySyncProvider.overrideWithValue(null),
   pushNotificationSyncProvider.overrideWithValue(null),
   blocklistSyncBridgeProvider.overrideWithValue(null),
   authServiceProvider.overrideWithValue(mockAuthService),

--- a/mobile/test/router/app_shell_own_profile_encoding_test.dart
+++ b/mobile/test/router/app_shell_own_profile_encoding_test.dart
@@ -44,6 +44,7 @@ List<Override> _overrides({
   relayStatisticsBridgeProvider.overrideWithValue(null),
   relaySetChangeBridgeProvider.overrideWithValue(null),
   zendeskIdentitySyncProvider.overrideWithValue(null),
+  analyticsIdentitySyncProvider.overrideWithValue(null),
   pushNotificationSyncProvider.overrideWithValue(null),
   blocklistSyncBridgeProvider.overrideWithValue(null),
   authServiceProvider.overrideWithValue(mockAuthService),

--- a/mobile/test/screens/comments/comments_screen_test.dart
+++ b/mobile/test/screens/comments/comments_screen_test.dart
@@ -52,6 +52,15 @@ class _RecordingAnalyticsEventSink implements AnalyticsEventSink {
   final events = <({String name, Map<String, Object> parameters})>[];
 
   @override
+  Future<void> setUserId(String? userId) async {}
+
+  @override
+  Future<void> setUserProperty({
+    required String name,
+    required String? value,
+  }) async {}
+
+  @override
   Future<void> logEvent({
     required String name,
     required Map<String, Object> parameters,

--- a/mobile/test/services/page_load_observer_test.dart
+++ b/mobile/test/services/page_load_observer_test.dart
@@ -17,6 +17,15 @@ class _RecordingAnalyticsEventSink implements AnalyticsEventSink {
       >[];
 
   @override
+  Future<void> setUserId(String? userId) async {}
+
+  @override
+  Future<void> setUserProperty({
+    required String name,
+    required String? value,
+  }) async {}
+
+  @override
   Future<void> logEvent({
     required String name,
     required Map<String, Object> parameters,

--- a/mobile/test/utils/camera_permission_check_test.dart
+++ b/mobile/test/utils/camera_permission_check_test.dart
@@ -90,7 +90,7 @@ void main() {
   void verifyNavigated() {
     verify(
       () => mockGoRouter.push<Object?>(
-        VideoRecorderScreen.path,
+        VideoRecorderScreen.pathForEntryPoint(CreationEntryPoint.cameraFab),
         extra: any(named: 'extra'),
       ),
     ).called(1);
@@ -99,7 +99,7 @@ void main() {
   void verifyNotNavigated() {
     verifyNever(
       () => mockGoRouter.push<Object?>(
-        VideoRecorderScreen.path,
+        VideoRecorderScreen.pathForEntryPoint(CreationEntryPoint.cameraFab),
         extra: any(named: 'extra'),
       ),
     );

--- a/mobile/test/widgets/upload_failure_listener_test.dart
+++ b/mobile/test/widgets/upload_failure_listener_test.dart
@@ -5,6 +5,7 @@
 
 import 'dart:async';
 
+import 'package:analytics/analytics.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -12,10 +13,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
+import 'package:openvine/features/post_publish/post_publish_experiment.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/main.dart' as app;
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/post_publish_providers.dart';
 import 'package:openvine/router/navigator_keys.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/video_publish/video_publish_service.dart';
@@ -39,6 +42,41 @@ class _FakeDraft extends Fake implements DivineVideoDraft {
   String get id => _id;
 }
 
+class _EnabledFlags implements PostPublishFlagClient {
+  @override
+  bool get createAgainEnabled => true;
+
+  @override
+  void dispose() {}
+
+  @override
+  Future<void> initialize() async {}
+}
+
+class _NoOpAnalytics implements AnalyticsEventSink {
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async {}
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) async {}
+
+  @override
+  Future<void> setUserId(String? userId) async {}
+
+  @override
+  Future<void> setUserProperty({
+    required String name,
+    required String? value,
+  }) async {}
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -54,9 +92,14 @@ Widget _buildHarness({
   required _MockBackgroundPublishBloc publishBloc,
   required _MockAuthService authService,
   bool wireRootNavigatorKey = true,
+  PostPublishExperiment? experiment,
 }) {
   return ProviderScope(
-    overrides: [authServiceProvider.overrideWithValue(authService)],
+    overrides: [
+      authServiceProvider.overrideWithValue(authService),
+      if (experiment != null)
+        postPublishExperimentProvider.overrideWithValue(experiment),
+    ],
     child: BlocProvider<BackgroundPublishBloc>.value(
       value: publishBloc,
       child: app.UploadFailureListener(
@@ -153,6 +196,38 @@ void main() {
       expect(tester.takeException(), isNull);
       final l10n = lookupAppLocalizations(const Locale('en'));
       expect(find.text(l10n.uploadPublishedCountMessage(2)), findsOneWidget);
+    });
+
+    testWidgets('shows create-again action for the treatment variant', (
+      tester,
+    ) async {
+      stubPublishBloc(const BackgroundPublishState());
+      when(() => authService.isAuthenticated).thenReturn(true);
+      final experiment = PostPublishExperiment(
+        flags: _EnabledFlags(),
+        analytics: _NoOpAnalytics(),
+      );
+      await experiment.screenShown(
+        publishId: 'draft-treatment',
+        destination: 'profile',
+        variant: PostPublishVariant.createAgain,
+      );
+
+      await tester.pumpWidget(
+        _buildHarness(
+          publishBloc: publishBloc,
+          authService: authService,
+          experiment: experiment,
+        ),
+      );
+
+      publishStream.add(_succeededState('draft-treatment'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.uploadPublishedCountMessage(1)), findsOneWidget);
+      expect(find.text(l10n.libraryRecordVideo), findsOneWidget);
     });
 
     testWidgets(

--- a/mobile/test/widgets/upload_failure_listener_test.dart
+++ b/mobile/test/widgets/upload_failure_listener_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/features/post_publish/post_publish_experiment.dart';
@@ -19,6 +20,7 @@ import 'package:openvine/main.dart' as app;
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/post_publish_providers.dart';
+import 'package:openvine/router/app_router.dart';
 import 'package:openvine/router/navigator_keys.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/video_publish/video_publish_service.dart';
@@ -41,6 +43,8 @@ class _FakeDraft extends Fake implements DivineVideoDraft {
   @override
   String get id => _id;
 }
+
+class _MockGoRouter extends Mock implements GoRouter {}
 
 class _EnabledFlags implements PostPublishFlagClient {
   @override
@@ -93,12 +97,14 @@ Widget _buildHarness({
   required _MockAuthService authService,
   bool wireRootNavigatorKey = true,
   PostPublishExperiment? experiment,
+  GoRouter? router,
 }) {
   return ProviderScope(
     overrides: [
       authServiceProvider.overrideWithValue(authService),
       if (experiment != null)
         postPublishExperimentProvider.overrideWithValue(experiment),
+      if (router != null) goRouterProvider.overrideWithValue(router),
     ],
     child: BlocProvider<BackgroundPublishBloc>.value(
       value: publishBloc,
@@ -124,9 +130,7 @@ BackgroundUpload _inProgress(String id) =>
 /// A [BackgroundPublishState] that carries success signals, with no remaining
 /// uploads — mirrors what the bloc emits on [PublishSuccess].
 BackgroundPublishState _succeededState(String id, [String? secondId]) =>
-    BackgroundPublishState(
-      recentlySucceededIds: {id, ?secondId},
-    );
+    BackgroundPublishState(recentlySucceededIds: {id, ?secondId});
 
 /// A [BackgroundPublishState] where upload [id] disappeared without a success
 /// signal — mirrors what the bloc emits on [BackgroundPublishVanished].
@@ -228,6 +232,50 @@ void main() {
       final l10n = lookupAppLocalizations(const Locale('en'));
       expect(find.text(l10n.uploadPublishedCountMessage(1)), findsOneWidget);
       expect(find.text(l10n.libraryRecordVideo), findsOneWidget);
+    });
+
+    testWidgets('create-again pushes the recorder over the payoff screen', (
+      tester,
+    ) async {
+      stubPublishBloc(const BackgroundPublishState());
+      when(() => authService.isAuthenticated).thenReturn(true);
+      final router = _MockGoRouter();
+      when(() => router.push<void>(any())).thenAnswer((_) async {});
+      final experiment = PostPublishExperiment(
+        flags: _EnabledFlags(),
+        analytics: _NoOpAnalytics(),
+      );
+      await experiment.screenShown(
+        publishId: 'draft-treatment',
+        destination: 'profile',
+        variant: PostPublishVariant.createAgain,
+      );
+
+      await tester.pumpWidget(
+        _buildHarness(
+          publishBloc: publishBloc,
+          authService: authService,
+          experiment: experiment,
+          router: router,
+        ),
+      );
+
+      publishStream.add(_succeededState('draft-treatment'));
+      await tester.pump();
+      // Let the snackbar finish sliding in so the action is hit-testable.
+      await tester.pump(const Duration(milliseconds: 750));
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.libraryRecordVideo), findsOneWidget);
+      await tester.tap(find.byType(SnackBarAction));
+      await tester.pump();
+
+      // `push`, not `go`: closing the recorder must pop back to the profile
+      // the experiment treats as the payoff, not reset to the feed.
+      verify(
+        () => router.push<void>('/video-recorder?entry_point=post_publish'),
+      ).called(1);
+      verifyNever(() => router.go(any()));
     });
 
     testWidgets(


### PR DESCRIPTION
## Description

Adds campaign-critical attribution by propagating the authenticated exact 64-character hex pubkey to Firebase Analytics and Crashlytics, setting invite-code attribution after successful redemption, and clearing account-scoped identity on logout. Records the complete creation funnel and adds a deterministic post-publish create-again experiment that preserves the existing profile payoff behind a Remote Config kill switch. Operational setup and end-to-end validation are documented in docs/ANALYTICS_OBSERVABILITY.md.

**Related Issue:** None

## Out of Scope

Dashboards, self-serve analytics, and new notification types.

## Verification

- [x] Pre-push generated-file verification, analyzer, and 499 changed-file tests
- [x] flutter analyze --no-pub
- [x] Analytics package test suite: 73 tests
- [x] Focused instrumentation, identity, auth, recorder, metadata, publish, routing, and UI suites: 352 tests
- [x] Golden verification and repository guard scripts
- [ ] Register event-scoped mode and user-scoped invite_code custom dimensions in GA4
- [ ] Publish post_publish_create_again_enabled = true in Remote Config; false is the live kill switch
- [ ] Publish from a test account and confirm BigQuery user_id is exact 64-character hex, matches the ClickHouse pubkey, and the full mode-attributed funnel is present

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore