### PR TITLE
fix(support): preserve portrait clip imports

### DIFF
--- a/mobile/lib/services/video_clip_import_service.dart
+++ b/mobile/lib/services/video_clip_import_service.dart
@@ -318,16 +318,10 @@ class VideoClipImportService {
       final metadata = await _readVideoMetadata(
         EditorVideo.file(copiedVideo.path),
       );
-      var width = metadata.resolution.width;
-      var height = metadata.resolution.height;
+      final width = metadata.resolution.width;
+      final height = metadata.resolution.height;
       if (width <= 0 || height <= 0) return null;
-      // Swap dimensions for portrait-rotated captures so the ratio reflects
-      // the displayed orientation rather than the raw frame.
-      if (metadata.rotation == 90 || metadata.rotation == 270) {
-        final swap = width;
-        width = height;
-        height = swap;
-      }
+      // ProVideoEditor reports display dimensions with rotation applied.
       return width / height;
     } catch (e) {
       Log.warning(

--- a/mobile/packages/models/lib/src/imeta_tag.dart
+++ b/mobile/packages/models/lib/src/imeta_tag.dart
@@ -1,0 +1,36 @@
+// ABOUTME: Shared parser for NIP-71 imeta tag key-value encodings.
+
+/// Parses an `imeta` tag and calls [onKeyValue] for each metadata key-value
+/// pair.
+///
+/// Supports both encodings seen in Divine events:
+/// - `['imeta', 'url https://...', 'm video/mp4']`
+/// - `['imeta', 'url', 'https://...', 'm', 'video/mp4']`
+void parseImetaTag(
+  List<String> tag,
+  void Function(String key, String value) onKeyValue,
+) {
+  if (tag.length <= 1) return;
+
+  final firstElement = tag[1];
+  final hasSpaceSeparatedValues = firstElement.contains(' ');
+
+  if (hasSpaceSeparatedValues) {
+    for (var i = 1; i < tag.length; i++) {
+      final element = tag[i];
+      final spaceIndex = element.indexOf(' ');
+      if (spaceIndex > 0) {
+        final key = element.substring(0, spaceIndex);
+        final value = element.substring(spaceIndex + 1);
+        onKeyValue(key, value);
+      }
+    }
+    return;
+  }
+
+  for (var i = 1; i < tag.length - 1; i += 2) {
+    final key = tag[i];
+    final value = tag[i + 1];
+    onKeyValue(key, value);
+  }
+}

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -6,6 +6,7 @@
 import 'dart:convert';
 
 import 'package:meta/meta.dart';
+import 'package:models/src/imeta_tag.dart';
 import 'package:models/src/nip71_video_kinds.dart';
 import 'package:models/src/video_attribution.dart';
 import 'package:models/src/video_url_resolver.dart';
@@ -393,7 +394,7 @@ class VideoEvent {
           // Parse imeta tag which contains comma-separated metadata
           // Ensure we have a List<String> for the parser
           final iMetaTag = List<String>.from(tag);
-          _parseImetaTag(iMetaTag, (key, value) {
+          parseImetaTag(iMetaTag, (key, value) {
             switch (key) {
               case 'url':
                 // Check if this is a valid video URL and add to candidates
@@ -1411,45 +1412,6 @@ class VideoEvent {
 
   static const int _vineShutdownAtUtcSeconds = 1484611200;
 
-  /// Parse imeta tag which contains space-separated key-value pairs
-  /// NIP-71 format: ["imeta", "key1 value1", "key2 value2", ...]
-  static void _parseImetaTag(
-    List<String> tag,
-    void Function(String key, String value) onKeyValue,
-  ) {
-    // Skip the first element which is "imeta"
-    // Support TWO formats:
-    // 1. OLD: ["imeta", "url https://...", "m video/mp4", ...]  (space-separated key-value)
-    // 2. NEW: ["imeta", "url", "https://...", "m", "video/mp4", ...] (positional key-value pairs)
-
-    // Detect format by checking if tag[1] contains a space
-    if (tag.length > 1) {
-      final firstElement = tag[1];
-      final hasSpace = firstElement.contains(' ');
-
-      if (hasSpace) {
-        // OLD FORMAT: space-separated key-value within each element
-        for (var i = 1; i < tag.length; i++) {
-          final element = tag[i];
-          final spaceIndex = element.indexOf(' ');
-          if (spaceIndex > 0) {
-            final key = element.substring(0, spaceIndex);
-            final value = element.substring(spaceIndex + 1);
-            onKeyValue(key, value);
-          }
-        }
-      } else {
-        // NEW FORMAT: positional key-value pairs (tag[i] is key, tag[i+1]
-        // is value)
-        for (var i = 1; i < tag.length - 1; i += 2) {
-          final key = tag[i];
-          final value = tag[i + 1];
-          onKeyValue(key, value);
-        }
-      }
-    }
-  }
-
   /// Whether [key] names a video URL inside an `imeta` tag.
   ///
   /// Mirrors the `url`-plus-POSTEL'S-LAW-alternates set that
@@ -1477,7 +1439,7 @@ class VideoEvent {
     final urls = <String>[];
     for (final tag in nostrEventTags) {
       if (tag.isEmpty || tag.first != 'imeta') continue;
-      _parseImetaTag(tag, (key, value) {
+      parseImetaTag(tag, (key, value) {
         final url = value.trim();
         if (_isImetaVideoUrlKey(key) && VideoUrlResolver.isValidVideoUrl(url)) {
           urls.add(url);

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -4,6 +4,7 @@
 
 import 'package:meta/meta.dart';
 import 'package:models/src/engagement_count_parser.dart';
+import 'package:models/src/imeta_tag.dart';
 import 'package:models/src/video_event.dart';
 
 /// Video with engagement metrics from Funnelcake API.
@@ -244,28 +245,19 @@ class VideoStats {
             blurhashFromTag = tagValue;
           }
           if (tagName == 'imeta') {
-            // Extract blurhash from imeta. Two formats are seen in the wild:
-            //   - space-separated: ['imeta', 'blurhash <hash>', ...]
-            //   - positional:      ['imeta', 'blurhash', '<hash>', ...]
-            for (var i = 1; i < tag.length; i++) {
-              final element = tag[i].toString();
-              final spaceIndex = element.indexOf(' ');
-              String? key;
-              String? value;
-              if (spaceIndex > 0) {
-                key = element.substring(0, spaceIndex);
-                value = element.substring(spaceIndex + 1);
-              } else if (element == 'blurhash' && i + 1 < tag.length) {
-                key = element;
-                value = tag[i + 1].toString();
-              }
+            parseImetaTag(List<String>.from(tag.map((e) => e.toString())), (
+              key,
+              value,
+            ) {
               if (key == 'blurhash' &&
                   blurhashFromTag == null &&
-                  value != null &&
                   value.isNotEmpty) {
                 blurhashFromTag = value;
               }
-            }
+              if (key == 'dim' && dimensions == null && value.isNotEmpty) {
+                dimensions = value;
+              }
+            });
           }
           if (tagName == 'dim' && dimensions == null) {
             dimensions = tagValue;

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -947,6 +947,18 @@ void main() {
         expect(stats.blurhash, equals('LEHV6nWB2yk8pyo0adR*.7kCMdnj'));
       });
 
+      test('extracts dimensions from space-separated imeta format', () {
+        final stats = VideoStats.fromJson(
+          jsonWithImetaTag([
+            'imeta',
+            'url https://example.com/video.mp4',
+            'dim 1080x1920',
+          ]),
+        );
+
+        expect(stats.dimensions, equals('1080x1920'));
+      });
+
       test('extracts blurhash from positional imeta format', () {
         final stats = VideoStats.fromJson(
           jsonWithImetaTag([
@@ -959,6 +971,20 @@ void main() {
         );
 
         expect(stats.blurhash, equals('LEHV6nWB2yk8pyo0adR*.7kCMdnj'));
+      });
+
+      test('extracts dimensions from positional imeta format', () {
+        final stats = VideoStats.fromJson(
+          jsonWithImetaTag([
+            'imeta',
+            'url',
+            'https://example.com/video.mp4',
+            'dim',
+            '720x1280',
+          ]),
+        );
+
+        expect(stats.dimensions, equals('720x1280'));
       });
 
       test('ignores empty blurhash value in imeta', () {

--- a/mobile/test/services/video_clip_import_service_test.dart
+++ b/mobile/test/services/video_clip_import_service_test.dart
@@ -7,6 +7,7 @@ import 'dart:ui';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' as models;
+import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/services/clip_library_service.dart';
 import 'package:openvine/services/video_clip_import_service.dart';
@@ -364,14 +365,14 @@ First useful caption
   });
 
   test(
-    'swaps width and height when metadata reports a 90 degree rotation',
+    'uses display dimensions when metadata reports a rotated portrait video',
     () async {
       final service = buildService(
         readVideoMetadata: (video) async => VideoMetadata(
           duration: const Duration(seconds: 6),
           extension: 'mp4',
           fileSize: 1024,
-          resolution: const Size(1920, 1080),
+          resolution: const Size(1080, 1920),
           rotation: 90,
           bitrate: 1000,
         ),
@@ -391,6 +392,67 @@ First useful caption
       expect(success.clip.originalAspectRatio, closeTo(1080 / 1920, 0.001));
     },
   );
+
+  test('keeps a rotated landscape display as square', () async {
+    final service = buildService(
+      readVideoMetadata: (video) async => VideoMetadata(
+        duration: const Duration(seconds: 6),
+        extension: 'mp4',
+        fileSize: 1024,
+        resolution: const Size(1920, 1080),
+        rotation: 90,
+        bitrate: 1000,
+      ),
+    );
+
+    final result = await service.importToLibrary(
+      _video(
+        id: 'own-rotated-landscape',
+        rawTags: const {'platform': 'divine'},
+        vineId: null,
+        dimensions: null,
+      ),
+    );
+
+    final success = result as VideoClipImportSuccess;
+    expect(success.clip.targetAspectRatio, models.AspectRatio.square);
+    expect(success.clip.originalAspectRatio, closeTo(1920 / 1080, 0.001));
+  });
+
+  test('uses imeta dimensions before probing file metadata', () async {
+    var metadataRead = false;
+    final service = buildService(
+      readVideoMetadata: (video) async {
+        metadataRead = true;
+        throw StateError('metadata should not be read');
+      },
+    );
+
+    final event = Event(
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      34236,
+      [
+        ['url', 'https://cdn.example.com/own-imeta-dim.mp4'],
+        ['platform', 'divine'],
+        [
+          'imeta',
+          'url https://cdn.example.com/own-imeta-dim.mp4',
+          'dim 1080x1920',
+        ],
+      ],
+      'Divine portrait post',
+      createdAt: 1786231401,
+    );
+
+    final result = await service.importToLibrary(
+      models.VideoEvent.fromNostrEvent(event),
+    );
+
+    final success = result as VideoClipImportSuccess;
+    expect(metadataRead, isFalse);
+    expect(success.clip.targetAspectRatio, models.AspectRatio.vertical);
+    expect(success.clip.originalAspectRatio, closeTo(1080 / 1920, 0.001));
+  });
 
   test(
     'falls back to vertical target ratio when metadata probe throws',


### PR DESCRIPTION
## Summary

- remove the extra rotation swap when probing clip import metadata, since ProVideoEditor already reports display dimensions
- parse `dim` from `imeta` in REST-backed `VideoStats` using the same parser as `VideoEvent`
- add regressions for imeta-only portrait imports and rotated display-dimension metadata

Closes #6905

## Verification

- `flutter test test/services/video_clip_import_service_test.dart`
- `flutter test test/src/video_stats_test.dart test/src/video_event_parsing_test.dart` from `mobile/packages/models`
- `flutter analyze`
- pre-push hook analyzer + changed-file tests
