### PR TITLE
test(flake): stop two suites failing on what ran before them

### DIFF
--- a/mobile/test/widgets/popular_videos_tab_test.dart
+++ b/mobile/test/widgets/popular_videos_tab_test.dart
@@ -201,6 +201,13 @@ void main() {
       );
       await tester.pumpAndSettle();
 
+      // A zero threshold makes the *first* load slow too, and whether that
+      // one spans a rebuild depends on how warm the isolate is — cold, the
+      // first page takes ~90ms and reports; warm, it lands inside a single
+      // build and does not. Only the variant switch is under test here, so
+      // the initial load is dropped rather than counted.
+      clearInteractions(errorTracker);
+
       final l10n = lookupAppLocalizations(const Locale('en'));
       await tester.tap(find.text(l10n.categoryGallerySortClassic));
       await tester.pump();

--- a/mobile/test/widgets/video_clip/clip_thumbnail_image_test.dart
+++ b/mobile/test/widgets/video_clip/clip_thumbnail_image_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Regression tests for #5796 — a missing clip thumbnail/ghost file
 // ABOUTME: must render a placeholder instead of surfacing PathNotFoundException.
 
+import 'dart:io';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -8,20 +10,27 @@ import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
 
 void main() {
   group(ClipThumbnailImage, () {
-    // Every test here resolves a deliberately missing file, and a failed
-    // resolution stays in the process-global cache. Under the merged-isolate
-    // test run that entry would outlive this file and deliver the error
-    // before the first build of any later test using the same path.
-    tearDown(() {
-      PaintingBinding.instance.imageCache
-        ..clear()
-        ..clearLiveImages();
-    });
+    // A failed resolution stays live in the process-global image cache, so
+    // each test evicts its own key and no two tests share a path. Clearing
+    // the whole cache instead also disposes what every other suite in the
+    // merged-isolate run put there, and `ImageCache` defers that disposal to
+    // a post-frame callback — it then lands in the *next* test's first frame
+    // as an `ImageInfo.dispose` assertion and fails a test that never
+    // touched an image.
+    void evictAfterTest(String path) {
+      addTearDown(
+        () => PaintingBinding.instance.imageCache.evict(FileImage(File(path))),
+      );
+    }
 
     Future<void> pumpMissingThumbnail(
-      WidgetTester tester, {
+      WidgetTester tester,
+      String path, {
       Widget? placeholder,
+      ImageFrameBuilder? frameBuilder,
     }) async {
+      evictAfterTest(path);
+
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -29,23 +38,42 @@ void main() {
               width: 120,
               height: 120,
               child: ClipThumbnailImage(
-                path: '/nonexistent/container/thumbnail_123.jpg',
+                path: path,
                 placeholder: placeholder,
+                frameBuilder: frameBuilder,
               ),
             ),
           ),
         ),
       );
-      await tester.runAsync(
-        () => Future<void>.delayed(const Duration(milliseconds: 100)),
-      );
-      await tester.pump();
+    }
+
+    // Resolving the file is real I/O, so the failure needs real time to
+    // arrive. Polled rather than slept on: a single fixed delay is a coin
+    // flip once the CI box is running four shards at once.
+    Future<void> pumpUntil(
+      WidgetTester tester,
+      bool Function() resolved,
+    ) async {
+      for (var attempt = 0; attempt < 50 && !resolved(); attempt++) {
+        await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 20)),
+        );
+        await tester.pump();
+      }
     }
 
     testWidgets('renders the neutral placeholder for a missing file', (
       tester,
     ) async {
-      await pumpMissingThumbnail(tester);
+      await pumpMissingThumbnail(
+        tester,
+        '/nonexistent/container/neutral_thumbnail.jpg',
+      );
+      await pumpUntil(
+        tester,
+        () => find.byType(DivineIcon).evaluate().isNotEmpty,
+      );
 
       expect(tester.takeException(), isNull);
       expect(find.byType(DivineIcon), findsOneWidget);
@@ -59,8 +87,10 @@ void main() {
 
       await pumpMissingThumbnail(
         tester,
+        '/nonexistent/container/custom_thumbnail.jpg',
         placeholder: const SizedBox.shrink(key: marker),
       );
+      await pumpUntil(tester, () => find.byKey(marker).evaluate().isNotEmpty);
 
       expect(tester.takeException(), isNull);
       expect(find.byKey(marker), findsOneWidget);
@@ -73,29 +103,17 @@ void main() {
       (tester) async {
         const marker = Key('frame-builder');
 
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Scaffold(
-              body: SizedBox(
-                width: 120,
-                height: 120,
-                child: ClipThumbnailImage(
-                  path: '/nonexistent/container/frame_builder_probe.jpg',
-                  placeholder: const SizedBox.shrink(),
-                  frameBuilder: (context, child, frame, _) =>
-                      SizedBox(key: marker, child: child),
-                ),
-              ),
-            ),
-          ),
+        await pumpMissingThumbnail(
+          tester,
+          '/nonexistent/container/frame_builder_probe.jpg',
+          placeholder: const SizedBox.shrink(),
+          frameBuilder: (context, child, frame, _) =>
+              SizedBox(key: marker, child: child),
         );
 
         expect(find.byKey(marker), findsOneWidget);
 
-        await tester.runAsync(
-          () => Future<void>.delayed(const Duration(milliseconds: 100)),
-        );
-        await tester.pump();
+        await pumpUntil(tester, () => find.byKey(marker).evaluate().isEmpty);
 
         expect(tester.takeException(), isNull);
         expect(find.byKey(marker), findsNothing);


### PR DESCRIPTION
Closes #6875

Two suites fail intermittently in CI. They look like one problem ("video tests are flaky") but have nothing in common except that both are invisible outside the merged VGV isolate, where every untagged suite shares one binding and one process-global state.

## `ClipThumbnailImage renders a custom placeholder for a missing file`

The CI log shows the assertion never got that far: `takeException()` returned *"Multiple exceptions (2) were detected"*, and both were the same framework assert, raised inside `pumpWidget`'s warm-up frame:

```
ImageInfo.dispose → ImageStreamCompleter._maybeDispose
  → ImageStreamCompleterHandle.dispose
  → _CachedImageBase.dispose.<anonymous closure>   ← post-frame callback
  → SchedulerBinding.handleDrawFrame
  → AutomatedTestWidgetsFlutterBinding.scheduleWarmUpFrame
```

The suite's `tearDown` called `imageCache.clear()` + `clearLiveImages()`. That is the *process-global* cache — in the merged isolate it holds whatever the ~800 suites that ran before put there. And `_CachedImageBase.dispose()` does not dispose the handle itself; it defers it via `addPostFrameCallback`. After a `tearDown` no further frame is pumped, so the callback fires in the **next** test's first frame and fails a test that never touched an image. In the failing run the shuffle put the frameBuilder test immediately before the custom-placeholder one, so the latter caught it.

Verified with a throwaway suite: with a foreign entry in the cache, `clear() + clearLiveImages()` takes it `1 → 0`; the targeted `evict(FileImage(...))` leaves it at `1 → 1`.

Each test now owns its own path and evicts only that key, so the suite can no longer reap anything it did not create. The fixed `Future.delayed(100ms)` is polled instead — resolving a missing file is real I/O, and a single fixed sleep is a coin flip once four shards share a runner.

## `PopularVideosTab reports a slow variant switch once, not once per rebuild`

Reproduces deterministically when run alone (5/5 red) and passes in the full file, which is the signature of a warm-up dependency rather than a race.

`slowLoadThresholdMs: 0` makes the *initial* load slow as well. Cold, that load takes ~90ms and spans several rebuilds, so `_trackSlowLoadIfNeeded` reports once for it; the variant switch then clears `_feedLoadStartTime`, which resets `_slowFeedLoadReported`, and reports again — two calls, asserted as one (confirmed by flipping the assertion to `.called(2)`). Warm, the first page lands inside a single build with `elapsed == 0` and never reports, so the count is one and the suite is green.

No production bug here: reporting a slow first load is the intended behaviour, and the per-load guard works. The test was just measuring both loads while claiming to measure the switch. Clearing the interactions recorded before the tap scopes the count to the switch.

## Test plan

- `flutter test test/widgets/popular_videos_tab_test.dart --plain-name 'reports a slow variant switch once'` — 5/5 red before, 3/3 green after (this is the cold-isolate path).
- `flutter test test/widgets/popular_videos_tab_test.dart` — 3/3 green (warm path).
- `flutter test test/widgets/video_clip/clip_thumbnail_image_test.dart --test-randomize-ordering-seed=1..6` — green on every seed.
- Both files together — green.
- `dart format` clean, `flutter analyze` clean on both files.

Test-only change; no app code is touched and there is nothing to verify on a device.