### PR TITLE
test(helpers): give each test process its own path_provider directories

### DIFF
--- a/mobile/test/helpers/real_integration_test_helper.dart
+++ b/mobile/test/helpers/real_integration_test_helper.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Helper utilities for real integration tests without over-mocking
 // ABOUTME: Provides real Nostr relay connections and minimal platform channel mocking
 
+import 'dart:io';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_client/nostr_client.dart';
@@ -14,6 +16,32 @@ import 'shared_channel_override.dart';
 /// Only mocks platform channels that can't be tested, uses real Nostr connections
 class RealIntegrationTestHelper {
   static bool _isSetup = false;
+
+  /// Per-process root for the directories `path_provider` hands back.
+  ///
+  /// `very_good test --optimization` runs the merged bundle and every
+  /// `skip_very_good_optimization` file as *separate, concurrent* processes.
+  /// These paths were hardcoded to `/tmp/test_documents` and
+  /// `/tmp/test_support`, so every one of those processes resolved to the
+  /// same directory — and therefore the same Hive boxes on disk.
+  ///
+  /// Sixteen suites open the `pending_uploads` box; eleven live in the
+  /// bundle and five run standalone. When a standalone suite called
+  /// `Hive.deleteBoxFromDisk('pending_uploads')` while a bundled one was
+  /// reading it, whichever lost the race failed on a box it did not mutate —
+  /// a seed-dependent failure with no connection to the diff under test.
+  /// Keying the root on the process id removes the shared resource.
+  static final Directory _processRoot = Directory.systemTemp.createTempSync(
+    'divine_test_${pid}_',
+  );
+
+  static final Directory _documentsDirectory = Directory(
+    '${_processRoot.path}/documents',
+  )..createSync(recursive: true);
+
+  static final Directory _supportDirectory = Directory(
+    '${_processRoot.path}/support',
+  )..createSync(recursive: true);
 
   static const MethodChannel _prefsChannel = MethodChannel(
     'plugins.flutter.io/shared_preferences',
@@ -135,13 +163,13 @@ class RealIntegrationTestHelper {
 
     overrideSharedChannel(_pathProviderChannel, (MethodCall methodCall) async {
       if (methodCall.method == 'getApplicationDocumentsDirectory') {
-        return '/tmp/test_documents';
+        return _documentsDirectory.path;
       }
       if (methodCall.method == 'getTemporaryDirectory') {
         return '/tmp';
       }
       if (methodCall.method == 'getApplicationSupportDirectory') {
-        return '/tmp/test_support';
+        return _supportDirectory.path;
       }
       return null;
     });

--- a/mobile/test/helpers/real_integration_test_helper.dart
+++ b/mobile/test/helpers/real_integration_test_helper.dart
@@ -20,7 +20,7 @@ class RealIntegrationTestHelper {
   /// Per-process root for the directories `path_provider` hands back.
   ///
   /// `very_good test --optimization` runs the merged bundle and every
-  /// `skip_very_good_optimization` file as *separate, concurrent* processes.
+  /// VGV-skip-tagged file as *separate, concurrent* processes.
   /// These paths were hardcoded to `/tmp/test_documents` and
   /// `/tmp/test_support`, so every one of those processes resolved to the
   /// same directory — and therefore the same Hive boxes on disk.

--- a/mobile/test/widgets/user_profile_tile_layout_test.dart
+++ b/mobile/test/widgets/user_profile_tile_layout_test.dart
@@ -649,10 +649,9 @@ void _setupPlatformMocks() {
     'plugins.flutter.io/path_provider',
   );
   // Per-process directories, not the shared `/tmp/test_*` these used to
-  // return: very_good runs the merged bundle and each
-  // skip_very_good_optimization file concurrently, and a shared path puts
-  // them all on the same Hive boxes on disk. See
-  // RealIntegrationTestHelper._processRoot.
+  // return: very_good runs the merged bundle and each VGV-skip-tagged
+  // file concurrently, and a shared path puts them all on the same Hive
+  // boxes on disk. See RealIntegrationTestHelper._processRoot.
   final processRoot = Directory.systemTemp.createTempSync(
     'divine_tile_layout_${pid}_',
   );

--- a/mobile/test/widgets/user_profile_tile_layout_test.dart
+++ b/mobile/test/widgets/user_profile_tile_layout_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Layout-focused TDD tests for UserProfileTile addressing widget display bugs
 // ABOUTME: Tests responsive layout, element positioning, state visibility, and edge case rendering
 
+import 'dart:io';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -646,14 +648,26 @@ void _setupPlatformMocks() {
   const MethodChannel pathProviderChannel = MethodChannel(
     'plugins.flutter.io/path_provider',
   );
+  // Per-process directories, not the shared `/tmp/test_*` these used to
+  // return: very_good runs the merged bundle and each
+  // skip_very_good_optimization file concurrently, and a shared path puts
+  // them all on the same Hive boxes on disk. See
+  // RealIntegrationTestHelper._processRoot.
+  final processRoot = Directory.systemTemp.createTempSync(
+    'divine_tile_layout_${pid}_',
+  );
   overrideSharedChannel(pathProviderChannel, (call) async {
     if (call.method == 'getApplicationDocumentsDirectory') {
-      return '/tmp/test_documents';
+      return (Directory(
+        '${processRoot.path}/documents',
+      )..createSync(recursive: true)).path;
     }
     if (call.method == 'getApplicationSupportDirectory') {
-      return '/tmp/test_support';
+      return (Directory(
+        '${processRoot.path}/support',
+      )..createSync(recursive: true)).path;
     }
-    return '/tmp/test';
+    return processRoot.path;
   });
 
   // Connectivity mock


### PR DESCRIPTION
Refs #6879

## Description

The shared test harness used fixed `path_provider` directories for every unit-test process:

```dart
getApplicationDocumentsDirectory -> /tmp/documents
getApplicationSupportDirectory -> /tmp/support
getTemporaryDirectory -> /tmp
```

`very_good test --optimization` runs the merged bundle plus each `skip_very_good_optimization` file as separate concurrent processes. With fixed directories, those processes could share Hive boxes, Drift databases, and other filesystem-backed test state.

This PR moves the canonical test `path_provider` directories under a per-process root created by `Directory.systemTemp.createTempSync('divine_test_${pid}_')`. The app-facing `PathProviderPlatform.instance` mock and the raw MethodChannel handler now resolve to the same process-local `temporary`, `documents`, and `support` directories.

## Change

- Key the canonical `path_provider` test directories on the current process id in `test_setup.dart`.
- Keep the raw MethodChannel path provider handler aligned with `PathProviderPlatform.instance`.
- Remove two hand-rolled path provider MethodChannel overrides that duplicated the canonical handler.
- Add contract coverage for the per-process directories and MethodChannel/platform-instance agreement.
- Move `draft_storage_service_test.dart` off fixed `/tmp/documents` so its recursive cleanup only deletes that test's own temp tree.
- Extend the heal-and-blame harness to restore a leaked `PathProviderPlatform.instance`, matching its existing shared-channel guard.
- Fix stale comments left behind by removing path provider overrides.
- Delete the per-process root at the end of the suite, so a run does not leave
  its Hive boxes and databases in the system temp directory.
- Keep the harness compiling on the web platform: the per-process root is
  filesystem work, and `flutter_test_config.dart` runs for web suites too.

## What this does not claim

It is not established that this fully fixes the shard-2 flake tracked in #6879. The original PR diagnosis named some suites and timing details that did not hold up after review: the first two edits were on a dead path because `path_provider` resolves through `PathProviderPlatform.instance`, and the standalone upload suites already redirect the platform instance to their own temp directories before touching Hive.

What does hold up: the canonical test harness really did use fixed `/tmp` paths, and at least one bundled suite still recursively deleted `/tmp/documents`. This PR removes that shared filesystem resource and the nearby fixed-path cleanup pattern. Keep #6879 open until shard 2 stays green over enough runs to prove the broader flake is gone.

## Verification

- `flutter test test/services/draft_storage_service_test.dart`
- `flutter test test/test_setup_test.dart test/helpers/shared_channel_override_test.dart`
- `flutter analyze lib test integration_test`
- `very_good test --optimization --concurrency=4 --exclude-tags integration`
- `CHROME_EXECUTABLE=... flutter test --platform chrome test/utils/path_resolver_test.dart test/test_setup_test.dart`

## Type of Change

- [x] Bug fix (test infrastructure)

