### PR TITLE
test(recorder): cover stop-motion mode with Maestro E2E

### DIFF
--- a/mobile/e2e/maestro/README.md
+++ b/mobile/e2e/maestro/README.md
@@ -43,14 +43,15 @@ dispatches, and GitHub CI does not cover this lane at all.
 
 ## The recorder flows
 
-Two of the recorder's five modes are covered, one flow each:
+Three of the recorder's five modes are covered, one flow each:
 
 | Flow | Mode | Covers |
 |---|---|---|
 | `flows/captureModeFlow.yaml` | capture | open, drive the control rail, record a clip, delete it, close |
 | `flows/lipSyncModeFlow.yaml` | lip-sync | open, drive the control rail, prove the shutter refuses without a sound and records with one, delete the clip, close |
+| `flows/stopMotionModeFlow.yaml` | stop-motion | open, drive the control rail, shoot two stills, undo them, close |
 
-Classic, stop-motion and upload are not covered yet.
+Classic and upload are not covered yet.
 
 The gate is lip-sync's own behaviour and it takes **both** shutter tests to
 cover it. `lipSyncModeAudioGate` proves the shutter refuses with no sound
@@ -65,20 +66,21 @@ picker's **Divine** tab, whose entries come from
 is the relay-backed one, and it is the live-content dependency this file names
 elsewhere as the suite's main source of flakiness — no flow goes near it.
 
-Every file in both flows has been run green on a Galaxy SM-S942B. The lip-sync
-tests were driven test-by-test against an already-signed-in app rather than
-through `lipSyncModeFlow.yaml` end to end, because the device runs a German
-system locale and `loginFreshInstall`'s `clearState` drops the per-app English
-override mid-run (see step 0b). The login and `removeKeys` bookends of that
-flow are the same ones `captureModeFlow` already runs.
+Every file in all three flows has been run green on a Galaxy SM-S942B. The
+lip-sync and stop-motion tests were driven test-by-test against an
+already-signed-in app rather than through their flow end to end, because the
+device runs a German system locale and `loginFreshInstall`'s `clearState` drops
+the per-app English override mid-run (see step 0b). The login and `removeKeys`
+bookends of both flows are the same ones `captureModeFlow` already runs.
 
-Neither is in **`smoke.yaml`**, and both are deliberately off the iOS lane:
+None of them is in **`smoke.yaml`**, and all three are deliberately off the iOS
+lane:
 
 - **They need real camera hardware.** Without a camera the bloc never reports
   `isCameraInitialized`, the record button stays disabled, and the recording
-  test hangs on its first wait. The lens switch in the shared rail needs one
-  too. The iOS Simulator has no camera at all; an Android emulator's virtual
-  scene camera is enough, and a device is best.
+  and shutter tests hang on their first wait. The lens switch in the shared
+  rail needs one too. The iOS Simulator has no camera at all; an Android
+  emulator's virtual scene camera is enough, and a device is best.
 - **The `…Open` tests alone** — the chrome assertions — do pass without a
   camera, because the viewfinder falls back to a placeholder and every control
   still renders. So does `lipSyncModeAudioGate`: the blocked shutter is
@@ -89,43 +91,80 @@ Run one against a booted Android emulator or a connected device:
 ```bash
 maestro --device <serial> test e2e/maestro/flows/captureModeFlow.yaml
 maestro --device <serial> test e2e/maestro/flows/lipSyncModeFlow.yaml
+maestro --device <serial> test e2e/maestro/flows/stopMotionModeFlow.yaml
 ```
 
 ### Reading state off an icon-only control
 
-`utils/driveCaptureRail.yaml` asserts the icon-only rail controls by their
-Semantics `value` (`.*Square.*`, `.*3 seconds.*`, `.*Front camera.*`). That
-works: Flutter folds `value` into the Android content description, and Maestro
-matches against it — confirmed on device. Two things follow, both worth
-knowing before writing more recorder selectors:
+The cycling rail controls are asserted by their Semantics `value`
+(`.*Square.*`, `.*3 seconds.*`, `.*Front camera.*`). That works: Flutter folds
+`value` into the Android content description, and Maestro matches against it —
+confirmed on device. Three things follow, all worth knowing before writing more
+recorder selectors:
 
 - **A selector may combine `id` with `text`**, and here it must: "Off" is the
   value of the flash control *and* the timer control — and, once its sheet is
   open, of the stabilization menu's own first row.
-- **`selected: true` is readable too**, which is what `assertCaptureMode` and
-  `assertLipSyncMode` use to prove the right mode is armed. The mode wheel
-  renders an entry for every mode in every mode, so a bare
-  `id: camera_mode_capture` would pass on the Upload tab just as happily.
+- **`selected: true` is readable too**, which is what `assertCaptureMode`,
+  `assertLipSyncMode` and `assertStopMotionMode` use to prove the right mode is
+  armed. The mode wheel renders an entry for every mode in every mode, so a
+  bare `id: camera_mode_capture` would pass on the Upload tab just as happily.
+- **`checked:` is how an on/off control reads.** The ghost-frame and grid
+  toggles carry a Semantics `toggled` flag rather than a `value`, and Flutter
+  maps that to the accessibility node's checked state, so
+  `stopMotionModeControls` drives them with `checked: true` / `checked: false`.
+  **Maestro does not print the flag in its run log** — the line reads
+  `Assert that id: camera_ghost_frame_button is visible`, exactly as it would
+  if the flag had been dropped, unlike `text:` and `enabled:` which both show
+  up. It is genuinely applied: asserting `checked: true` against the toggle in
+  its off state fails on device. Don't "fix" a `checked:` selector because the
+  log looks bare; prove it with a deliberately-wrong assertion instead.
 
-### What the two viewfinders share, and what tells them apart
+### What the three viewfinders share, and what tells them apart
 
-Lip-sync *is* the capture stack: same close, next, delete, library button,
-record button, and the same five rail controls in the same order, because it
-declares the same countdown-timer and stabilization support. The **only**
-element that differs is the sound picker it puts in the top bar's center slot,
-which capture mode leaves empty.
+All three *are* the capture stack: same close, next, delete, library button and
+record button. Only the top bar's center slot and the control rail differ.
 
-That makes the two asserts a subset trap. Assert only what each mode renders
-and `assertCaptureMode` passes on the Lip Sync tab, because everything it
-checks is there. So it asserts `audio_chip` *absent*, and that one line is what
-keeps it honest. `video_editor_audio_chip_test.dart` pins the anchor itself at
-the widget level.
+| | capture | lip-sync | stop-motion |
+|---|---|---|---|
+| `audio_chip` (center slot) | — | ✅ | — |
+| `camera_stop_motion_budget` (center slot) | — | — | ✅ |
+| `camera_flash_button` | ✅ | ✅ | ✅ |
+| `camera_aspect_ratio_button` | ✅ | ✅ | ✅ |
+| `camera_switch_camera_button` | ✅ | ✅ | ✅ |
+| `camera_timer_button` | ✅ | ✅ | — |
+| `camera_stabilization_button` | ✅ | ✅ | — |
+| `camera_ghost_frame_button` | — | — | ✅ |
+| `camera_grid_button` | — | — | ✅ |
 
-Because the rail is shared, both modes also *drive* it with the same file —
-`utils/driveCaptureRail.yaml`. Each mode's `…Controls` test is that util plus
-its own mode assert. Modes that render a different set (stop-motion adds a
-ghost-frame and grid toggle and drops timer and stabilization) will want their
-own sequence rather than this one with parts skipped.
+Lip-sync and capture are the subset trap. Their rails are identical, so assert
+only what each mode renders and `assertCaptureMode` passes on the Lip Sync tab,
+because everything it checks is there. It asserts `audio_chip` *absent*, and
+that one line is what keeps it honest. `video_editor_audio_chip_test.dart` pins
+the anchor itself at the widget level.
+
+Stop-motion is not that case, and its `assertNotVisible` block is there for a
+different reason. Its rail and capture's are **disjoint**, not nested — capture
+has timer and stabilization, stop-motion has ghost frame and grid — so each
+assert already fails on the other's viewfinder on the rail alone. What settles
+which viewfinder is up before either gets that far is the mode wheel's
+`selected` state, asserted on the first line of all three files.
+
+So the pairs those two asserts carry — `assertStopMotionMode` pinning timer and
+stabilization absent, `assertCaptureMode` pinning ghost frame, grid and the
+budget absent — are **leak guards**, not mode separators: they fail when a
+control starts rendering in a mode that does not declare it, which nothing else
+in the suite would catch. `video_recorder_capture_actions_test.dart` pins the
+same split at the widget level.
+
+Because flash, aspect ratio and the lens switch are unconditional, all three
+modes *drive* them with the same three files — `utils/driveAspectRatioControl`,
+`utils/driveLensControl`, `utils/driveFlashControl`. Capture and lip-sync wrap
+those in `utils/driveCaptureRail.yaml`, which adds the timer and stabilization
+controls they alone render; `stopMotionModeControls` calls the three directly
+and adds ghost frame and grid. Each mode's `…Controls` test is a rail sequence
+plus its own mode assert. A mode with yet another set composes the per-control
+utils in its own order rather than skipping parts of someone else's.
 
 ### Things the flows depend on that are easy to break by accident
 
@@ -136,29 +175,34 @@ Shared:
   whose buttons are OS-localized copy. Note the relaunch deliberately does
   *not* clear state: on Android `pm clear` wipes the encrypted preferences the
   Nostr key lives in and would sign the account back out mid-flow.
-- **Hardware for two of the five rail controls.** Flash and stabilization are
-  driven behind an `enabled: true` guard, because both are disabled outright
-  when the active lens has no flash unit or reports a single stabilization
-  mode. Where the feature is missing the block prints `SKIPPED` rather than
-  failing — check the run output before reading a green run as full rail
-  coverage. Both were exercised for real on the SM-S942B's back lens.
-- **Everything the recorder persists, which is more than the mode.** Three
-  preferences survive a run and each is asserted as a default somewhere:
-  `camera_last_used_recorder_mode` (absent ⇒ Capture), `camera_last_used_lens`
-  (absent ⇒ back, which the rail asserts first) and
-  `camera_last_used_stabilization`. Run from the top this is handled —
-  `loginFreshInstall`'s `clearState` wipes all three — but a standalone run
-  inherits whatever the last session left. A phone whose last session used the
-  front lens fails the rail on its first `.*Back camera.*`, and the two flows
-  leave the mode key on different values, so a `captureModeFlow` run straight
-  after a lip-sync one, skipping the login step, opens on the wrong mode. When
-  iterating standalone, either reset the keys or start from a flow that clears
-  state.
+- **Hardware for the guarded rail controls.** Flash (all three modes) and
+  stabilization (capture and lip-sync) are driven behind an `enabled: true`
+  guard, because both are disabled outright when the active lens has no flash
+  unit or reports a single stabilization mode. Where the feature is missing the
+  block prints `SKIPPED` rather than failing — check the run output before
+  reading a green run as full rail coverage. Both were exercised for real on
+  the SM-S942B's back lens.
+- **Everything the recorder persists, which is more than the mode.** Four
+  preferences survive a run and every one of them is asserted as a default
+  somewhere: `camera_last_used_recorder_mode` (absent ⇒ Capture),
+  `camera_last_used_lens` (absent ⇒ back, which the rail asserts first),
+  `camera_last_used_stabilization` and `camera_grid_lines_enabled` (absent ⇒
+  on, which `stopMotionModeControls` asserts first). Run from the top this is
+  handled — `loginFreshInstall`'s `clearState` wipes all four — but a
+  standalone run inherits whatever the last session left. A phone whose last
+  session used the front lens fails the rail on its first `.*Back camera.*`,
+  and the three flows leave the mode key on different values, so a
+  `captureModeFlow` run straight after a lip-sync or stop-motion one, skipping
+  the login step, opens on the wrong mode. When iterating standalone, either
+  reset the keys or start from a flow that clears state.
 - **An empty session when the rail is driven.** The aspect-ratio control is
   disabled once the session holds a clip, because clips of mixed ratios cannot
   share an editor timeline. `captureModeControls` therefore runs before the
   recording tests; lip-sync gets this for free, since nothing in that flow
-  records.
+  records. Stop-motion stills are not clips until the assemble, so its rail
+  stays live mid-session — but `stopMotionModeControls` closes on its mode
+  assert, which pins next and undo absent, so it needs the empty session
+  anyway and the flow keeps the same order.
 
 Capture only:
 
@@ -171,6 +215,8 @@ Capture only:
 - **Tap-to-toggle recording.** `HoldToRecordPreferenceService` defaults to
   false. On a device where a previous session turned hold-to-record on, the
   first tap does nothing and `captureModeRecordClip` fails on its wait.
+  Stop-motion is immune: the record button disables long-press outright for any
+  mode that captures stills.
 
 Lip-sync only:
 
@@ -209,9 +255,35 @@ Lip-sync only:
   needed: the snackbar proves the gate *fired*, the still-visible
   `camera_close_button` proves no recording started behind it.
 
+Stop-motion only:
+
+- **Reaching the mode at all.** `openStopMotionMode` selects rather than
+  asserts, for the same reason `openLipSyncMode` does. It taps the entry
+  directly instead of hopping: Stop Motion sits next to Capture, so the lazy
+  `ListView` has it built in both states this flow can arrive in. From Classic
+  or Upload it would not be, same trap as everywhere else on this wheel.
+- **The ghost-frame snackbar.** Each toggle raises a 4-second confirmation
+  banner that floats over the bottom of the screen — the record and undo
+  buttons included — so the controls test waits it out before handing over to
+  the shutter test.
+- **Undo leaving nothing behind.** Stills are written to the clip library as
+  they are shot (the session is upserted on every frame, not on the assemble),
+  so `stopMotionModeUndoFrame` is load-bearing teardown: undoing the last still
+  is what drops the session's library row again.
+- **Two stills, not one.** `stopMotionModeCaptureFrame` shoots twice and
+  `stopMotionModeUndoFrame` undoes twice, with the first undo asserting the
+  chrome is *still* up. That pairing is the only evidence the session
+  accumulates rather than overwriting — shortening either test to one tap
+  silently removes it. Verified the other way round on device: shoot once, undo
+  once, and that assertion goes red.
+
 Account creation is a precondition, not part of what is tested. The recorder
 route itself is public (`appRouterRedirect` exempts it), but the only way in is
 the feed's camera button and the feed is not public.
+
+The stop-motion assemble step — "next", which collects the stills into a clip
+and opens the editor — is out of scope on purpose: it leaves the recorder, and
+the editor has no coverage to hand off to yet.
 
 ---
 

--- a/mobile/e2e/maestro/asserts/assertCaptureMode.yaml
+++ b/mobile/e2e/maestro/asserts/assertCaptureMode.yaml
@@ -36,6 +36,20 @@ appId: co.openvine.app
 - assertNotVisible:
     id: audio_chip
 
+# What stop-motion adds and capture does not render: the two `capturesStills`
+# toggles and the shot budget in that same center slot. Unlike the line above
+# these are not load-bearing for telling the screens apart — the two rails are
+# disjoint, so this file already fails on a stop-motion viewfinder at
+# `camera_timer_button`. They are a leak guard, the mirror of the pair
+# assertStopMotionMode carries: a control starting to render in a mode that
+# does not declare it fails a run rather than passing quietly.
+- assertNotVisible:
+    id: camera_ghost_frame_button
+- assertNotVisible:
+    id: camera_grid_button
+- assertNotVisible:
+    id: camera_stop_motion_budget
+
 # Nothing recorded yet. Both buttons sit inside an AnimatedOpacity, and
 # RenderAnimatedOpacity drops its child from the semantics tree at opacity 0 —
 # so "not visible" here means "no clip in the session", not "scrolled away".

--- a/mobile/e2e/maestro/asserts/assertStopMotionFrameCaptured.yaml
+++ b/mobile/e2e/maestro/asserts/assertStopMotionFrameCaptured.yaml
@@ -1,0 +1,28 @@
+appId: co.openvine.app
+---
+# The stop-motion session holds at least one still: the top bar reveals its
+# assemble-and-continue button and the shutter row reveals undo-last-still.
+#
+# Both are gated on `stopMotionFrameCount > 0` through an AnimatedOpacity,
+# which drops its child from the semantics tree at opacity 0. Their presence is
+# therefore the assertion that the shutter actually produced a still — the
+# budget's count moves too, but its exact value is a function of the maximum
+# clip length and the output frame rate, which is not what this is testing.
+#
+# The wait covers the native capture, which takes hundreds of milliseconds and
+# longer on a cold camera.
+- extendedWaitUntil:
+    visible:
+      id: camera_next_button
+    timeout: 15000
+- assertVisible:
+    id: camera_delete_clip_button
+
+# Still on the idle viewfinder. Stop-motion never enters the recording state,
+# so unlike capture mode the top bar keeps its close/next row rather than
+# swapping in the recording-progress bar. A tap that started a video recording
+# instead of taking a still would fail here.
+- assertVisible:
+    id: camera_close_button
+- assertVisible:
+    id: camera_stop_motion_budget

--- a/mobile/e2e/maestro/asserts/assertStopMotionMode.yaml
+++ b/mobile/e2e/maestro/asserts/assertStopMotionMode.yaml
@@ -4,8 +4,9 @@ appId: co.openvine.app
 # yet.
 #
 # Stop-motion renders the capture stack, so most of this is the same chrome
-# assertCaptureMode pins. What separates the two screens is the control rail —
-# see the two blocks below.
+# assertCaptureMode pins. The mode wheel's `selected` state below is what
+# settles which viewfinder is up; the rail blocks pin what this mode does and
+# does not render.
 
 # Mode wheel with Stop Motion armed. `selected` is load-bearing: the wheel
 # renders an entry for every mode in every mode, so a bare id assertion here
@@ -41,9 +42,12 @@ appId: co.openvine.app
     id: camera_switch_camera_button
 
 # And the two capture mode has that this mode does not: stop-motion declares
-# neither `supportsCountdownTimer` nor `supportsVideoStabilization`. Without
-# this pair, assertCaptureMode's rail set is a subset of this one and both
-# asserts would pass on either screen.
+# neither `supportsCountdownTimer` nor `supportsVideoStabilization`. This pair
+# is a leak guard, not what separates the two screens — the mode wheel above
+# already does that, and the two rails are disjoint rather than nested, so
+# assertCaptureMode fails here on `camera_timer_button` regardless. What it
+# catches is a control starting to render in a mode that does not declare it,
+# which nothing else in the suite would.
 - assertNotVisible:
     id: camera_timer_button
 - assertNotVisible:

--- a/mobile/e2e/maestro/asserts/assertStopMotionMode.yaml
+++ b/mobile/e2e/maestro/asserts/assertStopMotionMode.yaml
@@ -1,0 +1,58 @@
+appId: co.openvine.app
+---
+# Stop-motion mode, idle: the viewfinder chrome is up and no still is captured
+# yet.
+#
+# Stop-motion renders the capture stack, so most of this is the same chrome
+# assertCaptureMode pins. What separates the two screens is the control rail —
+# see the two blocks below.
+
+# Mode wheel with Stop Motion armed. `selected` is load-bearing: the wheel
+# renders an entry for every mode in every mode, so a bare id assertion here
+# passes just as happily on the Capture tab.
+- assertVisible:
+    id: camera_mode_stopMotion
+    selected: true
+- assertVisible:
+    id: camera_record_button
+- assertVisible:
+    id: camera_close_button
+- assertVisible:
+    id: camera_library_button
+
+# The shot budget, in the top-bar slot capture mode leaves empty. Stop-motion
+# never enters the recording state, so the duration progress bar capture mode
+# shows while recording never appears; this counts stills instead. Its node
+# carries the remaining-shots count as its label.
+- assertVisible:
+    id: camera_stop_motion_budget
+
+# Control rail, top to bottom. Ghost frame and grid are rendered only by modes
+# that capture stills.
+- assertVisible:
+    id: camera_flash_button
+- assertVisible:
+    id: camera_ghost_frame_button
+- assertVisible:
+    id: camera_grid_button
+- assertVisible:
+    id: camera_aspect_ratio_button
+- assertVisible:
+    id: camera_switch_camera_button
+
+# And the two capture mode has that this mode does not: stop-motion declares
+# neither `supportsCountdownTimer` nor `supportsVideoStabilization`. Without
+# this pair, assertCaptureMode's rail set is a subset of this one and both
+# asserts would pass on either screen.
+- assertNotVisible:
+    id: camera_timer_button
+- assertNotVisible:
+    id: camera_stabilization_button
+
+# Nothing captured yet. Both buttons sit inside an AnimatedOpacity, and
+# RenderAnimatedOpacity drops its child from the semantics tree at opacity 0 —
+# so "not visible" here means "no still in the session", not "scrolled away".
+- assertNotVisible:
+    id: camera_next_button
+- assertNotVisible:
+    id: camera_delete_clip_button

--- a/mobile/e2e/maestro/flows/stopMotionModeFlow.yaml
+++ b/mobile/e2e/maestro/flows/stopMotionModeFlow.yaml
@@ -1,0 +1,49 @@
+appId: co.openvine.app
+---
+#Stop-motion journey: create an account, open the recorder on stop-motion,
+#drive its control rail, shoot two stills, undo them again, and sign the device
+#back out.
+#
+# Account creation is a precondition, not part of what is under test. The
+# recorder route itself is public — appRouterRedirect exempts it — but the only
+# way into it is the feed's camera button, and the feed is not public: an
+# unauthenticated launch redirects to Welcome.
+#
+# Requires real camera hardware for stopMotionModeCaptureFrame; see that file.
+#
+# The assemble step — "next", which collects the stills into a clip and opens
+# the editor — is deliberately out of scope. It leaves the recorder for the
+# editor, and the editor has no E2E coverage to hand off to yet.
+
+- runFlow: ../tests/loginFreshInstall.yaml
+
+# Relaunch with camera and microphone pre-granted. Otherwise the first camera
+# tap raises the native OS permission dialog, whose buttons are OS-localized
+# copy that no selector should depend on.
+#
+# Deliberately no clearState: on Android `pm clear` wipes the encrypted
+# preferences the Nostr key lives in, which would sign the account straight
+# back out. (The iOS keychain survives it — the platforms disagree here, so
+# the flow takes the option that works on both.)
+- launchApp:
+    permissions:
+      all: allow
+- extendedWaitUntil:
+    visible:
+      id: camera_button
+    timeout: 60000
+
+- runFlow: ../tests/stopMotionModeOpen.yaml
+
+# Selecting a mode persists it, so this second open finds Stop Motion already
+# armed rather than Capture. openStopMotionMode taps the entry either way.
+- runFlow: ../utils/openStopMotionMode.yaml
+- runFlow: ../tests/stopMotionModeControls.yaml
+- runFlow: ../tests/stopMotionModeCaptureFrame.yaml
+- runFlow: ../tests/stopMotionModeUndoFrame.yaml
+
+# Leave the recorder before teardown: removeKeys drives Settings from the
+# profile tab, which the full-screen recorder covers.
+- tapOn:
+    id: camera_close_button
+- runFlow: ../tests/removeKeys.yaml

--- a/mobile/e2e/maestro/tests/stopMotionModeCaptureFrame.yaml
+++ b/mobile/e2e/maestro/tests/stopMotionModeCaptureFrame.yaml
@@ -14,8 +14,8 @@ tags:
 #
 # Hold-to-record does not apply here: the record button disables long-press
 # whenever the mode captures stills, so the `HoldToRecordPreferenceService`
-# preference captureModeRecordClip has to warn about cannot affect this one
-# either way.
+# preference that captureModeRecordClip has to warn about cannot affect this
+# one either way.
 #Steps:
 # 1. Tap the shutter: a still lands in the session
 # 2. Tap it again: the session takes a second still

--- a/mobile/e2e/maestro/tests/stopMotionModeCaptureFrame.yaml
+++ b/mobile/e2e/maestro/tests/stopMotionModeCaptureFrame.yaml
@@ -1,0 +1,44 @@
+appId: co.openvine.app
+tags:
+  - recorder
+---
+#TC to capture stills in stop-motion mode,
+# given the recorder is open on an idle stop-motion viewfinder,
+# validate a shutter tap adds a still to the session without ever entering the
+# recording state.
+#
+# Needs real camera hardware. Without it the bloc never reports
+# `isCameraInitialized`, the record button stays disabled, and the tap does
+# nothing — so this cannot pass on the iOS Simulator. Run it on an Android
+# emulator (which has a virtual scene camera) or on a device.
+#
+# Hold-to-record does not apply here: the record button disables long-press
+# whenever the mode captures stills, so the `HoldToRecordPreferenceService`
+# preference captureModeRecordClip has to warn about cannot affect this one
+# either way.
+#Steps:
+# 1. Tap the shutter: a still lands in the session
+# 2. Tap it again: the session takes a second still
+
+# 1. One tap, one still.
+- tapOn:
+    id: camera_record_button
+- runFlow: ../asserts/assertStopMotionFrameCaptured.yaml
+
+# 2. A second still, which is what separates "the shutter works" from "the
+# session accumulates".
+#
+# There is nothing new to assert on this screen — next and undo are already
+# revealed by the first still, and the only element that moves with the count
+# is the budget label, whose value is a function of the maximum clip length and
+# the output frame rate. So the count is proven one layer down instead:
+# stopMotionModeUndoFrame has to undo *twice* to empty the session, and its
+# first undo asserts the chrome is still up. Shooting once here turns that
+# assertion red.
+#
+# The capture handler is `droppable()`, so a tap arriving while the native
+# capture is still in flight is discarded rather than queued. Waiting for the
+# first still to land above is what makes this tap count.
+- tapOn:
+    id: camera_record_button
+- runFlow: ../asserts/assertStopMotionFrameCaptured.yaml

--- a/mobile/e2e/maestro/tests/stopMotionModeControls.yaml
+++ b/mobile/e2e/maestro/tests/stopMotionModeControls.yaml
@@ -7,15 +7,16 @@ tags:
 # validate each control actually changes recorder state, and leave every one
 # of them back on its default.
 #
-# Two kinds of readable evidence, both off the controls' own Semantics:
-# - the cycling controls (aspect ratio, lens, flash) announce a `value`, which
-#   Flutter folds into the Android content description — same mechanism
-#   captureModeControls uses, confirmed on device;
-# - the two on/off controls (ghost frame, grid) carry a `toggled` flag, which
-#   Flutter maps to the accessibility node's checked state, so they are driven
-#   with `checked:` rather than `text:`. That selector is new to this suite —
-#   if it turns out not to resolve, the fallback is the ghost toggle's
-#   confirmation snackbar, which is copy and only works on an English UI.
+# Three of the five controls here — aspect ratio, lens and flash — are the
+# unconditional ones every rail renders, so they are the same per-control utils
+# driveCaptureRail sequences, in the same order. What is local to this file is
+# the pair capture mode does not render: the ghost-frame and grid toggles.
+#
+# Those two carry a Semantics `toggled` flag rather than a `value`, which
+# Flutter maps to the accessibility node's checked state, so they are driven
+# with `checked:` rather than `text:`. That selector is new to this suite — if
+# it turns out not to resolve, the fallback is the ghost toggle's confirmation
+# snackbar, which is copy and only works on an English UI.
 #
 # Preconditions beyond an open viewfinder:
 # - **Real camera hardware**, for the lens switch. See
@@ -24,17 +25,11 @@ tags:
 #   (`camera_grid_lines_enabled`) and defaults to on for grid-supporting modes,
 #   so step 2 reads it as on. Run from the top this is safe —
 #   loginFreshInstall's clearState wipes the key.
-#
-# Unlike capture mode, an empty session is *not* required: the aspect-ratio
-# control is disabled by clips, and stop-motion stills do not become a clip
-# until the assemble on "next". The order below still matches capture mode's,
-# because the shutter tests want a rail on defaults, not the other way round.
-#
-# Flash is driven behind an `enabled` guard, because it is disabled outright on
-# hardware whose active lens has no flash unit. An unguarded tap-and-assert
-# there would go green or red on the phone rather than on the code. A guarded
-# block prints "SKIPPED" in the run output, so a skipped control is visible
-# rather than silently counted as covered.
+# - **An empty session.** The rail itself does not need one, unlike capture
+#   mode's: the aspect-ratio control is disabled by clips, and stop-motion
+#   stills do not become a clip until the assemble on "next". The mode assert
+#   this closes on does, though — it pins next and undo absent — so the flow
+#   still runs this before the shutter tests.
 #Steps:
 # 1. Ghost frame: off -> on -> off
 # 2. Grid: on -> off -> on
@@ -84,78 +79,13 @@ tags:
     timeout: 10000
 
 # 3. Aspect ratio flips between two states.
-- assertVisible:
-    id: camera_aspect_ratio_button
-    text: ".*Vertical.*"
-- tapOn:
-    id: camera_aspect_ratio_button
-- extendedWaitUntil:
-    visible:
-      id: camera_aspect_ratio_button
-      text: ".*Square.*"
-    timeout: 10000
-- tapOn:
-    id: camera_aspect_ratio_button
-- extendedWaitUntil:
-    visible:
-      id: camera_aspect_ratio_button
-      text: ".*Vertical.*"
-    timeout: 10000
+- runFlow: ../utils/driveAspectRatioControl.yaml
 
-# 4. Lens switch. Slower than the others — the native camera rebinds and the
-# preview remounts on a fresh texture — so it gets a longer wait.
-- assertVisible:
-    id: camera_switch_camera_button
-    text: ".*Back camera.*"
-- tapOn:
-    id: camera_switch_camera_button
-- extendedWaitUntil:
-    visible:
-      id: camera_switch_camera_button
-      text: ".*Front camera.*"
-    timeout: 20000
-- tapOn:
-    id: camera_switch_camera_button
-- extendedWaitUntil:
-    visible:
-      id: camera_switch_camera_button
-      text: ".*Back camera.*"
-    timeout: 20000
+# 4. Lens switch.
+- runFlow: ../utils/driveLensControl.yaml
 
-# 5. Flash. Guarded: the control is disabled when the active lens reports no
-# flash unit (`hasFlash`) — true of most emulators, and of the front lens on
-# many phones. Selectors pin `id` as well as `text` for the same reason
-# captureModeControls does: "Off" is not a unique value on this screen.
-- runFlow:
-    when:
-      visible:
-        id: camera_flash_button
-        enabled: true
-    commands:
-      - assertVisible:
-          id: camera_flash_button
-          text: ".*Off.*"
-      - tapOn:
-          id: camera_flash_button
-      - extendedWaitUntil:
-          visible:
-            id: camera_flash_button
-            text: ".*On.*"
-          timeout: 10000
-      - tapOn:
-          id: camera_flash_button
-      - extendedWaitUntil:
-          visible:
-            id: camera_flash_button
-            text: ".*Auto.*"
-          timeout: 10000
-      - tapOn:
-          id: camera_flash_button
-      - extendedWaitUntil:
-          visible:
-            id: camera_flash_button
-            text: ".*Off.*"
-          timeout: 10000
+# 5. Flash, if the active lens has a unit.
+- runFlow: ../utils/driveFlashControl.yaml
 
 # The ghost-frame toggle raises a 4-second confirmation snackbar per tap, and
 # it floats over the bottom of the screen — the record and undo buttons

--- a/mobile/e2e/maestro/tests/stopMotionModeControls.yaml
+++ b/mobile/e2e/maestro/tests/stopMotionModeControls.yaml
@@ -1,0 +1,174 @@
+appId: co.openvine.app
+tags:
+  - recorder
+---
+#TC to drive the stop-motion control rail,
+# given the recorder is open on an idle stop-motion viewfinder with no stills,
+# validate each control actually changes recorder state, and leave every one
+# of them back on its default.
+#
+# Two kinds of readable evidence, both off the controls' own Semantics:
+# - the cycling controls (aspect ratio, lens, flash) announce a `value`, which
+#   Flutter folds into the Android content description — same mechanism
+#   captureModeControls uses, confirmed on device;
+# - the two on/off controls (ghost frame, grid) carry a `toggled` flag, which
+#   Flutter maps to the accessibility node's checked state, so they are driven
+#   with `checked:` rather than `text:`. That selector is new to this suite —
+#   if it turns out not to resolve, the fallback is the ghost toggle's
+#   confirmation snackbar, which is copy and only works on an English UI.
+#
+# Preconditions beyond an open viewfinder:
+# - **Real camera hardware**, for the lens switch. See
+#   stopMotionModeCaptureFrame.
+# - **A grid that starts on.** The grid preference persists
+#   (`camera_grid_lines_enabled`) and defaults to on for grid-supporting modes,
+#   so step 2 reads it as on. Run from the top this is safe —
+#   loginFreshInstall's clearState wipes the key.
+#
+# Unlike capture mode, an empty session is *not* required: the aspect-ratio
+# control is disabled by clips, and stop-motion stills do not become a clip
+# until the assemble on "next". The order below still matches capture mode's,
+# because the shutter tests want a rail on defaults, not the other way round.
+#
+# Flash is driven behind an `enabled` guard, because it is disabled outright on
+# hardware whose active lens has no flash unit. An unguarded tap-and-assert
+# there would go green or red on the phone rather than on the code. A guarded
+# block prints "SKIPPED" in the run output, so a skipped control is visible
+# rather than silently counted as covered.
+#Steps:
+# 1. Ghost frame: off -> on -> off
+# 2. Grid: on -> off -> on
+# 3. Aspect ratio: Vertical -> Square -> Vertical
+# 4. Camera: Back -> Front -> Back
+# 5. Flash (if present): Off -> On -> Auto -> Off
+
+# 1. Ghost frame (onion-skin). Not persisted, so it always starts off.
+- assertVisible:
+    id: camera_ghost_frame_button
+    checked: false
+- tapOn:
+    id: camera_ghost_frame_button
+- extendedWaitUntil:
+    visible:
+      id: camera_ghost_frame_button
+      checked: true
+    timeout: 10000
+# Restore. Leaving it on is not just untidy: the overlay draws the previous
+# still over the live preview, which makes a failure screenshot from any later
+# test much harder to read.
+- tapOn:
+    id: camera_ghost_frame_button
+- extendedWaitUntil:
+    visible:
+      id: camera_ghost_frame_button
+      checked: false
+    timeout: 10000
+
+# 2. Grid overlay.
+- assertVisible:
+    id: camera_grid_button
+    checked: true
+- tapOn:
+    id: camera_grid_button
+- extendedWaitUntil:
+    visible:
+      id: camera_grid_button
+      checked: false
+    timeout: 10000
+- tapOn:
+    id: camera_grid_button
+- extendedWaitUntil:
+    visible:
+      id: camera_grid_button
+      checked: true
+    timeout: 10000
+
+# 3. Aspect ratio flips between two states.
+- assertVisible:
+    id: camera_aspect_ratio_button
+    text: ".*Vertical.*"
+- tapOn:
+    id: camera_aspect_ratio_button
+- extendedWaitUntil:
+    visible:
+      id: camera_aspect_ratio_button
+      text: ".*Square.*"
+    timeout: 10000
+- tapOn:
+    id: camera_aspect_ratio_button
+- extendedWaitUntil:
+    visible:
+      id: camera_aspect_ratio_button
+      text: ".*Vertical.*"
+    timeout: 10000
+
+# 4. Lens switch. Slower than the others — the native camera rebinds and the
+# preview remounts on a fresh texture — so it gets a longer wait.
+- assertVisible:
+    id: camera_switch_camera_button
+    text: ".*Back camera.*"
+- tapOn:
+    id: camera_switch_camera_button
+- extendedWaitUntil:
+    visible:
+      id: camera_switch_camera_button
+      text: ".*Front camera.*"
+    timeout: 20000
+- tapOn:
+    id: camera_switch_camera_button
+- extendedWaitUntil:
+    visible:
+      id: camera_switch_camera_button
+      text: ".*Back camera.*"
+    timeout: 20000
+
+# 5. Flash. Guarded: the control is disabled when the active lens reports no
+# flash unit (`hasFlash`) — true of most emulators, and of the front lens on
+# many phones. Selectors pin `id` as well as `text` for the same reason
+# captureModeControls does: "Off" is not a unique value on this screen.
+- runFlow:
+    when:
+      visible:
+        id: camera_flash_button
+        enabled: true
+    commands:
+      - assertVisible:
+          id: camera_flash_button
+          text: ".*Off.*"
+      - tapOn:
+          id: camera_flash_button
+      - extendedWaitUntil:
+          visible:
+            id: camera_flash_button
+            text: ".*On.*"
+          timeout: 10000
+      - tapOn:
+          id: camera_flash_button
+      - extendedWaitUntil:
+          visible:
+            id: camera_flash_button
+            text: ".*Auto.*"
+          timeout: 10000
+      - tapOn:
+          id: camera_flash_button
+      - extendedWaitUntil:
+          visible:
+            id: camera_flash_button
+            text: ".*Off.*"
+          timeout: 10000
+
+# The ghost-frame toggle raises a 4-second confirmation snackbar per tap, and
+# it floats over the bottom of the screen — the record and undo buttons
+# included. Steps 2-5 usually outlast it, but not reliably: with flash skipped
+# and a quick lens rebind they can come in under four seconds, and then the
+# banner is still up when the next test taps the shutter.
+#
+# `waitForAnimationToEnd` runs its timeout out rather than returning early: it
+# waits for the screen to stop changing and the live camera preview never
+# does, which makes it the deterministic wait this needs.
+- waitForAnimationToEnd:
+    timeout: 4500
+
+# Everything back to default, so the tests after this one start where they
+# expect to.
+- runFlow: ../asserts/assertStopMotionMode.yaml

--- a/mobile/e2e/maestro/tests/stopMotionModeOpen.yaml
+++ b/mobile/e2e/maestro/tests/stopMotionModeOpen.yaml
@@ -1,0 +1,26 @@
+appId: co.openvine.app
+tags:
+  - recorder
+---
+#TC to open the video recorder in stop-motion mode,
+# given the user is signed in and on a feed surface,
+# validate the stop-motion viewfinder comes up with its own control set and
+# that closing it puts the user back on the feed.
+#Steps:
+# 1. Open the recorder and switch to Stop Motion: stop-motion mode is displayed
+# 2. Close the recorder: the user is back on the feed
+
+# 1. Open the recorder on stop-motion
+- runFlow: ../utils/openStopMotionMode.yaml
+
+# 2. Close it. The recorder is a full-screen push, so the bottom nav coming
+# back is what proves we left it — and the record button going away proves we
+# left it rather than stacking something on top.
+- tapOn:
+    id: camera_close_button
+- extendedWaitUntil:
+    visible:
+      id: camera_button
+    timeout: 15000
+- assertNotVisible:
+    id: camera_record_button

--- a/mobile/e2e/maestro/tests/stopMotionModeUndoFrame.yaml
+++ b/mobile/e2e/maestro/tests/stopMotionModeUndoFrame.yaml
@@ -1,0 +1,45 @@
+appId: co.openvine.app
+tags:
+  - recorder
+---
+#TC to undo captured stop-motion stills,
+# given the session holds the two stills stopMotionModeCaptureFrame shot,
+# validate undo drops one still per tap and the recorder returns to its empty
+# state.
+#
+# This is also the teardown for the recorder flow. Every still is written to
+# the clip library as it is shot — the session is upserted on each frame, not
+# on the assemble — so stills left behind survive the run and the next one
+# would start against a non-empty library. Undoing the last still drops the
+# session's library row again.
+#Steps:
+# 1. Tap undo: one still goes, the session chrome stays up
+# 2. Tap undo again: the last still goes and the empty state is restored
+
+# 1. Undo the second still. There is no confirmation dialog and no Undo
+# snackbar — unlike capture mode's clip delete, the stop-motion undo removes
+# the still and its file on the tap.
+#
+# The assertion is that next and undo are *still* there: they are gated on
+# `stopMotionFrameCount > 0`, so this is what proves the session held two
+# stills and that undo removed exactly one of them.
+- tapOn:
+    id: camera_delete_clip_button
+# Wait the fade out before asserting. Both buttons leave over a 220ms
+# AnimatedOpacity, so an assertVisible landing mid-fade would pass on a session
+# that just went empty — exactly the failure this step exists to catch.
+# `waitForAnimationToEnd` runs its timeout out here, because the live camera
+# preview never stops changing.
+- waitForAnimationToEnd:
+    timeout: 1000
+- runFlow: ../asserts/assertStopMotionFrameCaptured.yaml
+
+# 2. Undo the last one. next/undo drop back out of the semantics tree once the
+# session is empty.
+- tapOn:
+    id: camera_delete_clip_button
+- extendedWaitUntil:
+    notVisible:
+      id: camera_next_button
+    timeout: 15000
+- runFlow: ../asserts/assertStopMotionMode.yaml

--- a/mobile/e2e/maestro/utils/driveAspectRatioControl.yaml
+++ b/mobile/e2e/maestro/utils/driveAspectRatioControl.yaml
@@ -1,0 +1,30 @@
+appId: co.openvine.app
+---
+#Utility: flip the aspect-ratio control to Square and back, leaving it on its
+#default. Every mode that renders the control rail renders this one.
+#
+# The assertions read the control's Semantics `value`, which Flutter folds into
+# the Android content description / iOS accessibilityValue — see "Reading state
+# off an icon-only control" in e2e/maestro/README.md.
+#
+# Precondition the caller owns: **no clips in the session.** The control is
+# disabled once the session holds one, because clips of mixed ratios cannot
+# share an editor timeline.
+
+- assertVisible:
+    id: camera_aspect_ratio_button
+    text: ".*Vertical.*"
+- tapOn:
+    id: camera_aspect_ratio_button
+- extendedWaitUntil:
+    visible:
+      id: camera_aspect_ratio_button
+      text: ".*Square.*"
+    timeout: 10000
+- tapOn:
+    id: camera_aspect_ratio_button
+- extendedWaitUntil:
+    visible:
+      id: camera_aspect_ratio_button
+      text: ".*Vertical.*"
+    timeout: 10000

--- a/mobile/e2e/maestro/utils/driveCaptureRail.yaml
+++ b/mobile/e2e/maestro/utils/driveCaptureRail.yaml
@@ -4,6 +4,14 @@ appId: co.openvine.app
 #control rail (capture and lip-sync), drive every control and leave each one
 #back on its default.
 #
+# Three of the five controls are unconditional and are shared with every other
+# mode that renders a rail, so they live in their own utils and this file
+# sequences them. Timer and stabilization are rendered only by the modes that
+# declare `supportsCountdownTimer` / `supportsVideoStabilization`, so they stay
+# here. A mode with a different set composes the per-control utils in its own
+# order rather than calling this one with parts skipped —
+# `tests/stopMotionModeControls.yaml` is the worked example.
+#
 # The assertions read each control's Semantics `value`, which Flutter folds
 # into the Android content description / iOS accessibilityValue. That is the
 # only readable evidence a tap landed: the controls are icon-only, and what
@@ -34,23 +42,7 @@ appId: co.openvine.app
 # 5. Stabilization (if supported): Off -> some other mode -> Off
 
 # 1. Aspect ratio flips between two states.
-- assertVisible:
-    id: camera_aspect_ratio_button
-    text: ".*Vertical.*"
-- tapOn:
-    id: camera_aspect_ratio_button
-- extendedWaitUntil:
-    visible:
-      id: camera_aspect_ratio_button
-      text: ".*Square.*"
-    timeout: 10000
-- tapOn:
-    id: camera_aspect_ratio_button
-- extendedWaitUntil:
-    visible:
-      id: camera_aspect_ratio_button
-      text: ".*Vertical.*"
-    timeout: 10000
+- runFlow: driveAspectRatioControl.yaml
 
 # 2. Timer cycles through three states and wraps.
 - assertVisible:
@@ -80,62 +72,14 @@ appId: co.openvine.app
       text: ".*Off.*"
     timeout: 10000
 
-# 3. Lens switch. Slower than the other two — the native camera rebinds and
-# the preview remounts on a fresh texture — so it gets a longer wait.
-- assertVisible:
-    id: camera_switch_camera_button
-    text: ".*Back camera.*"
-- tapOn:
-    id: camera_switch_camera_button
-- extendedWaitUntil:
-    visible:
-      id: camera_switch_camera_button
-      text: ".*Front camera.*"
-    timeout: 20000
-- tapOn:
-    id: camera_switch_camera_button
-- extendedWaitUntil:
-    visible:
-      id: camera_switch_camera_button
-      text: ".*Back camera.*"
-    timeout: 20000
+# 3. Lens switch.
+- runFlow: driveLensControl.yaml
 
-# 4. Flash. Guarded: the control is disabled when the active lens reports no
-# flash unit (`hasFlash`) — true of most emulators, and of the front lens on
-# many phones.
-- runFlow:
-    when:
-      visible:
-        id: camera_flash_button
-        enabled: true
-    commands:
-      - assertVisible:
-          id: camera_flash_button
-          text: ".*Off.*"
-      - tapOn:
-          id: camera_flash_button
-      - extendedWaitUntil:
-          visible:
-            id: camera_flash_button
-            text: ".*On.*"
-          timeout: 10000
-      - tapOn:
-          id: camera_flash_button
-      - extendedWaitUntil:
-          visible:
-            id: camera_flash_button
-            text: ".*Auto.*"
-          timeout: 10000
-      - tapOn:
-          id: camera_flash_button
-      - extendedWaitUntil:
-          visible:
-            id: camera_flash_button
-            text: ".*Off.*"
-          timeout: 10000
+# 4. Flash, if the active lens has a unit.
+- runFlow: driveFlashControl.yaml
 
-# 5. Stabilization. Same guard, and when it passes the sheet is guaranteed to
-# offer a non-off mode: the native side only reports
+# 5. Stabilization. Same guard as flash, and when it passes the sheet is
+# guaranteed to offer a non-off mode: the native side only reports
 # `isVideoStabilizationSupported` when its mode list has more than one entry.
 # Which non-off modes exist is per-device (Android derives them from the
 # camera's CONTROL_AVAILABLE_VIDEO_STABILIZATION_MODES), hence the alternation

--- a/mobile/e2e/maestro/utils/driveFlashControl.yaml
+++ b/mobile/e2e/maestro/utils/driveFlashControl.yaml
@@ -1,0 +1,45 @@
+appId: co.openvine.app
+---
+#Utility: cycle the flash control Off -> On -> Auto -> Off, leaving it on its
+#default. Every mode that renders the control rail renders this one.
+#
+# Guarded: the control is disabled when the active lens reports no flash unit
+# (`hasFlash`) — true of most emulators, and of the front lens on many phones.
+# An unguarded tap-and-assert there would go green or red on the phone rather
+# than on the code. A guarded block prints "SKIPPED" in the run output, so a
+# skipped control is visible rather than silently counted as covered.
+#
+# Selectors pin `id` as well as `text` because "Off" is not a unique value on
+# this screen — the timer control reads the same, and so does the first row of
+# the stabilization menu once its sheet is open.
+
+- runFlow:
+    when:
+      visible:
+        id: camera_flash_button
+        enabled: true
+    commands:
+      - assertVisible:
+          id: camera_flash_button
+          text: ".*Off.*"
+      - tapOn:
+          id: camera_flash_button
+      - extendedWaitUntil:
+          visible:
+            id: camera_flash_button
+            text: ".*On.*"
+          timeout: 10000
+      - tapOn:
+          id: camera_flash_button
+      - extendedWaitUntil:
+          visible:
+            id: camera_flash_button
+            text: ".*Auto.*"
+          timeout: 10000
+      - tapOn:
+          id: camera_flash_button
+      - extendedWaitUntil:
+          visible:
+            id: camera_flash_button
+            text: ".*Off.*"
+          timeout: 10000

--- a/mobile/e2e/maestro/utils/driveLensControl.yaml
+++ b/mobile/e2e/maestro/utils/driveLensControl.yaml
@@ -1,0 +1,28 @@
+appId: co.openvine.app
+---
+#Utility: switch to the front lens and back, leaving it on its default. Every
+#mode that renders the control rail renders this one.
+#
+# Slower than the other rail controls — the native camera rebinds and the
+# preview remounts on a fresh texture — so it gets a longer wait.
+#
+# Precondition the caller owns: **real camera hardware**, for the switch to do
+# anything at all.
+
+- assertVisible:
+    id: camera_switch_camera_button
+    text: ".*Back camera.*"
+- tapOn:
+    id: camera_switch_camera_button
+- extendedWaitUntil:
+    visible:
+      id: camera_switch_camera_button
+      text: ".*Front camera.*"
+    timeout: 20000
+- tapOn:
+    id: camera_switch_camera_button
+- extendedWaitUntil:
+    visible:
+      id: camera_switch_camera_button
+      text: ".*Back camera.*"
+    timeout: 20000

--- a/mobile/e2e/maestro/utils/openStopMotionMode.yaml
+++ b/mobile/e2e/maestro/utils/openStopMotionMode.yaml
@@ -1,0 +1,28 @@
+appId: co.openvine.app
+---
+#Utility: given the user is signed in and on a feed surface, open the recorder
+#and leave it on a ready stop-motion viewfinder with an empty session.
+#
+# No launchApp, so this runs against whatever is already on screen — see the
+# "Iterating" section of e2e/maestro/README.md.
+#
+# Unlike openCaptureMode this *selects* the mode, because it has to: the
+# recorder restores the last-used mode from `camera_last_used_recorder_mode`
+# and falls back to Capture when the key is absent, so a first run after a
+# `clearState` never opens here on its own.
+#
+# The tap is safe from the two modes this flow can arrive in — Capture (fresh
+# install) and Stop Motion (a rerun, since selecting a mode persists it). The
+# wheel is a lazy ListView, so only entries near the armed one are rendered;
+# Stop Motion sits directly next to Capture and is its own neighbour. From
+# Upload or Classic the entry may not be built and the tap would fail to find
+# it, same trap openCaptureMode documents.
+
+- runFlow: openRecorder.yaml
+
+# Tapping the armed entry is a no-op in the bloc, so a rerun that already
+# opened on Stop Motion passes straight through.
+- tapOn:
+    id: camera_mode_stopMotion
+
+- runFlow: ../asserts/assertStopMotionMode.yaml

--- a/mobile/lib/constants/semantic_ids.dart
+++ b/mobile/lib/constants/semantic_ids.dart
@@ -31,9 +31,11 @@ abstract class SemanticIds {
   static const String cameraDeleteClipButton = 'camera_delete_clip_button';
   static const String cameraLibraryButton = 'camera_library_button';
 
-  /// Capture-mode control rail, top to bottom. Lip-sync declares the same
-  /// countdown-timer and stabilization support, so it renders this rail
-  /// unchanged and drives it with the same E2E util.
+  /// Capture-mode control rail, top to bottom. Flash, aspect ratio and the
+  /// lens switch are unconditional, so every mode that renders the rail drives
+  /// them with the same three E2E utils. Timer and stabilization are rendered
+  /// only by the modes that declare them — capture and lip-sync, which share
+  /// the rail unchanged and drive all five with `driveCaptureRail`.
   static const String cameraFlashButton = 'camera_flash_button';
   static const String cameraTimerButton = 'camera_timer_button';
   static const String cameraAspectRatioButton = 'camera_aspect_ratio_button';
@@ -59,6 +61,21 @@ abstract class SemanticIds {
 
   /// Confirms the currently selected sound in the sound picker.
   static const String audioSelectionDoneButton = 'audio_selection_done_button';
+
+  /// What stop-motion adds to that rail (both gated on `capturesStills`), plus
+  /// the shot budget it puts in the top bar's center slot. Which viewfinder is
+  /// up is settled by the mode wheel's `selected` state, not by these — the
+  /// rest of the chrome is shared, since stop-motion is the capture stack. The
+  /// E2E asserts pin their absence in the modes that do not declare them, so a
+  /// control leaking across modes fails a run rather than passing quietly.
+  ///
+  /// Classic mode has its own grid and ghost toggles in
+  /// `video_recorder_classic_actions_bottom.dart`. They are deliberately
+  /// untagged: no flow drives them yet, and an identifier nothing asserts on
+  /// drifts silently.
+  static const String cameraGhostFrameButton = 'camera_ghost_frame_button';
+  static const String cameraGridButton = 'camera_grid_button';
+  static const String cameraStopMotionBudget = 'camera_stop_motion_budget';
 
   /// Welcome screen. The fresh-install and returning-user branches show
   /// different buttons, so each action gets its own id rather than being

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_actions.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_actions.dart
@@ -81,6 +81,7 @@ class VideoRecorderCaptureActions extends ConsumerWidget {
                   _IconButton(
                     icon: .gridNine,
                     label: l10n.videoRecorderToggleGridLabel,
+                    identifier: SemanticIds.cameraGridButton,
                     toggled: state.showGridLines,
                     onTap: () => context.read<VideoRecorderBloc>().add(
                       const VideoRecorderGridLinesToggled(),
@@ -135,6 +136,7 @@ class _GhostFrameButton extends StatelessWidget {
     return _IconButton(
       icon: .ghost,
       label: context.l10n.videoRecorderToggleGhostFrameLabel,
+      identifier: SemanticIds.cameraGhostFrameButton,
       toggled: isVisible,
       onTap: () {
         final willEnable = !isVisible;

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_stop_motion_budget.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_stop_motion_budget.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
@@ -60,32 +61,41 @@ class VideoRecorderStopMotionBudget extends ConsumerWidget {
     final label = context.l10n.videoRecorderStopMotionShotsLeft(remaining);
 
     return Flexible(
-      child: Column(
-        mainAxisSize: .min,
-        spacing: _labelSpacing,
-        children: [
-          VideoRecorderProgressBar(
-            filled: captured.clamp(0, budget),
-            remaining: remaining,
-            overflow: (captured - budget).clamp(0, captured),
-            label: label,
-            labelAbove: true,
-            labelSpacing: _labelSpacing,
-          ),
-          // The row centers its children, which would put the *group* — count
-          // plus bar — on the buttons' center line and leave the bar riding
-          // low. Mirroring the label below balances the group so the bar
-          // itself lands on that line, with the count reading above it.
-          // Measured from real text, so it tracks the font and the user's text
-          // scale; invisible, so it costs no paint and carries no semantics.
-          Visibility(
-            visible: false,
-            maintainSize: true,
-            maintainAnimation: true,
-            maintainState: true,
-            child: Text(label, style: VideoRecorderProgressBar.labelStyle),
-          ),
-        ],
+      child: Semantics(
+        identifier: SemanticIds.cameraStopMotionBudget,
+        label: label,
+        // The count is announced once, from here. Excluding the subtree drops
+        // the duplicate the visible Text would otherwise contribute, and gives
+        // the identifier a node carrying something rather than an empty
+        // wrapper the platform is free to collapse.
+        excludeSemantics: true,
+        child: Column(
+          mainAxisSize: .min,
+          spacing: _labelSpacing,
+          children: [
+            VideoRecorderProgressBar(
+              filled: captured.clamp(0, budget),
+              remaining: remaining,
+              overflow: (captured - budget).clamp(0, captured),
+              label: label,
+              labelAbove: true,
+              labelSpacing: _labelSpacing,
+            ),
+            // The row centers its children, which would put the *group* —
+            // count plus bar — on the buttons' center line and leave the bar
+            // riding low. Mirroring the label below balances the group so the
+            // bar itself lands on that line, with the count reading above it.
+            // Measured from real text, so it tracks the font and the user's
+            // text scale; invisible, so it costs no paint.
+            Visibility(
+              visible: false,
+              maintainSize: true,
+              maintainAnimation: true,
+              maintainState: true,
+              child: Text(label, style: VideoRecorderProgressBar.labelStyle),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_actions_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_actions_test.dart
@@ -526,10 +526,10 @@ void main() {
         handle.dispose();
       });
 
-      // assertCaptureMode and assertStopMotionMode tell the two viewfinders
-      // apart by the controls each one leaves out. An id leaking into the
-      // wrong mode makes both asserts pass on either screen, and every other
-      // test here would stay green.
+      // assertCaptureMode and assertStopMotionMode each pin the other mode's
+      // controls absent, so a control that starts rendering in the wrong mode
+      // fails an E2E run rather than passing quietly. Nothing else here would
+      // catch it — every other test in this file asserts presence.
       testWidgets('keeps the stop-motion controls out of capture mode', (
         tester,
       ) async {

--- a/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_actions_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_actions_test.dart
@@ -500,6 +500,85 @@ void main() {
         handle.dispose();
       });
 
+      // Same contract for the two controls only stop-motion renders, driven by
+      // e2e/maestro/tests/stopMotionModeControls.yaml. Asserted separately
+      // because the capture-mode rail above renders neither.
+      testWidgets('exposes an E2E identifier on the stop-motion controls', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(
+          buildWidget(recorderMode: VideoRecorderMode.stopMotion),
+        );
+        await tester.pumpAndSettle();
+
+        for (final identifier in const [
+          SemanticIds.cameraGhostFrameButton,
+          SemanticIds.cameraGridButton,
+        ]) {
+          expect(
+            find.bySemanticsIdentifier(identifier),
+            findsOneWidget,
+            reason: 'missing E2E anchor: $identifier',
+          );
+        }
+
+        handle.dispose();
+      });
+
+      // assertCaptureMode and assertStopMotionMode tell the two viewfinders
+      // apart by the controls each one leaves out. An id leaking into the
+      // wrong mode makes both asserts pass on either screen, and every other
+      // test here would stay green.
+      testWidgets('keeps the stop-motion controls out of capture mode', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(
+          buildWidget(isVideoStabilizationSupported: true),
+        );
+        await tester.pumpAndSettle();
+
+        for (final identifier in const [
+          SemanticIds.cameraGhostFrameButton,
+          SemanticIds.cameraGridButton,
+        ]) {
+          expect(
+            find.bySemanticsIdentifier(identifier),
+            findsNothing,
+            reason: '$identifier must not render in capture mode',
+          );
+        }
+
+        handle.dispose();
+      });
+
+      testWidgets('keeps the capture-only controls out of stop-motion mode', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(
+          buildWidget(
+            recorderMode: VideoRecorderMode.stopMotion,
+            isVideoStabilizationSupported: true,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        for (final identifier in const [
+          SemanticIds.cameraTimerButton,
+          SemanticIds.cameraStabilizationButton,
+        ]) {
+          expect(
+            find.bySemanticsIdentifier(identifier),
+            findsNothing,
+            reason: '$identifier must not render in stop-motion mode',
+          );
+        }
+
+        handle.dispose();
+      });
+
       testWidgets('announces the grid overlay as toggled when on', (
         tester,
       ) async {

--- a/mobile/test/widgets/video_recorder/modes/capture/video_recorder_stop_motion_budget_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/capture/video_recorder_stop_motion_budget_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' as model show AspectRatio;
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -228,6 +229,29 @@ void main() {
           ),
         ),
       );
+    });
+
+    // The budget is the one piece of chrome capture mode does not render, so
+    // e2e/maestro/asserts/assertStopMotionMode.yaml uses it to prove the top
+    // bar's center slot is the stop-motion one. Every other test here reads
+    // the widget directly and would stay green with the anchor dropped.
+    testWidgets('exposes the E2E identifier, carrying the count', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(buildWidget(capturedFrames: 5));
+
+      final node = tester.getSemantics(
+        find.bySemanticsIdentifier(SemanticIds.cameraStopMotionBudget),
+      );
+      expect(
+        node.label,
+        l10n.videoRecorderStopMotionShotsLeft(
+          StopMotionFrameOps.maxCaptureFrames - 5,
+        ),
+      );
+
+      handle.dispose();
     });
 
     testWidgets('offers nothing once the composition fills the maximum', (


### PR DESCRIPTION
Closes #7042

## Description

Extends the recorder E2E suite to the **stop-motion** mode, the follow-up to #7018's capture coverage and a sibling to #7043's lip-sync one. Open, drive the control rail, shoot two stills, undo them, close.

Stop-motion renders the capture stack, so it already inherited most of #7018's identifiers. Three controls are its own and were still only reachable by localized copy — the ghost-frame and grid toggles and the shot budget — so they get identifiers here, each with a widget test.

**Both mode asserts now pin the controls the other mode renders.** Not because either would otherwise pass on the wrong screen — the two rails are disjoint and the mode wheel's `selected` state settles that on the first line of every assert — but as a leak guard: a control that starts rendering in a mode which does not declare it fails a run instead of passing quietly. Nothing else in the suite catches that, and `video_recorder_capture_actions_test.dart` pins the same split at the widget level.

**The rail's three unconditional controls are now shared.** #7043 landed `utils/driveCaptureRail.yaml` after this branch's base, and 64 of `stopMotionModeControls`' 101 command lines were byte-identical to it. It cannot be reused as-is — it also drives timer and stabilization, neither of which stop-motion renders — so aspect ratio, lens and flash each get their own util and every mode sequences them in its own order. Inlining the new `runFlow`s reproduces both files' previous command sequences byte for byte, so nothing about what runs on device changed.

**`openStopMotionMode` selects its mode instead of asserting it**, unlike `openCaptureMode`. It has to: `VideoRecorderMode.fromName` falls back to `capture` whenever the persisted mode key is absent, so a first run after a `clearState` never opens on stop-motion by itself. The tap is safe from the two modes the flow can arrive in — Capture and Stop Motion are neighbours in the wheel's lazy `ListView` — and the file says so, along with why it would not be safe from Classic or Upload.

**The two shutter tests are deliberately coupled**, and the comments in both say so. A second still adds nothing new to assert on the screen: next and undo are already revealed by the first, and the only element tracking the count is the budget label, whose value falls out of `maxDuration` divided by the output frame rate — not something an E2E file should hardcode. So the count is proven one layer down. `stopMotionModeUndoFrame` undoes twice and asserts after the *first* undo that the chrome is still up, which is only true if two stills existed. Shortening either test to one tap silently removes the only evidence that the session accumulates.

The README picks up two findings from the device run that apply to `captureModeFlow` just as much:

- Maestro honours a `checked:` selector but **never prints it in the run log**. A correct assertion reads exactly like one whose flag was dropped, which is a good way to talk yourself into "fixing" a working selector. Proven applied by asserting `checked: true` against the toggle in its off state and watching it fail.
- The recorder persists **four** preferences — mode, lens, stabilization, grid — and some test asserts each one as a default. `clearState` handles this from the top of a flow, but a standalone run inherits the last session, so a phone last used on the front lens fails `stopMotionModeControls` on its first `.*Back camera.*`. That already applied to `captureModeControls` and was undocumented.

**Related Issue:** 

## Out of Scope

- **The assemble step** ("next", which collects the stills into a clip and opens the editor). It leaves the recorder, and the editor has no E2E coverage to hand off to yet.
- **Classic and upload modes.** Lip-sync landed in #7043 while this was open; this branch is rebased on top of it, and `utils/openRecorder.yaml` plus the `openCaptureMode` split turned out byte-identical to what that PR shipped, so they dropped out of this diff entirely.
- **Classic's own grid and ghost toggles**, which stay untagged: no flow drives them, and an identifier nothing asserts on drifts silently.
- **The smoke suite.** The flow stays out, same reason capture and lip-sync do — the shutter needs real camera hardware to leave its disabled state, and the smoke lane runs on the iOS Simulator.

## Verification

Manually verified on a real **Samsung Galaxy SM-S942B**, STAGING debug build, against the actual camera:

- `stopMotionModeOpen` — green, including the new `camera_stop_motion_budget` anchor and the mode-wheel tap.
- `stopMotionModeControls` — green, all five controls including flash on the back lens (not skipped).
- `stopMotionModeCaptureFrame` + `stopMotionModeUndoFrame` — green; library button confirmed empty afterwards, so the undo teardown really does drop the session's library row.
- Negative controls, both red as intended: `checked: true` against the off toggle, and shoot-once/undo-once against the undo test's first assertion.

The tests were driven test-by-test against an already-signed-in app rather than through `stopMotionModeFlow.yaml` end to end, because the device runs a German system locale and `loginFreshInstall`'s `clearState` drops the per-app English override mid-run. The login and `removeKeys` bookends of that flow are the ones `captureModeFlow` already runs unchanged. Noted in the README.

**A second device pass is pending** and it is wider than the first: `assertCaptureMode` gained three assertions and the shared rail moved, so `captureModeFlow` and `lipSyncModeFlow` need a run too, not just the stop-motion one.

Also:

- `flutter analyze lib test integration_test` — clean
- `flutter test test/widgets/video_recorder/` — 279 passing
- `bash e2e/maestro/scripts/check_refs.sh` — clean

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
