### PR TITLE
fix(video-metadata): make the post-details flow readable to screen readers

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3892,7 +3892,7 @@
     "videoEditorCloseSemanticLabel": "ገጠመ",
     "videoEditorDoneSemanticLabel": "ተከናውኗል",
     "videoEditorLevelSemanticLabel": "ደረጃ",
-    "videoMetadataBackSemanticLabel": "ተመለስ",
+    "videoMetadataClosePostDetailsSemanticLabel": "የልጥፍ ዝርዝሮችን ዝጋ",
     "videoMetadataDismissHelpDialogSemanticLabel": "የእገዛ ንግግርን አሰናብት",
     "videoMetadataGotItButton": "ገባኝ!",
     "videoMetadataLimitReachedWarning": "64KB ገደብ ላይ ደርሷል። ለመቀጠል አንዳንድ ይዘቶችን ያስወግዱ።",
@@ -4184,8 +4184,8 @@
         "description": "Screen-reader announcement spoken after the user confirms a new cover thumbnail and the screen is about to close. Visual users get the screen pop as feedback; this is the audio equivalent."
     },
     "videoMetadataEditCoverTitle": "Edit cover",
-    "videoMetadataEditCoverCloseSemanticLabel": "Close cover editor",
-    "videoMetadataEditCoverConfirmSemanticLabel": "Confirm cover selection",
+    "videoMetadataEditCoverCloseSemanticLabel": "የሽፋን ለውጦችን አስወግድ",
+    "videoMetadataEditCoverConfirmSemanticLabel": "የተመረጠውን ፍሬም እንደ ቪዲዮ ሽፋን ተጠቀም",
     "videoMetadataEditCoverStripSemanticLabel": "Seek through video to select cover frame",
     "videoMetadataTagsPickerSearchHint": "መለያዎችን ይፈልጉ ወይም ያክሉ",
     "videoMetadataTagsPickerEmptyHint": "ሰዎች ቪዲዮዎን እንዲያገኙ መለያዎችን ያክሉ",
@@ -5057,5 +5057,12 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "ቅብብሎሽ አስወግድ"
+  "relaySettingsRemoveRelayTooltip": "ቅብብሎሽ አስወግድ",
+  "videoMetadataTagsPickerCancelSemanticLabel": "የመለያ ምርጫን ሰርዝ",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "የተመረጡ መለያዎችን ተግብር",
+  "userPickerCancelSemanticLabel": "የተጠቃሚ ምርጫን ሰርዝ",
+  "userPickerConfirmSemanticLabel": "የተመረጡ ተጠቃሚዎችን አረጋግጥ",
+  "userPickerClearSelectionSemanticLabel": "የተጠቃሚ ምርጫን አጽዳ",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "የይዘት ማስጠንቀቂያ ምርጫን ሰርዝ",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "የተመረጡ የይዘት ማስጠንቀቂያዎችን ተግብር"
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3136,7 +3136,7 @@
     "videoEditorUnmuteAudioSemanticLabel": "إلغاء كتم الصوت",
     "videoEditorVideoTimelineSemanticLabel": "الجدول الزمني للفيديو",
     "videoMetadataAddCollaboratorSemanticLabel": "إضافة متعاون",
-    "videoMetadataBackSemanticLabel": "رجوع",
+    "videoMetadataClosePostDetailsSemanticLabel": "إغلاق تفاصيل المنشور",
     "videoMetadataClassicDoneButton": "تم",
     "videoMetadataClosePreviewSemanticLabel": "إغلاق معاينة الفيديو",
     "videoMetadataCollaboratorsCount": "{count}/{max} متعاونين",
@@ -4036,8 +4036,8 @@
     "bugReportRemoveImage": "Remove image",
     "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
     "videoMetadataEditCoverTitle": "تعديل الغلاف",
-    "videoMetadataEditCoverCloseSemanticLabel": "إغلاق محرر الغلاف",
-    "videoMetadataEditCoverConfirmSemanticLabel": "تأكيد اختيار الغلاف",
+    "videoMetadataEditCoverCloseSemanticLabel": "تجاهل تغييرات الغلاف",
+    "videoMetadataEditCoverConfirmSemanticLabel": "استخدام الإطار المحدد كغلاف للفيديو",
     "videoMetadataEditCoverStripSemanticLabel": "التنقل عبر الفيديو لاختيار إطار الغلاف",
     "userPickerRemoveSelectionSemantics": "إزالة {name}",
     "@userPickerRemoveSelectionSemantics": {
@@ -4932,5 +4932,12 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "إزالة المحوّل"
+  "relaySettingsRemoveRelayTooltip": "إزالة المحوّل",
+  "videoMetadataTagsPickerCancelSemanticLabel": "إلغاء اختيار الوسوم",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "تطبيق الوسوم المحددة",
+  "userPickerCancelSemanticLabel": "إلغاء اختيار المستخدمين",
+  "userPickerConfirmSemanticLabel": "تأكيد المستخدمين المحددين",
+  "userPickerClearSelectionSemanticLabel": "مسح اختيار المستخدمين",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "إلغاء اختيار تحذيرات المحتوى",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "تطبيق تحذيرات المحتوى المحددة"
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3492,7 +3492,7 @@
     "videoEditorCloseSemanticLabel": "Затвори",
     "videoEditorDoneSemanticLabel": "Готово",
     "videoEditorLevelSemanticLabel": "Ниво",
-    "videoMetadataBackSemanticLabel": "Назад",
+    "videoMetadataClosePostDetailsSemanticLabel": "Затваряне на подробностите за публикацията",
     "videoMetadataDismissHelpDialogSemanticLabel": "Отхвърляне на диалоговия прозорец за помощ",
     "videoMetadataGotItButton": "Разбрах!",
     "videoMetadataLimitReachedWarning": "Лимитът от 64 KB е достигнат. Премахни малко съдържание, за да продължиш.",
@@ -4190,8 +4190,8 @@
         "description": "Screen-reader announcement spoken after the user confirms a new cover thumbnail and the screen is about to close. Visual users get the screen pop as feedback; this is the audio equivalent."
     },
     "videoMetadataEditCoverTitle": "Edit cover",
-    "videoMetadataEditCoverCloseSemanticLabel": "Close cover editor",
-    "videoMetadataEditCoverConfirmSemanticLabel": "Confirm cover selection",
+    "videoMetadataEditCoverCloseSemanticLabel": "Отхвърляне на промените по корицата",
+    "videoMetadataEditCoverConfirmSemanticLabel": "Използване на избрания кадър като корица на видеото",
     "videoMetadataEditCoverStripSemanticLabel": "Seek through video to select cover frame",
     "videoMetadataTagsPickerSearchHint": "Търсене или добавяне на тагове",
     "videoMetadataTagsPickerEmptyHint": "Добавете тагове, за да открият хората вашето видео",
@@ -5063,5 +5063,12 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Премахване на релето"
+  "relaySettingsRemoveRelayTooltip": "Премахване на релето",
+  "videoMetadataTagsPickerCancelSemanticLabel": "Отказ от избора на тагове",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "Прилагане на избраните тагове",
+  "userPickerCancelSemanticLabel": "Отказ от избора на потребители",
+  "userPickerConfirmSemanticLabel": "Потвърждаване на избраните потребители",
+  "userPickerClearSelectionSemanticLabel": "Изчистване на избора на потребители",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "Отказ от избора на предупреждения за съдържание",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "Прилагане на избраните предупреждения за съдържание"
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3222,7 +3222,7 @@
     "videoEditorCloseSemanticLabel": "Schließen",
     "videoEditorDoneSemanticLabel": "Fertig",
     "videoEditorLevelSemanticLabel": "Stufe",
-    "videoMetadataBackSemanticLabel": "Zurück",
+    "videoMetadataClosePostDetailsSemanticLabel": "Beitragsdetails schließen",
     "videoMetadataDismissHelpDialogSemanticLabel": "Hilfedialog schließen",
     "videoMetadataGotItButton": "Verstanden!",
     "videoMetadataLimitReachedWarning": "64KB-Limit erreicht. Entferne einige Inhalte, um fortzufahren.",
@@ -4036,8 +4036,8 @@
     "bugReportRemoveImage": "Remove image",
     "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
     "videoMetadataEditCoverTitle": "Cover bearbeiten",
-    "videoMetadataEditCoverCloseSemanticLabel": "Cover-Editor schließen",
-    "videoMetadataEditCoverConfirmSemanticLabel": "Coverauswahl bestätigen",
+    "videoMetadataEditCoverCloseSemanticLabel": "Cover-Änderungen verwerfen",
+    "videoMetadataEditCoverConfirmSemanticLabel": "Ausgewählten Frame als Video-Cover verwenden",
     "videoMetadataEditCoverStripSemanticLabel": "Durch Video scrollen, um Cover-Frame auszuwählen",
     "userPickerRemoveSelectionSemantics": "{name} entfernen",
     "@userPickerRemoveSelectionSemantics": {
@@ -4932,5 +4932,12 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Relay entfernen"
+  "relaySettingsRemoveRelayTooltip": "Relay entfernen",
+  "videoMetadataTagsPickerCancelSemanticLabel": "Tag-Auswahl abbrechen",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "Ausgewählte Tags anwenden",
+  "userPickerCancelSemanticLabel": "Nutzerauswahl abbrechen",
+  "userPickerConfirmSemanticLabel": "Ausgewählte Nutzer bestätigen",
+  "userPickerClearSelectionSemanticLabel": "Nutzerauswahl leeren",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "Auswahl der Inhaltswarnungen abbrechen",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "Ausgewählte Inhaltswarnungen anwenden"
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -5801,7 +5801,7 @@
   "videoEditorCloseSemanticLabel": "Close",
   "videoEditorDoneSemanticLabel": "Done",
   "videoEditorLevelSemanticLabel": "Level",
-  "videoMetadataBackSemanticLabel": "Back",
+  "videoMetadataClosePostDetailsSemanticLabel": "Close post details",
   "videoMetadataDismissHelpDialogSemanticLabel": "Dismiss help dialog",
   "videoMetadataGotItButton": "Got it!",
   "videoMetadataLimitReachedWarning": "64KB limit reached. Remove some content to continue.",
@@ -6206,8 +6206,8 @@
     "description": "Snackbar message shown when url_launcher fails to open the profile website link."
   },
   "videoMetadataEditCoverTitle": "Edit cover",
-  "videoMetadataEditCoverCloseSemanticLabel": "Close cover editor",
-  "videoMetadataEditCoverConfirmSemanticLabel": "Confirm cover selection",
+  "videoMetadataEditCoverCloseSemanticLabel": "Discard cover changes",
+  "videoMetadataEditCoverConfirmSemanticLabel": "Use selected frame as video cover",
   "videoMetadataEditCoverStripSemanticLabel": "Seek through video to select cover frame",
   "videoMetadataTagsPickerSearchHint": "Search or add tags",
   "videoMetadataTagsPickerEmptyHint": "Add tags to help people discover your video",
@@ -6628,5 +6628,12 @@
   "soundCreditTitleLabel": "Sound title",
   "soundCreditCreatorLabel": "Creator",
   "soundCreditSourceUrlLabel": "Source URL",
-  "soundCreditPublicHashtagsLabel": "Public hashtags"
+  "soundCreditPublicHashtagsLabel": "Public hashtags",
+  "videoMetadataTagsPickerCancelSemanticLabel": "Cancel tag selection",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "Apply selected tags",
+  "userPickerCancelSemanticLabel": "Cancel user selection",
+  "userPickerConfirmSemanticLabel": "Confirm selected users",
+  "userPickerClearSelectionSemanticLabel": "Clear user selection",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "Cancel content warning selection",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "Apply selected content warnings"
 }

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3230,7 +3230,7 @@
     "videoEditorCloseSemanticLabel": "Cerrar",
     "videoEditorDoneSemanticLabel": "Listo",
     "videoEditorLevelSemanticLabel": "Nivel",
-    "videoMetadataBackSemanticLabel": "Atrás",
+    "videoMetadataClosePostDetailsSemanticLabel": "Cerrar detalles de la publicación",
     "videoMetadataDismissHelpDialogSemanticLabel": "Cerrar diálogo de ayuda",
     "videoMetadataGotItButton": "¡Entendido!",
     "videoMetadataLimitReachedWarning": "Se alcanzó el límite de 64 KB. Elimina parte del contenido para continuar.",
@@ -4036,8 +4036,8 @@
     "bugReportRemoveImage": "Remove image",
     "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
     "videoMetadataEditCoverTitle": "Editar portada",
-    "videoMetadataEditCoverCloseSemanticLabel": "Cerrar editor de portada",
-    "videoMetadataEditCoverConfirmSemanticLabel": "Confirmar selección de portada",
+    "videoMetadataEditCoverCloseSemanticLabel": "Descartar cambios de portada",
+    "videoMetadataEditCoverConfirmSemanticLabel": "Usar el fotograma seleccionado como portada del vídeo",
     "videoMetadataEditCoverStripSemanticLabel": "Desliza el video para seleccionar el fotograma de portada",
     "userPickerRemoveSelectionSemantics": "Eliminar a {name}",
     "@userPickerRemoveSelectionSemantics": {
@@ -4932,5 +4932,12 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Quitar relay"
+  "relaySettingsRemoveRelayTooltip": "Quitar relay",
+  "videoMetadataTagsPickerCancelSemanticLabel": "Cancelar selección de etiquetas",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "Aplicar etiquetas seleccionadas",
+  "userPickerCancelSemanticLabel": "Cancelar selección de usuarios",
+  "userPickerConfirmSemanticLabel": "Confirmar usuarios seleccionados",
+  "userPickerClearSelectionSemanticLabel": "Borrar selección de usuarios",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "Cancelar selección de advertencias de contenido",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "Aplicar advertencias de contenido seleccionadas"
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2115,7 +2115,7 @@
     "videoEditorCloseSemanticLabel": "Isara",
     "videoEditorDoneSemanticLabel": "Tapos na",
     "videoEditorLevelSemanticLabel": "Level",
-    "videoMetadataBackSemanticLabel": "Bumalik",
+    "videoMetadataClosePostDetailsSemanticLabel": "Isara ang mga detalye ng post",
     "videoMetadataDismissHelpDialogSemanticLabel": "I-dismiss ang help dialog",
     "videoMetadataGotItButton": "Sige na!",
     "videoMetadataLimitReachedWarning": "Naabot na ang 64KB limit. Mag-alis ng content para magpatuloy.",
@@ -2212,8 +2212,8 @@
     "videoMetadataC2paMissingSkip": "Laktawan",
     "videoMetadataGenerationFailed": "Nabigo ang paggawa",
     "videoMetadataEditCoverTitle": "Edit cover",
-    "videoMetadataEditCoverCloseSemanticLabel": "Close cover editor",
-    "videoMetadataEditCoverConfirmSemanticLabel": "Confirm cover selection",
+    "videoMetadataEditCoverCloseSemanticLabel": "I-discard ang mga pagbabago sa cover",
+    "videoMetadataEditCoverConfirmSemanticLabel": "Gamitin ang napiling frame bilang cover ng video",
     "videoMetadataEditCoverStripSemanticLabel": "Seek through video to select cover frame",
     "bugReportSendFailed": "Hindi naipadala ang bug report. Subukan ulit mamaya.",
     "bugReportSendReport": "Ipadala ang Report",
@@ -3518,5 +3518,12 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Alisin ang relay"
+  "relaySettingsRemoveRelayTooltip": "Alisin ang relay",
+  "videoMetadataTagsPickerCancelSemanticLabel": "Kanselahin ang pagpili ng mga tag",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "Ilapat ang mga napiling tag",
+  "userPickerCancelSemanticLabel": "Kanselahin ang pagpili ng user",
+  "userPickerConfirmSemanticLabel": "Kumpirmahin ang mga napiling user",
+  "userPickerClearSelectionSemanticLabel": "I-clear ang pagpili ng user",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "Kanselahin ang pagpili ng mga babala sa content",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "Ilapat ang mga napiling babala sa content"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3222,7 +3222,7 @@
     "videoEditorCloseSemanticLabel": "Fermer",
     "videoEditorDoneSemanticLabel": "Terminé",
     "videoEditorLevelSemanticLabel": "Niveau",
-    "videoMetadataBackSemanticLabel": "Retour",
+    "videoMetadataClosePostDetailsSemanticLabel": "Fermer les détails de la publication",
     "videoMetadataDismissHelpDialogSemanticLabel": "Fermer la fenêtre d'aide",
     "videoMetadataGotItButton": "Compris !",
     "videoMetadataLimitReachedWarning": "Limite de 64 Ko atteinte. Supprimez du contenu pour continuer.",
@@ -4036,8 +4036,8 @@
     "bugReportRemoveImage": "Remove image",
     "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
     "videoMetadataEditCoverTitle": "Modifier la couverture",
-    "videoMetadataEditCoverCloseSemanticLabel": "Fermer l'éditeur de couverture",
-    "videoMetadataEditCoverConfirmSemanticLabel": "Confirmer la sélection de couverture",
+    "videoMetadataEditCoverCloseSemanticLabel": "Ignorer les modifications de la couverture",
+    "videoMetadataEditCoverConfirmSemanticLabel": "Utiliser l’image sélectionnée comme couverture vidéo",
     "videoMetadataEditCoverStripSemanticLabel": "Faire défiler la vidéo pour sélectionner l'image de couverture",
     "userPickerRemoveSelectionSemantics": "Retirer {name}",
     "@userPickerRemoveSelectionSemantics": {
@@ -4932,5 +4932,12 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Retirer le relay"
+  "relaySettingsRemoveRelayTooltip": "Retirer le relay",
+  "videoMetadataTagsPickerCancelSemanticLabel": "Annuler la sélection des tags",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "Appliquer les tags sélectionnés",
+  "userPickerCancelSemanticLabel": "Annuler la sélection des utilisateurs",
+  "userPickerConfirmSemanticLabel": "Confirmer les utilisateurs sélectionnés",
+  "userPickerClearSelectionSemanticLabel": "Effacer la sélection des utilisateurs",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "Annuler la sélection des avertissements de contenu",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "Appliquer les avertissements de contenu sélectionnés"
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3143,7 +3143,7 @@
     "videoEditorUnmuteAudioSemanticLabel": "Aktifkan suara",
     "videoEditorVideoTimelineSemanticLabel": "Timeline video",
     "videoMetadataAddCollaboratorSemanticLabel": "Tambah kolaborator",
-    "videoMetadataBackSemanticLabel": "Kembali",
+    "videoMetadataClosePostDetailsSemanticLabel": "Tutup detail postingan",
     "videoMetadataClassicDoneButton": "Selesai",
     "videoMetadataClosePreviewSemanticLabel": "Tutup pratinjau video",
     "videoMetadataCollaboratorsCount": "{count}/{max} Kolaborator",
@@ -4036,8 +4036,8 @@
     "bugReportRemoveImage": "Remove image",
     "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
     "videoMetadataEditCoverTitle": "Edit sampul",
-    "videoMetadataEditCoverCloseSemanticLabel": "Tutup editor sampul",
-    "videoMetadataEditCoverConfirmSemanticLabel": "Konfirmasi pilihan sampul",
+    "videoMetadataEditCoverCloseSemanticLabel": "Buang perubahan sampul",
+    "videoMetadataEditCoverConfirmSemanticLabel": "Gunakan bingkai yang dipilih sebagai sampul video",
     "videoMetadataEditCoverStripSemanticLabel": "Gulir video untuk memilih bingkai sampul",
     "userPickerRemoveSelectionSemantics": "Hapus {name}",
     "@userPickerRemoveSelectionSemantics": {
@@ -4932,5 +4932,12 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Hapus relay"
+  "relaySettingsRemoveRelayTooltip": "Hapus relay",
+  "videoMetadataTagsPickerCancelSemanticLabel": "Batalkan pemilihan tag",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "Terapkan tag yang dipilih",
+  "userPickerCancelSemanticLabel": "Batalkan pemilihan pengguna",
+  "userPickerConfirmSemanticLabel": "Konfirmasi pengguna yang dipilih",
+  "userPickerClearSelectionSemanticLabel": "Hapus pilihan pengguna",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "Batalkan pemilihan peringatan konten",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "Terapkan peringatan konten yang dipilih"
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3222,7 +3222,7 @@
     "videoEditorCloseSemanticLabel": "Chiudi",
     "videoEditorDoneSemanticLabel": "Fatto",
     "videoEditorLevelSemanticLabel": "Livello",
-    "videoMetadataBackSemanticLabel": "Indietro",
+    "videoMetadataClosePostDetailsSemanticLabel": "Chiudi dettagli del post",
     "videoMetadataDismissHelpDialogSemanticLabel": "Chiudi finestra di aiuto",
     "videoMetadataGotItButton": "Capito!",
     "videoMetadataLimitReachedWarning": "Limite di 64 KB raggiunto. Rimuovi alcuni contenuti per continuare.",
@@ -4036,8 +4036,8 @@
     "bugReportRemoveImage": "Remove image",
     "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
     "videoMetadataEditCoverTitle": "Modifica copertina",
-    "videoMetadataEditCoverCloseSemanticLabel": "Chiudi editor copertina",
-    "videoMetadataEditCoverConfirmSemanticLabel": "Conferma selezione copertina",
+    "videoMetadataEditCoverCloseSemanticLabel": "Annulla le modifiche alla copertina",
+    "videoMetadataEditCoverConfirmSemanticLabel": "Usa il fotogramma selezionato come copertina del video",
     "videoMetadataEditCoverStripSemanticLabel": "Scorri il video per selezionare il fotogramma di copertina",
     "userPickerRemoveSelectionSemantics": "Rimuovi {name}",
     "@userPickerRemoveSelectionSemantics": {
@@ -4932,5 +4932,12 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Rimuovi relay"
+  "relaySettingsRemoveRelayTooltip": "Rimuovi relay",
+  "videoMetadataTagsPickerCancelSemanticLabel": "Annulla selezione tag",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "Applica i tag selezionati",
+  "userPickerCancelSemanticLabel": "Annulla selezione utenti",
+  "userPickerConfirmSemanticLabel": "Conferma utenti selezionati",
+  "userPickerClearSelectionSemanticLabel": "Cancella selezione utenti",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "Annulla selezione avvisi sui contenuti",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "Applica gli avvisi sui contenuti selezionati"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3136,7 +3136,7 @@
     "videoEditorUnmuteAudioSemanticLabel": "音声のミュートを解除",
     "videoEditorVideoTimelineSemanticLabel": "動画タイムライン",
     "videoMetadataAddCollaboratorSemanticLabel": "コラボレーターを追加",
-    "videoMetadataBackSemanticLabel": "戻る",
+    "videoMetadataClosePostDetailsSemanticLabel": "投稿の詳細を閉じる",
     "videoMetadataClassicDoneButton": "完了",
     "videoMetadataClosePreviewSemanticLabel": "動画プレビューを閉じる",
     "videoMetadataCollaboratorsCount": "{count}/{max}人のコラボレーター",
@@ -4036,8 +4036,8 @@
     "bugReportRemoveImage": "Remove image",
     "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
     "videoMetadataEditCoverTitle": "カバーを編集",
-    "videoMetadataEditCoverCloseSemanticLabel": "カバーエディターを閉じる",
-    "videoMetadataEditCoverConfirmSemanticLabel": "カバー選択を確認",
+    "videoMetadataEditCoverCloseSemanticLabel": "カバーの変更を破棄",
+    "videoMetadataEditCoverConfirmSemanticLabel": "選択したフレームを動画のカバーに使用",
     "videoMetadataEditCoverStripSemanticLabel": "カバーフレームを選択するために動画をシーク",
     "userPickerRemoveSelectionSemantics": "{name}を削除",
     "@userPickerRemoveSelectionSemantics": {
@@ -4932,5 +4932,12 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "リレーを削除"
+  "relaySettingsRemoveRelayTooltip": "リレーを削除",
+  "videoMetadataTagsPickerCancelSemanticLabel": "タグの選択をキャンセル",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "選択したタグを適用",
+  "userPickerCancelSemanticLabel": "ユーザー選択をキャンセル",
+  "userPickerConfirmSemanticLabel": "選択したユーザーを確定",
+  "userPickerClearSelectionSemanticLabel": "ユーザー選択をクリア",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "コンテンツ警告の選択をキャンセル",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "選択したコンテンツ警告を適用"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2474,7 +2474,7 @@
     "videoEditorUnmuteAudioSemanticLabel": "오디오 음소거 해제",
     "videoEditorVideoTimelineSemanticLabel": "동영상 타임라인",
     "videoMetadataAddCollaboratorSemanticLabel": "협업자 추가",
-    "videoMetadataBackSemanticLabel": "뒤로",
+    "videoMetadataClosePostDetailsSemanticLabel": "게시물 세부 정보 닫기",
     "videoMetadataClassicDoneButton": "완료",
     "videoMetadataClosePreviewSemanticLabel": "동영상 미리보기 닫기",
     "videoMetadataCollaboratorsCount": "{count}/{max}명의 협업자",
@@ -3374,8 +3374,8 @@
     "bugReportRemoveImage": "Remove image",
     "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
     "videoMetadataEditCoverTitle": "커버 편집",
-    "videoMetadataEditCoverCloseSemanticLabel": "커버 편집기 닫기",
-    "videoMetadataEditCoverConfirmSemanticLabel": "커버 선택 확인",
+    "videoMetadataEditCoverCloseSemanticLabel": "커버 변경 사항 취소",
+    "videoMetadataEditCoverConfirmSemanticLabel": "선택한 프레임을 동영상 커버로 사용",
     "videoMetadataEditCoverStripSemanticLabel": "커버 프레임 선택을 위해 동영상 탐색",
     "userPickerRemoveSelectionSemantics": "{name} 제거",
     "@userPickerRemoveSelectionSemantics": {
@@ -4263,5 +4263,12 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "릴레이 제거"
+  "relaySettingsRemoveRelayTooltip": "릴레이 제거",
+  "videoMetadataTagsPickerCancelSemanticLabel": "태그 선택 취소",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "선택한 태그 적용",
+  "userPickerCancelSemanticLabel": "사용자 선택 취소",
+  "userPickerConfirmSemanticLabel": "선택한 사용자 확인",
+  "userPickerClearSelectionSemanticLabel": "사용자 선택 지우기",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "콘텐츠 경고 선택 취소",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "선택한 콘텐츠 경고 적용"
 }

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -5829,7 +5829,7 @@
   "videoEditorCloseSemanticLabel": "Tutup",
   "videoEditorDoneSemanticLabel": "Siap",
   "videoEditorLevelSemanticLabel": "Tahap",
-  "videoMetadataBackSemanticLabel": "Kembali",
+  "videoMetadataClosePostDetailsSemanticLabel": "Tutup butiran siaran",
   "videoMetadataDismissHelpDialogSemanticLabel": "Ketepikan dialog bantuan",
   "videoMetadataGotItButton": "Faham!",
   "videoMetadataLimitReachedWarning": "Had 64KB dicapai. Alih keluar sesetengah kandungan untuk meneruskan.",
@@ -6226,8 +6226,8 @@
     "description": "Snackbar message shown when url_launcher fails to open the profile website link."
   },
   "videoMetadataEditCoverTitle": "Sunting muka depan",
-  "videoMetadataEditCoverCloseSemanticLabel": "Tutup penyunting muka depan",
-  "videoMetadataEditCoverConfirmSemanticLabel": "Sahkan pemilihan muka depan",
+  "videoMetadataEditCoverCloseSemanticLabel": "Buang perubahan muka depan",
+  "videoMetadataEditCoverConfirmSemanticLabel": "Gunakan bingkai dipilih sebagai muka depan video",
   "videoMetadataEditCoverStripSemanticLabel": "Gerak melalui video untuk memilih bingkai muka depan",
   "videoMetadataTagsPickerSearchHint": "Cari atau tambah tag",
   "videoMetadataTagsPickerEmptyHint": "Tambah tag untuk membantu orang menemui video anda",
@@ -6777,5 +6777,12 @@
   },
   "relaySettingsRemoveRelayTooltip": "Buang relay",
   "profileBadgeFooterBody": "Lencana ialah anugerah kecil yang sesiapa sahaja boleh buat di Nostr. Berikan satu kepada rakan, pencipta, atau seseorang yang menceriakan hari anda.",
-  "profileBadgeFooterLink": "Buat lencana anda sendiri di badges.divine.video"
+  "profileBadgeFooterLink": "Buat lencana anda sendiri di badges.divine.video",
+  "videoMetadataTagsPickerCancelSemanticLabel": "Batalkan pemilihan tag",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "Gunakan tag yang dipilih",
+  "userPickerCancelSemanticLabel": "Batalkan pemilihan pengguna",
+  "userPickerConfirmSemanticLabel": "Sahkan pengguna yang dipilih",
+  "userPickerClearSelectionSemanticLabel": "Kosongkan pemilihan pengguna",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "Batalkan pemilihan amaran kandungan",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "Gunakan amaran kandungan yang dipilih"
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3222,7 +3222,7 @@
     "videoEditorCloseSemanticLabel": "Sluiten",
     "videoEditorDoneSemanticLabel": "Gereed",
     "videoEditorLevelSemanticLabel": "Niveau",
-    "videoMetadataBackSemanticLabel": "Terug",
+    "videoMetadataClosePostDetailsSemanticLabel": "Berichtdetails sluiten",
     "videoMetadataDismissHelpDialogSemanticLabel": "Helpdialoog sluiten",
     "videoMetadataGotItButton": "Begrepen!",
     "videoMetadataLimitReachedWarning": "Limiet van 64KB bereikt. Verwijder wat inhoud om door te gaan.",
@@ -4036,8 +4036,8 @@
     "bugReportRemoveImage": "Remove image",
     "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
     "videoMetadataEditCoverTitle": "Omslag bewerken",
-    "videoMetadataEditCoverCloseSemanticLabel": "Omslageditor sluiten",
-    "videoMetadataEditCoverConfirmSemanticLabel": "Omslagselectie bevestigen",
+    "videoMetadataEditCoverCloseSemanticLabel": "Wijzigingen aan omslag negeren",
+    "videoMetadataEditCoverConfirmSemanticLabel": "Geselecteerd frame als video-omslag gebruiken",
     "videoMetadataEditCoverStripSemanticLabel": "Door video scrollen om omslagframe te selecteren",
     "userPickerRemoveSelectionSemantics": "{name} verwijderen",
     "@userPickerRemoveSelectionSemantics": {
@@ -4932,5 +4932,12 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Relay verwijderen"
+  "relaySettingsRemoveRelayTooltip": "Relay verwijderen",
+  "videoMetadataTagsPickerCancelSemanticLabel": "Tagselectie annuleren",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "Geselecteerde tags toepassen",
+  "userPickerCancelSemanticLabel": "Gebruikersselectie annuleren",
+  "userPickerConfirmSemanticLabel": "Geselecteerde gebruikers bevestigen",
+  "userPickerClearSelectionSemanticLabel": "Gebruikersselectie wissen",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "Selectie van inhoudswaarschuwingen annuleren",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "Geselecteerde inhoudswaarschuwingen toepassen"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3222,7 +3222,7 @@
     "videoEditorCloseSemanticLabel": "Zamknij",
     "videoEditorDoneSemanticLabel": "Gotowe",
     "videoEditorLevelSemanticLabel": "Poziom",
-    "videoMetadataBackSemanticLabel": "Wstecz",
+    "videoMetadataClosePostDetailsSemanticLabel": "Zamknij szczegóły posta",
     "videoMetadataDismissHelpDialogSemanticLabel": "Zamknij okno pomocy",
     "videoMetadataGotItButton": "Rozumiem!",
     "videoMetadataLimitReachedWarning": "Osiągnięto limit 64 KB. Usuń część treści, aby kontynuować.",
@@ -4036,8 +4036,8 @@
     "bugReportRemoveImage": "Remove image",
     "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
     "videoMetadataEditCoverTitle": "Edytuj okładkę",
-    "videoMetadataEditCoverCloseSemanticLabel": "Zamknij edytor okładki",
-    "videoMetadataEditCoverConfirmSemanticLabel": "Potwierdź wybór okładki",
+    "videoMetadataEditCoverCloseSemanticLabel": "Odrzuć zmiany okładki",
+    "videoMetadataEditCoverConfirmSemanticLabel": "Użyj wybranej klatki jako okładki filmu",
     "videoMetadataEditCoverStripSemanticLabel": "Przewijaj wideo, aby wybrać klatkę okładki",
     "userPickerRemoveSelectionSemantics": "Usuń {name}",
     "@userPickerRemoveSelectionSemantics": {
@@ -4932,5 +4932,12 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Usuń przekaźnik"
+  "relaySettingsRemoveRelayTooltip": "Usuń przekaźnik",
+  "videoMetadataTagsPickerCancelSemanticLabel": "Anuluj wybór tagów",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "Zastosuj wybrane tagi",
+  "userPickerCancelSemanticLabel": "Anuluj wybór użytkowników",
+  "userPickerConfirmSemanticLabel": "Potwierdź wybranych użytkowników",
+  "userPickerClearSelectionSemanticLabel": "Wyczyść wybór użytkowników",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "Anuluj wybór ostrzeżeń o treści",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "Zastosuj wybrane ostrzeżenia o treści"
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3222,7 +3222,7 @@
     "videoEditorCloseSemanticLabel": "Fechar",
     "videoEditorDoneSemanticLabel": "Concluído",
     "videoEditorLevelSemanticLabel": "Nível",
-    "videoMetadataBackSemanticLabel": "Voltar",
+    "videoMetadataClosePostDetailsSemanticLabel": "Fechar detalhes da publicação",
     "videoMetadataDismissHelpDialogSemanticLabel": "Fechar diálogo de ajuda",
     "videoMetadataGotItButton": "Entendi!",
     "videoMetadataLimitReachedWarning": "Limite de 64 KB atingido. Remova parte do conteúdo para continuar.",
@@ -4036,8 +4036,8 @@
     "bugReportRemoveImage": "Remove image",
     "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
     "videoMetadataEditCoverTitle": "Editar capa",
-    "videoMetadataEditCoverCloseSemanticLabel": "Fechar editor de capa",
-    "videoMetadataEditCoverConfirmSemanticLabel": "Confirmar seleção de capa",
+    "videoMetadataEditCoverCloseSemanticLabel": "Descartar alterações da capa",
+    "videoMetadataEditCoverConfirmSemanticLabel": "Usar o fotograma selecionado como capa do vídeo",
     "videoMetadataEditCoverStripSemanticLabel": "Percorra o vídeo para selecionar o quadro de capa",
     "userPickerRemoveSelectionSemantics": "Remover {name}",
     "@userPickerRemoveSelectionSemantics": {
@@ -4932,5 +4932,12 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Remover relay"
+  "relaySettingsRemoveRelayTooltip": "Remover relay",
+  "videoMetadataTagsPickerCancelSemanticLabel": "Cancelar seleção de tags",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "Aplicar tags selecionadas",
+  "userPickerCancelSemanticLabel": "Cancelar seleção de utilizadores",
+  "userPickerConfirmSemanticLabel": "Confirmar utilizadores selecionados",
+  "userPickerClearSelectionSemanticLabel": "Limpar seleção de utilizadores",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "Cancelar seleção de avisos de conteúdo",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "Aplicar avisos de conteúdo selecionados"
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3222,7 +3222,7 @@
     "videoEditorCloseSemanticLabel": "Închide",
     "videoEditorDoneSemanticLabel": "Gata",
     "videoEditorLevelSemanticLabel": "Nivel",
-    "videoMetadataBackSemanticLabel": "Înapoi",
+    "videoMetadataClosePostDetailsSemanticLabel": "Închide detaliile postării",
     "videoMetadataDismissHelpDialogSemanticLabel": "Închide dialogul de ajutor",
     "videoMetadataGotItButton": "Am înțeles!",
     "videoMetadataLimitReachedWarning": "Limita de 64KB a fost atinsă. Elimină conținut pentru a continua.",
@@ -4036,8 +4036,8 @@
     "bugReportRemoveImage": "Remove image",
     "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
     "videoMetadataEditCoverTitle": "Editează coperta",
-    "videoMetadataEditCoverCloseSemanticLabel": "Închide editorul de copertă",
-    "videoMetadataEditCoverConfirmSemanticLabel": "Confirmă selecția copertei",
+    "videoMetadataEditCoverCloseSemanticLabel": "Renunță la modificările copertei",
+    "videoMetadataEditCoverConfirmSemanticLabel": "Folosește cadrul selectat drept copertă video",
     "videoMetadataEditCoverStripSemanticLabel": "Parcurge videoclipul pentru a selecta cadrul copertei",
     "userPickerRemoveSelectionSemantics": "Elimină {name}",
     "@userPickerRemoveSelectionSemantics": {
@@ -4932,5 +4932,12 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Elimină relay-ul"
+  "relaySettingsRemoveRelayTooltip": "Elimină relay-ul",
+  "videoMetadataTagsPickerCancelSemanticLabel": "Anulează selectarea etichetelor",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "Aplică etichetele selectate",
+  "userPickerCancelSemanticLabel": "Anulează selectarea utilizatorilor",
+  "userPickerConfirmSemanticLabel": "Confirmă utilizatorii selectați",
+  "userPickerClearSelectionSemanticLabel": "Șterge selecția utilizatorilor",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "Anulează selectarea avertismentelor de conținut",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "Aplică avertismentele de conținut selectate"
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3222,7 +3222,7 @@
     "videoEditorCloseSemanticLabel": "Stäng",
     "videoEditorDoneSemanticLabel": "Klar",
     "videoEditorLevelSemanticLabel": "Nivå",
-    "videoMetadataBackSemanticLabel": "Tillbaka",
+    "videoMetadataClosePostDetailsSemanticLabel": "Stäng inläggsdetaljer",
     "videoMetadataDismissHelpDialogSemanticLabel": "Stäng hjälpdialog",
     "videoMetadataGotItButton": "Jag fattar!",
     "videoMetadataLimitReachedWarning": "Gränsen på 64KB är nådd. Ta bort innehåll för att fortsätta.",
@@ -4036,8 +4036,8 @@
     "bugReportRemoveImage": "Remove image",
     "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
     "videoMetadataEditCoverTitle": "Redigera omslag",
-    "videoMetadataEditCoverCloseSemanticLabel": "Stäng omslagsredigerare",
-    "videoMetadataEditCoverConfirmSemanticLabel": "Bekräfta omslagsval",
+    "videoMetadataEditCoverCloseSemanticLabel": "Ignorera omslagsändringar",
+    "videoMetadataEditCoverConfirmSemanticLabel": "Använd vald bildruta som videoomslag",
     "videoMetadataEditCoverStripSemanticLabel": "Sök igenom videon för att välja omslagsbild",
     "userPickerRemoveSelectionSemantics": "Ta bort {name}",
     "@userPickerRemoveSelectionSemantics": {
@@ -4932,5 +4932,12 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Ta bort rel"
+  "relaySettingsRemoveRelayTooltip": "Ta bort rel",
+  "videoMetadataTagsPickerCancelSemanticLabel": "Avbryt taggval",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "Använd valda taggar",
+  "userPickerCancelSemanticLabel": "Avbryt användarval",
+  "userPickerConfirmSemanticLabel": "Bekräfta valda användare",
+  "userPickerClearSelectionSemanticLabel": "Rensa användarval",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "Avbryt val av innehållsvarningar",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "Använd valda innehållsvarningar"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3143,7 +3143,7 @@
     "videoEditorUnmuteAudioSemanticLabel": "Sesi aç",
     "videoEditorVideoTimelineSemanticLabel": "Video zaman çizelgesi",
     "videoMetadataAddCollaboratorSemanticLabel": "Ortak çalışan ekle",
-    "videoMetadataBackSemanticLabel": "Geri",
+    "videoMetadataClosePostDetailsSemanticLabel": "Gönderi ayrıntılarını kapat",
     "videoMetadataClassicDoneButton": "Bitti",
     "videoMetadataClosePreviewSemanticLabel": "Video önizlemesini kapat",
     "videoMetadataCollaboratorsCount": "{count}/{max} Ortak çalışan",
@@ -4036,8 +4036,8 @@
     "bugReportRemoveImage": "Remove image",
     "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
     "videoMetadataEditCoverTitle": "Kapağı düzenle",
-    "videoMetadataEditCoverCloseSemanticLabel": "Kapak düzenleyicisini kapat",
-    "videoMetadataEditCoverConfirmSemanticLabel": "Kapak seçimini onayla",
+    "videoMetadataEditCoverCloseSemanticLabel": "Kapak değişikliklerini iptal et",
+    "videoMetadataEditCoverConfirmSemanticLabel": "Seçili kareyi video kapağı olarak kullan",
     "videoMetadataEditCoverStripSemanticLabel": "Kapak karesi seçmek için videoda gezin",
     "userPickerRemoveSelectionSemantics": "{name} kaldır",
     "@userPickerRemoveSelectionSemantics": {
@@ -4932,5 +4932,12 @@
       }
     }
   },
-  "relaySettingsRemoveRelayTooltip": "Röleyi kaldır"
+  "relaySettingsRemoveRelayTooltip": "Röleyi kaldır",
+  "videoMetadataTagsPickerCancelSemanticLabel": "Etiket seçimini iptal et",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "Seçili etiketleri uygula",
+  "userPickerCancelSemanticLabel": "Kullanıcı seçimini iptal et",
+  "userPickerConfirmSemanticLabel": "Seçili kullanıcıları onayla",
+  "userPickerClearSelectionSemanticLabel": "Kullanıcı seçimini temizle",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "İçerik uyarısı seçimini iptal et",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "Seçili içerik uyarılarını uygula"
 }

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -5829,7 +5829,7 @@
   "videoEditorCloseSemanticLabel": "بند کریں",
   "videoEditorDoneSemanticLabel": "ہو گیا",
   "videoEditorLevelSemanticLabel": "سطح",
-  "videoMetadataBackSemanticLabel": "واپس",
+  "videoMetadataClosePostDetailsSemanticLabel": "پوسٹ کی تفصیلات بند کریں",
   "videoMetadataDismissHelpDialogSemanticLabel": "مدد کا ڈائیلاگ ہٹائیں",
   "videoMetadataGotItButton": "سمجھ گیا!",
   "videoMetadataLimitReachedWarning": "64KB کی حد پوری ہو گئی۔ جاری رکھنے کے لیے کچھ مواد ہٹائیں۔",
@@ -6226,8 +6226,8 @@
     "description": "Snackbar message shown when url_launcher fails to open the profile website link."
   },
   "videoMetadataEditCoverTitle": "کور میں ترمیم کریں",
-  "videoMetadataEditCoverCloseSemanticLabel": "کور ایڈیٹر بند کریں",
-  "videoMetadataEditCoverConfirmSemanticLabel": "کور انتخاب کی تصدیق کریں",
+  "videoMetadataEditCoverCloseSemanticLabel": "کور کی تبدیلیاں مسترد کریں",
+  "videoMetadataEditCoverConfirmSemanticLabel": "منتخب فریم کو ویڈیو کور کے طور پر استعمال کریں",
   "videoMetadataEditCoverStripSemanticLabel": "کور فریم منتخب کرنے کے لیے ویڈیو میں آگے پیچھے جائیں",
   "videoMetadataTagsPickerSearchHint": "ٹیگز تلاش یا شامل کریں",
   "videoMetadataTagsPickerEmptyHint": "لوگوں کی آپ کی ویڈیو دریافت کرنے میں مدد کے لیے ٹیگز شامل کریں",
@@ -6777,5 +6777,12 @@
   },
   "relaySettingsRemoveRelayTooltip": "ریلے ہٹائیں",
   "profileBadgeFooterBody": "بیجز چھوٹے انعامات ہیں جو کوئی بھی Nostr پر بنا سکتا ہے۔ کسی دوست، تخلیق کار، یا اس شخص کو دیں جس نے آپ کا دن بنا دیا۔",
-  "profileBadgeFooterLink": "badges.divine.video پر اپنا بیج بنائیں"
+  "profileBadgeFooterLink": "badges.divine.video پر اپنا بیج بنائیں",
+  "videoMetadataTagsPickerCancelSemanticLabel": "ٹیگ کا انتخاب منسوخ کریں",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "منتخب ٹیگز لاگو کریں",
+  "userPickerCancelSemanticLabel": "صارف کا انتخاب منسوخ کریں",
+  "userPickerConfirmSemanticLabel": "منتخب صارفین کی تصدیق کریں",
+  "userPickerClearSelectionSemanticLabel": "صارف کا انتخاب صاف کریں",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "مواد کی وارننگز کا انتخاب منسوخ کریں",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "منتخب مواد کی وارننگز لاگو کریں"
 }

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -5829,7 +5829,7 @@
   "videoEditorCloseSemanticLabel": "Đóng",
   "videoEditorDoneSemanticLabel": "Xong",
   "videoEditorLevelSemanticLabel": "Mức",
-  "videoMetadataBackSemanticLabel": "Quay lại",
+  "videoMetadataClosePostDetailsSemanticLabel": "Đóng chi tiết bài đăng",
   "videoMetadataDismissHelpDialogSemanticLabel": "Đóng hộp thoại trợ giúp",
   "videoMetadataGotItButton": "Đã hiểu!",
   "videoMetadataLimitReachedWarning": "Đã đạt giới hạn 64KB. Bớt nội dung để tiếp tục.",
@@ -6226,8 +6226,8 @@
     "description": "Snackbar message shown when url_launcher fails to open the profile website link."
   },
   "videoMetadataEditCoverTitle": "Chỉnh sửa ảnh bìa",
-  "videoMetadataEditCoverCloseSemanticLabel": "Đóng trình chỉnh sửa ảnh bìa",
-  "videoMetadataEditCoverConfirmSemanticLabel": "Xác nhận lựa chọn ảnh bìa",
+  "videoMetadataEditCoverCloseSemanticLabel": "Hủy thay đổi ảnh bìa",
+  "videoMetadataEditCoverConfirmSemanticLabel": "Dùng khung hình đã chọn làm ảnh bìa video",
   "videoMetadataEditCoverStripSemanticLabel": "Tua video để chọn khung hình làm ảnh bìa",
   "videoMetadataTagsPickerSearchHint": "Tìm hoặc thêm thẻ",
   "videoMetadataTagsPickerEmptyHint": "Thêm thẻ để giúp mọi người khám phá video của bạn",
@@ -6777,5 +6777,12 @@
   },
   "relaySettingsRemoveRelayTooltip": "Xoá relay",
   "profileBadgeFooterBody": "Huy hiệu là những phần thưởng nhỏ mà bất kỳ ai cũng có thể tạo trên Nostr. Tặng một huy hiệu cho bạn bè, nhà sáng tạo, hoặc người đã làm bừng sáng ngày của bạn.",
-  "profileBadgeFooterLink": "Tạo huy hiệu của riêng bạn tại badges.divine.video"
+  "profileBadgeFooterLink": "Tạo huy hiệu của riêng bạn tại badges.divine.video",
+  "videoMetadataTagsPickerCancelSemanticLabel": "Hủy chọn thẻ",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "Áp dụng các thẻ đã chọn",
+  "userPickerCancelSemanticLabel": "Hủy chọn người dùng",
+  "userPickerConfirmSemanticLabel": "Xác nhận người dùng đã chọn",
+  "userPickerClearSelectionSemanticLabel": "Xóa lựa chọn người dùng",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "Hủy chọn cảnh báo nội dung",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "Áp dụng các cảnh báo nội dung đã chọn"
 }

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -5829,7 +5829,7 @@
   "videoEditorCloseSemanticLabel": "关闭",
   "videoEditorDoneSemanticLabel": "完成",
   "videoEditorLevelSemanticLabel": "层级",
-  "videoMetadataBackSemanticLabel": "返回",
+  "videoMetadataClosePostDetailsSemanticLabel": "关闭帖子详情",
   "videoMetadataDismissHelpDialogSemanticLabel": "关闭帮助对话框",
   "videoMetadataGotItButton": "懂了！",
   "videoMetadataLimitReachedWarning": "已达 64KB 上限。请删减一些内容再继续。",
