### PR TITLE
fix(video-editor): stop the clip picker closing on a short drag

### DIFF
--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -448,8 +448,8 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
     final newClips = await VineBottomSheet.show<List<DivineVideoClip>>(
       context: context,
       maxChildSize: 1,
-      initialChildSize: 1,
-      minChildSize: 0.9,
+      initialChildSize: 0.9,
+      minChildSize: 0.5,
       buildScrollBody: (scrollController) => LibraryScreen(
         initialTabIndex: 1,
         selectionMode: true,


### PR DESCRIPTION
Closes #7057

## Description

The editor's add-clips sheet opened at `initialChildSize: 1` against `maxChildSize: 1`, so it sat flush on the safe-area edge with nothing of the editor left visible behind it — it read as a pushed screen rather than a sheet, and the drag handle had no air above it.

Worse, the remaining 10% down to `minChildSize: 0.9` was all it took to lose the sheet. `DraggableScrollableSheet` pops the modal the moment it reaches its minimum (`shouldCloseOnMinExtent`, default `true`), so an overscroll flick at the top of the clip grid dismissed the picker — and since the sheet returns its selection on pop, whatever was already ticked went with it.

It now opens at `0.9` and bottoms out at `0.5`: the editor stays visible behind the top edge, full height is still one drag up, and dismissing takes a deliberate pull past half the screen.

**Related Issue:** none

## Out of Scope

The stickers sheet in the same file is the other `1 / 0.8` outlier and has the same hair-trigger dismissal. It carries no selection state to lose, so it is left alone here rather than widened into a sweep of every sheet's sizing.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test test/router/all_routes_test.dart test/router/navigation_scenarios_test.dart test/router/route_coverage_test.dart test/router/routes/restored_route_extras_test.dart test/widgets/video_recorder/video_recorder_navigation_test.dart test/screens/profile_edit_video_navigation_test.dart` — 126 passing
- No new tests. The diff is two sizing fractions handed to `VineBottomSheet.show`; the only assertion available is that the call site passes the numbers it passes, which is the widget-property test the repo's testing rules rule out. The behaviour they drive — where `DraggableScrollableSheet` pops on reaching `minChildSize` — belongs to Flutter, not to this call site.
- Manually verified on a real Samsung Galaxy: the sheet opens with the editor visible behind it, overscrolling the clip grid no longer closes it, dragging past half the screen still dismisses it, and dragging up reaches full height.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore