### PR TITLE
fix(video-editor): make the crop editor feel smooth and on-brand

### DIFF
--- a/mobile/lib/screens/video_editor/video_clip_transform_screen.dart
+++ b/mobile/lib/screens/video_editor/video_clip_transform_screen.dart
@@ -182,6 +182,7 @@ class _VideoClipTransformScreenState extends State<VideoClipTransformScreen> {
             initAspectRatio: widget.clip.targetAspectRatio.value,
             style: CropRotateEditorStyle(
               background: context.vineColors.surfaceContainerHigh,
+              cropCornerColor: VineTheme.primary,
             ),
             widgets: CropRotateEditorWidgets(
               appBar: (editorState, rebuildStream) => ReactiveAppbar(

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1848,10 +1848,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_image_editor
-      sha256: b75e82792ff9d3c51d6627558b4d916e5da7bc1dfaeb59d17b296fc5ae03d773
+      sha256: "5db82a3570b8c56e13fe87041ca17aedc1a64e855e1f6c3c698456fd5c6b1082"
       url: "https://pub.dev"
     source: hosted
-    version: "13.3.0"
+    version: "13.3.1"
   pro_video_editor:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -337,7 +337,7 @@ dependencies:
   firebase_messaging: ^16.1.1
   audio_session: ^0.2.2
   pro_video_editor: ^2.11.2
-  pro_image_editor: ^13.3.0
+  pro_image_editor: ^13.3.1
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7
   sensors_plus: ^7.0.0


### PR DESCRIPTION
Closes #7063

## Description

The crop step of the video editor felt wrong to use: grabbing a handle snapped the crop frame onto the finger, corner drags with a fixed aspect ratio only followed horizontal movement instead of the diagonal, pinch-to-zoom jumped the moment the second finger landed, and resizing a tilted image made the picture jump around. On top of that the crop handles rendered in the package default color, so the frame read as someone else's UI sitting inside Divine.

All the jumpiness lives in the gesture math inside `pro_image_editor`, not in our screen, so the actual fixes were made in the package and released as `13.3.1`. This PR bumps to that version and points the crop handles at `VineTheme.primary`.

What `13.3.1` fixes:
- Handles no longer jump onto the finger at drag start (gesture slop and the distance to the grabbed handle are compensated).
- Corner drags with a fixed aspect ratio follow the finger diagonally and stay inside the image.
- Pinch-to-zoom no longer jumps at gesture start and is no longer interrupted when the second finger touches down.
- The dimmed overlay outside the crop area fades smoothly again when an interaction is interrupted.
- The auto zoom-out hit area is no longer misplaced on Android and with custom app bars — which is exactly our case, since we pass our own `appBar` / `bottomBar`.
- Resizing a tilted image no longer makes it jump; the tilt bounds follow the crop animation instead of overriding its zoom.

**Related Issue:** 

## Out of Scope

No test is added. The diff is a dependency bump plus one style property — a widget test asserting `cropCornerColor == VineTheme.primary` would assert configuration rather than behavior, and the gesture behavior it really fixes is covered by tests in `pro_image_editor` itself.

## Verification

- `dart format` and `flutter analyze lib/screens/video_editor/` — clean
- Manually verified on a real Samsung Galaxy: dragging each handle, corner drag with a locked aspect ratio, pinch-to-zoom with the second finger landing mid-gesture, and crop handles rendering in the Divine accent

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)