### PR TITLE
fix(routing): route divine:///saved-videos and close the custom-scheme gate

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -92,6 +92,7 @@ import 'package:openvine/screens/hashtag_screen_router.dart';
 import 'package:openvine/screens/inbox/inbox_page.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
+import 'package:openvine/screens/saved_videos_screen.dart';
 import 'package:openvine/screens/search_results/view/search_results_page.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/screens/video_recorder_screen.dart';
@@ -2339,6 +2340,44 @@ class _DivineAppState extends ConsumerState<DivineApp>
               } else {
                 Log.warning(
                   '⚠️ Invite deep link missing code',
+                  name: 'DeepLinkHandler',
+                  category: LogCategory.ui,
+                );
+              }
+            case DeepLinkType.savedVideos:
+              const targetPath = SavedVideosScreen.path;
+              Log.info(
+                '📱 Navigating to saved videos: $targetPath',
+                name: 'DeepLinkHandler',
+                category: LogCategory.ui,
+              );
+              try {
+                final action = resolveDeepLinkNavAction(
+                  currentLocation: currentLocation,
+                  targetPath: targetPath,
+                  isRouteFamilyLocation: (location) => location == targetPath,
+                );
+                switch (action) {
+                  case DeepLinkNavAction.skip:
+                  case DeepLinkNavAction.go:
+                    // Already on Saved Videos — GoRouter's custom-scheme
+                    // redirect got there first. Nothing to do: this family is
+                    // a single path, so `go` cannot mean "replace a sibling"
+                    // the way it does for /profile/*.
+                    break;
+                  case DeepLinkNavAction.push:
+                    // Keep the current route underneath so back returns to
+                    // wherever the user was instead of wiping the stack.
+                    router.push(targetPath);
+                }
+                Log.info(
+                  '✅ Navigation completed to: $targetPath',
+                  name: 'DeepLinkHandler',
+                  category: LogCategory.ui,
+                );
+              } catch (e) {
+                Log.error(
+                  '❌ Saved videos navigation failed: $e',
                   name: 'DeepLinkHandler',
                   category: LogCategory.ui,
                 );

--- a/mobile/lib/router/app_router_redirect.dart
+++ b/mobile/lib/router/app_router_redirect.dart
@@ -21,25 +21,40 @@ void clearAuthenticatedAuthRouteRedirectSuppression() {
   _suppressNextAuthenticatedAuthRouteRedirect = false;
 }
 
+/// Where a `divine://` location that is **not** an allow-listed app route has
+/// to go. Returns null for every other scheme.
+///
+/// This must never return null for a `divine://` URI. GoRouter matches a
+/// location by `uri.path` alone — scheme and host are never consulted — so
+/// falling through here does not mean "nothing happens", it means every one of
+/// the app's registered routes becomes openable by any app on the device.
+/// `divine:///developer-options` reaching the relay environment switcher is the
+/// worked example (#7074). [customSchemeToRouterPath] runs first and takes the
+/// allow-listed routes; everything left over lands here.
 @visibleForTesting
-String? signerCallbackRedirectTarget(Uri uri, AuthService authService) {
-  final deepLink = DeepLinkService.parseDeepLink(uri.toString());
-  if (deepLink.type != DeepLinkType.signerCallback) {
+String? divineSchemeRedirectTarget(Uri uri, AuthService authService) {
+  if (uri.scheme != 'divine') {
     return null;
   }
 
-  // The app-links stream handles this too, but GoRouter may see Android
-  // custom-scheme callbacks first. Keep this idempotent: it only preserves
-  // an already-listening NIP-46 session while routing back to its screen.
-  authService.onSignerCallbackReceived(relayUrl: deepLink.signerCallbackRelay);
-  if (authService.nostrConnectUrl != null) {
-    return NostrConnectScreen.path;
+  final deepLink = DeepLinkService.parseDeepLink(uri.toString());
+  if (deepLink.type == DeepLinkType.signerCallback) {
+    // The app-links stream handles this too, but GoRouter may see Android
+    // custom-scheme callbacks first. Keep this idempotent: it only preserves
+    // an already-listening NIP-46 session while routing back to its screen.
+    authService.onSignerCallbackReceived(
+      relayUrl: deepLink.signerCallbackRelay,
+    );
+    if (authService.nostrConnectUrl != null) {
+      return NostrConnectScreen.path;
+    }
   }
 
-  // No pairing is in flight, so this is a stray callback — a stale signer
-  // return, an expired session, or another app probing the scheme. Send a
-  // signed-in user home rather than to /welcome: go_router runs the top-level
-  // redirect at most once per navigation, so returning /welcome here is
+  // Either a stray callback (stale signer return, expired session, another app
+  // probing the scheme) or a URI naming a route that is not allow-listed.
+  //
+  // Send a signed-in user home rather than to /welcome: go_router runs the
+  // top-level redirect at most once per navigation, so this return value is
   // terminal and [appRouterRedirect]'s authenticated-auth-route bounce never
   // gets a second pass. The user would be left on the account picker, which
   // reads as a lost session.
@@ -180,7 +195,7 @@ bool minorAccountReviewStatusAffectsRouting(
       _minorReviewRoutingSignature(next);
 }
 
-/// Top-level GoRouter redirect: signer-callback → universal-link rewrite →
+/// Top-level GoRouter redirect: divine:// scheme → universal-link rewrite →
 /// minor-account-review gating → auth-route gating → unauthenticated gating.
 ///
 /// The order of these checks is load-bearing; reordering risks the
@@ -188,27 +203,14 @@ bool minorAccountReviewStatusAffectsRouting(
 /// un-rewritten universal-link URL into the matcher (Page Not Found).
 String? appRouterRedirect(Ref ref, GoRouterState state) {
   final authService = ref.read(authServiceProvider);
-  final signerCallbackRedirect = signerCallbackRedirectTarget(
-    state.uri,
-    authService,
-  );
-  if (signerCallbackRedirect != null) {
-    Log.info(
-      'Router redirect: signer callback '
-      '${redactUriStringForLogs(state.uri.toString())} -> '
-      '$signerCallbackRedirect',
-      name: 'AppRouter',
-      category: LogCategory.auth,
-    );
-    return signerCallbackRedirect;
-  }
 
   // Rewrite allow-listed divine:// app routes to their internal path. Doing
   // it here rather than leaving it to the matcher keeps the reported location
   // clean (/saved-videos, not divine:///saved-videos) for analytics, route
-  // normalization, and the listener's currentLocation comparison — GoRouter
-  // matches on uri.path alone and would otherwise land there under the raw
-  // custom-scheme location.
+  // normalization, and the listener's currentLocation comparison.
+  //
+  // This must stay ahead of divineSchemeRedirectTarget, which deliberately
+  // claims every remaining divine:// location.
   final customSchemeRedirect = customSchemeToRouterPath(state.uri);
   if (customSchemeRedirect != null) {
     Log.info(
@@ -219,6 +221,21 @@ String? appRouterRedirect(Ref ref, GoRouterState state) {
       category: LogCategory.ui,
     );
     return customSchemeRedirect;
+  }
+
+  final divineSchemeRedirect = divineSchemeRedirectTarget(
+    state.uri,
+    authService,
+  );
+  if (divineSchemeRedirect != null) {
+    Log.info(
+      'Router redirect: divine scheme '
+      '${redactUriStringForLogs(state.uri.toString())} -> '
+      '$divineSchemeRedirect',
+      name: 'AppRouter',
+      category: LogCategory.auth,
+    );
+    return divineSchemeRedirect;
   }
 
   // Rewrite divine.video universal-link URLs to internal paths before the

--- a/mobile/lib/router/app_router_redirect.dart
+++ b/mobile/lib/router/app_router_redirect.dart
@@ -21,20 +21,44 @@ void clearAuthenticatedAuthRouteRedirectSuppression() {
   _suppressNextAuthenticatedAuthRouteRedirect = false;
 }
 
-/// Where a `divine://` location that is **not** an allow-listed app route has
-/// to go. Returns null for every other scheme.
+/// Where a `divine://` location resolves, and whether [appRouterRedirect]'s
+/// gates still apply to it.
+///
+/// `gated: false` is reserved for the live NIP-46 pairing return.
+/// `/nostr-connect` is an auth route, so running it through the
+/// authenticated-auth-route bounce would pull a signed-in user straight out of
+/// the pairing they just approved. Every other outcome is an ordinary
+/// destination and must be gated like any other location.
+typedef DivineSchemeTarget = ({String path, bool gated});
+
+/// Where a `divine://` location has to go. Returns null for every other scheme.
 ///
 /// This must never return null for a `divine://` URI. GoRouter matches a
 /// location by `uri.path` alone — scheme and host are never consulted — so
 /// falling through here does not mean "nothing happens", it means every one of
 /// the app's registered routes becomes openable by any app on the device.
 /// `divine:///developer-options` reaching the relay environment switcher is the
-/// worked example (#7074). [customSchemeToRouterPath] runs first and takes the
-/// allow-listed routes; everything left over lands here.
+/// worked example (#7074).
+///
+/// Resolving to a path is not the same as being allowed to reach it: the
+/// returned [DivineSchemeTarget.path] is a *destination*, which
+/// [appRouterRedirect] then runs through the auth and minor-account-review
+/// gates unless [DivineSchemeTarget.gated] is false.
 @visibleForTesting
-String? divineSchemeRedirectTarget(Uri uri, AuthService authService) {
+DivineSchemeTarget? divineSchemeRedirectTarget(
+  Uri uri,
+  AuthService authService,
+) {
   if (uri.scheme != 'divine') {
     return null;
+  }
+
+  // Allow-listed app routes first, so the reported location stays clean
+  // (/saved-videos, not divine:///saved-videos) for analytics, route
+  // normalization, and the deep-link listener's currentLocation comparison.
+  final appRoute = customSchemeToRouterPath(uri);
+  if (appRoute != null) {
+    return (path: appRoute, gated: true);
   }
 
   final deepLink = DeepLinkService.parseDeepLink(uri.toString());
@@ -46,21 +70,22 @@ String? divineSchemeRedirectTarget(Uri uri, AuthService authService) {
       relayUrl: deepLink.signerCallbackRelay,
     );
     if (authService.nostrConnectUrl != null) {
-      return NostrConnectScreen.path;
+      return (path: NostrConnectScreen.path, gated: false);
     }
   }
 
   // Either a stray callback (stale signer return, expired session, another app
   // probing the scheme) or a URI naming a route that is not allow-listed.
   //
-  // Send a signed-in user home rather than to /welcome: go_router runs the
-  // top-level redirect at most once per navigation, so this return value is
-  // terminal and [appRouterRedirect]'s authenticated-auth-route bounce never
-  // gets a second pass. The user would be left on the account picker, which
-  // reads as a lost session.
-  return authService.authState == AuthState.authenticated
-      ? VideoFeedPage.pathForIndex(0)
-      : WelcomeScreen.path;
+  // Send a signed-in user home rather than to /welcome, which would leave them
+  // on the account picker and read as a lost session. This is a destination
+  // like any other, so the gates below still get to move them off it.
+  return (
+    path: authService.authState == AuthState.authenticated
+        ? VideoFeedPage.pathForIndex(0)
+        : WelcomeScreen.path,
+    gated: true,
+  );
 }
 
 /// Reset navigation state for testing purposes
@@ -201,42 +226,43 @@ bool minorAccountReviewStatusAffectsRouting(
 /// The order of these checks is load-bearing; reordering risks the
 /// loading-screen ↔ review-screen loop (issue #5195) or feeding an
 /// un-rewritten universal-link URL into the matcher (Page Not Found).
+///
+/// The divine:// step resolves a destination and then *keeps going*, so the
+/// gating below still applies to it. go_router calls this at most once per
+/// navigation, so returning a destination early would put the caller past
+/// every gate — see [divineSchemeRedirectTarget].
 String? appRouterRedirect(Ref ref, GoRouterState state) {
   final authService = ref.read(authServiceProvider);
 
-  // Rewrite allow-listed divine:// app routes to their internal path. Doing
-  // it here rather than leaving it to the matcher keeps the reported location
-  // clean (/saved-videos, not divine:///saved-videos) for analytics, route
-  // normalization, and the listener's currentLocation comparison.
+  // Resolve a divine:// location to the internal path it addresses — but do
+  // not return it here.
   //
-  // This must stay ahead of divineSchemeRedirectTarget, which deliberately
-  // claims every remaining divine:// location.
-  final customSchemeRedirect = customSchemeToRouterPath(state.uri);
-  if (customSchemeRedirect != null) {
-    Log.info(
-      'Router redirect: custom scheme '
-      '${redactUriStringForLogs(state.uri.toString())} -> '
-      '$customSchemeRedirect',
-      name: 'AppRouter',
-      category: LogCategory.ui,
-    );
-    return customSchemeRedirect;
-  }
-
-  final divineSchemeRedirect = divineSchemeRedirectTarget(
-    state.uri,
-    authService,
-  );
-  if (divineSchemeRedirect != null) {
+  // go_router runs this top-level redirect at most once per navigation and
+  // does not re-evaluate what it redirects to
+  // (`RouteConfiguration.applyTopLegacyRedirect`). Returning a destination
+  // from this point is therefore terminal, and terminal means every gate
+  // below is skipped: a restricted-minor account reached the feed by opening
+  // any divine:// URI, and a signed-out user reached /saved-videos and
+  // /video/:id. Carry the destination down to the gates instead and let them
+  // have the last word.
+  final divineScheme = divineSchemeRedirectTarget(state.uri, authService);
+  if (divineScheme != null) {
     Log.info(
       'Router redirect: divine scheme '
       '${redactUriStringForLogs(state.uri.toString())} -> '
-      '$divineSchemeRedirect',
+      '${divineScheme.path}${divineScheme.gated ? '' : ' (ungated)'}',
       name: 'AppRouter',
       category: LogCategory.auth,
     );
-    return divineSchemeRedirect;
+    if (!divineScheme.gated) {
+      return divineScheme.path;
+    }
   }
+
+  // Non-null only for a divine:// URI whose destination still has to clear the
+  // gates. Every `return deepLinkRewrite` below is a plain `return null` for
+  // ordinary in-app navigation, so nothing changes off the deep-link path.
+  final deepLinkRewrite = divineScheme?.path;
 
   // Rewrite divine.video universal-link URLs to internal paths before the
   // auth/match logic runs. Android delivers the full intent URL (scheme +
@@ -254,7 +280,7 @@ String? appRouterRedirect(Ref ref, GoRouterState state) {
     return universalRedirect;
   }
 
-  final location = state.matchedLocation;
+  final location = deepLinkRewrite ?? state.matchedLocation;
   final authState = authService.authState;
 
   // Screenshot capture runs drive each screen via an imperative
@@ -268,7 +294,7 @@ String? appRouterRedirect(Ref ref, GoRouterState state) {
   if (ScreenshotMode.enabled &&
       authState == AuthState.authenticated &&
       ScreenshotMode.initialRoute != null) {
-    return null;
+    return deepLinkRewrite;
   }
 
   final reviewStatusAsync = ref.read(currentMinorAccountReviewStatusProvider);
@@ -318,9 +344,14 @@ String? appRouterRedirect(Ref ref, GoRouterState state) {
       reviewStatusAsync.isLoading &&
       !reviewStatusAsync.hasValue) {
     if (!isReviewLoadingRoute) {
-      return _minorAccountReviewLoadingPath(state.uri.toString());
+      // Hand the loading screen the rewritten path, not the raw divine:// URI:
+      // it round-trips through `from` and re-entering the scheme handling on
+      // the way back would resolve it a second time.
+      return _minorAccountReviewLoadingPath(
+        deepLinkRewrite ?? state.uri.toString(),
+      );
     }
-    return null;
+    return deepLinkRewrite;
   }
 
   if (authState == AuthState.authenticated && isReviewLoadingRoute) {
@@ -387,7 +418,7 @@ String? appRouterRedirect(Ref ref, GoRouterState state) {
     // so they can re-authenticate instead of being bounced home
     if (authService.hasExpiredOAuthSession &&
         location == WelcomeScreen.loginOptionsPath) {
-      return null;
+      return deepLinkRewrite;
     }
     if (_suppressNextAuthenticatedAuthRouteRedirect) {
       _suppressNextAuthenticatedAuthRouteRedirect = false;
@@ -397,7 +428,7 @@ String? appRouterRedirect(Ref ref, GoRouterState state) {
         name: 'AppRouter',
         category: LogCategory.auth,
       );
-      return null;
+      return deepLinkRewrite;
     }
     // On first navigation, redirect to explore if user has no following
     if (!_hasNavigated) {
@@ -435,5 +466,5 @@ String? appRouterRedirect(Ref ref, GoRouterState state) {
     return WelcomeScreen.path;
   }
 
-  return null;
+  return deepLinkRewrite;
 }

--- a/mobile/lib/router/app_router_redirect.dart
+++ b/mobile/lib/router/app_router_redirect.dart
@@ -192,6 +192,24 @@ String? appRouterRedirect(Ref ref, GoRouterState state) {
     return signerCallbackRedirect;
   }
 
+  // Rewrite allow-listed divine:// app routes to their internal path. Doing
+  // it here rather than leaving it to the matcher keeps the reported location
+  // clean (/saved-videos, not divine:///saved-videos) for analytics, route
+  // normalization, and the listener's currentLocation comparison — GoRouter
+  // matches on uri.path alone and would otherwise land there under the raw
+  // custom-scheme location.
+  final customSchemeRedirect = customSchemeToRouterPath(state.uri);
+  if (customSchemeRedirect != null) {
+    Log.info(
+      'Router redirect: custom scheme '
+      '${redactUriStringForLogs(state.uri.toString())} -> '
+      '$customSchemeRedirect',
+      name: 'AppRouter',
+      category: LogCategory.ui,
+    );
+    return customSchemeRedirect;
+  }
+
   // Rewrite divine.video universal-link URLs to internal paths before the
   // auth/match logic runs. Android delivers the full intent URL (scheme +
   // host + path) to GoRouter, which only matches on path. Without this

--- a/mobile/lib/router/app_router_redirect.dart
+++ b/mobile/lib/router/app_router_redirect.dart
@@ -32,8 +32,19 @@ String? signerCallbackRedirectTarget(Uri uri, AuthService authService) {
   // custom-scheme callbacks first. Keep this idempotent: it only preserves
   // an already-listening NIP-46 session while routing back to its screen.
   authService.onSignerCallbackReceived(relayUrl: deepLink.signerCallbackRelay);
-  return authService.nostrConnectUrl != null
-      ? NostrConnectScreen.path
+  if (authService.nostrConnectUrl != null) {
+    return NostrConnectScreen.path;
+  }
+
+  // No pairing is in flight, so this is a stray callback — a stale signer
+  // return, an expired session, or another app probing the scheme. Send a
+  // signed-in user home rather than to /welcome: go_router runs the top-level
+  // redirect at most once per navigation, so returning /welcome here is
+  // terminal and [appRouterRedirect]'s authenticated-auth-route bounce never
+  // gets a second pass. The user would be left on the account picker, which
+  // reads as a lost session.
+  return authService.authState == AuthState.authenticated
+      ? VideoFeedPage.pathForIndex(0)
       : WelcomeScreen.path;
 }
 

--- a/mobile/lib/router/universal_link_resolver.dart
+++ b/mobile/lib/router/universal_link_resolver.dart
@@ -76,20 +76,58 @@ String? customSchemeToRouterPath(Uri uri) {
   if (uri.scheme != 'divine') return null;
 
   final deepLink = DeepLinkService.parseDeepLink(uri.toString());
-  switch (deepLink.type) {
-    case DeepLinkType.savedVideos:
-      return SavedVideosScreen.path;
-    case DeepLinkType.video:
-    case DeepLinkType.profile:
-    case DeepLinkType.hashtag:
-    case DeepLinkType.search:
-    case DeepLinkType.list:
-    case DeepLinkType.invite:
-    case DeepLinkType.signerCallback:
-    case DeepLinkType.unknown:
-      return null;
+  if (deepLink.type == DeepLinkType.savedVideos) {
+    return SavedVideosScreen.path;
   }
+
+  // Only the authority-less form addresses app routes. Anything else is a
+  // signer callback or untrusted input, and belongs to
+  // divineSchemeRedirectTarget.
+  if (uri.host.isNotEmpty) return null;
+
+  final segments = uri.pathSegments
+      .where((segment) => segment.isNotEmpty)
+      .toList();
+  // Every allow-listed prefix is a `/prefix/value` shape, so a bare prefix
+  // names no destination and must not fall through to the matcher.
+  if (segments.length < 2 ||
+      !_customSchemeRoutablePrefixes.contains(segments.first)) {
+    return null;
+  }
+
+  // Resolve through the https table so the two schemes cannot drift. It
+  // covers both the paths DeepLinkService models (/search/* becomes
+  // /search-results/:query) and deeper ones it does not (/video/:id/likers),
+  // which fall through to the path verbatim.
+  final canonical = Uri(
+    scheme: 'https',
+    host: 'divine.video',
+    pathSegments: segments,
+    queryParameters: uri.queryParameters.isEmpty ? null : uri.queryParameters,
+  );
+  final mapped = _pushRouteForDeepLink(
+    DeepLinkService.parseDeepLink(canonical.toString()),
+  );
+  if (mapped != null) return mapped;
+  return canonical.hasQuery
+      ? '${canonical.path}?${canonical.query}'
+      : canonical.path;
 }
+
+/// Path prefixes the `divine://` scheme may address beyond `saved-videos`.
+///
+/// Mirrors the universal-link claims in the served apple-app-site-association
+/// files, so the custom scheme reaches exactly what a web page can already
+/// reach over https — and nothing more. `invite` is deliberately absent: it
+/// has no GoRoute to land on and is handled by the [DeepLinkService] stream
+/// listener for https links only.
+const _customSchemeRoutablePrefixes = <String>{
+  'video',
+  'profile',
+  'hashtag',
+  'search',
+  'list',
+};
 
 /// Converts a universal-link [uri] into an internal GoRouter path.
 ///

--- a/mobile/lib/router/universal_link_resolver.dart
+++ b/mobile/lib/router/universal_link_resolver.dart
@@ -70,8 +70,8 @@ String? _pushRouteForDeepLink(DeepLink deepLink) {
 /// Converts a `divine://` custom-scheme app-route link into an internal path.
 ///
 /// Returns null for everything else, including NIP-46 signer callbacks. A
-/// custom scheme can be opened by any app on the device, so only the routes
-/// [DeepLinkService.parseDeepLink] allow-lists resolve to a location here.
+/// custom scheme can be opened by any app on the device, so only saved videos
+/// and the AASA-parity route prefixes resolve to a location here.
 String? customSchemeToRouterPath(Uri uri) {
   if (uri.scheme != 'divine') return null;
 

--- a/mobile/lib/router/universal_link_resolver.dart
+++ b/mobile/lib/router/universal_link_resolver.dart
@@ -1,10 +1,11 @@
-// ABOUTME: Pure resolver from universal-link URIs to internal GoRouter paths
+// ABOUTME: Pure resolvers from universal-link and divine:// URIs to GoRouter paths
 // ABOUTME: Shared source of truth used by the router redirect and tests
 
 import 'package:openvine/screens/curated_list_by_author_screen.dart';
 import 'package:openvine/screens/curated_list_feed_screen.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
+import 'package:openvine/screens/saved_videos_screen.dart';
 import 'package:openvine/screens/search_results/view/search_results_page.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/services/deep_link_service.dart';
@@ -56,6 +57,33 @@ String? _pushRouteForDeepLink(DeepLink deepLink) {
         pubkey: listPubkey,
         listId: listId,
       );
+    // savedVideos is unreachable here — it only arrives over divine://, which
+    // both callers reject before this point. customSchemeToRouterPath owns it.
+    case DeepLinkType.savedVideos:
+    case DeepLinkType.invite:
+    case DeepLinkType.signerCallback:
+    case DeepLinkType.unknown:
+      return null;
+  }
+}
+
+/// Converts a `divine://` custom-scheme app-route link into an internal path.
+///
+/// Returns null for everything else, including NIP-46 signer callbacks. A
+/// custom scheme can be opened by any app on the device, so only the routes
+/// [DeepLinkService.parseDeepLink] allow-lists resolve to a location here.
+String? customSchemeToRouterPath(Uri uri) {
+  if (uri.scheme != 'divine') return null;
+
+  final deepLink = DeepLinkService.parseDeepLink(uri.toString());
+  switch (deepLink.type) {
+    case DeepLinkType.savedVideos:
+      return SavedVideosScreen.path;
+    case DeepLinkType.video:
+    case DeepLinkType.profile:
+    case DeepLinkType.hashtag:
+    case DeepLinkType.search:
+    case DeepLinkType.list:
     case DeepLinkType.invite:
     case DeepLinkType.signerCallback:
     case DeepLinkType.unknown:
@@ -89,6 +117,7 @@ String? universalLinkToRouterPath(Uri uri) {
   final route = _pushRouteForDeepLink(deepLink);
   switch (deepLink.type) {
     case DeepLinkType.video:
+    case DeepLinkType.savedVideos:
     case DeepLinkType.invite:
     case DeepLinkType.signerCallback:
     case DeepLinkType.unknown:

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -12,13 +12,13 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/fullscreen_feed/fullscreen_feed_bloc.dart';
 import 'package:openvine/blocs/inline_comment_composer/inline_comment_composer_cubit.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_state.dart';
 import 'package:openvine/constants/semantic_ids.dart';
+import 'package:openvine/extensions/safe_pop_extension.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/l10n.dart';
@@ -461,11 +461,9 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
       onBack();
       return;
     }
-    if (context.canPop()) {
-      context.pop();
-      return;
-    }
-    context.go('/');
+    // safePop: a /video/:id deep link renders this screen with a one-entry
+    // stack and no onBack, and the old `go('/')` fallback matched no route.
+    context.safePop();
   }
 
   void _resumeAutoAdvanceAfterSwipe() => _autoAdvanceCubit.resumeAfterSwipe();
@@ -706,8 +704,7 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                     showBackButton: true,
                     // The BlocListener above already tried `maybePop` and
                     // failed (otherwise we wouldn't be rendering this
-                    // branch). Keep the same root-route fallback here so
-                    // cold-start deep links never strand the user.
+                    // branch), so this back button is the only way out.
                     onBackPressed: () => _handleBack(context),
                     backgroundMode: DiVineAppBarBackgroundMode.transparent,
                     forceMaterialTransparency: true,

--- a/mobile/lib/screens/profile_screen_router.dart
+++ b/mobile/lib/screens/profile_screen_router.dart
@@ -13,6 +13,7 @@ import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
 import 'package:openvine/blocs/profile_feed/profile_feed_cubit.dart';
 import 'package:openvine/blocs/profile_feed/profile_feed_scope.dart';
+import 'package:openvine/extensions/safe_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
@@ -342,7 +343,9 @@ class _ProfileContentView extends ConsumerWidget {
     final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
     if (blocklistRepository.hasMutedUs(userIdHex) ||
         blocklistRepository.hasBlockedUs(userIdHex)) {
-      return BlockedUserScreen(onBack: context.pop, userIdHex: userIdHex);
+      // safePop: a deep link to a profile whose owner blocked or muted the
+      // viewer lands here with a one-entry stack, where a raw pop throws.
+      return BlockedUserScreen(onBack: context.safePop, userIdHex: userIdHex);
     }
 
     // Fetch profile data if needed (post-frame to avoid build mutations)

--- a/mobile/lib/screens/saved_videos_screen.dart
+++ b/mobile/lib/screens/saved_videos_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/profile_saved_videos/profile_saved_videos_bloc.dart';
+import 'package:openvine/extensions/safe_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -34,13 +35,7 @@ class SavedVideosScreen extends ConsumerWidget {
 
     return Scaffold(
       backgroundColor: context.vineColors.surfaceContainerHigh,
-      appBar: AppBar(
-        backgroundColor: context.vineColors.surfaceContainerHigh,
-        title: Text(
-          context.l10n.shareMenuBookmarks,
-          style: VineTheme.titleMediumFont(color: context.vineColors.onNav),
-        ),
-      ),
+      appBar: const SavedVideosAppBar(),
       body: BlocProvider<ProfileSavedVideosBloc>(
         // Re-created when either captured dependency changes identity, so an
         // account switch cannot leave the grid reading the previous viewer's
@@ -54,6 +49,40 @@ class SavedVideosScreen extends ConsumerWidget {
           deletedVideoFilter: videosRepository.isVideoKnownDeleted,
         )..add(const ProfileSavedVideosSyncRequested()),
         child: SavedVideosView(userIdHex: currentUserPubkey),
+      ),
+    );
+  }
+}
+
+/// The screen's app bar, split out so its back affordance can be driven in
+/// tests without the screen's bookmark and video dependencies.
+@visibleForTesting
+class SavedVideosAppBar extends StatelessWidget implements PreferredSizeWidget {
+  @visibleForTesting
+  const SavedVideosAppBar({super.key});
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      backgroundColor: context.vineColors.surfaceContainerHigh,
+      // Explicit rather than automaticallyImplyLeading: a divine:// deep link
+      // lands here with a one-entry stack, and the screen sits outside the
+      // shell, so Material would render no back button and there is no bottom
+      // nav either — a dead end. safePop falls back to the feed.
+      leading: DivineIconButton(
+        icon: DivineIconName.caretLeft,
+        type: DivineIconButtonType.ghostSecondary,
+        size: DivineIconButtonSize.small,
+        showShadow: false,
+        semanticLabel: context.l10n.commonBack,
+        onPressed: context.safePop,
+      ),
+      title: Text(
+        context.l10n.shareMenuBookmarks,
+        style: VineTheme.titleMediumFont(color: context.vineColors.onNav),
       ),
     );
   }

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -9,10 +9,10 @@ import 'package:feed_repository/feed_repository.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:nostr_client/nostr_client.dart' show NostrClient;
 import 'package:openvine/constants/semantic_ids.dart';
+import 'package:openvine/extensions/safe_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -331,11 +331,10 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
     _relayReadySubscription = null;
     _retryScheduled = false;
 
-    if (context.canPop()) {
-      context.pop();
-      return;
-    }
-    context.go('/');
+    // safePop, not a hand-rolled canPop/go pair: `/video/:id` is a flat
+    // top-level route, so a deep link lands here with a one-entry stack and
+    // the fallback is the branch that actually runs.
+    context.safePop();
   }
 }
 

--- a/mobile/lib/services/deep_link_service.dart
+++ b/mobile/lib/services/deep_link_service.dart
@@ -165,6 +165,18 @@ class DeepLinkService {
         if (uri.host.isEmpty) {
           return _parseCustomSchemeAppRoute(uri);
         }
+        if (uri.host != _signerCallbackHost) {
+          // Any app can open a custom scheme, so an authority we never mint
+          // is untrusted input rather than a callback — classifying it as one
+          // would hand a stranger the signer-callback side effects (#6733).
+          Log.warning(
+            'Ignoring divine:// URL with an unrecognised authority: '
+            '${_describeUriForLogs(uri)}',
+            name: 'DeepLinkService',
+            category: LogCategory.ui,
+          );
+          return const DeepLink(type: DeepLinkType.unknown);
+        }
         // Signer apps open this scheme to bring our app back to foreground
         // after the user approves the connection. We emit signerCallback so
         // listeners can trigger relay reconnection for the nostrconnect
@@ -373,6 +385,11 @@ class DeepLinkService {
   void pushLink(DeepLink link) {
     _controller.add(link);
   }
+
+  /// The only authority Divine mints on its NIP-46 callback.
+  ///
+  /// See `NostrConnectCoordinator`, which embeds `divine://nostrconnect`.
+  static const _signerCallbackHost = 'nostrconnect';
 
   /// Routes the authority-less `divine:///<route>` form may open.
   ///

--- a/mobile/lib/services/deep_link_service.dart
+++ b/mobile/lib/services/deep_link_service.dart
@@ -406,8 +406,12 @@ class DeepLinkService {
         : null;
 
     if (type == null) {
-      Log.warning(
-        'Ignoring unroutable divine:// app route: ${_describeUriForLogs(uri)}',
+      // Not a warning, and not necessarily the end of the road: the router's
+      // allow-list resolves the universal-link claim paths that carry no
+      // DeepLinkType of their own. `AppRouter` logs the outcome either way.
+      Log.debug(
+        'No DeepLinkType for divine:// route, deferring to the router '
+        'allow-list: ${_describeUriForLogs(uri)}',
         name: 'DeepLinkService',
         category: LogCategory.ui,
       );

--- a/mobile/lib/services/deep_link_service.dart
+++ b/mobile/lib/services/deep_link_service.dart
@@ -16,6 +16,7 @@ enum DeepLinkType {
   search,
   invite,
   list,
+  savedVideos,
   signerCallback,
   unknown,
 }
@@ -79,6 +80,8 @@ class DeepLink {
       case DeepLinkType.list:
         return 'DeepLink(type: list, listPubkey: $listPubkey, '
             'listId: $listId)';
+      case DeepLinkType.savedVideos:
+        return 'DeepLink(type: savedVideos)';
       case DeepLinkType.signerCallback:
         return 'DeepLink(type: signerCallback)';
       case DeepLinkType.unknown:
@@ -154,11 +157,18 @@ class DeepLinkService {
     try {
       final uri = Uri.parse(url);
 
-      // Handle divine:// callback from NIP-46 signer apps.
-      // The signer opens this scheme to bring our app back to foreground
-      // after the user approves the connection. We emit signerCallback so
-      // listeners can trigger relay reconnection for the nostrconnect session.
+      // The divine:// scheme splits on the authority. Every callback anyone
+      // emits carries one — Divine mints `divine://nostrconnect`, and NIP-46
+      // gives signers no say over the callback string beyond appending query
+      // parameters — so the empty authority is free to address app routes.
       if (uri.scheme == 'divine') {
+        if (uri.host.isEmpty) {
+          return _parseCustomSchemeAppRoute(uri);
+        }
+        // Signer apps open this scheme to bring our app back to foreground
+        // after the user approves the connection. We emit signerCallback so
+        // listeners can trigger relay reconnection for the nostrconnect
+        // session.
         Log.info(
           'Received NIP-46 signer callback: ${redactUriStringForLogs(url)}',
           name: 'DeepLinkService',
@@ -362,6 +372,37 @@ class DeepLinkService {
   /// the widget tree can handle it uniformly.
   void pushLink(DeepLink link) {
     _controller.add(link);
+  }
+
+  /// Routes the authority-less `divine:///<route>` form may open.
+  ///
+  /// Deny-by-default: any app on the device can open a custom scheme, so a
+  /// route is only reachable this way by being listed here.
+  static const _customSchemeAppRoutes = <String, DeepLinkType>{
+    'saved-videos': DeepLinkType.savedVideos,
+  };
+
+  static DeepLink _parseCustomSchemeAppRoute(Uri uri) {
+    final segments = uri.pathSegments;
+    final type = segments.length == 1
+        ? _customSchemeAppRoutes[segments.single]
+        : null;
+
+    if (type == null) {
+      Log.warning(
+        'Ignoring unroutable divine:// app route: ${_describeUriForLogs(uri)}',
+        name: 'DeepLinkService',
+        category: LogCategory.ui,
+      );
+      return const DeepLink(type: DeepLinkType.unknown);
+    }
+
+    Log.info(
+      '📱 Parsed app-route deep link: /${segments.single}',
+      name: 'DeepLinkService',
+      category: LogCategory.ui,
+    );
+    return DeepLink(type: type);
   }
 
   static bool _isInternalAppRoute(Uri uri, String rawUrl) {

--- a/mobile/test/main_deep_link_nav_action_test.dart
+++ b/mobile/test/main_deep_link_nav_action_test.dart
@@ -7,6 +7,7 @@ import 'package:openvine/screens/curated_list_by_author_screen.dart';
 import 'package:openvine/screens/curated_list_feed_screen.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
+import 'package:openvine/screens/saved_videos_screen.dart';
 import 'package:openvine/screens/search_results/view/search_results_page.dart';
 
 void main() {
@@ -129,6 +130,27 @@ void main() {
       );
 
       expect(action, equals(app.DeepLinkNavAction.push));
+    });
+
+    test('pushes saved videos so back returns to where the user was', () {
+      final action = app.resolveDeepLinkNavAction(
+        currentLocation: '/home/0',
+        targetPath: SavedVideosScreen.path,
+        isRouteFamilyLocation: (location) => location == SavedVideosScreen.path,
+      );
+
+      expect(action, equals(app.DeepLinkNavAction.push));
+    });
+
+    test('skips saved videos when the router redirect already landed '
+        'there', () {
+      final action = app.resolveDeepLinkNavAction(
+        currentLocation: SavedVideosScreen.path,
+        targetPath: SavedVideosScreen.path,
+        isRouteFamilyLocation: (location) => location == SavedVideosScreen.path,
+      );
+
+      expect(action, equals(app.DeepLinkNavAction.skip));
     });
   });
 }

--- a/mobile/test/router/aasa_claim_coverage_test.dart
+++ b/mobile/test/router/aasa_claim_coverage_test.dart
@@ -5,6 +5,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/router/universal_link_resolver.dart';
 import 'package:openvine/services/deep_link_service.dart';
 
 const _divineAppId = 'GZCZBKH7MY.co.openvine.app';
@@ -60,7 +61,72 @@ const _allowlistedClaims = <String, String>{
       'Auth link path matches an internal GoRoute redirect directly; no DeepLinkType is emitted.',
 };
 
+// divine.video AASA claims the `divine://` scheme deliberately does NOT
+// mirror. Every other claim must resolve from both schemes so the two
+// contracts cannot drift (#6733).
+const _customSchemeExclusions = <String, String>{
+  '/app/callback':
+      'Keycast OAuth redirect consumed by the OAuth client, not routing.',
+  '/invite/*':
+      'No GoRoute to land on; invites are handled by the DeepLinkService '
+      'listener for https links only.',
+};
+
 void main() {
+  // GoRouter matches a custom-scheme location on uri.path alone, so this
+  // allow-list is what holds divine:// at parity with the https claim set
+  // instead of exposing every registered route (#6733).
+  group('divine:// custom scheme parity', () {
+    test('resolves every divine.video claim except documented exclusions', () {
+      for (final pattern in _claimPatternsForHost('divine.video')) {
+        final exclusionReason = _customSchemeExclusions[pattern];
+
+        for (final path in _representativePathsFor(pattern)) {
+          final target = customSchemeToRouterPath(Uri.parse('divine://$path'));
+
+          if (exclusionReason != null) {
+            expect(
+              target,
+              isNull,
+              reason:
+                  'divine://$path is excluded from custom-scheme routing '
+                  '($exclusionReason) and must not resolve.',
+            );
+          } else {
+            expect(
+              target,
+              isNotNull,
+              reason:
+                  'divine.video claims $pattern over https but divine://$path '
+                  'does not resolve. Add the prefix to the allow-list in '
+                  'universal_link_resolver.dart or document an exclusion.',
+            );
+          }
+        }
+      }
+    });
+
+    test('does not resolve routes the https contract never exposed', () {
+      for (final path in const <String>[
+        '/developer-options',
+        '/key-management',
+        '/import-key',
+        '/secure-account',
+        '/inbox',
+        '/inbox/message-requests',
+        '/settings',
+        '/relay-settings',
+        '/safety-settings',
+      ]) {
+        expect(
+          customSchemeToRouterPath(Uri.parse('divine://$path')),
+          isNull,
+          reason: '$path is not an AASA claim and must not be reachable.',
+        );
+      }
+    });
+  });
+
   group('AASA claim coverage', () {
     for (final host in _expectedClaimPatternsByHost.keys) {
       test('$host claimed paths are routed or explicitly allowlisted', () {

--- a/mobile/test/router/app_router_divine_scheme_gating_test.dart
+++ b/mobile/test/router/app_router_divine_scheme_gating_test.dart
@@ -1,0 +1,284 @@
+// ABOUTME: divine:// deep links must clear the same auth/minor-review gates
+// ABOUTME: as the plain path they address — the redirect runs only once
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/models/minor_account_review_status.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/router/router.dart';
+import 'package:openvine/screens/auth/nostr_connect_screen.dart';
+import 'package:openvine/screens/auth/welcome_screen.dart';
+import 'package:openvine/screens/feed/video_feed_page.dart';
+import 'package:openvine/screens/hashtag_screen_router.dart';
+import 'package:openvine/screens/minor_account_review_screen.dart';
+import 'package:openvine/screens/profile_screen_router.dart';
+import 'package:openvine/screens/saved_videos_screen.dart';
+import 'package:openvine/screens/search_results/view/search_results_page.dart';
+import 'package:openvine/screens/settings/settings_screen.dart';
+import 'package:openvine/screens/video_detail_screen.dart';
+import 'package:openvine/services/auth_service.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+/// Hands the test a real [Ref] so [appRouterRedirect] can be driven through a
+/// GoRouter instead of being called in isolation.
+final _refProvider = Provider<Ref>((ref) => ref);
+
+// go_router applies the legacy top-level redirect at most once per navigation
+// and does not re-evaluate the location it redirects to
+// (`RouteConfiguration.applyTopLegacyRedirect`). Anything appRouterRedirect
+// returns is therefore final, so resolving a divine:// URI to a destination
+// and returning it there would skip every gate below it. These tests drive the
+// whole redirect and compare each divine:// link against the plain path it
+// addresses: the two must land in the same place.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(resetNavigationState);
+
+  Future<String> resolve(
+    WidgetTester tester, {
+    required String target,
+    required AuthState authState,
+    bool restricted = false,
+    String? nostrConnectUrl,
+  }) async {
+    final authService = _MockAuthService();
+    when(() => authService.authState).thenReturn(authState);
+    when(() => authService.nostrConnectUrl).thenReturn(nostrConnectUrl);
+    when(() => authService.hasExpiredOAuthSession).thenReturn(false);
+    when(() => authService.currentPublicKeyHex).thenReturn('abc123');
+    when(
+      () => authService.onSignerCallbackReceived(
+        relayUrl: any(named: 'relayUrl'),
+      ),
+    ).thenReturn(null);
+
+    final container = ProviderContainer(
+      overrides: [
+        authServiceProvider.overrideWithValue(authService),
+        // The authenticated-auth-route branch consults this on first
+        // navigation; the empty-following bounce is not what these tests are
+        // about.
+        hasFollowingInCacheProvider.overrideWithValue(true),
+        currentMinorAccountReviewStatusProvider.overrideWith(
+          (ref) async => restricted
+              ? const MinorAccountReviewStatus(
+                  restrictionStatus:
+                      AccountRestrictionStatus.restrictedMinorReview,
+                )
+              : MinorAccountReviewStatus.active(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    // Settle the status so the redirect sees a value rather than AsyncLoading,
+    // which has its own loading-screen bounce.
+    await container.read(currentMinorAccountReviewStatusProvider.future);
+
+    final ref = container.read(_refProvider);
+    final router = GoRouter(
+      initialLocation: WelcomeScreen.path,
+      redirect: (_, state) => appRouterRedirect(ref, state),
+      routes: [
+        for (final path in <String>[
+          WelcomeScreen.path,
+          NostrConnectScreen.path,
+          VideoFeedPage.pathForIndex(0),
+          MinorAccountReviewScreen.path,
+          SavedVideosScreen.path,
+          SettingsScreen.path,
+          VideoDetailScreen.path,
+          '${VideoDetailScreen.path}/likers',
+          ProfileScreenRouter.pathWithNpub,
+          HashtagScreenRouter.path,
+          SearchResultsPage.path,
+        ])
+          GoRoute(
+            path: path,
+            builder: (_, _) => Scaffold(body: Text(path)),
+          ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.pumpAndSettle();
+
+    router.go(target);
+    await tester.pumpAndSettle();
+    return router.state.uri.toString();
+  }
+
+  // Each entry is (divine:// link, the plain path it addresses).
+  const allowListed = <(String, String)>[
+    ('divine:///saved-videos', SavedVideosScreen.path),
+    ('divine:///video/abc123', '/video/abc123'),
+    ('divine:///video/abc123/likers', '/video/abc123/likers'),
+    ('divine:///profile/npub1abc', '/profile/npub1abc'),
+    ('divine:///hashtag/art', '/hashtag/art'),
+    ('divine:///search/music', '/search-results/music'),
+  ];
+
+  group('a restricted-minor account', () {
+    testWidgets('cannot escape the review screen through an allow-listed '
+        'divine:// link', (tester) async {
+      for (final (link, plainPath) in allowListed) {
+        final viaScheme = await resolve(
+          tester,
+          target: link,
+          authState: AuthState.authenticated,
+          restricted: true,
+        );
+        final viaPath = await resolve(
+          tester,
+          target: plainPath,
+          authState: AuthState.authenticated,
+          restricted: true,
+        );
+
+        expect(
+          viaPath,
+          equals(MinorAccountReviewScreen.path),
+          reason: '$plainPath should be gated for a restricted account.',
+        );
+        expect(
+          viaScheme,
+          equals(viaPath),
+          reason:
+              '$link reached $viaScheme while $plainPath was gated to '
+              '$viaPath. A restricted account must not get a way around the '
+              'review screen by opening a custom-scheme link.',
+        );
+      }
+    });
+
+    testWidgets('cannot reach the feed through an unlisted divine:// link', (
+      tester,
+    ) async {
+      for (final link in const <String>[
+        'divine://nostrconnect',
+        'divine:///developer-options',
+        'divine:///settings',
+        'divine://attacker.example?relay=wss://evil.example',
+      ]) {
+        expect(
+          await resolve(
+            tester,
+            target: link,
+            authState: AuthState.authenticated,
+            restricted: true,
+          ),
+          equals(MinorAccountReviewScreen.path),
+          reason: '$link must not land a restricted account in the app.',
+        );
+      }
+    });
+  });
+
+  group('a signed-out user', () {
+    testWidgets('is sent to welcome by an allow-listed divine:// link', (
+      tester,
+    ) async {
+      for (final (link, plainPath) in allowListed) {
+        expect(
+          await resolve(
+            tester,
+            target: link,
+            authState: AuthState.unauthenticated,
+          ),
+          equals(WelcomeScreen.path),
+          reason:
+              '$link must be gated exactly like $plainPath, which bounces a '
+              'signed-out user to welcome.',
+        );
+      }
+    });
+  });
+
+  group('an ordinary signed-in user', () {
+    testWidgets('still reaches every allow-listed divine:// destination', (
+      tester,
+    ) async {
+      for (final (link, plainPath) in allowListed) {
+        expect(
+          await resolve(
+            tester,
+            target: link,
+            authState: AuthState.authenticated,
+          ),
+          equals(plainPath),
+          reason: '$link should open $plainPath.',
+        );
+      }
+    });
+
+    testWidgets('lands on the feed for a stray signer callback', (
+      tester,
+    ) async {
+      expect(
+        await resolve(
+          tester,
+          target: 'divine://nostrconnect',
+          authState: AuthState.authenticated,
+        ),
+        equals(VideoFeedPage.pathForIndex(0)),
+      );
+    });
+  });
+
+  // The one deliberate ungated case: /nostr-connect is an auth route, so
+  // gating it would hand a signed-in user straight back to the feed and drop
+  // the pairing they just approved.
+  group('a live NIP-46 pairing', () {
+    testWidgets('returns to nostr connect even when signed in', (tester) async {
+      expect(
+        await resolve(
+          tester,
+          target:
+              'divine://nostrconnect?x-source=aegis'
+              '&relay=wss://localrelay.link:28443',
+          authState: AuthState.authenticated,
+          nostrConnectUrl: 'nostrconnect://deadbeef',
+        ),
+        equals(NostrConnectScreen.path),
+      );
+    });
+
+    testWidgets('returns to nostr connect when signed out', (tester) async {
+      expect(
+        await resolve(
+          tester,
+          target: 'divine://nostrconnect',
+          authState: AuthState.unauthenticated,
+          nostrConnectUrl: 'nostrconnect://deadbeef',
+        ),
+        equals(NostrConnectScreen.path),
+      );
+    });
+  });
+
+  group('ordinary in-app navigation', () {
+    testWidgets('is unaffected — no divine:// rewrite in play', (tester) async {
+      expect(
+        await resolve(
+          tester,
+          target: SettingsScreen.path,
+          authState: AuthState.authenticated,
+        ),
+        equals(SettingsScreen.path),
+      );
+      expect(
+        await resolve(
+          tester,
+          target: SettingsScreen.path,
+          authState: AuthState.unauthenticated,
+        ),
+        equals(WelcomeScreen.path),
+      );
+    });
+  });
+}

--- a/mobile/test/router/app_router_test.dart
+++ b/mobile/test/router/app_router_test.dart
@@ -461,7 +461,11 @@ void main() {
         authService,
       );
 
-      expect(target, equals(NostrConnectScreen.path));
+      expect(target?.path, equals(NostrConnectScreen.path));
+      // Ungated on purpose: /nostr-connect is an auth route, so the
+      // authenticated-auth-route bounce would pull a signed-in user out of the
+      // pairing they just approved.
+      expect(target?.gated, isFalse);
       verify(
         () => authService.onSignerCallbackReceived(
           relayUrl: 'wss://localrelay.link:28443',
@@ -469,9 +473,6 @@ void main() {
       ).called(greaterThan(0));
     });
 
-    // go_router runs the top-level redirect at most once per navigation, so
-    // whatever this returns is terminal — the authenticated-auth-route bounce
-    // further down appRouterRedirect never gets a second pass (#7074).
     test('sends a signed-in user home when no pairing is in flight', () {
       final authService = _MockAuthService();
       when(() => authService.nostrConnectUrl).thenReturn(null);
@@ -487,7 +488,8 @@ void main() {
         authService,
       );
 
-      expect(target, equals(VideoFeedPage.pathForIndex(0)));
+      expect(target?.path, equals(VideoFeedPage.pathForIndex(0)));
+      expect(target?.gated, isTrue);
     });
 
     test('sends a signed-out user to welcome when no pairing is in '
@@ -506,7 +508,8 @@ void main() {
         authService,
       );
 
-      expect(target, equals(WelcomeScreen.path));
+      expect(target?.path, equals(WelcomeScreen.path));
+      expect(target?.gated, isTrue);
     });
 
     test('fires no signer side effect for a divine:// app route', () {
@@ -546,8 +549,8 @@ void main() {
     const unlistedPaths = <String>[
       '/developer-options',
       '/settings',
-      '/video/abc123',
-      '/profile/npub1abc',
+      '/relay-settings',
+      '/key-management',
     ];
 
     test('never fall through for a signed-in user', () {
@@ -557,7 +560,10 @@ void main() {
         when(() => authService.nostrConnectUrl).thenReturn(null);
 
         expect(
-          divineSchemeRedirectTarget(Uri.parse('divine://$path'), authService),
+          divineSchemeRedirectTarget(
+            Uri.parse('divine://$path'),
+            authService,
+          )?.path,
           equals(VideoFeedPage.pathForIndex(0)),
           reason:
               'divine://$path must not reach $path — go_router would match it '
@@ -573,10 +579,38 @@ void main() {
         when(() => authService.nostrConnectUrl).thenReturn(null);
 
         expect(
-          divineSchemeRedirectTarget(Uri.parse('divine://$path'), authService),
+          divineSchemeRedirectTarget(
+            Uri.parse('divine://$path'),
+            authService,
+          )?.path,
           equals(WelcomeScreen.path),
           reason: 'divine://$path must not reach $path.',
         );
+      }
+    });
+
+    // These resolve to a destination rather than a bounce, so asserting the
+    // resolver alone proves nothing about reachability — `gated` is what hands
+    // the decision to appRouterRedirect. The router-level suite below is what
+    // actually pins the outcome.
+    test('allow-listed paths resolve to a destination but stay gated', () {
+      for (final path in const <String>[
+        '/saved-videos',
+        '/video/abc123',
+        '/video/abc123/likers',
+        '/profile/npub1abc',
+        '/hashtag/art',
+      ]) {
+        final authService = _MockAuthService();
+        when(() => authService.authState).thenReturn(AuthState.authenticated);
+        when(() => authService.nostrConnectUrl).thenReturn(null);
+
+        final target = divineSchemeRedirectTarget(
+          Uri.parse('divine://$path'),
+          authService,
+        );
+
+        expect(target?.gated, isTrue, reason: 'divine://$path must be gated.');
       }
     });
 

--- a/mobile/test/router/app_router_test.dart
+++ b/mobile/test/router/app_router_test.dart
@@ -464,6 +464,23 @@ void main() {
         ),
       ).called(greaterThan(0));
     });
+
+    test('leaves a divine:// app route alone and fires no signer side '
+        'effect', () {
+      final authService = _MockAuthService();
+
+      final target = signerCallbackRedirectTarget(
+        Uri.parse('divine:///saved-videos'),
+        authService,
+      );
+
+      expect(target, isNull);
+      verifyNever(
+        () => authService.onSignerCallbackReceived(
+          relayUrl: any(named: 'relayUrl'),
+        ),
+      );
+    });
   });
 
   group('DM route extras', () {

--- a/mobile/test/router/app_router_test.dart
+++ b/mobile/test/router/app_router_test.dart
@@ -22,6 +22,8 @@ import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/router/routes/settings_routes.dart';
 import 'package:openvine/screens/auth/nostr_connect_screen.dart';
+import 'package:openvine/screens/auth/welcome_screen.dart';
+import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
 import 'package:openvine/screens/inbox/message_requests/request_preview_page.dart';
@@ -463,6 +465,46 @@ void main() {
           relayUrl: 'wss://localrelay.link:28443',
         ),
       ).called(greaterThan(0));
+    });
+
+    // go_router runs the top-level redirect at most once per navigation, so
+    // whatever this returns is terminal — the authenticated-auth-route bounce
+    // further down appRouterRedirect never gets a second pass (#7074).
+    test('sends a signed-in user home when no pairing is in flight', () {
+      final authService = _MockAuthService();
+      when(() => authService.nostrConnectUrl).thenReturn(null);
+      when(() => authService.authState).thenReturn(AuthState.authenticated);
+      when(
+        () => authService.onSignerCallbackReceived(
+          relayUrl: any(named: 'relayUrl'),
+        ),
+      ).thenReturn(null);
+
+      final target = signerCallbackRedirectTarget(
+        Uri.parse('divine://nostrconnect'),
+        authService,
+      );
+
+      expect(target, equals(VideoFeedPage.pathForIndex(0)));
+    });
+
+    test('sends a signed-out user to welcome when no pairing is in '
+        'flight', () {
+      final authService = _MockAuthService();
+      when(() => authService.nostrConnectUrl).thenReturn(null);
+      when(() => authService.authState).thenReturn(AuthState.unauthenticated);
+      when(
+        () => authService.onSignerCallbackReceived(
+          relayUrl: any(named: 'relayUrl'),
+        ),
+      ).thenReturn(null);
+
+      final target = signerCallbackRedirectTarget(
+        Uri.parse('divine://nostrconnect'),
+        authService,
+      );
+
+      expect(target, equals(WelcomeScreen.path));
     });
 
     test('leaves a divine:// app route alone and fires no signer side '

--- a/mobile/test/router/app_router_test.dart
+++ b/mobile/test/router/app_router_test.dart
@@ -21,12 +21,14 @@ import 'package:openvine/providers/protected_minor_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/router/routes/settings_routes.dart';
+import 'package:openvine/router/universal_link_resolver.dart';
 import 'package:openvine/screens/auth/nostr_connect_screen.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
 import 'package:openvine/screens/inbox/message_requests/request_preview_page.dart';
+import 'package:openvine/screens/saved_videos_screen.dart';
 import 'package:openvine/screens/search_results/view/search_results_page.dart';
 import 'package:openvine/screens/settings/settings_screen.dart';
 import 'package:openvine/screens/video_recorder_screen.dart';
@@ -452,7 +454,7 @@ void main() {
         ),
       ).thenReturn(null);
 
-      final target = signerCallbackRedirectTarget(
+      final target = divineSchemeRedirectTarget(
         Uri.parse(
           'divine://nostrconnect?x-source=aegis&relay=wss://localrelay.link:28443',
         ),
@@ -480,7 +482,7 @@ void main() {
         ),
       ).thenReturn(null);
 
-      final target = signerCallbackRedirectTarget(
+      final target = divineSchemeRedirectTarget(
         Uri.parse('divine://nostrconnect'),
         authService,
       );
@@ -499,7 +501,7 @@ void main() {
         ),
       ).thenReturn(null);
 
-      final target = signerCallbackRedirectTarget(
+      final target = divineSchemeRedirectTarget(
         Uri.parse('divine://nostrconnect'),
         authService,
       );
@@ -507,20 +509,81 @@ void main() {
       expect(target, equals(WelcomeScreen.path));
     });
 
-    test('leaves a divine:// app route alone and fires no signer side '
-        'effect', () {
+    test('fires no signer side effect for a divine:// app route', () {
       final authService = _MockAuthService();
+      when(() => authService.authState).thenReturn(AuthState.authenticated);
 
-      final target = signerCallbackRedirectTarget(
+      divineSchemeRedirectTarget(
         Uri.parse('divine:///saved-videos'),
         authService,
       );
 
-      expect(target, isNull);
       verifyNever(
         () => authService.onSignerCallbackReceived(
           relayUrl: any(named: 'relayUrl'),
         ),
+      );
+    });
+
+    test('ignores every other scheme', () {
+      final authService = _MockAuthService();
+
+      expect(
+        divineSchemeRedirectTarget(
+          Uri.parse('https://divine.video/video/abc123'),
+          authService,
+        ),
+        isNull,
+      );
+    });
+  });
+
+  // GoRouter matches a location by uri.path alone, so a divine:// URI that the
+  // redirect lets through is not inert — it opens whatever route shares that
+  // path. divine:///developer-options reaching the relay environment switcher
+  // was reproduced on device (#7074).
+  group('divine:// routes outside the allow-list', () {
+    const unlistedPaths = <String>[
+      '/developer-options',
+      '/settings',
+      '/video/abc123',
+      '/profile/npub1abc',
+    ];
+
+    test('never fall through for a signed-in user', () {
+      for (final path in unlistedPaths) {
+        final authService = _MockAuthService();
+        when(() => authService.authState).thenReturn(AuthState.authenticated);
+        when(() => authService.nostrConnectUrl).thenReturn(null);
+
+        expect(
+          divineSchemeRedirectTarget(Uri.parse('divine://$path'), authService),
+          equals(VideoFeedPage.pathForIndex(0)),
+          reason:
+              'divine://$path must not reach $path — go_router would match it '
+              'by path and open the screen.',
+        );
+      }
+    });
+
+    test('never fall through for a signed-out user', () {
+      for (final path in unlistedPaths) {
+        final authService = _MockAuthService();
+        when(() => authService.authState).thenReturn(AuthState.unauthenticated);
+        when(() => authService.nostrConnectUrl).thenReturn(null);
+
+        expect(
+          divineSchemeRedirectTarget(Uri.parse('divine://$path'), authService),
+          equals(WelcomeScreen.path),
+          reason: 'divine://$path must not reach $path.',
+        );
+      }
+    });
+
+    test('the allow-listed route still resolves to its screen', () {
+      expect(
+        customSchemeToRouterPath(Uri.parse('divine:///saved-videos')),
+        equals(SavedVideosScreen.path),
       );
     });
   });

--- a/mobile/test/router/universal_link_resolver_test.dart
+++ b/mobile/test/router/universal_link_resolver_test.dart
@@ -3,6 +3,10 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/router/universal_link_resolver.dart';
+import 'package:openvine/screens/hashtag_screen_router.dart';
+import 'package:openvine/screens/profile_screen_router.dart';
+import 'package:openvine/screens/search_results/view/search_results_page.dart';
+import 'package:openvine/screens/video_detail_screen.dart';
 
 void main() {
   group('divineUrlToPushRoute', () {
@@ -293,6 +297,68 @@ void main() {
     test('returns null for an unlisted app route', () {
       expect(
         customSchemeToRouterPath(Uri.parse('divine:///settings')),
+        isNull,
+      );
+    });
+
+    // Parity with the served AASA claim set: the custom scheme reaches
+    // exactly what a web page can already reach over https (#6733).
+    test('maps the universal-link claim paths to their routes', () {
+      expect(
+        customSchemeToRouterPath(Uri.parse('divine:///video/abc123')),
+        equals(VideoDetailScreen.pathForId('abc123')),
+      );
+      expect(
+        customSchemeToRouterPath(Uri.parse('divine:///profile/npub1abc123')),
+        equals(ProfileScreenRouter.pathForNpub('npub1abc123')),
+      );
+      expect(
+        customSchemeToRouterPath(Uri.parse('divine:///hashtag/vines')),
+        equals(HashtagScreenRouter.pathForTag('vines')),
+      );
+      expect(
+        customSchemeToRouterPath(Uri.parse('divine:///list/my-vines')),
+        isNotNull,
+      );
+    });
+
+    test('rewrites /search/* to the internal search-results route', () {
+      expect(
+        customSchemeToRouterPath(Uri.parse('divine:///search/music')),
+        equals(
+          SearchResultsPage.pathForQuery('music', requestFocusOnMount: false),
+        ),
+      );
+    });
+
+    // The issue's own repro (#6733): the likers screen had to be reached by
+    // long-press because the deep link would not route. DeepLinkService has
+    // no DeepLinkType for it, so it resolves by path passthrough.
+    test('passes deeper paths under a claimed prefix through verbatim', () {
+      expect(
+        customSchemeToRouterPath(Uri.parse('divine:///video/abc123/likers')),
+        equals('/video/abc123/likers'),
+      );
+    });
+
+    test('preserves the query string on a passthrough path', () {
+      expect(
+        customSchemeToRouterPath(
+          Uri.parse('divine:///video/abc123/likers?a=34236%3Apk%3Ad'),
+        ),
+        contains('a=34236'),
+      );
+    });
+
+    test('returns null for a bare claimed prefix naming no destination', () {
+      expect(customSchemeToRouterPath(Uri.parse('divine:///video')), isNull);
+    });
+
+    test('returns null for the authority form of a claimed prefix', () {
+      // Only the authority-less form addresses routes; `video` in the
+      // authority is an unrecognised callback host, not a path segment.
+      expect(
+        customSchemeToRouterPath(Uri.parse('divine://video/abc123')),
         isNull,
       );
     });

--- a/mobile/test/router/universal_link_resolver_test.dart
+++ b/mobile/test/router/universal_link_resolver_test.dart
@@ -260,6 +260,50 @@ void main() {
           isNull,
         );
       });
+
+      test('divine:// app routes return null — the custom scheme has its '
+          'own resolver', () {
+        expect(
+          universalLinkToRouterPath(Uri.parse('divine:///saved-videos')),
+          isNull,
+        );
+      });
+    });
+  });
+
+  group('customSchemeToRouterPath', () {
+    test('maps the authority-less saved-videos link to its route', () {
+      expect(
+        customSchemeToRouterPath(Uri.parse('divine:///saved-videos')),
+        equals('/saved-videos'),
+      );
+    });
+
+    test('returns null for a NIP-46 signer callback', () {
+      expect(
+        customSchemeToRouterPath(
+          Uri.parse(
+            'divine://nostrconnect?x-source=aegis&relay=wss://localrelay.link:28443',
+          ),
+        ),
+        isNull,
+      );
+    });
+
+    test('returns null for an unlisted app route', () {
+      expect(
+        customSchemeToRouterPath(Uri.parse('divine:///settings')),
+        isNull,
+      );
+    });
+
+    test('returns null for a divine.video universal link', () {
+      expect(
+        customSchemeToRouterPath(
+          Uri.parse('https://divine.video/video/abc123'),
+        ),
+        isNull,
+      );
     });
   });
 }

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -32,6 +32,7 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
 import 'package:openvine/screens/feed/feed_settings_menu.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
+import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/services/media_auth_interceptor.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
@@ -485,55 +486,65 @@ void main() {
         },
       );
 
+      // Was a test that built its own BackButton with the old
+      // `canPop ? pop : go('/')` inline and registered its own `/` route, so
+      // it asserted a reimplementation rather than _handleBack and could not
+      // fail. This pumps the real widget, and registers no `/` route — the
+      // app has none either.
       testWidgets(
-        'empty-state back button falls back to root when route cannot pop',
+        'empty-state back button lands on the feed when route cannot pop',
         (tester) async {
-          var sentinelBuilt = false;
+          when(() => mockBloc.state).thenReturn(
+            const FullscreenFeedState(
+              status: FullscreenFeedStatus.emptyAfterRemoval,
+            ),
+          );
+
           final router = GoRouter(
             initialLocation: '/empty-feed',
             routes: [
               GoRoute(
-                path: '/',
-                builder: (_, _) {
-                  sentinelBuilt = true;
-                  return const Scaffold(body: Text('home-sentinel'));
-                },
+                path: VideoFeedPage.pathForIndex(0),
+                builder: (_, _) => const Scaffold(body: Text('feed')),
               ),
               GoRoute(
                 path: '/empty-feed',
-                builder: (_, _) => Scaffold(
-                  appBar: AppBar(
-                    leading: Builder(
-                      builder: (context) => BackButton(
-                        onPressed: () =>
-                            context.canPop() ? context.pop() : context.go('/'),
-                      ),
-                    ),
-                  ),
-                  body: const Center(child: Text('empty-state-body')),
-                ),
+                builder: (_, _) => buildContent(contextTitle: 'Saved'),
               ),
             ],
           );
           addTearDown(router.dispose);
 
           await tester.pumpWidget(
-            MaterialApp.router(
-              localizationsDelegates: AppLocalizations.localizationsDelegates,
-              supportedLocales: AppLocalizations.supportedLocales,
-              routerConfig: router,
+            testProviderScope(
+              mockProfileRepository: mockProfileRepository,
+              mockNip05VerificationService: mockNip05VerificationService,
+              child: MaterialApp.router(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                routerConfig: router,
+              ),
             ),
           );
           await tester.pump();
           await tester.pump(const Duration(milliseconds: 100));
-          expect(find.text('empty-state-body'), findsOneWidget);
 
-          await tester.tap(find.byType(BackButton));
+          final removedText = lookupAppLocalizations(
+            const Locale('en'),
+          ).fullscreenFeedRemovedMessage;
+          expect(find.text(removedText), findsOneWidget);
+          expect(router.canPop(), isFalse);
+
+          tester
+              .widget<DivineAppBarIconButton>(
+                find.byType(DivineAppBarIconButton).first,
+              )
+              .onPressed
+              ?.call();
           await tester.pumpAndSettle();
 
-          expect(sentinelBuilt, isTrue);
-          expect(find.text('home-sentinel'), findsOneWidget);
-          expect(find.text('empty-state-body'), findsNothing);
+          expect(find.text('feed'), findsOneWidget);
+          expect(find.text(removedText), findsNothing);
         },
       );
 
@@ -645,8 +656,11 @@ void main() {
         expect(feedVideos.sourceDetail, 'npub-profile');
       });
 
+      // The fallback used to be `go('/')`, which matches no registered route
+      // in the app and rendered RouteErrorScreen. Only this test's own `/`
+      // route made it look like it worked, so the sentinel is the feed now.
       testWidgets(
-        'ready-state back button falls back to root when route cannot pop',
+        'ready-state back button lands on the feed when route cannot pop',
         (tester) async {
           final videos = createTestVideos(count: 1);
           final state = FullscreenFeedState(
@@ -662,7 +676,7 @@ void main() {
             initialLocation: '/shared-video',
             routes: [
               GoRoute(
-                path: '/',
+                path: VideoFeedPage.pathForIndex(0),
                 builder: (_, _) {
                   sentinelBuilt = true;
                   return const Scaffold(body: Text('home-sentinel'));

--- a/mobile/test/screens/profile_screen_router_test.dart
+++ b/mobile/test/screens/profile_screen_router_test.dart
@@ -95,7 +95,7 @@ void main() {
 
     // Verify second video shown
     expect(find.text('Profile 1/3'), findsOneWidget);
-    // TODO(any): Fix and re-enable this test
+    // TODO(#7160): Fix and re-enable this test.
   }, skip: true);
 
   testWidgets('PROFILE: Empty state shows when no videos', (tester) async {
@@ -115,7 +115,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.textContaining('No posts yet'), findsOneWidget);
-    // TODO(any): Fix and re-enable this test
+    // TODO(#7160): Fix and re-enable this test.
   }, skip: true);
 
   testWidgets('PROFILE: Lifecycle pause → activeVideoId becomes null', (
@@ -139,7 +139,7 @@ void main() {
 
     // When backgrounded, active video should be null
     expect(c.read(activeVideoIdProvider), isNull);
-    // TODO(any): Fix and re-enable this test
+    // TODO(#7160): Fix and re-enable this test.
   }, skip: true);
 
   // A divine:///profile/<npub> or https://divine.video/profile/<npub> deep

--- a/mobile/test/screens/profile_screen_router_test.dart
+++ b/mobile/test/screens/profile_screen_router_test.dart
@@ -1,17 +1,29 @@
 // ABOUTME: Tests for router-driven ProfileScreen implementation
 // ABOUTME: Verifies URL ↔ PageView synchronization for profile feeds
 
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/active_video_provider.dart';
 import 'package:openvine/providers/app_lifecycle_provider.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/profile_feed_providers.dart';
 import 'package:openvine/router/router.dart';
+import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/state/video_feed_state.dart';
+import 'package:openvine/widgets/profile/blocked_user_screen.dart';
+
+import '../helpers/test_provider_overrides.dart';
+
+class _MockContentBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {}
 
 void main() {
   Widget shell(ProviderContainer c) => UncontrolledProviderScope(
@@ -129,4 +141,66 @@ void main() {
     expect(c.read(activeVideoIdProvider), isNull);
     // TODO(any): Fix and re-enable this test
   }, skip: true);
+
+  // A divine:///profile/<npub> or https://divine.video/profile/<npub> deep
+  // link lands on this route with a one-entry stack. When that account has
+  // blocked or muted the viewer the screen swaps to BlockedUserScreen, whose
+  // app-bar back used to be a raw context.pop — GoError, dead caret.
+  group('$BlockedUserScreen back affordance', () {
+    const npub =
+        'npub1424242424242424242424242424242424242424242424242424qamrcaj';
+
+    testWidgets('back lands on the feed when there is nothing to pop', (
+      tester,
+    ) async {
+      final blocklistRepository = _MockContentBlocklistRepository();
+      when(() => blocklistRepository.hasBlockedUs(any())).thenReturn(true);
+      when(() => blocklistRepository.hasMutedUs(any())).thenReturn(false);
+
+      final profilePath = ProfileScreenRouter.pathForNpub(npub);
+      final router = GoRouter(
+        initialLocation: profilePath,
+        routes: [
+          GoRoute(
+            path: VideoFeedPage.pathForIndex(0),
+            builder: (_, _) => const Scaffold(body: Text('feed')),
+          ),
+          GoRoute(
+            path: ProfileScreenRouter.pathWithNpub,
+            builder: (_, _) => const ProfileScreenRouter(),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(
+        testProviderScope(
+          additionalOverrides: [
+            contentBlocklistRepositoryProvider.overrideWithValue(
+              blocklistRepository,
+            ),
+            routerLocationStreamProvider.overrideWithValue(
+              Stream.value(profilePath),
+            ),
+          ],
+          child: MaterialApp.router(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            routerConfig: router,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(BlockedUserScreen), findsOneWidget);
+      // Precondition: cold entry really does leave a one-entry stack, so a
+      // raw context.pop() here would throw GoError.
+      expect(router.canPop(), isFalse);
+
+      await tester.tap(find.byType(DivineAppBarIconButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('feed'), findsOneWidget);
+    });
+  });
 }

--- a/mobile/test/screens/saved_videos_screen_test.dart
+++ b/mobile/test/screens/saved_videos_screen_test.dart
@@ -1,14 +1,18 @@
-// ABOUTME: Tests pull-to-refresh on the standalone bookmarks screen's view
-// ABOUTME: Bookmarks lost the profile tab's refresh when they moved off-profile
+// ABOUTME: Pull-to-refresh on the bookmarks view, and the app bar's exit path
+// ABOUTME: Both regress when the screen is entered cold rather than pushed
+
+import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/profile_saved_videos/profile_saved_videos_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/saved_videos_screen.dart';
 
 import '../helpers/test_provider_overrides.dart';
@@ -91,6 +95,80 @@ void main() {
       verifyNever(
         () => mockBloc.add(any<ProfileSavedVideosSyncRequested>()),
       );
+    });
+  });
+
+  // A divine:///saved-videos deep link lands here with a one-entry stack, and
+  // the screen is registered outside the shell — no bottom nav either. Without
+  // an explicit back affordance that survives an empty stack, the deep link
+  // delivers a dead end (#7074).
+  group(SavedVideosAppBar, () {
+    GoRouter buildRouter({required String initialLocation}) {
+      return GoRouter(
+        initialLocation: initialLocation,
+        routes: [
+          GoRoute(
+            path: VideoFeedPage.pathForIndex(0),
+            builder: (_, _) => const Scaffold(body: Text('feed')),
+          ),
+          GoRoute(
+            path: SavedVideosScreen.path,
+            builder: (_, _) => const Scaffold(
+              appBar: SavedVideosAppBar(),
+              body: Text('bookmarks'),
+            ),
+          ),
+        ],
+      );
+    }
+
+    Widget wrap(GoRouter router) {
+      return MaterialApp.router(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        theme: VineTheme.theme,
+        routerConfig: router,
+      );
+    }
+
+    testWidgets('back lands on the feed when there is nothing to pop', (
+      tester,
+    ) async {
+      final router = buildRouter(initialLocation: SavedVideosScreen.path);
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(wrap(router));
+      await tester.pumpAndSettle();
+
+      // Precondition: cold entry really does leave a one-entry stack, so a
+      // raw context.pop() here would throw GoError.
+      expect(router.canPop(), isFalse);
+
+      await tester.tap(find.byType(DivineIconButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('feed'), findsOneWidget);
+    });
+
+    testWidgets('back pops when the user pushed here from elsewhere', (
+      tester,
+    ) async {
+      final router = buildRouter(
+        initialLocation: VideoFeedPage.pathForIndex(0),
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(wrap(router));
+      await tester.pumpAndSettle();
+
+      unawaited(router.push(SavedVideosScreen.path));
+      await tester.pumpAndSettle();
+      expect(find.text('bookmarks'), findsOneWidget);
+
+      await tester.tap(find.byType(DivineIconButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('feed'), findsOneWidget);
     });
   });
 }

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -15,6 +15,7 @@ import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
@@ -203,6 +204,74 @@ void main() {
           expect(find.text('caller screen'), findsOneWidget);
         },
       );
+
+      // A divine:///video/<id> or https://divine.video/video/<id> deep link
+      // lands on this flat top-level route with a one-entry stack. The exit
+      // used to fall back to `go('/')`, and no `path: '/'` route is registered
+      // anywhere in the app, so leaving rendered RouteErrorScreen instead of
+      // the feed. Note this router deliberately has no `/` route either.
+      testWidgets('exit lands on the feed when there is nothing to pop', (
+        tester,
+      ) async {
+        final completer = Completer<VideoEvent?>();
+        when(
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(any()),
+        ).thenAnswer((_) => completer.future);
+        addTearDown(() => completer.complete(null));
+
+        final router = GoRouter(
+          initialLocation: VideoDetailScreen.pathForId('test_video_id'),
+          routes: [
+            GoRoute(
+              path: VideoFeedPage.pathForIndex(0),
+              builder: (_, _) => const Scaffold(body: Text('feed')),
+            ),
+            GoRoute(
+              path: VideoDetailScreen.path,
+              builder: (_, state) =>
+                  VideoDetailScreen(videoId: state.pathParameters['id']!),
+            ),
+          ],
+        );
+        addTearDown(router.dispose);
+
+        await tester.pumpWidget(
+          testProviderScope(
+            mockNostrService: mockNostrClient,
+            mockFollowRepository: mockFollowRepository,
+            additionalOverrides: [
+              videoEventServiceProvider.overrideWithValue(
+                mockVideoEventService,
+              ),
+              contentBlocklistRepositoryProvider.overrideWithValue(
+                mockBlocklistRepository,
+              ),
+              videosRepositoryProvider.overrideWithValue(mockVideosRepository),
+            ],
+            child: MaterialApp.router(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              routerConfig: router,
+            ),
+          ),
+        );
+
+        // The branded indicator animates forever, so settle would time out.
+        await tester.pump();
+        await tester.pump(const Duration(seconds: 1));
+
+        // Precondition: cold entry really does leave a one-entry stack, so a
+        // raw context.pop() here would throw GoError.
+        expect(router.canPop(), isFalse);
+
+        await tester.tap(
+          find.bySemanticsLabel(l10n.videoDetailCloseSemanticLabel),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(seconds: 1));
+
+        expect(find.text('feed'), findsOneWidget);
+      });
 
       testWidgets(
         'does not resume the lookup after leaving a deferred cold start',

--- a/mobile/test/services/deep_link_service_test.dart
+++ b/mobile/test/services/deep_link_service_test.dart
@@ -380,6 +380,54 @@ void main() {
       });
     });
 
+    // The divine:// scheme splits on the authority: an authority means the
+    // NIP-46 callback namespace, an empty one means an internal app route.
+    // These cases pin both halves of that boundary (#7074).
+    group('Custom-Scheme App Routes', () {
+      test('routes the authority-less saved-videos link', () {
+        final result = DeepLinkService.parseDeepLink(
+          'divine:///saved-videos',
+        );
+
+        expect(result.type, equals(DeepLinkType.savedVideos));
+      });
+
+      test('leaves an authority-form saved-videos link as a callback', () {
+        final result = DeepLinkService.parseDeepLink('divine://saved-videos');
+
+        expect(result.type, equals(DeepLinkType.signerCallback));
+      });
+
+      test('leaves a divine.video-host link as a callback', () {
+        final result = DeepLinkService.parseDeepLink(
+          'divine://divine.video/saved-videos',
+        );
+
+        expect(result.type, equals(DeepLinkType.signerCallback));
+      });
+
+      test('rejects an unlisted app route instead of treating it as a '
+          'callback', () {
+        final result = DeepLinkService.parseDeepLink('divine:///settings');
+
+        expect(result.type, equals(DeepLinkType.unknown));
+      });
+
+      test('rejects a multi-segment app route', () {
+        final result = DeepLinkService.parseDeepLink(
+          'divine:///saved-videos/extra',
+        );
+
+        expect(result.type, equals(DeepLinkType.unknown));
+      });
+
+      test('rejects the bare authority-less scheme', () {
+        final result = DeepLinkService.parseDeepLink('divine:///');
+
+        expect(result.type, equals(DeepLinkType.unknown));
+      });
+    });
+
     group('Unknown URL Patterns', () {
       test('ignores internal app route paths', () {
         const url = '/profile/npub1abc123def456';
@@ -623,6 +671,11 @@ void main() {
           link.toString(),
           equals('DeepLink(type: profile, npub: npub1x, index: 2)'),
         );
+      });
+
+      test('formats saved videos deep link', () {
+        const link = DeepLink(type: DeepLinkType.savedVideos);
+        expect(link.toString(), equals('DeepLink(type: savedVideos)'));
       });
 
       test('formats hashtag deep link', () {

--- a/mobile/test/services/deep_link_service_test.dart
+++ b/mobile/test/services/deep_link_service_test.dart
@@ -380,9 +380,10 @@ void main() {
       });
     });
 
-    // The divine:// scheme splits on the authority: an authority means the
-    // NIP-46 callback namespace, an empty one means an internal app route.
-    // These cases pin both halves of that boundary (#7074).
+    // The divine:// scheme splits three ways on the authority: `nostrconnect`
+    // is the NIP-46 callback Divine mints, an empty authority addresses an
+    // internal app route, and any other authority is untrusted input. These
+    // cases pin all three (#6733/#7074).
     group('Custom-Scheme App Routes', () {
       test('routes the authority-less saved-videos link', () {
         final result = DeepLinkService.parseDeepLink(
@@ -392,18 +393,31 @@ void main() {
         expect(result.type, equals(DeepLinkType.savedVideos));
       });
 
-      test('leaves an authority-form saved-videos link as a callback', () {
+      test('rejects an authority-form saved-videos link', () {
         final result = DeepLinkService.parseDeepLink('divine://saved-videos');
 
-        expect(result.type, equals(DeepLinkType.signerCallback));
+        expect(result.type, equals(DeepLinkType.unknown));
       });
 
-      test('leaves a divine.video-host link as a callback', () {
+      test('rejects a divine.video-host link', () {
         final result = DeepLinkService.parseDeepLink(
           'divine://divine.video/saved-videos',
         );
 
-        expect(result.type, equals(DeepLinkType.signerCallback));
+        expect(result.type, equals(DeepLinkType.unknown));
+      });
+
+      // Regression guard for #6733: an authority Divine never mints must not
+      // inherit the signer-callback side effects (relay reconnection, and the
+      // attacker-supplied relay that rides along with them).
+      test('rejects an unrecognised authority instead of treating it as a '
+          'callback', () {
+        final result = DeepLinkService.parseDeepLink(
+          'divine://attacker-controlled?relay=wss://evil.example',
+        );
+
+        expect(result.type, equals(DeepLinkType.unknown));
+        expect(result.signerCallbackRelay, isNull);
       });
 
       test('rejects an unlisted app route instead of treating it as a '


### PR DESCRIPTION
## Description

`DeepLinkService.parseDeepLink` claimed the entire `divine://` scheme as a NIP-46 signer callback on its first branch, keyed on the scheme alone with no host or path check. So no custom-scheme URI could reach an app route — `divine:///saved-videos` parsed as `signerCallback` and the router sent it to `/welcome`.

Three commits, each revertable alone.

### 1. `40fba6ae4` — route `divine:///saved-videos` to Saved Videos

Split the scheme on its **authority**. Every callback anyone emits carries one: Divine mints `divine://nostrconnect`, NIP-46 defines no callback parameter at all so signers have no say over the string beyond appending query params (Aegis appends `x-source` and `relay`), and Keycast refuses custom schemes for OAuth outright (`keycast/api/src/api/http/oauth.rs:87` — *"any app can register any scheme"*). The empty authority is therefore free to address app routes, and `divine://<authority>…` keeps its meaning byte-for-byte. Every `divine://` fixture in the existing suite uses the authority form, so nothing changes meaning.

```
divine:///saved-videos     -> /saved-videos      (allow-listed app route)
divine:///<anything else>  -> blocked            (deny-by-default)
divine://<authority>...    -> signer callback    (unchanged)
```

Routes resolve through a small allow-list rather than the internal route table — see commit 3 for why that matters.

`SavedVideosScreen` also gains an explicit back affordance. It is registered outside the shell, so a deep link lands there with a one-entry stack, no automatic back button and no bottom nav — the fix would otherwise deliver a dead end. `context.safePop` falls back to the feed, matching `curated_list_by_author_screen` and `curated_list_feed_screen`.

### 2. `dbc195ddc` — keep a signed-in user in the app on a stray signer callback

**Not requested by the issue — found while fixing it, in the same function.**

`signerCallbackRedirectTarget` returned `/welcome` whenever a `divine://` callback arrived with no pairing in flight. go_router 16.3 runs the legacy top-level redirect **at most once per navigation** and does not re-evaluate the location it redirects to (`configuration.dart:490-492`), so that return value is terminal: `appRouterRedirect`'s authenticated-auth-route bounce never gets a second pass. A signed-in user was left on the account picker — "Continue as *name* / Use another account / Create new account" — reachable only by the close button, which reads as a lost session.

Authenticated users now go to the feed. Signed-out behaviour and the live-session path to `/nostr-connect` are unchanged.

### 3. `40c604b04` — stop unlisted `divine://` URIs reaching their route by path

**This is the fix for #6733, and it is the reason commit 1 cannot ship alone.**

`DeepLinkService` is not the gate. Both platforms hand GoRouter the raw scheme-ful location (`flutter_deeplinking_enabled` / `FlutterDeepLinkingEnabled` are unset and default to **true** in Flutter 3.44), and go_router matches on `uri.path` alone — scheme and host are never consulted. A parse verdict of `unknown` does **not** stop navigation.

Commit 1 narrowed the signer claim without accounting for that, which promoted `divine://` from "reaches nothing" to "reaches every registered route". Reproduced on device before this commit:

| URI | opened |
|---|---|
| `divine:///developer-options` | the relay **environment switcher** — Production / Staging / Test / POC `wss://` URLs |
| `divine:///settings` | Settings |

Universal links can only reach the six AASA-claimed paths, so this was a real surface expansion. The redirect now claims **every** `divine://` location: allow-listed app routes are rewritten first, everything else lands on the feed or `/welcome`. `signerCallbackRedirectTarget` is renamed `divineSchemeRedirectTarget` to match what it now covers.

Not affected: `divine://quick-action/camera`. `DivineQuickActionsPlugin.swift:203-204` matches `scheme == divine && host == quick-action` and claims the URL in the iOS responder chain before the framework sees it; Android's widget uses an explicit-component Intent with extras, not a URL.

### 4. `4d8153cb9`, `d134b1d77`, `85e02959b` — give the newly-opened paths a working back

**Review follow-up on commit 3, from @hm21.** Opening five prefixes over `divine://` means five screens now get reached with a one-entry stack, where a raw `context.pop()` throws and `context.go('/')` matches nothing. Three of them were dead ends:

| site | was | now |
|---|---|---|
| `video_detail_screen._handleExit` | `go('/')` → `RouteErrorScreen` | `safePop` → `/home/0` |
| `pooled_fullscreen_video_feed_screen._handleBack` | same, and this is the **success** path — `VideoDetailScreen` renders it with no `onBack` once the video resolves | `safePop` |
| `profile_screen_router` → `BlockedUserScreen` | raw `context.pop` → `GoError`, dead caret | `safePop` |

`safePop` is the helper commit 1 already used for `SavedVideosAppBar`; its fallback is `VideoFeedPage.pathForIndex(0)`, which is what all three were reaching for.

The `profile` finding in the review named `other_profile_screen.dart:501`. That screen is registered at `/profile-view/:npub`, which is not in the custom-scheme allow-list and is not produced by the https table either — it is reachable only by in-app push, where `canPop` is true. The profile allow-list resolves to `/profile/:npub`, which renders `ProfileGridView` with `onBack` unset, so no caret is drawn at all — except on the blocked/muted branch above, which is the one that was really broken.

Two back tests in `pooled_fullscreen_video_feed_screen_test.dart` had pinned the `go('/')` fallback against a `/` route the test router invented; one of them built its own `BackButton` with the old logic inline and never pumped the widget. Both now assert the feed against a router with no `/` route, matching the app.

**Related Issue:** Closes #7074, Closes #6733

## Out of Scope

- The remaining `context.go('/')` fallbacks — two auth screens, profile setup — are on flows this PR does not open over `divine://`, so they stay out. The three on the deep-linked paths are now fixed here (commit 4 below).
- `Admin/Documentation/TROUBLESHOOTING_GUIDE.md:375` documents `xcrun simctl openurl booted "divine://video/123"` as the way to test deep links. That convention has never worked and this contract does not adopt it (the authority namespace stays reserved for callbacks). Different repo.
- Reaching `/saved-videos` over `https://divine.video/saved-videos` would need a server-side AASA change in `divine-web`.

## Verification

`flutter analyze lib test integration_test` — clean. 462 tests across `test/router/`, `test/services/deep_link_service_test.dart`, `test/providers/deep_link_provider_test.dart`, `test/screens/saved_videos_screen_test.dart`, `test/main_deep_link_nav_action_test.dart`, `test/main_video_deep_link_nav_action_test.dart`, `test/extensions/safe_pop_extension_test.dart` — passing. All six ratchets green (`material_button`, `raw_colors`, `raw_textstyle`, `raw_dialog`, `untested_services_floor`, `test_unit_structure`).

Every new test was mutation-proved:

| Mutation | Turns red |
|---|---|
| `if (uri.host.isEmpty)` → `if (false)` | 4 of the 6 new `deep_link_service` cases |
| `onPressed: context.safePop` → `() => context.pop()` | the cold-entry app-bar test, with `GoError: There is nothing to pop` |
| the authenticated branch → unconditional `WelcomeScreen.path` | "sends a signed-in user home" |
| the catch-all → "only claim actual signer callbacks" | both "never fall through" guards |

### On device — iOS 26.5 simulator, signed in via Keycast OAuth, PRODUCTION

| URI fired | before | after |
|---|---|---|
| `divine:///saved-videos` | `-> /welcome`, stranded on the account picker | `-> /saved-videos`, `Screen viewed: saved_videos`, back caret returns to `/home/0` |
| `divine:///developer-options` | opened the relay environment switcher | `-> /home/0` |
| `divine:///settings` | opened Settings | `-> /home/0` |
| `divine://nostrconnect?x-source=…&relay=…`, no live session | `-> /welcome` | `-> /home/0`, pairing relays still reconnect |

The physical-device leg is **not** covered: the test iPhone dropped off the LAN mid-build and did not return. Everything above is simulator-verified.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

