### PR TITLE
refactor(packages): remove Flutter SDK dependencies from repository packages

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -81,6 +81,55 @@ of scope); the ui-service guard is further narrowed to the presentation
 subtrees. The full ratchet policy is in
 [docs/BLOC_UI_MIGRATION_PRD.md](BLOC_UI_MIGRATION_PRD.md).
 
+### Which packages may depend on Flutter (issue #3338)
+
+A package under `mobile/packages/` may declare a runtime Flutter SDK
+dependency when it is one of:
+
+- a **native plugin** — it ships a `flutter: plugin:` block and talks over a
+  `MethodChannel` (`background_uploader`, `caption_generator`,
+  `divine_quick_actions`, `image_metadata_stripper`), or wraps one
+  (`keycast_flutter`, `media_cache`, `nostr_key_manager`, `sound_service`,
+  `analytics`, `iap_repository`, `permissions_service`);
+- a **presentation-layer package** — it exports widgets
+  (`divine_ui`, `divine_camera`, `divine_video_player`,
+  `infinite_video_feed`, `tv_static_effect`);
+- a consumer of a **Flutter-only API with no pure-Dart substitute** —
+  `dm_repository` (`compute`, `kReleaseMode`), `unified_logger`
+  (`kDebugMode`/`kIsWeb`/`debugPrint`), `blurhash_service` (`foundation.dart`),
+  `nostr_sdk` (Android NIP-55 external signer).
+
+Anything else is out of policy. To re-derive the current set — the list above
+is hand-maintained and can drift:
+
+```bash
+awk 'FNR==1{d=0;hit=0} /^dependencies:/{d=1;next} /^[^ ]/{d=0}
+     !hit&&d&&/^  flutter(_web_plugins)?:$/{getline
+       if($0~/sdk: flutter/){print FILENAME;hit=1}}' mobile/packages/*/pubspec.yaml
+```
+
+`flutter_test` under `dev_dependencies:` is **not** counted — test-only Flutter
+is fine, and six packages on `main` already ship exactly that shape.
+
+In the API group, everything except `nostr_sdk` is a removal candidate:
+`unified_logger` needs an injected console sink, `blurhash_service` imports
+`foundation.dart` for almost nothing, and `dm_repository` needs `compute`
+replaced. None of the three decouples anything on its own while `nostr_sdk` is
+still in the way, which is the second point below.
+
+Two things are worth knowing before doing more of this work:
+
+- **Removing a `flutter: sdk: flutter` entry is zero-risk but also cosmetic.**
+  `pubspec.lock` is bit-identical across the removal and no native plugin is
+  deregistered (`flutter` has no `plugin:` key, so it is never a plugin). It
+  makes the manifest honest; it does not decouple anything.
+- **No package in the `nostr_sdk` cone can run under `dart test`.** `nostr_sdk`
+  declares the Flutter SDK and five Flutter plugins, and nearly every package
+  reaches it — `models` included, via `models -> nostr_sdk`. So a package with
+  no `flutter:` line is still not a pure-Dart package. Making that true
+  requires splitting `nostr_sdk`'s Android NIP-55 signer (4 files, 735 LOC)
+  into a Flutter-side shim, which is tracked as the #3338 follow-up epic.
+
 ## Go deeper
 
 - [`.claude/rules/architecture.md`](../.claude/rules/architecture.md) — the full contract (per-layer responsibilities, dependency graph, DI, barrel files, when to extract a package). **Source of truth.**

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -119,10 +119,18 @@ still in the way, which is the second point below.
 
 Two things are worth knowing before doing more of this work:
 
-- **Removing a `flutter: sdk: flutter` entry is zero-risk but also cosmetic.**
-  `pubspec.lock` is bit-identical across the removal and no native plugin is
-  deregistered (`flutter` has no `plugin:` key, so it is never a plugin). It
-  makes the manifest honest; it does not decouple anything.
+- **Removing a `flutter: sdk: flutter` entry changes nothing at build time,
+  but it is not cosmetic — it turns the boundary into a gate.** Nothing about
+  the build moves: `pubspec.lock` is bit-identical across the removal, and no
+  native plugin is deregistered (`flutter` has no `plugin:` key, so it is
+  never a plugin). What changes is what the package is *allowed to import*.
+  Every package under `mobile/packages/` includes `very_good_analysis`, which
+  enables `depend_on_referenced_packages`; with the entry gone, a
+  `package:flutter/...` import anywhere in that package's `lib/` becomes an
+  analyze failure, and each package's own CI workflow runs `flutter analyze`.
+  So re-opening the boundary costs a pubspec edit that shows up in review,
+  rather than an import nobody notices. (A package with no workflow of its
+  own — `nostr_apps` today — gets the local guard but no CI gate.)
 - **No package in the `nostr_sdk` cone can run under `dart test`.** `nostr_sdk`
   declares the Flutter SDK and five Flutter plugins, and nearly every package
   reaches it — `models` included, via `models -> nostr_sdk`. So a package with

--- a/mobile/packages/blossom_upload_service/pubspec.yaml
+++ b/mobile/packages/blossom_upload_service/pubspec.yaml
@@ -11,12 +11,6 @@ dependencies:
   convert: ^3.1.1
   crypto: ^3.0.6
   dio: ^5.7.0
-  # Required transitively by flutter_test (dev) and image_metadata_stripper.
-  # The lib/ sources do NOT import dart:ui or any flutter/* package — this
-  # package is a pure Dart data layer. Do not remove without first confirming
-  # both transitive deps are gone.
-  flutter:
-    sdk: flutter
   hive_ce: ^2.6.0
   image_metadata_stripper:
     path: ../image_metadata_stripper

--- a/mobile/packages/cache_sync/lib/src/cache_result.dart
+++ b/mobile/packages/cache_sync/lib/src/cache_result.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 /// A single value emitted by the cache system.
 ///

--- a/mobile/packages/cache_sync/pubspec.yaml
+++ b/mobile/packages/cache_sync/pubspec.yaml
@@ -6,12 +6,9 @@ resolution: workspace
 
 environment:
   sdk: ^3.11.0
-  flutter: ^3.41.1
 
 dependencies:
   drift: ^2.34.0
-  flutter:
-    sdk: flutter
   meta: ^1.16.0
   path: ^1.9.1
   path_provider: ^2.1.5

--- a/mobile/packages/content_blocklist_repository/lib/src/blocklist_change.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/blocklist_change.dart
@@ -1,7 +1,7 @@
 // ABOUTME: Granular blocklist change events emitted on the changes stream
 // ABOUTME: Subscribers (e.g. VideoEventService) react per-pubkey on additions
 
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 /// Type of blocklist mutation. Used by [BlocklistChange.op] so subscribers
 /// can decide whether the change should hide content

--- a/mobile/packages/content_blocklist_repository/pubspec.yaml
+++ b/mobile/packages/content_blocklist_repository/pubspec.yaml
@@ -8,12 +8,10 @@ resolution: workspace
 
 environment:
   sdk: ^3.11.0
-  flutter: ^3.41.1
 
 dependencies:
   content_policy:
-  flutter:
-    sdk: flutter
+  meta: ^1.17.0
   models:
     path: ../models
   nostr_client:

--- a/mobile/packages/curation_repository/pubspec.yaml
+++ b/mobile/packages/curation_repository/pubspec.yaml
@@ -10,8 +10,6 @@ environment:
   sdk: ^3.11.0
 
 dependencies:
-  flutter:
-    sdk: flutter
   http: ^1.3.0
   likes_repository:
     path: ../likes_repository

--- a/mobile/packages/db_client/pubspec.yaml
+++ b/mobile/packages/db_client/pubspec.yaml
@@ -6,13 +6,10 @@ resolution: workspace
 
 environment:
   sdk: ^3.11.0
-  flutter: ^3.41.1
 
 dependencies:
   collection: ^1.19.1
   drift: ^2.34.0
-  flutter:
-    sdk: flutter
   meta: ^1.16.0
   models:
     path: ../models

--- a/mobile/packages/feed_tuning_repository/pubspec.yaml
+++ b/mobile/packages/feed_tuning_repository/pubspec.yaml
@@ -10,8 +10,6 @@ environment:
   sdk: ^3.11.0
 
 dependencies:
-  flutter:
-    sdk: flutter
   meta: ^1.17.0
   models:
     path: ../models

--- a/mobile/packages/nostr_apps/pubspec.yaml
+++ b/mobile/packages/nostr_apps/pubspec.yaml
@@ -6,11 +6,8 @@ resolution: workspace
 
 environment:
   sdk: ^3.11.0
-  flutter: ^3.41.1
 
 dependencies:
-  flutter:
-    sdk: flutter
   http: ^1.5.0
   meta: ^1.17.0
   models:

--- a/mobile/packages/profile_repository/pubspec.yaml
+++ b/mobile/packages/profile_repository/pubspec.yaml
@@ -19,8 +19,6 @@ dev_dependencies:
 dependencies:
   db_client:
   equatable: ^2.0.8
-  flutter:
-    sdk: flutter
   funnelcake_api_client:
   http: ^1.2.2
   models:

--- a/mobile/packages/video_event_cache/pubspec.yaml
+++ b/mobile/packages/video_event_cache/pubspec.yaml
@@ -10,8 +10,6 @@ environment:
   sdk: ^3.11.0
 
 dependencies:
-  flutter:
-    sdk: flutter
   models:
     path: ../models
 


### PR DESCRIPTION
Relates to #3338. **Deliberately does not close it** — see "What's left" below.

## What this does

Removes the Flutter SDK dependency from every `mobile/packages/*` package that does not need it (29 → 20), and documents which packages may keep it and why.

## Why this is worth merging

Every package under `mobile/packages/` carries its own `analysis_options.yaml` that includes `very_good_analysis`, which enables **`depend_on_referenced_packages`**. Dropping the `flutter: sdk: flutter` entry is exactly what turns a `package:flutter/...` import in that package's `lib/` into an analyze failure — and 8 of the 9 packages touched here run `flutter analyze` in their own CI workflow.

So the boundary this PR draws is **enforced, not documentary**. Before: a repository package could grow a Flutter import and nothing would object. After: re-opening it costs a pubspec edit that is visible in review.

A/B on `feed_tuning_repository` — identical probe file (`import 'package:flutter/foundation.dart'` in `lib/src/`) in both arms, only the pubspec differing:

| pubspec shape | `flutter analyze lib` |
|---|---|
| `main` today (`flutter: sdk: flutter` present) | exit **0** — `No issues found!` |
| this PR (entry removed) | exit **1** — `depend_on_referenced_packages`, the only issue |

`follow_repository` already ships the stripped shape on `main`, so this is the existing convention being extended, not a new one being invented.

Credit to @hm21 for identifying this. The original description of this PR led with "cosmetic" and "`pubspec.lock` is bit-identical" and never mentioned the lint, which is a materially misleading framing of the change — that has been corrected here and in the committed docs page.

### Changes

| Commit | Change |
|---|---|
| 1 | Drop `flutter: sdk: flutter` from 7 packages whose `lib/` never imports it (+ the matching `environment: flutter:` constraints) |
| 2 | `@immutable` from `package:meta` instead of `flutter/foundation` in `cache_sync` + `content_blocklist_repository` |
| 3 | Document the sanctioned set: the policy, the packages in each group, and an `awk` one-liner to re-derive the list |
| 4 | Correct that docs page — the removal is a gate, not cosmetics (review follow-up) |

## Scope limits

These are the honest limits of the change. They are *not* reasons it lacks value — the enforcement above is separate from all of them.

