### PR TITLE
fix(ios): align firebase_remote_config with the firebase_core 4.4.0 release

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -765,10 +765,10 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_remote_config
-      sha256: "5d23c7021e69fbc9ef489ebcf4b1b941575e34ebacc7f20173c2a97f37f45b74"
+      sha256: "6d7be334b726537b3aa3a3ef1db9782951cd93c2b996eebc33f64a9f140e0409"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.2"
+    version: "6.1.4"
   firebase_remote_config_platform_interface:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -308,7 +308,7 @@ dependencies:
   firebase_core: ^4.4.0
   firebase_crashlytics: ^5.0.7
   # Pinned to the Firebase Core 4.4-compatible FlutterFire release family.
-  firebase_remote_config: 6.1.2
+  firebase_remote_config: 6.1.4
   go_router: ^16.2.4
   # Runtime splash-screen control via FlutterNativeSplash.preserve/remove.
   # Used ONLY for the runtime API — do NOT add a flutter_native_splash:


### PR DESCRIPTION
Closes #7017

## What

Bumps the `firebase_remote_config` pin from `6.1.2` to `6.1.4` (pubspec + lockfile only; `firebase_core` stays at 4.4.0).

## Why

The Codemagic iOS Build on `main` (build 402, commit 94aa462) fails during SPM resolution:

```
Dependencies could not be resolved because 'firebase_remote_config-6.1.2' depends on 'flutterfire' 4.2.1-firebase-core-swift and 'firebase_analytics-12.1.2' depends on 'flutterfire' 4.4.0-firebase-core-swift.
```

Each FlutterFire plugin's `Package.swift` pins the shared `flutterfire` Swift package at **exactly** `<firebase_core minimum from that plugin's own pubspec>-firebase-core-swift`. `firebase_remote_config 6.1.2` (added in #6871) declares `firebase_core: ^4.2.1`, while analytics 12.1.2, crashlytics 5.0.7, messaging 16.1.1, and performance 0.11.1+4 all declare `^4.4.0`. Two different exact pins on one SPM package can never resolve, so every fresh iOS build fails. This is **not** the stale-SPM-cache case documented in `.claude/rules/ios_build_troubleshooting.md` — the conflict is deterministic from the published manifests. `6.1.4` is the remote_config release aligned with core 4.4.0.

## Verification

- Reproduced the failure outside the app: a scratch Swift package depending on the pub-cache manifests for `firebase_core-4.4.0`, `firebase_analytics-12.1.2`, and `firebase_remote_config-6.1.2` fails `swift package resolve` with byte-for-byte the same error as Codemagic; swapping in `firebase_remote_config-6.1.4` resolves successfully (exit 0, full graph fetched). Conditions: local macOS, Xcode 26.2 toolchain — not the Codemagic Mac mini M2 image.
- `flutter pub get` (mise-pinned Flutter): lockfile diff is only remote_config 6.1.2→6.1.4; no other package moved.
- `flutter analyze lib/features/post_publish` (the only remote_config consumer): no issues.
- `flutter test test/features/post_publish/post_publish_experiment_test.dart`: 6/6 pass.

## Not verified

- I did not run a full local `flutter build ipa` against the Codemagic workflow (no codesigning identities locally), so the definitive proof is the next Codemagic iOS Build on `main` after this merges. The scratch-package resolve exercises the same SPM constraint graph that failed, but not the rest of the build.
- API compatibility 6.1.2→6.1.4 was verified only via analyzer + the feature's tests; it is a patch-level bump within the pinned-exact constraint style #6871 chose, which I kept rather than widening to a caret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)