### PR TITLE
fix(deep-links): stop classifying every divine:// URL as a NIP-46 signer callback

### DIFF
--- a/mobile/lib/router/app_router_redirect.dart
+++ b/mobile/lib/router/app_router_redirect.dart
@@ -37,6 +37,87 @@ String? signerCallbackRedirectTarget(Uri uri, AuthService authService) {
       : WelcomeScreen.path;
 }
 
+/// Path prefixes the `divine://` custom scheme is allowed to open.
+///
+/// Mirrors the universal-link claims in the served apple-app-site-association
+/// files, so the custom scheme reaches exactly what a web page can already
+/// reach over https — and nothing more. A custom scheme is unauthenticated
+/// input (any app can register `divine://`), so without this gate, narrowing
+/// the signer-callback predicate would expose all ~70 registered routes,
+/// including Developer Options and key management (#6733).
+///
+/// `invite` is intentionally absent: it has no GoRoute to land on and is
+/// handled by the [DeepLinkService] listener for https links only.
+const _divineSchemeRoutablePrefixes = <String>{
+  'video',
+  'profile',
+  'hashtag',
+  'search',
+  'list',
+  // Not an AASA claim — added deliberately for #7074. A read-only view of the
+  // signed-in user's own bookmarks, which publishes and deletes nothing.
+  'saved-videos',
+};
+
+/// Resolves a `divine://` app route to an internal path, or bounces it home.
+///
+/// Returns `null` when [uri] is not a custom-scheme app route, so the rest of
+/// the redirect chain runs unchanged. Signer callbacks are consumed earlier by
+/// [signerCallbackRedirectTarget] and are not this function's concern.
+@visibleForTesting
+String? divineSchemeRedirectTarget(Uri uri) {
+  if (uri.scheme != divineCustomScheme) return null;
+  if (isDivineSignerCallbackUri(uri)) return null;
+
+  final segments = _divineSchemePathSegments(uri);
+  if (segments.isEmpty) return null;
+
+  if (!_divineSchemeRoutablePrefixes.contains(segments.first)) {
+    Log.warning(
+      'Ignoring non-routable custom-scheme deep link: /${segments.first}',
+      name: 'AppRouter',
+      category: LogCategory.ui,
+    );
+    return VideoFeedPage.pathForIndex(0);
+  }
+
+  // Reuse the one mapper that owns public-URL vs internal-route differences
+  // (notably /search/* -> /search-results/:query) so the two cannot drift.
+  final canonical = Uri(
+    scheme: 'https',
+    host: 'divine.video',
+    pathSegments: segments,
+    queryParameters: uri.queryParameters.isEmpty ? null : uri.queryParameters,
+  );
+  final mapped = universalLinkToRouterPath(canonical);
+  if (mapped != null) return mapped;
+
+  // No public/internal difference (e.g. /video/:id, /saved-videos): the
+  // canonical path is already a registered GoRoute.
+  return canonical.hasQuery
+      ? '${canonical.path}?${canonical.query}'
+      : canonical.path;
+}
+
+/// Path segments of a `divine://` URL, tolerating both authority forms.
+///
+/// `divine:///video/abc` parses with an empty host, while `divine://video/abc`
+/// puts `video` in the host. Lift the host back into the segments so both
+/// forms resolve identically — unless it is a real divine.video host, where
+/// the segments are already correct.
+List<String> _divineSchemePathSegments(Uri uri) {
+  final segments = uri.pathSegments
+      .where((segment) => segment.isNotEmpty)
+      .toList();
+  final host = uri.host.toLowerCase();
+  if (host.isEmpty ||
+      host == 'divine.video' ||
+      host.endsWith('.divine.video')) {
+    return segments;
+  }
+  return <String>[host, ...segments];
+}
+
 /// Reset navigation state for testing purposes
 @visibleForTesting
 void resetNavigationState() {
@@ -190,6 +271,22 @@ String? appRouterRedirect(Ref ref, GoRouterState state) {
       category: LogCategory.auth,
     );
     return signerCallbackRedirect;
+  }
+
+  // Resolve divine:// app routes to internal paths, and bounce anything
+  // outside the universal-link path set. GoRouter matches a custom-scheme
+  // location on uri.path alone, so without this gate every registered route
+  // would be openable by any app or web page (#6733).
+  final customSchemeRedirect = divineSchemeRedirectTarget(state.uri);
+  if (customSchemeRedirect != null) {
+    Log.info(
+      'Router redirect: custom scheme '
+      '${redactUriStringForLogs(state.uri.toString())} -> '
+      '$customSchemeRedirect',
+      name: 'AppRouter',
+      category: LogCategory.ui,
+    );
+    return customSchemeRedirect;
   }
 
   // Rewrite divine.video universal-link URLs to internal paths before the

--- a/mobile/lib/services/deep_link_service.dart
+++ b/mobile/lib/services/deep_link_service.dart
@@ -87,6 +87,27 @@ class DeepLink {
   }
 }
 
+/// The custom URL scheme registered by the app on iOS and Android.
+const divineCustomScheme = 'divine';
+
+/// Host of the NIP-46 callback the app mints for signer apps.
+const divineSignerCallbackHost = 'nostrconnect';
+
+/// Whether [uri] is the NIP-46 signer callback rather than an app route.
+///
+/// True for `divine://nostrconnect` (with or without a trailing slash, path,
+/// or query — third-party signers such as Aegis append their own params) and
+/// for the bare `divine:` / `divine://` / `divine:///` foregrounding shapes,
+/// which carry no route intent.
+///
+/// Deliberately narrower than `uri.scheme == 'divine'`: matching on scheme
+/// alone classified every custom-scheme URL as a signer callback (#6733).
+bool isDivineSignerCallbackUri(Uri uri) {
+  if (uri.scheme != divineCustomScheme) return false;
+  if (uri.host == divineSignerCallbackHost) return true;
+  return uri.host.isEmpty && uri.pathSegments.isEmpty;
+}
+
 /// Service for handling universal/deep links
 class DeepLinkService {
   DeepLinkService();

--- a/mobile/lib/services/deep_link_service.dart
+++ b/mobile/lib/services/deep_link_service.dart
@@ -179,7 +179,14 @@ class DeepLinkService {
       // The signer opens this scheme to bring our app back to foreground
       // after the user approves the connection. We emit signerCallback so
       // listeners can trigger relay reconnection for the nostrconnect session.
-      if (uri.scheme == 'divine') {
+      //
+      // Match the callback the app actually mints — `divine://nostrconnect`
+      // (see NostrConnectCoordinator) — plus the bare scheme shapes
+      // (`divine:`, `divine://`, `divine:///`), which carry no route intent
+      // and should still foreground the app. Matching on scheme alone made
+      // every divine:// URL a signer callback and bounced it to /welcome
+      // (#6733).
+      if (isDivineSignerCallbackUri(uri)) {
         Log.info(
           'Received NIP-46 signer callback: ${redactUriStringForLogs(url)}',
           name: 'DeepLinkService',

--- a/mobile/test/router/aasa_claim_coverage_test.dart
+++ b/mobile/test/router/aasa_claim_coverage_test.dart
@@ -5,6 +5,8 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/router/router.dart';
+import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/services/deep_link_service.dart';
 
 const _divineAppId = 'GZCZBKH7MY.co.openvine.app';
@@ -60,7 +62,86 @@ const _allowlistedClaims = <String, String>{
       'Auth link path matches an internal GoRoute redirect directly; no DeepLinkType is emitted.',
 };
 
+// divine.video AASA claims the `divine://` custom scheme deliberately does
+// NOT mirror. Every other claim must stay reachable from both schemes so the
+// two contracts cannot drift (#6733).
+const _customSchemeExclusions = <String, String>{
+  '/app/callback':
+      'Keycast OAuth redirect consumed by the OAuth client, not routing.',
+  '/invite/*':
+      'No GoRoute to land on; invites are handled by the DeepLinkService '
+      'listener for https links only.',
+};
+
 void main() {
+  // GoRouter matches a custom-scheme location on uri.path alone, so the
+  // divine:// allowlist is what holds it at parity with the https claim set
+  // instead of exposing every registered route (#6733).
+  group('divine:// custom scheme parity', () {
+    test('reaches every divine.video claim except documented exclusions', () {
+      final home = VideoFeedPage.pathForIndex(0);
+
+      for (final pattern in _claimPatternsForHost('divine.video')) {
+        final exclusionReason = _customSchemeExclusions[pattern];
+
+        for (final path in _representativePathsFor(pattern)) {
+          final target = divineSchemeRedirectTarget(
+            Uri.parse('divine://$path'),
+          );
+
+          if (exclusionReason != null) {
+            expect(
+              target,
+              equals(home),
+              reason:
+                  'divine://$path is excluded from custom-scheme routing '
+                  '($exclusionReason) and must bounce home.',
+            );
+          } else {
+            expect(
+              target,
+              isNotNull,
+              reason:
+                  'divine.video claims $pattern over https but divine://$path '
+                  'is not routable. Add the prefix to the allowlist or '
+                  'document an exclusion.',
+            );
+            expect(
+              target,
+              isNot(equals(home)),
+              reason:
+                  'divine://$path bounced home despite $pattern being an '
+                  'AASA claim.',
+            );
+          }
+        }
+      }
+    });
+
+    test('denies routes the https contract never exposed', () {
+      final home = VideoFeedPage.pathForIndex(0);
+
+      for (final path in const <String>[
+        '/developer-options',
+        '/key-management',
+        '/import-key',
+        '/secure-account',
+        '/inbox',
+        '/inbox/message-requests',
+        '/settings',
+        '/relay-settings',
+        '/safety-settings',
+        '/account-review',
+      ]) {
+        expect(
+          divineSchemeRedirectTarget(Uri.parse('divine://$path')),
+          equals(home),
+          reason: '$path is not an AASA claim and must not be reachable.',
+        );
+      }
+    });
+  });
+
   group('AASA claim coverage', () {
     for (final host in _expectedClaimPatternsByHost.keys) {
       test('$host claimed paths are routed or explicitly allowlisted', () {

--- a/mobile/test/router/app_router_test.dart
+++ b/mobile/test/router/app_router_test.dart
@@ -22,11 +22,15 @@ import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/router/routes/settings_routes.dart';
 import 'package:openvine/screens/auth/nostr_connect_screen.dart';
+import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
 import 'package:openvine/screens/inbox/message_requests/request_preview_page.dart';
+import 'package:openvine/screens/profile_screen_router.dart';
+import 'package:openvine/screens/saved_videos_screen.dart';
 import 'package:openvine/screens/search_results/view/search_results_page.dart';
 import 'package:openvine/screens/settings/settings_screen.dart';
+import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/screens/video_recorder_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -463,6 +467,106 @@ void main() {
           relayUrl: 'wss://localrelay.link:28443',
         ),
       ).called(greaterThan(0));
+    });
+  });
+
+  // GoRouter matches a custom-scheme location on uri.path alone, so this gate
+  // is what keeps divine:// at parity with the universal-link claim set
+  // instead of exposing every registered route (#6733).
+  group('divine:// custom scheme routing', () {
+    test('resolves an allowlisted route to its internal path', () {
+      expect(
+        divineSchemeRedirectTarget(Uri.parse('divine:///video/abc123')),
+        equals(VideoDetailScreen.pathForId('abc123')),
+      );
+      expect(
+        divineSchemeRedirectTarget(
+          Uri.parse('divine:///profile/npub1abc123def456'),
+        ),
+        equals(ProfileScreenRouter.pathForNpub('npub1abc123def456')),
+      );
+      expect(
+        divineSchemeRedirectTarget(Uri.parse('divine:///hashtag/vines')),
+        equals(HashtagScreenRouter.pathForTag('vines')),
+      );
+    });
+
+    test('maps /search/* to the internal search-results route', () {
+      expect(
+        divineSchemeRedirectTarget(Uri.parse('divine:///search/music')),
+        equals(
+          SearchResultsPage.pathForQuery('music', requestFocusOnMount: false),
+        ),
+      );
+    });
+
+    test('opens saved videos, closing #7074', () {
+      expect(
+        divineSchemeRedirectTarget(Uri.parse('divine:///saved-videos')),
+        equals(SavedVideosScreen.path),
+      );
+    });
+
+    test('treats the two-slash authority form as a path segment', () {
+      expect(
+        divineSchemeRedirectTarget(Uri.parse('divine://video/abc123')),
+        equals(divineSchemeRedirectTarget(Uri.parse('divine:///video/abc123'))),
+      );
+    });
+
+    test('preserves the query string on a passthrough path', () {
+      expect(
+        divineSchemeRedirectTarget(
+          Uri.parse('divine:///video/abc123?a=34236%3Apubkey%3Adtag'),
+        ),
+        contains('a=34236'),
+      );
+    });
+
+    // The security core of #6733: a web page doing
+    // location = 'divine:///developer-options' must not reach the environment
+    // switcher just because the signer-callback predicate was narrowed.
+    for (final path in <String>[
+      '/developer-options',
+      '/key-management',
+      '/import-key',
+      '/secure-account',
+      '/inbox',
+      '/settings',
+      '/relay-settings',
+      // No GoRoute exists for invites, so it stays off the allowlist even
+      // though the AASA file claims /invite/* for https.
+      '/invite/ABCD-EFGH',
+    ]) {
+      test('bounces $path home instead of opening it', () {
+        expect(
+          divineSchemeRedirectTarget(Uri.parse('divine://$path')),
+          equals(VideoFeedPage.pathForIndex(0)),
+        );
+      });
+    }
+
+    test('ignores signer callbacks and bare scheme shapes', () {
+      for (final url in <String>[
+        'divine://nostrconnect?relay=wss://localrelay.link:28443',
+        'divine://nostrconnect',
+        'divine:',
+        'divine://',
+        'divine:///',
+      ]) {
+        expect(divineSchemeRedirectTarget(Uri.parse(url)), isNull, reason: url);
+      }
+    });
+
+    test('ignores universal links and internal routes', () {
+      for (final url in <String>[
+        'https://divine.video/video/abc123',
+        'https://evil.example/video/abc123',
+        '/home/0',
+        '/saved-videos',
+      ]) {
+        expect(divineSchemeRedirectTarget(Uri.parse(url)), isNull, reason: url);
+      }
     });
   });
 

--- a/mobile/test/services/deep_link_service_test.dart
+++ b/mobile/test/services/deep_link_service_test.dart
@@ -378,6 +378,50 @@ void main() {
           equals('wss://localrelay.link:28443'),
         );
       });
+
+      test('parses a bare nostrconnect callback with no query', () {
+        final result = DeepLinkService.parseDeepLink('divine://nostrconnect');
+
+        expect(result.type, equals(DeepLinkType.signerCallback));
+        expect(result.signerCallbackRelay, isNull);
+      });
+
+      test('parses a nostrconnect callback with a trailing slash', () {
+        final result = DeepLinkService.parseDeepLink('divine://nostrconnect/');
+
+        expect(result.type, equals(DeepLinkType.signerCallback));
+      });
+
+      // A signer that returns only the scheme still needs to foreground the
+      // app, and these shapes carry no route intent.
+      for (final url in <String>['divine:', 'divine://', 'divine:///']) {
+        test('treats the bare shape $url as a signer callback', () {
+          expect(
+            DeepLinkService.parseDeepLink(url).type,
+            equals(DeepLinkType.signerCallback),
+          );
+        });
+      }
+
+      // Regression guard for #6733: matching on scheme alone classified every
+      // divine:// URL as a signer callback, which bounced app routes to
+      // /welcome and let any third party trigger the callback side effects.
+      for (final url in <String>[
+        'divine:///video/abc123',
+        'divine://video/abc123',
+        'divine:///saved-videos',
+        'divine:///profile/npub1abc123def456',
+        'divine:///settings',
+        'divine:///developer-options',
+        'divine://quick-action/camera',
+      ]) {
+        test('does not classify $url as a signer callback', () {
+          expect(
+            DeepLinkService.parseDeepLink(url).type,
+            isNot(equals(DeepLinkType.signerCallback)),
+          );
+        });
+      }
     });
 
     group('Unknown URL Patterns', () {


### PR DESCRIPTION
## Description

`DeepLinkService.parseDeepLink` classified a URL as a NIP-46 signer callback on **scheme alone**, and it is the first branch in the function — so it pre-empted every route branch. Any `divine://` URL, whatever its path, became `signerCallback` and the router redirected it to `/welcome`.

Reproduced on an iPhone 17 Pro Max simulator: signed in and browsing the feed, opening `divine:///video/<id>/likers` ejected the user to the account picker.

```
[UI] 🔗 Processing deep link: DeepLink(type: signerCallback)
[UI] 🔗 Current router location: /home/0
[AUTH] Router redirect: signer callback … -> /welcome
```

Two commits, reviewable and revertable independently:

**1. Gate `divine://` routing to the universal-link path set.** GoRouter matches a custom-scheme location on `uri.path` alone, independently of `DeepLinkService`. That means simply narrowing the predicate would promote `divine://` from "reaches nothing" to "reaches all ~70 registered routes" — verified on device, `divine:///developer-options` opened the environment switcher (Production/Staging/Test/POC relay URLs). Universal links only ever exposed the six AASA-claimed paths. `divineSchemeRedirectTarget` holds the custom scheme at parity with that claim set and bounces everything else home. It reuses `universalLinkToRouterPath` so the public-vs-internal mapping (`/search/*` → `/search-results/:query`) cannot drift, and lifts the two-slash authority form so `divine://video/x` and `divine:///video/x` resolve identically.

**2. Match the signer callback on host.** `divine://nostrconnect` is what the app actually mints (`NostrConnectCoordinator`), plus the bare `divine:` / `divine://` / `divine:///` shapes, which carry no route intent and should still foreground the app. Third-party signers append their own params, so the host match tolerates any path or query.

This restores the narrower intent of #1700, which returned `unknown` here; #1713 widened it to `signerCallback` and #5622 then gave it a `/welcome` redirect.

`divine://quick-action/camera` (the shipped camera widget) is unaffected — `DivineQuickActionsPlugin` claims it natively on iOS before Dart sees it, and Android's widget uses an explicit-component Intent rather than a URL.

**Related Issues:** Closes #6733, Closes #7074

## Out of Scope

**Relay injection via the callback query param.** `signerCallbackRedirectTarget` calls `onSignerCallbackReceived(relayUrl:)`, which reaches `NostrConnectSession.addRelay` and will open a socket to any `ws(s)://` host. This PR does **not** close it — an attacker can use `divine://nostrconnect?relay=…`, the exact host that must stay accepted. It is pre-existing and bounded: a true no-op unless a pairing is actively listening, and even then the ceiling is metadata only (constant-time secret compare, `auth_url` challenge URLs never surfaced per #3760, junk responses dropped silently per #3355/#5683). It belongs with #3579 (deep-link parameter validation) rather than expanding this diff into auth-sensitive code.

`Admin/Documentation/TROUBLESHOOTING_GUIDE.md` documents `divine://video/123` as a debug command; it has never worked, and starts working with this change. Different repo, not touched here.

## Verification

- `dart format` clean; `flutter analyze lib test integration_test` — no issues.
- `flutter test test/router test/services/deep_link_service_test.dart` — **437 passing** (baseline before this branch: 90 for the three directly affected suites, now 117; 27 new tests).
- Each commit verified green **independently** (commit 1 alone: 363 passing).
- Extended `aasa_claim_coverage_test.dart` with a `divine://` parity table so the two schemes cannot drift, plus a documented exclusion list (`/app/callback`, `/invite/*` — the latter has no GoRoute to land on).
- **Device pass** on iPhone 17 Pro Max simulator, after the fix:

| URL | Result |
|---|---|
| `divine:///saved-videos` | → `/saved-videos` → Saved Videos ✅ (#7074) |
| `divine:///video/abc123def456` | → `/video/abc123def456` → video detail ✅ |
| `divine://nostrconnect?relay=…` | → signer callback → `/welcome` ✅ preserved |
| `divine:///developer-options` | → `Ignoring non-routable` → home feed ✅ blocked |
| `divine:///key-management` | → home feed ✅ blocked |
| `divine:///settings` | → home feed ✅ blocked |

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore