### PR TITLE
fix(collabs): render only confirmed collaborators to third-party viewers

### DIFF
--- a/mobile/lib/blocs/video_collaborator_status/video_collaborator_status_cubit.dart
+++ b/mobile/lib/blocs/video_collaborator_status/video_collaborator_status_cubit.dart
@@ -49,6 +49,7 @@ class VideoCollaboratorStatusCubit extends Cubit<VideoCollaboratorStatusState> {
               state.copyWith(
                 load: VideoCollaboratorStatusLoad.ready,
                 statusByPubkey: snapshot.statusByPubkey,
+                isResolved: snapshot.isResolved,
               ),
             );
           },

--- a/mobile/lib/blocs/video_collaborator_status/video_collaborator_status_state.dart
+++ b/mobile/lib/blocs/video_collaborator_status/video_collaborator_status_state.dart
@@ -19,10 +19,9 @@ class VideoCollaboratorStatusState extends Equatable {
   ///
   /// Distinct from [load]: `ready` means a snapshot arrived, which happens
   /// immediately and before any relay answer. Surfaces that hide unconfirmed
-  /// collaborators must gate on this instead, and it stays `false` on
-  /// [VideoCollaboratorStatusLoad.failure] so an unreachable relay keeps them
-  /// hidden rather than falling back to crediting untagged-but-unconfirmed
-  /// pubkeys.
+  /// collaborators must gate on this instead. A failure before EOSE leaves it
+  /// false, so an unreachable relay keeps third-party surfaces hidden rather
+  /// than falling back to crediting unconfirmed pubkeys.
   final bool isResolved;
 
   CollaboratorStatus statusFor(String pubkey) =>

--- a/mobile/lib/blocs/video_collaborator_status/video_collaborator_status_state.dart
+++ b/mobile/lib/blocs/video_collaborator_status/video_collaborator_status_state.dart
@@ -9,10 +9,21 @@ class VideoCollaboratorStatusState extends Equatable {
   const VideoCollaboratorStatusState({
     this.load = VideoCollaboratorStatusLoad.loading,
     this.statusByPubkey = const {},
+    this.isResolved = false,
   });
 
   final VideoCollaboratorStatusLoad load;
   final Map<String, CollaboratorStatus> statusByPubkey;
+
+  /// Whether the acceptance query has finished (relay EOSE).
+  ///
+  /// Distinct from [load]: `ready` means a snapshot arrived, which happens
+  /// immediately and before any relay answer. Surfaces that hide unconfirmed
+  /// collaborators must gate on this instead, and it stays `false` on
+  /// [VideoCollaboratorStatusLoad.failure] so an unreachable relay keeps them
+  /// hidden rather than falling back to crediting untagged-but-unconfirmed
+  /// pubkeys.
+  final bool isResolved;
 
   CollaboratorStatus statusFor(String pubkey) =>
       statusByPubkey[pubkey] ?? CollaboratorStatus.pending;
@@ -20,13 +31,15 @@ class VideoCollaboratorStatusState extends Equatable {
   VideoCollaboratorStatusState copyWith({
     VideoCollaboratorStatusLoad? load,
     Map<String, CollaboratorStatus>? statusByPubkey,
+    bool? isResolved,
   }) {
     return VideoCollaboratorStatusState(
       load: load ?? this.load,
       statusByPubkey: statusByPubkey ?? this.statusByPubkey,
+      isResolved: isResolved ?? this.isResolved,
     );
   }
 
   @override
-  List<Object?> get props => [load, statusByPubkey];
+  List<Object?> get props => [load, statusByPubkey, isResolved];
 }

--- a/mobile/lib/widgets/video_feed_item/collaborator_avatar_row.dart
+++ b/mobile/lib/widgets/video_feed_item/collaborator_avatar_row.dart
@@ -98,12 +98,16 @@ class _StatusAwareRow extends StatelessWidget {
     final statusByPubkey = context.select(
       (VideoCollaboratorStatusCubit c) => c.state.statusByPubkey,
     );
+    final isResolved = context.select(
+      (VideoCollaboratorStatusCubit c) => c.state.isResolved,
+    );
     return CollaboratorAvatarRowBody(
       visibility: CollaboratorVisibility(
         taggedPubkeys: pubkeys,
         statusByPubkey: statusByPubkey,
         currentUserPubkey: currentUserPubkey,
         creatorPubkey: video.pubkey,
+        isResolved: isResolved,
       ),
     );
   }

--- a/mobile/lib/widgets/video_feed_item/collaborator_avatar_row.dart
+++ b/mobile/lib/widgets/video_feed_item/collaborator_avatar_row.dart
@@ -1,7 +1,7 @@
 // ABOUTME: Collaborator avatar row for video feed overlay
 // ABOUTME: Status-aware: hides current user's avatar when ignored locally,
 // ABOUTME: greys pending avatars on the inviter's own video, otherwise
-// ABOUTME: renders raw collaborator p-tags as today.
+// ABOUTME: renders only confirmed collaborators to third-party viewers.
 
 import 'package:collaborator_repository/collaborator_repository.dart';
 import 'package:divine_ui/divine_ui.dart';
@@ -32,8 +32,8 @@ const _pickerMaxChildSize = 0.8;
 /// Hides the current user's own avatar when their local invite store says
 /// `ignored` for this video. On the inviter's own video, pending
 /// collaborator avatars render greyed until a kind-34238 acceptance flips
-/// them to confirmed. Third-party viewers see the same raw p-tag list as
-/// before this wiring (status-unaware fallback).
+/// them to confirmed. Third-party viewers only see confirmed collaborators
+/// after the acceptance query resolves.
 ///
 /// Returns [SizedBox.shrink] if the video has no collaborators after the
 /// status-aware filter.
@@ -410,10 +410,7 @@ class _SmallAvatar extends ConsumerWidget {
 
 /// Text label showing collaborator name(s).
 class _CollaboratorLabel extends ConsumerWidget {
-  const _CollaboratorLabel({
-    required this.pubkeys,
-    required this.pendingCount,
-  });
+  const _CollaboratorLabel({required this.pubkeys, required this.pendingCount});
 
   final List<String> pubkeys;
   final int pendingCount;
@@ -436,9 +433,9 @@ class _CollaboratorLabel extends ConsumerWidget {
 
     return Text(
       label,
-      style: VineTheme.labelMediumFont(color: VineTheme.whiteText).copyWith(
-        shadows: const [Shadow(blurRadius: 4)],
-      ),
+      style: VineTheme.labelMediumFont(
+        color: VineTheme.whiteText,
+      ).copyWith(shadows: const [Shadow(blurRadius: 4)]),
       maxLines: 1,
       overflow: TextOverflow.ellipsis,
     );

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
@@ -120,12 +120,16 @@ class _CollaboratorsSectionStatusAware extends StatelessWidget {
     final statusByPubkey = context.select(
       (VideoCollaboratorStatusCubit c) => c.state.statusByPubkey,
     );
+    final isResolved = context.select(
+      (VideoCollaboratorStatusCubit c) => c.state.isResolved,
+    );
     return MetadataCollaboratorsSectionBody(
       visibility: CollaboratorVisibility(
         taggedPubkeys: pubkeys,
         statusByPubkey: statusByPubkey,
         currentUserPubkey: currentUserPubkey,
         creatorPubkey: video.pubkey,
+        isResolved: isResolved,
       ),
     );
   }

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
@@ -62,7 +62,8 @@ class MetadataCreatorSection extends StatelessWidget {
 ///
 /// Hides the current user's chip when their local invite store says
 /// `ignored` for this video. Pending collaborator chips are dimmed when
-/// the current user is the video's creator.
+/// the current user is the video's creator. Third-party viewers only see
+/// confirmed collaborators after the acceptance query resolves.
 ///
 /// Shows placeholder chips while the names of the resulting list resolve,
 /// and renders nothing while that list is empty.

--- a/mobile/packages/collaborator_repository/lib/collaborator_repository.dart
+++ b/mobile/packages/collaborator_repository/lib/collaborator_repository.dart
@@ -1,8 +1,8 @@
 /// Repository for collaborator confirmation status on Divine videos.
 ///
-/// Drives per-video pending vs confirmed rendering for own-authored videos
-/// and the current user's local invite-response fast-path. Third-party
-/// rendering of collaborator p-tags is unchanged by this repository.
+/// Drives per-video pending vs confirmed rendering for authors, the current
+/// user's local invite-response fast-path, and confirmed-only third-party
+/// collaborator visibility.
 library;
 
 export 'src/collaborator_confirmation_repository.dart';

--- a/mobile/packages/collaborator_repository/lib/src/collaborator_confirmation_repository.dart
+++ b/mobile/packages/collaborator_repository/lib/src/collaborator_confirmation_repository.dart
@@ -66,6 +66,11 @@ class CollaboratorConfirmationRepository {
   final Map<String, StreamSubscription<Event>> _relaySubs =
       <String, StreamSubscription<Event>>{};
 
+  /// Video addresses whose acceptance query has reached relay EOSE. Until an
+  /// address is in here, a `pending` entry means "not heard back yet" rather
+  /// than "did not accept".
+  final Set<String> _resolved = <String>{};
+
   /// Per-video cache of the most recent watch parameters. Lets
   /// [markLocal] re-emit a snapshot without callers having to thread the
   /// creator pubkey and tagged-pubkey list through every accept/ignore site.
@@ -119,9 +124,15 @@ class CollaboratorConfirmationRepository {
     final isOwnVideo = creatorPubkey == _currentUserPubkey;
     if (isOwnVideo && !_relaySubs.containsKey(videoAddress)) {
       _relaySubs[videoAddress] = _nostrClient
-          .subscribe([
-            Filter(kinds: const [_kindCollaboratorResponse], a: [videoAddress]),
-          ])
+          .subscribe(
+            [
+              Filter(
+                kinds: const [_kindCollaboratorResponse],
+                a: [videoAddress],
+              ),
+            ],
+            onEose: () => _markResolved(videoAddress),
+          )
           .listen(
             (event) => _handleAcceptanceEvent(
               event,
@@ -154,6 +165,7 @@ class CollaboratorConfirmationRepository {
       _relayAccepted.remove(videoAddress);
       _currentUserOverride.remove(videoAddress);
       _watchContext.remove(videoAddress);
+      _resolved.remove(videoAddress);
       return;
     }
     _refCount[videoAddress] = current - 1;
@@ -218,6 +230,23 @@ class CollaboratorConfirmationRepository {
     _relayAccepted.clear();
     _currentUserOverride.clear();
     _watchContext.clear();
+    _resolved.clear();
+  }
+
+  /// Marks [videoAddress] resolved on relay EOSE and re-emits so surfaces
+  /// gated on [VideoCollaboratorStatus.isResolved] can render.
+  void _markResolved(String videoAddress) {
+    if (!_resolved.add(videoAddress)) return;
+    final subject = _subjects[videoAddress];
+    final context = _watchContext[videoAddress];
+    if (subject == null || context == null) return;
+    subject.add(
+      _snapshot(
+        videoAddress: videoAddress,
+        creatorPubkey: context.creatorPubkey,
+        taggedPubkeys: context.taggedPubkeys,
+      ),
+    );
   }
 
   void _handleAcceptanceEvent(
@@ -311,6 +340,7 @@ class CollaboratorConfirmationRepository {
     return VideoCollaboratorStatus(
       videoAddress: videoAddress,
       statusByPubkey: statusByPubkey,
+      isResolved: _resolved.contains(videoAddress),
     );
   }
 }

--- a/mobile/packages/collaborator_repository/lib/src/collaborator_confirmation_repository.dart
+++ b/mobile/packages/collaborator_repository/lib/src/collaborator_confirmation_repository.dart
@@ -20,12 +20,14 @@ const int _kindCollaboratorResponse = 34238;
 /// creator-side `'collaborator'`-role p-tags, and the current user's local
 /// invite-store fast-path into a single per-video status snapshot stream.
 ///
-/// Scope guard: the kind-34238 subscription is only opened when the current
-/// user authored the video. For other viewing contexts the repository emits
-/// from the local-store fast-path (so the current user's own ignore/accept
-/// flips their own avatar) without adding relay traffic. Third-party
-/// rendering of pending collaborators is unchanged by this repository —
-/// that broader fix lives in the lifecycle plan and depends on Funnelcake.
+/// The kind-34238 subscription opens for every viewer, not just the video's
+/// author. Third-party viewers need confirmation data to distinguish an
+/// accepted collaborator from someone the creator merely tagged; without it
+/// the render surfaces credit both identically (#6907).
+///
+/// Snapshots carry [VideoCollaboratorStatus.isResolved] so callers can tell
+/// "did not accept" from "have not heard back yet" — both leave a pubkey
+/// [CollaboratorStatus.pending], but only the former is a real answer.
 ///
 /// One subscription per `videoAddress`, ref-counted across watchers. The
 /// underlying [NostrClient.subscribe] also dedupes by filter hash, so even
@@ -120,15 +122,26 @@ class CollaboratorConfirmationRepository {
             ),
           );
 
-    // Open the relay subscription on demand, only for own-authored videos.
-    final isOwnVideo = creatorPubkey == _currentUserPubkey;
-    if (isOwnVideo && !_relaySubs.containsKey(videoAddress)) {
+    // Open the relay subscription on demand, for every viewer. Third-party
+    // viewers need it too: without confirmation data they cannot tell an
+    // accepted collaborator from someone the creator merely tagged, and the
+    // render surfaces would credit both. The relay serves kind-34238 to
+    // unauthenticated readers, so no signer or backend route is required.
+    //
+    // `authors` bounds the result set to pubkeys that could legitimately
+    // confirm; only tagged pubkeys are meaningful, and the handler
+    // re-checks membership anyway. Omitted when nothing is tagged, since an
+    // empty authors array is not a meaningful filter.
+    if (!_relaySubs.containsKey(videoAddress)) {
       _relaySubs[videoAddress] = _nostrClient
           .subscribe(
             [
               Filter(
                 kinds: const [_kindCollaboratorResponse],
                 a: [videoAddress],
+                authors: taggedPubkeys.isEmpty
+                    ? null
+                    : List<String>.of(taggedPubkeys),
               ),
             ],
             onEose: () => _markResolved(videoAddress),
@@ -309,29 +322,34 @@ class CollaboratorConfirmationRepository {
     final override = _currentUserOverride[videoAddress];
 
     for (final pubkey in taggedPubkeys) {
+      // The current user's own local decision is authoritative on this
+      // device and outranks the relay echo. Ignore is local-only with no
+      // protocol un-accept, so a kind-34238 from an earlier accept must not
+      // resurrect an avatar the user has since hidden. Other pubkeys' local
+      // states are unknown to this device.
+      //
+      // Order matters: before #6907 the subscription never opened for a
+      // recipient viewing someone else's video, so `accepted` was always
+      // empty here and checking the relay first was harmless. It opens for
+      // every viewer now, which would let the echo overwrite the ignore.
+      if (pubkey == _currentUserPubkey) {
+        final local =
+            override ??
+            _localStateReader.readLocalState(
+              videoAddress: videoAddress,
+              creatorPubkey: creatorPubkey,
+              collaboratorPubkey: pubkey,
+            );
+        if (local != null) {
+          statusByPubkey[pubkey] = local;
+          continue;
+        }
+      }
+
       // Relay-derived: kind-34238 acceptance event observed.
       if (accepted.contains(pubkey)) {
         statusByPubkey[pubkey] = CollaboratorStatus.confirmed;
         continue;
-      }
-
-      // Local-store fast-path for the current user only. Other pubkeys'
-      // states are unknown to this device.
-      if (pubkey == _currentUserPubkey) {
-        final inMemory = override;
-        if (inMemory != null) {
-          statusByPubkey[pubkey] = inMemory;
-          continue;
-        }
-        final fromStore = _localStateReader.readLocalState(
-          videoAddress: videoAddress,
-          creatorPubkey: creatorPubkey,
-          collaboratorPubkey: pubkey,
-        );
-        if (fromStore != null) {
-          statusByPubkey[pubkey] = fromStore;
-          continue;
-        }
       }
 
       statusByPubkey[pubkey] = CollaboratorStatus.pending;

--- a/mobile/packages/collaborator_repository/lib/src/collaborator_confirmation_repository.dart
+++ b/mobile/packages/collaborator_repository/lib/src/collaborator_confirmation_repository.dart
@@ -236,10 +236,16 @@ class CollaboratorConfirmationRepository {
     );
     if (!addressMatches) return;
 
-    final hasAcceptedStatus = event.tags.any(
-      (tag) => tag.length >= 2 && tag[0] == 'status' && tag[1] == 'accepted',
+    // A missing `status` tag means accepted. divine-web publishes acceptances
+    // as `[['a', coord], ['d', uuid]]` with no `status`, and Funnelcake's
+    // confirmed read model does not require one either — requiring it here
+    // silently dropped every web-made acceptance. Only an explicit
+    // non-accepted status rejects the event.
+    final statusTag = event.tags.firstWhere(
+      (tag) => tag.length >= 2 && tag[0] == 'status',
+      orElse: () => const <String>[],
     );
-    if (!hasAcceptedStatus) return;
+    if (statusTag.length >= 2 && statusTag[1] != 'accepted') return;
 
     if (!taggedPubkeys.contains(event.pubkey)) {
       Log.info(

--- a/mobile/packages/collaborator_repository/lib/src/collaborator_confirmation_repository.dart
+++ b/mobile/packages/collaborator_repository/lib/src/collaborator_confirmation_repository.dart
@@ -1,7 +1,8 @@
 // ABOUTME: Derives per-video collaborator confirmation status on mobile.
-// ABOUTME: Subscribes to kind-34238 acceptance events for own-authored videos.
+// ABOUTME: Subscribes to kind-34238 acceptance events for every viewer.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:collaborator_repository/src/local_state_reader.dart';
 import 'package:models/models.dart';
@@ -29,10 +30,10 @@ const int _kindCollaboratorResponse = 34238;
 /// "did not accept" from "have not heard back yet" — both leave a pubkey
 /// [CollaboratorStatus.pending], but only the former is a real answer.
 ///
-/// One subscription per `videoAddress`, ref-counted across watchers. The
-/// underlying [NostrClient.subscribe] also dedupes by filter hash, so even
-/// if the subscription opens twice it collapses to a single WebSocket
-/// subscription at the transport layer.
+/// One subscription per `(videoAddress, taggedPubkeys)` filter, ref-counted
+/// across watchers for the same video address. The repository owns the explicit
+/// Nostr subscription id so release/close can send `CLOSE` to relays instead
+/// of only cancelling the local Dart listener.
 class CollaboratorConfirmationRepository {
   CollaboratorConfirmationRepository({
     required NostrClient nostrClient,
@@ -64,9 +65,10 @@ class CollaboratorConfirmationRepository {
   /// Per-video ref counts. Subscriptions close when count drops to zero.
   final Map<String, int> _refCount = <String, int>{};
 
-  /// Per-video relay subscriptions. Only present for own-authored videos.
-  final Map<String, StreamSubscription<Event>> _relaySubs =
-      <String, StreamSubscription<Event>>{};
+  /// Per-video relay subscriptions. The active subscription's author filter is
+  /// captured here because it changes when the creator edits collaborators.
+  final Map<String, _RelaySubscription> _relaySubs =
+      <String, _RelaySubscription>{};
 
   /// Video addresses whose acceptance query has reached relay EOSE. Until an
   /// address is in here, a `pending` entry means "not heard back yet" rather
@@ -95,10 +97,11 @@ class CollaboratorConfirmationRepository {
     required String creatorPubkey,
     required List<String> taggedPubkeys,
   }) {
+    final normalizedTaggedPubkeys = _normalizePubkeys(taggedPubkeys);
     _refCount[videoAddress] = (_refCount[videoAddress] ?? 0) + 1;
     _watchContext[videoAddress] = _WatchContext(
       creatorPubkey: creatorPubkey,
-      taggedPubkeys: List.unmodifiable(taggedPubkeys),
+      taggedPubkeys: List.unmodifiable(normalizedTaggedPubkeys),
     );
 
     final subject =
@@ -108,7 +111,7 @@ class CollaboratorConfirmationRepository {
               _snapshot(
                 videoAddress: videoAddress,
                 creatorPubkey: creatorPubkey,
-                taggedPubkeys: taggedPubkeys,
+                taggedPubkeys: normalizedTaggedPubkeys,
               ),
             ),
           )
@@ -118,7 +121,7 @@ class CollaboratorConfirmationRepository {
             _snapshot(
               videoAddress: videoAddress,
               creatorPubkey: creatorPubkey,
-              taggedPubkeys: taggedPubkeys,
+              taggedPubkeys: normalizedTaggedPubkeys,
             ),
           );
 
@@ -132,37 +135,12 @@ class CollaboratorConfirmationRepository {
     // confirm; only tagged pubkeys are meaningful, and the handler
     // re-checks membership anyway. Omitted when nothing is tagged, since an
     // empty authors array is not a meaningful filter.
-    if (!_relaySubs.containsKey(videoAddress)) {
-      _relaySubs[videoAddress] = _nostrClient
-          .subscribe(
-            [
-              Filter(
-                kinds: const [_kindCollaboratorResponse],
-                a: [videoAddress],
-                authors: taggedPubkeys.isEmpty
-                    ? null
-                    : List<String>.of(taggedPubkeys),
-              ),
-            ],
-            onEose: () => _markResolved(videoAddress),
-          )
-          .listen(
-            (event) => _handleAcceptanceEvent(
-              event,
-              videoAddress: videoAddress,
-              creatorPubkey: creatorPubkey,
-              taggedPubkeys: taggedPubkeys,
-            ),
-            onError: (Object error, StackTrace stackTrace) {
-              Log.warning(
-                'kind-$_kindCollaboratorResponse subscription error for '
-                '$videoAddress: $error',
-                name: 'CollaboratorConfirmationRepository',
-                category: LogCategory.system,
-              );
-            },
-          );
-    }
+    _ensureRelaySubscription(
+      videoAddress: videoAddress,
+      creatorPubkey: creatorPubkey,
+      taggedPubkeys: normalizedTaggedPubkeys,
+      subject: subject,
+    );
 
     return subject.stream;
   }
@@ -173,7 +151,10 @@ class CollaboratorConfirmationRepository {
     final current = _refCount[videoAddress] ?? 0;
     if (current <= 1) {
       _refCount.remove(videoAddress);
-      unawaited(_relaySubs.remove(videoAddress)?.cancel());
+      final relaySub = _relaySubs.remove(videoAddress);
+      if (relaySub != null) {
+        unawaited(_cancelRelaySubscription(relaySub));
+      }
       unawaited(_subjects.remove(videoAddress)?.close());
       _relayAccepted.remove(videoAddress);
       _currentUserOverride.remove(videoAddress);
@@ -232,7 +213,7 @@ class CollaboratorConfirmationRepository {
   /// Disposes all subjects and subscriptions. Used on sign-out / shutdown.
   Future<void> close() async {
     for (final sub in _relaySubs.values) {
-      await sub.cancel();
+      await _cancelRelaySubscription(sub);
     }
     _relaySubs.clear();
     for (final subject in _subjects.values) {
@@ -248,11 +229,13 @@ class CollaboratorConfirmationRepository {
 
   /// Marks [videoAddress] resolved on relay EOSE and re-emits so surfaces
   /// gated on [VideoCollaboratorStatus.isResolved] can render.
-  void _markResolved(String videoAddress) {
-    if (!_resolved.add(videoAddress)) return;
+  void _markResolved(String videoAddress, {required String subscriptionId}) {
     final subject = _subjects[videoAddress];
     final context = _watchContext[videoAddress];
+    final relaySub = _relaySubs[videoAddress];
     if (subject == null || context == null) return;
+    if (relaySub?.subscriptionId != subscriptionId) return;
+    if (!_resolved.add(videoAddress)) return;
     subject.add(
       _snapshot(
         videoAddress: videoAddress,
@@ -265,10 +248,12 @@ class CollaboratorConfirmationRepository {
   void _handleAcceptanceEvent(
     Event event, {
     required String videoAddress,
+    required String subscriptionId,
     required String creatorPubkey,
     required List<String> taggedPubkeys,
   }) {
     if (event.kind != _kindCollaboratorResponse) return;
+    if (_relaySubs[videoAddress]?.subscriptionId != subscriptionId) return;
 
     // NIP-33 'a' tag references another addressable event (the video). The
     // kind-34238 event's own 'd' tag identifies itself, not the video, so
@@ -289,7 +274,8 @@ class CollaboratorConfirmationRepository {
     );
     if (statusTag.length >= 2 && statusTag[1] != 'accepted') return;
 
-    if (!taggedPubkeys.contains(event.pubkey)) {
+    final normalizedEventPubkey = event.pubkey.toLowerCase();
+    if (!taggedPubkeys.contains(normalizedEventPubkey)) {
       Log.info(
         'Ignoring kind-$_kindCollaboratorResponse from non-tagged pubkey '
         '${event.pubkey} for $videoAddress',
@@ -300,7 +286,7 @@ class CollaboratorConfirmationRepository {
     }
 
     final accepted = _relayAccepted.putIfAbsent(videoAddress, () => <String>{});
-    if (accepted.add(event.pubkey)) {
+    if (accepted.add(normalizedEventPubkey)) {
       final subject = _subjects[videoAddress];
       subject?.add(
         _snapshot(
@@ -310,6 +296,78 @@ class CollaboratorConfirmationRepository {
         ),
       );
     }
+  }
+
+  void _ensureRelaySubscription({
+    required String videoAddress,
+    required String creatorPubkey,
+    required List<String> taggedPubkeys,
+    required BehaviorSubject<VideoCollaboratorStatus> subject,
+  }) {
+    final subscriptionId = _subscriptionIdFor(
+      videoAddress: videoAddress,
+      taggedPubkeys: taggedPubkeys,
+    );
+    final existing = _relaySubs[videoAddress];
+    if (existing != null) {
+      if (existing.subscriptionId == subscriptionId) return;
+
+      _relaySubs.remove(videoAddress);
+      unawaited(_cancelRelaySubscription(existing));
+      _relayAccepted.remove(videoAddress);
+      _resolved.remove(videoAddress);
+      subject.add(
+        _snapshot(
+          videoAddress: videoAddress,
+          creatorPubkey: creatorPubkey,
+          taggedPubkeys: taggedPubkeys,
+        ),
+      );
+    }
+
+    // Owned by _RelaySubscription and cancelled from release/close.
+    // ignore: cancel_subscriptions
+    final relayStreamSub = _nostrClient
+        .subscribe(
+          [
+            Filter(
+              kinds: const [_kindCollaboratorResponse],
+              a: [videoAddress],
+              authors: taggedPubkeys.isEmpty
+                  ? null
+                  : List<String>.of(taggedPubkeys),
+            ),
+          ],
+          subscriptionId: subscriptionId,
+          onEose: () =>
+              _markResolved(videoAddress, subscriptionId: subscriptionId),
+        )
+        .listen(
+          (event) => _handleAcceptanceEvent(
+            event,
+            videoAddress: videoAddress,
+            subscriptionId: subscriptionId,
+            creatorPubkey: creatorPubkey,
+            taggedPubkeys: taggedPubkeys,
+          ),
+          onError: (Object error, StackTrace stackTrace) {
+            Log.warning(
+              'kind-$_kindCollaboratorResponse subscription error for '
+              '$videoAddress: $error',
+              name: 'CollaboratorConfirmationRepository',
+              category: LogCategory.system,
+            );
+          },
+        );
+    _relaySubs[videoAddress] = _RelaySubscription(
+      subscriptionId: subscriptionId,
+      streamSubscription: relayStreamSub,
+    );
+  }
+
+  Future<void> _cancelRelaySubscription(_RelaySubscription relaySub) async {
+    await relaySub.streamSubscription.cancel();
+    await _nostrClient.unsubscribe(relaySub.subscriptionId);
   }
 
   VideoCollaboratorStatus _snapshot({
@@ -361,6 +419,49 @@ class CollaboratorConfirmationRepository {
       isResolved: _resolved.contains(videoAddress),
     );
   }
+}
+
+List<String> _normalizePubkeys(List<String> pubkeys) {
+  final normalized = <String>[];
+  for (final pubkey in pubkeys) {
+    final lower = pubkey.toLowerCase();
+    if (lower.isNotEmpty && !normalized.contains(lower)) {
+      normalized.add(lower);
+    }
+  }
+  return normalized;
+}
+
+String _subscriptionIdFor({
+  required String videoAddress,
+  required List<String> taggedPubkeys,
+}) {
+  final filterKey = jsonEncode([
+    videoAddress,
+    [...taggedPubkeys]..sort(),
+  ]);
+  return 'collab-confirmation-${_fnv1a64(filterKey).toRadixString(16)}';
+}
+
+BigInt _fnv1a64(String value) {
+  var hash = BigInt.parse('cbf29ce484222325', radix: 16);
+  final prime = BigInt.parse('100000001b3', radix: 16);
+  final mask = BigInt.parse('ffffffffffffffff', radix: 16);
+  for (final codeUnit in value.codeUnits) {
+    hash ^= BigInt.from(codeUnit);
+    hash = (hash * prime) & mask;
+  }
+  return hash;
+}
+
+class _RelaySubscription {
+  const _RelaySubscription({
+    required this.subscriptionId,
+    required this.streamSubscription,
+  });
+
+  final String subscriptionId;
+  final StreamSubscription<Event> streamSubscription;
 }
 
 class _WatchContext {

--- a/mobile/packages/collaborator_repository/lib/src/collaborator_visibility.dart
+++ b/mobile/packages/collaborator_repository/lib/src/collaborator_visibility.dart
@@ -22,12 +22,14 @@ class CollaboratorVisibility extends Equatable {
     required this.statusByPubkey,
     required this.currentUserPubkey,
     required this.creatorPubkey,
+    this.isResolved = false,
   }) : _hasStatusPipeline = true;
 
   const CollaboratorVisibility.fallback({required this.taggedPubkeys})
     : statusByPubkey = const {},
       currentUserPubkey = '',
       creatorPubkey = '',
+      isResolved = false,
       _hasStatusPipeline = false;
 
   /// Pubkeys tagged with the `'collaborator'` role on the latest
@@ -43,6 +45,10 @@ class CollaboratorVisibility extends Equatable {
 
   /// Hex pubkey of the video's author. Empty in fallback mode.
   final String creatorPubkey;
+
+  /// Whether the acceptance query has finished. Non-author viewers render
+  /// nothing until this is true — see [visiblePubkeys].
+  final bool isResolved;
 
   final bool _hasStatusPipeline;
 
@@ -64,14 +70,29 @@ class CollaboratorVisibility extends Equatable {
     return CollaboratorStatus.pending;
   }
 
-  /// Pubkeys to render. The current user's pubkey is filtered out when
-  /// they have locally ignored the invite. In fallback mode this is the
-  /// raw [taggedPubkeys] list.
+  /// Pubkeys to render.
+  ///
+  /// - Fallback mode: the raw [taggedPubkeys] list, unchanged.
+  /// - Author's own video: every tagged pubkey, minus one the current user
+  ///   has locally ignored. Unconfirmed entries stay visible and are greyed
+  ///   via [isPendingForInviter] — the author needs to see who they invited.
+  /// - Everyone else: only confirmed collaborators, and only once
+  ///   [isResolved]. A creator can tag any pubkey, so rendering an
+  ///   unconfirmed one publicly credits someone who never accepted — or who
+  ///   explicitly ignored (#6907). Before the query resolves nothing renders
+  ///   at all, so an unconfirmed name is never shown even briefly.
   List<String> get visiblePubkeys {
     if (!_hasStatusPipeline) return taggedPubkeys;
+    if (isInviterView) {
+      return [
+        for (final pubkey in taggedPubkeys)
+          if (!_isHiddenByCurrentUserIgnore(pubkey)) pubkey,
+      ];
+    }
+    if (!isResolved) return const [];
     return [
       for (final pubkey in taggedPubkeys)
-        if (!_isHiddenByCurrentUserIgnore(pubkey)) pubkey,
+        if (statusFor(pubkey) == CollaboratorStatus.confirmed) pubkey,
     ];
   }
 
@@ -102,6 +123,7 @@ class CollaboratorVisibility extends Equatable {
     statusByPubkey,
     currentUserPubkey,
     creatorPubkey,
+    isResolved,
     _hasStatusPipeline,
   ];
 }

--- a/mobile/packages/collaborator_repository/test/src/collaborator_confirmation_repository_test.dart
+++ b/mobile/packages/collaborator_repository/test/src/collaborator_confirmation_repository_test.dart
@@ -74,9 +74,14 @@ void main() {
     late _MockNostrClient nostrClient;
     late StreamController<Event> relayController;
 
+    /// The `onEose` callback the repository handed to [NostrClient.subscribe],
+    /// so tests can fire relay end-of-stored-events on demand.
+    void Function()? capturedOnEose;
+
     setUp(() {
       nostrClient = _MockNostrClient();
       relayController = StreamController<Event>.broadcast();
+      capturedOnEose = null;
       when(
         () => nostrClient.subscribe(
           any(),
@@ -87,7 +92,10 @@ void main() {
           sendAfterAuth: any(named: 'sendAfterAuth'),
           onEose: any(named: 'onEose'),
         ),
-      ).thenAnswer((_) => relayController.stream);
+      ).thenAnswer((invocation) {
+        capturedOnEose = invocation.namedArguments[#onEose] as void Function()?;
+        return relayController.stream;
+      });
     });
 
     tearDown(() async {
@@ -327,6 +335,91 @@ void main() {
         repo.release(_videoAddress);
       },
     );
+
+    test('snapshot is unresolved until relay EOSE, resolved after', () async {
+      final repo = CollaboratorConfirmationRepository(
+        nostrClient: nostrClient,
+        localStateReader: _StaticLocalStateReader(const {}),
+        currentUserPubkey: _creatorPubkey,
+      );
+
+      final emissions = <VideoCollaboratorStatus>[];
+      final sub = repo
+          .watch(
+            _videoAddress,
+            creatorPubkey: _creatorPubkey,
+            taggedPubkeys: const [_collaboratorPubkey],
+          )
+          .listen(emissions.add);
+
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        emissions.last.isResolved,
+        isFalse,
+        reason:
+            'Before EOSE a pending entry means "not heard back yet", which '
+            'must not be rendered as "did not accept".',
+      );
+
+      capturedOnEose!();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emissions.last.isResolved, isTrue);
+      expect(
+        emissions.last.statusFor(_collaboratorPubkey),
+        equals(CollaboratorStatus.pending),
+        reason: 'EOSE with no acceptance is a real answer: still pending.',
+      );
+
+      await sub.cancel();
+      repo.release(_videoAddress);
+    });
+
+    test('a second watcher inherits the already-resolved snapshot', () async {
+      // Guards the NostrClient.subscribe dedup early-return: an identical
+      // filter returns the existing stream without invoking the new
+      // watcher's onEose, so resolution must come from the shared subject.
+      final repo = CollaboratorConfirmationRepository(
+        nostrClient: nostrClient,
+        localStateReader: _StaticLocalStateReader(const {}),
+        currentUserPubkey: _creatorPubkey,
+      );
+
+      final firstSub = repo
+          .watch(
+            _videoAddress,
+            creatorPubkey: _creatorPubkey,
+            taggedPubkeys: const [_collaboratorPubkey],
+          )
+          .listen((_) {});
+      await Future<void>.delayed(Duration.zero);
+      capturedOnEose!();
+      await Future<void>.delayed(Duration.zero);
+
+      final secondEmissions = <VideoCollaboratorStatus>[];
+      final secondSub = repo
+          .watch(
+            _videoAddress,
+            creatorPubkey: _creatorPubkey,
+            taggedPubkeys: const [_collaboratorPubkey],
+          )
+          .listen(secondEmissions.add);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        secondEmissions.last.isResolved,
+        isTrue,
+        reason:
+            'Otherwise the second watcher strands the video as unresolved '
+            'forever and its collaborator row never renders.',
+      );
+
+      await firstSub.cancel();
+      await secondSub.cancel();
+      repo
+        ..release(_videoAddress)
+        ..release(_videoAddress);
+    });
 
     test('ignores events with an explicit non-accepted status', () async {
       final repo = CollaboratorConfirmationRepository(

--- a/mobile/packages/collaborator_repository/test/src/collaborator_confirmation_repository_test.dart
+++ b/mobile/packages/collaborator_repository/test/src/collaborator_confirmation_repository_test.dart
@@ -96,6 +96,7 @@ void main() {
         capturedOnEose = invocation.namedArguments[#onEose] as void Function()?;
         return relayController.stream;
       });
+      when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});
     });
 
     tearDown(() async {
@@ -421,6 +422,126 @@ void main() {
         ..release(_videoAddress);
     });
 
+    test('release unsubscribes so a later re-watch resolves again', () async {
+      final repo = CollaboratorConfirmationRepository(
+        nostrClient: nostrClient,
+        localStateReader: _StaticLocalStateReader(const {}),
+        currentUserPubkey: _strangerPubkey,
+      );
+
+      final firstEmissions = <VideoCollaboratorStatus>[];
+      final firstSub = repo
+          .watch(
+            _videoAddress,
+            creatorPubkey: _creatorPubkey,
+            taggedPubkeys: const [_collaboratorPubkey],
+          )
+          .listen(firstEmissions.add);
+      await Future<void>.delayed(Duration.zero);
+
+      relayController.add(_acceptanceEvent(pubkey: _collaboratorPubkey));
+      capturedOnEose!();
+      await Future<void>.delayed(Duration.zero);
+      expect(firstEmissions.last.isResolved, isTrue);
+      expect(
+        firstEmissions.last.statusFor(_collaboratorPubkey),
+        equals(CollaboratorStatus.confirmed),
+      );
+
+      await firstSub.cancel();
+      repo.release(_videoAddress);
+      await Future<void>.delayed(Duration.zero);
+      verify(() => nostrClient.unsubscribe(any())).called(1);
+
+      final secondEmissions = <VideoCollaboratorStatus>[];
+      final secondSub = repo
+          .watch(
+            _videoAddress,
+            creatorPubkey: _creatorPubkey,
+            taggedPubkeys: const [_collaboratorPubkey],
+          )
+          .listen(secondEmissions.add);
+      await Future<void>.delayed(Duration.zero);
+      expect(secondEmissions.last.isResolved, isFalse);
+
+      relayController.add(_acceptanceEvent(pubkey: _collaboratorPubkey));
+      capturedOnEose!();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(secondEmissions.last.isResolved, isTrue);
+      expect(
+        secondEmissions.last.statusFor(_collaboratorPubkey),
+        equals(CollaboratorStatus.confirmed),
+        reason:
+            'A re-watch must open a fresh NostrClient subscription so EOSE and '
+            'stored acceptance events can be observed again.',
+      );
+      verify(
+        () => nostrClient.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+          relayTypes: any(named: 'relayTypes'),
+          sendAfterAuth: any(named: 'sendAfterAuth'),
+          onEose: any(named: 'onEose'),
+        ),
+      ).called(2);
+
+      await secondSub.cancel();
+      repo.release(_videoAddress);
+    });
+
+    test('late EOSE after release does not poison the next watch', () async {
+      final repo = CollaboratorConfirmationRepository(
+        nostrClient: nostrClient,
+        localStateReader: _StaticLocalStateReader(const {}),
+        currentUserPubkey: _strangerPubkey,
+      );
+
+      final firstSub = repo
+          .watch(
+            _videoAddress,
+            creatorPubkey: _creatorPubkey,
+            taggedPubkeys: const [_collaboratorPubkey],
+          )
+          .listen((_) {});
+      await Future<void>.delayed(Duration.zero);
+      final staleOnEose = capturedOnEose;
+
+      await firstSub.cancel();
+      repo.release(_videoAddress);
+      await Future<void>.delayed(Duration.zero);
+
+      staleOnEose!();
+      await Future<void>.delayed(Duration.zero);
+
+      final emissions = <VideoCollaboratorStatus>[];
+      final sub = repo
+          .watch(
+            _videoAddress,
+            creatorPubkey: _creatorPubkey,
+            taggedPubkeys: const [_collaboratorPubkey],
+          )
+          .listen(emissions.add);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        emissions.last.isResolved,
+        isFalse,
+        reason:
+            'An EOSE from a torn-down subscription must not mark the next '
+            'watch resolved before its own relay query finishes.',
+      );
+
+      capturedOnEose!();
+      await Future<void>.delayed(Duration.zero);
+      expect(emissions.last.isResolved, isTrue);
+
+      await sub.cancel();
+      repo.release(_videoAddress);
+    });
+
     test('ignores events with an explicit non-accepted status', () async {
       final repo = CollaboratorConfirmationRepository(
         nostrClient: nostrClient,
@@ -678,6 +799,74 @@ void main() {
 
       await sub.cancel();
       repo.release(_videoAddress);
+    });
+
+    test('reopens the relay subscription when tagged pubkeys change', () async {
+      final repo = CollaboratorConfirmationRepository(
+        nostrClient: nostrClient,
+        localStateReader: _StaticLocalStateReader(const {}),
+        currentUserPubkey: _strangerPubkey,
+      );
+
+      final firstSub = repo
+          .watch(
+            _videoAddress,
+            creatorPubkey: _creatorPubkey,
+            taggedPubkeys: const [_collaboratorPubkey],
+          )
+          .listen((_) {});
+      await Future<void>.delayed(Duration.zero);
+
+      final secondEmissions = <VideoCollaboratorStatus>[];
+      final secondSub = repo
+          .watch(
+            _videoAddress,
+            creatorPubkey: _creatorPubkey,
+            taggedPubkeys: const [
+              _collaboratorPubkey,
+              _secondCollaboratorPubkey,
+            ],
+          )
+          .listen(secondEmissions.add);
+      await Future<void>.delayed(Duration.zero);
+
+      final capturedFilters = verify(
+        () => nostrClient.subscribe(
+          captureAny(),
+          subscriptionId: any(named: 'subscriptionId'),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+          relayTypes: any(named: 'relayTypes'),
+          sendAfterAuth: any(named: 'sendAfterAuth'),
+          onEose: any(named: 'onEose'),
+        ),
+      ).captured.cast<List<Filter>>();
+      expect(capturedFilters, hasLength(2));
+      expect(capturedFilters.last.single.authors, [
+        _collaboratorPubkey,
+        _secondCollaboratorPubkey,
+      ]);
+      await Future<void>.delayed(Duration.zero);
+      verify(() => nostrClient.unsubscribe(any())).called(1);
+
+      relayController.add(_acceptanceEvent(pubkey: _secondCollaboratorPubkey));
+      capturedOnEose!();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(secondEmissions.last.isResolved, isTrue);
+      expect(
+        secondEmissions.last.statusFor(_secondCollaboratorPubkey),
+        equals(CollaboratorStatus.confirmed),
+        reason:
+            'The fresh authors filter must include collaborators added by a '
+            'newer creator-authored video event.',
+      );
+
+      await firstSub.cancel();
+      await secondSub.cancel();
+      repo
+        ..release(_videoAddress)
+        ..release(_videoAddress);
     });
 
     test('omits authors when nothing is tagged', () async {

--- a/mobile/packages/collaborator_repository/test/src/collaborator_confirmation_repository_test.dart
+++ b/mobile/packages/collaborator_repository/test/src/collaborator_confirmation_repository_test.dart
@@ -52,6 +52,18 @@ Event _acceptanceEvent({
   ], '');
 }
 
+/// A divine-web acceptance: only `a` + a random-UUID `d`, with no `status`,
+/// `p`, or `role` tag. Mirrors `divine-web/src/hooks/useApproveCollab.ts`.
+Event _webAcceptanceEvent({
+  required String pubkey,
+  String videoAddress = _videoAddress,
+}) {
+  return Event(pubkey, 34238, [
+    ['a', videoAddress, 'wss://relay.divine.video', 'root'],
+    ['d', '0e737d78-e3d8-4184-9394-d11690e8269b'],
+  ], '');
+}
+
 void main() {
   setUpAll(() {
     registerFallbackValue(<Filter>[]);
@@ -165,75 +177,72 @@ void main() {
       repo.release(_videoAddress);
     });
 
-    test(
-      'creator removal wins: re-watch with empty taggedPubkeys excludes '
-      'previously-confirmed collaborators',
-      () async {
-        // Spec invariant from
-        // docs/superpowers/plans/2026-04-25-collab-full-lifecycle.md:
-        // "Creator removal always wins. If the latest creator-authored video
-        // event no longer has the collaborator role `p` tag, Funnelcake must
-        // remove the pending/confirmed edge even if an old acceptance event
-        // still exists."
-        //
-        // Mobile-side analogue: even though `_relayAccepted` retains the
-        // historical acceptance, a re-watch driven by the latest creator-
-        // authored event with an empty (or shrunk) `taggedPubkeys` must
-        // produce a snapshot that does not surface the removed collaborator.
-        final repo = CollaboratorConfirmationRepository(
-          nostrClient: nostrClient,
-          localStateReader: _StaticLocalStateReader(const {}),
-          currentUserPubkey: _creatorPubkey,
-        );
+    test('creator removal wins: re-watch with empty taggedPubkeys excludes '
+        'previously-confirmed collaborators', () async {
+      // Spec invariant from
+      // docs/superpowers/plans/2026-04-25-collab-full-lifecycle.md:
+      // "Creator removal always wins. If the latest creator-authored video
+      // event no longer has the collaborator role `p` tag, Funnelcake must
+      // remove the pending/confirmed edge even if an old acceptance event
+      // still exists."
+      //
+      // Mobile-side analogue: even though `_relayAccepted` retains the
+      // historical acceptance, a re-watch driven by the latest creator-
+      // authored event with an empty (or shrunk) `taggedPubkeys` must
+      // produce a snapshot that does not surface the removed collaborator.
+      final repo = CollaboratorConfirmationRepository(
+        nostrClient: nostrClient,
+        localStateReader: _StaticLocalStateReader(const {}),
+        currentUserPubkey: _creatorPubkey,
+      );
 
-        // Initial state: B is tagged and has accepted.
-        final emissions = <VideoCollaboratorStatus>[];
-        final sub = repo
-            .watch(
-              _videoAddress,
-              creatorPubkey: _creatorPubkey,
-              taggedPubkeys: const [_collaboratorPubkey],
-            )
-            .listen(emissions.add);
+      // Initial state: B is tagged and has accepted.
+      final emissions = <VideoCollaboratorStatus>[];
+      final sub = repo
+          .watch(
+            _videoAddress,
+            creatorPubkey: _creatorPubkey,
+            taggedPubkeys: const [_collaboratorPubkey],
+          )
+          .listen(emissions.add);
 
-        await Future<void>.delayed(Duration.zero);
-        relayController.add(_acceptanceEvent(pubkey: _collaboratorPubkey));
-        await Future<void>.delayed(Duration.zero);
-        expect(
-          emissions.last.statusFor(_collaboratorPubkey),
-          equals(CollaboratorStatus.confirmed),
-        );
+      await Future<void>.delayed(Duration.zero);
+      relayController.add(_acceptanceEvent(pubkey: _collaboratorPubkey));
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        emissions.last.statusFor(_collaboratorPubkey),
+        equals(CollaboratorStatus.confirmed),
+      );
 
-        await sub.cancel();
-        repo.release(_videoAddress);
+      await sub.cancel();
+      repo.release(_videoAddress);
 
-        // Simulate the creator editing the video and removing B. A fresh
-        // watcher arrives with the new (empty) tagged list.
-        final reEmissions = <VideoCollaboratorStatus>[];
-        final reSub = repo
-            .watch(
-              _videoAddress,
-              creatorPubkey: _creatorPubkey,
-              taggedPubkeys: const <String>[],
-            )
-            .listen(reEmissions.add);
+      // Simulate the creator editing the video and removing B. A fresh
+      // watcher arrives with the new (empty) tagged list.
+      final reEmissions = <VideoCollaboratorStatus>[];
+      final reSub = repo
+          .watch(
+            _videoAddress,
+            creatorPubkey: _creatorPubkey,
+            taggedPubkeys: const <String>[],
+          )
+          .listen(reEmissions.add);
 
-        await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
 
-        // B was previously confirmed. The new snapshot must not surface them.
-        expect(reEmissions.last.statusByPubkey, isEmpty);
-        expect(
-          reEmissions.last.statusFor(_collaboratorPubkey),
-          equals(CollaboratorStatus.pending),
-          reason:
-              'statusFor falls back to pending for unknown pubkeys; the key '
-              'guarantee is that B is no longer in statusByPubkey.',
-        );
+      // B was previously confirmed. The new snapshot must not surface them.
+      expect(reEmissions.last.statusByPubkey, isEmpty);
+      expect(
+        reEmissions.last.statusFor(_collaboratorPubkey),
+        equals(CollaboratorStatus.pending),
+        reason:
+            'statusFor falls back to pending for unknown pubkeys; the key '
+            'guarantee is that B is no longer in statusByPubkey.',
+      );
 
-        await reSub.cancel();
-        repo.release(_videoAddress);
-      },
-    );
+      await reSub.cancel();
+      repo.release(_videoAddress);
+    });
 
     test(
       'rejects events whose only address tag is `d` (NIP-33 self-id)',
@@ -264,10 +273,7 @@ void main() {
         final beforeCount = emissions.length;
 
         relayController.add(
-          _acceptanceEvent(
-            pubkey: _collaboratorPubkey,
-            addressTag: 'd',
-          ),
+          _acceptanceEvent(pubkey: _collaboratorPubkey, addressTag: 'd'),
         );
         await Future<void>.delayed(Duration.zero);
 
@@ -282,7 +288,47 @@ void main() {
       },
     );
 
-    test('ignores events without status=accepted', () async {
+    test(
+      'confirms a divine-web acceptance that carries no status tag',
+      () async {
+        final repo = CollaboratorConfirmationRepository(
+          nostrClient: nostrClient,
+          localStateReader: _StaticLocalStateReader(const {}),
+          currentUserPubkey: _creatorPubkey,
+        );
+
+        final emissions = <VideoCollaboratorStatus>[];
+        final sub = repo
+            .watch(
+              _videoAddress,
+              creatorPubkey: _creatorPubkey,
+              taggedPubkeys: const [_collaboratorPubkey],
+            )
+            .listen(emissions.add);
+
+        await Future<void>.delayed(Duration.zero);
+        expect(
+          emissions.last.statusFor(_collaboratorPubkey),
+          equals(CollaboratorStatus.pending),
+        );
+
+        relayController.add(_webAcceptanceEvent(pubkey: _collaboratorPubkey));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          emissions.last.statusFor(_collaboratorPubkey),
+          equals(CollaboratorStatus.confirmed),
+          reason:
+              'divine-web publishes acceptances with no status tag; requiring '
+              'one silently dropped ~15% of production acceptances.',
+        );
+
+        await sub.cancel();
+        repo.release(_videoAddress);
+      },
+    );
+
+    test('ignores events with an explicit non-accepted status', () async {
       final repo = CollaboratorConfirmationRepository(
         nostrClient: nostrClient,
         localStateReader: _StaticLocalStateReader(const {}),
@@ -302,10 +348,7 @@ void main() {
       final beforeCount = emissions.length;
 
       relayController.add(
-        _acceptanceEvent(
-          pubkey: _collaboratorPubkey,
-          statusValue: 'declined',
-        ),
+        _acceptanceEvent(pubkey: _collaboratorPubkey, statusValue: 'declined'),
       );
       await Future<void>.delayed(Duration.zero);
 
@@ -319,52 +362,49 @@ void main() {
       repo.release(_videoAddress);
     });
 
-    test(
-      'recipient view: current user local store override flips current user '
-      'status without a relay subscription',
-      () async {
-        // No NostrClient.subscribe call expected because current user is
-        // NOT the creator.
-        final repo = CollaboratorConfirmationRepository(
-          nostrClient: nostrClient,
-          localStateReader: _StaticLocalStateReader(const {
-            '$_videoAddress|$_creatorPubkey|$_collaboratorPubkey':
-                CollaboratorStatus.ignored,
-          }),
-          currentUserPubkey: _collaboratorPubkey,
-        );
+    test('recipient view: current user local store override flips current user '
+        'status without a relay subscription', () async {
+      // No NostrClient.subscribe call expected because current user is
+      // NOT the creator.
+      final repo = CollaboratorConfirmationRepository(
+        nostrClient: nostrClient,
+        localStateReader: _StaticLocalStateReader(const {
+          '$_videoAddress|$_creatorPubkey|$_collaboratorPubkey':
+              CollaboratorStatus.ignored,
+        }),
+        currentUserPubkey: _collaboratorPubkey,
+      );
 
-        final emissions = <VideoCollaboratorStatus>[];
-        final sub = repo
-            .watch(
-              _videoAddress,
-              creatorPubkey: _creatorPubkey,
-              taggedPubkeys: const [_collaboratorPubkey],
-            )
-            .listen(emissions.add);
+      final emissions = <VideoCollaboratorStatus>[];
+      final sub = repo
+          .watch(
+            _videoAddress,
+            creatorPubkey: _creatorPubkey,
+            taggedPubkeys: const [_collaboratorPubkey],
+          )
+          .listen(emissions.add);
 
-        await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
 
-        expect(
-          emissions.last.statusFor(_collaboratorPubkey),
-          equals(CollaboratorStatus.ignored),
-        );
-        verifyNever(
-          () => nostrClient.subscribe(
-            any(),
-            subscriptionId: any(named: 'subscriptionId'),
-            tempRelays: any(named: 'tempRelays'),
-            targetRelays: any(named: 'targetRelays'),
-            relayTypes: any(named: 'relayTypes'),
-            sendAfterAuth: any(named: 'sendAfterAuth'),
-            onEose: any(named: 'onEose'),
-          ),
-        );
+      expect(
+        emissions.last.statusFor(_collaboratorPubkey),
+        equals(CollaboratorStatus.ignored),
+      );
+      verifyNever(
+        () => nostrClient.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+          relayTypes: any(named: 'relayTypes'),
+          sendAfterAuth: any(named: 'sendAfterAuth'),
+          onEose: any(named: 'onEose'),
+        ),
+      );
 
-        await sub.cancel();
-        repo.release(_videoAddress);
-      },
-    );
+      await sub.cancel();
+      repo.release(_videoAddress);
+    });
 
     test(
       'markLocal emits a new snapshot for the current user immediately',
@@ -499,42 +539,39 @@ void main() {
       },
     );
 
-    test(
-      'does not open a relay subscription when current user is not the '
-      'creator',
-      () async {
-        final repo = CollaboratorConfirmationRepository(
-          nostrClient: nostrClient,
-          localStateReader: _StaticLocalStateReader(const {}),
-          currentUserPubkey: _strangerPubkey,
-        );
+    test('does not open a relay subscription when current user is not the '
+        'creator', () async {
+      final repo = CollaboratorConfirmationRepository(
+        nostrClient: nostrClient,
+        localStateReader: _StaticLocalStateReader(const {}),
+        currentUserPubkey: _strangerPubkey,
+      );
 
-        final sub = repo
-            .watch(
-              _videoAddress,
-              creatorPubkey: _creatorPubkey,
-              taggedPubkeys: const [_collaboratorPubkey],
-            )
-            .listen((_) {});
+      final sub = repo
+          .watch(
+            _videoAddress,
+            creatorPubkey: _creatorPubkey,
+            taggedPubkeys: const [_collaboratorPubkey],
+          )
+          .listen((_) {});
 
-        await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
 
-        verifyNever(
-          () => nostrClient.subscribe(
-            any(),
-            subscriptionId: any(named: 'subscriptionId'),
-            tempRelays: any(named: 'tempRelays'),
-            targetRelays: any(named: 'targetRelays'),
-            relayTypes: any(named: 'relayTypes'),
-            sendAfterAuth: any(named: 'sendAfterAuth'),
-            onEose: any(named: 'onEose'),
-          ),
-        );
+      verifyNever(
+        () => nostrClient.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+          relayTypes: any(named: 'relayTypes'),
+          sendAfterAuth: any(named: 'sendAfterAuth'),
+          onEose: any(named: 'onEose'),
+        ),
+      );
 
-        await sub.cancel();
-        repo.release(_videoAddress);
-      },
-    );
+      await sub.cancel();
+      repo.release(_videoAddress);
+    });
 
     test('close cancels relay subs and clears state', () async {
       final repo = CollaboratorConfirmationRepository(

--- a/mobile/packages/collaborator_repository/test/src/collaborator_confirmation_repository_test.dart
+++ b/mobile/packages/collaborator_repository/test/src/collaborator_confirmation_repository_test.dart
@@ -455,10 +455,8 @@ void main() {
       repo.release(_videoAddress);
     });
 
-    test('recipient view: current user local store override flips current user '
-        'status without a relay subscription', () async {
-      // No NostrClient.subscribe call expected because current user is
-      // NOT the creator.
+    test('recipient view: current user local store override wins over the '
+        'relay-derived status', () async {
       final repo = CollaboratorConfirmationRepository(
         nostrClient: nostrClient,
         localStateReader: _StaticLocalStateReader(const {
@@ -483,16 +481,16 @@ void main() {
         emissions.last.statusFor(_collaboratorPubkey),
         equals(CollaboratorStatus.ignored),
       );
-      verifyNever(
-        () => nostrClient.subscribe(
-          any(),
-          subscriptionId: any(named: 'subscriptionId'),
-          tempRelays: any(named: 'tempRelays'),
-          targetRelays: any(named: 'targetRelays'),
-          relayTypes: any(named: 'relayTypes'),
-          sendAfterAuth: any(named: 'sendAfterAuth'),
-          onEose: any(named: 'onEose'),
-        ),
+
+      // The local ignore must survive an acceptance echo for the same pubkey:
+      // a stale kind-34238 from an earlier accept must not resurrect the
+      // avatar the user just hid.
+      relayController.add(_acceptanceEvent(pubkey: _collaboratorPubkey));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        emissions.last.statusFor(_collaboratorPubkey),
+        equals(CollaboratorStatus.ignored),
       );
 
       await sub.cancel();
@@ -632,8 +630,11 @@ void main() {
       },
     );
 
-    test('does not open a relay subscription when current user is not the '
-        'creator', () async {
+    test('opens a relay subscription for a third-party viewer, bounded by '
+        'authors', () async {
+      // Inverts the pre-#6907 behaviour: the subscription used to open only
+      // for the video's author, so third-party viewers had no confirmation
+      // data at all and every tagged pubkey rendered as a collaborator.
       final repo = CollaboratorConfirmationRepository(
         nostrClient: nostrClient,
         localStateReader: _StaticLocalStateReader(const {}),
@@ -650,16 +651,70 @@ void main() {
 
       await Future<void>.delayed(Duration.zero);
 
-      verifyNever(
-        () => nostrClient.subscribe(
-          any(),
-          subscriptionId: any(named: 'subscriptionId'),
-          tempRelays: any(named: 'tempRelays'),
-          targetRelays: any(named: 'targetRelays'),
-          relayTypes: any(named: 'relayTypes'),
-          sendAfterAuth: any(named: 'sendAfterAuth'),
-          onEose: any(named: 'onEose'),
-        ),
+      final captured =
+          verify(
+                () => nostrClient.subscribe(
+                  captureAny(),
+                  subscriptionId: any(named: 'subscriptionId'),
+                  tempRelays: any(named: 'tempRelays'),
+                  targetRelays: any(named: 'targetRelays'),
+                  relayTypes: any(named: 'relayTypes'),
+                  sendAfterAuth: any(named: 'sendAfterAuth'),
+                  onEose: any(named: 'onEose'),
+                ),
+              ).captured.single
+              as List<Filter>;
+
+      expect(captured, hasLength(1));
+      expect(captured.single.kinds, equals([34238]));
+      expect(captured.single.a, equals([_videoAddress]));
+      expect(
+        captured.single.authors,
+        equals([_collaboratorPubkey]),
+        reason:
+            'Only tagged pubkeys can legitimately confirm; bounding the '
+            'filter keeps the result set small.',
+      );
+
+      await sub.cancel();
+      repo.release(_videoAddress);
+    });
+
+    test('omits authors when nothing is tagged', () async {
+      final repo = CollaboratorConfirmationRepository(
+        nostrClient: nostrClient,
+        localStateReader: _StaticLocalStateReader(const {}),
+        currentUserPubkey: _strangerPubkey,
+      );
+
+      final sub = repo
+          .watch(
+            _videoAddress,
+            creatorPubkey: _creatorPubkey,
+            taggedPubkeys: const [],
+          )
+          .listen((_) {});
+
+      await Future<void>.delayed(Duration.zero);
+
+      final captured =
+          verify(
+                () => nostrClient.subscribe(
+                  captureAny(),
+                  subscriptionId: any(named: 'subscriptionId'),
+                  tempRelays: any(named: 'tempRelays'),
+                  targetRelays: any(named: 'targetRelays'),
+                  relayTypes: any(named: 'relayTypes'),
+                  sendAfterAuth: any(named: 'sendAfterAuth'),
+                  onEose: any(named: 'onEose'),
+                ),
+              ).captured.single
+              as List<Filter>;
+
+      expect(
+        captured.single.authors,
+        isNull,
+        reason: 'An empty authors array is not a meaningful relay filter.',
       );
 
       await sub.cancel();

--- a/mobile/packages/collaborator_repository/test/src/collaborator_visibility_test.dart
+++ b/mobile/packages/collaborator_repository/test/src/collaborator_visibility_test.dart
@@ -28,9 +28,7 @@ void main() {
       });
 
       test('isInviterView is always false', () {
-        const vis = CollaboratorVisibility.fallback(
-          taggedPubkeys: [_collab1],
-        );
+        const vis = CollaboratorVisibility.fallback(taggedPubkeys: [_collab1]);
         expect(vis.isInviterView, isFalse);
       });
 
@@ -42,16 +40,12 @@ void main() {
       });
 
       test('isPendingForInviter is always false', () {
-        const vis = CollaboratorVisibility.fallback(
-          taggedPubkeys: [_collab1],
-        );
+        const vis = CollaboratorVisibility.fallback(taggedPubkeys: [_collab1]);
         expect(vis.isPendingForInviter(_collab1), isFalse);
       });
 
       test('statusFor returns pending for any pubkey', () {
-        const vis = CollaboratorVisibility.fallback(
-          taggedPubkeys: [_collab1],
-        );
+        const vis = CollaboratorVisibility.fallback(taggedPubkeys: [_collab1]);
         expect(vis.statusFor(_collab1), equals(CollaboratorStatus.pending));
         expect(vis.statusFor(_collab2), equals(CollaboratorStatus.pending));
       });
@@ -319,9 +313,8 @@ void main() {
       });
 
       test('drops the author own entry when they self-tagged then ignored', () {
-        // buildCollaboratorPTag does not exclude the author, so a creator can
-        // end up tagged on their own video; their local ignore still hides
-        // their own chip on their own view.
+        // Defensive coverage for malformed or hand-built visibility inputs:
+        // a local ignore still hides the current user's own chip.
         const vis = CollaboratorVisibility(
           taggedPubkeys: [_creator, _collab1],
           statusByPubkey: {

--- a/mobile/packages/collaborator_repository/test/src/collaborator_visibility_test.dart
+++ b/mobile/packages/collaborator_repository/test/src/collaborator_visibility_test.dart
@@ -156,16 +156,6 @@ void main() {
         expect(vis.isPendingForInviter(_collab2), isFalse);
       });
 
-      test('current user filtered out when their status is ignored', () {
-        const vis = CollaboratorVisibility(
-          taggedPubkeys: [_collab1, _collab2],
-          statusByPubkey: {_collab1: CollaboratorStatus.ignored},
-          currentUserPubkey: _collab1,
-          creatorPubkey: _creator,
-        );
-        expect(vis.visiblePubkeys, equals([_collab2]));
-      });
-
       test(
         'current user ignore is hidden when visibility receives normalized tag',
         () {
@@ -174,51 +164,17 @@ void main() {
             statusByPubkey: {_collab1Upper: CollaboratorStatus.ignored},
             currentUserPubkey: _collab1Upper,
             creatorPubkey: _creator,
+            isResolved: true,
           );
           expect(vis.visiblePubkeys, isEmpty);
         },
       );
 
-      test('current user not filtered out when their status is confirmed', () {
-        const vis = CollaboratorVisibility(
-          taggedPubkeys: [_collab1, _collab2],
-          statusByPubkey: {_collab1: CollaboratorStatus.confirmed},
-          currentUserPubkey: _collab1,
-          creatorPubkey: _creator,
-        );
-        expect(vis.visiblePubkeys, equals([_collab1, _collab2]));
-      });
-
-      test(
-        'current user not filtered out when their status is missing (pending)',
-        () {
-          const vis = CollaboratorVisibility(
-            taggedPubkeys: [_collab1, _collab2],
-            statusByPubkey: {},
-            currentUserPubkey: _collab1,
-            creatorPubkey: _creator,
-          );
-          expect(vis.visiblePubkeys, equals([_collab1, _collab2]));
-        },
-      );
-
-      test(
-        'another collaborator with ignored status is NOT filtered out '
-        '(only current user is)',
-        () {
-          // `ignored` is local-only; another collaborator's `ignored` status
-          // could only come from a different device. The fast-path map is
-          // single-device, so this should never happen in practice — but the
-          // contract is: only the current user's own ignore filters them out.
-          const vis = CollaboratorVisibility(
-            taggedPubkeys: [_collab1, _collab2],
-            statusByPubkey: {_collab2: CollaboratorStatus.ignored},
-            currentUserPubkey: _collab1,
-            creatorPubkey: _creator,
-          );
-          expect(vis.visiblePubkeys, equals([_collab1, _collab2]));
-        },
-      );
+      // Pre-#6907 this group also pinned that a recipient sees the full raw
+      // tagged list — unconfirmed peers included, and their own entry visible
+      // even while pending. That contract is exactly what #6907 removes; the
+      // replacement lives in the 'tagged collaborator viewing a video they
+      // did not author' group below.
     });
 
     group('third-party view', () {
@@ -232,7 +188,7 @@ void main() {
         expect(vis.isInviterView, isFalse);
       });
 
-      test('no decoration / no filtering applied', () {
+      test('unconfirmed filtered out, and no pending decoration', () {
         const vis = CollaboratorVisibility(
           taggedPubkeys: [_collab1, _collab2],
           statusByPubkey: {
@@ -241,8 +197,9 @@ void main() {
           },
           currentUserPubkey: _viewer,
           creatorPubkey: _creator,
+          isResolved: true,
         );
-        expect(vis.visiblePubkeys, equals([_collab1, _collab2]));
+        expect(vis.visiblePubkeys, equals([_collab2]));
         expect(vis.pendingCount, equals(0));
         expect(vis.isPendingForInviter(_collab1), isFalse);
         expect(vis.isPendingForInviter(_collab2), isFalse);
@@ -277,6 +234,145 @@ void main() {
           creatorPubkey: '',
         );
         expect(fallback, isNot(equals(statusAware)));
+      });
+    });
+
+    group('third-party viewer', () {
+      test('renders nothing until the acceptance query resolves', () {
+        const vis = CollaboratorVisibility(
+          taggedPubkeys: [_collab1, _collab2],
+          statusByPubkey: {_collab1: CollaboratorStatus.confirmed},
+          currentUserPubkey: _viewer,
+          creatorPubkey: _creator,
+        );
+        expect(
+          vis.visiblePubkeys,
+          isEmpty,
+          reason:
+              'Before EOSE an absent entry means "not heard back yet"; '
+              'rendering then would flash a partial list.',
+        );
+      });
+
+      test('renders only confirmed collaborators once resolved', () {
+        const vis = CollaboratorVisibility(
+          taggedPubkeys: [_collab1, _collab2],
+          statusByPubkey: {
+            _collab1: CollaboratorStatus.confirmed,
+            _collab2: CollaboratorStatus.pending,
+          },
+          currentUserPubkey: _viewer,
+          creatorPubkey: _creator,
+          isResolved: true,
+        );
+        expect(
+          vis.visiblePubkeys,
+          equals([_collab1]),
+          reason:
+              'A creator can tag any pubkey; crediting an unconfirmed one '
+              'publicly is the #6907 leak.',
+        );
+      });
+
+      test('hides a collaborator who was tagged but never accepted', () {
+        const vis = CollaboratorVisibility(
+          taggedPubkeys: [_collab1],
+          statusByPubkey: {_collab1: CollaboratorStatus.pending},
+          currentUserPubkey: _viewer,
+          creatorPubkey: _creator,
+          isResolved: true,
+        );
+        expect(vis.visiblePubkeys, isEmpty);
+      });
+
+      test('pendingCount stays zero so no pending suffix leaks', () {
+        const vis = CollaboratorVisibility(
+          taggedPubkeys: [_collab1, _collab2],
+          statusByPubkey: {_collab1: CollaboratorStatus.pending},
+          currentUserPubkey: _viewer,
+          creatorPubkey: _creator,
+          isResolved: true,
+        );
+        expect(vis.pendingCount, isZero);
+      });
+    });
+
+    group('inviter view is unaffected by the third-party filter', () {
+      test('still shows unconfirmed collaborators once resolved', () {
+        const vis = CollaboratorVisibility(
+          taggedPubkeys: [_collab1, _collab2],
+          statusByPubkey: {
+            _collab1: CollaboratorStatus.confirmed,
+            _collab2: CollaboratorStatus.pending,
+          },
+          currentUserPubkey: _creator,
+          creatorPubkey: _creator,
+          isResolved: true,
+        );
+        expect(
+          vis.visiblePubkeys,
+          equals([_collab1, _collab2]),
+          reason: 'The author needs to see who they invited.',
+        );
+        expect(vis.pendingCount, equals(1));
+        expect(vis.isPendingForInviter(_collab2), isTrue);
+      });
+
+      test('drops the author own entry when they self-tagged then ignored', () {
+        // buildCollaboratorPTag does not exclude the author, so a creator can
+        // end up tagged on their own video; their local ignore still hides
+        // their own chip on their own view.
+        const vis = CollaboratorVisibility(
+          taggedPubkeys: [_creator, _collab1],
+          statusByPubkey: {
+            _creator: CollaboratorStatus.ignored,
+            _collab1: CollaboratorStatus.confirmed,
+          },
+          currentUserPubkey: _creator,
+          creatorPubkey: _creator,
+          isResolved: true,
+        );
+        expect(vis.visiblePubkeys, equals([_collab1]));
+      });
+
+      test('shows unconfirmed collaborators even before resolve', () {
+        const vis = CollaboratorVisibility(
+          taggedPubkeys: [_collab1],
+          statusByPubkey: {_collab1: CollaboratorStatus.pending},
+          currentUserPubkey: _creator,
+          creatorPubkey: _creator,
+        );
+        expect(
+          vis.visiblePubkeys,
+          equals([_collab1]),
+          reason:
+              'The author already knows who they tagged, so gating their own '
+              'view on EOSE would only make the row flicker.',
+        );
+      });
+    });
+
+    group('tagged collaborator viewing a video they did not author', () {
+      test('sees themselves once their acceptance is confirmed', () {
+        const vis = CollaboratorVisibility(
+          taggedPubkeys: [_collab1],
+          statusByPubkey: {_collab1: CollaboratorStatus.confirmed},
+          currentUserPubkey: _collab1,
+          creatorPubkey: _creator,
+          isResolved: true,
+        );
+        expect(vis.visiblePubkeys, equals([_collab1]));
+      });
+
+      test('does not see themselves after locally ignoring', () {
+        const vis = CollaboratorVisibility(
+          taggedPubkeys: [_collab1],
+          statusByPubkey: {_collab1: CollaboratorStatus.ignored},
+          currentUserPubkey: _collab1,
+          creatorPubkey: _creator,
+          isResolved: true,
+        );
+        expect(vis.visiblePubkeys, isEmpty);
       });
     });
   });

--- a/mobile/packages/models/lib/src/collaborator_status.dart
+++ b/mobile/packages/models/lib/src/collaborator_status.dart
@@ -32,6 +32,7 @@ class VideoCollaboratorStatus extends Equatable {
   const VideoCollaboratorStatus({
     required this.videoAddress,
     this.statusByPubkey = const {},
+    this.isResolved = false,
   });
 
   /// NIP-33 addressable id of the video, e.g. `34236:<creator>:<dTag>`.
@@ -41,18 +42,29 @@ class VideoCollaboratorStatus extends Equatable {
   /// [CollaboratorStatus.pending] by callers.
   final Map<String, CollaboratorStatus> statusByPubkey;
 
+  /// Whether the acceptance query has finished (relay EOSE reached).
+  ///
+  /// Distinguishes "nobody has accepted" from "we have not heard back yet" —
+  /// both leave a pubkey at [CollaboratorStatus.pending], but only the former
+  /// is a real answer. Render surfaces that hide unconfirmed collaborators
+  /// from third-party viewers must wait for this before drawing anything, or
+  /// they would flash an empty row and then fill it in.
+  final bool isResolved;
+
   CollaboratorStatus statusFor(String pubkey) =>
       statusByPubkey[pubkey] ?? CollaboratorStatus.pending;
 
   VideoCollaboratorStatus copyWith({
     Map<String, CollaboratorStatus>? statusByPubkey,
+    bool? isResolved,
   }) {
     return VideoCollaboratorStatus(
       videoAddress: videoAddress,
       statusByPubkey: statusByPubkey ?? this.statusByPubkey,
+      isResolved: isResolved ?? this.isResolved,
     );
   }
 
   @override
-  List<Object?> get props => [videoAddress, statusByPubkey];
+  List<Object?> get props => [videoAddress, statusByPubkey, isResolved];
 }

--- a/mobile/packages/models/test/src/collaborator_status_test.dart
+++ b/mobile/packages/models/test/src/collaborator_status_test.dart
@@ -61,5 +61,35 @@ void main() {
       expect(a, equals(b));
       expect(a, isNot(equals(c)));
     });
+
+    test('isResolved defaults to false', () {
+      const status = VideoCollaboratorStatus(videoAddress: address);
+      expect(status.isResolved, isFalse);
+    });
+
+    test('copyWith updates isResolved and preserves the status map', () {
+      const original = VideoCollaboratorStatus(
+        videoAddress: address,
+        statusByPubkey: {'a': CollaboratorStatus.confirmed},
+      );
+      final updated = original.copyWith(isResolved: true);
+      expect(updated.isResolved, isTrue);
+      expect(updated.statusFor('a'), equals(CollaboratorStatus.confirmed));
+    });
+
+    test('isResolved participates in equality', () {
+      const unresolved = VideoCollaboratorStatus(videoAddress: address);
+      const resolved = VideoCollaboratorStatus(
+        videoAddress: address,
+        isResolved: true,
+      );
+      expect(
+        unresolved,
+        isNot(equals(resolved)),
+        reason:
+            'Surfaces rebuild on the unresolved -> resolved transition; if '
+            'that is not an inequality the row never re-renders.',
+      );
+    });
   });
 }

--- a/mobile/test/widgets/video_feed_item/collaborator_avatar_row_test.dart
+++ b/mobile/test/widgets/video_feed_item/collaborator_avatar_row_test.dart
@@ -167,9 +167,13 @@ void main() {
           const CollaboratorAvatarRowBody(
             visibility: CollaboratorVisibility(
               taggedPubkeys: [_collab1, _collab2],
-              statusByPubkey: {_collab1: CollaboratorStatus.ignored},
+              statusByPubkey: {
+                _collab1: CollaboratorStatus.ignored,
+                _collab2: CollaboratorStatus.confirmed,
+              },
               currentUserPubkey: _collab1,
               creatorPubkey: _creatorPubkey,
+              isResolved: true,
             ),
           ),
           overrides: [
@@ -204,6 +208,7 @@ void main() {
               statusByPubkey: {_collab1: CollaboratorStatus.ignored},
               currentUserPubkey: _collab1,
               creatorPubkey: _creatorPubkey,
+              isResolved: true,
             ),
           ),
         ),
@@ -223,6 +228,7 @@ void main() {
                 statusByPubkey: {_collab1: CollaboratorStatus.confirmed},
                 currentUserPubkey: _collab1,
                 creatorPubkey: _creatorPubkey,
+                isResolved: true,
               ),
             ),
           ),
@@ -243,8 +249,11 @@ void main() {
     );
 
     testWidgets(
-      'third-party view: all avatars rendered without pending decoration',
+      'third-party view: unconfirmed collaborators are not rendered at all',
       (tester) async {
+        // Pre-#6907 this row rendered every creator-tagged pubkey to third
+        // parties, so tagging someone publicly credited them whether or not
+        // they ever accepted.
         await tester.pumpWidget(
           _wrap(
             const CollaboratorAvatarRowBody(
@@ -256,12 +265,74 @@ void main() {
                 },
                 currentUserPubkey: _thirdPartyPubkey,
                 creatorPubkey: _creatorPubkey,
+                isResolved: true,
               ),
             ),
           ),
         );
 
+        expect(_divineIcon(DivineIconName.users), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'third-party view: renders nothing until the query resolves',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            const CollaboratorAvatarRowBody(
+              visibility: CollaboratorVisibility(
+                taggedPubkeys: [_collab1],
+                statusByPubkey: {_collab1: CollaboratorStatus.confirmed},
+                currentUserPubkey: _thirdPartyPubkey,
+                creatorPubkey: _creatorPubkey,
+              ),
+            ),
+          ),
+        );
+
+        expect(_divineIcon(DivineIconName.users), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'third-party view: confirmed collaborators render without decoration',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            const CollaboratorAvatarRowBody(
+              visibility: CollaboratorVisibility(
+                taggedPubkeys: [_collab1, _collab2],
+                statusByPubkey: {
+                  _collab1: CollaboratorStatus.pending,
+                  _collab2: CollaboratorStatus.confirmed,
+                },
+                currentUserPubkey: _thirdPartyPubkey,
+                creatorPubkey: _creatorPubkey,
+                isResolved: true,
+              ),
+            ),
+            overrides: [
+              fetchUserProfileProvider(
+                _collab1,
+              ).overrideWith((ref) async => _makeProfile(_collab1, 'Alice')),
+              fetchUserProfileProvider(
+                _collab2,
+              ).overrideWith((ref) async => _makeProfile(_collab2, 'Bob')),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
         expect(_divineIcon(DivineIconName.users), findsOneWidget);
+        expect(
+          find.text(_l10n.videoCollaboratorWithOne('Bob')),
+          findsOneWidget,
+        );
+        expect(
+          find.text(_l10n.videoCollaboratorWithOne('Alice')),
+          findsNothing,
+        );
         // Third-party viewers never see the pending decoration.
         expect(find.byType(Opacity), findsNothing);
         expect(
@@ -339,9 +410,14 @@ void main() {
           const CollaboratorAvatarRowBody(
             visibility: CollaboratorVisibility(
               taggedPubkeys: [_collab1, _collab2, _collab3],
-              statusByPubkey: {_collab1: CollaboratorStatus.ignored},
+              statusByPubkey: {
+                _collab1: CollaboratorStatus.ignored,
+                _collab2: CollaboratorStatus.confirmed,
+                _collab3: CollaboratorStatus.confirmed,
+              },
               currentUserPubkey: _collab1,
               creatorPubkey: _creatorPubkey,
+              isResolved: true,
             ),
           ),
           overrides: [

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -1026,9 +1026,13 @@ void main() {
             child: const MetadataCollaboratorsSectionBody(
               visibility: CollaboratorVisibility(
                 taggedPubkeys: [_collaborator1, _collaborator2],
-                statusByPubkey: {_collaborator1: CollaboratorStatus.ignored},
+                statusByPubkey: {
+                  _collaborator1: CollaboratorStatus.ignored,
+                  _collaborator2: CollaboratorStatus.confirmed,
+                },
                 currentUserPubkey: _collaborator1,
                 creatorPubkey: _creatorPubkey,
+                isResolved: true,
               ),
             ),
           ),
@@ -1063,7 +1067,7 @@ void main() {
     );
 
     testWidgetsWithSurfaceSize(
-      'third-party view: no Pending decoration even for pending status',
+      'third-party view: confirmed chip renders with no Pending decoration',
       (tester) async {
         await tester.pumpWidget(
           buildSubject(
@@ -1075,9 +1079,10 @@ void main() {
             child: const MetadataCollaboratorsSectionBody(
               visibility: CollaboratorVisibility(
                 taggedPubkeys: [_collaborator1],
-                statusByPubkey: {_collaborator1: CollaboratorStatus.pending},
+                statusByPubkey: {_collaborator1: CollaboratorStatus.confirmed},
                 currentUserPubkey: _reposterPubkey,
                 creatorPubkey: _creatorPubkey,
+                isResolved: true,
               ),
             ),
           ),
@@ -1091,6 +1096,35 @@ void main() {
           findsNothing,
         );
         expect(_dimmed(), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'third-party view: unconfirmed collaborator is not rendered',
+      (tester) async {
+        // Pre-#6907 a creator-tagged pubkey rendered here regardless of
+        // whether they ever accepted, publicly crediting them.
+        await tester.pumpWidget(
+          buildSubject(
+            providerOverrides: [
+              fetchUserProfileProvider(_collaborator1).overrideWith(
+                (ref) async => _makeProfile(_collaborator1, 'Alice'),
+              ),
+            ],
+            child: const MetadataCollaboratorsSectionBody(
+              visibility: CollaboratorVisibility(
+                taggedPubkeys: [_collaborator1],
+                statusByPubkey: {_collaborator1: CollaboratorStatus.pending},
+                currentUserPubkey: _reposterPubkey,
+                creatorPubkey: _creatorPubkey,
+                isResolved: true,
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Alice'), findsNothing);
       },
     );
 


### PR DESCRIPTION
## Summary

Third-party viewers saw every pubkey a creator tagged rendered exactly like an accepted collaborator. Tagging someone publicly credited them whether or not they ever accepted — and even after they explicitly ignored the invite, since "ignore" only ever hid the avatar on the ignoring user's own device.

Closes #6907.

### Correction to the issue's premise

#6907 says this may be blocked on a Funnelcake per-video confirmed-collaborator endpoint. It isn't. The relay serves kind-34238 to unauthenticated readers, verified directly:

```
nak req -k 34238 -t a=34236:fc7031a810ce4b02b6195a7e477cfe3d08c0386038bd45b4431f82d9b3f5ffb0:50cca13b441b84fbd6b7ae25eb906613b4758e145e33978f94598dd0fcf528f4 wss://relay.divine.video
→ 2 acceptance events, no auth, no signer
```

divine-web already renders third-party-correct status this way (`useVideoCollaboratorStatus.ts`), ungated by viewer identity. Mobile's `isOwnVideo` gate was the outlier. No backend work required.

## What changed

Five commits, each independently reviewable:

1. **Accept kind-34238 events with no `status` tag.** Mobile required `status=accepted`; divine-web publishes `[['a', coord], ['d', uuid]]` with no such tag, and Funnelcake's confirmed MV doesn't check for one either. Mobile alone dropped web-made acceptances — **18 of 120 (15%)** of the kind-34238 events currently on the relay. The visible effect: accepting on web left you confirmed on your profile Collabs tab but permanently greyed as "pending" on the creator's mobile view.
2. **Add `VideoCollaboratorStatus.isResolved`,** set from the relay EOSE callback `NostrClient.subscribe` already exposes. Without it "pending" conflates "did not accept" with "have not heard back yet".
3. **Open the subscription for every viewer,** bounded by `authors: taggedPubkeys`. Also inverts precedence in `_snapshot` so the current user's local decision outranks the relay echo — see Unrequested below.
4. **Hide unconfirmed collaborators from third parties.** `visiblePubkeys` gains three branches: fallback (raw list), author (all tagged, unconfirmed greyed as before), everyone else (confirmed only, and only once resolved).
5. **Close and key relay subscriptions by their full filter.** `CollaboratorConfirmationRepository` now owns an explicit Nostr subscription id per `(videoAddress, taggedPubkeys)` filter, calls `NostrClient.unsubscribe` from `release()` and `close()`, ignores stale EOSE/event callbacks after teardown or filter changes, and reopens the relay query when the tagged collaborator set changes.

No UI changes were needed — `CollaboratorAvatarRowBody` already returns `SizedBox.shrink()` on an empty list, so "hide until resolved" falls out of the visibility change.

## Reproduction on production data

Sampled 400 recent kind-34236 events: 10 carry `collaborator`-role `p` tags (2.5%). Checking each tagged pubkey for an acceptance on that exact coordinate, **2 of 9 resolvable videos have a tagged collaborator who never published one** — credited to every viewer today, hidden after this change:

```
34236:f67d985c0bfbf87eaa33b056f1d38ad991a6aa625b138bddb2a838bdbac29f40:d5f1c837b086543c440b96e554c887337b47c397e7984e1f67207d827afcf382
  tagged   c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e   accepted: none

34236:d73d071c85e1a9250860509591df95b6b20f610b67aa37f252cd07f11e679b14:0d3363d0481c55196147fc00dc455b444a8650205aa6344c1b1210dc383d2a7d
  tagged   28128f8bd4cfe9c89293cad8bdf1a8431ace09a85d724421fb4ccbb5e60d02a8   accepted: none
```

That 2.5% rate also bounds the relay-load change below.

## Unrequested change, flagged

Commit 3 also inverts status precedence in `_snapshot`. Relay-derived acceptance was checked *before* the current user's local override. That was safe only while the subscription never opened for a recipient — `_relayAccepted` was always empty on that path. Opening it for every viewer would let a stale kind-34238 from an earlier accept override a later local `ignore`, resurrecting an avatar the user had hidden. Caught by a regression assertion added to the recipient-view test, not by the existing suite.

## Behaviour choice worth a reviewer's eye

This is **fail-closed**: if the relay is unreachable, EOSE never arrives and third parties see no collaborators rather than falling back to the raw tagged list. That is the right trade for a credit leak — showing unconfirmed names is the bug — but a relay outage now under-credits confirmed collaborators instead of over-crediting unconfirmed ones.

## Testing

- `collaborator_repository`: 45 tests (was 33), coverage 97.10% against its 96 gate
- `models`: 8 collaborator-status tests, full package suite 877 green
- app: 367 green across `test/widgets/video_feed_item/`, `test/blocs/video_collaborator_status/`, and the invite-actions cubit
- `flutter analyze lib test` clean for both the app and the package

Six pre-existing widget/visibility tests encoded the old contract (third parties see the raw list). They are updated to the new contract rather than deleted, with the superseded ones consolidated instead of restated.

Notable new coverage: a divine-web-shaped acceptance confirms; an explicit non-accepted status still rejects; unresolved-before-EOSE and resolved-after; a second watcher inherits the resolved snapshot; release -> re-watch resolves again; late EOSE after release does not poison the next watch; changed tagged-pubkey sets reopen the relay subscription.

## Manual verification

Built and launched on a physical iPhone (iOS 26.6) and on the iOS 26.5 simulator — both build, install, and run with the change.

**The visual before/after was not captured.** The simulator's stored account wedges on the account-selection screen (`hasExistingProfile=false`) and never reaches a video, and wireless debugging on the physical device can't attach the Dart VM Service without a local-network permission tap on the phone. Neither is related to this diff. The third-party render path is covered by the widget tests above; a reviewer with a working signed-in build can confirm visually against either coordinate listed in the reproduction section.

## Follow-ups this surfaced, not fixed here

- The mobile/web/Funnelcake disagreement on what counts as an acceptance deserves its own issue. Commit 1 fixes it only from mobile's side; divine-web should stamp `status` for forward clarity, and the contract should be written down — it currently exists only as divine-mobile's own test assertions from #4045.
- divine-web mints a random-UUID `d` tag, so each web accept creates a new event rather than replacing the previous one. That defeats the addressable-replaceable semantics kind 34238 was chosen for, and means web cannot express an un-accept by replacement. Same class as divinevideo/divine-connect#35.
- "Ignore" remains device-local with no protocol-level decline. After this change third parties stop seeing an ignored collaborator (they never confirmed), but the creator still does.