@@ -6226,8 +6226,8 @@
     "description": "Snackbar message shown when url_launcher fails to open the profile website link."
   },
   "videoMetadataEditCoverTitle": "编辑封面",
-  "videoMetadataEditCoverCloseSemanticLabel": "关闭封面编辑器",
-  "videoMetadataEditCoverConfirmSemanticLabel": "确认封面选择",
+  "videoMetadataEditCoverCloseSemanticLabel": "放弃封面更改",
+  "videoMetadataEditCoverConfirmSemanticLabel": "将所选帧用作视频封面",
   "videoMetadataEditCoverStripSemanticLabel": "拖动进度选择封面帧",
   "videoMetadataTagsPickerSearchHint": "搜索或添加标签",
   "videoMetadataTagsPickerEmptyHint": "添加标签，让更多人发现你的视频",
@@ -6777,5 +6777,12 @@
   },
   "relaySettingsRemoveRelayTooltip": "移除中继",
   "profileBadgeFooterBody": "徽章是任何人都可以在 Nostr 上制作的小奖励。送一个给朋友、创作者,或那个让你今天很开心的人。",
-  "profileBadgeFooterLink": "在 badges.divine.video 制作你自己的徽章"
+  "profileBadgeFooterLink": "在 badges.divine.video 制作你自己的徽章",
+  "videoMetadataTagsPickerCancelSemanticLabel": "取消标签选择",
+  "videoMetadataTagsPickerConfirmSemanticLabel": "应用所选标签",
+  "userPickerCancelSemanticLabel": "取消用户选择",
+  "userPickerConfirmSemanticLabel": "确认所选用户",
+  "userPickerClearSelectionSemanticLabel": "清除用户选择",
+  "videoMetadataContentWarningsPickerCancelSemanticLabel": "取消内容警告选择",
+  "videoMetadataContentWarningsPickerConfirmSemanticLabel": "应用所选内容警告"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -16516,11 +16516,11 @@ abstract class AppLocalizations {
   /// **'Level'**
   String get videoEditorLevelSemanticLabel;
 
-  /// No description provided for @videoMetadataBackSemanticLabel.
+  /// No description provided for @videoMetadataClosePostDetailsSemanticLabel.
   ///
   /// In en, this message translates to:
-  /// **'Back'**
-  String get videoMetadataBackSemanticLabel;
+  /// **'Close post details'**
+  String get videoMetadataClosePostDetailsSemanticLabel;
 
   /// No description provided for @videoMetadataDismissHelpDialogSemanticLabel.
   ///
@@ -17917,13 +17917,13 @@ abstract class AppLocalizations {
   /// No description provided for @videoMetadataEditCoverCloseSemanticLabel.
   ///
   /// In en, this message translates to:
-  /// **'Close cover editor'**
+  /// **'Discard cover changes'**
   String get videoMetadataEditCoverCloseSemanticLabel;
 
   /// No description provided for @videoMetadataEditCoverConfirmSemanticLabel.
   ///
   /// In en, this message translates to:
-  /// **'Confirm cover selection'**
+  /// **'Use selected frame as video cover'**
   String get videoMetadataEditCoverConfirmSemanticLabel;
 
   /// No description provided for @videoMetadataEditCoverStripSemanticLabel.
@@ -19071,6 +19071,48 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Public hashtags'**
   String get soundCreditPublicHashtagsLabel;
+
+  /// No description provided for @videoMetadataTagsPickerCancelSemanticLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel tag selection'**
+  String get videoMetadataTagsPickerCancelSemanticLabel;
+
+  /// No description provided for @videoMetadataTagsPickerConfirmSemanticLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Apply selected tags'**
+  String get videoMetadataTagsPickerConfirmSemanticLabel;
+
+  /// No description provided for @userPickerCancelSemanticLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel user selection'**
+  String get userPickerCancelSemanticLabel;
+
+  /// No description provided for @userPickerConfirmSemanticLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Confirm selected users'**
+  String get userPickerConfirmSemanticLabel;
+
+  /// No description provided for @userPickerClearSelectionSemanticLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear user selection'**
+  String get userPickerClearSelectionSemanticLabel;
+
+  /// No description provided for @videoMetadataContentWarningsPickerCancelSemanticLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel content warning selection'**
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel;
+
+  /// No description provided for @videoMetadataContentWarningsPickerConfirmSemanticLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Apply selected content warnings'**
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel;
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -9383,7 +9383,7 @@ class AppLocalizationsAm extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => 'ደረጃ';
 
   @override
-  String get videoMetadataBackSemanticLabel => 'ተመለስ';
+  String get videoMetadataClosePostDetailsSemanticLabel => 'የልጥፍ ዝርዝሮችን ዝጋ';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel => 'የእገዛ ንግግርን አሰናብት';
@@ -10202,11 +10202,11 @@ class AppLocalizationsAm extends AppLocalizations {
   String get videoMetadataEditCoverTitle => 'Edit cover';
 
   @override
-  String get videoMetadataEditCoverCloseSemanticLabel => 'Close cover editor';
+  String get videoMetadataEditCoverCloseSemanticLabel => 'የሽፋን ለውጦችን አስወግድ';
 
   @override
   String get videoMetadataEditCoverConfirmSemanticLabel =>
-      'Confirm cover selection';
+      'የተመረጠውን ፍሬም እንደ ቪዲዮ ሽፋን ተጠቀም';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel =>
@@ -10845,4 +10845,27 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel => 'የመለያ ምርጫን ሰርዝ';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel => 'የተመረጡ መለያዎችን ተግብር';
+
+  @override
+  String get userPickerCancelSemanticLabel => 'የተጠቃሚ ምርጫን ሰርዝ';
+
+  @override
+  String get userPickerConfirmSemanticLabel => 'የተመረጡ ተጠቃሚዎችን አረጋግጥ';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel => 'የተጠቃሚ ምርጫን አጽዳ';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      'የይዘት ማስጠንቀቂያ ምርጫን ሰርዝ';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      'የተመረጡ የይዘት ማስጠንቀቂያዎችን ተግብር';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -9527,7 +9527,8 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => 'المستوى';
 
   @override
-  String get videoMetadataBackSemanticLabel => 'رجوع';
+  String get videoMetadataClosePostDetailsSemanticLabel =>
+      'إغلاق تفاصيل المنشور';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel =>
@@ -10351,11 +10352,11 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoMetadataEditCoverTitle => 'تعديل الغلاف';
 
   @override
-  String get videoMetadataEditCoverCloseSemanticLabel => 'إغلاق محرر الغلاف';
+  String get videoMetadataEditCoverCloseSemanticLabel => 'تجاهل تغييرات الغلاف';
 
   @override
   String get videoMetadataEditCoverConfirmSemanticLabel =>
-      'تأكيد اختيار الغلاف';
+      'استخدام الإطار المحدد كغلاف للفيديو';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel =>
@@ -11006,4 +11007,29 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel =>
+      'إلغاء اختيار الوسوم';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel =>
+      'تطبيق الوسوم المحددة';
+
+  @override
+  String get userPickerCancelSemanticLabel => 'إلغاء اختيار المستخدمين';
+
+  @override
+  String get userPickerConfirmSemanticLabel => 'تأكيد المستخدمين المحددين';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel => 'مسح اختيار المستخدمين';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      'إلغاء اختيار تحذيرات المحتوى';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      'تطبيق تحذيرات المحتوى المحددة';
 }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -9689,7 +9689,8 @@ class AppLocalizationsBg extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => 'Ниво';
 
   @override
-  String get videoMetadataBackSemanticLabel => 'Назад';
+  String get videoMetadataClosePostDetailsSemanticLabel =>
+      'Затваряне на подробностите за публикацията';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel =>
@@ -10526,11 +10527,12 @@ class AppLocalizationsBg extends AppLocalizations {
   String get videoMetadataEditCoverTitle => 'Edit cover';
 
   @override
-  String get videoMetadataEditCoverCloseSemanticLabel => 'Close cover editor';
+  String get videoMetadataEditCoverCloseSemanticLabel =>
+      'Отхвърляне на промените по корицата';
 
   @override
   String get videoMetadataEditCoverConfirmSemanticLabel =>
-      'Confirm cover selection';
+      'Използване на избрания кадър като корица на видеото';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel =>
@@ -11195,4 +11197,31 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel =>
+      'Отказ от избора на тагове';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel =>
+      'Прилагане на избраните тагове';
+
+  @override
+  String get userPickerCancelSemanticLabel => 'Отказ от избора на потребители';
+
+  @override
+  String get userPickerConfirmSemanticLabel =>
+      'Потвърждаване на избраните потребители';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel =>
+      'Изчистване на избора на потребители';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      'Отказ от избора на предупреждения за съдържание';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      'Прилагане на избраните предупреждения за съдържание';
 }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -9706,7 +9706,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => 'Stufe';
 
   @override
-  String get videoMetadataBackSemanticLabel => 'Zurück';
+  String get videoMetadataClosePostDetailsSemanticLabel =>
+      'Beitragsdetails schließen';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel =>
@@ -10546,11 +10547,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get videoMetadataEditCoverCloseSemanticLabel =>
-      'Cover-Editor schließen';
+      'Cover-Änderungen verwerfen';
 
   @override
   String get videoMetadataEditCoverConfirmSemanticLabel =>
-      'Coverauswahl bestätigen';
+      'Ausgewählten Frame als Video-Cover verwenden';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel =>
@@ -11214,4 +11215,29 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel =>
+      'Tag-Auswahl abbrechen';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel =>
+      'Ausgewählte Tags anwenden';
+
+  @override
+  String get userPickerCancelSemanticLabel => 'Nutzerauswahl abbrechen';
+
+  @override
+  String get userPickerConfirmSemanticLabel => 'Ausgewählte Nutzer bestätigen';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel => 'Nutzerauswahl leeren';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      'Auswahl der Inhaltswarnungen abbrechen';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      'Ausgewählte Inhaltswarnungen anwenden';
 }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -9575,7 +9575,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => 'Level';
 
   @override
-  String get videoMetadataBackSemanticLabel => 'Back';
+  String get videoMetadataClosePostDetailsSemanticLabel => 'Close post details';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel =>
@@ -10403,11 +10403,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get videoMetadataEditCoverTitle => 'Edit cover';
 
   @override
-  String get videoMetadataEditCoverCloseSemanticLabel => 'Close cover editor';
+  String get videoMetadataEditCoverCloseSemanticLabel =>
+      'Discard cover changes';
 
   @override
   String get videoMetadataEditCoverConfirmSemanticLabel =>
-      'Confirm cover selection';
+      'Use selected frame as video cover';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel =>
@@ -11059,4 +11060,29 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel =>
+      'Cancel tag selection';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel =>
+      'Apply selected tags';
+
+  @override
+  String get userPickerCancelSemanticLabel => 'Cancel user selection';
+
+  @override
+  String get userPickerConfirmSemanticLabel => 'Confirm selected users';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel => 'Clear user selection';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      'Cancel content warning selection';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      'Apply selected content warnings';
 }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -9692,7 +9692,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => 'Nivel';
 
   @override
-  String get videoMetadataBackSemanticLabel => 'Atrás';
+  String get videoMetadataClosePostDetailsSemanticLabel =>
+      'Cerrar detalles de la publicación';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel =>
@@ -10531,11 +10532,11 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get videoMetadataEditCoverCloseSemanticLabel =>
-      'Cerrar editor de portada';
+      'Descartar cambios de portada';
 
   @override
   String get videoMetadataEditCoverConfirmSemanticLabel =>
-      'Confirmar selección de portada';
+      'Usar el fotograma seleccionado como portada del vídeo';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel =>
@@ -11199,4 +11200,31 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel =>
+      'Cancelar selección de etiquetas';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel =>
+      'Aplicar etiquetas seleccionadas';
+
+  @override
+  String get userPickerCancelSemanticLabel => 'Cancelar selección de usuarios';
+
+  @override
+  String get userPickerConfirmSemanticLabel =>
+      'Confirmar usuarios seleccionados';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel =>
+      'Borrar selección de usuarios';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      'Cancelar selección de advertencias de contenido';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      'Aplicar advertencias de contenido seleccionadas';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -9707,7 +9707,8 @@ class AppLocalizationsFil extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => 'Level';
 
   @override
-  String get videoMetadataBackSemanticLabel => 'Bumalik';
+  String get videoMetadataClosePostDetailsSemanticLabel =>
+      'Isara ang mga detalye ng post';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel =>
@@ -10543,11 +10544,12 @@ class AppLocalizationsFil extends AppLocalizations {
   String get videoMetadataEditCoverTitle => 'Edit cover';
 
   @override
-  String get videoMetadataEditCoverCloseSemanticLabel => 'Close cover editor';
+  String get videoMetadataEditCoverCloseSemanticLabel =>
+      'I-discard ang mga pagbabago sa cover';
 
   @override
   String get videoMetadataEditCoverConfirmSemanticLabel =>
-      'Confirm cover selection';
+      'Gamitin ang napiling frame bilang cover ng video';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel =>
@@ -11210,4 +11212,31 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel =>
+      'Kanselahin ang pagpili ng mga tag';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel =>
+      'Ilapat ang mga napiling tag';
+
+  @override
+  String get userPickerCancelSemanticLabel => 'Kanselahin ang pagpili ng user';
+
+  @override
+  String get userPickerConfirmSemanticLabel =>
+      'Kumpirmahin ang mga napiling user';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel =>
+      'I-clear ang pagpili ng user';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      'Kanselahin ang pagpili ng mga babala sa content';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      'Ilapat ang mga napiling babala sa content';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -9732,7 +9732,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => 'Niveau';
 
   @override
-  String get videoMetadataBackSemanticLabel => 'Retour';
+  String get videoMetadataClosePostDetailsSemanticLabel =>
+      'Fermer les détails de la publication';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel =>
@@ -10574,11 +10575,11 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get videoMetadataEditCoverCloseSemanticLabel =>
-      'Fermer l\'éditeur de couverture';
+      'Ignorer les modifications de la couverture';
 
   @override
   String get videoMetadataEditCoverConfirmSemanticLabel =>
-      'Confirmer la sélection de couverture';
+      'Utiliser l’image sélectionnée comme couverture vidéo';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel =>
@@ -11241,4 +11242,32 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel =>
+      'Annuler la sélection des tags';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel =>
+      'Appliquer les tags sélectionnés';
+
+  @override
+  String get userPickerCancelSemanticLabel =>
+      'Annuler la sélection des utilisateurs';
+
+  @override
+  String get userPickerConfirmSemanticLabel =>
+      'Confirmer les utilisateurs sélectionnés';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel =>
+      'Effacer la sélection des utilisateurs';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      'Annuler la sélection des avertissements de contenu';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      'Appliquer les avertissements de contenu sélectionnés';
 }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -9551,7 +9551,8 @@ class AppLocalizationsId extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => 'Level';
 
   @override
-  String get videoMetadataBackSemanticLabel => 'Kembali';
+  String get videoMetadataClosePostDetailsSemanticLabel =>
+      'Tutup detail postingan';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel =>
@@ -10382,11 +10383,12 @@ class AppLocalizationsId extends AppLocalizations {
   String get videoMetadataEditCoverTitle => 'Edit sampul';
 
   @override
-  String get videoMetadataEditCoverCloseSemanticLabel => 'Tutup editor sampul';
+  String get videoMetadataEditCoverCloseSemanticLabel =>
+      'Buang perubahan sampul';
 
   @override
   String get videoMetadataEditCoverConfirmSemanticLabel =>
-      'Konfirmasi pilihan sampul';
+      'Gunakan bingkai yang dipilih sebagai sampul video';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel =>
@@ -11042,4 +11044,30 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel =>
+      'Batalkan pemilihan tag';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel =>
+      'Terapkan tag yang dipilih';
+
+  @override
+  String get userPickerCancelSemanticLabel => 'Batalkan pemilihan pengguna';
+
+  @override
+  String get userPickerConfirmSemanticLabel =>
+      'Konfirmasi pengguna yang dipilih';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel => 'Hapus pilihan pengguna';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      'Batalkan pemilihan peringatan konten';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      'Terapkan peringatan konten yang dipilih';
 }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -9696,7 +9696,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => 'Livello';
 
   @override
-  String get videoMetadataBackSemanticLabel => 'Indietro';
+  String get videoMetadataClosePostDetailsSemanticLabel =>
+      'Chiudi dettagli del post';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel =>
@@ -10534,11 +10535,11 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get videoMetadataEditCoverCloseSemanticLabel =>
-      'Chiudi editor copertina';
+      'Annulla le modifiche alla copertina';
 
   @override
   String get videoMetadataEditCoverConfirmSemanticLabel =>
-      'Conferma selezione copertina';
+      'Usa il fotogramma selezionato come copertina del video';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel =>
@@ -11201,4 +11202,30 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel =>
+      'Annulla selezione tag';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel =>
+      'Applica i tag selezionati';
+
+  @override
+  String get userPickerCancelSemanticLabel => 'Annulla selezione utenti';
+
+  @override
+  String get userPickerConfirmSemanticLabel => 'Conferma utenti selezionati';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel =>
+      'Cancella selezione utenti';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      'Annulla selezione avvisi sui contenuti';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      'Applica gli avvisi sui contenuti selezionati';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -9178,7 +9178,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => 'レベル';
 
   @override
-  String get videoMetadataBackSemanticLabel => '戻る';
+  String get videoMetadataClosePostDetailsSemanticLabel => '投稿の詳細を閉じる';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel => 'ヘルプダイアログを閉じる';
@@ -9995,10 +9995,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoMetadataEditCoverTitle => 'カバーを編集';
 
   @override
-  String get videoMetadataEditCoverCloseSemanticLabel => 'カバーエディターを閉じる';
+  String get videoMetadataEditCoverCloseSemanticLabel => 'カバーの変更を破棄';
 
   @override
-  String get videoMetadataEditCoverConfirmSemanticLabel => 'カバー選択を確認';
+  String get videoMetadataEditCoverConfirmSemanticLabel => '選択したフレームを動画のカバーに使用';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel =>
@@ -10630,4 +10630,27 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel => 'タグの選択をキャンセル';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel => '選択したタグを適用';
+
+  @override
+  String get userPickerCancelSemanticLabel => 'ユーザー選択をキャンセル';
+
+  @override
+  String get userPickerConfirmSemanticLabel => '選択したユーザーを確定';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel => 'ユーザー選択をクリア';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      'コンテンツ警告の選択をキャンセル';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      '選択したコンテンツ警告を適用';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -9205,7 +9205,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => '레벨';
 
   @override
-  String get videoMetadataBackSemanticLabel => '뒤로';
+  String get videoMetadataClosePostDetailsSemanticLabel => '게시물 세부 정보 닫기';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel => '도움말 대화상자 닫기';
@@ -10021,10 +10021,11 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoMetadataEditCoverTitle => '커버 편집';
 
   @override
-  String get videoMetadataEditCoverCloseSemanticLabel => '커버 편집기 닫기';
+  String get videoMetadataEditCoverCloseSemanticLabel => '커버 변경 사항 취소';
 
   @override
-  String get videoMetadataEditCoverConfirmSemanticLabel => '커버 선택 확인';
+  String get videoMetadataEditCoverConfirmSemanticLabel =>
+      '선택한 프레임을 동영상 커버로 사용';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel => '커버 프레임 선택을 위해 동영상 탐색';
@@ -10656,4 +10657,27 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel => '태그 선택 취소';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel => '선택한 태그 적용';
+
+  @override
+  String get userPickerCancelSemanticLabel => '사용자 선택 취소';
+
+  @override
+  String get userPickerConfirmSemanticLabel => '선택한 사용자 확인';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel => '사용자 선택 지우기';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      '콘텐츠 경고 선택 취소';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      '선택한 콘텐츠 경고 적용';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -9648,7 +9648,8 @@ class AppLocalizationsMs extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => 'Tahap';
 
   @override
-  String get videoMetadataBackSemanticLabel => 'Kembali';
+  String get videoMetadataClosePostDetailsSemanticLabel =>
+      'Tutup butiran siaran';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel =>
@@ -10486,11 +10487,11 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get videoMetadataEditCoverCloseSemanticLabel =>
-      'Tutup penyunting muka depan';
+      'Buang perubahan muka depan';
 
   @override
   String get videoMetadataEditCoverConfirmSemanticLabel =>
-      'Sahkan pemilihan muka depan';
+      'Gunakan bingkai dipilih sebagai muka depan video';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel =>
@@ -11153,4 +11154,30 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel =>
+      'Batalkan pemilihan tag';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel =>
+      'Gunakan tag yang dipilih';
+
+  @override
+  String get userPickerCancelSemanticLabel => 'Batalkan pemilihan pengguna';
+
+  @override
+  String get userPickerConfirmSemanticLabel => 'Sahkan pengguna yang dipilih';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel =>
+      'Kosongkan pemilihan pengguna';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      'Batalkan pemilihan amaran kandungan';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      'Gunakan amaran kandungan yang dipilih';
 }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -9638,7 +9638,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => 'Niveau';
 
   @override
-  String get videoMetadataBackSemanticLabel => 'Terug';
+  String get videoMetadataClosePostDetailsSemanticLabel =>
+      'Berichtdetails sluiten';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel =>
@@ -10474,11 +10475,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get videoMetadataEditCoverTitle => 'Omslag bewerken';
 
   @override
-  String get videoMetadataEditCoverCloseSemanticLabel => 'Omslageditor sluiten';
+  String get videoMetadataEditCoverCloseSemanticLabel =>
+      'Wijzigingen aan omslag negeren';
 
   @override
   String get videoMetadataEditCoverConfirmSemanticLabel =>
-      'Omslagselectie bevestigen';
+      'Geselecteerd frame als video-omslag gebruiken';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel =>
@@ -11138,4 +11140,31 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel =>
+      'Tagselectie annuleren';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel =>
+      'Geselecteerde tags toepassen';
+
+  @override
+  String get userPickerCancelSemanticLabel => 'Gebruikersselectie annuleren';
+
+  @override
+  String get userPickerConfirmSemanticLabel =>
+      'Geselecteerde gebruikers bevestigen';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel =>
+      'Gebruikersselectie wissen';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      'Selectie van inhoudswaarschuwingen annuleren';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      'Geselecteerde inhoudswaarschuwingen toepassen';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -9780,7 +9780,8 @@ class AppLocalizationsPl extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => 'Poziom';
 
   @override
-  String get videoMetadataBackSemanticLabel => 'Wstecz';
+  String get videoMetadataClosePostDetailsSemanticLabel =>
+      'Zamknij szczegóły posta';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel =>
@@ -10615,11 +10616,11 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get videoMetadataEditCoverCloseSemanticLabel =>
-      'Zamknij edytor okładki';
+      'Odrzuć zmiany okładki';
 
   @override
   String get videoMetadataEditCoverConfirmSemanticLabel =>
-      'Potwierdź wybór okładki';
+      'Użyj wybranej klatki jako okładki filmu';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel =>
@@ -11285,4 +11286,30 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel => 'Anuluj wybór tagów';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel =>
+      'Zastosuj wybrane tagi';
+
+  @override
+  String get userPickerCancelSemanticLabel => 'Anuluj wybór użytkowników';
+
+  @override
+  String get userPickerConfirmSemanticLabel =>
+      'Potwierdź wybranych użytkowników';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel =>
+      'Wyczyść wybór użytkowników';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      'Anuluj wybór ostrzeżeń o treści';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      'Zastosuj wybrane ostrzeżenia o treści';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -9663,7 +9663,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => 'Nível';
 
   @override
-  String get videoMetadataBackSemanticLabel => 'Voltar';
+  String get videoMetadataClosePostDetailsSemanticLabel =>
+      'Fechar detalhes da publicação';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel =>
@@ -10500,11 +10501,11 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get videoMetadataEditCoverCloseSemanticLabel =>
-      'Fechar editor de capa';
+      'Descartar alterações da capa';
 
   @override
   String get videoMetadataEditCoverConfirmSemanticLabel =>
-      'Confirmar seleção de capa';
+      'Usar o fotograma selecionado como capa do vídeo';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel =>
@@ -11167,4 +11168,32 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel =>
+      'Cancelar seleção de tags';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel =>
+      'Aplicar tags selecionadas';
+
+  @override
+  String get userPickerCancelSemanticLabel =>
+      'Cancelar seleção de utilizadores';
+
+  @override
+  String get userPickerConfirmSemanticLabel =>
+      'Confirmar utilizadores selecionados';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel =>
+      'Limpar seleção de utilizadores';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      'Cancelar seleção de avisos de conteúdo';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      'Aplicar avisos de conteúdo selecionados';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -9798,7 +9798,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => 'Nivel';
 
   @override
-  String get videoMetadataBackSemanticLabel => 'Înapoi';
+  String get videoMetadataClosePostDetailsSemanticLabel =>
+      'Închide detaliile postării';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel =>
@@ -10638,11 +10639,11 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get videoMetadataEditCoverCloseSemanticLabel =>
-      'Închide editorul de copertă';
+      'Renunță la modificările copertei';
 
   @override
   String get videoMetadataEditCoverConfirmSemanticLabel =>
-      'Confirmă selecția copertei';
+      'Folosește cadrul selectat drept copertă video';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel =>
@@ -11305,4 +11306,32 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel =>
+      'Anulează selectarea etichetelor';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel =>
+      'Aplică etichetele selectate';
+
+  @override
+  String get userPickerCancelSemanticLabel =>
+      'Anulează selectarea utilizatorilor';
+
+  @override
+  String get userPickerConfirmSemanticLabel =>
+      'Confirmă utilizatorii selectați';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel =>
+      'Șterge selecția utilizatorilor';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      'Anulează selectarea avertismentelor de conținut';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      'Aplică avertismentele de conținut selectate';
 }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -9596,7 +9596,8 @@ class AppLocalizationsSv extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => 'Nivå';
 
   @override
-  String get videoMetadataBackSemanticLabel => 'Tillbaka';
+  String get videoMetadataClosePostDetailsSemanticLabel =>
+      'Stäng inläggsdetaljer';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel => 'Stäng hjälpdialog';
@@ -10429,11 +10430,11 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get videoMetadataEditCoverCloseSemanticLabel =>
-      'Stäng omslagsredigerare';
+      'Ignorera omslagsändringar';
 
   @override
   String get videoMetadataEditCoverConfirmSemanticLabel =>
-      'Bekräfta omslagsval';
+      'Använd vald bildruta som videoomslag';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel =>
@@ -11090,4 +11091,28 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel => 'Avbryt taggval';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel =>
+      'Använd valda taggar';
+
+  @override
+  String get userPickerCancelSemanticLabel => 'Avbryt användarval';
+
+  @override
+  String get userPickerConfirmSemanticLabel => 'Bekräfta valda användare';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel => 'Rensa användarval';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      'Avbryt val av innehållsvarningar';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      'Använd valda innehållsvarningar';
 }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -9548,7 +9548,8 @@ class AppLocalizationsTr extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => 'Seviye';
 
   @override
-  String get videoMetadataBackSemanticLabel => 'Geri';
+  String get videoMetadataClosePostDetailsSemanticLabel =>
+      'Gönderi ayrıntılarını kapat';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel =>
@@ -10382,11 +10383,11 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get videoMetadataEditCoverCloseSemanticLabel =>
-      'Kapak düzenleyicisini kapat';
+      'Kapak değişikliklerini iptal et';
 
   @override
   String get videoMetadataEditCoverConfirmSemanticLabel =>
-      'Kapak seçimini onayla';
+      'Seçili kareyi video kapağı olarak kullan';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel =>
@@ -11046,4 +11047,30 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel =>
+      'Etiket seçimini iptal et';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel =>
+      'Seçili etiketleri uygula';
+
+  @override
+  String get userPickerCancelSemanticLabel => 'Kullanıcı seçimini iptal et';
+
+  @override
+  String get userPickerConfirmSemanticLabel => 'Seçili kullanıcıları onayla';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel =>
+      'Kullanıcı seçimini temizle';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      'İçerik uyarısı seçimini iptal et';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      'Seçili içerik uyarılarını uygula';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -9594,7 +9594,8 @@ class AppLocalizationsUr extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => 'سطح';
 
   @override
-  String get videoMetadataBackSemanticLabel => 'واپس';
+  String get videoMetadataClosePostDetailsSemanticLabel =>
+      'پوسٹ کی تفصیلات بند کریں';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel =>
@@ -10425,11 +10426,12 @@ class AppLocalizationsUr extends AppLocalizations {
   String get videoMetadataEditCoverTitle => 'کور میں ترمیم کریں';
 
   @override
-  String get videoMetadataEditCoverCloseSemanticLabel => 'کور ایڈیٹر بند کریں';
+  String get videoMetadataEditCoverCloseSemanticLabel =>
+      'کور کی تبدیلیاں مسترد کریں';
 
   @override
   String get videoMetadataEditCoverConfirmSemanticLabel =>
-      'کور انتخاب کی تصدیق کریں';
+      'منتخب فریم کو ویڈیو کور کے طور پر استعمال کریں';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel =>
@@ -11090,4 +11092,29 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel =>
+      'ٹیگ کا انتخاب منسوخ کریں';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel =>
+      'منتخب ٹیگز لاگو کریں';
+
+  @override
+  String get userPickerCancelSemanticLabel => 'صارف کا انتخاب منسوخ کریں';
+
+  @override
+  String get userPickerConfirmSemanticLabel => 'منتخب صارفین کی تصدیق کریں';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel => 'صارف کا انتخاب صاف کریں';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      'مواد کی وارننگز کا انتخاب منسوخ کریں';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      'منتخب مواد کی وارننگز لاگو کریں';
 }

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -9595,7 +9595,8 @@ class AppLocalizationsVi extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => 'Mức';
 
   @override
-  String get videoMetadataBackSemanticLabel => 'Quay lại';
+  String get videoMetadataClosePostDetailsSemanticLabel =>
+      'Đóng chi tiết bài đăng';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel =>
@@ -10431,12 +10432,11 @@ class AppLocalizationsVi extends AppLocalizations {
   String get videoMetadataEditCoverTitle => 'Chỉnh sửa ảnh bìa';
 
   @override
-  String get videoMetadataEditCoverCloseSemanticLabel =>
-      'Đóng trình chỉnh sửa ảnh bìa';
+  String get videoMetadataEditCoverCloseSemanticLabel => 'Hủy thay đổi ảnh bìa';
 
   @override
   String get videoMetadataEditCoverConfirmSemanticLabel =>
-      'Xác nhận lựa chọn ảnh bìa';
+      'Dùng khung hình đã chọn làm ảnh bìa video';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel =>
@@ -11099,4 +11099,28 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel => 'Hủy chọn thẻ';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel =>
+      'Áp dụng các thẻ đã chọn';
+
+  @override
+  String get userPickerCancelSemanticLabel => 'Hủy chọn người dùng';
+
+  @override
+  String get userPickerConfirmSemanticLabel => 'Xác nhận người dùng đã chọn';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel => 'Xóa lựa chọn người dùng';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      'Hủy chọn cảnh báo nội dung';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      'Áp dụng các cảnh báo nội dung đã chọn';
 }

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -9107,7 +9107,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get videoEditorLevelSemanticLabel => '层级';
 
   @override
-  String get videoMetadataBackSemanticLabel => '返回';
+  String get videoMetadataClosePostDetailsSemanticLabel => '关闭帖子详情';
 
   @override
   String get videoMetadataDismissHelpDialogSemanticLabel => '关闭帮助对话框';
@@ -9870,10 +9870,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get videoMetadataEditCoverTitle => '编辑封面';
 
   @override
-  String get videoMetadataEditCoverCloseSemanticLabel => '关闭封面编辑器';
+  String get videoMetadataEditCoverCloseSemanticLabel => '放弃封面更改';
 
   @override
-  String get videoMetadataEditCoverConfirmSemanticLabel => '确认封面选择';
+  String get videoMetadataEditCoverConfirmSemanticLabel => '将所选帧用作视频封面';
 
   @override
   String get videoMetadataEditCoverStripSemanticLabel => '拖动进度选择封面帧';
@@ -10498,4 +10498,27 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get soundCreditPublicHashtagsLabel => 'Public hashtags';
+
+  @override
+  String get videoMetadataTagsPickerCancelSemanticLabel => '取消标签选择';
+
+  @override
+  String get videoMetadataTagsPickerConfirmSemanticLabel => '应用所选标签';
+
+  @override
+  String get userPickerCancelSemanticLabel => '取消用户选择';
+
+  @override
+  String get userPickerConfirmSemanticLabel => '确认所选用户';
+
+  @override
+  String get userPickerClearSelectionSemanticLabel => '清除用户选择';
+
+  @override
+  String get videoMetadataContentWarningsPickerCancelSemanticLabel =>
+      '取消内容警告选择';
+
+  @override
+  String get videoMetadataContentWarningsPickerConfirmSemanticLabel =>
+      '应用所选内容警告';
 }

--- a/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
@@ -641,15 +641,13 @@ class _TopBarContent extends StatelessWidget {
           child: Row(
             spacing: 16,
             children: [
-              Semantics(
-                label: context.l10n.videoMetadataEditCoverCloseSemanticLabel,
-                button: true,
-                child: DivineIconButton(
-                  icon: .x,
-                  type: .ghostOverMedia,
-                  size: .small,
-                  onPressed: onClose,
-                ),
+              DivineIconButton(
+                icon: .x,
+                type: .ghostOverMedia,
+                size: .small,
+                semanticLabel:
+                    context.l10n.videoMetadataEditCoverCloseSemanticLabel,
+                onPressed: onClose,
               ),
               Expanded(
                 child: Text(
@@ -660,22 +658,27 @@ class _TopBarContent extends StatelessWidget {
                   overflow: TextOverflow.ellipsis,
                 ),
               ),
-              Semantics(
-                label: context.l10n.videoMetadataEditCoverConfirmSemanticLabel,
-                button: true,
-                child: isConfirming
-                    // The indicator is an Image.asset that is not excluded
-                    // from semantics, so without this the confirm node
-                    // announces as an image as well as a button.
-                    ? const ExcludeSemantics(
-                        child: BrandedLoadingIndicator(size: 44),
-                      )
-                    : DivineIconButton(
-                        icon: .check,
-                        size: .small,
-                        onPressed: onConfirm,
-                      ),
-              ),
+              if (isConfirming)
+                Semantics(
+                  label:
+                      context.l10n.videoMetadataEditCoverConfirmSemanticLabel,
+                  button: true,
+                  enabled: false,
+                  // The indicator is an Image.asset that is not excluded
+                  // from semantics, so without this the confirm node
+                  // announces as an image as well as a disabled button.
+                  child: const ExcludeSemantics(
+                    child: BrandedLoadingIndicator(size: 44),
+                  ),
+                )
+              else
+                DivineIconButton(
+                  icon: .check,
+                  size: .small,
+                  semanticLabel:
+                      context.l10n.videoMetadataEditCoverConfirmSemanticLabel,
+                  onPressed: onConfirm,
+                ),
             ],
           ),
         ),

--- a/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
@@ -407,29 +407,31 @@ class _PreviewOverlay extends ConsumerWidget {
     // Lives in the outer full-screen Stack so it always renders at
     // phone-screen proportions, independent of the video's aspect ratio.
     return IgnorePointer(
-      child: Opacity(
-        opacity: 0.5,
-        child: Material(
-          type: .transparency,
-          child: ValueListenableBuilder(
-            valueListenable: isPreviewReady,
-            builder: (_, isActive, _) {
-              return Stack(
-                fit: StackFit.expand,
-                children: [
-                  const FeedModeSwitch(isPreviewMode: true),
-                  VideoOverlayActions.preview(
-                    previewData: VideoOverlayPreviewData(
-                      pubkey: publicKey,
-                      title: metadata.title,
-                      description: metadata.description,
+      child: ExcludeSemantics(
+        child: Opacity(
+          opacity: 0.5,
+          child: Material(
+            type: .transparency,
+            child: ValueListenableBuilder(
+              valueListenable: isPreviewReady,
+              builder: (_, isActive, _) {
+                return Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    const FeedModeSwitch(isPreviewMode: true),
+                    VideoOverlayActions.preview(
+                      previewData: VideoOverlayPreviewData(
+                        pubkey: publicKey,
+                        title: metadata.title,
+                        description: metadata.description,
+                      ),
+                      isVisible: true,
+                      isActive: isActive,
                     ),
-                    isVisible: true,
-                    isActive: isActive,
-                  ),
-                ],
-              );
-            },
+                  ],
+                );
+              },
+            ),
           ),
         ),
       ),

--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -373,6 +373,7 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
             icon: .x,
             type: .secondary,
             size: .small,
+            semanticLabel: context.l10n.userPickerCancelSemanticLabel,
             onPressed: context.pop,
           ),
           title: _UserPickerTitle(
@@ -385,6 +386,7 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
               ? DivineIconButton(
                   icon: .check,
                   size: .small,
+                  semanticLabel: context.l10n.userPickerConfirmSemanticLabel,
                   onPressed: _handleDone,
                 )
               : widget.initialSelectedProfiles.isNotEmpty
@@ -392,6 +394,8 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
                   icon: .trash,
                   size: .small,
                   type: .error,
+                  semanticLabel:
+                      context.l10n.userPickerClearSelectionSemanticLabel,
                   onPressed: _handleClear,
                 )
               : null,
@@ -552,58 +556,60 @@ class _UserSearchTile extends StatelessWidget {
       child: GestureDetector(
         behavior: HitTestBehavior.translucent,
         onTap: isDisabled ? null : onTap,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: Row(
-            spacing: 16,
-            children: [
-              Opacity(
-                opacity: isDisabled ? 0.5 : 1.0,
-                child: UserAvatar(
-                  imageUrl: profile.picture,
-                  name: profile.bestDisplayName,
-                  placeholderSeed: profile.pubkey,
-                  size: 40,
+        child: ExcludeSemantics(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Row(
+              spacing: 16,
+              children: [
+                Opacity(
+                  opacity: isDisabled ? 0.5 : 1.0,
+                  child: UserAvatar(
+                    imageUrl: profile.picture,
+                    name: profile.bestDisplayName,
+                    placeholderSeed: profile.pubkey,
+                    size: 40,
+                  ),
                 ),
-              ),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: .start,
-                  children: [
-                    Text(
-                      profile.bestDisplayName,
-                      maxLines: 1,
-                      overflow: .ellipsis,
-                      style: VineTheme.titleMediumFont(color: textColor),
-                    ),
-                    if (profile.nip05 != null && profile.nip05!.isNotEmpty)
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: .start,
+                    children: [
                       Text(
-                        profile.nip05!,
+                        profile.bestDisplayName,
                         maxLines: 1,
                         overflow: .ellipsis,
-                        style: VineTheme.bodyMediumFont(color: textColor),
+                        style: VineTheme.titleMediumFont(color: textColor),
                       ),
-                  ],
+                      if (profile.nip05 != null && profile.nip05!.isNotEmpty)
+                        Text(
+                          profile.nip05!,
+                          maxLines: 1,
+                          overflow: .ellipsis,
+                          style: VineTheme.bodyMediumFont(color: textColor),
+                        ),
+                    ],
+                  ),
                 ),
-              ),
-              Container(
-                padding: const .all(8),
-                decoration: ShapeDecoration(
-                  color: isDisabled
-                      ? context.vineColors.surfaceContainer
-                      : isSelected
-                      ? context.vineColors.surfaceContainer
-                      : VineTheme.primary,
-                  shape: RoundedRectangleBorder(borderRadius: .circular(16)),
+                Container(
+                  padding: const .all(8),
+                  decoration: ShapeDecoration(
+                    color: isDisabled
+                        ? context.vineColors.surfaceContainer
+                        : isSelected
+                        ? context.vineColors.surfaceContainer
+                        : VineTheme.primary,
+                    shape: RoundedRectangleBorder(borderRadius: .circular(16)),
+                  ),
+                  child: DivineIcon(
+                    icon: (isDisabled || isSelected) ? .check : .plus,
+                    color: (isDisabled || isSelected)
+                        ? context.vineColors.onSurfaceMuted
+                        : VineTheme.onPrimary,
+                  ),
                 ),
-                child: DivineIcon(
-                  icon: (isDisabled || isSelected) ? .check : .plus,
-                  color: (isDisabled || isSelected)
-                      ? context.vineColors.onSurfaceMuted
-                      : VineTheme.onPrimary,
-                ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -545,14 +545,17 @@ class _UserSearchTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textColor = context.vineColors.onSurface;
+    final action = isDisabled
+        ? context.l10n.userPickerAlreadyAddedSemantics(profile.bestDisplayName)
+        : context.l10n.userPickerSelectSemantics(profile.bestDisplayName);
+    final nip05 = profile.nip05;
 
     return Semantics(
       button: true,
-      label: isDisabled
-          ? context.l10n.userPickerAlreadyAddedSemantics(
-              profile.bestDisplayName,
-            )
-          : context.l10n.userPickerSelectSemantics(profile.bestDisplayName),
+      // The rendered nip05 is what tells two same-named users apart, so it
+      // rides along with the action instead of being dropped by the
+      // ExcludeSemantics below.
+      label: nip05 != null && nip05.isNotEmpty ? '$action. $nip05' : action,
       child: GestureDetector(
         behavior: HitTestBehavior.translucent,
         onTap: isDisabled ? null : onTap,

--- a/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_app_bar.dart
+++ b/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_app_bar.dart
@@ -61,7 +61,8 @@ class VideoMetadataCaptureAppBar extends ConsumerWidget
                 icon: .caretLeft,
                 type: .secondary,
                 size: .small,
-                semanticLabel: context.l10n.videoMetadataBackSemanticLabel,
+                semanticLabel:
+                    context.l10n.videoMetadataClosePostDetailsSemanticLabel,
                 onPressed: () => context.pop(),
               ),
             ),

--- a/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar.dart
+++ b/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar.dart
@@ -153,7 +153,9 @@ class _SaveForLaterButton extends ConsumerWidget {
                 GallerySaveService.destinationName,
               ),
         button: true,
+        excludeSemantics: true,
         enabled: !isSaving && !isProcessing,
+        onTap: isSaving || isProcessing ? null : onTap,
         child: DivineButton(
           onPressed: isSaving || isProcessing ? null : onTap,
           type: .secondary,
@@ -190,6 +192,8 @@ class _PostButton extends ConsumerWidget {
             : context.l10n.videoMetadataFormNotReadyHint,
         button: true,
         enabled: isValidToPost,
+        excludeSemantics: true,
+        onTap: isValidToPost ? onTap : null,
         child: DivineButton(
           onPressed: isValidToPost ? onTap : null,
           expanded: true,

--- a/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview.dart
+++ b/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview.dart
@@ -90,27 +90,29 @@ class VideoMetadataCaptureClipPreview extends ConsumerWidget {
                   child: Stack(
                     children: [
                       // Video thumbnail or placeholder
-                      AnimatedSwitcher(
-                        layoutBuilder: (currentChild, previousChildren) =>
-                            Stack(
-                              fit: .expand,
-                              alignment: .center,
-                              children: [...previousChildren, ?currentChild],
-                            ),
-
-                        duration: const Duration(milliseconds: 150),
-                        child: clip.thumbnailPath != null
-                            ? // Video thumbnail image
-                              VideoMetadataCapturePreviewThumbnail(clip: clip)
-                            : // Fallback placeholder
-                              ColoredBox(
-                                color: context.vineColors.onSurfaceMuted,
-                                child: const DivineIcon(
-                                  icon: .playCircle,
-                                  size: 64,
-                                  color: VineTheme.whiteText,
-                                ),
+                      ExcludeSemantics(
+                        child: AnimatedSwitcher(
+                          layoutBuilder: (currentChild, previousChildren) =>
+                              Stack(
+                                fit: .expand,
+                                alignment: .center,
+                                children: [...previousChildren, ?currentChild],
                               ),
+
+                          duration: const Duration(milliseconds: 150),
+                          child: clip.thumbnailPath != null
+                              ? // Video thumbnail image
+                                VideoMetadataCapturePreviewThumbnail(clip: clip)
+                              : // Fallback placeholder
+                                ColoredBox(
+                                  color: context.vineColors.onSurfaceMuted,
+                                  child: const DivineIcon(
+                                    icon: .playCircle,
+                                    size: 64,
+                                    color: VineTheme.whiteText,
+                                  ),
+                                ),
+                        ),
                       ),
                       // Processing overlay with edit-cover icon
                       VideoEditorProcessingOverlay(

--- a/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview.dart
+++ b/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview.dart
@@ -68,9 +68,7 @@ class VideoMetadataCaptureClipPreview extends ConsumerWidget {
         // child rides into the flight shuttle and fights the shape the
         // preview's flightShuttleBuilder is morphing towards.
         child: ClipRRect(
-          borderRadius: .circular(
-            VideoEditorConstants.clipPreviewCornerRadius,
-          ),
+          borderRadius: .circular(VideoEditorConstants.clipPreviewCornerRadius),
           // Hero animation to preview screen
           child: Hero(
             tag: VideoEditorConstants.heroMetaPreviewId,
@@ -125,18 +123,15 @@ class VideoMetadataCaptureClipPreview extends ConsumerWidget {
                             .read(videoEditorProvider.notifier)
                             .startRenderVideo(),
                         inactivePlaceholder: Center(
-                          child: Semantics(
-                            button: true,
-                            label: context.l10n.videoMetadataEditCoverTitle,
-                            excludeSemantics: true,
-                            child: DivineIconButton(
-                              icon: .pencilSimpleLine,
-                              type: .ghostOverMedia,
-                              size: .small,
-                              onPressed: () => _openCoverEditor(
-                                context,
-                                state.finalRenderedClip!,
-                              ),
+                          child: DivineIconButton(
+                            icon: .pencilSimpleLine,
+                            type: .ghostOverMedia,
+                            size: .small,
+                            semanticLabel:
+                                context.l10n.videoMetadataEditCoverTitle,
+                            onPressed: () => _openCoverEditor(
+                              context,
+                              state.finalRenderedClip!,
                             ),
                           ),
                         ),

--- a/mobile/lib/widgets/video_metadata/modes/classic/video_metadata_classic_app_bar.dart
+++ b/mobile/lib/widgets/video_metadata/modes/classic/video_metadata_classic_app_bar.dart
@@ -33,7 +33,8 @@ class VideoMetadataClassicAppBar extends StatelessWidget
                 icon: .caretLeft,
                 type: .ghostSecondary,
                 size: .small,
-                semanticLabel: context.l10n.videoMetadataBackSemanticLabel,
+                semanticLabel:
+                    context.l10n.videoMetadataClosePostDetailsSemanticLabel,
                 onPressed: () => context.pop(),
               ),
             ),

--- a/mobile/lib/widgets/video_metadata/modes/classic/video_metadata_classic_bottom_bar.dart
+++ b/mobile/lib/widgets/video_metadata/modes/classic/video_metadata_classic_bottom_bar.dart
@@ -57,10 +57,12 @@ class _PostButton extends ConsumerWidget {
       opacity: isValidToPost ? 1 : 0.32,
       child: Semantics(
         identifier: 'post_button',
-        label: context.l10n.videoMetadataOpenPreviewSemanticLabel,
+        label: context.l10n.videoMetadataPostSemanticLabel,
         hint: context.l10n.videoMetadataPublishVideoHint,
         button: true,
         enabled: isValidToPost,
+        excludeSemantics: true,
+        onTap: isValidToPost ? onTap : null,
         child: DivineButton(
           onPressed: isValidToPost ? onTap : null,
           expanded: true,

--- a/mobile/lib/widgets/video_metadata/video_metadata_content_warning_selector.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_content_warning_selector.dart
@@ -116,12 +116,18 @@ class _ContentWarningMultiSelectState
             icon: .x,
             type: .secondary,
             size: .small,
+            semanticLabel: context
+                .l10n
+                .videoMetadataContentWarningsPickerCancelSemanticLabel,
             onPressed: context.pop,
           ),
           title: const _ContentWarningHeaderTitle(),
           trailingAction: DivineIconButton(
             icon: .check,
             size: .small,
+            semanticLabel: context
+                .l10n
+                .videoMetadataContentWarningsPickerConfirmSemanticLabel,
             onPressed: () => context.pop(_selected),
           ),
         ),
@@ -190,27 +196,37 @@ class _ContentLabelTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      color: isChecked
-          ? context.vineColors.surfaceContainer
-          : VineTheme.transparent,
-      child: InkWell(
-        onTap: onTap,
-        child: Container(
-          height: 64,
-          padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: Row(
-            children: [
-              Expanded(
-                child: Text(
-                  localizedContentLabelName(context.l10n, label),
-                  style: VineTheme.titleMediumFont(
-                    color: context.vineColors.onSurface,
+    // The sprite checkbox carries no semantics of its own, so merge the label,
+    // the tap action and the checked flag into one node — screen readers
+    // announce e.g. "Nudity, checkbox, not checked".
+    return MergeSemantics(
+      child: Semantics(
+        checked: isChecked,
+        child: Material(
+          color: isChecked
+              ? context.vineColors.surfaceContainer
+              : VineTheme.transparent,
+          child: InkWell(
+            onTap: onTap,
+            child: Container(
+              height: 64,
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      localizedContentLabelName(context.l10n, label),
+                      style: VineTheme.titleMediumFont(
+                        color: context.vineColors.onSurface,
+                      ),
+                    ),
                   ),
-                ),
+                  DivineSpriteCheckbox(
+                    state: isChecked ? .selected : .unselected,
+                  ),
+                ],
               ),
-              DivineSpriteCheckbox(state: isChecked ? .selected : .unselected),
-            ],
+            ),
           ),
         ),
       ),

--- a/mobile/lib/widgets/video_metadata/video_metadata_tags_selector.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_tags_selector.dart
@@ -194,6 +194,8 @@ class _TagsPickerViewState extends State<_TagsPickerView> {
             icon: .x,
             type: .secondary,
             size: .small,
+            semanticLabel:
+                context.l10n.videoMetadataTagsPickerCancelSemanticLabel,
             onPressed: context.pop,
           ),
           title: Text(
@@ -203,6 +205,8 @@ class _TagsPickerViewState extends State<_TagsPickerView> {
           trailingAction: DivineIconButton(
             icon: .check,
             size: .small,
+            semanticLabel:
+                context.l10n.videoMetadataTagsPickerConfirmSemanticLabel,
             onPressed: () => context.pop(
               Set<String>.unmodifiable(
                 context.read<TagsPickerBloc>().state.selectedTags,

--- a/mobile/test/screens/video_metadata_cover_screen_test.dart
+++ b/mobile/test/screens/video_metadata_cover_screen_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for VideoMetadataCoverScreen widget
 // ABOUTME: Verifies rendering, semantics, navigation, and failure handling
 
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:divine_video_player/divine_video_player.dart';
 import 'package:flutter/material.dart';
@@ -44,13 +46,23 @@ class _NoopInitProVideoEditor extends MethodChannelProVideoEditor {
   Stream<dynamic> initializeStream() => const Stream.empty();
 }
 
+class _PendingEditorVideo extends Fake implements EditorVideo {
+  _PendingEditorVideo(this.path);
+
+  final Future<String> path;
+
+  @override
+  Future<String> safeFilePath() => path;
+}
+
 DivineVideoClip _createTestClip({
   String id = 'test-clip',
   models.AspectRatio aspectRatio = models.AspectRatio.square,
+  EditorVideo? video,
 }) {
   return DivineVideoClip(
     id: id,
-    video: EditorVideo.file('test.mp4'),
+    video: video ?? EditorVideo.file('test.mp4'),
     duration: const Duration(seconds: 10),
     recordedAt: DateTime.now(),
     targetAspectRatio: aspectRatio,
@@ -389,6 +401,42 @@ void main() {
       );
     });
 
+    testWidgets('confirm button keeps disabled semantics while confirming', (
+      tester,
+    ) async {
+      setUpPlayerChannel();
+      addTearDown(tearDownPlayerChannel);
+      final semanticsHandle = tester.ensureSemantics();
+      final pendingPath = Completer<String>();
+      final clip = _createTestClip(
+        video: _PendingEditorVideo(pendingPath.future),
+      );
+
+      await tester.pumpWidget(buildWidget(clip: clip));
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      await triggerConfirm(tester);
+      await tester.pump();
+
+      final confirmFinder = find.bySemanticsLabel(
+        l10n.videoMetadataEditCoverConfirmSemanticLabel,
+      );
+      expect(confirmFinder, findsOneWidget);
+      expect(find.byType(BrandedLoadingIndicator), findsWidgets);
+      expect(
+        tester.getSemantics(confirmFinder),
+        isSemantics(
+          label: l10n.videoMetadataEditCoverConfirmSemanticLabel,
+          isButton: true,
+          hasEnabledState: true,
+          isEnabled: false,
+        ),
+      );
+
+      semanticsHandle.dispose();
+    });
+
     testWidgets('shows thumbnail strip with correct semantics label', (
       tester,
     ) async {
@@ -453,7 +501,14 @@ void main() {
         setUpPlayerChannel();
         addTearDown(tearDownPlayerChannel);
 
-        await tester.pumpWidget(buildWidget());
+        await tester.pumpWidget(
+          buildWidget(
+            clip: _createTestClip(
+              id: 'missing-thumbnail-source',
+              video: EditorVideo.file('__missing_cover_thumbnail_source__.mp4'),
+            ),
+          ),
+        );
         await tester.pump(const Duration(milliseconds: 400));
 
         final l10n = lookupAppLocalizations(const Locale('en'));

--- a/mobile/test/screens/video_metadata_cover_screen_test.dart
+++ b/mobile/test/screens/video_metadata_cover_screen_test.dart
@@ -353,9 +353,16 @@ void main() {
       await tester.pump(const Duration(milliseconds: 400));
 
       final l10n = lookupAppLocalizations(const Locale('en'));
+      final closeFinder = find.bySemanticsLabel(
+        l10n.videoMetadataEditCoverCloseSemanticLabel,
+      );
+      expect(closeFinder, findsOneWidget);
       expect(
-        find.bySemanticsLabel(l10n.videoMetadataEditCoverCloseSemanticLabel),
-        findsOneWidget,
+        tester
+            .getSemantics(closeFinder)
+            .getSemanticsData()
+            .hasAction(SemanticsAction.tap),
+        isTrue,
       );
     });
 
@@ -369,9 +376,16 @@ void main() {
       await tester.pump(const Duration(milliseconds: 400));
 
       final l10n = lookupAppLocalizations(const Locale('en'));
+      final confirmFinder = find.bySemanticsLabel(
+        l10n.videoMetadataEditCoverConfirmSemanticLabel,
+      );
+      expect(confirmFinder, findsOneWidget);
       expect(
-        find.bySemanticsLabel(l10n.videoMetadataEditCoverConfirmSemanticLabel),
-        findsOneWidget,
+        tester
+            .getSemantics(confirmFinder)
+            .getSemanticsData()
+            .hasAction(SemanticsAction.tap),
+        isTrue,
       );
     });
 

--- a/mobile/test/widgets/user_picker_sheet_test.dart
+++ b/mobile/test/widgets/user_picker_sheet_test.dart
@@ -116,6 +116,86 @@ void main() {
 
   group(UserPickerSheet, () {
     group('renders', () {
+      testWidgets('header describes cancel and confirm actions', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              profileRepositoryProvider.overrideWithValue(
+                _createMockProfileRepository(),
+              ),
+              followRepositoryProvider.overrideWithValue(
+                _createMockFollowRepository(),
+              ),
+            ],
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: UserPickerSheet(
+                  title: 'Title',
+                  filterMode: UserPickerFilterMode.allUsers,
+                  maxCount: 2,
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(
+          find.bySemanticsLabel(l10n.userPickerCancelSemanticLabel),
+          findsOneWidget,
+        );
+        expect(
+          find.bySemanticsLabel(l10n.userPickerConfirmSemanticLabel),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('header describes clearing an existing selection', (
+        tester,
+      ) async {
+        final selectedProfile = UserProfile(
+          pubkey: 'selected-pubkey',
+          name: 'Selected User',
+          rawData: const {'name': 'Selected User'},
+          createdAt: DateTime(2026),
+          eventId: 'selected-event',
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              profileRepositoryProvider.overrideWithValue(
+                _createMockProfileRepository(),
+              ),
+              followRepositoryProvider.overrideWithValue(
+                _createMockFollowRepository(),
+              ),
+            ],
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: UserPickerSheet(
+                  title: 'Title',
+                  filterMode: UserPickerFilterMode.allUsers,
+                  initialSelectedProfiles: [selectedProfile],
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(
+          find.bySemanticsLabel(l10n.userPickerClearSelectionSemanticLabel),
+          findsOneWidget,
+        );
+      });
+
       testWidgets('search text field', (tester) async {
         await tester.pumpWidget(
           ProviderScope(

--- a/mobile/test/widgets/user_picker_sheet_test.dart
+++ b/mobile/test/widgets/user_picker_sheet_test.dart
@@ -494,6 +494,65 @@ void main() {
         expect(tester.takeException(), isNull);
       });
 
+      testWidgets('result tile announces the action and the nip05 handle', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+        final profile = UserProfile(
+          pubkey: 'pubkey1',
+          name: 'User One',
+          nip05: 'user.one@example.com',
+          rawData: const {'name': 'User One', 'nip05': 'user.one@example.com'},
+          createdAt: DateTime.now(),
+          eventId: 'event1',
+        );
+
+        final mockFollowRepo = _createMockFollowRepository(
+          followingPubkeys: ['pubkey1'],
+        );
+        when(
+          mockFollowRepo.streamMyFollowers,
+        ).thenAnswer((_) => Stream<List<String>>.value(['pubkey1']));
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              profileRepositoryProvider.overrideWithValue(
+                _createMockProfileRepository(cachedProfiles: [profile]),
+              ),
+              followRepositoryProvider.overrideWithValue(mockFollowRepo),
+              contentBlocklistRepositoryProvider.overrideWithValue(
+                _createMockContentBlocklistRepository(),
+              ),
+            ],
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: UserPickerSheet(
+                  title: 'Title',
+                  filterMode: UserPickerFilterMode.mutualFollowsOnly,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final label = tester
+            .getSemantics(find.text('User One'))
+            .getSemanticsData()
+            .label;
+
+        expect(label, contains(l10n.userPickerSelectSemantics('User One')));
+        // Two follows can share a display name; the handle is what tells
+        // them apart, so it must survive the tile's ExcludeSemantics.
+        expect(label, contains('user.one@example.com'));
+
+        handle.dispose();
+      });
+
       testWidgets('renders mutuals from the first follower source and adds '
           'later ones', (tester) async {
         final profiles = [

--- a/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_app_bar_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_app_bar_test.dart
@@ -124,7 +124,10 @@ void main() {
       // Verify we're showing the app bar
       expect(find.byType(VideoMetadataCaptureAppBar), findsOneWidget);
 
-      await tester.tap(find.bySemanticsLabel('Back'));
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      await tester.tap(
+        find.bySemanticsLabel(l10n.videoMetadataClosePostDetailsSemanticLabel),
+      );
       await tester.pumpAndSettle();
 
       verify(() => mockGoRouter.pop<Object?>(any())).called(1);

--- a/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar_test.dart
@@ -1,5 +1,6 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -168,6 +169,63 @@ void main() {
             .first,
       );
       expect(animatedOpacity.opacity, equals(1.0));
+    });
+
+    testWidgets('Post and Save draft are activatable by a screen reader', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      final validState = VideoEditorProviderState(
+        title: 'Test Video',
+        finalRenderedClip: DivineVideoClip(
+          id: 'test-clip',
+          video: EditorVideo.file('test.mp4'),
+          duration: const Duration(seconds: 10),
+          recordedAt: DateTime.now(),
+          targetAspectRatio: models.AspectRatio.square,
+          originalAspectRatio: 9 / 16,
+        ),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            videoEditorProvider.overrideWith(
+              () => _MockVideoEditorNotifier(validState),
+            ),
+            gallerySaveServiceProvider.overrideWith(
+              (ref) => mockGallerySaveService,
+            ),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: VideoMetadataCaptureBottomBar()),
+          ),
+        ),
+      );
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      // Both buttons exclude their child's semantics, so the label and the
+      // tap action have to meet on the wrapper node or the control is
+      // announced but not operable.
+      for (final label in [
+        l10n.videoMetadataPostSemanticLabel,
+        l10n.videoMetadataSaveForLaterSemanticLabel,
+      ]) {
+        final finder = find.bySemanticsLabel(label);
+        expect(finder, findsOneWidget, reason: label);
+        expect(
+          tester
+              .getSemantics(finder)
+              .getSemanticsData()
+              .hasAction(SemanticsAction.tap),
+          isTrue,
+          reason: label,
+        );
+      }
+
+      handle.dispose();
     });
 
     testWidgets('tapping Save draft button calls saveAsDraft', (tester) async {

--- a/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview_test.dart
@@ -1,5 +1,6 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart' hide AspectRatio;
+import 'package:flutter/semantics.dart';
 import 'package:flutter/widgets.dart' show AspectRatio;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -358,6 +359,63 @@ void main() {
         expect(tappable.onTap, isNotNull);
       },
     );
+
+    testWidgets('open-preview stays activatable alongside the cover button', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      final finalClip = DivineVideoClip(
+        id: 'final-clip',
+        video: EditorVideo.file('final.mp4'),
+        duration: const Duration(seconds: 15),
+        recordedAt: DateTime.now(),
+        targetAspectRatio: models.AspectRatio.square,
+        originalAspectRatio: 9 / 16,
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            clipManagerProvider.overrideWith(
+              () => _MockClipManagerNotifier([testClip]),
+            ),
+            videoEditorProvider.overrideWith(
+              () => _MockVideoEditorNotifier(
+                VideoEditorProviderState(finalRenderedClip: finalClip),
+              ),
+            ),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: VideoMetadataCaptureClipPreview()),
+          ),
+        ),
+      );
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      // The cover button sits inside the preview's tap target. Wrapping it in
+      // an excludeSemantics Semantics() cost the enclosing preview node its
+      // tap action — the whole 200px stage went inert for TalkBack while the
+      // pointer path still worked.
+      final openPreview = find.bySemanticsLabel(
+        l10n.videoMetadataOpenPreviewSemanticLabel,
+      );
+      expect(openPreview, findsOneWidget);
+      expect(
+        tester
+            .getSemantics(openPreview)
+            .getSemanticsData()
+            .hasAction(SemanticsAction.tap),
+        isTrue,
+      );
+      expect(
+        find.bySemanticsLabel(l10n.videoMetadataEditCoverTitle),
+        findsOneWidget,
+      );
+
+      handle.dispose();
+    });
   });
 }
 

--- a/mobile/test/widgets/video_metadata/modes/classic/video_metadata_classic_bottom_bar_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/classic/video_metadata_classic_bottom_bar_test.dart
@@ -1,23 +1,40 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' as models;
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/services/gallery_save_service.dart';
 import 'package:openvine/widgets/video_metadata/modes/classic/video_metadata_classic_bottom_bar.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+class _MockGallerySaveService extends Mock implements GallerySaveService {}
+
+class _FakeEditorVideo extends Fake implements EditorVideo {}
+
 void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeEditorVideo());
+  });
+
   group(VideoMetadataClassicBottomBar, () {
     late SharedPreferences prefs;
+    late _MockGallerySaveService mockGallerySaveService;
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
       prefs = await SharedPreferences.getInstance();
+      mockGallerySaveService = _MockGallerySaveService();
+      when(
+        () => mockGallerySaveService.saveVideoToGallery(any()),
+      ).thenAnswer((_) async => const GallerySaveSuccess());
     });
 
     testWidgets('renders Post button labeled "Done"', (tester) async {
@@ -105,7 +122,12 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [videoEditorProvider.overrideWith(() => mockNotifier)],
+          overrides: [
+            videoEditorProvider.overrideWith(() => mockNotifier),
+            gallerySaveServiceProvider.overrideWith(
+              (ref) => mockGallerySaveService,
+            ),
+          ],
           child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
@@ -120,10 +142,29 @@ void main() {
       expect(postVideoCalled, isTrue);
     });
 
-    testWidgets('button has correct semantics identifier', (tester) async {
+    testWidgets('Post button is activatable by a screen reader', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      final validState = VideoEditorProviderState(
+        title: 'Test Video',
+        finalRenderedClip: DivineVideoClip(
+          id: 'test-clip',
+          video: EditorVideo.file('test.mp4'),
+          duration: const Duration(seconds: 10),
+          recordedAt: DateTime.now(),
+          targetAspectRatio: models.AspectRatio.square,
+          originalAspectRatio: 9 / 16,
+        ),
+      );
+
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+          overrides: [
+            videoEditorProvider.overrideWith(
+              () => _MockVideoEditorNotifier(validState),
+            ),
+          ],
           child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
@@ -132,12 +173,22 @@ void main() {
         ),
       );
 
-      final semantics = tester.widget<Semantics>(
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      final postFinder = find.bySemanticsLabel(
+        l10n.videoMetadataPostSemanticLabel,
+      );
+      expect(postFinder, findsOneWidget);
+      final postData = tester.getSemantics(postFinder).getSemanticsData();
+
+      expect(postData.hasAction(SemanticsAction.tap), isTrue);
+      expect(
         find.byWidgetPredicate(
           (w) => w is Semantics && w.properties.identifier == 'post_button',
         ),
+        findsOneWidget,
       );
-      expect(semantics.properties.label, equals('Open post preview screen'));
+
+      handle.dispose();
     });
   });
 }

--- a/mobile/test/widgets/video_metadata/video_metadata_content_warning_selector_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_content_warning_selector_test.dart
@@ -156,6 +156,32 @@ void main() {
       expect(find.text('Alcohol'), findsOneWidget);
     });
 
+    testWidgets('bottom sheet header describes cancel and apply actions', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildWidget());
+
+      await tester.tap(
+        find.bySemanticsLabel(
+          l10n.videoMetadataSelectContentWarningsSemanticLabel,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.bySemanticsLabel(
+          l10n.videoMetadataContentWarningsPickerCancelSemanticLabel,
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.bySemanticsLabel(
+          l10n.videoMetadataContentWarningsPickerConfirmSemanticLabel,
+        ),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('tapping confirm button pops with selected labels', (
       tester,
     ) async {
@@ -240,6 +266,46 @@ void main() {
       verify(
         () => mockGoRouter.pop<Set<ContentLabel>>(<ContentLabel>{}),
       ).called(1);
+    });
+
+    testWidgets('announces each option as a checkbox with its checked state', (
+      tester,
+    ) async {
+      addTearDown(tester.view.reset);
+      tester.view.physicalSize = const Size(1080, 2400);
+      tester.view.devicePixelRatio = 1;
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(buildWidget());
+
+      await tester.tap(
+        find.bySemanticsLabel(
+          l10n.videoMetadataSelectContentWarningsSemanticLabel,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.getSemantics(find.text('Nudity')),
+        isSemantics(
+          // The label rides up from the child Text rather than being repeated
+          // in `label:`, so it cannot drift from the rendered string.
+          label: 'Nudity',
+          hasCheckedState: true,
+          isChecked: false,
+          hasTapAction: true,
+        ),
+      );
+
+      await tester.tap(find.text('Nudity'));
+      await tester.pump();
+
+      expect(
+        tester.getSemantics(find.text('Nudity')),
+        isSemantics(label: 'Nudity', hasCheckedState: true, isChecked: true),
+      );
+
+      handle.dispose();
     });
 
     testWidgets('tapping an option toggles its checkbox state', (tester) async {

--- a/mobile/test/widgets/video_metadata/video_metadata_tags_selector_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_tags_selector_test.dart
@@ -50,6 +50,38 @@ void main() {
       expect(find.text('flutter, dart'), findsOneWidget);
     });
 
+    testWidgets('picker header describes cancel and apply actions', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildTestApp(
+          hashtagRepository: hashtagRepository,
+          videoEditorState: VideoEditorProviderState(),
+        ),
+      );
+
+      await tester.tap(
+        find.byType(VideoMetadataSelectionTile),
+        warnIfMissed: false,
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(
+        find.bySemanticsLabel(
+          l10n.videoMetadataTagsPickerCancelSemanticLabel,
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.bySemanticsLabel(
+          l10n.videoMetadataTagsPickerConfirmSemanticLabel,
+        ),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('pasting multiple tags adds chips and clears the field', (
       tester,
     ) async {


### PR DESCRIPTION
Closes #6888

## Description

Walking the post-details flow with TalkBack turned it into a wall of unlabelled buttons and stray images. This fixes the semantics across that flow.

**Icon buttons announce their action.** The close/confirm/clear controls in the post-details app bars (capture + classic), the tag picker, the content-warning picker and the user picker had no label at all — TalkBack read them as bare "button". Each now passes `semanticLabel` to `DivineIconButton`, describing what activating it does rather than what it looks like.

**`videoMetadataBackSemanticLabel` → `videoMetadataClosePostDetailsSemanticLabel`.** "Back" describes the chevron, not the outcome. Translated in all 22 locales along with the seven new keys.

**Decorative layers stop competing with the content.** Three subtrees were readable but meaningless to a screen reader, so they're now `ExcludeSemantics`: the 50%-opacity feed preview overlay (a non-interactive mock of the feed chrome, already wrapped in `IgnorePointer`), the clip thumbnail in the capture preview, and the avatar/name/checkmark inside the user search tile — that tile's parent already carries the full label, so the children were duplicating it.

**Content-warning options announce as checkboxes.** `DivineSpriteCheckbox` carries no semantics of its own, so each row read as a plain text label with no indication it was selectable or selected. Each option is now a single `MergeSemantics` node with `checked:` state — "Nudity, checkbox, not checked". The label rides up from the child `Text` instead of being repeated in `label:`, so it cannot drift from the rendered string.

**Post / Save-for-later buttons.** These wrap a `DivineButton` in a `Semantics` that supplies the label and hint, but the inner button contributed its own node, so the meaningful label and the tappable node were separate. They now use `excludeSemantics: true` and hoist `onTap` to the `Semantics` wrapper, producing one node that is both labelled and actionable.

**Cover editor confirm keeps its identity while confirming.** During confirmation the button was replaced by a `BrandedLoadingIndicator`, and the label went with it — the control vanished mid-action. The label now stays on a `Semantics(button: true, enabled: false)` node wrapping the indicator, so it announces as a disabled button instead of disappearing.

**Related Issue:** 

## Out of Scope

Only the post-details/metadata flow and the user picker it opens. Other screens' semantics are untouched.

## Verification

- `flutter analyze lib test integration_test` — no issues
- `flutter test test/l10n/arb_consistency_test.dart test/screens/video_metadata_cover_screen_test.dart test/widgets/user_picker_sheet_test.dart test/widgets/video_metadata/` — 219 passed
- `dart format` clean on all changed files
- Manually verified on a real Samsung Galaxy with TalkBack: walked the post-details screen, both app bar variants, the tag / collaborator / content-warning pickers and the cover editor, confirming every control announces its action and the decorative layers are silent.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore