### PR TITLE
fix(a11y): honour reduced motion in tab transitions and the recorder mode wheel

### DIFF
--- a/mobile/lib/extensions/media_query_extensions.dart
+++ b/mobile/lib/extensions/media_query_extensions.dart
@@ -1,0 +1,74 @@
+// ABOUTME: BuildContext shorthands for the MediaQuery metrics read most often,
+// ABOUTME: plus Duration.autoReduceMotion for gating animation lengths on them.
+// ABOUTME: Each getter forwards to the aspect-scoped MediaQuery.xxxOf form.
+
+import 'package:flutter/widgets.dart';
+
+/// Shorthands for the handful of `MediaQuery` metrics this app reads
+/// everywhere.
+///
+/// Every getter forwards to the matching `MediaQuery.xxxOf(context)`, so the
+/// reader only rebuilds when that one metric changes. Reaching for
+/// `MediaQuery.of(context).size` instead subscribes the widget to every
+/// metric — a keyboard opening then rebuilds a widget that only cared about
+/// the screen size.
+///
+/// Deliberately partial. Only the metrics with real call-site pressure live
+/// here; rarer ones (`orientation`, `platformBrightness`, `boldText`, …) stay
+/// explicit `MediaQuery.xxxOf` calls so this doesn't drift into a second copy
+/// of the `MediaQuery` API.
+extension MediaQueryExtensions on BuildContext {
+  /// Whether the platform asked for reduced motion.
+  ///
+  /// Gate animations on this and fall back to `Duration.zero` or a static
+  /// frame — see `.claude/rules/accessibility.md`.
+  bool get reduceMotion => MediaQuery.disableAnimationsOf(this);
+
+  /// System text scaling to apply to font sizes.
+  TextScaler get textScaler => MediaQuery.textScalerOf(this);
+
+  /// Size of the media in logical pixels — the window, not this widget.
+  ///
+  /// Named `screenSize` rather than `size` because `BuildContext.size`
+  /// already means the render box's own size.
+  Size get screenSize => MediaQuery.sizeOf(this);
+
+  /// Display areas obscured by system UI, with anything already covered by
+  /// [viewInsets] (typically the keyboard) subtracted out.
+  EdgeInsets get padding => MediaQuery.paddingOf(this);
+
+  /// Display areas obscured by system UI, ignoring [viewInsets].
+  ///
+  /// Prefer this over [padding] for layout that must not jump when the
+  /// keyboard opens.
+  EdgeInsets get viewPadding => MediaQuery.viewPaddingOf(this);
+
+  /// Display areas fully obscured by system UI — in practice, the keyboard.
+  EdgeInsets get viewInsets => MediaQuery.viewInsetsOf(this);
+
+  /// Physical pixels per logical pixel.
+  double get devicePixelRatio => MediaQuery.devicePixelRatioOf(this);
+}
+
+/// Lets an animation length opt into the platform's reduced-motion setting.
+extension ReduceMotionDuration on Duration {
+  /// This duration, or [Duration.zero] when [BuildContext.reduceMotion] is on.
+  ///
+  /// ```dart
+  /// AnimatedContainer(
+  ///   duration: const Duration(milliseconds: 200).autoReduceMotion(context),
+  /// )
+  /// ```
+  ///
+  /// A zero duration makes implicit animations jump straight to their target,
+  /// which is what reduced motion asks for. Use this for tweens between two
+  /// legible states; an animation whose *end* state is the only readable one
+  /// (a spinner, a marquee) needs a static replacement instead, not a
+  /// zero-length run.
+  ///
+  /// Not every API tolerates a zero duration. `ScrollPosition.animateTo`
+  /// asserts `duration > Duration.zero`, so scroll positions have to branch on
+  /// [BuildContext.reduceMotion] and call `jumpTo` instead.
+  Duration autoReduceMotion(BuildContext context) =>
+      context.reduceMotion ? Duration.zero : this;
+}

--- a/mobile/lib/extensions/media_query_extensions.dart
+++ b/mobile/lib/extensions/media_query_extensions.dart
@@ -1,11 +1,10 @@
-// ABOUTME: BuildContext shorthands for the MediaQuery metrics read most often,
+// ABOUTME: BuildContext shorthands for the MediaQuery metrics this PR uses,
 // ABOUTME: plus Duration.autoReduceMotion for gating animation lengths on them.
 // ABOUTME: Each getter forwards to the aspect-scoped MediaQuery.xxxOf form.
 
 import 'package:flutter/widgets.dart';
 
-/// Shorthands for the handful of `MediaQuery` metrics this app reads
-/// everywhere.
+/// Shorthands for `MediaQuery` metrics this app reads often.
 ///
 /// Every getter forwards to the matching `MediaQuery.xxxOf(context)`, so the
 /// reader only rebuilds when that one metric changes. Reaching for
@@ -13,10 +12,8 @@ import 'package:flutter/widgets.dart';
 /// metric — a keyboard opening then rebuilds a widget that only cared about
 /// the screen size.
 ///
