### PR TITLE
fix(profile): remove deleted videos from profile tabs

### DIFF
--- a/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_bloc.dart
@@ -31,8 +31,11 @@ class ProfileCollabVideosBloc
   ProfileCollabVideosBloc({
     required VideosRepository videosRepository,
     required String targetUserPubkey,
+    required Stream<String> removedVideoIds,
+    required bool Function(VideoEvent video) deletedVideoFilter,
   }) : _videosRepository = videosRepository,
        _targetUserPubkey = targetUserPubkey,
+       _deletedVideoFilter = deletedVideoFilter,
        super(const ProfileCollabVideosState()) {
     on<ProfileCollabVideosFetchRequested>(
       _onFetchRequested,
@@ -42,10 +45,20 @@ class ProfileCollabVideosBloc
       transformer: sequential(),
     );
     on<ProfileCollabVideosLoadMoreRequested>(_onLoadMoreRequested);
+    on<ProfileCollabVideosVideoRemoved>(
+      _onVideoRemoved,
+      transformer: sequential(),
+    );
+    _removedVideoIdsSubscription = removedVideoIds.listen((videoId) {
+      if (isClosed) return;
+      add(ProfileCollabVideosVideoRemoved(videoId));
+    });
   }
 
   final VideosRepository _videosRepository;
   final String _targetUserPubkey;
+  late final StreamSubscription<String> _removedVideoIdsSubscription;
+  final bool Function(VideoEvent video) _deletedVideoFilter;
 
   /// Cache key for this profile's collab-videos snapshot.
   String get _cacheKey => '$_targetUserPubkey:profile_collab_videos';
@@ -145,6 +158,7 @@ class ProfileCollabVideosBloc
 
     final collabVideos = videos
         .where((v) => v.isSupportedOnCurrentPlatform)
+        .where((v) => !_deletedVideoFilter(v))
         .toList();
     final cursor = collabVideos.isNotEmpty ? collabVideos.last.createdAt : null;
     final hasMore = videos.length >= ProfileTabPagination.pageSize;
@@ -183,12 +197,14 @@ class ProfileCollabVideosBloc
     // (not re-fetched) are kept, deduped against the fresh page.
     final fresh = firstPage
         .where((v) => v.isSupportedOnCurrentPlatform)
+        .where((v) => !_deletedVideoFilter(v))
         .toList();
     final freshIds = fresh.map((v) => v.id).toSet();
     final tail = firstPage.length >= ProfileTabPagination.pageSize
         ? state.videos
               .skip(_tailStartAfterFreshOverlap(fresh))
               .where((v) => !freshIds.contains(v.id))
+              .where((v) => !_deletedVideoFilter(v))
               .toList()
         : <VideoEvent>[];
     final allVideos = [...fresh, ...tail];
@@ -239,10 +255,11 @@ class ProfileCollabVideosBloc
 
   Future<ProfileVideoCursorSnapshot?> _readCachedSnapshot() async {
     try {
-      return await CacheSync.read<ProfileVideoCursorSnapshot>(
+      final snapshot = await CacheSync.read<ProfileVideoCursorSnapshot>(
         key: _cacheKey,
         fromJson: ProfileVideoCursorSnapshot.fromJson,
       );
+      return snapshot == null ? null : _filterDeletedSnapshot(snapshot);
     } on Object catch (e) {
       Log.warning(
         'ProfileCollabVideosBloc: Failed to read cached snapshot - $e',
@@ -251,6 +268,23 @@ class ProfileCollabVideosBloc
       );
       return null;
     }
+  }
+
+  ProfileVideoCursorSnapshot _filterDeletedSnapshot(
+    ProfileVideoCursorSnapshot snapshot,
+  ) {
+    final videos = snapshot.videos
+        .where((video) => !_deletedVideoFilter(video))
+        .toList();
+    if (videos.length == snapshot.videos.length) return snapshot;
+
+    return ProfileVideoCursorSnapshot(
+      videos: videos,
+      paginationCursor: videos.isNotEmpty
+          ? videos.last.createdAt
+          : snapshot.paginationCursor,
+      hasMoreContent: snapshot.hasMoreContent,
+    );
   }
 
   Future<void> _persistSnapshot(ProfileVideoCursorSnapshot snapshot) async {
@@ -303,6 +337,7 @@ class ProfileCollabVideosBloc
 
       final newCollabVideos = videos
           .where((v) => v.isSupportedOnCurrentPlatform)
+          .where((v) => !_deletedVideoFilter(v))
           .toList();
 
       // Deduplicate against existing videos
@@ -316,7 +351,10 @@ class ProfileCollabVideosBloc
           ? uniqueNewVideos.last.createdAt
           : state.paginationCursor;
 
-      final allVideos = [...state.videos, ...uniqueNewVideos];
+      final allVideos = [
+        ...state.videos.where((v) => !_deletedVideoFilter(v)),
+        ...uniqueNewVideos,
+      ];
 
       Log.info(
         'ProfileCollabVideosBloc: Loaded ${uniqueNewVideos.length} more '
@@ -349,5 +387,39 @@ class ProfileCollabVideosBloc
       );
       emit(state.copyWith(isLoadingMore: false));
     }
+  }
+
+  Future<void> _onVideoRemoved(
+    ProfileCollabVideosVideoRemoved event,
+    Emitter<ProfileCollabVideosState> emit,
+  ) async {
+    final videos = state.videos
+        .where(
+          (video) => video.id != event.videoId && !_deletedVideoFilter(video),
+        )
+        .toList();
+    if (videos.length == state.videos.length) return;
+
+    final cursor = videos.isNotEmpty ? videos.last.createdAt : null;
+    emit(
+      state.copyWith(
+        videos: videos,
+        paginationCursor: cursor,
+        clearCursor: cursor == null,
+      ),
+    );
+    await _persistSnapshot(
+      ProfileVideoCursorSnapshot(
+        videos: videos,
+        paginationCursor: cursor,
+        hasMoreContent: state.hasMoreContent,
+      ),
+    );
+  }
+
+  @override
+  Future<void> close() {
+    _removedVideoIdsSubscription.cancel();
+    return super.close();
   }
 }

--- a/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_event.dart
+++ b/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_event.dart
@@ -28,3 +28,10 @@ final class ProfileCollabVideosLoadMoreRequested
     extends ProfileCollabVideosEvent {
   const ProfileCollabVideosLoadMoreRequested();
 }
+
+/// Internal: drop a video after the deletion bus reports it removed.
+final class ProfileCollabVideosVideoRemoved extends ProfileCollabVideosEvent {
+  const ProfileCollabVideosVideoRemoved(this.videoId);
+
+  final String videoId;
+}

--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
@@ -44,12 +44,15 @@ class ProfileLikedVideosBloc
     required VideosRepository videosRepository,
     required ContentBlocklistRepository contentBlocklistRepository,
     required String currentUserPubkey,
+    required Stream<String> removedVideoIds,
+    required bool Function(VideoEvent video) deletedVideoFilter,
     String? targetUserPubkey,
   }) : _likesRepository = likesRepository,
        _videosRepository = videosRepository,
        _blocklistRepository = contentBlocklistRepository,
        _currentUserPubkey = currentUserPubkey,
        _targetUserPubkey = targetUserPubkey,
+       _deletedVideoFilter = deletedVideoFilter,
        super(const ProfileLikedVideosState()) {
     on<ProfileLikedVideosSyncRequested>(
       _onSyncRequested,
@@ -68,6 +71,10 @@ class ProfileLikedVideosBloc
       _onBlocklistChanged,
       transformer: droppable(),
     );
+    on<ProfileLikedVideosVideoRemoved>(
+      _onVideoRemoved,
+      transformer: sequential(),
+    );
 
     // Re-filter the loaded grid whenever the blocklist changes. Broad changes
     // (account switch / identity adoption, relay-synced blocked-by-others,
@@ -76,6 +83,10 @@ class ProfileLikedVideosBloc
     _blocklistSubscription = _blocklistRepository.stateStream.listen((_) {
       if (isClosed) return;
       add(const ProfileLikedVideosBlocklistChanged());
+    });
+    _removedVideoIdsSubscription = removedVideoIds.listen((videoId) {
+      if (isClosed) return;
+      add(ProfileLikedVideosVideoRemoved(videoId));
     });
   }
 
@@ -86,6 +97,8 @@ class ProfileLikedVideosBloc
 
   /// Subscription to broad blocklist changes; cancelled in [close].
   late final StreamSubscription<ContentPolicyState> _blocklistSubscription;
+  late final StreamSubscription<String> _removedVideoIdsSubscription;
+  final bool Function(VideoEvent video) _deletedVideoFilter;
 
   /// The pubkey of the user whose likes to display.
   /// If null or same as current user, uses LikesRepository sync.
@@ -284,7 +297,8 @@ class ProfileLikedVideosBloc
     if (isClosed) return;
 
     if (listEquals(freshIds, state.likedEventIds) &&
-        !_isWindowUnderfilled(freshIds)) {
+        !_isWindowUnderfilled(freshIds) &&
+        !state.videos.any(_deletedVideoFilter)) {
       // Nothing changed — just hide the bar. No re-fetch, no re-serialize.
       emit(state.copyWith(isRefreshing: false));
       return;
@@ -322,7 +336,10 @@ class ProfileLikedVideosBloc
   /// bulk-fetches.
   Future<({List<VideoEvent> videos, int nextPageOffset, bool hasMoreContent})>
   _reconcile(List<String> freshIds) async {
-    final byId = {for (final video in state.videos) video.id: video};
+    final byId = {
+      for (final video in state.videos)
+        if (!_deletedVideoFilter(video)) video.id: video,
+    };
     // Count items newly prepended at the top by anchoring on the previous
     // top ID rather than on a length delta. A length delta breaks when the
     // persisted ID list was capped (its length no longer reflects the true
@@ -394,10 +411,11 @@ class ProfileLikedVideosBloc
   /// failure (cache problems must never break the load).
   Future<ProfileVideoListSnapshot?> _readCachedSnapshot() async {
     try {
-      return await CacheSync.read<ProfileVideoListSnapshot>(
+      final snapshot = await CacheSync.read<ProfileVideoListSnapshot>(
         key: _cacheKey,
         fromJson: ProfileVideoListSnapshot.fromJson,
       );
+      return snapshot == null ? null : _filterDeletedSnapshot(snapshot);
     } on Object catch (e) {
       Log.warning(
         'ProfileLikedVideosBloc: Failed to read cached snapshot - $e',
@@ -406,6 +424,31 @@ class ProfileLikedVideosBloc
       );
       return null;
     }
+  }
+
+  ProfileVideoListSnapshot _filterDeletedSnapshot(
+    ProfileVideoListSnapshot snapshot,
+  ) {
+    final deletedVideoIds = snapshot.videos
+        .where(_deletedVideoFilter)
+        .map((video) => video.id)
+        .toSet();
+    if (deletedVideoIds.isEmpty) return snapshot;
+
+    final videos = snapshot.videos
+        .where((video) => !deletedVideoIds.contains(video.id))
+        .toList();
+    final pruned = pruneProfileVideoListIds(
+      itemIds: snapshot.itemIds,
+      removedIds: deletedVideoIds,
+      nextPageOffset: snapshot.nextPageOffset,
+    );
+    return ProfileVideoListSnapshot(
+      videos: videos,
+      itemIds: pruned.itemIds,
+      nextPageOffset: pruned.nextPageOffset,
+      hasMoreContent: snapshot.hasMoreContent,
+    );
   }
 
   /// Persists [snapshot] under [_cacheKey] so reopening restores it. Cache
@@ -687,6 +730,51 @@ class ProfileLikedVideosBloc
     }
   }
 
+  Future<void> _onVideoRemoved(
+    ProfileLikedVideosVideoRemoved event,
+    Emitter<ProfileLikedVideosState> emit,
+  ) async {
+    final removedVideoIds = <String>{event.videoId};
+    final videos = <VideoEvent>[];
+    for (final video in state.videos) {
+      final isRemoved = video.id == event.videoId || _deletedVideoFilter(video);
+      if (isRemoved) {
+        removedVideoIds.add(video.id);
+      } else {
+        videos.add(video);
+      }
+    }
+
+    final pruned = pruneProfileVideoListIds(
+      itemIds: state.likedEventIds,
+      removedIds: removedVideoIds,
+      nextPageOffset: state.nextPageOffset,
+    );
+    if (videos.length == state.videos.length &&
+        pruned.itemIds.length == state.likedEventIds.length &&
+        pruned.nextPageOffset == state.nextPageOffset) {
+      return;
+    }
+
+    final hasMoreContent = state.hasMoreContent;
+    emit(
+      state.copyWith(
+        videos: videos,
+        likedEventIds: pruned.itemIds,
+        nextPageOffset: pruned.nextPageOffset,
+        hasMoreContent: hasMoreContent,
+      ),
+    );
+    await _persistSnapshot(
+      ProfileVideoListSnapshot(
+        videos: videos,
+        itemIds: pruned.itemIds,
+        nextPageOffset: pruned.nextPageOffset,
+        hasMoreContent: hasMoreContent,
+      ),
+    );
+  }
+
   /// Fetch videos for the given event IDs.
   ///
   /// Uses [VideosRepository.getVideosByIds] which implements cache-first:
@@ -792,6 +880,7 @@ class ProfileLikedVideosBloc
 
   @override
   Future<void> close() {
+    _removedVideoIdsSubscription.cancel();
     _blocklistSubscription.cancel();
     return super.close();
   }

--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_event.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_event.dart
@@ -51,6 +51,13 @@ final class ProfileLikedVideosBlocklistChanged extends ProfileLikedVideosEvent {
   const ProfileLikedVideosBlocklistChanged();
 }
 
+/// Internal: drop a video after the deletion bus reports it removed.
+final class ProfileLikedVideosVideoRemoved extends ProfileLikedVideosEvent {
+  const ProfileLikedVideosVideoRemoved(this.videoId);
+
+  final String videoId;
+}
+
 /// Internal: reconcile the displayed videos against a fresh liked-ID list.
 ///
 /// Dispatched from the [LikesRepository.watchLikedEventIds] subscription when

--- a/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
@@ -42,11 +42,14 @@ class ProfileRepostedVideosBloc
     required RepostsRepository repostsRepository,
     required VideosRepository videosRepository,
     required String currentUserPubkey,
+    required Stream<String> removedVideoIds,
+    required bool Function(VideoEvent video) deletedVideoFilter,
     String? targetUserPubkey,
   }) : _repostsRepository = repostsRepository,
        _videosRepository = videosRepository,
        _currentUserPubkey = currentUserPubkey,
        _targetUserPubkey = targetUserPubkey,
+       _deletedVideoFilter = deletedVideoFilter,
        super(const ProfileRepostedVideosState()) {
     on<ProfileRepostedVideosSyncRequested>(
       _onSyncRequested,
@@ -61,11 +64,21 @@ class ProfileRepostedVideosBloc
       transformer: sequential(),
     );
     on<ProfileRepostedVideosLoadMoreRequested>(_onLoadMoreRequested);
+    on<ProfileRepostedVideosVideoRemoved>(
+      _onVideoRemoved,
+      transformer: sequential(),
+    );
+    _removedVideoIdsSubscription = removedVideoIds.listen((videoId) {
+      if (isClosed) return;
+      add(ProfileRepostedVideosVideoRemoved(videoId));
+    });
   }
 
   final RepostsRepository _repostsRepository;
   final VideosRepository _videosRepository;
   final String _currentUserPubkey;
+  late final StreamSubscription<String> _removedVideoIdsSubscription;
+  final bool Function(VideoEvent video) _deletedVideoFilter;
 
   /// The pubkey of the user whose reposts to display.
   /// If null or same as current user, uses RepostsRepository sync.
@@ -240,7 +253,8 @@ class ProfileRepostedVideosBloc
     if (isClosed) return;
 
     if (listEquals(freshIds, state.repostedAddressableIds) &&
-        !_isWindowUnderfilled(freshIds)) {
+        !_isWindowUnderfilled(freshIds) &&
+        !state.videos.any(_deletedVideoFilter)) {
       emit(state.copyWith(isRefreshing: false));
       return;
     }
@@ -275,6 +289,7 @@ class ProfileRepostedVideosBloc
   _reconcile(List<String> freshIds) async {
     final byId = <String, VideoEvent>{};
     for (final video in state.videos) {
+      if (_deletedVideoFilter(video)) continue;
       final id = _computeAddressableId(video);
       if (id != null) byId[id] = video;
     }
@@ -341,10 +356,11 @@ class ProfileRepostedVideosBloc
   /// failure (cache problems must never break the load).
   Future<ProfileVideoListSnapshot?> _readCachedSnapshot() async {
     try {
-      return await CacheSync.read<ProfileVideoListSnapshot>(
+      final snapshot = await CacheSync.read<ProfileVideoListSnapshot>(
         key: _cacheKey,
         fromJson: ProfileVideoListSnapshot.fromJson,
       );
+      return snapshot == null ? null : _filterDeletedSnapshot(snapshot);
     } on Object catch (e) {
       Log.warning(
         'ProfileRepostedVideosBloc: Failed to read cached snapshot - $e',
@@ -353,6 +369,32 @@ class ProfileRepostedVideosBloc
       );
       return null;
     }
+  }
+
+  ProfileVideoListSnapshot _filterDeletedSnapshot(
+    ProfileVideoListSnapshot snapshot,
+  ) {
+    final deletedAddressableIds = snapshot.videos
+        .where(_deletedVideoFilter)
+        .map(_computeAddressableId)
+        .whereType<String>()
+        .toSet();
+    if (deletedAddressableIds.isEmpty) return snapshot;
+
+    final videos = snapshot.videos
+        .where((video) => !_deletedVideoFilter(video))
+        .toList();
+    final pruned = pruneProfileVideoListIds(
+      itemIds: snapshot.itemIds,
+      removedIds: deletedAddressableIds,
+      nextPageOffset: snapshot.nextPageOffset,
+    );
+    return ProfileVideoListSnapshot(
+      videos: videos,
+      itemIds: pruned.itemIds,
+      nextPageOffset: pruned.nextPageOffset,
+      hasMoreContent: snapshot.hasMoreContent,
+    );
   }
 
   /// Persists [snapshot] under [_cacheKey] so reopening restores it.
@@ -544,6 +586,49 @@ class ProfileRepostedVideosBloc
     }
   }
 
+  Future<void> _onVideoRemoved(
+    ProfileRepostedVideosVideoRemoved event,
+    Emitter<ProfileRepostedVideosState> emit,
+  ) async {
+    final removedAddressableIds = <String>{};
+    final videos = <VideoEvent>[];
+    for (final video in state.videos) {
+      final isRemoved = video.id == event.videoId || _deletedVideoFilter(video);
+      if (isRemoved) {
+        final addressableId = _computeAddressableId(video);
+        if (addressableId != null) removedAddressableIds.add(addressableId);
+      } else {
+        videos.add(video);
+      }
+    }
+    final pruned = pruneProfileVideoListIds(
+      itemIds: state.repostedAddressableIds,
+      removedIds: removedAddressableIds,
+      nextPageOffset: state.nextPageOffset,
+    );
+    if (videos.length == state.videos.length &&
+        pruned.itemIds.length == state.repostedAddressableIds.length &&
+        pruned.nextPageOffset == state.nextPageOffset) {
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        videos: videos,
+        repostedAddressableIds: pruned.itemIds,
+        nextPageOffset: pruned.nextPageOffset,
+      ),
+    );
+    await _persistSnapshot(
+      ProfileVideoListSnapshot(
+        videos: videos,
+        itemIds: pruned.itemIds,
+        nextPageOffset: pruned.nextPageOffset,
+        hasMoreContent: state.hasMoreContent,
+      ),
+    );
+  }
+
   /// Fetch videos for the given addressable IDs.
   ///
   /// Uses [VideosRepository.getVideosByAddressableIds] which:
@@ -587,5 +672,11 @@ class ProfileRepostedVideosBloc
   /// Returns null if the video doesn't have a real d-tag.
   String? _computeAddressableId(VideoEvent video) {
     return video.addressableId;
+  }
+
+  @override
+  Future<void> close() {
+    _removedVideoIdsSubscription.cancel();
+    return super.close();
   }
 }

--- a/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_event.dart
+++ b/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_event.dart
@@ -41,6 +41,14 @@ final class ProfileRepostedVideosLoadMoreRequested
   const ProfileRepostedVideosLoadMoreRequested();
 }
 
+/// Internal: drop a video after the deletion bus reports it removed.
+final class ProfileRepostedVideosVideoRemoved
+    extends ProfileRepostedVideosEvent {
+  const ProfileRepostedVideosVideoRemoved(this.videoId);
+
+  final String videoId;
+}
+
 /// Internal: reconcile the displayed videos against a fresh reposted-ID list.
 ///
 /// Dispatched from the [RepostsRepository.watchRepostedAddressableIds]

--- a/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
@@ -38,9 +38,12 @@ class ProfileSavedVideosBloc
     required Future<BookmarkService> bookmarkService,
     required VideosRepository videosRepository,
     required String currentUserPubkey,
+    required Stream<String> removedVideoIds,
+    required bool Function(VideoEvent video) deletedVideoFilter,
   }) : _bookmarkServiceFuture = bookmarkService,
        _videosRepository = videosRepository,
        _currentUserPubkey = currentUserPubkey,
+       _deletedVideoFilter = deletedVideoFilter,
        super(const ProfileSavedVideosState()) {
     on<ProfileSavedVideosSyncRequested>(
       _onSyncRequested,
@@ -50,6 +53,14 @@ class ProfileSavedVideosBloc
       transformer: sequential(),
     );
     on<ProfileSavedVideosLoadMoreRequested>(_onLoadMoreRequested);
+    on<ProfileSavedVideosVideoRemoved>(
+      _onVideoRemoved,
+      transformer: sequential(),
+    );
+    _removedVideoIdsSubscription = removedVideoIds.listen((videoId) {
+      if (isClosed) return;
+      add(ProfileSavedVideosVideoRemoved(videoId));
+    });
   }
 
   /// Resolved lazily on the first sync — [bookmarkServiceProvider] is an
@@ -58,6 +69,8 @@ class ProfileSavedVideosBloc
   final Future<BookmarkService> _bookmarkServiceFuture;
   final VideosRepository _videosRepository;
   final String _currentUserPubkey;
+  late final StreamSubscription<String> _removedVideoIdsSubscription;
+  final bool Function(VideoEvent video) _deletedVideoFilter;
 
   /// Cache key for the saved-videos snapshot (bookmarks are private, so the
   /// key is scoped to the signed-in user for sign-out invalidation).
@@ -206,7 +219,8 @@ class ProfileSavedVideosBloc
     Emitter<ProfileSavedVideosState> emit,
   ) async {
     if (listEquals(freshIds, state.savedEventIds) &&
-        !_isWindowUnderfilled(freshIds)) {
+        !_isWindowUnderfilled(freshIds) &&
+        !state.videos.any(_deletedVideoFilter)) {
       emit(state.copyWith(isRefreshing: false));
       return;
     }
@@ -239,7 +253,10 @@ class ProfileSavedVideosBloc
   /// IDs in the loaded window. Bounded so it never bulk-fetches.
   Future<({List<VideoEvent> videos, int nextPageOffset, bool hasMoreContent})>
   _reconcile(List<String> freshIds) async {
-    final byId = {for (final video in state.videos) video.id: video};
+    final byId = {
+      for (final video in state.videos)
+        if (!_deletedVideoFilter(video)) video.id: video,
+    };
     // Anchor on the previous top ID rather than a length delta, so a capped
     // persisted ID list can't balloon the reconcile window into a full
     // re-fetch on reopen (see ProfileLikedVideosBloc for the rationale).
@@ -300,10 +317,11 @@ class ProfileSavedVideosBloc
 
   Future<ProfileVideoListSnapshot?> _readCachedSnapshot() async {
     try {
-      return await CacheSync.read<ProfileVideoListSnapshot>(
+      final snapshot = await CacheSync.read<ProfileVideoListSnapshot>(
         key: _cacheKey,
         fromJson: ProfileVideoListSnapshot.fromJson,
       );
+      return snapshot == null ? null : _filterDeletedSnapshot(snapshot);
     } on Object catch (e) {
       Log.warning(
         'ProfileSavedVideosBloc: Failed to read cached snapshot - $e',
@@ -312,6 +330,31 @@ class ProfileSavedVideosBloc
       );
       return null;
     }
+  }
+
+  ProfileVideoListSnapshot _filterDeletedSnapshot(
+    ProfileVideoListSnapshot snapshot,
+  ) {
+    final deletedVideoIds = snapshot.videos
+        .where(_deletedVideoFilter)
+        .map((video) => video.id)
+        .toSet();
+    if (deletedVideoIds.isEmpty) return snapshot;
+
+    final videos = snapshot.videos
+        .where((video) => !deletedVideoIds.contains(video.id))
+        .toList();
+    final pruned = pruneProfileVideoListIds(
+      itemIds: snapshot.itemIds,
+      removedIds: deletedVideoIds,
+      nextPageOffset: snapshot.nextPageOffset,
+    );
+    return ProfileVideoListSnapshot(
+      videos: videos,
+      itemIds: pruned.itemIds,
+      nextPageOffset: pruned.nextPageOffset,
+      hasMoreContent: snapshot.hasMoreContent,
+    );
   }
 
   Future<void> _persistSnapshot(ProfileVideoListSnapshot snapshot) async {
@@ -418,6 +461,49 @@ class ProfileSavedVideosBloc
     }
   }
 
+  Future<void> _onVideoRemoved(
+    ProfileSavedVideosVideoRemoved event,
+    Emitter<ProfileSavedVideosState> emit,
+  ) async {
+    final removedVideoIds = <String>{event.videoId};
+    final videos = <VideoEvent>[];
+    for (final video in state.videos) {
+      final isRemoved = video.id == event.videoId || _deletedVideoFilter(video);
+      if (isRemoved) {
+        removedVideoIds.add(video.id);
+      } else {
+        videos.add(video);
+      }
+    }
+
+    final pruned = pruneProfileVideoListIds(
+      itemIds: state.savedEventIds,
+      removedIds: removedVideoIds,
+      nextPageOffset: state.nextPageOffset,
+    );
+    if (videos.length == state.videos.length &&
+        pruned.itemIds.length == state.savedEventIds.length &&
+        pruned.nextPageOffset == state.nextPageOffset) {
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        videos: videos,
+        savedEventIds: pruned.itemIds,
+        nextPageOffset: pruned.nextPageOffset,
+      ),
+    );
+    await _persistSnapshot(
+      ProfileVideoListSnapshot(
+        videos: videos,
+        itemIds: pruned.itemIds,
+        nextPageOffset: pruned.nextPageOffset,
+        hasMoreContent: state.hasMoreContent,
+      ),
+    );
+  }
+
   /// Fetch videos for the given event IDs via [VideosRepository], which
   /// handles cache-first lookups (SQLite local storage → relay fallback).
   ///
@@ -447,5 +533,11 @@ class ProfileSavedVideosBloc
     );
 
     return videos.where((v) => v.isSupportedOnCurrentPlatform).toList();
+  }
+
+  @override
+  Future<void> close() {
+    _removedVideoIdsSubscription.cancel();
+    return super.close();
   }
 }

--- a/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_event.dart
+++ b/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_event.dart
@@ -27,3 +27,10 @@ final class ProfileSavedVideosLoadMoreRequested
     extends ProfileSavedVideosEvent {
   const ProfileSavedVideosLoadMoreRequested();
 }
+
+/// Internal: drop a video after the deletion bus reports it removed.
+final class ProfileSavedVideosVideoRemoved extends ProfileSavedVideosEvent {
+  const ProfileSavedVideosVideoRemoved(this.videoId);
+
+  final String videoId;
+}

--- a/mobile/lib/blocs/profile_shared/profile_video_list_snapshot.dart
+++ b/mobile/lib/blocs/profile_shared/profile_video_list_snapshot.dart
@@ -91,3 +91,51 @@ class ProfileVideoListSnapshot {
     'hasMoreContent': hasMoreContent,
   });
 }
+
+/// Result of removing hidden/deleted IDs from an ID-list-backed tab.
+class ProfileVideoListPruneResult {
+  const ProfileVideoListPruneResult({
+    required this.itemIds,
+    required this.nextPageOffset,
+  });
+
+  final List<String> itemIds;
+  final int nextPageOffset;
+}
+
+/// Removes [removedIds] and shifts [nextPageOffset] left by removals that were
+/// already consumed.
+///
+/// `nextPageOffset` is a positional cursor into [itemIds]. If an item before
+/// the cursor is deleted, clamping to the new list length is not enough: the
+/// next page must start one slot earlier or it skips the item that shifted into
+/// the deleted entry's position.
+ProfileVideoListPruneResult pruneProfileVideoListIds({
+  required List<String> itemIds,
+  required Set<String> removedIds,
+  required int nextPageOffset,
+}) {
+  if (removedIds.isEmpty) {
+    return ProfileVideoListPruneResult(
+      itemIds: itemIds,
+      nextPageOffset: nextPageOffset.clamp(0, itemIds.length),
+    );
+  }
+
+  var removedBeforeOffset = 0;
+  final keptIds = <String>[];
+  for (var index = 0; index < itemIds.length; index++) {
+    final id = itemIds[index];
+    if (removedIds.contains(id)) {
+      if (index < nextPageOffset) removedBeforeOffset++;
+      continue;
+    }
+    keptIds.add(id);
+  }
+
+  final shiftedOffset = nextPageOffset - removedBeforeOffset;
+  return ProfileVideoListPruneResult(
+    itemIds: keptIds,
+    nextPageOffset: shiftedOffset.clamp(0, keptIds.length),
+  );
+}

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -503,6 +503,7 @@ VideosRepository videosRepository(Ref ref) {
   final feedAspectRatioPreference = ref.watch(
     feedAspectRatioPreferenceServiceProvider,
   );
+  final videoEventService = ref.watch(videoEventServiceProvider);
 
   final nsfwFilter = createNsfwFilter(
     contentFilterService,
@@ -513,6 +514,8 @@ VideosRepository videosRepository(Ref ref) {
     nostrClient: nostrClient,
     localStorage: localStorage,
     blockFilter: createBlockedAuthorFilter(ref),
+    deletedFilter: videoEventService.isVideoEventKnownDeleted,
+    removedVideoIds: videoEventService.removedVideoIds,
     contentFilter: (video) =>
         nsfwFilter(video) ||
         (divineHostFilterService.showDivineHostedOnly &&

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -938,7 +938,7 @@ final class VideosRepositoryProvider
   }
 }
 
-String _$videosRepositoryHash() => r'f98257a666f2fede19dd41cbc4e5dca57ae65328';
+String _$videosRepositoryHash() => r'ec516da3c1660e0b8d409ffd2adcc99a1c1570dd';
 
 /// Provider for LikesRepository instance
 ///

--- a/mobile/lib/screens/liked_videos_screen_router.dart
+++ b/mobile/lib/screens/liked_videos_screen_router.dart
@@ -105,6 +105,8 @@ class _LikedVideosScreenRouterState
             videosRepository: videosRepository,
             contentBlocklistRepository: contentBlocklistRepository,
             currentUserPubkey: currentUserPubkey,
+            removedVideoIds: videosRepository.removedVideoIds,
+            deletedVideoFilter: videosRepository.isVideoKnownDeleted,
           )..add(const ProfileLikedVideosSyncRequested()),
           child: ProfileLikedGrid(
             isOwnProfile: true,
@@ -127,6 +129,8 @@ class _LikedVideosScreenRouterState
         videosRepository: videosRepository,
         contentBlocklistRepository: contentBlocklistRepository,
         currentUserPubkey: currentUserPubkey,
+        removedVideoIds: videosRepository.removedVideoIds,
+        deletedVideoFilter: videosRepository.isVideoKnownDeleted,
       )..add(const ProfileLikedVideosSyncRequested()),
       child: _LikedVideosFeedView(
         videoIndex: videoIndex,

--- a/mobile/lib/screens/saved_videos_screen.dart
+++ b/mobile/lib/screens/saved_videos_screen.dart
@@ -38,9 +38,7 @@ class SavedVideosScreen extends ConsumerWidget {
         backgroundColor: context.vineColors.surfaceContainerHigh,
         title: Text(
           context.l10n.shareMenuBookmarks,
-          style: VineTheme.titleMediumFont(
-            color: context.vineColors.onNav,
-          ),
+          style: VineTheme.titleMediumFont(color: context.vineColors.onNav),
         ),
       ),
       body: BlocProvider<ProfileSavedVideosBloc>(
@@ -52,6 +50,8 @@ class SavedVideosScreen extends ConsumerWidget {
           bookmarkService: ref.read(bookmarkServiceProvider.future),
           videosRepository: videosRepository,
           currentUserPubkey: currentUserPubkey,
+          removedVideoIds: videosRepository.removedVideoIds,
+          deletedVideoFilter: videosRepository.isVideoKnownDeleted,
         )..add(const ProfileSavedVideosSyncRequested()),
         child: SavedVideosView(userIdHex: currentUserPubkey),
       ),

--- a/mobile/lib/widgets/profile/profile_grid.dart
+++ b/mobile/lib/widgets/profile/profile_grid.dart
@@ -363,11 +363,7 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
 
     final tabRefresh = _refreshSyncedTabs();
 
-    await Future.wait([
-      profileRefresh.future,
-      feedRefresh.future,
-      tabRefresh,
-    ]);
+    await Future.wait([profileRefresh.future, feedRefresh.future, tabRefresh]);
   }
 
   @override
@@ -497,6 +493,8 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
         contentBlocklistRepository: contentBlocklistRepository,
         currentUserPubkey: currentUserPubkey,
         targetUserPubkey: widget.userIdHex,
+        removedVideoIds: videosRepository.removedVideoIds,
+        deletedVideoFilter: videosRepository.isVideoKnownDeleted,
       )..add(const ProfileLikedVideosSubscriptionRequested());
       // Sync deferred until user views Liked tab
 
@@ -515,6 +513,8 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
         videosRepository: videosRepository,
         currentUserPubkey: currentUserPubkey,
         targetUserPubkey: widget.userIdHex,
+        removedVideoIds: videosRepository.removedVideoIds,
+        deletedVideoFilter: videosRepository.isVideoKnownDeleted,
       )..add(const ProfileRepostedVideosSubscriptionRequested());
       // Sync deferred until user views Reposts tab
 
@@ -530,6 +530,8 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
       _collabVideosBloc = ProfileCollabVideosBloc(
         videosRepository: videosRepository,
         targetUserPubkey: widget.userIdHex,
+        removedVideoIds: videosRepository.removedVideoIds,
+        deletedVideoFilter: videosRepository.isVideoKnownDeleted,
       );
       _collabsRefreshSub?.cancel();
       _collabsRefreshing = false;

--- a/mobile/packages/videos_repository/lib/src/video_event_filter.dart
+++ b/mobile/packages/videos_repository/lib/src/video_event_filter.dart
@@ -16,6 +16,11 @@ import 'package:videos_repository/videos_repository.dart';
 /// which runs before parsing for efficiency.
 typedef VideoContentFilter = bool Function(VideoEvent video);
 
+/// Filter callback for videos hidden by known NIP-09 deletion tombstones.
+///
+/// Returns `true` if the [video] should be hidden from results.
+typedef DeletedVideoFilter = bool Function(VideoEvent video);
+
 /// Resolver for content-warning labels that should remain visible behind
 /// a warning overlay rather than being hidden outright.
 typedef VideoWarningLabelsResolver = List<String> Function(VideoEvent video);

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -4,6 +4,7 @@
 // ABOUTME: Returns Future<List<VideoEvent>>, not streams -
 // ABOUTME: loading is pagination-based.
 
+import 'dart:async';
 import 'dart:math';
 
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
@@ -182,6 +183,8 @@ class VideosRepository {
     required NostrClient nostrClient,
     VideoLocalStorage? localStorage,
     BlockedVideoFilter? blockFilter,
+    DeletedVideoFilter? deletedFilter,
+    this.removedVideoIds = const Stream<String>.empty(),
     VideoContentFilter? contentFilter,
     VideoWarningLabelsResolver? warningLabelsResolver,
     FunnelcakeApiClient? funnelcakeApiClient,
@@ -191,6 +194,7 @@ class VideosRepository {
   }) : _nostrClient = nostrClient,
        _localStorage = localStorage,
        _blockFilter = blockFilter,
+       _deletedFilter = deletedFilter,
        _contentFilter = contentFilter,
        _warningLabelsResolver = warningLabelsResolver,
        _funnelcakeApiClient = funnelcakeApiClient,
@@ -201,6 +205,11 @@ class VideosRepository {
   final NostrClient _nostrClient;
   final VideoLocalStorage? _localStorage;
   final BlockedVideoFilter? _blockFilter;
+  final DeletedVideoFilter? _deletedFilter;
+
+  /// Emits IDs for videos removed by deletion handling.
+  final Stream<String> removedVideoIds;
+
   final VideoContentFilter? _contentFilter;
   final VideoWarningLabelsResolver? _warningLabelsResolver;
   final FunnelcakeApiClient? _funnelcakeApiClient;
@@ -212,6 +221,11 @@ class VideosRepository {
   final Random _random;
 
   String _recommendationSessionSeed = generateRecommendationSessionSeed();
+
+  /// Whether [video] is already known deleted by the app-wide deletion
+  /// contract supplied to this repository.
+  bool isVideoKnownDeleted(VideoEvent video) =>
+      _deletedFilter?.call(video) ?? false;
 
   /// Clears the in-memory feed cache.
   ///
@@ -1512,8 +1526,8 @@ class VideosRepository {
           final videoAddressableId = video.addressableId;
           if (videoAddressableId != null &&
               dTags.contains(video.addressableDTag)) {
-            // Apply content filter if configured
             if (_blockFilter?.call(video.pubkey) ?? false) continue;
+            if (_deletedFilter?.call(video) ?? false) continue;
             if (!video.hasVideo) continue;
             // Reject non-loopback http:// URLs that the OS layer blocks
             // under release transport security (#3836).
@@ -1556,8 +1570,8 @@ class VideosRepository {
 
       final video = stats.toVideoEvent();
 
-      // Block filter - check pubkey
       if (_blockFilter?.call(video.pubkey) ?? false) continue;
+      if (_deletedFilter?.call(video) ?? false) continue;
 
       // Skip videos without a playable URL
       if (!video.hasVideo) continue;
@@ -1608,6 +1622,8 @@ class VideosRepository {
     }
 
     final video = VideoEvent.fromNostrEvent(event, permissive: permissive);
+
+    if (_deletedFilter?.call(video) ?? false) return null;
 
     // Skip videos without a playable URL
     if (!video.hasVideo) return null;
@@ -1755,6 +1771,7 @@ class VideosRepository {
     final out = <VideoEvent>[];
     for (final video in videos) {
       if (_blockFilter?.call(video.pubkey) ?? false) continue;
+      if (_deletedFilter?.call(video) ?? false) continue;
       if (!_hasAllowedTransportScheme(video)) continue;
       final processed = _applyContentPreferences(video);
       if (processed != null) out.add(processed);

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -156,6 +156,34 @@ void main() {
       expect(repository, isNotNull);
     });
 
+    test('isVideoKnownDeleted delegates to the injected deletion filter', () {
+      final visibleVideo = VideoEvent(
+        id: 'visible-video',
+        pubkey: 'pubkey',
+        createdAt: 1704067200,
+        content: '',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1704067200 * 1000),
+        videoUrl: 'https://example.com/visible.mp4',
+      );
+      final deletedVideo = visibleVideo.copyWith(id: 'deleted-video');
+
+      expect(repository.isVideoKnownDeleted(visibleVideo), isFalse);
+
+      final repositoryWithDeletionFilter = VideosRepository(
+        nostrClient: mockNostrClient,
+        deletedFilter: (video) => video.id == deletedVideo.id,
+      );
+
+      expect(
+        repositoryWithDeletionFilter.isVideoKnownDeleted(visibleVideo),
+        isFalse,
+      );
+      expect(
+        repositoryWithDeletionFilter.isVideoKnownDeleted(deletedVideo),
+        isTrue,
+      );
+    });
+
     group('getNewVideos', () {
       group('Funnelcake API first', () {
         late MockFunnelcakeApiClient mockFunnelcakeClient;
@@ -5986,6 +6014,71 @@ void main() {
         // Verify filter was called for both pubkeys
         expect(filter.calls, contains(blockedPubkey));
         expect(filter.calls, contains(allowedPubkey));
+      });
+
+      test('filters deleted videos from event-id lookups', () async {
+        final repositoryWithFilter = VideosRepository(
+          nostrClient: mockNostrClient,
+          deletedFilter: (video) => video.id == 'deleted-video',
+        );
+
+        final deletedEvent = _createVideoEvent(
+          id: 'deleted-video',
+          pubkey: 'author-1',
+          videoUrl: 'https://example.com/deleted.mp4',
+          createdAt: 1704067200,
+        );
+        final visibleEvent = _createVideoEvent(
+          id: 'visible-video',
+          pubkey: 'author-1',
+          videoUrl: 'https://example.com/visible.mp4',
+          createdAt: 1704067201,
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [deletedEvent, visibleEvent]);
+
+        final result = await repositoryWithFilter.getVideosByIds([
+          'deleted-video',
+          'visible-video',
+        ]);
+
+        expect(result.map((video) => video.id), ['visible-video']);
+      });
+
+      test('filters deleted videos from addressable lookups', () async {
+        const authorPubkey = 'addressable-author';
+        final repositoryWithFilter = VideosRepository(
+          nostrClient: mockNostrClient,
+          deletedFilter: (video) => video.addressableDTag == 'deleted-d',
+        );
+
+        final deletedEvent = _createVideoEventWithDTag(
+          id: 'deleted-event-id',
+          pubkey: authorPubkey,
+          dTag: 'deleted-d',
+          videoUrl: 'https://example.com/deleted.mp4',
+          createdAt: 1704067200,
+        );
+        final visibleEvent = _createVideoEventWithDTag(
+          id: 'visible-event-id',
+          pubkey: authorPubkey,
+          dTag: 'visible-d',
+          videoUrl: 'https://example.com/visible.mp4',
+          createdAt: 1704067201,
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [deletedEvent, visibleEvent]);
+
+        final result = await repositoryWithFilter.getVideosByAddressableIds([
+          '${EventKind.videoVertical}:$authorPubkey:deleted-d',
+          '${EventKind.videoVertical}:$authorPubkey:visible-d',
+        ]);
+
+        expect(result.map((video) => video.addressableDTag), ['visible-d']);
       });
 
       test('filters blocked pubkeys in home feed', () async {

--- a/mobile/test/blocs/profile_collab_videos/profile_collab_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_collab_videos/profile_collab_videos_bloc_test.dart
@@ -69,9 +69,14 @@ void main() {
       await CacheSync.init(dao: cacheDao);
     });
 
-    ProfileCollabVideosBloc createBloc() => ProfileCollabVideosBloc(
+    ProfileCollabVideosBloc createBloc({
+      Stream<String>? removedVideoIds,
+      bool Function(VideoEvent video)? deletedVideoFilter,
+    }) => ProfileCollabVideosBloc(
       videosRepository: mockVideosRepository,
       targetUserPubkey: targetPubkey,
+      removedVideoIds: removedVideoIds ?? const Stream<String>.empty(),
+      deletedVideoFilter: deletedVideoFilter ?? (_) => false,
     );
 
     VideoEvent createTestVideo({
@@ -477,6 +482,102 @@ void main() {
                 'cached-1',
               ]),
         ],
+      );
+
+      blocTest<ProfileCollabVideosBloc, ProfileCollabVideosState>(
+        'filters tombstoned videos from cached cursor snapshot restore',
+        build: () {
+          when(
+            () => mockVideosRepository.getCollabVideos(
+              taggedPubkey: targetPubkey,
+              limit: any(named: 'limit'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              createTestVideo(id: 'cached-1', pubkey: authorPubkey),
+            ],
+          );
+          return createBloc(
+            deletedVideoFilter: (video) => video.id == 'deleted',
+          );
+        },
+        setUp: () async {
+          await cacheDao.write(
+            key: '$targetPubkey:profile_collab_videos',
+            payload: ProfileVideoCursorSnapshot(
+              videos: [
+                createTestVideo(
+                  id: 'cached-1',
+                  pubkey: authorPubkey,
+                  createdAt: 200,
+                ),
+                createTestVideo(
+                  id: 'deleted',
+                  pubkey: authorPubkey,
+                  createdAt: 100,
+                ),
+              ],
+              paginationCursor: 100,
+              hasMoreContent: false,
+            ).toJson(),
+          );
+        },
+        act: (bloc) => bloc.add(const ProfileCollabVideosFetchRequested()),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileCollabVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', true)
+              .having((s) => s.videos.map((v) => v.id).toList(), 'cached', [
+                'cached-1',
+              ]),
+          isA<ProfileCollabVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', false)
+              .having((s) => s.videos.map((v) => v.id).toList(), 'reconciled', [
+                'cached-1',
+              ]),
+        ],
+      );
+
+      blocTest<ProfileCollabVideosBloc, ProfileCollabVideosState>(
+        'removal event drops video and persists cursor snapshot without it',
+        build: () =>
+            createBloc(deletedVideoFilter: (video) => video.id == 'deleted'),
+        seed: () => ProfileCollabVideosState(
+          status: ProfileCollabVideosStatus.success,
+          videos: [
+            createTestVideo(
+              id: 'cached-1',
+              pubkey: authorPubkey,
+              createdAt: 200,
+            ),
+            createTestVideo(
+              id: 'deleted',
+              pubkey: authorPubkey,
+              createdAt: 100,
+            ),
+          ],
+          paginationCursor: 100,
+          hasMoreContent: false,
+        ),
+        act: (bloc) =>
+            bloc.add(const ProfileCollabVideosVideoRemoved('deleted')),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileCollabVideosState>()
+              .having((s) => s.videos.map((v) => v.id).toList(), 'videos', [
+                'cached-1',
+              ])
+              .having((s) => s.paginationCursor, 'paginationCursor', 200),
+        ],
+        verify: (_) async {
+          final cached = await CacheSync.read<ProfileVideoCursorSnapshot>(
+            key: '$targetPubkey:profile_collab_videos',
+            fromJson: ProfileVideoCursorSnapshot.fromJson,
+          );
+          expect(cached, isNotNull);
+          expect(cached!.videos.map((v) => v.id), ['cached-1']);
+          expect(cached.paginationCursor, 200);
+        },
       );
 
       blocTest<ProfileCollabVideosBloc, ProfileCollabVideosState>(

--- a/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
@@ -79,6 +79,7 @@ void main() {
     late _InMemoryCacheDao cacheDao;
     late StreamController<List<String>> likedIdsController;
     late StreamController<ContentPolicyState> blocklistStateController;
+    late StreamController<String> removedVideoIdsController;
 
     // Test pubkeys
     const currentUserPubkey =
@@ -95,6 +96,7 @@ void main() {
       likedIdsController = StreamController<List<String>>.broadcast();
       blocklistStateController =
           StreamController<ContentPolicyState>.broadcast();
+      removedVideoIdsController = StreamController<String>.broadcast();
 
       // Default stub for watchLikedEventIds
       when(
@@ -121,16 +123,22 @@ void main() {
     tearDown(() {
       likedIdsController.close();
       blocklistStateController.close();
+      removedVideoIdsController.close();
     });
 
-    ProfileLikedVideosBloc createBloc({String? targetUserPubkey}) =>
-        ProfileLikedVideosBloc(
-          likesRepository: mockLikesRepository,
-          videosRepository: mockVideosRepository,
-          contentBlocklistRepository: mockBlocklistRepository,
-          currentUserPubkey: currentUserPubkey,
-          targetUserPubkey: targetUserPubkey,
-        );
+    ProfileLikedVideosBloc createBloc({
+      String? targetUserPubkey,
+      Stream<String>? removedVideoIds,
+      bool Function(VideoEvent video)? deletedVideoFilter,
+    }) => ProfileLikedVideosBloc(
+      likesRepository: mockLikesRepository,
+      videosRepository: mockVideosRepository,
+      contentBlocklistRepository: mockBlocklistRepository,
+      currentUserPubkey: currentUserPubkey,
+      targetUserPubkey: targetUserPubkey,
+      removedVideoIds: removedVideoIds ?? const Stream<String>.empty(),
+      deletedVideoFilter: deletedVideoFilter ?? (_) => false,
+    );
 
     VideoEvent createTestVideo(String id) {
       // Create a minimal VideoEvent for testing
@@ -435,6 +443,159 @@ void main() {
             ),
           );
         },
+      );
+
+      blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
+        'filters tombstoned videos from cached snapshot restore',
+        setUp: () async {
+          await cacheDao.write(
+            key: '$currentUserPubkey:$currentUserPubkey:profile_liked_videos',
+            payload: ProfileVideoListSnapshot(
+              videos: [createTestVideo('a'), createTestVideo('deleted')],
+              itemIds: const ['a', 'deleted'],
+              nextPageOffset: 2,
+              hasMoreContent: false,
+            ).toJson(),
+          );
+          when(() => mockLikesRepository.syncUserReactions()).thenAnswer(
+            (_) async => const LikesSyncResult(
+              orderedEventIds: ['a'],
+              eventIdToReactionId: {},
+            ),
+          );
+        },
+        build: () =>
+            createBloc(deletedVideoFilter: (video) => video.id == 'deleted'),
+        act: (bloc) => bloc.add(const ProfileLikedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileLikedVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', true)
+              .having(
+                (s) => s.videos.map((v) => v.id).toList(),
+                'cached videos',
+                ['a'],
+              )
+              .having((s) => s.likedEventIds, 'likedEventIds', ['a']),
+          isA<ProfileLikedVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', false)
+              .having(
+                (s) => s.videos.map((v) => v.id).toList(),
+                'unchanged videos',
+                ['a'],
+              ),
+        ],
+      );
+
+      blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
+        'removal stream drops video and persists snapshot without it',
+        build: () => createBloc(
+          removedVideoIds: removedVideoIdsController.stream,
+          deletedVideoFilter: (video) => video.id == 'deleted',
+        ),
+        seed: () => ProfileLikedVideosState(
+          status: ProfileLikedVideosStatus.success,
+          videos: [createTestVideo('a'), createTestVideo('deleted')],
+          likedEventIds: const ['a', 'deleted'],
+          nextPageOffset: 2,
+          hasMoreContent: false,
+        ),
+        act: (_) => removedVideoIdsController.add('deleted'),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileLikedVideosState>()
+              .having((s) => s.videos.map((v) => v.id).toList(), 'videos', [
+                'a',
+              ])
+              .having((s) => s.likedEventIds, 'likedEventIds', ['a'])
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 1),
+        ],
+        verify: (_) async {
+          final cached = await CacheSync.read<ProfileVideoListSnapshot>(
+            key: '$currentUserPubkey:$currentUserPubkey:profile_liked_videos',
+            fromJson: ProfileVideoListSnapshot.fromJson,
+          );
+          expect(cached, isNotNull);
+          expect(cached!.videos.map((v) => v.id), ['a']);
+          expect(cached.itemIds, ['a']);
+        },
+      );
+
+      blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
+        'removal shifts nextPageOffset left when deleting before the cursor',
+        build: () => createBloc(
+          removedVideoIds: removedVideoIdsController.stream,
+          deletedVideoFilter: (video) => video.id == 'deleted',
+        ),
+        seed: () => ProfileLikedVideosState(
+          status: ProfileLikedVideosStatus.success,
+          videos: [createTestVideo('a'), createTestVideo('deleted')],
+          likedEventIds: const ['a', 'deleted', 'b', 'c', 'd'],
+          nextPageOffset: 2,
+        ),
+        act: (_) => removedVideoIdsController.add('deleted'),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileLikedVideosState>()
+              .having((s) => s.videos.map((v) => v.id).toList(), 'videos', [
+                'a',
+              ])
+              .having((s) => s.likedEventIds, 'likedEventIds', [
+                'a',
+                'b',
+                'c',
+                'd',
+              ])
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 1),
+        ],
+      );
+
+      blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
+        'removal drops IDs for videos removed only by the deletion filter',
+        build: () => createBloc(
+          removedVideoIds: removedVideoIdsController.stream,
+          deletedVideoFilter: (video) => video.id == 'edited-version',
+        ),
+        seed: () => ProfileLikedVideosState(
+          status: ProfileLikedVideosStatus.success,
+          videos: [createTestVideo('a'), createTestVideo('edited-version')],
+          likedEventIds: const ['a', 'edited-version', 'b'],
+          nextPageOffset: 2,
+        ),
+        act: (_) => removedVideoIdsController.add('original-version'),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileLikedVideosState>()
+              .having((s) => s.videos.map((v) => v.id).toList(), 'videos', [
+                'a',
+              ])
+              .having((s) => s.likedEventIds, 'likedEventIds', ['a', 'b'])
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 1),
+        ],
+      );
+
+      blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
+        'removal prunes unloaded IDs from the backing list',
+        build: () => createBloc(
+          removedVideoIds: removedVideoIdsController.stream,
+          deletedVideoFilter: (_) => false,
+        ),
+        seed: () => ProfileLikedVideosState(
+          status: ProfileLikedVideosStatus.success,
+          videos: [createTestVideo('a')],
+          likedEventIds: const ['a', 'deleted-but-unloaded', 'b'],
+          nextPageOffset: 2,
+        ),
+        act: (_) => removedVideoIdsController.add('deleted-but-unloaded'),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileLikedVideosState>()
+              .having((s) => s.videos.map((v) => v.id).toList(), 'videos', [
+                'a',
+              ])
+              .having((s) => s.likedEventIds, 'likedEventIds', ['a', 'b'])
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 1),
+        ],
       );
 
       blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(

--- a/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
@@ -95,13 +95,18 @@ void main() {
       repostedIdsController.close();
     });
 
-    ProfileRepostedVideosBloc createBloc({String? targetUserPubkey}) =>
-        ProfileRepostedVideosBloc(
-          repostsRepository: mockRepostsRepository,
-          videosRepository: mockVideosRepository,
-          currentUserPubkey: currentUserPubkey,
-          targetUserPubkey: targetUserPubkey,
-        );
+    ProfileRepostedVideosBloc createBloc({
+      String? targetUserPubkey,
+      Stream<String>? removedVideoIds,
+      bool Function(VideoEvent video)? deletedVideoFilter,
+    }) => ProfileRepostedVideosBloc(
+      repostsRepository: mockRepostsRepository,
+      videosRepository: mockVideosRepository,
+      currentUserPubkey: currentUserPubkey,
+      targetUserPubkey: targetUserPubkey,
+      removedVideoIds: removedVideoIds ?? const Stream<String>.empty(),
+      deletedVideoFilter: deletedVideoFilter ?? (_) => false,
+    );
 
     VideoEvent createTestVideo({
       required String id,
@@ -445,6 +450,163 @@ void main() {
             ),
           );
         },
+      );
+
+      blocTest<ProfileRepostedVideosBloc, ProfileRepostedVideosState>(
+        'filters tombstoned videos from cached snapshot restore',
+        setUp: () async {
+          final id1 = createAddressableId(currentUserPubkey, 'd1');
+          final deletedId = createAddressableId(currentUserPubkey, 'deleted-d');
+          await cacheDao.write(
+            key: '$currentUserPubkey:profile_reposted_videos',
+            payload: ProfileVideoListSnapshot(
+              videos: [
+                createTestVideo(
+                  id: 'e1',
+                  pubkey: currentUserPubkey,
+                  vineId: 'd1',
+                ),
+                createTestVideo(
+                  id: 'deleted-event',
+                  pubkey: currentUserPubkey,
+                  vineId: 'deleted-d',
+                ),
+              ],
+              itemIds: [id1, deletedId],
+              nextPageOffset: 2,
+              hasMoreContent: false,
+            ).toJson(),
+          );
+          when(() => mockRepostsRepository.syncUserReposts()).thenAnswer(
+            (_) async => RepostsSyncResult(
+              orderedAddressableIds: [id1],
+              addressableIdToRepostId: const {},
+            ),
+          );
+        },
+        build: () => createBloc(
+          deletedVideoFilter: (video) => video.id == 'deleted-event',
+        ),
+        act: (bloc) => bloc.add(const ProfileRepostedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileRepostedVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', true)
+              .having(
+                (s) => s.videos.map((v) => v.id).toList(),
+                'cached videos',
+                ['e1'],
+              ),
+          isA<ProfileRepostedVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', false)
+              .having(
+                (s) => s.videos.map((v) => v.id).toList(),
+                'unchanged videos',
+                ['e1'],
+              ),
+        ],
+      );
+
+      blocTest<ProfileRepostedVideosBloc, ProfileRepostedVideosState>(
+        'removal event drops video and persists snapshot without it',
+        build: () => createBloc(
+          deletedVideoFilter: (video) => video.id == 'deleted-event',
+        ),
+        seed: () {
+          final id1 = createAddressableId(currentUserPubkey, 'd1');
+          final deletedId = createAddressableId(currentUserPubkey, 'deleted-d');
+          return ProfileRepostedVideosState(
+            status: ProfileRepostedVideosStatus.success,
+            videos: [
+              createTestVideo(
+                id: 'e1',
+                pubkey: currentUserPubkey,
+                vineId: 'd1',
+              ),
+              createTestVideo(
+                id: 'deleted-event',
+                pubkey: currentUserPubkey,
+                vineId: 'deleted-d',
+              ),
+            ],
+            repostedAddressableIds: [id1, deletedId],
+            nextPageOffset: 2,
+            hasMoreContent: false,
+          );
+        },
+        act: (bloc) =>
+            bloc.add(const ProfileRepostedVideosVideoRemoved('deleted-event')),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileRepostedVideosState>()
+              .having((s) => s.videos.map((v) => v.id).toList(), 'videos', [
+                'e1',
+              ])
+              .having(
+                (s) => s.repostedAddressableIds,
+                'repostedAddressableIds',
+                [createAddressableId(currentUserPubkey, 'd1')],
+              )
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 1),
+        ],
+        verify: (_) async {
+          final cached = await CacheSync.read<ProfileVideoListSnapshot>(
+            key: '$currentUserPubkey:profile_reposted_videos',
+            fromJson: ProfileVideoListSnapshot.fromJson,
+          );
+          expect(cached, isNotNull);
+          expect(cached!.videos.map((v) => v.id), ['e1']);
+          expect(cached.itemIds, [
+            createAddressableId(currentUserPubkey, 'd1'),
+          ]);
+        },
+      );
+
+      blocTest<ProfileRepostedVideosBloc, ProfileRepostedVideosState>(
+        'removal shifts nextPageOffset left when deleting before the cursor',
+        build: () => createBloc(
+          deletedVideoFilter: (video) => video.id == 'deleted-event',
+        ),
+        seed: () {
+          final id1 = createAddressableId(currentUserPubkey, 'd1');
+          final deletedId = createAddressableId(currentUserPubkey, 'deleted-d');
+          final id2 = createAddressableId(currentUserPubkey, 'd2');
+          return ProfileRepostedVideosState(
+            status: ProfileRepostedVideosStatus.success,
+            videos: [
+              createTestVideo(
+                id: 'e1',
+                pubkey: currentUserPubkey,
+                vineId: 'd1',
+              ),
+              createTestVideo(
+                id: 'deleted-event',
+                pubkey: currentUserPubkey,
+                vineId: 'deleted-d',
+              ),
+            ],
+            repostedAddressableIds: [id1, deletedId, id2],
+            nextPageOffset: 2,
+          );
+        },
+        act: (bloc) =>
+            bloc.add(const ProfileRepostedVideosVideoRemoved('deleted-event')),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileRepostedVideosState>()
+              .having((s) => s.videos.map((v) => v.id).toList(), 'videos', [
+                'e1',
+              ])
+              .having(
+                (s) => s.repostedAddressableIds,
+                'repostedAddressableIds',
+                [
+                  createAddressableId(currentUserPubkey, 'd1'),
+                  createAddressableId(currentUserPubkey, 'd2'),
+                ],
+              )
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 1),
+        ],
       );
 
       blocTest<ProfileRepostedVideosBloc, ProfileRepostedVideosState>(

--- a/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
@@ -71,10 +71,15 @@ void main() {
       await CacheSync.init(dao: cacheDao);
     });
 
-    ProfileSavedVideosBloc createBloc() => ProfileSavedVideosBloc(
+    ProfileSavedVideosBloc createBloc({
+      Stream<String>? removedVideoIds,
+      bool Function(VideoEvent video)? deletedVideoFilter,
+    }) => ProfileSavedVideosBloc(
       bookmarkService: Future.value(mockBookmarkService),
       videosRepository: mockVideosRepository,
       currentUserPubkey: currentUserPubkey,
+      removedVideoIds: removedVideoIds ?? const Stream<String>.empty(),
+      deletedVideoFilter: deletedVideoFilter ?? (_) => false,
     );
 
     VideoEvent createTestVideo(String id) {
@@ -255,6 +260,168 @@ void main() {
             ),
           );
         },
+      );
+
+      blocTest<ProfileSavedVideosBloc, ProfileSavedVideosState>(
+        'filters tombstoned videos from cached snapshot restore',
+        setUp: () async {
+          await cacheDao.write(
+            key: '$currentUserPubkey:profile_saved_videos',
+            payload: ProfileVideoListSnapshot(
+              videos: [
+                createTestVideo('video-1'),
+                createTestVideo('deleted-video'),
+              ],
+              itemIds: const ['video-1', 'deleted-video'],
+              nextPageOffset: 2,
+              hasMoreContent: false,
+            ).toJson(),
+          );
+          when(
+            () => mockBookmarkService.globalBookmarks,
+          ).thenReturn(const [BookmarkItem(type: 'e', id: 'video-1')]);
+        },
+        build: () => createBloc(
+          deletedVideoFilter: (video) => video.id == 'deleted-video',
+        ),
+        act: (bloc) => bloc.add(const ProfileSavedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileSavedVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', true)
+              .having(
+                (s) => s.videos.map((v) => v.id).toList(),
+                'cached videos',
+                ['video-1'],
+              )
+              .having((s) => s.savedEventIds, 'savedEventIds', ['video-1']),
+          isA<ProfileSavedVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', false)
+              .having(
+                (s) => s.videos.map((v) => v.id).toList(),
+                'unchanged videos',
+                ['video-1'],
+              ),
+        ],
+      );
+
+      blocTest<ProfileSavedVideosBloc, ProfileSavedVideosState>(
+        'removal event drops video and persists snapshot without it',
+        build: () => createBloc(
+          deletedVideoFilter: (video) => video.id == 'deleted-video',
+        ),
+        seed: () => ProfileSavedVideosState(
+          status: ProfileSavedVideosStatus.success,
+          videos: [
+            createTestVideo('video-1'),
+            createTestVideo('deleted-video'),
+          ],
+          savedEventIds: const ['video-1', 'deleted-video'],
+          nextPageOffset: 2,
+          hasMoreContent: false,
+        ),
+        act: (bloc) =>
+            bloc.add(const ProfileSavedVideosVideoRemoved('deleted-video')),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileSavedVideosState>()
+              .having((s) => s.videos.map((v) => v.id).toList(), 'videos', [
+                'video-1',
+              ])
+              .having((s) => s.savedEventIds, 'savedEventIds', ['video-1'])
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 1),
+        ],
+        verify: (_) async {
+          final cached = await CacheSync.read<ProfileVideoListSnapshot>(
+            key: '$currentUserPubkey:profile_saved_videos',
+            fromJson: ProfileVideoListSnapshot.fromJson,
+          );
+          expect(cached, isNotNull);
+          expect(cached!.videos.map((v) => v.id), ['video-1']);
+          expect(cached.itemIds, ['video-1']);
+        },
+      );
+
+      blocTest<ProfileSavedVideosBloc, ProfileSavedVideosState>(
+        'removal shifts nextPageOffset left when deleting before the cursor',
+        build: () => createBloc(
+          deletedVideoFilter: (video) => video.id == 'deleted-video',
+        ),
+        seed: () => ProfileSavedVideosState(
+          status: ProfileSavedVideosStatus.success,
+          videos: [
+            createTestVideo('video-1'),
+            createTestVideo('deleted-video'),
+          ],
+          savedEventIds: const ['video-1', 'deleted-video', 'video-2'],
+          nextPageOffset: 2,
+        ),
+        act: (bloc) =>
+            bloc.add(const ProfileSavedVideosVideoRemoved('deleted-video')),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileSavedVideosState>()
+              .having((s) => s.videos.map((v) => v.id).toList(), 'videos', [
+                'video-1',
+              ])
+              .having((s) => s.savedEventIds, 'savedEventIds', [
+                'video-1',
+                'video-2',
+              ])
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 1),
+        ],
+      );
+
+      blocTest<ProfileSavedVideosBloc, ProfileSavedVideosState>(
+        'removal drops IDs for videos removed only by the deletion filter',
+        build: () => createBloc(
+          deletedVideoFilter: (video) => video.id == 'edited-video',
+        ),
+        seed: () => ProfileSavedVideosState(
+          status: ProfileSavedVideosStatus.success,
+          videos: [createTestVideo('video-1'), createTestVideo('edited-video')],
+          savedEventIds: const ['video-1', 'edited-video', 'video-2'],
+          nextPageOffset: 2,
+        ),
+        act: (bloc) =>
+            bloc.add(const ProfileSavedVideosVideoRemoved('original-video')),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileSavedVideosState>()
+              .having((s) => s.videos.map((v) => v.id).toList(), 'videos', [
+                'video-1',
+              ])
+              .having((s) => s.savedEventIds, 'savedEventIds', [
+                'video-1',
+                'video-2',
+              ])
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 1),
+        ],
+      );
+
+      blocTest<ProfileSavedVideosBloc, ProfileSavedVideosState>(
+        'removal prunes unloaded IDs from the backing list',
+        build: createBloc,
+        seed: () => ProfileSavedVideosState(
+          status: ProfileSavedVideosStatus.success,
+          videos: [createTestVideo('video-1')],
+          savedEventIds: const ['video-1', 'deleted-unloaded', 'video-2'],
+          nextPageOffset: 2,
+        ),
+        act: (bloc) =>
+            bloc.add(const ProfileSavedVideosVideoRemoved('deleted-unloaded')),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileSavedVideosState>()
+              .having((s) => s.videos.map((v) => v.id).toList(), 'videos', [
+                'video-1',
+              ])
+              .having((s) => s.savedEventIds, 'savedEventIds', [
+                'video-1',
+                'video-2',
+              ])
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 1),
+        ],
       );
 
       blocTest<ProfileSavedVideosBloc, ProfileSavedVideosState>(

--- a/mobile/test/helpers/test_provider_overrides.dart
+++ b/mobile/test/helpers/test_provider_overrides.dart
@@ -10,6 +10,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:media_cache/media_cache.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
@@ -25,6 +26,7 @@ import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/services/social_service.dart';
 import 'package:openvine/services/subscription_manager.dart';
+import 'package:openvine/services/video_event_service.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -52,6 +54,14 @@ class MockFollowRepository extends Mock implements FollowRepository {}
 
 class MockModerationLabelService extends Mock
     implements ModerationLabelService {}
+
+class MockVideoEventService extends Mock implements VideoEventService {
+  @override
+  Stream<String> get removedVideoIds => const Stream<String>.empty();
+
+  @override
+  bool isVideoEventKnownDeleted(VideoEvent video) => false;
+}
 
 /// Creates a properly stubbed MockSharedPreferences for testing
 MockSharedPreferences createMockSharedPreferences() {
@@ -327,6 +337,10 @@ MockModerationLabelService createMockModerationLabelService() {
   return mock;
 }
 
+MockVideoEventService createMockVideoEventService() {
+  return MockVideoEventService();
+}
+
 /// Standard provider overrides that fix most ProviderException failures
 List<dynamic> getStandardTestOverrides({
   SharedPreferences? mockSharedPreferences,
@@ -435,6 +449,7 @@ Widget testProviderScope({
   Nip05VerificationService? mockNip05VerificationService,
   ModerationLabelService? mockModerationLabelService,
   FollowRepository? mockFollowRepository,
+  VideoEventService? mockVideoEventService,
 }) {
   return ProviderScope(
     overrides: [
@@ -451,10 +466,20 @@ Widget testProviderScope({
         mockModerationLabelService: mockModerationLabelService,
         mockFollowRepository: mockFollowRepository,
       ),
+      if (!_overridesProvider(additionalOverrides, videoEventServiceProvider))
+        videoEventServiceProvider.overrideWithValue(
+          mockVideoEventService ?? createMockVideoEventService(),
+        ),
       ...?additionalOverrides,
     ],
     child: child,
   );
+}
+
+bool _overridesProvider(List<dynamic>? overrides, Object provider) {
+  final providerPrefix = '$provider.';
+  return overrides?.any((override) => '$override'.startsWith(providerPrefix)) ??
+      false;
 }
 
 /// MaterialApp wrapper with provider overrides for widget tests
@@ -487,6 +512,7 @@ Widget testMaterialApp({
   Nip05VerificationService? mockNip05VerificationService,
   ModerationLabelService? mockModerationLabelService,
   FollowRepository? mockFollowRepository,
+  VideoEventService? mockVideoEventService,
   ThemeData? theme,
 }) {
   return testProviderScope(
@@ -502,6 +528,7 @@ Widget testMaterialApp({
     mockNip05VerificationService: mockNip05VerificationService,
     mockModerationLabelService: mockModerationLabelService,
     mockFollowRepository: mockFollowRepository,
+    mockVideoEventService: mockVideoEventService,
     child: MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,

--- a/mobile/test/router/app_router_test.dart
+++ b/mobile/test/router/app_router_test.dart
@@ -538,6 +538,9 @@ void main() {
           dmReactionsRepositoryProvider.overrideWithValue(
             mockDmReactionsRepository,
           ),
+          videoEventServiceProvider.overrideWithValue(
+            createMockVideoEventService(),
+          ),
         ],
       );
       addTearDown(() async {
@@ -585,6 +588,9 @@ void main() {
           dmRepositoryProvider.overrideWithValue(mockDmRepository),
           dmReactionsRepositoryProvider.overrideWithValue(
             mockDmReactionsRepository,
+          ),
+          videoEventServiceProvider.overrideWithValue(
+            createMockVideoEventService(),
           ),
         ],
       );

--- a/mobile/test/router/saved_videos_route_test.dart
+++ b/mobile/test/router/saved_videos_route_test.dart
@@ -40,6 +40,9 @@ void main() {
         currentMinorAccountReviewStatusProvider.overrideWith(
           (ref) async => MinorAccountReviewStatus.active(),
         ),
+        videoEventServiceProvider.overrideWithValue(
+          createMockVideoEventService(),
+        ),
       ],
     );
     addTearDown(container.dispose);

--- a/mobile/test/screens/other_profile_screen_test.dart
+++ b/mobile/test/screens/other_profile_screen_test.dart
@@ -156,10 +156,19 @@ void main() {
     when(
       repostsRepository.watchRepostedAddressableIds,
     ).thenAnswer((_) => const Stream<Set<String>>.empty());
+    when(
+      () => videosRepository.removedVideoIds,
+    ).thenAnswer((_) => const Stream<String>.empty());
+    when(
+      () => videosRepository.isVideoKnownDeleted(any()),
+    ).thenReturn(false);
 
     when(
       () => videoEventService.authorVideos(any()),
     ).thenReturn(const <VideoEvent>[]);
+    when(
+      () => videoEventService.removedVideoIds,
+    ).thenAnswer((_) => const Stream<String>.empty());
     when(() => videoEventService.filterVideoList(any())).thenAnswer(
       (invocation) => invocation.positionalArguments.first as List<VideoEvent>,
     );

--- a/mobile/test/screens/saved_videos_screen_test.dart
+++ b/mobile/test/screens/saved_videos_screen_test.dart
@@ -9,20 +9,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/profile_saved_videos/profile_saved_videos_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
-import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/saved_videos_screen.dart';
-import 'package:openvine/services/video_event_service.dart';
 
 import '../helpers/test_provider_overrides.dart';
 
 class _MockProfileSavedVideosBloc
     extends MockBloc<ProfileSavedVideosEvent, ProfileSavedVideosState>
     implements ProfileSavedVideosBloc {}
-
-class _FakeVideoEventService extends Mock implements VideoEventService {
-  @override
-  Stream<String> get removedVideoIds => const Stream<String>.empty();
-}
 
 void main() {
   group(SavedVideosView, () {
@@ -38,9 +31,7 @@ void main() {
 
     Widget buildSubject() {
       return testProviderScope(
-        additionalOverrides: [
-          videoEventServiceProvider.overrideWithValue(_FakeVideoEventService()),
-        ],
+        additionalOverrides: [],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,

--- a/mobile/test/widgets/profile/profile_collabs_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_collabs_grid_test.dart
@@ -9,9 +9,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_collab_videos/profile_collab_videos_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
-import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
-import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/profile/profile_collabs_grid.dart';
 
@@ -21,11 +19,6 @@ import '../../helpers/test_provider_overrides.dart';
 class _MockProfileCollabVideosBloc
     extends MockBloc<ProfileCollabVideosEvent, ProfileCollabVideosState>
     implements ProfileCollabVideosBloc {}
-
-class _FakeVideoEventService extends Mock implements VideoEventService {
-  @override
-  Stream<String> get removedVideoIds => const Stream<String>.empty();
-}
 
 List<VideoEvent> _createTestVideos({int count = 2}) {
   final now = DateTime.now();
@@ -79,9 +72,6 @@ void main() {
       final scoped = ProviderScope(
         overrides: [
           ...getStandardTestOverrides(),
-          videoEventServiceProvider.overrideWithValue(
-            _FakeVideoEventService(),
-          ),
         ],
         child: app,
       );
@@ -294,9 +284,6 @@ void main() {
             ProviderScope(
               overrides: [
                 ...getStandardTestOverrides(),
-                videoEventServiceProvider.overrideWithValue(
-                  _FakeVideoEventService(),
-                ),
               ],
               child: MaterialApp(
                 localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -347,9 +334,6 @@ void main() {
             ProviderScope(
               overrides: [
                 ...getStandardTestOverrides(),
-                videoEventServiceProvider.overrideWithValue(
-                  _FakeVideoEventService(),
-                ),
               ],
               child: MaterialApp(
                 localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/mobile/test/widgets/profile/profile_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_grid_test.dart
@@ -95,6 +95,20 @@ class _FakeCuratedListsState extends CuratedListsState {
   Future<List<CuratedList>> build() async => _service.lists;
 }
 
+VideoEvent _fallbackVideoEvent() {
+  final now = DateTime(2024);
+  return VideoEvent(
+    id: 'fallback-video',
+    pubkey: '0' * 64,
+    createdAt: now.millisecondsSinceEpoch ~/ 1000,
+    content: '',
+    timestamp: now,
+    title: 'Fallback Video',
+    videoUrl: 'https://example.com/video.mp4',
+    thumbnailUrl: 'https://example.com/thumb.jpg',
+  );
+}
+
 void main() {
   const userIdHex =
       'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
@@ -113,6 +127,7 @@ void main() {
     setUpAll(() {
       registerFallbackValue(const MyProfileLoadRequested());
       registerFallbackValue(const ProfileFeedStarted());
+      registerFallbackValue(_fallbackVideoEvent());
     });
 
     setUp(() async {
@@ -140,6 +155,12 @@ void main() {
       when(
         () => blocklistRepository.currentState,
       ).thenReturn(ContentPolicyState.empty());
+      when(
+        () => videosRepository.removedVideoIds,
+      ).thenAnswer((_) => const Stream<String>.empty());
+      when(
+        () => videosRepository.isVideoKnownDeleted(any()),
+      ).thenReturn(false);
       when(() => blocklistRepository.isBlocked(any())).thenReturn(false);
       when(() => blocklistRepository.hasMutedUs(any())).thenReturn(false);
       when(() => blocklistRepository.hasBlockedUs(any())).thenReturn(false);

--- a/mobile/test/widgets/profile/profile_liked_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_liked_grid_test.dart
@@ -7,8 +7,6 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_liked_videos/profile_liked_videos_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
-import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/profile/profile_liked_grid.dart';
 
@@ -18,11 +16,6 @@ import '../../helpers/test_provider_overrides.dart';
 class _MockProfileLikedVideosBloc
     extends MockBloc<ProfileLikedVideosEvent, ProfileLikedVideosState>
     implements ProfileLikedVideosBloc {}
-
-class _FakeVideoEventService extends Mock implements VideoEventService {
-  @override
-  Stream<String> get removedVideoIds => const Stream<String>.empty();
-}
 
 List<VideoEvent> _createTestVideos({int count = 2}) {
   final now = DateTime.now();
@@ -60,9 +53,7 @@ void main() {
       MockGoRouter? goRouter,
     }) {
       final app = testProviderScope(
-        additionalOverrides: [
-          videoEventServiceProvider.overrideWithValue(_FakeVideoEventService()),
-        ],
+        additionalOverrides: [],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,

--- a/mobile/test/widgets/profile/profile_reposts_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_reposts_grid_test.dart
@@ -7,8 +7,6 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
-import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/profile/profile_reposts_grid.dart';
 
@@ -18,11 +16,6 @@ import '../../helpers/test_provider_overrides.dart';
 class _MockProfileRepostedVideosBloc
     extends MockBloc<ProfileRepostedVideosEvent, ProfileRepostedVideosState>
     implements ProfileRepostedVideosBloc {}
-
-class _FakeVideoEventService extends Mock implements VideoEventService {
-  @override
-  Stream<String> get removedVideoIds => const Stream<String>.empty();
-}
 
 List<VideoEvent> _createTestVideos({int count = 2}) {
   final now = DateTime.now();
@@ -60,9 +53,7 @@ void main() {
       MockGoRouter? goRouter,
     }) {
       final app = testProviderScope(
-        additionalOverrides: [
-          videoEventServiceProvider.overrideWithValue(_FakeVideoEventService()),
-        ],
+        additionalOverrides: [],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,

--- a/mobile/test/widgets/profile/profile_saved_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_saved_grid_test.dart
@@ -7,8 +7,6 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_saved_videos/profile_saved_videos_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
-import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/profile/profile_saved_grid.dart';
 
@@ -18,11 +16,6 @@ import '../../helpers/test_provider_overrides.dart';
 class _MockProfileSavedVideosBloc
     extends MockBloc<ProfileSavedVideosEvent, ProfileSavedVideosState>
     implements ProfileSavedVideosBloc {}
-
-class _FakeVideoEventService extends Mock implements VideoEventService {
-  @override
-  Stream<String> get removedVideoIds => const Stream<String>.empty();
-}
 
 List<VideoEvent> _createTestVideos({int count = 2}) {
   final now = DateTime.now();
@@ -57,9 +50,7 @@ void main() {
 
     Widget buildSubject({MockGoRouter? goRouter}) {
       final app = testProviderScope(
-        additionalOverrides: [
-          videoEventServiceProvider.overrideWithValue(_FakeVideoEventService()),
-        ],
+        additionalOverrides: [],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,


### PR DESCRIPTION
## Summary
- add repository-level deleted-video filtering to VideosRepository and wire it to VideoEventService tombstones
- subscribe Liked, Reposts, Saved, and Collabs profile tab blocs to removedVideoIds and filter restored snapshots
- cover repository lookup filters, profile tab removal/snapshot behavior, and profile grid provider wiring

Closes #6924

## Tests
- flutter analyze lib test integration_test
- flutter analyze lib test (mobile/packages/videos_repository)
- flutter test --coverage (mobile/packages/videos_repository)
- flutter test test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart test/blocs/profile_collab_videos/profile_collab_videos_bloc_test.dart
- flutter test test/widgets/profile/profile_grid_test.dart
- pre-push hook: analyzer, generated files, changed-file tests