### PR TITLE
fix(feed): clear a stranded page overlay when the shell is uncovered

### DIFF
--- a/mobile/lib/providers/shell_obscured_provider.dart
+++ b/mobile/lib/providers/shell_obscured_provider.dart
@@ -18,6 +18,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// without a pop event (e.g. sign-out → /welcome → back to home) cannot keep
 /// the feed paused.
 ///
+/// AppShell also clears `overlayVisibilityProvider.isPageOpen` when this flag
+/// becomes `false`. A page overlay is backed by a route above the shell, so an
+/// uncovered shell proves the page overlay should no longer block autoplay,
+/// even if go_router removed the route with `go()` and never completed the
+/// original `pushWithVideoPause` future.
+///
 /// The home feed reads this to know it is offstage behind a pushed screen.
 /// GoRouter's `routeInformationProvider` collapses to the shell location
 /// (`/home`) while popping between pushed routes, so the feed cannot rely on

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -11,6 +11,7 @@ import 'package:openvine/app_update/app_update.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/notifications/view/notifications_page.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/overlay_visibility_provider.dart';
 import 'package:openvine/providers/relay_list_repository_provider.dart';
 import 'package:openvine/providers/route_feed_providers.dart';
 import 'package:openvine/providers/shell_obscured_provider.dart';
@@ -108,6 +109,14 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       ref.read(shellObscuredProvider.notifier).setObscured(obscured: obscured);
+      if (!obscured) {
+        // Every page overlay is backed by a route above the shell, so an
+        // uncovered shell proves none is open. Not redundant with
+        // `pushWithVideoPause`'s own clear, which a `go()`-style back skips
+        // entirely — see its doc comment. Without this the home feed could stay
+        // permanently unable to autoplay on scroll (#6239).
+        ref.read(overlayVisibilityProvider.notifier).setPageOpen(false);
+      }
     });
   }
 

