### PR TITLE
build(mobile): upgrade patrol to 4.8.0 and pin patrol_cli 4.6.1

### DIFF
--- a/.agents/skills/e2e-test/SKILL.md
+++ b/.agents/skills/e2e-test/SKILL.md
@@ -5,7 +5,7 @@ description: |
   app against a local Docker backend (no mocks). Use when running
   E2E tests, debugging failures, or working on the local harness.
 author: Claude Code
-version: 1.2.0
+version: 1.3.0
 ---
 
 # E2E Integration Testing
@@ -33,6 +33,25 @@ merged docker+logcat+app timeline at `test_reports/*.jsonl`, and
 prints the native test XML path + failure excerpts when the APK
 fails to install. **Never call `patrol test` directly** — you'll
 lose the timeline and the diagnostics.
+
+## Version pair
+
+`patrol` (the package) and `patrol_cli` (the binary) ship as a matched
+pair, and `patrol_cli` enforces it at run time — a mismatch aborts the
+run before any test executes.
+
+| Half | Version | Declared in |
+|---|---|---|
+| `patrol` package | 4.8.0 | `mobile/pubspec.yaml` (`patrol: ^4.8.0`) |
+| `patrol_cli` binary | 4.6.1 | `local_stack/profile.sh` (`PATROL_CLI_VERSION`) |
+
+`profile.sh` checks the installed CLI and runs
+`dart pub global activate patrol_cli <version>` when it differs, so
+`mise run e2e_test` self-heals. That activation is **machine-global**:
+it switches the CLI for every checkout, including worktrees still on an
+older `patrol`, which will then fail the same compatibility check until
+they rebase. Change the two versions together — the compatibility table
+is at https://patrol.leancode.co/documentation/compatibility-table.
 
 ## Stack
 

--- a/.agents/skills/e2e-test/SKILL.md
+++ b/.agents/skills/e2e-test/SKILL.md
@@ -258,6 +258,28 @@ Patrol bundles every file in a target dir into one APK. When file B
 runs, file A shows up as "not requested" `[E]` markers in logcat.
 Trust only the final `✅`/`❌` lines.
 
+### Never put `/` in a patrol test name
+
+Patrol names each JUnit case `MainActivityTest#runDartTest[<dart test
+name>]`, and the AndroidX orchestrator writes a per-test output file
+named after it. Android's `ContextImpl.makeFilename` rejects any
+filename containing a path separator, so a test called e.g. `'strips
+metadata via separate input/output paths'` crashes the orchestrator:
+
+```
+FATAL EXCEPTION: AndroidTestOrchestrator
+java.lang.IllegalArgumentException: File …input/output paths].txt
+contains a path separator
+```
+
+The tell is a **green summary with a non-zero exit**: Gradle reports
+`Instrumentation run failed due to Process crashed` and exits 1, while
+patrol prints `Failed: 0` — because the offending test never started
+and so was never counted. Compare `Total:` against the number of tests
+in the file when the exit code disagrees with the summary.
+
+Write `input and output`, not `input/output`.
+
 ### NIP-98 URL binding
 
 The invite service rejects a signed request whose `u` tag does not

--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -5,7 +5,7 @@ description: |
   app against a local Docker backend (no mocks). Use when running
   E2E tests, debugging failures, or working on the local harness.
 author: Claude Code
-version: 1.2.0
+version: 1.3.0
 ---
 
 # E2E Integration Testing
@@ -33,6 +33,25 @@ merged docker+logcat+app timeline at `test_reports/*.jsonl`, and
 prints the native test XML path + failure excerpts when the APK
 fails to install. **Never call `patrol test` directly** — you'll
 lose the timeline and the diagnostics.
+
+## Version pair
+
+`patrol` (the package) and `patrol_cli` (the binary) ship as a matched
+pair, and `patrol_cli` enforces it at run time — a mismatch aborts the
+run before any test executes.
+
+| Half | Version | Declared in |
+|---|---|---|
+| `patrol` package | 4.8.0 | `mobile/pubspec.yaml` (`patrol: ^4.8.0`) |
+| `patrol_cli` binary | 4.6.1 | `local_stack/profile.sh` (`PATROL_CLI_VERSION`) |
+
+`profile.sh` checks the installed CLI and runs
+`dart pub global activate patrol_cli <version>` when it differs, so
+`mise run e2e_test` self-heals. That activation is **machine-global**:
+it switches the CLI for every checkout, including worktrees still on an
+older `patrol`, which will then fail the same compatibility check until
+they rebase. Change the two versions together — the compatibility table
+is at https://patrol.leancode.co/documentation/compatibility-table.
 
 ## Stack
 

