### PR TITLE
fix(support): align follower counts

### DIFF
--- a/mobile/lib/blocs/followers/follower_visibility.dart
+++ b/mobile/lib/blocs/followers/follower_visibility.dart
@@ -1,0 +1,43 @@
+// ABOUTME: Shared follower list visibility helpers.
+// ABOUTME: Keeps follower count and blocklist filtering semantics consistent.
+
+import 'dart:math';
+
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+
+/// Computes the locally visible follower count from an authoritative count and
+/// the known hidden followers.
+int visibleFollowerCount({
+  required int visiblePubkeyCount,
+  required int rawPubkeyCount,
+  required int authoritativeFollowerCount,
+}) => max(
+  visiblePubkeyCount,
+  authoritativeFollowerCount - (rawPubkeyCount - visiblePubkeyCount),
+);
+
+/// Filters followers hidden from the current user's own follower list.
+List<String> filterMyFollowerPubkeys({
+  required List<String> pubkeys,
+  required ContentBlocklistRepository blocklistRepository,
+}) => pubkeys
+    .where(
+      (pubkey) =>
+          !blocklistRepository.isBlocked(pubkey) &&
+          !blocklistRepository.isFollowSevered(pubkey),
+    )
+    .toList();
+
+/// Filters followers hidden from another user's follower list.
+List<String> filterOtherFollowerPubkeys({
+  required List<String> pubkeys,
+  required ContentBlocklistRepository blocklistRepository,
+  required bool isFollowingTarget,
+  required String currentUserPubkey,
+}) => pubkeys
+    .where(
+      (pubkey) =>
+          !blocklistRepository.isBlocked(pubkey) &&
+          !(!isFollowingTarget && pubkey == currentUserPubkey),
+    )
+    .toList();

--- a/mobile/lib/blocs/my_followers/my_followers_bloc.dart
+++ b/mobile/lib/blocs/my_followers/my_followers_bloc.dart
@@ -59,18 +59,6 @@ class MyFollowersBloc extends Bloc<MyFollowersEvent, MyFollowersState> {
     ),
   );
 
-  int _visibleFollowerCount({
-    required List<String> rawPubkeys,
-    required List<String> visiblePubkeys,
-    required int authoritativeCount,
-  }) {
-    final hiddenKnownFollowers = rawPubkeys.length - visiblePubkeys.length;
-    return max(
-      visiblePubkeys.length,
-      authoritativeCount - hiddenKnownFollowers,
-    );
-  }
-
   /// Handle request to load current user's followers list.
   ///
   /// Delegates to [FollowRepository.watchMyFollowersCached] for
@@ -101,11 +89,7 @@ class MyFollowersBloc extends Bloc<MyFollowersEvent, MyFollowersState> {
             rawFollowersPubkeys: result.data.pubkeys,
             rawDatedCount: result.data.datedCount,
             followersPubkeys: visiblePubkeys,
-            followerCount: _visibleFollowerCount(
-              rawPubkeys: result.data.pubkeys,
-              visiblePubkeys: visiblePubkeys,
-              authoritativeCount: result.data.count,
-            ),
+            authoritativeFollowerCount: result.data.count,
             isRefreshing: result.isStale,
           );
         },
@@ -133,19 +117,11 @@ class MyFollowersBloc extends Bloc<MyFollowersEvent, MyFollowersState> {
       datedCount: state.rawDatedCount,
       sortOrder: state.sortOrder,
     );
-    final previousHiddenKnownFollowers =
-        state.rawFollowersPubkeys.length - state.followersPubkeys.length;
-    final authoritativeCount =
-        state.followerCount + previousHiddenKnownFollowers;
-
+    // followerCount derives from the unchanged authoritative count, so
+    // re-filtering alone updates it.
     emit(
       state.copyWith(
         followersPubkeys: visiblePubkeys,
-        followerCount: _visibleFollowerCount(
-          rawPubkeys: state.rawFollowersPubkeys,
-          visiblePubkeys: visiblePubkeys,
-          authoritativeCount: authoritativeCount,
-        ),
       ),
     );
   }
@@ -162,10 +138,6 @@ class MyFollowersBloc extends Bloc<MyFollowersEvent, MyFollowersState> {
       datedCount: state.rawDatedCount,
       sortOrder: event.sortOrder,
     );
-    final previousHiddenKnownFollowers =
-        state.rawFollowersPubkeys.length - state.followersPubkeys.length;
-    final authoritativeCount =
-        state.followerCount + previousHiddenKnownFollowers;
 
     // The sort is remembered even before the first load resolves, so the
     // pending list arrives in the order the user already asked for.
@@ -173,11 +145,6 @@ class MyFollowersBloc extends Bloc<MyFollowersEvent, MyFollowersState> {
       state.copyWith(
         sortOrder: event.sortOrder,
         followersPubkeys: visiblePubkeys,
-        followerCount: _visibleFollowerCount(
-          rawPubkeys: state.rawFollowersPubkeys,
-          visiblePubkeys: visiblePubkeys,
-          authoritativeCount: authoritativeCount,
-        ),
       ),
     );
   }

--- a/mobile/lib/blocs/my_followers/my_followers_bloc.dart
+++ b/mobile/lib/blocs/my_followers/my_followers_bloc.dart
@@ -1,12 +1,11 @@
 // ABOUTME: BLoC for displaying current user's followers list
 // ABOUTME: Fetches Kind 3 events that mention current user in 'p' tags
 
-import 'dart:math';
-
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:follow_repository/follow_repository.dart';
+import 'package:openvine/blocs/followers/follower_visibility.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 part 'my_followers_event.dart';
@@ -35,15 +34,6 @@ class MyFollowersBloc extends Bloc<MyFollowersEvent, MyFollowersState> {
   final FollowRepository _followRepository;
   final ContentBlocklistRepository _blocklistRepository;
 
-  /// Filter pubkeys by removing blocked and follow-severed users.
-  List<String> _filterPubkeys(List<String> pubkeys) => pubkeys
-      .where(
-        (pk) =>
-            !_blocklistRepository.isBlocked(pk) &&
-            !_blocklistRepository.isFollowSevered(pk),
-      )
-      .toList();
-
   /// The rows to show: [rawPubkeys] arranged for [sortOrder], then filtered.
   ///
   /// Ordering runs first because filtering preserves relative order, so the
@@ -52,11 +42,12 @@ class MyFollowersBloc extends Bloc<MyFollowersEvent, MyFollowersState> {
     required List<String> rawPubkeys,
     required int datedCount,
     required FollowSortOrder sortOrder,
-  }) => _filterPubkeys(
-    sortOrder.fromNewestFirst(
+  }) => filterMyFollowerPubkeys(
+    pubkeys: sortOrder.fromNewestFirst(
       rawPubkeys,
       datedCount: datedCount,
     ),
+    blocklistRepository: _blocklistRepository,
   );
 
   /// Handle request to load current user's followers list.

--- a/mobile/lib/blocs/my_followers/my_followers_bloc.dart
+++ b/mobile/lib/blocs/my_followers/my_followers_bloc.dart
@@ -1,6 +1,8 @@
 // ABOUTME: BLoC for displaying current user's followers list
 // ABOUTME: Fetches Kind 3 events that mention current user in 'p' tags
 
+import 'dart:math';
+
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -57,6 +59,18 @@ class MyFollowersBloc extends Bloc<MyFollowersEvent, MyFollowersState> {
     ),
   );
 
+  int _visibleFollowerCount({
+    required List<String> rawPubkeys,
+    required List<String> visiblePubkeys,
+    required int authoritativeCount,
+  }) {
+    final hiddenKnownFollowers = rawPubkeys.length - visiblePubkeys.length;
+    return max(
+      visiblePubkeys.length,
+      authoritativeCount - hiddenKnownFollowers,
+    );
+  }
+
   /// Handle request to load current user's followers list.
   ///
   /// Delegates to [FollowRepository.watchMyFollowersCached] for
