### PR TITLE
feat(profile): hide a small loop total from profile visitors

### DIFF
--- a/mobile/lib/widgets/profile/profile_header_media.dart
+++ b/mobile/lib/widgets/profile/profile_header_media.dart
@@ -10,6 +10,14 @@ part of 'profile_header_widget.dart';
 ///
 /// A product call, not a technical one — the single value to change if the
 /// bar sits wrong.
+///
+/// Deliberately higher than `publicLoopCountFloor` in
+/// `widgets/video_feed_item/video_card_meta.dart`, which hides small counts on
+/// feed cards. A profile headline is a summary of a whole creator and carries
+/// more weight than a number beside one video, so it earns a higher bar. The
+/// two are independent product calls, not a value that drifted — do not
+/// collapse them into one constant without deciding that both surfaces want
+/// the same number.
 const int profileLoopsVisibilityFloor = 10000;
 
 /// Hero tag for the avatar ↔ lightbox shared-element flight, scoped to the
@@ -221,10 +229,17 @@ class _BannerImage extends StatelessWidget {
 /// Stats row displaying Followers, Following, Likes, and Loops with dividers.
 ///
 /// Shows a skeleton for up to [_ProfileStatsRowState._skeletonTimeout] while
-/// stats are being fetched. After the timeout the row keeps all four columns
+/// stats are being fetched. After the timeout the row keeps its columns
 /// visible but renders a `—` placeholder for each count, rather than
 /// shimmering indefinitely or collapsing the row (which would shift the
 /// surrounding profile layout).
+///
+/// One shift is unavoidable and accepted: whether Loops is shown depends on
+/// the count, which is not known until stats load. A visitor to a profile
+/// under [profileLoopsVisibilityFloor] therefore sees four skeleton columns
+/// resolve to three. Reserving the slot only for owners would move that shift
+/// onto popular profiles instead of removing it, so the loading state stays
+/// uniform and the settle is where the column count changes.
 class _ProfileStatsRow extends StatefulWidget {
   const _ProfileStatsRow({
     required this.userIdHex,

--- a/mobile/lib/widgets/profile/profile_header_media.dart
+++ b/mobile/lib/widgets/profile/profile_header_media.dart
@@ -1,5 +1,17 @@
 part of 'profile_header_widget.dart';
 
+/// Smallest lifetime loop total a profile shows to visitors.
+///
+/// Below this the Loops column is omitted for everyone but the owner: a small
+/// headline number on a new creator's profile discourages the visitor and
+/// tells them nothing useful. Owners always see their own total, since
+/// correcting a creator's underestimate of their audience is what keeps them
+/// posting.
+///
+/// A product call, not a technical one — the single value to change if the
+/// bar sits wrong.
+const int profileLoopsVisibilityFloor = 10000;
+
 /// Hero tag for the avatar ↔ lightbox shared-element flight, scoped to the
 /// user. A global tag would let two profile headers with the same tag in one
 /// navigator (e.g. other-profile → other-profile, both on the root navigator)
@@ -214,9 +226,21 @@ class _BannerImage extends StatelessWidget {
 /// shimmering indefinitely or collapsing the row (which would shift the
 /// surrounding profile layout).
 class _ProfileStatsRow extends StatefulWidget {
-  const _ProfileStatsRow({required this.userIdHex, this.profileStats});
+  const _ProfileStatsRow({
+    required this.userIdHex,
+    required this.isOwnProfile,
+    this.profileStats,
+  });
 
   final String userIdHex;
+
+  /// Whether the signed-in viewer owns this profile.
+  ///
+  /// Owners always see their own loop total, however small. A visitor only
+  /// sees it once it is large enough to impress — see
+  /// [profileLoopsVisibilityFloor].
+  final bool isOwnProfile;
+
   final ProfileStats? profileStats;
 
   @override
@@ -257,15 +281,20 @@ class _ProfileStatsRowState extends State<_ProfileStatsRow> {
     final hasFollowers = widget.profileStats?.followers != null;
     final hasFollowing = widget.profileStats?.following != null;
     final hasLikes = widget.profileStats?.totalLikes != null;
-    final hasLoops = widget.profileStats?.totalViews != null;
+    final totalViews = widget.profileStats?.totalViews;
+    // A visitor landing on a new creator's profile should not be met by a
+    // discouraging headline number. Owners keep theirs, and a total large
+    // enough to impress still leads the row.
+    final loopsAreVisible =
+        totalViews != null &&
+        (widget.isOwnProfile || totalViews >= profileLoopsVisibilityFloor);
+    final hasLoops = loopsAreVisible;
 
     final l10n = context.l10n;
     final columns = <Widget>[
       if (hasLoops || isLoading)
         ProfileStatColumn(
-          count: isLoading
-              ? _skeletonPlaceholderCount
-              : widget.profileStats!.totalViews,
+          count: isLoading ? _skeletonPlaceholderCount : totalViews!,
           label: l10n.profileLoopsLabel,
           isLoading: isLoading && _timeoutExpired,
         ),

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -420,6 +420,7 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
             padding: const EdgeInsets.symmetric(horizontal: 24),
             child: _ProfileStatsRow(
               userIdHex: widget.userIdHex,
+              isOwnProfile: widget.isOwnProfile,
               profileStats: widget.profileStats,
             ),
           ),

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -1329,11 +1329,12 @@ void main() {
       tester,
     ) async {
       final testProfile = createTestProfile(displayName: 'Counted User');
+      // Above profileLoopsVisibilityFloor so a visitor still sees Loops.
       const profileStats = ProfileStats(
         pubkey: testUserHex,
         videoCount: 42,
         totalLikes: 100,
-        totalViews: 5000,
+        totalViews: 50000,
       );
 
       await tester.pumpWidget(
@@ -1348,6 +1349,80 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Likes'), findsOneWidget);
+      expect(find.text('Loops'), findsOneWidget);
+    });
+
+    testWidgets('hides Loops from a visitor when the total is small', (
+      tester,
+    ) async {
+      final testProfile = createTestProfile(displayName: 'New Creator');
+      const profileStats = ProfileStats(
+        pubkey: testUserHex,
+        videoCount: 2,
+        totalLikes: 3,
+        totalViews: 7,
+      );
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          userIdHex: testUserHex,
+          isOwnProfile: false,
+          suppliedProfile: testProfile,
+          profileStats: profileStats,
+          videoCount: 2,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The rest of the row still renders; only the discouraging headline
+      // number is withheld.
+      expect(find.text('Loops'), findsNothing);
+      expect(find.text('Likes'), findsOneWidget);
+    });
+
+    testWidgets('shows an owner their own small Loops total', (tester) async {
+      final testProfile = createTestProfile(displayName: 'New Creator');
+      const profileStats = ProfileStats(
+        pubkey: testUserHex,
+        videoCount: 2,
+        totalLikes: 3,
+        totalViews: 7,
+      );
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          userIdHex: testUserHex,
+          isOwnProfile: true,
+          suppliedProfile: testProfile,
+          profileStats: profileStats,
+          videoCount: 2,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Loops'), findsOneWidget);
+    });
+
+    testWidgets('shows a visitor a total exactly at the floor', (tester) async {
+      final testProfile = createTestProfile(displayName: 'Counted User');
+      const profileStats = ProfileStats(
+        pubkey: testUserHex,
+        videoCount: 42,
+        totalLikes: 100,
+        totalViews: profileLoopsVisibilityFloor,
+      );
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          userIdHex: testUserHex,
+          isOwnProfile: false,
+          suppliedProfile: testProfile,
+          profileStats: profileStats,
+          videoCount: 3,
+        ),
+      );
+      await tester.pumpAndSettle();
+
       expect(find.text('Loops'), findsOneWidget);
     });
 


### PR DESCRIPTION
## What

Every profile leads with a **Loops** stat rendered straight from `profileStats.totalViews`, unconditionally. A brand-new creator's profile greets every visitor with `0 Loops`, in the largest stat treatment on the screen, next to Likes / Following / Followers.

That's the same discouraging number #6872 removes from the feed card — on the surface creators actually send people to, and with no "more info" tap to demote it behind.

Visitors now see the column only once the total clears `profileLoopsVisibilityFloor` (**10,000**). Owners always see their own, however small.

| viewer | total | Loops column |
|---|---|---|
| visitor | 7 | hidden |
| visitor | 10,000 | shown |
| visitor | 50,000 | shown |
| owner | 7 | shown |

The rest of the row is untouched — only the discouraging headline number is withheld, and the row already renders columns conditionally, so there's no layout special-casing.

## Why owners still see it

Bernstein et al. (CHI 2013): people badly underestimate their audience, and perceived audience drives production. Hiding a creator's own number works against the thing we want. The number is only withheld where it functions as a public verdict.

## Notes

- **`isOwnProfile` was already threaded** to `ProfileActionButtons` on the same widget, so ownership is injected into `_ProfileStatsRow` rather than read from Riverpod in the child.
- **No feature flag.** #6872 carries one because it changes the feed on every scroll; this is a single column on one surface and reverts cleanly in one commit. Say the word if you'd rather it were gated.
- **10,000 is a product call**, not a technical one — a named constant, one line to change. It is deliberately higher than the per-video floor in #6872, since a lifetime total across all of a creator's videos should clear a higher bar to read as impressive.
- **Independent of #6872** — no shared code, targets `main`, either can merge first.

## Testing

`profile_header_widget_test.dart`: visitor-below-floor hides, visitor-at-floor shows, owner-below-floor shows. One existing test (`displays stats from ProfileStats when provided`, `totalViews: 5000`, `isOwnProfile: false`) asserted the old behaviour and **failed on this change** — moved to 50,000 so it still tests what its name says.

295 profile tests green, `flutter analyze lib test integration_test` clean, all four design-system ratchets and the test-structure floor pass.

**Not done: nobody has run this on a device.** Screenshots should go on before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