--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -258,6 +258,28 @@ Patrol bundles every file in a target dir into one APK. When file B
 runs, file A shows up as "not requested" `[E]` markers in logcat.
 Trust only the final `✅`/`❌` lines.
 
+### Never put `/` in a patrol test name
+
+Patrol names each JUnit case `MainActivityTest#runDartTest[<dart test
+name>]`, and the AndroidX orchestrator writes a per-test output file
+named after it. Android's `ContextImpl.makeFilename` rejects any
+filename containing a path separator, so a test called e.g. `'strips
+metadata via separate input/output paths'` crashes the orchestrator:
+
+```
+FATAL EXCEPTION: AndroidTestOrchestrator
+java.lang.IllegalArgumentException: File …input/output paths].txt
+contains a path separator
+```
+
+The tell is a **green summary with a non-zero exit**: Gradle reports
+`Instrumentation run failed due to Process crashed` and exits 1, while
+patrol prints `Failed: 0` — because the offending test never started
+and so was never counted. Compare `Total:` against the number of tests
+in the file when the exit code disagrees with the summary.
+
+Write `input and output`, not `input/output`.
+
 ### NIP-98 URL binding
 
 The invite service rejects a signed request whose `u` tag does not

--- a/local_stack/profile.sh
+++ b/local_stack/profile.sh
@@ -124,6 +124,7 @@ echo "Running: patrol test ${TEST_PATH} ..." >&2
 cd "$MOBILE_DIR"
 set +e
 PATH="$PUB_CACHE_BIN:$PATH" patrol test \
+    --device "$DEVICE" \
     --target "$TEST_PATH" \
     --dart-define=DEFAULT_ENV=LOCAL \
     --dart-define=INVITE_SERVER_URL="$INVITE_SERVER_URL" \

--- a/local_stack/profile.sh
+++ b/local_stack/profile.sh
@@ -65,6 +65,33 @@ if ! local_stack_has_running_container "$COMPOSE_FILE"; then
     exit 1
 fi
 
+# --- Ensure the patrol CLI matches the patrol package ---
+# patrol_cli enforces the pairing itself and aborts the run on a mismatch
+# (patrol_cli 4.5.0+ pairs with patrol 4.7.0+). Activating the pinned CLI before
+# log capture starts keeps install/compile time out of the profiler timeline.
+# Keep in sync with the patrol constraint in mobile/pubspec.yaml.
+PATROL_CLI_VERSION=4.6.1
+PATROL_BIN=""
+if [ -x "$PUB_CACHE_BIN/patrol" ]; then
+    PATROL_BIN="$PUB_CACHE_BIN/patrol"
+elif command -v patrol >/dev/null 2>&1; then
+    PATROL_BIN="$(command -v patrol)"
+fi
+
+PATROL_CURRENT_VERSION=""
+if [ -n "$PATROL_BIN" ]; then
+    # `patrol --version` prints an update banner before the version line. The
+    # update check can fail offline, so treat probe failure as "version unknown"
+    # and let the pinned activation below repair the install.
+    PATROL_CURRENT_VERSION="$("$PATROL_BIN" --version 2>/dev/null |
+        sed -n 's/^patrol_cli v\([0-9][0-9.]*\).*/\1/p' | tail -1)" || true
+fi
+
+if [ "$PATROL_CURRENT_VERSION" != "$PATROL_CLI_VERSION" ]; then
+    echo "Installing patrol_cli ${PATROL_CLI_VERSION} (pinned to match the patrol package)..." >&2
+    dart pub global activate patrol_cli "$PATROL_CLI_VERSION" >&2
+fi
+
 # --- Start docker log capture (background, from now only) ---
 echo "Starting docker log capture..." >&2
 docker compose -f "$COMPOSE_FILE" logs -f -t --since "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
@@ -92,31 +119,6 @@ echo "Starting logcat capture..." >&2
 adb -s "$DEVICE" logcat -c 2>/dev/null || true
 adb -s "$DEVICE" logcat -v UTC -v year flutter:I BandwidthTracker:I IndividualVideoController:I C2PAManager:D OpenVineProofMode:D '*:S' > "$LOGCAT_LOG" 2>&1 &
 LOGCAT_PID=$!
-
-# --- Ensure the patrol CLI matches the patrol package ---
-# patrol_cli enforces the pairing itself and aborts the run on a mismatch
-# (patrol_cli 4.5.0+ pairs with patrol 4.7.0+). Activating the pinned CLI up
-# front means that never lands mid-run, after the stack and emulator are up.
-# Keep in sync with the patrol constraint in mobile/pubspec.yaml.
-PATROL_CLI_VERSION=4.6.1
-PATROL_BIN=""
-if [ -x "$PUB_CACHE_BIN/patrol" ]; then
-    PATROL_BIN="$PUB_CACHE_BIN/patrol"
-elif command -v patrol >/dev/null 2>&1; then
-    PATROL_BIN="$(command -v patrol)"
-fi
-
-PATROL_CURRENT_VERSION=""
-if [ -n "$PATROL_BIN" ]; then
-    # `patrol --version` prints an update banner before the version line.
-    PATROL_CURRENT_VERSION="$("$PATROL_BIN" --version 2>/dev/null |
-        sed -n 's/^patrol_cli v\([0-9][0-9.]*\).*/\1/p' | tail -1)"
-fi
-
-if [ "$PATROL_CURRENT_VERSION" != "$PATROL_CLI_VERSION" ]; then
-    echo "Installing patrol_cli ${PATROL_CLI_VERSION} (pinned to match the patrol package)..." >&2
-    dart pub global activate patrol_cli "$PATROL_CLI_VERSION" >&2
-fi
 
 # --- Run E2E test ---
 # Disable errexit so we can capture the exit code through the pipe.

--- a/local_stack/profile.sh
+++ b/local_stack/profile.sh
@@ -91,6 +91,31 @@ adb -s "$DEVICE" logcat -c 2>/dev/null || true
 adb -s "$DEVICE" logcat -v UTC -v year flutter:I BandwidthTracker:I IndividualVideoController:I C2PAManager:D OpenVineProofMode:D '*:S' > "$LOGCAT_LOG" 2>&1 &
 LOGCAT_PID=$!
 
+# --- Ensure the patrol CLI matches the patrol package ---
+# patrol_cli enforces the pairing itself and aborts the run on a mismatch
+# (patrol_cli 4.5.0+ pairs with patrol 4.7.0+). Activating the pinned CLI up
+# front means that never lands mid-run, after the stack and emulator are up.
+# Keep in sync with the patrol constraint in mobile/pubspec.yaml.
+PATROL_CLI_VERSION=4.6.1
+PATROL_BIN=""
+if [ -x "$PUB_CACHE_BIN/patrol" ]; then
+    PATROL_BIN="$PUB_CACHE_BIN/patrol"
+elif command -v patrol >/dev/null 2>&1; then
+    PATROL_BIN="$(command -v patrol)"
+fi
+
+PATROL_CURRENT_VERSION=""
+if [ -n "$PATROL_BIN" ]; then
+    # `patrol --version` prints an update banner before the version line.
+    PATROL_CURRENT_VERSION="$("$PATROL_BIN" --version 2>/dev/null |
+        sed -n 's/^patrol_cli v\([0-9][0-9.]*\).*/\1/p' | tail -1)"
+fi
+
+if [ "$PATROL_CURRENT_VERSION" != "$PATROL_CLI_VERSION" ]; then
+    echo "Installing patrol_cli ${PATROL_CLI_VERSION} (pinned to match the patrol package)..." >&2
+    dart pub global activate patrol_cli "$PATROL_CLI_VERSION" >&2
+fi
+
 # --- Run E2E test ---
 # Disable errexit so we can capture the exit code through the pipe.
 echo "Running: patrol test ${TEST_PATH} ..." >&2

--- a/local_stack/profile.sh
+++ b/local_stack/profile.sh
@@ -80,6 +80,8 @@ if [[ -z "$DEVICE" ]]; then
 fi
 echo "Device:     ${DEVICE}" >&2
 
+# Expanded below with the "${a[@]+"${a[@]}"}" guard: macOS ships bash 3.2,
+# where a plain "${a[@]}" on an empty array trips `set -u`.
 PATROL_EXTRA_ARGS=()
 if [[ "${PATROL_NO_UNINSTALL:-}" == "true" ]]; then
     PATROL_EXTRA_ARGS+=(--no-uninstall)
@@ -125,7 +127,7 @@ PATH="$PUB_CACHE_BIN:$PATH" patrol test \
     --target "$TEST_PATH" \
     --dart-define=DEFAULT_ENV=LOCAL \
     --dart-define=INVITE_SERVER_URL="$INVITE_SERVER_URL" \
-    "${PATROL_EXTRA_ARGS[@]}" \
+    "${PATROL_EXTRA_ARGS[@]+"${PATROL_EXTRA_ARGS[@]}"}" \
     2>&1 | tee "$APP_LOG"
 TEST_EXIT="${PIPESTATUS[0]}"
 set -e

--- a/local_stack/profile.sh
+++ b/local_stack/profile.sh
@@ -17,6 +17,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MOBILE_DIR="$(cd "${SCRIPT_DIR}/../mobile" && pwd)"
 COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yml"
 MERGE_SCRIPT="${SCRIPT_DIR}/merge_logs.py"
+# Honour a relocated pub cache; $HOME/.pub-cache does not exist when
+# PUB_CACHE points elsewhere. Same resolution as mobile/mise.toml.
+PUB_CACHE_BIN="${PUB_CACHE:-$HOME/.pub-cache}/bin"
 
 # shellcheck source=android_sdk.sh
 source "${SCRIPT_DIR}/android_sdk.sh"
@@ -93,7 +96,7 @@ LOGCAT_PID=$!
 echo "Running: patrol test ${TEST_PATH} ..." >&2
 cd "$MOBILE_DIR"
 set +e
-PATH="$HOME/.pub-cache/bin:$PATH" patrol test \
+PATH="$PUB_CACHE_BIN:$PATH" patrol test \
     --target "$TEST_PATH" \
     --dart-define=DEFAULT_ENV=LOCAL \
     --dart-define=INVITE_SERVER_URL="$INVITE_SERVER_URL" \

--- a/local_stack/test_android_scripts.sh
+++ b/local_stack/test_android_scripts.sh
@@ -248,6 +248,8 @@ assert_contains 'PATROL_CLI_VERSION=4.6.1' "${SCRIPT_DIR}/profile.sh" \
   "profile runner should pin patrol_cli to the version paired with the patrol package"
 assert_contains 'PATH="$PUB_CACHE_BIN:$PATH" patrol test' "${SCRIPT_DIR}/profile.sh" \
   "profile runner should invoke patrol from the configured PUB_CACHE"
+assert_contains '--device "$DEVICE"' "${SCRIPT_DIR}/profile.sh" \
+  "profile runner should pass the detected device to patrol so it never prompts"
 assert_contains '"${PATROL_EXTRA_ARGS[@]+"${PATROL_EXTRA_ARGS[@]}"}"' "${SCRIPT_DIR}/profile.sh" \
   "profile runner should guard the optional patrol args for bash 3.2 (macOS) under set -u"
 assert_not_contains '    "${PATROL_EXTRA_ARGS[@]}" \' "${SCRIPT_DIR}/profile.sh" \

--- a/local_stack/test_android_scripts.sh
+++ b/local_stack/test_android_scripts.sh
@@ -244,6 +244,10 @@ assert_contains 'local_stack_has_running_container "$COMPOSE_FILE"' "${SCRIPT_DI
   "profile runner should reuse the shared local stack status check"
 assert_contains 'android_emulator_invite_server_url' "${SCRIPT_DIR}/profile.sh" \
   "profile runner should reuse the shared Android emulator invite-server URL"
+assert_contains 'PATROL_CLI_VERSION=4.6.1' "${SCRIPT_DIR}/profile.sh" \
+  "profile runner should pin patrol_cli to the version paired with the patrol package"
+assert_contains 'PATH="$PUB_CACHE_BIN:$PATH" patrol test' "${SCRIPT_DIR}/profile.sh" \
+  "profile runner should invoke patrol from the configured PUB_CACHE"
 
 cat > "${tmp_dir}/bin/uname" <<'STUB'
 #!/usr/bin/env bash

--- a/local_stack/test_android_scripts.sh
+++ b/local_stack/test_android_scripts.sh
@@ -248,6 +248,10 @@ assert_contains 'PATROL_CLI_VERSION=4.6.1' "${SCRIPT_DIR}/profile.sh" \
   "profile runner should pin patrol_cli to the version paired with the patrol package"
 assert_contains 'PATH="$PUB_CACHE_BIN:$PATH" patrol test' "${SCRIPT_DIR}/profile.sh" \
   "profile runner should invoke patrol from the configured PUB_CACHE"
+assert_contains '"${PATROL_EXTRA_ARGS[@]+"${PATROL_EXTRA_ARGS[@]}"}"' "${SCRIPT_DIR}/profile.sh" \
+  "profile runner should guard the optional patrol args for bash 3.2 (macOS) under set -u"
+assert_not_contains '    "${PATROL_EXTRA_ARGS[@]}" \' "${SCRIPT_DIR}/profile.sh" \
+  "profile runner should not expand the optional patrol args unguarded"
 
 cat > "${tmp_dir}/bin/uname" <<'STUB'
 #!/usr/bin/env bash

--- a/local_stack/test_android_scripts.sh
+++ b/local_stack/test_android_scripts.sh
@@ -57,6 +57,26 @@ assert_not_file_exists() {
   fi
 }
 
+assert_line_before() {
+  local first="$1"
+  local second="$2"
+  local file="$3"
+  local message="$4"
+  local first_line
+  local second_line
+
+  first_line="$(grep -nF -- "$first" "$file" | head -1 | cut -d: -f1)"
+  second_line="$(grep -nF -- "$second" "$file" | head -1 | cut -d: -f1)"
+
+  if [[ -z "$first_line" || -z "$second_line" || "$first_line" -ge "$second_line" ]]; then
+    echo "FAIL: ${message}" >&2
+    echo "  first:  ${first} (${first_line:-missing})" >&2
+    echo "  second: ${second} (${second_line:-missing})" >&2
+    echo "  file:   ${file}" >&2
+    exit 1
+  fi
+}
+
 extract_mise_task() {
   local task_name="$1"
   local file="$2"
@@ -246,6 +266,10 @@ assert_contains 'android_emulator_invite_server_url' "${SCRIPT_DIR}/profile.sh" 
   "profile runner should reuse the shared Android emulator invite-server URL"
 assert_contains 'PATROL_CLI_VERSION=4.6.1' "${SCRIPT_DIR}/profile.sh" \
   "profile runner should pin patrol_cli to the version paired with the patrol package"
+assert_contains ')" || true' "${SCRIPT_DIR}/profile.sh" \
+  "profile runner should tolerate offline patrol --version update-check failures"
+assert_line_before 'PATROL_CLI_VERSION=4.6.1' 'Starting docker log capture' "${SCRIPT_DIR}/profile.sh" \
+  "profile runner should activate patrol_cli before profiler log capture starts"
 assert_contains 'PATH="$PUB_CACHE_BIN:$PATH" patrol test' "${SCRIPT_DIR}/profile.sh" \
   "profile runner should invoke patrol from the configured PUB_CACHE"
 assert_contains '--device "$DEVICE"' "${SCRIPT_DIR}/profile.sh" \

--- a/mobile/integration_test/privacy/image_metadata_stripper_test.dart
+++ b/mobile/integration_test/privacy/image_metadata_stripper_test.dart
@@ -181,8 +181,10 @@ void main() {
       },
     );
 