-/// Deliberately partial. Only the metrics with real call-site pressure live
-/// here; rarer ones (`orientation`, `platformBrightness`, `boldText`, …) stay
-/// explicit `MediaQuery.xxxOf` calls so this doesn't drift into a second copy
-/// of the `MediaQuery` API.
+/// Deliberately partial. Add new shorthands only alongside production call
+/// sites, so this does not drift into a second copy of the `MediaQuery` API.
 extension MediaQueryExtensions on BuildContext {
   /// Whether the platform asked for reduced motion.
   ///
@@ -26,28 +23,6 @@ extension MediaQueryExtensions on BuildContext {
 
   /// System text scaling to apply to font sizes.
   TextScaler get textScaler => MediaQuery.textScalerOf(this);
-
-  /// Size of the media in logical pixels — the window, not this widget.
-  ///
-  /// Named `screenSize` rather than `size` because `BuildContext.size`
-  /// already means the render box's own size.
-  Size get screenSize => MediaQuery.sizeOf(this);
-
-  /// Display areas obscured by system UI, with anything already covered by
-  /// [viewInsets] (typically the keyboard) subtracted out.
-  EdgeInsets get padding => MediaQuery.paddingOf(this);
-
-  /// Display areas obscured by system UI, ignoring [viewInsets].
-  ///
-  /// Prefer this over [padding] for layout that must not jump when the
-  /// keyboard opens.
-  EdgeInsets get viewPadding => MediaQuery.viewPaddingOf(this);
-
-  /// Display areas fully obscured by system UI — in practice, the keyboard.
-  EdgeInsets get viewInsets => MediaQuery.viewInsetsOf(this);
-
-  /// Physical pixels per logical pixel.
-  double get devicePixelRatio => MediaQuery.devicePixelRatioOf(this);
 }
 
 /// Lets an animation length opt into the platform's reduced-motion setting.

--- a/mobile/lib/mixins/reduced_motion_tab_controller_mixin.dart
+++ b/mobile/lib/mixins/reduced_motion_tab_controller_mixin.dart
@@ -1,0 +1,107 @@
+// ABOUTME: Owns a TabController whose animation length follows the platform's
+// ABOUTME: reduced-motion setting, rebuilding it when that or the tab count
+// ABOUTME: changes and carrying the open tab and listener across.
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:openvine/extensions/media_query_extensions.dart';
+
+/// Owns a [TabController] that honours the platform's reduced-motion setting.
+///
+/// [TabController.animationDuration] drives both the [TabBar] indicator slide
+/// and the [TabBarView] page transition, and Flutter short-circuits both when
+/// it is [Duration.zero] — but it is fixed at construction. Reacting to a
+/// mid-session toggle therefore means building a replacement controller, which
+/// is what [syncTabController] does. It handles the same swap for a changed
+/// [tabCount], so screens with conditional tabs need only the one call.
+///
+/// Requires [TickerProviderStateMixin] rather than
+/// `SingleTickerProviderStateMixin`, which permits only one ticker per State
+/// and throws on the second controller.
+///
+/// ```dart
+/// class _MyViewState extends State<MyView>
+///     with TickerProviderStateMixin, ReducedMotionTabControllerMixin {
+///   @override
+///   int get tabCount => 3;
+///
+///   @override
+///   void onTabChanged() => setState(() {});
+///
+///   @override
+///   void didChangeDependencies() {
+///     super.didChangeDependencies();
+///     syncTabController();
+///   }
+///
+///   @override
+///   Widget build(BuildContext context) =>
+///       TabBar(controller: tabController, tabs: ...);
+/// }
+/// ```
+mixin ReducedMotionTabControllerMixin<T extends StatefulWidget>
+    on State<T>, TickerProviderStateMixin<T> {
+  TabController? _tabController;
+
+  /// The current controller.
+  ///
+  /// Valid from the first [syncTabController] call until `dispose`, so call
+  /// that from `didChangeDependencies` before the first `build`.
+  TabController get tabController => _tabController!;
+
+  /// How many tabs the controller should carry. Re-read on every sync.
+  int get tabCount;
+
+  /// Tab the *first* controller opens on — a restored or deep-linked tab.
+  ///
+  /// Later rebuilds carry the open tab over instead, so this is read once.
+  int get initialTabIndex => 0;
+
+  /// Invoked on every [TabController] notification.
+  ///
+  /// The mixin moves this across controller rebuilds, so implementers never
+  /// add or remove the listener themselves.
+  void onTabChanged() {}
+
+  /// Installs a controller matching [tabCount] and the current reduced-motion
+  /// setting, keeping the existing one when it already matches.
+  ///
+  /// Opens on [index] when given, otherwise carries the open tab over — or
+  /// [initialTabIndex] on the first sync — clamped into the new range. Returns
+  /// whether a new controller was installed.
+  ///
+  /// Call this from `didChangeDependencies` — that is what picks up a
+  /// reduced-motion toggle — and again wherever [tabCount] can change.
+  bool syncTabController({int? index}) {
+    final duration = kTabScrollDuration.autoReduceMotion(context);
+    final previous = _tabController;
+    if (previous != null &&
+        previous.length == tabCount &&
+        previous.animationDuration == duration &&
+        (index == null || index == previous.index)) {
+      return false;
+    }
+    _tabController = TabController(
+      length: tabCount,
+      vsync: this,
+      initialIndex: (index ?? previous?.index ?? initialTabIndex).clamp(
+        0,
+        math.max(0, tabCount - 1),
+      ),
+      animationDuration: duration,
+    )..addListener(onTabChanged);
+    previous
+      ?..removeListener(onTabChanged)
+      ..dispose();
+    return true;
+  }
+
+  @override
+  void dispose() {
+    _tabController
+      ?..removeListener(onTabChanged)
+      ..dispose();
+    super.dispose();
+  }
+}

--- a/mobile/lib/notifications/view/inbox_notifications_page.dart
+++ b/mobile/lib/notifications/view/inbox_notifications_page.dart
@@ -12,6 +12,7 @@ import 'package:models/models.dart';
 import 'package:notification_repository/notification_repository.dart';
 import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/mixins/reduced_motion_tab_controller_mixin.dart';
 import 'package:openvine/notifications/bloc/notification_feed_bloc.dart';
 import 'package:openvine/notifications/providers/notification_repository_provider.dart';
 import 'package:openvine/notifications/view/notifications_view.dart';
@@ -63,14 +64,13 @@ class _InboxNotificationsScaffold extends StatefulWidget {
 
 class _InboxNotificationsScaffoldState
     extends State<_InboxNotificationsScaffold>
-    with SingleTickerProviderStateMixin {
-  late final TabController _tabController;
-  static const _tabCount = 5;
+    with TickerProviderStateMixin, ReducedMotionTabControllerMixin {
+  @override
+  int get tabCount => 5;
 
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: _tabCount, vsync: this);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       context.read<InviteStatusCubit>().load();
@@ -78,9 +78,9 @@ class _InboxNotificationsScaffoldState
   }
 
   @override
-  void dispose() {
-    _tabController.dispose();
-    super.dispose();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    syncTabController();
   }
 
   @override
@@ -97,7 +97,7 @@ class _InboxNotificationsScaffoldState
             Material(
               type: MaterialType.transparency,
               child: TabBar(
-                controller: _tabController,
+                controller: tabController,
                 isScrollable: true,
                 tabAlignment: TabAlignment.start,
                 padding: const EdgeInsetsDirectional.only(start: 16),
@@ -125,7 +125,7 @@ class _InboxNotificationsScaffoldState
             ),
             Expanded(
               child: TabBarView(
-                controller: _tabController,
+                controller: tabController,
                 children: [
                   _NotificationTab(
                     notificationRepository: widget.notificationRepository,

--- a/mobile/lib/screens/explore/explore_view.dart
+++ b/mobile/lib/screens/explore/explore_view.dart
@@ -10,6 +10,7 @@ import 'package:openvine/blocs/explore_tabs/explore_tabs_cubit.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/mixins/reduced_motion_tab_controller_mixin.dart';
 import 'package:openvine/providers/classic_vines_provider.dart';
 import 'package:openvine/providers/for_you_provider.dart';
 import 'package:openvine/providers/route_feed_providers.dart';
@@ -38,46 +39,51 @@ class ExploreView extends ConsumerStatefulWidget {
 }
 
 class _ExploreViewState extends ConsumerState<ExploreView>
-    with TickerProviderStateMixin {
-  TabController? _tabController;
+    with TickerProviderStateMixin, ReducedMotionTabControllerMixin {
   // Feed mode and videos are derived from URL + providers - no internal state.
 
   ExploreTabsCubit get _tabs => context.read<ExploreTabsCubit>();
   ExploreTabsState get _tabsState => _tabs.state;
 
-  /// Build a new [TabController]. [previousTabName] is the name of the tab the
-  /// user was on before a rebuild (resolved while the old availability flags
-  /// were still in effect). Resolution order:
+  @override
+  int get tabCount => _tabsState.tabCount;
+
+  @override
+  int get initialTabIndex => _indexForTabName();
+
+  /// Index the controller should open on, resolved by name.
+  ///
+  /// [previousTabName] is the tab the user was on before a rebuild (resolved
+  /// while the old availability flags were still in effect). Resolution order:
   /// [ExploreView.initialTabName] > previous tab > persisted tab > default.
   /// Falls back by name — never by raw index, because indices shift when
   /// optional tabs appear or disappear.
-  void _initTabController({String? previousTabName}) {
+  int _indexForTabName({String? previousTabName}) {
     final targetTabName =
         widget.initialTabName ??
         previousTabName ??
         ref.read(exploreTabNameProvider) ??
         exploreDefaultTabName;
-    final initialIndex = _tabsState.indexForName(targetTabName);
+    final index = _tabsState.indexForName(targetTabName);
 
     Log.info(
-      '🎯 ExploreScreen: Using tab "$targetTabName" -> index $initialIndex',
+      '🎯 ExploreScreen: Using tab "$targetTabName" -> index $index',
       name: 'ExploreScreen',
       category: LogCategory.ui,
     );
 
-    _tabController = TabController(
-      length: _tabsState.tabCount,
-      vsync: this,
-      initialIndex: initialIndex,
-    );
-    _tabController!.addListener(_onTabChanged);
+    return index;
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    syncTabController();
   }
 
   @override
   void initState() {
     super.initState();
-
-    _initTabController();
 
     // Track Explore-specific data load completion from child tabs.
     _tabs.trackScreenLoad();
@@ -110,23 +116,17 @@ class _ExploreViewState extends ConsumerState<ExploreView>
     }
   }
 
-  @override
-  void dispose() {
-    _tabController?.removeListener(_onTabChanged);
-    _tabController?.dispose();
-    super.dispose();
-  }
-
   void _openSearchPage() {
     context.push(
       SearchResultsPage.pathForEmptyQuery(requestFocusOnMount: true),
     );
   }
 
-  void _onTabChanged() {
-    if (!mounted || _tabController == null) return;
+  @override
+  void onTabChanged() {
+    if (!mounted) return;
 
-    final index = _tabController!.index;
+    final index = tabController.index;
     final tabName = _tabsState.nameForIndex(index);
 
     // Persist the selected tab by stable name because optional tabs can shift
@@ -176,14 +176,10 @@ class _ExploreViewState extends ConsumerState<ExploreView>
     if (_tabsState != previousState) {
       // Resolve the current tab name using the PREVIOUS state, because indices
       // are about to shift.
-      final previousTabName = previousState.nameForIndex(
-        _tabController?.index ?? 0,
+      final previousTabName = previousState.nameForIndex(tabController.index);
+      syncTabController(
+        index: _indexForTabName(previousTabName: previousTabName),
       );
-
-      _tabController?.removeListener(_onTabChanged);
-      final oldController = _tabController;
-      _initTabController(previousTabName: previousTabName);
-      oldController?.dispose();
     }
 
     // Derive feed mode from URL
@@ -228,7 +224,7 @@ class _ExploreViewState extends ConsumerState<ExploreView>
                   children: [
                     const SizedBox(height: 12),
                     ExploreTabBar(
-                      controller: _tabController,
+                      controller: tabController,
                       tabsState: _tabsState,
                       onTap: _onTabTap,
                     ),
@@ -246,7 +242,7 @@ class _ExploreViewState extends ConsumerState<ExploreView>
   void _onTabTap(int index) {
     // Tapping the active tab exits feed/hashtag mode; otherwise switching tabs
     // resets to grid mode if needed.
-    if (index == _tabController?.index) {
+    if (index == tabController.index) {
       final isInFeedMode =
           ref
               .read(pageContextProvider)
@@ -277,7 +273,7 @@ class _ExploreViewState extends ConsumerState<ExploreView>
             }
 
             return ExploreTabView(
-              controller: _tabController,
+              controller: tabController,
               tabsState: _tabsState,
             );
           },

--- a/mobile/lib/screens/explore/widgets/explore_tab_bar.dart
+++ b/mobile/lib/screens/explore/widgets/explore_tab_bar.dart
@@ -22,7 +22,7 @@ class ExploreTabBar extends StatelessWidget {
   });
 
   /// Controller driving tab selection; must match [tabsState.tabCount].
-  final TabController? controller;
+  final TabController controller;
 
   /// Current tab availability/order.
   final ExploreTabsState tabsState;

--- a/mobile/lib/screens/explore/widgets/explore_tab_view.dart
+++ b/mobile/lib/screens/explore/widgets/explore_tab_view.dart
@@ -25,7 +25,7 @@ class ExploreTabView extends StatelessWidget {
   });
 
   /// Controller driving tab selection; must match [tabsState.tabCount].
-  final TabController? controller;
+  final TabController controller;
 
   /// Current tab availability/order.
   final ExploreTabsState tabsState;
@@ -50,18 +50,17 @@ class ExploreTabView extends StatelessWidget {
           ],
         ),
         // New videos banner only shows on the New Videos and Trending tabs.
-        if (controller != null)
-          AnimatedBuilder(
-            animation: controller!,
-            builder: (context, _) {
-              final currentIndex = controller!.index;
-              if (currentIndex == tabsState.newVideosIndex ||
-                  currentIndex == tabsState.trendingIndex) {
-                return const ExploreBufferedVideosBanner();
-              }
-              return const SizedBox.shrink();
-            },
-          ),
+        AnimatedBuilder(
+          animation: controller,
+          builder: (context, _) {
+            final currentIndex = controller.index;
+            if (currentIndex == tabsState.newVideosIndex ||
+                currentIndex == tabsState.trendingIndex) {
+              return const ExploreBufferedVideosBanner();
+            }
+            return const SizedBox.shrink();
+          },
+        ),
       ],
     );
   }

--- a/mobile/lib/screens/library_screen.dart
+++ b/mobile/lib/screens/library_screen.dart
@@ -10,6 +10,7 @@ import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/clips_library/clips_library_bloc.dart';
 import 'package:openvine/blocs/drafts_library/drafts_library_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/mixins/reduced_motion_tab_controller_mixin.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/models/video_publish/video_publish_state.dart';
@@ -163,9 +164,15 @@ class _LibraryView extends ConsumerStatefulWidget {
 }
 
 class _LibraryViewState extends ConsumerState<_LibraryView>
-    with SingleTickerProviderStateMixin {
-  late final TabController _tabController;
+    with TickerProviderStateMixin, ReducedMotionTabControllerMixin {
   late int _activeTabIndex;
+
+  @override
+  int get tabCount => _isClipsOnlyMode ? 1 : 3;
+
+  @override
+  int get initialTabIndex =>
+      _isClipsOnlyMode ? 0 : widget.initialTabIndex.clamp(0, 2);
 
   bool get _isClipsOnlyMode =>
       widget.selectionMode || widget.tabsMode == LibraryTabsMode.clipsOnly;
@@ -184,15 +191,7 @@ class _LibraryViewState extends ConsumerState<_LibraryView>
   @override
   void initState() {
     super.initState();
-    final initialIndex = _isClipsOnlyMode
-        ? 0
-        : widget.initialTabIndex.clamp(0, 2);
-    _activeTabIndex = initialIndex;
-    _tabController = TabController(
-      length: _isClipsOnlyMode ? 1 : 3,
-      initialIndex: initialIndex,
-      vsync: this,
-    )..addListener(_onTabChanged);
+    _activeTabIndex = initialTabIndex;
 
     Log.info(
       '📚 ClipLibrary opened (selectionMode: ${widget.selectionMode})',
@@ -202,22 +201,22 @@ class _LibraryViewState extends ConsumerState<_LibraryView>
   }
 
   @override
-  void dispose() {
-    _tabController.removeListener(_onTabChanged);
-    _tabController.dispose();
-    super.dispose();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    syncTabController();
   }
 
-  void _onTabChanged() {
+  @override
+  void onTabChanged() {
     if (!mounted) return;
-    if (_activeTabIndex == _tabController.index) return;
+    if (_activeTabIndex == tabController.index) return;
     setState(() {
-      _activeTabIndex = _tabController.index;
+      _activeTabIndex = tabController.index;
     });
 
     final clipsBloc = context.read<ClipsLibraryBloc>();
     final clipsState = clipsBloc.state;
-    final isClipsTabActive = _isClipsOnlyMode || _tabController.index == 1;
+    final isClipsTabActive = _isClipsOnlyMode || tabController.index == 1;
     if (!widget.selectionMode &&
         !_isClipsOnlyMode &&
         clipsState.isLibrarySelectionMode &&
@@ -532,7 +531,7 @@ class _LibraryViewState extends ConsumerState<_LibraryView>
                         Expanded(
                           child: _LibraryContent(
                             isClipsOnlyMode: _isClipsOnlyMode,
-                            tabController: _tabController,
+                            tabController: tabController,
                             selectionMode: widget.selectionMode,
                             scrollController: widget.scrollController,
                             targetAspectRatio: targetAspectRatio,

--- a/mobile/lib/screens/library_screen.dart
+++ b/mobile/lib/screens/library_screen.dart
@@ -207,6 +207,14 @@ class _LibraryViewState extends ConsumerState<_LibraryView>
   }
 
   @override
+  void didUpdateWidget(_LibraryView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // selectionMode and tabsMode decide the tab count, so a flip needs a
+    // matching controller before build renders the TabBar against it.
+    if (syncTabController()) _activeTabIndex = tabController.index;
+  }
+
+  @override
   void onTabChanged() {
     if (!mounted) return;
     if (_activeTabIndex == tabController.index) return;

--- a/mobile/lib/widgets/profile/profile_grid.dart
+++ b/mobile/lib/widgets/profile/profile_grid.dart
@@ -17,6 +17,7 @@ import 'package:openvine/blocs/profile_liked_videos/profile_liked_videos_bloc.da
 import 'package:openvine/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+import 'package:openvine/mixins/reduced_motion_tab_controller_mixin.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/profile_tab_index_provider.dart';
@@ -121,8 +122,15 @@ class ProfileGridView extends ConsumerStatefulWidget {
 }
 
 class _ProfileGridViewState extends ConsumerState<ProfileGridView>
-    with TickerProviderStateMixin {
-  late TabController _tabController;
+    with TickerProviderStateMixin, ReducedMotionTabControllerMixin {
+  @override
+  int get tabCount => _tabKinds.length;
+
+  /// Restores the previously selected tab so navigating back from a fullscreen
+  /// video doesn't drop the user on Videos. The mixin clamps it.
+  @override
+  int get initialTabIndex =>
+      ref.read(profileTabIndexProvider)[_tabIndexKey] ?? 0;
 
   /// Direct references to BLoCs for refresh capability.
   ProfileLikedVideosBloc? _likedVideosBloc;
@@ -148,7 +156,7 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
   /// Videos reads the [ProfileFeedCubit]'s refreshing flag, passed in from
   /// [build] because that cubit is provided by the ancestor `ProfileFeedScope`.
   bool _activeTabRefreshing(bool videosRefreshing) =>
-      switch (_tabKinds[_tabController.index]) {
+      switch (_tabKinds[tabController.index]) {
         ProfileTabKind.videos => videosRefreshing,
         ProfileTabKind.liked => _likedRefreshing,
         ProfileTabKind.reposts => _repostsRefreshing,
@@ -202,18 +210,13 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
   @override
   void initState() {
     super.initState();
-    // Restore the previously selected tab index (if any) so navigating back
-    // from a fullscreen video doesn't drop the user on the Videos tab.
-    final tabCount = _tabKinds.length;
-    final restoredIndex = (ref.read(profileTabIndexProvider)[_tabIndexKey] ?? 0)
-        .clamp(0, tabCount - 1);
-    _tabController = TabController(
-      length: tabCount,
-      vsync: this,
-      initialIndex: restoredIndex,
-    );
-    _tabController.addListener(_onTabChanged);
     widget.refreshNotifier?.addListener(_onRefreshRequested);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    syncTabController();
   }
 
   @override
@@ -223,21 +226,12 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
       oldWidget.refreshNotifier?.removeListener(_onRefreshRequested);
       widget.refreshNotifier?.addListener(_onRefreshRequested);
     }
-    final tabCount = _tabKinds.length;
-    if (_tabController.length != tabCount) {
-      final restoredIndex = _tabController.index.clamp(0, tabCount - 1);
-      _tabController.removeListener(_onTabChanged);
-      _tabController.dispose();
-      _tabController = TabController(
-        length: tabCount,
-        vsync: this,
-        initialIndex: restoredIndex,
-      );
-      _tabController.addListener(_onTabChanged);
-    }
+    // An own↔other flip changes the tab set (#5213).
+    syncTabController();
   }
 
-  void _onTabChanged() {
+  @override
+  void onTabChanged() {
     // Trigger rebuild to update SVG icon colors
     if (mounted) setState(() {});
 
@@ -245,7 +239,7 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
     // transitions that briefly take the URL off the profile route) can
     // restore the user to the tab they were on.
     final notifier = ref.read(profileTabIndexProvider.notifier);
-    notifier.state = {...notifier.state, _tabIndexKey: _tabController.index};
+    notifier.state = {...notifier.state, _tabIndexKey: tabController.index};
 
     _syncCurrentTabIfNeeded();
   }
@@ -255,7 +249,7 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
   /// triggered after BLoCs are created on first build — [_onTabChanged]
   /// doesn't fire for the initial [TabController] index.
   void _syncCurrentTabIfNeeded() {
-    final kind = _tabKinds[_tabController.index];
+    final kind = _tabKinds[tabController.index];
     if (_syncedKinds.contains(kind)) return;
     switch (kind) {
       case ProfileTabKind.videos:
@@ -379,8 +373,6 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
   @override
   void dispose() {
     widget.refreshNotifier?.removeListener(_onRefreshRequested);
-    _tabController.removeListener(_onTabChanged);
-    _tabController.dispose();
     _likedRefreshSub?.cancel();
     _repostsRefreshSub?.cancel();
     _collabsRefreshSub?.cancel();
@@ -585,7 +577,7 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
       child: ColoredBox(
         color: context.vineColors.surfaceContainerHigh,
         child: TabBarView(
-          controller: _tabController,
+          controller: tabController,
           children: [for (final kind in _tabKinds) _gridForKind(kind)],
         ),
       ),
@@ -642,7 +634,7 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
 
                 // Sticky Tab Bar
                 ProfileTabBar(
-                  controller: _tabController,
+                  controller: tabController,
                   scrollController: widget.scrollController,
                   tabs: [
                     for (final kind in _tabKinds) _tabPresentationFor(kind),

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
@@ -10,6 +10,7 @@ import 'package:models/models.dart' show AudioEvent, VineSound;
 import 'package:openvine/blocs/saved_sounds/saved_sounds_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/mixins/reduced_motion_tab_controller_mixin.dart';
 import 'package:openvine/providers/sound_library_service_provider.dart';
 import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
@@ -97,7 +98,7 @@ class AudioSelectionBottomSheet extends ConsumerStatefulWidget {
 
 class _AudioSelectionBottomSheetState
     extends ConsumerState<AudioSelectionBottomSheet>
-    with SingleTickerProviderStateMixin {
+    with TickerProviderStateMixin, ReducedMotionTabControllerMixin {
   late final AudioPlaybackService _audioService;
   final _searchController = TextEditingController();
   String? _loadedSoundId;
@@ -106,29 +107,32 @@ class _AudioSelectionBottomSheetState
   String _searchQuery = '';
   bool _isLoadingAudio = false;
 
-  late final _tabController = TabController(
-    length: AudioCategory.values.length,
-    vsync: this,
-  );
+  @override
+  int get tabCount => AudioCategory.values.length;
 
   @override
   void initState() {
     super.initState();
     _audioService = widget.audioService ?? AudioPlaybackService();
-    _tabController.addListener(_onTabChanged);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    syncTabController();
   }
 
   @override
   void dispose() {
     _audioService.dispose();
     _searchController.dispose();
-    _tabController.dispose();
     super.dispose();
   }
 
-  void _onTabChanged() {
-    if (_tabController.indexIsChanging) return;
-    final newCategory = AudioCategory.values[_tabController.index];
+  @override
+  void onTabChanged() {
+    if (tabController.indexIsChanging) return;
+    final newCategory = AudioCategory.values[tabController.index];
     if (_category != newCategory) {
       setState(() => _category = newCategory);
     }
@@ -137,7 +141,7 @@ class _AudioSelectionBottomSheetState
   void _selectCategory(AudioCategory category) {
     setState(() {
       _category = category;
-      _tabController.animateTo(
+      tabController.animateTo(
         AudioCategory.values.indexWhere((el) => el == category),
       );
     });
@@ -464,7 +468,7 @@ class _AudioSelectionBottomSheetState
             _ImportAudioAction(onTap: _importAudio),
             Expanded(
               child: TabBarView(
-                controller: _tabController,
+                controller: tabController,
                 children: [
                   _SoundsContent(
                     scrollController: widget.scrollController,

--- a/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
@@ -103,7 +103,10 @@ class _VideoRecorderModeSelectorWheelState
     _scrollController.jumpTo(_snapOffsets[index]);
   }
 
-  Future<void> _animateTo(int index) async {
+  /// Scrolls the wheel to centre [index], animating unless reduced motion is
+  /// on. Unlike [_jumpTo] it holds [_isSnapping] for the whole move, so the
+  /// scroll it drives doesn't re-enter [_snapToNearest].
+  Future<void> _moveTo(int index) async {
     if (!_scrollController.hasClients) return;
     _isSnapping = true;
 
@@ -152,7 +155,7 @@ class _VideoRecorderModeSelectorWheelState
   }
 
   void _selectIndex(int index, {bool animate = false}) {
-    if (animate) _animateTo(index);
+    if (animate) _moveTo(index);
     if (index == _selectedIndex) return;
     setState(() => _selectedIndex = index);
     HapticFeedback.selectionClick();
@@ -294,7 +297,7 @@ class _VideoRecorderModeSelectorWheelState
                             behavior: HitTestBehavior.opaque,
                             onTap: () {
                               _selectIndex(i, animate: true);
-                              if (!_isSnapping) _animateTo(i);
+                              if (!_isSnapping) _moveTo(i);
                             },
                             child: Center(
                               child: AnimatedDefaultTextStyle(

--- a/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
@@ -4,6 +4,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:openvine/constants/semantic_ids.dart';
+import 'package:openvine/extensions/media_query_extensions.dart';
 import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
 
 /// Horizontal picker-wheel mode selector.
@@ -50,6 +51,10 @@ class _VideoRecorderModeSelectorWheelState
   /// label, so consecutive labels stay [_labelGap] apart no matter how much
   /// their text widths differ.
   static const double _labelGap = 44.0;
+
+  /// Shared length of the snap scroll, the pill resize, and the label colour
+  /// tween — the three run together and must stay in step.
+  static const Duration _animationDuration = Duration(milliseconds: 200);
 
   @override
   void initState() {
@@ -102,11 +107,17 @@ class _VideoRecorderModeSelectorWheelState
     if (!_scrollController.hasClients) return;
     _isSnapping = true;
 
-    await _scrollController.animateTo(
-      _snapOffsets[index],
-      duration: const Duration(milliseconds: 200),
-      curve: Curves.easeInOut,
-    );
+    // Jump rather than animate to a zero duration — `animateTo` asserts on
+    // `Duration.zero`, so `autoReduceMotion` is not usable on this one.
+    if (context.reduceMotion) {
+      _scrollController.jumpTo(_snapOffsets[index]);
+    } else {
+      await _scrollController.animateTo(
+        _snapOffsets[index],
+        duration: _animationDuration,
+        curve: Curves.easeInOut,
+      );
+    }
     _isSnapping = false;
   }
 
@@ -194,9 +205,7 @@ class _VideoRecorderModeSelectorWheelState
   @override
   Widget build(BuildContext context) {
     const modes = VideoRecorderMode.values;
-    final textScaler = MediaQuery.textScalerOf(
-      context,
-    ).clamp(maxScaleFactor: 1.3);
+    final textScaler = context.textScaler.clamp(maxScaleFactor: 1.3);
     final itemWidths = _itemWidths(textScaler);
     _snapOffsets = _snapOffsetsFor(itemWidths);
     final pendingJumpIndex = _pendingJumpIndex;
@@ -221,7 +230,7 @@ class _VideoRecorderModeSelectorWheelState
               // Fixed pill — always centered, width follows selected label.
               IgnorePointer(
                 child: AnimatedContainer(
-                  duration: const Duration(milliseconds: 200),
+                  duration: _animationDuration.autoReduceMotion(context),
                   curve: Curves.easeInOut,
                   height: _pillHeight,
                   width: _pillWidth(modes[_selectedIndex].label, textScaler),
@@ -289,7 +298,9 @@ class _VideoRecorderModeSelectorWheelState
                             },
                             child: Center(
                               child: AnimatedDefaultTextStyle(
-                                duration: const Duration(milliseconds: 200),
+                                duration: _animationDuration.autoReduceMotion(
+                                  context,
+                                ),
                                 style: VineTheme.titleSmallFont(
                                   color: isSelected
                                       ? isLight

--- a/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
@@ -297,7 +297,6 @@ class _VideoRecorderModeSelectorWheelState
                             behavior: HitTestBehavior.opaque,
                             onTap: () {
                               _selectIndex(i, animate: true);
-                              if (!_isSnapping) _moveTo(i);
                             },
                             child: Center(
                               child: AnimatedDefaultTextStyle(

--- a/mobile/test/extensions/media_query_extensions_test.dart
+++ b/mobile/test/extensions/media_query_extensions_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/extensions/media_query_extensions.dart';
+
+void main() {
+  group('MediaQueryExtensions', () {
+    const data = MediaQueryData(
+      size: Size(390, 844),
+      devicePixelRatio: 3,
+      textScaler: TextScaler.linear(1.4),
+      disableAnimations: true,
+      viewPadding: EdgeInsets.only(top: 47, bottom: 34),
+      padding: EdgeInsets.only(top: 47),
+      viewInsets: EdgeInsets.only(bottom: 336),
+    );
+
+    Future<BuildContext> pumpContext(
+      WidgetTester tester,
+      MediaQueryData data,
+    ) async {
+      late BuildContext captured;
+      await tester.pumpWidget(
+        MediaQuery(
+          data: data,
+          child: Builder(
+            builder: (context) {
+              captured = context;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+      return captured;
+    }
+
+    testWidgets('reads scalar metrics from the ambient $MediaQuery', (
+      tester,
+    ) async {
+      final context = await pumpContext(tester, data);
+
+      expect(context.reduceMotion, isTrue);
+      expect(context.textScaler, equals(const TextScaler.linear(1.4)));
+      expect(context.screenSize, equals(const Size(390, 844)));
+      expect(context.devicePixelRatio, equals(3.0));
+    });
+
+    testWidgets('keeps padding, viewPadding and viewInsets distinct', (
+      tester,
+    ) async {
+      final context = await pumpContext(tester, data);
+
+      expect(context.padding, equals(const EdgeInsets.only(top: 47)));
+      expect(
+        context.viewPadding,
+        equals(const EdgeInsets.only(top: 47, bottom: 34)),
+      );
+      expect(context.viewInsets, equals(const EdgeInsets.only(bottom: 336)));
+    });
+
+    testWidgets('depends only on the metric it reads', (tester) async {
+      // The child is const so it is identical across pumps — the only thing
+      // that can rebuild it is the inherited metric it depends on.
+      _ReduceMotionProbe.buildCount = 0;
+      Widget build(MediaQueryData data) =>
+          MediaQuery(data: data, child: const _ReduceMotionProbe());
+
+      await tester.pumpWidget(build(data));
+      expect(_ReduceMotionProbe.buildCount, equals(1));
+
+      // An unrelated metric changing must not wake a reduce-motion reader.
+      // Reading through MediaQuery.of(context) instead would rebuild here.
+      await tester.pumpWidget(build(data.copyWith(devicePixelRatio: 2)));
+      expect(_ReduceMotionProbe.buildCount, equals(1));
+
+      await tester.pumpWidget(build(data.copyWith(disableAnimations: false)));
+      expect(_ReduceMotionProbe.buildCount, equals(2));
+    });
+  });
+
+  group('ReduceMotionDuration', () {
+    Future<BuildContext> pumpContext(
+      WidgetTester tester, {
+      required bool reduceMotion,
+    }) async {
+      late BuildContext captured;
+      await tester.pumpWidget(
+        MediaQuery(
+          data: MediaQueryData(disableAnimations: reduceMotion),
+          child: Builder(
+            builder: (context) {
+              captured = context;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+      return captured;
+    }
+
+    testWidgets('collapses to zero when reduced motion is on', (tester) async {
+      final context = await pumpContext(tester, reduceMotion: true);
+
+      expect(
+        const Duration(milliseconds: 200).autoReduceMotion(context),
+        equals(Duration.zero),
+      );
+    });
+
+    testWidgets('keeps the duration when reduced motion is off', (
+      tester,
+    ) async {
+      final context = await pumpContext(tester, reduceMotion: false);
+
+      expect(
+        const Duration(milliseconds: 200).autoReduceMotion(context),
+        equals(const Duration(milliseconds: 200)),
+      );
+    });
+  });
+}
+
+/// Counts its own builds so a test can assert which metric changes reach it.
+class _ReduceMotionProbe extends StatelessWidget {
+  const _ReduceMotionProbe();
+
+  static int buildCount = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    buildCount++;
+    return SizedBox.square(dimension: context.reduceMotion ? 1 : 2);
+  }
+}

--- a/mobile/test/extensions/media_query_extensions_test.dart
+++ b/mobile/test/extensions/media_query_extensions_test.dart
@@ -5,13 +5,8 @@ import 'package:openvine/extensions/media_query_extensions.dart';
 void main() {
   group('MediaQueryExtensions', () {
     const data = MediaQueryData(
-      size: Size(390, 844),
-      devicePixelRatio: 3,
       textScaler: TextScaler.linear(1.4),
       disableAnimations: true,
-      viewPadding: EdgeInsets.only(top: 47, bottom: 34),
-      padding: EdgeInsets.only(top: 47),
-      viewInsets: EdgeInsets.only(bottom: 336),
     );
 
     Future<BuildContext> pumpContext(
@@ -33,28 +28,11 @@ void main() {
       return captured;
     }
 
-    testWidgets('reads scalar metrics from the ambient $MediaQuery', (
-      tester,
-    ) async {
+    testWidgets('reads metrics from the ambient $MediaQuery', (tester) async {
       final context = await pumpContext(tester, data);
 
       expect(context.reduceMotion, isTrue);
       expect(context.textScaler, equals(const TextScaler.linear(1.4)));
-      expect(context.screenSize, equals(const Size(390, 844)));
-      expect(context.devicePixelRatio, equals(3.0));
-    });
-
-    testWidgets('keeps padding, viewPadding and viewInsets distinct', (
-      tester,
-    ) async {
-      final context = await pumpContext(tester, data);
-
-      expect(context.padding, equals(const EdgeInsets.only(top: 47)));
-      expect(
-        context.viewPadding,
-        equals(const EdgeInsets.only(top: 47, bottom: 34)),
-      );
-      expect(context.viewInsets, equals(const EdgeInsets.only(bottom: 336)));
     });
 
     testWidgets('depends only on the metric it reads', (tester) async {
@@ -69,7 +47,9 @@ void main() {
 
       // An unrelated metric changing must not wake a reduce-motion reader.
       // Reading through MediaQuery.of(context) instead would rebuild here.
-      await tester.pumpWidget(build(data.copyWith(devicePixelRatio: 2)));
+      await tester.pumpWidget(
+        build(data.copyWith(textScaler: const TextScaler.linear(1.2))),
+      );
       expect(_ReduceMotionProbe.buildCount, equals(1));
 
       await tester.pumpWidget(build(data.copyWith(disableAnimations: false)));

--- a/mobile/test/mixins/reduced_motion_tab_controller_mixin_test.dart
+++ b/mobile/test/mixins/reduced_motion_tab_controller_mixin_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/mixins/reduced_motion_tab_controller_mixin.dart';
+
+void main() {
+  group('ReducedMotionTabControllerMixin', () {
+    Future<_HostState> pumpHost(
+      WidgetTester tester, {
+      bool reduceMotion = false,
+      int tabCount = 3,
+      int initialTabIndex = 0,
+    }) async {
+      await tester.pumpWidget(
+        MediaQuery(
+          data: MediaQueryData(disableAnimations: reduceMotion),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: _Host(
+              tabCount: tabCount,
+              initialTabIndex: initialTabIndex,
+            ),
+          ),
+        ),
+      );
+      return tester.state<_HostState>(find.byType(_Host));
+    }
+
+    testWidgets('opens on initialTabIndex with the default duration', (
+      tester,
+    ) async {
+      final host = await pumpHost(tester, initialTabIndex: 2);
+
+      expect(host.tabController.index, equals(2));
+      expect(host.tabController.animationDuration, equals(kTabScrollDuration));
+    });
+
+    testWidgets('collapses the duration when reduced motion is on', (
+      tester,
+    ) async {
+      final host = await pumpHost(tester, reduceMotion: true);
+
+      expect(host.tabController.animationDuration, equals(Duration.zero));
+    });
+
+    testWidgets('clamps initialTabIndex into range', (tester) async {
+      final host = await pumpHost(tester, tabCount: 2, initialTabIndex: 7);
+
+      expect(host.tabController.index, equals(1));
+    });
+
+    testWidgets('reuses the controller when nothing changed', (tester) async {
+      final host = await pumpHost(tester);
+      final first = host.tabController;
+
+      expect(host.syncTabController(), isFalse);
+      expect(host.tabController, same(first));
+    });
+
+    testWidgets('swaps the controller when reduced motion is toggled', (
+      tester,
+    ) async {
+      final host = await pumpHost(tester);
+      host.tabController.index = 2;
+      final first = host.tabController;
+
+      await pumpHost(tester, reduceMotion: true);
+
+      expect(host.tabController, isNot(same(first)));
+      expect(host.tabController.animationDuration, equals(Duration.zero));
+      // The open tab survives the swap.
+      expect(host.tabController.index, equals(2));
+    });
+
+    testWidgets('carries the open tab across a tab-count change, clamped', (
+      tester,
+    ) async {
+      final host = await pumpHost(tester, tabCount: 4);
+      host.tabController.index = 3;
+
+      host
+        ..tabCount = 2
+        ..syncTabController();
+
+      expect(host.tabController.length, equals(2));
+      expect(host.tabController.index, equals(1));
+    });
+
+    testWidgets('moves onTabChanged onto the replacement controller', (
+      tester,
+    ) async {
+      final host = await pumpHost(tester);
+      await pumpHost(tester, reduceMotion: true);
+      host.changes = 0;
+
+      host.tabController.index = 1;
+
+      expect(host.changes, greaterThan(0));
+    });
+
+    testWidgets('disposes the controller it owns', (tester) async {
+      final host = await pumpHost(tester);
+      final controller = host.tabController;
+
+      await tester.pumpWidget(const SizedBox.shrink());
+
+      // A disposed TabController drops its animation.
+      expect(controller.animation, isNull);
+    });
+  });
+}
+
+class _Host extends StatefulWidget {
+  const _Host({required this.tabCount, required this.initialTabIndex});
+
+  final int tabCount;
+  final int initialTabIndex;
+
+  @override
+  State<_Host> createState() => _HostState();
+}
+
+class _HostState extends State<_Host>
+    with TickerProviderStateMixin, ReducedMotionTabControllerMixin {
+  int? _tabCountOverride;
+  int changes = 0;
+
+  @override
+  int get tabCount => _tabCountOverride ?? widget.tabCount;
+
+  set tabCount(int value) => _tabCountOverride = value;
+
+  @override
+  int get initialTabIndex => widget.initialTabIndex;
+
+  @override
+  void onTabChanged() => changes++;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    syncTabController();
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/mobile/test/notifications/view/inbox_notifications_page_test.dart
+++ b/mobile/test/notifications/view/inbox_notifications_page_test.dart
@@ -51,7 +51,7 @@ void main() {
       when(mockInviteCubit.load).thenAnswer((_) async {});
     });
 
-    Widget buildSubject() {
+    Widget buildSubject({bool reduceMotion = false}) {
       return testMaterialApp(
         mockFollowRepository: mockFollowRepo,
         additionalOverrides: [
@@ -59,9 +59,16 @@ void main() {
             mockNotificationRepo,
           ),
         ],
-        home: BlocProvider<InviteStatusCubit>.value(
-          value: mockInviteCubit,
-          child: Scaffold(body: const InboxNotificationsPage()),
+        home: Builder(
+          builder: (context) => MediaQuery(
+            data: MediaQuery.of(
+              context,
+            ).copyWith(disableAnimations: reduceMotion),
+            child: BlocProvider<InviteStatusCubit>.value(
+              value: mockInviteCubit,
+              child: Scaffold(body: const InboxNotificationsPage()),
+            ),
+          ),
         ),
       );
     }
@@ -160,6 +167,56 @@ void main() {
 
       verifyNever(() => mockNotificationRepo.refreshFeed(null));
       verifyNever(() => mockNotificationRepo.markAllAsRead());
+    });
+
+    group('reduced motion', () {
+      TabController controller(WidgetTester tester) =>
+          tester.widget<TabBar>(find.byType(TabBar)).controller!;
+
+      testWidgets('switches tabs without sliding the indicator or the page', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildSubject(reduceMotion: true));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byType(Tab).at(3));
+        await tester.pump();
+
+        // The controller's animation drives both the indicator slide and the
+        // TabBarView page offset, so landing on the target in the first frame
+        // is the whole transition resolving instantly.
+        expect(controller(tester).animation!.value, equals(3.0));
+        expect(controller(tester).indexIsChanging, isFalse);
+      });
+
+      testWidgets('still animates when reduced motion is off', (tester) async {
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byType(Tab).at(3));
+        await tester.pump();
+
+        expect(controller(tester).animation!.value, lessThan(3.0));
+        await tester.pumpAndSettle();
+        expect(controller(tester).animation!.value, equals(3.0));
+      });
+
+      testWidgets('keeps the open tab when the setting is toggled', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+        await tester.tap(find.byType(Tab).at(2));
+        await tester.pumpAndSettle();
+
+        // The controller is rebuilt to pick up the new duration; the tab the
+        // user was reading must survive that swap.
+        await tester.pumpWidget(buildSubject(reduceMotion: true));
+        await tester.pumpAndSettle();
+
+        expect(controller(tester).index, equals(2));
+        expect(controller(tester).animationDuration, equals(Duration.zero));
+      });
     });
 
     group('invite banner', () {

--- a/mobile/test/widgets/video_recorder/video_recorder_mode_selector_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_mode_selector_test.dart
@@ -23,11 +23,21 @@ void main() {
       modeChanges = [];
     });
 
-    Widget buildWidget({VideoRecorderMode? mode, ThemeData? theme}) {
+    Widget buildWidget({
+      VideoRecorderMode? mode,
+      ThemeData? theme,
+      bool reduceMotion = false,
+    }) {
       return MaterialApp(
         theme: theme,
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
+        builder: (context, child) => MediaQuery(
+          data: MediaQuery.of(
+            context,
+          ).copyWith(disableAnimations: reduceMotion),
+          child: child!,
+        ),
         home: Scaffold(
           body: Center(
             child: SizedBox(
@@ -46,12 +56,15 @@ void main() {
       WidgetTester tester, {
       VideoRecorderMode? mode,
       ThemeData? theme,
+      bool reduceMotion = false,
     }) async {
       tester.view.physicalSize = const Size(surfaceWidth, 400);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
       addTearDown(tester.view.resetDevicePixelRatio);
-      await tester.pumpWidget(buildWidget(mode: mode, theme: theme));
+      await tester.pumpWidget(
+        buildWidget(mode: mode, theme: theme, reduceMotion: reduceMotion),
+      );
       await tester.pumpAndSettle();
     }
 
@@ -237,6 +250,29 @@ void main() {
             greaterThanOrEqualTo(kMinInteractiveDimension),
           );
         }
+      });
+
+      testWidgets('under reduced motion the pill resizes without tweening', (
+        tester,
+      ) async {
+        await pumpSelector(
+          tester,
+          mode: VideoRecorderMode.capture,
+          reduceMotion: true,
+        );
+        double pillWidth() =>
+            tester.getSize(find.byType(AnimatedContainer)).width;
+        final before = pillWidth();
+
+        await tester.tap(find.text(VideoRecorderMode.stopMotion.label));
+        await tester.pump();
+        final immediate = pillWidth();
+        await tester.pumpAndSettle();
+
+        // One frame after the tap the pill is already at the width it settles
+        // on — a tween would still be part-way there.
+        expect(immediate, equals(pillWidth()));
+        expect(immediate, isNot(equals(before)));
       });
     });
 


### PR DESCRIPTION
Closes #6884

## Description

Reduced motion was ignored across the app's tab screens and the recorder mode wheel. Turning the system setting on and switching tabs still played the full indicator slide and page transition.

**Tab screens (5 sites).** `TabController.animationDuration` drives both the `TabBar` indicator and the `TabBarView` page transition, and Flutter short-circuits both when it is `Duration.zero` (`_warpToAdjacentTab` jumps instead of animating; `_changeIndex` sets the controller value directly). There is nothing to gate in the widget tree — the duration is the only lever. It is fixed at construction, though, so reacting to a mid-session toggle means building a replacement controller.

`ReducedMotionTabControllerMixin` owns that lifecycle once: it rebuilds when the duration or `tabCount` changes, carries the open tab over clamped into the new range, and moves `onTabChanged` onto the replacement. That subsumes the hand-written recreate paths explore and profile already had for their changing tab sets, so those two shrink rather than grow. Both keep their own index resolution — explore deliberately carries the tab **by name**, because indices shift when optional tabs appear or disappear.

The mixin requires `TickerProviderStateMixin`; `SingleTickerProviderStateMixin` permits one ticker per `State` and throws on the replacement controller. Two sites are switched over.

**MediaQuery shorthands.** This PR adds only the `BuildContext` shorthands it uses: `reduceMotion` and `textScaler`. Each forwards to the aspect-scoped `MediaQuery.xxxOf` form, so readers only rebuild when the metric they use changes. `Duration.autoReduceMotion(context)` pairs with `reduceMotion` for animation durations.

One sharp edge is documented on `autoReduceMotion`: `ScrollPosition.animateTo` asserts `duration > Duration.zero`, so scroll positions must branch and call `jumpTo`. The recorder's snap scroll does exactly that.

**Recorder mode wheel.** Its snap scroll, pill resize, and label colour tween ignored the setting; they now honour reduced motion. The tap handler also relies on the single `_selectIndex(..., animate: true)` move instead of scheduling a duplicate jump when reduced motion completes synchronously.

The five tab screens and the mode wheel are the only behaviour changes. Broader `MediaQuery.xxxOf` / `MediaQuery.of(context).x` cleanup is left out of this behaviour fix.

**Related Issue:** #6884

## Out of Scope

- Migrating the remaining `MediaQuery.xxxOf` / `MediaQuery.of(context).x` call sites to shorthands.
- Other reduced-motion gaps outside tab bars and the mode wheel.

## Verification

- `flutter analyze lib test integration_test` — clean.
- `flutter test test/mixins/ test/extensions/ test/notifications/ test/screens/explore/ test/widgets/profile/ test/widgets/video_recorder/video_recorder_mode_selector_test.dart` — 721 passing.
- `flutter test test/screens/library_screen_test.dart test/widgets/video_editor/audio_editor/` — 80 passing.
- Each new reduced-motion test was checked to fail without its fix, not just to pass with it (tab tests: `animation.value` 0.0 instead of 3.0 after one frame; wheel test: pill width 130.7 mid-tween instead of the settled 117.9).
- [x] Manual pass on a real Samsung Galaxy — reduced motion on and off, tab switches on Inbox / Explore / Library / Profile / audio sheet, and the recorder mode wheel.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor
