### PR TITLE
fix(likes): chunk the reaction REQ filters like the deletion probe

### DIFF
--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -5,7 +5,7 @@
 // ABOUTME: Supports offline queuing via callback injection.
 
 import 'dart:async';
-import 'dart:math';
+import 'dart:convert';
 
 import 'package:likes_repository/src/blocked_liker_filter.dart';
 import 'package:likes_repository/src/exceptions.dart';
@@ -34,9 +34,19 @@ const _downvoteContent = '-';
 /// (512KB). An oversized frame errors the socket and `queryEvents` fails
 /// open — silently counting deleted likes, or returning no reactions at all.
 /// 500 ids is ~34KB, well under 512KB and the advertised `max_event_tags`
-/// of 2000. A `kind:pubkey:dtag` coordinate costs more per entry than a bare
-/// id, but 500 of them still lands far inside the cap. See #5751.
+/// of 2000. See #5751.
 const _reqEidChunkSize = 500;
+
+/// Max cumulative UTF-8 bytes of tag values per `#e` or `#a` REQ filter.
+///
+/// The count cap only byte-bounds fixed-width values like event ids. A
+/// `kind:pubkey:dtag` coordinate is typically ~135 bytes, but nothing
+/// validates `d` tag length, so 500 coordinates minted by another client
+/// can still blow past `max_message_length`. 128KB of values keeps 4x
+/// headroom under the 512KB cap and never splits a typical batch. A single
+/// value over the budget still ships, alone — that REQ cannot be made any
+/// smaller.
+const int _reqTagValueChunkBytes = 128 * 1024;
 
 /// Callback to check if the device is currently online
 typedef IsOnlineCallback = bool Function();
@@ -1961,8 +1971,9 @@ class LikesRepository {
     );
   }
 
-  /// Runs [buildFilter] over [values] in chunks of [_reqEidChunkSize], so no
-  /// single REQ frame can exceed the relay's message cap.
+  /// Runs [buildFilter] over [values] in chunks capped at [_reqEidChunkSize]
+  /// values and [_reqTagValueChunkBytes] bytes, so no single REQ frame can
+  /// exceed the relay's message cap.
   ///
   /// Deduplicates by event id once there is more than one chunk. Each chunk
   /// is its own `queryEvents` call with its own dedup box, so an event that
@@ -1988,10 +1999,25 @@ class LikesRepository {
   }
 
   List<List<String>> _chunkStrings(List<String> values, int chunkSize) {
-    return [
-      for (var i = 0; i < values.length; i += chunkSize)
-        values.sublist(i, min(i + chunkSize, values.length)),
-    ];
+    final chunks = <List<String>>[];
+    var chunk = <String>[];
+    var chunkBytes = 0;
+    for (final value in values) {
+      final valueBytes = utf8.encode(value).length;
+      final closesChunk =
+          chunk.length >= chunkSize ||
+          (chunk.isNotEmpty &&
+              chunkBytes + valueBytes > _reqTagValueChunkBytes);
+      if (closesChunk) {
+        chunks.add(chunk);
+        chunk = <String>[];
+        chunkBytes = 0;
+      }
+      chunk.add(value);
+      chunkBytes += valueBytes;
+    }
+    if (chunk.isNotEmpty) chunks.add(chunk);
+    return chunks;
   }
 
   Set<String> _reactionTargetEventIds(

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -27,14 +27,15 @@ const _likeContent = '+';
 /// NIP-25 reaction content for a downvote.
 const _downvoteContent = '-';
 
-/// Max number of event ids per `#e` REQ filter.
+/// Max number of tag values per `#e` or `#a` REQ filter.
 ///
 /// A 64-char id costs ~67 bytes in JSON, so a single `#e` filter with enough
 /// of them builds a REQ frame near/over the relay's `max_message_length`
 /// (512KB). An oversized frame errors the socket and `queryEvents` fails
 /// open — silently counting deleted likes, or returning no reactions at all.
 /// 500 ids is ~34KB, well under 512KB and the advertised `max_event_tags`
-/// of 2000. See #5751.
+/// of 2000. A `kind:pubkey:dtag` coordinate costs more per entry than a bare
+/// id, but 500 of them still lands far inside the cap. See #5751.
 const _reqEidChunkSize = 500;
 
 /// Callback to check if the device is currently online
@@ -1322,18 +1323,16 @@ class LikesRepository {
     required Map<String, String> eventIdByCoordinate,
     List<String>? authors,
   }) async {
-    final eEventsFuture = _nostrClient.queryEvents([
-      Filter(kinds: const [EventKind.reaction], authors: authors, e: eventIds),
-    ]);
-    final aEventsFuture = eventIdByCoordinate.isEmpty
-        ? Future<List<Event>>.value(const <Event>[])
-        : _nostrClient.queryEvents([
-            Filter(
-              kinds: const [EventKind.reaction],
-              authors: authors,
-              a: eventIdByCoordinate.keys.toList(),
-            ),
-          ]);
+    final eEventsFuture = _queryChunked(
+      eventIds,
+      (chunk) =>
+          Filter(kinds: const [EventKind.reaction], authors: authors, e: chunk),
+    );
+    final aEventsFuture = _queryChunked(
+      eventIdByCoordinate.keys.toList(),
+      (chunk) =>
+          Filter(kinds: const [EventKind.reaction], authors: authors, a: chunk),
+    );
     final results = await Future.wait([eEventsFuture, aEventsFuture]);
 
     final eventsById = <String, Event>{};
@@ -1955,26 +1954,35 @@ class LikesRepository {
     return _queryEventsByEIds(eventIds, kind: EventKind.reaction);
   }
 
-  /// Events of [kind] targeting any of [eventIds] via `#e`, chunked so no
+  /// Events of [kind] targeting any of [eventIds] via `#e`.
+  Future<List<Event>> _queryEventsByEIds(
+    List<String> eventIds, {
+    required int kind,
+  }) {
+    return _queryChunked(
+      eventIds,
+      (chunk) => Filter(kinds: [kind], e: chunk),
+    );
+  }
+
+  /// Runs [buildFilter] over [values] in chunks of [_reqEidChunkSize], so no
   /// single REQ frame can exceed the relay's message cap.
   ///
   /// Deduplicates by event id once there is more than one chunk. Each chunk
   /// is its own `queryEvents` call with its own dedup box, so an event that
-  /// `#e`-tags targets in two different chunks comes back from both — and
+  /// tags targets in two different chunks comes back from both — and
   /// [getLikeCounts] counts per e-tag occurrence, so a raw concatenation
   /// would score that reaction twice. A single chunk is already deduped by
   /// the client.
-  Future<List<Event>> _queryEventsByEIds(
-    List<String> eventIds, {
-    required int kind,
-  }) async {
-    if (eventIds.isEmpty) return const <Event>[];
+  Future<List<Event>> _queryChunked(
+    List<String> values,
+    Filter Function(List<String> chunk) buildFilter,
+  ) async {
+    if (values.isEmpty) return const <Event>[];
 
     final results = await Future.wait([
-      for (final chunk in _chunkStrings(eventIds, _reqEidChunkSize))
-        _nostrClient.queryEvents([
-          Filter(kinds: [kind], e: chunk),
-        ]),
+      for (final chunk in _chunkStrings(values, _reqEidChunkSize))
+        _nostrClient.queryEvents([buildFilter(chunk)]),
     ]);
     if (results.length == 1) return results.first;
     return {

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -1957,19 +1957,30 @@ class LikesRepository {
 
   /// Events of [kind] targeting any of [eventIds] via `#e`, chunked so no
   /// single REQ frame can exceed the relay's message cap.
+  ///
+  /// Deduplicates by event id once there is more than one chunk. Each chunk
+  /// is its own `queryEvents` call with its own dedup box, so an event that
+  /// `#e`-tags targets in two different chunks comes back from both — and
+  /// [getLikeCounts] counts per e-tag occurrence, so a raw concatenation
+  /// would score that reaction twice. A single chunk is already deduped by
+  /// the client.
   Future<List<Event>> _queryEventsByEIds(
     List<String> eventIds, {
     required int kind,
   }) async {
     if (eventIds.isEmpty) return const <Event>[];
 
-    final chunks = await Future.wait([
+    final results = await Future.wait([
       for (final chunk in _chunkStrings(eventIds, _reqEidChunkSize))
         _nostrClient.queryEvents([
           Filter(kinds: [kind], e: chunk),
         ]),
     ]);
-    return [for (final chunk in chunks) ...chunk];
+    if (results.length == 1) return results.first;
+    return {
+      for (final chunk in results)
+        for (final event in chunk) event.id: event,
+    }.values.toList();
   }
 
   List<List<String>> _chunkStrings(List<String> values, int chunkSize) {

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -27,17 +27,15 @@ const _likeContent = '+';
 /// NIP-25 reaction content for a downvote.
 const _downvoteContent = '-';
 
-/// Max number of reaction ids per Kind 5 deletion REQ.
+/// Max number of event ids per `#e` REQ filter.
 ///
-/// The resolver scopes the deletion query to the reaction ids it fetched,
-/// which can approach the relay's per-REQ cap (~5000) on a very
-/// high-engagement video. A single `#e` filter with that many 64-char ids
-/// (~67 bytes each in JSON) would build a REQ frame near/over the relay's
-/// `max_message_length` (512KB); an oversized frame errors the socket and
-/// `queryEvents` fails open, silently counting deleted likes. Chunking keeps
-/// every frame small (500 ids ~= 34KB, well under 512KB and the advertised
-/// `max_event_tags` of 2000). See #5751.
-const _deletionReqEidChunkSize = 500;
+/// A 64-char id costs ~67 bytes in JSON, so a single `#e` filter with enough
+/// of them builds a REQ frame near/over the relay's `max_message_length`
+/// (512KB). An oversized frame errors the socket and `queryEvents` fails
+/// open — silently counting deleted likes, or returning no reactions at all.
+/// 500 ids is ~34KB, well under 512KB and the advertised `max_event_tags`
+/// of 2000. See #5751.
+const _reqEidChunkSize = 500;
 
 /// Callback to check if the device is currently online
 typedef IsOnlineCallback = bool Function();
@@ -1148,12 +1146,9 @@ class LikesRepository {
       return counts;
     }
 
-    // Query relays for count of Kind 7 reactions on uncached events
-    final filterByE = Filter(kinds: const [EventKind.reaction], e: uncachedIds);
-
     // NIP-45 COUNT with multiple event IDs returns total count, not per-event
     // So we need to fall back to querying events and counting client-side
-    final eventsByE = await _nostrClient.queryEvents([filterByE]);
+    final eventsByE = await _queryReactionsByEventIds(uncachedIds);
 
     // Count reactions per target event from e-tag query
     final uncachedIdSet = uncachedIds.toSet();
@@ -1875,8 +1870,7 @@ class LikesRepository {
         if (entry.value.isNotEmpty) entry.value: entry.key,
     };
 
-    final filterByE = Filter(kinds: const [EventKind.reaction], e: eventIds);
-    final eEventsFuture = _nostrClient.queryEvents([filterByE]);
+    final eEventsFuture = _queryReactionsByEventIds(eventIds);
     final aEventsFuture = aTagToEventId.isEmpty
         ? Future<List<Event>>.value(const <Event>[])
         : _nostrClient.queryEvents([
@@ -1936,34 +1930,53 @@ class LikesRepository {
     final reactionIds = reactionsById.keys.toList();
     if (reactionIds.isEmpty) return const {};
 
-    final chunkedDeletions = await Future.wait([
-      for (var i = 0; i < reactionIds.length; i += _deletionReqEidChunkSize)
-        _nostrClient.queryEvents([
-          Filter(
-            kinds: const [EventKind.eventDeletion],
-            e: reactionIds.sublist(
-              i,
-              min(i + _deletionReqEidChunkSize, reactionIds.length),
-            ),
-          ),
-        ]),
-    ]);
+    final deletions = await _queryEventsByEIds(
+      reactionIds,
+      kind: EventKind.eventDeletion,
+    );
 
     final deleted = <String>{};
-    for (final chunk in chunkedDeletions) {
-      for (final deletion in chunk) {
-        for (final tag in deletion.tags) {
-          if (tag.length > 1 && tag[0] == 'e') {
-            final targetId = tag[1];
-            final target = reactionsById[targetId];
-            if (target != null && target.pubkey == deletion.pubkey) {
-              deleted.add(targetId);
-            }
+    for (final deletion in deletions) {
+      for (final tag in deletion.tags) {
+        if (tag.length > 1 && tag[0] == 'e') {
+          final targetId = tag[1];
+          final target = reactionsById[targetId];
+          if (target != null && target.pubkey == deletion.pubkey) {
+            deleted.add(targetId);
           }
         }
       }
     }
     return deleted;
+  }
+
+  /// Kind 7 reactions targeting any of [eventIds] via `#e`.
+  Future<List<Event>> _queryReactionsByEventIds(List<String> eventIds) {
+    return _queryEventsByEIds(eventIds, kind: EventKind.reaction);
+  }
+
+  /// Events of [kind] targeting any of [eventIds] via `#e`, chunked so no
+  /// single REQ frame can exceed the relay's message cap.
+  Future<List<Event>> _queryEventsByEIds(
+    List<String> eventIds, {
+    required int kind,
+  }) async {
+    if (eventIds.isEmpty) return const <Event>[];
+
+    final chunks = await Future.wait([
+      for (final chunk in _chunkStrings(eventIds, _reqEidChunkSize))
+        _nostrClient.queryEvents([
+          Filter(kinds: [kind], e: chunk),
+        ]),
+    ]);
+    return [for (final chunk in chunks) ...chunk];
+  }
+
+  List<List<String>> _chunkStrings(List<String> values, int chunkSize) {
+    return [
+      for (var i = 0; i < values.length; i += chunkSize)
+        values.sublist(i, min(i + chunkSize, values.length)),
+    ];
   }
 
   Set<String> _reactionTargetEventIds(

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -2432,13 +2432,14 @@ class LikesRepository {
     final candidates = candidatesById.values.toList();
     if (candidates.isEmpty) return null;
 
-    final deletions = await _nostrClient.queryEvents([
-      Filter(
+    final deletions = await _queryChunked(
+      candidates.map((event) => event.id).toList(),
+      (chunk) => Filter(
         kinds: const [EventKind.eventDeletion],
         authors: [pubkey],
-        e: candidates.map((event) => event.id).toList(),
+        e: chunk,
       ),
-    ]);
+    );
 
     final deletedIds = <String>{};
     for (final deletion in deletions) {

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -1870,14 +1870,10 @@ class LikesRepository {
     };
 
     final eEventsFuture = _queryReactionsByEventIds(eventIds);
-    final aEventsFuture = aTagToEventId.isEmpty
-        ? Future<List<Event>>.value(const <Event>[])
-        : _nostrClient.queryEvents([
-            Filter(
-              kinds: const [EventKind.reaction],
-              a: aTagToEventId.keys.toList(),
-            ),
-          ]);
+    final aEventsFuture = _queryChunked(
+      aTagToEventId.keys.toList(),
+      (chunk) => Filter(kinds: const [EventKind.reaction], a: chunk),
+    );
     final queryResults = await Future.wait([eEventsFuture, aEventsFuture]);
 
     final reactionsByTarget = {

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:likes_repository/likes_repository.dart';
 import 'package:mocktail/mocktail.dart';
@@ -5279,6 +5280,52 @@ void main() {
           expect(
             {...aFilters[0].a!, ...aFilters[1].a!},
             hasLength(600),
+            reason: 'chunks partition every coordinate without overlap',
+          );
+        },
+      );
+
+      test(
+        'chunks the coordinate query by bytes when d tags are oversized',
+        () async {
+          // An event id is fixed at 64 chars, so the 500-value count cap
+          // byte-bounds the `#e` legs on its own. A coordinate is not fixed:
+          // nothing validates `d` tag length, so the `#a` legs need the byte
+          // budget too. 300 coordinates of ~1KB each is ~300KB of values —
+          // far past the frame cap while nowhere near the count cap.
+          final eventIds = [for (var i = 0; i < 300; i++) 'vote_target_$i'];
+          final oversizedDTag = 'd' * 1024;
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => <Event>[]);
+
+          repository = createRepository(withLocalStorage: false);
+          await repository.getVoteCounts(
+            eventIds,
+            addressableIds: {
+              for (final id in eventIds)
+                id: '34236:$testAuthorPubkey:$oversizedDTag$id',
+            },
+          );
+
+          final aFilters =
+              verify(() => mockNostrClient.queryEvents(captureAny())).captured
+                  .cast<List<Filter>>()
+                  .map((filters) => filters.single)
+                  .where((f) => f.a != null)
+                  .toList();
+
+          expect(aFilters.length, greaterThan(1));
+          for (final filter in aFilters) {
+            final chunkBytes = filter.a!.fold<int>(
+              0,
+              (sum, value) => sum + utf8.encode(value).length,
+            );
+            expect(chunkBytes, lessThanOrEqualTo(128 * 1024));
+          }
+          expect(
+            {for (final f in aFilters) ...f.a!},
+            hasLength(300),
             reason: 'chunks partition every coordinate without overlap',
           );
         },

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -1851,6 +1851,56 @@ void main() {
       );
 
       test(
+        'chunks the cold-cache deletion probe so no REQ exceeds the frame '
+        'limit',
+        () async {
+          // 600 live relay downvotes on one target force the Kind 5 probe
+          // into 2 `#e` chunks (500 + 100) — this was the last query leg in
+          // the file still building its filter unchunked.
+          repository = createRepository(withLocalStorage: false);
+          final reactions = [
+            for (var i = 0; i < 600; i++)
+              createMockReaction(
+                id: 'downvote_$i',
+                targetEventId: testEventId,
+                content: '-',
+              ),
+          ];
+          mockQueryEventsSequence([reactions, <Event>[], <Event>[]]);
+          when(
+            () => mockNostrClient.deleteEvent(any()),
+          ).thenAnswer((_) async => MockEvent());
+
+          await repository.removeDownvote(testEventId);
+
+          final deletionFilters =
+              verify(() => mockNostrClient.queryEvents(captureAny())).captured
+                  .cast<List<Filter>>()
+                  .map((filters) => filters.single)
+                  .where(
+                    (f) => f.kinds?.contains(EventKind.eventDeletion) ?? false,
+                  )
+                  .toList();
+
+          expect(deletionFilters, hasLength(2));
+          expect(deletionFilters[0].e, hasLength(500));
+          expect(deletionFilters[1].e, hasLength(100));
+          for (final filter in deletionFilters) {
+            expect(
+              filter.authors,
+              equals([testUserPubkey]),
+              reason: 'probe stays scoped to own deletions in every chunk',
+            );
+          }
+          expect(
+            {...deletionFilters[0].e!, ...deletionFilters[1].e!},
+            hasLength(600),
+            reason: 'chunks partition every candidate id without overlap',
+          );
+        },
+      );
+
+      test(
         'does not delete a relay downvote that was already deleted (#6124)',
         () async {
           repository = createRepository(withLocalStorage: false);

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -2519,6 +2519,31 @@ void main() {
         },
       );
 
+      test('counts a reaction spanning two chunks once', () async {
+        // Each chunk is its own queryEvents call with its own dedup box, so a
+        // reaction that e-tags a target in chunk 0 and one in chunk 1 comes
+        // back from both. The count loop adds per e-tag occurrence, so
+        // without a dedup across chunks both targets score 2.
+        final eventIds = [for (var i = 0; i < 600; i++) 'event_id_$i'];
+        final reaction = createMockReaction(
+          id: 'reaction_spanning_chunks',
+          targetEventId: 'event_id_0',
+          tags: [
+            ['e', 'event_id_0'],
+            ['e', 'event_id_500'],
+          ],
+        );
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [reaction]);
+
+        repository = createRepository();
+        final counts = await repository.getLikeCounts(eventIds);
+
+        expect(counts['event_id_0'], 1);
+        expect(counts['event_id_500'], 1);
+      });
+
       test('handles events with non-list or empty tags', () async {
         const eventId = 'event_id_1234567890abcdef01234567890abcdef';
 

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -2496,16 +2496,20 @@ void main() {
             },
           );
 
-          final reactionEFilters =
+          final reactionFilters =
               verify(() => mockNostrClient.queryEvents(captureAny())).captured
                   .cast<List<Filter>>()
                   .map((filters) => filters.single)
                   .where(
-                    (f) =>
-                        (f.kinds?.contains(EventKind.reaction) ?? false) &&
-                        f.e != null,
+                    (f) => f.kinds?.contains(EventKind.reaction) ?? false,
                   )
                   .toList();
+          final reactionEFilters = reactionFilters
+              .where((filter) => filter.e != null)
+              .toList();
+          final reactionAFilters = reactionFilters
+              .where((filter) => filter.a != null)
+              .toList();
 
           expect(reactionEFilters, hasLength(2));
           for (final filter in reactionEFilters) {
@@ -2515,6 +2519,15 @@ void main() {
             {for (final f in reactionEFilters) ...f.e!},
             hasLength(600),
             reason: 'chunks partition every id without overlap',
+          );
+          expect(reactionAFilters, hasLength(2));
+          for (final filter in reactionAFilters) {
+            expect(filter.a!.length, lessThanOrEqualTo(500));
+          }
+          expect(
+            {for (final f in reactionAFilters) ...f.a!},
+            hasLength(600),
+            reason: 'chunks partition every coordinate without overlap',
           );
         },
       );

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -2446,6 +2446,79 @@ void main() {
         expect(result, {eventId1: 2, eventId2: 1, eventId3: 0});
       });
 
+      test(
+        'chunks the reaction query so no REQ exceeds the frame limit',
+        () async {
+          // 600 target ids must split into 2 `#e` chunks (500 + 100). A single
+          // filter with all of them approaches the relay's
+          // max_message_length, and an oversized frame errors the socket —
+          // queryEvents then fails open and every count reads 0 (#5751).
+          final eventIds = [for (var i = 0; i < 600; i++) 'event_id_$i'];
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => <Event>[]);
+
+          repository = createRepository();
+          await repository.getLikeCounts(eventIds);
+
+          final filters =
+              verify(() => mockNostrClient.queryEvents(captureAny())).captured
+                  .cast<List<Filter>>()
+                  .map((filters) => filters.single)
+                  .toList();
+
+          expect(filters, hasLength(2));
+          expect(filters[0].e, hasLength(500));
+          expect(filters[1].e, hasLength(100));
+          expect(
+            {...filters[0].e!, ...filters[1].e!},
+            hasLength(600),
+            reason: 'chunks partition every id without overlap',
+          );
+        },
+      );
+
+      test(
+        'chunks the reaction query on the addressable path too',
+        () async {
+          // The addressable branch resolves through a different call site, so
+          // it needs its own guard against an oversized `#e` frame.
+          final eventIds = [for (var i = 0; i < 600; i++) 'event_id_$i'];
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => <Event>[]);
+
+          repository = createRepository();
+          await repository.getLikeCounts(
+            eventIds,
+            addressableIds: {
+              for (final id in eventIds) id: '34236:author_pubkey:$id',
+            },
+          );
+
+          final reactionEFilters =
+              verify(() => mockNostrClient.queryEvents(captureAny())).captured
+                  .cast<List<Filter>>()
+                  .map((filters) => filters.single)
+                  .where(
+                    (f) =>
+                        (f.kinds?.contains(EventKind.reaction) ?? false) &&
+                        f.e != null,
+                  )
+                  .toList();
+
+          expect(reactionEFilters, hasLength(2));
+          for (final filter in reactionEFilters) {
+            expect(filter.e!.length, lessThanOrEqualTo(500));
+          }
+          expect(
+            {for (final f in reactionEFilters) ...f.e!},
+            hasLength(600),
+            reason: 'chunks partition every id without overlap',
+          );
+        },
+      );
+
       test('handles events with non-list or empty tags', () async {
         const eventId = 'event_id_1234567890abcdef01234567890abcdef';
 

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -5151,6 +5151,76 @@ void main() {
         },
       );
 
+      test(
+        'chunks the vote-target reaction query so no REQ exceeds the frame '
+        'limit',
+        () async {
+          // The vote path is a third unbounded Kind 7 `#e` filter, bounded
+          // today only by the comment page size — the same incidental bound
+          // the like path already stopped relying on.
+          final eventIds = [for (var i = 0; i < 600; i++) 'vote_target_$i'];
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => <Event>[]);
+
+          repository = createRepository(withLocalStorage: false);
+          await repository.getVoteCounts(eventIds);
+
+          final eFilters =
+              verify(() => mockNostrClient.queryEvents(captureAny())).captured
+                  .cast<List<Filter>>()
+                  .map((filters) => filters.single)
+                  .where((f) => f.e != null)
+                  .toList();
+
+          expect(eFilters, hasLength(2));
+          expect(eFilters[0].e, hasLength(500));
+          expect(eFilters[1].e, hasLength(100));
+          expect(
+            {...eFilters[0].e!, ...eFilters[1].e!},
+            hasLength(600),
+            reason: 'chunks partition every id without overlap',
+          );
+        },
+      );
+
+      test(
+        'chunks the vote-target coordinate query too',
+        () async {
+          // A `kind:pubkey:dtag` coordinate is longer than a bare id, so the
+          // `#a` leg reaches the frame cap sooner than the `#e` leg it runs
+          // beside.
+          final eventIds = [for (var i = 0; i < 600; i++) 'vote_target_$i'];
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => <Event>[]);
+
+          repository = createRepository(withLocalStorage: false);
+          await repository.getVoteCounts(
+            eventIds,
+            addressableIds: {
+              for (final id in eventIds) id: '34236:$testAuthorPubkey:$id',
+            },
+          );
+
+          final aFilters =
+              verify(() => mockNostrClient.queryEvents(captureAny())).captured
+                  .cast<List<Filter>>()
+                  .map((filters) => filters.single)
+                  .where((f) => f.a != null)
+                  .toList();
+
+          expect(aFilters, hasLength(2));
+          expect(aFilters[0].a, hasLength(500));
+          expect(aFilters[1].a, hasLength(100));
+          expect(
+            {...aFilters[0].a!, ...aFilters[1].a!},
+            hasLength(600),
+            reason: 'chunks partition every coordinate without overlap',
+          );
+        },
+      );
+
       test('getUserVoteStatuses resolves the own vote by coordinate', () async {
         mockQueryEventsSequence([
           <Event>[],


### PR DESCRIPTION
Closes #6998

Salvaged from #6711, which was closed. This part stands on its own and has nothing to do with revision resolution.

## Summary

#5751 chunked the Kind 5 deletion `#e` filter at 500 ids so a REQ frame could not approach the relay's `max_message_length`. The Kind 7 **reaction** filters sitting next to it were left unbounded at the query boundary. There are three event-id legs, plus two coordinate legs:

- `getLikeCounts` -> `Filter(kinds: [reaction], e: uncachedIds)` over the whole uncached batch
- the addressable like branch -> `_fetchResolvedLikersByEvent`, carrying both an `#e` filter over target ids and an `#a` filter over coordinates
- `_queryVoteTargetReactions` -> reached from `getVoteCounts` / `getUserVoteStatuses` via `comment_reactions_bloc.dart:144`, carrying both an `#e` filter over the target ids and an `#a` filter over their coordinates

Review round two closed the last two gaps: `_resolveRemoteDownvoteRecord`'s cold-cache Kind 5 probe was still building its `#e` filter directly, and every `#a` leg was bounded by *count* but not by *bytes* — a coordinate embeds a `d` tag whose length nothing validates. All six legs now route through the same chunker, and every chunk closes at 500 values **or** 128KB of tag-value bytes, whichever comes first.

## Why this is worth closing, stated honestly

**No oversized frame has been observed, and I'm not claiming one.** What makes it worth fixing is that today's safety is incidental rather than enforced.

The largest caller is the curation sort (`curation_repository.dart:135`), which passes `_videoEventCache.discoveryVideos` - every discovery video, with no cap of its own. That list happens to be capped at 500 by a memory guard in a completely different file (`video_event_service.dart:2973`, `:3204` - `if (list.length > 500) list.removeRange(500, list.length)`).

So the worst case today lands **exactly on** the 500 that the deletion probe already treats as the largest safe frame - zero headroom - and the bound lives in a service that has no idea it is load-bearing for a relay frame size. Raise that memory cap, or add a caller that doesn't go through it, and the filter silently goes over.

The coordinate legs matter at least as much as their `#e` siblings: `|coordinates| <= |eventIds|`, but a `kind:pubkey:dtag` coordinate costs more bytes per entry than a bare 64-char id, so that leg reaches the cap sooner. And unlike an id, a coordinate has no fixed width - nothing in the models layer validates `d` tag length, so the count cap alone cannot byte-bound the `#a` legs. That is what the byte budget enforces.

The vote path is the same argument one layer over: it is bounded at 50 today only by `_pageSize` in `comments_list_bloc.dart:61`, a comment-pagination constant with no relationship to frame size.

The remaining caller is safely bounded independently: `video_event_service` batches like-count requests at `_likeCountBatchMaxSize = 50`.

Worth knowing about the failure mode: an oversized frame errors the socket and `queryEvents` **fails open**. It doesn't throw - the counts just come back 0 and the liker list comes back empty, which reads as "nobody liked this" rather than as an error.

## Changes

- `_deletionReqEidChunkSize` -> `_reqEidChunkSize`, now shared by both kinds and by `#a` as well as `#e`; doc rewritten to match.
- `_reqTagValueChunkBytes = 128KB`: chunks also close on cumulative UTF-8 bytes of tag values. Never splits a typical batch (500 real coordinates is ~68KB, and the cap can never bind for 64-char ids) and keeps 4x headroom under `max_message_length` for oversized `d` tags. A single value over the budget ships alone - that REQ cannot be made any smaller.
- Chunk-and-dedup mechanics live in one place, `_queryChunked(values, buildFilter)`. `_queryEventsByEIds` is the `#e` wrapper over it, `_queryReactionsByEventIds` the Kind 7 wrapper over that.
- `_deletedReactionIds`, both `_fetchResolvedLikersByEvent` legs, both `_queryVoteTargetReactions` legs, and `_resolveRemoteDownvoteRecord`'s cold-cache deletion probe go through the same path.
- Chunked results are deduplicated by event id. Each chunk is its own `queryEvents` call with its own `EventMemBox`, so a reaction that `#e`-tags targets landing in two different chunks comes back from both, and `getLikeCounts` counts per e-tag occurrence - a 600-id batch with one reaction tagging `event_id_0` and `event_id_500` scored 2/2 instead of 1/1 without this. The single-chunk path is untouched.
- Every chunk stays a **single-filter** REQ, which `NostrClient` requires to keep the local event cache active.

Net: **+395 / -62** across 2 files. No behavior change for any input under 500 ids / 128KB of tag-value bytes.

## Testing

Seven chunking tests: one per guarded query leg - the two like-path filters, the Kind 5 deletion sweep, the vote path's `#e` and `#a` legs, the cold-cache downvote deletion probe - plus the byte bound. All mutation-verified rather than just observed green, in both directions:

- `_reqEidChunkSize = 100000` turns the **six count guards** red together.
- `_reqTagValueChunkBytes = 1 << 60` turns the **byte-bound test** red alone (the count guards stay green, pinning that the byte cap never binds for fixed-width ids).

The deletion-sweep guard is the pre-existing #5751 test - it going red under the same mutation confirms the refactor kept the deletion probe wired to the same constant. Reverting the dedup turns the double-count test red independently.

- `flutter test` in `packages/likes_repository`: **228 passing**
- pre-push changed-file test: `packages/likes_repository/test/src/likes_repository_test.dart` **168 passing**
- coverage **97.15%** (gate: 62)
- `flutter analyze lib test`: clean