+    // No "/" in the name: the AndroidX orchestrator writes a per-test output
+    // file named after the JUnit test, and a path separator makes it throw.
     patrolTest(
-      'strips metadata via separate input/output paths',
+      'strips metadata via separate input and output paths',
       ($) async {
         // Arrange
         final inputFile = File('${tempDir.path}/input.jpg');

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -556,10 +556,10 @@ packages:
     dependency: "direct main"
     description:
       name: equatable
-      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
+      sha256: "3bce007a596ff8b3119c45d68aaef631272537c03d30e5d4534dd24bf4c5eaa2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
   fake_async:
     dependency: "direct dev"
     description:
@@ -1663,26 +1663,26 @@ packages:
     dependency: "direct dev"
     description:
       name: patrol
-      sha256: c46dd59eeaca0b78419815e1d8a83a742b83a24666e21a586fc9f67c3cd08b60
+      sha256: bdeec6400d0ec22aefb875b2fd17a7bd4f25d37a40fd3bd83a74441c65f69f1e
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "4.8.0"
   patrol_finders:
     dependency: transitive
     description:
       name: patrol_finders
-      sha256: ac0bfaf3eaaa6cc3d49c8a365329cc7f4361a5f486f1adb45edc96dbfc854da9
+      sha256: "8608cdacaab90a3b00ecd7b09df11f13a62b01dea13c211b9f13fd86854e103a"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.6.0"
   patrol_log:
     dependency: transitive
     description:
       name: patrol_log
-      sha256: b3bd2862c15bd6b163763d7d2a80ae07c24af6da07d62d202798ceea327045d7
+      sha256: "1f5b6f7e1d9feaab7a60eef31e34a83a6168d754e5c0336006a4f50fb5f27526"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.10.0"
   permission_handler:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -358,7 +358,7 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   # Paired with patrol_cli 4.6.1, which patrol_cli itself enforces at run
-  # time. Keep this floor at 4.7.0+ so pub cannot resolve back into the
+  # time. Keep this floor at 4.8.0+ so pub cannot resolve back into the
   # 4.2.0-4.6.1 band that the installed CLI rejects.
   patrol: ^4.8.0
   flutter_launcher_icons: ^0.14.4

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -357,7 +357,10 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  patrol: ^4.2.0
+  # Paired with patrol_cli 4.6.1, which patrol_cli itself enforces at run
+  # time. Keep this floor at 4.7.0+ so pub cannot resolve back into the
+  # 4.2.0-4.6.1 band that the installed CLI rejects.
+  patrol: ^4.8.0
   flutter_launcher_icons: ^0.14.4
 
   very_good_analysis: ^10.2.0


### PR DESCRIPTION
## Description

`patrol` has been pinned at `^4.2.0` since it landed with the E2E harness in #1928, and the lock still resolved exactly `4.2.0`. Latest is **4.8.0**.

The pairing matters more than the version. `patrol` and `patrol_cli` ship as a matched pair and **`patrol_cli` enforces it at run time** — its `versionCompatibilityList` maps `patrol_cli 4.5.0+` to `patrol 4.7.0+`, and `patrol test` runs that check with `--check-compatibility` defaulting to on. Nothing in this repo pinned `patrol_cli`; the only invocation, `local_stack/profile.sh`, took whatever binary happened to be on `PATH`.

| `patrol_cli` | `patrol` | Result |
|---|---|---|
| **4.6.1** | **4.8.0** | ✅ compatible — this PR |
| 4.2.0 | 4.2.0 | ✅ compatible — before this PR |
| 4.6.1 | 4.2.0 | ❌ **rejected** — what a fresh machine hits today |
| 4.2.0 | 4.8.0 | ❌ rejected — half-upgrading |

Row 3 is live: anyone installing `patrol_cli` fresh right now gets 4.6.1 and cannot run this repo's E2E suite at all.

4.8.0 / 4.6.1 are the highest versions that exist for either package — nothing newer is published, including prereleases — and both clear our Dart 3.12.0 / Flutter 3.44.0.

Running the suite to verify the bump surfaced three further blockers, each of which fails *after* the Docker stack and logcat capture are already up. All are pre-existing on `main` and all are fixed here as separate commits — see **Unrequested fixes**.

**Related Issue:** Closes #6930.

Also relates to #4239, but does **not** close it — this PR touches no file under `.github/workflows/`, so that issue's three axes (patrol runner in the workflow, emulator provisioning, PR triggers) are all still open. What it does do is remove a hard prerequisite: any CI lane #4239 stands up would `dart pub global activate patrol_cli` fresh and be rejected by the version handshake on day one. The version to pin is **`patrol_cli 4.6.1`**, paired with `patrol 4.8.0`.

### Commits

| Commit | |
|---|---|
| `fix(e2e): resolve patrol from the configured PUB_CACHE` | `profile.sh` prepended a hardcoded `$HOME/.pub-cache/bin` to `PATH`, which does not exist when `PUB_CACHE` points elsewhere — a silent no-op, so the script had no control over which CLI ran. |
| `build(mobile): upgrade patrol to 4.8.0` | `mobile/pubspec.yaml` + `mobile/pubspec.lock`. |
| `build(e2e): pin patrol_cli 4.6.1 in the profile runner` | Version preflight at the single call site + guards. |
| `docs(e2e-test): record the patrol / patrol_cli version pair` | The two halves live in different files and neither pointed at the other. |
| `fix(e2e): guard the optional patrol args for macOS bash 3.2` | *Unrequested* |
| `fix(e2e): pass the detected device to patrol` | *Unrequested* |
| `fix(e2e): drop the path separator from a patrol test name` | *Unrequested* |

### Why a constraint edit rather than a lock-only bump

`dart pub upgrade patrol` **cannot reach 4.8.0** — it caps at 4.6.1, because 4.7.0+ requires `equatable ^2.1.0` and `upgrade <pkg>` will not unlock `equatable`. Raising the floor to `^4.8.0` also forbids pub from resolving *backwards* into the 4.2.0–4.6.1 band the installed CLI rejects; that mismatch surfaces only as a run-time handshake failure, never as a compile error.

Resulting `pubspec.lock` delta is 4 packages / 8 lines:

| Package | Before | After |
|---|---|---|
| `patrol` | 4.2.0 | 4.8.0 |
| `patrol_finders` | 3.1.0 | 3.6.0 |
| `patrol_log` | 0.7.1 | 0.10.0 |
| `equatable` | 2.0.8 | 2.1.0 |

**On `equatable`:** it rides along as patrol's requirement, and the 2.0.8→2.1.0 diff is behaviour-neutral — `==`, `hashCode`, `toString`, `mapEquals`, `iterableEquals`, `setEquals` and `EquatableConfig` are behaviorally unchanged. 2.1.0 only turns `Equatable` into an `abstract mixin class` and deprecates `EquatableMixin`, which this repo never uses (0 occurrences under `mobile/`). All 23 workspace constraints are `^2.0.x` and already admit it, so no package pubspec changes.

### API surface

**Only one `.dart` file changes here, and only a test name string.** The repo's entire patrol surface is `patrolTest` (77×), `PatrolIntegrationTester` (8×), `PatrolBinding` (1×), `$.tester`, and five `$.platformAutomator` methods (`mobile.isPermissionDialogVisible`, `mobile.grantPermissionWhenInUse`, `mobile.denyPermission`, `mobile.pressHome`, `mobile.openApp`) plus `$.platformAutomator.tap(Selector(...))`. All exist unchanged in 4.8.0. The `patrol_finders` `$('text')` API is never used here, so the 3.4.0 visibility-wait and 3.5.0 `enterText` rewrite don't reach this repo.

## Unrequested fixes

All three are pre-existing on `main`, all block the E2E path, and none is cosmetic. Flagging them separately since none is part of the version bump.

**1. `PATROL_EXTRA_ARGS` unbound under macOS bash 3.2.** `profile.sh` runs `set -euo pipefail`, and macOS ships only bash 3.2, where expanding an empty array as `"${a[@]}"` trips `set -u`. The array is empty unless `PATROL_NO_UNINSTALL=true`, so every default `mise run e2e_test` on macOS died with `PATROL_EXTRA_ARGS[@]: unbound variable`. Reproduced against `origin/main`'s copy. Fixed with `"${a[@]+"${a[@]}"}"` (0 words when empty, elements preserved otherwise — verified on bash 3.2.57).

**2. The detected device was never passed to patrol.** `profile.sh` reads the device from `adb`, prints it, then omits it from the `patrol test` invocation. With more than one target attached — an iOS simulator, macOS and Chrome all count — patrol prompts for a selection and, under a non-interactive runner, loops on invalid input until killed.

**3. A `/` in a patrol test name crashes the AndroidX orchestrator.** patrol names each JUnit case `MainActivityTest#runDartTest[<dart test name>]`, and the orchestrator writes a per-test output file named after it. `ContextImpl.makeFilename` rejects filenames containing a path separator, so `'strips metadata via separate input/output paths'` produced:

```
FATAL EXCEPTION: AndroidTestOrchestrator
java.lang.IllegalArgumentException: File …input/output paths].txt contains a path separator
    at androidx.test.orchestrator.AndroidTestOrchestrator.getOutputStream
```

Gradle reported `Instrumentation run failed due to Process crashed` and exited 1. **The dangerous part is that it looked green:** the crash happened while starting the third test, so it was never counted — patrol printed `Total: 2 / Successful: 2 / Failed: 0` and the JUnit XML agreed (`tests="2" failures="0"`) for a file containing three tests. Renaming is the minimal fix; disabling `ANDROIDX_TEST_ORCHESTRATOR` would also stop the crash but would cost the per-test isolation and `clearPackageData` the app module deliberately configures. The rule is now documented in `.claude/skills/e2e-test/SKILL.md`.

One latent instance remains at `perf/dm_remote_signer_backfill_frame_test.dart:163` (`build/raster`), in the plain-`integration_test` group that patrol does not run today — left alone rather than speculatively renamed.

Fixes 1 and 2 ship with `assert_contains` guards in `local_stack/test_android_scripts.sh`, each **mutation-checked**: reverting the fix turns its own assertion red, restoring it turns it green.

## Out of Scope

- **iOS patrol integration.** Nothing to verify: `origin/main` has no `RunnerUITests` target, and patrol is a `dev_dependency`, so `pod install` installs **43 pods and zero patrol** — no `Pods/patrol/`, no `Podfile.lock` entry. patrol's iOS code is not compiled into any build produced from `main`, so patrol 4.7.0's darwin source restructure cannot affect iOS here and this PR cannot regress it. Once a UI-test target lands, the follow-up is whether 4.8.0 lets it drop the `inherit! :complete` / `ENABLE_TESTING_SEARCH_PATHS` workarounds.
- **The `ProviderScope` bug in `camera_permission_denied_test.dart`** — see below. Repairing it needs a `ProviderScope` with overrides for `clipManagerProvider` / `videoEditorProvider` / `sharedPreferencesProvider`; unrelated to a version bump.
- **Fixing `mobile_service_integration_tests.yaml`** — that is #4239.
- **Enabling Swift Package Manager** — a ~50-plugin migration. CocoaPods remains supported by patrol 4.8.0.

## Verification

Run from `mobile/` unless noted. The device rungs are local-only; CI runs none of them.

| Check | What it proves | Result |
|---|---|---|
| `dart pub upgrade --dry-run patrol` | resolution exists; showed the 4.6.1 cap | ✅ |
| `flutter analyze lib test integration_test` | all 31 patrol-importing files resolve against 4.8.0's API; no ambiguous imports from the new `Notification` / `Rectangle` / `Point2D` exports | ✅ `No issues found!` |
| `flutter analyze integration_test` on the **regenerated** `test_bundle.dart` | the internal coupling — the bundle imports `package:patrol/src/platform/contracts/contracts.dart` and calls `PatrolBinding.ensureInitialized`, `platformAutomator.initialize`, `markPatrolAppServiceReady` | ✅ `No issues found!` |
| `patrol build android --debug` | patrol 4.8.0's new Ktor 3.2.2 / http4k 5.47 graph dexes onto the androidTest classpath; its Kotlin 2.1.0 buildscript assembles under AGP 8.11.1 / KGP 2.2.20 / `android.builtInKotlin=false`. Runs `--check-compatibility`, so this is the **empirical** proof that CLI 4.6.1 ↔ patrol 4.8.0 pair. | ✅ both APKs built, 0 duplicate-class errors |
| `local_stack/test_stack_scripts.sh` + `test_android_scripts.sh` | the new guards | ✅ |
| **Emulator E2E** — `privacy/image_metadata_stripper_test.dart` via `profile.sh` | full round trip: bundle generation, `PatrolJUnitRunner` + orchestrator enumeration, on-device execution, per-test reporting | ✅ **`Total: 3, Successful: 3, Failed: 0`**, JUnit XML `tests="3" failures="0" errors="0"`, `✓ Completed executing`, 0 orchestrator crashes |
| Emulator E2E — `video_recorder/camera_permission_denied_test.dart` | native automation specifically — `isPermissionDialogVisible` / `denyPermission` | ✅ native step executed; test then fails on a **pre-existing** app bug, below |
| `pod install` (`mobile/ios`) | patrol contributes no iOS pod on `main` | ✅ 43 pods, 0 patrol |

### A pre-existing broken test found on the way (not fixed here)

`integration_test/video_recorder/camera_permission_denied_test.dart` fails with `Bad state: No ProviderScope found`. It pumps `MaterialApp(home: BlocProvider(… VideoRecorderScreen))`, but `VideoRecorderScreen`'s `_VideoRecorderBlocScope` is a `ConsumerWidget` calling `ref.watch(clipManagerProvider.notifier)` — Riverpod needs a `ProviderScope` ancestor the test never provides.

**Proven pre-existing** by running the same test on `origin/main` at patrol 4.2.0 with patrol_cli 4.2.0 in a throwaway worktree:

| | `Total` | `Successful` | `Failed` | Outcome |
|---|---|---|---|---|
| `origin/main` — patrol 4.2.0 / CLI 4.2.0 | 1 | 0 | 0 | same `StateError: No ProviderScope found` |
| this branch — patrol 4.8.0 / CLI 4.6.1 | 1 | 0 | 1 | same `StateError: No ProviderScope found` |

Note the reporting difference: 4.2.0 lost the attribution entirely (`Failed: 0` despite exiting 1), while 4.8.0 reports `Failed: 1` and names the test — an improvement from the upgrade.

### What CI proves here: nothing native

No workflow runs `flutter build apk`, `xcodebuild`, `gradlew`, or patrol. The only CI signal this PR gets is `flutter analyze lib test integration_test` (`mobile_ci.yaml:321`). Green checks say nothing about the device rungs above — those were run locally and are reported here.

### Two things to know before pulling

- **`dart pub global activate patrol_cli 4.6.1` is machine-global** and git cannot roll it back. `profile.sh` now does it automatically on the next `mise run e2e_test`. Any other worktree still on `patrol 4.2.0` will then fail the compatibility check until it rebases onto this — loudly, with the exact remediation command.
- **The lock change re-arms one `build_runner` pass** for everyone on first pull: `docs/BUILD_SPEED_CHECKLIST.md:21-38` short-circuits codegen on a `pubspec.lock` hash.

## Type of Change

- [x] ✅ Build configuration change
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation

