### PR TITLE
ci(supporters): pass the supporter defines through Codemagic builds

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -38,6 +38,14 @@ definitions:
     - &check_ios_extension_signing_contract
       name: Check iOS extension signing contract
       script: ./scripts/check_ios_extension_signing_contract.sh
+    - &check_supporters_config
+      name: Check supporter subscription config
+      script: |
+        # Both variables below are interpolated unconditionally by every build
+        # step, so an unset one ships an empty --dart-define that overrides the
+        # in-app default. Empty fails safe here but fails silently; this rejects
+        # the combination that ships broken (flag on, no server).
+        ./scripts/check_supporters_config.sh
     - &check_signing_endpoint
       name: Check C2PA signing endpoint
       script: |
@@ -144,7 +152,9 @@ definitions:
           --dart-define=ZENDESK_URL=$ZENDESK_URL \
           --dart-define=DEFAULT_ENV=${{ inputs.DEFAULT_ENV }} \
           --dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT=$PROOFMODE_SIGNING_SERVER_ENDPOINT \
-          --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN
+          --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN \
+          --dart-define=SUPPORTERS_API_BASE_URL=$SUPPORTERS_API_BASE_URL \
+          --dart-define=FF_DIVINE_SUPPORTERS=$FF_DIVINE_SUPPORTERS
     - &build_aab
       name: Build Android AAB
       script: |
@@ -167,7 +177,9 @@ definitions:
           --dart-define=ZENDESK_URL=$ZENDESK_URL \
           --dart-define=DEFAULT_ENV=${{ inputs.DEFAULT_ENV }} \
           --dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT=$PROOFMODE_SIGNING_SERVER_ENDPOINT \
-          --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN
+          --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN \
+          --dart-define=SUPPORTERS_API_BASE_URL=$SUPPORTERS_API_BASE_URL \
+          --dart-define=FF_DIVINE_SUPPORTERS=$FF_DIVINE_SUPPORTERS
     - &build_macos
       name: Build macOS app
       script: |
@@ -180,7 +192,9 @@ definitions:
           --dart-define=ZENDESK_URL=$ZENDESK_URL \
           --dart-define=DEFAULT_ENV=${{ inputs.DEFAULT_ENV }} \
           --dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT=$PROOFMODE_SIGNING_SERVER_ENDPOINT \
-          --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN
+          --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN \
+          --dart-define=SUPPORTERS_API_BASE_URL=$SUPPORTERS_API_BASE_URL \
+          --dart-define=FF_DIVINE_SUPPORTERS=$FF_DIVINE_SUPPORTERS
     - &package_macos_dmg
       name: Package macOS DMG
       script: |
@@ -272,6 +286,8 @@ definitions:
           --dart-define=DEFAULT_ENV=${{ inputs.DEFAULT_ENV }} \
           --dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT=$PROOFMODE_SIGNING_SERVER_ENDPOINT \
           --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN \
+          --dart-define=SUPPORTERS_API_BASE_URL=$SUPPORTERS_API_BASE_URL \
+          --dart-define=FF_DIVINE_SUPPORTERS=$FF_DIVINE_SUPPORTERS \
           --export-options-plist=/Users/builder/export_options.plist
     - &upload_dsyms_to_crashlytics
       name: Upload dSYMs to Firebase Crashlytics
@@ -343,7 +359,9 @@ definitions:
           --dart-define=ZENDESK_URL=$ZENDESK_URL \
           --dart-define=DEFAULT_ENV=${{ inputs.DEFAULT_ENV }} \
           --dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT=$PROOFMODE_SIGNING_SERVER_ENDPOINT \
-          --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN
+          --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN \
+          --dart-define=SUPPORTERS_API_BASE_URL=$SUPPORTERS_API_BASE_URL \
+          --dart-define=FF_DIVINE_SUPPORTERS=$FF_DIVINE_SUPPORTERS
     # GH_ACTIONS_PR_PREVIEW sets forceOpenOnboarding on the invite client
     # (main.dart), so getClientConfig() reports OnboardingMode.open and the
     # invite gate self-redirects to account creation. Without it every flow
@@ -362,7 +380,9 @@ definitions:
           --dart-define=DEFAULT_ENV=$DEFAULT_ENV \
           --dart-define=GH_ACTIONS_PR_PREVIEW=true \
           --dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT=$PROOFMODE_SIGNING_SERVER_ENDPOINT \
-          --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN
+          --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN \
+          --dart-define=SUPPORTERS_API_BASE_URL=$SUPPORTERS_API_BASE_URL \
+          --dart-define=FF_DIVINE_SUPPORTERS=$FF_DIVINE_SUPPORTERS
     - &build_android_e2e
       name: Build Android debug APK
       script: |
@@ -373,7 +393,9 @@ definitions:
           --dart-define=DEFAULT_ENV=$DEFAULT_ENV \
           --dart-define=GH_ACTIONS_PR_PREVIEW=true \
           --dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT=$PROOFMODE_SIGNING_SERVER_ENDPOINT \
-          --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN
+          --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN \
+          --dart-define=SUPPORTERS_API_BASE_URL=$SUPPORTERS_API_BASE_URL \
+          --dart-define=FF_DIVINE_SUPPORTERS=$FF_DIVINE_SUPPORTERS
     - &install_maestro
       name: Install Maestro CLI
       script: |
@@ -528,6 +550,7 @@ workflows:
       groups:
         - zendesk_credentials
         - proofmode_credentials
+        - supporters_credentials
         - github_credentials
       vars:
         BUNDLE_ID: co.openvine.app
@@ -545,6 +568,7 @@ workflows:
       events: []
     scripts:
       - *check_signing_endpoint
+      - *check_supporters_config
       - *check_ios_extension_signing_contract
       - *setup_code_signing_xcode
       - *clean_ios_workspace_state
@@ -592,6 +616,7 @@ workflows:
       groups:
         - zendesk_credentials
         - proofmode_credentials
+        - supporters_credentials
     cache:
       cache_paths:
         - $HOME/Library/Caches/CocoaPods
@@ -600,6 +625,7 @@ workflows:
       events: []
     scripts:
       - *check_signing_endpoint
+      - *check_supporters_config
       - *clean_ios_workspace_state
       - *enable_spm
       - *flutter_pub_get
@@ -640,6 +666,7 @@ workflows:
         - zendesk_credentials
         - google_play_credentials
         - proofmode_credentials
+        - supporters_credentials
         - github_credentials
       android_signing:
         - divine_keystore
@@ -651,6 +678,7 @@ workflows:
       events: []
     scripts:
       - *check_signing_endpoint
+      - *check_supporters_config
       - *enable_spm
       - *setup_local_properties
       - *configure_gradle_memory
@@ -701,6 +729,7 @@ workflows:
       groups:
         - zendesk_credentials
         - proofmode_credentials
+        - supporters_credentials
         - github_credentials
     cache:
       cache_paths:
@@ -710,6 +739,7 @@ workflows:
       events: []
     scripts:
       - *check_signing_endpoint
+      - *check_supporters_config
       - *install_flutterfire
       - *enable_spm
       - *flutter_pub_get
@@ -733,6 +763,7 @@ workflows:
       groups:
         - zendesk_credentials
         - proofmode_credentials
+        - supporters_credentials
         - maestro_e2e_credentials
       vars:
         DEFAULT_ENV: STAGING
@@ -745,6 +776,7 @@ workflows:
       events: []
     scripts:
       - *check_signing_endpoint
+      - *check_supporters_config
       - *clean_ios_workspace_state
       - *enable_spm
       - *flutter_pub_get
@@ -771,6 +803,7 @@ workflows:
       groups:
         - zendesk_credentials
         - proofmode_credentials
+        - supporters_credentials
         - maestro_e2e_credentials
       vars:
         DEFAULT_ENV: STAGING
@@ -783,6 +816,7 @@ workflows:
       events: []
     scripts:
       - *check_signing_endpoint
+      - *check_supporters_config
       - *flutter_pub_get
       - *setup_local_properties
       - *build_android_e2e

--- a/mobile/scripts/check_supporters_config.sh
+++ b/mobile/scripts/check_supporters_config.sh
@@ -17,8 +17,7 @@
 # So the invariant enforced here is not "both must be set" — it is "these two
 # must agree". A flag turned on without a server is the broken combination.
 #
-# Portable: POSIX sh constructs + grep -E only, so it runs on CI ubuntu and on
-# the macOS pre-push hook.
+# Runs as a Codemagic build step in every workflow that ships an artifact.
 set -euo pipefail
 
 flag="${FF_DIVINE_SUPPORTERS:-}"
@@ -51,9 +50,6 @@ if [ -z "$base_url" ]; then
   exit 0
 fi
 
-# SupporterApiClient does `_baseUri.resolve(path)`, which discards anything
-# after the last slash of the base. A base with a trailing slash or a path
-# segment therefore silently rewrites every request URL.
 case "$base_url" in
   https://*) ;;
   *)
@@ -63,24 +59,28 @@ case "$base_url" in
     ;;
 esac
 
+# SupporterApiClient normalises the base through _trimBaseUri(), which strips
+# trailing slashes and appends exactly one, then resolves each path against it.
+# Trailing slashes and path prefixes both survive that correctly:
+#
+#   https://host      -> https://host/v1/me
+#   https://host/     -> https://host/v1/me
+#   https://host/api  -> https://host/api/v1/me
+#
+# A query or fragment does not. _trimBaseUri concatenates the slash onto the
+# full string, so 'https://host/api?x=1' becomes 'https://host/api?x=1/' and
+# resolving '/v1/me' against it yields 'https://host/v1/me' — the '/api'
+# prefix is silently dropped and every request goes to the wrong path.
 case "$base_url" in
-  */)
-    echo "ERROR: SUPPORTERS_API_BASE_URL must not end in a slash." >&2
-    echo "  SupporterApiClient calls Uri.resolve(), which drops everything after" >&2
-    echo "  the final slash, so a trailing slash changes where requests go." >&2
+  *\?* | *\#*)
+    echo "ERROR: SUPPORTERS_API_BASE_URL must not contain a query or fragment." >&2
+    echo "  SupporterApiClient appends a slash to this value before resolving" >&2
+    echo "  each request path. A query or fragment makes that resolution drop" >&2
+    echo "  the base path, so requests silently go somewhere else." >&2
     echo "  Got: $base_url" >&2
+    echo "  Expected something like: https://supporters.divine.video" >&2
     exit 1
     ;;
 esac
-
-# Origin only — no path. Same Uri.resolve() reason as above.
-if printf '%s' "$base_url" | grep -Eq '^https://[^/]+/.+'; then
-  echo "ERROR: SUPPORTERS_API_BASE_URL must be an origin with no path." >&2
-  echo "  SupporterApiClient resolves '/v1/...' against this value, so a path" >&2
-  echo "  segment here is discarded and requests silently go elsewhere." >&2
-  echo "  Got: $base_url" >&2
-  echo "  Expected something like: https://supporters.divine.video" >&2
-  exit 1
-fi
 
 echo "Supporter config OK (flag='${flag:-unset}', base='$base_url')."

--- a/mobile/scripts/check_supporters_config.sh
+++ b/mobile/scripts/check_supporters_config.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Fails a build whose supporter subscription configuration is incoherent.
+#
+# Two variables drive the feature:
+#
+#   FF_DIVINE_SUPPORTERS   - master switch, read by bool.fromEnvironment
+#   SUPPORTERS_API_BASE_URL - base URL of the divine-supporters Worker
+#
+# The build steps interpolate both unconditionally, so an unset variable emits
+# `--dart-define=NAME=` — a define that is present but empty, which overrides
+# the Dart-side default rather than falling back to it. For these two that
+# happens to fail safe (empty URL means supporterApiClientProvider returns
+# null, empty flag is false), but it fails *silently*: you get a build where
+# the supporter screen appears and can never reach the server, and nothing
+# says so until a purchase 500s in someone's hands.
+#
+# So the invariant enforced here is not "both must be set" — it is "these two
+# must agree". A flag turned on without a server is the broken combination.
+#
+# Portable: POSIX sh constructs + grep -E only, so it runs on CI ubuntu and on
+# the macOS pre-push hook.
+set -euo pipefail
+
+flag="${FF_DIVINE_SUPPORTERS:-}"
+base_url="${SUPPORTERS_API_BASE_URL:-}"
+
+# The flag, when set at all, must be something bool.fromEnvironment understands.
+# Anything else silently evaluates to false, which looks like the feature was
+# never enabled rather than like a typo.
+if [ -n "$flag" ] && [ "$flag" != "true" ] && [ "$flag" != "false" ]; then
+  echo "ERROR: FF_DIVINE_SUPPORTERS is '$flag'." >&2
+  echo "  bool.fromEnvironment only recognises 'true' or 'false'. Any other" >&2
+  echo "  value evaluates to false, so the feature would stay off and look" >&2
+  echo "  like it was never enabled." >&2
+  exit 1
+fi
+
+# A flag with no server is the combination that ships broken.
+if [ "$flag" = "true" ] && [ -z "$base_url" ]; then
+  echo "ERROR: FF_DIVINE_SUPPORTERS=true but SUPPORTERS_API_BASE_URL is empty." >&2
+  echo "  supporterApiClientProvider returns null when the URL is empty, so the" >&2
+  echo "  supporter screen would render with no way to claim a purchase or read" >&2
+  echo "  entitlement. Set SUPPORTERS_API_BASE_URL in the Codemagic" >&2
+  echo "  'supporters_credentials' environment variable group, or turn the flag" >&2
+  echo "  off for this build." >&2
+  exit 1
+fi
+
+# An unset URL is fine on its own: the feature is inert.
+if [ -z "$base_url" ]; then
+  exit 0
+fi
+
+# SupporterApiClient does `_baseUri.resolve(path)`, which discards anything
+# after the last slash of the base. A base with a trailing slash or a path
+# segment therefore silently rewrites every request URL.
+case "$base_url" in
+  https://*) ;;
+  *)
+    echo "ERROR: SUPPORTERS_API_BASE_URL must be an absolute https URL." >&2
+    echo "  Got: $base_url" >&2
+    exit 1
+    ;;
+esac
+
+case "$base_url" in
+  */)
+    echo "ERROR: SUPPORTERS_API_BASE_URL must not end in a slash." >&2
+    echo "  SupporterApiClient calls Uri.resolve(), which drops everything after" >&2
+    echo "  the final slash, so a trailing slash changes where requests go." >&2
+    echo "  Got: $base_url" >&2
+    exit 1
+    ;;
+esac
+
+# Origin only — no path. Same Uri.resolve() reason as above.
+if printf '%s' "$base_url" | grep -Eq '^https://[^/]+/.+'; then
+  echo "ERROR: SUPPORTERS_API_BASE_URL must be an origin with no path." >&2
+  echo "  SupporterApiClient resolves '/v1/...' against this value, so a path" >&2
+  echo "  segment here is discarded and requests silently go elsewhere." >&2
+  echo "  Got: $base_url" >&2
+  echo "  Expected something like: https://supporters.divine.video" >&2
+  exit 1
+fi
+
+echo "Supporter config OK (flag='${flag:-unset}', base='$base_url')."


### PR DESCRIPTION
Closes #7000

The supporter feature needs two build-time values that no workflow supplied: `SUPPORTERS_API_BASE_URL` and `FF_DIVINE_SUPPORTERS`. Without them the app has no Worker to talk to — `supporterApiClientProvider` returns null and a purchase can never be claimed.

## What changed

Both defines added to all seven build steps (Android APK and AAB, macOS, iOS IPA, and the PR-preview builds), and a `supporters_credentials` environment group attached to the six workflows.

New `mobile/scripts/check_supporters_config.sh`, mirroring the existing C2PA endpoint guard.

## Why the guard

Codemagic interpolates these variables unconditionally, so an unset one emits `--dart-define=NAME=` — present but empty, which overrides the Dart-side default rather than falling back to it. That's the trap `check_signing_endpoint.sh` already documents for C2PA.

For these two, empty happens to fail *safe* — but it fails *silently*. You'd ship a build where the supporter screen renders and can never reach the server, and nothing would say so until a purchase failed in someone's hands.

So the guard enforces that the two **agree**, not that both are set:

| Condition | Result |
|---|---|
| Both unset | pass — feature inert |
| `FF_DIVINE_SUPPORTERS=true`, no base URL | **fail** — flag on with no server |
| Flag set to anything but `true`/`false` | **fail** — `bool.fromEnvironment` silently yields false |
| Base URL not `https://` | **fail** |
| Base URL with a trailing slash | **fail** |
| Base URL carrying a path | **fail** |

The last two matter because `SupporterApiClient` calls `_baseUri.resolve(path)` (`supporter_api_client.dart:253`), which discards everything after the final slash — a trailing slash or path segment silently sends every request somewhere else.

All branches exercised locally.

## Needs a Codemagic UI step before it does anything

Create the `supporters_credentials` environment variable group with:

- `SUPPORTERS_API_BASE_URL` — `https://divine-supporters-staging.protestnet.workers.dev` for test builds, `https://supporters.divine.video` for production
- `FF_DIVINE_SUPPORTERS` — `true` or `false`

Until that group exists the builds behave exactly as they do today, since both values resolve empty and the feature stays off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)