### PR TITLE
test(relay-discovery): stop the invalid-signature test degenerating

### DIFF
--- a/mobile/test/services/relay_discovery_service_test.dart
+++ b/mobile/test/services/relay_discovery_service_test.dart
@@ -487,7 +487,13 @@ void _authenticityTests() {
 
     test('rejects a frame with an invalid signature', () async {
       final badSignature = signedRelayList(privateKey: victimKey);
-      badSignature['sig'] = '00${(badSignature['sig'] as String).substring(2)}';
+      final sig = badSignature['sig'] as String;
+      // BIP-340 signing draws fresh aux randomness every run, so overwriting
+      // the first byte with a constant '00' is a no-op on the 1-in-256
+      // signature that already starts with '00' — leaving the frame valid.
+      final flipped = int.parse(sig.substring(0, 2), radix: 16) ^ 0xff;
+      badSignature['sig'] =
+          '${flipped.toRadixString(16).padLeft(2, '0')}${sig.substring(2)}';
       expect(await query(badSignature), isEmpty);
     });
 


### PR DESCRIPTION
Closes #6996

## Summary

`test/services/relay_discovery_service_test.dart` fails on roughly 1 in 256 shard runs, for no reason connected to the branch it runs on. Most recently it took down `Tests (shard 0/4)` on #6711.

The test corrupts a signature by overwriting its first byte with the literal `00`:

```dart
badSignature['sig'] = '00${(badSignature['sig'] as String).substring(2)}';
```

`Event.sign` (`mobile/packages/nostr_sdk/lib/event.dart:122`) draws BIP-340 auxiliary randomness from `getRandomHexString()`, which is `Random.secure()` (`nostr_sdk/lib/client_utils/keys.dart:26`). The signature is therefore different on every run — and when it already begins with `00`, the overwrite is a **no-op**. The frame stays genuinely valid, `_authenticRelayList` correctly accepts it, and the `isEmpty` assertion fails:

```
Expected: empty
  Actual: [DiscoveredRelay(url: wss://legit.example, read: true, write: true)]
```

The reported relay is the frame's own `r` tag, which makes the failure look like cross-test leakage from the positive control. It isn't — the rejection path is working correctly on an input that was never actually corrupted.

## Measurement

Signing 4000 events with the test's own key and counting the signatures that begin with `00`:

```
PROBE: 16/4000 signatures start with 00 (expected ~15.625)
```

0.40%, against the 0.39% the encoding predicts. That is the failure rate.

## Why only this one test

The four sibling rejection tests mutate in ways that cannot degenerate — empty `sig`, a different signing key, tampered `tags` (breaking the id), a different `kind`. Only the constant-prefix overwrite has a fixed point.

## The fix

Flip the first byte instead of overwriting it. `x ^ 0xff` never equals `x`, so the signature is always different from the valid one.

## Testing

- `flutter test test/services/relay_discovery_service_test.dart` — 35 passing, run 8×
- `flutter analyze lib test integration_test` — clean
- `dart format` — clean

Test-only change; no production code touched.