### PR TITLE
fix(a11y): announce the branded loading indicator as busy

### DIFF
--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3858,7 +3858,7 @@
   "commonNotNow": "Not now",
   "commonLoading": "Loading",
   "@commonLoading": {
-    "description": "Screen-reader label for a blocking progress spinner that covers the screen while an action is being prepared. Announced instead of the content behind it, which is not reachable while the spinner is up."
+    "description": "Screen-reader label for a progress indicator, announced while content or an action is loading. Covers both a full-screen spinner that blocks the content behind it and a small inline one next to content that stays reachable."
   },
   "videoMetadataEditCoverFailedSnackbar": "Couldn't update the cover. Try again.",
   "@videoMetadataEditCoverFailedSnackbar": {

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -3664,7 +3664,7 @@
   "commonNotNow": "Bukan Sekarang",
   "commonLoading": "Memuatkan",
   "@commonLoading": {
-    "description": "Screen-reader label for a blocking progress spinner that covers the screen while an action is being prepared. Announced instead of the content behind it, which is not reachable while the spinner is up."
+    "description": "Screen-reader label for a progress indicator, announced while content or an action is loading. Covers both a full-screen spinner that blocks the content behind it and a small inline one next to content that stays reachable."
   },
   "videoMetadataEditCoverFailedSnackbar": "Tidak dapat mengemas kini muka depan. Cuba lagi.",
   "@videoMetadataEditCoverFailedSnackbar": {

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -3664,7 +3664,7 @@
   "commonNotNow": "ابھی نہیں",
   "commonLoading": "لوڈ ہو رہا ہے",
   "@commonLoading": {
-    "description": "Screen-reader label for a blocking progress spinner that covers the screen while an action is being prepared. Announced instead of the content behind it, which is not reachable while the spinner is up."
+    "description": "Screen-reader label for a progress indicator, announced while content or an action is loading. Covers both a full-screen spinner that blocks the content behind it and a small inline one next to content that stays reachable."
   },
   "videoMetadataEditCoverFailedSnackbar": "کور اپڈیٹ نہیں ہو سکا۔ دوبارہ کوشش کریں۔",
   "@videoMetadataEditCoverFailedSnackbar": {

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -3664,7 +3664,7 @@
   "commonNotNow": "Để sau",
   "commonLoading": "Đang tải",
   "@commonLoading": {
-    "description": "Screen-reader label for a blocking progress spinner that covers the screen while an action is being prepared. Announced instead of the content behind it, which is not reachable while the spinner is up."
+    "description": "Screen-reader label for a progress indicator, announced while content or an action is loading. Covers both a full-screen spinner that blocks the content behind it and a small inline one next to content that stays reachable."
   },
   "videoMetadataEditCoverFailedSnackbar": "Không cập nhật được ảnh bìa. Thử lại nhé.",
   "@videoMetadataEditCoverFailedSnackbar": {

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -3664,7 +3664,7 @@
   "commonNotNow": "暂不",
   "commonLoading": "加载中",
   "@commonLoading": {
-    "description": "Screen-reader label for a blocking progress spinner that covers the screen while an action is being prepared. Announced instead of the content behind it, which is not reachable while the spinner is up."
+    "description": "Screen-reader label for a progress indicator, announced while content or an action is loading. Covers both a full-screen spinner that blocks the content behind it and a small inline one next to content that stays reachable."
   },
   "videoMetadataEditCoverFailedSnackbar": "封面更新失败，请重试。",
   "@videoMetadataEditCoverFailedSnackbar": {

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -10970,7 +10970,7 @@ abstract class AppLocalizations {
   /// **'Not now'**
   String get commonNotNow;
 
-  /// Screen-reader label for a blocking progress spinner that covers the screen while an action is being prepared. Announced instead of the content behind it, which is not reachable while the spinner is up.
+  /// Screen-reader label for a progress indicator, announced while content or an action is loading. Covers both a full-screen spinner that blocks the content behind it and a small inline one next to content that stays reachable.
   ///
   /// In en, this message translates to:
   /// **'Loading'**

--- a/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
+++ b/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
@@ -728,7 +728,10 @@ class _SandboxStatusCard extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               children: [
                 if (showSpinner) ...[
-                  const BrandedLoadingIndicator(size: 60),
+                  // [title] below already announces the wait.
+                  const ExcludeSemantics(
+                    child: BrandedLoadingIndicator(size: 60),
+                  ),
                   const SizedBox(height: 20),
                 ] else ...[
                   const DivineIcon(

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -1058,10 +1058,13 @@ class LoadingMorePill extends StatelessWidget {
                 mainAxisSize: MainAxisSize.min,
                 spacing: 10,
                 children: [
+                  // The label beside it already announces the wait.
                   const SizedBox(
                     width: 16,
                     height: 16,
-                    child: BrandedLoadingIndicator(size: 16),
+                    child: ExcludeSemantics(
+                      child: BrandedLoadingIndicator(size: 16),
+                    ),
                   ),
                   Text(
                     context.l10n.feedLoadingMore,

--- a/mobile/lib/screens/relay_settings_screen.dart
+++ b/mobile/lib/screens/relay_settings_screen.dart
@@ -488,10 +488,13 @@ class _RelayInfoSection extends StatelessWidget {
           Divider(color: context.vineColors.mutedText, height: 24),
           Row(
             children: [
+              // The label beside it already announces the wait.
               const SizedBox(
                 width: 16,
                 height: 16,
-                child: BrandedLoadingIndicator(size: 16),
+                child: ExcludeSemantics(
+                  child: BrandedLoadingIndicator(size: 16),
+                ),
               ),
               const SizedBox(width: 8),
               Text(

--- a/mobile/lib/screens/video_editor/video_clip_chroma_key_screen.dart
+++ b/mobile/lib/screens/video_editor/video_clip_chroma_key_screen.dart
@@ -471,7 +471,10 @@ class _BakingOverlay extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               spacing: 16,
               children: [
-                const BrandedLoadingIndicator(size: 44),
+                // The label below already announces the wait.
+                const ExcludeSemantics(
+                  child: BrandedLoadingIndicator(size: 44),
+                ),
                 Text(
                   context.l10n.videoEditorChromaKeyApplying,
                   style: VineTheme.titleSmallFont(color: VineTheme.onSurface),

--- a/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
@@ -664,12 +664,10 @@ class _TopBarContent extends StatelessWidget {
                       context.l10n.videoMetadataEditCoverConfirmSemanticLabel,
                   button: true,
                   enabled: false,
-                  // The indicator is an Image.asset that is not excluded
-                  // from semantics, so without this the confirm node
-                  // announces as an image as well as a disabled button.
-                  child: const ExcludeSemantics(
-                    child: BrandedLoadingIndicator(size: 44),
-                  ),
+                  // The indicator's own "Loading" label merges in, so the
+                  // disabled confirm button announces that it is busy rather
+                  // than just unavailable.
+                  child: const BrandedLoadingIndicator(size: 44),
                 )
               else
                 DivineIconButton(

--- a/mobile/lib/widgets/branded_loading_indicator.dart
+++ b/mobile/lib/widgets/branded_loading_indicator.dart
@@ -5,6 +5,7 @@ import 'dart:ui' as ui;
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// A branded loading indicator that displays the animated Divine logo.
@@ -19,7 +20,11 @@ import 'package:unified_logger/unified_logger.dart';
 /// - Consistent animation across widget rebuilds
 /// - Better performance on repeated displays
 class BrandedLoadingIndicator extends StatefulWidget {
-  const BrandedLoadingIndicator({super.key, this.size = 80.0});
+  const BrandedLoadingIndicator({
+    super.key,
+    this.size = 80.0,
+    this.semanticsLabel,
+  });
 
   /// Sprite sheet backing the animation: the Divine brand mark
   /// (`assets/icon/divine_mark.svg`) in white, drawn as a wing-flap cycle.
@@ -35,6 +40,13 @@ class BrandedLoadingIndicator extends StatefulWidget {
 
   /// The size (width and height) of the loading indicator.
   final double size;
+
+  /// What a screen reader announces while the indicator is on screen.
+  ///
+  /// Defaults to the localized "Loading". Pass a more specific label when the
+  /// indicator stands in for a named control; wrap the indicator in
+  /// [ExcludeSemantics] instead when a sibling already announces the wait.
+  final String? semanticsLabel;
 
   @override
   State<BrandedLoadingIndicator> createState() =>
@@ -90,72 +102,81 @@ class _BrandedLoadingIndicatorState extends State<BrandedLoadingIndicator>
           )
         : null;
 
-    return AnimatedBuilder(
-      animation: _controller,
-      builder: (context, child) {
-        // Calculate current frame based on animation value
-        final frameIndex =
-            (_controller.value * BrandedLoadingIndicator.frameCount).floor();
-        final clampedFrame = frameIndex.clamp(
-          0,
-          BrandedLoadingIndicator.frameCount - 1,
-        );
+    // The sprite is an unlabelled [Image], which reaches a screen reader as a
+    // bare "image" node. Excluding it and labelling the wrapper is what turns
+    // the indicator into an announcement that something is still running.
+    return Semantics(
+      label: widget.semanticsLabel ?? context.l10n.commonLoading,
+      child: ExcludeSemantics(
+        child: AnimatedBuilder(
+          animation: _controller,
+          builder: (context, child) {
+            // Calculate current frame based on animation value
+            final frameIndex =
+                (_controller.value * BrandedLoadingIndicator.frameCount)
+                    .floor();
+            final clampedFrame = frameIndex.clamp(
+              0,
+              BrandedLoadingIndicator.frameCount - 1,
+            );
 
-        final mark = _SpriteFrame(
-          size: widget.size,
-          frameIndex: clampedFrame,
-          child: child!,
-        );
+            final mark = _SpriteFrame(
+              size: widget.size,
+              frameIndex: clampedFrame,
+              child: child!,
+            );
 
-        if (shadowSprite == null) return mark;
+            if (shadowSprite == null) return mark;
 
-        return Stack(
-          alignment: Alignment.center,
-          children: [
-            Transform.translate(
-              offset: Offset(0, widget.size * _shadowOffsetRatio),
-              // Blurring the sliced frame rather than the full sheet keeps the
-              // filter layer at the indicator's size.
-              child: ImageFiltered(
-                imageFilter: ui.ImageFilter.blur(
-                  sigmaX: widget.size * _shadowBlurRatio,
-                  sigmaY: widget.size * _shadowBlurRatio,
+            return Stack(
+              alignment: Alignment.center,
+              children: [
+                Transform.translate(
+                  offset: Offset(0, widget.size * _shadowOffsetRatio),
+                  // Blurring the sliced frame rather than the full sheet keeps
+                  // the filter layer at the indicator's size.
+                  child: ImageFiltered(
+                    imageFilter: ui.ImageFilter.blur(
+                      sigmaX: widget.size * _shadowBlurRatio,
+                      sigmaY: widget.size * _shadowBlurRatio,
+                    ),
+                    child: _SpriteFrame(
+                      size: widget.size,
+                      frameIndex: clampedFrame,
+                      child: shadowSprite,
+                    ),
+                  ),
                 ),
-                child: _SpriteFrame(
-                  size: widget.size,
-                  frameIndex: clampedFrame,
-                  child: shadowSprite,
-                ),
-              ),
-            ),
-            mark,
-          ],
-        );
-      },
-      child: Image.asset(
-        BrandedLoadingIndicator.spriteAsset,
-        width: widget.size,
-        height: widget.size * BrandedLoadingIndicator.frameCount,
-        fit: BoxFit.fitWidth,
-        errorBuilder: (context, error, stackTrace) {
-          Log.warning(
-            'Failed to load sprite sheet: $error',
-            name: 'BrandedLoadingIndicator',
-            category: LogCategory.ui,
-          );
-          return SizedBox(
+                mark,
+              ],
+            );
+          },
+          child: Image.asset(
+            BrandedLoadingIndicator.spriteAsset,
             width: widget.size,
-            height: widget.size,
-            child: Center(
-              child: CircularProgressIndicator(
-                strokeWidth: 2,
-                valueColor: AlwaysStoppedAnimation<Color>(
-                  context.vineColors.onSurfaceMuted,
+            height: widget.size * BrandedLoadingIndicator.frameCount,
+            fit: BoxFit.fitWidth,
+            errorBuilder: (context, error, stackTrace) {
+              Log.warning(
+                'Failed to load sprite sheet: $error',
+                name: 'BrandedLoadingIndicator',
+                category: LogCategory.ui,
+              );
+              return SizedBox(
+                width: widget.size,
+                height: widget.size,
+                child: Center(
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    valueColor: AlwaysStoppedAnimation<Color>(
+                      context.vineColors.onSurfaceMuted,
+                    ),
+                  ),
                 ),
-              ),
-            ),
-          );
-        },
+              );
+            },
+          ),
+        ),
       ),
     );
   }

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_captions_sheet.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_captions_sheet.dart
@@ -265,7 +265,10 @@ class _GeneratingView extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       spacing: 16,
       children: [
-        const Center(child: BrandedLoadingIndicator(size: 60)),
+        // The title below already announces the wait.
+        const ExcludeSemantics(
+          child: Center(child: BrandedLoadingIndicator(size: 60)),
+        ),
         Text(
           l10n.videoEditorCaptionsGeneratingTitle,
           textAlign: TextAlign.center,

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart
@@ -279,8 +279,8 @@ class _ControlButton extends StatelessWidget {
           ),
         // The caption repeats the button's own label, so it is excluded only
         // while that button is there to carry it. The spinner that replaces it
-        // has no semantics of its own, and dropping both would leave the
-        // control silent for the whole run.
+        // announces the wait but not what is waiting, so the caption is what
+        // names the control for the length of the run.
         ExcludeSemantics(
           excluding: !isLoading,
           child: Text(

--- a/mobile/lib/widgets/video_feed_item/video_loading_placeholder.dart
+++ b/mobile/lib/widgets/video_feed_item/video_loading_placeholder.dart
@@ -135,6 +135,11 @@ class _LoadingIndicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Center(child: BrandedLoadingIndicator(size: 60));
+    // Excluded like the thumbnail above it: the enclosing "Play video" surface
+    // owns this region's semantics, and a buffering placeholder this transient
+    // would only leave a stale "Loading" on a button that is already playable.
+    return const ExcludeSemantics(
+      child: Center(child: BrandedLoadingIndicator(size: 60)),
+    );
   }
 }

--- a/mobile/test/screens/video_metadata_cover_screen_test.dart
+++ b/mobile/test/screens/video_metadata_cover_screen_test.dart
@@ -401,7 +401,9 @@ void main() {
       );
     });
 
-    testWidgets('confirm button keeps disabled semantics while confirming', (
+    // Disabled alone reads as "unavailable"; the indicator's own label merges
+    // in so the button announces that it is busy, not broken.
+    testWidgets('confirm button announces disabled and busy while confirming', (
       tester,
     ) async {
       setUpPlayerChannel();
@@ -419,15 +421,16 @@ void main() {
       await triggerConfirm(tester);
       await tester.pump();
 
-      final confirmFinder = find.bySemanticsLabel(
-        l10n.videoMetadataEditCoverConfirmSemanticLabel,
-      );
+      final busyLabel =
+          '${l10n.videoMetadataEditCoverConfirmSemanticLabel}\n'
+          '${l10n.commonLoading}';
+      final confirmFinder = find.bySemanticsLabel(busyLabel);
       expect(confirmFinder, findsOneWidget);
       expect(find.byType(BrandedLoadingIndicator), findsWidgets);
       expect(
         tester.getSemantics(confirmFinder),
         isSemantics(
-          label: l10n.videoMetadataEditCoverConfirmSemanticLabel,
+          label: busyLabel,
           isButton: true,
           hasEnabledState: true,
           isEnabled: false,

--- a/mobile/test/widgets/branded_loading_indicator_test.dart
+++ b/mobile/test/widgets/branded_loading_indicator_test.dart
@@ -99,7 +99,6 @@ void main() {
       expect(find.semantics.byLabel(en.commonLoading), findsOneWidget);
 
       semantics.dispose();
-      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
     });
 
     testWidgets('announces a caller-supplied label instead', (tester) async {
@@ -115,7 +114,6 @@ void main() {
       expect(find.semantics.byLabel(en.commonLoading), findsNothing);
 
       semantics.dispose();
-      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
     });
 
     // The sprite sheet is an unlabelled [Image]; left in the tree it reaches
@@ -134,7 +132,6 @@ void main() {
       expect(node.childrenCount, isZero);
 
       semantics.dispose();
-      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
     });
 
     testWidgets('advances through the sheet while loading', (tester) async {

--- a/mobile/test/widgets/branded_loading_indicator_test.dart
+++ b/mobile/test/widgets/branded_loading_indicator_test.dart
@@ -7,6 +7,7 @@ import 'dart:typed_data';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:yaml/yaml.dart';
 
@@ -43,13 +44,25 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group(BrandedLoadingIndicator, () {
-    testWidgets('configures the branded sprite sheet', (tester) async {
-      await tester.pumpWidget(
+    final en = lookupAppLocalizations(const Locale('en'));
+
+    Future<void> pumpIndicator(
+      WidgetTester tester, {
+      ThemeData? theme,
+      Widget indicator = const BrandedLoadingIndicator(),
+    }) {
+      return tester.pumpWidget(
         MaterialApp(
-          theme: VineTheme.theme,
-          home: const Scaffold(body: BrandedLoadingIndicator()),
+          theme: theme ?? VineTheme.theme,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: indicator),
         ),
       );
+    }
+
+    testWidgets('configures the branded sprite sheet', (tester) async {
+      await pumpIndicator(tester);
 
       final image = tester.widget<Image>(find.byType(Image));
       expect((image.image as AssetImage).assetName, equals(_spriteAssetKey));
@@ -57,12 +70,7 @@ void main() {
     });
 
     testWidgets('draws the mark alone in dark mode', (tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: VineTheme.theme,
-          home: const Scaffold(body: BrandedLoadingIndicator()),
-        ),
-      );
+      await pumpIndicator(tester);
 
       // White on the dark palette needs no help, so the shadow layer — and
       // its per-frame blur — stays out of the tree entirely.
@@ -71,12 +79,7 @@ void main() {
     });
 
     testWidgets('backs the mark with a shadow in light mode', (tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: VineTheme.lightTheme,
-          home: const Scaffold(body: BrandedLoadingIndicator()),
-        ),
-      );
+      await pumpIndicator(tester, theme: VineTheme.lightTheme);
 
       // Untinted, the white mark all but vanishes on the light surfaces.
       expect(find.byType(ImageFiltered), findsOneWidget);
@@ -87,13 +90,55 @@ void main() {
       expect(layers.last.color, isNull);
     });
 
-    testWidgets('advances through the sheet while loading', (tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: VineTheme.theme,
-          home: const Scaffold(body: BrandedLoadingIndicator()),
+    // Without this the spinner is silent: a screen reader user gets no signal
+    // that the screen — or the control the indicator replaced — is busy.
+    testWidgets('announces that something is loading', (tester) async {
+      final semantics = tester.ensureSemantics();
+      await pumpIndicator(tester);
+
+      expect(find.semantics.byLabel(en.commonLoading), findsOneWidget);
+
+      semantics.dispose();
+      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    });
+
+    testWidgets('announces a caller-supplied label instead', (tester) async {
+      final semantics = tester.ensureSemantics();
+      await pumpIndicator(
+        tester,
+        indicator: const BrandedLoadingIndicator(
+          semanticsLabel: 'Rendering your video',
         ),
       );
+
+      expect(find.semantics.byLabel('Rendering your video'), findsOneWidget);
+      expect(find.semantics.byLabel(en.commonLoading), findsNothing);
+
+      semantics.dispose();
+      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    });
+
+    // The sprite sheet is an unlabelled [Image]; left in the tree it reaches
+    // the reader as a second, meaningless "image" node beside the label.
+    testWidgets('keeps the sprite itself out of the semantics tree', (
+      tester,
+    ) async {
+      final semantics = tester.ensureSemantics();
+      await pumpIndicator(tester, theme: VineTheme.lightTheme);
+
+      // Light mode stacks two sprite layers, so an unexcluded sheet would
+      // show up twice over.
+      final node = tester.getSemantics(find.byType(BrandedLoadingIndicator));
+      expect(node.label, equals(en.commonLoading));
+      expect(node.flagsCollection.isImage, isFalse);
+      expect(node.childrenCount, isZero);
+
+      semantics.dispose();
+      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    });
+
+    testWidgets('advances through the sheet while loading', (tester) async {
+      await pumpIndicator(tester);
 
       // Storage index 13 is the matrix's y translation — how far up the sheet
       // has been scrolled to expose the current frame.

--- a/mobile/test/widgets/video_feed_item/video_loading_placeholder_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_loading_placeholder_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/video_feed_item/video_loading_placeholder.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
@@ -10,6 +11,8 @@ void main() {
     bool shouldPortraitExpand = true,
   }) {
     return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(
         body: VideoLoadingPlaceholder(
           videoId: 'video-1',


### PR DESCRIPTION
Closes #6957

## Description

`BrandedLoadingIndicator` emitted no semantics of its own. Its sprite sheet is an unlabelled `Image`, so a screen reader got a bare "image" node and none of the ~60 call sites announced that anything was happening.

The clearest victim was the cover editor's confirm button: while confirming it swaps the check icon for the indicator, so VoiceOver/TalkBack read "Use selected frame as video cover, disabled" — unavailable, with no hint it was busy. `video_metadata_cover_screen.dart` even carried a hand-rolled `ExcludeSemantics` to suppress the stray image node, which is the same noise this change removes globally.

The indicator now labels itself with the localized `commonLoading` ("Loading", already translated in every locale) and excludes the sprite beneath it. Because `Semantics` merges into an enclosing annotation, the confirm button now reads "Use selected frame as video cover, Loading, disabled" without any per-call-site work.

Why the details are the way they are:

- **`semanticsLabel` parameter.** A caller that wants a more specific label can't just nest its own `Semantics` — the labels would merge and double-announce. The parameter mirrors `CircularProgressIndicator.semanticsLabel`, which this widget replaces throughout the app.
- **A static label, not `liveRegion: true`.** A live region would announce proactively on appearance, but the repo's existing loading precedents (`ModalProgressOverlay`, the people-search skeleton) use a plain label, and `.claude/rules/accessibility.md` reserves proactive announcements for `SemanticsService.sendAnnouncement`. Easy to revisit if we want the louder behaviour.
- **Five sites opt out** — the feed load-more pill, the relay-info row, the sandbox status card, the captions sheet ("Listening for speech…") and the chroma-key overlay ("Applying the green screen…") — because a sibling `Text` already names the wait, and the generic "Loading" would only preempt the more specific copy.
- **The feed placeholder stays silent.** `VideoLoadingPlaceholder` lives inside the feed item's "Play video" button, which already owns that region's semantics (its thumbnail was excluded for the same reason). Buffering there is usually sub-second, so a merged "Play video Loading" would mostly be stale by the time a user focused it.
- **One comment updated in `video_editor_timeline_controls.dart`**, which #6885 wrote around the old behaviour ("the spinner ... has no semantics of its own"). The logic there is unchanged and still correct — the caption names the control, the spinner now names the wait.

**Related Issue:** 

## Out of Scope

- No copy changes: reuses the existing `commonLoading` key rather than adding a new one.
- Loading indicators that are not `BrandedLoadingIndicator` (raw `CircularProgressIndicator`, skeletons) are untouched.

## Verification

- `flutter analyze lib test` — clean
- `flutter test` — full suite green (~15k tests)
- New cases in `branded_loading_indicator_test.dart`: default label, caller-supplied label, and the sprite kept out of the tree (node is not flagged `isImage` and has no children)
- `video_metadata_cover_screen_test.dart` now pins the merged busy label instead of the bare one
- Manual pass with TalkBack on a real Samsung Galaxy 

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
