### PR TITLE
fix(likes): retract a like unliked while its publish is in flight

### DIFF
--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -151,8 +151,12 @@ class LikesRepository {
   /// (unlike the in-memory-only precedent in #4478's comment count cache).
   final Map<String, LikeRecord> _likeRecordsByAddressableId = {};
 
-  /// Target event ids whose in-flight like publish must be retracted as soon
-  /// as it resolves.
+  /// Pending like placeholder ids currently owned by an awaiting [likeEvent]
+  /// publish.
+  final Set<String> _inFlightLikePublishPlaceholders = {};
+
+  /// Pending like placeholder ids whose in-flight publish must be retracted as
+  /// soon as it resolves.
   ///
   /// [unlikeEvent] cannot reference a `pending_` placeholder in a Kind 5 —
   /// the real reaction id does not exist yet. The reaction may already be
@@ -560,6 +564,7 @@ class LikesRepository {
     // relay is technically connected). Without a wired callback, fall back
     // to rollback + rethrow to preserve the original contract for tests
     // and non-app embedders.
+    _inFlightLikePublishPlaceholders.add(placeholderId);
     try {
       final reactionEvent = await _nostrClient.sendLike(
         eventId,
@@ -580,8 +585,14 @@ class LikesRepository {
         addressableId: addressableId,
       );
 
-      if (_unlikeRequestedWhilePending.remove(eventId)) {
-        await _retractLikeUnlikedMidPublish(reactionEvent.id, confirmed);
+      _inFlightLikePublishPlaceholders.remove(placeholderId);
+      if (_unlikeRequestedWhilePending.remove(placeholderId)) {
+        await _retractLikeUnlikedMidPublish(
+          confirmed: confirmed,
+          restoredCount: previousCount == null ? null : previousCount + 1,
+          countEventId: eventId,
+          countAddressableId: addressableId,
+        );
         return reactionEvent.id;
       }
 
@@ -594,9 +605,10 @@ class LikesRepository {
 
       return reactionEvent.id;
     } catch (e, stackTrace) {
-      // Nothing reached the relay, so there is nothing to retract. Drop the
-      // intent rather than leaving it to fire against an unrelated later like.
-      _unlikeRequestedWhilePending.remove(eventId);
+      _inFlightLikePublishPlaceholders.remove(placeholderId);
+      // The publish did not produce a reaction id this method can retract.
+      // Drop this attempt's intent so it cannot fire against a later like.
+      _unlikeRequestedWhilePending.remove(placeholderId);
       if (_queueOfflineAction != null) {
         Log.error(
           'Like publish failed; queuing optimistic action for retry',
@@ -638,16 +650,18 @@ class LikesRepository {
   /// On failure the [confirmed] record is indexed after all, so a later
   /// unlike can still reference the real reaction id — dropping it would
   /// leave the reaction live and unreachable by the normal unlike flow.
-  Future<void> _retractLikeUnlikedMidPublish(
-    String reactionEventId,
-    LikeRecord confirmed,
-  ) async {
+  Future<void> _retractLikeUnlikedMidPublish({
+    required LikeRecord confirmed,
+    required int? restoredCount,
+    required String countEventId,
+    required String? countAddressableId,
+  }) async {
     try {
-      final deletion = await _nostrClient.deleteEvent(reactionEventId);
+      final deletion = await _nostrClient.deleteEvent(
+        confirmed.reactionEventId,
+      );
       if (deletion == null) {
-        throw const UnlikeFailedException(
-          'Failed to publish unlike deletion',
-        );
+        throw const UnlikeFailedException('Failed to publish unlike deletion');
       }
     } on Object catch (e, stackTrace) {
       Log.error(
@@ -664,7 +678,22 @@ class LikesRepository {
         description: 'saving the confirmed like',
         site: LikesRepositoryReportableSites.likeEventSaveConfirmed,
       );
+      if (restoredCount != null) {
+        _writeCachedLikeCount(
+          countEventId,
+          restoredCount,
+          addressableId: countAddressableId,
+        );
+      }
       _emitLikedIds();
+      if (_queueOfflineAction != null) {
+        await _queueOfflineAction(
+          isLike: false,
+          eventId: confirmed.targetEventId,
+          authorPubkey: '', // Not needed for unlike
+          addressableId: confirmed.addressableId,
+        );
+      }
     }
   }
 
@@ -836,9 +865,14 @@ class LikesRepository {
     // rethrow to preserve the original contract.
     if (snapshotRecord.reactionEventId.startsWith('pending_')) {
       // The real reaction id does not exist yet, so nothing can be referenced
-      // in a Kind 5 here. Record the intent instead — [likeEvent] retracts it
-      // the moment the publish resolves (#7001).
-      _unlikeRequestedWhilePending.add(resolvedEventId);
+      // in a Kind 5 here. If this placeholder belongs to a currently awaited
+      // publish, record the intent for that exact attempt — [likeEvent]
+      // retracts it the moment the publish resolves (#7001).
+      if (_inFlightLikePublishPlaceholders.contains(
+        snapshotRecord.reactionEventId,
+      )) {
+        _unlikeRequestedWhilePending.add(snapshotRecord.reactionEventId);
+      }
       return;
     }
 
@@ -2191,6 +2225,7 @@ class LikesRepository {
   Future<void> clearCache() async {
     _likeRecords.clear();
     _likeRecordsByAddressableId.clear();
+    _inFlightLikePublishPlaceholders.clear();
     _unlikeRequestedWhilePending.clear();
     _downvoteRecords.clear();
     _downvoteRecordsByAddressableId.clear();

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -151,6 +151,18 @@ class LikesRepository {
   /// (unlike the in-memory-only precedent in #4478's comment count cache).
   final Map<String, LikeRecord> _likeRecordsByAddressableId = {};
 
+  /// Target event ids whose in-flight like publish must be retracted as soon
+  /// as it resolves.
+  ///
+  /// [unlikeEvent] cannot reference a `pending_` placeholder in a Kind 5 —
+  /// the real reaction id does not exist yet. The reaction may already be
+  /// live on a relay by then, because [likeEvent] only swaps the placeholder
+  /// after `sendLike` returns and a send succeeds as soon as one socket takes
+  /// the frame. Dropping the intent strands the reaction: live and counted
+  /// forever, while local state says "not liked", so the next tap publishes a
+  /// second one (#7001).
+  final Set<String> _unlikeRequestedWhilePending = {};
+
   /// In-memory cache of downvote records keyed by target event ID.
   ///
   /// Mirror of [_likeRecords] for kind-7 reactions whose content is `-`.
@@ -567,6 +579,12 @@ class LikesRepository {
         createdAt: placeholder.createdAt,
         addressableId: addressableId,
       );
+
+      if (_unlikeRequestedWhilePending.remove(eventId)) {
+        await _retractLikeUnlikedMidPublish(reactionEvent.id, confirmed);
+        return reactionEvent.id;
+      }
+
       _indexLikeRecord(confirmed);
       await _bestEffortLocalStorage(
         () async => _localStorage?.saveLikeRecord(confirmed),
@@ -576,6 +594,9 @@ class LikesRepository {
 
       return reactionEvent.id;
     } catch (e, stackTrace) {
+      // Nothing reached the relay, so there is nothing to retract. Drop the
+      // intent rather than leaving it to fire against an unrelated later like.
+      _unlikeRequestedWhilePending.remove(eventId);
       if (_queueOfflineAction != null) {
         Log.error(
           'Like publish failed; queuing optimistic action for retry',
@@ -608,6 +629,42 @@ class LikesRepository {
       }
       _emitLikedIds();
       rethrow;
+    }
+  }
+
+  /// Publishes the Kind 5 for a reaction the user unliked while its own
+  /// publish was still in flight (#7001).
+  ///
+  /// On failure the [confirmed] record is indexed after all, so a later
+  /// unlike can still reference the real reaction id — dropping it would
+  /// leave the reaction live and unreachable by the normal unlike flow.
+  Future<void> _retractLikeUnlikedMidPublish(
+    String reactionEventId,
+    LikeRecord confirmed,
+  ) async {
+    try {
+      final deletion = await _nostrClient.deleteEvent(reactionEventId);
+      if (deletion == null) {
+        throw const UnlikeFailedException(
+          'Failed to publish unlike deletion',
+        );
+      }
+    } on Object catch (e, stackTrace) {
+      Log.error(
+        'Failed to retract a like unliked mid-publish; keeping the record '
+        'so a later unlike can reference the reaction',
+        name: 'LikesRepository',
+        category: LogCategory.relay,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      _indexLikeRecord(confirmed);
+      await _bestEffortLocalStorage(
+        () async => _localStorage?.saveLikeRecord(confirmed),
+        description: 'saving the confirmed like',
+        site: LikesRepositoryReportableSites.likeEventSaveConfirmed,
+      );
+      _emitLikedIds();
     }
   }
 
@@ -771,13 +828,17 @@ class LikesRepository {
       return;
     }
 
-    // 3. Online → publish kind 5 (skipped for never-synced placeholders).
+    // 3. Online → publish kind 5 (deferred while the like is still in
+    // flight; see [_unlikeRequestedWhilePending]).
     // On failure, prefer queuing via [_queueOfflineAction] when wired so the
     // optimistic unlike survives transient relay-pool problems (mirror of
     // [likeEvent]). Without a wired callback, fall back to rollback +
     // rethrow to preserve the original contract.
     if (snapshotRecord.reactionEventId.startsWith('pending_')) {
-      // Pending like never reached the relay; nothing to delete on the wire.
+      // The real reaction id does not exist yet, so nothing can be referenced
+      // in a Kind 5 here. Record the intent instead — [likeEvent] retracts it
+      // the moment the publish resolves (#7001).
+      _unlikeRequestedWhilePending.add(resolvedEventId);
       return;
     }
 
@@ -2130,6 +2191,7 @@ class LikesRepository {
   Future<void> clearCache() async {
     _likeRecords.clear();
     _likeRecordsByAddressableId.clear();
+    _unlikeRequestedWhilePending.clear();
     _downvoteRecords.clear();
     _downvoteRecordsByAddressableId.clear();
     _likeCountCache.clear();

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -993,6 +993,129 @@ void main() {
           );
         },
       );
+      test(
+        'does not retract a later like for a stale pending placeholder',
+        () async {
+          when(
+            () => mockLocalStorage.getAllLikeRecords(),
+          ).thenAnswer(
+            (_) async => [
+              createLikeRecord(
+                reactionEventId: 'pending_like_$testEventId',
+              ),
+            ],
+          );
+          when(
+            () => mockLocalStorage.deleteLikeRecord(testEventId),
+          ).thenAnswer((_) async => true);
+          when(
+            () => mockLocalStorage.saveLikeRecord(any()),
+          ).thenAnswer((_) async {});
+
+          final reactionB = MockEvent();
+          when(() => reactionB.id).thenReturn('reaction_b');
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer((_) async => reactionB);
+
+          repository = createRepository(
+            isOnline: () => true,
+            queueOfflineAction:
+                ({
+                  required isLike,
+                  required eventId,
+                  required authorPubkey,
+                  addressableId,
+                  targetKind,
+                }) async {},
+          );
+          await repository.isLiked(testEventId); // Initialize stale placeholder
+
+          await repository.unlikeEvent(testEventId);
+          expect(await repository.isLiked(testEventId), isFalse);
+
+          await repository.likeEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+
+          verifyNever(() => mockNostrClient.deleteEvent(any()));
+          expect(await repository.isLiked(testEventId), isTrue);
+        },
+      );
+      test(
+        'queues retry and restores count when mid-publish retraction fails',
+        () async {
+          when(
+            () => mockNostrClient.countEvents(any()),
+          ).thenAnswer((_) async => const CountResult(count: 10));
+          when(
+            () => mockLocalStorage.saveLikeRecord(any()),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockLocalStorage.deleteLikeRecord(testEventId),
+          ).thenAnswer((_) async => true);
+
+          final publishGate = Completer<Event>();
+          final reactionA = MockEvent();
+          when(() => reactionA.id).thenReturn('reaction_a');
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer((_) => publishGate.future);
+          when(
+            () => mockNostrClient.deleteEvent('reaction_a'),
+          ).thenAnswer((_) async => null);
+
+          bool? queuedIsLike;
+          String? queuedEventId;
+          repository = createRepository(
+            isOnline: () => true,
+            queueOfflineAction:
+                ({
+                  required isLike,
+                  required eventId,
+                  required authorPubkey,
+                  addressableId,
+                  targetKind,
+                }) async {
+                  queuedIsLike = isLike;
+                  queuedEventId = eventId;
+                },
+          );
+          expect(await repository.getLikeCount(testEventId), equals(10));
+
+          final inFlightLike = repository.likeEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+          await Future<void>.delayed(Duration.zero);
+          expect(await repository.getLikeCount(testEventId), equals(11));
+
+          await repository.unlikeEvent(testEventId);
+          expect(await repository.getLikeCount(testEventId), equals(10));
+
+          publishGate.complete(reactionA);
+          await inFlightLike;
+
+          verify(() => mockNostrClient.deleteEvent('reaction_a')).called(1);
+          expect(queuedIsLike, isFalse);
+          expect(queuedEventId, equals(testEventId));
+          expect(await repository.isLiked(testEventId), isTrue);
+          expect(await repository.getLikeCount(testEventId), equals(11));
+        },
+      );
       test('publishes deletion and removes record', () async {
         when(
           () => mockLocalStorage.getAllLikeRecords(),

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -945,6 +945,54 @@ void main() {
     });
 
     group('unlikeEvent', () {
+      test(
+        'retracts a reaction whose publish is still in flight (#7001)',
+        () async {
+          // The placeholder id means "the confirmed swap has not run yet",
+          // NOT "the reaction never reached a relay" — likeEvent only swaps
+          // it after sendLike returns, and RelayPool.send reports success as
+          // soon as one socket takes the frame. Unliking inside that window
+          // must still publish the Kind 5, or the reaction stays live and
+          // counted forever while local state says "not liked", so the next
+          // tap publishes a second one.
+          final publishGate = Completer<Event>();
+          final reactionA = MockEvent();
+          when(() => reactionA.id).thenReturn('reaction_a');
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer((_) => publishGate.future);
+          when(
+            () => mockNostrClient.deleteEvent(any()),
+          ).thenAnswer((_) async => MockEvent());
+
+          repository = createRepository();
+          final inFlightLike = repository.likeEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+          await Future<void>.delayed(Duration.zero);
+
+          // The user taps again before the relay round-trip resolves.
+          await repository.unlikeEvent(testEventId);
+
+          // The relay had already stored it.
+          publishGate.complete(reactionA);
+          await inFlightLike;
+
+          verify(() => mockNostrClient.deleteEvent('reaction_a')).called(1);
+          expect(
+            await repository.isLiked(testEventId),
+            isFalse,
+            reason: 'the confirmed swap must not resurrect an unliked record',
+          );
+        },
+      );
       test('publishes deletion and removes record', () async {
         when(
           () => mockLocalStorage.getAllLikeRecords(),


### PR DESCRIPTION
Refs #7001.

## The bug

Unlike inside the publish window left the reaction **live on the relay with no Kind 5 retracting it**, and cleared the local record. The heart went empty while the like still counted, and the next tap published a second live `+`.

That is the duplicate observed in production: two `+` reactions from one pubkey on `8dfd7bbd51c2aace60d30b61a95e70dae3b20a3e2d393787b4588336f72f0a0c`, **6 seconds apart, no `-` between them and no Kind 5 deleting either** — both still live. funnelcake reads that video as count 89 / likers 84, on a video with exactly one revision, so no amount of revision widening touches it.

## Root cause

`unlikeEvent` returned early whenever the record still held a `pending_` placeholder:

```dart
if (snapshotRecord.reactionEventId.startsWith('pending_')) {
  // Pending like never reached the relay; nothing to delete on the wire.
  return;
}
```

**That assumption is false.** `likeEvent` writes the placeholder at `:509-521` and only swaps it for the real reaction id at `:570`, *after* `await _nostrClient.sendLike(...)` returns. And the send reports success as soon as one socket takes the frame — `RelayPool.send` returns `result.sentTo.isNotEmpty`, whose own doc says an entry means "the relay's WebSocket accepted the frame … It does NOT mean the relay accepted the event at the protocol level."

So for the whole round trip the record reads `pending_` while the reaction may already be stored. `unlikeEvent` deindexes the local record first (`:755`), then hits that early return — reaction live, no retraction, local state says "not liked".

## The fix

Record the intent instead of dropping it. `likeEvent` retracts the reaction the moment it has a real id to reference.

A failed retraction re-indexes the confirmed record, so a later unlike can still find the reaction — dropping it is what stranded it in the first place. The intent is also cleared when the publish genuinely fails (nothing to retract) and on `clearCache`.

## What I ruled out first

- **In-isolate double-tap.** Already closed: `:492` checks `_likeRecords.containsKey` and `:516` indexes the placeholder with no `await` between, so check-then-set is atomic; a second concurrent call throws `AlreadyLikedException`.
- **Publish-failure retry double-publishing.** I first ruled this out, then **re-checked and found I was wrong** — it is real, and it is a *separate* mechanism from the one this PR fixes. `RelayBase.send` queues the EVENT frame for replay-on-reconnect **and still returns false** (`relay_base.dart:154-157`), and `_sendCollect` passes `queueIfFailed: deadline == null`, which is true on the like path (`relay_pool.dart:1927`). So the frame can land on reconnect while `publishEvent` reports `PublishFailed`, `likeEvent`'s catch queues a retry, and `executeLikeAction` publishes a second one — its coordinate guard cannot stop that, because `_indexLikeRecord` writes the *same* `LikeRecord` instance into both maps, so `byCoordinate.reactionEventId != ownReactionEventId` reduces to `'pending_like_X' != 'pending_like_X'` = false. That path needs its own fix and is tracked on #7001; it is out of scope here and this PR does not claim to close it.
- **like → unlike → like toggling.** Would show a Kind 5 between the two `+`. Queried the relay: that author has 112 Kind 5 deletions, and **neither** of these two reactions is targeted by any of them.
- **The DM reaction sweep** in the device logs is `dm_reaction_retry_service.dart` — DM reactions, not video likes.

## Testing

New test `retracts a reaction whose publish is still in flight (#7001)` holds `sendLike` open on a `Completer`, unlikes inside the window, then resolves the publish, and asserts the Kind 5 goes out for the real reaction id.

Mutation-verified rather than just observed green — removing the recorded intent turns it red:

```
+31 -1: LikesRepository unlikeEvent retracts a reaction whose publish is still in flight (#7001) [E]
  No matching calls. All calls: MockNostrClient.sendLike(...)
```

- `flutter test` in `packages/likes_repository`: **222 passing**
- coverage **96.50%** (gate: 62)
- `flutter analyze lib test integration_test`: clean

## Scope

This closes the mechanism I could reproduce. It does **not** retract the duplicates already published — those need a separate decision, and #7001 tracks that. The count/list denominator mismatch that turns a duplicate into a permanent visible gap is divinevideo/divine-funnelcake#626.