### PR TITLE
fix(dm): recognize divine-web's legacy DM video-share citation

### DIFF
--- a/mobile/lib/screens/inbox/conversation/dm_video_target.dart
+++ b/mobile/lib/screens/inbox/conversation/dm_video_target.dart
@@ -3,7 +3,6 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:models/models.dart';
-import 'package:openvine/utils/divine_video_url.dart';
 
 /// Normalized identity and routing metadata for a video shared in a DM.
 @immutable

--- a/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
@@ -198,11 +198,15 @@ class MessageBubble extends StatelessWidget {
           .toList();
       personalMessage = beforeLines.isEmpty ? null : beforeLines.join('\n');
     } else if (videoTarget != null) {
+      // Identity came from the citation rather than a URL in the body, so the
+      // body is not the share template — it is only what the sender typed.
+      // Strip the machine-readable `nostr:` line we append on the wire, but
+      // NOT the quoted-title line: with no template to strip a title from,
+      // that filter would swallow a comment the sender wrapped in quotes.
       final lines = safeMessage
           .split('\n')
           .map((line) => line.trim())
           .where((line) => line.isNotEmpty)
-          .where((line) => !_quotedTitleRegex.hasMatch(line))
           .where((line) => !_nostrRefLineRegex.hasMatch(line))
           .toList();
       personalMessage = lines.isEmpty ? null : lines.join('\n');

--- a/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
@@ -22,7 +22,6 @@ import 'package:openvine/screens/inbox/conversation/dm_video_target.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/video_link_preview_cubit.dart';
 import 'package:openvine/screens/search_results/view/search_results_page.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
-import 'package:openvine/utils/divine_video_url.dart';
 import 'package:openvine/utils/external_link_launcher.dart';
 import 'package:openvine/utils/string_utils.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_support.dart';

--- a/mobile/lib/screens/inbox/widgets/conversation_tile.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_tile.dart
@@ -12,7 +12,6 @@ import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/widgets/moderation_identity.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
-import 'package:openvine/utils/divine_video_url.dart';
 import 'package:openvine/utils/string_utils.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:unified_logger/unified_logger.dart';

--- a/mobile/packages/dm_repository/lib/src/dm_shared_video_citation.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_shared_video_citation.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Builds + parses the NIP-18 `q` citation for a video shared in a DM.
 // ABOUTME: Encodes naddr (addressable 34236) / nevent (regular 22) per NIP-19.
+// ABOUTME: Also reads divine-web's legacy `r` + `a` share shape (#6224).
 
+import 'package:dm_repository/src/collaborator_invite_recovery.dart';
 import 'package:models/models.dart';
 import 'package:nostr_sdk/nip19/nip19_tlv.dart';
 
@@ -71,10 +73,17 @@ class DmSharedVideoCitation {
     );
   }
 
-  /// Parses the first `q` tag of a kind-14 rumor's [tags] into a
-  /// [DmSharedVideoRef]. Total — returns `null` for absent/malformed tags so a
-  /// plain message degrades gracefully.
-  static DmSharedVideoRef? parse(List<List<String>> tags) {
+  /// Parses a kind-14 rumor's [tags] into a [DmSharedVideoRef]. Total —
+  /// returns `null` for absent/malformed tags so a plain message degrades
+  /// gracefully.
+  ///
+  /// Tries the canonical NIP-18 `q` citation first, then falls back to the
+  /// legacy divine-web share shape (see [_parseLegacyWebShare]).
+  static DmSharedVideoRef? parse(List<List<String>> tags) =>
+      _parseQTag(tags) ?? _parseLegacyWebShare(tags);
+
+  /// Parses the first `q` tag into a [DmSharedVideoRef].
+  static DmSharedVideoRef? _parseQTag(List<List<String>> tags) {
     for (final tag in tags) {
       if (tag.length < 2 || tag[0] != 'q') continue;
       final value = tag[1];
@@ -117,4 +126,74 @@ class DmSharedVideoCitation {
     }
     return null;
   }
+
+  /// Parses divine-web's legacy share shape: `['r', <canonical url>]` plus
+  /// `['a', '<kind>:<author>:<d>']` (#6224).
+  ///
+  /// divine-web emitted this from 2026-03-09 until its DM share path was
+  /// removed on 2026-08-04, and never wrote the URL into the rumor content —
+  /// so without this fallback those messages render as plain text, or as an
+  /// empty bubble when the sender attached the share with no comment.
+  ///
+  /// Two tags are deliberately NOT accepted:
+  ///
+  /// - **`e`**, because NIP-17 reserves it for the reply parent and
+  ///   `DmRepository` already assigns any `e` tag to `replyToId`. Treating it
+  ///   as a citation would render a compact quoted preview instead of a share
+  ///   card and leave the video actions disabled. divine-web only ever shared
+  ///   kind 34236, so its `e` branch was effectively unreachable anyway.
+  /// - **A bare `a` with no companion `r`**, because Divine's own
+  ///   collaborator-invite DM also carries an addressable video coordinate.
+  static DmSharedVideoRef? _parseLegacyWebShare(List<List<String>> tags) {
+    if (_hasCollaboratorInviteMarker(tags)) return null;
+
+    // divine-web wrote `r` first and unconditionally on every share, and no
+    // Divine DM producer emits an `r` tag otherwise — so requiring a canonical
+    // divine.video URL is what makes the `a` fallback unambiguous.
+    if (!_hasDivineVideoUrlTag(tags)) return null;
+
+    for (final tag in tags) {
+      if (tag.length < 2 || tag[0] != 'a') continue;
+      final coordinate = tag[1];
+      final parts = coordinate.split(':');
+      if (parts.length < 3) continue;
+
+      final kind = int.tryParse(parts.first);
+      if (kind != DmSharedVideoKind.addressableShortVideo.kind &&
+          kind != DmSharedVideoKind.addressableNormalVideo.kind) {
+        continue;
+      }
+
+      // divine-web built the coordinate from unvalidated URL query params, so
+      // guard both segments rather than trusting the wire.
+      final author = parts[1];
+      if (!_isHex64(author)) continue;
+      if (parts.sublist(2).join(':').isEmpty) continue;
+
+      return DmSharedVideoRef(
+        coordinateOrId: coordinate,
+        videoKind: DmSharedVideoKind.fromKind(kind!),
+        relayHint: tag.length >= 3 && tag[2].isNotEmpty ? tag[2] : null,
+        authorPubkey: author,
+      );
+    }
+    return null;
+  }
+
+  /// Whether [tags] carry the `['divine', 'collab-invite']` marker that
+  /// identifies a collaborator invite rather than a shared video.
+  static bool _hasCollaboratorInviteMarker(List<List<String>> tags) => tags.any(
+    (tag) =>
+        tag.length >= 2 &&
+        tag[0] == CollaboratorInviteTags.markerName &&
+        tag[1] == CollaboratorInviteTags.markerValue,
+  );
+
+  /// Whether [tags] carry an `r` tag holding a canonical divine.video URL.
+  static bool _hasDivineVideoUrlTag(List<List<String>> tags) => tags.any(
+    (tag) =>
+        tag.length >= 2 &&
+        tag[0] == 'r' &&
+        divineVideoUrlRegex.hasMatch(tag[1]),
+  );
 }

--- a/mobile/packages/dm_repository/lib/src/dm_shared_video_citation.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_shared_video_citation.dart
@@ -189,11 +189,18 @@ class DmSharedVideoCitation {
         tag[1] == CollaboratorInviteTags.markerValue,
   );
 
-  /// Whether [tags] carry an `r` tag holding a canonical divine.video URL.
+  /// Whether [tags] carry an `r` tag that *starts with* a divine.video share
+  /// URL.
+  ///
+  /// Anchored at the start so a URL merely embedded in some other string
+  /// (`https://elsewhere.example/?next=<share url>`) cannot satisfy the gate.
+  /// Not anchored at the end: divine-web interpolated the video's `d` tag into
+  /// the path without percent-encoding, so a legitimate share can carry a
+  /// trailing `.`, `?`, `#`, or `/` that a full-string match would reject.
   static bool _hasDivineVideoUrlTag(List<List<String>> tags) => tags.any(
     (tag) =>
         tag.length >= 2 &&
         tag[0] == 'r' &&
-        divineVideoUrlRegex.hasMatch(tag[1]),
+        divineVideoUrlRegex.matchAsPrefix(tag[1]) != null,
   );
 }

--- a/mobile/packages/dm_repository/test/src/dm_shared_video_citation_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_shared_video_citation_test.dart
@@ -280,6 +280,30 @@ void main() {
       );
     });
 
+    test('rejects an `r` tag that merely embeds a divine.video URL', () {
+      expect(
+        DmSharedVideoCitation.parse(
+          webShareTags(url: 'https://elsewhere.example/?next=$shareUrl'),
+        ),
+        isNull,
+      );
+    });
+
+    test('accepts a share URL carrying an unescaped d-tag', () {
+      // divine-web interpolated the `d` tag into the path with no
+      // percent-encoding, so a relay-supplied d-tag puts characters the URL
+      // grammar would otherwise end on straight into the `r` value.
+      const dottedTag = 'my.vine.2024';
+      final ref = DmSharedVideoCitation.parse(
+        webShareTags(
+          coordinate: '34236:$author:$dottedTag',
+          url: 'https://divine.video/video/$dottedTag',
+        ),
+      )!;
+
+      expect(ref.dTag, equals(dottedTag));
+    });
+
     test('rejects a coordinate whose author is not 64-hex', () {
       // divine-web built the coordinate from unvalidated URL query params.
       expect(

--- a/mobile/packages/dm_repository/test/src/dm_shared_video_citation_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_shared_video_citation_test.dart
@@ -199,4 +199,133 @@ void main() {
       expect(ref.isAddressable, isTrue);
     });
   });
+
+  // divine-web's `buildDmShareTags`, live 2026-03-09 → 2026-08-04, wrote
+  // `['r', url]` first and unconditionally, then an optional `['title', …]`,
+  // then either `['a', '34236:<pubkey>:<d>']` or `['e', <id>]` — and never put
+  // the URL in the rumor content. See #6224.
+  group('DmSharedVideoCitation.parse — legacy divine-web share', () {
+    const shareUrl = 'https://divine.video/video/$dTag';
+
+    List<List<String>> webShareTags({
+      String? coordinate,
+      String url = shareUrl,
+      bool omitCoordinate = false,
+    }) {
+      final address = coordinate ?? '34236:$author:$dTag';
+      return <List<String>>[
+        ['p', 'b' * 64],
+        ['r', url],
+        ['title', 'My reel'],
+        if (!omitCoordinate) ['a', address],
+      ];
+    }
+
+    test('parses the r + a share shape into an addressable ref', () {
+      final ref = DmSharedVideoCitation.parse(webShareTags())!;
+
+      expect(ref.coordinateOrId, equals('34236:$author:$dTag'));
+      expect(ref.videoKind, equals(DmSharedVideoKind.addressableShortVideo));
+      expect(ref.authorPubkey, equals(author));
+      expect(ref.dTag, equals(dTag));
+    });
+
+    test('parses the addressable normal-video (34235) coordinate', () {
+      final ref = DmSharedVideoCitation.parse(
+        webShareTags(coordinate: '34235:$author:$dTag'),
+      )!;
+
+      expect(ref.videoKind, equals(DmSharedVideoKind.addressableNormalVideo));
+    });
+
+    test('a `q` tag still wins when both shapes are present', () {
+      final ref = DmSharedVideoCitation.parse([
+        ...webShareTags(),
+        ['q', '34236:$eventId:other-reel', relay],
+      ])!;
+
+      expect(ref.coordinateOrId, equals('34236:$eventId:other-reel'));
+    });
+
+    test('ignores a collaborator invite carrying the same coordinate', () {
+      // The invite ships its own addressable `a` tag; without the marker guard
+      // it would render as a shared-video card.
+      expect(
+        DmSharedVideoCitation.parse([
+          ['divine', 'collab-invite'],
+          ['r', shareUrl],
+          ['a', '34236:$author:$dTag', relay, 'root'],
+          ['role', 'Collaborator'],
+        ]),
+        isNull,
+      );
+    });
+
+    test('requires a companion divine.video `r` tag', () {
+      expect(
+        DmSharedVideoCitation.parse([
+          ['p', 'b' * 64],
+          ['a', '34236:$author:$dTag'],
+        ]),
+        isNull,
+      );
+    });
+
+    test('rejects an `r` tag pointing somewhere other than divine.video', () {
+      expect(
+        DmSharedVideoCitation.parse(
+          webShareTags(url: 'https://example.com/video/$dTag'),
+        ),
+        isNull,
+      );
+    });
+
+    test('rejects a coordinate whose author is not 64-hex', () {
+      // divine-web built the coordinate from unvalidated URL query params.
+      expect(
+        DmSharedVideoCitation.parse(
+          webShareTags(coordinate: '34236:not-a-pubkey:$dTag'),
+        ),
+        isNull,
+      );
+    });
+
+    test('rejects a coordinate with an empty d-tag', () {
+      expect(
+        DmSharedVideoCitation.parse(webShareTags(coordinate: '34236:$author:')),
+        isNull,
+      );
+    });
+
+    test('rejects a non-video kind in the coordinate', () {
+      expect(
+        DmSharedVideoCitation.parse(
+          webShareTags(coordinate: '30023:$author:$dTag'),
+        ),
+        isNull,
+      );
+    });
+
+    test('never treats an `e` tag as a citation, even beside an `r`', () {
+      // NIP-17 reserves `e` for the reply parent, and DmRepository already
+      // assigns any `e` tag to replyToId — parsing it here would render a
+      // quoted preview instead of a share card and leave the actions dead.
+      expect(
+        DmSharedVideoCitation.parse([
+          ['p', 'b' * 64],
+          ['r', 'https://divine.video/video/$eventId'],
+          ['e', eventId],
+        ]),
+        isNull,
+      );
+    });
+
+    test('an `r` tag alone is not a citation', () {
+      // Carries no event identity, so there is nothing to resolve or save.
+      expect(
+        DmSharedVideoCitation.parse(webShareTags(omitCoordinate: true)),
+        isNull,
+      );
+    });
+  });
 }

--- a/mobile/packages/models/lib/models.dart
+++ b/mobile/packages/models/lib/models.dart
@@ -14,6 +14,7 @@ export 'src/curated_list.dart';
 export 'src/curation_publish_status.dart';
 export 'src/curation_set.dart';
 export 'src/divine_filter.dart';
+export 'src/divine_video_url.dart';
 export 'src/dm_conversation.dart';
 export 'src/dm_message.dart';
 export 'src/dm_reaction.dart';

--- a/mobile/packages/models/lib/src/divine_video_url.dart
+++ b/mobile/packages/models/lib/src/divine_video_url.dart
@@ -1,5 +1,6 @@
 // ABOUTME: Regex + helpers for extracting divine.video URLs from text.
-// ABOUTME: Shared by the conversation bubble and the long-press handler.
+// ABOUTME: Shared by the conversation bubble, the long-press handler, and the
+// ABOUTME: DM shared-video citation parser.
 
 /// Detects the canonical share-link shape
 /// (`https://divine.video/video/<id>`).

--- a/mobile/packages/models/lib/src/dm_message.dart
+++ b/mobile/packages/models/lib/src/dm_message.dart
@@ -63,11 +63,12 @@ class DmMessage extends Equatable {
   /// File metadata for kind 15 messages. Null for kind 14.
   final DmFileMetadata? fileMetadata;
 
-  /// Structured reference to a video event cited via a NIP-18 `q` tag.
+  /// Structured reference to a video event cited via a NIP-18 `q` tag, or via
+  /// divine-web's legacy `r` + `a` share tags (#6224).
   ///
   /// Non-null when this message shares a video (e.g. a reel shared into the
   /// DM); lets the UI render a deterministic video card. Null for ordinary
-  /// messages and for legacy URL-only shares.
+  /// messages and for shares that carry only a URL and no event identity.
   final DmSharedVideoRef? sharedVideoRef;
 
   /// Durable, collision-proof id of the group-send fan-out this message

--- a/mobile/packages/models/lib/src/dm_shared_video_ref.dart
+++ b/mobile/packages/models/lib/src/dm_shared_video_ref.dart
@@ -31,9 +31,10 @@ enum DmSharedVideoKind {
 /// A structured reference to a video event cited inside a NIP-17 DM.
 ///
 /// Built from a NIP-18 `q` tag on a kind-14 rumor:
-/// `["q", "<coordinate-or-id>", "<relay-hint>", "<author?>"]`. Lets the
-/// recipient render a deterministic video card instead of regex-matching a URL
-/// embedded in the message text.
+/// `["q", "<coordinate-or-id>", "<relay-hint>", "<author?>"]`, or from
+/// divine-web's legacy `['r', <url>]` + `['a', <coordinate>]` share shape
+/// (#6224). Lets the recipient render a deterministic video card instead of
+/// regex-matching a URL embedded in the message text.
 class DmSharedVideoRef extends Equatable {
   const DmSharedVideoRef({
     required this.coordinateOrId,
@@ -80,8 +81,7 @@ class DmSharedVideoRef extends Equatable {
   /// `null` for addressable events.
   String? get eventId => isAddressable ? null : coordinateOrId;
 
-  /// JSON form for persistence in the `direct_messages.shared_video_ref_json`
-  /// Drift column.
+  /// JSON form of the reference.
   Map<String, dynamic> toJson() => <String, dynamic>{
     'coordinateOrId': coordinateOrId,
     'kind': videoKind.kind,

--- a/mobile/packages/models/test/src/divine_video_url_test.dart
+++ b/mobile/packages/models/test/src/divine_video_url_test.dart
@@ -1,5 +1,8 @@
-import 'package:flutter_test/flutter_test.dart';
-import 'package:openvine/utils/divine_video_url.dart';
+// ABOUTME: Tests for the canonical divine.video share-URL regexes.
+// ABOUTME: Covers casing, trailing punctuation, query strings, and id shapes.
+
+import 'package:models/models.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('divineVideoUrlLineRegex', () {

--- a/mobile/test/screens/inbox/conversation/dm_video_target_test.dart
+++ b/mobile/test/screens/inbox/conversation/dm_video_target_test.dart
@@ -139,19 +139,11 @@ void main() {
       expect(target!.stableId, equals(dTag));
       expect(target.authorPubkey, equals(author));
       expect(target.videoKind, equals(34236));
+      expect(target.fallbackRouteIds, equals(['34236:$author:$dTag']));
       expect(
         target.canonicalUrl,
         equals('https://divine.video/video/$dTag'),
       );
-    });
-
-    test('keeps the author-scoped fallback route for repository lookup', () {
-      final target = resolveDmVideoTarget(
-        content: '',
-        sharedVideoRef: webRef(),
-      );
-
-      expect(target!.fallbackRouteIds, equals(['34236:$author:$dTag']));
     });
 
     test('a typed comment does not displace the citation identity', () {

--- a/mobile/test/screens/inbox/conversation/dm_video_target_test.dart
+++ b/mobile/test/screens/inbox/conversation/dm_video_target_test.dart
@@ -154,14 +154,18 @@ void main() {
       expect(target!.fallbackRouteIds, equals(['34236:$author:$dTag']));
     });
 
-    test('resolves when the sender typed a comment alongside the share', () {
+    test('a typed comment does not displace the citation identity', () {
+      // The comment carries no URL, so the citation must remain the only
+      // source of identity — not fall back to regex-matching the body.
       final target = resolveDmVideoTarget(
-        content: 'check this out',
+        content: 'check this out https://example.com/video/decoy',
         sharedVideoRef: webRef(),
       );
 
       expect(target, isNotNull);
       expect(target!.stableId, equals(dTag));
+      expect(target.authorPubkey, equals(author));
+      expect(target.videoKind, equals(34236));
     });
   });
 }

--- a/mobile/test/screens/inbox/conversation/dm_video_target_test.dart
+++ b/mobile/test/screens/inbox/conversation/dm_video_target_test.dart
@@ -116,4 +116,52 @@ void main() {
       expect(target.fallbackRouteIds, isEmpty);
     });
   });
+
+  // divine-web never wrote the share URL into the rumor content and allowed
+  // sending a share with an empty draft, so the citation is the only identity
+  // these messages carry. See #6224.
+  group('resolveDmVideoTarget — legacy divine-web share', () {
+    const dTag = 'my-reel-123';
+
+    DmSharedVideoRef webRef() => const DmSharedVideoRef(
+      coordinateOrId: '34236:$author:$dTag',
+      videoKind: DmSharedVideoKind.addressableShortVideo,
+      authorPubkey: author,
+    );
+
+    test('resolves from the citation alone when content is empty', () {
+      final target = resolveDmVideoTarget(
+        content: '',
+        sharedVideoRef: webRef(),
+      );
+
+      expect(target, isNotNull);
+      expect(target!.stableId, equals(dTag));
+      expect(target.authorPubkey, equals(author));
+      expect(target.videoKind, equals(34236));
+      expect(
+        target.canonicalUrl,
+        equals('https://divine.video/video/$dTag'),
+      );
+    });
+
+    test('keeps the author-scoped fallback route for repository lookup', () {
+      final target = resolveDmVideoTarget(
+        content: '',
+        sharedVideoRef: webRef(),
+      );
+
+      expect(target!.fallbackRouteIds, equals(['34236:$author:$dTag']));
+    });
+
+    test('resolves when the sender typed a comment alongside the share', () {
+      final target = resolveDmVideoTarget(
+        content: 'check this out',
+        sharedVideoRef: webRef(),
+      );
+
+      expect(target, isNotNull);
+      expect(target!.stableId, equals(dTag));
+    });
+  });
 }

--- a/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
@@ -908,6 +908,36 @@ void main() {
         ).called(greaterThanOrEqualTo(1));
       });
 
+      // divine-web put the share only in tags and allowed an empty draft, so
+      // before #6224 this bubble rendered with no card — and mid-group, with
+      // no text and no timestamp either, i.e. completely blank.
+      testWidgets(
+        'renders a legacy divine-web share that carries no content at all',
+        (tester) async {
+          when(
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+              'abc123',
+              fallbackRouteIds: any(named: 'fallbackRouteIds'),
+            ),
+          ).thenAnswer((_) async => testVideo);
+
+          await tester.pumpWidget(
+            buildWithVideoMessage(
+              message: '',
+              sharedVideoRef: const DmSharedVideoRef(
+                coordinateOrId: '34236:$_testHexPubkey:abc123',
+                videoKind: DmSharedVideoKind.addressableShortVideo,
+                authorPubkey: _testHexPubkey,
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.byType(VideoThumbnailWidget), findsOneWidget);
+          expect(find.text('My Cool Video'), findsOneWidget);
+        },
+      );
+
       testWidgets('renders the shared-video bubble on a neutral dark frame', (
         tester,
       ) async {

--- a/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
@@ -938,6 +938,35 @@ void main() {
         },
       );
 
+      // A legacy share's body is not the share template — it is only what the
+      // sender typed. Stripping the template's quoted-title line here would
+      // swallow a comment the sender happened to wrap in quotes.
+      testWidgets('keeps a quoted comment on a citation-only share', (
+        tester,
+      ) async {
+        when(
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            'abc123',
+            fallbackRouteIds: any(named: 'fallbackRouteIds'),
+          ),
+        ).thenAnswer((_) async => testVideo);
+
+        await tester.pumpWidget(
+          buildWithVideoMessage(
+            message: '"nice one"',
+            sharedVideoRef: const DmSharedVideoRef(
+              coordinateOrId: '34236:$_testHexPubkey:abc123',
+              videoKind: DmSharedVideoKind.addressableShortVideo,
+              authorPubkey: _testHexPubkey,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(VideoThumbnailWidget), findsOneWidget);
+        expect(find.text('"nice one"'), findsOneWidget);
+      });
+
       testWidgets('renders the shared-video bubble on a neutral dark frame', (
         tester,
       ) async {


### PR DESCRIPTION
## Description

A video shared into a DM from divine-web rendered on mobile as plain text — or, mid-thread with an empty draft, as a **completely blank bubble** (no card, no text, not even a timestamp) — with no video card, no **Copy video URL** and no **Save Video**.

The two clients cited a shared video with disjoint tag shapes. divine-web wrote the citation into tags only:

```
kind 14 rumor
content: ""                                  ← the URL was NEVER written here
tags:    [["p", sender], ["p", recipient],
          ["r", "https://divine.video/video/<d>"],   ← always, first
          ["title", "…"],                            ← optional
          ["a", "34236:<pubkey>:<d>"]]               ← or ["e", <id>]
```

Mobile's `DmSharedVideoCitation.parse` skipped every tag that was not `q`, so `sharedVideoRef` stayed null; `resolveDmVideoTarget` then had neither a content URL nor a structured ref and returned null, and `MessageBubble` fell through to a branch that emits **no children at all** when the content is empty.

This adds a legacy fallback, tried only when no `q` tag is present.

**Two tags are deliberately not accepted:**

- **`e`** — NIP-17 reserves it for the reply parent, and the inbound parser already assigns any `e` tag to `replyToId` (`dm_repository.dart:1853`, last-wins, no marker filter). Accepting it would render a compact quoted preview *instead of* a share card and leave the video actions dead. divine-web's `VIDEO_KINDS == [34236]` and a 34236 without a d-tag is dropped before it can be shared, so its `e` branch was effectively unreachable anyway.
- **A bare `a` with no companion divine.video `r` tag** — Divine's own collaborator-invite DM also ships an addressable video coordinate in a kind-14. The `['divine','collab-invite']` marker guards that a second time.

The coordinate's author and d-tag segments are now validated, since divine-web built them from unvalidated URL query params (`34236:<garbage>:<garbage>` was producible).

**This is retroactive.** `parse` is called at row→model read time over tags the inbound path already persists verbatim (`tagsJson: jsonEncode(rumor.tags)`), so already-stored messages light up with **no migration and no relay refetch**. Caveat worth knowing: rows ingested before the `tags_json` column shipped in **1.0.9** (2026-04-28) have no tags to read; those are repaired only by the full re-drain a sign-out or reinstall triggers.

**Related Issue:** Closes #6224

## Context: the producer is already gone

divine-web deleted its DM share path in divinevideo/divine-web#516 (`793d1b0c`, 2026-08-04) — 15 days after this issue was filed — as collateral of restricting web messaging to Divine Support. `buildDmShareTags`, the function the issue names as root cause, no longer exists, and a CI guard asserts its absence.

So the issue's **Option A ("divine-web conforms") is moot for this repo**; its home is divine-web#457, which is itself largely obsoleted because #516 made web Support-only for *reading* too. What this PR serves is **already-published wraps** (producer live and unflagged for 148 days, 2026-03-09 → 2026-08-04) plus any third-party NIP-17 client that cites a video the same way.

Worth flagging: NIP-17's `q` is an uppercase **MAY**, NIP-27 calls quote tags "optional", and NIP-01 makes `a` a standard cross-kind tag — so web's shape was *legal-but-undefined* for citation, not wrong. Only `e` was a genuine collision.

## Out of Scope

Found while investigating, deliberately not fixed here:

- **`r`-only shares** (an `r` tag with no `a`). Not in the issue's acceptance criteria, and not producible by any live or historical UI path — it needed a hand-edited `/messages?shareUrl=…` query, and that whole path is deleted. Supporting it needs a new `DmMessage` field plus 3 call sites, because representing it as a `DmSharedVideoRef` would require a malformed coordinate that `inline_reel_reply_cubit.dart:50` re-emits onto the wire.
- **`dm_repository.dart:1853`** assigns any `e` tag to `replyToId` with no NIP-10 marker filter. Real but inert, and stays inert precisely because this PR never parses `e`.
- **`parse` rejects the spec-legal 3-element `q` tag** (`["q", id, relay]`), dropping conformant third-party citations — Amethyst's chat composer can emit fewer than 4 elements. Landed in #6213; separate concern.
- **divine-web's reader** takes the first `e` tag of any kind-14 as a video id, so an ordinary mobile DM reply renders on web as a broken video card. Wrong repo — belongs on divine-web#457.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter analyze lib test` in `packages/dm_repository` and `packages/models` — clean
- `dart format --set-exit-if-changed` over all 12 changed files — clean
- `packages/dm_repository` — **573 tests pass** (12 new legacy-share parser cases)
- `packages/models` — **898 tests pass** (25 relocated URL-regex tests)
- `test/screens/inbox/` — **417 tests pass** (4 new regression cases)

The change was developed against a failing repro first: a test driving the real `parse → resolveDmVideoTarget → MessageBubble` pipeline with the recovered web wire shape reproduced all five defect assertions, including the blank bubble, and a control proved the same video renders fine via mobile's `q` shape with an identical repository stub. Those assertions are now inverted into the regression tests above.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
