### PR TITLE
fix(invites): drive invite status from the nostr session readiness contract

### DIFF
--- a/.claude/rules/self_review_checklist.md
+++ b/.claude/rules/self_review_checklist.md
@@ -137,11 +137,12 @@ State management:
   child via `BlocProvider`-keyed-on-identity (the existing rule
   then covers the parent). See
   [`state_management.md`](state_management.md#stateful-widgets-that-hold-the-captured-dep-bloc-directly).
-- [ ] Anything that signs, publishes, or sends a NIP-98 header waits on
-  `nostrSessionProvider` reaching `nostrReady`, not on
-  `authStateStream` / `currentAuthStateProvider` / `canPublishNostrWritesNow`.
-  Auth state only says the pubkey is known; a Keycast signer with no
-  local key arrives after it. See
+- [ ] Anything that signs or publishes through the app-wide `NostrClient`
+  waits on `nostrSessionProvider` reaching `nostrReady`; relay-free
+  signing such as REST NIP-98 watches a signer-capability signal such as
+  `currentAuthRpcCapabilityProvider` before sampling
+  `canPublishNostrWritesNow`. Auth state only says the pubkey is known;
+  a Keycast signer with no local key arrives after it. See
   [`state_management.md`](state_management.md#signing-readiness-identity-known-is-not-signer-ready).
 - [ ] No error strings / exception objects in BLoC `state`. Use status
   enums + `addError`. See [`state_management.md`](state_management.md).

--- a/.claude/rules/self_review_checklist.md
+++ b/.claude/rules/self_review_checklist.md
@@ -137,6 +137,12 @@ State management:
   child via `BlocProvider`-keyed-on-identity (the existing rule
   then covers the parent). See
   [`state_management.md`](state_management.md#stateful-widgets-that-hold-the-captured-dep-bloc-directly).
+- [ ] Anything that signs, publishes, or sends a NIP-98 header waits on
+  `nostrSessionProvider` reaching `nostrReady`, not on
+  `authStateStream` / `currentAuthStateProvider` / `canPublishNostrWritesNow`.
+  Auth state only says the pubkey is known; a Keycast signer with no
+  local key arrives after it. See
+  [`state_management.md`](state_management.md#signing-readiness-identity-known-is-not-signer-ready).
 - [ ] No error strings / exception objects in BLoC `state`. Use status
   enums + `addError`. See [`state_management.md`](state_management.md).
 - [ ] No mutable instance variables on a BLoC class. All state lives in

--- a/.claude/rules/state_management.md
+++ b/.claude/rules/state_management.md
@@ -24,23 +24,32 @@ app-wide contract, and it is two-tier:
 | Phase | Carries | Use it for |
 |-------|---------|------------|
 | `identityKnown` | pubkey | reads, scoping caches/repositories to an owner, UI gating |
-| `nostrReady` | pubkey **and** a keyed `NostrClient` | anything that signs, publishes, or sends a NIP-98 header |
+| `nostrReady` | pubkey **and** a keyed `NostrClient` | Nostr-client signing/publishing that needs the initialized client |
 
 Rules:
 
-- **Anything that signs watches `nostrReady`**, via
+- **Anything that signs or publishes through the app-wide `NostrClient`
+  watches `nostrReady`**, via
   `ref.watch(nostrSessionProvider).isReadyForActiveClient` or a
   `ref.listen` on the provider. `profileRepositoryProvider` (nullable
   gate) and `notificationsProviders` (auth state for teardown +
   readiness for work) are the reference implementations.
+- **Relay-free signing watches signer capability, not relay readiness.**
+  For example, REST NIP-98 calls that use `Nip98AuthService(authService:)`
+  need an identity that can sign now, but do not need relay connections.
+  Watch `currentAuthStateProvider` for account changes and
+  `currentAuthRpcCapabilityProvider` for the Keycast
+  `unavailable -> rpcReady` transition, then sample
+  `AuthService.canPublishNostrWritesNow`.
 - **Never gate a signer-dependent side effect on `authStateStream` or
-  `currentAuthStateProvider`.** Those are identity signals. Watching
-  them is correct when you only need to re-scope to a new pubkey or
-  show/hide UI.
+  `currentAuthStateProvider` alone.** Those are identity signals.
+  Watching them is correct when you only need to re-scope to a new
+  pubkey or show/hide UI.
 - `AuthService.canPublishNostrWritesNow` answers "is this identity
-  *capable* of signing", not "is the client ready". It has no stream, so
-  sample it at the moment of use; never use it as the trigger a
-  one-shot effect waits on.
+  *capable* of signing", not "is the client ready". It has no direct
+  stream, so sample it at the moment of use; for push consumers, pair
+  that sample with a real rebuild trigger such as
+  `currentAuthRpcCapabilityProvider`.
 
 The distinction matters most for **push** consumers — code that asks
 once and then waits. Pull consumers that re-read at call time cannot go

--- a/.claude/rules/state_management.md
+++ b/.claude/rules/state_management.md
@@ -11,6 +11,43 @@
 **Riverpod owns:** app-level DI, long-lived services/clients, infrastructure side-effects.  
 **BLoC/Cubit owns:** all feature UI state, all UI side effects, all loading/error/success states.
 
+## Signing readiness: identity known is not signer ready
+
+`AuthState.authenticated` means the pubkey is known. It does **not** mean
+anything can be signed. For a Keycast identity with no local key the
+signer becomes usable *after* the auth state settles, on a different
+signal entirely.
+
+`nostrSessionProvider` (`lib/providers/nostr_client_provider.dart`) is the
+app-wide contract, and it is two-tier:
+
+| Phase | Carries | Use it for |
+|-------|---------|------------|
+| `identityKnown` | pubkey | reads, scoping caches/repositories to an owner, UI gating |
+| `nostrReady` | pubkey **and** a keyed `NostrClient` | anything that signs, publishes, or sends a NIP-98 header |
+
+Rules:
+
+- **Anything that signs watches `nostrReady`**, via
+  `ref.watch(nostrSessionProvider).isReadyForActiveClient` or a
+  `ref.listen` on the provider. `profileRepositoryProvider` (nullable
+  gate) and `notificationsProviders` (auth state for teardown +
+  readiness for work) are the reference implementations.
+- **Never gate a signer-dependent side effect on `authStateStream` or
+  `currentAuthStateProvider`.** Those are identity signals. Watching
+  them is correct when you only need to re-scope to a new pubkey or
+  show/hide UI.
+- `AuthService.canPublishNostrWritesNow` answers "is this identity
+  *capable* of signing", not "is the client ready". It has no stream, so
+  sample it at the moment of use; never use it as the trigger a
+  one-shot effect waits on.
+
+The distinction matters most for **push** consumers — code that asks
+once and then waits. Pull consumers that re-read at call time cannot go
+stale and are fine either way. #6977 is the worked example: the invites
+screen asked at `authenticated`, got "cannot sign", and never heard the
+correction 21ms later.
+
 ## Allowed / Disallowed Patterns
 
 | Pattern | Verdict |
@@ -291,9 +328,8 @@ world.
 
 **Before applying this rule, check whether Pattern A is available.**
 Some Riverpod-provided dependencies are *already* gated on a
-readiness signal — `profileRepositoryProvider` and
-`pendingActionServiceProvider` return `null` until
-`isNostrReadyProvider` resolves. When that's the case, the consumer
+readiness signal — `profileRepositoryProvider` returns `null` until
+`nostrSessionProvider` reports `isReadyForActiveClient`. When that's the case, the consumer
 reads the nullable value and renders a loading / disabled
 affordance until it's non-null; the bloc never gets a chance to
 capture a stale instance, and there's nothing for this rule to
@@ -417,8 +453,8 @@ that test fails loudly so the state loss can be re-evaluated.
 3. **Pattern A (gate the provider on readiness) is available.**
    When the dependency can be in a "not ready" state, the cleaner
    option is to gate the *provider itself* on a readiness flag —
-   `profileRepositoryProvider` and `pendingActionServiceProvider`
-   already gate on `isNostrReadyProvider` and return `null` until
+   `profileRepositoryProvider` already gates on
+   `nostrSessionProvider` and returns `null` until
    the real instance is available. The widget renders a loading /
    disabled affordance until the provider hands over a non-null
    dependency, and the bloc never gets to capture a stale one.

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -74,6 +74,7 @@ import 'package:openvine/providers/device_scope.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/foreground_idle_warmup_provider.dart';
 import 'package:openvine/providers/install_source_provider.dart';
+import 'package:openvine/providers/invite_status_auth_sessions.dart';
 import 'package:openvine/providers/layer_rasterizer_provider.dart';
 import 'package:openvine/providers/list_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -2766,22 +2767,15 @@ class _DivineAppState extends ConsumerState<DivineApp>
               ),
               BlocProvider(
                 lazy: false,
-                create: (context) {
-                  final authService = ref.read(authServiceProvider);
-                  InviteStatusAuthSession currentAuthSession() =>
-                      InviteStatusAuthSession(
-                        accountId: authService.currentPublicKeyHex,
-                        isSignerReady: authService.canPublishNostrWritesNow,
-                      );
-
-                  return InviteStatusCubit(
-                    inviteApiClient: context.read<InviteApiClient>(),
-                    initialAuthSession: currentAuthSession(),
-                    authSessionStream: authService.authStateStream.map(
-                      (_) => currentAuthSession(),
-                    ),
-                  )..start();
-                },
+                create: (context) => InviteStatusCubit(
+                  inviteApiClient: context.read<InviteApiClient>(),
+                  initialAuthSession: inviteStatusAuthSessionOf(
+                    ref.read(nostrSessionProvider),
+                  ),
+                  authSessionStream: ref.read(
+                    inviteStatusAuthSessionsProvider,
+                  ),
+                )..start(),
               ),
               BlocProvider(
                 create: (_) => AppUpdateBloc(

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2769,12 +2769,8 @@ class _DivineAppState extends ConsumerState<DivineApp>
                 lazy: false,
                 create: (context) => InviteStatusCubit(
                   inviteApiClient: context.read<InviteApiClient>(),
-                  initialAuthSession: inviteStatusAuthSessionOf(
-                    ref.read(nostrSessionProvider),
-                  ),
-                  authSessionStream: ref.read(
-                    inviteStatusAuthSessionsProvider,
-                  ),
+                  initialAuthSession: ref.read(inviteStatusAuthSessionProvider),
+                  authSessionStream: ref.read(inviteStatusAuthSessionsProvider),
                 )..start(),
               ),
               BlocProvider(

--- a/mobile/lib/providers/invite_status_auth_sessions.dart
+++ b/mobile/lib/providers/invite_status_auth_sessions.dart
@@ -1,0 +1,42 @@
+// ABOUTME: Bridges the app-wide Nostr readiness contract into invite status.
+// ABOUTME: Feeds InviteStatusCubit the signer-ready phase, not raw auth state.
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+
+/// Maps a [NostrSessionReadiness] snapshot onto the cubit's session type.
+///
+/// `identityKnown` carries a pubkey but no usable signer, so it maps to a
+/// session that is addressed to an account yet not allowed to call the invite
+/// API. Only `nostrReady` reports a signer.
+InviteStatusAuthSession inviteStatusAuthSessionOf(
+  NostrSessionReadiness readiness,
+) => InviteStatusAuthSession(
+  accountId: readiness.pubkey,
+  isSignerReady: readiness.isReadyForActiveClient,
+);
+
+/// Session updates for [InviteStatusCubit].
+///
+/// Reads from [nostrSessionProvider] rather than `authStateStream`: auth state
+/// only says the identity is known, and a Keycast signer with no local key
+/// becomes usable *after* that (#6977). The cubit asks once and then waits for
+/// a push, so watching the wrong signal strands it forever.
+final inviteStatusAuthSessionsProvider =
+    Provider<Stream<InviteStatusAuthSession>>((ref) {
+      final controller = StreamController<InviteStatusAuthSession>.broadcast();
+      final subscription = ref.listen<NostrSessionReadiness>(
+        nostrSessionProvider,
+        (_, next) => controller.add(inviteStatusAuthSessionOf(next)),
+      );
+
+      ref.onDispose(() {
+        subscription.close();
+        unawaited(controller.close());
+      });
+
+      return controller.stream;
+    });

--- a/mobile/lib/providers/invite_status_auth_sessions.dart
+++ b/mobile/lib/providers/invite_status_auth_sessions.dart
@@ -1,42 +1,36 @@
-// ABOUTME: Bridges the app-wide Nostr readiness contract into invite status.
-// ABOUTME: Feeds InviteStatusCubit the signer-ready phase, not raw auth state.
-
-import 'dart:async';
+// ABOUTME: Bridges auth signer capability into invite status.
+// ABOUTME: Feeds InviteStatusCubit a push signal for late RPC readiness.
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
-import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/provider_identity_stream.dart';
 
-/// Maps a [NostrSessionReadiness] snapshot onto the cubit's session type.
+/// Current auth session for invite status.
 ///
-/// `identityKnown` carries a pubkey but no usable signer, so it maps to a
-/// session that is addressed to an account yet not allowed to call the invite
-/// API. Only `nostrReady` reports a signer.
-InviteStatusAuthSession inviteStatusAuthSessionOf(
-  NostrSessionReadiness readiness,
-) => InviteStatusAuthSession(
-  accountId: readiness.pubkey,
-  isSignerReady: readiness.isReadyForActiveClient,
-);
+/// Invite status uses NIP-98 over the REST invite API. That requires an
+/// authenticated identity that can sign now, but it does not require the
+/// app-wide `NostrClient` to finish relay initialization.
+final inviteStatusAuthSessionProvider = Provider<InviteStatusAuthSession>((
+  ref,
+) {
+  final authService = ref.watch(authServiceProvider);
+  ref.watch(currentAuthStateProvider);
+  ref.watch(currentAuthRpcCapabilityProvider);
+
+  return InviteStatusAuthSession(
+    accountId: authService.currentPublicKeyHex,
+    isSignerReady: authService.canPublishNostrWritesNow,
+  );
+});
 
 /// Session updates for [InviteStatusCubit].
 ///
-/// Reads from [nostrSessionProvider] rather than `authStateStream`: auth state
-/// only says the identity is known, and a Keycast signer with no local key
-/// becomes usable *after* that (#6977). The cubit asks once and then waits for
-/// a push, so watching the wrong signal strands it forever.
-final inviteStatusAuthSessionsProvider =
-    Provider<Stream<InviteStatusAuthSession>>((ref) {
-      final controller = StreamController<InviteStatusAuthSession>.broadcast();
-      final subscription = ref.listen<NostrSessionReadiness>(
-        nostrSessionProvider,
-        (_, next) => controller.add(inviteStatusAuthSessionOf(next)),
-      );
-
-      ref.onDispose(() {
-        subscription.close();
-        unawaited(controller.close());
-      });
-
-      return controller.stream;
-    });
+/// Reads from [inviteStatusAuthSessionProvider] rather than `authStateStream`
+/// alone: auth state only says the identity is known, and a Keycast signer with
+/// no local key becomes usable on the RPC-capability signal (#6977). The cubit
+/// asks once and then waits for a push, so watching only auth state strands it.
+final Provider<Stream<InviteStatusAuthSession>>
+inviteStatusAuthSessionsProvider = identityStreamOf<InviteStatusAuthSession>(
+  inviteStatusAuthSessionProvider,
+);

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -400,7 +400,12 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// Current authentication state
   AuthState get authState => _authState;
 
-  /// Stream of authentication state changes
+  /// Stream of authentication state changes.
+  ///
+  /// Identity only. `authenticated` says the pubkey is known, not that anything
+  /// can be signed. Side effects that sign or publish must watch
+  /// `nostrSessionProvider` instead; gating them here strands them when the
+  /// signer arrives later (#6977).
   Stream<AuthState> get authStateStream => _authStateController.stream;
 
   /// Current user profile (null if not authenticated)
@@ -498,6 +503,11 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// True when the identity has a local private key (can sign locally)
   /// OR when RPC is fully ready. False for pubkey-only identities that
   /// are still waiting for RPC warmup.
+  ///
+  /// This answers "is this identity *capable* of signing", not "is the
+  /// signer-backed client ready". It has no stream, so it is safe to sample at
+  /// the moment of use and unsafe to gate a one-shot side effect on. For the
+  /// latter, watch `nostrSessionProvider`.
   bool get canPublishNostrWritesNow {
     return switch (_currentIdentity) {
       null => false,

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -403,9 +403,10 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// Stream of authentication state changes.
   ///
   /// Identity only. `authenticated` says the pubkey is known, not that anything
-  /// can be signed. Side effects that sign or publish must watch
-  /// `nostrSessionProvider` instead; gating them here strands them when the
-  /// signer arrives later (#6977).
+  /// can be signed. Side effects that sign through the app-wide Nostr client
+  /// must watch `nostrSessionProvider`; relay-free signing must watch a signer
+  /// capability signal such as `currentAuthRpcCapabilityProvider`. Gating them
+  /// here strands them when the signer arrives later (#6977).
   Stream<AuthState> get authStateStream => _authStateController.stream;
 
   /// Current user profile (null if not authenticated)
@@ -505,9 +506,9 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// are still waiting for RPC warmup.
   ///
   /// This answers "is this identity *capable* of signing", not "is the
-  /// signer-backed client ready". It has no stream, so it is safe to sample at
-  /// the moment of use and unsafe to gate a one-shot side effect on. For the
-  /// latter, watch `nostrSessionProvider`.
+  /// signer-backed client ready". It has no direct stream, so it is safe to
+  /// sample at the moment of use. Push consumers that wait for this to flip must
+  /// also watch a rebuild trigger such as `currentAuthRpcCapabilityProvider`.
   bool get canPublishNostrWritesNow {
     return switch (_currentIdentity) {
       null => false,

--- a/mobile/test/providers/invite_status_auth_sessions_test.dart
+++ b/mobile/test/providers/invite_status_auth_sessions_test.dart
@@ -1,28 +1,18 @@
-// ABOUTME: Tests the invite status bridge onto the Nostr readiness contract.
-// ABOUTME: Pins that a late signer still reaches the invite status cubit.
+// ABOUTME: Tests the invite status auth-session bridge.
+// ABOUTME: Pins late signer capability without waiting for relay readiness.
+
+import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
+import 'package:openvine/models/auth_rpc_capability.dart';
+import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/invite_status_auth_sessions.dart';
-import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/services/auth_service.dart';
 
-class _MockNostrClient extends Mock implements NostrClient {}
-
-class _TestNostrSession extends NostrSession {
-  _TestNostrSession(this._initialReadiness);
-
-  final NostrSessionReadiness _initialReadiness;
-
-  @override
-  NostrSessionReadiness build() => _initialReadiness;
-
-  void setReadiness(NostrSessionReadiness readiness) {
-    state = readiness;
-  }
-}
+class _MockAuthService extends Mock implements AuthService {}
 
 void main() {
   // A Keycast identity with no local key: the pubkey is known well before the
@@ -30,76 +20,141 @@ void main() {
   const keycastPubkey =
       'fc7031a810ce4b02b6195a7e477cfe3d08c0386038bd45b4431f82d9b3f5ffb0';
 
-  late _MockNostrClient nostrClient;
+  late _MockAuthService authService;
+  late StreamController<AuthState> authStateController;
+  late StreamController<AuthRpcCapability> rpcCapabilityController;
 
   setUp(() {
-    nostrClient = _MockNostrClient();
-    when(() => nostrClient.hasKeys).thenReturn(true);
-    when(() => nostrClient.publicKey).thenReturn(keycastPubkey);
+    authService = _MockAuthService();
+    authStateController = StreamController<AuthState>.broadcast();
+    rpcCapabilityController = StreamController<AuthRpcCapability>.broadcast();
+
+    when(() => authService.authState).thenReturn(AuthState.authenticated);
+    when(
+      () => authService.authStateStream,
+    ).thenAnswer((_) => authStateController.stream);
+    when(() => authService.currentPublicKeyHex).thenReturn(keycastPubkey);
+    when(() => authService.canPublishNostrWritesNow).thenReturn(false);
+    when(
+      () => authService.authRpcCapability,
+    ).thenReturn(AuthRpcCapability.unavailable);
+    when(
+      () => authService.authRpcCapabilityStream,
+    ).thenAnswer((_) => rpcCapabilityController.stream);
   });
 
-  NostrSessionReadiness readySession() => NostrSessionReadiness.nostrReady(
-    pubkey: keycastPubkey,
-    client: nostrClient,
+  tearDown(() async {
+    await authStateController.close();
+    await rpcCapabilityController.close();
+  });
+
+  ProviderContainer createContainer() {
+    final container = ProviderContainer(
+      overrides: [authServiceProvider.overrideWithValue(authService)],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  InviteStatusAuthSession session({
+    required String? accountId,
+    required bool isSignerReady,
+  }) => InviteStatusAuthSession(
+    accountId: accountId,
+    isSignerReady: isSignerReady,
   );
 
-  group('inviteStatusAuthSessionOf', () {
-    test('reports no signer while only the identity is known', () {
-      final session = inviteStatusAuthSessionOf(
-        const NostrSessionReadiness.identityKnown(pubkey: keycastPubkey),
-      );
-
-      expect(session.accountId, equals(keycastPubkey));
-      expect(session.isSignerReady, isFalse);
-    });
-
-    test('reports a signer once the session is nostr ready', () {
-      final session = inviteStatusAuthSessionOf(readySession());
-
-      expect(session.accountId, equals(keycastPubkey));
-      expect(session.isSignerReady, isTrue);
-    });
-
+  group('inviteStatusAuthSessionProvider', () {
     test('reports no account while signed out', () {
-      final session = inviteStatusAuthSessionOf(
-        const NostrSessionReadiness.signedOut(),
-      );
+      when(() => authService.authState).thenReturn(AuthState.unauthenticated);
+      when(() => authService.currentPublicKeyHex).thenReturn(null);
 
-      expect(session.accountId, isNull);
-      expect(session.isSignerReady, isFalse);
+      final container = createContainer();
+
+      expect(
+        container.read(inviteStatusAuthSessionProvider),
+        equals(session(accountId: null, isSignerReady: false)),
+      );
+    });
+
+    test('reports no signer while only the identity is known', () {
+      final container = createContainer();
+
+      expect(
+        container.read(inviteStatusAuthSessionProvider),
+        equals(session(accountId: keycastPubkey, isSignerReady: false)),
+      );
+    });
+
+    test('reports a signer from auth capability before relay readiness', () {
+      when(() => authService.canPublishNostrWritesNow).thenReturn(true);
+      when(
+        () => authService.authRpcCapability,
+      ).thenReturn(AuthRpcCapability.rpcReady);
+
+      final container = createContainer();
+
+      expect(
+        container.read(inviteStatusAuthSessionProvider),
+        equals(session(accountId: keycastPubkey, isSignerReady: true)),
+      );
     });
   });
 
   group('inviteStatusAuthSessionsProvider', () {
-    // Reading auth state instead of readiness makes this await forever rather
-    // than fail, so the await is bounded (#6977).
+    // Reading auth state instead of RPC capability makes this await forever
+    // rather than fail, so the await is bounded (#6977).
     const awaitBound = Duration(seconds: 5);
 
     test(
-      'emits a ready session when the signer arrives after the identity',
+      'emits a ready session when RPC capability arrives after identity',
       () async {
-        final nostrSession = _TestNostrSession(
-          const NostrSessionReadiness.identityKnown(pubkey: keycastPubkey),
-        );
-        final container = ProviderContainer(
-          overrides: [nostrSessionProvider.overrideWith(() => nostrSession)],
-        );
-        addTearDown(container.dispose);
+        final container = createContainer();
 
         final sessions = container.read(inviteStatusAuthSessionsProvider);
-        final firstSession = sessions.first.timeout(awaitBound);
-
-        nostrSession.setReadiness(readySession());
-
-        expect(
-          await firstSession,
-          equals(
-            const InviteStatusAuthSession(
-              accountId: keycastPubkey,
-              isSignerReady: true,
-            ),
-          ),
+        final expectation = expectLater(
+          sessions.timeout(awaitBound),
+          emitsInOrder([
+            session(accountId: keycastPubkey, isSignerReady: false),
+            session(accountId: keycastPubkey, isSignerReady: true),
+          ]),
         );
+
+        await Future<void>.delayed(Duration.zero);
+        when(() => authService.canPublishNostrWritesNow).thenReturn(true);
+        when(
+          () => authService.authRpcCapability,
+        ).thenReturn(AuthRpcCapability.rpcReady);
+        rpcCapabilityController.add(AuthRpcCapability.rpcReady);
+
+        await expectation;
+      },
+    );
+
+    test(
+      'emits when the auth session source recomputes after being read once',
+      () async {
+        when(() => authService.authState).thenReturn(AuthState.unauthenticated);
+        when(() => authService.currentPublicKeyHex).thenReturn(null);
+
+        final container = createContainer();
+
+        final sessions = container.read(inviteStatusAuthSessionsProvider);
+        final expectation = expectLater(
+          sessions.timeout(awaitBound),
+          emitsInOrder([
+            session(accountId: null, isSignerReady: false),
+            session(accountId: keycastPubkey, isSignerReady: true),
+          ]),
+        );
+
+        await Future<void>.delayed(Duration.zero);
+        when(() => authService.authState).thenReturn(AuthState.authenticated);
+        when(() => authService.currentPublicKeyHex).thenReturn(keycastPubkey);
+        when(() => authService.canPublishNostrWritesNow).thenReturn(true);
+        authStateController.add(AuthState.authenticated);
+
+        await expectation;
       },
     );
   });

--- a/mobile/test/providers/invite_status_auth_sessions_test.dart
+++ b/mobile/test/providers/invite_status_auth_sessions_test.dart
@@ -1,0 +1,106 @@
+// ABOUTME: Tests the invite status bridge onto the Nostr readiness contract.
+// ABOUTME: Pins that a late signer still reaches the invite status cubit.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
+import 'package:openvine/providers/invite_status_auth_sessions.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _TestNostrSession extends NostrSession {
+  _TestNostrSession(this._initialReadiness);
+
+  final NostrSessionReadiness _initialReadiness;
+
+  @override
+  NostrSessionReadiness build() => _initialReadiness;
+
+  void setReadiness(NostrSessionReadiness readiness) {
+    state = readiness;
+  }
+}
+
+void main() {
+  // A Keycast identity with no local key: the pubkey is known well before the
+  // remote signer is usable.
+  const keycastPubkey =
+      'fc7031a810ce4b02b6195a7e477cfe3d08c0386038bd45b4431f82d9b3f5ffb0';
+
+  late _MockNostrClient nostrClient;
+
+  setUp(() {
+    nostrClient = _MockNostrClient();
+    when(() => nostrClient.hasKeys).thenReturn(true);
+    when(() => nostrClient.publicKey).thenReturn(keycastPubkey);
+  });
+
+  NostrSessionReadiness readySession() => NostrSessionReadiness.nostrReady(
+    pubkey: keycastPubkey,
+    client: nostrClient,
+  );
+
+  group('inviteStatusAuthSessionOf', () {
+    test('reports no signer while only the identity is known', () {
+      final session = inviteStatusAuthSessionOf(
+        const NostrSessionReadiness.identityKnown(pubkey: keycastPubkey),
+      );
+
+      expect(session.accountId, equals(keycastPubkey));
+      expect(session.isSignerReady, isFalse);
+    });
+
+    test('reports a signer once the session is nostr ready', () {
+      final session = inviteStatusAuthSessionOf(readySession());
+
+      expect(session.accountId, equals(keycastPubkey));
+      expect(session.isSignerReady, isTrue);
+    });
+
+    test('reports no account while signed out', () {
+      final session = inviteStatusAuthSessionOf(
+        const NostrSessionReadiness.signedOut(),
+      );
+
+      expect(session.accountId, isNull);
+      expect(session.isSignerReady, isFalse);
+    });
+  });
+
+  group('inviteStatusAuthSessionsProvider', () {
+    // Reading auth state instead of readiness makes this await forever rather
+    // than fail, so the await is bounded (#6977).
+    const awaitBound = Duration(seconds: 5);
+
+    test(
+      'emits a ready session when the signer arrives after the identity',
+      () async {
+        final nostrSession = _TestNostrSession(
+          const NostrSessionReadiness.identityKnown(pubkey: keycastPubkey),
+        );
+        final container = ProviderContainer(
+          overrides: [nostrSessionProvider.overrideWith(() => nostrSession)],
+        );
+        addTearDown(container.dispose);
+
+        final sessions = container.read(inviteStatusAuthSessionsProvider);
+        final firstSession = sessions.first.timeout(awaitBound);
+
+        nostrSession.setReadiness(readySession());
+
+        expect(
+          await firstSession,
+          equals(
+            const InviteStatusAuthSession(
+              accountId: keycastPubkey,
+              isSignerReady: true,
+            ),
+          ),
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Description

Keycast users who sign over RPC with no local nsec never saw their invites. The Invites row was absent from Settings and the screen sat in its error state, even with invites allocated server side.

`InviteStatusCubit` was gated on `AuthService.canPublishNostrWritesNow`, sampled from `authStateStream`. Auth state only reports that the pubkey is known. For a Keycast identity whose key lives on the server, the signer becomes usable *after* that, and the app publishes that fact on a different signal. The cubit asked once at `authenticated`, got "cannot sign", and never heard the correction. It waited out its 12s bound and fell through to the error state.

From the reporter's log, the only two relevant transitions in the whole session:

```text
06:25:56.705414  [AuthService] Auth state: authenticating -> authenticated
06:25:56.726403  [AuthService] RPC capability: unavailable -> rpcReady
```

21ms apart, and no further `Auth state:` line for the rest of the log.

The app never called the invite API at all. Across the session there is no NIP-98 token creation for `invite.divine.video` though there are six for other hosts, no `[InviteApiClient]` warning, and no invite API error of any kind. Meanwhile Keycast signing itself was healthy, with ten successful `sign_event` calls at HTTP 200.

### The fix

Invite status uses NIP-98 over the REST invite API. Its auth header is created through `InviteApiClient -> nip98AuthServiceProvider -> Nip98AuthService(authService:)`, so it needs an authenticated identity that can sign now, but it does not need the app-wide `NostrClient` to finish relay initialization.

This adds `inviteStatusAuthSessionProvider`, which watches:

- `currentAuthStateProvider` for account/sign-out changes
- `currentAuthRpcCapabilityProvider` for the Keycast `unavailable -> rpcReady` transition

It then samples `AuthService.canPublishNostrWritesNow` and feeds the cubit through `identityStreamOf`, the existing seeded stream helper for Riverpod dependencies captured by app-shell `BlocProvider.create`.

The bloc layer is unchanged and stays free of Riverpod.

### Blast radius

Every Keycast/divineOAuth account with no local nsec, on any build containing #6574. Accounts with a local key have `signsWithLocalKey == true`, so readiness is true immediately, which is why this did not surface in testing.

### Documentation

Second and takeover commits. `.claude/rules/state_management.md` still pointed at `isNostrReadyProvider` for the readiness pattern, and that provider no longer exists anywhere in `lib`. Someone reading the rules for the readiness pattern got a name with zero hits, and raw auth state is the natural fallback.

The guidance now distinguishes two cases:

- Nostr-client signing/publishing waits on `nostrSessionProvider` reaching `nostrReady`.
- Relay-free signing, such as REST NIP-98 through `Nip98AuthService(authService:)`, watches signer capability (`currentAuthRpcCapabilityProvider`) and samples `canPublishNostrWritesNow`.

**Related Issue:** Closes #6977

## Out of Scope

- `canPublishNostrWritesNow` remains at four pull-style call sites (`repository_providers.dart:135`, `video_providers.dart:593,689`, and `video_sharing_service.dart:170`). They sample at the moment of use, so they cannot go stale in the way this bug did. Worth its own look; no failure verified.
- #6604 (bunker reconnect) is untouched. `BunkerNostrIdentity` reports readiness unconditionally and fails a different way.

## Verification

Unit/provider tests, analyzer, and before/after device checks.

- `flutter test test/providers/invite_status_auth_sessions_test.dart`
- `flutter test test/providers/invite_status_auth_sessions_test.dart test/blocs/invite_status`
- `flutter analyze lib test integration_test`
- Pre-push hook: analyzer + changed-file provider test

On device, same account and same stack, only the build differing. The account is a Keycast email identity created through the Keycast API, so the key lives server side with no local nsec, which is the condition the bug needs.

**Before (origin/main, 1.0.19+819)**, reproducing the reporter's ordering:

```text
20:03:28.045  Auth state: authenticating -> authenticated
20:03:28.750  RPC capability: unavailable -> rpcReady
```

No Invites row anywhere in Settings, and zero invite API calls in the log.

**After**, cold restart matching the reporter's session-restore path:

```text
21:24:09.217  Auth state: authenticating -> authenticated
21:24:10.218  Creating new NIP-98 auth token for GET /v1/invite-status
21:24:10.662  RPC capability: unavailable -> rpcReady
```

Settings showed Invites 10, the screen loaded "9 invites ready to generate", and Generate produced a working code with the counter stepping down and the codes persisting across a reinstall.

Both auth paths were exercised on the final implementation: interactive sign-in and cold restart.

Not claimed: origin/main was reproduced through sign-in rather than cold restart. The cold-restart variant on origin/main is evidenced by the reporter's production log, which is that path and stops at `rpcReady` with no invite call.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
