### PR TITLE
fix(storage): preserve notification prefs during cache recovery

### DIFF
--- a/mobile/lib/constants/hive_box_names.dart
+++ b/mobile/lib/constants/hive_box_names.dart
@@ -1,0 +1,23 @@
+// ABOUTME: Shared Hive box names used by app storage owners and wipe policy.
+// ABOUTME: Keeps cache recovery classification tied to the boxes it can affect.
+
+abstract final class HiveBoxNames {
+  static const personalEvents = 'personal_events';
+  static const personalEventsMetadata = 'personal_events_metadata';
+  static const hashtagStats = 'hashtag_stats';
+  static const peopleLists = 'people_lists_v1';
+  static const pendingUploads = 'pending_uploads';
+  static const notifications = 'notifications';
+  static const pushNotificationPreferencesDirty =
+      'push_notification_preferences_dirty';
+
+  static const Set<String> all = {
+    personalEvents,
+    personalEventsMetadata,
+    hashtagStats,
+    peopleLists,
+    pendingUploads,
+    notifications,
+    pushNotificationPreferencesDirty,
+  };
+}

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -5119,7 +5119,7 @@
   "settingsStorageRepairDescription": "መተግበሪያው በተደጋጋሚ የሚቋረጥ ወይም እንግዳ ባህሪ የሚያሳይ ከሆነ፣ የአካባቢ ውሂቡን ዳግም ማስጀመር አብዛኛውን ጊዜ ይፈታዋል። ክሊፖችህና ረቂቆችህ ይቀራሉ።",
   "settingsStorageRepairButton": "የመተግበሪያ ውሂብ ዳግም አስጀምር",
   "settingsStorageRepairConfirmTitle": "የመተግበሪያ ውሂብ ዳግም ይጀመር?",
-  "settingsStorageRepairConfirmMessage": "ይህ ማሳወቂያዎችን፣ የተቀመጡ መገለጫዎችን፣ ዕልባቶችንና ጊዜያዊ ፋይሎችን ያጠፋል። ክሊፖችህና ረቂቆችህ ይቀራሉ፣ ነገር ግን ትወጣለህ እና መተግበሪያውን እንደገና ማስጀመር አለብህ።",
+  "settingsStorageRepairConfirmMessage": "ይህ የተቀመጠ የፊድ ውሂብንና ጊዜያዊ ፋይሎችን ያጸዳል። ክሊፖችህ፣ ረቂቆችህ፣ ቅንብሮችህና መግቢያህ ይቀራሉ፣ ነገር ግን ከዚያ በኋላ መተግበሪያውን እንደገና ማስጀመር አለብህ።",
   "settingsStorageRepairFootprint": "{size} ይሰረዛል",
   "settingsStorageRepairConfirmAction": "ዳግም አስጀምር",
   "settingsStorageRepairInProgress": "ዳግም በማስጀመር ላይ…",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4994,7 +4994,7 @@
   "settingsStorageRepairDescription": "إذا كان التطبيق يتعطل أو يتصرف بغرابة، فإعادة ضبط بياناته المحلية تحل المشكلة غالبًا. مقاطعك ومسوداتك تبقى كما هي.",
   "settingsStorageRepairButton": "إعادة ضبط بيانات التطبيق",
   "settingsStorageRepairConfirmTitle": "إعادة ضبط بيانات التطبيق؟",
-  "settingsStorageRepairConfirmMessage": "سيؤدي هذا إلى حذف الإشعارات والملفات الشخصية المخزنة مؤقتًا والإشارات المرجعية والملفات المؤقتة. تبقى مقاطعك ومسوداتك، لكن سيتم تسجيل خروجك وعليك إعادة تشغيل التطبيق.",
+  "settingsStorageRepairConfirmMessage": "سيؤدي هذا إلى مسح بيانات الموجز المخزنة مؤقتًا والملفات المؤقتة. تبقى مقاطعك ومسوداتك وإعداداتك وتسجيل دخولك، لكن عليك إعادة تشغيل التطبيق بعد ذلك.",
   "settingsStorageRepairFootprint": "سيتم حذف {size}",
   "settingsStorageRepairConfirmAction": "إعادة ضبط",
   "settingsStorageRepairInProgress": "جارٍ إعادة الضبط…",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -5125,7 +5125,7 @@
   "settingsStorageRepairDescription": "Ако приложението постоянно се срива или се държи странно, нулирането на локалните данни обикновено помага. Клиповете и черновите ти остават.",
   "settingsStorageRepairButton": "Нулиране на данните",
   "settingsStorageRepairConfirmTitle": "Да нулираме ли данните?",
-  "settingsStorageRepairConfirmMessage": "Това изтрива известията, кешираните профили, отметките и временните файлове. Клиповете и черновите ти остават, но ще излезеш от профила си и ще трябва да рестартираш приложението.",
+  "settingsStorageRepairConfirmMessage": "Това изчиства кешираните данни от емисията и временните файлове. Клиповете, черновите, настройките и профилът ти остават, но след това ще трябва да рестартираш приложението.",
   "settingsStorageRepairFootprint": "Ще бъдат изтрити {size}",
   "settingsStorageRepairConfirmAction": "Нулирай",
   "settingsStorageRepairInProgress": "Нулиране…",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4994,7 +4994,7 @@
   "settingsStorageRepairDescription": "Wenn die App ständig abstürzt oder sich seltsam verhält, hilft meist ein Zurücksetzen der lokalen Daten. Deine Clips und Entwürfe bleiben.",
   "settingsStorageRepairButton": "App-Daten zurücksetzen",
   "settingsStorageRepairConfirmTitle": "App-Daten zurücksetzen?",
-  "settingsStorageRepairConfirmMessage": "Das löscht Benachrichtigungen, zwischengespeicherte Profile, Lesezeichen und temporäre Dateien. Deine Clips und Entwürfe bleiben, aber du wirst abgemeldet und musst die App neu starten.",
+  "settingsStorageRepairConfirmMessage": "Das löscht zwischengespeicherte Feed-Daten und temporäre Dateien. Deine Clips, Entwürfe, Einstellungen und Anmeldung bleiben, aber du musst die App danach neu starten.",
   "settingsStorageRepairFootprint": "{size} werden gelöscht",
   "settingsStorageRepairConfirmAction": "Zurücksetzen",
   "settingsStorageRepairInProgress": "Wird zurückgesetzt…",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -6764,7 +6764,7 @@
   "@settingsStorageRepairButton": {"description": "Button that wipes local app data to recover from a broken install."},
   "settingsStorageRepairConfirmTitle": "Reset app data?",
   "@settingsStorageRepairConfirmTitle": {"description": "Title of the confirmation sheet before the repair reset."},
-  "settingsStorageRepairConfirmMessage": "This wipes notifications, cached profiles, bookmarks and temporary files. Your clips and drafts stay, but you'll be signed out and have to restart the app.",
+  "settingsStorageRepairConfirmMessage": "This clears cached feed data and temporary files. Your clips, drafts, settings and sign-in stay, but you'll need to restart the app afterwards.",
   "@settingsStorageRepairConfirmMessage": {"description": "Body of the repair confirmation sheet: what is removed, what survives, and that a restart is needed."},
   "settingsStorageRepairFootprint": "{size} will be removed",
   "@settingsStorageRepairFootprint": {"description": "Shows how much disk the repair reset frees, inside the confirmation sheet.", "placeholders": {"size": {"type": "String"}}},

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4994,7 +4994,7 @@
   "settingsStorageRepairDescription": "Si la app se cierra o se comporta raro, restablecer sus datos locales suele arreglarlo. Tus clips y borradores se quedan.",
   "settingsStorageRepairButton": "Restablecer datos de la app",
   "settingsStorageRepairConfirmTitle": "¿Restablecer datos de la app?",
-  "settingsStorageRepairConfirmMessage": "Esto borra notificaciones, perfiles en caché, marcadores y archivos temporales. Tus clips y borradores se quedan, pero cerrarás sesión y tendrás que reiniciar la app.",
+  "settingsStorageRepairConfirmMessage": "Esto borra los datos del feed en caché y los archivos temporales. Tus clips, borradores, ajustes y sesión se quedan, pero tendrás que reiniciar la app después.",
   "settingsStorageRepairFootprint": "Se borrarán {size}",
   "settingsStorageRepairConfirmAction": "Restablecer",
   "settingsStorageRepairInProgress": "Restableciendo…",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -3580,7 +3580,7 @@
   "settingsStorageRepairDescription": "Kung paulit-ulit na nagka-crash o kakaiba ang app, kadalasang nakakatulong ang pag-reset ng lokal na data. Nananatili ang mga clip at draft mo.",
   "settingsStorageRepairButton": "I-reset ang app data",
   "settingsStorageRepairConfirmTitle": "I-reset ang app data?",
-  "settingsStorageRepairConfirmMessage": "Buburahin nito ang mga notification, naka-cache na profile, bookmark, at pansamantalang file. Mananatili ang mga clip at draft mo, pero masa-sign out ka at kailangan mong i-restart ang app.",
+  "settingsStorageRepairConfirmMessage": "Buburahin nito ang naka-cache na data ng feed at ang mga pansamantalang file. Mananatili ang mga clip, draft, setting at pag-sign in mo, pero kailangan mong i-restart ang app pagkatapos.",
   "settingsStorageRepairFootprint": "Buburahin ang {size}",
   "settingsStorageRepairConfirmAction": "I-reset",
   "settingsStorageRepairInProgress": "Nagre-reset…",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4994,7 +4994,7 @@
   "settingsStorageRepairDescription": "Si l'appli plante ou se comporte bizarrement, réinitialiser ses données locales règle souvent le problème. Tes clips et brouillons restent.",
   "settingsStorageRepairButton": "Réinitialiser les données",
   "settingsStorageRepairConfirmTitle": "Réinitialiser les données ?",
-  "settingsStorageRepairConfirmMessage": "Ça efface les notifications, les profils en cache, les favoris et les fichiers temporaires. Tes clips et brouillons restent, mais tu devras te reconnecter et redémarrer l'appli.",
+  "settingsStorageRepairConfirmMessage": "Ça efface les données de fil en cache et les fichiers temporaires. Tes clips, brouillons, réglages et ta connexion restent, mais tu devras redémarrer l'appli après.",
   "settingsStorageRepairFootprint": "{size} seront supprimés",
   "settingsStorageRepairConfirmAction": "Réinitialiser",
   "settingsStorageRepairInProgress": "Réinitialisation…",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4994,7 +4994,7 @@
   "settingsStorageRepairDescription": "Kalau aplikasi sering crash atau berperilaku aneh, reset data lokalnya biasanya menyelesaikan masalah. Klip dan draf kamu tetap aman.",
   "settingsStorageRepairButton": "Reset data aplikasi",
   "settingsStorageRepairConfirmTitle": "Reset data aplikasi?",
-  "settingsStorageRepairConfirmMessage": "Ini menghapus notifikasi, profil di cache, bookmark, dan file sementara. Klip dan draf kamu tetap ada, tapi kamu akan keluar dari akun dan harus memulai ulang aplikasi.",
+  "settingsStorageRepairConfirmMessage": "Ini menghapus data feed di cache dan file sementara. Klip, draf, pengaturan, dan sesi login kamu tetap ada, tapi setelahnya kamu harus memulai ulang aplikasi.",
   "settingsStorageRepairFootprint": "{size} akan dihapus",
   "settingsStorageRepairConfirmAction": "Reset",
   "settingsStorageRepairInProgress": "Mereset…",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4994,7 +4994,7 @@
   "settingsStorageRepairDescription": "Se l'app continua a crashare o si comporta in modo strano, azzerare i dati locali di solito risolve. I tuoi clip e le bozze restano.",
   "settingsStorageRepairButton": "Azzera i dati dell'app",
   "settingsStorageRepairConfirmTitle": "Azzerare i dati dell'app?",
-  "settingsStorageRepairConfirmMessage": "Questo cancella notifiche, profili in cache, segnalibri e file temporanei. I tuoi clip e le bozze restano, ma dovrai accedere di nuovo e riavviare l'app.",
+  "settingsStorageRepairConfirmMessage": "Questo cancella i dati del feed in cache e i file temporanei. I tuoi clip, le bozze, le impostazioni e l'accesso restano, ma dopo dovrai riavviare l'app.",
   "settingsStorageRepairFootprint": "Verranno rimossi {size}",
   "settingsStorageRepairConfirmAction": "Azzera",
   "settingsStorageRepairInProgress": "Azzeramento…",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4994,7 +4994,7 @@
   "settingsStorageRepairDescription": "アプリが落ちたり動きがおかしいときは、ローカルデータをリセットすると直ることが多いよ。クリップと下書きはそのまま残る。",
   "settingsStorageRepairButton": "アプリデータをリセット",
   "settingsStorageRepairConfirmTitle": "アプリデータをリセットする?",
-  "settingsStorageRepairConfirmMessage": "通知、キャッシュ済みのプロフィール、ブックマーク、一時ファイルを消すよ。クリップと下書きは残るけど、ログアウトされるからアプリを再起動してね。",
+  "settingsStorageRepairConfirmMessage": "キャッシュ済みのフィードデータと一時ファイルを消すよ。クリップ、下書き、設定、ログインは残るけど、あとでアプリを再起動してね。",
   "settingsStorageRepairFootprint": "{size} を削除するよ",
   "settingsStorageRepairConfirmAction": "リセット",
   "settingsStorageRepairInProgress": "リセット中…",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -4325,7 +4325,7 @@
   "settingsStorageRepairDescription": "앱이 자꾸 종료되거나 이상하게 작동하면 로컬 데이터를 초기화하면 대개 해결돼요. 클립과 초안은 그대로 남아요.",
   "settingsStorageRepairButton": "앱 데이터 초기화",
   "settingsStorageRepairConfirmTitle": "앱 데이터를 초기화할까요?",
-  "settingsStorageRepairConfirmMessage": "알림, 캐시된 프로필, 북마크, 임시 파일이 삭제돼요. 클립과 초안은 남지만 로그아웃되고 앱을 다시 시작해야 해요.",
+  "settingsStorageRepairConfirmMessage": "캐시된 피드 데이터와 임시 파일이 삭제돼요. 클립, 초안, 설정, 로그인은 남지만 그다음에 앱을 다시 시작해야 해요.",
   "settingsStorageRepairFootprint": "{size}가 삭제돼요",
   "settingsStorageRepairConfirmAction": "초기화",
   "settingsStorageRepairInProgress": "초기화 중…",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -6705,7 +6705,7 @@
   "settingsStorageRepairDescription": "Kalau apl kerap crash atau berkelakuan pelik, set semula data setempat biasanya membantu. Klip dan draf anda kekal.",
   "settingsStorageRepairButton": "Set semula data apl",
   "settingsStorageRepairConfirmTitle": "Set semula data apl?",
-  "settingsStorageRepairConfirmMessage": "Ini memadamkan pemberitahuan, profil dalam cache, penanda buku dan fail sementara. Klip dan draf anda kekal, tetapi anda akan dilog keluar dan perlu mulakan semula apl.",
+  "settingsStorageRepairConfirmMessage": "Ini memadamkan data suapan dalam cache dan fail sementara. Klip, draf, tetapan dan log masuk anda kekal, tetapi anda perlu mulakan semula apl selepas itu.",
   "settingsStorageRepairFootprint": "{size} akan dipadam",
   "settingsStorageRepairConfirmAction": "Set semula",
   "settingsStorageRepairInProgress": "Menetapkan semula…",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4994,7 +4994,7 @@
   "settingsStorageRepairDescription": "Als de app blijft crashen of raar doet, helpt het meestal om de lokale gegevens te resetten. Je clips en concepten blijven staan.",
   "settingsStorageRepairButton": "App-gegevens resetten",
   "settingsStorageRepairConfirmTitle": "App-gegevens resetten?",
-  "settingsStorageRepairConfirmMessage": "Dit wist meldingen, gecachte profielen, bladwijzers en tijdelijke bestanden. Je clips en concepten blijven, maar je wordt uitgelogd en moet de app opnieuw starten.",
+  "settingsStorageRepairConfirmMessage": "Dit wist gecachte feedgegevens en tijdelijke bestanden. Je clips, concepten, instellingen en aanmelding blijven, maar je moet de app daarna opnieuw starten.",
   "settingsStorageRepairFootprint": "{size} wordt verwijderd",
   "settingsStorageRepairConfirmAction": "Resetten",
   "settingsStorageRepairInProgress": "Bezig met resetten…",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4994,7 +4994,7 @@
   "settingsStorageRepairDescription": "Jeśli aplikacja się wysypuje albo dziwnie działa, zresetowanie danych lokalnych zwykle pomaga. Twoje klipy i wersje robocze zostają.",
   "settingsStorageRepairButton": "Zresetuj dane aplikacji",
   "settingsStorageRepairConfirmTitle": "Zresetować dane aplikacji?",
-  "settingsStorageRepairConfirmMessage": "To usunie powiadomienia, zapisane profile, zakładki i pliki tymczasowe. Twoje klipy i wersje robocze zostaną, ale wylogujemy Cię i trzeba będzie zrestartować aplikację.",
+  "settingsStorageRepairConfirmMessage": "To usunie zapisane dane kanału i pliki tymczasowe. Twoje klipy, wersje robocze, ustawienia i zalogowanie zostaną, ale trzeba będzie potem zrestartować aplikację.",
   "settingsStorageRepairFootprint": "Zostanie usunięte: {size}",
   "settingsStorageRepairConfirmAction": "Zresetuj",
   "settingsStorageRepairInProgress": "Resetowanie…",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4994,7 +4994,7 @@
   "settingsStorageRepairDescription": "Se o app trava ou age de forma estranha, redefinir os dados locais costuma resolver. Seus clipes e rascunhos ficam.",
   "settingsStorageRepairButton": "Redefinir dados do app",
   "settingsStorageRepairConfirmTitle": "Redefinir dados do app?",
-  "settingsStorageRepairConfirmMessage": "Isso apaga notificações, perfis em cache, favoritos e arquivos temporários. Seus clipes e rascunhos ficam, mas você sairá da conta e terá que reiniciar o app.",
+  "settingsStorageRepairConfirmMessage": "Isso apaga os dados do feed em cache e os arquivos temporários. Seus clipes, rascunhos, configurações e login ficam, mas você terá que reiniciar o app depois.",
   "settingsStorageRepairFootprint": "{size} serão removidos",
   "settingsStorageRepairConfirmAction": "Redefinir",
   "settingsStorageRepairInProgress": "Redefinindo…",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4994,7 +4994,7 @@
   "settingsStorageRepairDescription": "Dacă aplicația se blochează sau se comportă ciudat, resetarea datelor locale rezolvă de obicei. Clipurile și schițele tale rămân.",
   "settingsStorageRepairButton": "Resetează datele aplicației",
   "settingsStorageRepairConfirmTitle": "Resetezi datele aplicației?",
-  "settingsStorageRepairConfirmMessage": "Asta șterge notificările, profilurile din cache, marcajele și fișierele temporare. Clipurile și schițele tale rămân, dar vei fi deconectat și va trebui să repornești aplicația.",
+  "settingsStorageRepairConfirmMessage": "Asta șterge datele din feed salvate în cache și fișierele temporare. Clipurile, schițele, setările și contul tău conectat rămân, dar va trebui să repornești aplicația după.",
   "settingsStorageRepairFootprint": "Se vor șterge {size}",
   "settingsStorageRepairConfirmAction": "Resetează",
   "settingsStorageRepairInProgress": "Se resetează…",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4994,7 +4994,7 @@
   "settingsStorageRepairDescription": "Om appen kraschar eller beter sig konstigt brukar en återställning av lokala data lösa det. Dina klipp och utkast finns kvar.",
   "settingsStorageRepairButton": "Återställ appdata",
   "settingsStorageRepairConfirmTitle": "Återställa appdata?",
-  "settingsStorageRepairConfirmMessage": "Det här raderar aviseringar, cachade profiler, bokmärken och tillfälliga filer. Dina klipp och utkast finns kvar, men du loggas ut och måste starta om appen.",
+  "settingsStorageRepairConfirmMessage": "Det här raderar cachad flödesdata och tillfälliga filer. Dina klipp, utkast, inställningar och inloggning finns kvar, men du måste starta om appen efteråt.",
   "settingsStorageRepairFootprint": "{size} tas bort",
   "settingsStorageRepairConfirmAction": "Återställ",
   "settingsStorageRepairInProgress": "Återställer…",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4994,7 +4994,7 @@
   "settingsStorageRepairDescription": "Uygulama sürekli çöküyor ya da tuhaf davranıyorsa yerel verileri sıfırlamak genelde çözer. Kliplerin ve taslakların kalır.",
   "settingsStorageRepairButton": "Uygulama verilerini sıfırla",
   "settingsStorageRepairConfirmTitle": "Uygulama verileri sıfırlansın mı?",
-  "settingsStorageRepairConfirmMessage": "Bu; bildirimleri, önbellekteki profilleri, yer imlerini ve geçici dosyaları siler. Kliplerin ve taslakların kalır ama oturumun kapanır ve uygulamayı yeniden başlatman gerekir.",
+  "settingsStorageRepairConfirmMessage": "Bu; önbellekteki akış verilerini ve geçici dosyaları siler. Kliplerin, taslakların, ayarların ve oturumun kalır ama sonrasında uygulamayı yeniden başlatman gerekir.",
   "settingsStorageRepairFootprint": "{size} silinecek",
   "settingsStorageRepairConfirmAction": "Sıfırla",
   "settingsStorageRepairInProgress": "Sıfırlanıyor…",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -6705,7 +6705,7 @@
   "settingsStorageRepairDescription": "اگر ایپ بار بار بند ہو رہی ہے یا عجیب چل رہی ہے تو مقامی ڈیٹا ری سیٹ کرنے سے عموماً مسئلہ حل ہو جاتا ہے۔ آپ کی کلپس اور ڈرافٹس محفوظ رہیں گے۔",
   "settingsStorageRepairButton": "ایپ ڈیٹا ری سیٹ کریں",
   "settingsStorageRepairConfirmTitle": "ایپ ڈیٹا ری سیٹ کریں؟",
-  "settingsStorageRepairConfirmMessage": "اس سے اطلاعات، کیش شدہ پروفائلز، بک مارکس اور عارضی فائلیں مٹ جائیں گی۔ آپ کی کلپس اور ڈرافٹس رہیں گے، لیکن آپ لاگ آؤٹ ہو جائیں گے اور ایپ دوبارہ شروع کرنی ہوگی۔",
+  "settingsStorageRepairConfirmMessage": "اس سے کیش شدہ فیڈ ڈیٹا اور عارضی فائلیں مٹ جائیں گی۔ آپ کی کلپس، ڈرافٹس، ترتیبات اور لاگ اِن رہیں گے، لیکن بعد میں ایپ دوبارہ شروع کرنی ہوگی۔",
   "settingsStorageRepairFootprint": "{size} حذف ہو جائے گا",
   "settingsStorageRepairConfirmAction": "ری سیٹ",
   "settingsStorageRepairInProgress": "ری سیٹ ہو رہا ہے…",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -6705,7 +6705,7 @@
   "settingsStorageRepairDescription": "Nếu ứng dụng cứ bị lỗi hoặc chạy lạ, đặt lại dữ liệu cục bộ thường sẽ khắc phục được. Clip và bản nháp của bạn vẫn còn.",
   "settingsStorageRepairButton": "Đặt lại dữ liệu ứng dụng",
   "settingsStorageRepairConfirmTitle": "Đặt lại dữ liệu ứng dụng?",
-  "settingsStorageRepairConfirmMessage": "Thao tác này xóa thông báo, hồ sơ đã lưu tạm, dấu trang và tệp tạm. Clip và bản nháp của bạn vẫn còn, nhưng bạn sẽ bị đăng xuất và phải khởi động lại ứng dụng.",
+  "settingsStorageRepairConfirmMessage": "Thao tác này xóa dữ liệu bảng tin đã lưu tạm và tệp tạm. Clip, bản nháp, cài đặt và phiên đăng nhập của bạn vẫn còn, nhưng sau đó bạn phải khởi động lại ứng dụng.",
   "settingsStorageRepairFootprint": "Sẽ xóa {size}",
   "settingsStorageRepairConfirmAction": "Đặt lại",
   "settingsStorageRepairInProgress": "Đang đặt lại…",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -6705,7 +6705,7 @@
   "settingsStorageRepairDescription": "如果应用总是崩溃或行为异常，重置本地数据通常能解决。你的片段和草稿会保留。",
   "settingsStorageRepairButton": "重置应用数据",
   "settingsStorageRepairConfirmTitle": "要重置应用数据吗？",
