### PR TITLE
docs(testing): add 4337 test debt plan

### DIFF
--- a/tasks/plan_4337.md
+++ b/tasks/plan_4337.md
@@ -1,0 +1,119 @@
+# Issue #4337 Test Debt Plan
+
+Issue #4337 coordinates the mobile test-debt ratchets and paydown work. The
+ratchets freeze known debt so it can only shrink; do not regenerate a baseline
+to add debt.
+
+## Current State
+
+| Workstream | Issue | State | Current execution rule |
+| --- | --- | --- | --- |
+| WS-1 skipped tests | #4836 | Open | `mobile/test/**/*_test.dart` files with unconditional `skip:` are frozen in `mobile/scripts/baseline/skip_tests.txt`. |
+| WS-2 `Future.delayed` in tests | #4837 | Open | `mobile/test/**/*.dart` files using `Future.delayed` are frozen in `mobile/scripts/baseline/future_delayed_tests.txt`. |
+| WS-3 untested services | #4838 | Open | `mobile/lib/services/*.dart` files without same-named tests are frozen in `mobile/scripts/baseline/untested_services.txt`. |
+| WS-4 coverage floors | #4839 | Closed | Package coverage-floor ratchets are wired in CI. |
+| WS-5 golden suite | #4840 | Open | The golden tag exists, but golden tests must be restored or retired before CI gating is meaningful. |
+| WS-6 integration coverage | #4841 | Open | Blocked on the integration runner tier decision. |
+| WS-7 `test/unit` structure | #4842 | Closed | `mobile/test/unit/**/*_test.dart` is frozen in `mobile/scripts/baseline/test_unit_files.txt`. |
+
+## Baseline Commands
+
+Run ratchets from the repository root unless noted otherwise.
+
+```bash
+bash mobile/scripts/check_skip_ceiling.sh
+bash mobile/scripts/check_future_delayed_ceiling.sh
+bash mobile/scripts/check_untested_services_floor.sh
+bash mobile/scripts/check_test_unit_structure.sh
+```
+
+After a paydown PR removes debt, shrink only the affected baseline:
+
+```bash
+UPDATE_BASELINE=1 bash mobile/scripts/check_skip_ceiling.sh
+UPDATE_BASELINE=1 bash mobile/scripts/check_future_delayed_ceiling.sh
+UPDATE_BASELINE=1 bash mobile/scripts/check_untested_services_floor.sh
+UPDATE_BASELINE=1 bash mobile/scripts/check_test_unit_structure.sh
+```
+
+Never use `UPDATE_BASELINE=1` to add a new skipped test, a new
+`Future.delayed` test file, a new untested service, or a new file under
+`mobile/test/unit`.
+
+## WS-1 Skipped-Test Triage
+
+For each skipped test file, choose exactly one outcome:
+
+- Delete: remove dead or low-value tests whose assertions no longer represent
+  useful product behavior.
+- Recover: fix the test and remove the unconditional `skip:`.
+- Quarantine: move genuinely environment-dependent coverage behind an explicit
+  tag or integration lane instead of an unconditional skip.
+- Rewrite: replace brittle setup with a focused test that asserts the behavior
+  the product still needs.
+
+Do not add `skip: true`, `skip: 'reason'`, `@Skip`, or equivalent disabled-test
+mechanisms to silence failures. If the test is not worth fixing, delete it.
+
+## WS-2 Timing Debt
+
+Replace wall-clock waits in tests with deterministic synchronization:
+
+- Use `fakeAsync` when the code under test depends on timers, timeouts, or
+  debounced work.
+- Use `pumpEventQueue` only for microtask or stream-settling cases.
+- Prefer explicit callbacks, completers, stream expectations, or controlled
+  fakes when the test can observe the actual boundary.
+
+Do not replace one `Future.delayed` with a longer wait.
+
+## WS-3 Untested Services
+
+For each actionable service entry:
+
+- Add a same-named `mobile/test/services/<service>_test.dart` when the service is
+  still live and meaningful.
+- Delete the service when it is dead.
+- Leave annotated `# noise:`, `# defer:`, and `# decision:` entries alone until
+  the owning issue or owner decision resolves.
+
+`social_service` remains blocked on OD-2: decide keep versus delete before
+testing it.
+
+## WS-5 Golden Suite
+
+Do not add a CI `flutter test --tags golden` gate until the suite is meaningful.
+The current repo state has a registered `golden` tag and checked-in image
+artifacts, but restoring the workstream requires first proving that live tests
+perform real golden comparisons.
+
+Correct sequence:
+
+1. Audit `mobile/test/goldens/**`, `mobile/test/widgets/goldens/**`, and stale
+   `failures/**` PNGs.
+2. Decide which image artifacts are canonical and delete stale artifacts.
+3. Add or restore real golden assertions, such as `matchesGoldenFile`, for the
+   canonical scenarios.
+4. Tag only real golden tests with `@Tags(['golden'])`.
+5. Prove `flutter test --tags golden` runs nonzero meaningful tests and fails on
+   intentional image drift.
+6. Add the CI gate after the above is true.
+
+## Owner Decisions
+
+- OD-1: Choose the integration runner tier for WS-6 and #4239: hosted
+  SwiftShader, GPU self-hosted, or local-only.
+- OD-2: Decide whether `mobile/lib/services/social_service.dart` should be kept
+  and tested or deleted.
+- OD-3: No-test production packages are delegated to #4338.
+- OD-6: Coverage-floor false-closure concern is moot while #3576, #3577, and
+  WS-4 are closed.
+
+## Recommended Execution Order
+
+1. WS-3: pay down unblocked actionable service entries; leave `social_service`
+   for OD-2.
+2. WS-1: batch skipped-test triage by directory.
+3. WS-2: batch `Future.delayed` migrations by directory.
+4. WS-5: restore or retire golden coverage, then gate it.
+5. WS-6: resume after OD-1 lands.

--- a/tasks/plan_4337.md
+++ b/tasks/plan_4337.md
@@ -9,7 +9,7 @@ to add debt.
 | Workstream | Issue | State | Current execution rule |
 | --- | --- | --- | --- |
 | WS-1 skipped tests | #4836 | Open | `mobile/test/**/*_test.dart` files with unconditional `skip:` are frozen in `mobile/scripts/baseline/skip_tests.txt`. |
-| WS-2 `Future.delayed` in tests | #4837 | Open | `mobile/test/**/*.dart` files using `Future.delayed` are frozen in `mobile/scripts/baseline/future_delayed_tests.txt`. |
+| WS-2 `Future.delayed` in tests | #4837 | Open | `mobile/test/**/*.dart` files using `Future.delayed` are frozen in `mobile/scripts/baseline/future_delayed_tests.txt`; the production sibling `mobile/scripts/check_future_delayed_production_ceiling.sh` is separately gated under #4339. |
 | WS-3 untested services | #4838 | Open | `mobile/lib/services/*.dart` files without same-named tests are frozen in `mobile/scripts/baseline/untested_services.txt`. |
 | WS-4 coverage floors | #4839 | Closed | Package coverage-floor ratchets are wired in CI. |
 | WS-5 golden suite | #4840 | Open | The golden tag exists, but golden tests must be restored or retired before CI gating is meaningful. |
@@ -18,7 +18,8 @@ to add debt.
 
 ## Baseline Commands
 
-Run ratchets from the repository root unless noted otherwise.
+Ratchets resolve their own paths and run identically from the repository root or
+`mobile/`. The examples below use repository-root paths.
 
 ```bash
 bash mobile/scripts/check_skip_ceiling.sh
@@ -106,8 +107,9 @@ Correct sequence:
 - OD-2: Decide whether `mobile/lib/services/social_service.dart` should be kept
   and tested or deleted.
 - OD-3: No-test production packages are delegated to #4338.
-- OD-6: Coverage-floor false-closure concern is moot while #3576, #3577, and
-  WS-4 are closed.
+- OD-6: Coverage-floor false-closure concern is superseded by WS-4's shipped CI
+  gate: package coverage floors are wired in CI and locked by a monotonic
+  rise-only baseline.
 
 ## Recommended Execution Order
 


### PR DESCRIPTION
Closes #4337

## Summary
- add tasks/plan_4337.md so existing ratchet failure hints resolve
- document the current #4337 workstreams, baseline commands, and owner decisions
- correct WS-5 sequencing so golden CI gating waits for real golden assertions and nonzero tagged coverage

## Verification
- git grep -n "tasks/plan_4337.md" -- mobile .github tasks
- git diff --check
- pre-push hook: no Dart files changed, skipped Dart checks