### PR TITLE
test(recorder): cover classic mode with Maestro E2E

### DIFF
--- a/mobile/e2e/maestro/README.md
+++ b/mobile/e2e/maestro/README.md
@@ -341,13 +341,21 @@ Classic only:
   `utils/recordCaptureClip.yaml` is not reusable and classic gets its own
   `utils/recordClassicClip.yaml`. Both wait on the close button leaving and
   coming back, because classic fades its whole top-bar row out while recording.
-- **One 6.3s budget for the whole session.** Classic is the only mode that
-  declares `hasRecordingLimit`, so every clip it records comes out of one
-  budget and the bloc refuses to start a recording below 30ms remaining. That
-  is why `recordClassicClip` records for two seconds where the capture util
-  records for three: `classicModeRecordingLimit` still has to be able to start
-  a second recording. Stretch the first one and that test fails on its opening
-  wait, not on the limit.
+- **One 6.3s budget for the whole session, and Maestro's own overhead eats
+  most of it.** Classic is the only mode that declares `hasRecordingLimit`, so
+  every clip comes out of one budget and the bloc refuses to start a recording
+  below 30ms remaining. Maestro dumps the view hierarchy around every command,
+  which on the SM-S942B makes a tap cost 2-3.5s of wall-clock; the two taps in
+  `recordClassicClip` span ~4.1s of the budget on their own. So that util has
+  no accumulate-footage wait where the capture one records for three seconds —
+  a `waitForAnimationToEnd: 2000` there measured 3.7s (the live preview never
+  settles, so it runs its timeout out and then some) and pushed the pair to
+  ~7.9s, past the limit. The first device run failed exactly there, and it cost
+  both shutter tests at once: the recording was ended by the native auto-stop
+  rather than the stop tap, so `classicModeRecordClip` stopped proving what it
+  is named for, and `classicModeRecordingLimit` could not start at all against
+  a spent budget. Anything added between those two taps comes out of the ~2.1s
+  the limit test runs on.
 - **The limit test asserts a fact, not a duration.** It starts a recording,
   never stops it, and waits for the top bar to come back — which only the
   native auto-stop can do. It deliberately does not assert *when*, because the

--- a/mobile/e2e/maestro/README.md
+++ b/mobile/e2e/maestro/README.md
@@ -188,12 +188,13 @@ rail*, the three capture-stack modes drive them with the same three files —
 `utils/driveAspectRatioControl`, `utils/driveLensControl`,
 `utils/driveFlashControl`. Capture and lip-sync wrap those in
 `utils/driveCaptureRail.yaml`, which adds the timer and stabilization controls
-they alone render; `stopMotionModeControls` calls the three directly and adds
-ghost frame and grid. Each mode's `…Controls` test is a rail sequence plus its
-own mode assert. A mode with yet another set composes the per-control utils in
-its own order rather than skipping parts of someone else's — `classicModeControls`
-is the worked example of that, running only `driveLensControl` before its own
-grid and ghost blocks.
+they alone render. The two `supportGridLines` / ghost toggles are shared by
+stop-motion and classic, so they are per-control utils on the same rule —
+`utils/driveGridControl`, `utils/driveGhostFrameControl`. Each mode's
+`…Controls` test is a sequence of those utils plus its own mode assert, and
+what it owns is the **order**, not the sequences. `classicModeControls` is the
+worked example: the same three utils stop-motion runs, in the order classic's
+horizontal action row needs them — ghost last, then the banner wait.
 
 Classic is the case none of the above covers, because it is a different stack
 rather than the same one with a different rail. Two consequences for its

--- a/mobile/e2e/maestro/README.md
+++ b/mobile/e2e/maestro/README.md
@@ -43,15 +43,16 @@ dispatches, and GitHub CI does not cover this lane at all.
 
 ## The recorder flows
 
-Three of the recorder's five modes are covered, one flow each:
+Four of the recorder's five modes are covered, one flow each:
 
 | Flow | Mode | Covers |
 |---|---|---|
 | `flows/captureModeFlow.yaml` | capture | open, drive the control rail, record a clip, delete it, close |
 | `flows/lipSyncModeFlow.yaml` | lip-sync | open, drive the control rail, prove the shutter refuses without a sound and records with one, delete the clip, close |
 | `flows/stopMotionModeFlow.yaml` | stop-motion | open, drive the control rail, shoot two stills, undo them, close |
+| `flows/classicModeFlow.yaml` | classic | open, drive the action row, record a clip off the preview, prove a second recording stops itself at the duration limit, delete both, close |
 
-Classic and upload are not covered yet.
+Upload is not covered yet.
 
 The gate is lip-sync's own behaviour and it takes **both** shutter tests to
 cover it. `lipSyncModeAudioGate` proves the shutter refuses with no sound
@@ -66,14 +67,24 @@ picker's **Divine** tab, whose entries come from
 is the relay-backed one, and it is the live-content dependency this file names
 elsewhere as the suite's main source of flakiness — no flow goes near it.
 
-Every file in all three flows has been run green on a Galaxy SM-S942B. The
-lip-sync and stop-motion tests were driven test-by-test against an
-already-signed-in app rather than through their flow end to end, because the
-device runs a German system locale and `loginFreshInstall`'s `clearState` drops
-the per-app English override mid-run (see step 0b). The login and `removeKeys`
-bookends of both flows are the same ones `captureModeFlow` already runs.
+Every file in the capture, lip-sync and stop-motion flows has been run green on
+a Galaxy SM-S942B. The lip-sync and stop-motion tests were driven test-by-test
+against an already-signed-in app rather than through their flow end to end,
+because the device runs a German system locale and `loginFreshInstall`'s
+`clearState` drops the per-app English override mid-run (see step 0b). The login
+and `removeKeys` bookends of both flows are the same ones `captureModeFlow`
+already runs.
 
-None of them is in **`smoke.yaml`**, and all three are deliberately off the iOS
+**`classicModeFlow` has not been run on hardware yet.** It was written against
+the classic stack's widget tree and its selectors are pinned at the widget level
+(`video_recorder_classic_*_test.dart` each assert their E2E anchors), but no
+part of it has been executed on a device. Treat a first failure there as a
+possible flow bug, not automatically an app regression — the two selector calls
+most worth checking first are `classicModeRecordingLimit`'s reliance on the
+native auto-stop reaching the Flutter side, and whether the ghost-frame
+snackbar in `classicModeControls` covers the action row it sits above.
+
+None of them is in **`smoke.yaml`**, and all four are deliberately off the iOS
 lane:
 
 - **They need real camera hardware.** Without a camera the bloc never reports
@@ -92,6 +103,7 @@ Run one against a booted Android emulator or a connected device:
 maestro --device <serial> test e2e/maestro/flows/captureModeFlow.yaml
 maestro --device <serial> test e2e/maestro/flows/lipSyncModeFlow.yaml
 maestro --device <serial> test e2e/maestro/flows/stopMotionModeFlow.yaml
