### PR TITLE
fix(dm): re-derive the DM publish backstop and bound the crypto chain

### DIFF
--- a/mobile/lib/services/outgoing_dm_retry_service.dart
+++ b/mobile/lib/services/outgoing_dm_retry_service.dart
@@ -498,7 +498,7 @@ class OutgoingDmRetryService {
 
           // Min-age guard: if the row was recently enqueued, the
           // originating sendMessage call may still be in flight in this
-          // process (inbox resolution + the 90s publish backstop). Wait
+          // process (inbox resolution + the derived publish backstop). Wait
           // out that window before treating the row as interrupted, or a
           // trigger fired mid-send dispatches a concurrent duplicate
           // publish of the same rumor. Idempotent receiver dedup makes a

--- a/mobile/lib/services/outgoing_dm_retry_service.dart
+++ b/mobile/lib/services/outgoing_dm_retry_service.dart
@@ -131,14 +131,36 @@ class OutgoingDmRetryService {
   final DateTime Function() _now;
   final CrashReportingService _crashReporting;
 
+  /// Extra margin over [DmSendBudget.messagePublishTimeout] for the work a
+  /// send does OUTSIDE that backstop — chiefly recipient kind-10050 inbox
+  /// resolution, which runs before the publish is wrapped and is not itself
+  /// bounded end-to-end. It is a margin, not a guarantee; bounding those
+  /// segments is tracked separately.
+  static const Duration _inboxResolutionMargin = Duration(seconds: 30);
+
   /// Minimum age of a still-`pending` row before the interrupted-send arm
   /// may re-drive it. Must exceed the worst-case legitimately-in-flight
-  /// send (inbox resolution plus the 90s `_messagePublishTimeout` backstop
-  /// in `dm_repository`), or a foreground/connectivity trigger fired during
-  /// a live send dispatches a concurrent duplicate publish of the same
-  /// rumor. Receiver dedup makes that safe but wasteful; the old value
-  /// (the 2s `initialDelay`) made it the common case.
-  static const Duration _interruptedMinAge = Duration(seconds: 120);
+  /// send, or a foreground/connectivity trigger fired during a live send
+  /// dispatches a concurrent duplicate publish of the same rumor. Receiver
+  /// dedup makes that safe but wasteful; the old value (the 2s
+  /// `initialDelay`) made it the common case.
+  ///
+  /// Derived from the backstop rather than restated as a literal. It was
+  /// previously hardcoded to 120s against a 90s backstop, and #6586 showed why
+  /// that is fragile twice over: the backstop had itself drifted below the
+  /// chain it bounds, and `Future.timeout` does not cancel — so the abandoned
+  /// send keeps running past the cap and this guard has to outlive the
+  /// IN-FLIGHT send, not merely the cap.
+  static final Duration _interruptedMinAge =
+      DmSendBudget.messagePublishTimeout + _inboxResolutionMargin;
+
+  /// The interrupted-send guard, for tests that need to age a row across it.
+  ///
+  /// Exposed so tests derive their timings from the guard instead of restating
+  /// a literal — a hardcoded age silently stops testing the boundary the
+  /// moment the budget moves, which is how #6586 stayed invisible.
+  @visibleForTesting
+  static Duration get interruptedMinAge => _interruptedMinAge;
 
   /// Gap between a sweep that left retryable work behind and the follow-up
   /// sweep it schedules. Without an in-session heartbeat, a soft-unconfirmed

--- a/mobile/packages/dm_repository/lib/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/dm_repository.dart
@@ -5,6 +5,7 @@ export 'src/dm_reactions_repository.dart';
 export 'src/dm_reactions_repository_reportable_sites.dart';
 export 'src/dm_repository.dart';
 export 'src/dm_repository_reportable_sites.dart';
+export 'src/dm_send_budget.dart';
 export 'src/dm_send_policy.dart';
 export 'src/dm_sync_state.dart';
 export 'src/dm_verify_isolate.dart';

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -171,8 +171,10 @@ const Duration _dmRelayListSignTimeout = Duration(seconds: 10);
 /// retry budget terminalised them into a red bubble. The cure is not a bigger
 /// number — the wrap builds now carry explicit bounds
 /// ([DmSendBudget.recipientWrapBuild], [DmSendBudget.selfWrapBuild]), which is
-/// what stops the *signing chain* outrunning this cap regardless of the
-/// signer's own per-op bound — Amber's `AndroidNostrSigner` allows 300s.
+/// what stops the *signing chain* outrunning this cap even when the signer path
+/// is slower. Amber's NIP-55 intent path for `nip44Encrypt` and `signEvent` is
+/// human-gated and unbounded, so a recipient-build timeout leaves the durable
+/// row pending for retry instead of red-failed.
 ///
 /// That covers the signing chain, not the whole send. Three awaited steps
 /// inside this cap are still unbounded and deliberately NOT in
@@ -3156,10 +3158,11 @@ class DmRepository {
         rumorId: rumor.id,
       );
     } else if (result.retryablePending && outgoingDao != null) {
-      // Soft-unconfirmed: the recipient frame was written but no NIP-20 OK
-      // arrived (and no explicit rejection). Keep the row pending — it
-      // renders as a plain optimistic bubble, never a red failure — and let
-      // the retry sweep re-drive it. A lost OK is not proof of loss.
+      // Soft retry: either the recipient frame was written but no NIP-20 OK
+      // arrived, or the pre-publish wrap build timed out while a human-gated
+      // signer approval may still be pending. Keep the row pending — it renders
+      // as a plain optimistic bubble, never a red failure — and let the retry
+      // sweep re-drive it.
       await _finalizeAfterRecipientUnconfirmed(
         outgoingDao: outgoingDao,
         rumorId: rumor.id,
@@ -3859,9 +3862,10 @@ class DmRepository {
       // refuses every time. This attempt delivered nothing.
       await _finalizeAfterRecipientBlocked(outgoingDao: dao, rumorId: rumorId);
     } else if (result.retryablePending) {
-      // Soft-unconfirmed retry: frame written, no OK yet. Keep the row
-      // pending (plain optimistic bubble, not a red failure) and let the
-      // next sweep re-drive it; only bump the retry count so it eventually
+      // Soft retry: frame written with no OK yet, or a pre-publish wrap build
+      // timeout while a human-gated signer approval may still be pending. Keep
+      // the row pending (plain optimistic bubble, not a red failure) and let
+      // the next sweep re-drive it; only bump the retry count so it eventually
       // exhausts.
       await _finalizeAfterRecipientUnconfirmed(
         outgoingDao: dao,
@@ -4256,11 +4260,12 @@ class DmRepository {
     }
   }
 
-  /// Apply the queue-row transition for a soft, retryable-pending recipient
-  /// publish — the relay frame was written but no NIP-20 `OK` arrived within
-  /// the confirm window (and no explicit rejection). A lost OK is not proof
-  /// of loss, so the row stays `pending` (rendering as a plain optimistic
-  /// bubble, never a red failure) and the retry sweep re-drives it.
+  /// Apply the queue-row transition for a soft, retryable-pending failure: an
+  /// inconclusive recipient publish (frame written, no NIP-20 `OK`, no explicit
+  /// rejection) or a bounded pre-publish wrap build timeout where a human-gated
+  /// signer approval may still be pending. The row stays `pending` (rendering
+  /// as a plain optimistic bubble, never a red failure) and the retry sweep
+  /// re-drives it.
   ///
   /// Only `incrementRetry` runs: it records the attempt timestamp so the
   /// next sweep applies backoff, and counts this attempt toward the retry

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -170,9 +170,18 @@ const Duration _dmRelayListSignTimeout = Duration(seconds: 10);
 /// recipient had already received, parking them as soft-unconfirmed until the
 /// retry budget terminalised them into a red bubble. The cure is not a bigger
 /// number — the wrap builds now carry explicit bounds
-/// ([DmSendBudget.recipientWrapBuild], [DmSendBudget.selfWrapBuild]) so the
-/// chain cannot outrun this cap for ANY signer, including Amber, whose own
-/// per-op bound is 300s.
+/// ([DmSendBudget.recipientWrapBuild], [DmSendBudget.selfWrapBuild]), which is
+/// what stops the *signing chain* outrunning this cap regardless of the
+/// signer's own per-op bound — Amber's `AndroidNostrSigner` allows 300s.
+///
+/// That covers the signing chain, not the whole send. Three awaited steps
+/// inside this cap are still unbounded and deliberately NOT in
+/// [DmSendBudget.chainWorstCase]: `refreshPublicKey()` (a real round trip for
+/// any signer that doesn't cache the pubkey, e.g. a NIP-46 bunker — Keycast
+/// does cache it), the send-policy protected-minor check, and the connectivity
+/// probe. So this cap remains a genuine backstop for those, and
+/// [DmSendBudget.chainWorstCase] is a floor on what a send can cost, not a
+/// ceiling. Bounding them is tracked separately.
 ///
 /// A 15s cap here (the original value) fired during routine slow-Keycast
 /// sends, turning sends that were still legitimately in flight into

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -16,6 +16,7 @@ import 'package:dm_repository/src/dm_decrypt_isolate.dart';
 import 'package:dm_repository/src/dm_decryption_worker.dart';
 import 'package:dm_repository/src/dm_reactions_repository.dart';
 import 'package:dm_repository/src/dm_repository_reportable_sites.dart';
+import 'package:dm_repository/src/dm_send_budget.dart';
 import 'package:dm_repository/src/dm_shared_video_citation.dart';
 import 'package:dm_repository/src/dm_sync_state.dart';
 import 'package:dm_repository/src/dm_verify_isolate.dart';
@@ -152,16 +153,31 @@ const Duration _dmRelayListSignTimeout = Duration(seconds: 10);
 /// durable queue keeps the row and the retry sweep re-drives it rather than
 /// parking a red chip.
 ///
-/// Every sub-step now carries its own tight bound — Keycast RPCs 12s each
-/// (`KeycastRpc.defaultRequestTimeout`), the recipient OK window 10s, the
-/// self-wrap publish 10s — so this cap exists only to bound a truly hung
-/// await, and it must sit ABOVE the capped worst case or it fires mid-send
-/// and misclassifies it. Remote-signer worst case: recipient wrap build
-/// (2 RPCs, 24s) + OK window (10s) + deferred self-wrap build (2 RPCs, 24s)
-/// + self-wrap publish (10s) ≈ 68s + overhead → 90s. A 15s cap here (the
-/// original value) fired during routine slow-Keycast sends, turning sends
-/// that were still legitimately in flight into eternally-retrying rows.
-const Duration _messagePublishTimeout = Duration(seconds: 90);
+/// Every sub-step carries its own bound — see [DmSendBudget], which owns the
+/// derivation. This cap exists only to bound a truly hung await, and it must
+/// sit ABOVE [DmSendBudget.chainWorstCase] or it fires mid-send and
+/// misclassifies it.
+///
+/// That is exactly what went wrong in #6586. The bound was hand-derived from a
+/// Keycast per-RPC timeout of 12s; #6075 raised that timeout to 30s (correctly
+/// — 12s had regressed video-publish signing, likes, reposts and follows) and
+/// the derivation here was never redone. A 1:1 send costs **four** measured
+/// signer round trips, so the honest chain became (2 × 30s) + 10s + (2 × 30s)
+/// + 10s = 140s against a 90s cap.
+///
+/// Because the self-wrap is built only after the recipient's `OK true`
+/// arrives, that 140s path was the *delivery* path: the cap fired on sends the
+/// recipient had already received, parking them as soft-unconfirmed until the
+/// retry budget terminalised them into a red bubble. The cure is not a bigger
+/// number — the wrap builds now carry explicit bounds
+/// ([DmSendBudget.recipientWrapBuild], [DmSendBudget.selfWrapBuild]) so the
+/// chain cannot outrun this cap for ANY signer, including Amber, whose own
+/// per-op bound is 300s.
+///
+/// A 15s cap here (the original value) fired during routine slow-Keycast
+/// sends, turning sends that were still legitimately in flight into
+/// eternally-retrying rows — the reason this backstop must stay generous.
+const Duration _messagePublishTimeout = DmSendBudget.messagePublishTimeout;
 
 /// Outcome of resolving a user's own kind-10050 DM inbox relay list (#4974).
 ///

--- a/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
@@ -122,32 +122,31 @@ abstract final class DmSendBudget {
   /// wrong trade — it would push the send past the backstop and misclassify a
   /// delivered message as unconfirmed, which is the #6586 failure itself.
   ///
-  /// Applies only inside a send. The out-of-band rebuild is bounded by
-  /// [selfWrapRecoveryBuild], which is sized differently for the reason
+  /// Applies only when the caller has an outer cap. Uncapped callers use
+  /// [selfWrapUncappedBuild], which is sized differently for the reason
   /// documented there.
   static const Duration selfWrapBuild = Duration(
     seconds: _selfWrapBuildSeconds,
   );
 
-  /// Hard bound on rebuilding the self-addressed gift wrap on the out-of-band
-  /// recovery path (`NIP17MessageService.publishSelfWrap`, driven by
-  /// `DmRepository.recoverSelfWrap`).
+  /// Hard bound on building the self-addressed gift wrap when the caller has no
+  /// outer cap.
   ///
   /// Sized like [recipientWrapBuild], not like [selfWrapBuild]. The tightness
-  /// of [selfWrapBuild] buys headroom inside [messagePublishTimeout]; recovery
-  /// runs on its own with no outer cap to protect, so there a tight bound can
-  /// only fail a build the transport itself would have completed.
+  /// of [selfWrapBuild] buys headroom inside [messagePublishTimeout]; uncapped
+  /// callers have no outer budget to protect, so there a tight bound can only
+  /// fail a build the transport itself would have completed.
   ///
-  /// The rebuild is the same two round trips, so at [selfWrapBuild] it could
-  /// never finish against a signer running near its own 30s-per-op bound —
-  /// which is precisely the signer that leaves a self-wrap outstanding in the
-  /// first place. Recovery would then fail every attempt and the row would
-  /// exhaust its retry budget into a permanently missing self-wrap, losing the
-  /// cross-device copy this recovery arm exists to save.
+  /// This covers both out-of-band recovery
+  /// (`NIP17MessageService.publishSelfWrap`, driven by
+  /// `DmRepository.recoverSelfWrap`) and direct uncapped sends such as
+  /// `NIP17MessageService.sendPrivateMessage`. The build is the same two
+  /// round trips, so at [selfWrapBuild] it could never finish against a signer
+  /// running near its own 30s-per-op bound.
   ///
-  /// Deliberately NOT part of [chainWorstCase]: recovery runs outside the send
-  /// that budget bounds.
-  static const Duration selfWrapRecoveryBuild = Duration(
+  /// Deliberately NOT part of [chainWorstCase]: callers that use this bound do
+  /// not use the send-level [messagePublishTimeout] chain budget.
+  static const Duration selfWrapUncappedBuild = Duration(
     seconds: _recipientWrapBuildSeconds,
   );
 

--- a/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
@@ -90,8 +90,34 @@ abstract final class DmSendBudget {
   /// the recipient-sized budget here to avoid a *recovery step* would be the
   /// wrong trade — it would push the send past the backstop and misclassify a
   /// delivered message as unconfirmed, which is the #6586 failure itself.
+  ///
+  /// Applies only inside a send. The out-of-band rebuild is bounded by
+  /// [selfWrapRecoveryBuild], which is sized differently for the reason
+  /// documented there.
   static const Duration selfWrapBuild = Duration(
     seconds: _selfWrapBuildSeconds,
+  );
+
+  /// Hard bound on rebuilding the self-addressed gift wrap on the out-of-band
+  /// recovery path (`NIP17MessageService.publishSelfWrap`, driven by
+  /// `DmRepository.recoverSelfWrap`).
+  ///
+  /// Sized like [recipientWrapBuild], not like [selfWrapBuild]. The tightness
+  /// of [selfWrapBuild] buys headroom inside [messagePublishTimeout]; recovery
+  /// runs on its own with no outer cap to protect, so there a tight bound can
+  /// only fail a build the transport itself would have completed.
+  ///
+  /// The rebuild is the same two round trips, so at [selfWrapBuild] it could
+  /// never finish against a signer running near its own 30s-per-op bound —
+  /// which is precisely the signer that leaves a self-wrap outstanding in the
+  /// first place. Recovery would then fail every attempt and the row would
+  /// exhaust its retry budget into a permanently missing self-wrap, losing the
+  /// cross-device copy this recovery arm exists to save.
+  ///
+  /// Deliberately NOT part of [chainWorstCase]: recovery runs outside the send
+  /// that budget bounds.
+  static const Duration selfWrapRecoveryBuild = Duration(
+    seconds: _recipientWrapBuildSeconds,
   );
 
   /// Hard bound on publishing the self-addressed gift wrap.

--- a/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
@@ -1,0 +1,129 @@
+// ABOUTME: Time budget for a single NIP-17 message send, as linked constants.
+// ABOUTME: The publish backstop is derived from these, never hand-computed.
+
+/// The time budget for one NIP-17 1:1 message send, expressed as its parts.
+///
+/// ## Why this exists
+///
+/// The send-level backstop used to be a hand-computed number written into a
+/// doc comment. #6046 derived it from a Keycast per-RPC bound of 12s; #6075
+/// raised that bound to 30s without re-deriving the backstop, and the comment
+/// kept asserting the 12s arithmetic long after it was false (#6586). The cap
+/// ended up *smaller* than the work it bounds, so it fired on sends that had
+/// already been delivered.
+///
+/// Every sub-bound now lives here and the totals are computed from the same
+/// private seconds constants, so the derivation cannot silently go stale
+/// again. A guard test in the app layer (which can see both this package and
+/// `keycast_flutter`) pins the relationship against the real transport bound.
+///
+/// The totals are built from `int` seconds rather than by adding [Duration]s
+/// because `Duration.operator+` is not `const` — summing durations would force
+/// these off `const` and let a hand-typed total creep back in.
+///
+/// ## The shape being bounded
+///
+/// A 1:1 kind-14 send costs **four** remote-signer round trips, measured
+/// against the real send path (#6586):
+///
+/// * recipient wrap: `nip44Encrypt` (seal content) + `signEvent` (seal)
+/// * self wrap: the same two, built lazily after the recipient publish confirms
+///
+/// The kind-1059 gift wrap itself is signed with a freshly generated ephemeral
+/// key (NIP-59), so it never reaches the signer. Local-key signers build both
+/// wraps in one isolate hop and spend no round trips at all — these bounds sit
+/// far above that path and never bind it.
+abstract final class DmSendBudget {
+  /// Seconds allowed for building the recipient gift wrap. See
+  /// [recipientWrapBuild].
+  static const int _recipientWrapBuildSeconds = 60;
+
+  /// Seconds allowed for the recipient OK confirmation. See
+  /// [recipientOkConfirm].
+  static const int _recipientOkConfirmSeconds = 10;
+
+  /// Seconds allowed for building the self-addressed gift wrap. See
+  /// [selfWrapBuild].
+  static const int _selfWrapBuildSeconds = 20;
+
+  /// Seconds allowed for publishing the self-addressed gift wrap. See
+  /// [selfWrapPublish].
+  static const int _selfWrapPublishSeconds = 10;
+
+  /// Slack between [chainWorstCase] and [messagePublishTimeout].
+  ///
+  /// Absorbs event-loop scheduling, isolate hops, and the DAO work interleaved
+  /// with the publish. The backstop must sit strictly above the capped worst
+  /// case or it fires mid-send and misclassifies it — the #6586 defect.
+  static const int _headroomSeconds = 20;
+
+  /// Hard bound on building the recipient gift wrap.
+  ///
+  /// Sized as two Keycast single-op round trips at the transport's own 30s
+  /// bound (`KeycastRpc.defaultRequestTimeout`), so this can never fail a
+  /// request the transport itself would have allowed. Tightening it below that
+  /// is the specific mistake #6046 made and #6075 reverted: production Keycast
+  /// runs 20-30s per single op under DB-pool contention (keycast#291), and a
+  /// tighter bound turns slow-but-succeeding sends into hard failures.
+  ///
+  /// It bounds the *chain*, not the transport, so it also covers signers whose
+  /// own per-op bound is far looser — Amber's `AndroidNostrSigner` allows 300s
+  /// per op, more than triple [messagePublishTimeout] itself.
+  static const Duration recipientWrapBuild = Duration(
+    seconds: _recipientWrapBuildSeconds,
+  );
+
+  /// OK-confirmation window for the recipient wrap.
+  ///
+  /// Read by `NIP17MessageService._recipientOkConfirmTimeout`.
+  static const Duration recipientOkConfirm = Duration(
+    seconds: _recipientOkConfirmSeconds,
+  );
+
+  /// Hard bound on building the self-addressed gift wrap.
+  ///
+  /// Deliberately tighter than [recipientWrapBuild]. By the time this runs the
+  /// recipient already has the message, and a missing self-wrap is an
+  /// explicitly supported outcome: the send returns success with
+  /// `selfWrapPublished: false`, the durable row survives, and the retry
+  /// sweep's `recoverSelfWrap` arm finishes it out of band (#4124). Spending
+  /// the recipient-sized budget here to avoid a *recovery step* would be the
+  /// wrong trade — it would push the send past the backstop and misclassify a
+  /// delivered message as unconfirmed, which is the #6586 failure itself.
+  static const Duration selfWrapBuild = Duration(
+    seconds: _selfWrapBuildSeconds,
+  );
+
+  /// Hard bound on publishing the self-addressed gift wrap.
+  ///
+  /// Read by `NIP17MessageService._selfWrapPublishTimeout`.
+  static const Duration selfWrapPublish = Duration(
+    seconds: _selfWrapPublishSeconds,
+  );
+
+  /// Serial worst case for the bounded portion of a send.
+  ///
+  /// Every step above runs in sequence on the remote-signer path, so the worst
+  /// case is their sum.
+  static const Duration chainWorstCase = Duration(
+    seconds:
+        _recipientWrapBuildSeconds +
+        _recipientOkConfirmSeconds +
+        _selfWrapBuildSeconds +
+        _selfWrapPublishSeconds,
+  );
+
+  /// Hard backstop on a single NIP-17 message publish.
+  ///
+  /// Derived, never hand-written. Callers that need to outlive an in-flight
+  /// send must key off this rather than restating a number — see
+  /// `OutgoingDmRetryService.interruptedMinAge`.
+  static const Duration messagePublishTimeout = Duration(
+    seconds:
+        _recipientWrapBuildSeconds +
+        _recipientOkConfirmSeconds +
+        _selfWrapBuildSeconds +
+        _selfWrapPublishSeconds +
+        _headroomSeconds,
+  );
+}

--- a/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
@@ -98,8 +98,11 @@ abstract final class DmSendBudget {
   /// slow-but-succeeding sends into hard failures.
   ///
   /// It bounds the *chain*, not the transport, so it also covers signers whose
-  /// own per-op bound is far looser — Amber's `AndroidNostrSigner` allows 300s
-  /// per op, more than triple [messagePublishTimeout] itself.
+  /// own operation can wait much longer than this method should. On the Amber
+  /// NIP-55 intent path, the `nip44Encrypt` and `signEvent` approval waits are
+  /// human-gated and unbounded; timing out here leaves the recipient publish
+  /// unsent, so durable callers classify the row as retryable-pending rather
+  /// than red-failed.
   static const Duration recipientWrapBuild = Duration(
     seconds: _recipientWrapBuildSeconds,
   );

--- a/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
@@ -34,9 +34,31 @@
 /// wraps in one isolate hop and spend no round trips at all — these bounds sit
 /// far above that path and never bind it.
 abstract final class DmSendBudget {
+  /// The two seal round trips a wrap build spends, at the transport's own
+  /// per-op bound (`KeycastRpc.defaultRequestTimeout`, 30s).
+  ///
+  /// Restated here because `dm_repository` cannot import `keycast_flutter`.
+  /// The app-layer guard test asserts the real relationship, so this going
+  /// stale fails CI rather than silently under-sizing the bound — which is the
+  /// #6586 failure mode itself.
+  static const int _twoTransportBoundsSeconds = 60;
+
+  /// Margin inside a wrap-build bound for the local work that runs alongside
+  /// the two remote round trips: seal construction, the ephemeral keypair,
+  /// the NIP-44 ECDH + ChaCha20 encryption of the seal, and the wrap's
+  /// secp256k1 signature (`GiftWrapUtil.getGiftWrapEvent`).
+  ///
+  /// Without it the bound would sit at *exactly* two transport bounds, so two
+  /// ops that each returned just under 30s would still blow it — failing a
+  /// build the transport itself had completed. That is the same
+  /// "sized at the worst case with no margin" shape #6586 was about, one step
+  /// earlier in the chain.
+  static const int _wrapBuildLocalCryptoSeconds = 5;
+
   /// Seconds allowed for building the recipient gift wrap. See
   /// [recipientWrapBuild].
-  static const int _recipientWrapBuildSeconds = 60;
+  static const int _recipientWrapBuildSeconds =
+      _twoTransportBoundsSeconds + _wrapBuildLocalCryptoSeconds;
 
   /// Seconds allowed for the recipient OK confirmation. See
   /// [recipientOkConfirm].
@@ -55,16 +77,25 @@ abstract final class DmSendBudget {
   /// Absorbs event-loop scheduling, isolate hops, and the DAO work interleaved
   /// with the publish. The backstop must sit strictly above the capped worst
   /// case or it fires mid-send and misclassifies it — the #6586 defect.
-  static const int _headroomSeconds = 20;
+  ///
+  /// Trimmed by [_wrapBuildLocalCryptoSeconds] when that margin was moved into
+  /// [_recipientWrapBuildSeconds], so [messagePublishTimeout] holds at 120s and
+  /// `OutgoingDmRetryService.interruptedMinAge` does not have to move with it.
+  static const int _headroomSeconds = 15;
 
   /// Hard bound on building the recipient gift wrap.
   ///
   /// Sized as two Keycast single-op round trips at the transport's own 30s
-  /// bound (`KeycastRpc.defaultRequestTimeout`), so this can never fail a
-  /// request the transport itself would have allowed. Tightening it below that
-  /// is the specific mistake #6046 made and #6075 reverted: production Keycast
-  /// runs 20-30s per single op under DB-pool contention (keycast#291), and a
-  /// tighter bound turns slow-but-succeeding sends into hard failures.
+  /// bound (`KeycastRpc.defaultRequestTimeout`) **plus**
+  /// [_wrapBuildLocalCryptoSeconds] for the local crypto that runs between and
+  /// after them, so two ops that each returned inside the transport's limit
+  /// cannot together trip this bound. Sizing it at exactly `2 × 30s` would
+  /// leave nothing for that work and fail such a build.
+  ///
+  /// Tightening it below two transport bounds is the specific mistake #6046
+  /// made and #6075 reverted: production Keycast runs 20-30s per single op
+  /// under DB-pool contention (keycast#291), and a tighter bound turns
+  /// slow-but-succeeding sends into hard failures.
   ///
   /// It bounds the *chain*, not the transport, so it also covers signers whose
   /// own per-op bound is far looser — Amber's `AndroidNostrSigner` allows 300s

--- a/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
@@ -140,12 +140,17 @@ abstract final class DmSendBudget {
   /// callers have no outer budget to protect, so there a tight bound can only
   /// fail a build the transport itself would have completed.
   ///
-  /// This covers both out-of-band recovery
-  /// (`NIP17MessageService.publishSelfWrap`, driven by
-  /// `DmRepository.recoverSelfWrap`) and direct uncapped sends such as
-  /// `NIP17MessageService.sendPrivateMessage`. The build is the same two
-  /// round trips, so at [selfWrapBuild] it could never finish against a signer
-  /// running near its own 30s-per-op bound.
+  /// This covers out-of-band recovery (`NIP17MessageService.publishSelfWrap`,
+  /// driven by `DmRepository.recoverSelfWrap`) and
+  /// `NIP17MessageService.publishSelfApplicationMarker`. The build is the same
+  /// two round trips, so at [selfWrapBuild] it could never finish against a
+  /// signer running near its own 30s-per-op bound.
+  ///
+  /// It deliberately does **not** cover `sendPrivateMessage`, which builds its
+  /// self wrap uncapped. A bound only makes sense where a timed-out build can
+  /// still be finished later; that caller owns no `outgoing_dms` row, which
+  /// `DmRepository.recoverSelfWrap` requires, so for it even this wide bound
+  /// would drop the sender's cross-device copy permanently.
   ///
   /// Deliberately NOT part of [chainWorstCase]: callers that use this bound do
   /// not use the send-level [messagePublishTimeout] chain budget.

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -340,6 +340,13 @@ class NIP17MessageService {
   /// contract: soft-unconfirmed recipient publishes return retryable failure
   /// and the caller owns any fallback behavior.
   ///
+  /// [recipientWrapBuildTimeout] bounds the recipient-wrap build, defaulting to
+  /// [DmSendBudget.recipientWrapBuild] for callers whose durable retry queue
+  /// can keep a pre-publish timeout pending and re-drive it. Passing `null`
+  /// leaves recipient-wrap construction uncapped; only callers with no outer
+  /// cap and no retry row should do that, because a slow human-gated signer
+  /// approval is otherwise indistinguishable from a hung signer.
+  ///
   /// [selfWrapBuildTimeout] bounds the self-wrap build, defaulting to the
   /// tight [DmSendBudget.selfWrapBuild] for callers that protect the full
   /// publish with an outer cap. Durable message sends use
@@ -359,8 +366,10 @@ class NIP17MessageService {
     List<String>? targetRelays,
     bool awaitRecipientOk = false,
     bool selfWrapOnSoftUnconfirmed = true,
+    Duration? recipientWrapBuildTimeout = DmSendBudget.recipientWrapBuild,
     Duration? selfWrapBuildTimeout,
   }) async {
+    final recipientWrapBound = recipientWrapBuildTimeout;
     final selfWrapBound = selfWrapBuildTimeout ?? DmSendBudget.selfWrapBuild;
     try {
       // Send gate (#176): the lowest recipient-delivering primitive, so every
@@ -439,24 +448,29 @@ class NIP17MessageService {
       // (#6586). Timing out before any publish leaves nothing delivered, so the
       // durable queue can safely keep it retryable.
       var recipientWrapBuildTimedOut = false;
-      final (giftWrapEvent, prebuiltSelfWrap) =
-          await _buildBothWraps(
-            nostr: nostr,
-            rumorEvent: rumorEvent,
-            recipientPubkey: recipientPubkey,
-          ).timeout(
-            DmSendBudget.recipientWrapBuild,
-            onTimeout: () {
-              recipientWrapBuildTimedOut = true;
-              return (null, null);
-            },
-          );
+      final recipientWrapBuild = _buildBothWraps(
+        nostr: nostr,
+        rumorEvent: rumorEvent,
+        recipientPubkey: recipientPubkey,
+      );
+      final (
+        giftWrapEvent,
+        prebuiltSelfWrap,
+      ) = await (recipientWrapBound == null
+          ? recipientWrapBuild
+          : recipientWrapBuild.timeout(
+              recipientWrapBound,
+              onTimeout: () {
+                recipientWrapBuildTimedOut = true;
+                return (null, null);
+              },
+            ));
 
       if (giftWrapEvent == null) {
         return NIP17SendResult.failure(
           recipientWrapBuildTimedOut
               ? 'Recipient gift wrap build timed out after '
-                    '${DmSendBudget.recipientWrapBuild.inSeconds}s'
+                    '${recipientWrapBound!.inSeconds}s'
               : 'Failed to create gift wrap event',
           retryablePending: recipientWrapBuildTimedOut,
         );
@@ -876,6 +890,10 @@ class NIP17MessageService {
       targetRelays: targetRelays,
       awaitRecipientOk: awaitRecipientOk,
       selfWrapOnSoftUnconfirmed: selfWrapOnSoftUnconfirmed,
+      // No caller of this method owns an outgoing_dms row, so a bounded
+      // pre-publish Amber approval would return retryablePending with nowhere
+      // to retry from. Preserve the pre-PR uncapped recipient-build contract.
+      recipientWrapBuildTimeout: null,
       // No caller of this method imposes an outer cap, so the tight
       // send-sized bound would protect nothing and could only fail a
       // self-wrap the transport would have completed.

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -5,6 +5,7 @@
 
 import 'dart:async';
 
+import 'package:dm_repository/src/dm_send_budget.dart';
 import 'package:dm_repository/src/dm_send_policy.dart';
 import 'package:dm_repository/src/gift_wrap_build_worker.dart';
 import 'package:flutter/foundation.dart' show compute;
@@ -296,13 +297,14 @@ class NIP17MessageService {
   /// with `awaitRecipientOk: true` (reaction sends and message sends). Kept
   /// well under the caller's outer publish cap so the confirmation resolves
   /// with headroom for the subsequent self-wrap before that timeout fires.
-  static const Duration _recipientOkConfirmTimeout = Duration(seconds: 10);
+  static const Duration _recipientOkConfirmTimeout =
+      DmSendBudget.recipientOkConfirm;
 
   /// Hard bound on the self-wrap publish. `publishEvent` is frame-accept
   /// with no timeout of its own, so a stalled socket would otherwise hang
   /// the send's tail past the caller's outer cap and misclassify a
   /// recipient-confirmed send as retryable-pending.
-  static const Duration _selfWrapPublishTimeout = Duration(seconds: 10);
+  static const Duration _selfWrapPublishTimeout = DmSendBudget.selfWrapPublish;
 
   /// Wrap and publish a pre-built [rumorEvent] to the recipient and to
   /// ourselves (self-addressed gift wrap for cross-device recovery).
@@ -412,11 +414,24 @@ class NIP17MessageService {
       // both are built in one isolate hop (half the spawn cost vs two separate
       // calls); for remote signers the self-wrap is deferred to
       // _publishSelfWrap after the recipient publish confirms delivery.
-      final (giftWrapEvent, prebuiltSelfWrap) = await _buildBothWraps(
-        nostr: nostr,
-        rumorEvent: rumorEvent,
-        recipientPubkey: recipientPubkey,
-      );
+      // Bounded: the wrap build is 2 remote signer round trips, and no signer
+      // interface exposes a per-call timeout — the transport's own bound is
+      // whatever that signer chose (Keycast 30s/op, Amber 300s/op, a bunker
+      // none at all). Without a bound here the chain can outrun the caller's
+      // publish backstop, which then fires AFTER the recipient publish has
+      // already landed and misclassifies a delivered message (#6586). Timing
+      // out before any publish is the honest failure: nothing was sent.
+      final (giftWrapEvent, prebuiltSelfWrap) =
+          await _buildBothWraps(
+            nostr: nostr,
+            rumorEvent: rumorEvent,
+            recipientPubkey: recipientPubkey,
+          ).timeout(
+            DmSendBudget.recipientWrapBuild,
+            // Falls into the null-wrap arm below, reusing the existing
+            // build-failure contract rather than adding a second failure shape.
+            onTimeout: () => (null, null),
+          );
 
       if (giftWrapEvent == null) {
         return const NIP17SendResult.failure(
@@ -700,13 +715,21 @@ class NIP17MessageService {
     Event? prebuiltSelfWrap,
   }) async {
     try {
+      // Bounded, and deliberately tighter than the recipient wrap build: the
+      // recipient already has the message by the time this runs, so a missing
+      // self-wrap costs a recovery step, not a delivery. Letting these 2 remote
+      // round trips run unbounded is what pushed a delivered send past the
+      // caller's backstop and got it misclassified as unconfirmed (#6586).
+      // Timing out returns false, which the caller reports as
+      // `selfWrapPublished: false` — the durable row survives and the retry
+      // sweep's recoverSelfWrap arm finishes it out of band (#4124).
       final selfWrapEvent =
           prebuiltSelfWrap ??
           await _buildWrap(
             nostr: nostr,
             rumorEvent: rumorEvent,
             receiverPublicKey: _senderPublicKey,
-          );
+          ).timeout(DmSendBudget.selfWrapBuild, onTimeout: () => null);
       if (selfWrapEvent == null) {
         Log.warning(
           'Self-wrap creation returned null — the sender will not see '

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -353,12 +353,15 @@ class NIP17MessageService {
   /// `DmRepository._sendRumorWithTimeout`; reactions keep their existing 15s
   /// `_publishTimeout`, which can fire before these internal build bounds.
   ///
-  /// A caller with NO outer cap must pass [DmSendBudget.selfWrapUncappedBuild]
-  /// instead — there the tight bound protects no budget and can only fail a
-  /// rebuild the transport itself would have completed, permanently losing the
-  /// sender's cross-device copy. [sendPrivateMessage] does exactly that, which
-  /// is what `DmRepository.sendFileMessage` and the bug-report send reach it
-  /// through; neither imposes a cap of its own.
+  /// Passing `null` leaves self-wrap construction uncapped, the same null
+  /// semantics [recipientWrapBuildTimeout] carries. Only callers with no outer
+  /// cap and no durable row should do that. A self-wrap build timeout is
+  /// reported as `selfWrapPublished: false`, and the arm that is supposed to
+  /// finish it out of band — `DmRepository.recoverSelfWrap` — requires an
+  /// `outgoing_dms` row that those callers never create, so any bound there
+  /// costs the sender their cross-device copy permanently and silently.
+  /// [sendPrivateMessage] is that caller, reached by
+  /// `DmRepository.sendFileMessage` and the bug-report send.
   @useResult
   Future<NIP17SendResult> sendRumor({
     required Event rumorEvent,
@@ -367,10 +370,10 @@ class NIP17MessageService {
     bool awaitRecipientOk = false,
     bool selfWrapOnSoftUnconfirmed = true,
     Duration? recipientWrapBuildTimeout = DmSendBudget.recipientWrapBuild,
-    Duration? selfWrapBuildTimeout,
+    Duration? selfWrapBuildTimeout = DmSendBudget.selfWrapBuild,
   }) async {
     final recipientWrapBound = recipientWrapBuildTimeout;
-    final selfWrapBound = selfWrapBuildTimeout ?? DmSendBudget.selfWrapBuild;
+    final selfWrapBound = selfWrapBuildTimeout;
     try {
       // Send gate (#176): the lowest recipient-delivering primitive, so every
       // publisher — direct send, group fan-out, drain replay, reactions,
@@ -752,7 +755,7 @@ class NIP17MessageService {
   Future<bool> _publishSelfWrap({
     required Nostr nostr,
     required Event rumorEvent,
-    required Duration wrapBuildTimeout,
+    required Duration? wrapBuildTimeout,
     Event? prebuiltSelfWrap,
   }) async {
     try {
@@ -763,20 +766,31 @@ class NIP17MessageService {
       // survives and the retry sweep's recoverSelfWrap arm finishes it out of
       // band (#4124).
       //
-      // The bound is the caller's, because the two callers are not paying for
-      // the same thing: inside a send it is the tight
+      // The bound is the caller's, because the callers are not paying for the
+      // same thing: inside a send it is the tight
       // [DmSendBudget.selfWrapBuild] that keeps the chain under the backstop,
       // while recovery runs with no outer cap and uses the wider
       // [DmSendBudget.selfWrapUncappedBuild] — bounding recovery at the tight
       // one would fail rebuilds against the same slow signer that left the
       // self-wrap outstanding.
-      final selfWrapEvent =
-          prebuiltSelfWrap ??
-          await _buildWrap(
-            nostr: nostr,
-            rumorEvent: rumorEvent,
-            receiverPublicKey: _senderPublicKey,
-          ).timeout(wrapBuildTimeout, onTimeout: () => null);
+      //
+      // A `null` bound means uncapped, for callers that own no `outgoing_dms`
+      // row: recoverSelfWrap needs one, so for them the "durable row survives
+      // and recovery finishes it" contract above does not hold and any bound
+      // loses the cross-device copy outright.
+      final Event? selfWrapEvent;
+      if (prebuiltSelfWrap != null) {
+        selfWrapEvent = prebuiltSelfWrap;
+      } else {
+        final build = _buildWrap(
+          nostr: nostr,
+          rumorEvent: rumorEvent,
+          receiverPublicKey: _senderPublicKey,
+        );
+        selfWrapEvent = wrapBuildTimeout == null
+            ? await build
+            : await build.timeout(wrapBuildTimeout, onTimeout: () => null);
+      }
       if (selfWrapEvent == null) {
         Log.warning(
           'Self-wrap creation returned null — the sender will not see '
@@ -894,10 +908,10 @@ class NIP17MessageService {
       // pre-publish Amber approval would return retryablePending with nowhere
       // to retry from. Preserve the pre-PR uncapped recipient-build contract.
       recipientWrapBuildTimeout: null,
-      // No caller of this method imposes an outer cap, so the tight
-      // send-sized bound would protect nothing and could only fail a
-      // self-wrap the transport would have completed.
-      selfWrapBuildTimeout: DmSendBudget.selfWrapUncappedBuild,
+      // Same reasoning on the self-wrap: with no outgoing_dms row there is no
+      // recoverSelfWrap arm to finish a timed-out build, so any bound here
+      // silently costs the sender their cross-device copy for good.
+      selfWrapBuildTimeout: null,
     );
   }
 

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -340,13 +340,26 @@ class NIP17MessageService {
   /// contract: soft-unconfirmed recipient publishes return retryable failure
   /// and the caller owns any fallback behavior.
   @useResult
+  /// [selfWrapBuildTimeout] bounds the self-wrap build, defaulting to the
+  /// tight [DmSendBudget.selfWrapBuild] because both direct callers
+  /// (`DmRepository._sendRumorWithTimeout`, `DmReactionsRepository`) wrap this
+  /// in an outer cap the tight bound exists to keep the chain under.
+  ///
+  /// A caller with NO outer cap must pass [DmSendBudget.selfWrapRecoveryBuild]
+  /// instead — there the tight bound protects no budget and can only fail a
+  /// rebuild the transport itself would have completed, permanently losing the
+  /// sender's cross-device copy. [sendPrivateMessage] does exactly that, which
+  /// is what `DmRepository.sendFileMessage` and the bug-report send reach it
+  /// through; neither imposes a cap of its own.
   Future<NIP17SendResult> sendRumor({
     required Event rumorEvent,
     required String recipientPubkey,
     List<String>? targetRelays,
     bool awaitRecipientOk = false,
     bool selfWrapOnSoftUnconfirmed = true,
+    Duration? selfWrapBuildTimeout,
   }) async {
+    final selfWrapBound = selfWrapBuildTimeout ?? DmSendBudget.selfWrapBuild;
     try {
       // Send gate (#176): the lowest recipient-delivering primitive, so every
       // publisher — direct send, group fan-out, drain replay, reactions,
@@ -504,7 +517,7 @@ class NIP17MessageService {
             await _publishSelfWrap(
               nostr: nostr,
               rumorEvent: rumorEvent,
-              wrapBuildTimeout: DmSendBudget.selfWrapBuild,
+              wrapBuildTimeout: selfWrapBound,
               prebuiltSelfWrap: prebuiltSelfWrap,
             );
 
@@ -581,7 +594,7 @@ class NIP17MessageService {
       final selfWrapPublished = await _publishSelfWrap(
         nostr: nostr,
         rumorEvent: rumorEvent,
-        wrapBuildTimeout: DmSendBudget.selfWrapBuild,
+        wrapBuildTimeout: selfWrapBound,
         prebuiltSelfWrap: prebuiltSelfWrap,
       );
 
@@ -853,6 +866,10 @@ class NIP17MessageService {
       targetRelays: targetRelays,
       awaitRecipientOk: awaitRecipientOk,
       selfWrapOnSoftUnconfirmed: selfWrapOnSoftUnconfirmed,
+      // No caller of this method imposes an outer cap, so the tight
+      // send-sized bound would protect nothing and could only fail a
+      // self-wrap the transport would have completed.
+      selfWrapBuildTimeout: DmSendBudget.selfWrapRecoveryBuild,
     );
   }
 

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -504,6 +504,7 @@ class NIP17MessageService {
             await _publishSelfWrap(
               nostr: nostr,
               rumorEvent: rumorEvent,
+              wrapBuildTimeout: DmSendBudget.selfWrapBuild,
               prebuiltSelfWrap: prebuiltSelfWrap,
             );
 
@@ -580,6 +581,7 @@ class NIP17MessageService {
       final selfWrapPublished = await _publishSelfWrap(
         nostr: nostr,
         rumorEvent: rumorEvent,
+        wrapBuildTimeout: DmSendBudget.selfWrapBuild,
         prebuiltSelfWrap: prebuiltSelfWrap,
       );
 
@@ -676,6 +678,7 @@ class NIP17MessageService {
       final published = await _publishSelfWrap(
         nostr: nostr,
         rumorEvent: rumorEvent,
+        wrapBuildTimeout: DmSendBudget.selfWrapRecoveryBuild,
       );
       if (!published) {
         return const NIP17SendResult.failure('Self-wrap publish failed');
@@ -712,24 +715,31 @@ class NIP17MessageService {
   Future<bool> _publishSelfWrap({
     required Nostr nostr,
     required Event rumorEvent,
+    required Duration wrapBuildTimeout,
     Event? prebuiltSelfWrap,
   }) async {
     try {
-      // Bounded, and deliberately tighter than the recipient wrap build: the
-      // recipient already has the message by the time this runs, so a missing
-      // self-wrap costs a recovery step, not a delivery. Letting these 2 remote
-      // round trips run unbounded is what pushed a delivered send past the
-      // caller's backstop and got it misclassified as unconfirmed (#6586).
-      // Timing out returns false, which the caller reports as
-      // `selfWrapPublished: false` — the durable row survives and the retry
-      // sweep's recoverSelfWrap arm finishes it out of band (#4124).
+      // Bounded: letting these 2 remote round trips run unbounded is what
+      // pushed a delivered send past the caller's backstop and got it
+      // misclassified as unconfirmed (#6586). Timing out returns false, which
+      // the caller reports as `selfWrapPublished: false` — the durable row
+      // survives and the retry sweep's recoverSelfWrap arm finishes it out of
+      // band (#4124).
+      //
+      // The bound is the caller's, because the two callers are not paying for
+      // the same thing: inside a send it is the tight
+      // [DmSendBudget.selfWrapBuild] that keeps the chain under the backstop,
+      // while recovery runs with no outer cap and uses the wider
+      // [DmSendBudget.selfWrapRecoveryBuild] — bounding recovery at the tight
+      // one would fail every rebuild against exactly the slow signer that left
+      // the self-wrap outstanding.
       final selfWrapEvent =
           prebuiltSelfWrap ??
           await _buildWrap(
             nostr: nostr,
             rumorEvent: rumorEvent,
             receiverPublicKey: _senderPublicKey,
-          ).timeout(DmSendBudget.selfWrapBuild, onTimeout: () => null);
+          ).timeout(wrapBuildTimeout, onTimeout: () => null);
       if (selfWrapEvent == null) {
         Log.warning(
           'Self-wrap creation returned null — the sender will not see '

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -339,18 +339,20 @@ class NIP17MessageService {
   /// that also pass `false` are choosing a hard no-self-wrap confirmation
   /// contract: soft-unconfirmed recipient publishes return retryable failure
   /// and the caller owns any fallback behavior.
-  @useResult
-  /// [selfWrapBuildTimeout] bounds the self-wrap build, defaulting to the
-  /// tight [DmSendBudget.selfWrapBuild] because both direct callers
-  /// (`DmRepository._sendRumorWithTimeout`, `DmReactionsRepository`) wrap this
-  /// in an outer cap the tight bound exists to keep the chain under.
   ///
-  /// A caller with NO outer cap must pass [DmSendBudget.selfWrapRecoveryBuild]
+  /// [selfWrapBuildTimeout] bounds the self-wrap build, defaulting to the
+  /// tight [DmSendBudget.selfWrapBuild] for callers that protect the full
+  /// publish with an outer cap. Durable message sends use
+  /// `DmRepository._sendRumorWithTimeout`; reactions keep their existing 15s
+  /// `_publishTimeout`, which can fire before these internal build bounds.
+  ///
+  /// A caller with NO outer cap must pass [DmSendBudget.selfWrapUncappedBuild]
   /// instead — there the tight bound protects no budget and can only fail a
   /// rebuild the transport itself would have completed, permanently losing the
   /// sender's cross-device copy. [sendPrivateMessage] does exactly that, which
   /// is what `DmRepository.sendFileMessage` and the bug-report send reach it
   /// through; neither imposes a cap of its own.
+  @useResult
   Future<NIP17SendResult> sendRumor({
     required Event rumorEvent,
     required String recipientPubkey,
@@ -691,7 +693,7 @@ class NIP17MessageService {
       final published = await _publishSelfWrap(
         nostr: nostr,
         rumorEvent: rumorEvent,
-        wrapBuildTimeout: DmSendBudget.selfWrapRecoveryBuild,
+        wrapBuildTimeout: DmSendBudget.selfWrapUncappedBuild,
       );
       if (!published) {
         return const NIP17SendResult.failure('Self-wrap publish failed');
@@ -743,9 +745,9 @@ class NIP17MessageService {
       // the same thing: inside a send it is the tight
       // [DmSendBudget.selfWrapBuild] that keeps the chain under the backstop,
       // while recovery runs with no outer cap and uses the wider
-      // [DmSendBudget.selfWrapRecoveryBuild] — bounding recovery at the tight
-      // one would fail every rebuild against exactly the slow signer that left
-      // the self-wrap outstanding.
+      // [DmSendBudget.selfWrapUncappedBuild] — bounding recovery at the tight
+      // one would fail rebuilds against the same slow signer that left the
+      // self-wrap outstanding.
       final selfWrapEvent =
           prebuiltSelfWrap ??
           await _buildWrap(
@@ -869,7 +871,7 @@ class NIP17MessageService {
       // No caller of this method imposes an outer cap, so the tight
       // send-sized bound would protect nothing and could only fail a
       // self-wrap the transport would have completed.
-      selfWrapBuildTimeout: DmSendBudget.selfWrapRecoveryBuild,
+      selfWrapBuildTimeout: DmSendBudget.selfWrapUncappedBuild,
     );
   }
 

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -431,11 +431,14 @@ class NIP17MessageService {
       // _publishSelfWrap after the recipient publish confirms delivery.
       // Bounded: the wrap build is 2 remote signer round trips, and no signer
       // interface exposes a per-call timeout — the transport's own bound is
-      // whatever that signer chose (Keycast 30s/op, Amber 300s/op, a bunker
-      // none at all). Without a bound here the chain can outrun the caller's
-      // publish backstop, which then fires AFTER the recipient publish has
-      // already landed and misclassifies a delivered message (#6586). Timing
-      // out before any publish is the honest failure: nothing was sent.
+      // whatever that signer chose. Keycast is 30s/op; Amber's NIP-55 intent
+      // path for `nip44Encrypt` and `signEvent` is human-gated and unbounded; a
+      // bunker can be unbounded too. Without a bound here the chain can outrun
+      // the caller's publish backstop, which then fires AFTER the recipient
+      // publish has already landed and misclassifies a delivered message
+      // (#6586). Timing out before any publish leaves nothing delivered, so the
+      // durable queue can safely keep it retryable.
+      var recipientWrapBuildTimedOut = false;
       final (giftWrapEvent, prebuiltSelfWrap) =
           await _buildBothWraps(
             nostr: nostr,
@@ -443,14 +446,19 @@ class NIP17MessageService {
             recipientPubkey: recipientPubkey,
           ).timeout(
             DmSendBudget.recipientWrapBuild,
-            // Falls into the null-wrap arm below, reusing the existing
-            // build-failure contract rather than adding a second failure shape.
-            onTimeout: () => (null, null),
+            onTimeout: () {
+              recipientWrapBuildTimedOut = true;
+              return (null, null);
+            },
           );
 
       if (giftWrapEvent == null) {
-        return const NIP17SendResult.failure(
-          'Failed to create gift wrap event',
+        return NIP17SendResult.failure(
+          recipientWrapBuildTimedOut
+              ? 'Recipient gift wrap build timed out after '
+                    '${DmSendBudget.recipientWrapBuild.inSeconds}s'
+              : 'Failed to create gift wrap event',
+          retryablePending: recipientWrapBuildTimedOut,
         );
       }
 
@@ -820,7 +828,7 @@ class NIP17MessageService {
         nostr: nostr,
         rumorEvent: rumor,
         receiverPublicKey: _senderPublicKey,
-      );
+      ).timeout(DmSendBudget.selfWrapUncappedBuild, onTimeout: () => null);
       if (selfWrapEvent == null) return false;
       final published = (targetRelays != null && targetRelays.isNotEmpty)
           ? await _nostrService.publishEvent(

--- a/mobile/packages/dm_repository/pubspec.yaml
+++ b/mobile/packages/dm_repository/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
     path: ../unified_logger
 
 dev_dependencies:
+  fake_async: ^1.3.3
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -2053,6 +2053,61 @@ void main() {
       );
 
       test(
+        'a send with no retry row leaves the recipient build uncapped',
+        () {
+          // `sendFileMessage` and the bug-report send reach sendRumor through
+          // sendPrivateMessage and do not own an outgoing_dms row. If an Amber
+          // approval takes longer than the send-chain recipient bound,
+          // returning retryablePending gives those callers nowhere to retry
+          // from. Keep this pre-publish build uncapped for that convenience
+          // path.
+          final senderPublicKey = getPublicKey(_testPrivateKey);
+          final slowApproval =
+              DmSendBudget.recipientWrapBuild + const Duration(seconds: 5);
+
+          NIP17SendResult? result;
+          fakeAsync((async) {
+            var builds = 0;
+            final service = NIP17MessageService(
+              signer: LocalNostrSigner(_testPrivateKey),
+              senderPublicKey: senderPublicKey,
+              nostrService: client,
+              giftWrapBuilder: (nostr, rumor, receiverPubkey) {
+                builds++;
+                return Future.delayed(
+                  builds == 1 ? slowApproval : Duration.zero,
+                  () => GiftWrapUtil.getGiftWrapEvent(
+                    nostr,
+                    rumor,
+                    receiverPubkey,
+                  ),
+                );
+              },
+            );
+
+            unawaited(
+              service
+                  .sendPrivateMessage(
+                    recipientPubkey: _recipientPubkey,
+                    content: 'slow recipient approval',
+                    awaitRecipientOk: true,
+                  )
+                  .then((r) => result = r),
+            );
+
+            async
+              ..flushMicrotasks()
+              ..elapse(slowApproval)
+              ..flushMicrotasks();
+          });
+
+          expect(result, isNotNull, reason: 'send must resolve, not time out');
+          expect(result!.success, isTrue);
+          expect(result!.retryablePending, isFalse);
+        },
+      );
+
+      test(
         'self-wrap build that outruns its bound still reports a delivered send',
         () {
           // The recipient wrap is already published and OK-confirmed here, so

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -2,7 +2,10 @@
 // ABOUTME: Covers NIP-17 gift wrap creation, encryption, publishing,
 // ABOUTME: self-wrap fallback, and error handling paths.
 
+import 'dart:async';
+
 import 'package:dm_repository/dm_repository.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' show NIP17SendResult;
@@ -11,6 +14,7 @@ import 'package:nostr_sdk/client_utils/keys.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/event_kind.dart';
 import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
+import 'package:nostr_sdk/nostr.dart';
 import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:nostr_sdk/signer/isolate_decrypt_signer.dart';
 import 'package:nostr_sdk/signer/local_nostr_signer.dart';
@@ -1892,6 +1896,152 @@ void main() {
           expect(result.success, isTrue);
         },
       );
+    });
+
+    // #6586. A 1:1 send costs four remote signer round trips, and no signer
+    // interface exposes a per-call timeout — Keycast bounds an op at 30s,
+    // Amber's AndroidNostrSigner at 300s, a bunker at nothing. Before these
+    // bounds existed the chain could outrun the caller's publish backstop,
+    // which then fired AFTER the recipient publish had landed and reported a
+    // delivered message as unconfirmed.
+    group('wrap-build bounds (#6586)', () {
+      late _MockNostrClient client;
+
+      setUp(() {
+        client = _MockNostrClient();
+        when(
+          () => client.publishEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => const PublishOutcome(
+            eventId: 'gift-wrap-id',
+            acceptedBy: ['wss://relay.example.com'],
+            rejectedBy: {},
+            noResponseFrom: [],
+          ),
+        );
+        when(() => client.publishEvent(any())).thenAnswer(
+          (inv) async =>
+              PublishSuccess(event: inv.positionalArguments[0] as Event),
+        );
+      });
+
+      // `GiftWrapBuilder` is hidden from the package barrel, so spell the
+      // signature out rather than reaching into `src/`.
+      NIP17MessageService serviceWithBuilder(
+        Future<Event?> Function(Nostr, Event, String) builder,
+      ) => NIP17MessageService(
+        signer: LocalNostrSigner(_testPrivateKey),
+        senderPublicKey: _testPublicKey,
+        nostrService: client,
+        giftWrapBuilder: builder,
+      );
+
+      test(
+        'recipient wrap build that outruns its bound fails BEFORE publishing',
+        () {
+          // The load-bearing assertion is the negative one: a build that never
+          // completes must not reach the relay. Timing out after the publish is
+          // the #6586 defect — the recipient has the message and the sender is
+          // told it is unconfirmed.
+          NIP17SendResult? result;
+          fakeAsync((async) {
+            unawaited(
+              serviceWithBuilder((_, _, _) => Completer<Event?>().future)
+                  .sendRumor(
+                    rumorEvent: Event(
+                      _testPublicKey,
+                      EventKind.privateDirectMessage,
+                      const [],
+                      'hangs while wrapping',
+                    ),
+                    recipientPubkey: _recipientPubkey,
+                    awaitRecipientOk: true,
+                    selfWrapOnSoftUnconfirmed: false,
+                  )
+                  .then((r) => result = r),
+            );
+
+            async.elapse(DmSendBudget.recipientWrapBuild * 2);
+          });
+
+          expect(result, isNotNull, reason: 'send must resolve, not hang');
+          expect(result!.success, isFalse);
+          verifyNever(
+            () => client.publishEventAwaitOk(
+              any(),
+              timeout: any(named: 'timeout'),
+            ),
+          );
+          verifyNever(() => client.publishEvent(any()));
+        },
+      );
+
+      test(
+        'self-wrap build that outruns its bound still reports a delivered send',
+        () {
+          // The recipient wrap is already published and OK-confirmed here, so
+          // the send DID happen. A slow self-wrap must degrade to partial
+          // delivery (recoverSelfWrap picks it up, #4124), never to a failure —
+          // reporting failure here is what parked delivered messages as
+          // soft-unconfirmed until the retry budget turned them red.
+          var builds = 0;
+          NIP17SendResult? result;
+          fakeAsync((async) {
+            unawaited(
+              serviceWithBuilder((nostr, rumor, receiverPubkey) {
+                    builds++;
+                    // First call = recipient wrap: succeed. Second = self:
+                    // hang.
+                    return builds == 1
+                        ? GiftWrapUtil.getGiftWrapEvent(
+                            nostr,
+                            rumor,
+                            receiverPubkey,
+                          )
+                        : Completer<Event?>().future;
+                  })
+                  .sendRumor(
+                    rumorEvent: Event(
+                      _testPublicKey,
+                      EventKind.privateDirectMessage,
+                      const [],
+                      'self-wrap hangs',
+                    ),
+                    recipientPubkey: _recipientPubkey,
+                    awaitRecipientOk: true,
+                    selfWrapOnSoftUnconfirmed: false,
+                  )
+                  .then((r) => result = r),
+            );
+
+            async.elapse(DmSendBudget.selfWrapBuild * 2);
+          });
+
+          expect(result, isNotNull, reason: 'send must resolve, not hang');
+          expect(
+            result!.success,
+            isTrue,
+            reason: 'the recipient wrap was published and OK-confirmed',
+          );
+          expect(
+            result!.selfWrapPublished,
+            isFalse,
+            reason: 'partial delivery, recoverable via recoverSelfWrap',
+          );
+        },
+      );
+
+      test('the self-wrap bound is tighter than the recipient bound', () {
+        // Encodes the asymmetry the bounds exist for: a slow recipient wrap
+        // costs a delivery, a slow self-wrap costs a recovery step.
+        expect(
+          DmSendBudget.selfWrapBuild,
+          lessThan(DmSendBudget.recipientWrapBuild),
+        );
+      });
     });
   });
 }

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -2230,17 +2230,18 @@ void main() {
       );
 
       test(
-        'a send with no outer cap also gets the wider rebuild bound',
+        'a send with no retry row leaves the self-wrap build uncapped',
         () {
           // `sendFileMessage` and the bug-report send reach sendRumor via
-          // sendPrivateMessage and impose NO outer cap, so the tight
-          // send-sized bound would fail a self-wrap the transport itself
-          // would have completed — permanently losing the sender's
-          // cross-device copy, since neither is queued for recoverSelfWrap.
-          // Only DmRepository's capped path opts into `selfWrapBuild`.
+          // sendPrivateMessage, impose NO outer cap, and own no outgoing_dms
+          // row. A self-wrap build timeout reports selfWrapPublished: false
+          // and leans on recoverSelfWrap to finish out of band — but that
+          // requires the queue row they never create, so ANY bound here drops
+          // the sender's cross-device copy for good. Drive the rebuild past
+          // even the widest bound to pin that it is uncapped, not just wide.
           final senderPublicKey = getPublicKey(_testPrivateKey);
           final slowRebuild =
-              DmSendBudget.selfWrapBuild + const Duration(seconds: 5);
+              DmSendBudget.selfWrapUncappedBuild + const Duration(seconds: 5);
 
           NIP17SendResult? result;
           fakeAsync((async) {
@@ -2281,7 +2282,7 @@ void main() {
 
             async
               ..flushMicrotasks()
-              ..elapse(DmSendBudget.selfWrapUncappedBuild)
+              ..elapse(slowRebuild)
               ..flushMicrotasks();
           });
 
@@ -2291,8 +2292,8 @@ void main() {
             result!.selfWrapPublished,
             isTrue,
             reason:
-                'a rebuild slower than selfWrapBuild must still land when '
-                'the caller imposes no cap of its own',
+                'a rebuild slower than every self-wrap bound must still land '
+                'for a caller with no row to recover from',
           );
         },
       );

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -8,7 +8,7 @@ import 'package:dm_repository/dm_repository.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:models/models.dart' show NIP17SendResult;
+import 'package:models/models.dart' show NIP17SendFailure, NIP17SendResult;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/client_utils/keys.dart';
 import 'package:nostr_sdk/event.dart';
@@ -756,6 +756,37 @@ void main() {
           expect(ok, isFalse);
         },
       );
+
+      test('returns false when the gift wrap build times out', () {
+        bool? ok;
+        fakeAsync((async) {
+          final hangingService = NIP17MessageService(
+            signer: LocalNostrSigner(_testPrivateKey),
+            senderPublicKey: _testPublicKey,
+            nostrService: mockNostrClient,
+            giftWrapBuilder: (_, _, _) => Completer<Event?>().future,
+          );
+
+          unawaited(
+            hangingService
+                .publishSelfApplicationMarker(
+                  content: '{"v":1,"read":{}}',
+                  tags: const [
+                    ['d', 'divine/dm-read/v1'],
+                  ],
+                )
+                .then((value) => ok = value),
+          );
+
+          async
+            ..flushMicrotasks()
+            ..elapse(DmSendBudget.selfWrapUncappedBuild * 2)
+            ..flushMicrotasks();
+        });
+
+        expect(ok, isFalse);
+        verifyNever(() => mockNostrClient.publishEvent(any()));
+      });
     });
 
     group('sendPrivateMessage', () {
@@ -1900,10 +1931,11 @@ void main() {
 
     // #6586. A 1:1 send costs four remote signer round trips, and no signer
     // interface exposes a per-call timeout — Keycast bounds an op at 30s,
-    // Amber's AndroidNostrSigner at 300s, a bunker at nothing. Before these
-    // bounds existed the chain could outrun the caller's publish backstop,
-    // which then fired AFTER the recipient publish had landed and reported a
-    // delivered message as unconfirmed.
+    // Amber's NIP-55 intent path for nip44Encrypt/signEvent is human-gated and
+    // unbounded, and a bunker may be unbounded too. Before these bounds existed
+    // the chain could outrun the caller's publish backstop, which then fired
+    // AFTER the recipient publish had landed and reported a delivered message
+    // as unconfirmed.
     group('wrap-build bounds (#6586)', () {
       late _MockNostrClient client;
 
@@ -1940,12 +1972,15 @@ void main() {
       );
 
       test(
-        'recipient wrap build that outruns its bound fails BEFORE publishing',
+        'recipient wrap build timeout is retryable-pending before publishing',
         () {
           // The load-bearing assertion is the negative one: a build that never
           // completes must not reach the relay. Timing out after the publish is
           // the #6586 defect — the recipient has the message and the sender is
-          // told it is unconfirmed.
+          // told it is unconfirmed. Timing out before publish leaves nothing
+          // delivered, but NIP-55/Amber may still be waiting on a human approval,
+          // so the durable queue keeps the row pending for retry instead of
+          // red.
           NIP17SendResult? result;
           fakeAsync((async) {
             unawaited(
@@ -1969,6 +2004,44 @@ void main() {
 
           expect(result, isNotNull, reason: 'send must resolve, not hang');
           expect(result!.success, isFalse);
+          expect(result!.retryablePending, isTrue);
+          expect(
+            (result! as NIP17SendFailure).error,
+            'Recipient gift wrap build timed out after '
+            '${DmSendBudget.recipientWrapBuild.inSeconds}s',
+          );
+          verifyNever(
+            () => client.publishEventAwaitOk(
+              any(),
+              timeout: any(named: 'timeout'),
+            ),
+          );
+          verifyNever(() => client.publishEvent(any()));
+        },
+      );
+
+      test(
+        'recipient wrap builder returning null remains a hard failure',
+        () async {
+          final result = await serviceWithBuilder((_, _, _) async => null)
+              .sendRumor(
+                rumorEvent: Event(
+                  _testPublicKey,
+                  EventKind.privateDirectMessage,
+                  const [],
+                  'builder returned null',
+                ),
+                recipientPubkey: _recipientPubkey,
+                awaitRecipientOk: true,
+                selfWrapOnSoftUnconfirmed: false,
+              );
+
+          expect(result.success, isFalse);
+          expect(result.retryablePending, isFalse);
+          expect(
+            (result as NIP17SendFailure).error,
+            'Failed to create gift wrap event',
+          );
           verifyNever(
             () => client.publishEventAwaitOk(
               any(),

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -2059,7 +2059,7 @@ void main() {
           final slowRebuild = DmSendBudget.selfWrapBuild * 2;
           expect(
             slowRebuild,
-            lessThan(DmSendBudget.selfWrapRecoveryBuild),
+            lessThan(DmSendBudget.selfWrapUncappedBuild),
             reason: 'the rebuild must sit between the two bounds to test them',
           );
 
@@ -2092,7 +2092,7 @@ void main() {
                   .then((r) => result = r),
             );
 
-            async.elapse(DmSendBudget.selfWrapRecoveryBuild);
+            async.elapse(DmSendBudget.selfWrapUncappedBuild);
           });
 
           expect(result, isNotNull, reason: 'recovery must resolve, not hang');
@@ -2153,7 +2153,7 @@ void main() {
 
             async
               ..flushMicrotasks()
-              ..elapse(DmSendBudget.selfWrapRecoveryBuild)
+              ..elapse(DmSendBudget.selfWrapUncappedBuild)
               ..flushMicrotasks();
           });
 

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -2100,6 +2100,74 @@ void main() {
           expect(result!.selfWrapPublished, isTrue);
         },
       );
+
+      test(
+        'a send with no outer cap also gets the wider rebuild bound',
+        () {
+          // `sendFileMessage` and the bug-report send reach sendRumor via
+          // sendPrivateMessage and impose NO outer cap, so the tight
+          // send-sized bound would fail a self-wrap the transport itself
+          // would have completed — permanently losing the sender's
+          // cross-device copy, since neither is queued for recoverSelfWrap.
+          // Only DmRepository's capped path opts into `selfWrapBuild`.
+          final senderPublicKey = getPublicKey(_testPrivateKey);
+          final slowRebuild =
+              DmSendBudget.selfWrapBuild + const Duration(seconds: 5);
+
+          NIP17SendResult? result;
+          fakeAsync((async) {
+            var builds = 0;
+            final service = NIP17MessageService(
+              signer: LocalNostrSigner(_testPrivateKey),
+              senderPublicKey: senderPublicKey,
+              nostrService: client,
+              giftWrapBuilder: (nostr, rumor, receiverPubkey) {
+                builds++;
+                // Recipient wrap is prompt; only the self-wrap rebuild is slow.
+                return builds == 1
+                    ? GiftWrapUtil.getGiftWrapEvent(
+                        nostr,
+                        rumor,
+                        receiverPubkey,
+                      )
+                    : Future.delayed(
+                        slowRebuild,
+                        () => GiftWrapUtil.getGiftWrapEvent(
+                          nostr,
+                          rumor,
+                          receiverPubkey,
+                        ),
+                      );
+              },
+            );
+
+            unawaited(
+              service
+                  .sendPrivateMessage(
+                    recipientPubkey: _recipientPubkey,
+                    content: 'uncapped caller',
+                    awaitRecipientOk: true,
+                  )
+                  .then((r) => result = r),
+            );
+
+            async
+              ..flushMicrotasks()
+              ..elapse(DmSendBudget.selfWrapRecoveryBuild)
+              ..flushMicrotasks();
+          });
+
+          expect(result, isNotNull, reason: 'send must resolve, not hang');
+          expect(result!.success, isTrue);
+          expect(
+            result!.selfWrapPublished,
+            isTrue,
+            reason:
+                'a rebuild slower than selfWrapBuild must still land when '
+                'the caller imposes no cap of its own',
+          );
+        },
+      );
     });
   });
 }

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -2042,6 +2042,64 @@ void main() {
           lessThan(DmSendBudget.recipientWrapBuild),
         );
       });
+
+      test(
+        'a self-wrap rebuild too slow for the send bound still recovers '
+        'out of band',
+        () {
+          // The tight in-send bound buys headroom under the publish backstop.
+          // Recovery has no backstop to protect, so bounding it the same way
+          // would only fail rebuilds the signer would have completed — and the
+          // rebuild is the same two round trips that left the self-wrap
+          // outstanding, so it would fail against exactly the slow signer this
+          // arm exists for, every attempt, until the row exhausted its retry
+          // budget with the cross-device copy permanently missing.
+          final senderPublicKey = getPublicKey(_testPrivateKey);
+          // Past the in-send bound, well inside the recovery bound.
+          final slowRebuild = DmSendBudget.selfWrapBuild * 2;
+          expect(
+            slowRebuild,
+            lessThan(DmSendBudget.selfWrapRecoveryBuild),
+            reason: 'the rebuild must sit between the two bounds to test them',
+          );
+
+          NIP17SendResult? result;
+          fakeAsync((async) {
+            final service = NIP17MessageService(
+              signer: LocalNostrSigner(_testPrivateKey),
+              // Derived from the signer: the self-wrap ECDH keys on it, and
+              // the synthetic _testPublicKey is not a valid secp256k1 point.
+              senderPublicKey: senderPublicKey,
+              nostrService: client,
+              giftWrapBuilder: (nostr, rumor, receiverPubkey) => Future.delayed(
+                slowRebuild,
+                () => GiftWrapUtil.getGiftWrapEvent(
+                  nostr,
+                  rumor,
+                  receiverPubkey,
+                ),
+              ),
+            );
+
+            unawaited(
+              service
+                  .publishSelfWrap(
+                    rumorEvent: service.buildRumor(
+                      recipientPubkey: _recipientPubkey,
+                      content: 'slow self-wrap rebuild',
+                    ),
+                  )
+                  .then((r) => result = r),
+            );
+
+            async.elapse(DmSendBudget.selfWrapRecoveryBuild);
+          });
+
+          expect(result, isNotNull, reason: 'recovery must resolve, not hang');
+          expect(result!.success, isTrue);
+          expect(result!.selfWrapPublished, isTrue);
+        },
+      );
     });
   });
 }

--- a/mobile/packages/models/lib/src/nip17_send_result.dart
+++ b/mobile/packages/models/lib/src/nip17_send_result.dart
@@ -61,13 +61,13 @@ sealed class NIP17SendResult {
 
   /// Build a failure result.
   ///
-  /// [retryablePending] marks a "soft" failure where the recipient wrap frame
-  /// was written to the relay but no NIP-20 `OK` arrived within the window
-  /// (and no relay explicitly rejected it) — the send is *unconfirmed*, not
-  /// proven-failed. A lost/late `OK` on a flaky relay is indistinguishable from
-  /// actual delivery, so reaction callers keep such a send in a retryable
-  /// pending state rather than flipping it to a hard failure. Defaults to
-  /// `false` (a confirmed rejection or error).
+  /// [retryablePending] marks a "soft" failure where the send should remain
+  /// pending and be retried rather than turning into a hard failure. The usual
+  /// case is a recipient wrap frame written to the relay with no NIP-20 `OK`
+  /// within the window (and no explicit rejection): the send is *unconfirmed*,
+  /// not proven-failed. It can also represent a bounded pre-publish crypto
+  /// build timeout, such as a human-gated NIP-55 signer approval that has not
+  /// returned yet. Defaults to `false` (a confirmed rejection or error).
   ///
   /// [queuedRumorId] is the durable `outgoing_dms` row the send left behind
   /// for the retry sweep — see [NIP17SendResult.queuedRumorId].
@@ -91,11 +91,10 @@ sealed class NIP17SendResult {
   /// error. Blocked sends are not retriable. Always `false` for success.
   bool get blocked => false;
 
-  /// Whether a failure is an *unconfirmed* recipient publish (frame written,
-  /// no relay `OK` within the window, no explicit rejection) rather than a
-  /// confirmed rejection/error. Always `false` on success and on hard
-  /// failures. Reaction callers keep a `retryablePending` send in a pending,
-  /// sweep-retryable state instead of marking it failed.
+  /// Whether a failure should stay in a pending, sweep-retryable state instead
+  /// of being marked failed. Covers inconclusive recipient publishes
+  /// (frame written, no relay `OK`, no explicit rejection) and bounded
+  /// pre-publish crypto build timeouts where retry is still the honest outcome.
   bool get retryablePending => false;
 
   /// The `outgoing_dms` row this send left parked for the retry sweep, when

--- a/mobile/test/services/outgoing_dm_retry_service_test.dart
+++ b/mobile/test/services/outgoing_dm_retry_service_test.dart
@@ -10,6 +10,7 @@ import 'package:db_client/db_client.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' show NIP17SendResult;
 import 'package:openvine/services/crash_reporting_service.dart';
@@ -367,13 +368,16 @@ void main() {
         () {
           fakeAsync((async) {
             final base = DateTime.utc(2026, 5, 10, 12);
-            // The row was queued 60s before the first pass: too young for
-            // the 120s min-age at t=0 and t=30, old enough at t=60.
+            // Derived from the guard, not restated: the row starts one
+            // follow-up gap short of it, so it is too young at t=0 and
+            // t=+gap, and exactly old enough at t=+2×gap.
+            const gap = Duration(seconds: 30);
+            final minAge = OutgoingDmRetryService.interruptedMinAge;
             final row = _row(
               id: 'young-pending',
               recipient: OutgoingWrapStatus.pending,
               self: OutgoingWrapStatus.pending,
-              queuedAt: base.subtract(const Duration(seconds: 60)),
+              queuedAt: base.subtract(minAge - gap * 2),
             );
             var terminalized = false;
             when(
@@ -406,7 +410,7 @@ void main() {
 
             unawaited(service.sweep());
             async.flushMicrotasks();
-            // Age 60s < 120s: nothing flipped, but the follow-up is armed.
+            // Two gaps short of the guard: nothing flipped, follow-up armed.
             verifyNever(
               () => dao.markRecipientWrapStatus(
                 id: any(named: 'id'),
@@ -416,9 +420,9 @@ void main() {
             );
 
             async
-              ..elapse(const Duration(seconds: 30))
+              ..elapse(gap)
               ..flushMicrotasks();
-            // Age 90s: still young, chain re-armed.
+            // One gap short of the guard: still young, chain re-armed.
             verifyNever(
               () => dao.markRecipientWrapStatus(
                 id: any(named: 'id'),
@@ -428,9 +432,9 @@ void main() {
             );
 
             async
-              ..elapse(const Duration(seconds: 30))
+              ..elapse(gap)
               ..flushMicrotasks();
-            // Age 120s: flipped to failed so it stops looking delivered.
+            // Guard reached: flipped to failed so it stops looking delivered.
             verify(
               () => dao.markRecipientWrapStatus(
                 id: 'young-pending',
@@ -2014,6 +2018,54 @@ void main() {
     test('retry growth caps at maxDelay', () {
       // Default config: 2s × 2^N — after enough retries we hit 5min cap.
       expect(cfg.backoffFor(20), cfg.maxDelay);
+    });
+  });
+
+  // #6586. The DM send budget is assembled from constants in three packages,
+  // and nothing but this test connects them. `dm_repository` cannot import
+  // `keycast_flutter`, so the app layer — which depends on both — is the only
+  // place the full relationship can be asserted.
+  //
+  // The drift these pin actually happened: #6046 derived the publish backstop
+  // from a 12s Keycast per-RPC bound, #6075 raised that bound to 30s without
+  // re-deriving it, and the cap silently became smaller than the chain it
+  // bounds.
+  //
+  // Only the first assertion is a regression test — replaying the pre-fix
+  // constants (90s backstop, 140s honest chain) turns it red and the other two
+  // stay green. The second and third guard the two ways this could break next:
+  // tightening the build bound below the transport (the #6046 mistake), and
+  // letting the sweep guard fall to or below the backstop.
+  group('DM send budget invariants', () {
+    test('the backstop exceeds the chain it bounds', () {
+      expect(
+        DmSendBudget.chainWorstCase,
+        lessThan(DmSendBudget.messagePublishTimeout),
+        reason:
+            'a backstop below its own worst case fires mid-send and '
+            'misclassifies an already-delivered message',
+      );
+    });
+
+    test('the recipient wrap build covers two Keycast round trips', () {
+      // A 1:1 send costs four measured signer round trips: nip44Encrypt +
+      // signEvent for the seal, per wrap. Sizing the recipient build below
+      // two transport bounds would fail requests the transport itself would
+      // have allowed — the #6046 mistake that #6075 had to revert.
+      expect(
+        DmSendBudget.recipientWrapBuild,
+        greaterThanOrEqualTo(KeycastRpc.defaultRequestTimeout * 2),
+      );
+    });
+
+    test('the sweep guard outlives the whole backstop', () {
+      // `Future.timeout` does not cancel, so an abandoned send keeps running
+      // past the cap. A guard at or below it re-drives a rumor that is still
+      // in flight and publishes a concurrent duplicate.
+      expect(
+        OutgoingDmRetryService.interruptedMinAge,
+        greaterThan(DmSendBudget.messagePublishTimeout),
+      );
     });
   });
 }

--- a/mobile/test/services/outgoing_dm_retry_service_test.dart
+++ b/mobile/test/services/outgoing_dm_retry_service_test.dart
@@ -2047,14 +2047,20 @@ void main() {
       );
     });
 
-    test('the recipient wrap build covers two Keycast round trips', () {
+    test('the recipient wrap build exceeds two Keycast round trips', () {
       // A 1:1 send costs four measured signer round trips: nip44Encrypt +
       // signEvent for the seal, per wrap. Sizing the recipient build below
       // two transport bounds would fail requests the transport itself would
       // have allowed — the #6046 mistake that #6075 had to revert.
+      //
+      // Strictly greater, not >=: the bound also covers the seal
+      // construction, ephemeral keypair, NIP-44 encryption and wrap signature
+      // that run alongside those round trips. At exactly 2x, two ops each
+      // returning just inside 30s would still trip it, which is the same
+      // no-margin shape #6586 was about.
       expect(
         DmSendBudget.recipientWrapBuild,
-        greaterThanOrEqualTo(KeycastRpc.defaultRequestTimeout * 2),
+        greaterThan(KeycastRpc.defaultRequestTimeout * 2),
       );
     });
 


### PR DESCRIPTION
Closes #6586.

## Description

`dm_repository`'s 90s publish backstop documented its own derivation as "Keycast RPCs 12s each". #6046 computed 90s from that bound; #6075 raised the bound to 30s — correctly, since 12s had regressed video-publish signing, likes, reposts and follows — but never re-derived the backstop.

The stale comment turned out to be the smallest part of it.

**A 1:1 send costs four signer round trips, measured against the real send path** — `nip44Encrypt` + `signEvent` for the seal, once per wrap; the kind-1059 wrap is ephemeral-signed and never reaches the signer. So the honest chain was `(2 × 30s) + 10s + (2 × 30s) + 10s = 140s` against a 90s cap.

**The cap therefore fired on successful sends.** The self-wrap is only built *after* the recipient's `OK true` arrives, so that 140s path is the delivery path: the recipient had the message, and the sender got a stuck "sending" bubble, five duplicate republishes, then a red "failed" bubble. keycast#291 records the same failure from production mobile logs — `nip44_encrypt` at 23s and 30s, and *"a kind-14 DM send hit the mobile 30s timeout and did not deliver."*

**Amber/NIP-55 is human-gated in the way that matters here.** `AndroidNostrSigner`'s 300s timeout only bounds waiting for its serialized signer lock; the `nip44Encrypt` and `signEvent` intent calls can wait unbounded for the user's approval. That makes the app-layer chain bound the only pre-publish guard for a user who backgrounds into Amber approvals.

## Approach

Correcting the number alone would not have fixed the Amber arm, and no signer interface exposes a per-call timeout. So the fix bounds the **send chain** rather than the transport for queued durable sends, while preserving the previous uncapped behavior for `sendPrivateMessage` callers that have no retry queue.

When the recipient wrap build times out before any publish, durable DM sends now classify it as `retryablePending: true`: nothing reached a relay, so the row should stay pending and let the sweep re-drive instead of turning a slow human approval into a red bubble. A builder that actually returns `null` remains a hard failure.

The key behavioural change is *where* a slow signer fails:

| Scenario | Before | After |
|---|---|---|
| Slow queued recipient build | publishes, delivers, dies at 90s → stuck bubble, 5 duplicate republishes, red bubble on a delivered message | times out at the build bound **before any publish**; durable sends stay retryable-pending and are re-driven |
| Slow uncapped recipient build (`sendPrivateMessage`) | waits for the signer approval | still waits; no retryable-pending result with no queue row to retry from |
| Slow self-wrap build | eats the remaining budget, trips the backstop, misclassifies a **delivered** message | returns `selfWrapPublished: false` → existing `recoverSelfWrap` finishes it out of band (#4124); uncapped callers get the wider self-wrap build bound |
| Amber/NIP-55 approval | backstop is the only bound, and user approval can outlive it | queued recipient build timeout is pre-publish and retryable-pending; uncapped convenience sends preserve their prior wait behavior |

## Commits

1. **`fix(dm): derive the publish backstop from its sub-bounds`** — moves every sub-bound into `DmSendBudget` and computes totals from shared constants.
2. **`fix(dm): bound the gift-wrap builds so the backstop cannot be outrun`** — adds recipient/self wrap build bounds so the send backstop cannot fire after delivery.
3. **`fix(dm): derive the interrupted-send guard from the publish backstop`** — derives `_interruptedMinAge` from the real send budget.
4. **`fix(dm): bound self-wrap recovery on its own budget, not the send's`** — keeps out-of-band recovery off the tight in-send self-wrap bound.
5. **`fix(dm): give the wrap-build bound margin over the two transport ops`** — gives recipient-wrap build local crypto margin over `2 × 30s` and scopes the budget docs.
6. **`fix(dm): don't apply the send-sized self-wrap bound to uncapped callers`** — widens self-wrap build for `sendPrivateMessage` callers with no outer cap.
7. **`docs(dm): align self-wrap budget comments`** — fixes the self-wrap naming/docs/accounting from review.
8. **`fix(dm): keep Amber wrap timeouts retryable`** — keeps queued Amber recipient-build timeouts pending/retryable and bounds `publishSelfApplicationMarker` (#7093, now closed).
9. **`fix(dm): keep uncapped recipient wrap builds retryable`** — preserves uncapped recipient-wrap construction for `sendPrivateMessage` callers that have no retry row.

## Testing

- Recipient-build timeout → retryable-pending failure **and `publishEventAwaitOk` is never called**, proving nothing was delivered.
- `sendPrivateMessage` with a recipient build slower than `recipientWrapBuild` → succeeds instead of returning retryable-pending with no queue row.
- Recipient builder returning `null` → hard failure, preserving the true build-failure classification.
- Self-wrap-build timeout → `success == true` with `selfWrapPublished == false`, proving the partial-delivery path rather than a send failure.
- Self-application-marker wrap build timeout → returns `false` without publishing, covering the adjacent unbounded call.
- Cross-package budget invariants in the app layer (`dm_repository` cannot import `keycast_flutter`, so this is the only place the full relationship can be asserted).
- Existing tests that hardcoded the 120s boundary now derive it from the guard, so a moving budget cannot silently stop testing the boundary.

Local verification after the final takeover commit:

- `flutter test test/src/nip17_message_service_test.dart` from `mobile/packages/dm_repository`
- `flutter analyze` from `mobile/packages/dm_repository`
- `flutter test` from `mobile/packages/dm_repository`
- `flutter analyze` from `mobile`
- Pre-push hook analyze and changed-file tests, including `packages/dm_repository/test/src/nip17_message_service_test.dart` and `test/services/outgoing_dm_retry_service_test.dart`

## Out of scope — tracked separately

1. #7090 — adopt `nip17_wrap_batch` (4 signer round trips → 1) once the production Keycast verb is confirmed.
2. #7091 — bound the send segments outside the publish backstop: kind-10050 inbox resolution, the connectivity probe, and `retryDisconnectedRelays()`'s missing aggregate cap.
3. #7092 — reconcile the client's 30s per-op bound with Keycast's new 8s server bound once deployment behavior is confirmed.

## Notes for reviewers

No UI change, so no screenshots. The trade-off worth a second opinion is the backstop moving 90s → 120s: the ceiling rises, but the common queued slow path now fails at 65s before delivery and remains retryable for durable DM sends, so typical time-to-feedback drops without turning human-gated Amber approval into a red bubble.
