### PR TITLE
test(recorder): cover capture mode with Maestro E2E

### DIFF
--- a/mobile/e2e/maestro/README.md
+++ b/mobile/e2e/maestro/README.md
@@ -4,8 +4,7 @@ End-to-end UI tests written with **Maestro**, driving a real build against
 **STAGING**.
 
 They exist for fast, high-signal regression detection on critical user flows.
-They are not a replacement for unit or widget tests, and they do not cover
-camera or recording.
+They are not a replacement for unit or widget tests.
 
 ## What the smoke suite covers today
 
@@ -28,11 +27,107 @@ The `e2e-smoke-ios` and `e2e-smoke-android` Codemagic workflows are
 `triggering: events: []`, so nothing runs them automatically. They are manual
 dispatches, and GitHub CI does not cover this lane at all.
 
+## The recorder flow
+
+`flows/captureModeFlow.yaml` covers the recorder's **capture** mode: open it
+from the feed, drive the control rail, record a clip, delete it, close. The
+other four modes (classic, stop-motion, lip-sync, upload) are not covered yet.
+
+Every file in it has been run green on a Galaxy SM-S942B.
+
+It is **not in `smoke.yaml`**, and it is deliberately not on the iOS lane:
+
+- **It needs real camera hardware.** Without a camera the bloc never reports
+  `isCameraInitialized`, the record button stays disabled, and the recording
+  test hangs on its first wait. The iOS Simulator has no camera at all;
+  an Android emulator's virtual scene camera is enough, and a device is best.
+- **`captureModeOpen` alone** — the chrome assertion — does pass without a
+  camera, because the viewfinder falls back to a placeholder and every control
+  still renders.
+
+Run it against a booted Android emulator or a connected device:
+
+```bash
+maestro --device <serial> test e2e/maestro/flows/captureModeFlow.yaml
+```
+
+`captureModeControls` asserts the icon-only rail controls by their Semantics
+`value` (`.*Square.*`, `.*3 seconds.*`, `.*Front camera.*`). That works:
+Flutter folds `value` into the Android content description, and Maestro
+matches against it — confirmed on device. Two things follow, both worth
+knowing before writing more recorder selectors:
+
+- **A selector may combine `id` with `text`**, and here it must: "Off" is the
+  value of the flash control *and* the timer control — and, once its sheet is
+  open, of the stabilization menu's own first row.
+- **`selected: true` is readable too**, which is what `assertCaptureMode` uses
+  to prove Capture is armed. The mode wheel renders an entry for every mode in
+  every mode, so a bare `id: camera_mode_capture` would pass on the Upload tab
+  just as happily.
+
+Three things the flow depends on that are easy to break by accident:
+
+- **Tap-to-toggle recording.** `HoldToRecordPreferenceService` defaults to
+  false. On a device where a previous session turned hold-to-record on, the
+  first tap does nothing and `captureModeRecordClip` fails on its wait.
+- **An empty session when the rail is driven.** `captureModeControls` runs
+  before the recording tests because the aspect-ratio control is disabled once
+  a clip exists — clips of mixed ratios cannot share an editor timeline.
+- **Hardware for two of the five rail controls.** Flash and stabilization are
+  driven behind an `enabled: true` guard, because both are disabled outright
+  when the active lens has no flash unit or reports a single stabilization
+  mode. Where the feature is missing the block prints `SKIPPED` rather than
+  failing — check the run output before reading a green run as full rail
+  coverage. Both were exercised for real on the SM-S942B's back lens.
+- **Camera and mic pre-granted.** The flow relaunches with
+  `permissions: all: allow` rather than tapping through the native dialog,
+  whose buttons are OS-localized copy. Note the relaunch deliberately does
+  *not* clear state: on Android `pm clear` wipes the encrypted preferences the
+  Nostr key lives in and would sign the account back out mid-flow.
+
+Account creation is a precondition, not part of what is tested. The recorder
+route itself is public (`appRouterRedirect` exempts it), but the only way in is
+the feed's camera button and the feed is not public.
+
 ---
 
 ## Running them
 
 Everything below runs from `mobile/`.
+
+### 0. Install the CLI
+
+```bash
+curl -fsSL "https://get.maestro.mobile.dev" | bash
+export PATH="$PATH:$HOME/.maestro/bin"
+```
+
+Not `brew install maestro`. That name resolves to an unrelated cask — "Maestro,
+AI agent command center", ~680 MB — that installs a macOS app and no CLI, so
+the next command still fails with `maestro: command not found`.
+
+### 0b. Put the device's app UI in English
+
+**The suite only runs against an English UI.** Not every selector is an id yet:
+`loginFreshInstall` taps "Use Divine with no backup", `removeKeys` taps
+"Cancel" / "Remove from device", `assertLogin` pins the three legal links. On a
+German phone the app renders "Nutzungsbedingungen" and the run dies in the
+first assert — which reads like a regression and isn't one.
+
+CI runners are English, so this only bites locally — and locally it is
+awkward, because the per-app override does not survive the suite:
+
+```bash
+# Android 13+, per app, without touching the system language:
+adb shell cmd locale set-app-locales co.openvine.app --locales en-US
+```
+
+**`launchApp: clearState` wipes that again.** It runs `pm clear`, which drops
+the package's locale override along with its data, so any flow that starts
+from `loginFreshInstall` is back in the system language by its first assert.
+On a non-English phone the options are a scratch flow that skips `clearState`,
+or setting the system language. This is not a problem worth engineering around
+— it disappears once the remaining copy selectors become identifiers.
 
 ### 1. Build the app
 
@@ -133,8 +228,15 @@ from. Identifiers are snake_case and defined in
 If the element you need has no identifier, add one — that is a smaller change
 than the assertion you would otherwise write, and it survives translation.
 
-Two traps worth knowing:
+Three traps worth knowing:
 
+- **Opacity 0 is invisible to Maestro, `IgnorePointer` is not.**
+  `RenderOpacity`/`RenderAnimatedOpacity` drop their child from the semantics
+  tree at `alpha == 0` (unless `alwaysIncludeSemantics`), so a faded-out
+  control genuinely fails `assertVisible` — that is what the recorder's
+  next/delete assertions rely on. A control that is only wrapped in
+  `IgnorePointer` stays in the tree and will happily satisfy `assertVisible`
+  while being untappable.
 - **`TabBar` composes a compound label.** A tab reads as `"New\nTab 2 of 6"`,
   and Maestro matches the whole label, so a bare `New` does not match. Use a
   prefix (`New.*`) or the tab's identifier — never the `Tab N of M` count,

--- a/mobile/e2e/maestro/README.md
+++ b/mobile/e2e/maestro/README.md
@@ -65,8 +65,16 @@ knowing before writing more recorder selectors:
   every mode, so a bare `id: camera_mode_capture` would pass on the Upload tab
   just as happily.
 
-Three things the flow depends on that are easy to break by accident:
+Five things the flow depends on that are easy to break by accident:
 
+- **The recorder opening on Capture.** It doesn't always: the recorder
+  restores the last-used mode from `camera_last_used_recorder_mode`
+  (`VideoRecorderMode.fromName` falls back to `capture` only when that key is
+  absent), and `openCaptureMode` asserts the mode rather than selecting it.
+  Run from the top this is safe — `loginFreshInstall`'s `clearState` wipes the
+  key — but a standalone run against a device whose last session used another
+  mode dies on `id: camera_mode_capture, selected` with no hint why. Reproduced
+  on the iOS Simulator with the key left on `classic`.
 - **Tap-to-toggle recording.** `HoldToRecordPreferenceService` defaults to
   false. On a device where a previous session turned hold-to-record on, the
   first tap does nothing and `captureModeRecordClip` fails on its wait.

--- a/mobile/e2e/maestro/asserts/assertCaptureClipRecorded.yaml
+++ b/mobile/e2e/maestro/asserts/assertCaptureClipRecorded.yaml
@@ -1,0 +1,18 @@
+appId: co.openvine.app
+---
+# The capture session holds at least one clip: the top bar reveals its
+# continue-to-editor button and the shutter row reveals delete-last-clip.
+#
+# Both are gated on `hasClips` through an AnimatedOpacity, which drops its
+# child from the semantics tree at opacity 0. Their presence is therefore the
+# assertion that the recording actually produced a clip — there is no clip
+# counter on this screen to read instead.
+#
+# The wait covers the gap between the stop tap and the recorder finalizing the
+# file; on a cold camera the first clip can take a moment to land.
+- extendedWaitUntil:
+    visible:
+      id: camera_next_button
+    timeout: 15000
+- assertVisible:
+    id: camera_delete_clip_button

--- a/mobile/e2e/maestro/asserts/assertCaptureMode.yaml
+++ b/mobile/e2e/maestro/asserts/assertCaptureMode.yaml
@@ -1,0 +1,39 @@
+appId: co.openvine.app
+---
+# Capture mode, idle: the viewfinder chrome is up and no clip is recorded yet.
+
+# Mode wheel with Capture armed. `selected` is load-bearing: the wheel renders
+# an entry for every mode in every mode, so a bare id assertion here passes
+# just as happily on the Upload tab.
+- assertVisible:
+    id: camera_mode_capture
+    selected: true
+- assertVisible:
+    id: camera_record_button
+- assertVisible:
+    id: camera_close_button
+- assertVisible:
+    id: camera_library_button
+
+# Control rail, top to bottom. Timer and stabilization are rendered only by
+# the modes that declare `supportsCountdownTimer` / `supportsVideoStabilization`
+# (capture and lip-sync), so this set is also what separates capture mode from
+# classic and stop-motion.
+- assertVisible:
+    id: camera_flash_button
+- assertVisible:
+    id: camera_timer_button
+- assertVisible:
+    id: camera_aspect_ratio_button
+- assertVisible:
+    id: camera_switch_camera_button
+- assertVisible:
+    id: camera_stabilization_button
+
+# Nothing recorded yet. Both buttons sit inside an AnimatedOpacity, and
+# RenderAnimatedOpacity drops its child from the semantics tree at opacity 0 —
+# so "not visible" here means "no clip in the session", not "scrolled away".
+- assertNotVisible:
+    id: camera_next_button
+- assertNotVisible:
+    id: camera_delete_clip_button