-  "settingsStorageRepairConfirmMessage": "这会清除通知、缓存的资料、书签和临时文件。你的片段和草稿会保留，但会退出登录，需要重启应用。",
+  "settingsStorageRepairConfirmMessage": "这会清除缓存的信息流数据和临时文件。你的片段、草稿、设置和登录状态会保留，但之后需要重启应用。",
   "settingsStorageRepairFootprint": "将删除 {size}",
   "settingsStorageRepairConfirmAction": "重置",
   "settingsStorageRepairInProgress": "正在重置…",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -19189,7 +19189,7 @@ abstract class AppLocalizations {
   /// Body of the repair confirmation sheet: what is removed, what survives, and that a restart is needed.
   ///
   /// In en, this message translates to:
-  /// **'This wipes notifications, cached profiles, bookmarks and temporary files. Your clips and drafts stay, but you\'ll be signed out and have to restart the app.'**
+  /// **'This clears cached feed data and temporary files. Your clips, drafts, settings and sign-in stay, but you\'ll need to restart the app afterwards.'**
   String get settingsStorageRepairConfirmMessage;
 
   /// Shows how much disk the repair reset frees, inside the confirmation sheet.

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -10946,7 +10946,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      'ይህ ማሳወቂያዎችን፣ የተቀመጡ መገለጫዎችን፣ ዕልባቶችንና ጊዜያዊ ፋይሎችን ያጠፋል። ክሊፖችህና ረቂቆችህ ይቀራሉ፣ ነገር ግን ትወጣለህ እና መተግበሪያውን እንደገና ማስጀመር አለብህ።';
+      'ይህ የተቀመጠ የፊድ ውሂብንና ጊዜያዊ ፋይሎችን ያጸዳል። ክሊፖችህ፣ ረቂቆችህ፣ ቅንብሮችህና መግቢያህ ይቀራሉ፣ ነገር ግን ከዚያ በኋላ መተግበሪያውን እንደገና ማስጀመር አለብህ።';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -11106,7 +11106,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      'سيؤدي هذا إلى حذف الإشعارات والملفات الشخصية المخزنة مؤقتًا والإشارات المرجعية والملفات المؤقتة. تبقى مقاطعك ومسوداتك، لكن سيتم تسجيل خروجك وعليك إعادة تشغيل التطبيق.';
+      'سيؤدي هذا إلى مسح بيانات الموجز المخزنة مؤقتًا والملفات المؤقتة. تبقى مقاطعك ومسوداتك وإعداداتك وتسجيل دخولك، لكن عليك إعادة تشغيل التطبيق بعد ذلك.';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -11301,7 +11301,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      'Това изтрива известията, кешираните профили, отметките и временните файлове. Клиповете и черновите ти остават, но ще излезеш от профила си и ще трябва да рестартираш приложението.';
+      'Това изчиства кешираните данни от емисията и временните файлове. Клиповете, черновите, настройките и профилът ти остават, но след това ще трябва да рестартираш приложението.';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -11311,7 +11311,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      'Das löscht Benachrichtigungen, zwischengespeicherte Profile, Lesezeichen und temporäre Dateien. Deine Clips und Entwürfe bleiben, aber du wirst abgemeldet und musst die App neu starten.';
+      'Das löscht zwischengespeicherte Feed-Daten und temporäre Dateien. Deine Clips, Entwürfe, Einstellungen und Anmeldung bleiben, aber du musst die App danach neu starten.';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -11160,7 +11160,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      'This wipes notifications, cached profiles, bookmarks and temporary files. Your clips and drafts stay, but you\'ll be signed out and have to restart the app.';
+      'This clears cached feed data and temporary files. Your clips, drafts, settings and sign-in stay, but you\'ll need to restart the app afterwards.';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -11302,7 +11302,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      'Esto borra notificaciones, perfiles en caché, marcadores y archivos temporales. Tus clips y borradores se quedan, pero cerrarás sesión y tendrás que reiniciar la app.';
+      'Esto borra los datos del feed en caché y los archivos temporales. Tus clips, borradores, ajustes y sesión se quedan, pero tendrás que reiniciar la app después.';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -11312,7 +11312,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      'Buburahin nito ang mga notification, naka-cache na profile, bookmark, at pansamantalang file. Mananatili ang mga clip at draft mo, pero masa-sign out ka at kailangan mong i-restart ang app.';
+      'Buburahin nito ang naka-cache na data ng feed at ang mga pansamantalang file. Mananatili ang mga clip, draft, setting at pag-sign in mo, pero kailangan mong i-restart ang app pagkatapos.';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -11342,7 +11342,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      'Ça efface les notifications, les profils en cache, les favoris et les fichiers temporaires. Tes clips et brouillons restent, mais tu devras te reconnecter et redémarrer l\'appli.';
+      'Ça efface les données de fil en cache et les fichiers temporaires. Tes clips, brouillons, réglages et ta connexion restent, mais tu devras redémarrer l\'appli après.';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -11149,7 +11149,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      'Ini menghapus notifikasi, profil di cache, bookmark, dan file sementara. Klip dan draf kamu tetap ada, tapi kamu akan keluar dari akun dan harus memulai ulang aplikasi.';
+      'Ini menghapus data feed di cache dan file sementara. Klip, draf, pengaturan, dan sesi login kamu tetap ada, tapi setelahnya kamu harus memulai ulang aplikasi.';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -11304,7 +11304,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      'Questo cancella notifiche, profili in cache, segnalibri e file temporanei. I tuoi clip e le bozze restano, ma dovrai accedere di nuovo e riavviare l\'app.';
+      'Questo cancella i dati del feed in cache e i file temporanei. I tuoi clip, le bozze, le impostazioni e l\'accesso restano, ma dopo dovrai riavviare l\'app.';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -10728,7 +10728,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      '通知、キャッシュ済みのプロフィール、ブックマーク、一時ファイルを消すよ。クリップと下書きは残るけど、ログアウトされるからアプリを再起動してね。';
+      'キャッシュ済みのフィードデータと一時ファイルを消すよ。クリップ、下書き、設定、ログインは残るけど、あとでアプリを再起動してね。';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -10757,7 +10757,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      '알림, 캐시된 프로필, 북마크, 임시 파일이 삭제돼요. 클립과 초안은 남지만 로그아웃되고 앱을 다시 시작해야 해요.';
+      '캐시된 피드 데이터와 임시 파일이 삭제돼요. 클립, 초안, 설정, 로그인은 남지만 그다음에 앱을 다시 시작해야 해요.';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -11252,7 +11252,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      'Ini memadamkan pemberitahuan, profil dalam cache, penanda buku dan fail sementara. Klip dan draf anda kekal, tetapi anda akan dilog keluar dan perlu mulakan semula apl.';
+      'Ini memadamkan data suapan dalam cache dan fail sementara. Klip, draf, tetapan dan log masuk anda kekal, tetapi anda perlu mulakan semula apl selepas itu.';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -11242,7 +11242,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      'Dit wist meldingen, gecachte profielen, bladwijzers en tijdelijke bestanden. Je clips en concepten blijven, maar je wordt uitgelogd en moet de app opnieuw starten.';
+      'Dit wist gecachte feedgegevens en tijdelijke bestanden. Je clips, concepten, instellingen en aanmelding blijven, maar je moet de app daarna opnieuw starten.';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -11395,7 +11395,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      'To usunie powiadomienia, zapisane profile, zakładki i pliki tymczasowe. Twoje klipy i wersje robocze zostaną, ale wylogujemy Cię i trzeba będzie zrestartować aplikację.';
+      'To usunie zapisane dane kanału i pliki tymczasowe. Twoje klipy, wersje robocze, ustawienia i zalogowanie zostaną, ale trzeba będzie potem zrestartować aplikację.';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -11266,7 +11266,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      'Isso apaga notificações, perfis em cache, favoritos e arquivos temporários. Seus clipes e rascunhos ficam, mas você sairá da conta e terá que reiniciar o app.';
+      'Isso apaga os dados do feed em cache e os arquivos temporários. Seus clipes, rascunhos, configurações e login ficam, mas você terá que reiniciar o app depois.';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -11410,7 +11410,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      'Asta șterge notificările, profilurile din cache, marcajele și fișierele temporare. Clipurile și schițele tale rămân, dar vei fi deconectat și va trebui să repornești aplicația.';
+      'Asta șterge datele din feed salvate în cache și fișierele temporare. Clipurile, schițele, setările și contul tău conectat rămân, dar va trebui să repornești aplicația după.';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -11193,7 +11193,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      'Det här raderar aviseringar, cachade profiler, bokmärken och tillfälliga filer. Dina klipp och utkast finns kvar, men du loggas ut och måste starta om appen.';
+      'Det här raderar cachad flödesdata och tillfälliga filer. Dina klipp, utkast, inställningar och inloggning finns kvar, men du måste starta om appen efteråt.';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -11148,7 +11148,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      'Bu; bildirimleri, önbellekteki profilleri, yer imlerini ve geçici dosyaları siler. Kliplerin ve taslakların kalır ama oturumun kapanır ve uygulamayı yeniden başlatman gerekir.';
+      'Bu; önbellekteki akış verilerini ve geçici dosyaları siler. Kliplerin, taslakların, ayarların ve oturumun kalır ama sonrasında uygulamayı yeniden başlatman gerekir.';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -11190,7 +11190,7 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      'اس سے اطلاعات، کیش شدہ پروفائلز، بک مارکس اور عارضی فائلیں مٹ جائیں گی۔ آپ کی کلپس اور ڈرافٹس رہیں گے، لیکن آپ لاگ آؤٹ ہو جائیں گے اور ایپ دوبارہ شروع کرنی ہوگی۔';
+      'اس سے کیش شدہ فیڈ ڈیٹا اور عارضی فائلیں مٹ جائیں گی۔ آپ کی کلپس، ڈرافٹس، ترتیبات اور لاگ اِن رہیں گے، لیکن بعد میں ایپ دوبارہ شروع کرنی ہوگی۔';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -11198,7 +11198,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      'Thao tác này xóa thông báo, hồ sơ đã lưu tạm, dấu trang và tệp tạm. Clip và bản nháp của bạn vẫn còn, nhưng bạn sẽ bị đăng xuất và phải khởi động lại ứng dụng.';
+      'Thao tác này xóa dữ liệu bảng tin đã lưu tạm và tệp tạm. Clip, bản nháp, cài đặt và phiên đăng nhập của bạn vẫn còn, nhưng sau đó bạn phải khởi động lại ứng dụng.';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -10596,7 +10596,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get settingsStorageRepairConfirmMessage =>
-      '这会清除通知、缓存的资料、书签和临时文件。你的片段和草稿会保留，但会退出登录，需要重启应用。';
+      '这会清除缓存的信息流数据和临时文件。你的片段、草稿、设置和登录状态会保留，但之后需要重启应用。';
 
   @override
   String settingsStorageRepairFootprint(String size) {

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -22,6 +22,7 @@ import 'package:hive_ce/hive_ce.dart';
 import 'package:http/http.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/constants/app_constants.dart';
+import 'package:openvine/constants/hive_box_names.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/providers/auth_providers.dart';
@@ -455,7 +456,7 @@ class CuratedListsState extends _$CuratedListsState {
 }
 
 /// Name of the Hive box used for caching NIP-51 kind 30000 people lists.
-const String _peopleListsBoxName = 'people_lists_v1';
+const String _peopleListsBoxName = HiveBoxNames.peopleLists;
 
 /// Repository for NIP-51 kind 30000 people lists.
 ///

--- a/mobile/lib/services/cache_recovery_service.dart
+++ b/mobile/lib/services/cache_recovery_service.dart
@@ -133,6 +133,21 @@ class CacheRecoveryService {
     'database',
   ];
 
+  /// Hive boxes holding local-only state that cache clearing must preserve.
+  ///
+  /// `notifications` is named for the feature, not its contents: its only key
+  /// is `push_preferences`, the notification settings the user chose. The
+  /// notification inbox is a Drift table inside the protected database dir.
+  /// Wiping this box drops the user back to all-on defaults, which the next
+  /// toggle republishes over the choices they made (#6919).
+  /// `push_notification_preferences_dirty` holds edits that have not reached
+  /// the push service yet plus the published-kinds schema marker, so losing it
+  /// strands an unsynced edit.
+  ///
+  /// Their files sit under `{appSupport}/openvine/` — the uploads-box
+  /// initializer re-points Hive's home path there during startup — which is
+  /// why [_clearAppSupportDirectory] has to protect them by path as well as
+  /// skipping them above.
   static const List<String> _durableHiveBoxNames = [
     'pending_uploads',
     'notifications',

--- a/mobile/lib/services/cache_recovery_service.dart
+++ b/mobile/lib/services/cache_recovery_service.dart
@@ -54,7 +54,7 @@ class CacheRecoveryService {
     }
   }
 
-  /// Clear all Hive database boxes
+  /// Clear disposable Hive cache boxes.
   static Future<int> _clearHiveBoxes() async {
     int cleared = 0;
 
@@ -62,7 +62,6 @@ class CacheRecoveryService {
       // Get all open boxes and clear them
       // Note: We iterate over known box names instead of trying to access all open boxes
       final knownBoxNames = [
-        'notifications',
         'user_profiles',
         'personal_events',
         'personal_events_metadata',

--- a/mobile/lib/services/cache_recovery_service.dart
+++ b/mobile/lib/services/cache_recovery_service.dart
@@ -59,15 +59,14 @@ class CacheRecoveryService {
     int cleared = 0;
 
     try {
-      // Get all open boxes and clear them
-      // Note: We iterate over known box names instead of trying to access all open boxes
+      // Get all open boxes and clear them. We iterate over known disposable box
+      // names instead of trying to access all open boxes.
       final knownBoxNames = [
-        'user_profiles',
         'personal_events',
         'personal_events_metadata',
-        'bookmarks',
+        'hashtag_stats',
+        'people_lists_v1',
         'video_cache',
-        'secure_keys',
       ];
 
       for (final boxName in knownBoxNames) {
@@ -134,9 +133,17 @@ class CacheRecoveryService {
     'database',
   ];
 
-  static const List<List<String>> _durablePendingUploadsBoxSegments = [
-    ['openvine', 'pending_uploads.hive'],
-    ['openvine', 'pending_uploads.lock'],
+  static const List<String> _durableHiveBoxNames = [
+    'pending_uploads',
+    'notifications',
+    'push_notification_preferences_dirty',
+  ];
+
+  static List<List<String>> get _durableHiveBoxFileSegments => [
+    for (final boxName in _durableHiveBoxNames) ...[
+      ['openvine', '$boxName.hive'],
+      ['openvine', '$boxName.lock'],
+    ],
   ];
 
   /// Clear app support directory (NOT Documents - that's sandboxed on macOS),
@@ -149,14 +156,14 @@ class CacheRecoveryService {
         appSupportDir.path,
         ..._durableDatabaseDirSegments,
       ]);
-      final protectedPendingUploadsPaths = [
-        for (final segments in _durablePendingUploadsBoxSegments)
+      final protectedHiveBoxPaths = [
+        for (final segments in _durableHiveBoxFileSegments)
           p.joinAll([appSupportDir.path, ...segments]),
       ];
       return await deleteDirectoryContentsExcept(
         appSupportDir,
         protectedPath: protectedPath,
-        additionalProtectedPaths: protectedPendingUploadsPaths,
+        additionalProtectedPaths: protectedHiveBoxPaths,
       );
     } catch (e) {
       Log.warning(

--- a/mobile/lib/services/cache_recovery_service.dart
+++ b/mobile/lib/services/cache_recovery_service.dart
@@ -13,6 +13,13 @@ import 'package:unified_logger/unified_logger.dart';
 class CacheRecoveryService {
   static const String _logName = 'CacheRecoveryService';
 
+  static const Set<String> _disposableHiveBoxNames = {
+    'personal_events',
+    'personal_events_metadata',
+    'hashtag_stats',
+    'people_lists_v1',
+  };
+
   /// Clear all app caches and databases to recover from corruption
   /// This works on iOS devices, Android, and desktop platforms
   static Future<bool> clearAllCaches() async {
@@ -61,15 +68,9 @@ class CacheRecoveryService {
     try {
       // Get all open boxes and clear them. We iterate over known disposable box
       // names instead of trying to access all open boxes.
-      final knownBoxNames = [
-        'personal_events',
-        'personal_events_metadata',
-        'hashtag_stats',
-        'people_lists_v1',
-        'video_cache',
-      ];
+      final boxNames = _disposableHiveBoxNames.difference(_durableHiveBoxNames);
 
-      for (final boxName in knownBoxNames) {
+      for (final boxName in boxNames) {
         try {
           if (Hive.isBoxOpen(boxName)) {
             final box = Hive.box(boxName);
@@ -91,7 +92,7 @@ class CacheRecoveryService {
       }
 
       // Also try to delete known box files from disk
-      for (final boxName in knownBoxNames) {
+      for (final boxName in boxNames) {
         try {
           await Hive.deleteBoxFromDisk(boxName);
           cleared++;
@@ -117,6 +118,10 @@ class CacheRecoveryService {
 
   @visibleForTesting
   static Future<int> clearHiveBoxesForTesting() => _clearHiveBoxes();
+
+  @visibleForTesting
+  static Set<String> get disposableHiveBoxNamesForTesting =>
+      _disposableHiveBoxNames;
 
   /// Durable database directory under Application Support that must NEVER be
   /// deleted by cache clearing. It holds the live SQLite database
@@ -148,13 +153,16 @@ class CacheRecoveryService {
   /// initializer re-points Hive's home path there during startup — which is
   /// why [_clearAppSupportDirectory] has to protect them by path as well as
   /// skipping them above.
-  static const List<String> _durableHiveBoxNames = [
+  static const Set<String> _durableHiveBoxNames = {
     'pending_uploads',
     'notifications',
     'push_notification_preferences_dirty',
-  ];
+  };
 
-  static List<List<String>> get _durableHiveBoxFileSegments => [
+  @visibleForTesting
+  static Set<String> get durableHiveBoxNamesForTesting => _durableHiveBoxNames;
+
+  static final List<List<String>> _durableHiveBoxFileSegments = [
     for (final boxName in _durableHiveBoxNames) ...[
       ['openvine', '$boxName.hive'],
       ['openvine', '$boxName.lock'],
@@ -167,18 +175,10 @@ class CacheRecoveryService {
     try {
       final appSupportDir = await getApplicationSupportDirectory();
       if (!appSupportDir.existsSync()) return 0;
-      final protectedPath = p.joinAll([
-        appSupportDir.path,
-        ..._durableDatabaseDirSegments,
-      ]);
-      final protectedHiveBoxPaths = [
-        for (final segments in _durableHiveBoxFileSegments)
-          p.joinAll([appSupportDir.path, ...segments]),
-      ];
       return await deleteDirectoryContentsExcept(
         appSupportDir,
-        protectedPath: protectedPath,
-        additionalProtectedPaths: protectedHiveBoxPaths,
+        protectedPath: _durableDatabasePath(appSupportDir),
+        additionalProtectedPaths: _durableHiveBoxPaths(appSupportDir),
       );
     } catch (e) {
       Log.warning(
@@ -244,6 +244,16 @@ class CacheRecoveryService {
     }
     return cleared;
   }
+
+  static String _durableDatabasePath(Directory appSupportDir) => p.joinAll([
+    appSupportDir.path,
+    ..._durableDatabaseDirSegments,
+  ]);
+
+  static List<String> _durableHiveBoxPaths(Directory appSupportDir) => [
+    for (final segments in _durableHiveBoxFileSegments)
+      p.joinAll([appSupportDir.path, ...segments]),
+  ];
 
   static bool _pathExists(String path) =>
       FileSystemEntity.typeSync(path) != FileSystemEntityType.notFound;
@@ -317,26 +327,35 @@ class CacheRecoveryService {
   /// Best-effort: a directory that cannot be read contributes zero. Throws if
   /// the platform cannot resolve one of the directories at all.
   static Future<int> cacheSizeBytes() async {
-    final dirs = [
-      await getApplicationSupportDirectory(),
-      await getTemporaryDirectory(),
-      await getApplicationCacheDirectory(),
-    ];
+    final appSupportDir = await getApplicationSupportDirectory();
+    final tempDir = await getTemporaryDirectory();
+    final cacheDir = await getApplicationCacheDirectory();
 
     var totalSize = 0;
-    for (final dir in dirs) {
-      if (dir.existsSync()) {
-        totalSize += await _getDirectorySize(dir);
-      }
+    if (appSupportDir.existsSync()) {
+      totalSize += await _getDirectorySize(
+        appSupportDir,
+        excludedPaths: [
+          _durableDatabasePath(appSupportDir),
+          ..._durableHiveBoxPaths(appSupportDir),
+        ],
+      );
+    }
+    for (final dir in [tempDir, cacheDir]) {
+      if (dir.existsSync()) totalSize += await _getDirectorySize(dir);
     }
     return totalSize;
   }
 
   /// Calculate directory size recursively
-  static Future<int> _getDirectorySize(Directory directory) async {
+  static Future<int> _getDirectorySize(
+    Directory directory, {
+    List<String> excludedPaths = const [],
+  }) async {
     int size = 0;
     try {
       await for (final entity in directory.list(recursive: true)) {
+        if (_isExcluded(entity.path, excludedPaths)) continue;
         if (entity is File) {
           size += await entity.length();
         }
@@ -346,4 +365,10 @@ class CacheRecoveryService {
     }
     return size;
   }
+
+  static bool _isExcluded(String path, List<String> excludedPaths) =>
+      excludedPaths.any(
+        (excludedPath) =>
+            p.equals(path, excludedPath) || p.isWithin(excludedPath, path),
+      );
 }

--- a/mobile/lib/services/cache_recovery_service.dart
+++ b/mobile/lib/services/cache_recovery_service.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:hive_ce/hive.dart';
 import 'package:meta/meta.dart';
+import 'package:openvine/constants/hive_box_names.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -14,10 +15,10 @@ class CacheRecoveryService {
   static const String _logName = 'CacheRecoveryService';
 
   static const Set<String> _disposableHiveBoxNames = {
-    'personal_events',
-    'personal_events_metadata',
-    'hashtag_stats',
-    'people_lists_v1',
+    HiveBoxNames.personalEvents,
+    HiveBoxNames.personalEventsMetadata,
+    HiveBoxNames.hashtagStats,
+    HiveBoxNames.peopleLists,
   };
 
   /// Clear all app caches and databases to recover from corruption
@@ -154,9 +155,9 @@ class CacheRecoveryService {
   /// why [_clearAppSupportDirectory] has to protect them by path as well as
   /// skipping them above.
   static const Set<String> _durableHiveBoxNames = {
-    'pending_uploads',
-    'notifications',
-    'push_notification_preferences_dirty',
+    HiveBoxNames.pendingUploads,
+    HiveBoxNames.notifications,
+    HiveBoxNames.pushNotificationPreferencesDirty,
   };
 
   @visibleForTesting

--- a/mobile/lib/services/hashtag_cache_service.dart
+++ b/mobile/lib/services/hashtag_cache_service.dart
@@ -2,11 +2,12 @@
 // ABOUTME: Provides fast local storage and retrieval of trending hashtags with automatic updates
 
 import 'package:hive_ce/hive.dart';
+import 'package:openvine/constants/hive_box_names.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Service for persistent caching of hashtag statistics
 class HashtagCacheService {
-  static const String _boxName = 'hashtag_stats';
+  static const String _boxName = HiveBoxNames.hashtagStats;
   static const String _popularHashtagsKey = 'popular_hashtags';
   static const String _lastUpdateKey = 'last_update';
   static const Duration _cacheExpiry = Duration(hours: 1); // Cache for 1 hour

--- a/mobile/lib/services/notification_preferences_service.dart
+++ b/mobile/lib/services/notification_preferences_service.dart
@@ -4,6 +4,7 @@
 import 'dart:convert';
 
 import 'package:hive_ce/hive.dart';
+import 'package:openvine/constants/hive_box_names.dart';
 import 'package:openvine/models/notification_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -39,8 +40,9 @@ class HiveNotificationPreferencesStore implements NotificationPreferencesStore {
   final Future<Box<dynamic>> Function() _openBox;
   final Future<Box<dynamic>> Function() _openDirtyBox;
 
-  static const _boxName = 'notifications';
-  static const _dirtyBoxName = 'push_notification_preferences_dirty';
+  static const String _boxName = HiveBoxNames.notifications;
+  static const String _dirtyBoxName =
+      HiveBoxNames.pushNotificationPreferencesDirty;
   static const _prefsKey = 'push_preferences';
   static const _dirtyPrefix = 'push_preferences_dirty_';
   static const _schemaVersionPrefix = 'push_preferences_schema_';

--- a/mobile/lib/services/personal_event_cache_service.dart
+++ b/mobile/lib/services/personal_event_cache_service.dart
@@ -5,13 +5,14 @@ import 'dart:async';
 
 import 'package:hive_ce/hive.dart';
 import 'package:nostr_sdk/event.dart';
+import 'package:openvine/constants/hive_box_names.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Service for aggressively caching ALL of the current user's own events
 /// This ensures the user's own data is always instantly available
 class PersonalEventCacheService {
-  static const String _boxName = 'personal_events';
-  static const String _metadataBoxName = 'personal_events_metadata';
+  static const String _boxName = HiveBoxNames.personalEvents;
+  static const String _metadataBoxName = HiveBoxNames.personalEventsMetadata;
   static const int _maxPendingEventWrites = 100;
 
   Box<dynamic>? _eventsBox;

--- a/mobile/lib/services/upload_initialization_helper.dart
+++ b/mobile/lib/services/upload_initialization_helper.dart
@@ -8,6 +8,7 @@ import 'dart:math';
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:openvine/constants/hive_box_names.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/utils/async_utils.dart';
@@ -17,7 +18,7 @@ import 'package:unified_logger/unified_logger.dart';
 
 /// Robust initialization helper for UploadManager
 class UploadInitializationHelper {
-  static const String _uploadsBoxName = 'pending_uploads';
+  static const String _uploadsBoxName = HiveBoxNames.pendingUploads;
   static const int _maxRetries =
       3; // Reduced from 5 since we fail fast on permanent errors
   static const Duration _baseDelay = Duration(milliseconds: 250);

--- a/mobile/test/constants/hive_box_names_test.dart
+++ b/mobile/test/constants/hive_box_names_test.dart
@@ -1,0 +1,87 @@
+// ABOUTME: Ties the Hive wipe policy to the real Hive.openBox call sites.
+// ABOUTME: A box that skips HiveBoxNames fails here instead of being wiped.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/constants/hive_box_names.dart';
+
+/// `Hive.openBox<T>(arg` / `Hive.openLazyBox(arg`, capturing the first
+/// argument. The argument may sit on the next line, so whitespace is skipped.
+final _openBoxCall = RegExp(
+  r'''Hive\.open(?:Lazy)?Box(?:<[^>]*>)?\(\s*([A-Za-z_$][\w.]*|'[^']*'|"[^"]*")''',
+);
+
+/// A `static const`/`const` declaration and its initializer, e.g.
+/// `static const String _boxName = HiveBoxNames.hashtagStats;`.
+String? _initializerOf(String source, String identifier) => RegExp(
+  'const\\s+(?:\\w+\\s+)?$identifier\\s*=\\s*([^;]+);',
+).firstMatch(source)?.group(1)?.trim();
+
+/// `static const notifications = 'notifications';` — the `all` set is skipped
+/// because its initializer is not a quoted string.
+final _boxNameDeclaration = RegExp(
+  r'''static\s+const\s+(?:String\s+)?(\w+)\s*=\s*'([^']*)'\s*;''',
+);
+
+Iterable<File> _dartSources() sync* {
+  for (final root in [Directory('lib'), Directory('packages')]) {
+    if (!root.existsSync()) continue;
+    for (final entity in root.listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      if (entity.path.contains('/test/')) continue;
+      yield entity;
+    }
+  }
+}
+
+void main() {
+  group(HiveBoxNames, () {
+    test('every declared box name is in HiveBoxNames.all', () {
+      final source = File(
+        'lib/constants/hive_box_names.dart',
+      ).readAsStringSync();
+      final declared = {
+        for (final match in _boxNameDeclaration.allMatches(source))
+          match.group(2)!,
+      };
+
+      expect(declared, isNotEmpty);
+      expect(
+        declared,
+        unorderedEquals(HiveBoxNames.all),
+        reason:
+            'HiveBoxNames.all is what CacheRecoveryService classifies as '
+            'disposable or durable. A member missing from it is a box no '
+            'wipe policy covers.',
+      );
+    });
+
+    test('every Hive.openBox call site names its box via HiveBoxNames', () {
+      final offenders = <String>[];
+
+      for (final file in _dartSources()) {
+        final source = file.readAsStringSync();
+        for (final call in _openBoxCall.allMatches(source)) {
+          final argument = call.group(1)!;
+          final resolved = argument.startsWith('HiveBoxNames.')
+              ? argument
+              : _initializerOf(source, argument);
+          if (resolved != null && resolved.startsWith('HiveBoxNames.')) {
+            continue;
+          }
+          offenders.add('${file.path}: Hive.openBox($argument)');
+        }
+      }
+
+      expect(
+        offenders,
+        isEmpty,
+        reason:
+            'Every Hive box must be named from HiveBoxNames so the cache '
+            'wipe policy classifies it. Add the name to HiveBoxNames and to '
+            "CacheRecoveryService's disposable or durable set (#6919).",
+      );
+    });
+  });
+}

--- a/mobile/test/constants/hive_box_names_test.dart
+++ b/mobile/test/constants/hive_box_names_test.dart
@@ -6,10 +6,14 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/constants/hive_box_names.dart';
 
-/// `Hive.openBox<T>(arg` / `Hive.openLazyBox(arg`, capturing the first
-/// argument. The argument may sit on the next line, so whitespace is skipped.
+/// `.openBox<T>(arg` / `.openLazyBox(arg`, capturing the first argument. The
+/// argument may sit on the next line, so whitespace is skipped.
+///
+/// The receiver is intentionally broad: app-layer code can use `Hive.openBox`
+/// directly, while packages receive injected open-box callbacks because they
+/// cannot import app-owned [HiveBoxNames].
 final _openBoxCall = RegExp(
-  r'''Hive\.open(?:Lazy)?Box(?:<[^>]*>)?\(\s*([A-Za-z_$][\w.]*|'[^']*'|"[^"]*")''',
+  r'''\.open(?:Lazy)?Box(?:<[^>]*>)?\(\s*([A-Za-z_$][\w.]*|'[^']*'|"[^"]*")''',
 );
 
 /// A `static const`/`const` declaration and its initializer, e.g.
@@ -37,6 +41,18 @@ Iterable<File> _dartSources() sync* {
 
 void main() {
   group(HiveBoxNames, () {
+    test('openBox scanner includes injected HiveInterface receivers', () {
+      const source = '''
+class ProbeB {
+  ProbeB(this._hive);
+  final HiveInterface _hive;
+  Future<Box<dynamic>> open() => _hive.openBox<dynamic>('draft_notes_v1');
+}
+''';
+
+      expect(_openBoxCall.firstMatch(source)?.group(1), "'draft_notes_v1'");
+    });
+
     test('every declared box name is in HiveBoxNames.all', () {
       final source = File(
         'lib/constants/hive_box_names.dart',

--- a/mobile/test/services/cache_recovery_service_test.dart
+++ b/mobile/test/services/cache_recovery_service_test.dart
@@ -36,15 +36,24 @@ void main() {
         await TestHelpers.cleanupHiveBox('notifications');
         await TestHelpers.cleanupHiveBox('push_notification_preferences_dirty');
         await TestHelpers.cleanupHiveBox('pending_uploads');
-        await TestHelpers.cleanupHiveBox('video_cache');
+        await TestHelpers.cleanupHiveBox('hashtag_stats');
       });
 
       tearDown(() async {
         await TestHelpers.cleanupHiveBox('notifications');
         await TestHelpers.cleanupHiveBox('push_notification_preferences_dirty');
         await TestHelpers.cleanupHiveBox('pending_uploads');
-        await TestHelpers.cleanupHiveBox('video_cache');
+        await TestHelpers.cleanupHiveBox('hashtag_stats');
         if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+      });
+
+      test('keeps durable Hive boxes out of the disposable wipe set', () {
+        expect(
+          CacheRecoveryService.disposableHiveBoxNamesForTesting.intersection(
+            CacheRecoveryService.durableHiveBoxNamesForTesting,
+          ),
+          isEmpty,
+        );
       });
 
       test(
@@ -53,16 +62,16 @@ void main() {
           final pendingUploads = Hive.isBoxOpen('pending_uploads')
               ? Hive.box<PendingUpload>('pending_uploads')
               : await Hive.openBox<PendingUpload>('pending_uploads');
-          final videoCache = Hive.isBoxOpen('video_cache')
-              ? Hive.box('video_cache')
-              : await Hive.openBox('video_cache');
+          final hashtagStats = Hive.isBoxOpen('hashtag_stats')
+              ? Hive.box('hashtag_stats')
+              : await Hive.openBox('hashtag_stats');
           final upload = PendingUpload.create(
             localVideoPath: '/tmp/durable-upload.mp4',
             nostrPubkey:
                 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           );
           await pendingUploads.put(upload.id, upload);
-          await videoCache.put('cache-id', 'cached video');
+          await hashtagStats.put('popular_hashtags', ['divine']);
 
           await CacheRecoveryService.clearHiveBoxesForTesting();
 
@@ -72,10 +81,10 @@ void main() {
             ).get(upload.id)?.localVideoPath,
             upload.localVideoPath,
           );
-          expect(Hive.isBoxOpen('video_cache'), isFalse);
-          final reopenedVideoCache = await Hive.openBox('video_cache');
-          addTearDown(reopenedVideoCache.close);
-          expect(reopenedVideoCache.get('cache-id'), isNull);
+          expect(Hive.isBoxOpen('hashtag_stats'), isFalse);
+          final reopenedHashtagStats = await Hive.openBox('hashtag_stats');
+          addTearDown(reopenedHashtagStats.close);
+          expect(reopenedHashtagStats.get('popular_hashtags'), isNull);
         },
       );
 
@@ -89,19 +98,16 @@ void main() {
               Hive.isBoxOpen('push_notification_preferences_dirty')
               ? Hive.box('push_notification_preferences_dirty')
               : await Hive.openBox('push_notification_preferences_dirty');
-          final videoCache = Hive.isBoxOpen('video_cache')
-              ? Hive.box('video_cache')
-              : await Hive.openBox('video_cache');
+          final hashtagStats = Hive.isBoxOpen('hashtag_stats')
+              ? Hive.box('hashtag_stats')
+              : await Hive.openBox('hashtag_stats');
           const preferences = NotificationPreferences(commentsEnabled: false);
           const dirtyPreferencesKey =
               'push_preferences_dirty_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
           final storedPreferences = jsonEncode(preferences.toJson());
           await notifications.put('push_preferences', storedPreferences);
-          await dirtyNotifications.put(
-            dirtyPreferencesKey,
-            storedPreferences,
-          );
-          await videoCache.put('cache-id', 'cached video');
+          await dirtyNotifications.put(dirtyPreferencesKey, storedPreferences);
+          await hashtagStats.put('popular_hashtags', ['divine']);
 
           await CacheRecoveryService.clearHiveBoxesForTesting();
 
@@ -115,10 +121,10 @@ void main() {
             ).get(dirtyPreferencesKey),
             storedPreferences,
           );
-          expect(Hive.isBoxOpen('video_cache'), isFalse);
-          final reopenedVideoCache = await Hive.openBox('video_cache');
-          addTearDown(reopenedVideoCache.close);
-          expect(reopenedVideoCache.get('cache-id'), isNull);
+          expect(Hive.isBoxOpen('hashtag_stats'), isFalse);
+          final reopenedHashtagStats = await Hive.openBox('hashtag_stats');
+          addTearDown(reopenedHashtagStats.close);
+          expect(reopenedHashtagStats.get('popular_hashtags'), isNull);
         },
       );
     });
@@ -217,6 +223,36 @@ void main() {
           expect(scratch.existsSync(), isFalse);
           expect(temp.existsSync(), isFalse);
           expect(cache.existsSync(), isFalse);
+        },
+      );
+
+      test(
+        'cacheSizeBytes excludes protected app support state',
+        () async {
+          write('support/openvine/database/divine_db.db', 'database');
+          write('support/openvine/pending_uploads.hive', 'pending uploads');
+          write('support/openvine/pending_uploads.lock', 'lock');
+          write('support/openvine/notifications.hive', 'preferences');
+          write('support/openvine/notifications.lock', 'lock');
+          write(
+            'support/openvine/push_notification_preferences_dirty.hive',
+            'dirty preferences',
+          );
+          write(
+            'support/openvine/push_notification_preferences_dirty.lock',
+            'lock',
+          );
+          write('support/openvine/cache/cache_sync.db', 'cache');
+          write('support/openvine/scratch.txt', 'scratch');
+          write('temp/transient.tmp', 'temp');
+          write('cache/download.bin', 'cache');
+
+          final bytes = await CacheRecoveryService.cacheSizeBytes();
+
+          expect(
+            bytes,
+            'cache'.length + 'scratch'.length + 'temp'.length + 'cache'.length,
+          );
         },
       );
     });

--- a/mobile/test/services/cache_recovery_service_test.dart
+++ b/mobile/test/services/cache_recovery_service_test.dart
@@ -34,12 +34,14 @@ void main() {
         tmp = Directory.systemTemp.createTempSync('cache_recovery_hive_test');
         Hive.init(tmp.path);
         await TestHelpers.cleanupHiveBox('notifications');
+        await TestHelpers.cleanupHiveBox('push_notification_preferences_dirty');
         await TestHelpers.cleanupHiveBox('pending_uploads');
         await TestHelpers.cleanupHiveBox('video_cache');
       });
 
       tearDown(() async {
         await TestHelpers.cleanupHiveBox('notifications');
+        await TestHelpers.cleanupHiveBox('push_notification_preferences_dirty');
         await TestHelpers.cleanupHiveBox('pending_uploads');
         await TestHelpers.cleanupHiveBox('video_cache');
         if (tmp.existsSync()) tmp.deleteSync(recursive: true);
@@ -83,18 +85,34 @@ void main() {
           final notifications = Hive.isBoxOpen('notifications')
               ? Hive.box('notifications')
               : await Hive.openBox('notifications');
+          final dirtyNotifications =
+              Hive.isBoxOpen('push_notification_preferences_dirty')
+              ? Hive.box('push_notification_preferences_dirty')
+              : await Hive.openBox('push_notification_preferences_dirty');
           final videoCache = Hive.isBoxOpen('video_cache')
               ? Hive.box('video_cache')
               : await Hive.openBox('video_cache');
           const preferences = NotificationPreferences(commentsEnabled: false);
+          const dirtyPreferencesKey =
+              'push_preferences_dirty_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
           final storedPreferences = jsonEncode(preferences.toJson());
           await notifications.put('push_preferences', storedPreferences);
+          await dirtyNotifications.put(
+            dirtyPreferencesKey,
+            storedPreferences,
+          );
           await videoCache.put('cache-id', 'cached video');
 
           await CacheRecoveryService.clearHiveBoxesForTesting();
 
           expect(
             Hive.box('notifications').get('push_preferences'),
+            storedPreferences,
+          );
+          expect(
+            Hive.box(
+              'push_notification_preferences_dirty',
+            ).get(dirtyPreferencesKey),
             storedPreferences,
           );
           expect(Hive.isBoxOpen('video_cache'), isFalse);
@@ -160,6 +178,47 @@ void main() {
         expect(temp.existsSync(), isFalse);
         expect(cache.existsSync(), isFalse);
       });
+
+      test(
+        'preserves durable notification preferences during clearAllCaches',
+        () async {
+          final notifications = write(
+            'support/openvine/notifications.hive',
+            'preferences',
+          );
+          final notificationsLock = write(
+            'support/openvine/notifications.lock',
+            'lock',
+          );
+          final dirtyPreferences = write(
+            'support/openvine/push_notification_preferences_dirty.hive',
+            'dirty preferences',
+          );
+          final dirtyPreferencesLock = write(
+            'support/openvine/push_notification_preferences_dirty.lock',
+            'lock',
+          );
+          final cacheSync = write(
+            'support/openvine/cache/cache_sync.db',
+            'cache',
+          );
+          final scratch = write('support/openvine/scratch.txt', 'scratch');
+          final temp = write('temp/transient.tmp', 'temp');
+          final cache = write('cache/download.bin', 'cache');
+
+          final recovered = await CacheRecoveryService.clearAllCaches();
+
+          expect(recovered, isTrue);
+          expect(notifications.existsSync(), isTrue);
+          expect(notificationsLock.existsSync(), isTrue);
+          expect(dirtyPreferences.existsSync(), isTrue);
+          expect(dirtyPreferencesLock.existsSync(), isTrue);
+          expect(cacheSync.existsSync(), isFalse);
+          expect(scratch.existsSync(), isFalse);
+          expect(temp.existsSync(), isFalse);
+          expect(cache.existsSync(), isFalse);
+        },
+      );
     });
 
     group('deleteDirectoryContentsExcept', () {

--- a/mobile/test/services/cache_recovery_service_test.dart
+++ b/mobile/test/services/cache_recovery_service_test.dart
@@ -1,10 +1,12 @@
 // ABOUTME: Tests for CacheRecoveryService's directory clearing
 // ABOUTME: Pins #4968 — the durable database dir is preserved while caches are cleared
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_ce/hive.dart';
+import 'package:openvine/models/notification_preferences.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/cache_recovery_service.dart';
 import 'package:path/path.dart' as p;
@@ -31,11 +33,13 @@ void main() {
       setUp(() async {
         tmp = Directory.systemTemp.createTempSync('cache_recovery_hive_test');
         Hive.init(tmp.path);
+        await TestHelpers.cleanupHiveBox('notifications');
         await TestHelpers.cleanupHiveBox('pending_uploads');
         await TestHelpers.cleanupHiveBox('video_cache');
       });
 
       tearDown(() async {
+        await TestHelpers.cleanupHiveBox('notifications');
         await TestHelpers.cleanupHiveBox('pending_uploads');
         await TestHelpers.cleanupHiveBox('video_cache');
         if (tmp.existsSync()) tmp.deleteSync(recursive: true);
@@ -72,6 +76,33 @@ void main() {
           expect(reopenedVideoCache.get('cache-id'), isNull);
         },
       );
+
+      test(
+        'preserves durable notification preferences while clearing caches',
+        () async {
+          final notifications = Hive.isBoxOpen('notifications')
+              ? Hive.box('notifications')
+              : await Hive.openBox('notifications');
+          final videoCache = Hive.isBoxOpen('video_cache')
+              ? Hive.box('video_cache')
+              : await Hive.openBox('video_cache');
+          const preferences = NotificationPreferences(commentsEnabled: false);
+          final storedPreferences = jsonEncode(preferences.toJson());
+          await notifications.put('push_preferences', storedPreferences);
+          await videoCache.put('cache-id', 'cached video');
+
+          await CacheRecoveryService.clearHiveBoxesForTesting();
+
+          expect(
+            Hive.box('notifications').get('push_preferences'),
+            storedPreferences,
+          );
+          expect(Hive.isBoxOpen('video_cache'), isFalse);
+          final reopenedVideoCache = await Hive.openBox('video_cache');
+          addTearDown(reopenedVideoCache.close);
+          expect(reopenedVideoCache.get('cache-id'), isNull);
+        },
+      );
     });
 
     group('full cache recovery', () {
@@ -101,10 +132,7 @@ void main() {
       }
 
       test('preserves durable pending uploads during clearAllCaches', () async {
-        final db = write(
-          'support/openvine/database/divine_db.db',
-          'database',
-        );
+        final db = write('support/openvine/database/divine_db.db', 'database');
         final pendingUploads = write(
           'support/openvine/pending_uploads.hive',
           'pending uploads',
@@ -190,10 +218,7 @@ void main() {
           expect(top.existsSync(), isFalse);
 
           // The ancestor dir of the protected subtree is kept (it holds it).
-          expect(
-            Directory(p.join(tmp.path, 'openvine')).existsSync(),
-            isTrue,
-          );
+          expect(Directory(p.join(tmp.path, 'openvine')).existsSync(), isTrue);
           expect(cleared, greaterThan(0));
         },
       );

--- a/mobile/test/services/cache_recovery_service_test.dart
+++ b/mobile/test/services/cache_recovery_service_test.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_ce/hive.dart';
+import 'package:openvine/constants/hive_box_names.dart';
 import 'package:openvine/models/notification_preferences.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/cache_recovery_service.dart';
@@ -33,38 +34,50 @@ void main() {
       setUp(() async {
         tmp = Directory.systemTemp.createTempSync('cache_recovery_hive_test');
         Hive.init(tmp.path);
-        await TestHelpers.cleanupHiveBox('notifications');
-        await TestHelpers.cleanupHiveBox('push_notification_preferences_dirty');
-        await TestHelpers.cleanupHiveBox('pending_uploads');
-        await TestHelpers.cleanupHiveBox('hashtag_stats');
+        await TestHelpers.cleanupHiveBox(HiveBoxNames.notifications);
+        await TestHelpers.cleanupHiveBox(
+          HiveBoxNames.pushNotificationPreferencesDirty,
+        );
+        await TestHelpers.cleanupHiveBox(HiveBoxNames.pendingUploads);
+        await TestHelpers.cleanupHiveBox(HiveBoxNames.hashtagStats);
       });
 
       tearDown(() async {
-        await TestHelpers.cleanupHiveBox('notifications');
-        await TestHelpers.cleanupHiveBox('push_notification_preferences_dirty');
-        await TestHelpers.cleanupHiveBox('pending_uploads');
-        await TestHelpers.cleanupHiveBox('hashtag_stats');
+        await TestHelpers.cleanupHiveBox(HiveBoxNames.notifications);
+        await TestHelpers.cleanupHiveBox(
+          HiveBoxNames.pushNotificationPreferencesDirty,
+        );
+        await TestHelpers.cleanupHiveBox(HiveBoxNames.pendingUploads);
+        await TestHelpers.cleanupHiveBox(HiveBoxNames.hashtagStats);
         if (tmp.existsSync()) tmp.deleteSync(recursive: true);
       });
 
-      test('keeps durable Hive boxes out of the disposable wipe set', () {
+      test('classifies every known Hive box exactly once', () {
+        final classifiedHiveBoxNames = {
+          ...CacheRecoveryService.disposableHiveBoxNamesForTesting,
+          ...CacheRecoveryService.durableHiveBoxNamesForTesting,
+        };
+
         expect(
           CacheRecoveryService.disposableHiveBoxNamesForTesting.intersection(
             CacheRecoveryService.durableHiveBoxNamesForTesting,
           ),
           isEmpty,
         );
+        expect(classifiedHiveBoxNames, unorderedEquals(HiveBoxNames.all));
       });
 
       test(
         'preserves pending uploads while clearing disposable Hive caches',
         () async {
-          final pendingUploads = Hive.isBoxOpen('pending_uploads')
-              ? Hive.box<PendingUpload>('pending_uploads')
-              : await Hive.openBox<PendingUpload>('pending_uploads');
-          final hashtagStats = Hive.isBoxOpen('hashtag_stats')
-              ? Hive.box('hashtag_stats')
-              : await Hive.openBox('hashtag_stats');
+          final pendingUploads = Hive.isBoxOpen(HiveBoxNames.pendingUploads)
+              ? Hive.box<PendingUpload>(HiveBoxNames.pendingUploads)
+              : await Hive.openBox<PendingUpload>(
+                  HiveBoxNames.pendingUploads,
+                );
+          final hashtagStats = Hive.isBoxOpen(HiveBoxNames.hashtagStats)
+              ? Hive.box(HiveBoxNames.hashtagStats)
+              : await Hive.openBox(HiveBoxNames.hashtagStats);
           final upload = PendingUpload.create(
             localVideoPath: '/tmp/durable-upload.mp4',
             nostrPubkey:
@@ -77,12 +90,14 @@ void main() {
 
           expect(
             Hive.box<PendingUpload>(
-              'pending_uploads',
+              HiveBoxNames.pendingUploads,
             ).get(upload.id)?.localVideoPath,
             upload.localVideoPath,
           );
-          expect(Hive.isBoxOpen('hashtag_stats'), isFalse);
-          final reopenedHashtagStats = await Hive.openBox('hashtag_stats');
+          expect(Hive.isBoxOpen(HiveBoxNames.hashtagStats), isFalse);
+          final reopenedHashtagStats = await Hive.openBox(
+            HiveBoxNames.hashtagStats,
+          );
           addTearDown(reopenedHashtagStats.close);
           expect(reopenedHashtagStats.get('popular_hashtags'), isNull);
         },
@@ -91,16 +106,18 @@ void main() {
       test(
         'preserves durable notification preferences while clearing caches',
         () async {
-          final notifications = Hive.isBoxOpen('notifications')
-              ? Hive.box('notifications')
-              : await Hive.openBox('notifications');
+          final notifications = Hive.isBoxOpen(HiveBoxNames.notifications)
+              ? Hive.box(HiveBoxNames.notifications)
+              : await Hive.openBox(HiveBoxNames.notifications);
           final dirtyNotifications =
-              Hive.isBoxOpen('push_notification_preferences_dirty')
-              ? Hive.box('push_notification_preferences_dirty')
-              : await Hive.openBox('push_notification_preferences_dirty');
-          final hashtagStats = Hive.isBoxOpen('hashtag_stats')
-              ? Hive.box('hashtag_stats')
-              : await Hive.openBox('hashtag_stats');
+              Hive.isBoxOpen(HiveBoxNames.pushNotificationPreferencesDirty)
+              ? Hive.box(HiveBoxNames.pushNotificationPreferencesDirty)
+              : await Hive.openBox(
+                  HiveBoxNames.pushNotificationPreferencesDirty,
+                );
+          final hashtagStats = Hive.isBoxOpen(HiveBoxNames.hashtagStats)
+              ? Hive.box(HiveBoxNames.hashtagStats)
+              : await Hive.openBox(HiveBoxNames.hashtagStats);
           const preferences = NotificationPreferences(commentsEnabled: false);
           const dirtyPreferencesKey =
               'push_preferences_dirty_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
@@ -112,17 +129,19 @@ void main() {
           await CacheRecoveryService.clearHiveBoxesForTesting();
 
           expect(
-            Hive.box('notifications').get('push_preferences'),
+            Hive.box(HiveBoxNames.notifications).get('push_preferences'),
             storedPreferences,
           );
           expect(
             Hive.box(
-              'push_notification_preferences_dirty',
+              HiveBoxNames.pushNotificationPreferencesDirty,
             ).get(dirtyPreferencesKey),
             storedPreferences,
           );
-          expect(Hive.isBoxOpen('hashtag_stats'), isFalse);
-          final reopenedHashtagStats = await Hive.openBox('hashtag_stats');
+          expect(Hive.isBoxOpen(HiveBoxNames.hashtagStats), isFalse);
+          final reopenedHashtagStats = await Hive.openBox(
+            HiveBoxNames.hashtagStats,
+          );
           addTearDown(reopenedHashtagStats.close);
           expect(reopenedHashtagStats.get('popular_hashtags'), isNull);
         },
@@ -158,11 +177,11 @@ void main() {
       test('preserves durable pending uploads during clearAllCaches', () async {
         final db = write('support/openvine/database/divine_db.db', 'database');
         final pendingUploads = write(
-          'support/openvine/pending_uploads.hive',
+          'support/openvine/${HiveBoxNames.pendingUploads}.hive',
           'pending uploads',
         );
         final pendingUploadsLock = write(
-          'support/openvine/pending_uploads.lock',
+          'support/openvine/${HiveBoxNames.pendingUploads}.lock',
           'lock',
         );
         final cacheSync = write(
@@ -189,19 +208,21 @@ void main() {
         'preserves durable notification preferences during clearAllCaches',
         () async {
           final notifications = write(
-            'support/openvine/notifications.hive',
+            'support/openvine/${HiveBoxNames.notifications}.hive',
             'preferences',
           );
           final notificationsLock = write(
-            'support/openvine/notifications.lock',
+            'support/openvine/${HiveBoxNames.notifications}.lock',
             'lock',
           );
           final dirtyPreferences = write(
-            'support/openvine/push_notification_preferences_dirty.hive',
+            'support/openvine/'
+                '${HiveBoxNames.pushNotificationPreferencesDirty}.hive',
             'dirty preferences',
           );
           final dirtyPreferencesLock = write(
-            'support/openvine/push_notification_preferences_dirty.lock',
+            'support/openvine/'
+                '${HiveBoxNames.pushNotificationPreferencesDirty}.lock',
             'lock',
           );
           final cacheSync = write(
@@ -230,16 +251,24 @@ void main() {
         'cacheSizeBytes excludes protected app support state',
         () async {
           write('support/openvine/database/divine_db.db', 'database');
-          write('support/openvine/pending_uploads.hive', 'pending uploads');
-          write('support/openvine/pending_uploads.lock', 'lock');
-          write('support/openvine/notifications.hive', 'preferences');
-          write('support/openvine/notifications.lock', 'lock');
           write(
-            'support/openvine/push_notification_preferences_dirty.hive',
+            'support/openvine/${HiveBoxNames.pendingUploads}.hive',
+            'pending uploads',
+          );
+          write('support/openvine/${HiveBoxNames.pendingUploads}.lock', 'lock');
+          write(
+            'support/openvine/${HiveBoxNames.notifications}.hive',
+            'preferences',
+          );
+          write('support/openvine/${HiveBoxNames.notifications}.lock', 'lock');
+          write(
+            'support/openvine/'
+                '${HiveBoxNames.pushNotificationPreferencesDirty}.hive',
             'dirty preferences',
           );
           write(
-            'support/openvine/push_notification_preferences_dirty.lock',
+            'support/openvine/'
+                '${HiveBoxNames.pushNotificationPreferencesDirty}.lock',
             'lock',
           );
           write('support/openvine/cache/cache_sync.db', 'cache');


### PR DESCRIPTION
## Description

Removes the durable `notifications` Hive box from `CacheRecoveryService`'s disposable cache wipe list. Push notification preferences are stored in that box under `push_preferences`, so clearing it could reset the settings UI to all-on defaults while the push service still had the previously published preferences.

Adds regression coverage that verifies notification preferences survive the Hive cache wipe while real disposable Hive cache data (`hashtag_stats`) is still cleared.

Also protects `notifications.hive`/`.lock` and `push_notification_preferences_dirty.hive`/`.lock` under `{appSupport}/openvine/` from the Application Support wipe, so the box file survives step 2 of `clearAllCaches` and not just the box-name skip in step 1.

While reworking that list the wipe set changed in both directions: `user_profiles`, `bookmarks`, `secure_keys`, and the dead Hive name `video_cache` are gone, and `hashtag_stats` and `people_lists_v1` are added. `hashtag_stats` is a short-lived cache. `people_lists_v1` is cache-scoped and refilled by sync; it does include local deletion tombstones, so this PR treats it as disposable cache state rather than durable user data. Because #6958 documents that Hive box location can depend on startup ordering, the additions may remove box files that previously survived when Hive put them outside Application Support.

The repair confirmation footprint now excludes protected durable Application Support state, so the `{size} will be removed` value matches the same protected database and Hive paths that `clearAllCaches` preserves.

**Related Issue:** Closes #6919. Part of #4335.

## Out of Scope

- Moving push preferences to a newly named durable box.
- The broader #4335 storage/cache policy work.
- Fixing Hive home-path reassignment; tracked separately in #6958.

## Verification

- `dart format lib/services/cache_recovery_service.dart test/services/cache_recovery_service_test.dart`
- `flutter analyze lib/services/cache_recovery_service.dart test/services/cache_recovery_service_test.dart`
- `flutter test test/services/cache_recovery_service_test.dart`
- Earlier PR verification before the follow-up commit:
  - `mise exec -- dart format lib test integration_test`
  - `flutter analyze lib test integration_test`
  - `flutter test test/services/cache_recovery_service_test.dart test/services/notification_preferences_service_test.dart`
  - Pre-push hook: analyzer clean, `test/services/cache_recovery_service_test.dart` passed
  - Manual, iPhone 17 Pro Max simulator: turned Mentions off, ran Settings > General > Storage > Reset app data, confirmed `notifications.hive` survived with `"mentionsEnabled":false` and the toggle was still off after a cold restart

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