--- a/mobile/lib/utils/pause_aware_modals.dart
+++ b/mobile/lib/utils/pause_aware_modals.dart
@@ -32,6 +32,15 @@ extension PauseAwareModals on BuildContext {
   /// Calls [OverlayVisibility.setPageOpen(true)] before pushing and
   /// [setPageOpen(false)] when the pushed route is popped.
   /// This releases all video players to free memory.
+  ///
+  /// The returned future only completes on a **pop**: go_router completes an
+  /// `ImperativeRouteMatch` from `_completeRouteMatch`, which runs on the pop
+  /// path alone, so a `go()` that rebuilds the match list removes the route and
+  /// drops the pending completer. `AppShell` therefore also clears the flag
+  /// whenever the shell is uncovered — without that safety net a `go()`-style
+  /// back (the Android back handler, a deep link, a refresh redirect) strands
+  /// the flag `true` and the home feed never autoplays again (#6239). Do not
+  /// make this future the only clear path.
   Future<T?> pushWithVideoPause<T extends Object?>(
     String location, {
     Object? extra,

--- a/mobile/test/router/app_shell_obscured_test.dart
+++ b/mobile/test/router/app_shell_obscured_test.dart
@@ -16,6 +16,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/environment_provider.dart';
+import 'package:openvine/providers/overlay_visibility_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/shell_obscured_provider.dart';
 import 'package:openvine/router/router.dart';
@@ -193,6 +194,52 @@ void main() {
       // didPush fires once as the fresh shell subscribes, clearing the flag so
       // the home feed can resume.
       expect(container.read(shellObscuredProvider), isFalse);
+    },
+  );
+
+  testWidgets(
+    'uncovering the shell clears a page overlay stranded by a go()-style back '
+    '(#6239)',
+    (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          mockAuthService: mockAuthService,
+          sharedPreferences: sharedPreferences,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(AppShell)),
+      );
+      final navigator = Navigator.of(tester.element(find.byType(AppShell)));
+
+      // `pushWithVideoPause` raises the page flag, then pushes the route.
+      container.read(overlayVisibilityProvider.notifier).setPageOpen(true);
+      unawaited(
+        navigator.push(
+          MaterialPageRoute<void>(builder: (_) => const SizedBox.shrink()),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(container.read(shellObscuredProvider), isTrue);
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+
+      // Uncover the shell without the `push` future's clear ever running —
+      // the state a `go()`-style back leaves behind, since go_router drops the
+      // pending completer when it removes the route instead of popping it
+      // (pinned by pause_aware_modals_test). A declarative `go()` removal
+      // drives the same `didPopNext` on the shell as this pop does.
+      navigator.pop();
+      await tester.pumpAndSettle();
+
+      // The shell is uncovered, so no page overlay can still be open — the
+      // home feed must be allowed to autoplay again.
+      expect(
+        container.read(overlayVisibilityProvider).isPageOpen,
+        isFalse,
+        reason: 'a stranded page flag keeps the home feed from autoplaying',
+      );
     },
   );
 

--- a/mobile/test/router/app_shell_obscured_test.dart
+++ b/mobile/test/router/app_shell_obscured_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/app_update/app_update.dart';
 import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
@@ -22,6 +23,7 @@ import 'package:openvine/providers/shell_obscured_provider.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/feed/home_feed_retap_cubit.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -198,43 +200,98 @@ void main() {
   );
 
   testWidgets(
-    'uncovering the shell clears a page overlay stranded by a go()-style back '
-    '(#6239)',
+    'router.go() uncovering the shell clears a page overlay stranded by '
+    'pushWithVideoPause (#6239)',
     (tester) async {
-      await tester.pumpWidget(
-        _buildSubject(
+      final rootNavigatorKey = GlobalKey<NavigatorState>();
+      final container = ProviderContainer(
+        overrides: _overrides(
           mockAuthService: mockAuthService,
           sharedPreferences: sharedPreferences,
         ),
       );
-      await tester.pumpAndSettle();
+      addTearDown(container.dispose);
 
-      final container = ProviderScope.containerOf(
-        tester.element(find.byType(AppShell)),
+      late final GoRouter router;
+      router = GoRouter(
+        navigatorKey: rootNavigatorKey,
+        initialLocation: '/',
+        observers: [routeObserver],
+        routes: [
+          ShellRoute(
+            pageBuilder: (context, state, child) => NoTransitionPage<void>(
+              key: state.pageKey,
+              child: AppShell(
+                currentIndex: state.uri.path == '/explore' ? 1 : 0,
+                child: child,
+              ),
+            ),
+            routes: [
+              GoRoute(
+                path: '/',
+                pageBuilder: (_, state) => NoTransitionPage<void>(
+                  key: state.pageKey,
+                  child: Center(
+                    child: Builder(
+                      builder: (context) => TextButton(
+                        onPressed: () => unawaited(
+                          context.pushWithVideoPause<void>('/hashtag'),
+                        ),
+                        child: const Text('Open hashtag'),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              GoRoute(
+                path: '/explore',
+                pageBuilder: (_, state) => NoTransitionPage<void>(
+                  key: state.pageKey,
+                  child: const Center(child: Text('Explore')),
+                ),
+              ),
+            ],
+          ),
+          GoRoute(
+            path: '/hashtag',
+            parentNavigatorKey: rootNavigatorKey,
+            pageBuilder: (_, state) => MaterialPage<void>(
+              key: state.pageKey,
+              child: const Scaffold(body: Center(child: Text('Hashtag'))),
+            ),
+          ),
+        ],
       );
-      final navigator = Navigator.of(tester.element(find.byType(AppShell)));
+      addTearDown(router.dispose);
 
-      // `pushWithVideoPause` raises the page flag, then pushes the route.
-      container.read(overlayVisibilityProvider.notifier).setPageOpen(true);
-      unawaited(
-        navigator.push(
-          MaterialPageRoute<void>(builder: (_) => const SizedBox.shrink()),
+      await tester.pumpWidget(
+        _wrapWithBlocs(
+          UncontrolledProviderScope(
+            container: container,
+            child: MaterialApp.router(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              routerConfig: router,
+            ),
+          ),
         ),
       );
       await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Open hashtag'));
+      await tester.pumpAndSettle();
+      expect(find.text('Hashtag'), findsOneWidget);
       expect(container.read(shellObscuredProvider), isTrue);
       expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
 
-      // Uncover the shell without the `push` future's clear ever running —
-      // the state a `go()`-style back leaves behind, since go_router drops the
-      // pending completer when it removes the route instead of popping it
-      // (pinned by pause_aware_modals_test). A declarative `go()` removal
-      // drives the same `didPopNext` on the shell as this pop does.
-      navigator.pop();
+      // A go()-style back removes the pushed route declaratively, so
+      // pushWithVideoPause's future never completes. AppShell must still notice
+      // that the shell is uncovered and clear the stranded page flag.
+      router.go('/explore');
       await tester.pumpAndSettle();
 
-      // The shell is uncovered, so no page overlay can still be open — the
-      // home feed must be allowed to autoplay again.
+      expect(find.text('Explore'), findsOneWidget);
+      expect(container.read(shellObscuredProvider), isFalse);
       expect(
         container.read(overlayVisibilityProvider).isPageOpen,
         isFalse,

--- a/mobile/test/utils/pause_aware_modals_test.dart
+++ b/mobile/test/utils/pause_aware_modals_test.dart
@@ -3,10 +3,13 @@
 // ABOUTME: Comments after migration) rely on for tap-outside dismissal
 // ABOUTME: and overlay-visibility integration.
 
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:openvine/providers/overlay_visibility_provider.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
 
@@ -204,6 +207,102 @@ void main() {
         expect(
           container.read(overlayVisibilityProvider).isBottomSheetOpen,
           isFalse,
+        );
+      },
+    );
+  });
+
+  group('pushWithVideoPause', () {
+    GoRouter buildRouter() => GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(
+          path: '/',
+          pageBuilder: (_, state) => NoTransitionPage<void>(
+            key: state.pageKey,
+            child: Scaffold(
+              body: Builder(
+                builder: (context) => TextButton(
+                  onPressed: () =>
+                      unawaited(context.pushWithVideoPause<void>('/hashtag')),
+                  child: const Text('Open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+        GoRoute(
+          path: '/explore',
+          pageBuilder: (_, state) => NoTransitionPage<void>(
+            key: state.pageKey,
+            child: const Scaffold(body: Text('Explore')),
+          ),
+        ),
+        GoRoute(
+          path: '/hashtag',
+          pageBuilder: (_, state) => MaterialPage<void>(
+            key: state.pageKey,
+            child: const Scaffold(body: Text('Hashtag')),
+          ),
+        ),
+      ],
+    );
+
+    Future<(GoRouter, ProviderContainer)> pumpApp(WidgetTester tester) async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final router = buildRouter();
+      addTearDown(router.dispose);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return (router, container);
+    }
+
+    testWidgets('clears isPageOpen when the pushed route is popped', (
+      tester,
+    ) async {
+      final (router, container) = await pumpApp(tester);
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+      expect(find.text('Hashtag'), findsOneWidget);
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+
+      router.pop();
+      await tester.pumpAndSettle();
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
+    });
+
+    testWidgets(
+      'leaves isPageOpen set when a go() removes the pushed route — the '
+      'go_router behaviour AppShell has to compensate for (#6239)',
+      (tester) async {
+        final (router, container) = await pumpApp(tester);
+
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+        expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+
+        // What the Android back handler does for several route types, and what
+        // a deep link or a refresh redirect does: navigate rather than pop. The
+        // route is removed from the match list, so go_router's
+        // `_completeRouteMatch` never runs and the `push` future stays pending
+        // forever — the `whenComplete` clear below never fires.
+        router.go('/explore');
+        await tester.pumpAndSettle();
+        expect(find.text('Explore'), findsOneWidget);
+
+        expect(
+          container.read(overlayVisibilityProvider).isPageOpen,
+          isTrue,
+          reason:
+              'if go_router ever completes the future on removal, drop this '
+              'test and the AppShell safety net it justifies',
         );
       },
     );


### PR DESCRIPTION
## Description

The home feed only autoplays while `overlayVisibilityProvider.isPageOpen` is false (`video_feed_page.dart:294`). `pushWithVideoPause` raises that flag before pushing and clears it from the `push` future's `whenComplete` — but go_router completes an `ImperativeRouteMatch` only in `_completeRouteMatch`, which runs on the pop path alone. A `go()` that rebuilds the match list *removes* the route and drops the pending completer, so the clear never runs and the flag stays `true`.

`BackButtonHandler` navigates with `router.go(...)` rather than popping for several route types (hashtag unconditionally; the `videoIndex` and tab-history branches too), and deep links do the same whenever the current location is already in the target route family (`DeepLinkNavAction.go`), as do refresh redirects. So: open a hashtag, sound, or author profile from the feed, leave it via a go-style navigation, and every later scroll lands on a paused video until another page overlay happens to clear the flag.

A page overlay is always backed by a route above the shell, so an uncovered shell proves none is open. `AppShell` already resets its sibling `shellObscuredProvider` from `didPush`/`didPopNext`, and those callbacks fire for the shell-uncovered `go()` removal case. Clearing the page flag from that same signal closes the gap.

**Related Issue:** Fixes #6239

## Out of Scope

- **Not changing where a `go()`-style back lands.** Making `BackButtonHandler` prefer `pop()` when it can would move the hashtag back target off Explore — a product-behavior call, not a bug fix. The safety net here holds regardless of which navigation removed the route.
- **Page-overlay ownership/refcounting.** `setPageOpen` remains a boolean in this PR; the broader nested-overlay sharp edge is tracked in #6898.
- **Separate autoplay gate gaps.** Externally-driven autoplay gate changes are tracked in #6899, and feed page-change playback coverage is tracked in #6900.

## Verification

- `flutter analyze lib/providers/shell_obscured_provider.dart test/router/app_shell_obscured_test.dart test/utils/pause_aware_modals_test.dart` — clean.
- `flutter test test/router/app_shell_obscured_test.dart test/utils/pause_aware_modals_test.dart` — 10 passed.
- Pre-push hook reran the changed-file analyzer and the two affected test files — passed.
- Regression coverage now drives the real path: `AppShell` under `MaterialApp.router`, `pushWithVideoPause`, then `router.go(...)`, asserting the stranded page flag clears when the shell is uncovered.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)