### PR TITLE
fix(badges): translate the profile badge sheet into every locale

### DIFF
--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3996,7 +3996,7 @@
     "badgeAwardSubmitAction": "{count, plural, =0{امنح الشارة} =1{امنحها لشخص واحد} other{امنحها لـ {count} أشخاص}}",
     "profileBadgeAwardedBy": "من منحها",
     "profileBadgeRecipients": "المستلمون",
-    "profileBadgeMoreRecipients": "+{count} آخرون",
+    "profileBadgeMoreRecipients": "+{count} آخرين",
     "profileBadgeSemanticLabel": "شارة {name}",
     "profileBadgeFallbackSemanticLabel": "شارة",
     "profileBadgeFooterBody": "الشارات جوائز صغيرة يمكن لأي شخص إنشاؤها على Nostr. امنح واحدة لصديق أو لصانع محتوى أو لشخص أسعد يومك.",

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -10058,7 +10058,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String profileBadgeMoreRecipients(int count) {
-    return '+$count آخرون';
+    return '+$count آخرين';
   }
 
   @override

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -369,7 +369,15 @@ void main() {
       for (final file in arbFiles) {
         final arb = _readArb(file);
 
-        for (final key in _profileBadgeSheetKeys) {
+        final profileBadgeSheetKeys = {
+          ..._profileBadgeSheetKeys,
+          if (!_profileBadgeFallbackSemanticLabelEnglishLocales.any(
+            file.path.endsWith,
+          ))
+            'profileBadgeFallbackSemanticLabel',
+        };
+
+        for (final key in profileBadgeSheetKeys) {
           final value = arb[key];
 
           expect(
@@ -439,9 +447,6 @@ const _knownUntranslatedDebt = <String>{
   'videoMetadataC2paMissingNoteServiceUnavailable',
 };
 
-// profileBadgeFallbackSemanticLabel is deliberately absent: "Badge" is the
-// word several of these locales actually use, so matching English there is a
-// translation, not a gap.
 const _profileBadgeSheetKeys = <String>{
   'profileBadgeAwardedBy',
   'profileBadgeRecipients',
@@ -449,6 +454,16 @@ const _profileBadgeSheetKeys = <String>{
   'profileBadgeSemanticLabel',
   'profileBadgeFooterBody',
   'profileBadgeFooterLink',
+};
+
+// "Badge" is the word these languages actually use, so matching English here
+// is a translation rather than a gap. Every other locale localizes the noun.
+const _profileBadgeFallbackSemanticLabelEnglishLocales = <String>{
+  'app_de.arb',
+  'app_fil.arb',
+  'app_fr.arb',
+  'app_it.arb',
+  'app_nl.arb',
 };
 
 const _signatureVerificationKeys = <String>{


### PR DESCRIPTION
Closes #7024

## Description

The profile badge sheet was only translated for `ms`, `ur`, `vi`, and `zh`. In the other 17 locales its section titles and overflow counter rendered in English — a German user opening a badge saw "Awarded by", "Recipients", and "+3 more" sitting between fully translated copy. The two screen-reader labels had the same gap, so VoiceOver/TalkBack announced "Scene Stealer badge" in every language.

This fills in `profileBadgeAwardedBy`, `profileBadgeRecipients`, `profileBadgeMoreRecipients`, `profileBadgeSemanticLabel`, and `profileBadgeFallbackSemanticLabel` for all 17.

Each locale reuses the badge vocabulary its own badge-detail screen already established rather than picking a fresh word. The takeover follow-up also aligned the few mismatches caught in review:

- Bulgarian now uses `Значка`/`Значки` consistently, including feminine agreement for `Раздадена от`.
- Arabic, Bulgarian, and Romanian now match the locale's existing `metadataMoreReposters` shape for the same `+{count} more` source copy.
- Portuguese and Indonesian keep `Badge`, matching the rest of each locale's badge feature copy.

`profileBadgeFallbackSemanticLabel` stays "Badge" in `de`, `fil`, `fr`, `id`, `it`, `nl`, and `pt`. That is the word those languages actually use for it, so matching English there is a translation rather than a leftover. The ARB consistency test covers that key for every other locale, and guards the full sheet instead of only its footer.

## Out of Scope

- `libraryDraftInProgressBadge` ("In progress") is untranslated in **all 21** locales. Different feature (library drafts), left alone.
- Pre-existing terminology splits inside single locales, untouched because changing them is a copy decision rather than a gap: `de` says "Abzeichen" for the screen title but "Badge" elsewhere, `sv` mixes "Märken" and "badge", and `fr` mixes "Insignes" and "badge".

## Verification

- `flutter gen-l10n`
- `dart format lib/l10n test/l10n`
- `mise exec -- dart format lib test integration_test`
- `flutter test test/l10n/arb_consistency_test.dart`
- `flutter analyze lib/l10n test/l10n`
- Pre-push hook: merge-conflict check, analyzer, and changed-file l10n test passed.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
