### PR TITLE
fix(support): preserve text edits on imported vines

### DIFF
--- a/mobile/lib/models/video_editor/caption_style.dart
+++ b/mobile/lib/models/video_editor/caption_style.dart
@@ -143,13 +143,8 @@ class CaptionStyle {
   static const double _bottomOffsetFactor = 0.32;
 
   /// Builds the burned-in editor layer for [cue].
-  ///
-  /// [fittedBoxScale] and [bodySize] are the canvas metrics the editor screen
-  /// exposes, used to place the cue bottom-center in render coordinates (the
-  /// same conversion the sticker flow applies).
   TextLayer buildLayer(
     CaptionCue cue, {
-    required double fittedBoxScale,
     required Size bodySize,
   }) {
     return TextLayer(
@@ -160,7 +155,7 @@ class CaptionStyle {
       background: background,
       align: TextAlign.center,
       fontScale: fontScale,
-      offset: Offset(0, bodySize.height * _bottomOffsetFactor / fittedBoxScale),
+      offset: Offset(0, bodySize.shortestSide * _bottomOffsetFactor),
       startTime: cue.start,
       endTime: cue.end,
       animations: [...enter, ...leave].toLayerAnimations(),

--- a/mobile/lib/models/video_editor/caption_style_preset.dart
+++ b/mobile/lib/models/video_editor/caption_style_preset.dart
@@ -68,13 +68,8 @@ class CaptionStylePreset {
   /// Builds the burned-in editor layer for [cue].
   TextLayer buildLayer(
     CaptionCue cue, {
-    required double fittedBoxScale,
     required Size bodySize,
-  }) => style.buildLayer(
-    cue,
-    fittedBoxScale: fittedBoxScale,
-    bodySize: bodySize,
-  );
+  }) => style.buildLayer(cue, bodySize: bodySize);
 
   /// Resolves [id] to its preset, falling back to the first preset so an
   /// unknown id from an old draft still renders.

--- a/mobile/lib/models/video_editor/video_editor_provider_state.dart
+++ b/mobile/lib/models/video_editor/video_editor_provider_state.dart
@@ -303,8 +303,7 @@ class VideoEditorProviderState {
           ? null
           : (finalRenderedClip ?? this.finalRenderedClip),
       editorStateHistory: editorStateHistory ?? this.editorStateHistory,
-      editorEditingParameters:
-          clearEditorEditingParameters || clearFinalRenderedClip
+      editorEditingParameters: clearEditorEditingParameters
           ? null
           : editorEditingParameters ?? this.editorEditingParameters,
       collaboratorPubkeys: collaboratorPubkeys ?? this.collaboratorPubkeys,

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -650,7 +650,6 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
             track.customStyle?.resolve() ??
             CaptionStylePreset.byId(track.presetId).style;
         final bodySize = _bodySizeNotifier.value;
-        final scale = _fittedBoxScale;
         // Preserve any on-canvas position/rotation/scale the user already
         // applied to a cue's layer, keyed by cue id, so re-editing captions
         // doesn't reset their manual adjustments.
@@ -665,7 +664,6 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
               preserveCaptionLayerTransform(
                 style.buildLayer(
                   cue,
-                  fittedBoxScale: scale,
                   bodySize: bodySize,
                 ),
                 existingByCueId[cue.id],

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -135,9 +135,13 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
   DivineVideoClip? get _clip => ref.read(clipManagerProvider).firstClipOrNull;
 
   /// FittedBox scale factor between bodySize and renderSize.
+  ///
+  /// Must pass the same arguments as [VideoEditorScope.fittedBoxScale] —
+  /// layers sized here are painted by the canvas at that scale.
   double get _fittedBoxScale => VideoEditorScope.calculateFittedBoxScale(
     _bodySizeNotifier.value,
     _clip?.originalAspectRatio ?? 9 / 16,
+    targetAspectRatio: _clip?.targetAspectRatio.value,
   );
 
   @override

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -986,6 +986,7 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
               editorKey: _editorKey,
               removeAreaKey: _removeAreaKey,
               originalClipAspectRatio: clip?.originalAspectRatio ?? 9 / 16,
+              targetClipAspectRatio: clip?.targetAspectRatio.value,
               bodySizeNotifier: _bodySizeNotifier,
               zoomMatrixNotifier: _zoomMatrixNotifier,
               playTimeNotifier: _playTimeNotifier,

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -2887,22 +2887,10 @@ class _CanvasFitter extends ConsumerWidget {
         // Notify parent about body size
         scope.bodySizeNotifier.value = bodySize;
 
-        // Contain mode: fit targetAspectRatio within bodySize,
-        // then cover that area with the original aspect ratio
-        final Size targetSize;
-        if (bodySize.aspectRatio > clip.targetAspectRatio.value) {
-          // Body is wider, height is limiting
-          targetSize = Size(
-            bodySize.height * clip.targetAspectRatio.value,
-            bodySize.height,
-          );
-        } else {
-          // Body is narrower, width is limiting
-          targetSize = Size(
-            bodySize.width,
-            bodySize.width / clip.targetAspectRatio.value,
-          );
-        }
+        final targetSize = VideoEditorScope.calculateTargetSize(
+          bodySize,
+          clip.targetAspectRatio.value,
+        );
 
         // The visual chain below (Center > SizedBox > FittedBox >
         // SizedBox > Navigator) owns the aspect-ratio mapping: cover-fit

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_scope.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_scope.dart
@@ -110,6 +110,15 @@ class VideoEditorScope extends InheritedWidget {
     targetAspectRatio: targetClipAspectRatio,
   );
 
+  /// Calculates the visible target area fitted inside [bodySize].
+  static Size calculateTargetSize(Size bodySize, double targetAspectRatio) {
+    if (bodySize == Size.zero) return Size.zero;
+    if (bodySize.aspectRatio > targetAspectRatio) {
+      return Size(bodySize.height * targetAspectRatio, bodySize.height);
+    }
+    return Size(bodySize.width, bodySize.width / targetAspectRatio);
+  }
+
   /// Calculates the FittedBox scale factor for a given body size and aspect ratio.
   static double calculateFittedBoxScale(
     Size bodySize,
@@ -120,13 +129,7 @@ class VideoEditorScope extends InheritedWidget {
     final targetRatio = targetAspectRatio ?? aspectRatio;
     final height = bodySize.shortestSide;
     final renderSize = Size(height * aspectRatio, height);
-
-    final Size targetSize;
-    if (bodySize.aspectRatio > targetRatio) {
-      targetSize = Size(bodySize.height * targetRatio, bodySize.height);
-    } else {
-      targetSize = Size(bodySize.width, bodySize.width / targetRatio);
-    }
+    final targetSize = calculateTargetSize(bodySize, targetRatio);
 
     return max(
       targetSize.width / renderSize.width,
@@ -193,5 +196,7 @@ class VideoEditorScope extends InheritedWidget {
   bool updateShouldNotify(VideoEditorScope oldWidget) =>
       editorKey != oldWidget.editorKey ||
       removeAreaKey != oldWidget.removeAreaKey ||
+      originalClipAspectRatio != oldWidget.originalClipAspectRatio ||
+      targetClipAspectRatio != oldWidget.targetClipAspectRatio ||
       zoomMatrixNotifier != oldWidget.zoomMatrixNotifier;
 }

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_scope.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_scope.dart
@@ -32,6 +32,7 @@ class VideoEditorScope extends InheritedWidget {
     required this.zoomMatrixNotifier,
     required this.playTimeNotifier,
     required this.fromLibrary,
+    this.targetClipAspectRatio,
     this.editorOverride,
     this.awaitPushCoverTransition,
     super.child = const SizedBox.shrink(),
@@ -71,6 +72,9 @@ class VideoEditorScope extends InheritedWidget {
   /// Original aspect ratio of the clip being edited.
   final double originalClipAspectRatio;
 
+  /// Target crop aspect ratio of the clip being edited.
+  final double? targetClipAspectRatio;
+
   /// Whether the clip was selected from the device library.
   final bool fromLibrary;
 
@@ -100,17 +104,33 @@ class VideoEditorScope extends InheritedWidget {
   final Future<void> Function()? awaitPushCoverTransition;
 
   /// FittedBox scale factor between bodySize and renderSize.
-  double get fittedBoxScale =>
-      calculateFittedBoxScale(bodySizeNotifier.value, originalClipAspectRatio);
+  double get fittedBoxScale => calculateFittedBoxScale(
+    bodySizeNotifier.value,
+    originalClipAspectRatio,
+    targetAspectRatio: targetClipAspectRatio,
+  );
 
   /// Calculates the FittedBox scale factor for a given body size and aspect ratio.
-  static double calculateFittedBoxScale(Size bodySize, double aspectRatio) {
+  static double calculateFittedBoxScale(
+    Size bodySize,
+    double aspectRatio, {
+    double? targetAspectRatio,
+  }) {
     if (bodySize == Size.zero) return 1.0;
+    final targetRatio = targetAspectRatio ?? aspectRatio;
     final height = bodySize.shortestSide;
     final renderSize = Size(height * aspectRatio, height);
+
+    final Size targetSize;
+    if (bodySize.aspectRatio > targetRatio) {
+      targetSize = Size(bodySize.height * targetRatio, bodySize.height);
+    } else {
+      targetSize = Size(bodySize.width, bodySize.width / targetRatio);
+    }
+
     return max(
-      bodySize.width / renderSize.width,
-      bodySize.height / renderSize.height,
+      targetSize.width / renderSize.width,
+      targetSize.height / renderSize.height,
     );
   }
 

--- a/mobile/test/models/video_editor/caption_style_preset_test.dart
+++ b/mobile/test/models/video_editor/caption_style_preset_test.dart
@@ -102,7 +102,6 @@ void main() {
     test('buildLayer marks the layer as a caption cue with its id', () {
       final layer = classic.buildLayer(
         cue,
-        fittedBoxScale: 2,
         bodySize: const Size(400, 800),
       );
 
@@ -116,7 +115,6 @@ void main() {
     test('buildLayer carries the cue timing and text', () {
       final layer = classic.buildLayer(
         cue,
-        fittedBoxScale: 1,
         bodySize: const Size(400, 800),
       );
 
@@ -127,24 +125,34 @@ void main() {
     });
 
     test(
-      'buildLayer positions the cue below canvas center, scale-adjusted',
+      'buildLayer positions square captions against render height',
       () {
         final layer = classic.buildLayer(
           cue,
-          fittedBoxScale: 2,
+          bodySize: const Size(411, 800),
+        );
+
+        expect(layer.offset.dx, equals(0));
+        expect(layer.offset.dy, closeTo(411 * 0.32, 0.001));
+      },
+    );
+
+    test(
+      'buildLayer positions vertical captions against render height',
+      () {
+        final layer = classic.buildLayer(
+          cue,
           bodySize: const Size(400, 800),
         );
 
         expect(layer.offset.dx, equals(0));
-        // 800 * 0.32 / 2 — below center in render coordinates.
-        expect(layer.offset.dy, closeTo(128, 0.001));
+        expect(layer.offset.dy, closeTo(400 * 0.32, 0.001));
       },
     );
 
     test('buildLayer applies the preset font, colors, and animations', () {
       final layer = classic.buildLayer(
         cue,
-        fittedBoxScale: 1,
         bodySize: const Size(400, 800),
       );
 

--- a/mobile/test/models/video_editor/caption_style_test.dart
+++ b/mobile/test/models/video_editor/caption_style_test.dart
@@ -142,7 +142,6 @@ void main() {
     test('buildLayer marks the caption cue layer with its id and timing', () {
       final layer = style.buildLayer(
         cue,
-        fittedBoxScale: 1,
         bodySize: const Size(200, 400),
       );
 

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -970,6 +970,34 @@ void main() {
           expect(cleared.c2paSigningFailed, isFalse);
         },
       );
+
+      test('keeps editorEditingParameters when the clip is cleared', () {
+        final params = CompleteParameters.fromMap(
+          <String, dynamic>{},
+        ).copyWith(blur: 0.25);
+        final state = VideoEditorProviderState(
+          finalRenderedClip: DivineVideoClip(
+            id: 'rendered',
+            video: EditorVideo.file('/docs/rendered.mp4'),
+            duration: const Duration(seconds: 3),
+            recordedAt: DateTime.now(),
+            targetAspectRatio: .vertical,
+            originalAspectRatio: 9 / 16,
+          ),
+          editorEditingParameters: params,
+        );
+
+        final cleared = state.copyWith(clearFinalRenderedClip: true);
+
+        expect(cleared.finalRenderedClip, isNull);
+        expect(
+          cleared.editorEditingParameters,
+          same(params),
+          reason:
+              'restoring a draft with a missing cached render must keep the '
+              'editing parameters needed to re-render overlays at publish time',
+        );
+      });
     });
 
     group('acknowledgeC2paSigningFailure (#6058)', () {

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_scope_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_scope_test.dart
@@ -50,6 +50,16 @@ void main() {
       expect(scale, closeTo(16 / 9, 0.001));
     });
 
+    test('calculateFittedBoxScale covers target area on wide body', () {
+      final scale = VideoEditorScope.calculateFittedBoxScale(
+        const Size(800, 400),
+        1,
+        targetAspectRatio: 9 / 16,
+      );
+
+      expect(scale, closeTo(1, 0.001));
+    });
+
     test('calculateFittedBoxScale uses target aspect ratio separately', () {
       final scale = VideoEditorScope.calculateFittedBoxScale(
         const Size(400, 800),
@@ -57,7 +67,19 @@ void main() {
         targetAspectRatio: 9 / 16,
       );
 
-      expect(scale, closeTo(400 / (400 * 9 / 16), 0.001));
+      // A square render covers a vertical target, so the height ratio wins.
+      expect(scale, closeTo(16 / 9, 0.001));
+    });
+
+    test('calculateTargetSize contains target ratio inside the body', () {
+      expect(
+        VideoEditorScope.calculateTargetSize(const Size(400, 800), 9 / 16),
+        equals(const Size(400, 400 / (9 / 16))),
+      );
+      expect(
+        VideoEditorScope.calculateTargetSize(const Size(800, 400), 9 / 16),
+        equals(const Size(400 * 9 / 16, 400)),
+      );
     });
 
     testWidgets('of returns nearest scope from context', (tester) async {

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_scope_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_scope_test.dart
@@ -30,6 +30,36 @@ void main() {
       expect(scale, greaterThan(0));
     });
 
+    test('calculateFittedBoxScale matches square canvas on portrait body', () {
+      final scale = VideoEditorScope.calculateFittedBoxScale(
+        const Size(400, 800),
+        1,
+        targetAspectRatio: 1,
+      );
+
+      expect(scale, equals(1));
+    });
+
+    test('calculateFittedBoxScale covers contained vertical target area', () {
+      final scale = VideoEditorScope.calculateFittedBoxScale(
+        const Size(400, 800),
+        9 / 16,
+        targetAspectRatio: 9 / 16,
+      );
+
+      expect(scale, closeTo(16 / 9, 0.001));
+    });
+
+    test('calculateFittedBoxScale uses target aspect ratio separately', () {
+      final scale = VideoEditorScope.calculateFittedBoxScale(
+        const Size(400, 800),
+        1,
+        targetAspectRatio: 9 / 16,
+      );
+
+      expect(scale, closeTo(400 / (400 * 9 / 16), 0.001));
+    });
+
     testWidgets('of returns nearest scope from context', (tester) async {
       final editorKey = GlobalKey<ProImageEditorState>();
       final removeAreaKey = GlobalKey();


### PR DESCRIPTION
## Summary
- preserve editor editing parameters when a missing cached render is cleared so restored drafts can re-render overlays
- pass the clip target aspect ratio into VideoEditorScope and match the canvas contain-then-cover scale calculation
- add regression coverage for square imported-vine text scale and render invalidation preserving edit parameters

Closes #6906

## Verification
- flutter test test/widgets/video_editor/main_editor/video_editor_scope_test.dart
- flutter test test/providers/video_editor_provider_test.dart
- flutter test test/providers/video_publish_provider_test.dart
- flutter analyze
- pre-push hook: analyzer + changed-file tests