### PR TITLE
docs(data-foundation): define storage and cache policy

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,6 +19,7 @@ Generic Flutter and Dart standards live in `.claude/rules/`:
 - `rules/agent_workflow.md`: worktree-from-`origin/main`, rebase-at-boundaries, no-stacked-PRs, no-tech-debt, failing-tests-are-your-fault
 - `rules/pr_takeover.md`: check PR authorship *first*, takeover gates, answer every review item, never hand back before CI is green
 - `rules/architecture.md`: layered flow, package boundaries, barrel files
+- `rules/data_foundation.md`: storage/cache decision tree, `cache_sync` default, Drift migrations, Hive restrictions
 - `rules/state_management.md`: BLoC-first UI, BlocProvider laziness, cross-route state persistence, Riverpod legacy rules, event transformers
 - `rules/code_style.md`: naming, widget composition, Effective Dart guidance
 - `rules/testing.md`: test structure, assertions, BLoC tests, goldens, strict-coverage packages, l10n delegates in widget tests

--- a/.claude/rules/data_foundation.md
+++ b/.claude/rules/data_foundation.md
@@ -19,9 +19,10 @@ cached, or how a local schema evolves.
    options, and other values where losing the value is recoverable and no
    query/schema model is needed.
 4. **Secrets and signing material** never belong in these general stores.
-   Use the existing secure-storage/key-management path.
+   Use `mobile/packages/nostr_key_manager` and its secure-storage path.
 5. **Media bytes and file downloads** use the owning media cache or file
-   pipeline, not ad hoc rows in app data stores.
+   pipeline, such as `mobile/packages/media_cache`, not ad hoc rows in app
+   data stores.
 
 If a value fits multiple buckets, prefer the more structured shared store.
 Avoid inventing a feature-local persistence layer just because it is faster to
@@ -44,7 +45,10 @@ Good `cache_sync` candidates:
 When adding a `cache_sync` cache:
 
 - choose a key shape that is stable, explicit, and scoped by pubkey when the
-  data is account-specific
+  data is account-specific. Account-scoped keys should follow the
+  `${pubkeyHex}:${operation}` convention from `cache_sync` (RFC #4244) so
+  `CacheSync.invalidatePrefix(pubkeyHex)` clears that account's entries at
+  sign-out without touching other accounts.
 - set a TTL that matches the product freshness expectation
 - define invalidation at the repository or service boundary that owns the
   data, not in the UI
@@ -98,7 +102,9 @@ justification must explain:
 
 Existing Hive-backed paths can stay while they are being retired
 incrementally, but new work should not expand Hive usage without a deliberate
-storage decision.
+storage decision. Known legacy owners include the hashtag and personal-event
+cache services, notification preferences, pending/resumable upload state, the
+people-lists local cache, and cache recovery.
 
 ## Drift Schema Changes Use Real Migrations
 
@@ -108,8 +114,9 @@ migrations.
 - Bump `schemaVersion` when the schema changes for existing installs.
 - Add `MigrationStrategy.onUpgrade` steps for table, column, index, and data
   migrations.
-- Keep migration tests with generated schema snapshots where the package uses
-  them.
+- For `db_client`, keep generated snapshots under
+  `mobile/packages/db_client/drift_schemas/app_database/` and migration tests
+  in `mobile/packages/db_client/test/drift/app_database/migration_test.dart`.
 - Use `beforeOpen` for startup cleanup and validation only, not as the primary
   place to accumulate `CREATE TABLE IF NOT EXISTS` or `ALTER TABLE` repair SQL.
 
@@ -124,6 +131,8 @@ run yet when the upgrade step executes. Make the first `1 -> 2` step
 idempotent (probe `sqlite_master` / `PRAGMA table_info` before altering), and
 treat the generated v1 snapshot as the declared schema rather than as what
 every install actually has.
+
+See #6921 for the tracked `db_client` repair-to-migration cleanup.
 
 ## Review Checklist
 

--- a/.claude/rules/data_foundation.md
+++ b/.claude/rules/data_foundation.md
@@ -116,6 +116,15 @@ migrations.
 Startup repair SQL may be used only as a narrow compatibility bridge for
 already-shipped damage, and should not be the pattern for new schema changes.
 
+`db_client`'s v1 is a special case for whoever writes its first real
+migration. Because the repair block lives in `beforeOpen`, two installs can
+both report `user_version = 1` with different tables, columns, and indexes on
+disk — and Drift runs `onUpgrade` *before* `beforeOpen`, so the repair has not
+run yet when the upgrade step executes. Make the first `1 -> 2` step
+idempotent (probe `sqlite_master` / `PRAGMA table_info` before altering), and
+treat the generated v1 snapshot as the declared schema rather than as what
+every install actually has.
+
 ## Review Checklist
 
 Before approving a data/storage change, confirm:

--- a/.claude/rules/data_foundation.md
+++ b/.claude/rules/data_foundation.md
@@ -1,0 +1,128 @@
+# Data Foundation
+
+Use this rule whenever new work chooses where data should live, how it is
+cached, or how a local schema evolves.
+
+## Default Decision Tree
+
+1. **Remote-derived cacheable data** defaults to `cache_sync`.
+   This includes data fetched from REST, GraphQL, relays, or other network
+   sources when the app can refetch it and callers benefit from
+   stale-while-revalidate behavior.
+2. **Structured durable app data** belongs in Drift, usually through
+   `mobile/packages/db_client`.
+   Choose Drift when data needs queries, relationships, indexes, reactive
+   streams, account-scoped cleanup, schema evolution, or durable offline
+   behavior that is more than a small setting.
+3. **Small local-only preferences** may use `SharedPreferences`.
+   Keep it to scalar settings, dismissals, feature flags, last-selected UI
+   options, and other values where losing the value is recoverable and no
+   query/schema model is needed.
+4. **Secrets and signing material** never belong in these general stores.
+   Use the existing secure-storage/key-management path.
+5. **Media bytes and file downloads** use the owning media cache or file
+   pipeline, not ad hoc rows in app data stores.
+
+If a value fits multiple buckets, prefer the more structured shared store.
+Avoid inventing a feature-local persistence layer just because it is faster to
+wire in the moment.
+
+## `cache_sync` Is The Default Cache
+
+For new remote-derived cacheable data, use `cache_sync` unless there is a
+clear reason not to.
+
+Good `cache_sync` candidates:
+
+- profile, list, feed, count, or metadata responses that can be regenerated
+  from relays or APIs
+- data where showing cached content immediately is better than blocking on a
+  fresh network response
+- account-scoped cache entries that can be invalidated by key prefix
+- simple JSON payloads that do not need relational queries
+
+When adding a `cache_sync` cache:
+
+- choose a key shape that is stable, explicit, and scoped by pubkey when the
+  data is account-specific
+- set a TTL that matches the product freshness expectation
+- define invalidation at the repository or service boundary that owns the
+  data, not in the UI
+- keep serialization failures and corrupt entries recoverable by refetching
+
+Do not create a new cache service, in-memory singleton, Hive box, or
+SharedPreferences JSON blob for remote-derived cacheable data until
+`cache_sync` has been ruled out in the PR notes.
+
+## Drift Owns Durable Structured Data
+
+Use Drift when the app is the durable owner of structured local state or when
+the local copy needs database behavior.
+
+Prefer Drift for:
+
+- drafts, pending queues, outbox state, local-only collections, and offline
+  workflow state
+- denormalized tables that need indexes, joins, ordering, pruning, or reactive
+  watchers
+- local data that must survive app restarts and account switches with clear
+  cleanup semantics
+- data that requires migrations as fields or invariants change
+
+Durable local-only user data belongs in Drift once it grows beyond a small
+preference. `SharedPreferences` should not become a hidden document store.
+
+## SharedPreferences Is Narrow
+
+`SharedPreferences` is acceptable for small, flat, local-only values:
+
+- booleans, enums, timestamps, and simple strings
+- one-off dismissal or onboarding flags
+- user preferences such as selected modes or display options
+- compatibility reads while migrating legacy values into the correct store
+
+Do not use `SharedPreferences` for remote caches, lists of domain objects,
+large JSON payloads, append-only histories, queues, or anything that needs
+partial updates, indexes, or schema migration.
+
+## Hive Is Legacy By Default
+
+New Hive boxes require explicit justification in the issue or PR. The
+justification must explain:
+
+- why `cache_sync` is not appropriate
+- why Drift is not appropriate
+- how corruption, migration, account cleanup, and low-storage behavior are
+  handled
+- how the box will be tested
+
+Existing Hive-backed paths can stay while they are being retired
+incrementally, but new work should not expand Hive usage without a deliberate
+storage decision.
+
+## Drift Schema Changes Use Real Migrations
+
+For `db_client` and other Drift databases, schema evolution belongs in Drift
+migrations.
+
+- Bump `schemaVersion` when the schema changes for existing installs.
+- Add `MigrationStrategy.onUpgrade` steps for table, column, index, and data
+  migrations.
+- Keep migration tests with generated schema snapshots where the package uses
+  them.
+- Use `beforeOpen` for startup cleanup and validation only, not as the primary
+  place to accumulate `CREATE TABLE IF NOT EXISTS` or `ALTER TABLE` repair SQL.
+
+Startup repair SQL may be used only as a narrow compatibility bridge for
+already-shipped damage, and should not be the pattern for new schema changes.
+
+## Review Checklist
+
+Before approving a data/storage change, confirm:
+
+- the selected store matches the decision tree above
+- account-scoped data has account-scoped keys or cleanup
+- remote caches have explicit freshness and invalidation behavior
+- durable local data has migration and recovery behavior
+- new Hive usage has a written justification
+- Drift schema changes are represented as real migrations

--- a/.claude/rules/self_review_checklist.md
+++ b/.claude/rules/self_review_checklist.md
@@ -52,6 +52,10 @@ Architecture and ownership:
   Any logic that filters, sorts, fetches conditionally, falls back, or
   composes data sources belongs **below** the UI. See
   [`architecture.md`](architecture.md).
+- [ ] New storage/cache choices follow the data-foundation decision tree:
+  `cache_sync` for remote-derived cacheable data, Drift for durable
+  structured data, narrow `SharedPreferences`, and no new Hive boxes without
+  explicit justification. See [`data_foundation.md`](data_foundation.md).
 - [ ] "Cache warming" and "pre-fetch" work belongs in the **repository**
   layer, not in a `BlocProvider` wrapper. BlocProviders are lazy — see
   [`state_management.md`](state_management.md#blocprovider-is-lazy-by-default).


### PR DESCRIPTION
## Description

Adds the data-foundation storage/cache rule for new work, including:

- `cache_sync` as the default for remote-derived cacheable data, including the `${pubkeyHex}:${operation}` account-scoped key convention
- concrete paths for secure key storage, media cache ownership, and `db_client` migration snapshots/tests
- Drift/db_client guidance for durable structured data and real migrations, including the v1 repair caveat for the first `1 -> 2` migration
- narrow SharedPreferences usage
- explicit justification requirements for new Hive boxes and named legacy Hive-backed owners

Also links the new rule from the self-review checklist and the Claude rules index.

**Related Issue:** Closes #6922
**Related Follow-up:** #6921 tracks moving `db_client` startup schema repairs into Drift migrations.

## Out of Scope

No storage migrations or code changes. This PR only documents the policy requested by #6922.

## Verification

- `git diff --check`
- `git diff --cached --check`
- `git diff --check origin/main...HEAD`
- `git fetch origin && git rebase origin/main`
- pre-push hook: no Dart files changed, skipped Dart checks after merge-conflict check passed

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes a problem)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
