### PR TITLE
docs: add the misaligned-plugin cause to iOS SPM troubleshooting

### DIFF
--- a/.claude/rules/ios_build_troubleshooting.md
+++ b/.claude/rules/ios_build_troubleshooting.md
@@ -1,6 +1,24 @@
 # iOS Build Troubleshooting
 
-When iOS build fails with "Could not resolve package dependencies" and Firebase plugins require different FlutterFire versions, it's a stale Xcode SPM cache, not a code issue.
+When iOS build fails with "Could not resolve package dependencies" and Firebase plugins require different FlutterFire versions (`'X' depends on 'flutterfire' A-firebase-core-swift and 'Y' depends on 'flutterfire' B-firebase-core-swift`), there are two distinct causes. Diagnose which one you have before fixing.
+
+## Cause 1: misaligned Firebase plugin versions (check this first)
+
+Each FlutterFire plugin's `Package.swift` pins the shared `flutterfire` Swift package at exactly the `firebase_core` minimum declared in that plugin's own pubspec. If any Firebase plugin in `mobile/pubspec.lock` declares a different `firebase_core` minimum than its siblings, SPM resolution fails deterministically on every fresh machine, including CI — no cache clearing helps. (Codemagic iOS Build broke this way when `firebase_remote_config` 6.1.2 declared `^4.2.1` while every sibling declared `^4.4.0`; fixed by #7016.)
+
+Check the constraints for the locked plugin versions:
+
+```bash
+grep -h "firebase_core:" ~/.pub-cache/hosted/pub.dev/firebase_*/pubspec.yaml
+```
+
+All `firebase_core` minimums must be identical and match the locked `firebase_core` version. If one differs, bump that plugin to the release aligned with the locked `firebase_core` — pub.dev's API lists every version's dependencies (`https://pub.dev/api/packages/<pkg>`) — and commit the pubspec + lockfile change. GitHub CI does not run an SPM iOS build, so this misalignment goes green on PRs and only surfaces on Codemagic after merge.
+
+To confirm a suspected conflict without building the app: a scratch `Package.swift` with `.package(path:)` dependencies into `~/.pub-cache/hosted/pub.dev/<pkg>-<version>/ios/<pkg>` for `firebase_core` plus the suspect plugins reproduces the exact error with `swift package resolve` in seconds.
+
+## Cause 2: stale local Xcode SPM cache
+
+If the plugin constraints are aligned and the failure is on a local machine, it's a stale Xcode SPM cache, not a code issue.
 
 Fix:
 
@@ -10,4 +28,4 @@ cd mobile/ios && rm -rf Pods Podfile.lock .symlinks
 flutter clean && flutter pub get && cd ios && pod install
 ```
 
-Do not create PRs to change `pubspec.lock` or `Package.resolved` for this.
+Do not create PRs to change `pubspec.lock` or `Package.resolved` for the stale-cache case.


### PR DESCRIPTION
Closes #7021

## What

Rewrites `.claude/rules/ios_build_troubleshooting.md` so the FlutterFire SPM version-conflict error documents both of its causes, with diagnosis-first ordering.

## Why

The doc attributed the `'X' depends on 'flutterfire' A-firebase-core-swift and 'Y' depends on 'flutterfire' B-firebase-core-swift` error solely to a stale local Xcode SPM cache and instructed agents not to PR `pubspec.lock` changes for it. Today's Codemagic iOS Build failure (build 402, fixed by #7016) proved a second, deterministic cause: Firebase plugin versions in the lockfile declaring different `firebase_core` minimums, which makes each plugin's `Package.swift` pin a different exact `flutterfire` version. For that case the pubspec change is exactly the fix, and cache clearing does nothing — so the old doc actively misdirected the next reader who hits it.

The doc now explains how to distinguish the cases (compare `firebase_core` minimums across the locked plugin manifests), the fix for each, why GitHub CI can't catch the misalignment (no SPM iOS build on PRs), and the scratch-package `swift package resolve` technique for confirming a conflict in seconds without building the app.

## Verification

Docs-only change; no code paths affected. Commands in the doc are the ones actually used to diagnose and verify #7016 on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)