+maestro --device <serial> test e2e/maestro/flows/classicModeFlow.yaml
 ```
 
 ### Reading state off an icon-only control
@@ -105,14 +117,21 @@ recorder selectors:
 - **A selector may combine `id` with `text`**, and here it must: "Off" is the
   value of the flash control *and* the timer control — and, once its sheet is
   open, of the stabilization menu's own first row.
-- **`selected: true` is readable too**, which is what `assertCaptureMode`,
-  `assertLipSyncMode` and `assertStopMotionMode` use to prove the right mode is
-  armed. The mode wheel renders an entry for every mode in every mode, so a
-  bare `id: camera_mode_capture` would pass on the Upload tab just as happily.
+- **`selected: true` is readable too**, which is what all four `assert…Mode`
+  files use to prove the right mode is armed. The mode wheel renders an entry
+  for every mode in every mode, so a bare `id: camera_mode_capture` would pass
+  on the Upload tab just as happily.
+- **`enabled:` is readable, and sometimes it is the only signal.**
+  `driveCaptureRail` uses it as a *guard* on hardware-dependent controls, but
+  `assertClassicMode` and `assertClassicClipRecorded` assert on it directly:
+  classic's next button stays mounted and goes disabled on an empty session
+  rather than fading out of the tree, so `enabled` is the only thing that moves
+  when a clip lands.
 - **`checked:` is how an on/off control reads.** The ghost-frame and grid
   toggles carry a Semantics `toggled` flag rather than a `value`, and Flutter
   maps that to the accessibility node's checked state, so
-  `stopMotionModeControls` drives them with `checked: true` / `checked: false`.
+  `stopMotionModeControls` and `classicModeControls` drive them with
+  `checked: true` / `checked: false`.
   **Maestro does not print the flag in its run log** — the line reads
   `Assert that id: camera_ghost_frame_button is visible`, exactly as it would
   if the flag had been dropped, unlike `text:` and `enabled:` which both show
@@ -120,22 +139,26 @@ recorder selectors:
   its off state fails on device. Don't "fix" a `checked:` selector because the
   log looks bare; prove it with a deliberately-wrong assertion instead.
 
-### What the three viewfinders share, and what tells them apart
+### What the four viewfinders share, and what tells them apart
 
-All three *are* the capture stack: same close, next, delete, library button and
-record button. Only the top bar's center slot and the control rail differ.
+Three of them *are* the capture stack: same close, next, delete, library button
+and record button. Between those three, only the top bar's center slot and the
+control rail differ. Classic is the odd one out — its own stack, its own top
+bar, its own action rows, and no record button at all.
 
-| | capture | lip-sync | stop-motion |
-|---|---|---|---|
-| `audio_chip` (center slot) | — | ✅ | — |
-| `camera_stop_motion_budget` (center slot) | — | — | ✅ |
-| `camera_flash_button` | ✅ | ✅ | ✅ |
-| `camera_aspect_ratio_button` | ✅ | ✅ | ✅ |
-| `camera_switch_camera_button` | ✅ | ✅ | ✅ |
-| `camera_timer_button` | ✅ | ✅ | — |
-| `camera_stabilization_button` | ✅ | ✅ | — |
-| `camera_ghost_frame_button` | — | — | ✅ |
-| `camera_grid_button` | — | — | ✅ |
+| | capture | lip-sync | stop-motion | classic |
+|---|---|---|---|---|
+| `camera_record_button` | ✅ | ✅ | ✅ | — |
+| `camera_classic_shutter` (the preview) | — | — | — | ✅ |
+| `audio_chip` (center slot) | — | ✅ | — | — |
+| `camera_stop_motion_budget` (center slot) | — | — | ✅ | — |
+| `camera_flash_button` | ✅ | ✅ | ✅ | — |
+| `camera_aspect_ratio_button` | ✅ | ✅ | ✅ | — |
+| `camera_switch_camera_button` | ✅ | ✅ | ✅ | ✅ |
+| `camera_timer_button` | ✅ | ✅ | — | — |
+| `camera_stabilization_button` | ✅ | ✅ | — | — |
+| `camera_ghost_frame_button` | — | — | ✅ | ✅ |
+| `camera_grid_button` | — | — | ✅ | ✅ |
 
 Lip-sync and capture are the subset trap. Their rails are identical, so assert
 only what each mode renders and `assertCaptureMode` passes on the Lip Sync tab,
@@ -157,14 +180,34 @@ control starts rendering in a mode that does not declare it, which nothing else
 in the suite would catch. `video_recorder_capture_actions_test.dart` pins the
 same split at the widget level.
 
-Because flash, aspect ratio and the lens switch are unconditional, all three
-modes *drive* them with the same three files — `utils/driveAspectRatioControl`,
-`utils/driveLensControl`, `utils/driveFlashControl`. Capture and lip-sync wrap
-those in `utils/driveCaptureRail.yaml`, which adds the timer and stabilization
-controls they alone render; `stopMotionModeControls` calls the three directly
-and adds ghost frame and grid. Each mode's `…Controls` test is a rail sequence
-plus its own mode assert. A mode with yet another set composes the per-control
-utils in its own order rather than skipping parts of someone else's.
+Because flash, aspect ratio and the lens switch are unconditional *on that
+rail*, the three capture-stack modes drive them with the same three files —
+`utils/driveAspectRatioControl`, `utils/driveLensControl`,
+`utils/driveFlashControl`. Capture and lip-sync wrap those in
+`utils/driveCaptureRail.yaml`, which adds the timer and stabilization controls
+they alone render; `stopMotionModeControls` calls the three directly and adds
+ghost frame and grid. Each mode's `…Controls` test is a rail sequence plus its
+own mode assert. A mode with yet another set composes the per-control utils in
+its own order rather than skipping parts of someone else's — `classicModeControls`
+is the worked example of that, running only `driveLensControl` before its own
+grid and ghost blocks.
+
+Classic is the case none of the above covers, because it is a different stack
+rather than the same one with a different rail. Two consequences for its
+selectors:
+
+- **It has no record button.** The square preview is the shutter, wrapped in
+  its own `Semantics` node carrying `camera_classic_shutter`. It keeps that
+  identifier in both recording states while its *label* flips between "tap to
+  start" and "tap to stop", which is what makes it a usable anchor.
+- **Next is disabled, not hidden.** The capture stack fades next and delete out
+  of the semantics tree when the session is empty; classic's top bar keeps next
+  mounted and passes `onPressed: null`. So `assertClassicMode` reads an empty
+  session off `enabled: false` there, and `assertClassicClipRecorded` waits on
+  `enabled: true` rather than on visibility — a visibility wait would pass
+  instantly and prove nothing. Delete does still drop out of the tree, so it is
+  asserted the usual way. `video_recorder_classic_top_bar_test.dart` pins both
+  halves of that contract.
 
 ### Things the flows depend on that are easy to break by accident
 
@@ -187,14 +230,14 @@ Shared:
   somewhere: `camera_last_used_recorder_mode` (absent ⇒ Capture),
   `camera_last_used_lens` (absent ⇒ back, which the rail asserts first),
   `camera_last_used_stabilization` and `camera_grid_lines_enabled` (absent ⇒
-  on, which `stopMotionModeControls` asserts first). Run from the top this is
-  handled — `loginFreshInstall`'s `clearState` wipes all four — but a
-  standalone run inherits whatever the last session left. A phone whose last
-  session used the front lens fails the rail on its first `.*Back camera.*`,
-  and the three flows leave the mode key on different values, so a
-  `captureModeFlow` run straight after a lip-sync or stop-motion one, skipping
-  the login step, opens on the wrong mode. When iterating standalone, either
-  reset the keys or start from a flow that clears state.
+  on, which `stopMotionModeControls` and `classicModeControls` both assert
+  first). Run from the top this is handled — `loginFreshInstall`'s `clearState`
+  wipes all four — but a standalone run inherits whatever the last session left.
+  A phone whose last session used the front lens fails the rail on its first
+  `.*Back camera.*`, and the four flows leave the mode key on different values,
+  so a `captureModeFlow` run straight after a lip-sync, stop-motion or classic
+  one, skipping the login step, opens on the wrong mode. When iterating
+  standalone, either reset the keys or start from a flow that clears state.
 - **An empty session when the rail is driven.** The aspect-ratio control is
   disabled once the session holds a clip, because clips of mixed ratios cannot
   share an editor timeline. `captureModeControls` therefore runs before the
@@ -202,7 +245,10 @@ Shared:
   records. Stop-motion stills are not clips until the assemble, so its rail
   stays live mid-session — but `stopMotionModeControls` closes on its mode
   assert, which pins next and undo absent, so it needs the empty session
-  anyway and the flow keeps the same order.
+  anyway and the flow keeps the same order. Classic renders no aspect-ratio
+  control at all (it is square by definition), so nothing there is gated on
+  clips either — but `classicModeControls` closes on the same kind of mode
+  assert and keeps the same order for the same reason.
 
 Capture only:
 
@@ -277,13 +323,47 @@ Stop-motion only:
   silently removes it. Verified the other way round on device: shoot once, undo
   once, and that assertion goes red.
 
+Classic only:
+
+- **Reaching the mode at all.** Classic is the last entry on the wheel, three
+  places from Capture — further than any other mode has to travel on a lazy
+  `ListView` that only builds entries near the armed one. `openClassicMode`
+  therefore hops one entry at a time, and guards the hops on Classic not
+  already being on screen: on a rerun the recorder opens straight on Classic
+  (selecting a mode persists it), and from there Stop Motion is two entries
+  away and may not be built at all.
+- **The shutter is the preview.** There is no `camera_record_button` here, so
+  `utils/recordCaptureClip.yaml` is not reusable and classic gets its own
+  `utils/recordClassicClip.yaml`. Both wait on the close button leaving and
+  coming back, because classic fades its whole top-bar row out while recording.
+- **One 6.3s budget for the whole session.** Classic is the only mode that
+  declares `hasRecordingLimit`, so every clip it records comes out of one
+  budget and the bloc refuses to start a recording below 30ms remaining. That
+  is why `recordClassicClip` records for two seconds where the capture util
+  records for three: `classicModeRecordingLimit` still has to be able to start
+  a second recording. Stretch the first one and that test fails on its opening
+  wait, not on the limit.
+- **The limit test asserts a fact, not a duration.** It starts a recording,
+  never stops it, and waits for the top bar to come back — which only the
+  native auto-stop can do. It deliberately does not assert *when*, because the
+  budget left depends on what the previous test spent.
+- **The ghost-frame snackbar, over a horizontal row.** Each toggle raises the
+  same 4-second banner stop-motion has, but classic's controls are a row above
+  the mode wheel rather than a vertical rail on the right. The banner sits
+  below that row, so the two taps that restore the toggle are not covered —
+  but `classicModeControls` still drives ghost *last*, so if that turns out to
+  be wrong on some screen size the failure lands on that control alone rather
+  than taking the lens and grid blocks with it.
+
 Account creation is a precondition, not part of what is tested. The recorder
 route itself is public (`appRouterRedirect` exempts it), but the only way in is
 the feed's camera button and the feed is not public.
 
 The stop-motion assemble step — "next", which collects the stills into a clip
 and opens the editor — is out of scope on purpose: it leaves the recorder, and
-the editor has no coverage to hand off to yet.
+the editor has no coverage to hand off to yet. So is classic's "next", which
+skips the editor entirely (classic is the one mode declaring no
+`hasVideoEditor`) and pushes the metadata screen with a render already started.
 
 ---
 

--- a/mobile/e2e/maestro/README.md
+++ b/mobile/e2e/maestro/README.md
@@ -221,8 +221,9 @@ Shared:
   whose buttons are OS-localized copy. Note the relaunch deliberately does
   *not* clear state: on Android `pm clear` wipes the encrypted preferences the
   Nostr key lives in and would sign the account back out mid-flow.
-- **Hardware for the guarded rail controls.** Flash (all three modes) and
-  stabilization (capture and lip-sync) are driven behind an `enabled: true`
+- **Hardware for the guarded rail controls.** Flash (the three capture-stack
+  modes — classic renders no rail at all) and stabilization (capture and
+  lip-sync) are driven behind an `enabled: true`
   guard, because both are disabled outright when the active lens has no flash
   unit or reports a single stabilization mode. Where the feature is missing the
   block prints `SKIPPED` rather than failing — check the run output before

--- a/mobile/e2e/maestro/README.md
+++ b/mobile/e2e/maestro/README.md
@@ -67,22 +67,18 @@ picker's **Divine** tab, whose entries come from
 is the relay-backed one, and it is the live-content dependency this file names
 elsewhere as the suite's main source of flakiness — no flow goes near it.
 
-Every file in the capture, lip-sync and stop-motion flows has been run green on
-a Galaxy SM-S942B. The lip-sync and stop-motion tests were driven test-by-test
-against an already-signed-in app rather than through their flow end to end,
-because the device runs a German system locale and `loginFreshInstall`'s
-`clearState` drops the per-app English override mid-run (see step 0b). The login
-and `removeKeys` bookends of both flows are the same ones `captureModeFlow`
-already runs.
+Every file in all four flows has been run green on a Galaxy SM-S942B. The
+lip-sync, stop-motion and classic tests were driven test-by-test against an
+already-signed-in app rather than through their flow end to end, because the
+device runs a German system locale and `loginFreshInstall`'s `clearState` drops
+the per-app English override mid-run (see step 0b). The login and `removeKeys`
+bookends of those three flows are the same ones `captureModeFlow` already runs.
 
-**`classicModeFlow` has not been run on hardware yet.** It was written against
-the classic stack's widget tree and its selectors are pinned at the widget level
-(`video_recorder_classic_*_test.dart` each assert their E2E anchors), but no
-part of it has been executed on a device. Treat a first failure there as a
-possible flow bug, not automatically an app regression — the two selector calls
-most worth checking first are `classicModeRecordingLimit`'s reliance on the
-native auto-stop reaching the Flutter side, and whether the ghost-frame
-snackbar in `classicModeControls` covers the action row it sits above.
+The classic run settled the two things only hardware could, both of which had
+been flagged as unknowns while it was written: the native auto-stop reaches the
+Flutter side as a clip, so `classicModeRecordingLimit` sees the session hold it,
+and the ghost-frame snackbar does not cover the action row `classicModeControls`
+drives above it.
 
 None of them is in **`smoke.yaml`**, and all four are deliberately off the iOS
 lane:

--- a/mobile/e2e/maestro/README.md
+++ b/mobile/e2e/maestro/README.md
@@ -171,13 +171,16 @@ different reason. Its rail and capture's are **disjoint**, not nested — captur
 has timer and stabilization, stop-motion has ghost frame and grid — so each
 assert already fails on the other's viewfinder on the rail alone. What settles
 which viewfinder is up before either gets that far is the mode wheel's
-`selected` state, asserted on the first line of all three files.
+`selected` state, asserted on the first line of all four files.
 
 So the pairs those two asserts carry — `assertStopMotionMode` pinning timer and
 stabilization absent, `assertCaptureMode` pinning ghost frame, grid and the
 budget absent — are **leak guards**, not mode separators: they fail when a
 control starts rendering in a mode that does not declare it, which nothing else
-in the suite would catch. `video_recorder_capture_actions_test.dart` pins the
+in the suite would catch. `camera_classic_shutter`, pinned absent by all three
+capture-stack asserts, is the same kind of line: the record button is already
+enough to tell classic apart, and `assertClassicMode` pins that one absent from
+its side. `video_recorder_capture_actions_test.dart` pins the
 same split at the widget level.
 
 Because flash, aspect ratio and the lens switch are unconditional *on that

--- a/mobile/e2e/maestro/asserts/assertCaptureMode.yaml
+++ b/mobile/e2e/maestro/asserts/assertCaptureMode.yaml
@@ -50,6 +50,13 @@ appId: co.openvine.app
 - assertNotVisible:
     id: camera_stop_motion_budget
 
+# And classic's shutter, which is the other half of why it gets an id of its
+# own rather than reusing `camera_record_button`: the record button is pinned
+# absent in assertClassicMode and this one absent in every capture-stack mode,
+# so the pair is what proves which stack is up.
+- assertNotVisible:
+    id: camera_classic_shutter
+
 # Nothing recorded yet. Both buttons sit inside an AnimatedOpacity, and
 # RenderAnimatedOpacity drops its child from the semantics tree at opacity 0 —
 # so "not visible" here means "no clip in the session", not "scrolled away".

--- a/mobile/e2e/maestro/asserts/assertClassicClipRecorded.yaml
+++ b/mobile/e2e/maestro/asserts/assertClassicClipRecorded.yaml
@@ -1,0 +1,26 @@
+appId: co.openvine.app
+---
+# The classic session holds at least one clip: the top bar's continue button
+# goes live and the row above the preview reveals delete-last-clip.
+#
+# The capture stack's equivalent waits on `camera_next_button` becoming
+# *visible*. Classic's next never leaves the semantics tree — it is mounted and
+# disabled while the session is empty — so the state change to wait on here is
+# `enabled`, not visibility. Waiting on visibility would pass instantly against
+# an empty session and prove nothing.
+#
+# The wait covers the gap between the stop and the recorder finalizing the
+# file; on a cold camera the first clip can take a moment to land.
+- extendedWaitUntil:
+    visible:
+      id: camera_next_button
+      enabled: true
+    timeout: 15000
+- assertVisible:
+    id: camera_delete_clip_button
+
+# Back on the idle viewfinder. Classic fades its whole top-bar row out while
+# recording, so the close button being here is what proves the recording
+# actually stopped rather than still running behind the assertion above.
+- assertVisible:
+    id: camera_close_button

--- a/mobile/e2e/maestro/asserts/assertClassicMode.yaml
+++ b/mobile/e2e/maestro/asserts/assertClassicMode.yaml
@@ -1,0 +1,59 @@
+appId: co.openvine.app
+---
+# Classic mode, idle: the viewfinder chrome is up and no clip is recorded yet.
+#
+# Classic is the one recording mode that is *not* the capture stack. It has its
+# own top bar, its own action rows, and no record button at all — the square
+# preview is the shutter. So unlike the other three asserts, most of this file
+# is pinning a different screen rather than the same one with a different rail.
+
+# Mode wheel with Classic armed. `selected` is load-bearing: the wheel renders
+# an entry for every mode in every mode, so a bare id assertion here passes
+# just as happily on the Lip Sync tab.
+- assertVisible:
+    id: camera_mode_classic
+    selected: true
+- assertVisible:
+    id: camera_classic_shutter
+- assertVisible:
+    id: camera_close_button
+- assertVisible:
+    id: camera_library_button
+
+# Action row under the preview, left to right.
+- assertVisible:
+    id: camera_switch_camera_button
+- assertVisible:
+    id: camera_grid_button
+- assertVisible:
+    id: camera_ghost_frame_button
+
+# Nothing recorded yet — and classic reports that differently from the capture
+# stack, which is the trap this file exists to pin. Next stays mounted and goes
+# *disabled* (`onPressed: null` while `!hasClips`), so `assertNotVisible` here
+# would fail on an empty session. Delete does drop out of the tree: its row
+# sits inside an AnimatedOpacity, and RenderAnimatedOpacity drops its child
+# from the semantics tree at opacity 0.
+- assertVisible:
+    id: camera_next_button
+    enabled: false
+- assertNotVisible:
+    id: camera_delete_clip_button
+
+# The capture stack, absent. Flash and aspect ratio are unconditional there —
+# every mode that renders that rail renders both — so their absence is what
+# proves the classic stack is up rather than capture's, and the record button's
+# absence proves the shutter really is the preview. Timer and stabilization are
+# the declared-only pair, the same leak guard assertStopMotionMode carries: a
+# control starting to render in a mode that does not declare it fails a run
+# rather than passing quietly.
+- assertNotVisible:
+    id: camera_record_button
+- assertNotVisible:
+    id: camera_flash_button
+- assertNotVisible:
+    id: camera_aspect_ratio_button
+- assertNotVisible:
+    id: camera_timer_button
+- assertNotVisible:
+    id: camera_stabilization_button

--- a/mobile/e2e/maestro/asserts/assertLipSyncMode.yaml
+++ b/mobile/e2e/maestro/asserts/assertLipSyncMode.yaml
@@ -37,6 +37,15 @@ appId: co.openvine.app
 - assertVisible:
     id: camera_stabilization_button
 
+# Classic's shutter, absent. A leak guard rather than a mode separator — the
+# record button above already fails this file on a classic viewfinder — and the
+# other half of why the shutter gets an id of its own rather than reusing
+# `camera_record_button`: the record button is pinned absent in
+# assertClassicMode and this one absent in every capture-stack mode, so the
+# pair is what proves which stack is up.
+- assertNotVisible:
+    id: camera_classic_shutter
+
 # Nothing recorded yet. Both buttons sit inside an AnimatedOpacity, and
 # RenderAnimatedOpacity drops its child from the semantics tree at opacity 0 —
 # so "not visible" here means "no clip in the session", not "scrolled away".

--- a/mobile/e2e/maestro/asserts/assertStopMotionMode.yaml
+++ b/mobile/e2e/maestro/asserts/assertStopMotionMode.yaml
@@ -53,6 +53,12 @@ appId: co.openvine.app
 - assertNotVisible:
     id: camera_stabilization_button
 
+# And classic's shutter, for the same reason assertCaptureMode pins it: the
+# record button is pinned absent in assertClassicMode and this one absent in
+# every capture-stack mode, so the pair is what proves which stack is up.
+- assertNotVisible:
+    id: camera_classic_shutter
+
 # Nothing captured yet. Both buttons sit inside an AnimatedOpacity, and
 # RenderAnimatedOpacity drops its child from the semantics tree at opacity 0 —
 # so "not visible" here means "no still in the session", not "scrolled away".

--- a/mobile/e2e/maestro/flows/classicModeFlow.yaml
+++ b/mobile/e2e/maestro/flows/classicModeFlow.yaml
@@ -1,0 +1,61 @@
+appId: co.openvine.app
+---
+#Classic journey: create an account, open the recorder on classic, drive its
+#action row, record a clip by tapping the preview, prove a second recording
+#stops itself at the session's duration limit, delete both clips, and sign the
+#device back out.
+#
+# Account creation is a precondition, not part of what is under test. The
+# recorder route itself is public — appRouterRedirect exempts it — but the only
+# way into it is the feed's camera button, and the feed is not public: an
+# unauthenticated launch redirects to Welcome.
+#
+# Requires real camera hardware, for the lens switch in classicModeControls and
+# for both recordings.
+#
+# The two shutter tests run in this order and cannot be swapped.
+# classicModeRecordClip proves tap-to-start / tap-to-stop; classicModeRecordingLimit
+# then starts a recording and never stops it, so it needs a session that
+# already holds a clip to be spending a *partial* budget rather than the full
+# 6.3s. Between them they cover both ways a classic recording can end.
+#
+# The step after "next" — which skips the editor entirely, because classic is
+# the one mode that declares no `hasVideoEditor`, and goes straight to the
+# metadata screen with a render already started — is deliberately out of scope.
+# It leaves the recorder, and there is no E2E coverage on the other side to
+# hand off to yet.
+
+- runFlow: ../tests/loginFreshInstall.yaml
+
+# Relaunch with camera and microphone pre-granted. Otherwise the first camera
+# tap raises the native OS permission dialog, whose buttons are OS-localized
+# copy that no selector should depend on.
+#
+# Deliberately no clearState: on Android `pm clear` wipes the encrypted
+# preferences the Nostr key lives in, which would sign the account straight
+# back out. (The iOS keychain survives it — the platforms disagree here, so
+# the flow takes the option that works on both.)
+- launchApp:
+    permissions:
+      all: allow
+- extendedWaitUntil:
+    visible:
+      id: camera_button
+    timeout: 60000
+
+- runFlow: ../tests/classicModeOpen.yaml
+
+# Selecting a mode persists it, so this second open finds Classic already
+# armed rather than Capture. openClassicMode guards its wheel hops on exactly
+# that, so it lands here either way.
+- runFlow: ../utils/openClassicMode.yaml
+- runFlow: ../tests/classicModeControls.yaml
+- runFlow: ../tests/classicModeRecordClip.yaml
+- runFlow: ../tests/classicModeRecordingLimit.yaml
+- runFlow: ../tests/classicModeDeleteClip.yaml
+
+# Leave the recorder before teardown: removeKeys drives Settings from the
+# profile tab, which the full-screen recorder covers.
+- tapOn:
+    id: camera_close_button
+- runFlow: ../tests/removeKeys.yaml

--- a/mobile/e2e/maestro/tests/classicModeControls.yaml
+++ b/mobile/e2e/maestro/tests/classicModeControls.yaml
@@ -10,7 +10,7 @@ tags:
 # Classic renders three controls where capture renders five and stop-motion
 # five: a lens switch, the grid toggle and the ghost toggle. There is no flash
 # control (classic has no rail at all), no aspect ratio (classic is square by
-# definition — `defaultAspectRatio` is the only mode that returns it), and
+# definition — the only mode whose `defaultAspectRatio` returns square), and
 # neither of the declared-only pair.
 #
 # The lens switch is the same control every other mode drives, announcing the

--- a/mobile/e2e/maestro/tests/classicModeControls.yaml
+++ b/mobile/e2e/maestro/tests/classicModeControls.yaml
@@ -1,0 +1,97 @@
+appId: co.openvine.app
+tags:
+  - recorder
+---
+#TC to drive the classic action row,
+# given the recorder is open on an idle classic viewfinder with no clips,
+# validate each control actually changes recorder state, and leave every one
+# of them back on its default.
+#
+# Classic renders three controls where capture renders five and stop-motion
+# five: a lens switch, the grid toggle and the ghost toggle. There is no flash
+# control (classic has no rail at all), no aspect ratio (classic is square by
+# definition — `defaultAspectRatio` is the only mode that returns it), and
+# neither of the declared-only pair.
+#
+# The lens switch is the same control every other mode drives, announcing the
+# same `value`, so it runs the shared ../utils/driveLensControl.yaml. Grid and
+# ghost carry a Semantics `toggled` flag rather than a `value`, which Flutter
+# maps to the accessibility node's checked state, so they are driven with
+# `checked:` — see the note on that selector in e2e/maestro/README.md.
+#
+# Preconditions beyond an open viewfinder:
+# - **Real camera hardware**, for the lens switch. See classicModeRecordClip.
+# - **A grid that starts on.** The grid preference persists
+#   (`camera_grid_lines_enabled`) and defaults to on for grid-supporting modes,
+#   so step 2 reads it as on. Run from the top this is safe —
+#   loginFreshInstall's clearState wipes the key.
+# - **An empty session.** Not for the controls themselves — none of the three
+#   is gated on clips, unlike capture's aspect-ratio control — but for the mode
+#   assert this closes on, which pins next disabled and delete absent.
+#Steps:
+# 1. Camera: Back -> Front -> Back
+# 2. Grid: on -> off -> on
+# 3. Ghost frame: off -> on -> off
+
+# 1. Lens switch.
+- runFlow: ../utils/driveLensControl.yaml
+
+# 2. Grid overlay.
+- assertVisible:
+    id: camera_grid_button
+    checked: true
+- tapOn:
+    id: camera_grid_button
+- extendedWaitUntil:
+    visible:
+      id: camera_grid_button
+      checked: false
+    timeout: 10000
+- tapOn:
+    id: camera_grid_button
+- extendedWaitUntil:
+    visible:
+      id: camera_grid_button
+      checked: true
+    timeout: 10000
+
+# 3. Ghost frame (onion-skin), deliberately last. Not persisted, so it always
+# starts off — but each tap raises a 4-second confirmation snackbar that floats
+# at the bottom of the screen, and classic's controls are a horizontal row
+# rather than stop-motion's vertical rail. The row sits above the mode wheel
+# and clear of the banner, but running the other two controls first means a
+# mistake there fails on this control alone instead of taking the rest with it.
+- assertVisible:
+    id: camera_ghost_frame_button
+    checked: false
+- tapOn:
+    id: camera_ghost_frame_button
+- extendedWaitUntil:
+    visible:
+      id: camera_ghost_frame_button
+      checked: true
+    timeout: 10000
+# Restore. Leaving it on is not just untidy: the overlay draws the previous
+# clip's last frame over the live preview, which makes a failure screenshot
+# from any later test much harder to read.
+- tapOn:
+    id: camera_ghost_frame_button
+- extendedWaitUntil:
+    visible:
+      id: camera_ghost_frame_button
+      checked: false
+    timeout: 10000
+
+# Let the banner go before handing over to the shutter tests — it floats over
+# the bottom of the screen, and classic's shutter is the preview above it, but
+# a banner still up during a recording lands in every failure screenshot.
+#
+# `waitForAnimationToEnd` runs its timeout out rather than returning early: it
+# waits for the screen to stop changing and the live camera preview never
+# does, which makes it the deterministic wait this needs.
+- waitForAnimationToEnd:
+    timeout: 4500
+
+# Everything back to default, so the tests after this one start where they
+# expect to.
+- runFlow: ../asserts/assertClassicMode.yaml

--- a/mobile/e2e/maestro/tests/classicModeControls.yaml
+++ b/mobile/e2e/maestro/tests/classicModeControls.yaml
@@ -13,11 +13,13 @@ tags:
 # definition — the only mode whose `defaultAspectRatio` returns square), and
 # neither of the declared-only pair.
 #
-# The lens switch is the same control every other mode drives, announcing the
-# same `value`, so it runs the shared ../utils/driveLensControl.yaml. Grid and
-# ghost carry a Semantics `toggled` flag rather than a `value`, which Flutter
-# maps to the accessibility node's checked state, so they are driven with
-# `checked:` — see the note on that selector in e2e/maestro/README.md.
+# All three are shared per-control utils: the lens switch with every mode that
+# renders a rail, grid and ghost with stop-motion, the other mode that declares
+# them. So what this file actually owns is the order — see step 3 — not the
+# sequences themselves. Grid and ghost carry a Semantics `toggled` flag rather
+# than a `value`, which Flutter maps to the accessibility node's checked state,
+# so they are driven with `checked:` — see the note on that selector in
+# e2e/maestro/README.md.
 #
 # Preconditions beyond an open viewfinder:
 # - **Real camera hardware**, for the lens switch. See classicModeRecordClip.
@@ -37,50 +39,15 @@ tags:
 - runFlow: ../utils/driveLensControl.yaml
 
 # 2. Grid overlay.
-- assertVisible:
-    id: camera_grid_button
-    checked: true
-- tapOn:
-    id: camera_grid_button
-- extendedWaitUntil:
-    visible:
-      id: camera_grid_button
-      checked: false
-    timeout: 10000
-- tapOn:
-    id: camera_grid_button
-- extendedWaitUntil:
-    visible:
-      id: camera_grid_button
-      checked: true
-    timeout: 10000
+- runFlow: ../utils/driveGridControl.yaml
 
-# 3. Ghost frame (onion-skin), deliberately last. Not persisted, so it always
-# starts off — but each tap raises a 4-second confirmation snackbar that floats
-# at the bottom of the screen, and classic's controls are a horizontal row
-# rather than stop-motion's vertical rail. The row sits above the mode wheel
-# and clear of the banner, but running the other two controls first means a
-# mistake there fails on this control alone instead of taking the rest with it.
-- assertVisible:
-    id: camera_ghost_frame_button
-    checked: false
-- tapOn:
-    id: camera_ghost_frame_button
-- extendedWaitUntil:
-    visible:
-      id: camera_ghost_frame_button
-      checked: true
-    timeout: 10000
-# Restore. Leaving it on is not just untidy: the overlay draws the previous
-# clip's last frame over the live preview, which makes a failure screenshot
-# from any later test much harder to read.
-- tapOn:
-    id: camera_ghost_frame_button
-- extendedWaitUntil:
-    visible:
-      id: camera_ghost_frame_button
-      checked: false
-    timeout: 10000
+# 3. Ghost frame (onion-skin), deliberately last. Each tap raises a 4-second
+# confirmation snackbar that floats at the bottom of the screen, and classic's
+# controls are a horizontal row rather than stop-motion's vertical rail. The
+# row sits above the mode wheel and clear of the banner, but running the other
+# two controls first means a mistake there fails on this control alone instead
+# of taking the rest with it.
+- runFlow: ../utils/driveGhostFrameControl.yaml
 
 # Let the banner go before handing over to the shutter tests — it floats over
 # the bottom of the screen, and classic's shutter is the preview above it, but

--- a/mobile/e2e/maestro/tests/classicModeDeleteClip.yaml
+++ b/mobile/e2e/maestro/tests/classicModeDeleteClip.yaml
@@ -1,0 +1,46 @@
+appId: co.openvine.app
+tags:
+  - recorder
+---
+#TC to delete recorded classic clips,
+# given the session holds the two clips classicModeRecordClip and
+# classicModeRecordingLimit recorded,
+# validate delete drops one clip per tap and the recorder returns to its empty
+# state.
+#
+# This is also the teardown for the classic flow. Clips are written to the clip
+# library as they are recorded, so anything left behind survives the run and
+# the next one would start against a non-empty session and fail
+# assertClassicMode.
+#Steps:
+# 1. Tap delete: one clip goes, the session chrome stays live
+# 2. Tap delete again: the last clip goes and the empty state is restored
+
+# 1. Delete the second clip. There is no confirmation dialog — the delete is a
+# soft-delete with a 5-second Undo snackbar, so the clip leaves the session on
+# the tap. The snackbar floats at the bottom; classic's delete button sits
+# above the preview, so the second tap below is not covered by it.
+#
+# The assertion is that next is *still* enabled and delete *still* rendered:
+# both are gated on `hasClips`, so this is what proves the session held two
+# clips and that the tap removed exactly one of them.
+- tapOn:
+    id: camera_delete_clip_button
+# Wait the fade out before asserting. The delete button leaves over a 220ms
+# AnimatedOpacity, so an assertVisible landing mid-fade would pass on a session
+# that just went empty — exactly the failure this step exists to catch.
+# `waitForAnimationToEnd` runs its timeout out here, because the live camera
+# preview never stops changing.
+- waitForAnimationToEnd:
+    timeout: 1000
+- runFlow: ../asserts/assertClassicClipRecorded.yaml
+
+# 2. Delete the last one. Delete drops back out of the semantics tree and next
+# goes disabled once the session is empty.
+- tapOn:
+    id: camera_delete_clip_button
+- extendedWaitUntil:
+    notVisible:
+      id: camera_delete_clip_button
+    timeout: 15000
+- runFlow: ../asserts/assertClassicMode.yaml

--- a/mobile/e2e/maestro/tests/classicModeOpen.yaml
+++ b/mobile/e2e/maestro/tests/classicModeOpen.yaml
@@ -1,0 +1,26 @@
+appId: co.openvine.app
+tags:
+  - recorder
+---
+#TC to open the video recorder in classic mode,
+# given the user is signed in and on a feed surface,
+# validate the classic viewfinder comes up with its own chrome and that closing
+# it puts the user back on the feed.
+#Steps:
+# 1. Open the recorder and switch to Classic: classic mode is displayed
+# 2. Close the recorder: the user is back on the feed
+
+# 1. Open the recorder on classic
+- runFlow: ../utils/openClassicMode.yaml
+
+# 2. Close it. The recorder is a full-screen push, so the bottom nav coming
+# back is what proves we left it — and the shutter going away proves we left it
+# rather than stacking something on top.
+- tapOn:
+    id: camera_close_button
+- extendedWaitUntil:
+    visible:
+      id: camera_button
+    timeout: 15000
+- assertNotVisible:
+    id: camera_classic_shutter

--- a/mobile/e2e/maestro/tests/classicModeRecordClip.yaml
+++ b/mobile/e2e/maestro/tests/classicModeRecordClip.yaml
@@ -1,0 +1,26 @@
+appId: co.openvine.app
+tags:
+  - recorder
+---
+#TC to record a clip in classic mode,
+# given the recorder is open on an idle classic viewfinder,
+# validate tap-to-start / tap-to-stop on the preview produces a clip in the
+# session.
+#
+# Classic has no record button: the square preview *is* the shutter, wrapped in
+# its own Semantics node. That is the one structural difference from capture
+# mode's recording path — everything after the tap is the same clip manager.
+#
+# Needs real camera hardware. Without it the bloc never reports
+# `isCameraInitialized`, the shutter stays disabled, and the first tap does
+# nothing — so this cannot pass on the iOS Simulator. Run it on an Android
+# emulator (which has a virtual scene camera) or on a device.
+#
+# Tap-to-toggle is the default; hold-to-record is opt-in
+# (`HoldToRecordPreferenceService` defaults to false). A run against a device
+# where a previous session enabled it will hang on the first assertion.
+#Steps:
+# 1. Tap the preview: recording starts and the top-bar chrome fades out
+# 2. Tap it again: recording stops and the session holds one clip
+
+- runFlow: ../utils/recordClassicClip.yaml

--- a/mobile/e2e/maestro/tests/classicModeRecordingLimit.yaml
+++ b/mobile/e2e/maestro/tests/classicModeRecordingLimit.yaml
@@ -1,0 +1,46 @@
+appId: co.openvine.app
+tags:
+  - recorder
+---
+#TC for classic mode's recording limit,
+# given the recorder is open on a classic viewfinder that already holds the
+# clip classicModeRecordClip recorded,
+# validate a recording started here stops on its own when the session's
+# remaining budget runs out, without a second tap.
+#
+# This is the behaviour classic alone declares. `hasRecordingLimit` is true
+# only for this mode, and it is what makes the recorder hand the native camera
+# a `maxDuration` — the session's remaining share of the 6.3s total. Capture
+# and lip-sync pass none and record until the user stops them; the editor
+# trims afterwards.
+#
+# Deliberately does not assert *how long* the recording ran. The budget left
+# here is whatever classicModeRecordClip did not spend, which depends on how
+# quickly the device started and finalized that clip, so the assertion is that
+# the recording ended without a second tap — not that it ended at a number.
+#
+# Needs real camera hardware, like every recording test.
+#Steps:
+# 1. Tap the preview once: recording starts
+# 2. Wait without touching anything: the recorder comes back on its own
+# 3. Validate the session took the clip
+
+# 1. Start. Classic fades its whole top-bar row out while recording, so the
+# close button leaving is what reports that the recording actually started.
+- tapOn:
+    id: camera_classic_shutter
+- extendedWaitUntil:
+    notVisible:
+      id: camera_close_button
+    timeout: 15000
+
+# 2. No second tap. The close button coming back is the auto-stop: nothing else
+# in this mode restores the top bar. The timeout covers a full 6.3s budget plus
+# finalization, so it holds even if step 1 of the flow recorded almost nothing.
+- extendedWaitUntil:
+    visible:
+      id: camera_close_button
+    timeout: 20000
+
+# 3. And the recording became a clip rather than being discarded at the limit.
+- runFlow: ../asserts/assertClassicClipRecorded.yaml

--- a/mobile/e2e/maestro/tests/classicModeRecordingLimit.yaml
+++ b/mobile/e2e/maestro/tests/classicModeRecordingLimit.yaml
@@ -23,7 +23,7 @@ tags:
 #Steps:
 # 1. Tap the preview once: recording starts
 # 2. Wait without touching anything: the recorder comes back on its own
-# 3. Validate the session took the clip
+# 3. Validate the recorder is back on a live idle viewfinder
 
 # 1. Start. The readiness wait is load-bearing here in a way it is not in
 # recordClassicClip: this test needs budget left, and a session already holding
@@ -52,5 +52,10 @@ tags:
       id: camera_close_button
     timeout: 20000
 
-# 3. And the recording became a clip rather than being discarded at the limit.
+# 3. And the recorder came back to a live idle viewfinder rather than a stuck
+# one. This cannot prove the auto-stop produced a *second* clip: both halves of
+# the assert are gated on `hasClips`, which the clip from classicModeRecordClip
+# already satisfies on the way in. classicModeDeleteClip is what pins the count
+# — it deletes once and re-runs this same assert, which only holds if there
+# were two.
 - runFlow: ../asserts/assertClassicClipRecorded.yaml

--- a/mobile/e2e/maestro/tests/classicModeRecordingLimit.yaml
+++ b/mobile/e2e/maestro/tests/classicModeRecordingLimit.yaml
@@ -25,8 +25,18 @@ tags:
 # 2. Wait without touching anything: the recorder comes back on its own
 # 3. Validate the session took the clip
 
-# 1. Start. Classic fades its whole top-bar row out while recording, so the
-# close button leaving is what reports that the recording actually started.
+# 1. Start. The readiness wait is load-bearing here in a way it is not in
+# recordClassicClip: this test needs budget left, and a session already holding
+# a clip is exactly where it can have run out. The shutter reports that gate,
+# so a spent budget fails here rather than 15s later on a tap that did nothing.
+- extendedWaitUntil:
+    visible:
+      id: camera_classic_shutter
+      enabled: true
+    timeout: 15000
+
+# Classic fades its whole top-bar row out while recording, so the close button
+# leaving is what reports that the recording actually started.
 - tapOn:
     id: camera_classic_shutter
 - extendedWaitUntil:

--- a/mobile/e2e/maestro/tests/stopMotionModeControls.yaml
+++ b/mobile/e2e/maestro/tests/stopMotionModeControls.yaml
@@ -9,8 +9,10 @@ tags:
 #
 # Three of the five controls here — aspect ratio, lens and flash — are the
 # unconditional ones every rail renders, so they are the same per-control utils
-# driveCaptureRail sequences, in the same order. What is local to this file is
-# the pair capture mode does not render: the ghost-frame and grid toggles.
+# driveCaptureRail sequences, in the same order. The pair capture mode does not
+# render — the ghost-frame and grid toggles — are the two classic also renders,
+# so they are per-control utils too. What is local to this file is only the
+# order they run in.
 #
 # Those two carry a Semantics `toggled` flag rather than a `value`, which
 # Flutter maps to the accessibility node's checked state, so they are driven
@@ -37,46 +39,13 @@ tags:
 # 4. Camera: Back -> Front -> Back
 # 5. Flash (if present): Off -> On -> Auto -> Off
 
-# 1. Ghost frame (onion-skin). Not persisted, so it always starts off.
-- assertVisible:
-    id: camera_ghost_frame_button
-    checked: false
-- tapOn:
-    id: camera_ghost_frame_button
-- extendedWaitUntil:
-    visible:
-      id: camera_ghost_frame_button
-      checked: true
-    timeout: 10000
-# Restore. Leaving it on is not just untidy: the overlay draws the previous
-# still over the live preview, which makes a failure screenshot from any later
-# test much harder to read.
-- tapOn:
-    id: camera_ghost_frame_button
-- extendedWaitUntil:
-    visible:
-      id: camera_ghost_frame_button
-      checked: false
-    timeout: 10000
+# 1. Ghost frame (onion-skin). Driven first here, unlike classic: this rail is
+# vertical and on the right, so the confirmation snackbar floating at the
+# bottom does not sit over it, and steps 2-5 double as the wait it out.
+- runFlow: ../utils/driveGhostFrameControl.yaml
 
 # 2. Grid overlay.
-- assertVisible:
-    id: camera_grid_button
-    checked: true
-- tapOn:
-    id: camera_grid_button
-- extendedWaitUntil:
-    visible:
-      id: camera_grid_button
-      checked: false
-    timeout: 10000
-- tapOn:
-    id: camera_grid_button
-- extendedWaitUntil:
-    visible:
-      id: camera_grid_button
-      checked: true
-    timeout: 10000
+- runFlow: ../utils/driveGridControl.yaml
 
 # 3. Aspect ratio flips between two states.
 - runFlow: ../utils/driveAspectRatioControl.yaml

--- a/mobile/e2e/maestro/utils/driveGhostFrameControl.yaml
+++ b/mobile/e2e/maestro/utils/driveGhostFrameControl.yaml
@@ -1,0 +1,40 @@
+appId: co.openvine.app
+---
+#Utility: toggle the ghost-frame (onion-skin) overlay on and back off, leaving
+#it on its default. Rendered by both modes that draw the previous frame over
+#the live preview — stop-motion on the capture rail, classic in its own action
+#row.
+#
+# Not persisted, so it always starts off. Restoring it is not just tidiness:
+# the overlay draws the previous still (stop-motion) or the last clip's final
+# frame (classic) over the live preview, which makes a failure screenshot from
+# any later test much harder to read.
+#
+# The control carries a Semantics `toggled` flag rather than a `value`, which
+# Flutter maps to the accessibility node's checked state, so it is driven with
+# `checked:` rather than `text:`. **Maestro does not print the flag in its run
+# log** — see the note on that selector in e2e/maestro/README.md before
+# "fixing" a line here because the log looks bare.
+#
+# Each tap raises a 4-second confirmation snackbar floating over the bottom of
+# the screen. This util does not wait it out — where that banner lands relative
+# to the controls differs per mode, so the caller owns both the ordering and
+# the wait.
+
+- assertVisible:
+    id: camera_ghost_frame_button
+    checked: false
+- tapOn:
+    id: camera_ghost_frame_button
+- extendedWaitUntil:
+    visible:
+      id: camera_ghost_frame_button
+      checked: true
+    timeout: 10000
+- tapOn:
+    id: camera_ghost_frame_button
+- extendedWaitUntil:
+    visible:
+      id: camera_ghost_frame_button
+      checked: false
+    timeout: 10000

--- a/mobile/e2e/maestro/utils/driveGridControl.yaml
+++ b/mobile/e2e/maestro/utils/driveGridControl.yaml
@@ -1,0 +1,34 @@
+appId: co.openvine.app
+---
+#Utility: toggle the grid overlay off and back on, leaving it on its default.
+#Rendered by every mode that declares `supportGridLines` — stop-motion on the
+#capture rail, classic in its own action row.
+#
+# The control carries a Semantics `toggled` flag rather than a `value`, which
+# Flutter maps to the accessibility node's checked state, so it is driven with
+# `checked:` rather than `text:`. **Maestro does not print the flag in its run
+# log** — see the note on that selector in e2e/maestro/README.md before
+# "fixing" a line here because the log looks bare.
+#
+# Precondition the caller owns: **a grid that starts on.** The preference
+# persists (`camera_grid_lines_enabled`) and defaults to on for
+# grid-supporting modes, so the first assertion reads it as on. Run from the
+# top this is safe — loginFreshInstall's clearState wipes the key.
+
+- assertVisible:
+    id: camera_grid_button
+    checked: true
+- tapOn:
+    id: camera_grid_button
+- extendedWaitUntil:
+    visible:
+      id: camera_grid_button
+      checked: false
+    timeout: 10000
+- tapOn:
+    id: camera_grid_button
+- extendedWaitUntil:
+    visible:
+      id: camera_grid_button
+      checked: true
+    timeout: 10000

--- a/mobile/e2e/maestro/utils/openClassicMode.yaml
+++ b/mobile/e2e/maestro/utils/openClassicMode.yaml
@@ -1,0 +1,44 @@
+appId: co.openvine.app
+---
+#Utility: given the user is signed in and on a feed surface, open the recorder
+#and leave it on a ready classic viewfinder with an empty session.
+#
+# No launchApp, so this runs against whatever is already on screen — see the
+# "Iterating" section of e2e/maestro/README.md.
+#
+# Like openLipSyncMode and openStopMotionMode this *selects* the mode: the
+# recorder restores the last-used mode from `camera_last_used_recorder_mode`
+# and falls back to Capture when the key is absent, so a first run after a
+# `clearState` never opens here on its own.
+#
+# Classic is the last entry on the wheel and sits three places from Capture,
+# which is further than any other mode has to travel. The wheel is a lazy
+# ListView that only builds entries near the armed one, so the hops below step
+# one entry at a time rather than betting on how many the viewport happens to
+# have built — openCaptureMode documents the same trap from the other end
+# ("from Classic the Capture entry is not rendered at all").
+#
+# The hops are guarded on Classic not already being on screen, which is what
+# makes a rerun pass: selecting a mode persists it, so a second run opens
+# straight on Classic, from where Stop Motion is two entries away and may not
+# be built. When the guard does let the hops through, each tap lands on the
+# armed entry's immediate neighbour, which the wheel always has built.
+
+- runFlow: openRecorder.yaml
+
+- runFlow:
+    when:
+      notVisible:
+        id: camera_mode_classic
+    commands:
+      - tapOn:
+          id: camera_mode_stopMotion
+      - tapOn:
+          id: camera_mode_lipSync
+
+# Tapping the armed entry is a no-op in the bloc, so this is also safe on the
+# rerun path that skipped the hops above.
+- tapOn:
+    id: camera_mode_classic
+
+- runFlow: ../asserts/assertClassicMode.yaml

--- a/mobile/e2e/maestro/utils/recordClassicClip.yaml
+++ b/mobile/e2e/maestro/utils/recordClassicClip.yaml
@@ -1,0 +1,33 @@
+appId: co.openvine.app
+---
+#Utility: given the recorder is on a ready classic viewfinder with tap-to-toggle
+#recording enabled, record one clip and leave it in the session.
+#
+# Classic's shutter is the square preview, not a button, so this cannot reuse
+# recordCaptureClip.yaml — and it stops on the second tap rather than letting
+# the recording run out, which is what classicModeRecordingLimit covers.
+
+# The preview looks the same in both states, so it is the close button that
+# reports the transition: classic fades its whole top-bar row out while
+# recording.
+- tapOn:
+    id: camera_classic_shutter
+- extendedWaitUntil:
+    notVisible:
+      id: camera_close_button
+    timeout: 15000
+
+# Let a couple of seconds of footage accumulate — deliberately less than the
+# capture util's three. Classic is the only mode that declares
+# `hasRecordingLimit`, so every clip it records comes out of one 6.3s budget,
+# and classicModeRecordingLimit still needs enough of that budget left to start
+# a second recording at all (the bloc refuses below 30ms remaining).
+#
+# The live preview never settles, so this waits its timeout out rather than
+# returning early.
+- waitForAnimationToEnd:
+    timeout: 2000
+
+- tapOn:
+    id: camera_classic_shutter
+- runFlow: ../asserts/assertClassicClipRecorded.yaml

--- a/mobile/e2e/maestro/utils/recordClassicClip.yaml
+++ b/mobile/e2e/maestro/utils/recordClassicClip.yaml
@@ -27,17 +27,23 @@ appId: co.openvine.app
       id: camera_close_button
     timeout: 15000
 
-# Let a couple of seconds of footage accumulate — deliberately less than the
-# capture util's three. Classic is the only mode that declares
-# `hasRecordingLimit`, so every clip it records comes out of one 6.3s budget,
-# and classicModeRecordingLimit still needs enough of that budget left to start
-# a second recording at all (the bloc refuses below 30ms remaining).
+# Straight to the stop tap. No accumulate-footage wait, unlike the capture
+# util — classic cannot afford one, and the first device run is what proved it.
 #
-# The live preview never settles, so this waits its timeout out rather than
-# returning early.
-- waitForAnimationToEnd:
-    timeout: 2000
-
+# Classic is the only mode that declares `hasRecordingLimit`, so the whole
+# session shares one 6.3s budget and everything this util spends comes out of
+# what classicModeRecordingLimit has left to work with. On the SM-S942B the two
+# taps alone span ~4.1s of it: Maestro dumps the view hierarchy around every
+# command, so the start tap took 3.5s wall-clock and the stop tap 2.0s. A
+# `waitForAnimationToEnd: 2000` between them measured 3.7s — the live camera
+# preview never settles, so it always runs its timeout out and then some — and
+# pushed the pair to ~7.9s. Past 6.3s the native auto-stop ends the recording
+# first, which cost both tests at once: this one stopped proving tap-to-stop,
+# and the limit test could not start at all against a spent budget.
+#
+# ~4.1s spent leaves ~2.1s, which is enough for the limit test to start a
+# recording and watch it end itself. Anything added here comes out of that
+# margin.
 - tapOn:
     id: camera_classic_shutter
 - runFlow: ../asserts/assertClassicClipRecorded.yaml

--- a/mobile/e2e/maestro/utils/recordClassicClip.yaml
+++ b/mobile/e2e/maestro/utils/recordClassicClip.yaml
@@ -7,6 +7,16 @@ appId: co.openvine.app
 # recordCaptureClip.yaml — and it stops on the second tap rather than letting
 # the recording run out, which is what classicModeRecordingLimit covers.
 
+# The shutter reports its own readiness — the same gate the tap runs on: a
+# camera that is not up, or a session budget below 30ms. Without this the tap
+# lands on a dead target, does nothing, and the wait below burns its full 15s
+# before failing on a symptom instead of the precondition.
+- extendedWaitUntil:
+    visible:
+      id: camera_classic_shutter
+      enabled: true
+    timeout: 15000
+
 # The preview looks the same in both states, so it is the close button that
 # reports the transition: classic fades its whole top-bar row out while
 # recording.

--- a/mobile/lib/constants/semantic_ids.dart
+++ b/mobile/lib/constants/semantic_ids.dart
@@ -22,10 +22,24 @@ abstract class SemanticIds {
   static String cameraMode(String mode) => 'camera_mode_$mode';
   static const String cameraRecordButton = 'camera_record_button';
 
+  /// Classic mode's shutter. It has no record button — the square preview
+  /// itself is the tap target — so it gets its own id rather than reusing
+  /// [cameraRecordButton] for a different widget. The E2E asserts pin the
+  /// record button *absent* in classic and this one absent everywhere else,
+  /// which is what proves the right stack is up.
+  static const String cameraClassicShutter = 'camera_classic_shutter';
+
   /// Recorder chrome. Close, next and delete-clip come from the capture
-  /// stack, which capture, stop-motion and lip-sync all render; the library
-  /// button lives in the bottom bar, which every mode renders. Every label
-  /// behind these is localized, so the E2E capture flow drives them by id.
+  /// stack, which capture, stop-motion and lip-sync all render, and from
+  /// classic mode's own top bar and action row; the library button lives in
+  /// the bottom bar, which every mode renders. Every label behind these is
+  /// localized, so the E2E recorder flows drive them by id.
+  ///
+  /// The two stacks reveal next and delete differently, and the E2E asserts
+  /// have to match: capture fades them out of the semantics tree entirely
+  /// when the session is empty, while classic keeps next mounted and
+  /// disables it — so an empty classic session reads `enabled: false` there,
+  /// not `notVisible`.
   static const String cameraCloseButton = 'camera_close_button';
   static const String cameraNextButton = 'camera_next_button';
   static const String cameraDeleteClipButton = 'camera_delete_clip_button';
@@ -69,10 +83,11 @@ abstract class SemanticIds {
   /// E2E asserts pin their absence in the modes that do not declare them, so a
   /// control leaking across modes fails a run rather than passing quietly.
   ///
-  /// Classic mode has its own grid and ghost toggles in
-  /// `video_recorder_classic_actions_bottom.dart`. They are deliberately
-  /// untagged: no flow drives them yet, and an identifier nothing asserts on
-  /// drifts silently.
+  /// Classic mode renders its own grid and ghost toggles in
+  /// `video_recorder_classic_actions_bottom.dart`, and its own lens switch
+  /// next to them. They drive the same bloc state and announce the same
+  /// `toggled` / `value`, so they carry the same ids and the E2E flow drives
+  /// them with the same per-control utils.
   static const String cameraGhostFrameButton = 'camera_ghost_frame_button';
   static const String cameraGridButton = 'camera_grid_button';
   static const String cameraStopMotionBudget = 'camera_stop_motion_budget';

--- a/mobile/lib/constants/semantic_ids.dart
+++ b/mobile/lib/constants/semantic_ids.dart
@@ -25,8 +25,8 @@ abstract class SemanticIds {
   /// Classic mode's shutter. It has no record button — the square preview
   /// itself is the tap target — so it gets its own id rather than reusing
   /// [cameraRecordButton] for a different widget. The E2E asserts pin the
-  /// record button *absent* in classic and this one absent everywhere else,
-  /// which is what proves the right stack is up.
+  /// record button *absent* in classic and this one absent in every
+  /// capture-stack mode, which is what proves the right stack is up.
   static const String cameraClassicShutter = 'camera_classic_shutter';
 
   /// Recorder chrome. Close, next and delete-clip come from the capture

--- a/mobile/lib/widgets/video_recorder/modes/classic/video_recorder_classic_actions_bottom.dart
+++ b/mobile/lib/widgets/video_recorder/modes/classic/video_recorder_classic_actions_bottom.dart
@@ -2,6 +2,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/l10n/l10n.dart';
 
 class VideoRecorderClassicActionsBottom extends StatelessWidget {
@@ -35,6 +36,7 @@ class VideoRecorderClassicActionsBottom extends StatelessWidget {
           DivineIconButton(
             icon: .arrowsCounterClockwise,
             semanticLabel: l10n.videoRecorderSwitchCameraLabel,
+            semanticIdentifier: SemanticIds.cameraSwitchCameraButton,
             semanticValue: state.isFrontCamera
                 ? l10n.videoRecorderCameraValueFront
                 : l10n.videoRecorderCameraValueBack,
@@ -47,6 +49,7 @@ class VideoRecorderClassicActionsBottom extends StatelessWidget {
           DivineIconButton(
             icon: .gridNine,
             semanticLabel: l10n.videoRecorderToggleGridLabel,
+            semanticIdentifier: SemanticIds.cameraGridButton,
             semanticToggled: state.showGridLines,
             size: .small,
             type: .ghostSecondary,
@@ -57,6 +60,7 @@ class VideoRecorderClassicActionsBottom extends StatelessWidget {
           DivineIconButton(
             icon: .ghost,
             semanticLabel: l10n.videoRecorderToggleGhostFrameLabel,
+            semanticIdentifier: SemanticIds.cameraGhostFrameButton,
             semanticToggled: state.showLastClipOverlay,
             size: .small,
             type: .ghostSecondary,

--- a/mobile/lib/widgets/video_recorder/modes/classic/video_recorder_classic_actions_top.dart
+++ b/mobile/lib/widgets/video_recorder/modes/classic/video_recorder_classic_actions_top.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/widgets/video_recorder/clip_delete_snackbar.dart';
@@ -33,6 +34,7 @@ class VideoRecorderClassicActionsTop extends ConsumerWidget {
           DivineIconButton(
             icon: .trash,
             semanticLabel: context.l10n.videoRecorderDeleteLastClipLabel,
+            semanticIdentifier: SemanticIds.cameraDeleteClipButton,
             size: .small,
             type: .ghostSecondary,
             onPressed: () => _deleteLastClip(context, ref),

--- a/mobile/lib/widgets/video_recorder/modes/classic/video_recorder_classic_stack.dart
+++ b/mobile/lib/widgets/video_recorder/modes/classic/video_recorder_classic_stack.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/preferences_providers.dart';
@@ -62,6 +63,7 @@ class VideoRecorderClassicStack extends ConsumerWidget {
                   child: AspectRatio(
                     aspectRatio: 1,
                     child: Semantics(
+                      identifier: SemanticIds.cameraClassicShutter,
                       button: true,
                       liveRegion: true,
                       label: state.isRecording

--- a/mobile/lib/widgets/video_recorder/modes/classic/video_recorder_classic_stack.dart
+++ b/mobile/lib/widgets/video_recorder/modes/classic/video_recorder_classic_stack.dart
@@ -65,6 +65,12 @@ class VideoRecorderClassicStack extends ConsumerWidget {
                     child: Semantics(
                       identifier: SemanticIds.cameraClassicShutter,
                       button: true,
+                      // Same value the gesture detector below is gated on, so
+                      // the node stops announcing a tappable button once the
+                      // shutter is dead — no camera, or the session's 6.3s
+                      // budget spent. Mirrors the capture stack's record
+                      // button, which has always reported it.
+                      enabled: isEnabled,
                       liveRegion: true,
                       label: state.isRecording
                           ? context.l10n.videoRecorderRecordingTapToStopLabel

--- a/mobile/lib/widgets/video_recorder/modes/classic/video_recorder_classic_top_bar.dart
+++ b/mobile/lib/widgets/video_recorder/modes/classic/video_recorder_classic_top_bar.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
@@ -33,6 +34,7 @@ class VideoRecorderClassicTopBar extends ConsumerWidget {
                 DivineIconButton(
                   icon: .x,
                   semanticLabel: context.l10n.videoRecorderCloseLabel,
+                  semanticIdentifier: SemanticIds.cameraCloseButton,
                   size: .small,
                   type: .ghostSecondary,
                   onPressed: isRecording
@@ -43,6 +45,7 @@ class VideoRecorderClassicTopBar extends ConsumerWidget {
                   icon: .caretRight,
                   semanticLabel:
                       context.l10n.videoRecorderContinueToEditorLabel,
+                  semanticIdentifier: SemanticIds.cameraNextButton,
                   size: .small,
                   type: .ghostSecondary,
                   onPressed: isRecording || !hasClips

--- a/mobile/test/widgets/video_recorder/modes/classic/video_recorder_classic_actions_bottom_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/classic/video_recorder_classic_actions_bottom_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/video_recorder/video_recorder_state.dart';
@@ -157,6 +158,31 @@ void main() {
           find.bySemanticsLabel(l10n.videoRecorderToggleGhostFrameLabel),
         );
         expect(node.flagsCollection.isToggled, Tristate.isFalse);
+
+        handle.dispose();
+      });
+
+      // The Maestro classic flow drives this row by identifier
+      // (e2e/maestro/tests/classicModeControls.yaml). Dropping one is
+      // invisible to every other test here — the labels and toggled flags
+      // above would still be correct — and only surfaces on a manual E2E run,
+      // since that lane is not part of CI.
+      testWidgets('exposes an E2E identifier on every action', (tester) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(buildWidget());
+        await tester.pumpAndSettle();
+
+        for (final identifier in const [
+          SemanticIds.cameraSwitchCameraButton,
+          SemanticIds.cameraGridButton,
+          SemanticIds.cameraGhostFrameButton,
+        ]) {
+          expect(
+            find.bySemanticsIdentifier(identifier),
+            findsOneWidget,
+            reason: 'missing E2E anchor: $identifier',
+          );
+        }
 
         handle.dispose();
       });

--- a/mobile/test/widgets/video_recorder/modes/classic/video_recorder_classic_actions_top_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/classic/video_recorder_classic_actions_top_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -70,6 +71,41 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.byType(DivineIconButton), findsOneWidget);
+      });
+
+      // The Maestro classic flow taps this button by identifier
+      // (e2e/maestro/tests/classicModeDeleteClip.yaml). Dropping it only
+      // surfaces on a manual E2E run, since that lane is not part of CI.
+      //
+      // Needs a clip: with an empty session the row is at opacity 0, and
+      // RenderAnimatedOpacity drops its child from the semantics tree there —
+      // which is exactly what assertClassicMode reads as "nothing recorded".
+      testWidgets('exposes an E2E identifier on the delete button', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(
+          buildWidget(
+            clips: [
+              DivineVideoClip(
+                id: 'clip1',
+                video: EditorVideo.file('/test/clip1.mp4'),
+                duration: const Duration(seconds: 2),
+                recordedAt: DateTime.now(),
+                targetAspectRatio: .square,
+                originalAspectRatio: 1,
+              ),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          find.bySemanticsIdentifier(SemanticIds.cameraDeleteClipButton),
+          findsOneWidget,
+        );
+
+        handle.dispose();
       });
     });
 

--- a/mobile/test/widgets/video_recorder/modes/classic/video_recorder_classic_stack_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/classic/video_recorder_classic_stack_test.dart
@@ -8,9 +8,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/constants/semantic_ids.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
 import 'package:openvine/models/video_recorder/video_recorder_state.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
@@ -19,6 +21,7 @@ import 'package:openvine/widgets/video_recorder/modes/classic/video_recorder_cla
 import 'package:openvine/widgets/video_recorder/modes/classic/video_recorder_classic_stack.dart';
 import 'package:openvine/widgets/video_recorder/modes/classic/video_recorder_classic_top_bar.dart';
 import 'package:openvine/widgets/video_recorder/preview/video_recorder_camera_preview.dart';
+import 'package:pro_video_editor/core/models/video/editor_video_model.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockVideoRecorderBloc
@@ -54,6 +57,11 @@ void main() {
           recordingState: recordingState,
           isCameraInitialized: isCameraInitialized,
           canRecord: canRecord,
+          // The state default is `capture`, and this stack only ever renders
+          // in classic. It matters for more than tidiness: `hasRecordingLimit`
+          // is true only here, and it is what puts the session budget into the
+          // shutter's enabled gate.
+          recorderMode: VideoRecorderMode.classic,
         ),
       );
 
@@ -257,6 +265,54 @@ void main() {
 
         handle.dispose();
       });
+
+      testWidgets(
+        'reports the shutter disabled when the camera cannot record',
+        (tester) async {
+          final handle = tester.ensureSemantics();
+          await tester.pumpWidget(buildWidget(canRecord: false));
+          await tester.pumpAndSettle();
+
+          final node = tester.getSemantics(
+            find.bySemanticsIdentifier(SemanticIds.cameraClassicShutter),
+          );
+          expect(node.flagsCollection.isEnabled, Tristate.isFalse);
+
+          handle.dispose();
+        },
+      );
+
+      // The third arm of the gate, and the only one specific to this mode:
+      // classic is the sole `hasRecordingLimit` mode, so a session that has
+      // spent the 6.3s budget cannot start another recording. This is the case
+      // classicModeRecordingLimit's readiness wait exists to fail fast on.
+      testWidgets('reports the shutter disabled once the budget is spent', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(
+          buildWidget(
+            clips: [
+              DivineVideoClip(
+                id: 'clip1',
+                video: EditorVideo.file('/test/clip1.mp4'),
+                duration: VideoEditorConstants.maxDuration,
+                recordedAt: DateTime.now(),
+                targetAspectRatio: .square,
+                originalAspectRatio: 1,
+              ),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final node = tester.getSemantics(
+          find.bySemanticsIdentifier(SemanticIds.cameraClassicShutter),
+        );
+        expect(node.flagsCollection.isEnabled, Tristate.isFalse);
+
+        handle.dispose();
+      });
     });
 
     group('long press', () {
@@ -273,9 +329,7 @@ void main() {
         await tester.pumpAndSettle();
 
         verify(
-          () => recorderBloc.add(
-            const VideoRecorderRecordingStartRequested(),
-          ),
+          () => recorderBloc.add(const VideoRecorderRecordingStartRequested()),
         ).called(1);
       });
 
@@ -294,9 +348,7 @@ void main() {
         await tester.pumpAndSettle();
 
         verify(
-          () => recorderBloc.add(
-            const VideoRecorderRecordingStopRequested(),
-          ),
+          () => recorderBloc.add(const VideoRecorderRecordingStopRequested()),
         ).called(1);
       });
     });
@@ -305,38 +357,33 @@ void main() {
     // long-touch on the preview shutter while a tap-started recording is
     // in progress must NOT call stopRecording on release.
     group('phantom click regression (issue #4409)', () {
-      testWidgets(
-        'long-press release does not stop a tap-started recording',
-        (tester) async {
-          await tester.pumpWidget(
-            buildWidget(recordingState: VideoRecorderState.recording),
-          );
-          await tester.pumpAndSettle();
+      testWidgets('long-press release does not stop a tap-started recording', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(recordingState: VideoRecorderState.recording),
+        );
+        await tester.pumpAndSettle();
 
-          final gesture = await tester.startGesture(
-            tester.getCenter(
-              find.ancestor(
-                of: find.byType(VideoRecorderCameraPreview),
-                matching: find.byType(GestureDetector),
-              ),
+        final gesture = await tester.startGesture(
+          tester.getCenter(
+            find.ancestor(
+              of: find.byType(VideoRecorderCameraPreview),
+              matching: find.byType(GestureDetector),
             ),
-          );
-          await tester.pump(const Duration(seconds: 1));
-          await gesture.up();
-          await tester.pumpAndSettle();
+          ),
+        );
+        await tester.pump(const Duration(seconds: 1));
+        await gesture.up();
+        await tester.pumpAndSettle();
 
-          verifyNever(
-            () => recorderBloc.add(
-              const VideoRecorderRecordingStopRequested(),
-            ),
-          );
-          verifyNever(
-            () => recorderBloc.add(
-              const VideoRecorderRecordingStartRequested(),
-            ),
-          );
-        },
-      );
+        verifyNever(
+          () => recorderBloc.add(const VideoRecorderRecordingStopRequested()),
+        );
+        verifyNever(
+          () => recorderBloc.add(const VideoRecorderRecordingStartRequested()),
+        );
+      });
     });
   });
 }

--- a/mobile/test/widgets/video_recorder/modes/classic/video_recorder_classic_stack_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/classic/video_recorder_classic_stack_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show Tristate;
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -44,12 +46,14 @@ void main() {
     Widget buildWidget({
       VideoRecorderState recordingState = VideoRecorderState.idle,
       List<DivineVideoClip>? clips,
+      bool isCameraInitialized = true,
+      bool canRecord = true,
     }) {
       when(() => recorderBloc.state).thenReturn(
         VideoRecorderBlocState(
           recordingState: recordingState,
-          isCameraInitialized: true,
-          canRecord: true,
+          isCameraInitialized: isCameraInitialized,
+          canRecord: canRecord,
         ),
       );
 
@@ -211,6 +215,45 @@ void main() {
           find.bySemanticsIdentifier(SemanticIds.cameraClassicShutter),
           findsOneWidget,
         );
+
+        handle.dispose();
+      });
+
+      // The anchor is stable across recording states, but the node's enabled
+      // flag is not meant to be: it carries the same gate the gesture detector
+      // runs on, so a screen reader stops offering a button that does nothing
+      // and assertClassicMode can tell a live viewfinder from a dead one. The
+      // capture stack's record button has always reported this.
+      //
+      // One pump per state: the bloc is a mock and does not emit, so
+      // re-pumping over a live tree leaves `context.select` on the value it
+      // already read.
+      testWidgets('reports the shutter enabled once the camera is ready', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(buildWidget());
+        await tester.pumpAndSettle();
+
+        final node = tester.getSemantics(
+          find.bySemanticsIdentifier(SemanticIds.cameraClassicShutter),
+        );
+        expect(node.flagsCollection.isEnabled, Tristate.isTrue);
+
+        handle.dispose();
+      });
+
+      testWidgets('reports the shutter disabled before the camera is ready', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(buildWidget(isCameraInitialized: false));
+        await tester.pumpAndSettle();
+
+        final node = tester.getSemantics(
+          find.bySemanticsIdentifier(SemanticIds.cameraClassicShutter),
+        );
+        expect(node.flagsCollection.isEnabled, Tristate.isFalse);
 
         handle.dispose();
       });

--- a/mobile/test/widgets/video_recorder/modes/classic/video_recorder_classic_stack_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/classic/video_recorder_classic_stack_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -182,6 +183,36 @@ void main() {
           ),
           findsNothing,
         );
+      });
+
+      // Classic has no record button — the preview is the shutter — so the
+      // Maestro flow taps it by this identifier
+      // (e2e/maestro/utils/recordClassicClip.yaml). The label assertions above
+      // move with the recording state; the anchor must not, or the E2E flow
+      // loses its only way to start a classic recording. That only surfaces on
+      // a manual run, since the Maestro lane is not part of CI.
+      testWidgets('exposes a stable E2E anchor on the shutter in both states', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+
+        await tester.pumpWidget(buildWidget());
+        await tester.pumpAndSettle();
+        expect(
+          find.bySemanticsIdentifier(SemanticIds.cameraClassicShutter),
+          findsOneWidget,
+        );
+
+        await tester.pumpWidget(
+          buildWidget(recordingState: VideoRecorderState.recording),
+        );
+        await tester.pumpAndSettle();
+        expect(
+          find.bySemanticsIdentifier(SemanticIds.cameraClassicShutter),
+          findsOneWidget,
+        );
+
+        handle.dispose();
       });
     });
 

--- a/mobile/test/widgets/video_recorder/modes/classic/video_recorder_classic_top_bar_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/classic/video_recorder_classic_top_bar_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show Tristate;
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -6,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -121,6 +124,82 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.byType(Stack), findsWidgets);
+      });
+    });
+
+    group('E2E anchors', () {
+      // The Maestro classic flow drives this bar by identifier
+      // (e2e/maestro/asserts/assertClassicMode.yaml). Dropping one is
+      // invisible to the label assertions above and only surfaces on a manual
+      // E2E run, since that lane is not part of CI.
+      testWidgets('exposes an E2E identifier on close and next', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(buildWidget());
+        await tester.pumpAndSettle();
+
+        for (final identifier in [
+          SemanticIds.cameraCloseButton,
+          SemanticIds.cameraNextButton,
+        ]) {
+          expect(
+            find.bySemanticsIdentifier(identifier),
+            findsOneWidget,
+            reason: 'missing E2E anchor: $identifier',
+          );
+        }
+
+        handle.dispose();
+      });
+
+      // assertClassicMode reads an empty session off `enabled: false` on next
+      // rather than off its absence, because unlike the capture stack classic
+      // keeps the button mounted and disables it. Wrapping it in an
+      // AnimatedOpacity later would drop it from the semantics tree and break
+      // that assert in a lane CI does not run.
+      testWidgets(
+        'keeps next mounted and disabled while the session is empty',
+        (
+          tester,
+        ) async {
+          final handle = tester.ensureSemantics();
+          await tester.pumpWidget(buildWidget());
+          await tester.pumpAndSettle();
+
+          final node = tester.getSemantics(
+            find.bySemanticsIdentifier(SemanticIds.cameraNextButton),
+          );
+          expect(node.flagsCollection.isEnabled, Tristate.isFalse);
+
+          handle.dispose();
+        },
+      );
+
+      testWidgets('enables next once the session holds a clip', (tester) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(
+          buildWidget(
+            clips: [
+              DivineVideoClip(
+                id: 'clip1',
+                video: EditorVideo.file('/test/clip1.mp4'),
+                duration: const Duration(seconds: 3),
+                recordedAt: DateTime.now(),
+                targetAspectRatio: .square,
+                originalAspectRatio: 1,
+              ),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final node = tester.getSemantics(
+          find.bySemanticsIdentifier(SemanticIds.cameraNextButton),
+        );
+        expect(node.flagsCollection.isEnabled, Tristate.isTrue);
+
+        handle.dispose();
       });
     });
 


### PR DESCRIPTION
Closes #7079

## Description

Extends the recorder E2E suite to the **classic** mode, the fourth of five, after #7018's capture coverage, #7043's lip-sync and #7036's stop-motion. Open, drive the action row, record a clip off the preview, prove a second recording stops itself at the duration limit, delete both, close.

**Classic needs more of its own files than the other three modes did, because it is a different stack rather than the same one with a different rail.** Capture, lip-sync and stop-motion all render `VideoRecorderCaptureStack` and differ only in the top bar's center slot and which rail controls they declare, which is why they share `driveCaptureRail` and most of each other's asserts. Classic renders `VideoRecorderClassicStack`: its own top bar, its own action rows above and below a square preview, and no control rail at all. So it gets its own mode assert, its own clip-recorded assert and its own record util. What it does share is the lens switch — the same control announcing the same `value` — so `classicModeControls` runs the existing `utils/driveLensControl.yaml` rather than duplicating it.

**The shutter is the preview, and it gets its own identifier.** There is no `camera_record_button` in classic; the square preview is wrapped in a `Semantics` node that flips its label between "tap to start" and "tap to stop". That node now carries `camera_classic_shutter`. Reusing `camera_record_button` would have made `utils/recordCaptureClip.yaml` reusable for exactly one line, at the cost of putting the same id on a different widget — which `SemanticIds` explicitly forbids, and which would have made the leak-guard `assertNotVisible` lines in the other three asserts ambiguous. A widget test pins that the anchor survives both recording states, since the label around it does not.

**Next is disabled, not hidden — and the asserts have to read it that way.** The capture stack wraps next and delete in an `AnimatedOpacity` and lets `RenderAnimatedOpacity` drop them from the semantics tree on an empty session, which is what every existing `assert…Mode` reads as "nothing recorded yet". Classic's top bar keeps next mounted and passes `onPressed: null`. So `assertClassicMode` asserts `enabled: false` there and `assertClassicClipRecorded` waits on `enabled: true` — a visibility wait would pass instantly against an empty session and prove nothing. Delete does still leave the tree, so it stays asserted the usual way. `video_recorder_classic_top_bar_test.dart` pins both halves of that contract, so a later refactor toward the capture stack's shape fails there rather than silently in a lane CI does not run.

**`classicModeRecordingLimit` covers the one behaviour classic alone declares.** `hasRecordingLimit` is true only for this mode, and it is what makes the recorder hand the native camera a `maxDuration` — the session's remaining share of the 6.3s total. Capture and lip-sync pass none and record until the user stops them. The test starts a recording, never stops it, and waits for the top bar to come back, which only the native auto-stop can do. It deliberately asserts *that* rather than *when*: the budget left depends on what `classicModeRecordClip` spent. That coupling is also why `recordClassicClip` records for two seconds where `recordCaptureClip` records for three — the bloc refuses to start a recording below 30ms remaining, so a longer first clip would fail the limit test on its opening wait rather than on the limit.

**`openClassicMode` guards its wheel hops instead of tapping unconditionally.** Classic is the last entry and sits three places from Capture, further than any other mode has to travel on a lazy `ListView` that only builds entries near the armed one. So the hops step one entry at a time, and they are guarded on Classic not already being on screen: selecting a mode persists it, so a rerun opens straight on Classic, from where Stop Motion is two entries away and may not be built at all. `openLipSyncMode`'s unconditional two taps work because Lip Sync is only two places out; that does not generalise to the end of the wheel.

**Ghost is driven last in the controls test.** Each toggle raises the same 4-second confirmation snackbar stop-motion has, but classic's controls are a horizontal row above the mode wheel rather than a vertical rail on the right. By layout the banner sits below that row and does not cover the two taps that restore the toggle — but running lens and grid first means that if it turns out to overlap on some screen size, the failure lands on that control alone instead of taking the rest of the test with it.

One behaviour fix came out of the tagging: classic's shutter computed `isEnabled` — no camera, or the 6.3s budget spent — and passed it only to the gesture detector, so the `Semantics` node announced a tappable button either way. The capture stack's record button has always reported it. The flag is read by a readiness wait in `recordClassicClip` and another in `classicModeRecordingLimit`, which is what turns a dead viewfinder into an immediate failure instead of one fifteen seconds later on the close-button wait. Not on `assertClassicMode`: that file runs from `openClassicMode` the moment the recorder opens, so an `enabled: true` there would fail the whole mode assert on a camera that is merely still warming up. `ScreenshotMode` is deliberately not mirrored: the record button ORs it in so screenshot builds render the visual prominent, and classic's preview has no disabled visual to keep honest.

Seven identifiers were added along the way — six the other modes already had, plus the shutter's own. Classic's grid and ghost toggles were deliberately left untagged in #7036 on the grounds that no flow drove them and an identifier nothing asserts on drifts silently; one does now, so they are tagged, and that comment in `SemanticIds` is updated rather than left contradicting the code.

## Out of Scope

- **Classic's "next".** It skips the editor entirely — classic is the one mode declaring no `hasVideoEditor` — and pushes the metadata screen with a render already started. Same reason stop-motion's assemble step is out: it leaves the recorder, and there is no coverage on the other side to hand off to.
- **Upload mode**, the fifth and last. It has no camera, no shutter and no clips; its stack is a static explainer, so it shares nothing with the four flows and needs a different shape of test.
- **The smoke suite.** The flow stays out for the same reason the other three do — the shutter needs real camera hardware to leave its disabled state, and the smoke lane runs on the iOS Simulator.
- **A negative-control pass.** #7036 proved its `checked:` selectors really applied by asserting them against the opposite state and watching them fail. The same is worth doing here for the new `enabled:` assertions on next, and is part of the device pass below.

## Verification

**All four recorder flows run green end to end on a Samsung Galaxy SM-S942B**, STAGING debug build (`DEFAULT_ENV=STAGING`, `GH_ACTIONS_PR_PREVIEW=true`):

| Flow | Commands | Failed | Skipped | Wall-clock |
|---|---|---|---|---|
| classic | 194 | 0 | 2 | 153s |
| stop-motion | 208 | 0 | 1 | 170s |
| capture | 203 | 0 | 1 | 167s |
| lip-sync | 225 | 0 | 1 | 197s |

The other three were re-run because this PR touches them — a `camera_classic_shutter` leak-guard line in each `assert…Mode`, and the util extraction in `stopMotionModeControls`. All five per-control utils fire in the stop-motion run, the two new ones included, and `driveFlashControl` was not skipped, so the flash block was exercised for real rather than guarded past.

Every skipped block is a guard doing its job: the "Why six seconds?" onboarding dialog that did not appear (all four runs), and `openClassicMode`'s wheel hops on the second open, where Classic was already armed. The hops themselves ran on the first open, so both branches of that guard are covered.

The device runs a `de-CH` system locale, so the run went through the scratch flow README step 0b describes rather than `classicModeFlow` itself: `pm clear` and the `en-US` app-locale override applied from adb, in that order, then everything from `classicModeOpen` onward byte-for-byte as the flow runs it. Same workaround lip-sync and stop-motion needed.

**The first device run failed, and it found a real flow bug** — `classicModeRecordingLimit` could not start, shutter `enabled: false`, progress bar completely full off a single clip. Classic shares one 6.3s budget and Maestro charges its own overhead to it: the start tap cost 3.5s and the stop tap 2.0s, and the `waitForAnimationToEnd: 2000` between them measured 3.7s, since the live preview never settles and it runs its timeout out and then some. ~7.9s against a 6.3s cap, so the native auto-stop was ending the recording instead of the stop tap. That broke both shutter tests at once and hid it — `classicModeRecordClip` stopped proving the tap-to-stop it is named for and still passed green, while the limit test had no budget to start on. Dropping the wait puts the pair at ~4.1s and leaves ~2.1s, which is what the limit test runs on.

What the device settled that nothing local could:

- **The native auto-stop reaches the Flutter side as a clip.** `classicModeRecordingLimit` taps once, the top bar leaves, and it comes back on its own with the session holding the clip — the flagged unknown, and it holds.
- **The ghost-frame snackbar does not cover classic's action row.** `classicModeControls` drives all three controls and closes on its mode assert.
- **`enabled: false` on next and `enabled: true` on the shutter both resolve on device**, as does `checked:` on grid and ghost.
- **Two deletes, and the assert between them holds**, which is what proves the session held two clips.

Local, on the final commit:

- `flutter analyze lib test integration_test` — clean
- `flutter test test/widgets/video_recorder/` — 291 passing
- `flutter test test/screens/video_recorder_screen_test.dart test/models/video_recorder/` — passing
- `bash e2e/maestro/scripts/check_refs.sh` — clean
- `dart format` — clean

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore




