### PR TITLE
fix(account): clear dm_message_reactions on sign-out and Delete Account

### DIFF
--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -709,6 +709,18 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
           'processedGiftWraps',
           db.processedGiftWrapsDao.clearAll,
         );
+        // Reaction rows keep decrypted rumor payloads (rumor_event_json) —
+        // DM data of the same class as direct_messages, so they must not
+        // outlive the account's DMs on any sign-out path, including Delete
+        // Account. Owner-scoped rather than clearAll: ownerPubkey is
+        // non-nullable here, so unlike direct_messages there are no legacy
+        // NULL-owner rows a scoped delete would strand. See #6984.
+        if (userPubkey != null) {
+          await safeCleanup(
+            'dmReactions',
+            () => db.dmReactionsDao.deleteAllForOwner(userPubkey),
+          );
+        }
         // Scoped to the leaving account so a switch does not wipe the other
         // account's cached inbox along with this one's.
         await safeCleanup(

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -709,16 +709,20 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
           'processedGiftWraps',
           db.processedGiftWrapsDao.clearAll,
         );
-        // Reaction rows keep decrypted rumor payloads (rumor_event_json) —
-        // DM data of the same class as direct_messages, so they must not
-        // outlive the account's DMs on any sign-out path, including Delete
-        // Account. Owner-scoped rather than clearAll: ownerPubkey is
-        // non-nullable here, so unlike direct_messages there are no legacy
-        // NULL-owner rows a scoped delete would strand. See #6984.
+        // Reaction rows keep decrypted rumor payloads (rumor_event_json). Most
+        // are re-fetchable DM data and should be wiped with direct_messages,
+        // but retryable own rows are also the outgoing queue for unpublished
+        // reactions and kind-5 removals. Preserve that subset on a plain
+        // account switch, matching outgoing_dms; destructive cleanup wipes all.
+        // Owner-scoped rather than clearAll: ownerPubkey is non-nullable here,
+        // so unlike direct_messages there are no legacy NULL-owner rows a
+        // scoped delete would strand. See #6984.
         if (userPubkey != null) {
           await safeCleanup(
             'dmReactions',
-            () => db.dmReactionsDao.deleteAllForOwner(userPubkey),
+            () => deleteUserData
+                ? db.dmReactionsDao.deleteAllForOwner(userPubkey)
+                : db.dmReactionsDao.deleteNonRetryableForOwner(userPubkey),
           );
         }
         // Scoped to the leaving account so a switch does not wipe the other

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -626,7 +626,7 @@ final class UserDataCleanupServiceProvider
 }
 
 String _$userDataCleanupServiceHash() =>
-    r'f05f93ce197b50082d8e1ab988bf687b769d6716';
+    r'b5fea23e08fa3a852f0dd4c7535e7e6072306605';
 
 /// Hashtag service depends on Video event service and cache service
 

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -626,7 +626,7 @@ final class UserDataCleanupServiceProvider
 }
 
 String _$userDataCleanupServiceHash() =>
-    r'd6f753049d1ee1e217e24b5841c04fc5046af72f';
+    r'f05f93ce197b50082d8e1ab988bf687b769d6716';
 
 /// Hashtag service depends on Video event service and cache service
 

--- a/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
@@ -482,4 +482,27 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
       dmMessageReactions,
     )..where((t) => t.ownerPubkey.equals(ownerPubkey))).go();
   }
+
+  /// Delete owner-scoped reaction rows that can be recovered from relays.
+  ///
+  /// Non-destructive account switches preserve retryable own rows because their
+  /// stored `rumor_event_json` is the only durable payload for unpublished
+  /// reactions and pending kind-5 removals.
+  Future<int> deleteNonRetryableForOwner(String ownerPubkey) async {
+    return (delete(dmMessageReactions)..where((t) {
+          final retryableOwnReaction =
+              t.reactorPubkey.equals(ownerPubkey) &
+              t.isDeleted.equals(false) &
+              t.rumorEventJson.isNotNull() &
+              t.publishStatus.isIn(const ['failed', 'pending']);
+          final retryableOwnDeletion =
+              t.reactorPubkey.equals(ownerPubkey) &
+              t.isDeleted.equals(true) &
+              t.rumorEventJson.isNotNull() &
+              t.publishStatus.equals(_deletionPendingStatus);
+          return t.ownerPubkey.equals(ownerPubkey) &
+              (retryableOwnReaction | retryableOwnDeletion).not();
+        }))
+        .go();
+  }
 }

--- a/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
@@ -61,11 +61,12 @@ void main() {
       String reactorPubkey = _reactorA,
       String emoji = '🔥',
       int createdAt = 1_700_000_000,
+      String targetMessageId = _targetMessageId,
     }) {
       return dao.insertOwnReactionSuperseding(
         placeholderId: id,
         conversationId: _conversationId,
-        targetMessageId: _targetMessageId,
+        targetMessageId: targetMessageId,
         targetMessageAuthor: _targetAuthor,
         reactorPubkey: reactorPubkey,
         emoji: emoji,
@@ -757,5 +758,77 @@ void main() {
       expect(await dao.getById(id: _pendingId, ownerPubkey: _ownerA), isNull);
       expect(await dao.getById(id: _sentId, ownerPubkey: _ownerB), isNotNull);
     });
+
+    test(
+      'deleteNonRetryableForOwner preserves outgoing retry rows only',
+      () async {
+        const failedId =
+            '2222222222222222222222222222222222222222222222222222222222222222';
+        const deletionId =
+            '3333333333333333333333333333333333333333333333333333333333333333';
+        const incomingId =
+            '4444444444444444444444444444444444444444444444444444444444444444';
+        const blockedId =
+            '5555555555555555555555555555555555555555555555555555555555555555';
+        const otherOwnerId =
+            '6666666666666666666666666666666666666666666666666666666666666666';
+        const target2 =
+            '7777777777777777777777777777777777777777777777777777777777777777';
+        const target3 =
+            '8888888888888888888888888888888888888888888888888888888888888888';
+        const target4 =
+            '9999999999999999999999999999999999999999999999999999999999999999';
+
+        await insertPending();
+        await insertPending(id: failedId, targetMessageId: target2);
+        await dao.markFailed(placeholderId: failedId, ownerPubkey: _ownerA);
+        await insertPending(id: deletionId, targetMessageId: target3);
+        await dao.markOwnDeletionPending(
+          id: deletionId,
+          ownerPubkey: _ownerA,
+          deletionRumorJson: '{"kind":5}',
+        );
+        await insertPending(id: blockedId, targetMessageId: target4);
+        await dao.markBlocked(id: blockedId, ownerPubkey: _ownerA);
+        await dao.upsertIncoming(
+          id: incomingId,
+          conversationId: _conversationId,
+          targetMessageId: _targetMessageId,
+          targetMessageAuthor: _targetAuthor,
+          reactorPubkey: _reactorB,
+          emoji: '😂',
+          createdAt: 1_700_000_200,
+          giftWrapId: incomingId,
+          ownerPubkey: _ownerA,
+        );
+        await insertPending(
+          id: otherOwnerId,
+          ownerPubkey: _ownerB,
+          reactorPubkey: _ownerB,
+        );
+
+        final deleted = await dao.deleteNonRetryableForOwner(_ownerA);
+
+        expect(deleted, equals(2));
+        expect(
+          await dao.getById(id: _pendingId, ownerPubkey: _ownerA),
+          isNotNull,
+        );
+        expect(
+          await dao.getById(id: failedId, ownerPubkey: _ownerA),
+          isNotNull,
+        );
+        expect(
+          await dao.getById(id: deletionId, ownerPubkey: _ownerA),
+          isNotNull,
+        );
+        expect(await dao.getById(id: incomingId, ownerPubkey: _ownerA), isNull);
+        expect(await dao.getById(id: blockedId, ownerPubkey: _ownerA), isNull);
+        expect(
+          await dao.getById(id: otherOwnerId, ownerPubkey: _ownerB),
+          isNotNull,
+        );
+      },
+    );
   });
 }

--- a/mobile/test/providers/social_providers_cleanup_test.dart
+++ b/mobile/test/providers/social_providers_cleanup_test.dart
@@ -41,6 +41,12 @@ const _dmConversationId =
     'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
 const _dmTargetMessageId =
     'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+const _dmSecondTargetMessageId =
+    '1111111111111111111111111111111111111111111111111111111111111111';
+const _pendingReactionId =
+    '2222222222222222222222222222222222222222222222222222222222222222';
+const _pendingDeletionId =
+    '3333333333333333333333333333333333333333333333333333333333333333';
 
 void main() {
   group(userDataCleanupServiceProvider, () {
@@ -206,11 +212,48 @@ void main() {
       );
     }
 
+    Future<void> seedPendingOwnReaction({
+      required String id,
+      required String targetMessageId,
+    }) async {
+      await db.dmReactionsDao.insertOwnReactionSuperseding(
+        placeholderId: id,
+        conversationId: _dmConversationId,
+        targetMessageId: targetMessageId,
+        targetMessageAuthor: _pubkeyB,
+        reactorPubkey: _pubkeyA,
+        emoji: '😂',
+        createdAt: 1_700_000_000,
+        ownerPubkey: _pubkeyA,
+        rumorEventJson: '{"id":"$id"}',
+      );
+    }
+
+    Future<void> seedPendingOwnDeletion({
+      required String id,
+      required String targetMessageId,
+    }) async {
+      await seedPendingOwnReaction(id: id, targetMessageId: targetMessageId);
+      await db.dmReactionsDao.markOwnDeletionPending(
+        id: id,
+        ownerPubkey: _pubkeyA,
+        deletionRumorJson: '{"kind":5}',
+      );
+    }
+
     test(
       'destructive cleanup purges dm reactions for the departing user',
       () async {
         await seedDmReaction(id: _reactionIdA, ownerPubkey: _pubkeyA);
         await seedDmReaction(id: _reactionIdB, ownerPubkey: _pubkeyB);
+        await seedPendingOwnReaction(
+          id: _pendingReactionId,
+          targetMessageId: _dmTargetMessageId,
+        );
+        await seedPendingOwnDeletion(
+          id: _pendingDeletionId,
+          targetMessageId: _dmSecondTargetMessageId,
+        );
 
         final subscription = container.listen(
           userDataCleanupServiceProvider,
@@ -234,6 +277,20 @@ void main() {
         );
         expect(
           await db.dmReactionsDao.getById(
+            id: _pendingReactionId,
+            ownerPubkey: _pubkeyA,
+          ),
+          isNull,
+        );
+        expect(
+          await db.dmReactionsDao.getById(
+            id: _pendingDeletionId,
+            ownerPubkey: _pubkeyA,
+          ),
+          isNull,
+        );
+        expect(
+          await db.dmReactionsDao.getById(
             id: _reactionIdB,
             ownerPubkey: _pubkeyB,
           ),
@@ -243,9 +300,17 @@ void main() {
     );
 
     test(
-      'non-destructive cleanup clears dm reactions for the leaving account',
+      'non-destructive cleanup preserves retryable outgoing dm reactions',
       () async {
         await seedDmReaction(id: _reactionIdA, ownerPubkey: _pubkeyA);
+        await seedPendingOwnReaction(
+          id: _pendingReactionId,
+          targetMessageId: _dmTargetMessageId,
+        );
+        await seedPendingOwnDeletion(
+          id: _pendingDeletionId,
+          targetMessageId: _dmSecondTargetMessageId,
+        );
 
         final subscription = container.listen(
           userDataCleanupServiceProvider,
@@ -264,6 +329,19 @@ void main() {
           ),
           isNull,
         );
+        expect(
+          await db.dmReactionsDao.getById(
+            id: _pendingReactionId,
+            ownerPubkey: _pubkeyA,
+          ),
+          isNotNull,
+        );
+        final deletion = await db.dmReactionsDao.getById(
+          id: _pendingDeletionId,
+          ownerPubkey: _pubkeyA,
+        );
+        expect(deletion, isNotNull);
+        expect(deletion!.publishStatus, equals('deletion_pending'));
       },
     );
   });

--- a/mobile/test/providers/social_providers_cleanup_test.dart
+++ b/mobile/test/providers/social_providers_cleanup_test.dart
@@ -33,6 +33,14 @@ const _pubkeyA =
     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const _pubkeyB =
     'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const _reactionIdA =
+    'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+const _reactionIdB =
+    'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+const _dmConversationId =
+    'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+const _dmTargetMessageId =
+    'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
 
 void main() {
   group(userDataCleanupServiceProvider, () {
@@ -180,5 +188,83 @@ void main() {
         isEmpty,
       );
     });
+
+    Future<void> seedDmReaction({
+      required String id,
+      required String ownerPubkey,
+    }) {
+      return db.dmReactionsDao.upsertIncoming(
+        id: id,
+        conversationId: _dmConversationId,
+        targetMessageId: _dmTargetMessageId,
+        targetMessageAuthor: _pubkeyB,
+        reactorPubkey: _pubkeyB,
+        emoji: '😂',
+        createdAt: 1_700_000_000,
+        giftWrapId: id,
+        ownerPubkey: ownerPubkey,
+      );
+    }
+
+    test(
+      'destructive cleanup purges dm reactions for the departing user',
+      () async {
+        await seedDmReaction(id: _reactionIdA, ownerPubkey: _pubkeyA);
+        await seedDmReaction(id: _reactionIdB, ownerPubkey: _pubkeyB);
+
+        final subscription = container.listen(
+          userDataCleanupServiceProvider,
+          (_, _) {},
+        );
+        addTearDown(subscription.close);
+        final service = subscription.read();
+
+        expect(service.onDatabaseCleanup, isNotNull);
+        await service.onDatabaseCleanup!(
+          userPubkey: _pubkeyA,
+          deleteUserData: true,
+        );
+
+        expect(
+          await db.dmReactionsDao.getById(
+            id: _reactionIdA,
+            ownerPubkey: _pubkeyA,
+          ),
+          isNull,
+        );
+        expect(
+          await db.dmReactionsDao.getById(
+            id: _reactionIdB,
+            ownerPubkey: _pubkeyB,
+          ),
+          isNotNull,
+        );
+      },
+    );
+
+    test(
+      'non-destructive cleanup clears dm reactions for the leaving account',
+      () async {
+        await seedDmReaction(id: _reactionIdA, ownerPubkey: _pubkeyA);
+
+        final subscription = container.listen(
+          userDataCleanupServiceProvider,
+          (_, _) {},
+        );
+        addTearDown(subscription.close);
+        final service = subscription.read();
+
+        expect(service.onDatabaseCleanup, isNotNull);
+        await service.onDatabaseCleanup!(userPubkey: _pubkeyA);
+
+        expect(
+          await db.dmReactionsDao.getById(
+            id: _reactionIdA,
+            ownerPubkey: _pubkeyA,
+          ),
+          isNull,
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Description

`DmReactionsDao.deleteAllForOwner` was doc-commented "Sign-out cleanup" but had zero production callers, so `dm_message_reactions` rows — including decrypted rumor payloads in `rumor_event_json` — survived cleanup paths.

This wires reaction cleanup into the `onDatabaseCleanup` callback in `social_providers.dart`, grouped with the other DM-class tables (`direct_messages`, `conversations`, `pending_gift_wraps`, `processed_gift_wraps`). All three cleanup paths funnel through this one callback (`signOut` → `clearUserSpecificData`, and `_setupUserSession`'s identity-change path → `clearUserSpecificData`).

The cleanup stays owner-scoped. On destructive cleanup (`deleteUserData: true`, including Delete Account), it deletes all `dm_message_reactions` rows for the departing owner. On non-destructive sign-out/account switch, it deletes re-fetchable reaction rows but preserves retryable own rows (`pending`/`failed` outgoing reactions and `deletion_pending` kind-5 removals) because their stored `rumor_event_json` is the durable outgoing queue; deleting those rows would silently lose unpublished reactions/removals. This mirrors the existing `outgoing_dms` policy.

**Related Issue:** Closes #6984 (part of epic #4335)

## Out of Scope

The adjacent finding documented in #6984 (unscoped `clearAll` on `direct_messages`/`conversations`/`pending_gift_wraps` vs. their unused `clearAllForUser` methods) is deliberately untouched — switching those to scoped deletes is unsafe until the legacy NULL-owner row disposition is decided, and the issue recommends tracking it separately.

## Verification

- `dart run build_runner build --delete-conflicting-outputs` — regenerated the Riverpod provider hash.
- `dart format --output=none --set-exit-if-changed lib/providers/social_providers.dart test/providers/social_providers_cleanup_test.dart packages/db_client/lib/src/database/daos/dm_reactions_dao.dart packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart` — clean.
- `flutter analyze` — no issues.
- `flutter test packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart test/providers/social_providers_cleanup_test.dart test/services/user_data_cleanup_service_test.dart test/services/auth_service_signout_cleanup_test.dart test/services/auth_service_data_cleanup_ordering_test.dart` — 89/89 pass.
- Pre-push hook also passed generated-file verification, analyzer for changed files, and changed-file tests.

No visual change.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