--- a/mobile/e2e/maestro/flows/captureModeFlow.yaml
+++ b/mobile/e2e/maestro/flows/captureModeFlow.yaml
@@ -1,0 +1,44 @@
+appId: co.openvine.app
+---
+#Capture-mode journey: create an account, open the recorder, record a clip,
+#delete it again, and sign the device back out.
+#
+# Account creation is a precondition, not part of what is under test. The
+# recorder route itself is public — appRouterRedirect exempts it — but the only
+# way into it is the feed's camera button, and the feed is not public: an
+# unauthenticated launch redirects to Welcome.
+#
+# Requires real camera hardware for captureModeRecordClip; see that file.
+
+- runFlow: ../tests/loginFreshInstall.yaml
+
+# Relaunch with camera and microphone pre-granted. Otherwise the first camera
+# tap raises the native OS permission dialog, whose buttons are OS-localized
+# copy that no selector should depend on.
+#
+# Deliberately no clearState: on Android `pm clear` wipes the encrypted
+# preferences the Nostr key lives in, which would sign the account straight
+# back out. (The iOS keychain survives it — the platforms disagree here, so
+# the flow takes the option that works on both.)
+- launchApp:
+    permissions:
+      all: allow
+- extendedWaitUntil:
+    visible:
+      id: camera_button
+    timeout: 60000
+
+- runFlow: ../tests/captureModeOpen.yaml
+
+- runFlow: ../utils/openCaptureMode.yaml
+# Before the recording tests, not after: the aspect-ratio control is disabled
+# once the session holds a clip.
+- runFlow: ../tests/captureModeControls.yaml
+- runFlow: ../tests/captureModeRecordClip.yaml
+- runFlow: ../tests/captureModeDeleteClip.yaml
+
+# Leave the recorder before teardown: removeKeys drives Settings from the
+# profile tab, which the full-screen recorder covers.
+- tapOn:
+    id: camera_close_button
+- runFlow: ../tests/removeKeys.yaml

--- a/mobile/e2e/maestro/scripts/ui_smoke_ios.sh
+++ b/mobile/e2e/maestro/scripts/ui_smoke_ios.sh
@@ -61,7 +61,9 @@ export PATH="${PATH}:${HOME}/.maestro/bin"
 info "Validating prerequisites..."
 require_cmd xcrun "Install Xcode + Command Line Tools."
 require_cmd plutil "plutil should exist on macOS."
-require_cmd "${MAESTRO_CLI}" "Install Maestro: brew install maestro"
+# Not 'brew install maestro' -- that name now resolves to an unrelated cask
+# ("Maestro, AI agent command center", ~680 MB) which ships no CLI at all.
+require_cmd "${MAESTRO_CLI}" 'Install Maestro: curl -fsSL "https://get.maestro.mobile.dev" | bash'
 [[ -f "${SUITE_PATH}" ]] || fail "Suite not found: ${SUITE_PATH}"
 [[ -d "${APP_PATH}" ]] || fail "Runner.app not found at: ${APP_PATH}
 

--- a/mobile/e2e/maestro/tests/captureModeControls.yaml
+++ b/mobile/e2e/maestro/tests/captureModeControls.yaml
@@ -161,9 +161,11 @@ tags:
             id: camera_stabilization_button
             text: ".*Off.*"
           timeout: 10000
-      # Restore. Safe even if the barrier ever stopped blocking semantics: the
-      # rail button no longer reads "Off" at this point, so ".*Off.*" can only
-      # be the sheet's own row.
+      # Restore. The bare ".*Off.*" leans on the barrier blocking the rail
+      # underneath (ModalBarrier wraps itself in BlockSemantics) — it is not
+      # independently safe. The stabilization button no longer reads "Off"
+      # here, but the flash and timer controls both do, and picking the timer
+      # would arm the countdown that step 2 exists to clear.
       - tapOn:
           id: camera_stabilization_button
       - tapOn: ".*Off.*"

--- a/mobile/e2e/maestro/tests/captureModeControls.yaml
+++ b/mobile/e2e/maestro/tests/captureModeControls.yaml
@@ -1,0 +1,178 @@
+appId: co.openvine.app
+tags:
+  - recorder
+---
+#TC to drive the capture-mode control rail,
+# given the recorder is open on an idle capture viewfinder with no clips,
+# validate each control actually changes recorder state, and leave every one
+# of them back on its default.
+#
+# The assertions read each control's Semantics `value`, which Flutter folds
+# into the Android content description / iOS accessibilityValue. That is the
+# only readable evidence a tap landed: the controls are icon-only, and what
+# they change — flash mode, sensor crop, active lens — is invisible to a UI
+# driver. Selectors pin `id` as well as `text` because "Off" is the value of
+# both the flash and the timer control.
+#
+# Two preconditions beyond an open viewfinder:
+# - **No clips.** The aspect-ratio control is disabled once the session holds
+#   one, because clips of mixed ratios cannot share an editor timeline.
+# - **Real camera hardware**, for the lens switch. See captureModeRecordClip.
+#
+# Flash and stabilization are driven behind an `enabled` guard, because both
+# are disabled outright on hardware that lacks the feature — no flash unit on
+# the active lens, or a camera that reports a single stabilization mode. An
+# unguarded tap-and-assert there would go green or red on the phone rather
+# than on the code. A guarded block prints "SKIPPED" in the run output, so a
+# skipped control is visible rather than silently counted as covered.
+#Steps:
+# 1. Aspect ratio: Vertical -> Square -> Vertical
+# 2. Timer: Off -> 3 seconds -> 10 seconds -> Off
+# 3. Camera: Back -> Front -> Back
+# 4. Flash (if present): Off -> On -> Auto -> Off
+# 5. Stabilization (if supported): Off -> some other mode -> Off
+
+# 1. Aspect ratio flips between two states.
+- assertVisible:
+    id: camera_aspect_ratio_button
+    text: ".*Vertical.*"
+- tapOn:
+    id: camera_aspect_ratio_button
+- extendedWaitUntil:
+    visible:
+      id: camera_aspect_ratio_button
+      text: ".*Square.*"
+    timeout: 10000
+- tapOn:
+    id: camera_aspect_ratio_button
+- extendedWaitUntil:
+    visible:
+      id: camera_aspect_ratio_button
+      text: ".*Vertical.*"
+    timeout: 10000
+
+# 2. Timer cycles through three states and wraps.
+- assertVisible:
+    id: camera_timer_button
+    text: ".*Off.*"
+- tapOn:
+    id: camera_timer_button
+- extendedWaitUntil:
+    visible:
+      id: camera_timer_button
+      text: ".*3 seconds.*"
+    timeout: 10000
+- tapOn:
+    id: camera_timer_button
+- extendedWaitUntil:
+    visible:
+      id: camera_timer_button
+      text: ".*10 seconds.*"
+    timeout: 10000
+# The wrap back to Off is not just symmetry: a timer left armed puts a
+# countdown in front of every recording later in the flow.
+- tapOn:
+    id: camera_timer_button
+- extendedWaitUntil:
+    visible:
+      id: camera_timer_button
+      text: ".*Off.*"
+    timeout: 10000
+
+# 3. Lens switch. Slower than the other two — the native camera rebinds and
+# the preview remounts on a fresh texture — so it gets a longer wait.
+- assertVisible:
+    id: camera_switch_camera_button
+    text: ".*Back camera.*"
+- tapOn:
+    id: camera_switch_camera_button
+- extendedWaitUntil:
+    visible:
+      id: camera_switch_camera_button
+      text: ".*Front camera.*"
+    timeout: 20000
+- tapOn:
+    id: camera_switch_camera_button
+- extendedWaitUntil:
+    visible:
+      id: camera_switch_camera_button
+      text: ".*Back camera.*"
+    timeout: 20000
+
+# 4. Flash. Guarded: the control is disabled when the active lens reports no
+# flash unit (`hasFlash`) — true of most emulators, and of the front lens on
+# many phones.
+- runFlow:
+    when:
+      visible:
+        id: camera_flash_button
+        enabled: true
+    commands:
+      - assertVisible:
+          id: camera_flash_button
+          text: ".*Off.*"
+      - tapOn:
+          id: camera_flash_button
+      - extendedWaitUntil:
+          visible:
+            id: camera_flash_button
+            text: ".*On.*"
+          timeout: 10000
+      - tapOn:
+          id: camera_flash_button
+      - extendedWaitUntil:
+          visible:
+            id: camera_flash_button
+            text: ".*Auto.*"
+          timeout: 10000
+      - tapOn:
+          id: camera_flash_button
+      - extendedWaitUntil:
+          visible:
+            id: camera_flash_button
+            text: ".*Off.*"
+          timeout: 10000
+
+# 5. Stabilization. Same guard, and when it passes the sheet is guaranteed to
+# offer a non-off mode: the native side only reports
+# `isVideoStabilizationSupported` when its mode list has more than one entry.
+# Which non-off modes exist is per-device (Android derives them from the
+# camera's CONTROL_AVAILABLE_VIDEO_STABILIZATION_MODES), hence the alternation
+# rather than a fixed label.
+- runFlow:
+    when:
+      visible:
+        id: camera_stabilization_button
+        enabled: true
+    commands:
+      - assertVisible:
+          id: camera_stabilization_button
+          text: ".*Off.*"
+      - tapOn:
+          id: camera_stabilization_button
+      # The sheet is a modal route, so its barrier blocks the semantics of the
+      # rail underneath and these labels are unambiguous while it is open.
+      - extendedWaitUntil:
+          visible: ".*(Standard|Cinematic|Preview Optimized|Low Latency|Auto).*"
+          timeout: 10000
+      - tapOn: ".*(Standard|Cinematic|Preview Optimized|Low Latency|Auto).*"
+      - extendedWaitUntil:
+          notVisible:
+            id: camera_stabilization_button
+            text: ".*Off.*"
+          timeout: 10000
+      # Restore. Safe even if the barrier ever stopped blocking semantics: the
+      # rail button no longer reads "Off" at this point, so ".*Off.*" can only
+      # be the sheet's own row.
+      - tapOn:
+          id: camera_stabilization_button
+      - tapOn: ".*Off.*"
+      - extendedWaitUntil:
+          visible:
+            id: camera_stabilization_button
+            text: ".*Off.*"
+          timeout: 10000
+
+# Everything back to default, so the tests after this one start where they
+# expect to.
+- runFlow: ../asserts/assertCaptureMode.yaml

--- a/mobile/e2e/maestro/tests/captureModeDeleteClip.yaml
+++ b/mobile/e2e/maestro/tests/captureModeDeleteClip.yaml
@@ -1,0 +1,27 @@
+appId: co.openvine.app
+tags:
+  - recorder
+---
+#TC to delete the last recorded clip,
+# given the capture session holds at least one clip,
+# validate the delete button drops it and the recorder returns to its empty
+# state.
+#
+# This is also the teardown for the recorder flow. A clip left behind is
+# written to the clip library and survives the run, so the next one would
+# start with a non-empty session and fail assertCaptureMode.
+#Steps:
+# 1. Tap delete last clip
+# 2. Validate the empty capture state is restored
+
+# 1. Delete the last clip. There is no confirmation dialog — the delete is a
+# soft-delete with an Undo snackbar, so the clip leaves the session on the tap.
+- tapOn:
+    id: camera_delete_clip_button
+
+# 2. next/delete drop back out of the semantics tree once the session is empty.
+- extendedWaitUntil:
+    notVisible:
+      id: camera_next_button
+    timeout: 15000
+- runFlow: ../asserts/assertCaptureMode.yaml

--- a/mobile/e2e/maestro/tests/captureModeOpen.yaml
+++ b/mobile/e2e/maestro/tests/captureModeOpen.yaml
@@ -1,0 +1,26 @@
+appId: co.openvine.app
+tags:
+  - recorder
+---
+#TC to open the video recorder in capture mode,
+# given the user is signed in and on a feed surface,
+# validate the capture viewfinder comes up with its full control set and that
+# closing it puts the user back on the feed.
+#Steps:
+# 1. Tap the bottom-nav camera button: capture mode is displayed
+# 2. Close the recorder: the user is back on the feed
+
+# 1. Open the recorder
+- runFlow: ../utils/openCaptureMode.yaml
+
+# 2. Close it. The recorder is a full-screen push, so the bottom nav coming
+# back is what proves we left it — and the record button going away proves we
+# left it rather than stacking something on top.
+- tapOn:
+    id: camera_close_button
+- extendedWaitUntil:
+    visible:
+      id: camera_button
+    timeout: 15000
+- assertNotVisible:
+    id: camera_record_button

--- a/mobile/e2e/maestro/tests/captureModeRecordClip.yaml
+++ b/mobile/e2e/maestro/tests/captureModeRecordClip.yaml
@@ -1,0 +1,42 @@
+appId: co.openvine.app
+tags:
+  - recorder
+---
+#TC to record a clip in capture mode,
+# given the recorder is open on an idle capture viewfinder,
+# validate tap-to-start / tap-to-stop produces a clip in the session.
+#
+# Needs real camera hardware. Without it the bloc never reports
+# `isCameraInitialized`, the record button stays disabled, and the first tap
+# does nothing — so this cannot pass on the iOS Simulator. Run it on an
+# Android emulator (which has a virtual scene camera) or on a device.
+#
+# Tap-to-toggle is the default; hold-to-record is opt-in
+# (`HoldToRecordPreferenceService` defaults to false). A run against a device
+# where a previous session enabled it will hang on the first assertion.
+#Steps:
+# 1. Tap the record button: recording starts and the top-bar chrome collapses
+# 2. Tap it again: recording stops and the session holds one clip
+
+# 1. Start recording.
+#
+# The record button looks near-identical in both states, so it is the close
+# button that reports the transition: while recording, the top bar swaps its
+# close/next row out for the recording-progress bar entirely.
+- tapOn:
+    id: camera_record_button
+- extendedWaitUntil:
+    notVisible:
+      id: camera_close_button
+    timeout: 15000
+
+# Let a couple of seconds of footage accumulate. The progress bar animates for
+# the whole recording, so this waits the timeout out instead of returning
+# early — there is no elapsed-duration element to wait on instead.
+- waitForAnimationToEnd:
+    timeout: 3000
+
+# 2. Stop recording
+- tapOn:
+    id: camera_record_button
+- runFlow: ../asserts/assertCaptureClipRecorded.yaml

--- a/mobile/e2e/maestro/utils/openCaptureMode.yaml
+++ b/mobile/e2e/maestro/utils/openCaptureMode.yaml
@@ -5,6 +5,14 @@ appId: co.openvine.app
 #
 # No launchApp, so this runs against whatever is already on screen — see the
 # "Iterating" section of e2e/maestro/README.md.
+#
+# It asserts Capture rather than selecting it. The recorder restores the
+# last-used mode from `camera_last_used_recorder_mode`, so that only holds
+# after a `clearState` (which the flow gets from loginFreshInstall). Run
+# standalone against a device whose last session used another mode, this fails
+# on `id: camera_mode_capture, selected`. Selecting the mode here is not a
+# one-liner: the wheel is a lazy ListView, so from Classic the Capture entry
+# is not rendered and a bare tapOn cannot find it.
 
 - tapOn:
     id: camera_button

--- a/mobile/e2e/maestro/utils/openCaptureMode.yaml
+++ b/mobile/e2e/maestro/utils/openCaptureMode.yaml
@@ -1,0 +1,32 @@
+appId: co.openvine.app
+---
+#Utility: given the user is signed in and on a feed surface, open the recorder
+#and leave it on a ready capture-mode viewfinder.
+#
+# No launchApp, so this runs against whatever is already on screen — see the
+# "Iterating" section of e2e/maestro/README.md.
+
+- tapOn:
+    id: camera_button
+
+# The first camera open of an install shows the "Why six seconds?" education
+# sheet on top of the recorder. It is one-shot per install (the
+# `why_six_seconds_shown` preference), so a rerun on a device that has already
+# seen it must not wait for it — hence the conditional.
+#
+# Selected by copy rather than by id: the sheet is a VineBottomSheetPrompt,
+# which takes no semantics identifier. Adding one is a divine_ui change that
+# drags that package's 100% coverage gate along with it — the same call
+# removeKeys.yaml already makes for its confirmation sheet.
+#
+# Which means this line needs an English app UI, like the rest of the suite.
+# On a localized device the `when` simply never matches, the sheet stays up
+# over the recorder, and assertCaptureMode fails on every id at once. See the
+# "Put the device's app UI in English" step in e2e/maestro/README.md.
+- runFlow:
+    when:
+      visible: "Why six seconds?"
+    commands:
+      - tapOn: "Got it!"
+
+- runFlow: ../asserts/assertCaptureMode.yaml

--- a/mobile/lib/constants/semantic_ids.dart
+++ b/mobile/lib/constants/semantic_ids.dart
@@ -22,7 +22,9 @@ abstract class SemanticIds {
   static String cameraMode(String mode) => 'camera_mode_$mode';
   static const String cameraRecordButton = 'camera_record_button';
 
-  /// Recorder chrome shared by capture and stop-motion mode. Every label
+  /// Recorder chrome. Close, next and delete-clip come from the capture
+  /// stack, which capture, stop-motion and lip-sync all render; the library
+  /// button lives in the bottom bar, which every mode renders. Every label
   /// behind these is localized, so the E2E capture flow drives them by id.
   static const String cameraCloseButton = 'camera_close_button';
   static const String cameraNextButton = 'camera_next_button';

--- a/mobile/lib/constants/semantic_ids.dart
+++ b/mobile/lib/constants/semantic_ids.dart
@@ -22,6 +22,20 @@ abstract class SemanticIds {
   static String cameraMode(String mode) => 'camera_mode_$mode';
   static const String cameraRecordButton = 'camera_record_button';
 
+  /// Recorder chrome shared by capture and stop-motion mode. Every label
+  /// behind these is localized, so the E2E capture flow drives them by id.
+  static const String cameraCloseButton = 'camera_close_button';
+  static const String cameraNextButton = 'camera_next_button';
+  static const String cameraDeleteClipButton = 'camera_delete_clip_button';
+  static const String cameraLibraryButton = 'camera_library_button';
+
+  /// Capture-mode control rail, top to bottom.
+  static const String cameraFlashButton = 'camera_flash_button';
+  static const String cameraTimerButton = 'camera_timer_button';
+  static const String cameraAspectRatioButton = 'camera_aspect_ratio_button';
+  static const String cameraSwitchCameraButton = 'camera_switch_camera_button';
+  static const String cameraStabilizationButton = 'camera_stabilization_button';
+
   /// Welcome screen. The fresh-install and returning-user branches show
   /// different buttons, so each action gets its own id rather than being
   /// disambiguated by position.

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_actions.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_actions.dart
@@ -6,6 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' as model show AspectRatio;
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/video_recorder/video_recorder_flash_mode.dart';
 import 'package:openvine/models/video_recorder/video_recorder_timer_duration.dart';
@@ -57,6 +58,7 @@ class VideoRecorderCaptureActions extends ConsumerWidget {
                 _IconButton(
                   icon: state.flashMode.icon,
                   label: l10n.videoRecorderToggleFlashLabel,
+                  identifier: SemanticIds.cameraFlashButton,
                   value: _flashModeValue(l10n, state.flashMode),
                   onTap: state.hasFlash
                       ? () => context.read<VideoRecorderBloc>().add(
@@ -68,6 +70,7 @@ class VideoRecorderCaptureActions extends ConsumerWidget {
                   _IconButton(
                     icon: state.timer.icon,
                     label: l10n.videoRecorderCycleTimerLabel,
+                    identifier: SemanticIds.cameraTimerButton,
                     value: _timerDurationValue(l10n, state.timer),
                     onTap: () => context.read<VideoRecorderBloc>().add(
                       const VideoRecorderTimerCycled(),
@@ -88,6 +91,7 @@ class VideoRecorderCaptureActions extends ConsumerWidget {
                       ? .cropSquare
                       : .cropPortrait,
                   label: l10n.videoRecorderToggleAspectRatioLabel,
+                  identifier: SemanticIds.cameraAspectRatioButton,
                   value: _aspectRatioValue(l10n, state.aspectRatio),
                   onTap: !hasClips
                       ? () => context.read<VideoRecorderBloc>().add(
@@ -98,6 +102,7 @@ class VideoRecorderCaptureActions extends ConsumerWidget {
                 _IconButton(
                   icon: .arrowsClockwise,
                   label: l10n.videoRecorderSwitchCameraLabel,
+                  identifier: SemanticIds.cameraSwitchCameraButton,
                   value: state.isFrontCamera
                       ? l10n.videoRecorderCameraValueFront
                       : l10n.videoRecorderCameraValueBack,
@@ -168,6 +173,7 @@ class _StabilizationButton extends StatelessWidget {
     return _IconButton(
       icon: .sparkle,
       label: context.l10n.videoRecorderStabilizationLabel,
+      identifier: SemanticIds.cameraStabilizationButton,
       value: _stabilizationModeLabel(context.l10n, mode),
       onTap: isSupported ? () => _showStabilizationMenu(context) : null,
     );
@@ -251,6 +257,7 @@ class _IconButton extends StatelessWidget {
     required this.icon,
     required this.label,
     required this.onTap,
+    this.identifier,
     this.value,
     this.toggled,
   });
@@ -258,6 +265,10 @@ class _IconButton extends StatelessWidget {
   final String label;
   final DivineIconName icon;
   final VoidCallback? onTap;
+
+  /// Stable `Semantics(identifier:)` anchor for E2E tests. Never announced,
+  /// so it carries no meaning for a screen-reader user — that is [label].
+  final String? identifier;
 
   /// Current setting of a control that cycles through more than two states,
   /// announced after [label] (e.g. the active flash mode).
@@ -270,6 +281,7 @@ class _IconButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Semantics(
+      identifier: identifier,
       button: true,
       enabled: onTap != null,
       label: label,

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart
@@ -6,6 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/widgets/video_recorder/clip_delete_snackbar.dart';
@@ -137,6 +138,7 @@ class VideoRecorderCaptureStack extends ConsumerWidget {
                         icon: .trash,
                         semanticLabel:
                             context.l10n.videoRecorderDeleteLastClipLabel,
+                        semanticIdentifier: SemanticIds.cameraDeleteClipButton,
                         type: .ghostOverMedia,
                         size: .small,
                         onPressed: recorderMode.capturesStills

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_top_bar.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_top_bar.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
@@ -68,6 +69,7 @@ class VideoRecorderCaptureTopBar extends ConsumerWidget {
                     DivineIconButton(
                       icon: .x,
                       semanticLabel: context.l10n.videoRecorderCloseLabel,
+                      semanticIdentifier: SemanticIds.cameraCloseButton,
                       size: .small,
                       type: .ghostOverMedia,
                       onPressed: () => fromEditor
@@ -82,6 +84,7 @@ class VideoRecorderCaptureTopBar extends ConsumerWidget {
                         icon: .caretRight,
                         semanticLabel:
                             context.l10n.videoRecorderContinueToEditorLabel,
+                        semanticIdentifier: SemanticIds.cameraNextButton,
                         size: .small,
                         type: .ghostOverMedia,
                         onPressed: capturesStills

--- a/mobile/lib/widgets/video_recorder/video_recorder_library_button.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_library_button.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
@@ -113,6 +114,7 @@ class _VideoRecorderLibraryButtonState
     return Padding(
       padding: const .only(left: 16),
       child: Semantics(
+        identifier: SemanticIds.cameraLibraryButton,
         button: widget.interactive,
         // A stop-motion session counts captured stills, not clips — the clip
         // label would announce 12 stills as "12 clips". Its own label also

--- a/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_actions_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_actions_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' as model show AspectRatio;
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -465,6 +466,36 @@ void main() {
           node.value,
           equals(l10n.videoRecorderStabilizationModeCinematic),
         );
+
+        handle.dispose();
+      });
+
+      // The Maestro capture-mode flow drives the whole rail by identifier
+      // (e2e/maestro/asserts/assertCaptureMode.yaml). Dropping one is
+      // invisible to every other test here — the labels would still be
+      // correct — and only surfaces on a manual E2E run.
+      testWidgets('exposes an E2E identifier on every rail control', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(
+          buildWidget(isVideoStabilizationSupported: true),
+        );
+        await tester.pumpAndSettle();
+
+        for (final identifier in const [
+          SemanticIds.cameraFlashButton,
+          SemanticIds.cameraTimerButton,
+          SemanticIds.cameraAspectRatioButton,
+          SemanticIds.cameraSwitchCameraButton,
+          SemanticIds.cameraStabilizationButton,
+        ]) {
+          expect(
+            find.bySemanticsIdentifier(identifier),
+            findsOneWidget,
+            reason: 'missing E2E anchor: $identifier',
+          );
+        }
 
         handle.dispose();
       });

--- a/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_stack_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_stack_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -155,6 +156,32 @@ void main() {
             .widgetList<AnimatedOpacity>(find.byType(AnimatedOpacity))
             .toList();
         expect(opacities.any((o) => o.opacity == 1), isTrue);
+      });
+
+      // Anchor for the Maestro capture-mode flow, which deletes the recorded
+      // clip by id as its teardown (e2e/maestro/tests/captureModeDeleteClip
+      // .yaml). Nothing else in this file would notice the id going missing.
+      testWidgets('exposes an E2E identifier on the undo button', (
+        tester,
+      ) async {
+        final clips = [
+          DivineVideoClip(
+            id: 'clip1',
+            video: EditorVideo.file('/test/clip1.mp4'),
+            duration: const Duration(seconds: 2),
+            recordedAt: DateTime.now(),
+            targetAspectRatio: .vertical,
+            originalAspectRatio: 9 / 16,
+          ),
+        ];
+
+        await tester.pumpWidget(buildWidget(clips: clips));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.bySemanticsIdentifier(SemanticIds.cameraDeleteClipButton),
+          findsOneWidget,
+        );
       });
 
       testWidgets('undo button is hidden during recording even with clips', (

--- a/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_top_bar_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_top_bar_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -142,6 +143,34 @@ void main() {
         expect(opacities.any((o) => o.opacity == 1), isTrue);
         expect(
           find.bySemanticsLabel(l10n.videoRecorderContinueToEditorLabel),
+          findsOneWidget,
+        );
+      });
+
+      // Anchors for the Maestro capture-mode flow, which drives both buttons
+      // by id (e2e/maestro/tests/captureModeOpen.yaml). The labels above stay
+      // green if an identifier is dropped, so pin the identifiers too.
+      testWidgets('exposes E2E identifiers on close and next', (tester) async {
+        final clips = [
+          DivineVideoClip(
+            id: 'clip1',
+            video: EditorVideo.file('/test/clip1.mp4'),
+            duration: const Duration(seconds: 2),
+            recordedAt: DateTime.now(),
+            targetAspectRatio: .vertical,
+            originalAspectRatio: 9 / 16,
+          ),
+        ];
+
+        await tester.pumpWidget(buildWidget(clips: clips));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.bySemanticsIdentifier(SemanticIds.cameraCloseButton),
+          findsOneWidget,
+        );
+        expect(
+          find.bySemanticsIdentifier(SemanticIds.cameraNextButton),
           findsOneWidget,
         );
       });

--- a/mobile/test/widgets/video_recorder/video_recorder_library_button_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_library_button_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -227,6 +228,20 @@ void main() {
           find.bySemanticsLabel('Clip library, no clips'),
         );
         expect(semantics.flagsCollection.isButton, isTrue);
+      });
+
+      // Anchor for the Maestro capture-mode flow
+      // (e2e/maestro/asserts/assertCaptureMode.yaml). The label assertions
+      // above go through unchanged if the identifier is dropped, so it needs
+      // its own guard.
+      testWidgets('exposes an E2E identifier', (tester) async {
+        await tester.pumpWidget(buildWidget());
+        await tester.pumpAndSettle();
+
+        expect(
+          find.bySemanticsIdentifier(SemanticIds.cameraLibraryButton),
+          findsOneWidget,
+        );
       });
     });
 


### PR DESCRIPTION
Closes #7019

## Description

Maestro E2E coverage for the video recorder, starting with **capture** mode. The other four modes (classic, stop-motion, lip-sync, upload) are untouched.

`flows/captureModeFlow.yaml` runs: open the recorder from the feed → drive the control rail → record a clip → delete it → close → sign the device out.

Three things in here are non-obvious enough to call out:

**Identifiers, not copy.** Capture mode was only addressable by `camera_record_button` and the mode wheel. Everything else — close, next, delete-clip, library, and all five rail controls — had to be selected by localized strings, which is precisely what left this suite broken for six months the last time product moved copy. Each new identifier ships with a widget test, because the existing label assertions stay green when an identifier is dropped and nothing else would catch it.

**Flash and stabilization are guarded, not skipped.** Both are disabled outright when the active lens has no flash unit (`hasFlash`) or reports a single stabilization mode (natively `modes.size > 1`). Driving them unguarded would make the test pass or fail on the phone rather than on the code, so they sit behind `enabled: true` and print `SKIPPED` where the hardware lacks the feature — visible in the run output rather than silently counted as covered. The stabilization options are matched by alternation rather than a fixed label because Android derives the list from the camera's `CONTROL_AVAILABLE_VIDEO_STABILIZATION_MODES`; only `off` is guaranteed.

**The permission relaunch deliberately skips `clearState`.** The flow relaunches with `permissions: all: allow` instead of tapping through the native dialog, whose buttons are OS-localized copy. It does not clear state, because on Android `pm clear` wipes the encrypted preferences holding the Nostr key and would sign the account straight back out mid-flow. (The iOS keychain survives it — the platforms disagree, so the flow takes the option that works on both.)

Also fixes two things I walked into while doing this: `brew install maestro` now resolves to an unrelated cask ("Maestro, AI agent command center", ~680 MB) that ships no CLI, and the suite's long-standing requirement for an English app UI was nowhere written down — on a German phone the very first assert fails and reads like a regression.

**Related Issue:** 

## Out of Scope

- **Not added to `smoke.yaml`.** Capture mode needs real camera hardware; without it the bloc never reports `isCameraInitialized`, the record button stays disabled, and the recording test hangs on its first wait. The smoke lane runs on the iOS Simulator, which has no camera.
- **The other four recorder modes.**
- **`assertLogin.yaml` asserting the three legal links by English copy.** It is the shared entry-point assert for the whole suite; making it locale-proof is a separate change with blast radius beyond this PR.
- **A `semanticIdentifier` on `VineBottomSheetPrompt`.** The one-shot "Why six seconds?" sheet is still dismissed by copy. Adding the hook means a `divine_ui` change and that package's 100% coverage gate — the same call `removeKeys.yaml` already makes for its confirmation sheet.
- **Untranslated German copy on the welcome screen.** Noticed while debugging: `authTermsPrefix`, `authTermsAgeAuthorizationCta` and `authTermsAfterAgeAuthorization` are still English in `app_de.arb` while `authTermsOfService` and `authTermsAnd` are translated, so the legal line renders as a mixed-language sentence. Not touched here.

## Verification

`flutter analyze lib test` clean. `flutter test test/widgets/video_recorder/ test/screens/video_recorder_screen_test.dart` — 299 passing. `check_refs.sh` and `maestro check-syntax` green on all eight new files.

Run on a real **Samsung Galaxy SM-S942B** (Android, back lens), green end to end:

| Step | Result |
|---|---|
| Open recorder, full control set, close back to feed | pass |
| Aspect ratio Vertical → Square → Vertical | pass |
| Timer Off → 3 seconds → 10 seconds → Off | pass |
| Camera Back → Front → Back | pass |
| Flash Off → On → Auto → Off | pass (guard open) |
| Stabilization Off → other mode → Off | pass (guard open) |
| Record a clip, next + delete appear | pass |
| Delete the clip, empty state restored | pass |
| `removeKeys` teardown | pass |
| Session survives the permission relaunch | pass |

The one composition not run as-is on hardware is `loginFreshInstall` at the head of the flow: it fails on a German device at `assertLogin`, which is the pre-existing locale limitation this PR documents. Its steps were exercised through an equivalent harness that skipped `clearState`, and every step downstream of it ran green.

No visual changes — the production diff adds `Semantics(identifier:)` values only, so there is nothing to screenshot.

## Type of Change

- [x] ✅ Build configuration change
- [x] 📝 Documentation