### PR TITLE
feat(perf): tag video_upload with an outcome attribute

### DIFF
--- a/mobile/lib/providers/upload_media_providers.dart
+++ b/mobile/lib/providers/upload_media_providers.dart
@@ -173,6 +173,10 @@ class _FirebasePerformanceAdapter implements BlossomPerformanceMonitor {
   @override
   void setMetric(String traceName, String metricName, int value) =>
       _monitor.setMetric(traceName, metricName, value);
+
+  @override
+  void putAttribute(String traceName, String attribute, String value) =>
+      _monitor.putAttribute(traceName, attribute, value);
 }
 
 /// Blossom BUD-01 authentication service for age-restricted content

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_performance_monitor.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_performance_monitor.dart
@@ -14,6 +14,13 @@ abstract class BlossomPerformanceMonitor {
 
   /// Set a metric value on an active trace.
   void setMetric(String traceName, String metricName, int value);
+
+  /// Set an attribute on an active trace, so the APM console can slice the
+  /// duration distribution by it.
+  ///
+  /// Call before [stopTrace] — an attribute set after the trace is reported
+  /// is dropped.
+  void putAttribute(String traceName, String attribute, String value);
 }
 
 /// A no-op implementation that silently discards all performance calls.
@@ -29,4 +36,7 @@ class NoOpPerformanceMonitor implements BlossomPerformanceMonitor {
 
   @override
   void setMetric(String traceName, String metricName, int value) {}
+
+  @override
+  void putAttribute(String traceName, String attribute, String value) {}
 }

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -34,6 +34,40 @@ void _logUploadPhase(String phase, Duration elapsed, {String? detail}) {
   );
 }
 
+/// Name of the performance trace covering a video upload.
+const _uploadTraceName = 'video_upload';
+
+/// Attribute tagging how the traced upload ended, so the console can keep
+/// failed, cancelled and handed-off uploads out of the duration distribution.
+const _outcomeAttribute = 'outcome';
+
+/// The upload reached the server and the blob is addressable.
+const _outcomeSuccess = 'success';
+
+/// The user stopped the upload. Terminal but not a failure, so it is kept
+/// apart from `error:*` rather than folded into it.
+const _outcomeCancelled = 'cancelled';
+
+/// The file was handed to the OS background transport and the traced,
+/// in-process work is done. The transfer itself completes later, outside this
+/// trace, so its duration says nothing about upload throughput.
+const _outcomeEnqueued = 'enqueued';
+
+/// Something escaped the upload without producing a result.
+const _outcomeThrew = 'threw';
+
+/// Value for [_outcomeAttribute] describing how [result] ended.
+///
+/// Mirrors the `video_publish` convention: `success`, or `error:<reason>`
+/// keyed on [BlossomUploadFailureReason], with a user cancellation broken out
+/// as its own value.
+String _uploadOutcome(BlossomUploadResult result) {
+  if (result.success) return _outcomeSuccess;
+  final reason = result.failureReason;
+  if (reason == BlossomUploadFailureReason.cancelled) return _outcomeCancelled;
+  return 'error:${(reason ?? BlossomUploadFailureReason.unknown).name}';
+}
+
 bool _hasTransientDioSignal(DioException error) {
   final statusCode = error.response?.statusCode;
   if (statusCode != null && statusCode >= 500) return true;
@@ -1922,8 +1956,48 @@ class BlossomUploadService {
     void Function(double)? onProgress,
   }) async {
     // Start performance trace for video upload
-    await _performanceMonitor.startTrace('video_upload');
+    await _performanceMonitor.startTrace(_uploadTraceName);
 
+    try {
+      final result = await _uploadVideoTraced(
+        videoFile: videoFile,
+        nostrPubkey: nostrPubkey,
+        title: title,
+        proofManifestJson: proofManifestJson,
+        description: description,
+        hashtags: hashtags,
+        resumableSession: resumableSession,
+        onResumableSessionUpdated: onResumableSessionUpdated,
+        onProgress: onProgress,
+      );
+      _performanceMonitor.putAttribute(
+        _uploadTraceName,
+        _outcomeAttribute,
+        _uploadOutcome(result),
+      );
+      return result;
+    } finally {
+      // Stop performance trace
+      await _performanceMonitor.stopTrace(_uploadTraceName);
+    }
+  }
+
+  /// Body of [uploadVideo], run inside its `video_upload` trace.
+  ///
+  /// Split out so the outcome can be tagged from the single returned result
+  /// instead of at each of the method's exits.
+  Future<BlossomUploadResult> _uploadVideoTraced({
+    required File videoFile,
+    required String nostrPubkey,
+    required String title,
+    required String? proofManifestJson,
+    required String? description,
+    required List<String>? hashtags,
+    required BlossomResumableUploadSession? resumableSession,
+    required void Function(BlossomResumableUploadSession)?
+    onResumableSessionUpdated,
+    required void Function(double)? onProgress,
+  }) async {
     try {
       // Check authentication before attempting any uploads
       if (!authProvider.isAuthenticated) {
@@ -1957,7 +2031,7 @@ class BlossomUploadService {
 
       // Add file size metric to performance trace
       _performanceMonitor.setMetric(
-        'video_upload',
+        _uploadTraceName,
         'file_size_bytes',
         fileSize,
       );
@@ -2145,9 +2219,6 @@ class BlossomUploadService {
         errorMessage: 'Blossom upload failed: $e',
         failureReason: _classifyUploadException(e),
       );
-    } finally {
-      // Stop performance trace
-      await _performanceMonitor.stopTrace('video_upload');
     }
   }
 
@@ -2189,13 +2260,21 @@ class BlossomUploadService {
     }
 
     var traceRunning = false;
+    // Overwritten before every exit that produces a result; the initial value
+    // covers a throw on the way to one (hashing, server discovery, signing).
+    var traceOutcome = _outcomeThrew;
     Future<void> stopTraceOnce() async {
       if (!traceRunning) return;
       traceRunning = false;
-      await _performanceMonitor.stopTrace('video_upload');
+      _performanceMonitor.putAttribute(
+        _uploadTraceName,
+        _outcomeAttribute,
+        traceOutcome,
+      );
+      await _performanceMonitor.stopTrace(_uploadTraceName);
     }
 
-    await _performanceMonitor.startTrace('video_upload');
+    await _performanceMonitor.startTrace(_uploadTraceName);
     traceRunning = true;
     try {
       onProgress?.call(0.1);
@@ -2203,7 +2282,7 @@ class BlossomUploadService {
       final fileSize = hashResult.size;
       final fileHash = hashResult.hash;
       _performanceMonitor.setMetric(
-        'video_upload',
+        _uploadTraceName,
         'file_size_bytes',
         fileSize,
       );
@@ -2225,6 +2304,7 @@ class BlossomUploadService {
         );
         if (result.success) {
           onProgress?.call(1);
+          traceOutcome = _outcomeSuccess;
           return result;
         }
       }
@@ -2239,11 +2319,13 @@ class BlossomUploadService {
         authTtl: _backgroundAuthTtl,
       );
       if (authHeader == null) {
-        return const BlossomUploadResult(
+        const result = BlossomUploadResult(
           success: false,
           errorMessage: 'Failed to create Blossom authentication',
           failureReason: BlossomUploadFailureReason.authUnavailable,
         );
+        traceOutcome = _uploadOutcome(result);
+        return result;
       }
 
       final headers = <String, dynamic>{
@@ -2259,6 +2341,9 @@ class BlossomUploadService {
       );
 
       final completer = Completer<BlossomUploadResult>();
+      // Mirrors what the completer holds, readable synchronously so the trace
+      // can be tagged with a terminal outcome that landed before hand-off ends.
+      BlossomUploadResult? settledResult;
       final sub = transport.events
           .where((event) => event.taskId == taskId)
           .listen((event) {
@@ -2273,6 +2358,7 @@ class BlossomUploadService {
               serverUrl: serverUrl,
             );
             if (result.success) onProgress?.call(1);
+            settledResult = result;
             completer.complete(result);
           });
 
@@ -2288,21 +2374,32 @@ class BlossomUploadService {
             headers: stringHeaders,
             filePath: videoFile.path,
           );
+          // A transfer that already reached a terminal state during hand-off
+          // (a fast failure, or a cancel that raced it) really was covered by
+          // this trace, so report what happened. Anything still in flight
+          // outlives the trace and `enqueued` is all it can truthfully claim.
+          final settled = settledResult;
+          traceOutcome = settled == null
+              ? _outcomeEnqueued
+              : _uploadOutcome(settled);
         } on Object catch (e) {
+          final failure = BlossomUploadResult(
+            success: false,
+            errorMessage: 'Failed to enqueue background upload: $e',
+            failureReason: _classifyUploadException(e),
+          );
+          traceOutcome = _uploadOutcome(failure);
           if (!completer.isCompleted) {
-            completer.complete(
-              BlossomUploadResult(
-                success: false,
-                errorMessage: 'Failed to enqueue background upload: $e',
-                failureReason: _classifyUploadException(e),
-              ),
-            );
+            completer.complete(failure);
           }
         }
 
         // Setup + enqueue are the only in-process work; stop the trace here so
         // it doesn't span the OS-owned transfer wait (which can include a long
-        // app suspension and would otherwise pollute the perf metric).
+        // app suspension and would otherwise pollute the perf metric). The
+        // transfer's own terminal outcome lands after this point, so a handed-
+        // off upload is tagged `enqueued` rather than claiming a success it
+        // cannot yet know about.
         await stopTraceOnce();
         return await completer.future.timeout(
           timeout,

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_outcome_trace_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_outcome_trace_test.dart
@@ -1,0 +1,387 @@
+// ABOUTME: Tests the `outcome` attribute tagged on the video_upload trace
+// ABOUTME: for every terminal path of the in-process and OS-background uploads
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockAuthProvider extends Mock implements BlossomAuthProvider {}
+
+class _MockDio extends Mock implements Dio {}
+
+/// Records every attribute put on a trace, keyed by trace name, so a test can
+/// assert what the console would receive.
+class _RecordingPerformanceMonitor implements BlossomPerformanceMonitor {
+  final List<({String trace, String attribute, String value})> attributes = [];
+  final List<String> stopped = [];
+
+  /// Attributes that arrived after their trace was already reported. Firebase
+  /// silently drops these, so any entry here is a bug the tests must catch.
+  final List<String> lateAttributes = [];
+
+  /// The `outcome` values tagged on the `video_upload` trace, in order.
+  List<String> get uploadOutcomes => attributes
+      .where((a) => a.trace == 'video_upload' && a.attribute == 'outcome')
+      .map((a) => a.value)
+      .toList();
+
+  @override
+  Future<void> startTrace(String traceName) async {}
+
+  @override
+  Future<void> stopTrace(String traceName) async => stopped.add(traceName);
+
+  @override
+  void setMetric(String traceName, String metricName, int value) {}
+
+  @override
+  void putAttribute(String traceName, String attribute, String value) {
+    if (stopped.contains(traceName)) {
+      lateAttributes.add('$traceName.$attribute');
+    }
+    attributes.add((trace: traceName, attribute: attribute, value: value));
+  }
+}
+
+/// Emits [emitOnEnqueue] from inside [enqueue], after the service subscribed,
+/// so a terminal event that lands during hand-off is never missed by a race.
+class _FakeTransport implements BlossomBackgroundTransport {
+  _FakeTransport({
+    this.emitOnEnqueue = const [],
+    this.throwOnEnqueue = false,
+    this.bufferedTerminal,
+  });
+
+  final List<BlossomBackgroundTransferEvent> emitOnEnqueue;
+  final bool throwOnEnqueue;
+  final BlossomBackgroundTransferEvent? bufferedTerminal;
+
+  final StreamController<BlossomBackgroundTransferEvent> _controller =
+      StreamController<BlossomBackgroundTransferEvent>.broadcast();
+
+  @override
+  Stream<BlossomBackgroundTransferEvent> get events => _controller.stream;
+
+  /// Delivers [event] after hand-off, the way the OS reports a transfer that
+  /// was still running when [enqueue] returned.
+  void emit(BlossomBackgroundTransferEvent event) => _controller.add(event);
+
+  @override
+  Future<void> enqueue({
+    required String taskId,
+    required String url,
+    required String method,
+    required Map<String, String> headers,
+    required String filePath,
+  }) async {
+    if (throwOnEnqueue) throw Exception('enqueue failed');
+    emitOnEnqueue.forEach(_controller.add);
+  }
+
+  @override
+  Future<void> cancel(String taskId) async {}
+
+  @override
+  Future<BlossomBackgroundTransferEvent?> takeBufferedTerminalEvent(
+    String taskId,
+  ) async => bufferedTerminal;
+}
+
+const _server = 'https://media.divine.video';
+const _taskId = 'upload-1';
+const _publicKey =
+    '0223456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    registerFallbackValue(Options());
+  });
+
+  late _MockAuthProvider auth;
+  late _MockDio dio;
+  late _RecordingPerformanceMonitor monitor;
+  late Directory tempDir;
+  late File videoFile;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(const <String, Object>{});
+    auth = _MockAuthProvider();
+    dio = _MockDio();
+    monitor = _RecordingPerformanceMonitor();
+
+    when(() => auth.isAuthenticated).thenReturn(true);
+    when(
+      () => auth.createAndSignEvent(
+        kind: any(named: 'kind'),
+        content: any(named: 'content'),
+        tags: any(named: 'tags'),
+      ),
+    ).thenAnswer(
+      (_) async => const BlossomSignedEvent(
+        json: <String, dynamic>{
+          'id': 'test_id',
+          'pubkey': _publicKey,
+          'created_at': 0,
+          'kind': 24242,
+          'tags': <dynamic>[],
+          'content': 'Upload video to Blossom server',
+          'sig': 'test_sig',
+        },
+      ),
+    );
+
+    tempDir = await Directory.systemTemp.createTemp('blossom_outcome_test_');
+    videoFile = File('${tempDir.path}/video.mp4')
+      ..writeAsBytesSync(List<int>.generate(8, (i) => i));
+  });
+
+  tearDown(() async => tempDir.delete(recursive: true));
+
+  BlossomUploadService service({BlossomBackgroundTransport? transport}) =>
+      BlossomUploadService(
+        authProvider: auth,
+        dio: dio,
+        defaultServerUrl: _server,
+        backgroundTransport: transport,
+        performanceMonitor: monitor,
+      );
+
+  /// Stubs the legacy whole-file PUT path: capability discovery reports no
+  /// resumable support, then the blob PUT answers with [statusCode].
+  void stubLegacyPut({required int statusCode}) {
+    when(
+      () => dio.head<dynamic>(any(), options: any(named: 'options')),
+    ).thenAnswer(
+      (_) async => Response(
+        requestOptions: RequestOptions(path: '/upload'),
+        statusCode: 200,
+        headers: Headers(),
+      ),
+    );
+    when(
+      () => dio.put<dynamic>(
+        any(),
+        data: any(named: 'data'),
+        options: any(named: 'options'),
+        onSendProgress: any(named: 'onSendProgress'),
+      ),
+    ).thenAnswer(
+      (_) async => Response(
+        requestOptions: RequestOptions(path: '/upload'),
+        statusCode: statusCode,
+        headers: Headers(),
+        data: const <String, dynamic>{'url': '$_server/blob', 'size': 8},
+      ),
+    );
+  }
+
+  Future<BlossomUploadResult> upload(BlossomUploadService s) => s.uploadVideo(
+    videoFile: videoFile,
+    nostrPubkey: _publicKey,
+    title: 'Test Video',
+    description: null,
+    hashtags: null,
+    proofManifestJson: null,
+  );
+
+  group('uploadVideo outcome attribute', () {
+    test('tags success when the blob reaches the server', () async {
+      stubLegacyPut(statusCode: 200);
+
+      final result = await upload(service());
+
+      expect(result.errorMessage, isNull);
+      expect(result.success, isTrue);
+      expect(monitor.uploadOutcomes, ['success']);
+    });
+
+    test('tags error:<reason> when every server rejects the blob', () async {
+      stubLegacyPut(statusCode: 500);
+
+      final result = await upload(service());
+
+      expect(result.success, isFalse);
+      expect(monitor.uploadOutcomes, ['error:server']);
+    });
+
+    test('tags error:auth when the user is not signed in', () async {
+      when(() => auth.isAuthenticated).thenReturn(false);
+
+      final result = await upload(service());
+
+      expect(result.success, isFalse);
+      expect(monitor.uploadOutcomes, ['error:auth']);
+    });
+
+    test('tags the outcome before the trace is stopped', () async {
+      stubLegacyPut(statusCode: 200);
+
+      await upload(service());
+
+      expect(monitor.stopped, ['video_upload']);
+      expect(monitor.lateAttributes, isEmpty);
+    });
+  });
+
+  group('uploadVideoInBackground outcome attribute', () {
+    BlossomBackgroundTransferEvent event(
+      BlossomBackgroundTransferStatus status, {
+      int? httpStatusCode,
+    }) => BlossomBackgroundTransferEvent(
+      taskId: _taskId,
+      status: status,
+      httpStatusCode: httpStatusCode,
+    );
+
+    Future<BlossomUploadResult> background(BlossomUploadService s) =>
+        s.uploadVideoInBackground(
+          videoFile: videoFile,
+          taskId: _taskId,
+          proofManifestJson: null,
+        );
+
+    test('tags enqueued once the OS owns the still-running transfer', () async {
+      final transport = _FakeTransport(
+        emitOnEnqueue: [event(BlossomBackgroundTransferStatus.running)],
+      );
+
+      final future = background(service(transport: transport));
+      // The transfer has not reached a terminal state, so the trace can only
+      // claim the hand-off it actually measured.
+      await pumpEventQueue();
+      expect(monitor.uploadOutcomes, ['enqueued']);
+
+      transport.emit(
+        event(BlossomBackgroundTransferStatus.completed, httpStatusCode: 200),
+      );
+      expect((await future).success, isTrue);
+    });
+
+    test('tags cancelled when the user stops the transfer', () async {
+      final transport = _FakeTransport(
+        emitOnEnqueue: [event(BlossomBackgroundTransferStatus.cancelled)],
+      );
+
+      final result = await background(service(transport: transport));
+
+      expect(result.failureReason, BlossomUploadFailureReason.cancelled);
+      expect(monitor.uploadOutcomes, ['cancelled']);
+    });
+
+    test(
+      'tags error:<reason> when the transfer fails during hand-off',
+      () async {
+        final transport = _FakeTransport(
+          emitOnEnqueue: [
+            event(BlossomBackgroundTransferStatus.failed, httpStatusCode: 500),
+          ],
+        );
+
+        final result = await background(service(transport: transport));
+
+        expect(result.success, isFalse);
+        expect(monitor.uploadOutcomes, ['error:server']);
+      },
+    );
+
+    test('tags error:authUnavailable when the signer is unreachable', () async {
+      when(
+        () => auth.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer((_) async => null);
+
+      final result = await background(service(transport: _FakeTransport()));
+
+      expect(
+        result.failureReason,
+        BlossomUploadFailureReason.authUnavailable,
+      );
+      expect(monitor.uploadOutcomes, ['error:authUnavailable']);
+    });
+
+    test('tags error:<reason> when the transfer cannot be enqueued', () async {
+      final transport = _FakeTransport(throwOnEnqueue: true);
+
+      final result = await background(service(transport: transport));
+
+      expect(result.success, isFalse);
+      expect(monitor.uploadOutcomes, ['error:unknown']);
+    });
+
+    test('tags success when a buffered terminal event is claimed', () async {
+      final transport = _FakeTransport(
+        bufferedTerminal: event(
+          BlossomBackgroundTransferStatus.completed,
+          httpStatusCode: 200,
+        ),
+      );
+
+      final result = await background(service(transport: transport));
+
+      expect(result.success, isTrue);
+      expect(monitor.uploadOutcomes, ['success']);
+    });
+
+    test('tags threw when setup throws before any result exists', () async {
+      // A missing file makes the streaming hash throw, which no catch inside
+      // uploadVideoInBackground converts into a result.
+      await videoFile.delete();
+
+      await expectLater(
+        background(service(transport: _FakeTransport())),
+        throwsA(isA<Object>()),
+      );
+
+      expect(monitor.uploadOutcomes, ['threw']);
+    });
+
+    test('tags the trace exactly once across both stop sites', () async {
+      final transport = _FakeTransport(
+        emitOnEnqueue: [
+          event(BlossomBackgroundTransferStatus.completed, httpStatusCode: 200),
+        ],
+      );
+
+      await background(service(transport: transport));
+
+      // stopTraceOnce runs after enqueue and again in the outer finally; the
+      // second call must not report a duplicate trace or re-tag it.
+      expect(monitor.stopped, ['video_upload']);
+      expect(monitor.uploadOutcomes, hasLength(1));
+      expect(monitor.lateAttributes, isEmpty);
+    });
+  });
+
+  group('NoOpPerformanceMonitor', () {
+    test('accepts attributes without a monitor configured', () async {
+      stubLegacyPut(statusCode: 200);
+
+      final result =
+          await BlossomUploadService(
+            authProvider: auth,
+            dio: dio,
+            defaultServerUrl: _server,
+          ).uploadVideo(
+            videoFile: videoFile,
+            nostrPubkey: _publicKey,
+            title: 'Test Video',
+            description: null,
+            hashtags: null,
+            proofManifestJson: null,
+          );
+
+      expect(result.success, isTrue);
+    });
+  });
+}

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_outcome_trace_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_outcome_trace_test.dart
@@ -3,7 +3,6 @@
 
 import 'dart:async';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:dio/dio.dart';

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_with_resume_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_with_resume_test.dart
@@ -123,6 +123,9 @@ class _ThrowingPerformanceMonitor implements BlossomPerformanceMonitor {
 
   @override
   void setMetric(String traceName, String metricName, int value) {}
+
+  @override
+  void putAttribute(String traceName, String attribute, String value) {}
 }
 
 const _testServer = 'https://media.divine.video';
@@ -649,45 +652,42 @@ void main() {
       },
     );
 
-    test(
-      'resumableTimeout does NOT bound the OS-first leg',
-      () async {
-        // The OS PUT succeeds only after a delay that far exceeds the tiny
-        // resumableTimeout. If a regression wrapped the OS leg in
-        // `.timeout(resumableTimeout)`, that timeout would fire first and this
-        // upload would fail / fall through to the resumable path. Because the
-        // OS leg is deliberately unbounded by resumableTimeout, the delayed OS
-        // success is returned and the resumable control plane is never touched.
-        final transport = _FakeTransport(
-          completionDelay: const Duration(milliseconds: 150),
-        );
-        final service = BlossomUploadService(
-          authProvider: auth,
-          dio: dio,
-          defaultServerUrl: _testServer,
-          backgroundTransport: transport,
-        );
+    test('resumableTimeout does NOT bound the OS-first leg', () async {
+      // The OS PUT succeeds only after a delay that far exceeds the tiny
+      // resumableTimeout. If a regression wrapped the OS leg in
+      // `.timeout(resumableTimeout)`, that timeout would fire first and this
+      // upload would fail / fall through to the resumable path. Because the
+      // OS leg is deliberately unbounded by resumableTimeout, the delayed OS
+      // success is returned and the resumable control plane is never touched.
+      final transport = _FakeTransport(
+        completionDelay: const Duration(milliseconds: 150),
+      );
+      final service = BlossomUploadService(
+        authProvider: auth,
+        dio: dio,
+        defaultServerUrl: _testServer,
+        backgroundTransport: transport,
+      );
 
-        final result = await service.uploadVideoWithResume(
-          videoFile: videoFile,
-          nostrPubkey: _testPublicKey,
-          taskId: 'task-os-slow',
-          title: 'slow OS success under short resumable timeout',
-          description: null,
-          hashtags: null,
-          proofManifestJson: null,
-          resumableTimeout: const Duration(milliseconds: 5),
-        );
+      final result = await service.uploadVideoWithResume(
+        videoFile: videoFile,
+        nostrPubkey: _testPublicKey,
+        taskId: 'task-os-slow',
+        title: 'slow OS success under short resumable timeout',
+        description: null,
+        hashtags: null,
+        proofManifestJson: null,
+        resumableTimeout: const Duration(milliseconds: 5),
+      );
 
-        expect(result.success, isTrue);
-        expect(transport.enqueuedTaskIds, equals(['task-os-slow']));
-        // Resumable leg never reached: the OS leg outlived resumableTimeout and
-        // still won, proving resumableTimeout did not cut it.
-        verifyNever(
-          () => dio.head<dynamic>(any(), options: any(named: 'options')),
-        );
-      },
-    );
+      expect(result.success, isTrue);
+      expect(transport.enqueuedTaskIds, equals(['task-os-slow']));
+      // Resumable leg never reached: the OS leg outlived resumableTimeout and
+      // still won, proving resumableTimeout did not cut it.
+      verifyNever(
+        () => dio.head<dynamic>(any(), options: any(named: 'options')),
+      );
+    });
 
     test(
       'resumableTimeout bounds the in-process resumable leg when reached',
@@ -715,9 +715,7 @@ void main() {
             options: any(named: 'options'),
             onSendProgress: any(named: 'onSendProgress'),
           ),
-        ).thenAnswer(
-          (_) => Completer<Response<dynamic>>().future,
-        );
+        ).thenAnswer((_) => Completer<Response<dynamic>>().future);
 
         await expectLater(
           service.uploadVideoWithResume(


### PR DESCRIPTION
## Description

`video_upload` was the only instrumented trace in the app with zero custom attributes, so a 6 MB upload that timed out after two minutes and one that succeeded in eight seconds sat in the same duration distribution with no way to separate them.

`BlossomPerformanceMonitor` physically could not express this — it declared only `startTrace`, `stopTrace` and `setMetric` — so it gains `putAttribute(traceName, attribute, value)`, mirrored in the no-op default and in `_FirebasePerformanceAdapter`. The app-side `PerformanceTraceMonitor` already had the matching method, so the adapter is a straight delegation.

Both `video_upload` trace sites now tag an `outcome` before stopping. Values follow the `video_publish` convention — `success`, or `error:<reason>` keyed on `BlossomUploadFailureReason` — with a user cancellation broken out as `cancelled` rather than folded into `error:*`, the same separation that makes `video_generation`'s distribution readable.

**Why the OS-background path is tagged `enqueued`.** That path deliberately stops its trace right after enqueue so the trace does not span the OS-owned transfer wait (which can include a long app suspension). It therefore usually cannot know how the transfer ended, so it reports `enqueued` rather than claiming a success it has not observed. A terminal event that *does* land during hand-off — a fast failure, or a cancel that races it — really was covered by the trace, so that outcome is reported instead. That case is also what makes a cancellation observable by this trace at all.

This is likely to explain the histogram in #7119: the sub-second spike (94% of iOS `video_upload` under 1 second, for a 6.16 MB median payload) is almost certainly these setup-only spans rather than fast uploads. Once this ships, filtering `outcome != enqueued` reads the in-process distribution cleanly.

**Why `uploadVideo`'s body moved.** It has six exit points. Rather than set an outcome at each one, the body moved into a private `_uploadVideoTraced` so the wrapper derives the outcome once from the single returned result. The body itself is unchanged.

**Related Issue:** Closes #7121

## Out of Scope

- The `startOperationTrace` migration the issue flags as adjacent is #7119. Nobody is on it, and it reshapes this same interface. Ordering-wise this lands first; #7119 then converts these name-keyed calls to handle-based ones and the outcome vocabulary carries over unchanged.
- `video_event_service.dart`'s `feed_load_*` traces, also named-keyed, are #7119's other call site and untouched here.

## Verification

- `blossom_upload_service`: 247 tests pass, coverage **996/996 = 100%** (the package's CI gate).
- New `blossom_upload_outcome_trace_test.dart` covers all nine terminal paths across both upload methods, plus an assertion that no attribute arrives after its trace was stopped — Firebase drops those silently, so the ordering is the whole point.
- Adding the outcome exposed one genuinely untested branch: `uploadVideoInBackground`'s `authHeader == null` path. It had read as covered only because `return const …` emits no coverage line. It now has a test.
- `flutter analyze lib test integration_test` — clean. `dart format` — clean.
- App-side upload and publish suites: `test/services/upload`, `test/services/video_publish`, `upload_manager_error_handling_test.dart` (316 pass), plus `upload_manager_cancel_test.dart`, `upload_manager_resumable_upload_test.dart`, `blossom_resumable_upload_integration_test.dart`, `upload_media_providers_test.dart` (35 pass).

## Test Plan

Telemetry-only, so the observable check is the Firebase console rather than the device UI. Not yet run on the Samsung Galaxy — publishing a video and confirming `video_upload` arrives carrying `outcome` is the manual step still outstanding.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
