### PR TITLE
build(ios): refresh the SPM lockfiles for patrol's Swift Package

### DIFF
--- a/mobile/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "cocoaasyncsocket",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/robbiehanson/CocoaAsyncSocket",
+      "state" : {
+        "revision" : "dbdc00669c1ced63b27c3c5f052ee4d28f10150c",
+        "version" : "7.6.5"
+      }
+    },
+    {
       "identity" : "dkcamera",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zhangao0086/DKCamera",

--- a/mobile/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "cocoaasyncsocket",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/robbiehanson/CocoaAsyncSocket",
+      "state" : {
+        "revision" : "dbdc00669c1ced63b27c3c5f052ee4d28f10150c",
+        "version" : "7.6.5"
+      }
+    },
+    {
       "identity" : "dkcamera",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zhangao0086/DKCamera",


### PR DESCRIPTION
Closes #7067

## Description

Both tracked iOS SwiftPM lockfiles show up as modified after every local build, and the churn has already leaked into unrelated PRs (two commits on `feat/video-card-post-date`). They are not machine-specific artifacts — the checked-in files are simply stale.

The timeline:

- Both lockfiles were last written on 2026-06-19 (`3b2005ebfa`, the SQLCipher fix), and they are the same blob on `main` (`92baa9372`).
- #6925 moved patrol from 4.2.0 to 4.8.0 on 2026-08-09.
- patrol 4.2.0 shipped as a CocoaPods pod. 4.8.0 is the first version with a `Package.swift`, and it depends on CocoaAsyncSocket 7.6.5.

Nobody has committed a resolve since that bump, so Xcode re-adds the pin on every build and the files have been coming back dirty for two months.

Both files are updated because Xcode writes them from two separate resolves: flutter's prefetch runs `xcodebuild -resolvePackageDependencies` with no `-project` and no `-workspace` (`xcodeproj.dart:208-227`), which resolves `Runner.xcodeproj` and writes the inner file, while the build itself passes `-workspace Runner.xcworkspace` and writes the outer one. The repo already treats them as a pair — `ios/.gitignore` keeps the inner one tracked "alongside the outer workspace lock", `sqlite3mc_configuration_test.dart` asserts over both, #5328 dropped the `csqlite` pin from both symmetrically, and `codemagic.yaml:306` reads the outer one for the Crashlytics symbol upload.

The revision (`dbdc00669c1ced63b27c3c5f052ee4d28f10150c`, 7.6.5) is exactly the one patrol pins in its own `darwin/patrol/Package.resolved`, so this adds no independent version decision.

**Related Issue:** 

## Out of Scope

An earlier revision of this description claimed release builds would prune the pin again, because Flutter filters dev-dependency plugins out in release mode. That filter does not apply to Darwin: `injectPlugins` re-resolves from the unfiltered plugin list under `if (iosPlatform || macOSPlatform)`, commented "iOS and macOS doesn't yet support filtering out dev dependencies" (flutter/flutter#163874). iOS never filters patrol out, in any mode, so the pin is stable and a release `flutter build ipa` will not remove it.

The flip side is that patrol — and CocoaAsyncSocket with it — is linked into release iOS builds today. That arrived with #6925 and is out of scope here; this PR only records a resolve that already happens.

## Verification

- `flutter test test/database/sqlite3mc_configuration_test.dart` — 4/4 pass (this is the test that reads both lockfiles)
- Both files are valid JSON with 25 pins, and byte-identical to each other, as they are on `main`
- Diff is additive: one pin object per file, no existing entry touched or reordered
- Pinned revision compared against `~/.pub-cache/hosted/pub.dev/patrol-4.8.0/darwin/patrol/Package.resolved` — identical

## Type of Change

- [x] ✅ Build configuration change