### PR TITLE
fix(imeta): parse positional comment and NIP-94 metadata

### DIFF
--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -1172,27 +1172,30 @@ class CommentsRepository {
       String? imetaUrlCandidate;
       String? imetaMimeType;
 
-      for (var i = 1; i < tag.length; i++) {
-        final field = tag[i].trim();
-        if (field.startsWith('url ')) {
-          imetaUrlCandidate = field.substring(4).trim();
-        } else if (field.startsWith('m ')) {
-          imetaMimeType = field.substring(2).trim().toLowerCase();
-        } else if (field.startsWith('image ')) {
-          thumbnailUrl = field.substring(6).trim();
-        } else if (field.startsWith('dim ')) {
-          videoDimensions = field.substring(4).trim();
-        } else if (field.startsWith('duration ')) {
-          videoDuration = int.tryParse(field.substring(9).trim());
-        } else if (field.startsWith('blurhash ')) {
-          videoBlurhash = field.substring(9).trim();
+      parseImetaTag(tag, (key, rawValue) {
+        final value = rawValue.trim();
+        switch (key) {
+          case 'url':
+            imetaUrlCandidate = value;
+          case 'm':
+            imetaMimeType = value.toLowerCase();
+          case 'image':
+          case 'thumb':
+            thumbnailUrl = value;
+          case 'dim':
+            videoDimensions = value;
+          case 'duration':
+            videoDuration = int.tryParse(value);
+          case 'blurhash':
+            videoBlurhash = value;
         }
-      }
+      });
 
-      if (imetaUrlCandidate != null &&
+      final candidate = imetaUrlCandidate;
+      if (candidate != null &&
           ((imetaMimeType?.startsWith('video/') ?? false) ||
-              _isVideoUrl(imetaUrlCandidate))) {
-        videoUrl = imetaUrlCandidate;
+              _isVideoUrl(candidate))) {
+        videoUrl = candidate;
       }
     }
 

--- a/mobile/packages/comments_repository/test/src/comments_repository_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_test.dart
@@ -313,6 +313,88 @@ void main() {
         verifyNever(() => mockNostrClient.queryEvents(any()));
       });
 
+      test('maps video metadata from positional REST imeta tags', () async {
+        when(() => mockFunnelcakeApiClient.isAvailable).thenReturn(true);
+        when(
+          () => mockFunnelcakeApiClient.getVideoComments(
+            videoId: any(named: 'videoId'),
+            sort: any(named: 'sort'),
+            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
+            cacheBustToken: any(named: 'cacheBustToken'),
+          ),
+        ).thenAnswer(
+          (_) async => VideoCommentsResponse(
+            comments: [
+              VideoComment(
+                id: 'rest_video_reply',
+                pubkey: testUserPubkey,
+                createdAt: 1000,
+                kind: EventKind.videoVertical,
+                content: 'REST video reply',
+                sig: 'sig',
+                tags: [
+                  ['E', testRootEventId],
+                  ['K', _testRootEventKind.toString()],
+                  ['P', testRootAuthorPubkey],
+                  ['e', testRootEventId],
+                  ['k', _testRootEventKind.toString()],
+                  ['p', testRootAuthorPubkey],
+                  [
+                    'imeta',
+                    'url',
+                    'https://media.divine.video/reply/12345',
+                    'm',
+                    'video/mp4',
+                    'thumb',
+                    'https://media.divine.video/reply/12345.jpg',
+                    'dim',
+                    '720x1280',
+                    'duration',
+                    '6',
+                    'blurhash',
+                    'LKO2?U%2Tw=w]~RBVZRi};RPxuwH',
+                  ],
+                ],
+              ),
+            ],
+            total: 1,
+          ),
+        );
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => []);
+
+        repository = CommentsRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcakeApiClient,
+        );
+
+        final result = await repository.loadComments(
+          rootEventId: testRootEventId,
+          rootEventKind: _testRootEventKind,
+          includeVideoReplies: true,
+        );
+
+        expect(result.comments, hasLength(1));
+        expect(result.comments.first.hasVideo, isTrue);
+        expect(
+          result.comments.first.videoUrl,
+          equals('https://media.divine.video/reply/12345'),
+        );
+        expect(
+          result.comments.first.thumbnailUrl,
+          equals('https://media.divine.video/reply/12345.jpg'),
+        );
+        expect(result.comments.first.videoDimensions, equals('720x1280'));
+        expect(result.comments.first.videoDuration, equals(6));
+        expect(
+          result.comments.first.videoBlurhash,
+          equals('LKO2?U%2Tw=w]~RBVZRi};RPxuwH'),
+        );
+        verifyNever(() => mockNostrClient.queryEvents(any()));
+      });
+
       test(
         'maps coordinate and kind from a REST video reply (#6124)',
         () async {
@@ -674,6 +756,64 @@ void main() {
           expect(
             result.comments.first.videoUrl,
             equals('https://media.divine.video/reply/12345'),
+          );
+        },
+      );
+
+      test(
+        'maps relay video metadata from positional imeta tags',
+        () async {
+          final videoReplyEvent = _createCommentEvent(
+            id: 'video_reply',
+            kind: EventKind.videoVertical,
+            content: 'Reply title',
+            pubkey: testUserPubkey,
+            rootEventId: testRootEventId,
+            rootAuthorPubkey: testRootAuthorPubkey,
+            rootEventKind: _testRootEventKind,
+            extraTags: const [
+              [
+                'imeta',
+                'url',
+                'https://media.divine.video/reply/12345',
+                'm',
+                'video/mp4',
+                'image',
+                'https://media.divine.video/reply/12345.jpg',
+                'dim',
+                '720x1280',
+                'duration',
+                '6',
+                'blurhash',
+                'LKO2?U%2Tw=w]~RBVZRi};RPxuwH',
+              ],
+            ],
+          );
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [videoReplyEvent]);
+
+          final result = await repository.loadComments(
+            rootEventId: testRootEventId,
+            rootEventKind: _testRootEventKind,
+            includeVideoReplies: true,
+          );
+
+          expect(result.comments, hasLength(1));
+          expect(result.comments.first.hasVideo, isTrue);
+          expect(
+            result.comments.first.videoUrl,
+            equals('https://media.divine.video/reply/12345'),
+          );
+          expect(
+            result.comments.first.thumbnailUrl,
+            equals('https://media.divine.video/reply/12345.jpg'),
+          );
+          expect(result.comments.first.videoDimensions, equals('720x1280'));
+          expect(result.comments.first.videoDuration, equals(6));
+          expect(
+            result.comments.first.videoBlurhash,
+            equals('LKO2?U%2Tw=w]~RBVZRi};RPxuwH'),
           );
         },
       );

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -6,7 +6,6 @@
 import 'dart:convert';
 
 import 'package:meta/meta.dart';
-import 'package:models/src/imeta_tag.dart';
 import 'package:models/src/nip71_video_kinds.dart';
 import 'package:models/src/video_attribution.dart';
 import 'package:models/src/video_url_resolver.dart';

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -4,8 +4,8 @@
 
 import 'package:meta/meta.dart';
 import 'package:models/src/engagement_count_parser.dart';
-import 'package:models/src/imeta_tag.dart';
 import 'package:models/src/video_event.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
 
 /// Video with engagement metrics from Funnelcake API.
 ///

--- a/mobile/packages/nostr_sdk/lib/nip92/imeta_tag.dart
+++ b/mobile/packages/nostr_sdk/lib/nip92/imeta_tag.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Shared parser for NIP-71 imeta tag key-value encodings.
+// ABOUTME: Shared parser for NIP-92 imeta tag key-value encodings.
 
 /// Parses an `imeta` tag and calls [onKeyValue] for each metadata key-value
 /// pair.

--- a/mobile/packages/nostr_sdk/lib/nip94/file_metadata.dart
+++ b/mobile/packages/nostr_sdk/lib/nip94/file_metadata.dart
@@ -1,3 +1,4 @@
+import 'package:nostr_sdk/nip92/imeta_tag.dart';
 import 'package:nostr_sdk/utils/path_type_util.dart';
 
 import '../utils/string_util.dart';
@@ -71,47 +72,40 @@ class FileMetadata {
       String? alt;
       List<String> fallback = [];
 
-      for (var text in tag) {
-        if (text == "imeta") {
-          continue;
-        }
-
-        var strs = text.split(" ");
-        if (strs.length < 2) {
-          continue;
-        }
-
-        var key = strs[0];
+      parseImetaTag(List<String>.from(tag.map((e) => e.toString())), (
+        key,
+        value,
+      ) {
         if (key == "url") {
-          url = strs[1];
+          url = value;
         } else if (key == "m") {
-          m = strs[1];
+          m = value;
         } else if (key == "x") {
-          x = strs[1];
+          x = value;
         } else if (key == "ox") {
-          ox = strs[1];
+          ox = value;
         } else if (key == "size") {
-          size = strs[1];
+          size = value;
         } else if (key == "dim") {
-          dim = strs[1];
+          dim = value;
         } else if (key == "magnet") {
-          magnet = strs[1];
+          magnet = value;
         } else if (key == "i") {
-          i = strs[1];
+          i = value;
         } else if (key == "blurhash") {
-          blurhash = strs[1];
+          blurhash = value;
         } else if (key == "thumb") {
-          thumb = strs[1];
+          thumb = value;
         } else if (key == "image") {
-          image = strs[1];
+          image = value;
         } else if (key == "summary") {
-          summary = strs[1];
+          summary = value;
         } else if (key == "alt") {
-          alt = strs[1];
+          alt = value;
         } else if (key == "fallback") {
-          fallback.add(strs[1]);
+          fallback.add(value);
         }
-      }
+      });
 
       if (StringUtil.isBlank(m) && StringUtil.isNotBlank(url)) {
         var pathType = PathTypeUtil.getPathType(url!);

--- a/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
@@ -41,6 +41,7 @@ export 'nip65/nip65.dart';
 export 'nip65/relay_list_metadata.dart';
 export 'nip69/poll_info.dart';
 export 'nip75/zap_goals_info.dart';
+export 'nip92/imeta_tag.dart';
 export 'nip94/file_metadata.dart';
 // Core classes - essential for any Nostr application
 export 'nostr.dart';

--- a/mobile/packages/nostr_sdk/test/nip92/imeta_tag_test.dart
+++ b/mobile/packages/nostr_sdk/test/nip92/imeta_tag_test.dart
@@ -1,0 +1,79 @@
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('parseImetaTag', () {
+    Map<String, List<String>> parse(List<String> tag) {
+      final values = <String, List<String>>{};
+      parseImetaTag(tag, (key, value) {
+        values.putIfAbsent(key, () => []).add(value);
+      });
+      return values;
+    }
+
+    test('parses space-separated fields', () {
+      expect(
+        parse([
+          'imeta',
+          'url https://media.divine.video/video.mp4',
+          'm video/mp4',
+          'dim 720x1280',
+        ]),
+        equals({
+          'url': ['https://media.divine.video/video.mp4'],
+          'm': ['video/mp4'],
+          'dim': ['720x1280'],
+        }),
+      );
+    });
+
+    test('parses positional key-value fields', () {
+      expect(
+        parse([
+          'imeta',
+          'url',
+          'https://media.divine.video/video.mp4',
+          'm',
+          'video/mp4',
+          'dim',
+          '720x1280',
+        ]),
+        equals({
+          'url': ['https://media.divine.video/video.mp4'],
+          'm': ['video/mp4'],
+          'dim': ['720x1280'],
+        }),
+      );
+    });
+
+    test('ignores empty and one-element tags', () {
+      expect(parse([]), isEmpty);
+      expect(parse(['imeta']), isEmpty);
+    });
+
+    test('ignores odd trailing positional key without value', () {
+      expect(
+        parse(['imeta', 'url', 'https://media.divine.video/video.mp4', 'dim']),
+        equals({
+          'url': ['https://media.divine.video/video.mp4'],
+        }),
+      );
+    });
+
+    test('preserves values containing spaces', () {
+      expect(
+        parse([
+          'imeta',
+          'url https://media.divine.video/video.mp4',
+          'alt A caption with spaces',
+          'summary A longer summary with spaces',
+        ]),
+        equals({
+          'url': ['https://media.divine.video/video.mp4'],
+          'alt': ['A caption with spaces'],
+          'summary': ['A longer summary with spaces'],
+        }),
+      );
+    });
+  });
+}

--- a/mobile/packages/nostr_sdk/test/nip94/file_metadata_test.dart
+++ b/mobile/packages/nostr_sdk/test/nip94/file_metadata_test.dart
@@ -1,0 +1,43 @@
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('FileMetadata.fromNIP92Tag', () {
+    test('parses positional imeta metadata', () {
+      final metadata = FileMetadata.fromNIP92Tag([
+        'imeta',
+        'url',
+        'https://media.divine.video/image.jpg',
+        'm',
+        'image/jpeg',
+        'dim',
+        '720x1280',
+        'thumb',
+        'https://media.divine.video/thumb.jpg',
+        'blurhash',
+        'LKO2?U%2Tw=w]~RBVZRi};RPxuwH',
+      ]);
+
+      expect(metadata, isNotNull);
+      expect(metadata!.url, equals('https://media.divine.video/image.jpg'));
+      expect(metadata.m, equals('image/jpeg'));
+      expect(metadata.dim, equals('720x1280'));
+      expect(metadata.thumb, equals('https://media.divine.video/thumb.jpg'));
+      expect(metadata.blurhash, equals('LKO2?U%2Tw=w]~RBVZRi};RPxuwH'));
+    });
+
+    test('preserves space-separated alt and summary values with spaces', () {
+      final metadata = FileMetadata.fromNIP92Tag([
+        'imeta',
+        'url https://media.divine.video/image.jpg',
+        'm image/jpeg',
+        'alt A caption with spaces',
+        'summary A longer summary with spaces',
+      ]);
+
+      expect(metadata, isNotNull);
+      expect(metadata!.alt, equals('A caption with spaces'));
+      expect(metadata.summary, equals('A longer summary with spaces'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- move the shared `imeta` parser from `models` into `nostr_sdk` and export it there
- use the shared parser for comment video metadata and NIP-94 file metadata
- accept `thumb` as a comment thumbnail key alongside `image` while parsing shared `imeta` metadata
- add regression coverage for positional `imeta` in comments and NIP-94, plus direct parser tests

Closes #6959
Refs #6961

## Verification

- `flutter test test/nip92/imeta_tag_test.dart test/nip94/file_metadata_test.dart` from `mobile/packages/nostr_sdk`
- `flutter test test/src/comments_repository_test.dart` from `mobile/packages/comments_repository`
- `flutter test test/src/video_event_parsing_test.dart test/src/video_stats_test.dart` from `mobile/packages/models`
- `flutter analyze lib test` from `mobile/packages/nostr_sdk`
- `flutter analyze lib test` from `mobile/packages/comments_repository`
- `flutter analyze lib test` from `mobile/packages/models`
- `flutter test --coverage` from `mobile/packages/comments_repository`
- `flutter test --coverage` from `mobile/packages/models`
- `flutter test --coverage` from `mobile/packages/nostr_sdk`
- pre-push hook: analyzer and changed-file tests passed