### PR TITLE
fix(profile): drop the extra vertical gap around the follower search field

### DIFF
--- a/mobile/lib/widgets/profile/searchable_follow_list.dart
+++ b/mobile/lib/widgets/profile/searchable_follow_list.dart
@@ -98,7 +98,7 @@ class _SearchableFollowListState extends State<SearchableFollowList> {
     return Column(
       children: [
         Padding(
-          padding: const EdgeInsets.all(16),
+          padding: const .symmetric(horizontal: 16),
           child: DivineSearchBar(
             controller: _controller,
             hintText: context.l10n.exploreSearchHint,


### PR DESCRIPTION
Closes #7012

## Description

The search field on the followers / following lists was padded `EdgeInsets.all(16)`. Its bottom padding stacked with the `EdgeInsets.all(16)` every `UserProfileTile` already carries, leaving a 32px gap before the first row, and the top padding pushed the field away from the app bar. Padding horizontally only keeps the field aligned with the rows and removes the extra vertical space.

Affects all four screens that use `SearchableFollowList`: my followers, others' followers, my following, others' following.

**Related Issue:** 

## Out of Scope

Other search surfaces keep their current spacing — `explore_view.dart` still uses `EdgeInsets.all(16)` and `inbox_view.dart` uses `fromLTRB(16, 8, 16, 0)`. Aligning all search bars on one spacing rule is a separate design decision.

## Verification

- `flutter analyze lib/widgets/profile/searchable_follow_list.dart` — clean
- `flutter test test/widgets/profile/searchable_follow_list_test.dart test/screens/followers/others_followers_screen_test.dart test/screens/following/others_following_screen_test.dart` — 7/7 passing
- Manually checked on a real Samsung Galaxy device

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore