### PR TITLE
fix(video-metadata): stop painting the clip cover's edits twice

### DIFF
--- a/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_preview_thumbnail.dart
+++ b/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_preview_thumbnail.dart
@@ -1,25 +1,15 @@
-import 'dart:typed_data';
-
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/models/divine_video_clip.dart';
-import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
-import 'package:pro_image_editor/features/filter_editor/widgets/filter_generator.dart';
-import 'package:pro_image_editor/pro_image_editor.dart';
 
-class VideoMetadataCapturePreviewThumbnail extends ConsumerWidget {
+class VideoMetadataCapturePreviewThumbnail extends StatelessWidget {
   const VideoMetadataCapturePreviewThumbnail({required this.clip, super.key});
 
   final DivineVideoClip clip;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final editingParameters = ref.watch(
-      videoEditorProvider.select((s) => s.editorEditingParameters),
-    );
-
+  Widget build(BuildContext context) {
     if (clip.thumbnailPath == null) {
       return Center(
         child: DivineIcon(
@@ -30,162 +20,9 @@ class VideoMetadataCapturePreviewThumbnail extends ConsumerWidget {
       );
     }
 
-    final thumbnail = ClipThumbnailImage(
+    return ClipThumbnailImage(
       path: clip.thumbnailPath!,
       fit: .cover,
-    );
-
-    return Stack(
-      fit: .expand,
-      children: [
-        thumbnail,
-        _EditedPreviewOverlay(
-          editingParameters: editingParameters,
-          thumbnail: thumbnail,
-        ),
-      ],
-    );
-  }
-}
-
-class _EditedPreviewOverlay extends StatefulWidget {
-  const _EditedPreviewOverlay({
-    required this.editingParameters,
-    required this.thumbnail,
-  });
-
-  final CompleteParameters? editingParameters;
-  final Widget thumbnail;
-
-  @override
-  State<_EditedPreviewOverlay> createState() => _EditedPreviewOverlayState();
-}
-
-class _EditedPreviewOverlayState extends State<_EditedPreviewOverlay> {
-  static const _firstFrameSpan = Duration(milliseconds: 10);
-  static const _switchDuration = Duration(milliseconds: 240);
-
-  final ValueNotifier<Duration> _playTimeNotifier = ValueNotifier(.zero);
-
-  @override
-  void dispose() {
-    _playTimeNotifier.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final params = widget.editingParameters;
-
-    return AnimatedSwitcher(
-      duration: _switchDuration,
-      child: params == null
-          ? const SizedBox.shrink()
-          : LayoutBuilder(
-              builder: (context, constraints) {
-                final targetSize = constraints.biggest;
-                final bodySize = params.bodySize;
-                final hasValidBodySize =
-                    bodySize != null &&
-                    bodySize.width > 0 &&
-                    bodySize.height > 0;
-                final sourceSize = hasValidBodySize ? bodySize : targetSize;
-                final sourceCenter = Offset(
-                  sourceSize.width / 2,
-                  sourceSize.height / 2,
-                );
-                final fittedSizes = applyBoxFit(
-                  BoxFit.cover,
-                  sourceSize,
-                  targetSize,
-                );
-                final sourceRect = Alignment.center.inscribe(
-                  fittedSizes.source,
-                  Offset.zero & sourceSize,
-                );
-                final destinationRect = Alignment.center.inscribe(
-                  fittedSizes.destination,
-                  Offset.zero & targetSize,
-                );
-                final coverScaleX = destinationRect.width / sourceRect.width;
-                final coverScaleY = destinationRect.height / sourceRect.height;
-
-                return Stack(
-                  alignment: .center,
-                  fit: .expand,
-                  children: [
-                    ColorFilterGenerator(
-                      playTimeNotifier: _playTimeNotifier,
-                      filters: const [],
-                      filterStates: params.filterStates,
-                      tuneAdjustments: params.tuneAdjustments,
-                      child: widget.thumbnail,
-                    ),
-                    for (final item in params.capturedLayers)
-                      if (item.layer.startTime == null ||
-                          item.layer.startTime! < _firstFrameSpan)
-                        _PositionedLayer(
-                          bytes: item.bytes,
-                          logicalSize: item.logicalSize,
-                          layerOffset: item.layer.offset,
-                          sourceCenter: sourceCenter,
-                          sourceRect: sourceRect,
-                          destinationRect: destinationRect,
-                          coverScaleX: coverScaleX,
-                          coverScaleY: coverScaleY,
-                        ),
-                  ],
-                );
-              },
-            ),
-    );
-  }
-}
-
-class _PositionedLayer extends StatelessWidget {
-  const _PositionedLayer({
-    required this.bytes,
-    required this.logicalSize,
-    required this.layerOffset,
-    required this.sourceCenter,
-    required this.sourceRect,
-    required this.destinationRect,
-    required this.coverScaleX,
-    required this.coverScaleY,
-  });
-
-  final Uint8List bytes;
-  final Size logicalSize;
-  final Offset layerOffset;
-  final Offset sourceCenter;
-  final Rect sourceRect;
-  final Rect destinationRect;
-  final double coverScaleX;
-  final double coverScaleY;
-
-  @override
-  Widget build(BuildContext context) {
-    final sourcePosition = Offset(
-      layerOffset.dx + sourceCenter.dx,
-      layerOffset.dy + sourceCenter.dy,
-    );
-    final destinationPosition = Offset(
-      destinationRect.left +
-          (sourcePosition.dx - sourceRect.left) * coverScaleX,
-      destinationRect.top + (sourcePosition.dy - sourceRect.top) * coverScaleY,
-    );
-
-    return Positioned(
-      left: destinationPosition.dx,
-      top: destinationPosition.dy,
-      child: FractionalTranslation(
-        translation: const Offset(-0.5, -0.5),
-        child: Image.memory(
-          bytes,
-          width: logicalSize.width * coverScaleX,
-          height: logicalSize.height * coverScaleY,
-        ),
-      ),
     );
   }
 }


### PR DESCRIPTION
Closes #6894

## Description

`VideoMetadataCapturePreviewThumbnail` stacked an `_EditedPreviewOverlay` on top of the clip cover, which re-applied the editor's filter states, tune adjustments and captured layers via `ColorFilterGenerator` plus positioned `Image.memory` layers.

Every call site already shows a cover that has all of that baked in:

- `VideoMetadataCaptureClipPreview` uses `state.finalRenderedClip ?? clips.first`, so after the render it is the rendered cover.
- `VideoMetadataPreviewScreen` from `VideoMetadataCaptureAppBar` gates the tap on `finalRenderedClip != null`. That clip's cover is extracted from the **rendered** file (`VideoEditorRenderService`, with an explicit comment on why it must not be inherited from the source clip).
- `VideoMetadataPreviewScreen` from `UploadFailureSheet` (`previewOnly: true`) shows a draft whose render already finished. Here the overlay was not just redundant but wrong: it painted whatever `videoEditorProvider` happened to hold at that moment onto a cover from a different, already-baked session.

In every case the overlay painted the effects a second time. The only window where it added anything was the raw thumbnail shown while the render is still running — and there it sits under `VideoEditorProcessingOverlay`'s 70% black scrim and spinner, and is swapped for the rendered cover as soon as the render lands. That approximation is what this change gives up; everything else it did was a double-apply.

With the overlay gone the widget no longer reads `videoEditorProvider`, so it drops from `ConsumerWidget` back to `StatelessWidget`, and the now single-child `Stack(fit: .expand)` goes with it. Both layout hosts already hand it tight constraints — the `AnimatedSwitcher` layout builder's expanded stack in the clip preview, and `DivineVideoPlayer`, which returns the placeholder straight into the `SizedBox(width: ratio * 100, height: 100)` while its controller is null and otherwise wraps it in its own expanded stack — so the cover-fitted image fills the same box on its own.

Net effect: 187 lines down to 27, and five imports removed.

**Related Issue:** 

## Out of Scope

Restoring an edited-look preview for the pre-render window. If that turns out to be missed, it belongs on the processing overlay rather than under it.

## Verification

- `dart format` — clean
- `flutter analyze lib/widgets/video_metadata lib/screens/video_metadata` — no issues
- `flutter test test/widgets/video_metadata` — 162 passing (no test referenced the removed widget or overlay)
- Manual pass on a real Samsung Galaxy still pending — record a clip, apply a filter and a sticker, watch the metadata screen through the render, then open the full-screen preview and the cover picker. Undrafting once that is done.

CI shard 2 is red on a failure this branch does not cause: `main` at this PR's base (95a05362f) is itself red there on `ClipThumbnailImage renders a custom placeholder for a missing file` and `PopularVideosTab reports a slow variant switch once`. This branch failed `ClipSpeedRenderService caps concurrent native renders` on the first run and `ClipThumbnailImage renders the neutral placeholder for a missing file` on the re-run — a different test each time, and the second is the same file that fails on `main`, dying on leaked `ImageStreamCompleter` exceptions from an earlier suite in the merged isolate. Seed-dependent shard pollution, tracked separately rather than patched in here.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