@@ -77,16 +91,21 @@ class MyFollowersBloc extends Bloc<MyFollowersEvent, MyFollowersState> {
       await emit.forEach<CacheResult<FollowersSnapshot>>(
         _followRepository.watchMyFollowersCached(),
         onData: (result) {
+          final visiblePubkeys = _visiblePubkeys(
+            rawPubkeys: result.data.pubkeys,
+            datedCount: result.data.datedCount,
+            sortOrder: state.sortOrder,
+          );
           return state.copyWith(
             status: MyFollowersStatus.success,
             rawFollowersPubkeys: result.data.pubkeys,
             rawDatedCount: result.data.datedCount,
-            followersPubkeys: _visiblePubkeys(
+            followersPubkeys: visiblePubkeys,
+            followerCount: _visibleFollowerCount(
               rawPubkeys: result.data.pubkeys,
-              datedCount: result.data.datedCount,
-              sortOrder: state.sortOrder,
+              visiblePubkeys: visiblePubkeys,
+              authoritativeCount: result.data.count,
             ),
-            followerCount: result.data.count,
             isRefreshing: result.isStale,
           );
         },
@@ -109,13 +128,23 @@ class MyFollowersBloc extends Bloc<MyFollowersEvent, MyFollowersState> {
     Emitter<MyFollowersState> emit,
   ) {
     if (state.status != MyFollowersStatus.success) return;
+    final visiblePubkeys = _visiblePubkeys(
+      rawPubkeys: state.rawFollowersPubkeys,
+      datedCount: state.rawDatedCount,
+      sortOrder: state.sortOrder,
+    );
+    final previousHiddenKnownFollowers =
+        state.rawFollowersPubkeys.length - state.followersPubkeys.length;
+    final authoritativeCount =
+        state.followerCount + previousHiddenKnownFollowers;
 
     emit(
       state.copyWith(
-        followersPubkeys: _visiblePubkeys(
+        followersPubkeys: visiblePubkeys,
+        followerCount: _visibleFollowerCount(
           rawPubkeys: state.rawFollowersPubkeys,
-          datedCount: state.rawDatedCount,
-          sortOrder: state.sortOrder,
+          visiblePubkeys: visiblePubkeys,
+          authoritativeCount: authoritativeCount,
         ),
       ),
     );
@@ -128,15 +157,26 @@ class MyFollowersBloc extends Bloc<MyFollowersEvent, MyFollowersState> {
   ) {
     if (event.sortOrder == state.sortOrder) return;
 
+    final visiblePubkeys = _visiblePubkeys(
+      rawPubkeys: state.rawFollowersPubkeys,
+      datedCount: state.rawDatedCount,
+      sortOrder: event.sortOrder,
+    );
+    final previousHiddenKnownFollowers =
+        state.rawFollowersPubkeys.length - state.followersPubkeys.length;
+    final authoritativeCount =
+        state.followerCount + previousHiddenKnownFollowers;
+
     // The sort is remembered even before the first load resolves, so the
     // pending list arrives in the order the user already asked for.
     emit(
       state.copyWith(
         sortOrder: event.sortOrder,
-        followersPubkeys: _visiblePubkeys(
+        followersPubkeys: visiblePubkeys,
+        followerCount: _visibleFollowerCount(
           rawPubkeys: state.rawFollowersPubkeys,
-          datedCount: state.rawDatedCount,
-          sortOrder: event.sortOrder,
+          visiblePubkeys: visiblePubkeys,
+          authoritativeCount: authoritativeCount,
         ),
       ),
     );

--- a/mobile/lib/blocs/my_followers/my_followers_state.dart
+++ b/mobile/lib/blocs/my_followers/my_followers_state.dart
@@ -52,11 +52,11 @@ final class MyFollowersState extends Equatable {
   /// The order [followersPubkeys] is presented in.
   final FollowSortOrder sortOrder;
 
-  /// Authoritative follower count (max of list length and COUNT query).
+  /// Visible follower count after applying local blocklist filters.
   ///
-  /// Downloading all kind 3 events is limited by relay result caps,
-  /// so [followersPubkeys.length] may undercount. This field uses
-  /// the higher of the list length and a COUNT query result.
+  /// Downloading all kind 3 events is limited by relay result caps, so this may
+  /// still exceed [followersPubkeys.length]. Known blocked and follow-severed
+  /// users are subtracted from the repository's authoritative count.
   final int followerCount;
 
   /// True while cached data is shown but a fresh network fetch is in progress.

--- a/mobile/lib/blocs/my_followers/my_followers_state.dart
+++ b/mobile/lib/blocs/my_followers/my_followers_state.dart
@@ -67,10 +67,10 @@ final class MyFollowersState extends Equatable {
   /// [authoritativeFollowerCount] may exceed the number of pubkeys actually
   /// fetched. Followers we know are hidden locally are subtracted from it, and
   /// the result never drops below the number of followers on screen.
-  int get followerCount => max(
-    followersPubkeys.length,
-    authoritativeFollowerCount -
-        (rawFollowersPubkeys.length - followersPubkeys.length),
+  int get followerCount => visibleFollowerCount(
+    visiblePubkeyCount: followersPubkeys.length,
+    rawPubkeyCount: rawFollowersPubkeys.length,
+    authoritativeFollowerCount: authoritativeFollowerCount,
   );
 
   /// True while cached data is shown but a fresh network fetch is in progress.

--- a/mobile/lib/blocs/my_followers/my_followers_state.dart
+++ b/mobile/lib/blocs/my_followers/my_followers_state.dart
@@ -26,7 +26,7 @@ final class MyFollowersState extends Equatable {
     this.rawFollowersPubkeys = const [],
     this.rawDatedCount = 0,
     this.sortOrder = FollowSortOrder.newestFirst,
-    this.followerCount = 0,
+    this.authoritativeFollowerCount = 0,
     this.isRefreshing = false,
   });
 
@@ -52,12 +52,26 @@ final class MyFollowersState extends Equatable {
   /// The order [followersPubkeys] is presented in.
   final FollowSortOrder sortOrder;
 
+  /// Follower count as reported by the repository, before any local
+  /// blocklist filtering.
+  ///
+  /// Kept verbatim rather than derived from [followerCount] so re-filtering
+  /// stays exact: reconstructing it by inverting a previous [followerCount]
+  /// emission is only correct when that emission did not clamp to the visible
+  /// list length.
+  final int authoritativeFollowerCount;
+
   /// Visible follower count after applying local blocklist filters.
   ///
-  /// Downloading all kind 3 events is limited by relay result caps, so this may
-  /// still exceed [followersPubkeys.length]. Known blocked and follow-severed
-  /// users are subtracted from the repository's authoritative count.
-  final int followerCount;
+  /// Downloading all kind 3 events is limited by relay result caps, so
+  /// [authoritativeFollowerCount] may exceed the number of pubkeys actually
+  /// fetched. Followers we know are hidden locally are subtracted from it, and
+  /// the result never drops below the number of followers on screen.
+  int get followerCount => max(
+    followersPubkeys.length,
+    authoritativeFollowerCount -
+        (rawFollowersPubkeys.length - followersPubkeys.length),
+  );
 
   /// True while cached data is shown but a fresh network fetch is in progress.
   final bool isRefreshing;
@@ -69,7 +83,7 @@ final class MyFollowersState extends Equatable {
     List<String>? rawFollowersPubkeys,
     int? rawDatedCount,
     FollowSortOrder? sortOrder,
-    int? followerCount,
+    int? authoritativeFollowerCount,
     bool? isRefreshing,
   }) {
     return MyFollowersState(
@@ -78,7 +92,8 @@ final class MyFollowersState extends Equatable {
       rawFollowersPubkeys: rawFollowersPubkeys ?? this.rawFollowersPubkeys,
       rawDatedCount: rawDatedCount ?? this.rawDatedCount,
       sortOrder: sortOrder ?? this.sortOrder,
-      followerCount: followerCount ?? this.followerCount,
+      authoritativeFollowerCount:
+          authoritativeFollowerCount ?? this.authoritativeFollowerCount,
       isRefreshing: isRefreshing ?? this.isRefreshing,
     );
   }
@@ -90,7 +105,7 @@ final class MyFollowersState extends Equatable {
     rawFollowersPubkeys,
     rawDatedCount,
     sortOrder,
-    followerCount,
+    authoritativeFollowerCount,
     isRefreshing,
   ];
 }

--- a/mobile/lib/blocs/others_followers/others_followers_bloc.dart
+++ b/mobile/lib/blocs/others_followers/others_followers_bloc.dart
@@ -8,6 +8,7 @@ import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:follow_repository/follow_repository.dart';
+import 'package:openvine/blocs/followers/follower_visibility.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 part 'others_followers_event.dart';
@@ -44,18 +45,6 @@ class OthersFollowersBloc
   final FollowRepository _followRepository;
   final ContentBlocklistRepository _blocklistRepository;
   final String _currentUserPubkey;
-
-  /// Filter pubkeys by removing blocked users.
-  List<String> _filterPubkeys(
-    List<String> pubkeys, {
-    required bool isFollowingTarget,
-  }) => pubkeys
-      .where(
-        (pk) =>
-            !_blocklistRepository.isBlocked(pk) &&
-            !(!isFollowingTarget && pk == _currentUserPubkey),
-      )
-      .toList();
 
   /// Handle request to load another user's followers list.
   ///
@@ -96,9 +85,11 @@ class OthersFollowersBloc
           final isFollowingTarget = _followRepository.isFollowing(
             event.targetPubkey,
           );
-          final visiblePubkeys = _filterPubkeys(
-            result.data.pubkeys,
+          final visiblePubkeys = filterOtherFollowerPubkeys(
+            pubkeys: result.data.pubkeys,
+            blocklistRepository: _blocklistRepository,
             isFollowingTarget: isFollowingTarget,
+            currentUserPubkey: _currentUserPubkey,
           );
           return state.copyWith(
             status: .success,
@@ -148,9 +139,11 @@ class OthersFollowersBloc
     // Only increment if not already in the list
     if (!rawPubkeys.contains(event.followerPubkey)) {
       final newRaw = [...rawPubkeys, event.followerPubkey];
-      final visiblePubkeys = _filterPubkeys(
-        newRaw,
+      final visiblePubkeys = filterOtherFollowerPubkeys(
+        pubkeys: newRaw,
+        blocklistRepository: _blocklistRepository,
         isFollowingTarget: state.isFollowingTarget,
+        currentUserPubkey: _currentUserPubkey,
       );
       emit(
         state.copyWith(
@@ -179,9 +172,11 @@ class OthersFollowersBloc
       final newRaw = rawPubkeys
           .where((pubkey) => pubkey != event.followerPubkey)
           .toList();
-      final visiblePubkeys = _filterPubkeys(
-        newRaw,
+      final visiblePubkeys = filterOtherFollowerPubkeys(
+        pubkeys: newRaw,
+        blocklistRepository: _blocklistRepository,
         isFollowingTarget: state.isFollowingTarget,
+        currentUserPubkey: _currentUserPubkey,
       );
       emit(
         state.copyWith(
@@ -207,9 +202,11 @@ class OthersFollowersBloc
     Emitter<OthersFollowersState> emit,
   ) {
     if (state.status != OthersFollowersStatus.success) return;
-    final visiblePubkeys = _filterPubkeys(
-      state.rawFollowersPubkeys,
+    final visiblePubkeys = filterOtherFollowerPubkeys(
+      pubkeys: state.rawFollowersPubkeys,
+      blocklistRepository: _blocklistRepository,
       isFollowingTarget: state.isFollowingTarget,
+      currentUserPubkey: _currentUserPubkey,
     );
     // followerCount derives from the unchanged authoritative count, so
     // re-filtering alone updates it.

--- a/mobile/lib/blocs/others_followers/others_followers_bloc.dart
+++ b/mobile/lib/blocs/others_followers/others_followers_bloc.dart
@@ -57,6 +57,18 @@ class OthersFollowersBloc
       )
       .toList();
 
+  int _visibleFollowerCount({
+    required List<String> rawPubkeys,
+    required List<String> visiblePubkeys,
+    required int authoritativeCount,
+  }) {
+    final hiddenKnownFollowers = rawPubkeys.length - visiblePubkeys.length;
+    return max(
+      visiblePubkeys.length,
+      authoritativeCount - hiddenKnownFollowers,
+    );
+  }
+
   /// Handle request to load another user's followers list.
   ///
   /// Delegates to [FollowRepository.watchOthersFollowersCached] for
@@ -91,15 +103,20 @@ class OthersFollowersBloc
           final isFollowingTarget = _followRepository.isFollowing(
             event.targetPubkey,
           );
+          final visiblePubkeys = _filterPubkeys(
+            result.data.pubkeys,
+            isFollowingTarget: isFollowingTarget,
+          );
           return state.copyWith(
             status: .success,
             targetPubkey: event.targetPubkey,
             rawFollowersPubkeys: result.data.pubkeys,
-            followersPubkeys: _filterPubkeys(
-              result.data.pubkeys,
-              isFollowingTarget: isFollowingTarget,
+            followersPubkeys: visiblePubkeys,
+            followerCount: _visibleFollowerCount(
+              rawPubkeys: result.data.pubkeys,
+              visiblePubkeys: visiblePubkeys,
+              authoritativeCount: result.data.count,
             ),
-            followerCount: max(result.data.pubkeys.length, result.data.count),
             isRefreshing: result.isStale,
             isFollowingTarget: isFollowingTarget,
           );
@@ -142,14 +159,22 @@ class OthersFollowersBloc
     // Only increment if not already in the list
     if (!rawPubkeys.contains(event.followerPubkey)) {
       final newRaw = [...rawPubkeys, event.followerPubkey];
+      final visiblePubkeys = _filterPubkeys(
+        newRaw,
+        isFollowingTarget: state.isFollowingTarget,
+      );
+      final hiddenKnownFollowers =
+          state.rawFollowersPubkeys.length - state.followersPubkeys.length;
+      final authoritativeCount = state.followerCount + hiddenKnownFollowers + 1;
       emit(
         state.copyWith(
           rawFollowersPubkeys: newRaw,
-          followersPubkeys: _filterPubkeys(
-            newRaw,
-            isFollowingTarget: state.isFollowingTarget,
+          followersPubkeys: visiblePubkeys,
+          followerCount: _visibleFollowerCount(
+            rawPubkeys: newRaw,
+            visiblePubkeys: visiblePubkeys,
+            authoritativeCount: authoritativeCount,
           ),
-          followerCount: state.followerCount + 1,
         ),
       );
       Log.debug(
@@ -172,14 +197,25 @@ class OthersFollowersBloc
       final newRaw = rawPubkeys
           .where((pubkey) => pubkey != event.followerPubkey)
           .toList();
+      final visiblePubkeys = _filterPubkeys(
+        newRaw,
+        isFollowingTarget: state.isFollowingTarget,
+      );
+      final hiddenKnownFollowers =
+          state.rawFollowersPubkeys.length - state.followersPubkeys.length;
+      final authoritativeCount = max(
+        0,
+        state.followerCount + hiddenKnownFollowers - 1,
+      );
       emit(
         state.copyWith(
           rawFollowersPubkeys: newRaw,
-          followersPubkeys: _filterPubkeys(
-            newRaw,
-            isFollowingTarget: state.isFollowingTarget,
+          followersPubkeys: visiblePubkeys,
+          followerCount: _visibleFollowerCount(
+            rawPubkeys: newRaw,
+            visiblePubkeys: visiblePubkeys,
+            authoritativeCount: authoritativeCount,
           ),
-          followerCount: max(0, state.followerCount - 1),
         ),
       );
       Log.debug(
@@ -196,12 +232,22 @@ class OthersFollowersBloc
     Emitter<OthersFollowersState> emit,
   ) {
     if (state.status != OthersFollowersStatus.success) return;
+    final visiblePubkeys = _filterPubkeys(
+      state.rawFollowersPubkeys,
+      isFollowingTarget: state.isFollowingTarget,
+    );
+    final previousHiddenKnownFollowers =
+        state.rawFollowersPubkeys.length - state.followersPubkeys.length;
+    final authoritativeCount =
+        state.followerCount + previousHiddenKnownFollowers;
 
     emit(
       state.copyWith(
-        followersPubkeys: _filterPubkeys(
-          state.rawFollowersPubkeys,
-          isFollowingTarget: state.isFollowingTarget,
+        followersPubkeys: visiblePubkeys,
+        followerCount: _visibleFollowerCount(
+          rawPubkeys: state.rawFollowersPubkeys,
+          visiblePubkeys: visiblePubkeys,
+          authoritativeCount: authoritativeCount,
         ),
       ),
     );

--- a/mobile/lib/blocs/others_followers/others_followers_bloc.dart
+++ b/mobile/lib/blocs/others_followers/others_followers_bloc.dart
@@ -57,18 +57,6 @@ class OthersFollowersBloc
       )
       .toList();
 
-  int _visibleFollowerCount({
-    required List<String> rawPubkeys,
-    required List<String> visiblePubkeys,
-    required int authoritativeCount,
-  }) {
-    final hiddenKnownFollowers = rawPubkeys.length - visiblePubkeys.length;
-    return max(
-      visiblePubkeys.length,
-      authoritativeCount - hiddenKnownFollowers,
-    );
-  }
-
   /// Handle request to load another user's followers list.
   ///
   /// Delegates to [FollowRepository.watchOthersFollowersCached] for
@@ -79,15 +67,20 @@ class OthersFollowersBloc
     Emitter<OthersFollowersState> emit,
   ) async {
     if (state.status != .success || state.targetPubkey != event.targetPubkey) {
+      final isSameTarget = state.targetPubkey == event.targetPubkey;
       emit(
         state.copyWith(
           status: .loading,
           targetPubkey: event.targetPubkey,
-          followersPubkeys: state.targetPubkey == event.targetPubkey
-              ? state.followersPubkeys
+          followersPubkeys: isSameTarget ? state.followersPubkeys : const [],
+          // Must clear alongside followersPubkeys: the visible count derives
+          // from the gap between the raw and filtered lists, so carrying the
+          // previous target's raw pubkeys over would skew it.
+          rawFollowersPubkeys: isSameTarget
+              ? state.rawFollowersPubkeys
               : const [],
-          followerCount: state.targetPubkey == event.targetPubkey
-              ? state.followerCount
+          authoritativeFollowerCount: isSameTarget
+              ? state.authoritativeFollowerCount
               : 0,
         ),
       );
@@ -112,11 +105,7 @@ class OthersFollowersBloc
             targetPubkey: event.targetPubkey,
             rawFollowersPubkeys: result.data.pubkeys,
             followersPubkeys: visiblePubkeys,
-            followerCount: _visibleFollowerCount(
-              rawPubkeys: result.data.pubkeys,
-              visiblePubkeys: visiblePubkeys,
-              authoritativeCount: result.data.count,
-            ),
+            authoritativeFollowerCount: result.data.count,
             isRefreshing: result.isStale,
             isFollowingTarget: isFollowingTarget,
           );
@@ -163,18 +152,11 @@ class OthersFollowersBloc
         newRaw,
         isFollowingTarget: state.isFollowingTarget,
       );
-      final hiddenKnownFollowers =
-          state.rawFollowersPubkeys.length - state.followersPubkeys.length;
-      final authoritativeCount = state.followerCount + hiddenKnownFollowers + 1;
       emit(
         state.copyWith(
           rawFollowersPubkeys: newRaw,
           followersPubkeys: visiblePubkeys,
-          followerCount: _visibleFollowerCount(
-            rawPubkeys: newRaw,
-            visiblePubkeys: visiblePubkeys,
-            authoritativeCount: authoritativeCount,
-          ),
+          authoritativeFollowerCount: state.authoritativeFollowerCount + 1,
         ),
       );
       Log.debug(
@@ -201,20 +183,13 @@ class OthersFollowersBloc
         newRaw,
         isFollowingTarget: state.isFollowingTarget,
       );
-      final hiddenKnownFollowers =
-          state.rawFollowersPubkeys.length - state.followersPubkeys.length;
-      final authoritativeCount = max(
-        0,
-        state.followerCount + hiddenKnownFollowers - 1,
-      );
       emit(
         state.copyWith(
           rawFollowersPubkeys: newRaw,
           followersPubkeys: visiblePubkeys,
-          followerCount: _visibleFollowerCount(
-            rawPubkeys: newRaw,
-            visiblePubkeys: visiblePubkeys,
-            authoritativeCount: authoritativeCount,
+          authoritativeFollowerCount: max(
+            0,
+            state.authoritativeFollowerCount - 1,
           ),
         ),
       );
@@ -236,20 +211,8 @@ class OthersFollowersBloc
       state.rawFollowersPubkeys,
       isFollowingTarget: state.isFollowingTarget,
     );
-    final previousHiddenKnownFollowers =
-        state.rawFollowersPubkeys.length - state.followersPubkeys.length;
-    final authoritativeCount =
-        state.followerCount + previousHiddenKnownFollowers;
-
-    emit(
-      state.copyWith(
-        followersPubkeys: visiblePubkeys,
-        followerCount: _visibleFollowerCount(
-          rawPubkeys: state.rawFollowersPubkeys,
-          visiblePubkeys: visiblePubkeys,
-          authoritativeCount: authoritativeCount,
-        ),
-      ),
-    );
+    // followerCount derives from the unchanged authoritative count, so
+    // re-filtering alone updates it.
+    emit(state.copyWith(followersPubkeys: visiblePubkeys));
   }
 }

--- a/mobile/lib/blocs/others_followers/others_followers_state.dart
+++ b/mobile/lib/blocs/others_followers/others_followers_state.dart
@@ -58,10 +58,10 @@ final class OthersFollowersState extends Equatable {
   /// fetched. Followers we know are hidden locally (blocked, or a
   /// follow-severed viewer) are subtracted from it, and the result never
   /// drops below the number of followers on screen.
-  int get followerCount => max(
-    followersPubkeys.length,
-    authoritativeFollowerCount -
-        (rawFollowersPubkeys.length - followersPubkeys.length),
+  int get followerCount => visibleFollowerCount(
+    visiblePubkeyCount: followersPubkeys.length,
+    rawPubkeyCount: rawFollowersPubkeys.length,
+    authoritativeFollowerCount: authoritativeFollowerCount,
   );
 
   /// The pubkey whose followers list is being viewed (for retry)

--- a/mobile/lib/blocs/others_followers/others_followers_state.dart
+++ b/mobile/lib/blocs/others_followers/others_followers_state.dart
@@ -24,7 +24,7 @@ final class OthersFollowersState extends Equatable {
     this.status = OthersFollowersStatus.initial,
     this.followersPubkeys = const [],
     this.rawFollowersPubkeys = const [],
-    this.followerCount = 0,
+    this.authoritativeFollowerCount = 0,
     this.targetPubkey,
     this.isRefreshing = false,
     this.isFollowingTarget = false,
@@ -42,12 +42,27 @@ final class OthersFollowersState extends Equatable {
   /// replay the full list without waiting for a new network event.
   final List<String> rawFollowersPubkeys;
 
-  /// Authoritative follower count (max of list length and COUNT query).
+  /// Follower count as reported by the repository, before any local
+  /// blocklist filtering.
   ///
-  /// Downloading all kind 3 events is limited by relay result caps,
-  /// so [followersPubkeys.length] may undercount. This field uses
-  /// the higher of the list length and a COUNT query result.
-  final int followerCount;
+  /// Kept verbatim rather than derived from [followerCount] so optimistic
+  /// mutations stay exact: reconstructing it by inverting a previous
+  /// [followerCount] emission is only correct when that emission did not
+  /// clamp to the visible list length.
+  final int authoritativeFollowerCount;
+
+  /// Visible follower count after applying local blocklist filters.
+  ///
+  /// Downloading all kind 3 events is limited by relay result caps, so
+  /// [authoritativeFollowerCount] may exceed the number of pubkeys actually
+  /// fetched. Followers we know are hidden locally (blocked, or a
+  /// follow-severed viewer) are subtracted from it, and the result never
+  /// drops below the number of followers on screen.
+  int get followerCount => max(
+    followersPubkeys.length,
+    authoritativeFollowerCount -
+        (rawFollowersPubkeys.length - followersPubkeys.length),
+  );
 
   /// The pubkey whose followers list is being viewed (for retry)
   final String? targetPubkey;
@@ -69,7 +84,7 @@ final class OthersFollowersState extends Equatable {
     OthersFollowersStatus? status,
     List<String>? followersPubkeys,
     List<String>? rawFollowersPubkeys,
-    int? followerCount,
+    int? authoritativeFollowerCount,
     String? targetPubkey,
     bool? isRefreshing,
     bool? isFollowingTarget,
@@ -78,7 +93,8 @@ final class OthersFollowersState extends Equatable {
       status: status ?? this.status,
       followersPubkeys: followersPubkeys ?? this.followersPubkeys,
       rawFollowersPubkeys: rawFollowersPubkeys ?? this.rawFollowersPubkeys,
-      followerCount: followerCount ?? this.followerCount,
+      authoritativeFollowerCount:
+          authoritativeFollowerCount ?? this.authoritativeFollowerCount,
       targetPubkey: targetPubkey ?? this.targetPubkey,
       isRefreshing: isRefreshing ?? this.isRefreshing,
       isFollowingTarget: isFollowingTarget ?? this.isFollowingTarget,
@@ -90,7 +106,7 @@ final class OthersFollowersState extends Equatable {
     status,
     followersPubkeys,
     rawFollowersPubkeys,
-    followerCount,
+    authoritativeFollowerCount,
     targetPubkey,
     isRefreshing,
     isFollowingTarget,

--- a/mobile/lib/widgets/profile/profile_followers_stat.dart
+++ b/mobile/lib/widgets/profile/profile_followers_stat.dart
@@ -87,11 +87,12 @@ class _MyFollowersStatView extends ConsumerWidget {
         final isLoading =
             state.status == MyFollowersStatus.initial ||
             state.status == MyFollowersStatus.loading;
+        final hasLoadedCount = state.status == MyFollowersStatus.success;
 
         return ProfileStatColumn(
-          count: isLoading ? initialCount : state.followerCount,
+          count: hasLoadedCount ? state.followerCount : initialCount,
           label: context.l10n.profileFollowersLabel,
-          isLoading: isLoading && initialCount == null,
+          isLoading: (isLoading || !hasLoadedCount) && initialCount == null,
           onTap: () => context.push(
             FollowersScreenRouter.pathForPubkey(pubkey),
             extra: displayName,
@@ -127,11 +128,12 @@ class _OthersFollowersStatView extends ConsumerWidget {
         final isLoading =
             state.status == OthersFollowersStatus.initial ||
             state.status == OthersFollowersStatus.loading;
+        final hasLoadedCount = state.status == OthersFollowersStatus.success;
 
         return ProfileStatColumn(
-          count: isLoading ? initialCount : state.followerCount,
+          count: hasLoadedCount ? state.followerCount : initialCount,
           label: context.l10n.profileFollowersLabel,
-          isLoading: isLoading && initialCount == null,
+          isLoading: (isLoading || !hasLoadedCount) && initialCount == null,
           onTap: () => context.push(
             FollowersScreenRouter.pathForPubkey(pubkey),
             extra: displayName,

--- a/mobile/lib/widgets/profile/profile_followers_stat.dart
+++ b/mobile/lib/widgets/profile/profile_followers_stat.dart
@@ -41,6 +41,7 @@ class ProfileFollowersStat extends ConsumerWidget {
 
     if (isOwnProfile) {
       return BlocProvider(
+        key: ValueKey((followRepository, blocklistRepository, pubkey)),
         create: (_) => MyFollowersBloc(
           followRepository: followRepository,
           contentBlocklistRepository: blocklistRepository,
@@ -128,7 +129,9 @@ class _OthersFollowersStatView extends ConsumerWidget {
         final isLoading =
             state.status == OthersFollowersStatus.initial ||
             state.status == OthersFollowersStatus.loading;
-        final hasLoadedCount = state.status == OthersFollowersStatus.success;
+        final hasLoadedCount =
+            state.status == OthersFollowersStatus.success &&
+            state.targetPubkey == pubkey;
 
         return ProfileStatColumn(
           count: hasLoadedCount ? state.followerCount : initialCount,

--- a/mobile/lib/widgets/profile/profile_following_stat.dart
+++ b/mobile/lib/widgets/profile/profile_following_stat.dart
@@ -18,6 +18,7 @@ class ProfileFollowingStat extends ConsumerWidget {
   const ProfileFollowingStat({
     required this.pubkey,
     required this.displayName,
+    this.initialCount,
     super.key,
   });
 
@@ -26,6 +27,9 @@ class ProfileFollowingStat extends ConsumerWidget {
 
   /// The display name of the user for the following screen title.
   final String? displayName;
+
+  /// Initial count from profile data, shown while the BLoC loads.
+  final int? initialCount;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -40,7 +44,11 @@ class ProfileFollowingStat extends ConsumerWidget {
           followRepository: followRepository,
           contentBlocklistRepository: blocklistRepository,
         )..add(const MyFollowingListLoadRequested()),
-        child: _MyFollowingStatView(pubkey: pubkey, displayName: displayName),
+        child: _MyFollowingStatView(
+          pubkey: pubkey,
+          displayName: displayName,
+          initialCount: initialCount,
+        ),
       );
     } else {
       return BlocProvider(
@@ -52,6 +60,7 @@ class ProfileFollowingStat extends ConsumerWidget {
         child: _OthersFollowingStatView(
           pubkey: pubkey,
           displayName: displayName,
+          initialCount: initialCount,
         ),
       );
     }
@@ -60,10 +69,15 @@ class ProfileFollowingStat extends ConsumerWidget {
 
 /// View widget for current user's following stat.
 class _MyFollowingStatView extends ConsumerWidget {
-  const _MyFollowingStatView({required this.pubkey, required this.displayName});
+  const _MyFollowingStatView({
+    required this.pubkey,
+    required this.displayName,
+    this.initialCount,
+  });
 
   final String pubkey;
   final String? displayName;
+  final int? initialCount;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -75,11 +89,14 @@ class _MyFollowingStatView extends ConsumerWidget {
       builder: (context, state) {
         // MyFollowingBloc starts with success status (cached data)
         final isLoading = state.status == MyFollowingStatus.initial;
+        final hasLoadedCount =
+            state.status == MyFollowingStatus.success ||
+            state.status == MyFollowingStatus.toggleFailure;
 
         return ProfileStatColumn(
-          count: isLoading ? null : state.followingPubkeys.length,
+          count: hasLoadedCount ? state.followingPubkeys.length : initialCount,
           label: context.l10n.profileFollowingStatLabel,
-          isLoading: isLoading,
+          isLoading: (isLoading || !hasLoadedCount) && initialCount == null,
           onTap: () => context.push(
             FollowingScreenRouter.pathForPubkey(pubkey),
             extra: displayName,
@@ -95,10 +112,12 @@ class _OthersFollowingStatView extends ConsumerWidget {
   const _OthersFollowingStatView({
     required this.pubkey,
     required this.displayName,
+    this.initialCount,
   });
 
   final String pubkey;
   final String? displayName;
+  final int? initialCount;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -111,11 +130,12 @@ class _OthersFollowingStatView extends ConsumerWidget {
     return BlocBuilder<OthersFollowingBloc, OthersFollowingState>(
       builder: (context, state) {
         final isLoading = state.status == OthersFollowingStatus.initial;
+        final hasLoadedCount = state.status == OthersFollowingStatus.success;
 
         return ProfileStatColumn(
-          count: isLoading ? null : state.followingPubkeys.length,
+          count: hasLoadedCount ? state.followingPubkeys.length : initialCount,
           label: context.l10n.profileFollowingStatLabel,
-          isLoading: isLoading,
+          isLoading: (isLoading || !hasLoadedCount) && initialCount == null,
           onTap: () => context.push(
             FollowingScreenRouter.pathForPubkey(pubkey),
             extra: displayName,

--- a/mobile/lib/widgets/profile/profile_following_stat.dart
+++ b/mobile/lib/widgets/profile/profile_following_stat.dart
@@ -18,6 +18,7 @@ class ProfileFollowingStat extends ConsumerWidget {
   const ProfileFollowingStat({
     required this.pubkey,
     required this.displayName,
+    required this.isOwnProfile,
     this.initialCount,
     super.key,
   });
@@ -28,6 +29,9 @@ class ProfileFollowingStat extends ConsumerWidget {
   /// The display name of the user for the following screen title.
   final String? displayName;
 
+  /// Whether this is the current user's own profile.
+  final bool isOwnProfile;
+
   /// Initial count from profile data, shown while the BLoC loads.
   final int? initialCount;
 
@@ -36,10 +40,10 @@ class ProfileFollowingStat extends ConsumerWidget {
     final followRepository = ref.watch(followRepositoryProvider);
     final nostrClient = ref.watch(nostrServiceProvider);
     final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
-    final isCurrentUser = pubkey == nostrClient.publicKey;
 
-    if (isCurrentUser) {
+    if (isOwnProfile) {
       return BlocProvider(
+        key: ValueKey((followRepository, blocklistRepository, pubkey)),
         create: (_) => MyFollowingBloc(
           followRepository: followRepository,
           contentBlocklistRepository: blocklistRepository,
@@ -52,6 +56,14 @@ class ProfileFollowingStat extends ConsumerWidget {
       );
     } else {
       return BlocProvider(
+        key: ValueKey(
+          (
+            followRepository,
+            blocklistRepository,
+            nostrClient.publicKey,
+            pubkey,
+          ),
+        ),
         create: (_) => OthersFollowingBloc(
           followRepository: followRepository,
           contentBlocklistRepository: blocklistRepository,

--- a/mobile/lib/widgets/profile/profile_grid.dart
+++ b/mobile/lib/widgets/profile/profile_grid.dart
@@ -671,6 +671,12 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
     // follow/unfollow action.
     if (!widget.isOwnProfile) {
       return BlocProvider<OthersFollowersBloc>(
+        key: ValueKey((
+          followRepository,
+          contentBlocklistRepository,
+          currentUserPubkey,
+          widget.userIdHex,
+        )),
         create: (_) => OthersFollowersBloc(
           followRepository: followRepository,
           contentBlocklistRepository: contentBlocklistRepository,

--- a/mobile/lib/widgets/profile/profile_header_media.dart
+++ b/mobile/lib/widgets/profile/profile_header_media.dart
@@ -337,6 +337,7 @@ class _ProfileStatsRowState extends State<_ProfileStatsRow> {
         ProfileFollowingStat(
           pubkey: widget.userIdHex,
           displayName: widget.displayName,
+          isOwnProfile: widget.isOwnProfile,
           initialCount: widget.profileStats!.following,
         ),
       if (isLoading)

--- a/mobile/lib/widgets/profile/profile_header_media.dart
+++ b/mobile/lib/widgets/profile/profile_header_media.dart
@@ -243,6 +243,7 @@ class _BannerImage extends StatelessWidget {
 class _ProfileStatsRow extends StatefulWidget {
   const _ProfileStatsRow({
     required this.userIdHex,
+    required this.displayName,
     required this.isOwnProfile,
     this.profileStats,
   });
@@ -256,6 +257,7 @@ class _ProfileStatsRow extends StatefulWidget {
   /// [profileLoopsVisibilityFloor].
   final bool isOwnProfile;
 
+  final String? displayName;
   final ProfileStats? profileStats;
 
   @override
@@ -322,27 +324,38 @@ class _ProfileStatsRowState extends State<_ProfileStatsRow> {
           isLoading: isLoading && _timeoutExpired,
         ),
       if (hasFollowing || isLoading)
-        ProfileStatColumn(
-          count: isLoading
-              ? _skeletonPlaceholderCount
-              : widget.profileStats!.following,
-          label: l10n.profileFollowingLabel,
-          isLoading: isLoading && _timeoutExpired,
-          onTap: () => context.push(
-            FollowingScreenRouter.pathForPubkey(widget.userIdHex),
+        if (isLoading)
+          ProfileStatColumn(
+            count: _skeletonPlaceholderCount,
+            label: l10n.profileFollowingLabel,
+            isLoading: _timeoutExpired,
+            onTap: () => context.push(
+              FollowingScreenRouter.pathForPubkey(widget.userIdHex),
+            ),
+          )
+        else
+          ProfileFollowingStat(
+            pubkey: widget.userIdHex,
+            displayName: widget.displayName,
+            initialCount: widget.profileStats!.following,
           ),
-        ),
       if (hasFollowers || isLoading)
-        ProfileStatColumn(
-          count: isLoading
-              ? _skeletonPlaceholderCount
-              : widget.profileStats!.followers,
-          label: l10n.profileFollowersLabel,
-          isLoading: isLoading && _timeoutExpired,
-          onTap: () => context.push(
-            FollowersScreenRouter.pathForPubkey(widget.userIdHex),
+        if (isLoading)
+          ProfileStatColumn(
+            count: _skeletonPlaceholderCount,
+            label: l10n.profileFollowersLabel,
+            isLoading: _timeoutExpired,
+            onTap: () => context.push(
+              FollowersScreenRouter.pathForPubkey(widget.userIdHex),
+            ),
+          )
+        else
+          ProfileFollowersStat(
+            pubkey: widget.userIdHex,
+            displayName: widget.displayName,
+            isOwnProfile: widget.isOwnProfile,
+            initialCount: widget.profileStats!.followers,
           ),
-        ),
     ];
 
     return Skeletonizer(

--- a/mobile/lib/widgets/profile/profile_header_media.dart
+++ b/mobile/lib/widgets/profile/profile_header_media.dart
@@ -295,8 +295,6 @@ class _ProfileStatsRowState extends State<_ProfileStatsRow> {
   Widget build(BuildContext context) {
     final isLoading = widget.profileStats == null;
 
-    final hasFollowers = widget.profileStats?.followers != null;
-    final hasFollowing = widget.profileStats?.following != null;
     final hasLikes = widget.profileStats?.totalLikes != null;
     final totalViews = widget.profileStats?.totalViews;
     // A visitor landing on a new creator's profile should not be met by a
@@ -323,39 +321,40 @@ class _ProfileStatsRowState extends State<_ProfileStatsRow> {
           label: l10n.profileLikesLabel,
           isLoading: isLoading && _timeoutExpired,
         ),
-      if (hasFollowing || isLoading)
-        if (isLoading)
-          ProfileStatColumn(
-            count: _skeletonPlaceholderCount,
-            label: l10n.profileFollowingLabel,
-            isLoading: _timeoutExpired,
-            onTap: () => context.push(
-              FollowingScreenRouter.pathForPubkey(widget.userIdHex),
-            ),
-          )
-        else
-          ProfileFollowingStat(
-            pubkey: widget.userIdHex,
-            displayName: widget.displayName,
-            initialCount: widget.profileStats!.following,
+      // Followers / Following always render: the BLoC-backed columns own their
+      // own loading state, and a null cached count means "not known yet"
+      // rather than zero.
+      if (isLoading)
+        ProfileStatColumn(
+          count: _skeletonPlaceholderCount,
+          label: l10n.profileFollowingLabel,
+          isLoading: _timeoutExpired,
+          onTap: () => context.push(
+            FollowingScreenRouter.pathForPubkey(widget.userIdHex),
           ),
-      if (hasFollowers || isLoading)
-        if (isLoading)
-          ProfileStatColumn(
-            count: _skeletonPlaceholderCount,
-            label: l10n.profileFollowersLabel,
-            isLoading: _timeoutExpired,
-            onTap: () => context.push(
-              FollowersScreenRouter.pathForPubkey(widget.userIdHex),
-            ),
-          )
-        else
-          ProfileFollowersStat(
-            pubkey: widget.userIdHex,
-            displayName: widget.displayName,
-            isOwnProfile: widget.isOwnProfile,
-            initialCount: widget.profileStats!.followers,
+        )
+      else
+        ProfileFollowingStat(
+          pubkey: widget.userIdHex,
+          displayName: widget.displayName,
+          initialCount: widget.profileStats!.following,
+        ),
+      if (isLoading)
+        ProfileStatColumn(
+          count: _skeletonPlaceholderCount,
+          label: l10n.profileFollowersLabel,
+          isLoading: _timeoutExpired,
+          onTap: () => context.push(
+            FollowersScreenRouter.pathForPubkey(widget.userIdHex),
           ),
+        )
+      else
+        ProfileFollowersStat(
+          pubkey: widget.userIdHex,
+          displayName: widget.displayName,
+          isOwnProfile: widget.isOwnProfile,
+          initialCount: widget.profileStats!.followers,
+        ),
     ];
 
     return Skeletonizer(

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -42,6 +42,8 @@ import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
 import 'package:openvine/widgets/profile/profile_action_buttons_widget.dart';
 import 'package:openvine/widgets/profile/profile_actions_sheet/profile_actions_sheet.dart';
+import 'package:openvine/widgets/profile/profile_followers_stat.dart';
+import 'package:openvine/widgets/profile/profile_following_stat.dart';
 import 'package:openvine/widgets/profile/profile_stats_row_widget.dart';
 import 'package:openvine/widgets/profile/profile_support_sheet.dart';
 import 'package:openvine/widgets/profile/profile_website_row.dart';
@@ -420,6 +422,7 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
             padding: const EdgeInsets.symmetric(horizontal: 24),
             child: _ProfileStatsRow(
               userIdHex: widget.userIdHex,
+              displayName: widget.displayName,
               isOwnProfile: widget.isOwnProfile,
               profileStats: widget.profileStats,
             ),

--- a/mobile/packages/db_client/drift_schemas/app_database/drift_schema_v3.json
+++ b/mobile/packages/db_client/drift_schemas/app_database/drift_schema_v3.json
@@ -479,6 +479,16 @@
             "default_dart": null,
             "default_client_dart": null,
             "dsl_features": []
+          },
+          {
+            "name": "follower_counts_updated_at",
+            "getter_name": "followerCountsUpdatedAt",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
           }
         ],
         "is_virtual": false,
@@ -3068,7 +3078,7 @@
       "sql": [
         {
           "dialect": "sqlite",
-          "sql": "CREATE TABLE IF NOT EXISTS \"profile_statistics\" (\"pubkey\" TEXT NOT NULL, \"video_count\" INTEGER NULL, \"follower_count\" INTEGER NULL, \"following_count\" INTEGER NULL, \"total_views\" INTEGER NULL, \"total_likes\" INTEGER NULL, \"cached_at\" INTEGER NOT NULL, PRIMARY KEY (\"pubkey\"));"
+          "sql": "CREATE TABLE IF NOT EXISTS \"profile_statistics\" (\"pubkey\" TEXT NOT NULL, \"video_count\" INTEGER NULL, \"follower_count\" INTEGER NULL, \"following_count\" INTEGER NULL, \"total_views\" INTEGER NULL, \"total_likes\" INTEGER NULL, \"cached_at\" INTEGER NOT NULL, \"follower_counts_updated_at\" INTEGER NULL, PRIMARY KEY (\"pubkey\"));"
         }
       ]
     },

--- a/mobile/packages/db_client/lib/src/database/app_database.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.dart
@@ -150,7 +150,7 @@ class AppDatabase extends _$AppDatabase {
         await _addColumnIfMissing(
           'profile_statistics',
           'follower_counts_updated_at',
-          'INTEGER',
+          'INTEGER NULL',
         );
         await _backfillFollowerCountTimestamps();
       }
@@ -174,7 +174,7 @@ class AppDatabase extends _$AppDatabase {
     await _addColumnIfMissing(
       'profile_statistics',
       'follower_counts_updated_at',
-      'INTEGER',
+      'INTEGER NULL',
     );
     await _backfillFollowerCountTimestamps();
   }

--- a/mobile/packages/db_client/lib/src/database/app_database.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.dart
@@ -147,21 +147,51 @@ class AppDatabase extends _$AppDatabase {
             ],
           ),
         );
+        await _addColumnIfMissing(
+          'profile_statistics',
+          'follower_counts_updated_at',
+          'INTEGER',
+        );
+        await _backfillFollowerCountTimestamps();
       }
     },
     beforeOpen: (details) async {
       // v1 databases are normalized by onUpgrade. This guarded path remains
-      // only as recovery for damaged or manually-mutated v2 databases.
+      // only as recovery for damaged or manually-mutated databases.
       if (!details.wasCreated &&
           !details.hadUpgrade &&
           await _needsSchemaRepair()) {
         await _normalizeLegacyV1Schema();
+        await _repairSchemaV3();
       }
 
       // Run cleanup of expired data on every app startup
       await runStartupCleanup();
     },
   );
+
+  Future<void> _repairSchemaV3() async {
+    await _addColumnIfMissing(
+      'profile_statistics',
+      'follower_counts_updated_at',
+      'INTEGER',
+    );
+    await _backfillFollowerCountTimestamps();
+  }
+
+  /// Anchors pre-v3 follower counts to the time they were written.
+  ///
+  /// Rows that predate `follower_counts_updated_at` carry counts with a NULL
+  /// timestamp. Backfilling during the v3 upgrade gives the follower freshness
+  /// clock a stable anchor without running an UPDATE on every database open.
+  Future<void> _backfillFollowerCountTimestamps() async {
+    await customStatement(
+      'UPDATE profile_statistics '
+      'SET follower_counts_updated_at = cached_at '
+      'WHERE follower_counts_updated_at IS NULL '
+      'AND (follower_count IS NOT NULL OR following_count IS NOT NULL)',
+    );
+  }
 
   /// Normalizes all historical schema drift from version 1 to version 2.
   ///
@@ -1024,6 +1054,7 @@ class AppDatabase extends _$AppDatabase {
       'pending_product_events': ['owner_pubkey'],
       'outgoing_dms': ['send_batch_id'],
       'personal_reactions': ['addressable_id'],
+      'profile_statistics': ['follower_counts_updated_at'],
     };
 
     for (final entry in requiredColumns.entries) {

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -2146,6 +2146,17 @@ class $ProfileStatsTable extends ProfileStats
     type: DriftSqlType.dateTime,
     requiredDuringInsert: true,
   );
+  static const VerificationMeta _followerCountsUpdatedAtMeta =
+      const VerificationMeta('followerCountsUpdatedAt');
+  @override
+  late final GeneratedColumn<DateTime> followerCountsUpdatedAt =
+      GeneratedColumn<DateTime>(
+        'follower_counts_updated_at',
+        aliasedName,
+        true,
+        type: DriftSqlType.dateTime,
+        requiredDuringInsert: false,
+      );
   @override
   List<GeneratedColumn> get $columns => [
     pubkey,
@@ -2155,6 +2166,7 @@ class $ProfileStatsTable extends ProfileStats
     totalViews,
     totalLikes,
     cachedAt,
+    followerCountsUpdatedAt,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -2220,6 +2232,15 @@ class $ProfileStatsTable extends ProfileStats
     } else if (isInserting) {
       context.missing(_cachedAtMeta);
     }
+    if (data.containsKey('follower_counts_updated_at')) {
+      context.handle(
+        _followerCountsUpdatedAtMeta,
+        followerCountsUpdatedAt.isAcceptableOrUnknown(
+          data['follower_counts_updated_at']!,
+          _followerCountsUpdatedAtMeta,
+        ),
+      );
+    }
     return context;
   }
 
@@ -2257,6 +2278,10 @@ class $ProfileStatsTable extends ProfileStats
         DriftSqlType.dateTime,
         data['${effectivePrefix}cached_at'],
       )!,
+      followerCountsUpdatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}follower_counts_updated_at'],
+      ),
     );
   }
 
@@ -2274,6 +2299,7 @@ class ProfileStatRow extends DataClass implements Insertable<ProfileStatRow> {
   final int? totalViews;
   final int? totalLikes;
   final DateTime cachedAt;
+  final DateTime? followerCountsUpdatedAt;
   const ProfileStatRow({
     required this.pubkey,
     this.videoCount,
@@ -2282,6 +2308,7 @@ class ProfileStatRow extends DataClass implements Insertable<ProfileStatRow> {
     this.totalViews,
     this.totalLikes,
     required this.cachedAt,
+    this.followerCountsUpdatedAt,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -2303,6 +2330,11 @@ class ProfileStatRow extends DataClass implements Insertable<ProfileStatRow> {
       map['total_likes'] = Variable<int>(totalLikes);
     }
     map['cached_at'] = Variable<DateTime>(cachedAt);
+    if (!nullToAbsent || followerCountsUpdatedAt != null) {
+      map['follower_counts_updated_at'] = Variable<DateTime>(
+        followerCountsUpdatedAt,
+      );
+    }
     return map;
   }
 
@@ -2325,6 +2357,9 @@ class ProfileStatRow extends DataClass implements Insertable<ProfileStatRow> {
           ? const Value.absent()
           : Value(totalLikes),
       cachedAt: Value(cachedAt),
+      followerCountsUpdatedAt: followerCountsUpdatedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(followerCountsUpdatedAt),
     );
   }
 
@@ -2341,6 +2376,9 @@ class ProfileStatRow extends DataClass implements Insertable<ProfileStatRow> {
       totalViews: serializer.fromJson<int?>(json['totalViews']),
       totalLikes: serializer.fromJson<int?>(json['totalLikes']),
       cachedAt: serializer.fromJson<DateTime>(json['cachedAt']),
+      followerCountsUpdatedAt: serializer.fromJson<DateTime?>(
+        json['followerCountsUpdatedAt'],
+      ),
     );
   }
   @override
@@ -2354,6 +2392,9 @@ class ProfileStatRow extends DataClass implements Insertable<ProfileStatRow> {
       'totalViews': serializer.toJson<int?>(totalViews),
       'totalLikes': serializer.toJson<int?>(totalLikes),
       'cachedAt': serializer.toJson<DateTime>(cachedAt),
+      'followerCountsUpdatedAt': serializer.toJson<DateTime?>(
+        followerCountsUpdatedAt,
+      ),
     };
   }
 
@@ -2365,6 +2406,7 @@ class ProfileStatRow extends DataClass implements Insertable<ProfileStatRow> {
     Value<int?> totalViews = const Value.absent(),
     Value<int?> totalLikes = const Value.absent(),
     DateTime? cachedAt,
+    Value<DateTime?> followerCountsUpdatedAt = const Value.absent(),
   }) => ProfileStatRow(
     pubkey: pubkey ?? this.pubkey,
     videoCount: videoCount.present ? videoCount.value : this.videoCount,
@@ -2377,6 +2419,9 @@ class ProfileStatRow extends DataClass implements Insertable<ProfileStatRow> {
     totalViews: totalViews.present ? totalViews.value : this.totalViews,
     totalLikes: totalLikes.present ? totalLikes.value : this.totalLikes,
     cachedAt: cachedAt ?? this.cachedAt,
+    followerCountsUpdatedAt: followerCountsUpdatedAt.present
+        ? followerCountsUpdatedAt.value
+        : this.followerCountsUpdatedAt,
   );
   ProfileStatRow copyWithCompanion(ProfileStatsCompanion data) {
     return ProfileStatRow(
@@ -2397,6 +2442,9 @@ class ProfileStatRow extends DataClass implements Insertable<ProfileStatRow> {
           ? data.totalLikes.value
           : this.totalLikes,
       cachedAt: data.cachedAt.present ? data.cachedAt.value : this.cachedAt,
+      followerCountsUpdatedAt: data.followerCountsUpdatedAt.present
+          ? data.followerCountsUpdatedAt.value
+          : this.followerCountsUpdatedAt,
     );
   }
 
@@ -2409,7 +2457,8 @@ class ProfileStatRow extends DataClass implements Insertable<ProfileStatRow> {
           ..write('followingCount: $followingCount, ')
           ..write('totalViews: $totalViews, ')
           ..write('totalLikes: $totalLikes, ')
-          ..write('cachedAt: $cachedAt')
+          ..write('cachedAt: $cachedAt, ')
+          ..write('followerCountsUpdatedAt: $followerCountsUpdatedAt')
           ..write(')'))
         .toString();
   }
@@ -2423,6 +2472,7 @@ class ProfileStatRow extends DataClass implements Insertable<ProfileStatRow> {
     totalViews,
     totalLikes,
     cachedAt,
+    followerCountsUpdatedAt,
   );
   @override
   bool operator ==(Object other) =>
@@ -2434,7 +2484,8 @@ class ProfileStatRow extends DataClass implements Insertable<ProfileStatRow> {
           other.followingCount == this.followingCount &&
           other.totalViews == this.totalViews &&
           other.totalLikes == this.totalLikes &&
-          other.cachedAt == this.cachedAt);
+          other.cachedAt == this.cachedAt &&
+          other.followerCountsUpdatedAt == this.followerCountsUpdatedAt);
 }
 
 class ProfileStatsCompanion extends UpdateCompanion<ProfileStatRow> {
@@ -2445,6 +2496,7 @@ class ProfileStatsCompanion extends UpdateCompanion<ProfileStatRow> {
   final Value<int?> totalViews;
   final Value<int?> totalLikes;
   final Value<DateTime> cachedAt;
+  final Value<DateTime?> followerCountsUpdatedAt;
   final Value<int> rowid;
   const ProfileStatsCompanion({
     this.pubkey = const Value.absent(),
@@ -2454,6 +2506,7 @@ class ProfileStatsCompanion extends UpdateCompanion<ProfileStatRow> {
     this.totalViews = const Value.absent(),
     this.totalLikes = const Value.absent(),
     this.cachedAt = const Value.absent(),
+    this.followerCountsUpdatedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   ProfileStatsCompanion.insert({
@@ -2464,6 +2517,7 @@ class ProfileStatsCompanion extends UpdateCompanion<ProfileStatRow> {
     this.totalViews = const Value.absent(),
     this.totalLikes = const Value.absent(),
     required DateTime cachedAt,
+    this.followerCountsUpdatedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : pubkey = Value(pubkey),
        cachedAt = Value(cachedAt);
@@ -2475,6 +2529,7 @@ class ProfileStatsCompanion extends UpdateCompanion<ProfileStatRow> {
     Expression<int>? totalViews,
     Expression<int>? totalLikes,
     Expression<DateTime>? cachedAt,
+    Expression<DateTime>? followerCountsUpdatedAt,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -2485,6 +2540,8 @@ class ProfileStatsCompanion extends UpdateCompanion<ProfileStatRow> {
       if (totalViews != null) 'total_views': totalViews,
       if (totalLikes != null) 'total_likes': totalLikes,
       if (cachedAt != null) 'cached_at': cachedAt,
+      if (followerCountsUpdatedAt != null)
+        'follower_counts_updated_at': followerCountsUpdatedAt,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -2497,6 +2554,7 @@ class ProfileStatsCompanion extends UpdateCompanion<ProfileStatRow> {
     Value<int?>? totalViews,
     Value<int?>? totalLikes,
     Value<DateTime>? cachedAt,
+    Value<DateTime?>? followerCountsUpdatedAt,
     Value<int>? rowid,
   }) {
     return ProfileStatsCompanion(
@@ -2507,6 +2565,8 @@ class ProfileStatsCompanion extends UpdateCompanion<ProfileStatRow> {
       totalViews: totalViews ?? this.totalViews,
       totalLikes: totalLikes ?? this.totalLikes,
       cachedAt: cachedAt ?? this.cachedAt,
+      followerCountsUpdatedAt:
+          followerCountsUpdatedAt ?? this.followerCountsUpdatedAt,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -2535,6 +2595,11 @@ class ProfileStatsCompanion extends UpdateCompanion<ProfileStatRow> {
     if (cachedAt.present) {
       map['cached_at'] = Variable<DateTime>(cachedAt.value);
     }
+    if (followerCountsUpdatedAt.present) {
+      map['follower_counts_updated_at'] = Variable<DateTime>(
+        followerCountsUpdatedAt.value,
+      );
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -2551,6 +2616,7 @@ class ProfileStatsCompanion extends UpdateCompanion<ProfileStatRow> {
           ..write('totalViews: $totalViews, ')
           ..write('totalLikes: $totalLikes, ')
           ..write('cachedAt: $cachedAt, ')
+          ..write('followerCountsUpdatedAt: $followerCountsUpdatedAt, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -17937,6 +18003,7 @@ typedef $$ProfileStatsTableCreateCompanionBuilder =
       Value<int?> totalViews,
       Value<int?> totalLikes,
       required DateTime cachedAt,
+      Value<DateTime?> followerCountsUpdatedAt,
       Value<int> rowid,
     });
 typedef $$ProfileStatsTableUpdateCompanionBuilder =
@@ -17948,6 +18015,7 @@ typedef $$ProfileStatsTableUpdateCompanionBuilder =
       Value<int?> totalViews,
       Value<int?> totalLikes,
       Value<DateTime> cachedAt,
+      Value<DateTime?> followerCountsUpdatedAt,
       Value<int> rowid,
     });
 
@@ -17992,6 +18060,11 @@ class $$ProfileStatsTableFilterComposer
 
   ColumnFilters<DateTime> get cachedAt => $composableBuilder(
     column: $table.cachedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get followerCountsUpdatedAt => $composableBuilder(
+    column: $table.followerCountsUpdatedAt,
     builder: (column) => ColumnFilters(column),
   );
 }
@@ -18039,6 +18112,11 @@ class $$ProfileStatsTableOrderingComposer
     column: $table.cachedAt,
     builder: (column) => ColumnOrderings(column),
   );
+
+  ColumnOrderings<DateTime> get followerCountsUpdatedAt => $composableBuilder(
+    column: $table.followerCountsUpdatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
 }
 
 class $$ProfileStatsTableAnnotationComposer
@@ -18080,6 +18158,11 @@ class $$ProfileStatsTableAnnotationComposer
 
   GeneratedColumn<DateTime> get cachedAt =>
       $composableBuilder(column: $table.cachedAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get followerCountsUpdatedAt => $composableBuilder(
+    column: $table.followerCountsUpdatedAt,
+    builder: (column) => column,
+  );
 }
 
 class $$ProfileStatsTableTableManager
@@ -18120,6 +18203,7 @@ class $$ProfileStatsTableTableManager
                 Value<int?> totalViews = const Value.absent(),
                 Value<int?> totalLikes = const Value.absent(),
                 Value<DateTime> cachedAt = const Value.absent(),
+                Value<DateTime?> followerCountsUpdatedAt = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => ProfileStatsCompanion(
                 pubkey: pubkey,
@@ -18129,6 +18213,7 @@ class $$ProfileStatsTableTableManager
                 totalViews: totalViews,
                 totalLikes: totalLikes,
                 cachedAt: cachedAt,
+                followerCountsUpdatedAt: followerCountsUpdatedAt,
                 rowid: rowid,
               ),
           createCompanionCallback:
@@ -18140,6 +18225,7 @@ class $$ProfileStatsTableTableManager
                 Value<int?> totalViews = const Value.absent(),
                 Value<int?> totalLikes = const Value.absent(),
                 required DateTime cachedAt,
+                Value<DateTime?> followerCountsUpdatedAt = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => ProfileStatsCompanion.insert(
                 pubkey: pubkey,
@@ -18149,6 +18235,7 @@ class $$ProfileStatsTableTableManager
                 totalViews: totalViews,
                 totalLikes: totalLikes,
                 cachedAt: cachedAt,
+                followerCountsUpdatedAt: followerCountsUpdatedAt,
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0

--- a/mobile/packages/db_client/lib/src/database/app_database.steps.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.steps.dart
@@ -2685,7 +2685,7 @@ final class Schema3 extends i0.VersionedSchema {
     ),
     alias: null,
   );
-  late final Shape3 profileStatistics = Shape3(
+  late final Shape26 profileStatistics = Shape26(
     source: i0.VersionedTable(
       entityName: 'profile_statistics',
       withoutRowId: false,
@@ -2699,6 +2699,7 @@ final class Schema3 extends i0.VersionedSchema {
         _column_34,
         _column_35,
         _column_36,
+        _column_170,
       ],
       attachedDatabase: database,
     ),
@@ -3095,13 +3096,13 @@ final class Schema3 extends i0.VersionedSchema {
     ),
     alias: null,
   );
-  late final Shape26 identityEvents = Shape26(
+  late final Shape27 identityEvents = Shape27(
     source: i0.VersionedTable(
       entityName: 'identity_events',
       withoutRowId: false,
       isStrict: false,
       tableConstraints: ['PRIMARY KEY(pubkey)'],
-      columns: [_column_1, _column_163, _column_164, _column_170, _column_171],
+      columns: [_column_1, _column_163, _column_164, _column_171, _column_172],
       attachedDatabase: database,
     ),
     alias: null,
@@ -3145,6 +3146,35 @@ class Shape26 extends i0.VersionedTable {
   Shape26({required super.source, required super.alias}) : super.aliased();
   i1.GeneratedColumn<String> get pubkey =>
       columnsByName['pubkey']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<int> get videoCount =>
+      columnsByName['video_count']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<int> get followerCount =>
+      columnsByName['follower_count']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<int> get followingCount =>
+      columnsByName['following_count']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<int> get totalViews =>
+      columnsByName['total_views']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<int> get totalLikes =>
+      columnsByName['total_likes']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<int> get cachedAt =>
+      columnsByName['cached_at']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<int> get followerCountsUpdatedAt =>
+      columnsByName['follower_counts_updated_at']! as i1.GeneratedColumn<int>;
+}
+
+i1.GeneratedColumn<int> _column_170(String aliasedName) =>
+    i1.GeneratedColumn<int>(
+      'follower_counts_updated_at',
+      aliasedName,
+      true,
+      type: i1.DriftSqlType.int,
+      $customConstraints: 'NULL',
+    );
+
+class Shape27 extends i0.VersionedTable {
+  Shape27({required super.source, required super.alias}) : super.aliased();
+  i1.GeneratedColumn<String> get pubkey =>
+      columnsByName['pubkey']! as i1.GeneratedColumn<String>;
   i1.GeneratedColumn<String> get tagsJson =>
       columnsByName['tags_json']! as i1.GeneratedColumn<String>;
   i1.GeneratedColumn<int> get sourceKind =>
@@ -3155,7 +3185,7 @@ class Shape26 extends i0.VersionedTable {
       columnsByName['source_event_id']! as i1.GeneratedColumn<String>;
 }
 
-i1.GeneratedColumn<int> _column_170(String aliasedName) =>
+i1.GeneratedColumn<int> _column_171(String aliasedName) =>
     i1.GeneratedColumn<int>(
       'source_created_at',
       aliasedName,
@@ -3163,7 +3193,7 @@ i1.GeneratedColumn<int> _column_170(String aliasedName) =>
       type: i1.DriftSqlType.int,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_171(String aliasedName) =>
+i1.GeneratedColumn<String> _column_172(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'source_event_id',
       aliasedName,

--- a/mobile/packages/db_client/lib/src/database/daos/profile_stats_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/profile_stats_dao.dart
@@ -14,10 +14,13 @@ const profileStatsCacheDuration = Duration(minutes: 5);
 /// Follower counts live in this row but are owned by `FollowRepository`, which
 /// stabilizes them with hysteresis against the persisted value. That
 /// stabilization only works if the baseline survives a restart, so the counts
-/// outlive the 5-minute stats cache. One hour matches `FollowRepository`'s own
-/// staleness window: past that point a lower fresh count is accepted outright,
-/// so the persisted baseline no longer affects the result.
-const profileFollowerCountsCacheDuration = Duration(hours: 1);
+/// outlive the 5-minute stats cache.
+///
+/// This must stay comfortably longer than `FollowRepository`'s own staleness
+/// window, so the baseline is still on disk for as long as the repository would
+/// still trust it. Sizing them equally would race: the row could be swept in
+/// the same launch the repository still wanted to compare against it.
+const profileFollowerCountsCacheDuration = Duration(hours: 48);
 
 @DriftAccessor(tables: [ProfileStats, VanishedProfiles])
 class ProfileStatsDao extends DatabaseAccessor<AppDatabase>
@@ -69,10 +72,16 @@ class ProfileStatsDao extends DatabaseAccessor<AppDatabase>
     await into(profileStats).insertOnConflictUpdate(companion);
   }
 
-  /// Get stats for a pubkey (returns null if not found or expired)
+  /// Get stats for a pubkey (returns null if not found or expired).
+  ///
+  /// An expired row is only deleted when it carries nothing worth keeping.
+  /// Follower counts outlive this cache ([followerCountsExpiry]) and are the
+  /// baseline `FollowRepository` stabilizes against, so evicting them here
+  /// would reintroduce the loss that [deleteExpired] is careful to avoid.
   Future<ProfileStatRow?> getStats(
     String pubkey, {
     Duration expiry = profileStatsCacheDuration,
+    Duration followerCountsExpiry = profileFollowerCountsCacheDuration,
   }) async {
     final query = select(profileStats)..where((t) => t.pubkey.equals(pubkey));
     final result = await query.getSingleOrNull();
@@ -80,10 +89,17 @@ class ProfileStatsDao extends DatabaseAccessor<AppDatabase>
     if (result == null) return null;
 
     // Check expiry
-    final expiryTime = DateTime.now().subtract(expiry);
-    if (result.cachedAt.isBefore(expiryTime)) {
-      // Expired - delete and return null
-      await deleteStats(pubkey);
+    final now = DateTime.now();
+    if (result.cachedAt.isBefore(now.subtract(expiry))) {
+      final hasCounts =
+          result.followerCount != null || result.followingCount != null;
+      final countsWrittenAt = result.followerCountsUpdatedAt ?? result.cachedAt;
+      final countsWorthKeeping =
+          hasCounts &&
+          !countsWrittenAt.isBefore(now.subtract(followerCountsExpiry));
+      if (!countsWorthKeeping) {
+        await deleteStats(pubkey);
+      }
       return null;
     }
 
@@ -97,13 +113,19 @@ class ProfileStatsDao extends DatabaseAccessor<AppDatabase>
 
   /// Delete all expired stats.
   ///
-  /// A row is only dropped once *both* lifecycles have expired: the general
-  /// stats cache ([expiry], measured from `cached_at`) and the follower counts
-  /// ([followerCountsExpiry], measured from `follower_counts_updated_at`).
+  /// A row survives only while it still carries useful follower counts:
+  /// it must hold at least one count, and that count must be newer than
+  /// [followerCountsExpiry]. Everything else is governed by [expiry] alone.
   /// Dropping a row that still holds fresh follower counts would destroy the
   /// baseline `FollowRepository` stabilizes against, which is exactly the
-  /// cross-restart case its hysteresis exists for. Rows that never held
-  /// follower counts are governed by [expiry] alone.
+  /// cross-restart case its hysteresis exists for.
+  ///
+  /// `follower_counts_updated_at` falls back to `cached_at` when NULL, matching
+  /// `FollowRepository`'s own read. Rows written before that column existed
+  /// carry counts with a NULL timestamp, and on the first launch after the
+  /// v1 → v2 upgrade those are exactly the baselines worth keeping — treating
+  /// NULL as "already expired" would delete them before the new column was ever
+  /// populated.
   Future<int> deleteExpired({
     Duration expiry = profileStatsCacheDuration,
     Duration followerCountsExpiry = profileFollowerCountsCacheDuration,
@@ -111,14 +133,19 @@ class ProfileStatsDao extends DatabaseAccessor<AppDatabase>
     final now = DateTime.now();
     final expiryTime = now.subtract(expiry);
     final followerExpiryTime = now.subtract(followerCountsExpiry);
-    return (delete(profileStats)..where(
-          (t) =>
-              t.cachedAt.isSmallerThan(Variable(expiryTime)) &
-              (t.followerCountsUpdatedAt.isNull() |
-                  t.followerCountsUpdatedAt.isSmallerThan(
-                    Variable(followerExpiryTime),
-                  )),
-        ))
+    return (delete(profileStats)..where((t) {
+          final hasCounts =
+              t.followerCount.isNotNull() | t.followingCount.isNotNull();
+          final countsWrittenAt = coalesce([
+            t.followerCountsUpdatedAt,
+            t.cachedAt,
+          ]);
+          final countsWorthKeeping =
+              hasCounts &
+              countsWrittenAt.isBiggerOrEqualValue(followerExpiryTime);
+          return t.cachedAt.isSmallerThan(Variable(expiryTime)) &
+              countsWorthKeeping.not();
+        }))
         .go();
   }
 

--- a/mobile/packages/db_client/lib/src/database/daos/profile_stats_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/profile_stats_dao.dart
@@ -41,6 +41,9 @@ class ProfileStatsDao extends DatabaseAccessor<AppDatabase>
     final existing = await (select(
       profileStats,
     )..where((t) => t.pubkey.equals(pubkey))).getSingleOrNull();
+    final countsUpdatedAt = followerCount != null || followingCount != null
+        ? DateTime.now()
+        : existing?.followerCountsUpdatedAt;
 
     final companion = ProfileStatsCompanion.insert(
       pubkey: pubkey,
@@ -50,6 +53,7 @@ class ProfileStatsDao extends DatabaseAccessor<AppDatabase>
       totalViews: Value(totalViews ?? existing?.totalViews),
       totalLikes: Value(totalLikes ?? existing?.totalLikes),
       cachedAt: DateTime.now(),
+      followerCountsUpdatedAt: Value(countsUpdatedAt),
     );
 
     await into(profileStats).insertOnConflictUpdate(companion);

--- a/mobile/packages/db_client/lib/src/database/daos/profile_stats_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/profile_stats_dao.dart
@@ -9,6 +9,16 @@ part 'profile_stats_dao.g.dart';
 /// Default cache duration for profile stats (5 minutes)
 const profileStatsCacheDuration = Duration(minutes: 5);
 
+/// How long follower/following counts stay useful after they were written.
+///
+/// Follower counts live in this row but are owned by `FollowRepository`, which
+/// stabilizes them with hysteresis against the persisted value. That
+/// stabilization only works if the baseline survives a restart, so the counts
+/// outlive the 5-minute stats cache. One hour matches `FollowRepository`'s own
+/// staleness window: past that point a lower fresh count is accepted outright,
+/// so the persisted baseline no longer affects the result.
+const profileFollowerCountsCacheDuration = Duration(hours: 1);
+
 @DriftAccessor(tables: [ProfileStats, VanishedProfiles])
 class ProfileStatsDao extends DatabaseAccessor<AppDatabase>
     with _$ProfileStatsDaoMixin {
@@ -85,13 +95,29 @@ class ProfileStatsDao extends DatabaseAccessor<AppDatabase>
     return (delete(profileStats)..where((t) => t.pubkey.equals(pubkey))).go();
   }
 
-  /// Delete all expired stats
-  Future<int> deleteExpired({Duration expiry = profileStatsCacheDuration}) {
-    final expiryTime = DateTime.now().subtract(expiry);
+  /// Delete all expired stats.
+  ///
+  /// A row is only dropped once *both* lifecycles have expired: the general
+  /// stats cache ([expiry], measured from `cached_at`) and the follower counts
+  /// ([followerCountsExpiry], measured from `follower_counts_updated_at`).
+  /// Dropping a row that still holds fresh follower counts would destroy the
+  /// baseline `FollowRepository` stabilizes against, which is exactly the
+  /// cross-restart case its hysteresis exists for. Rows that never held
+  /// follower counts are governed by [expiry] alone.
+  Future<int> deleteExpired({
+    Duration expiry = profileStatsCacheDuration,
+    Duration followerCountsExpiry = profileFollowerCountsCacheDuration,
+  }) {
+    final now = DateTime.now();
+    final expiryTime = now.subtract(expiry);
+    final followerExpiryTime = now.subtract(followerCountsExpiry);
     return (delete(profileStats)..where(
-          (t) => t.cachedAt.isSmallerThan(
-            Variable(expiryTime),
-          ),
+          (t) =>
+              t.cachedAt.isSmallerThan(Variable(expiryTime)) &
+              (t.followerCountsUpdatedAt.isNull() |
+                  t.followerCountsUpdatedAt.isSmallerThan(
+                    Variable(followerExpiryTime),
+                  )),
         ))
         .go();
   }

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -189,6 +189,8 @@ class ProfileStats extends Table {
   IntColumn get totalViews => integer().nullable().named('total_views')();
   IntColumn get totalLikes => integer().nullable().named('total_likes')();
   DateTimeColumn get cachedAt => dateTime().named('cached_at')();
+  DateTimeColumn get followerCountsUpdatedAt =>
+      dateTime().nullable().named('follower_counts_updated_at')();
 
   @override
   Set<Column> get primaryKey => {pubkey};

--- a/mobile/packages/db_client/test/drift/app_database/generated/schema_v3.dart
+++ b/mobile/packages/db_client/test/drift/app_database/generated/schema_v3.dart
@@ -1792,6 +1792,15 @@ class ProfileStatistics extends Table
     requiredDuringInsert: true,
     $customConstraints: 'NOT NULL',
   );
+  late final GeneratedColumn<int> followerCountsUpdatedAt =
+      GeneratedColumn<int>(
+        'follower_counts_updated_at',
+        aliasedName,
+        true,
+        type: DriftSqlType.int,
+        requiredDuringInsert: false,
+        $customConstraints: 'NULL',
+      );
   @override
   List<GeneratedColumn> get $columns => [
     pubkey,
@@ -1801,6 +1810,7 @@ class ProfileStatistics extends Table
     totalViews,
     totalLikes,
     cachedAt,
+    followerCountsUpdatedAt,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -1841,6 +1851,10 @@ class ProfileStatistics extends Table
         DriftSqlType.int,
         data['${effectivePrefix}cached_at'],
       )!,
+      followerCountsUpdatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}follower_counts_updated_at'],
+      ),
     );
   }
 
@@ -1864,6 +1878,7 @@ class ProfileStatisticsData extends DataClass
   final int? totalViews;
   final int? totalLikes;
   final int cachedAt;
+  final int? followerCountsUpdatedAt;
   const ProfileStatisticsData({
     required this.pubkey,
     this.videoCount,
@@ -1872,6 +1887,7 @@ class ProfileStatisticsData extends DataClass
     this.totalViews,
     this.totalLikes,
     required this.cachedAt,
+    this.followerCountsUpdatedAt,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -1893,6 +1909,11 @@ class ProfileStatisticsData extends DataClass
       map['total_likes'] = Variable<int>(totalLikes);
     }
     map['cached_at'] = Variable<int>(cachedAt);
+    if (!nullToAbsent || followerCountsUpdatedAt != null) {
+      map['follower_counts_updated_at'] = Variable<int>(
+        followerCountsUpdatedAt,
+      );
+    }
     return map;
   }
 
@@ -1915,6 +1936,9 @@ class ProfileStatisticsData extends DataClass
           ? const Value.absent()
           : Value(totalLikes),
       cachedAt: Value(cachedAt),
+      followerCountsUpdatedAt: followerCountsUpdatedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(followerCountsUpdatedAt),
     );
   }
 
@@ -1931,6 +1955,9 @@ class ProfileStatisticsData extends DataClass
       totalViews: serializer.fromJson<int?>(json['totalViews']),
       totalLikes: serializer.fromJson<int?>(json['totalLikes']),
       cachedAt: serializer.fromJson<int>(json['cachedAt']),
+      followerCountsUpdatedAt: serializer.fromJson<int?>(
+        json['followerCountsUpdatedAt'],
+      ),
     );
   }
   @override
@@ -1944,6 +1971,9 @@ class ProfileStatisticsData extends DataClass
       'totalViews': serializer.toJson<int?>(totalViews),
       'totalLikes': serializer.toJson<int?>(totalLikes),
       'cachedAt': serializer.toJson<int>(cachedAt),
+      'followerCountsUpdatedAt': serializer.toJson<int?>(
+        followerCountsUpdatedAt,
+      ),
     };
   }
 
@@ -1955,6 +1985,7 @@ class ProfileStatisticsData extends DataClass
     Value<int?> totalViews = const Value.absent(),
     Value<int?> totalLikes = const Value.absent(),
     int? cachedAt,
+    Value<int?> followerCountsUpdatedAt = const Value.absent(),
   }) => ProfileStatisticsData(
     pubkey: pubkey ?? this.pubkey,
     videoCount: videoCount.present ? videoCount.value : this.videoCount,
@@ -1967,6 +1998,9 @@ class ProfileStatisticsData extends DataClass
     totalViews: totalViews.present ? totalViews.value : this.totalViews,
     totalLikes: totalLikes.present ? totalLikes.value : this.totalLikes,
     cachedAt: cachedAt ?? this.cachedAt,
+    followerCountsUpdatedAt: followerCountsUpdatedAt.present
+        ? followerCountsUpdatedAt.value
+        : this.followerCountsUpdatedAt,
   );
   ProfileStatisticsData copyWithCompanion(ProfileStatisticsCompanion data) {
     return ProfileStatisticsData(
@@ -1987,6 +2021,9 @@ class ProfileStatisticsData extends DataClass
           ? data.totalLikes.value
           : this.totalLikes,
       cachedAt: data.cachedAt.present ? data.cachedAt.value : this.cachedAt,
+      followerCountsUpdatedAt: data.followerCountsUpdatedAt.present
+          ? data.followerCountsUpdatedAt.value
+          : this.followerCountsUpdatedAt,
     );
   }
 
@@ -1999,7 +2036,8 @@ class ProfileStatisticsData extends DataClass
           ..write('followingCount: $followingCount, ')
           ..write('totalViews: $totalViews, ')
           ..write('totalLikes: $totalLikes, ')
-          ..write('cachedAt: $cachedAt')
+          ..write('cachedAt: $cachedAt, ')
+          ..write('followerCountsUpdatedAt: $followerCountsUpdatedAt')
           ..write(')'))
         .toString();
   }
@@ -2013,6 +2051,7 @@ class ProfileStatisticsData extends DataClass
     totalViews,
     totalLikes,
     cachedAt,
+    followerCountsUpdatedAt,
   );
   @override
   bool operator ==(Object other) =>
@@ -2024,7 +2063,8 @@ class ProfileStatisticsData extends DataClass
           other.followingCount == this.followingCount &&
           other.totalViews == this.totalViews &&
           other.totalLikes == this.totalLikes &&
-          other.cachedAt == this.cachedAt);
+          other.cachedAt == this.cachedAt &&
+          other.followerCountsUpdatedAt == this.followerCountsUpdatedAt);
 }
 
 class ProfileStatisticsCompanion
@@ -2036,6 +2076,7 @@ class ProfileStatisticsCompanion
   final Value<int?> totalViews;
   final Value<int?> totalLikes;
   final Value<int> cachedAt;
+  final Value<int?> followerCountsUpdatedAt;
   final Value<int> rowid;
   const ProfileStatisticsCompanion({
     this.pubkey = const Value.absent(),
@@ -2045,6 +2086,7 @@ class ProfileStatisticsCompanion
     this.totalViews = const Value.absent(),
     this.totalLikes = const Value.absent(),
     this.cachedAt = const Value.absent(),
+    this.followerCountsUpdatedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   ProfileStatisticsCompanion.insert({
@@ -2055,6 +2097,7 @@ class ProfileStatisticsCompanion
     this.totalViews = const Value.absent(),
     this.totalLikes = const Value.absent(),
     required int cachedAt,
+    this.followerCountsUpdatedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : pubkey = Value(pubkey),
        cachedAt = Value(cachedAt);
@@ -2066,6 +2109,7 @@ class ProfileStatisticsCompanion
     Expression<int>? totalViews,
     Expression<int>? totalLikes,
     Expression<int>? cachedAt,
+    Expression<int>? followerCountsUpdatedAt,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -2076,6 +2120,8 @@ class ProfileStatisticsCompanion
       if (totalViews != null) 'total_views': totalViews,
       if (totalLikes != null) 'total_likes': totalLikes,
       if (cachedAt != null) 'cached_at': cachedAt,
+      if (followerCountsUpdatedAt != null)
+        'follower_counts_updated_at': followerCountsUpdatedAt,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -2088,6 +2134,7 @@ class ProfileStatisticsCompanion
     Value<int?>? totalViews,
     Value<int?>? totalLikes,
     Value<int>? cachedAt,
+    Value<int?>? followerCountsUpdatedAt,
     Value<int>? rowid,
   }) {
     return ProfileStatisticsCompanion(
@@ -2098,6 +2145,8 @@ class ProfileStatisticsCompanion
       totalViews: totalViews ?? this.totalViews,
       totalLikes: totalLikes ?? this.totalLikes,
       cachedAt: cachedAt ?? this.cachedAt,
+      followerCountsUpdatedAt:
+          followerCountsUpdatedAt ?? this.followerCountsUpdatedAt,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -2126,6 +2175,11 @@ class ProfileStatisticsCompanion
     if (cachedAt.present) {
       map['cached_at'] = Variable<int>(cachedAt.value);
     }
+    if (followerCountsUpdatedAt.present) {
+      map['follower_counts_updated_at'] = Variable<int>(
+        followerCountsUpdatedAt.value,
+      );
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -2142,6 +2196,7 @@ class ProfileStatisticsCompanion
           ..write('totalViews: $totalViews, ')
           ..write('totalLikes: $totalLikes, ')
           ..write('cachedAt: $cachedAt, ')
+          ..write('followerCountsUpdatedAt: $followerCountsUpdatedAt, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();

--- a/mobile/packages/db_client/test/drift/app_database/migration_test.dart
+++ b/mobile/packages/db_client/test/drift/app_database/migration_test.dart
@@ -1,6 +1,6 @@
 // dart format width=80
 import 'package:db_client/src/database/app_database.dart';
-import 'package:drift/drift.dart';
+import 'package:drift/drift.dart' hide isNull;
 import 'package:drift/native.dart';
 import 'package:drift_dev/api/migrations_native.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/mobile/packages/db_client/test/drift/app_database/migration_test.dart
+++ b/mobile/packages/db_client/test/drift/app_database/migration_test.dart
@@ -45,17 +45,20 @@ void main() {
 
     test('migrates v2 profile statistic follower timestamps to v3', () async {
       final schema = await verifier.schemaAt(2);
-      final db = AppDatabase(schema.newConnection());
-      final cachedAt = DateTime(2026).millisecondsSinceEpoch ~/ 1000;
+      final cachedAt =
+          DateTime.now()
+              .subtract(const Duration(hours: 10))
+              .millisecondsSinceEpoch ~/
+          1000;
 
-      await db.customStatement(
+      schema.rawDatabase.execute(
         'INSERT INTO profile_statistics '
         '(pubkey, video_count, follower_count, following_count, total_views, '
         'total_likes, cached_at) '
         'VALUES (?, NULL, ?, ?, NULL, NULL, ?)',
         ['withcounts', 12, 7, cachedAt],
       );
-      await db.customStatement(
+      schema.rawDatabase.execute(
         'INSERT INTO profile_statistics '
         '(pubkey, video_count, follower_count, following_count, total_views, '
         'total_likes, cached_at) '
@@ -63,6 +66,7 @@ void main() {
         ['withoutcounts', cachedAt],
       );
 
+      final db = AppDatabase(schema.newConnection());
       await verifier.migrateAndValidate(db, 3);
 
       final rows = await db
@@ -80,8 +84,8 @@ void main() {
         cachedAt,
       );
       expect(
-        byPubkey['withoutcounts']!.read<int?>('follower_counts_updated_at'),
-        isNull,
+        byPubkey.containsKey('withoutcounts'),
+        isFalse,
       );
       await db.close();
     });

--- a/mobile/packages/db_client/test/drift/app_database/migration_test.dart
+++ b/mobile/packages/db_client/test/drift/app_database/migration_test.dart
@@ -43,6 +43,49 @@ void main() {
       await db.close();
     });
 
+    test('migrates v2 profile statistic follower timestamps to v3', () async {
+      final schema = await verifier.schemaAt(2);
+      final db = AppDatabase(schema.newConnection());
+      final cachedAt = DateTime(2026).millisecondsSinceEpoch ~/ 1000;
+
+      await db.customStatement(
+        'INSERT INTO profile_statistics '
+        '(pubkey, video_count, follower_count, following_count, total_views, '
+        'total_likes, cached_at) '
+        'VALUES (?, NULL, ?, ?, NULL, NULL, ?)',
+        ['withcounts', 12, 7, cachedAt],
+      );
+      await db.customStatement(
+        'INSERT INTO profile_statistics '
+        '(pubkey, video_count, follower_count, following_count, total_views, '
+        'total_likes, cached_at) '
+        'VALUES (?, NULL, NULL, NULL, NULL, NULL, ?)',
+        ['withoutcounts', cachedAt],
+      );
+
+      await verifier.migrateAndValidate(db, 3);
+
+      final rows = await db
+          .customSelect(
+            'SELECT pubkey, follower_counts_updated_at '
+            'FROM profile_statistics ORDER BY pubkey',
+          )
+          .get();
+      final byPubkey = {
+        for (final row in rows) row.read<String>('pubkey'): row,
+      };
+
+      expect(
+        byPubkey['withcounts']!.read<int?>('follower_counts_updated_at'),
+        cachedAt,
+      );
+      expect(
+        byPubkey['withoutcounts']!.read<int?>('follower_counts_updated_at'),
+        isNull,
+      );
+      await db.close();
+    });
+
     test('v2 identity_events rows survive the v3 upgrade unstamped', () async {
       await verifier.testWithDataIntegrity(
         oldVersion: 2,

--- a/mobile/packages/db_client/test/src/database/app_database_test.dart
+++ b/mobile/packages/db_client/test/src/database/app_database_test.dart
@@ -306,7 +306,7 @@ void main() {
         expect(fetched.selfWrapStatus, OutgoingWrapStatus.pending);
       });
 
-      test('upgrade path — legacy v1 database migrates to v2', () async {
+      test('upgrade path — legacy v1 database migrates to v3', () async {
         // The generated `migration_test.dart` cannot cover this: both
         // `drift_schema_v1.json` and `drift_schema_v2.json` are dumps of the
         // same declared table set, so `schemaAt(1)` already hands back a

--- a/mobile/packages/db_client/test/src/database/app_database_test.dart
+++ b/mobile/packages/db_client/test/src/database/app_database_test.dart
@@ -82,29 +82,56 @@ void main() {
         expect(result.expiredEventsDeleted, equals(1));
       });
 
-      test('deletes expired profile stats', () async {
-        // Insert stats with old cachedAt using proper Drift insert
-        final oldTime = DateTime.now().subtract(const Duration(minutes: 10));
-        await database
-            .into(database.profileStats)
-            .insert(
-              ProfileStatsCompanion.insert(
-                pubkey: testPubkey,
-                videoCount: const Value(10),
-                followerCount: const Value(100),
-                cachedAt: oldTime,
-              ),
-            );
+      test(
+        'deletes expired profile stats that hold no follower counts',
+        () async {
+          // Insert stats with old cachedAt using proper Drift insert
+          final oldTime = DateTime.now().subtract(const Duration(minutes: 10));
+          await database
+              .into(database.profileStats)
+              .insert(
+                ProfileStatsCompanion.insert(
+                  pubkey: testPubkey,
+                  videoCount: const Value(10),
+                  cachedAt: oldTime,
+                ),
+              );
 
-        // Run cleanup (default expiry is 5 minutes, entry is 10 minutes old)
-        final result = await database.runStartupCleanup();
+          // Run cleanup (default expiry is 5 minutes, entry is 10 minutes old)
+          final result = await database.runStartupCleanup();
 
-        // Expired stats should be deleted
-        final stats = await database.profileStatsDao.getStats(testPubkey);
-        expect(stats, isNull);
+          // Expired stats should be deleted
+          final stats = await database.profileStatsDao.getStats(testPubkey);
+          expect(stats, isNull);
 
-        expect(result.expiredProfileStatsDeleted, equals(1));
-      });
+          expect(result.expiredProfileStatsDeleted, equals(1));
+        },
+      );
+
+      test(
+        'keeps expired profile stats that still hold follower counts',
+        () async {
+          // Startup cleanup runs on every cold start, so deleting this row
+          // is how the follower baseline used to vanish overnight (#6902).
+          final oldTime = DateTime.now().subtract(const Duration(minutes: 10));
+          await database
+              .into(database.profileStats)
+              .insert(
+                ProfileStatsCompanion.insert(
+                  pubkey: testPubkey,
+                  videoCount: const Value(10),
+                  followerCount: const Value(100),
+                  cachedAt: oldTime,
+                ),
+              );
+
+          final result = await database.runStartupCleanup();
+
+          expect(result.expiredProfileStatsDeleted, equals(0));
+          final row = await database.profileStatsDao.getStatsRaw(testPubkey);
+          expect(row!.followerCount, equals(100));
+        },
+      );
 
       test('deletes expired hashtag stats', () async {
         // Insert stats with old cachedAt using proper Drift insert

--- a/mobile/packages/db_client/test/src/database/daos/profile_stats_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/profile_stats_dao_test.dart
@@ -336,6 +336,7 @@ void main() {
               ProfileStatsCompanion.insert(
                 pubkey: testPubkey,
                 videoCount: const Value(10),
+                followerCount: const Value(98),
                 cachedAt: oldTime,
                 followerCountsUpdatedAt: Value(
                   DateTime.now().subtract(const Duration(minutes: 1)),
@@ -350,14 +351,64 @@ void main() {
         expect(row, isNotNull);
       });
 
+      test(
+        'keeps pre-upgrade rows whose follower timestamp is still NULL',
+        () async {
+          // Rows written before follower_counts_updated_at existed carry
+          // counts with a NULL timestamp. On the first launch after the
+          // v1 -> v2 upgrade those are exactly the baselines #6902 needs, so
+          // NULL must fall back to cached_at rather than reading as "expired".
+          final writtenAt = DateTime.now().subtract(const Duration(hours: 10));
+          await database
+              .into(database.profileStats)
+              .insert(
+                ProfileStatsCompanion.insert(
+                  pubkey: testPubkey,
+                  followerCount: const Value(98),
+                  cachedAt: writtenAt,
+                ),
+              );
+
+          final deleted = await dao.deleteExpired();
+
+          expect(deleted, equals(0));
+          final row = await appDbClient.getProfileStatRow(testPubkey);
+          expect(row!.followerCount, equals(98));
+        },
+      );
+
+      test(
+        'deletes stats-only rows that never carried follower counts',
+        () async {
+          // The follower fallback must not turn the 5-minute stats cache into a
+          // 48-hour one for rows that hold no counts at all.
+          final oldTime = DateTime.now().subtract(const Duration(minutes: 10));
+          await database
+              .into(database.profileStats)
+              .insert(
+                ProfileStatsCompanion.insert(
+                  pubkey: testPubkey,
+                  videoCount: const Value(10),
+                  cachedAt: oldTime,
+                ),
+              );
+
+          final deleted = await dao.deleteExpired();
+
+          expect(deleted, equals(1));
+          expect(await appDbClient.countProfileStats(), equals(0));
+        },
+      );
+
       test('deletes rows whose follower counts are also expired', () async {
-        final oldTime = DateTime.now().subtract(const Duration(hours: 3));
+        final oldTime = DateTime.now().subtract(const Duration(hours: 72));
         await database
             .into(database.profileStats)
             .insert(
               ProfileStatsCompanion.insert(
                 pubkey: testPubkey,
                 videoCount: const Value(10),
+                followerCount: const Value(98),
                 cachedAt: oldTime,
                 followerCountsUpdatedAt: Value(oldTime),
               ),

--- a/mobile/packages/db_client/test/src/database/daos/profile_stats_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/profile_stats_dao_test.dart
@@ -400,6 +400,43 @@ void main() {
         },
       );
 
+      test('keeps a following-only count with a NULL timestamp', () async {
+        // The other pre-upgrade shape: a row carrying only following_count.
+        final writtenAt = DateTime.now().subtract(const Duration(hours: 10));
+        await database
+            .into(database.profileStats)
+            .insert(
+              ProfileStatsCompanion.insert(
+                pubkey: testPubkey,
+                followingCount: const Value(20),
+                cachedAt: writtenAt,
+              ),
+            );
+
+        expect(await dao.deleteExpired(), equals(0));
+        final row = await appDbClient.getProfileStatRow(testPubkey);
+        expect(row!.followingCount, equals(20));
+      });
+
+      test('deletes a NULL-timestamp row once cached_at passes the follower '
+          'window', () async {
+        // NULL falls back to cached_at, so a pre-upgrade row still expires
+        // eventually rather than being retained forever.
+        final writtenAt = DateTime.now().subtract(const Duration(hours: 72));
+        await database
+            .into(database.profileStats)
+            .insert(
+              ProfileStatsCompanion.insert(
+                pubkey: testPubkey,
+                followerCount: const Value(98),
+                cachedAt: writtenAt,
+              ),
+            );
+
+        expect(await dao.deleteExpired(), equals(1));
+        expect(await appDbClient.countProfileStats(), equals(0));
+      });
+
       test('deletes rows whose follower counts are also expired', () async {
         final oldTime = DateTime.now().subtract(const Duration(hours: 72));
         await database

--- a/mobile/packages/db_client/test/src/database/daos/profile_stats_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/profile_stats_dao_test.dart
@@ -125,6 +125,26 @@ void main() {
         expect(result.cachedAt.isBefore(after), isTrue);
       });
 
+      test('does not refresh follower timestamp for unrelated stats', () async {
+        await dao.upsertStats(
+          pubkey: testPubkey,
+          followerCount: 100,
+          followingCount: 50,
+        );
+        final original = await appDbClient.getProfileStatRow(testPubkey);
+        expect(original!.followerCountsUpdatedAt, isNotNull);
+
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        await dao.upsertStats(pubkey: testPubkey, videoCount: 10);
+
+        final result = await appDbClient.getProfileStatRow(testPubkey);
+        expect(result!.videoCount, equals(10));
+        expect(
+          result.followerCountsUpdatedAt,
+          equals(original.followerCountsUpdatedAt),
+        );
+      });
+
       test('no-ops for a pubkey that requested deletion', () async {
         // The classic-viner seed import re-runs on every manifest bump and
         // writes counters straight to this DAO.

--- a/mobile/packages/db_client/test/src/database/daos/profile_stats_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/profile_stats_dao_test.dart
@@ -324,6 +324,50 @@ void main() {
         expect(deleted, equals(0));
         expect(await appDbClient.countProfileStats(), equals(1));
       });
+
+      test('keeps rows whose follower counts are still fresh', () async {
+        // Startup cleanup runs on every cold start. Dropping this row would
+        // destroy the baseline FollowRepository stabilizes lower fresh counts
+        // against, so the overnight drop in #6902 would never be caught.
+        final oldTime = DateTime.now().subtract(const Duration(minutes: 10));
+        await database
+            .into(database.profileStats)
+            .insert(
+              ProfileStatsCompanion.insert(
+                pubkey: testPubkey,
+                videoCount: const Value(10),
+                cachedAt: oldTime,
+                followerCountsUpdatedAt: Value(
+                  DateTime.now().subtract(const Duration(minutes: 1)),
+                ),
+              ),
+            );
+
+        final deleted = await dao.deleteExpired();
+
+        expect(deleted, equals(0));
+        final row = await appDbClient.getProfileStatRow(testPubkey);
+        expect(row, isNotNull);
+      });
+
+      test('deletes rows whose follower counts are also expired', () async {
+        final oldTime = DateTime.now().subtract(const Duration(hours: 3));
+        await database
+            .into(database.profileStats)
+            .insert(
+              ProfileStatsCompanion.insert(
+                pubkey: testPubkey,
+                videoCount: const Value(10),
+                cachedAt: oldTime,
+                followerCountsUpdatedAt: Value(oldTime),
+              ),
+            );
+
+        final deleted = await dao.deleteExpired();
+
+        expect(deleted, equals(1));
+        expect(await appDbClient.countProfileStats(), equals(0));
+      });
     });
 
     group('clearAll', () {

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -658,6 +658,11 @@ class FollowRepository {
   /// Drops within this threshold are assumed to be relay query variance.
   static const _hysteresisThreshold = 0.8;
 
+  /// Small accounts should reflect one-person changes immediately; percentage
+  /// hysteresis is only useful once counts are large enough for relay variance
+  /// to dominate individual follow/unfollow events.
+  static const _hysteresisMinimumCount = 20;
+
   /// In-memory cache for follower/following counts.
   final Map<String, FollowerStats> _followerStatsCache = {};
 
@@ -675,7 +680,7 @@ class FollowRepository {
     return (
       followers: row.followerCount ?? 0,
       following: row.followingCount ?? 0,
-      timestamp: row.cachedAt,
+      timestamp: row.followerCountsUpdatedAt ?? row.cachedAt,
     );
   }
 
@@ -700,6 +705,9 @@ class FollowRepository {
   }) {
     // Fresh count is higher → always accept
     if (freshCount >= persistedCount) return freshCount;
+
+    // One-person changes are meaningful for small accounts.
+    if (persistedCount < _hysteresisMinimumCount) return freshCount;
 
     // Persisted count is stale → accept the fresh count
     if (DateTime.now().difference(persistedTimestamp) > _staleDuration) {

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -651,7 +651,18 @@ class FollowRepository {
 
   /// Counts older than this are considered stale and will be replaced
   /// even if the new value is lower.
-  static const _staleDuration = Duration(hours: 1);
+  ///
+  /// This has to outlast the gap between closing the app at night and opening
+  /// it the next day, because that gap is the failure in #6902: a count that
+  /// dropped overnight and stayed wrong. A one-hour window expired during every
+  /// such gap, so the persisted baseline was always considered stale by morning
+  /// and the low fresh count was accepted outright — the stabilization never
+  /// ran in the one case it exists for.
+  ///
+  /// A genuine drop larger than [_hysteresisThreshold] still shows up
+  /// immediately; only drops small enough to look like relay variance wait for
+  /// this window.
+  static const _staleDuration = Duration(hours: 24);
 
   /// A new count must drop below this fraction of the persisted count
   /// before being treated as a genuine decrease (when not stale).

--- a/mobile/packages/models/lib/src/profile_stats.dart
+++ b/mobile/packages/models/lib/src/profile_stats.dart
@@ -11,8 +11,8 @@ class ProfileStats {
     required this.pubkey,
     this.videoCount = 0,
     this.totalLikes = 0,
-    this.followers = 0,
-    this.following = 0,
+    this.followers,
+    this.following,
     this.totalViews = 0,
     this.lastUpdated,
   });
@@ -26,11 +26,18 @@ class ProfileStats {
   /// Total likes across all videos.
   final int totalLikes;
 
-  /// Number of followers.
-  final int followers;
+  /// Number of followers, or `null` when no follower count has been cached
+  /// yet.
+  ///
+  /// Follower and following counts are owned by `FollowRepository`, which
+  /// writes them independently of the rest of this row. `null` means "not
+  /// known yet" and must not be rendered as zero — callers should show a
+  /// loading affordance instead.
+  final int? followers;
 
-  /// Number of accounts this user follows.
-  final int following;
+  /// Number of accounts this user follows, or `null` when no following count
+  /// has been cached yet. See [followers].
+  final int? following;
 
   /// Total views across all videos.
   final int totalViews;

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -635,8 +635,8 @@ class ProfileRepository implements ProfileReader {
         pubkey: row.pubkey,
         videoCount: row.videoCount ?? 0,
         totalLikes: row.totalLikes ?? 0,
-        followers: row.followerCount ?? 0,
-        following: row.followingCount ?? 0,
+        followers: row.followerCount,
+        following: row.followingCount,
         totalViews: row.totalViews ?? 0,
         lastUpdated: row.cachedAt,
       );

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -643,8 +643,11 @@ class ProfileRepository implements ProfileReader {
     });
   }
 
-  /// Caches profile stats (social counts, video stats, engagement data) from a
+  /// Caches profile stats (video stats and engagement data) from a
   /// [UserProfileResult] into the local [ProfileStatsDao].
+  ///
+  /// Follower/following counts are owned by FollowRepository because it merges
+  /// REST, relay, and persisted inputs with hysteresis stabilization.
   Future<void> _cacheProfileStatsFromResult(
     String pubkey,
     UserProfileResult result,
@@ -654,11 +657,10 @@ class ProfileRepository implements ProfileReader {
 
     // Both variants expose social/stats/engagement on the sealed base class,
     // so no switch is needed here.
-    final social = result.social;
     final stats = result.stats;
     final engagement = result.engagement;
 
-    if (social == null && stats == null && engagement == null) return;
+    if (stats == null && engagement == null) return;
 
     int? publicViewCount;
     if (engagement != null) {
@@ -669,8 +671,6 @@ class ProfileRepository implements ProfileReader {
 
     await dao.upsertStats(
       pubkey: pubkey,
-      followerCount: social?.followerCount,
-      followingCount: social?.followingCount,
       videoCount: stats?.videoCount,
       totalLikes: engagement?.totalReactions,
       totalViews: publicViewCount,

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -1872,7 +1872,7 @@ class ProfileRepository implements ProfileReader {
       final profiles = restResults
           .map((result) => result.toUserProfile())
           .where((p) => !(_blockFilter?.call(p.pubkey) ?? false));
-      return _enrichFromCache(profiles.toList());
+      return await _enrichFromCache(profiles.toList());
     } on Exception catch (e) {
       Log.warning(
         'REST profile search failed: $e',

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -497,29 +497,38 @@ void main() {
         await expectLater(stream, emits(isNull));
       });
 
-      test('defaults nullable int fields to zero', () async {
-        final row = ProfileStatRow(
-          pubkey: testPubkey,
-          cachedAt: DateTime(2026),
-        );
-        when(
-          () => mockProfileStatsDao.watchStats(any()),
-        ).thenAnswer((_) => Stream.value(row));
+      test(
+        'defaults engagement counts to zero but leaves follower counts null',
+        () async {
+          final row = ProfileStatRow(
+            pubkey: testPubkey,
+            cachedAt: DateTime(2026),
+          );
+          when(
+            () => mockProfileStatsDao.watchStats(any()),
+          ).thenAnswer((_) => Stream.value(row));
 
-        final stream = profileRepository.watchProfileStats(pubkey: testPubkey);
+          final stream = profileRepository.watchProfileStats(
+            pubkey: testPubkey,
+          );
 
-        await expectLater(
-          stream,
-          emits(
-            isA<ProfileStats>()
-                .having((s) => s.videoCount, 'videoCount', equals(0))
-                .having((s) => s.totalLikes, 'totalLikes', equals(0))
-                .having((s) => s.followers, 'followers', equals(0))
-                .having((s) => s.following, 'following', equals(0))
-                .having((s) => s.totalViews, 'totalViews', equals(0)),
-          ),
-        );
-      });
+          await expectLater(
+            stream,
+            emits(
+              isA<ProfileStats>()
+                  .having((s) => s.videoCount, 'videoCount', equals(0))
+                  .having((s) => s.totalLikes, 'totalLikes', equals(0))
+                  // Follower counts stay null: FollowRepository owns them, and
+                  // "not written yet" must stay distinguishable from a genuine
+                  // zero so the profile header can show a placeholder instead
+                  // of a wrong count.
+                  .having((s) => s.followers, 'followers', isNull)
+                  .having((s) => s.following, 'following', isNull)
+                  .having((s) => s.totalViews, 'totalViews', equals(0)),
+            ),
+          );
+        },
+      );
 
       test('returns empty stream when ProfileStatsDao not injected', () async {
         final repoWithoutStats = ProfileRepository(

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -1253,8 +1253,6 @@ void main() {
           verify(
             () => mockProfileStatsDao.upsertStats(
               pubkey: testPubkey,
-              followerCount: 12,
-              followingCount: 7,
               videoCount: 3,
               totalLikes: 42,
               totalViews: 99,

--- a/mobile/test/blocs/my_followers/my_followers_bloc_test.dart
+++ b/mobile/test/blocs/my_followers/my_followers_bloc_test.dart
@@ -243,7 +243,7 @@ void main() {
             status: MyFollowersStatus.success,
             followersPubkeys: [validPubkey('ok')],
             rawFollowersPubkeys: [validPubkey('blocked'), validPubkey('ok')],
-            followerCount: 2,
+            followerCount: 1,
           ),
         ],
       );
@@ -280,7 +280,7 @@ void main() {
             status: MyFollowersStatus.success,
             followersPubkeys: [validPubkey('b')],
             rawFollowersPubkeys: [validPubkey('a'), validPubkey('b')],
-            followerCount: 2,
+            followerCount: 1,
           ),
         ],
       );

--- a/mobile/test/blocs/my_followers/my_followers_bloc_test.dart
+++ b/mobile/test/blocs/my_followers/my_followers_bloc_test.dart
@@ -77,7 +77,7 @@ void main() {
               validPubkey('follower1'),
               validPubkey('follower2'),
             ],
-            followerCount: 2,
+            authoritativeFollowerCount: 2,
           ),
         ],
       );
@@ -107,7 +107,7 @@ void main() {
             status: MyFollowersStatus.success,
             followersPubkeys: [validPubkey('old')],
             rawFollowersPubkeys: [validPubkey('old')],
-            followerCount: 1,
+            authoritativeFollowerCount: 1,
           ),
           MyFollowersState(
             status: MyFollowersStatus.success,
@@ -119,7 +119,7 @@ void main() {
               validPubkey('follower1'),
               validPubkey('follower2'),
             ],
-            followerCount: 2,
+            authoritativeFollowerCount: 2,
           ),
         ],
       );
@@ -146,7 +146,7 @@ void main() {
             status: MyFollowersStatus.success,
             followersPubkeys: [validPubkey('follower1')],
             rawFollowersPubkeys: [validPubkey('follower1')],
-            followerCount: 500,
+            authoritativeFollowerCount: 500,
           ),
         ],
       );
@@ -211,7 +211,7 @@ void main() {
             status: MyFollowersStatus.success,
             followersPubkeys: [validPubkey('cached')],
             rawFollowersPubkeys: [validPubkey('cached')],
-            followerCount: 1,
+            authoritativeFollowerCount: 1,
           ),
         ],
       );
@@ -243,7 +243,7 @@ void main() {
             status: MyFollowersStatus.success,
             followersPubkeys: [validPubkey('ok')],
             rawFollowersPubkeys: [validPubkey('blocked'), validPubkey('ok')],
-            followerCount: 1,
+            authoritativeFollowerCount: 2,
           ),
         ],
       );
@@ -280,7 +280,7 @@ void main() {
             status: MyFollowersStatus.success,
             followersPubkeys: [validPubkey('b')],
             rawFollowersPubkeys: [validPubkey('a'), validPubkey('b')],
-            followerCount: 1,
+            authoritativeFollowerCount: 2,
           ),
         ],
       );
@@ -340,7 +340,7 @@ void main() {
               validPubkey('undated'),
             ],
             rawDatedCount: 2,
-            followerCount: 3,
+            authoritativeFollowerCount: 3,
           ),
         ],
       );
@@ -404,7 +404,7 @@ void main() {
               validPubkey('undated'),
             ],
             rawDatedCount: 2,
-            followerCount: 3,
+            authoritativeFollowerCount: 3,
           ),
         ],
       );
@@ -440,7 +440,7 @@ void main() {
               validPubkey('undated'),
             ],
             rawDatedCount: 2,
-            followerCount: 3,
+            authoritativeFollowerCount: 3,
           ),
         ],
       );
@@ -489,7 +489,7 @@ void main() {
       const state = MyFollowersState(
         status: MyFollowersStatus.success,
         followersPubkeys: ['pubkey1'],
-        followerCount: 10,
+        authoritativeFollowerCount: 10,
       );
 
       expect(state.props, [

--- a/mobile/test/blocs/others_followers/others_followers_bloc_test.dart
+++ b/mobile/test/blocs/others_followers/others_followers_bloc_test.dart
@@ -526,6 +526,35 @@ void main() {
       );
 
       blocTest<OthersFollowersBloc, OthersFollowersState>(
+        'keeps the visible count steady when removing a blocked follower',
+        setUp: () {
+          when(
+            () => mockBlocklistRepository.isBlocked(validPubkey('blocked')),
+          ).thenReturn(true);
+        },
+        build: createBloc,
+        seed: () => OthersFollowersState(
+          status: OthersFollowersStatus.success,
+          followersPubkeys: [validPubkey('existing')],
+          rawFollowersPubkeys: [
+            validPubkey('existing'),
+            validPubkey('blocked'),
+          ],
+          authoritativeFollowerCount: 500,
+          targetPubkey: validPubkey('target'),
+        ),
+        act: (bloc) => bloc.add(
+          OthersFollowersDecrementRequested(validPubkey('blocked')),
+        ),
+        verify: (bloc) {
+          expect(bloc.state.authoritativeFollowerCount, equals(499));
+          expect(bloc.state.rawFollowersPubkeys, [validPubkey('existing')]);
+          expect(bloc.state.followersPubkeys, [validPubkey('existing')]);
+          expect(bloc.state.followerCount, equals(499));
+        },
+      );
+
+      blocTest<OthersFollowersBloc, OthersFollowersState>(
         'removes last follower leaving empty list with zero count',
         build: createBloc,
         seed: () => OthersFollowersState(
@@ -543,6 +572,42 @@ void main() {
             targetPubkey: validPubkey('target'),
           ),
         ],
+      );
+    });
+
+    group('OthersFollowersBlocklistChanged', () {
+      blocTest<OthersFollowersBloc, OthersFollowersState>(
+        'subtracts newly hidden known followers from the visible count',
+        setUp: () {
+          when(
+            () => mockBlocklistRepository.isBlocked(validPubkey('hidden')),
+          ).thenReturn(true);
+        },
+        build: createBloc,
+        seed: () => OthersFollowersState(
+          status: OthersFollowersStatus.success,
+          followersPubkeys: [validPubkey('visible'), validPubkey('hidden')],
+          rawFollowersPubkeys: [validPubkey('visible'), validPubkey('hidden')],
+          authoritativeFollowerCount: 500,
+          targetPubkey: validPubkey('target'),
+        ),
+        act: (bloc) => bloc.add(const OthersFollowersBlocklistChanged()),
+        verify: (bloc) {
+          expect(bloc.state.authoritativeFollowerCount, equals(500));
+          expect(bloc.state.rawFollowersPubkeys, [
+            validPubkey('visible'),
+            validPubkey('hidden'),
+          ]);
+          expect(bloc.state.followersPubkeys, [validPubkey('visible')]);
+          expect(bloc.state.followerCount, equals(499));
+        },
+      );
+
+      blocTest<OthersFollowersBloc, OthersFollowersState>(
+        'does nothing when not in success state',
+        build: createBloc,
+        act: (bloc) => bloc.add(const OthersFollowersBlocklistChanged()),
+        expect: () => <OthersFollowersState>[],
       );
     });
   });

--- a/mobile/test/blocs/others_followers/others_followers_bloc_test.dart
+++ b/mobile/test/blocs/others_followers/others_followers_bloc_test.dart
@@ -337,7 +337,7 @@ void main() {
         seed: () => OthersFollowersState(
           status: OthersFollowersStatus.success,
           followersPubkeys: [validPubkey('follower1')],
-          followerCount: 1,
+          authoritativeFollowerCount: 1,
           targetPubkey: validPubkey('target'),
         ),
         act: (bloc) => bloc.add(
@@ -358,6 +358,38 @@ void main() {
       );
     });
 
+    blocTest<OthersFollowersBloc, OthersFollowersState>(
+      'clears the previous target followers when switching profiles',
+      setUp: () {
+        when(
+          () => mockFollowRepository.watchOthersFollowersCached(
+            any(),
+            forceRefresh: any(named: 'forceRefresh'),
+          ),
+        ).thenAnswer(
+          (_) => const Stream<CacheResult<FollowersSnapshot>>.empty(),
+        );
+      },
+      build: createBloc,
+      seed: () => OthersFollowersState(
+        status: OthersFollowersStatus.success,
+        followersPubkeys: [validPubkey('a'), validPubkey('b')],
+        rawFollowersPubkeys: [validPubkey('a'), validPubkey('b')],
+        authoritativeFollowerCount: 500,
+        targetPubkey: validPubkey('target'),
+      ),
+      act: (bloc) =>
+          bloc.add(OthersFollowersListLoadRequested(validPubkey('other'))),
+      verify: (bloc) {
+        // Carrying the previous target's raw pubkeys over would leave the
+        // visible count deriving from someone else's follower list.
+        expect(bloc.state.rawFollowersPubkeys, isEmpty);
+        expect(bloc.state.followersPubkeys, isEmpty);
+        expect(bloc.state.authoritativeFollowerCount, equals(0));
+        expect(bloc.state.followerCount, equals(0));
+      },
+    );
+
     group('OthersFollowersIncrementRequested', () {
       blocTest<OthersFollowersBloc, OthersFollowersState>(
         'adds follower pubkey to list and increments count',
@@ -366,7 +398,7 @@ void main() {
           status: OthersFollowersStatus.success,
           followersPubkeys: [validPubkey('existing')],
           rawFollowersPubkeys: [validPubkey('existing')],
-          followerCount: 500,
+          authoritativeFollowerCount: 500,
           targetPubkey: validPubkey('target'),
         ),
         act: (bloc) =>
@@ -376,10 +408,37 @@ void main() {
             status: OthersFollowersStatus.success,
             followersPubkeys: [validPubkey('existing'), validPubkey('new')],
             rawFollowersPubkeys: [validPubkey('existing'), validPubkey('new')],
-            followerCount: 501,
+            authoritativeFollowerCount: 501,
             targetPubkey: validPubkey('target'),
           ),
         ],
+      );
+
+      blocTest<OthersFollowersBloc, OthersFollowersState>(
+        'keeps the visible count steady when the new follower is blocked',
+        setUp: () {
+          when(
+            () => mockBlocklistRepository.isBlocked(validPubkey('new')),
+          ).thenReturn(true);
+        },
+        build: createBloc,
+        seed: () => OthersFollowersState(
+          status: OthersFollowersStatus.success,
+          followersPubkeys: [validPubkey('existing')],
+          rawFollowersPubkeys: [validPubkey('existing')],
+          authoritativeFollowerCount: 500,
+          targetPubkey: validPubkey('target'),
+        ),
+        act: (bloc) =>
+            bloc.add(OthersFollowersIncrementRequested(validPubkey('new'))),
+        verify: (bloc) {
+          // The target really did gain a follower, so the authoritative count
+          // moves; the viewer just cannot see that follower, so the displayed
+          // count must not.
+          expect(bloc.state.authoritativeFollowerCount, equals(501));
+          expect(bloc.state.followersPubkeys, [validPubkey('existing')]);
+          expect(bloc.state.followerCount, equals(500));
+        },
       );
 
       blocTest<OthersFollowersBloc, OthersFollowersState>(
@@ -389,7 +448,7 @@ void main() {
           status: OthersFollowersStatus.success,
           followersPubkeys: [validPubkey('existing')],
           rawFollowersPubkeys: [validPubkey('existing')],
-          followerCount: 1,
+          authoritativeFollowerCount: 1,
           targetPubkey: validPubkey('target'),
         ),
         act: (bloc) => bloc.add(
@@ -412,7 +471,7 @@ void main() {
             status: OthersFollowersStatus.success,
             followersPubkeys: [validPubkey('first')],
             rawFollowersPubkeys: [validPubkey('first')],
-            followerCount: 1,
+            authoritativeFollowerCount: 1,
             targetPubkey: validPubkey('target'),
           ),
         ],
@@ -433,7 +492,7 @@ void main() {
             validPubkey('follower1'),
             validPubkey('follower2'),
           ],
-          followerCount: 500,
+          authoritativeFollowerCount: 500,
           targetPubkey: validPubkey('target'),
         ),
         act: (bloc) => bloc.add(
@@ -444,7 +503,7 @@ void main() {
             status: OthersFollowersStatus.success,
             followersPubkeys: [validPubkey('follower2')],
             rawFollowersPubkeys: [validPubkey('follower2')],
-            followerCount: 499,
+            authoritativeFollowerCount: 499,
             targetPubkey: validPubkey('target'),
           ),
         ],
@@ -457,7 +516,7 @@ void main() {
           status: OthersFollowersStatus.success,
           followersPubkeys: [validPubkey('existing')],
           rawFollowersPubkeys: [validPubkey('existing')],
-          followerCount: 1,
+          authoritativeFollowerCount: 1,
           targetPubkey: validPubkey('target'),
         ),
         act: (bloc) => bloc.add(
@@ -473,7 +532,7 @@ void main() {
           status: OthersFollowersStatus.success,
           followersPubkeys: [validPubkey('only')],
           rawFollowersPubkeys: [validPubkey('only')],
-          followerCount: 1,
+          authoritativeFollowerCount: 1,
           targetPubkey: validPubkey('target'),
         ),
         act: (bloc) =>
@@ -536,7 +595,7 @@ void main() {
       const state = OthersFollowersState(
         status: OthersFollowersStatus.success,
         followersPubkeys: ['pubkey1'],
-        followerCount: 10,
+        authoritativeFollowerCount: 10,
         targetPubkey: 'target',
       );
 

--- a/mobile/test/blocs/others_followers/others_followers_bloc_test.dart
+++ b/mobile/test/blocs/others_followers/others_followers_bloc_test.dart
@@ -139,7 +139,7 @@ void main() {
             bloc.add(OthersFollowersListLoadRequested(validPubkey('target'))),
         verify: (bloc) {
           expect(bloc.state.followersPubkeys, [validPubkey('follower1')]);
-          expect(bloc.state.followerCount, 2);
+          expect(bloc.state.followerCount, 1);
         },
       );
 

--- a/mobile/test/repositories/follow_repository_follower_stats_test.dart
+++ b/mobile/test/repositories/follow_repository_follower_stats_test.dart
@@ -204,9 +204,9 @@ void main() {
       test('accepts lower count when persisted data is stale', () async {
         final apiClient = _MockFunnelcakeApiClient();
         final dao = _MockProfileStatsDao();
-        // Persisted 2 hours ago — stale.
+        // Persisted well beyond the staleness window.
         final staleTimestamp = DateTime.now().subtract(
-          const Duration(hours: 2),
+          const Duration(hours: 30),
         );
         final repository = _createRepository(
           apiClient: apiClient,
@@ -231,7 +231,7 @@ void main() {
         final apiClient = _MockFunnelcakeApiClient();
         final dao = _MockProfileStatsDao();
         final staleCountsTimestamp = DateTime.now().subtract(
-          const Duration(hours: 2),
+          const Duration(hours: 30),
         );
         final repository = _createRepository(
           apiClient: apiClient,
@@ -250,6 +250,31 @@ void main() {
 
         expect(stats.followers, equals(85));
         expect(stats.following, equals(18));
+      });
+
+      test('holds the count across an overnight gap (#6902)', () async {
+        final apiClient = _MockFunnelcakeApiClient();
+        final dao = _MockProfileStatsDao();
+        // The reported failure: last seen at 98 the night before, relays
+        // answer 86 in the morning. A window shorter than the gap would treat
+        // the baseline as stale and accept 86 outright.
+        final lastNight = DateTime.now().subtract(const Duration(hours: 10));
+        final repository = _createRepository(
+          apiClient: apiClient,
+          dao: dao,
+          restFollowers: 86,
+          restFollowing: 20,
+          persistedRow: _persistedRow(
+            followers: 98,
+            following: 20,
+            cachedAt: lastNight,
+            followerCountsUpdatedAt: lastNight,
+          ),
+        );
+
+        final stats = await repository.getFollowerStats(_testPubkey);
+
+        expect(stats.followers, equals(98));
       });
 
       test('accepts one-person drops for small accounts', () async {

--- a/mobile/test/repositories/follow_repository_follower_stats_test.dart
+++ b/mobile/test/repositories/follow_repository_follower_stats_test.dart
@@ -78,12 +78,14 @@ ProfileStatRow _persistedRow({
   required int followers,
   required int following,
   DateTime? cachedAt,
+  DateTime? followerCountsUpdatedAt,
 }) {
   return ProfileStatRow(
     pubkey: _testPubkey,
     followerCount: followers,
     followingCount: following,
     cachedAt: cachedAt ?? DateTime.now(),
+    followerCountsUpdatedAt: followerCountsUpdatedAt,
   );
 }
 
@@ -223,6 +225,48 @@ void main() {
         // Stale → accept fresh count even though it's within threshold.
         expect(stats.followers, equals(85));
         expect(stats.following, equals(18));
+      });
+
+      test('uses follower timestamp instead of unrelated cachedAt', () async {
+        final apiClient = _MockFunnelcakeApiClient();
+        final dao = _MockProfileStatsDao();
+        final staleCountsTimestamp = DateTime.now().subtract(
+          const Duration(hours: 2),
+        );
+        final repository = _createRepository(
+          apiClient: apiClient,
+          dao: dao,
+          restFollowers: 85,
+          restFollowing: 18,
+          persistedRow: _persistedRow(
+            followers: 100,
+            following: 20,
+            cachedAt: DateTime.now(),
+            followerCountsUpdatedAt: staleCountsTimestamp,
+          ),
+        );
+
+        final stats = await repository.getFollowerStats(_testPubkey);
+
+        expect(stats.followers, equals(85));
+        expect(stats.following, equals(18));
+      });
+
+      test('accepts one-person drops for small accounts', () async {
+        final apiClient = _MockFunnelcakeApiClient();
+        final dao = _MockProfileStatsDao();
+        final repository = _createRepository(
+          apiClient: apiClient,
+          dao: dao,
+          restFollowers: 8,
+          restFollowing: 4,
+          persistedRow: _persistedRow(followers: 9, following: 5),
+        );
+
+        final stats = await repository.getFollowerStats(_testPubkey);
+
+        expect(stats.followers, equals(8));
+        expect(stats.following, equals(4));
       });
 
       test('does not apply hysteresis when no persisted data exists', () async {

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -1449,6 +1449,94 @@ void main() {
     });
 
     testWidgets(
+      'shows a placeholder, not "0", when no follower count has been cached '
+      'and the followers BLoC has not loaded yet',
+      (tester) async {
+        // A profile row exists for the video/engagement stats, but
+        // FollowRepository has not written follower counts for this pubkey
+        // yet, so they arrive as null. Rendering that as "0" is the bug in
+        // #6764: a settled, wrong count that never shimmers, and that sticks
+        // permanently if the followers fetch fails.
+        const profileStats = ProfileStats(
+          pubkey: testUserHex,
+          totalLikes: 10,
+          totalViews: 20,
+        );
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: false,
+            suppliedProfile: createTestProfile(displayName: 'Unknown Counts'),
+            profileStats: profileStats,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          find.descendant(
+            of: find
+                .ancestor(
+                  of: find.text('Followers'),
+                  matching: find.byType(ProfileStatColumn),
+                )
+                .first,
+            matching: find.text('—'),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.descendant(
+            of: find
+                .ancestor(
+                  of: find.text('Followers'),
+                  matching: find.byType(ProfileStatColumn),
+                )
+                .first,
+            matching: find.text('0'),
+          ),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets(
+      'shows the cached follower count while the followers BLoC loads',
+      (tester) async {
+        const profileStats = ProfileStats(
+          pubkey: testUserHex,
+          followers: 7,
+          following: 3,
+          totalLikes: 10,
+          totalViews: 20,
+        );
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: false,
+            suppliedProfile: createTestProfile(displayName: 'Cached Counts'),
+            profileStats: profileStats,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          find.descendant(
+            of: find
+                .ancestor(
+                  of: find.text('Followers'),
+                  matching: find.byType(ProfileStatColumn),
+                )
+                .first,
+            matching: find.text('7'),
+          ),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
       'keeps all stat columns visible with em-dash placeholders once the '
       'skeleton timeout expires and profileStats is still null',
       (tester) async {


### PR DESCRIPTION
## Summary
- make FollowRepository the owner of follower/following counts by stopping ProfileRepository from writing raw REST social counts
- add a dedicated follower-count timestamp as Drift schema v3, layered on top of the schema repair migration already on main
- fold the follower timestamp into the startup schema-repair required-column map, with the backfill handled by the v3 migration/repair path
- keep profile stats, follower screen headers, and filtered follower lists in sync through the follower BLoCs
- let small accounts accept one-person count drops immediately while preserving hysteresis for larger accounts
- show locally visible follower counts by subtracting known blocked/follow-severed followers from the authoritative count
- load the profile header follower/following numbers through the same BLoCs as the follower/following screens, so opening a profile can trigger those list fetches

Closes #6764
Closes #6902

## Verification
- flutter analyze
- flutter analyze lib test integration_test
- flutter test test/blocs/my_followers/my_followers_bloc_test.dart test/blocs/others_followers/others_followers_bloc_test.dart test/widgets/profile/profile_header_widget_test.dart test/repositories/follow_repository_follower_stats_test.dart
- flutter test packages/profile_repository/test/src/profile_repository_test.dart
- flutter test packages/follow_repository/test/src/follow_repository_test.dart
- flutter test packages/db_client/test/drift/app_database/migration_test.dart packages/db_client/test/src/database/app_database_test.dart packages/db_client/test/src/database/daos/profile_stats_dao_test.dart
- dart run build_runner build --delete-conflicting-outputs (packages/db_client)
- dart run drift_dev make-migrations (packages/db_client)
- pre-push hook: no merge conflicts with main, analyzer, generated files, changed-file tests

## Tradeoff

A follower count that drops by less than the variance threshold is held for 24 hours before a lower value is accepted.

This is what closes #6902: the reported failure was a count that fell overnight and stayed wrong, and a shorter window expired during every such gap, so the stabilization never ran in the case it exists for.

The cost is that a genuine loss of that size takes until the next day to show. Drops beyond the threshold, and any change on a small account, still appear immediately.

Profile-stat rows that carry follower/following counts are retained for up to 48 hours so the 24-hour trust window can survive startup cleanup. Rows without follower counts still use the normal shorter profile-stat cleanup path.

Known hidden followers are subtracted from the displayed count, so the profile header and follower-screen title show the locally visible count rather than the raw authoritative count.

The header now instantiates the follower/following BLoCs for its stat columns. That keeps the profile header and list screens aligned, but it means viewing a profile can also kick off the relevant kind-3 follower/following list loads.

## Follow-ups

- #6954 tracks corroborating follower counts across sources so one over-counting source cannot win and be held for the trust window.
