### PR TITLE
fix(deps): declare permissions_service in the app pubspec

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -133,9 +133,6 @@ dependencies:
   webview_flutter_android: ^4.10.13 # Direct dep for AndroidWebViewController (frame attestation, #4105)
   webview_flutter_wkwebview: ^3.24.1
 
-  # Not imported by lib/ directly — consumed through permissions_service. Kept
-  # declared because it is a Flutter plugin: dropping it would deregister the
-  # permission_handler native plugins and fail at runtime, not at compile time.
   permission_handler: ^12.0.1 # Handle runtime permissions
   record: ^7.1.0 # Microphone capture for voice-over recording
 

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -133,6 +133,9 @@ dependencies:
   webview_flutter_android: ^4.10.13 # Direct dep for AndroidWebViewController (frame attestation, #4105)
   webview_flutter_wkwebview: ^3.24.1
 
+  # Not imported by lib/ directly — consumed through permissions_service. Kept
+  # declared because it is a Flutter plugin: dropping it would deregister the
+  # permission_handler native plugins and fail at runtime, not at compile time.
   permission_handler: ^12.0.1 # Handle runtime permissions
   record: ^7.1.0 # Microphone capture for voice-over recording
 
@@ -258,6 +261,9 @@ dependencies:
 
   # People Lists Repository - NIP-51 kind 30000 follow sets
   people_lists_repository:
+
+  # Permissions Service - runtime permission checks (camera, mic, photos)
+  permissions_service:
 
   # Profile Repository - Kind 0 user metadata persistence and search
   profile_repository:


### PR DESCRIPTION
## Description

`mobile/lib` imports `package:permissions_service/permissions_service.dart` from seven files — `main.dart`, `providers/permissions_providers.dart`, `blocs/camera_permission/camera_permission_bloc.dart`, `blocs/video_editor/voice_over/voice_over_cubit.dart`, `screens/video_editor/voice_over_recorder_screen.dart`, `services/gallery_save_service.dart` and `widgets/gallery_permission_sheet.dart` — but the package appears in `mobile/pubspec.yaml` only inside the `workspace:` block. It was never declared as a dependency. It resolves today purely because workspace members share one package config.

This declares the real dependency.

One consequence worth recording: `permissions_service` depends on `permission_handler: ^12.0.1`, so declaring it also pulls `permission_handler` and its five platform packages into the app's dependency closure transitively, not only through the app's own direct entry. Plugin registration is derived from that closure, so the six `permission_handler*` packages stay registered by either path.

**Related Issue:** Relates to #3338 — found while auditing package Flutter dependencies there. Split out of #7107 at reviewer request, since it is independent of that PR's refactor and can merge on its own schedule.

## Out of Scope

Nothing else from #7107 — that PR keeps the Flutter-dependency removals and the architecture docs.

No attempt to remove the app's direct `permission_handler` entry or to change plugin registration in any way.

## Verification

- `flutter pub get` — resolves clean, `pubspec.lock` unchanged (the package was already resolved via the workspace, so declaring it is a manifest-only fix)
- `flutter analyze lib test integration_test` — No issues found
- Verified against `origin/main` that `permissions_service` appears there only in the `workspace:` block and never under `dependencies:`
- Confirmed in `.dart_tool/package_graph.json` on this branch that `openvine` reaches `permission_handler` both directly and through `permissions_service`, and that all six `permission_handler*` packages resolve

No behaviour change: nothing is added to or removed from the resolved dependency graph.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
