### PR TITLE
fix(feed): make the first tap on a stopped video play it

### DIFF
--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -44,6 +44,7 @@ import 'package:openvine/widgets/video_feed_item/double_tap_like_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/feed_immersive_chrome.dart';
 import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/paused_video_overlay.dart';
+import 'package:openvine/widgets/video_feed_item/player_tap_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/subtitle_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/verifying_aware_video_error_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
@@ -738,12 +739,13 @@ class __OverlayState extends ConsumerState<_Overlay> {
   void _handlePlayerTap() {
     widget.onSuppressAutoAdvance?.call();
 
-    if (widget.controller != null) {
-      if (widget.controller!.state.isPaused) {
-        widget.controller!.play();
-      } else {
-        widget.controller!.pause();
-      }
+    final controller = widget.controller;
+    if (controller == null) return;
+    switch (resolvePlayerTapAction(controller.state.status)) {
+      case PlayerTapAction.play:
+        controller.play();
+      case PlayerTapAction.pause:
+        controller.pause();
     }
   }
 

--- a/mobile/lib/widgets/video_feed_item/player_tap_helpers.dart
+++ b/mobile/lib/widgets/video_feed_item/player_tap_helpers.dart
@@ -1,0 +1,32 @@
+// ABOUTME: Pure decision helper for the tap-to-toggle-playback gesture on feed
+// ABOUTME: videos. Keeps the "which states count as running" rule testable in
+// ABOUTME: isolation from the FeedVideos overlay widget and the native player.
+
+import 'package:divine_video_player/divine_video_player.dart';
+
+/// The action a tap on a feed video should trigger.
+enum PlayerTapAction {
+  /// Start (or restart) playback.
+  play,
+
+  /// Stop playback.
+  pause,
+}
+
+/// Decides how a tap on a feed video should behave, given the player's
+/// [status].
+///
+/// Keyed on whether the player is *running*, not on whether it is paused.
+/// [PlaybackStatus.isPaused] is strictly `status == paused`, so a controller
+/// that initialized but never started ([PlaybackStatus.ready]) and a finished
+/// non-looping clip ([PlaybackStatus.completed]) are both stopped without being
+/// `paused`. Keying on `isPaused` sent those to `pause()`, so the viewer's first
+/// tap did nothing and they had to tap twice (#6239).
+///
+/// [PlaybackStatus.buffering] counts as running, so a tap mid-load still
+/// pauses rather than issuing a redundant play.
+PlayerTapAction resolvePlayerTapAction(PlaybackStatus status) {
+  return status.isPlaying || status.isBuffering
+      ? PlayerTapAction.pause
+      : PlayerTapAction.play;
+}

--- a/mobile/lib/widgets/video_feed_item/player_tap_helpers.dart
+++ b/mobile/lib/widgets/video_feed_item/player_tap_helpers.dart
@@ -6,7 +6,7 @@ import 'package:divine_video_player/divine_video_player.dart';
 
 /// The action a tap on a feed video should trigger.
 enum PlayerTapAction {
-  /// Start (or restart) playback.
+  /// Request playback.
   play,
 
   /// Stop playback.
@@ -20,8 +20,9 @@ enum PlayerTapAction {
 /// [PlaybackStatus.isPaused] is strictly `status == paused`, so a controller
 /// that initialized but never started ([PlaybackStatus.ready]) and a finished
 /// non-looping clip ([PlaybackStatus.completed]) are both stopped without being
-/// `paused`. Keying on `isPaused` sent those to `pause()`, so the viewer's first
-/// tap did nothing and they had to tap twice (#6239).
+/// `paused`. Keying on `isPaused` sent stopped states to `pause()`, which can
+/// turn the first tap into a no-op when a rendered frame is visible but playback
+/// is not running.
 ///
 /// [PlaybackStatus.buffering] counts as running, so a tap mid-load still
 /// pauses rather than issuing a redundant play.

--- a/mobile/test/widgets/video_feed_item/player_tap_helpers_test.dart
+++ b/mobile/test/widgets/video_feed_item/player_tap_helpers_test.dart
@@ -1,6 +1,6 @@
 // ABOUTME: Tests for resolvePlayerTapAction — the pure decision behind
 // ABOUTME: tap-to-toggle-playback on feed videos, including the stopped-but-not
-// ABOUTME: -paused states whose dead first tap was the #6239 symptom.
+// ABOUTME: -paused states that should request playback instead of pausing.
 
 import 'package:divine_video_player/divine_video_player.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -8,59 +8,26 @@ import 'package:openvine/widgets/video_feed_item/player_tap_helpers.dart';
 
 void main() {
   group('resolvePlayerTapAction', () {
-    test('pauses a playing video', () {
-      expect(
-        resolvePlayerTapAction(PlaybackStatus.playing),
-        PlayerTapAction.pause,
-      );
-    });
+    test('maps every playback status to the expected tap action', () {
+      const expectedActions = <PlaybackStatus, PlayerTapAction>{
+        PlaybackStatus.idle: PlayerTapAction.play,
+        PlaybackStatus.ready: PlayerTapAction.play,
+        PlaybackStatus.playing: PlayerTapAction.pause,
+        PlaybackStatus.paused: PlayerTapAction.play,
+        PlaybackStatus.buffering: PlayerTapAction.pause,
+        PlaybackStatus.completed: PlayerTapAction.play,
+        PlaybackStatus.error: PlayerTapAction.play,
+      };
 
-    test('plays a paused video', () {
-      expect(
-        resolvePlayerTapAction(PlaybackStatus.paused),
-        PlayerTapAction.play,
-      );
-    });
+      expect(expectedActions.keys, unorderedEquals(PlaybackStatus.values));
 
-    test('plays a ready video that was initialized but never started', () {
-      // The #6239 case, observed on an iPhone: the feed had been gated off, so
-      // the controller sat in `ready` rather than `paused`. Keying the toggle on
-      // isPaused sent this to pause() — the viewer's first tap did nothing and
-      // they had to tap the frame twice to start it.
-      expect(
-        resolvePlayerTapAction(PlaybackStatus.ready),
-        PlayerTapAction.play,
-      );
-    });
-
-    test('restarts a completed clip', () {
-      // A non-looping clip that ran to its end is stopped without being
-      // `paused`, so a tap has to restart it rather than pause it again.
-      expect(
-        resolvePlayerTapAction(PlaybackStatus.completed),
-        PlayerTapAction.play,
-      );
-    });
-
-    test('pauses while buffering', () {
-      // Buffering means playback is underway, so the tap must stop it —
-      // otherwise tapping a slow-loading video issues a redundant play.
-      expect(
-        resolvePlayerTapAction(PlaybackStatus.buffering),
-        PlayerTapAction.pause,
-      );
-    });
-
-    test('plays an idle player', () {
-      expect(resolvePlayerTapAction(PlaybackStatus.idle), PlayerTapAction.play);
-    });
-
-    test('every status resolves without falling through', () {
-      // The tap target is gated on a rendered first frame, so `error` is not
-      // reachable in practice; assert the resolver still answers for it rather
-      // than leaving a status unhandled.
-      for (final status in PlaybackStatus.values) {
-        expect(resolvePlayerTapAction(status), isA<PlayerTapAction>());
+      for (final MapEntry(key: status, value: expectedAction)
+          in expectedActions.entries) {
+        expect(
+          resolvePlayerTapAction(status),
+          expectedAction,
+          reason: 'Unexpected tap action for $status',
+        );
       }
     });
   });

--- a/mobile/test/widgets/video_feed_item/player_tap_helpers_test.dart
+++ b/mobile/test/widgets/video_feed_item/player_tap_helpers_test.dart
@@ -1,0 +1,67 @@
+// ABOUTME: Tests for resolvePlayerTapAction — the pure decision behind
+// ABOUTME: tap-to-toggle-playback on feed videos, including the stopped-but-not
+// ABOUTME: -paused states whose dead first tap was the #6239 symptom.
+
+import 'package:divine_video_player/divine_video_player.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/widgets/video_feed_item/player_tap_helpers.dart';
+
+void main() {
+  group('resolvePlayerTapAction', () {
+    test('pauses a playing video', () {
+      expect(
+        resolvePlayerTapAction(PlaybackStatus.playing),
+        PlayerTapAction.pause,
+      );
+    });
+
+    test('plays a paused video', () {
+      expect(
+        resolvePlayerTapAction(PlaybackStatus.paused),
+        PlayerTapAction.play,
+      );
+    });
+
+    test('plays a ready video that was initialized but never started', () {
+      // The #6239 case, observed on an iPhone: the feed had been gated off, so
+      // the controller sat in `ready` rather than `paused`. Keying the toggle on
+      // isPaused sent this to pause() — the viewer's first tap did nothing and
+      // they had to tap the frame twice to start it.
+      expect(
+        resolvePlayerTapAction(PlaybackStatus.ready),
+        PlayerTapAction.play,
+      );
+    });
+
+    test('restarts a completed clip', () {
+      // A non-looping clip that ran to its end is stopped without being
+      // `paused`, so a tap has to restart it rather than pause it again.
+      expect(
+        resolvePlayerTapAction(PlaybackStatus.completed),
+        PlayerTapAction.play,
+      );
+    });
+
+    test('pauses while buffering', () {
+      // Buffering means playback is underway, so the tap must stop it —
+      // otherwise tapping a slow-loading video issues a redundant play.
+      expect(
+        resolvePlayerTapAction(PlaybackStatus.buffering),
+        PlayerTapAction.pause,
+      );
+    });
+
+    test('plays an idle player', () {
+      expect(resolvePlayerTapAction(PlaybackStatus.idle), PlayerTapAction.play);
+    });
+
+    test('every status resolves without falling through', () {
+      // The tap target is gated on a rendered first frame, so `error` is not
+      // reachable in practice; assert the resolver still answers for it rather
+      // than leaving a status unhandled.
+      for (final status in PlaybackStatus.values) {
+        expect(resolvePlayerTapAction(status), isA<PlayerTapAction>());
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Description

`_handlePlayerTap` toggled on `controller.state.isPaused`, which is strictly `status == paused`. Stopped player statuses such as `ready`, `idle`, `completed`, and `error` are not running, but they are also not `paused`, so they fell to the `pause()` branch instead of requesting playback.

The toggle now keys on whether the player is running. `playing` and `buffering` pause; every stopped status requests play. `buffering` still counts as running, so a tap mid-load stops playback instead of issuing a redundant play. Behavior in the ordinary `playing` <-> `paused` cycle is unchanged.

This is a correctness fix for the tap resolver and covers stopped-but-not-paused states across player backends. On iOS and Android, native `ready` is reported to Dart as `paused`, so this PR should not be treated as proof that the mobile #6239 reproduction was caused by a Dart-visible `ready` status. If that mobile symptom is still reproducible, #6239 should keep tracking the device-specific root cause.

Traced through both native backends to confirm that: iOS serializes `ready` with `rate == 0` as `paused` (`DivineVideoPlayerInstance.swift`), and Android maps `STATE_READY` to `playing`/`paused` depending on `playWhenReady` (`DivineVideoPlayerInstance.kt`). The stopped-but-not-paused statuses that *are* Dart-visible on mobile are `idle`, `completed`, and `error` — all three previously fell to the `pause()` branch, and `idle` is the first case the resolver test turns red on when the old `isPaused` keying is restored.

Extracted as a pure resolver alongside the existing `resolveDoubleTapLikeAction`: the tap target is gated on `isFirstFrameRendered`, so exercising it needs a live native controller and cannot be driven from a widget test. The resolver is unit-testable and now pins the expected action for every `PlaybackStatus` value.

**Related Issue:** Refs #6239

## Out of Scope

- The paused-overlay behavior is tracked separately in #6784/#6889. This PR only changes the tap action resolver, not the paused affordance.
- Restarting native playback from a genuinely completed non-looping clip may require a seek before `play()`. This PR only ensures the tap resolver requests playback instead of pause for completed status.

## Verification

- `flutter analyze lib/widgets/video_feed_item/player_tap_helpers.dart test/widgets/video_feed_item/player_tap_helpers_test.dart` - clean.
- `flutter test test/widgets/video_feed_item/player_tap_helpers_test.dart` - passed.
- Pre-push hook - passed:
  - no merge conflicts with `main`
  - analyzer clean for changed files
  - `flutter test test/widgets/video_feed_item/feed_videos_test.dart test/widgets/video_feed_item/player_tap_helpers_test.dart` - 40 passed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

