### PR TITLE
fix(lists): refresh discover list subscriptions

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2908,6 +2908,7 @@
     },
     "discoverListsLoading": "የህዝብ ዝርዝሮችን በመፈለግ ላይ...",
     "discoverListsRelayTimeout": "ሪሌው በጊዜው ዝርዝሮችን አልመለሰም። እንደገና ሞክር።",
+    "discoverListsServiceUnavailable": "አገልግሎቱ አይገኝም።",
     "discoverListsEmptyTitle": "ምንም የህዝብ ዝርዝሮች አልተገኙም",
     "discoverListsEmptySubtitle": "ለአዳዲስ ዝርዝሮች ቆይተው ይመልከቱ",
     "discoverListsByAuthorPrefix": "በ",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2907,6 +2907,7 @@
         }
     },
     "discoverListsLoading": "የህዝብ ዝርዝሮችን በመፈለግ ላይ...",
+    "discoverListsRelayTimeout": "ሪሌው በጊዜው ዝርዝሮችን አልመለሰም። እንደገና ሞክር።",
     "discoverListsEmptyTitle": "ምንም የህዝብ ዝርዝሮች አልተገኙም",
     "discoverListsEmptySubtitle": "ለአዳዲስ ዝርዝሮች ቆይተው ይመልከቱ",
     "discoverListsByAuthorPrefix": "በ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3740,6 +3740,7 @@
     },
     "discoverListsLoading": "جاري اكتشاف القوائم العامة...",
     "discoverListsRelayTimeout": "لم يُرجع الريلاي القوائم في الوقت المناسب. حاول مرة أخرى.",
+    "discoverListsServiceUnavailable": "الخدمة غير متاحة.",
     "discoverListsEmptyTitle": "لم يتم العثور على قوائم عامة",
     "discoverListsEmptySubtitle": "عاود التحقق لاحقًا لرؤية قوائم جديدة",
     "discoverListsByAuthorPrefix": "بقلم",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3739,6 +3739,7 @@
         }
     },
     "discoverListsLoading": "جاري اكتشاف القوائم العامة...",
+    "discoverListsRelayTimeout": "لم يُرجع الريلاي القوائم في الوقت المناسب. حاول مرة أخرى.",
     "discoverListsEmptyTitle": "لم يتم العثور على قوائم عامة",
     "discoverListsEmptySubtitle": "عاود التحقق لاحقًا لرؤية قوائم جديدة",
     "discoverListsByAuthorPrefix": "بقلم",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3871,6 +3871,7 @@
     },
     "discoverListsLoading": "Откриваме публични списъци...",
     "discoverListsRelayTimeout": "Релето не върна списъци навреме. Опитай пак.",
+    "discoverListsServiceUnavailable": "Услугата не е налична.",
     "discoverListsEmptyTitle": "Не са намерени публични списъци",
     "discoverListsEmptySubtitle": "Върни се по-късно за нови списъци",
     "discoverListsByAuthorPrefix": "от",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3870,6 +3870,7 @@
         }
     },
     "discoverListsLoading": "Откриваме публични списъци...",
+    "discoverListsRelayTimeout": "Релето не върна списъци навреме. Опитай пак.",
     "discoverListsEmptyTitle": "Не са намерени публични списъци",
     "discoverListsEmptySubtitle": "Върни се по-късно за нови списъци",
     "discoverListsByAuthorPrefix": "от",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3739,6 +3739,7 @@
         }
     },
     "discoverListsLoading": "Öffentliche Listen werden entdeckt...",
+    "discoverListsRelayTimeout": "Das Relay hat nicht rechtzeitig Listen geliefert. Versuch es nochmal.",
     "discoverListsEmptyTitle": "Keine öffentlichen Listen gefunden",
     "discoverListsEmptySubtitle": "Schau später nochmal nach neuen Listen",
     "discoverListsByAuthorPrefix": "von",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3740,6 +3740,7 @@
     },
     "discoverListsLoading": "Öffentliche Listen werden entdeckt...",
     "discoverListsRelayTimeout": "Das Relay hat nicht rechtzeitig Listen geliefert. Versuch es nochmal.",
+    "discoverListsServiceUnavailable": "Dienst nicht verfügbar.",
     "discoverListsEmptyTitle": "Keine öffentlichen Listen gefunden",
     "discoverListsEmptySubtitle": "Schau später nochmal nach neuen Listen",
     "discoverListsByAuthorPrefix": "von",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3900,6 +3900,7 @@
   },
   "discoverListsLoading": "Discovering public lists...",
   "discoverListsRelayTimeout": "The relay did not return lists in time. Try again.",
+  "discoverListsServiceUnavailable": "Service not available.",
   "discoverListsEmptyTitle": "No public lists found",
   "discoverListsEmptySubtitle": "Check back later for new lists",
   "discoverListsByAuthorPrefix": "by",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3899,6 +3899,7 @@
     }
   },
   "discoverListsLoading": "Discovering public lists...",
+  "discoverListsRelayTimeout": "The relay did not return lists in time. Try again.",
   "discoverListsEmptyTitle": "No public lists found",
   "discoverListsEmptySubtitle": "Check back later for new lists",
   "discoverListsByAuthorPrefix": "by",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3743,6 +3743,7 @@
         }
     },
     "discoverListsLoading": "Descubriendo listas públicas...",
+    "discoverListsRelayTimeout": "El relay no devolvió listas a tiempo. Inténtalo de nuevo.",
     "discoverListsEmptyTitle": "No se encontraron listas públicas",
     "discoverListsEmptySubtitle": "Volvé más tarde para ver listas nuevas",
     "discoverListsByAuthorPrefix": "por",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3744,6 +3744,7 @@
     },
     "discoverListsLoading": "Descubriendo listas públicas...",
     "discoverListsRelayTimeout": "El relay no devolvió listas a tiempo. Inténtalo de nuevo.",
+    "discoverListsServiceUnavailable": "Servicio no disponible.",
     "discoverListsEmptyTitle": "No se encontraron listas públicas",
     "discoverListsEmptySubtitle": "Volvé más tarde para ver listas nuevas",
     "discoverListsByAuthorPrefix": "por",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2267,6 +2267,7 @@
     "discoverListsFailedToLoadWithError": "Hindi na-load ang mga listahan: {error}",
     "discoverListsLoading": "Naghahanap ng mga public list...",
     "discoverListsRelayTimeout": "Hindi nagbalik ng mga list ang relay sa oras. Subukan ulit.",
+    "discoverListsServiceUnavailable": "Hindi available ang serbisyo.",
     "discoverListsTitle": "Tuklasin ang mga Listahan",
     "featureRequestDescriptionHint": "I-describe ang feature na gusto mo",
     "featureRequestDescriptionRequiredLabel": "Ano ang gusto mo? *",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2266,6 +2266,7 @@
     "discoverListsFailedToLoad": "Hindi na-load ang mga listahan",
     "discoverListsFailedToLoadWithError": "Hindi na-load ang mga listahan: {error}",
     "discoverListsLoading": "Naghahanap ng mga public list...",
+    "discoverListsRelayTimeout": "Hindi nagbalik ng mga list ang relay sa oras. Subukan ulit.",
     "discoverListsTitle": "Tuklasin ang mga Listahan",
     "featureRequestDescriptionHint": "I-describe ang feature na gusto mo",
     "featureRequestDescriptionRequiredLabel": "Ano ang gusto mo? *",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3739,6 +3739,7 @@
         }
     },
     "discoverListsLoading": "Recherche de listes publiques...",
+    "discoverListsRelayTimeout": "Le relais n'a pas renvoyé de listes à temps. Réessaie.",
     "discoverListsEmptyTitle": "Aucune liste publique trouvée",
     "discoverListsEmptySubtitle": "Reviens plus tard pour de nouvelles listes",
     "discoverListsByAuthorPrefix": "par",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3740,6 +3740,7 @@
     },
     "discoverListsLoading": "Recherche de listes publiques...",
     "discoverListsRelayTimeout": "Le relais n'a pas renvoyé de listes à temps. Réessaie.",
+    "discoverListsServiceUnavailable": "Service indisponible.",
     "discoverListsEmptyTitle": "Aucune liste publique trouvée",
     "discoverListsEmptySubtitle": "Reviens plus tard pour de nouvelles listes",
     "discoverListsByAuthorPrefix": "par",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3739,6 +3739,7 @@
         }
     },
     "discoverListsLoading": "Mencari daftar publik...",
+    "discoverListsRelayTimeout": "Relay tidak mengembalikan daftar tepat waktu. Coba lagi.",
     "discoverListsEmptyTitle": "Tidak ada daftar publik",
     "discoverListsEmptySubtitle": "Cek lagi nanti untuk daftar baru",
     "discoverListsByAuthorPrefix": "oleh",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3740,6 +3740,7 @@
     },
     "discoverListsLoading": "Mencari daftar publik...",
     "discoverListsRelayTimeout": "Relay tidak mengembalikan daftar tepat waktu. Coba lagi.",
+    "discoverListsServiceUnavailable": "Layanan tidak tersedia.",
     "discoverListsEmptyTitle": "Tidak ada daftar publik",
     "discoverListsEmptySubtitle": "Cek lagi nanti untuk daftar baru",
     "discoverListsByAuthorPrefix": "oleh",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3739,6 +3739,7 @@
         }
     },
     "discoverListsLoading": "Cercando liste pubbliche...",
+    "discoverListsRelayTimeout": "Il relay non ha restituito liste in tempo. Riprova.",
     "discoverListsEmptyTitle": "Nessuna lista pubblica trovata",
     "discoverListsEmptySubtitle": "Torna più tardi per nuove liste",
     "discoverListsByAuthorPrefix": "di",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3740,6 +3740,7 @@
     },
     "discoverListsLoading": "Cercando liste pubbliche...",
     "discoverListsRelayTimeout": "Il relay non ha restituito liste in tempo. Riprova.",
+    "discoverListsServiceUnavailable": "Servizio non disponibile.",
     "discoverListsEmptyTitle": "Nessuna lista pubblica trovata",
     "discoverListsEmptySubtitle": "Torna più tardi per nuove liste",
     "discoverListsByAuthorPrefix": "di",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3740,6 +3740,7 @@
     },
     "discoverListsLoading": "公開リストを探してるよ...",
     "discoverListsRelayTimeout": "リレーが時間内にリストを返さなかったよ。もう一度試してね。",
+    "discoverListsServiceUnavailable": "サービスを利用できません。",
     "discoverListsEmptyTitle": "公開リストが見つからなかった",
     "discoverListsEmptySubtitle": "あとでまたチェックしてみてね",
     "discoverListsByAuthorPrefix": "作成者:",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3739,6 +3739,7 @@
         }
     },
     "discoverListsLoading": "公開リストを探してるよ...",
+    "discoverListsRelayTimeout": "リレーが時間内にリストを返さなかったよ。もう一度試してね。",
     "discoverListsEmptyTitle": "公開リストが見つからなかった",
     "discoverListsEmptySubtitle": "あとでまたチェックしてみてね",
     "discoverListsByAuthorPrefix": "作成者:",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3077,6 +3077,7 @@
         }
     },
     "discoverListsLoading": "공개 리스트를 찾는 중...",
+    "discoverListsRelayTimeout": "릴레이가 제때 리스트를 주지 않았어요. 다시 시도해 주세요.",
     "discoverListsEmptyTitle": "공개 리스트를 찾지 못했어요",
     "discoverListsEmptySubtitle": "새 리스트가 올라오면 다시 와봐요",
     "discoverListsByAuthorPrefix": "작성자",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3078,6 +3078,7 @@
     },
     "discoverListsLoading": "공개 리스트를 찾는 중...",
     "discoverListsRelayTimeout": "릴레이가 제때 리스트를 주지 않았어요. 다시 시도해 주세요.",
+    "discoverListsServiceUnavailable": "서비스를 사용할 수 없어요.",
     "discoverListsEmptyTitle": "공개 리스트를 찾지 못했어요",
     "discoverListsEmptySubtitle": "새 리스트가 올라오면 다시 와봐요",
     "discoverListsByAuthorPrefix": "작성자",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -3643,6 +3643,7 @@
   },
   "discoverListsLoading": "Menemui senarai awam...",
   "discoverListsRelayTimeout": "Relay tidak memulangkan senarai tepat pada masanya. Cuba lagi.",
+  "discoverListsServiceUnavailable": "Perkhidmatan tidak tersedia.",
   "discoverListsEmptyTitle": "Tiada senarai awam ditemui",
   "discoverListsEmptySubtitle": "Semak semula nanti untuk senarai baharu",
   "discoverListsByAuthorPrefix": "oleh",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -3642,6 +3642,7 @@
     }
   },
   "discoverListsLoading": "Menemui senarai awam...",
+  "discoverListsRelayTimeout": "Relay tidak memulangkan senarai tepat pada masanya. Cuba lagi.",
   "discoverListsEmptyTitle": "Tiada senarai awam ditemui",
   "discoverListsEmptySubtitle": "Semak semula nanti untuk senarai baharu",
   "discoverListsByAuthorPrefix": "oleh",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3740,6 +3740,7 @@
     },
     "discoverListsLoading": "Publieke lijsten worden ontdekt...",
     "discoverListsRelayTimeout": "De relay leverde niet op tijd lijsten. Probeer het opnieuw.",
+    "discoverListsServiceUnavailable": "Service niet beschikbaar.",
     "discoverListsEmptyTitle": "Geen publieke lijsten gevonden",
     "discoverListsEmptySubtitle": "Kom later terug voor nieuwe lijsten",
     "discoverListsByAuthorPrefix": "door",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3739,6 +3739,7 @@
         }
     },
     "discoverListsLoading": "Publieke lijsten worden ontdekt...",
+    "discoverListsRelayTimeout": "De relay leverde niet op tijd lijsten. Probeer het opnieuw.",
     "discoverListsEmptyTitle": "Geen publieke lijsten gevonden",
     "discoverListsEmptySubtitle": "Kom later terug voor nieuwe lijsten",
     "discoverListsByAuthorPrefix": "door",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3740,6 +3740,7 @@
     },
     "discoverListsLoading": "Odkrywanie publicznych list...",
     "discoverListsRelayTimeout": "Relay nie zwrócił list na czas. Spróbuj ponownie.",
+    "discoverListsServiceUnavailable": "Usługa niedostępna.",
     "discoverListsEmptyTitle": "Nie znaleziono publicznych list",
     "discoverListsEmptySubtitle": "Wróć później po nowe listy",
     "discoverListsByAuthorPrefix": "od",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3739,6 +3739,7 @@
         }
     },
     "discoverListsLoading": "Odkrywanie publicznych list...",
+    "discoverListsRelayTimeout": "Relay nie zwrócił list na czas. Spróbuj ponownie.",
     "discoverListsEmptyTitle": "Nie znaleziono publicznych list",
     "discoverListsEmptySubtitle": "Wróć później po nowe listy",
     "discoverListsByAuthorPrefix": "od",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3739,6 +3739,7 @@
         }
     },
     "discoverListsLoading": "Descobrindo listas públicas...",
+    "discoverListsRelayTimeout": "O relay não devolveu listas a tempo. Tente de novo.",
     "discoverListsEmptyTitle": "Nenhuma lista pública encontrada",
     "discoverListsEmptySubtitle": "Volte mais tarde para ver novas listas",
     "discoverListsByAuthorPrefix": "por",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3740,6 +3740,7 @@
     },
     "discoverListsLoading": "Descobrindo listas públicas...",
     "discoverListsRelayTimeout": "O relay não devolveu listas a tempo. Tente de novo.",
+    "discoverListsServiceUnavailable": "Serviço indisponível.",
     "discoverListsEmptyTitle": "Nenhuma lista pública encontrada",
     "discoverListsEmptySubtitle": "Volte mais tarde para ver novas listas",
     "discoverListsByAuthorPrefix": "por",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3739,6 +3739,7 @@
         }
     },
     "discoverListsLoading": "Se descoperă liste publice...",
+    "discoverListsRelayTimeout": "Releul nu a returnat liste la timp. Încearcă din nou.",
     "discoverListsEmptyTitle": "Nicio listă publică găsită",
     "discoverListsEmptySubtitle": "Revino mai târziu pentru liste noi",
     "discoverListsByAuthorPrefix": "de",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3740,6 +3740,7 @@
     },
     "discoverListsLoading": "Se descoperă liste publice...",
     "discoverListsRelayTimeout": "Releul nu a returnat liste la timp. Încearcă din nou.",
+    "discoverListsServiceUnavailable": "Serviciul nu este disponibil.",
     "discoverListsEmptyTitle": "Nicio listă publică găsită",
     "discoverListsEmptySubtitle": "Revino mai târziu pentru liste noi",
     "discoverListsByAuthorPrefix": "de",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3739,6 +3739,7 @@
         }
     },
     "discoverListsLoading": "Söker upp publika listor...",
+    "discoverListsRelayTimeout": "Relayen returnerade inga listor i tid. Försök igen.",
     "discoverListsEmptyTitle": "Inga publika listor hittades",
     "discoverListsEmptySubtitle": "Kom tillbaka senare för nya listor",
     "discoverListsByAuthorPrefix": "av",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3740,6 +3740,7 @@
     },
     "discoverListsLoading": "Söker upp publika listor...",
     "discoverListsRelayTimeout": "Relayen returnerade inga listor i tid. Försök igen.",
+    "discoverListsServiceUnavailable": "Tjänsten är inte tillgänglig.",
     "discoverListsEmptyTitle": "Inga publika listor hittades",
     "discoverListsEmptySubtitle": "Kom tillbaka senare för nya listor",
     "discoverListsByAuthorPrefix": "av",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3739,6 +3739,7 @@
         }
     },
     "discoverListsLoading": "Herkese açık listeler keşfediliyor...",
+    "discoverListsRelayTimeout": "Relay listeleri zamanında döndürmedi. Tekrar dene.",
     "discoverListsEmptyTitle": "Herkese açık liste bulunamadı",
     "discoverListsEmptySubtitle": "Yeni listeler için sonra tekrar bak",
     "discoverListsByAuthorPrefix": "yazan",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3740,6 +3740,7 @@
     },
     "discoverListsLoading": "Herkese açık listeler keşfediliyor...",
     "discoverListsRelayTimeout": "Relay listeleri zamanında döndürmedi. Tekrar dene.",
+    "discoverListsServiceUnavailable": "Hizmet kullanılamıyor.",
     "discoverListsEmptyTitle": "Herkese açık liste bulunamadı",
     "discoverListsEmptySubtitle": "Yeni listeler için sonra tekrar bak",
     "discoverListsByAuthorPrefix": "yazan",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -3643,6 +3643,7 @@
   },
   "discoverListsLoading": "عوامی فہرستیں دریافت ہو رہی ہیں...",
   "discoverListsRelayTimeout": "ریلے نے وقت پر فہرستیں واپس نہیں کیں۔ دوبارہ کوشش کریں۔",
+  "discoverListsServiceUnavailable": "سروس دستیاب نہیں ہے۔",
   "discoverListsEmptyTitle": "کوئی عوامی فہرست نہیں ملی",
   "discoverListsEmptySubtitle": "نئی فہرستوں کے لیے بعد میں دیکھیں",
   "discoverListsByAuthorPrefix": "از",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -3642,6 +3642,7 @@
     }
   },
   "discoverListsLoading": "عوامی فہرستیں دریافت ہو رہی ہیں...",
+  "discoverListsRelayTimeout": "ریلے نے وقت پر فہرستیں واپس نہیں کیں۔ دوبارہ کوشش کریں۔",
   "discoverListsEmptyTitle": "کوئی عوامی فہرست نہیں ملی",
   "discoverListsEmptySubtitle": "نئی فہرستوں کے لیے بعد میں دیکھیں",
   "discoverListsByAuthorPrefix": "از",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -3643,6 +3643,7 @@
   },
   "discoverListsLoading": "Đang khám phá danh sách công khai...",
   "discoverListsRelayTimeout": "Relay không trả về danh sách kịp lúc. Thử lại nhé.",
+  "discoverListsServiceUnavailable": "Dịch vụ không khả dụng.",
   "discoverListsEmptyTitle": "Không tìm thấy danh sách công khai nào",
   "discoverListsEmptySubtitle": "Quay lại sau để xem danh sách mới nhé",
   "discoverListsByAuthorPrefix": "bởi",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -3642,6 +3642,7 @@
     }
   },
   "discoverListsLoading": "Đang khám phá danh sách công khai...",
+  "discoverListsRelayTimeout": "Relay không trả về danh sách kịp lúc. Thử lại nhé.",
   "discoverListsEmptyTitle": "Không tìm thấy danh sách công khai nào",
   "discoverListsEmptySubtitle": "Quay lại sau để xem danh sách mới nhé",
   "discoverListsByAuthorPrefix": "bởi",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -3642,6 +3642,7 @@
     }
   },
   "discoverListsLoading": "正在发现公开列表...",
+  "discoverListsRelayTimeout": "中继没有及时返回列表。再试一次。",
   "discoverListsEmptyTitle": "没有找到公开列表",
   "discoverListsEmptySubtitle": "过会儿再来看看新列表",
   "discoverListsByAuthorPrefix": "来自",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -3643,6 +3643,7 @@
   },
   "discoverListsLoading": "正在发现公开列表...",
   "discoverListsRelayTimeout": "中继没有及时返回列表。再试一次。",
+  "discoverListsServiceUnavailable": "服务不可用。",
   "discoverListsEmptyTitle": "没有找到公开列表",
   "discoverListsEmptySubtitle": "过会儿再来看看新列表",
   "discoverListsByAuthorPrefix": "来自",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -10910,6 +10910,12 @@ abstract class AppLocalizations {
   /// **'The relay did not return lists in time. Try again.'**
   String get discoverListsRelayTimeout;
 
+  /// No description provided for @discoverListsServiceUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Service not available.'**
+  String get discoverListsServiceUnavailable;
+
   /// No description provided for @discoverListsEmptyTitle.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -10904,6 +10904,12 @@ abstract class AppLocalizations {
   /// **'Discovering public lists...'**
   String get discoverListsLoading;
 
+  /// No description provided for @discoverListsRelayTimeout.
+  ///
+  /// In en, this message translates to:
+  /// **'The relay did not return lists in time. Try again.'**
+  String get discoverListsRelayTimeout;
+
   /// No description provided for @discoverListsEmptyTitle.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -6117,6 +6117,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get discoverListsRelayTimeout => 'ሪሌው በጊዜው ዝርዝሮችን አልመለሰም። እንደገና ሞክር።';
 
   @override
+  String get discoverListsServiceUnavailable => 'አገልግሎቱ አይገኝም።';
+
+  @override
   String get discoverListsEmptyTitle => 'ምንም የህዝብ ዝርዝሮች አልተገኙም';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -6114,6 +6114,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get discoverListsLoading => 'የህዝብ ዝርዝሮችን በመፈለግ ላይ...';
 
   @override
+  String get discoverListsRelayTimeout => 'ሪሌው በጊዜው ዝርዝሮችን አልመለሰም። እንደገና ሞክር።';
+
+  @override
   String get discoverListsEmptyTitle => 'ምንም የህዝብ ዝርዝሮች አልተገኙም';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -6197,6 +6197,9 @@ class AppLocalizationsAr extends AppLocalizations {
       'لم يُرجع الريلاي القوائم في الوقت المناسب. حاول مرة أخرى.';
 
   @override
+  String get discoverListsServiceUnavailable => 'الخدمة غير متاحة.';
+
+  @override
   String get discoverListsEmptyTitle => 'لم يتم العثور على قوائم عامة';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -6193,6 +6193,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get discoverListsLoading => 'جاري اكتشاف القوائم العامة...';
 
   @override
+  String get discoverListsRelayTimeout =>
+      'لم يُرجع الريلاي القوائم في الوقت المناسب. حاول مرة أخرى.';
+
+  @override
   String get discoverListsEmptyTitle => 'لم يتم العثور على قوائم عامة';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -6302,6 +6302,9 @@ class AppLocalizationsBg extends AppLocalizations {
       'Релето не върна списъци навреме. Опитай пак.';
 
   @override
+  String get discoverListsServiceUnavailable => 'Услугата не е налична.';
+
+  @override
   String get discoverListsEmptyTitle => 'Не са намерени публични списъци';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -6298,6 +6298,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get discoverListsLoading => 'Откриваме публични списъци...';
 
   @override
+  String get discoverListsRelayTimeout =>
+      'Релето не върна списъци навреме. Опитай пак.';
+
+  @override
   String get discoverListsEmptyTitle => 'Не са намерени публични списъци';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -6319,6 +6319,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get discoverListsLoading => 'Öffentliche Listen werden entdeckt...';
 
   @override
+  String get discoverListsRelayTimeout =>
+      'Das Relay hat nicht rechtzeitig Listen geliefert. Versuch es nochmal.';
+
+  @override
   String get discoverListsEmptyTitle => 'Keine öffentlichen Listen gefunden';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -6323,6 +6323,9 @@ class AppLocalizationsDe extends AppLocalizations {
       'Das Relay hat nicht rechtzeitig Listen geliefert. Versuch es nochmal.';
 
   @override
+  String get discoverListsServiceUnavailable => 'Dienst nicht verfügbar.';
+
+  @override
   String get discoverListsEmptyTitle => 'Keine öffentlichen Listen gefunden';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -6242,6 +6242,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'The relay did not return lists in time. Try again.';
 
   @override
+  String get discoverListsServiceUnavailable => 'Service not available.';
+
+  @override
   String get discoverListsEmptyTitle => 'No public lists found';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -6238,6 +6238,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get discoverListsLoading => 'Discovering public lists...';
 
   @override
+  String get discoverListsRelayTimeout =>
+      'The relay did not return lists in time. Try again.';
+
+  @override
   String get discoverListsEmptyTitle => 'No public lists found';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -6296,6 +6296,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'El relay no devolvió listas a tiempo. Inténtalo de nuevo.';
 
   @override
+  String get discoverListsServiceUnavailable => 'Servicio no disponible.';
+
+  @override
   String get discoverListsEmptyTitle => 'No se encontraron listas públicas';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -6292,6 +6292,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get discoverListsLoading => 'Descubriendo listas públicas...';
 
   @override
+  String get discoverListsRelayTimeout =>
+      'El relay no devolvió listas a tiempo. Inténtalo de nuevo.';
+
+  @override
   String get discoverListsEmptyTitle => 'No se encontraron listas públicas';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -6320,6 +6320,9 @@ class AppLocalizationsFil extends AppLocalizations {
       'Hindi nagbalik ng mga list ang relay sa oras. Subukan ulit.';
 
   @override
+  String get discoverListsServiceUnavailable => 'Hindi available ang serbisyo.';
+
+  @override
   String get discoverListsEmptyTitle => 'Walang nakitang public list';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -6316,6 +6316,10 @@ class AppLocalizationsFil extends AppLocalizations {
   String get discoverListsLoading => 'Naghahanap ng mga public list...';
 
   @override
+  String get discoverListsRelayTimeout =>
+      'Hindi nagbalik ng mga list ang relay sa oras. Subukan ulit.';
+
+  @override
   String get discoverListsEmptyTitle => 'Walang nakitang public list';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -6322,6 +6322,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'Le relais n\'a pas renvoyé de listes à temps. Réessaie.';
 
   @override
+  String get discoverListsServiceUnavailable => 'Service indisponible.';
+
+  @override
   String get discoverListsEmptyTitle => 'Aucune liste publique trouvée';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -6318,6 +6318,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get discoverListsLoading => 'Recherche de listes publiques...';
 
   @override
+  String get discoverListsRelayTimeout =>
+      'Le relais n\'a pas renvoyé de listes à temps. Réessaie.';
+
+  @override
   String get discoverListsEmptyTitle => 'Aucune liste publique trouvée';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -6205,6 +6205,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get discoverListsLoading => 'Mencari daftar publik...';
 
   @override
+  String get discoverListsRelayTimeout =>
+      'Relay tidak mengembalikan daftar tepat waktu. Coba lagi.';
+
+  @override
   String get discoverListsEmptyTitle => 'Tidak ada daftar publik';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -6209,6 +6209,9 @@ class AppLocalizationsId extends AppLocalizations {
       'Relay tidak mengembalikan daftar tepat waktu. Coba lagi.';
 
   @override
+  String get discoverListsServiceUnavailable => 'Layanan tidak tersedia.';
+
+  @override
   String get discoverListsEmptyTitle => 'Tidak ada daftar publik';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -6300,6 +6300,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get discoverListsLoading => 'Cercando liste pubbliche...';
 
   @override
+  String get discoverListsRelayTimeout =>
+      'Il relay non ha restituito liste in tempo. Riprova.';
+
+  @override
   String get discoverListsEmptyTitle => 'Nessuna lista pubblica trovata';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -6304,6 +6304,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'Il relay non ha restituito liste in tempo. Riprova.';
 
   @override
+  String get discoverListsServiceUnavailable => 'Servizio non disponibile.';
+
+  @override
   String get discoverListsEmptyTitle => 'Nessuna lista pubblica trovata';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5971,6 +5971,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get discoverListsRelayTimeout => 'リレーが時間内にリストを返さなかったよ。もう一度試してね。';
 
   @override
+  String get discoverListsServiceUnavailable => 'サービスを利用できません。';
+
+  @override
   String get discoverListsEmptyTitle => '公開リストが見つからなかった';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5968,6 +5968,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get discoverListsLoading => '公開リストを探してるよ...';
 
   @override
+  String get discoverListsRelayTimeout => 'リレーが時間内にリストを返さなかったよ。もう一度試してね。';
+
+  @override
   String get discoverListsEmptyTitle => '公開リストが見つからなかった';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5992,6 +5992,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get discoverListsRelayTimeout => '릴레이가 제때 리스트를 주지 않았어요. 다시 시도해 주세요.';
 
   @override
+  String get discoverListsServiceUnavailable => '서비스를 사용할 수 없어요.';
+
+  @override
   String get discoverListsEmptyTitle => '공개 리스트를 찾지 못했어요';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5989,6 +5989,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get discoverListsLoading => '공개 리스트를 찾는 중...';
 
   @override
+  String get discoverListsRelayTimeout => '릴레이가 제때 리스트를 주지 않았어요. 다시 시도해 주세요.';
+
+  @override
   String get discoverListsEmptyTitle => '공개 리스트를 찾지 못했어요';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -6293,6 +6293,9 @@ class AppLocalizationsMs extends AppLocalizations {
       'Relay tidak memulangkan senarai tepat pada masanya. Cuba lagi.';
 
   @override
+  String get discoverListsServiceUnavailable => 'Perkhidmatan tidak tersedia.';
+
+  @override
   String get discoverListsEmptyTitle => 'Tiada senarai awam ditemui';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -6289,6 +6289,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get discoverListsLoading => 'Menemui senarai awam...';
 
   @override
+  String get discoverListsRelayTimeout =>
+      'Relay tidak memulangkan senarai tepat pada masanya. Cuba lagi.';
+
+  @override
   String get discoverListsEmptyTitle => 'Tiada senarai awam ditemui';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -6273,6 +6273,9 @@ class AppLocalizationsNl extends AppLocalizations {
       'De relay leverde niet op tijd lijsten. Probeer het opnieuw.';
 
   @override
+  String get discoverListsServiceUnavailable => 'Service niet beschikbaar.';
+
+  @override
   String get discoverListsEmptyTitle => 'Geen publieke lijsten gevonden';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -6269,6 +6269,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get discoverListsLoading => 'Publieke lijsten worden ontdekt...';
 
   @override
+  String get discoverListsRelayTimeout =>
+      'De relay leverde niet op tijd lijsten. Probeer het opnieuw.';
+
+  @override
   String get discoverListsEmptyTitle => 'Geen publieke lijsten gevonden';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6392,6 +6392,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get discoverListsLoading => 'Odkrywanie publicznych list...';
 
   @override
+  String get discoverListsRelayTimeout =>
+      'Relay nie zwrócił list na czas. Spróbuj ponownie.';
+
+  @override
   String get discoverListsEmptyTitle => 'Nie znaleziono publicznych list';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6396,6 +6396,9 @@ class AppLocalizationsPl extends AppLocalizations {
       'Relay nie zwrócił list na czas. Spróbuj ponownie.';
 
   @override
+  String get discoverListsServiceUnavailable => 'Usługa niedostępna.';
+
+  @override
   String get discoverListsEmptyTitle => 'Nie znaleziono publicznych list';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -6287,6 +6287,9 @@ class AppLocalizationsPt extends AppLocalizations {
       'O relay não devolveu listas a tempo. Tente de novo.';
 
   @override
+  String get discoverListsServiceUnavailable => 'Serviço indisponível.';
+
+  @override
   String get discoverListsEmptyTitle => 'Nenhuma lista pública encontrada';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -6283,6 +6283,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get discoverListsLoading => 'Descobrindo listas públicas...';
 
   @override
+  String get discoverListsRelayTimeout =>
+      'O relay não devolveu listas a tempo. Tente de novo.';
+
+  @override
   String get discoverListsEmptyTitle => 'Nenhuma lista pública encontrada';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6396,6 +6396,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get discoverListsLoading => 'Se descoperă liste publice...';
 
   @override
+  String get discoverListsRelayTimeout =>
+      'Releul nu a returnat liste la timp. Încearcă din nou.';
+
+  @override
   String get discoverListsEmptyTitle => 'Nicio listă publică găsită';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6400,6 +6400,9 @@ class AppLocalizationsRo extends AppLocalizations {
       'Releul nu a returnat liste la timp. Încearcă din nou.';
 
   @override
+  String get discoverListsServiceUnavailable => 'Serviciul nu este disponibil.';
+
+  @override
   String get discoverListsEmptyTitle => 'Nicio listă publică găsită';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -6238,6 +6238,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get discoverListsLoading => 'Söker upp publika listor...';
 
   @override
+  String get discoverListsRelayTimeout =>
+      'Relayen returnerade inga listor i tid. Försök igen.';
+
+  @override
   String get discoverListsEmptyTitle => 'Inga publika listor hittades';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -6242,6 +6242,9 @@ class AppLocalizationsSv extends AppLocalizations {
       'Relayen returnerade inga listor i tid. Försök igen.';
 
   @override
+  String get discoverListsServiceUnavailable => 'Tjänsten är inte tillgänglig.';
+
+  @override
   String get discoverListsEmptyTitle => 'Inga publika listor hittades';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -6212,6 +6212,9 @@ class AppLocalizationsTr extends AppLocalizations {
       'Relay listeleri zamanında döndürmedi. Tekrar dene.';
 
   @override
+  String get discoverListsServiceUnavailable => 'Hizmet kullanılamıyor.';
+
+  @override
   String get discoverListsEmptyTitle => 'Herkese açık liste bulunamadı';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -6208,6 +6208,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get discoverListsLoading => 'Herkese açık listeler keşfediliyor...';
 
   @override
+  String get discoverListsRelayTimeout =>
+      'Relay listeleri zamanında döndürmedi. Tekrar dene.';
+
+  @override
   String get discoverListsEmptyTitle => 'Herkese açık liste bulunamadı';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -6251,6 +6251,9 @@ class AppLocalizationsUr extends AppLocalizations {
       'ریلے نے وقت پر فہرستیں واپس نہیں کیں۔ دوبارہ کوشش کریں۔';
 
   @override
+  String get discoverListsServiceUnavailable => 'سروس دستیاب نہیں ہے۔';
+
+  @override
   String get discoverListsEmptyTitle => 'کوئی عوامی فہرست نہیں ملی';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -6247,6 +6247,10 @@ class AppLocalizationsUr extends AppLocalizations {
   String get discoverListsLoading => 'عوامی فہرستیں دریافت ہو رہی ہیں...';
 
   @override
+  String get discoverListsRelayTimeout =>
+      'ریلے نے وقت پر فہرستیں واپس نہیں کیں۔ دوبارہ کوشش کریں۔';
+
+  @override
   String get discoverListsEmptyTitle => 'کوئی عوامی فہرست نہیں ملی';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -6252,6 +6252,9 @@ class AppLocalizationsVi extends AppLocalizations {
       'Relay không trả về danh sách kịp lúc. Thử lại nhé.';
 
   @override
+  String get discoverListsServiceUnavailable => 'Dịch vụ không khả dụng.';
+
+  @override
   String get discoverListsEmptyTitle =>
       'Không tìm thấy danh sách công khai nào';
 

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -6248,6 +6248,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get discoverListsLoading => 'Đang khám phá danh sách công khai...';
 
   @override
+  String get discoverListsRelayTimeout =>
+      'Relay không trả về danh sách kịp lúc. Thử lại nhé.';
+
+  @override
   String get discoverListsEmptyTitle =>
       'Không tìm thấy danh sách công khai nào';
 

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -5942,6 +5942,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get discoverListsLoading => '正在发现公开列表...';
 
   @override
+  String get discoverListsRelayTimeout => '中继没有及时返回列表。再试一次。';
+
+  @override
   String get discoverListsEmptyTitle => '没有找到公开列表';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -5945,6 +5945,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get discoverListsRelayTimeout => '中继没有及时返回列表。再试一次。';
 
   @override
+  String get discoverListsServiceUnavailable => '服务不可用。';
+
+  @override
   String get discoverListsEmptyTitle => '没有找到公开列表';
 
   @override

--- a/mobile/lib/screens/discover_lists_screen.dart
+++ b/mobile/lib/screens/discover_lists_screen.dart
@@ -123,17 +123,22 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
       await _subscription?.cancel();
       _initialLoadTimeoutTimer?.cancel();
       var hasReceivedStreamUpdate = false;
-      _initialLoadTimeoutTimer = Timer(_initialLoadTimeout, () {
-        if (!mounted || hasReceivedStreamUpdate) return;
+      // Only guard the empty screen. The error view replaces the list
+      // entirely, so arming this during a refresh would wipe lists the user
+      // is already reading whenever a relay answers slowly.
+      if (!hadExistingLists) {
+        _initialLoadTimeoutTimer = Timer(_initialLoadTimeout, () {
+          if (!mounted || hasReceivedStreamUpdate) return;
 
-        unawaited(_subscription?.cancel());
-        _subscription = null;
-        provider.setLoading(false);
-        setState(() {
-          _isRefreshing = false;
-          _errorMessage = context.l10n.discoverListsRelayTimeout;
+          unawaited(_subscription?.cancel());
+          _subscription = null;
+          provider.setLoading(false);
+          setState(() {
+            _isRefreshing = false;
+            _errorMessage = context.l10n.discoverListsRelayTimeout;
+          });
         });
-      });
+      }
       _subscription = service.streamPublicListsFromRelays().listen(
         (lists) {
           hasReceivedStreamUpdate = true;

--- a/mobile/lib/screens/discover_lists_screen.dart
+++ b/mobile/lib/screens/discover_lists_screen.dart
@@ -37,7 +37,7 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
   String? _errorMessage;
   StreamSubscription<List<CuratedList>>? _subscription;
   final _scrollController = ScrollController();
-  Timer? _initialLoadTimeoutTimer;
+  Timer? _streamTimeoutTimer;
 
   // Debounce timer for batching rapid stream updates
   Timer? _updateDebounceTimer;
@@ -50,7 +50,7 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
   int _autoPaginationAttempts = 0;
   static const int _maxAutoPaginationAttempts = 5;
   static const int _minListsBeforeAutoPaginate = 10;
-  static const Duration _initialLoadTimeout = Duration(seconds: 8);
+  static const Duration _streamTimeout = Duration(seconds: 8);
 
   @override
   ScrollController get paginationScrollController => _scrollController;
@@ -78,7 +78,7 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
 
   @override
   void dispose() {
-    _initialLoadTimeoutTimer?.cancel();
+    _streamTimeoutTimer?.cancel();
     _updateDebounceTimer?.cancel();
     _subscription?.cancel();
     disposePagination();
@@ -114,35 +114,36 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
       if (service == null) {
         provider.setLoading(false);
         setState(() {
-          _errorMessage = 'Service not available';
+          _isRefreshing = false;
+          _errorMessage = context.l10n.discoverListsServiceUnavailable;
         });
         return;
       }
 
       // Stream results - UI updates with debouncing to handle rapid events
       await _subscription?.cancel();
-      _initialLoadTimeoutTimer?.cancel();
+      _streamTimeoutTimer?.cancel();
       var hasReceivedStreamUpdate = false;
       // Only guard the empty screen. The error view replaces the list
       // entirely, so arming this during a refresh would wipe lists the user
       // is already reading whenever a relay answers slowly.
-      if (!hadExistingLists) {
-        _initialLoadTimeoutTimer = Timer(_initialLoadTimeout, () {
-          if (!mounted || hasReceivedStreamUpdate) return;
+      _streamTimeoutTimer = Timer(_streamTimeout, () {
+        if (!mounted || hasReceivedStreamUpdate) return;
 
-          unawaited(_subscription?.cancel());
-          _subscription = null;
-          provider.setLoading(false);
-          setState(() {
-            _isRefreshing = false;
+        unawaited(_subscription?.cancel());
+        _subscription = null;
+        provider.setLoading(false);
+        setState(() {
+          _isRefreshing = false;
+          if (!hadExistingLists) {
             _errorMessage = context.l10n.discoverListsRelayTimeout;
-          });
+          }
         });
-      }
+      });
       _subscription = service.streamPublicListsFromRelays().listen(
         (lists) {
           hasReceivedStreamUpdate = true;
-          _initialLoadTimeoutTimer?.cancel();
+          _streamTimeoutTimer?.cancel();
           if (mounted) {
             // Track oldest timestamp for pagination
             for (final list in lists) {
@@ -214,7 +215,7 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
           }
         },
         onError: (error) {
-          _initialLoadTimeoutTimer?.cancel();
+          _streamTimeoutTimer?.cancel();
           if (mounted) {
             provider.setLoading(false);
             setState(() {
@@ -226,7 +227,7 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
           }
         },
         onDone: () {
-          _initialLoadTimeoutTimer?.cancel();
+          _streamTimeoutTimer?.cancel();
           if (mounted && !hasReceivedStreamUpdate) {
             provider.setLoading(false);
             setState(() {
@@ -236,7 +237,7 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
         },
       );
     } catch (e) {
-      _initialLoadTimeoutTimer?.cancel();
+      _streamTimeoutTimer?.cancel();
       if (mounted) {
         ref.read(discoveredListsProvider.notifier).setLoading(false);
         setState(() {

--- a/mobile/lib/screens/discover_lists_screen.dart
+++ b/mobile/lib/screens/discover_lists_screen.dart
@@ -131,9 +131,7 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
         provider.setLoading(false);
         setState(() {
           _isRefreshing = false;
-          _errorMessage = context.l10n.discoverListsFailedToLoadWithError(
-            'The relay did not return lists in time. Try again.',
-          );
+          _errorMessage = context.l10n.discoverListsRelayTimeout;
         });
       });
       _subscription = service.streamPublicListsFromRelays().listen(

--- a/mobile/lib/screens/discover_lists_screen.dart
+++ b/mobile/lib/screens/discover_lists_screen.dart
@@ -37,6 +37,7 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
   String? _errorMessage;
   StreamSubscription<List<CuratedList>>? _subscription;
   final _scrollController = ScrollController();
+  Timer? _initialLoadTimeoutTimer;
 
   // Debounce timer for batching rapid stream updates
   Timer? _updateDebounceTimer;
@@ -49,6 +50,7 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
   int _autoPaginationAttempts = 0;
   static const int _maxAutoPaginationAttempts = 5;
   static const int _minListsBeforeAutoPaginate = 10;
+  static const Duration _initialLoadTimeout = Duration(seconds: 8);
 
   @override
   ScrollController get paginationScrollController => _scrollController;
@@ -76,6 +78,7 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
 
   @override
   void dispose() {
+    _initialLoadTimeoutTimer?.cancel();
     _updateDebounceTimer?.cancel();
     _subscription?.cancel();
     disposePagination();
@@ -97,13 +100,13 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
       _hasReachedEnd = false;
     });
 
-    // Set loading state in provider
-    provider.setLoading(!hadExistingLists);
-
     // Clear lists only if not refreshing
     if (!isRefresh) {
       provider.clear();
     }
+
+    // Set loading state in provider after any clear() call.
+    provider.setLoading(!hadExistingLists);
 
     try {
       final service = ref.read(curatedListsStateProvider.notifier).service;
@@ -117,9 +120,26 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
       }
 
       // Stream results - UI updates with debouncing to handle rapid events
-      _subscription?.cancel();
+      await _subscription?.cancel();
+      _initialLoadTimeoutTimer?.cancel();
+      var hasReceivedStreamUpdate = false;
+      _initialLoadTimeoutTimer = Timer(_initialLoadTimeout, () {
+        if (!mounted || hasReceivedStreamUpdate) return;
+
+        unawaited(_subscription?.cancel());
+        _subscription = null;
+        provider.setLoading(false);
+        setState(() {
+          _isRefreshing = false;
+          _errorMessage = context.l10n.discoverListsFailedToLoadWithError(
+            'The relay did not return lists in time. Try again.',
+          );
+        });
+      });
       _subscription = service.streamPublicListsFromRelays().listen(
         (lists) {
+          hasReceivedStreamUpdate = true;
+          _initialLoadTimeoutTimer?.cancel();
           if (mounted) {
             // Track oldest timestamp for pagination
             for (final list in lists) {
@@ -191,23 +211,34 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
           }
         },
         onError: (error) {
+          _initialLoadTimeoutTimer?.cancel();
           if (mounted) {
             provider.setLoading(false);
             setState(() {
+              _isRefreshing = false;
               _errorMessage = context.l10n.discoverListsFailedToLoadWithError(
                 '$error',
               );
             });
           }
         },
+        onDone: () {
+          _initialLoadTimeoutTimer?.cancel();
+          if (mounted && !hasReceivedStreamUpdate) {
+            provider.setLoading(false);
+            setState(() {
+              _isRefreshing = false;
+            });
+          }
+        },
       );
     } catch (e) {
+      _initialLoadTimeoutTimer?.cancel();
       if (mounted) {
         ref.read(discoveredListsProvider.notifier).setLoading(false);
         setState(() {
-          _errorMessage = context.l10n.discoverListsFailedToLoadWithError(
-            '$e',
-          );
+          _isRefreshing = false;
+          _errorMessage = context.l10n.discoverListsFailedToLoadWithError('$e');
         });
         Log.error(
           'Failed to discover public lists: $e',

--- a/mobile/lib/services/curated_list_service.dart
+++ b/mobile/lib/services/curated_list_service.dart
@@ -1313,6 +1313,8 @@ class CuratedListService extends ChangeNotifier {
       category: LogCategory.system,
     );
 
+    StreamSubscription<Event>? relaySubscription;
+    Timer? timeoutTimer;
     try {
       final completer = Completer<void>();
       final receivedEvents = <Event>[];
@@ -1330,7 +1332,6 @@ class CuratedListService extends ChangeNotifier {
       final subscription = _nostrService.subscribe([filter]);
 
       // Set a timeout for the subscription
-      Timer? timeoutTimer;
       timeoutTimer = Timer(const Duration(seconds: 10), () {
         Log.debug(
           'Relay sync timeout reached, processing received events',
@@ -1338,11 +1339,14 @@ class CuratedListService extends ChangeNotifier {
           category: LogCategory.system,
         );
         if (!completer.isCompleted) {
+          final subscription = relaySubscription;
+          relaySubscription = null;
+          unawaited(subscription?.cancel());
           completer.complete();
         }
       });
 
-      subscription.listen(
+      relaySubscription = subscription.listen(
         (event) {
           receivedEvents.add(event);
           Log.debug(
@@ -1395,6 +1399,9 @@ class CuratedListService extends ChangeNotifier {
         name: 'CuratedListService',
         category: LogCategory.system,
       );
+    } finally {
+      timeoutTimer?.cancel();
+      await relaySubscription?.cancel();
     }
   }
 
@@ -1573,6 +1580,8 @@ class CuratedListService extends ChangeNotifier {
       category: LogCategory.system,
     );
 
+    StreamSubscription<Event>? relaySubscription;
+    Timer? timeoutTimer;
     try {
       final completer = Completer<void>();
       final receivedEvents = <Event>[];
@@ -1588,7 +1597,6 @@ class CuratedListService extends ChangeNotifier {
       final subscription = _nostrService.subscribe([filter]);
 
       // Set a timeout for the subscription
-      Timer? timeoutTimer;
       timeoutTimer = Timer(const Duration(seconds: 10), () {
         Log.debug(
           'Public lists containing video fetch timeout, processing received events',
@@ -1596,11 +1604,14 @@ class CuratedListService extends ChangeNotifier {
           category: LogCategory.system,
         );
         if (!completer.isCompleted) {
+          final subscription = relaySubscription;
+          relaySubscription = null;
+          unawaited(subscription?.cancel());
           completer.complete();
         }
       });
 
-      subscription.listen(
+      relaySubscription = subscription.listen(
         (event) {
           receivedEvents.add(event);
           Log.debug(
@@ -1676,6 +1687,9 @@ class CuratedListService extends ChangeNotifier {
         category: LogCategory.system,
       );
       return [];
+    } finally {
+      timeoutTimer?.cancel();
+      await relaySubscription?.cancel();
     }
   }
 

--- a/mobile/lib/services/social_service.dart
+++ b/mobile/lib/services/social_service.dart
@@ -4,8 +4,6 @@
 // ABOUTME: Note: NIP-18 reposts are handled by RepostsRepository
 // ABOUTME: Note: NIP-51 kind 30000 people lists are handled by PeopleListsRepository
 
-import 'dart:async';
-
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/constants/nip71_migration.dart';
@@ -32,40 +30,14 @@ class SocialService {
     );
 
     try {
-      final completer = Completer<int>();
-      var videoCount = 0;
-
-      // Subscribe to user's video events using NIP-71 compliant kinds
-      final subscription = _nostrService.subscribe([
+      final events = await _nostrService.queryEvents([
         Filter(
           authors: [pubkey],
           kinds:
               NIP71VideoKinds.getAllVideoKinds(), // NIP-71 video kinds: 22, 21, 34236, 34235
         ),
       ]);
-
-      subscription.listen(
-        (event) {
-          videoCount++;
-        },
-        onDone: () {
-          if (!completer.isCompleted) {
-            completer.complete(videoCount);
-          }
-        },
-        onError: (error) {
-          Log.error(
-            'Error fetching video count: $error',
-            name: 'SocialService',
-            category: LogCategory.system,
-          );
-          if (!completer.isCompleted) {
-            completer.complete(0);
-          }
-        },
-      );
-
-      final result = await completer.future;
+      final result = events.length;
       Log.debug(
         '📱 Video count fetched: $result',
         name: 'SocialService',

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -94,18 +94,43 @@ class FollowRepository {
     required String pubkey,
     int fallbackTimeoutSeconds = 10,
   }) async {
+    final completer = Completer<Event?>();
+    StreamSubscription<Event>? subscription;
+    Timer? timeoutTimer;
     try {
-      return await eventStream
-          .where((e) => e.kind == EventKind.contactList && e.pubkey == pubkey)
-          .first
-          .timeout(Duration(seconds: fallbackTimeoutSeconds));
-    } on TimeoutException {
-      return null;
-      // Catching StateError is intentional: `.first` throws it when the
-      // stream closes without a matching event.
-      // ignore: avoid_catching_errors
-    } on StateError {
-      return null;
+      timeoutTimer = Timer(Duration(seconds: fallbackTimeoutSeconds), () {
+        if (!completer.isCompleted) {
+          final activeSubscription = subscription;
+          subscription = null;
+          unawaited(activeSubscription?.cancel());
+          completer.complete(null);
+        }
+      });
+
+      subscription = eventStream.listen(
+        (event) {
+          if (event.kind == EventKind.contactList && event.pubkey == pubkey) {
+            if (!completer.isCompleted) {
+              completer.complete(event);
+            }
+          }
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          if (!completer.isCompleted) {
+            completer.completeError(error, stackTrace);
+          }
+        },
+        onDone: () {
+          if (!completer.isCompleted) {
+            completer.complete(null);
+          }
+        },
+      );
+
+      return await completer.future;
+    } finally {
+      timeoutTimer?.cancel();
+      await subscription?.cancel();
     }
   }
 

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -3507,6 +3507,76 @@ void main() {
         expect(repository.followingCount, 0);
       });
 
+      test('handles connected relay query stream error gracefully', () async {
+        when(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            sendAfterAuth: any(named: 'sendAfterAuth'),
+            onEose: any(named: 'onEose'),
+          ),
+        ).thenAnswer((invocation) {
+          final subscriptionId =
+              invocation.namedArguments[#subscriptionId] as String?;
+          if (subscriptionId != null) {
+            return const Stream<Event>.empty();
+          }
+          return Stream<Event>.error(Exception('Relay stream error'));
+        });
+
+        await repository.initialize();
+
+        expect(repository.followingCount, 0);
+      });
+
+      test('cancels connected relay contact list query on timeout', () {
+        fakeAsync((async) {
+          var queryStreamCanceled = false;
+          final controller = StreamController<Event>(
+            onCancel: () {
+              queryStreamCanceled = true;
+            },
+          );
+
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              sendAfterAuth: any(named: 'sendAfterAuth'),
+              onEose: any(named: 'onEose'),
+            ),
+          ).thenAnswer((invocation) {
+            final subscriptionId =
+                invocation.namedArguments[#subscriptionId] as String?;
+            if (subscriptionId != null) {
+              return const Stream<Event>.empty();
+            }
+            return controller.stream;
+          });
+
+          var completed = false;
+          unawaited(
+            repository.initialize().then((_) {
+              completed = true;
+            }),
+          );
+
+          async
+            ..flushMicrotasks()
+            ..elapse(const Duration(seconds: 6))
+            ..flushMicrotasks();
+
+          expect(completed, isTrue);
+          expect(queryStreamCanceled, isTrue);
+        });
+      });
+
       test(
         'picks best contact list by createdAt (newer wins)',
         () async {

--- a/mobile/packages/nostr_client/lib/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/nostr_client.dart
@@ -1,7 +1,7 @@
 /// Nostr client abstraction layer
 ///
 /// Provides a clean API for Nostr communication that abstracts away
-/// the complexities of relay management, subscription deduplication,
+/// the complexities of relay management, subscription lifecycle,
 /// and connection handling. Integrates SDK, gateway, and caching.
 library;
 

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -618,9 +618,6 @@ class NostrClient {
   /// Number of active subscriptions
   int get activeSubscriptionCount => _subscriptionStreams.length;
 
-  /// Map of subscription IDs to their filter hashes (for diagnostics)
-  final Map<String, String> _subscriptionFilters = {};
-
   /// Map of active subscriptions
   final Map<String, StreamController<Event>> _subscriptionStreams = {};
 
@@ -1121,7 +1118,9 @@ class NostrClient {
   ///
   /// Returns a broadcast stream of events. Anonymous subscriptions receive a
   /// fresh relay subscription every call so bounded query screens can
-  /// re-enter safely after a previous listener was canceled.
+  /// re-enter safely after a previous listener was canceled. The returned
+  /// stream is closed when its last listener cancels; call [subscribe] again
+  /// instead of retaining and re-listening to the old stream.
   Stream<Event> subscribe(
     List<Filter> filters, {
     String? subscriptionId,
@@ -1158,8 +1157,10 @@ class NostrClient {
       if (!_subscriptionStreams.containsKey(effectiveId)) return;
       _nostr.unsubscribe(effectiveId);
       _subscriptionStreams.remove(effectiveId);
-      _subscriptionFilters.remove(effectiveId);
       statisticsObserver?.onSubscriptionClosed(effectiveId);
+      if (!controller.isClosed) {
+        unawaited(controller.close());
+      }
     }
 
     // Create new stream controller
@@ -1167,7 +1168,6 @@ class NostrClient {
       onCancel: cleanupSubscription,
     );
     _subscriptionStreams[id] = controller;
-    _subscriptionFilters[id] = filterHash;
 
     // Convert filters to JSON format expected by nostr_sdk
     final filtersJson = filters.map((f) => f.toJson()).toList();
@@ -1207,7 +1207,6 @@ class NostrClient {
     if (effectiveId != id) {
       _subscriptionStreams.remove(id);
       _subscriptionStreams[effectiveId] = controller;
-      _subscriptionFilters[effectiveId] = filterHash;
     }
 
     statisticsObserver?.onSubscriptionStarted(effectiveId);
@@ -1222,7 +1221,6 @@ class NostrClient {
     if (controller != null && !controller.isClosed) {
       await controller.close();
     }
-    _subscriptionFilters.remove(subscriptionId);
     statisticsObserver?.onSubscriptionClosed(subscriptionId);
   }
 
@@ -1757,7 +1755,6 @@ class NostrClient {
     _nostr.close();
     _verifyWorker?.close();
     _verifyWorker = null;
-    _subscriptionFilters.clear();
     _isDisposed = true;
   }
 

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -59,7 +59,7 @@ typedef NostrClientInitializationObserver =
 /// Abstraction layer for Nostr communication
 ///
 /// This client wraps nostr_sdk and provides:
-/// - Subscription deduplication (prevents duplicate subscriptions)
+/// - Subscription lifecycle (relay REQ closed when the last listener cancels)
 /// - Local database caching for faster queries
 /// - Clean API for repositories to use
 /// - Proper resource management

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -618,11 +618,13 @@ class NostrClient {
   /// Number of active subscriptions
   int get activeSubscriptionCount => _subscriptionStreams.length;
 
-  /// Map of subscription IDs to their filter hashes (for deduplication)
+  /// Map of subscription IDs to their filter hashes (for diagnostics)
   final Map<String, String> _subscriptionFilters = {};
 
   /// Map of active subscriptions
   final Map<String, StreamController<Event>> _subscriptionStreams = {};
+
+  int _anonymousSubscriptionCounter = 0;
 
   /// Publishes an event to relays
   ///
@@ -1115,10 +1117,11 @@ class NostrClient {
     return null;
   }
 
-  /// Subscribes to events matching the given filters
+  /// Subscribes to events matching the given filters.
   ///
-  /// Returns a stream of events. Automatically deduplicates subscriptions
-  /// with identical filters to prevent duplicate WebSocket subscriptions.
+  /// Returns a broadcast stream of events. Anonymous subscriptions receive a
+  /// fresh relay subscription every call so bounded query screens can
+  /// re-enter safely after a previous listener was canceled.
   Stream<Event> subscribe(
     List<Filter> filters, {
     String? subscriptionId,
@@ -1130,12 +1133,15 @@ class NostrClient {
   }) {
     final effectiveTempRelays = _allowedRelays(tempRelays);
     final effectiveTargetRelays = _allowedRelays(targetRelays);
-    // Generate deterministic subscription ID based on filter content
     final filterHash = _generateFilterHash(filters);
-    final id = subscriptionId ?? 'sub_$filterHash';
+    final id =
+        subscriptionId ??
+        'sub_${filterHash}_${_anonymousSubscriptionCounter++}';
 
-    // Check if we already have this exact subscription
-    if (_subscriptionStreams.containsKey(id) &&
+    // Explicit subscription IDs are caller-owned. Preserve their sharing
+    // semantics so manual unsubscribe call sites keep working as before.
+    if (subscriptionId != null &&
+        _subscriptionStreams.containsKey(id) &&
         !_subscriptionStreams[id]!.isClosed) {
       return _subscriptionStreams[id]!.stream;
     }
@@ -1145,8 +1151,21 @@ class NostrClient {
       unawaited(retryDisconnectedRelays());
     }
 
+    late final StreamController<Event> controller;
+    var effectiveId = id;
+
+    void cleanupSubscription() {
+      if (!_subscriptionStreams.containsKey(effectiveId)) return;
+      _nostr.unsubscribe(effectiveId);
+      _subscriptionStreams.remove(effectiveId);
+      _subscriptionFilters.remove(effectiveId);
+      statisticsObserver?.onSubscriptionClosed(effectiveId);
+    }
+
     // Create new stream controller
-    final controller = StreamController<Event>.broadcast();
+    controller = StreamController<Event>.broadcast(
+      onCancel: cleanupSubscription,
+    );
     _subscriptionStreams[id] = controller;
     _subscriptionFilters[id] = filterHash;
 
@@ -1184,7 +1203,7 @@ class NostrClient {
     );
 
     // If nostr_sdk generated a different ID, update our mapping
-    final effectiveId = (actualId != id && actualId.isNotEmpty) ? actualId : id;
+    effectiveId = (actualId != id && actualId.isNotEmpty) ? actualId : id;
     if (effectiveId != id) {
       _subscriptionStreams.remove(id);
       _subscriptionStreams[effectiveId] = controller;

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -2115,6 +2115,35 @@ void main() {
         },
       );
 
+      test('closes anonymous stream after last listener cancels', () async {
+        final filters = [
+          Filter(kinds: [EventKind.textNote], limit: 10),
+        ];
+
+        when(
+          () => mockNostr.subscribe(
+            any(),
+            any(),
+            id: any(named: 'id'),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            sendAfterAuth: any(named: 'sendAfterAuth'),
+            onEose: any(named: 'onEose'),
+          ),
+        ).thenAnswer(
+          (invocation) => invocation.namedArguments[#id] as String,
+        );
+        when(() => mockNostr.unsubscribe(any())).thenReturn(null);
+
+        final stream = client.subscribe(filters);
+        final subscription = stream.listen((_) {});
+
+        await subscription.cancel();
+
+        await expectLater(stream, emitsDone);
+      });
+
       test('uses custom subscription ID when provided', () {
         final filters = [
           Filter(kinds: [EventKind.textNote], limit: 10),

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -2039,6 +2039,82 @@ void main() {
         ).called(2);
       });
 
+      test('creates fresh anonymous subscriptions for identical filters', () {
+        final filters = [
+          Filter(kinds: [EventKind.textNote], limit: 10),
+        ];
+        final requestedIds = <String>[];
+
+        when(
+          () => mockNostr.subscribe(
+            any(),
+            any(),
+            id: any(named: 'id'),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            sendAfterAuth: any(named: 'sendAfterAuth'),
+            onEose: any(named: 'onEose'),
+          ),
+        ).thenAnswer((invocation) {
+          final id = invocation.namedArguments[#id] as String;
+          requestedIds.add(id);
+          return id;
+        });
+
+        client
+          ..subscribe(filters)
+          ..subscribe(filters);
+
+        expect(requestedIds, hasLength(2));
+        expect(requestedIds.toSet(), hasLength(2));
+        verify(
+          () => mockNostr.subscribe(
+            any(),
+            any(),
+            id: any(named: 'id'),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            sendAfterAuth: any(named: 'sendAfterAuth'),
+            onEose: any(named: 'onEose'),
+          ),
+        ).called(2);
+      });
+
+      test(
+        'cancels anonymous relay subscription when listener cancels',
+        () async {
+          final filters = [
+            Filter(kinds: [EventKind.textNote], limit: 10),
+          ];
+
+          when(
+            () => mockNostr.subscribe(
+              any(),
+              any(),
+              id: any(named: 'id'),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              sendAfterAuth: any(named: 'sendAfterAuth'),
+              onEose: any(named: 'onEose'),
+            ),
+          ).thenAnswer(
+            (invocation) => invocation.namedArguments[#id] as String,
+          );
+          when(() => mockNostr.unsubscribe(any())).thenReturn(null);
+
+          final stream = client.subscribe(filters);
+          final subscription = stream.listen((_) {});
+
+          await subscription.cancel();
+
+          verify(() => mockNostr.unsubscribe(any())).called(1);
+          expect(client.activeSubscriptionCount, 0);
+        },
+      );
+
       test('uses custom subscription ID when provided', () {
         final filters = [
           Filter(kinds: [EventKind.textNote], limit: 10),

--- a/mobile/test/screens/discover_lists_screen_test.dart
+++ b/mobile/test/screens/discover_lists_screen_test.dart
@@ -233,7 +233,12 @@ void main() {
       addTearDown(tester.view.resetDevicePixelRatio);
 
       final l10n = lookupAppLocalizations(const Locale('en'));
-      final controller = StreamController<List<CuratedList>>();
+      var refreshStreamCanceled = false;
+      final controller = StreamController<List<CuratedList>>(
+        onCancel: () {
+          refreshStreamCanceled = true;
+        },
+      );
       addTearDown(controller.close);
 
       when(
@@ -258,6 +263,7 @@ void main() {
       expect(find.text('List list_0'), findsOneWidget);
       expect(find.text(l10n.discoverListsFailedToLoad), findsNothing);
       expect(find.text(l10n.discoverListsRelayTimeout), findsNothing);
+      expect(refreshStreamCanceled, isTrue);
     });
   });
 }

--- a/mobile/test/screens/discover_lists_screen_test.dart
+++ b/mobile/test/screens/discover_lists_screen_test.dart
@@ -202,6 +202,7 @@ void main() {
     testWidgets('initial load times out when relay stream never emits', (
       tester,
     ) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
       final controller = StreamController<List<CuratedList>>();
       addTearDown(controller.close);
 
@@ -219,8 +220,9 @@ void main() {
       await tester.pump();
 
       expect(find.byType(CircularProgressIndicator), findsNothing);
-      expect(find.text('Failed to load lists'), findsOneWidget);
-      expect(find.text('Retry'), findsOneWidget);
+      expect(find.text(l10n.discoverListsFailedToLoad), findsOneWidget);
+      expect(find.text(l10n.discoverListsRelayTimeout), findsOneWidget);
+      expect(find.text(l10n.commonRetry), findsOneWidget);
     });
   });
 }

--- a/mobile/test/screens/discover_lists_screen_test.dart
+++ b/mobile/test/screens/discover_lists_screen_test.dart
@@ -81,9 +81,11 @@ void main() {
       final lists = initialLists ?? preloadedLists;
       final oldest =
           oldestTimestamp ??
-          lists
-              .map((list) => list.createdAt)
-              .reduce((a, b) => a.isBefore(b) ? a : b);
+          (lists.isEmpty
+              ? null
+              : lists
+                    .map((list) => list.createdAt)
+                    .reduce((a, b) => a.isBefore(b) ? a : b));
 
       return ProviderScope(
         overrides: [
@@ -196,5 +198,29 @@ void main() {
         );
       },
     );
+
+    testWidgets('initial load times out when relay stream never emits', (
+      tester,
+    ) async {
+      final controller = StreamController<List<CuratedList>>();
+      addTearDown(controller.close);
+
+      when(
+        () => mockService.streamPublicListsFromRelays(),
+      ).thenAnswer((_) => controller.stream);
+
+      await tester.pumpWidget(buildSubject(initialLists: []));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      await tester.pump(const Duration(seconds: 9));
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.text('Failed to load lists'), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+    });
   });
 }

--- a/mobile/test/screens/discover_lists_screen_test.dart
+++ b/mobile/test/screens/discover_lists_screen_test.dart
@@ -224,5 +224,40 @@ void main() {
       expect(find.text(l10n.discoverListsRelayTimeout), findsOneWidget);
       expect(find.text(l10n.commonRetry), findsOneWidget);
     });
+    testWidgets('refresh that never emits keeps the lists already on screen', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(390, 844);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      final controller = StreamController<List<CuratedList>>();
+      addTearDown(controller.close);
+
+      when(
+        () => mockService.streamPublicListsFromRelays(),
+      ).thenAnswer((_) => controller.stream);
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('List list_0'), findsOneWidget);
+
+      // Pull to refresh against a relay that never answers.
+      await tester.fling(find.text('List list_0'), const Offset(0, 400), 1000);
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+      await tester.pump(const Duration(seconds: 9));
+      await tester.pump();
+
+      // The initial-load timeout must not fire here: replacing a populated
+      // screen with the error view would lose content the user was reading.
+      expect(find.text('List list_0'), findsOneWidget);
+      expect(find.text(l10n.discoverListsFailedToLoad), findsNothing);
+      expect(find.text(l10n.discoverListsRelayTimeout), findsNothing);
+    });
   });
 }

--- a/mobile/test/services/curated_list_service_query_test.dart
+++ b/mobile/test/services/curated_list_service_query_test.dart
@@ -1,6 +1,9 @@
 // ABOUTME: Unit tests for CuratedListService query operations
 // ABOUTME: Tests searching, filtering, and retrieving lists
 
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' hide LogCategory;
@@ -347,6 +350,44 @@ void main() {
         // Assert
         expect(lists, isEmpty);
       });
+
+      test(
+        'cancels relay subscription when containing-video query times out',
+        () {
+          fakeAsync((async) {
+            const targetVideoId = 'orphan_video_id_123456789abcdef';
+            var streamCanceled = false;
+            final controller = StreamController<Event>(
+              onCancel: () {
+                streamCanceled = true;
+              },
+            );
+
+            when(
+              () => mockNostr.subscribe(any()),
+            ).thenAnswer((_) => controller.stream);
+
+            List<CuratedList>? lists;
+            unawaited(
+              service.fetchPublicListsContainingVideo(targetVideoId).then((
+                result,
+              ) {
+                lists = result;
+              }),
+            );
+
+            async
+              ..flushMicrotasks()
+              ..elapse(const Duration(seconds: 11))
+              ..flushMicrotasks()
+              ..flushMicrotasks()
+              ..flushMicrotasks();
+
+            expect(lists, isEmpty);
+            expect(streamCanceled, isTrue);
+          });
+        },
+      );
 
       test('returns stream for progressive loading', () async {
         const targetVideoId = 'target_video_123456789abcdef';

--- a/mobile/test/unit/curated_list_relay_sync_test.dart
+++ b/mobile/test/unit/curated_list_relay_sync_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
@@ -65,6 +66,43 @@ void main() {
         expect(curatedListService.lists.length, 0);
       },
     );
+
+    test('cancels relay subscription when user-list sync times out', () {
+      fakeAsync((async) {
+        when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        when(() => mockAuthService.currentPublicKeyHex).thenReturn(
+          '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        );
+
+        var streamCanceled = false;
+        final streamController = StreamController<Event>(
+          onCancel: () {
+            streamCanceled = true;
+          },
+        );
+
+        when(
+          () => mockNostrService.subscribe(any()),
+        ).thenAnswer((_) => streamController.stream);
+
+        var completed = false;
+        unawaited(
+          curatedListService.fetchUserListsFromRelays().then((_) {
+            completed = true;
+          }),
+        );
+
+        async
+          ..flushMicrotasks()
+          ..elapse(const Duration(seconds: 11))
+          ..flushMicrotasks()
+          ..flushMicrotasks()
+          ..flushMicrotasks();
+
+        expect(completed, isTrue);
+        expect(streamCanceled, isTrue);
+      });
+    });
 
     // TODO(any): Fix and re-enable this test
     //test(


### PR DESCRIPTION
Closes #7098

## Summary
- create fresh anonymous Nostr subscriptions so repeated query-style screens do not attach to stale broadcast streams
- clean up relay subscriptions when the last listener cancels
- add a Discover Lists timeout/error path so no-event streams stop showing an indefinite loader

## Verification
- flutter test test/src/nostr_client_test.dart (from mobile/packages/nostr_client)
- flutter test test/screens/discover_lists_screen_test.dart (from mobile)
- flutter analyze lib/screens/discover_lists_screen.dart test/screens/discover_lists_screen_test.dart packages/nostr_client/lib/src/nostr_client.dart packages/nostr_client/test/src/nostr_client_test.dart
- flutter analyze lib test integration_test
- pre-push hook: analyzer + changed-file tests