### PR TITLE
fix(support): vary classics feed sessions

### DIFF
--- a/mobile/lib/providers/classic_vines_provider.dart
+++ b/mobile/lib/providers/classic_vines_provider.dart
@@ -2,9 +2,7 @@
 // ABOUTME: Uses REST API when available, falls back to Nostr videos with embedded stats
 
 import 'dart:async';
-import 'dart:math';
 
-import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/providers/feed_refresh_helpers.dart';
@@ -22,27 +20,17 @@ part 'classic_vines_provider.g.dart';
 /// ClassicVines feed provider - shows pre-2017 Vine archive sorted by loops
 ///
 /// Uses REST API (Funnelcake) with offset pagination to load pages on demand.
-/// Each page is 50 videos. With ~10k classic vines, there are ~200 pages.
+/// Each page is 50 videos.
 ///
 /// Pull-to-refresh selects a fresh random slice of classics while retrying
 /// transient failures and empty pages.
 @Riverpod(keepAlive: true)
 class ClassicVinesFeed extends _$ClassicVinesFeed {
   static const int _pageSize = 50;
-  static const int _totalClassicVines = 10000; // Approximate total
   static const int _initialRequestAttempts = 2;
 
-  /// Shared with the home feed's Classics mode so both surfaces open on the
-  /// same slice of the archive.
-  static const int _maxRandomStartOffset = classicsMaxRandomStartOffset;
-
-  final Random _random = Random();
-
-  /// Starting offset for the current loaded classics window.
-  int _startOffset = 0;
-
-  /// Number of additional pages appended via loadMore
-  int _loadMorePages = 0;
+  /// Repository cursor for the next page of the current loaded classics window.
+  String? _paginationCursor;
 
   @override
   Future<VideoFeedState> build() async {
@@ -76,54 +64,53 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
     final funnelcakeAvailable =
         ref.watch(funnelcakeAvailableProvider).asData?.value ?? false;
 
-    _startOffset = _randomStartOffset();
-    _loadMorePages = 0;
+    _paginationCursor = null;
 
     return _loadFirstPage(funnelcakeAvailable: funnelcakeAvailable);
-  }
-
-  int _randomStartOffset() {
-    const pageCount = (_maxRandomStartOffset ~/ _pageSize) + 1;
-    return _random.nextInt(pageCount) * _pageSize;
   }
 
   Future<VideoFeedState> _loadFirstPage({
     required bool funnelcakeAvailable,
     bool preserveCurrentOnEmptyFallback = false,
+    bool skipCache = false,
   }) async {
-    final client = ref.read(funnelcakeApiClientProvider);
     final videoEventService = ref.read(videoEventServiceProvider);
     final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
     Object? restError;
 
-    Future<List<VideoEvent>> fetchFilteredRestPage(
-      int offset, {
+    Future<HomeFeedResult> fetchRestPage({
       required bool retryOnError,
+      String? cursor,
+      bool skipCache = false,
     }) async {
+      final repository = ref.read(videosRepositoryProvider);
       final attempts = retryOnError ? _initialRequestAttempts : 1;
       for (var attempt = 1; attempt <= attempts; attempt++) {
         try {
-          final stats = await client.getClassicVines(offset: offset);
-          final videos = stats.toVideoEvents();
-
-          // Filter for platform compatibility, content preferences,
-          // blocked users, dedupe by addressable identity, and shuffle
-          final filteredVideos = dedupeByFeedKey(
-            videoEventService.filterVideoList(
-              videos
-                  .where((v) => v.isSupportedOnCurrentPlatform)
-                  .where(
-                    (v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey),
-                  )
-                  .toList(),
-            ),
+          final result = await repository.getClassicVideos(
+            limit: _pageSize,
+            cursor: cursor,
+            skipCache: skipCache,
           );
 
-          return filteredVideos..shuffle(_random);
+          if (result.videos.isNotEmpty || (result.hasMore ?? false)) {
+            return result;
+          }
+
+          if (attempt < attempts) {
+            Log.warning(
+              '🎬 ClassicVinesFeed: REST API returned no videos, retrying',
+              name: 'ClassicVinesFeedProvider',
+              category: LogCategory.video,
+            );
+            continue;
+          }
+
+          return result;
         } catch (e) {
           if (attempt < attempts) {
             Log.warning(
-              '🎬 ClassicVinesFeed: REST API error at offset $offset, retrying: $e',
+              '🎬 ClassicVinesFeed: REST API error, retrying: $e',
               name: 'ClassicVinesFeedProvider',
               category: LogCategory.video,
             );
@@ -136,23 +123,18 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
       throw StateError('Classics API retry loop exhausted');
     }
 
-    VideoFeedState restFeedState({
-      required List<VideoEvent> videos,
-      required int offset,
-    }) {
-      _startOffset = offset;
-      final nextOffset = offset + _pageSize;
+    VideoFeedState restFeedState({required HomeFeedResult result}) {
+      _paginationCursor = result.paginationCursor;
 
       Log.info(
-        '🎬 ClassicVinesFeed: Loaded ${videos.length} videos '
-        '(offset: $offset, shuffled)',
+        '🎬 ClassicVinesFeed: Loaded ${result.videos.length} videos',
         name: 'ClassicVinesFeedProvider',
         category: LogCategory.video,
       );
 
       return VideoFeedState(
-        videos: videos,
-        hasMoreContent: nextOffset < _totalClassicVines,
+        videos: result.videos,
+        hasMoreContent: result.hasMore ?? false,
         lastUpdated: DateTime.now(),
       );
     }
@@ -160,33 +142,31 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
     // Try REST API first (Funnelcake has comprehensive classic Vine data)
     if (funnelcakeAvailable) {
       try {
-        final firstPage = await fetchFilteredRestPage(
-          _startOffset,
+        final firstPage = await fetchRestPage(
           retryOnError: true,
+          skipCache: skipCache,
         );
 
-        if (firstPage.isNotEmpty) {
-          return restFeedState(videos: firstPage, offset: _startOffset);
+        if (firstPage.videos.isNotEmpty) {
+          return restFeedState(result: firstPage);
         }
 
-        restError = StateError(
-          'Classics API returned no videos at offset $_startOffset',
-        );
+        restError = StateError('Classics API returned no videos');
         Log.warning(
-          '🎬 ClassicVinesFeed: REST API returned no videos at offset $_startOffset, trying next page',
+          '🎬 ClassicVinesFeed: REST API returned no videos, trying next page',
           name: 'ClassicVinesFeedProvider',
           category: LogCategory.video,
         );
 
-        final recoveryOffset = _startOffset + _pageSize;
-        final recoveryPage = await fetchFilteredRestPage(
-          recoveryOffset,
+        final recoveryPage = await fetchRestPage(
+          cursor: firstPage.paginationCursor,
           retryOnError: false,
+          skipCache: true,
         );
 
-        if (recoveryPage.isEmpty) {
+        if (recoveryPage.videos.isEmpty) {
           restError = StateError(
-            'Classics API returned no videos at offset $recoveryOffset',
+            'Classics API recovery page returned no videos',
           );
           Log.warning(
             '🎬 ClassicVinesFeed: REST API recovery page returned no videos, falling back to Nostr',
@@ -195,7 +175,7 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
           );
           // Fall through to Nostr fallback.
         } else {
-          return restFeedState(videos: recoveryPage, offset: recoveryOffset);
+          return restFeedState(result: recoveryPage);
         }
       } catch (e) {
         restError = e;
@@ -216,24 +196,18 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
     );
 
     final allVideos = videoEventService.discoveryVideos;
-    final classicVideos =
-        dedupeByFeedKey(
-          videoEventService.filterVideoList(
-            allVideos
-                .where((v) => v.isOriginalVine)
-                .where((v) => v.isSupportedOnCurrentPlatform)
-                .where(
-                  (v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey),
-                )
-                .toList(),
-          ),
-        )..sort(
-          (a, b) => (b.originalLoops ?? 0).compareTo(a.originalLoops ?? 0),
-        );
+    final classicVideos = dedupeByFeedKey(
+      videoEventService.filterVideoList(
+        allVideos
+            .where((v) => v.isOriginalVine)
+            .where((v) => v.isSupportedOnCurrentPlatform)
+            .where((v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey))
+            .toList(),
+      ),
+    )..sort((a, b) => (b.originalLoops ?? 0).compareTo(a.originalLoops ?? 0));
 
     // Take top entries then shuffle for variety
-    final topClassics = classicVideos.take(_pageSize).toList()
-      ..shuffle(_random);
+    final topClassics = classicVideos.take(_pageSize).toList()..shuffle();
 
     if (topClassics.isEmpty && preserveCurrentOnEmptyFallback) {
       throw restError ?? StateError('Classics API unavailable');
@@ -252,11 +226,10 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
     final funnelcakeAvailable =
         ref.read(funnelcakeAvailableProvider).asData?.value ?? false;
 
-    _startOffset = _randomStartOffset();
-    _loadMorePages = 0;
+    _paginationCursor = null;
 
     Log.info(
-      '🎬 ClassicVinesFeed: Refreshing with offset $_startOffset',
+      '🎬 ClassicVinesFeed: Refreshing',
       name: 'ClassicVinesFeedProvider',
       category: LogCategory.video,
     );
@@ -268,6 +241,7 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
       fetchFresh: () => _loadFirstPage(
         funnelcakeAvailable: funnelcakeAvailable,
         preserveCurrentOnEmptyFallback: true,
+        skipCache: true,
       ),
     );
   }
@@ -278,7 +252,7 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
     final currentState = state.value!;
     if (currentState.isLoadingMore) return;
 
-    final client = ref.read(funnelcakeApiClientProvider);
+    final repository = ref.read(videosRepositoryProvider);
     final funnelcakeAvailable =
         ref.read(funnelcakeAvailableProvider).asData?.value ?? false;
 
@@ -287,32 +261,22 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
     state = AsyncData(currentState.copyWith(isLoadingMore: true));
 
     try {
-      _loadMorePages++;
-      final nextOffset = _startOffset + _loadMorePages * _pageSize;
-
-      final stats = await client.getClassicVines(offset: nextOffset);
-      final videos = stats.toVideoEvents();
-
-      final videoEventService = ref.read(videoEventServiceProvider);
-      final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
+      final page = await repository.getClassicVideos(
+        limit: _pageSize,
+        cursor: _paginationCursor,
+        skipCache: true,
+      );
       final filteredVideos = dedupeByFeedKey(
-        videoEventService.filterVideoList(
-          videos
-              .where((v) => v.isSupportedOnCurrentPlatform)
-              .where(
-                (v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey),
-              )
-              .toList(),
-        ),
+        page.videos,
         alreadySeen: currentState.videos.map((v) => v.feedDedupKey),
       );
 
       final allVideos = [...currentState.videos, ...filteredVideos];
-      final followingOffset = nextOffset + _pageSize;
+      _paginationCursor = page.paginationCursor;
 
       Log.info(
         '🎬 ClassicVinesFeed: Loaded ${filteredVideos.length} more '
-        '(offset: $nextOffset, total: ${allVideos.length})',
+        '(total: ${allVideos.length})',
         name: 'ClassicVinesFeedProvider',
         category: LogCategory.video,
       );
@@ -320,12 +284,11 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
       state = AsyncData(
         VideoFeedState(
           videos: allVideos,
-          hasMoreContent: followingOffset < _totalClassicVines,
+          hasMoreContent: page.hasMore ?? false,
           lastUpdated: DateTime.now(),
         ),
       );
     } catch (e) {
-      _loadMorePages--; // Revert so retry works
       Log.error(
         '🎬 ClassicVinesFeed: Error loading more: $e',
         name: 'ClassicVinesFeedProvider',

--- a/mobile/lib/providers/classic_vines_provider.dart
+++ b/mobile/lib/providers/classic_vines_provider.dart
@@ -3,6 +3,8 @@
 
 import 'dart:async';
 
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/providers/feed_refresh_helpers.dart';
@@ -10,6 +12,7 @@ import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/providers/readiness_gate_providers.dart';
 import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/providers/video_providers.dart';
+import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/state/video_feed_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -92,9 +95,15 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
             cursor: cursor,
             skipCache: skipCache,
           );
+          final filteredResult = _filterRepositoryResult(
+            result,
+            videoEventService,
+            blocklistRepository,
+          );
 
-          if (result.videos.isNotEmpty || (result.hasMore ?? false)) {
-            return result;
+          if (filteredResult.videos.isNotEmpty ||
+              (filteredResult.hasMore ?? false)) {
+            return filteredResult;
           }
 
           if (attempt < attempts) {
@@ -106,7 +115,7 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
             continue;
           }
 
-          return result;
+          return filteredResult;
         } catch (e) {
           if (attempt < attempts) {
             Log.warning(
@@ -254,6 +263,8 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
     if (currentState.isLoadingMore) return;
 
     final repository = ref.read(videosRepositoryProvider);
+    final videoEventService = ref.read(videoEventServiceProvider);
+    final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
     final funnelcakeAvailable =
         ref.read(funnelcakeAvailableProvider).asData?.value ?? false;
 
@@ -269,7 +280,11 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
         skipCache: true,
       );
       final filteredVideos = dedupeByFeedKey(
-        page.videos,
+        _filterRepositoryVideos(
+          page.videos,
+          videoEventService,
+          blocklistRepository,
+        ),
         alreadySeen: currentState.videos.map((v) => v.feedDedupKey),
       );
 
@@ -300,6 +315,39 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
         currentState.copyWith(isLoadingMore: false, error: e.toString()),
       );
     }
+  }
+
+  HomeFeedResult _filterRepositoryResult(
+    HomeFeedResult result,
+    VideoEventService videoEventService,
+    ContentBlocklistRepository blocklistRepository,
+  ) {
+    return HomeFeedResult(
+      videos: _filterRepositoryVideos(
+        result.videos,
+        videoEventService,
+        blocklistRepository,
+      ),
+      videoListSources: result.videoListSources,
+      listOnlyVideoIds: result.listOnlyVideoIds,
+      consumedItemCount: result.consumedItemCount,
+      nextCursor: result.nextCursor,
+      paginationCursor: result.paginationCursor,
+      hasMore: result.hasMore,
+    );
+  }
+
+  List<VideoEvent> _filterRepositoryVideos(
+    List<VideoEvent> videos,
+    VideoEventService videoEventService,
+    ContentBlocklistRepository blocklistRepository,
+  ) {
+    return videoEventService.filterVideoList(
+      videos
+          .where((v) => v.isSupportedOnCurrentPlatform)
+          .where((v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey))
+          .toList(),
+    );
   }
 }
 

--- a/mobile/lib/providers/classic_vines_provider.dart
+++ b/mobile/lib/providers/classic_vines_provider.dart
@@ -127,7 +127,8 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
       _paginationCursor = result.paginationCursor;
 
       Log.info(
-        '🎬 ClassicVinesFeed: Loaded ${result.videos.length} videos',
+        '🎬 ClassicVinesFeed: Loaded ${result.videos.length} videos '
+        '(next cursor: ${result.paginationCursor})',
         name: 'ClassicVinesFeedProvider',
         category: LogCategory.video,
       );
@@ -261,9 +262,10 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
     state = AsyncData(currentState.copyWith(isLoadingMore: true));
 
     try {
+      final requestCursor = _paginationCursor;
       final page = await repository.getClassicVideos(
         limit: _pageSize,
-        cursor: _paginationCursor,
+        cursor: requestCursor,
         skipCache: true,
       );
       final filteredVideos = dedupeByFeedKey(
@@ -276,7 +278,7 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
 
       Log.info(
         '🎬 ClassicVinesFeed: Loaded ${filteredVideos.length} more '
-        '(total: ${allVideos.length})',
+        '(cursor: $requestCursor, total: ${allVideos.length})',
         name: 'ClassicVinesFeedProvider',
         category: LogCategory.video,
       );

--- a/mobile/lib/providers/classic_vines_provider.g.dart
+++ b/mobile/lib/providers/classic_vines_provider.g.dart
@@ -54,7 +54,7 @@ final class ClassicVinesFeedProvider
   ClassicVinesFeed create() => ClassicVinesFeed();
 }
 
-String _$classicVinesFeedHash() => r'87d7d1965b601ed2173e0d47ed7662830c9ce7e2';
+String _$classicVinesFeedHash() => r'2b1175eb74dfdeeaf5b0a52244825f165a2ac138';
 
 /// ClassicVines feed provider - shows pre-2017 Vine archive sorted by loops
 ///

--- a/mobile/lib/providers/classic_vines_provider.g.dart
+++ b/mobile/lib/providers/classic_vines_provider.g.dart
@@ -11,7 +11,7 @@ part of 'classic_vines_provider.dart';
 /// ClassicVines feed provider - shows pre-2017 Vine archive sorted by loops
 ///
 /// Uses REST API (Funnelcake) with offset pagination to load pages on demand.
-/// Each page is 50 videos. With ~10k classic vines, there are ~200 pages.
+/// Each page is 50 videos.
 ///
 /// Pull-to-refresh selects a fresh random slice of classics while retrying
 /// transient failures and empty pages.
@@ -22,7 +22,7 @@ final classicVinesFeedProvider = ClassicVinesFeedProvider._();
 /// ClassicVines feed provider - shows pre-2017 Vine archive sorted by loops
 ///
 /// Uses REST API (Funnelcake) with offset pagination to load pages on demand.
-/// Each page is 50 videos. With ~10k classic vines, there are ~200 pages.
+/// Each page is 50 videos.
 ///
 /// Pull-to-refresh selects a fresh random slice of classics while retrying
 /// transient failures and empty pages.
@@ -31,7 +31,7 @@ final class ClassicVinesFeedProvider
   /// ClassicVines feed provider - shows pre-2017 Vine archive sorted by loops
   ///
   /// Uses REST API (Funnelcake) with offset pagination to load pages on demand.
-  /// Each page is 50 videos. With ~10k classic vines, there are ~200 pages.
+  /// Each page is 50 videos.
   ///
   /// Pull-to-refresh selects a fresh random slice of classics while retrying
   /// transient failures and empty pages.
@@ -54,12 +54,12 @@ final class ClassicVinesFeedProvider
   ClassicVinesFeed create() => ClassicVinesFeed();
 }
 
-String _$classicVinesFeedHash() => r'0de34401a1012fa881eaade7880dcd8a62767569';
+String _$classicVinesFeedHash() => r'87d7d1965b601ed2173e0d47ed7662830c9ce7e2';
 
 /// ClassicVines feed provider - shows pre-2017 Vine archive sorted by loops
 ///
 /// Uses REST API (Funnelcake) with offset pagination to load pages on demand.
-/// Each page is 50 videos. With ~10k classic vines, there are ~200 pages.
+/// Each page is 50 videos.
 ///
 /// Pull-to-refresh selects a fresh random slice of classics while retrying
 /// transient failures and empty pages.

--- a/mobile/lib/providers/classic_vines_provider.g.dart
+++ b/mobile/lib/providers/classic_vines_provider.g.dart
@@ -54,7 +54,7 @@ final class ClassicVinesFeedProvider
   ClassicVinesFeed create() => ClassicVinesFeed();
 }
 
-String _$classicVinesFeedHash() => r'2b1175eb74dfdeeaf5b0a52244825f165a2ac138';
+String _$classicVinesFeedHash() => r'67d40a5dee41997a46756991501383af30ecffdb';
 
 /// ClassicVines feed provider - shows pre-2017 Vine archive sorted by loops
 ///

--- a/mobile/packages/videos_repository/lib/src/in_memory_feed_cache.dart
+++ b/mobile/packages/videos_repository/lib/src/in_memory_feed_cache.dart
@@ -20,16 +20,30 @@ import 'package:videos_repository/src/home_feed_result.dart';
 /// {@endtemplate}
 class InMemoryFeedCache {
   /// {@macro in_memory_feed_cache}
-  InMemoryFeedCache();
+  InMemoryFeedCache({DateTime Function()? now}) : _now = now ?? DateTime.now;
 
-  final Map<String, HomeFeedResult> _store = {};
+  final DateTime Function() _now;
+  final Map<String, _HomeFeedCacheEntry> _store = {};
   final Map<String, AuthorFeedResult> _authorStore = {};
 
   /// Returns the cached result for [key], or `null` if not cached.
-  HomeFeedResult? get(String key) => _store[key];
+  HomeFeedResult? get(String key) {
+    final entry = _store[key];
+    if (entry == null) return null;
+    if (entry.isExpired(_now())) {
+      _store.remove(key);
+      return null;
+    }
+    return entry.result;
+  }
 
   /// Stores [result] under [key], replacing any previous entry.
-  void set(String key, HomeFeedResult result) => _store[key] = result;
+  void set(String key, HomeFeedResult result, {Duration? ttl}) {
+    _store[key] = _HomeFeedCacheEntry(
+      result,
+      expiresAt: ttl == null ? null : _now().add(ttl),
+    );
+  }
 
   /// Returns the cached author-feed result for [key], or `null`.
   ///
@@ -53,5 +67,17 @@ class InMemoryFeedCache {
   void clear() {
     _store.clear();
     _authorStore.clear();
+  }
+}
+
+class _HomeFeedCacheEntry {
+  const _HomeFeedCacheEntry(this.result, {this.expiresAt});
+
+  final HomeFeedResult result;
+  final DateTime? expiresAt;
+
+  bool isExpired(DateTime now) {
+    final expiresAt = this.expiresAt;
+    return expiresAt != null && !now.isBefore(expiresAt);
   }
 }

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -79,17 +79,19 @@ const String _popularCacheKey = 'popular';
 const String _popularLegacyBeforeCursorPrefix = 'before:';
 const String _classicsCacheKey = 'classics';
 const String _classicsOffsetCursorPrefix = 'classic-offset:';
+const Duration _classicsFirstPageCacheTtl = Duration(minutes: 15);
 
 /// Highest archive offset the Classics feed may open a session on.
 ///
-/// The archive holds roughly 10k videos; starting anywhere in the most-viewed
-/// few hundred keeps the feed varied between sessions without dropping the
-/// user into the unwatched long tail. (`sort=loops` orders by views first and
-/// loops as the tiebreak on this path, because the request carries a
+/// The imported Vine archive is much deeper than the old 10k estimate, but
+/// opening too deep can still bury users in the long tail. Starting anywhere
+/// in the first couple thousand most-viewed classics gives meaningful variety
+/// while keeping the opening slice recognizable. (`sort=loops` orders by views
+/// first and loops as the tiebreak on this path, because the request carries a
 /// `platform` filter and so misses Funnelcake's rank-ordered classic
 /// snapshot.) Shared with the Explore → Classics tab so both surfaces draw
 /// from the same window.
-const int classicsMaxRandomStartOffset = 400;
+const int classicsMaxRandomStartOffset = 2000;
 
 /// Archive pages one Classics fetch may read while trying to fill its page.
 ///
@@ -911,13 +913,13 @@ class VideosRepository {
   /// read, so trimming to [limit] would drop those videos rather than defer
   /// them.
   ///
-  /// The in-memory cache keeps the *first* page stable while the process
-  /// lives, so leaving and re-entering the feed resumes on the same opening
-  /// run instead of reshuffling under the user; later pages are re-drawn and
-  /// re-shuffled on re-entry. Pull-to-refresh ([skipCache] `true`) draws a
-  /// fresh slice, and a cold start begins from an empty cache. An empty page
-  /// is never cached, so a slice that filters down to nothing is redrawn on
-  /// the next entry rather than pinned for the session.
+  /// The in-memory cache keeps the *first* page stable for a short window, so
+  /// quick mode switches resume on the same opening run without pinning a
+  /// long-lived iOS process to the same classics for days. Later pages are
+  /// re-drawn and re-shuffled on re-entry. Pull-to-refresh ([skipCache] `true`)
+  /// draws a fresh slice, and a cold start begins from an empty cache. An
+  /// empty page is never cached, so a slice that filters down to nothing is
+  /// redrawn on the next entry rather than pinned for the session.
   ///
   /// Funnelcake-only: returns an empty result when no Funnelcake relay is
   /// connected (relays do not expose the server-side `platform` filter).
@@ -1050,7 +1052,11 @@ class VideosRepository {
     );
 
     if (!failed && isFirstPage && collected.isNotEmpty) {
-      _inMemoryFeedCache?.set(_classicsCacheKey, result);
+      _inMemoryFeedCache?.set(
+        _classicsCacheKey,
+        result,
+        ttl: _classicsFirstPageCacheTtl,
+      );
     }
     return result;
   }

--- a/mobile/packages/videos_repository/test/src/in_memory_feed_cache_test.dart
+++ b/mobile/packages/videos_repository/test/src/in_memory_feed_cache_test.dart
@@ -34,6 +34,29 @@ void main() {
         cache.set('home', createResult());
         expect(cache.get('latest'), isNull);
       });
+
+      test('returns null and removes entry after TTL expires', () {
+        var now = DateTime(2026, 8, 11, 12);
+        cache = InMemoryFeedCache(now: () => now);
+        final result = createResult();
+
+        cache.set('classics', result, ttl: const Duration(minutes: 15));
+        now = now.add(const Duration(minutes: 15));
+
+        expect(cache.get('classics'), isNull);
+        expect(cache.get('classics'), isNull);
+      });
+
+      test('returns entry before TTL expires', () {
+        var now = DateTime(2026, 8, 11, 12);
+        cache = InMemoryFeedCache(now: () => now);
+        final result = createResult();
+
+        cache.set('classics', result, ttl: const Duration(minutes: 15));
+        now = now.add(const Duration(minutes: 14, seconds: 59));
+
+        expect(cache.get('classics'), equals(result));
+      });
     });
 
     group('set', () {

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -4520,10 +4520,13 @@ void main() {
 
       /// Repository wired to a live cache, so the cache guards are load-bearing
       /// in every test rather than only in the ones that name the cache.
-      VideosRepository buildRepository({Random? random}) => VideosRepository(
+      VideosRepository buildRepository({
+        Random? random,
+        InMemoryFeedCache? feedCache,
+      }) => VideosRepository(
         nostrClient: mockNostrClient,
         funnelcakeApiClient: mockFunnelcakeClient,
-        inMemoryFeedCache: InMemoryFeedCache(),
+        inMemoryFeedCache: feedCache ?? InMemoryFeedCache(),
         random: random,
       );
 
@@ -4543,7 +4546,7 @@ void main() {
         await buildRepository(random: random).getClassicVideos(limit: 20);
 
         // The offset is drawn over the reachable page count, not a raw index.
-        expect(random.recordedMaxima.first, 21); // (400 ~/ 20) + 1
+        expect(random.recordedMaxima.first, 101); // (2000 ~/ 20) + 1
         verify(
           () => mockFunnelcakeClient.getClassicVines(
             sort: any(named: 'sort'),
@@ -4564,7 +4567,7 @@ void main() {
           final random = _StubRandom(firstOffsetDraw: 7);
           await buildRepository(random: random).getClassicVideos();
 
-          expect(random.recordedMaxima.first, 17); // (400 ~/ 25) + 1
+          expect(random.recordedMaxima.first, 81); // (2000 ~/ 25) + 1
           verify(
             () => mockFunnelcakeClient.getClassicVines(
               sort: any(named: 'sort'),
@@ -4747,6 +4750,37 @@ void main() {
             before: any(named: 'before'),
           ),
         ).called(1);
+      });
+
+      test('redraws the cached first page after its TTL expires', () async {
+        stubArchiveByOffset(
+          (offset) =>
+              offset == 0 ? archivePage(20) : archivePage(20, startIndex: 20),
+        );
+        var now = DateTime(2026, 8, 11, 12);
+        final random = _StubRandom();
+        final repository = buildRepository(
+          random: random,
+          feedCache: InMemoryFeedCache(now: () => now),
+        );
+
+        final first = await repository.getClassicVideos(limit: 20);
+        random.expectOffsetDraw(1);
+        now = now.add(const Duration(minutes: 15));
+        final reentry = await repository.getClassicVideos(limit: 20);
+
+        expect(
+          reentry.videos.map((v) => v.id),
+          isNot(first.videos.map((v) => v.id)),
+        );
+        verify(
+          () => mockFunnelcakeClient.getClassicVines(
+            sort: any(named: 'sort'),
+            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
+            before: any(named: 'before'),
+          ),
+        ).called(2);
       });
 
       test(

--- a/mobile/test/providers/classic_vines_refresh_test.dart
+++ b/mobile/test/providers/classic_vines_refresh_test.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -106,6 +107,55 @@ void main() {
           limit: 50,
         ),
       ).called(1);
+    });
+
+    test('filters repository classics through app feed filters', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      when(
+        () => mockVideosRepository.getClassicVideos(
+          limit: any(named: 'limit'),
+          cursor: any(named: 'cursor'),
+          skipCache: any(named: 'skipCache'),
+        ),
+      ).thenAnswer(
+        (_) async => HomeFeedResult(
+          videos: [
+            _videoEvent('classic-supported'),
+            _videoEvent('classic-blocked', pubkey: 'blocked-author'),
+            _videoEvent(
+              'classic-webm',
+              videoUrl: 'https://example.com/classic-webm.webm',
+            ),
+          ],
+          paginationCursor: 'classic-offset:50',
+          hasMore: true,
+        ),
+      );
+      when(
+        () => mockBlocklistRepository.shouldFilterFromFeeds('blocked-author'),
+      ).thenReturn(true);
+
+      final filteredIds = <List<String>>[];
+      when(() => mockVideoEventService.filterVideoList(any())).thenAnswer((
+        invocation,
+      ) {
+        final videos = invocation.positionalArguments.first as List<VideoEvent>;
+        filteredIds.add(videos.map((video) => video.id).toList());
+        return videos;
+      });
+
+      final container = createContainer();
+      addTearDown(container.dispose);
+
+      await container.read(funnelcakeAvailableProvider.future);
+      final state = await container.read(classicVinesFeedProvider.future);
+
+      expect(state.videos.map((video) => video.id), ['classic-supported']);
+      expect(filteredIds, [
+        ['classic-supported'],
+      ]);
     });
 
     test('refresh requests a fresh repository page', () async {
@@ -305,6 +355,90 @@ void main() {
       },
     );
 
+    test('loadMore appends the next cursor page and dedupes videos', () async {
+      when(
+        () => mockVideosRepository.getClassicVideos(
+          limit: any(named: 'limit'),
+          cursor: any(named: 'cursor'),
+          skipCache: any(named: 'skipCache'),
+        ),
+      ).thenAnswer((invocation) async {
+        final cursor = invocation.namedArguments[#cursor] as String?;
+        if (cursor == null) {
+          return HomeFeedResult(
+            videos: [_videoEvent('classic-initial')],
+            paginationCursor: 'classic-offset:50',
+            hasMore: true,
+          );
+        }
+        return HomeFeedResult(
+          videos: [
+            _videoEvent('classic-initial'),
+            _videoEvent('classic-more'),
+          ],
+          paginationCursor: 'classic-offset:100',
+          hasMore: false,
+        );
+      });
+
+      final container = createContainer();
+      addTearDown(container.dispose);
+
+      await container.read(funnelcakeAvailableProvider.future);
+      await container.read(classicVinesFeedProvider.future);
+      await container.read(classicVinesFeedProvider.notifier).loadMore();
+
+      final state = container.read(classicVinesFeedProvider).value!;
+      expect(state.videos.map((video) => video.id), [
+        'classic-initial',
+        'classic-more',
+      ]);
+      expect(state.hasMoreContent, isFalse);
+      expect(state.isLoadingMore, isFalse);
+      verify(
+        () => mockVideosRepository.getClassicVideos(
+          limit: 50,
+          cursor: 'classic-offset:50',
+          skipCache: true,
+        ),
+      ).called(1);
+    });
+
+    test(
+      'loadMore preserves existing videos when the next page fails',
+      () async {
+        when(
+          () => mockVideosRepository.getClassicVideos(
+            limit: any(named: 'limit'),
+            cursor: any(named: 'cursor'),
+            skipCache: any(named: 'skipCache'),
+          ),
+        ).thenAnswer((invocation) async {
+          final cursor = invocation.namedArguments[#cursor] as String?;
+          if (cursor == null) {
+            return HomeFeedResult(
+              videos: [_videoEvent('classic-initial')],
+              paginationCursor: 'classic-offset:50',
+              hasMore: true,
+            );
+          }
+          throw Exception('next page unavailable');
+        });
+
+        final container = createContainer();
+        addTearDown(container.dispose);
+
+        await container.read(funnelcakeAvailableProvider.future);
+        await container.read(classicVinesFeedProvider.future);
+        await container.read(classicVinesFeedProvider.notifier).loadMore();
+
+        final state = container.read(classicVinesFeedProvider).value!;
+        expect(state.videos.map((video) => video.id), ['classic-initial']);
+        expect(state.isLoadingMore, isFalse);
+        expect(state.error, contains('next page unavailable'));
+      },
+    );
+
     test('stays loading while funnelcake availability is still resolving', () {
       _loadingAvailabilityCompleter = Completer<bool>();
 
@@ -329,6 +463,7 @@ VideoEvent _videoEvent(
   String id, {
   String? pubkey,
   bool isOriginalVine = false,
+  String? videoUrl,
 }) {
   return VideoEvent(
     id: id,
@@ -337,7 +472,7 @@ VideoEvent _videoEvent(
     content: id,
     timestamp: DateTime(2026, 3, 17),
     title: id,
-    videoUrl: 'https://example.com/$id.mp4',
+    videoUrl: videoUrl ?? 'https://example.com/$id.mp4',
     thumbnailUrl: 'https://example.com/$id.jpg',
     originalLoops: 100,
     rawTags: isOriginalVine ? const {'platform': 'vine'} : const {},

--- a/mobile/test/providers/classic_vines_refresh_test.dart
+++ b/mobile/test/providers/classic_vines_refresh_test.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -16,8 +15,9 @@ import 'package:openvine/providers/readiness_gate_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:videos_repository/videos_repository.dart';
 
-class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
+class _MockVideosRepository extends Mock implements VideosRepository {}
 
 class _MockVideoEventService extends Mock implements VideoEventService {}
 
@@ -38,7 +38,7 @@ class _LoadingFunnelcakeAvailable extends FunnelcakeAvailable {
 
 void main() {
   group(ClassicVinesFeed, () {
-    late _MockFunnelcakeApiClient mockFunnelcakeClient;
+    late _MockVideosRepository mockVideosRepository;
     late _MockVideoEventService mockVideoEventService;
     late _MockContentBlocklistRepository mockBlocklistRepository;
     late SharedPreferences sharedPreferences;
@@ -47,15 +47,27 @@ void main() {
       SharedPreferences.setMockInitialValues({});
       sharedPreferences = await SharedPreferences.getInstance();
 
-      mockFunnelcakeClient = _MockFunnelcakeApiClient();
+      mockVideosRepository = _MockVideosRepository();
       mockVideoEventService = _MockVideoEventService();
       mockBlocklistRepository = _MockContentBlocklistRepository();
 
-      when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
-      when(() => mockVideoEventService.discoveryVideos).thenReturn(const []);
       when(
-        () => mockVideoEventService.filterVideoList(any()),
-      ).thenAnswer((invocation) {
+        () => mockVideosRepository.getClassicVideos(
+          limit: any(named: 'limit'),
+          cursor: any(named: 'cursor'),
+          skipCache: any(named: 'skipCache'),
+        ),
+      ).thenAnswer(
+        (_) async => HomeFeedResult(
+          videos: [_videoEvent('classic-default')],
+          paginationCursor: 'classic-offset:50',
+          hasMore: true,
+        ),
+      );
+      when(() => mockVideoEventService.discoveryVideos).thenReturn(const []);
+      when(() => mockVideoEventService.filterVideoList(any())).thenAnswer((
+        invocation,
+      ) {
         return invocation.positionalArguments.first as List<VideoEvent>;
       });
       when(
@@ -68,7 +80,7 @@ void main() {
         overrides: [
           appReadyProvider.overrideWithValue(true),
           sharedPreferencesProvider.overrideWithValue(sharedPreferences),
-          funnelcakeApiClientProvider.overrideWithValue(mockFunnelcakeClient),
+          videosRepositoryProvider.overrideWithValue(mockVideosRepository),
           videoEventServiceProvider.overrideWithValue(mockVideoEventService),
           contentBlocklistRepositoryProvider.overrideWithValue(
             mockBlocklistRepository,
@@ -80,49 +92,37 @@ void main() {
       );
     }
 
-    test(
-      'loads a random page-aligned classics page within the top classics',
-      () async {
-        final offsets = <int>[];
-        final limits = <int>[];
-        when(
-          () => mockFunnelcakeClient.getClassicVines(
-            offset: any(named: 'offset'),
-          ),
-        ).thenAnswer((invocation) async {
-          limits.add(invocation.namedArguments[#limit] as int);
-          offsets.add(invocation.namedArguments[#offset] as int);
-          return [_videoStats('classic-${offsets.length}')];
-        });
+    test('loads the first classics page through the repository', () async {
+      final container = createContainer();
+      addTearDown(container.dispose);
 
-        for (var i = 0; i < 12; i++) {
-          final container = createContainer();
-          addTearDown(container.dispose);
+      await container.read(funnelcakeAvailableProvider.future);
+      final state = await container.read(classicVinesFeedProvider.future);
 
-          await container.read(funnelcakeAvailableProvider.future);
-          await container.read(classicVinesFeedProvider.future);
-        }
+      expect(state.videos.map((video) => video.id), ['classic-default']);
+      expect(state.hasMoreContent, isTrue);
+      verify(
+        () => mockVideosRepository.getClassicVideos(
+          limit: 50,
+        ),
+      ).called(1);
+    });
 
-        expect(offsets, hasLength(12));
-        expect(offsets, everyElement(inInclusiveRange(0, 400)));
-        expect(
-          offsets,
-          everyElement(predicate<int>((offset) => offset % 50 == 0)),
-        );
-        expect(offsets.toSet(), hasLength(greaterThan(1)));
-        expect(limits, everyElement(lessThanOrEqualTo(50)));
-      },
-    );
-
-    test('refresh selects a fresh random classics page', () async {
-      final offsets = <int>[];
+    test('refresh requests a fresh repository page', () async {
+      var calls = 0;
       when(
-        () => mockFunnelcakeClient.getClassicVines(
-          offset: any(named: 'offset'),
+        () => mockVideosRepository.getClassicVideos(
+          limit: any(named: 'limit'),
+          cursor: any(named: 'cursor'),
+          skipCache: any(named: 'skipCache'),
         ),
       ).thenAnswer((invocation) async {
-        offsets.add(invocation.namedArguments[#offset] as int);
-        return [_videoStats('classic-${offsets.length}')];
+        calls++;
+        return HomeFeedResult(
+          videos: [_videoEvent('classic-$calls')],
+          paginationCursor: 'classic-offset:${calls * 50}',
+          hasMore: true,
+        );
       });
 
       final container = createContainer();
@@ -134,30 +134,40 @@ void main() {
         await container.read(classicVinesFeedProvider.notifier).refresh();
       }
 
-      expect(offsets, hasLength(13));
-      expect(offsets, everyElement(inInclusiveRange(0, 400)));
-      expect(
-        offsets,
-        everyElement(predicate<int>((offset) => offset % 50 == 0)),
-      );
-      expect(offsets.toSet(), hasLength(greaterThan(1)));
+      expect(calls, 13);
+      verify(
+        () => mockVideosRepository.getClassicVideos(
+          limit: 50,
+          skipCache: true,
+        ),
+      ).called(12);
     });
 
     test(
       'tries the next classics page when the first page has no videos',
       () async {
-        final offsets = <int>[];
+        final cursors = <String?>[];
         when(
-          () => mockFunnelcakeClient.getClassicVines(
-            offset: any(named: 'offset'),
+          () => mockVideosRepository.getClassicVideos(
+            limit: any(named: 'limit'),
+            cursor: any(named: 'cursor'),
+            skipCache: any(named: 'skipCache'),
           ),
         ).thenAnswer((invocation) async {
-          final offset = invocation.namedArguments[#offset] as int;
-          offsets.add(offset);
-          if (offsets.length == 1) {
-            return const [];
+          final cursor = invocation.namedArguments[#cursor] as String?;
+          cursors.add(cursor);
+          if (cursors.length == 1) {
+            return const HomeFeedResult(
+              videos: [],
+              paginationCursor: 'classic-offset:50',
+              hasMore: true,
+            );
           }
-          return [_videoStats('classic-recovered')];
+          return HomeFeedResult(
+            videos: [_videoEvent('classic-recovered')],
+            paginationCursor: 'classic-offset:100',
+            hasMore: true,
+          );
         });
 
         final container = createContainer();
@@ -167,28 +177,30 @@ void main() {
         final state = await container.read(classicVinesFeedProvider.future);
 
         expect(state.videos.map((video) => video.id), ['classic-recovered']);
-        expect(offsets, hasLength(2));
-        expect(offsets[1], offsets[0] + 50);
+        expect(cursors, [null, 'classic-offset:50']);
       },
     );
 
     test(
       'retries the first classics page after a transient API error',
       () async {
-        final offsets = <int>[];
         var calls = 0;
         when(
-          () => mockFunnelcakeClient.getClassicVines(
-            offset: any(named: 'offset'),
+          () => mockVideosRepository.getClassicVideos(
+            limit: any(named: 'limit'),
+            cursor: any(named: 'cursor'),
+            skipCache: any(named: 'skipCache'),
           ),
-        ).thenAnswer((invocation) async {
+        ).thenAnswer((_) async {
           calls++;
-          final offset = invocation.namedArguments[#offset] as int;
-          offsets.add(offset);
           if (calls == 1) {
             throw Exception('network unavailable');
           }
-          return [_videoStats('classic-retry')];
+          return HomeFeedResult(
+            videos: [_videoEvent('classic-retry')],
+            paginationCursor: 'classic-offset:50',
+            hasMore: true,
+          );
         });
 
         final container = createContainer();
@@ -198,8 +210,7 @@ void main() {
         final state = await container.read(classicVinesFeedProvider.future);
 
         expect(state.videos.map((video) => video.id), ['classic-retry']);
-        expect(offsets, hasLength(2));
-        expect(offsets[1], offsets[0]);
+        expect(calls, 2);
       },
     );
 
@@ -208,13 +219,19 @@ void main() {
       () async {
         var calls = 0;
         when(
-          () => mockFunnelcakeClient.getClassicVines(
-            offset: any(named: 'offset'),
+          () => mockVideosRepository.getClassicVideos(
+            limit: any(named: 'limit'),
+            cursor: any(named: 'cursor'),
+            skipCache: any(named: 'skipCache'),
           ),
         ).thenAnswer((_) async {
           calls++;
           if (calls == 1) {
-            return [_videoStats('classic-initial')];
+            return HomeFeedResult(
+              videos: [_videoEvent('classic-initial')],
+              paginationCursor: 'classic-offset:50',
+              hasMore: true,
+            );
           }
           throw Exception('server unavailable');
         });
@@ -249,15 +266,21 @@ void main() {
       () async {
         var calls = 0;
         when(
-          () => mockFunnelcakeClient.getClassicVines(
-            offset: any(named: 'offset'),
+          () => mockVideosRepository.getClassicVideos(
+            limit: any(named: 'limit'),
+            cursor: any(named: 'cursor'),
+            skipCache: any(named: 'skipCache'),
           ),
         ).thenAnswer((_) async {
           calls++;
           if (calls == 1) {
-            return [_videoStats('classic-initial')];
+            return HomeFeedResult(
+              videos: [_videoEvent('classic-initial')],
+              paginationCursor: 'classic-offset:50',
+              hasMore: true,
+            );
           }
-          return const [];
+          return const HomeFeedResult(videos: [], hasMore: false);
         });
 
         final container = createContainer();
@@ -302,25 +325,21 @@ void main() {
   });
 }
 
-VideoStats _videoStats(
+VideoEvent _videoEvent(
   String id, {
   String? pubkey,
   bool isOriginalVine = false,
 }) {
-  return VideoStats(
+  return VideoEvent(
     id: id,
     pubkey: pubkey ?? 'author-$id',
-    createdAt: DateTime(2026, 3, 17),
-    kind: 34236,
-    dTag: id,
+    createdAt: DateTime(2026, 3, 17).millisecondsSinceEpoch ~/ 1000,
+    content: id,
+    timestamp: DateTime(2026, 3, 17),
     title: id,
-    thumbnail: 'https://example.com/$id.jpg',
     videoUrl: 'https://example.com/$id.mp4',
-    reactions: 0,
-    comments: 0,
-    reposts: 0,
-    engagementScore: 0,
-    loops: 100,
+    thumbnailUrl: 'https://example.com/$id.jpg',
+    originalLoops: 100,
     rawTags: isOriginalVine ? const {'platform': 'vine'} : const {},
   );
 }


### PR DESCRIPTION
## Summary
- widen the random opening window for Classics from the first 450 videos to the first ~2,050 videos
- add a 15-minute TTL to the in-memory Classics first-page cache so long-lived app processes redraw instead of replaying indefinitely
- route Explore Classics through VideosRepository so it shares Classics freshness/filtering and repository pagination state, while preserving the local fallback

Closes #7068

## Verification
- flutter analyze
- flutter test test/providers/classic_vines_refresh_test.dart
- flutter test test/src/in_memory_feed_cache_test.dart test/src/videos_repository_test.dart from mobile/packages/videos_repository
- pre-push hook: analyzer, generated-file verification, changed-file tests