**`mobile/pubspec.lock` is bit-identical after this PR.** Nothing about the build moves. No plugin is deregistered either — `flutter` has no `plugin:` key, so it is never itself a plugin. What changes is what each package is permitted to import.

**No package here becomes pure Dart at runtime.** Every one of the nine still reaches Flutter transitively:

| Package | Still reaches Flutter via |
|---|---|
| `cache_sync` | `path_provider` |
| `blossom_upload_service` | `image_metadata_stripper`, `unified_logger` |
| `db_client` | `models`→`nostr_sdk`, `nostr_sdk`, `path_provider` |
| `curation_repository`, `profile_repository`, `content_blocklist_repository` | `models`→`nostr_sdk`, `nostr_sdk`, `unified_logger` |
| `feed_tuning_repository` | `models`→`nostr_sdk`, `nostr_sdk` |
| `nostr_apps`, `video_event_cache` | `models`→`nostr_sdk` |

**Acceptance criterion 3 ("package tests pass with pure Dart `dart test`") is not achievable yet** and I'd suggest amending it. `nostr_sdk` declares the Flutter SDK plus five Flutter plugins, and essentially every package reaches it — `models` included. Demonstrated:

```
packages/count_formatter  (no nostr_sdk edge)   $ dart test  ->  +19 All tests passed!
packages/models           (has nostr_sdk edge)  $ dart test  ->  +0 -52 Some tests failed.
```

Not a new discovery — commit `03e9d4d4d` (#2988) already recorded it: *"Workspace resolution requires Flutter SDK even for Dart-only packages, so `dart_package.yml` fails with version solving error."*

**`nostr_apps` has no CI workflow of its own**, so it gets the analyzer guard locally but no CI gate. Pre-existing (it also has no `test/` directory on `main`), not introduced here.

## What's left

The remaining decoupling needs `nostr_sdk` split, which is the follow-up epic. The encouraging part: only **735 LOC (4.6%)** of its 15,869 is genuinely platform-bound (the NIP-55 Android signer), **1,468 LOC (9.3%) is dead**, and of the 388 files importing `nostr_sdk`, only 6 touch a shim symbol — **none in `mobile/packages`**.

Because that work is outstanding, this PR relates to #3338 rather than closing it.

## Scope changes during review

Three commits came out of this PR after [an earlier review](https://github.com/divinevideo/divine-mobile/pull/7107#pullrequestreview-4913678097):

- **The `compute` shim** in `dm_repository` — a pure-Dart port of Flutter's `compute`, which is what would buy that package the same enforced boundary.
- **The `check_package_flutter_boundary.sh` ratchet** — a shrink-only guard on the count of direct `flutter:` declarations, which is what would stop a re-added pubspec entry from silently re-opening a boundary.
- **`permissions_service` declaration** → split to #7116, which has since merged. Independent of this refactor; that split stands regardless.

[That review has since been retracted](https://github.com/divinevideo/divine-mobile/pull/7107#pullrequestreview-4914709120), and its author's position is now that the shim and the ratchet do earn their cost, for the same enforcement reason this PR leads with. **Whether to restore them here or ship them as a focused follow-up is open** — neither is lost work, and the current diff stands on its own either way.

## Verification

- `flutter pub get` — resolves clean, `pubspec.lock` unchanged (confirming the bit-identical claim above)
- `flutter analyze lib test integration_test` — No issues found
- The enforcement A/B above, run on `feed_tuning_repository` with the probe removed and the pubspec restored afterwards
- All nine touched packages: no `package:flutter/` import remains anywhere in `lib/`
- Package tests green — `db_client` 919, `profile_repository` 407, `blossom_upload_service` 234 (+3 skipped), `content_blocklist_repository` 118, `cache_sync` 83, `curation_repository` 82, `feed_tuning_repository` 16, `video_event_cache` 7
- The documented `awk` one-liner returns exactly the 20 packages the docs list

No behaviour change and no runtime surface in this diff: nine manifests, two `@immutable` imports, and a docs page.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [x] 📝 Documentation
- [ ] 🗑️ Chore
