### PR TITLE
feat(upload): report the nostr blurhash pass as a publish metric

### DIFF
--- a/mobile/lib/services/video_publish/publish_timeline.dart
+++ b/mobile/lib/services/video_publish/publish_timeline.dart
@@ -55,6 +55,23 @@ abstract class PublishPhases {
 /// parallel with [PublishPhases.uploadTransfer], so `upload_ms` is roughly the
 /// longer of the two rather than their sum. Only the summary log line's
 /// top-level phases add up to the total.
+///
+/// `nostr_blurhash_ms` is a slice inside `nostr_ms`, beside `sign_ms` and
+/// `nostr_publish_ms`. It carries the parent's prefix because the upload leg
+/// derives a blurhash of its own ([PublishPhases.uploadThumbnailBlurhash]).
+///
+/// Its presence means the Nostr leg entered the fallback path for deriving a
+/// second blurhash, not that one was successfully produced. Its absence on a
+/// publish that reached the relay usually means the Nostr leg reused
+/// `PendingUpload.blurhash`; it can also mean the fallback had no local video
+/// path to decode. The other exception is a publish that coalesced onto another
+/// chain's event and reported no `nostr.*` slice at all, which
+/// [logPublishPhase] describes.
+///
+/// [PublishPhases.uploadThumbnailExtract],
+/// [PublishPhases.uploadThumbnailBlurhash], and
+/// [PublishPhases.uploadThumbnailPut] stay unmapped because
+/// [PublishPhases.uploadThumbnail] already accounts for their time.
 const Map<String, String> _metricByPhase = {
   PublishPhases.upload: 'upload_ms',
   PublishPhases.uploadTransfer: 'transfer_ms',
@@ -62,6 +79,7 @@ const Map<String, String> _metricByPhase = {
   PublishPhases.mentions: 'mentions_ms',
   PublishPhases.subtitles: 'subtitles_ms',
   PublishPhases.nostr: 'nostr_ms',
+  PublishPhases.nostrBlurhash: 'nostr_blurhash_ms',
   PublishPhases.nostrSign: 'sign_ms',
   PublishPhases.nostrPublish: 'nostr_publish_ms',
   PublishPhases.invites: 'invites_ms',
@@ -123,8 +141,12 @@ typedef PublishPhase = ({String name, Duration elapsed});
 ///   them, so attributing them to the publish that happened to wait would be
 ///   the wrong answer, not a missing one.
 /// - `VideoEventPublisher` (`nostr.sign`, `nostr.publish`, `nostr.blurhash`) —
-///   always inside the zone; `publishVideoEvent` is awaited directly by
-///   `VideoPublishService`.
+///   inside the zone when this publish signed its own event, because
+///   `VideoPublishService` awaits `publishVideoEvent` directly. Outside it
+///   when `publishDirectUpload` finds an event already in flight for the same
+///   video and returns that future rather than signing a duplicate (#6018).
+///   The slices then run in the first chain's zone, so the publish that joined
+///   reports `nostr_ms` with nothing inside it.
 ///
 /// A `Timer`, an isolate hop, or a future scheduled outside `run` would drop
 /// the metric the same silent way. There is deliberately no assert for it:

--- a/mobile/test/services/video_publish/publish_timeline_test.dart
+++ b/mobile/test/services/video_publish/publish_timeline_test.dart
@@ -276,6 +276,65 @@ void main() {
         expect(monitor.trace.metrics['transfer_ms'], equals(240000));
       });
 
+      test('reports the second blurhash pass the Nostr leg made', () async {
+        await traced.run(() async {
+          traced.record(PublishPhases.nostr, const Duration(seconds: 4));
+          logPublishPhase(
+            PublishPhases.nostrBlurhash,
+            const Duration(milliseconds: 3800),
+          );
+        });
+
+        traced.finish(outcome: 'success');
+
+        // Unmapped, this decode was 3.8s of `nostr_ms` the console could not
+        // attribute to anything.
+        expect(monitor.trace.metrics['nostr_blurhash_ms'], equals(3800));
+        expect(monitor.trace.metrics['nostr_ms'], equals(4000));
+      });
+
+      test('omits the blurhash metric when the upload leg supplied one', () {
+        // The Nostr leg emits no phase at all when it reuses the upload's
+        // blurhash, so an absent `nostr_blurhash_ms` on a successful publish
+        // counts as "the second decode was skipped" rather than zero-cost work.
+        traced
+          ..record(PublishPhases.nostr, const Duration(milliseconds: 120))
+          ..finish(outcome: 'success');
+
+        expect(monitor.trace.metrics['nostr_ms'], equals(120));
+        expect(monitor.trace.metrics.containsKey('nostr_blurhash_ms'), isFalse);
+      });
+
+      test('leaves the thumbnail sub-phases as log-only detail', () async {
+        await traced.run(() async {
+          traced.record(
+            PublishPhases.uploadThumbnail,
+            const Duration(milliseconds: 150),
+          );
+          logPublishPhase(
+            PublishPhases.uploadThumbnailExtract,
+            const Duration(milliseconds: 90),
+          );
+          logPublishPhase(
+            PublishPhases.uploadThumbnailBlurhash,
+            const Duration(milliseconds: 20),
+          );
+          logPublishPhase(
+            PublishPhases.uploadThumbnailPut,
+            const Duration(milliseconds: 40),
+          );
+        });
+
+        traced.finish(outcome: 'success');
+
+        // Their parent is mapped, so leaving them out hides no time. The whole
+        // key set is pinned so mapping any sub-phase under any name trips this.
+        expect(
+          monitor.trace.metrics.keys,
+          unorderedEquals(<String>['thumbnail_ms', publishTotalMetric]),
+        );
+      });
+
       test('omits a metric for a phase that never ran', () {
         traced.finish(outcome: 'success');
 


### PR DESCRIPTION
## Description

`PublishPhases.nostrBlurhash` was measured at its call site but had no entry in `_metricByPhase`, so the console never saw it. Joining the publish phase metrics per individual publish, that left 31% of the median iOS publish — 3,969 ms — inside the Nostr leg with no metric to attribute it to, against 1.3% on Android. It is now mapped to `nostr_blurhash_ms`.

The doc comment above `_metricByPhase` states the three invariants a future reader needs in order to read the metric correctly. The measurement that produced each one lives here rather than in the comment, so the comment stays true as the numbers age.

**The metric carries its leg's prefix.** The upload leg derives a blurhash too (`upload.thumbnail.blurhash`), so a bare `blurhash_ms` would stop saying which pass it measured the moment that one is mapped as well. A Firebase metric cannot be renamed without orphaning the series behind it, so the prefix is free now and impossible once a release ships. Same reason `nostr.publish` reports as `nostr_publish_ms` rather than `publish_ms`.

**Absence is mostly a reading, not a hole.** The Nostr leg decodes a second frame only when the upload leg left `PendingUpload.blurhash` empty (#6554 made it reuse the upload's blurhash). So how often `nostr_blurhash_ms` appears is how often that fallback still fires — which is the redundancy question #7120 asks, answerable against real traffic instead of 23 iOS samples. One caveat: `publishDirectUpload` returns an already-in-flight future when one exists for the same video (#6018), and a publish that coalesces runs the `nostr.*` slices in the first chain's zone. Those publishes report `nostr_ms` with nothing inside it, so they subtract from the fallback count rather than adding to it.

**`upload.thumbnail.{extract,blurhash,put}` stay deliberately log-only.** They subdivide a parent whose own metric already accounts for them, so omitting them hides no time from the console — the measured upload gap is 16 ms on iOS and 59 ms on Android. That is the opposite of `nostr.blurhash`, which left `nostr_ms` minus its siblings unexplained. Not a quota question either way: Firebase allows 32 metrics per trace and this brings `video_publish` to 13. Worth revisiting only if `thumbnail_ms` itself becomes the outlier.

**Related Issue:** Relates to #7120

#7120 stays open on merge. This PR ships the instrument its acceptance criteria are measured with, not the measurement: `nostr_blurhash_ms` appearing in the export, the iOS nostr gap being accounted for, and the reuse decision for the nostr-leg thumbnail extraction all need a release build to ship and traffic to accumulate behind it. Closing #7120 here would close it on the setup rather than on the answer.

## Out of Scope

Mapping `nostr_blurhash_ms` may not close the whole iOS gap. The audio legs — consent verification for a selected sound, and extracting/uploading/publishing a Kind 1063 for reusable audio — run unmeasured on the same critical path (the "20s+" path `publishDirectUpload`'s own doc warns about). Both are gated on the draft carrying a selected sound or opting into audio reuse, so neither can explain a gap at the *median*, which is why the blurhash fallback is the measurement worth taking first. An `audio_ms` phase is the natural next issue if `nostr_blurhash_ms` comes back small — filing it now would be guessing at which leg the data will implicate.

Attributing the coalesced publishes described above is also out of scope — it needs the timeline threaded through `_inFlightDirectPublishes` rather than carried in a zone, which is a change to the publisher's shape and not to this mapping.

## Verification

- `flutter test test/services/video_publish/publish_timeline_test.dart` — 32/32, including three new cases: the metric is reported for a publish that ran the phase, it is absent for one that reused the upload's blurhash, and the full metric key set is pinned so mapping a thumbnail sub-phase under any name trips the test rather than silently deepening the trace.
- `flutter test test/services/video_publish/` — 114/114.
- `flutter analyze lib/services/video_publish test/services/video_publish` — clean.
- `dart format --set-exit-if-changed` — clean.
- Publish verified on a real Samsung Galaxy. The device confirms the phase timing on the `PUBTIME` summary line; `nostr_blurhash_ms` itself is only observable in the Firebase console once a release build ships, which is what keeps #7120 open.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
