### PR TITLE
feat(perf): instrument Dart-side HTTP with HttpMetric

### DIFF
--- a/mobile/docs/NETWORK_PERFORMANCE_MONITORING.md
+++ b/mobile/docs/NETWORK_PERFORMANCE_MONITORING.md
@@ -66,12 +66,13 @@ Everything below routes through `instrumentedHttpClientFactoryProvider`.
 | Username claim / release / check | `names.divine.video`, `login.divine.video` | `repository_providers.dart` |
 | Relay-manager (minor-account review) | `api-relay-*.divine.video` | `upload_media_providers.dart` |
 | Invite server | `invite.divine.video` | `main.dart` |
-| Apps-directory audit | `apps.divine.video` | `nostr_apps_providers.dart` |
+| Apps-directory listing + audit | `apps.divine.video` | `nostr_apps_providers.dart` |
 | NIP-39 identity verification | `verifier.divine.video` | `auth_providers.dart` |
 | CAWG identity verification | `verifyer.divine.video` | `auth_providers.dart` |
 | Crossposting (settings, manual crossposts) | `crossposter.divine.video` | `upload_media_providers.dart`, `crossposting_providers.dart` |
 | Supporter worker (build-gated) | build-supplied | `supporter_providers.dart` |
 | Subtitle / VTT fetch | `media.divine.video` | `subtitle_providers.dart` |
+| Moderation check-result (playback UX) | `moderation-api.divine.video` | `video_moderation_status_service.dart` |
 | NIP-11 relay capability probe | relay HTTP origin | `relay_providers.dart` |
 
 ## What is deliberately not instrumented

--- a/mobile/docs/NETWORK_PERFORMANCE_MONITORING.md
+++ b/mobile/docs/NETWORK_PERFORMANCE_MONITORING.md
@@ -63,7 +63,8 @@ Everything below routes through `instrumentedHttpClientFactoryProvider`.
 | Funnelcake REST API — feeds, search, profiles, notifications, video stats | `api.divine.video` | `curation_providers.dart` |
 | Event publish (REST-first kind 34236) | relay HTTP origin | `video_providers.dart` |
 | Product analytics ingest | `api.divine.video` | `social_providers.dart` |
-| Username claim / release / check | `names.divine.video`, `login.divine.video` | `repository_providers.dart` |
+| Username claim / release / check | `names.divine.video` | `repository_providers.dart` |
+| Keycast OAuth (login/register/token/poll/reset) | `login.divine.video` | `auth_providers.dart` |
 | Relay-manager (minor-account review) | `api-relay-*.divine.video` | `upload_media_providers.dart` |
 | Invite server | `invite.divine.video` | `main.dart` |
 | Apps-directory listing + audit | `apps.divine.video` | `nostr_apps_providers.dart` |

--- a/mobile/docs/NETWORK_PERFORMANCE_MONITORING.md
+++ b/mobile/docs/NETWORK_PERFORMANCE_MONITORING.md
@@ -1,0 +1,134 @@
+# Network performance monitoring
+
+What the Firebase console's **Network Requests** tab covers, what it deliberately
+does not, and how to keep it that way. Issue: #7122.
+
+## Why anything had to be built
+
+Firebase Performance auto-instruments network traffic by swizzling the *native*
+HTTP stacks. Requests the app issues from Dart never touch those, so they were
+invisible: the export had **zero** `NETWORK_REQUEST` events on Android, and on
+iOS 24,843 events of which essentially all were Apple and Google SDK telemetry
+(`app-analytics-services.com`, `app-ads-services.com`,
+`firebase-settings.crashlytics.com`, …). The only Divine host present was
+`media.divine.video` with 414 events — native video-player traffic, not
+anything Dart sent. Relay latency, feed query latency, CDN behaviour and upload
+transport were all absent from a tab that looked like it covered them.
+
+`HttpMetric` is the API that fixes this, and it has to be driven explicitly.
+
+## How it works
+
+One decorator at the client boundary, not per call site:
+
+| Piece | File |
+|---|---|
+| `PerformanceHttpClient` — `http.BaseClient` that opens one metric per request | `lib/observability/network/performance_http_client.dart` |
+| `HttpMetricRecorder` / `HttpMetricSpan` — backend-agnostic port | `lib/observability/network/http_metric_recorder.dart` |
+| `FirebaseHttpMetricRecorder` — the Firebase implementation | `lib/observability/network/firebase_http_metric_recorder.dart` |
+| `httpMetricUrlPattern` / `isInstrumentedHost` — reported-URL policy | `lib/observability/network/http_url_pattern.dart` |
+| `instrumentedHttpClientFactoryProvider` — the wiring entry point | `lib/providers/service_providers.dart` |
+
+Each request reports method, URL pattern, response code, request and response
+payload sizes, and response content type. The span covers the whole transfer:
+it ends when the response body completes, fails, or its subscription is
+cancelled — not at time-to-first-byte.
+
+Nothing is recorded until `PerformanceMonitoringService.initialize()` has
+succeeded (`isEnabled`), which is sampled per request rather than captured,
+because clients are built with the provider graph before startup finishes.
+
+### Instrumenting a new client
+
+Use the factory instead of `http.Client()`:
+
+```dart
+final httpClient = ref.watch(instrumentedHttpClientFactoryProvider)();
+ref.onDispose(httpClient.close);
+return SomeApiClient(baseUrl: ..., httpClient: httpClient);
+```
+
+It is a factory, not a shared client, so each call site keeps owning and
+closing its own client — one consumer's `close()` cannot cancel another's
+in-flight requests. Injecting a client often flips the callee from owner to
+borrower, so check whether its own `dispose()` still closes anything; if not,
+close it from the provider as above.
+
+## What is instrumented
+
+Everything below routes through `instrumentedHttpClientFactoryProvider`.
+
+| Traffic | Host | Wired in |
+|---|---|---|
+| Funnelcake REST API — feeds, search, profiles, notifications, video stats | `api.divine.video` | `curation_providers.dart` |
+| Event publish (REST-first kind 34236) | relay HTTP origin | `video_providers.dart` |
+| Product analytics ingest | `api.divine.video` | `social_providers.dart` |
+| Username claim / release / check | `names.divine.video`, `login.divine.video` | `repository_providers.dart` |
+| Relay-manager (minor-account review) | `api-relay-*.divine.video` | `upload_media_providers.dart` |
+| Invite server | `invite.divine.video` | `main.dart` |
+| Apps-directory audit | `apps.divine.video` | `nostr_apps_providers.dart` |
+| NIP-39 identity verification | `verifier.divine.video` | `auth_providers.dart` |
+| CAWG identity verification | `verifyer.divine.video` | `auth_providers.dart` |
+| Crossposting (settings, manual crossposts) | `crossposter.divine.video` | `upload_media_providers.dart`, `crossposting_providers.dart` |
+| Supporter worker (build-gated) | build-supplied | `supporter_providers.dart` |
+| Subtitle / VTT fetch | `media.divine.video` | `subtitle_providers.dart` |
+| NIP-11 relay capability probe | relay HTTP origin | `relay_providers.dart` |
+
+## What is deliberately not instrumented
+
+| Traffic | Why not |
+|---|---|
+| **Relay WebSockets** — every Nostr subscription and publish over `wss://` | Not HTTP requests; `HttpMetric` cannot express them. Relay latency needs its own custom trace, which is a separate piece of work. |
+| **Blossom uploads** (`media.divine.video`) | Goes through Dio, and through the OS background transport (URLSession / Android foreground service) on the shipped path — which Firebase *does* auto-instrument natively. Upload timing is already reported as custom traces via `BlossomPerformanceMonitor`, which measures the whole chunked/resumable operation rather than fragmenting it into per-chunk events. |
+| **Video and image byte traffic** — `media_cache`, `divine_video_player`, `cached_network_image` | High volume (one or more events per feed item) for little diagnostic value beyond the native `media.divine.video` events already reported. Download throughput is what matters here and `BandwidthTrackerService` already tracks it. |
+| **Third-party hosts** — GitHub releases, Zendesk, the geo-blocker worker on `workers.dev`, NIP-05 resolution, remote avatar SVGs, user-configured relays and Blossom servers | Not ours to measure, and Firebase drops URL patterns past a per-app cap — spending it on hosts we cannot act on is a straight loss. Enforced at runtime by `isInstrumentedHost`, so wrapping a client that *may* be pointed at a third-party host stays safe. |
+| **`nostr_sdk` Dio uploaders** (nostr.build, void.cat, …) | Third-party media hosts on a legacy path the app does not use. |
+
+If any of these becomes worth measuring, the decision to add it belongs in this
+file next to the reason it was left out.
+
+## URL patterns
+
+Firebase aggregates by URL and drops high-cardinality patterns, so an
+identifier in a path would give one pattern per request and blow the cap.
+`httpMetricUrlPattern` reports the route instead:
+
+```
+https://api.divine.video/api/users/<64-hex pubkey>/videos?limit=20
+  -> https://api.divine.video/api/users/{id}/videos
+https://media.divine.video/<sha256>.mp4
+  -> https://media.divine.video/{id}.mp4
+https://names.divine.video/api/username/by-pubkey/npub1…
+  -> https://names.divine.video/api/username/by-pubkey/{npub}
+```
+
+Collapsed automatically: long hex ids (pubkeys, event ids, sha256 hashes),
+NIP-19 bech32 entities (reported as `{npub}`, `{nevent}`, … so the type stays
+readable), UUIDs, all-digit segments, and opaque base64url-ish tokens. Query
+strings, fragments and userinfo are dropped entirely.
+
+Identifiers are replaced **whole**, never shortened. A truncated Nostr id is
+still a Nostr id, and emitting one is banned repo-wide (AGENTS.md, "Nostr And
+Async Rules") — aggregating by route pattern is the sanctioned answer.
+
+**Free-text path segments need an explicit entry.** No generic rule can tell
+`/api/username/check/alice` from a route word, so routes that interpolate a
+username, slug or search term into the *path* are listed in
+`_freeTextRoutePatterns` in `http_url_pattern.dart`. Add an entry when you add
+such an endpoint. Query parameters need nothing.
+
+## Verifying a change
+
+Firebase surfaces network data in the console within ~12 hours, so the loop is
+slow; check the cheap things first.
+
+1. Unit level: `flutter test test/observability/network`.
+2. Local stack: loopback hosts are instrumented on purpose, so a LOCAL run
+   against `local_stack/` exercises the same path end to end. The cost is that
+   debug runs report `http://localhost:<port>/…` patterns into the same
+   project — a handful of extra patterns, the same routes on a different
+   authority. That is the same trade the existing custom traces already make.
+3. Console: **Performance → Network Requests**, filtered to `divine.video` /
+   `dvines.org`. Confirm requests appear from **both** platforms and that each
+   endpoint shows as one aggregated pattern with placeholders — a list of
+   near-identical URLs differing by one segment means a missing rule.

--- a/mobile/docs/NETWORK_PERFORMANCE_MONITORING.md
+++ b/mobile/docs/NETWORK_PERFORMANCE_MONITORING.md
@@ -95,17 +95,26 @@ identifier in a path would give one pattern per request and blow the cap.
 
 ```
 https://api.divine.video/api/users/<64-hex pubkey>/videos?limit=20
-  -> https://api.divine.video/api/users/{id}/videos
+  -> https://api.divine.video/api/users/:id/videos
 https://media.divine.video/<sha256>.mp4
-  -> https://media.divine.video/{id}.mp4
+  -> https://media.divine.video/:id.mp4
 https://names.divine.video/api/username/by-pubkey/npub1…
-  -> https://names.divine.video/api/username/by-pubkey/{npub}
+  -> https://names.divine.video/api/username/by-pubkey/:npub
 ```
 
 Collapsed automatically: long hex ids (pubkeys, event ids, sha256 hashes),
-NIP-19 bech32 entities (reported as `{npub}`, `{nevent}`, … so the type stays
+NIP-19 bech32 entities (reported as `:npub`, `:nevent`, … so the type stays
 readable), UUIDs, all-digit segments, and opaque base64url-ish tokens. Query
 strings, fragments and userinfo are dropped entirely.
+
+**Placeholders are `:name`, not `{name}`.** Both SDKs parse the reported URL
+before they will record it, and braces are excluded characters in RFC
+2396/3986. Android's `FirebasePerfNetworkValidator` calls
+`java.net.URI.create` on it and drops the metric at dispatch when that throws
+("URL cannot be parsed"); iOS 16's `NSURL(string:)` returns nil and the plugin
+fails the call with `invalid-url`. A braced pattern therefore reports nothing,
+with no error surfaced to the app. A colon is a legal `pchar`. The character
+set is pinned by `http_url_pattern_test.dart`.
 
 Identifiers are replaced **whole**, never shortened. A truncated Nostr id is
 still a Nostr id, and emitting one is banned repo-wide (AGENTS.md, "Nostr And

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2680,6 +2680,7 @@ class _DivineAppState extends ConsumerState<DivineApp>
         RepositoryProvider(
           create: (_) => InviteApiClient(
             baseUrl: ref.read(currentEnvironmentProvider).inviteBaseUrl,
+            client: ref.read(instrumentedHttpClientFactoryProvider)(),
             // ignore: avoid_redundant_argument_values
             forceOpenOnboarding: forceOpenOnboarding,
             authHeaderProvider:

--- a/mobile/lib/observability/network/firebase_http_metric_recorder.dart
+++ b/mobile/lib/observability/network/firebase_http_metric_recorder.dart
@@ -1,0 +1,124 @@
+// ABOUTME: Firebase Performance implementation of the HttpMetricRecorder port.
+// ABOUTME: Turns each instrumented request into a NETWORK_REQUEST metric.
+
+import 'dart:async';
+
+import 'package:firebase_performance/firebase_performance.dart';
+import 'package:openvine/observability/network/http_metric_recorder.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Creates the underlying Firebase metric. Injected so the recorder can be
+/// tested without a Firebase app.
+typedef HttpMetricFactory =
+    HttpMetric Function(String url, HttpMethod httpMethod);
+
+const String _logName = 'HttpMetricRecorder';
+
+/// Reports HTTP requests to Firebase Performance Monitoring.
+///
+/// Firebase only auto-instruments the *native* HTTP stacks, so Dart-side
+/// requests are invisible unless something opens an [HttpMetric] for them
+/// (#7122). This is that something.
+class FirebaseHttpMetricRecorder implements HttpMetricRecorder {
+  FirebaseHttpMetricRecorder({
+    required bool Function() isEnabled,
+    HttpMetricFactory? newHttpMetric,
+  }) : _isEnabled = isEnabled,
+       _newHttpMetric = newHttpMetric ?? _firebaseHttpMetric;
+
+  /// Whether performance collection has initialised. Sampled per request, not
+  /// captured, because clients are built during startup — before
+  /// `PerformanceMonitoringService.initialize` completes.
+  final bool Function() _isEnabled;
+
+  final HttpMetricFactory _newHttpMetric;
+
+  static HttpMetric _firebaseHttpMetric(String url, HttpMethod httpMethod) =>
+      FirebasePerformance.instance.newHttpMetric(url, httpMethod);
+
+  @override
+  HttpMetricSpan? start({required String urlPattern, required String method}) {
+    if (!_isEnabled()) return null;
+
+    final httpMethod = _parseHttpMethod(method);
+    if (httpMethod == null) {
+      Log.debug(
+        'Skipping metric for unsupported HTTP method $method',
+        name: _logName,
+      );
+      return null;
+    }
+
+    try {
+      final metric = _newHttpMetric(urlPattern, httpMethod);
+      final started = metric.start().catchError((Object e) {
+        Log.error('Failed to start metric for $urlPattern: $e', name: _logName);
+      });
+      return _FirebaseHttpMetricSpan(metric, started);
+    } catch (e) {
+      Log.error('Failed to create metric for $urlPattern: $e', name: _logName);
+      return null;
+    }
+  }
+}
+
+HttpMethod? _parseHttpMethod(String method) => switch (method.toUpperCase()) {
+  'CONNECT' => HttpMethod.Connect,
+  'DELETE' => HttpMethod.Delete,
+  'GET' => HttpMethod.Get,
+  'HEAD' => HttpMethod.Head,
+  'OPTIONS' => HttpMethod.Options,
+  'PATCH' => HttpMethod.Patch,
+  'POST' => HttpMethod.Post,
+  'PUT' => HttpMethod.Put,
+  'TRACE' => HttpMethod.Trace,
+  _ => null,
+};
+
+class _FirebaseHttpMetricSpan implements HttpMetricSpan {
+  _FirebaseHttpMetricSpan(this._metric, this._started);
+
+  final HttpMetric _metric;
+
+  /// Completion of the metric's start round-trip. [complete] waits on it
+  /// because the plugin drops a stop that arrives before the platform handed
+  /// back a handle — the metric is then never reported *and* leaks natively.
+  /// A cache hit or a 304 answered in a few milliseconds would race it.
+  final Future<void> _started;
+
+  bool _completed = false;
+
+  @override
+  void setRequestPayloadSize(int bytes) {
+    if (_completed) return;
+    _metric.requestPayloadSize = bytes;
+  }
+
+  @override
+  void complete({
+    int? statusCode,
+    int? responsePayloadSize,
+    String? responseContentType,
+  }) {
+    if (_completed) return;
+    _completed = true;
+
+    if (statusCode != null) _metric.httpResponseCode = statusCode;
+    if (responsePayloadSize != null) {
+      _metric.responsePayloadSize = responsePayloadSize;
+    }
+    if (responseContentType != null) {
+      _metric.responseContentType = responseContentType;
+    }
+    unawaited(_stop());
+  }
+
+  Future<void> _stop() async {
+    try {
+      await _started;
+      await _metric.stop();
+    } catch (e) {
+      Log.error('Failed to stop metric: $e', name: _logName);
+    }
+  }
+}

--- a/mobile/lib/observability/network/http_metric_recorder.dart
+++ b/mobile/lib/observability/network/http_metric_recorder.dart
@@ -1,0 +1,43 @@
+// ABOUTME: Backend-agnostic port for reporting one HTTP request's timing.
+// ABOUTME: Implemented over Firebase Performance in the app, faked in tests.
+
+/// One in-flight HTTP request's performance span.
+///
+/// The span times the whole request — from just before the client sends it
+/// until the response body finishes, fails, or is cancelled.
+abstract class HttpMetricSpan {
+  /// Records the request body size in bytes, when the client knows it.
+  void setRequestPayloadSize(int bytes);
+
+  /// Records the outcome and ends the span. Idempotent: later calls are
+  /// ignored, so a stream that both errors and is cancelled reports once.
+  ///
+  /// A null [statusCode] means the request never produced a response (DNS
+  /// failure, timeout, connection reset). Implementations still end the span
+  /// so the backend does not leak a native handle.
+  void complete({
+    int? statusCode,
+    int? responsePayloadSize,
+    String? responseContentType,
+  });
+}
+
+/// Opens [HttpMetricSpan]s for outgoing HTTP requests.
+abstract class HttpMetricRecorder {
+  /// Opens a span for a [method] request reported as [urlPattern], or returns
+  /// null when this request is not being recorded (monitoring disabled, an
+  /// unsupported verb, or the backend refused the metric).
+  HttpMetricSpan? start({required String urlPattern, required String method});
+}
+
+/// Records nothing. The default wherever no backend is wired — tests, and
+/// any build where performance monitoring never initialised.
+class NoOpHttpMetricRecorder implements HttpMetricRecorder {
+  const NoOpHttpMetricRecorder();
+
+  @override
+  HttpMetricSpan? start({
+    required String urlPattern,
+    required String method,
+  }) => null;
+}

--- a/mobile/lib/observability/network/http_url_pattern.dart
+++ b/mobile/lib/observability/network/http_url_pattern.dart
@@ -1,0 +1,129 @@
+// ABOUTME: URL policy for Firebase Performance network-request metrics.
+// ABOUTME: Decides which hosts are reported and collapses identifier path
+// ABOUTME: segments into route patterns so the console aggregates them.
+
+import 'package:nostr_sdk/nostr_sdk.dart' show isLoopbackHost;
+
+/// Hosts Divine operates, matched as the host itself or any subdomain.
+///
+/// `dvines.org` carries the `poc` and `test` relay/API hosts; `divine.video`
+/// carries production, staging, the media/Blossom host, the names service and
+/// the auxiliary workers. Keep in sync with `EnvironmentConfig`.
+const Set<String> _divineHostSuffixes = {'divine.video', 'dvines.org'};
+
+/// Whether requests to [host] are reported to Firebase Performance.
+///
+/// Only Divine-operated hosts and the local-stack loopback hosts are. Two
+/// reasons to filter rather than report everything an instrumented client
+/// sends:
+///
+/// * Firebase aggregates network requests per URL pattern and drops patterns
+///   past a per-app cap. A user-configured relay, Blossom server or avatar
+///   host would spend that cap on hosts we cannot act on.
+/// * Third-party hosts (a user's own media server, an arbitrary NIP-05
+///   domain) are not ours to measure, and their URLs can carry
+///   user-identifying paths.
+///
+/// Loopback is included so a local-stack run can be verified end to end
+/// against the console before shipping a change.
+bool isInstrumentedHost(String host) {
+  final normalized = host.toLowerCase();
+  if (normalized.isEmpty) return false;
+  if (isLoopbackHost(normalized)) return true;
+  return _divineHostSuffixes.any(
+    (suffix) => normalized == suffix || normalized.endsWith('.$suffix'),
+  );
+}
+
+/// Routes whose path carries free text that no generic rule can recognise as
+/// an identifier, mapped to the pattern reported instead.
+///
+/// Add an entry when a new endpoint interpolates something arbitrary (a
+/// username, a slug, a search term) into its *path*. Query parameters need no
+/// entry — [httpMetricUrlPattern] drops the query entirely.
+const List<(String, String)> _freeTextRoutePatterns = [
+  // names.divine.video/api/username/check/<username> — one pattern per
+  // username typed into the claim field otherwise.
+  ('/api/username/check/', '/api/username/check/{username}'),
+];
+
+final RegExp _digits = RegExp(r'^\d+$');
+final RegExp _uuid = RegExp(
+  r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
+  caseSensitive: false,
+);
+
+/// Nostr bech32 entities (NIP-19). Reported as `{npub}`, `{nevent}`, … so the
+/// entity type stays readable in the console.
+final RegExp _bech32Entity = RegExp(
+  r'^(npub|nsec|note|nevent|naddr|nprofile|nrelay|ncryptsec)1[a-z0-9]{6,}$',
+  caseSensitive: false,
+);
+
+/// Hex identifiers: 64-char pubkeys, event ids and sha256 hashes, plus any
+/// other long hex token.
+final RegExp _hexIdentifier = RegExp(r'^[0-9a-f]{32,}$', caseSensitive: false);
+
+/// Opaque tokens (base64url-ish). Requires a digit so ordinary long words
+/// stay untouched.
+final RegExp _opaqueIdentifier = RegExp(r'^(?=[^\d]*\d)[A-Za-z0-9_-]{20,}$');
+
+final RegExp _fileExtension = RegExp(r'^[A-Za-z0-9]{1,5}$');
+
+/// The URL reported to Firebase for a request to [url].
+///
+/// Keeps scheme, host and an explicit port; drops userinfo, query and
+/// fragment; and replaces identifier path segments with placeholders so every
+/// call to one endpoint lands on one pattern:
+///
+/// ```
+/// https://api.divine.video/api/users/<64-hex>/videos?limit=20
+///   -> https://api.divine.video/api/users/{id}/videos
+/// https://media.divine.video/<sha256>.mp4
+///   -> https://media.divine.video/{id}.mp4
+/// ```
+///
+/// Identifiers are replaced whole, never shortened — a truncated Nostr id is
+/// still an id, and the repo bans emitting one (AGENTS.md, "Nostr And Async
+/// Rules").
+String httpMetricUrlPattern(Uri url) {
+  final host = url.host.toLowerCase();
+  final authority = url.hasPort ? '$host:${url.port}' : host;
+  return '${url.scheme}://$authority${_normalizePath(url.path)}';
+}
+
+String _normalizePath(String path) {
+  for (final (prefix, pattern) in _freeTextRoutePatterns) {
+    if (path.startsWith(prefix) && path.length > prefix.length) {
+      return pattern;
+    }
+  }
+  return path.split('/').map(_normalizeSegment).join('/');
+}
+
+String _normalizeSegment(String segment) {
+  if (segment.isEmpty) return segment;
+
+  final lastDot = segment.lastIndexOf('.');
+  if (lastDot > 0) {
+    final extension = segment.substring(lastDot + 1);
+    if (_fileExtension.hasMatch(extension)) {
+      final stem = _normalizeIdentifier(segment.substring(0, lastDot));
+      return '$stem.${extension.toLowerCase()}';
+    }
+  }
+  return _normalizeIdentifier(segment);
+}
+
+String _normalizeIdentifier(String value) {
+  if (value.isEmpty) return value;
+  if (_digits.hasMatch(value)) return '{n}';
+  if (_uuid.hasMatch(value)) return '{uuid}';
+
+  final entity = _bech32Entity.firstMatch(value);
+  if (entity != null) return '{${entity.group(1)!.toLowerCase()}}';
+
+  if (_hexIdentifier.hasMatch(value)) return '{id}';
+  if (_opaqueIdentifier.hasMatch(value)) return '{id}';
+  return value;
+}

--- a/mobile/lib/observability/network/http_url_pattern.dart
+++ b/mobile/lib/observability/network/http_url_pattern.dart
@@ -41,10 +41,13 @@ bool isInstrumentedHost(String host) {
 /// Add an entry when a new endpoint interpolates something arbitrary (a
 /// username, a slug, a search term) into its *path*. Query parameters need no
 /// entry — [httpMetricUrlPattern] drops the query entirely.
+///
+/// Placeholders use the `:name` form for the reason given on
+/// [_normalizeIdentifier] — braces would make the URL unparseable.
 const List<(String, String)> _freeTextRoutePatterns = [
   // names.divine.video/api/username/check/<username> — one pattern per
   // username typed into the claim field otherwise.
-  ('/api/username/check/', '/api/username/check/{username}'),
+  ('/api/username/check/', '/api/username/check/:username'),
 ];
 
 final RegExp _digits = RegExp(r'^\d+$');
@@ -53,7 +56,7 @@ final RegExp _uuid = RegExp(
   caseSensitive: false,
 );
 
-/// Nostr bech32 entities (NIP-19). Reported as `{npub}`, `{nevent}`, … so the
+/// Nostr bech32 entities (NIP-19). Reported as `:npub`, `:nevent`, … so the
 /// entity type stays readable in the console.
 final RegExp _bech32Entity = RegExp(
   r'^(npub|nsec|note|nevent|naddr|nprofile|nrelay|ncryptsec)1[a-z0-9]{6,}$',
@@ -78,9 +81,9 @@ final RegExp _fileExtension = RegExp(r'^[A-Za-z0-9]{1,5}$');
 ///
 /// ```
 /// https://api.divine.video/api/users/<64-hex>/videos?limit=20
-///   -> https://api.divine.video/api/users/{id}/videos
+///   -> https://api.divine.video/api/users/:id/videos
 /// https://media.divine.video/<sha256>.mp4
-///   -> https://media.divine.video/{id}.mp4
+///   -> https://media.divine.video/:id.mp4
 /// ```
 ///
 /// Identifiers are replaced whole, never shortened — a truncated Nostr id is
@@ -115,15 +118,28 @@ String _normalizeSegment(String segment) {
   return _normalizeIdentifier(segment);
 }
 
+/// Placeholders use `:name`, never `{name}`.
+///
+/// Both Firebase SDKs parse the reported URL before they will record it, and
+/// braces are excluded characters in RFC 2396/3986. Android's
+/// `FirebasePerfNetworkValidator` runs it through `java.net.URI.create`,
+/// which throws, and the metric is dropped at dispatch with "URL cannot be
+/// parsed" — so a braced pattern reports nothing at all. iOS 16's
+/// `NSURL(string:)` returns nil for the same reason and the plugin fails the
+/// call with `invalid-url`; newer Foundation percent-encodes it to
+/// `%7Bid%7D`. A colon is a legal `pchar`, so `:id` parses on both.
+///
+/// `http_url_pattern_test.dart` pins the character set. Do not "tidy" these
+/// back into braces.
 String _normalizeIdentifier(String value) {
   if (value.isEmpty) return value;
-  if (_digits.hasMatch(value)) return '{n}';
-  if (_uuid.hasMatch(value)) return '{uuid}';
+  if (_digits.hasMatch(value)) return ':n';
+  if (_uuid.hasMatch(value)) return ':uuid';
 
   final entity = _bech32Entity.firstMatch(value);
-  if (entity != null) return '{${entity.group(1)!.toLowerCase()}}';
+  if (entity != null) return ':${entity.group(1)!.toLowerCase()}';
 
-  if (_hexIdentifier.hasMatch(value)) return '{id}';
-  if (_opaqueIdentifier.hasMatch(value)) return '{id}';
+  if (_hexIdentifier.hasMatch(value)) return ':id';
+  if (_opaqueIdentifier.hasMatch(value)) return ':id';
   return value;
 }

--- a/mobile/lib/observability/network/http_url_pattern.dart
+++ b/mobile/lib/observability/network/http_url_pattern.dart
@@ -35,12 +35,12 @@ bool isInstrumentedHost(String host) {
   );
 }
 
-/// Routes whose path carries free text that no generic rule can recognise as
-/// an identifier, mapped to the pattern reported instead.
+/// Prefix free-text routes: any remainder after [prefix] is one identifier.
 ///
 /// Add an entry when a new endpoint interpolates something arbitrary (a
-/// username, a slug, a search term) into its *path*. Query parameters need no
-/// entry — [httpMetricUrlPattern] drops the query entirely.
+/// username, a slug, a search term) into its *path* and the remainder is a
+/// single segment. Query parameters need no entry — [httpMetricUrlPattern]
+/// drops the query entirely.
 ///
 /// Placeholders use the `:name` form for the reason given on
 /// [_normalizeIdentifier] — braces would make the URL unparseable.
@@ -48,6 +48,28 @@ const List<(String, String)> _freeTextRoutePatterns = [
   // names.divine.video/api/username/check/<username> — one pattern per
   // username typed into the claim field otherwise.
   ('/api/username/check/', '/api/username/check/:username'),
+];
+
+/// Structured free-text routes whose identifier is not the whole remainder
+/// (subpaths after the id, or static siblings that must stay distinct).
+///
+/// Funnelcake accepts stableId / d-tag / vine shortcodes on video paths —
+/// values like `5gITeYOlL7g` that fail the hex/uuid/opaque recognisers and
+/// would otherwise mint one Firebase pattern per video.
+final List<(RegExp, String Function(Match))> _structuredFreeTextRoutes = [
+  // /api/videos/<id> and /api/videos/<id>/{stats|views}, but not
+  // /api/videos/stats/bulk (static "stats" segment).
+  (
+    RegExp(r'^/api/videos/(?!stats(?:/|$))([^/]+)(?:/(stats|views))?$'),
+    (m) {
+      final suffix = m.group(2);
+      return suffix == null ? '/api/videos/:id' : '/api/videos/:id/$suffix';
+    },
+  ),
+  (
+    RegExp(r'^/api/v2/videos/([^/]+)/comments$'),
+    (_) => '/api/v2/videos/:id/comments',
+  ),
 ];
 
 final RegExp _digits = RegExp(r'^\d+$');
@@ -91,7 +113,12 @@ final RegExp _fileExtension = RegExp(r'^[A-Za-z0-9]{1,5}$');
 /// Rules").
 String httpMetricUrlPattern(Uri url) {
   final host = url.host.toLowerCase();
-  final authority = url.hasPort ? '$host:${url.port}' : host;
+  // Bracket IPv6 hosts so the reported URL stays parseable by the Firebase
+  // SDKs (same silent-drop failure mode as the braced-placeholder bug).
+  final hostForAuthority = host.contains(':') ? '[$host]' : host;
+  final authority = url.hasPort
+      ? '$hostForAuthority:${url.port}'
+      : hostForAuthority;
   return '${url.scheme}://$authority${_normalizePath(url.path)}';
 }
 
@@ -100,6 +127,10 @@ String _normalizePath(String path) {
     if (path.startsWith(prefix) && path.length > prefix.length) {
       return pattern;
     }
+  }
+  for (final (pattern, rewrite) in _structuredFreeTextRoutes) {
+    final match = pattern.firstMatch(path);
+    if (match != null) return rewrite(match);
   }
   return path.split('/').map(_normalizeSegment).join('/');
 }

--- a/mobile/lib/observability/network/performance_http_client.dart
+++ b/mobile/lib/observability/network/performance_http_client.dart
@@ -1,0 +1,92 @@
+// ABOUTME: http.Client decorator that reports Divine-host requests as
+// ABOUTME: Firebase Performance network requests, one metric per request.
+
+import 'package:http/http.dart' as http;
+import 'package:openvine/observability/network/http_metric_recorder.dart';
+import 'package:openvine/observability/network/http_url_pattern.dart';
+
+/// Wraps an [http.Client] and reports every request it sends to a
+/// Divine-operated host (see [isInstrumentedHost]) to [HttpMetricRecorder].
+///
+/// One instrumentation point for the whole Dart HTTP surface: wire this in
+/// where a client is constructed and every call the owning client makes is
+/// covered, with no per-call-site bookkeeping.
+///
+/// The span ends when the response body ends — completed, failed, or the
+/// subscription cancelled — so the reported duration covers the transfer, not
+/// just time to first byte. A caller that takes a [http.StreamedResponse] and
+/// never listens to its stream leaves the span open; that already leaks the
+/// underlying connection, so it is a bug at the call site rather than
+/// something this client papers over.
+class PerformanceHttpClient extends http.BaseClient {
+  PerformanceHttpClient({
+    required http.Client inner,
+    required HttpMetricRecorder recorder,
+  }) : _inner = inner,
+       _recorder = recorder;
+
+  final http.Client _inner;
+  final HttpMetricRecorder _recorder;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    if (!isInstrumentedHost(request.url.host)) {
+      return _inner.send(request);
+    }
+
+    final span = _recorder.start(
+      urlPattern: httpMetricUrlPattern(request.url),
+      method: request.method,
+    );
+    if (span == null) return _inner.send(request);
+
+    final requestPayloadSize = request.contentLength;
+    if (requestPayloadSize != null) {
+      span.setRequestPayloadSize(requestPayloadSize);
+    }
+
+    final http.StreamedResponse response;
+    try {
+      response = await _inner.send(request);
+    } catch (_) {
+      span.complete();
+      rethrow;
+    }
+
+    return http.StreamedResponse(
+      _trackBody(response, span),
+      response.statusCode,
+      contentLength: response.contentLength,
+      request: response.request,
+      headers: response.headers,
+      isRedirect: response.isRedirect,
+      persistentConnection: response.persistentConnection,
+      reasonPhrase: response.reasonPhrase,
+    );
+  }
+
+  Stream<List<int>> _trackBody(
+    http.StreamedResponse response,
+    HttpMetricSpan span,
+  ) async* {
+    var received = 0;
+    try {
+      await for (final chunk in response.stream) {
+        received += chunk.length;
+        yield chunk;
+      }
+    } finally {
+      span.complete(
+        statusCode: response.statusCode,
+        responsePayloadSize: received,
+        responseContentType: response.headers['content-type'],
+      );
+    }
+  }
+
+  @override
+  void close() {
+    _inner.close();
+    super.close();
+  }
+}

--- a/mobile/lib/providers/auth_providers.dart
+++ b/mobile/lib/providers/auth_providers.dart
@@ -18,6 +18,7 @@ import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/repository_providers.dart';
+import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/services/account_deletion_service.dart';
@@ -151,18 +152,31 @@ AuthService authService(Ref ref) {
       // set, so the router redirect has accurate cache data and sends
       // user to /home not /explore.
       final environmentConfig = ref.read(currentEnvironmentProvider);
-      final client = FunnelcakeApiClient(baseUrl: environmentConfig.apiBaseUrl);
+      // Instrumented and closed here: this one-shot client blocks the login
+      // redirect, so its latency is worth reporting, and nothing reuses it.
+      final httpClient = ref.read(instrumentedHttpClientFactoryProvider)();
+      final client = FunnelcakeApiClient(
+        baseUrl: environmentConfig.apiBaseUrl,
+        httpClient: httpClient,
+      );
       final prefs = ref.read(sharedPreferencesProvider);
-      final result = await client.getFollowing(pubkey: pubkeyHex, limit: 5000);
-      if (result.pubkeys.isNotEmpty) {
-        final key = 'following_list_$pubkeyHex';
-        await prefs.setString(key, jsonEncode(result.pubkeys));
-        Log.info(
-          'Pre-fetched ${result.pubkeys.length} following for '
-          'router redirect cache',
-          name: 'AuthService',
-          category: LogCategory.auth,
+      try {
+        final result = await client.getFollowing(
+          pubkey: pubkeyHex,
+          limit: 5000,
         );
+        if (result.pubkeys.isNotEmpty) {
+          final key = 'following_list_$pubkeyHex';
+          await prefs.setString(key, jsonEncode(result.pubkeys));
+          Log.info(
+            'Pre-fetched ${result.pubkeys.length} following for '
+            'router redirect cache',
+            name: 'AuthService',
+            category: LogCategory.auth,
+          );
+        }
+      } finally {
+        httpClient.close();
       }
     },
   );
@@ -277,8 +291,12 @@ final cawgVerifierBaseUriProvider = Provider<Uri>((ref) {
 /// Provider for the optional CAWG identity verifier client.
 final cawgVerifierClientProvider = Provider<CawgVerifierClient>((ref) {
   final baseUri = ref.watch(cawgVerifierBaseUriProvider);
-  final client = CawgVerifierClient(baseUri: baseUri);
+  // The client's own dispose() only closes a client it created, so the
+  // injected one is closed here.
+  final httpClient = ref.watch(instrumentedHttpClientFactoryProvider)();
+  final client = CawgVerifierClient(baseUri: baseUri, httpClient: httpClient);
   ref.onDispose(client.dispose);
+  ref.onDispose(httpClient.close);
   return client;
 });
 
@@ -430,7 +448,9 @@ Future<void> _setZendeskIdentity(
 @Riverpod(keepAlive: true)
 VerifierClient verifierClient(Ref ref) {
   final env = ref.watch(currentEnvironmentProvider);
-  return VerifierClient(baseUrl: env.verifierBaseUrl);
+  final httpClient = ref.watch(instrumentedHttpClientFactoryProvider)();
+  ref.onDispose(httpClient.close);
+  return VerifierClient(baseUrl: env.verifierBaseUrl, httpClient: httpClient);
 }
 
 /// Provider for [IdentityClaimsRepository] composing the verifier client

--- a/mobile/lib/providers/auth_providers.dart
+++ b/mobile/lib/providers/auth_providers.dart
@@ -89,8 +89,14 @@ PendingVerificationService pendingVerificationService(Ref ref) =>
 KeycastOAuth oauthClient(Ref ref) {
   final config = ref.watch(oauthConfigProvider);
   final storage = ref.watch(secureKeycastStorageProvider);
-
-  final oauth = KeycastOAuth(config: config, storage: storage);
+  // login.divine.video auth traffic (token, poll, password reset, …).
+  // close() owns the injected client.
+  final httpClient = ref.watch(instrumentedHttpClientFactoryProvider)();
+  final oauth = KeycastOAuth(
+    config: config,
+    storage: storage,
+    httpClient: httpClient,
+  );
 
   ref.onDispose(oauth.close);
 

--- a/mobile/lib/providers/auth_providers.g.dart
+++ b/mobile/lib/providers/auth_providers.g.dart
@@ -472,7 +472,7 @@ final class AuthServiceProvider
   }
 }
 
-String _$authServiceHash() => r'b3067ab4e67df436daf979fc7d8e5fbd4f451bf3';
+String _$authServiceHash() => r'bfe49af6f81e63824cd62720f00a59c9f925f221';
 
 /// Provider that returns current auth state and rebuilds when it changes.
 /// Widgets should watch this instead of authService.authState directly
@@ -802,7 +802,7 @@ final class VerifierClientProvider
   }
 }
 
-String _$verifierClientHash() => r'1d6966c5483814cd7fa203e7e9e198dc5c9c232d';
+String _$verifierClientHash() => r'0cb119940e69355f90bd4532588ed27ba302c416';
 
 /// Provider for [IdentityClaimsRepository] composing the verifier client
 /// with NIP-39 i tag parsing, the persistent verdict cache (#3936) and the

--- a/mobile/lib/providers/auth_providers.g.dart
+++ b/mobile/lib/providers/auth_providers.g.dart
@@ -284,7 +284,7 @@ final class OauthClientProvider
   }
 }
 
-String _$oauthClientHash() => r'0cc53348fbc3c769c81e52dd200c0efc6c20de3c';
+String _$oauthClientHash() => r'217c3c01dd4f147990ee0f189f5d4fe5bcd89d45';
 
 @ProviderFor(passwordResetListener)
 final passwordResetListenerProvider = PasswordResetListenerProvider._();

--- a/mobile/lib/providers/crossposting_providers.dart
+++ b/mobile/lib/providers/crossposting_providers.dart
@@ -4,6 +4,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/features/oauth/app_oauth_support.dart';
 import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/repositories/crossposting_repository.dart';
 import 'package:openvine/services/auth_service.dart' show AuthState;
 import 'package:openvine/services/crossposting_api_client.dart';
@@ -27,8 +28,11 @@ typedef CrosspostingApiClientFactory =
 
 final crosspostingApiClientFactoryProvider =
     Provider<CrosspostingApiClientFactory>((ref) {
-      return (accessTokenReader) =>
-          CrosspostingApiClient(accessTokenReader: accessTokenReader);
+      final newHttpClient = ref.watch(instrumentedHttpClientFactoryProvider);
+      return (accessTokenReader) => CrosspostingApiClient(
+        accessTokenReader: accessTokenReader,
+        httpClient: newHttpClient(),
+      );
     });
 
 final crosspostingApiClientProvider = Provider<CrosspostingApiClient>((ref) {

--- a/mobile/lib/providers/curation_providers.dart
+++ b/mobile/lib/providers/curation_providers.dart
@@ -9,6 +9,7 @@ import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/feed_refresh_helpers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/repository_providers.dart';
+import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/video_events_providers.dart';
 import 'package:openvine/state/curation_state.dart';
 import 'package:openvine/utils/relay_url_utils.dart';
@@ -26,7 +27,11 @@ FunnelcakeApiClient funnelcakeApiClient(Ref ref) {
     configuredRelays: nostrService.configuredRelays,
     fallbackBaseUrl: environmentConfig.apiBaseUrl,
   );
-  return FunnelcakeApiClient(baseUrl: baseUrl);
+  // Injecting the client makes the API client a non-owner, so the close that
+  // its own dispose() would have done has to happen here instead.
+  final httpClient = ref.watch(instrumentedHttpClientFactoryProvider)();
+  ref.onDispose(httpClient.close);
+  return FunnelcakeApiClient(baseUrl: baseUrl, httpClient: httpClient);
 }
 
 /// Single source of truth for Funnelcake REST API availability.

--- a/mobile/lib/providers/curation_providers.g.dart
+++ b/mobile/lib/providers/curation_providers.g.dart
@@ -59,7 +59,7 @@ final class FunnelcakeApiClientProvider
 }
 
 String _$funnelcakeApiClientHash() =>
-    r'ca05a6e880a17e8778fd64a6178b93dfa52d8d22';
+    r'2c71e9e5b8844ea7239eb1a690ad7f5c9fb42b43';
 
 /// Single source of truth for Funnelcake REST API availability.
 ///

--- a/mobile/lib/providers/nostr_apps_providers.dart
+++ b/mobile/lib/providers/nostr_apps_providers.dart
@@ -2,7 +2,6 @@
 // ABOUTME: Owns the apps-directory client, grant store, audit, bridge policy/service
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:http/http.dart';
 import 'package:nostr_app_bridge_repository/nostr_app_bridge_repository.dart';
 import 'package:openvine/config/app_config.dart';
 import 'package:openvine/providers/auth_providers.dart';
@@ -15,7 +14,7 @@ final nostrAppDirectoryServiceProvider = Provider<NostrAppDirectoryService>((
   ref,
 ) {
   final prefs = ref.watch(sharedPreferencesProvider);
-  final client = Client();
+  final client = ref.watch(instrumentedHttpClientFactoryProvider)();
   ref.onDispose(client.close);
   return NostrAppDirectoryService(
     sharedPreferences: prefs,

--- a/mobile/lib/providers/nostr_apps_providers.dart
+++ b/mobile/lib/providers/nostr_apps_providers.dart
@@ -6,6 +6,7 @@ import 'package:http/http.dart';
 import 'package:nostr_app_bridge_repository/nostr_app_bridge_repository.dart';
 import 'package:openvine/config/app_config.dart';
 import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
 import 'package:openvine/services/nip98_auth_service.dart';
@@ -39,7 +40,7 @@ final nostrAppBridgePolicyProvider = Provider<NostrAppBridgePolicy>((ref) {
 
 final nostrAppAuditServiceProvider = Provider<NostrAppAuditService>((ref) {
   final nip98AuthService = ref.watch(nip98AuthServiceProvider);
-  final client = Client();
+  final client = ref.watch(instrumentedHttpClientFactoryProvider)();
   ref.onDispose(client.close);
   return NostrAppAuditService(
     workerBaseUri: Uri.parse(AppConfig.appsDirectoryBaseUrl),

--- a/mobile/lib/providers/relay_providers.dart
+++ b/mobile/lib/providers/relay_providers.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nostr_client/nostr_client.dart'
     show NostrClient, RelayConnectionStatus, RelayRemoveSource, RelayState;
 import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/video_providers.dart';
 import 'package:openvine/services/connection_status_service.dart';
 import 'package:openvine/services/relay_capability_service.dart';
@@ -501,8 +502,12 @@ ConnectionStatusService connectionStatusService(Ref ref) {
 /// Relay capability service for detecting NIP-11 Divine extensions
 @Riverpod(keepAlive: true)
 RelayCapabilityService relayCapabilityService(Ref ref) {
-  final service = RelayCapabilityService();
+  // The service's dispose() only clears its cache, so the injected client is
+  // closed here.
+  final httpClient = ref.watch(instrumentedHttpClientFactoryProvider)();
+  final service = RelayCapabilityService(httpClient: httpClient);
   ref.onDispose(service.dispose);
+  ref.onDispose(httpClient.close);
   return service;
 }
 

--- a/mobile/lib/providers/relay_providers.g.dart
+++ b/mobile/lib/providers/relay_providers.g.dart
@@ -112,7 +112,7 @@ final class RelayCapabilityServiceProvider
 }
 
 String _$relayCapabilityServiceHash() =>
-    r'99f5caa2c958c29928c911ef3c747961279ce8cc';
+    r'ed5dd07c834c2921fe4a8d9c2f5ee42c72c446a3';
 
 /// Relay statistics service for tracking per-relay metrics
 

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -19,7 +19,6 @@ import 'package:flutter_riverpod/misc.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:hashtag_repository/hashtag_repository.dart';
 import 'package:hive_ce/hive_ce.dart';
-import 'package:http/http.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
@@ -368,7 +367,10 @@ ProfileRepository _buildProfileRepository(Ref ref, {required bool warmCache}) {
     // Durable NIP-62 vanish markers, so a deleted account stays evicted
     // across restarts.
     vanishedProfilesDao: ref.watch(databaseProvider).vanishedProfilesDao,
-    httpClient: Client(),
+    // Not closed on dispose, matching the previous `Client()`: this repository
+    // is rebuilt on every auth flip, and closing the old instance's client
+    // would abort an in-flight username claim mid-flow.
+    httpClient: ref.watch(instrumentedHttpClientFactoryProvider)(),
     funnelcakeApiClient: funnelcakeClient,
     indexerRelays: env.indexerRelays,
     profileSearchFilter: (query, profiles) =>

--- a/mobile/lib/providers/service_providers.dart
+++ b/mobile/lib/providers/service_providers.dart
@@ -2,6 +2,10 @@
 // ABOUTME: lazy-static singleton pattern to constructor injection (#4743).
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:openvine/observability/network/firebase_http_metric_recorder.dart';
+import 'package:openvine/observability/network/http_metric_recorder.dart';
+import 'package:openvine/observability/network/performance_http_client.dart';
 import 'package:openvine/services/logging_config_service.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/top_hashtags_service.dart';
@@ -36,3 +40,30 @@ final performanceMonitoringServiceProvider =
     Provider<PerformanceMonitoringService>(
       (ref) => PerformanceMonitoringService(),
     );
+
+/// Reports Dart-side HTTP requests as Firebase `NETWORK_REQUEST` metrics.
+///
+/// Firebase auto-instruments only the native HTTP stacks, so nothing the app
+/// issues from Dart reaches the Network Requests tab on its own (#7122).
+final httpMetricRecorderProvider = Provider<HttpMetricRecorder>((ref) {
+  final monitoring = ref.watch(performanceMonitoringServiceProvider);
+  return FirebaseHttpMetricRecorder(isEnabled: () => monitoring.isEnabled);
+});
+
+/// Builds an HTTP client that reports its Divine-host requests to Firebase
+/// Performance. **Use this instead of `http.Client()` for any client that
+/// talks to our own hosts.**
+///
+/// A factory rather than a shared client: each call site keeps owning (and
+/// closing) its own client, so one consumer's `close()` cannot cancel
+/// another's in-flight requests. Close the returned client as you would a
+/// plain `http.Client` — it closes the client it wraps.
+///
+/// See `docs/NETWORK_PERFORMANCE_MONITORING.md` for what is instrumented and
+/// what is deliberately not.
+final instrumentedHttpClientFactoryProvider = Provider<http.Client Function()>((
+  ref,
+) {
+  final recorder = ref.watch(httpMetricRecorderProvider);
+  return () => PerformanceHttpClient(inner: http.Client(), recorder: recorder);
+});

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -8,7 +8,6 @@ import 'package:collaborator_repository/collaborator_repository.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 import 'package:openvine/config/app_config.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
@@ -19,6 +18,7 @@ import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/relay_providers.dart';
 import 'package:openvine/providers/repository_providers.dart';
+import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/upload_media_providers.dart';
 import 'package:openvine/providers/video_providers.dart';
@@ -531,7 +531,7 @@ ViewEventRetryService? viewEventRetryService(Ref ref) {
 ProductEventQueue productEventQueue(Ref ref) {
   final db = ref.watch(databaseProvider);
   final env = ref.watch(currentEnvironmentProvider);
-  final client = http.Client();
+  final client = ref.watch(instrumentedHttpClientFactoryProvider)();
   ref.onDispose(client.close);
 
   final ingestClient = AnalyticsIngestClient(

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -354,7 +354,7 @@ final class ProductEventQueueProvider
   }
 }
 
-String _$productEventQueueHash() => r'5862cf1f79c8e494b395ced71d50a8a0ca8dd203';
+String _$productEventQueueHash() => r'036ae0aac74a5bcb7613c56f074fbbe020b20002';
 
 /// Analytics service with opt-out support.
 ///

--- a/mobile/lib/providers/subtitle_providers.dart
+++ b/mobile/lib/providers/subtitle_providers.dart
@@ -4,6 +4,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
 import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/subtitle_fetcher.dart';
 import 'package:openvine/services/subtitle_service.dart';
@@ -14,7 +15,7 @@ part 'subtitle_providers.g.dart';
 const _subtitleVisibilityPreferenceKey = 'subtitle_visibility_enabled';
 
 final subtitleHttpClientProvider = Provider<http.Client>((ref) {
-  final client = http.Client();
+  final client = ref.watch(instrumentedHttpClientFactoryProvider)();
   ref.onDispose(client.close);
   return client;
 });

--- a/mobile/lib/providers/supporter_providers.dart
+++ b/mobile/lib/providers/supporter_providers.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:iap_repository/iap_repository.dart';
 import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/supporter_api_client.dart';
 import 'package:openvine/services/supporter_repository.dart';
@@ -37,6 +38,7 @@ SupporterApiClient? supporterApiClient(Ref ref) {
   final authService = ref.watch(nip98AuthServiceProvider);
   final client = SupporterApiClient(
     baseUri: Uri.parse(supporterApiBaseUrl),
+    httpClient: ref.watch(instrumentedHttpClientFactoryProvider)(),
     authHeaderProvider: ({required url, required method, payload}) async {
       final token = await authService.createAuthToken(
         url: url,

--- a/mobile/lib/providers/supporter_providers.g.dart
+++ b/mobile/lib/providers/supporter_providers.g.dart
@@ -59,7 +59,7 @@ final class SupporterApiClientProvider
 }
 
 String _$supporterApiClientHash() =>
-    r'd57bf39319ce0f97bd63fcd9e2706a26deb2c8e0';
+    r'715fac50da56c5849e3451b87c5fad149e223d1b';
 
 /// The store-backed [EntitlementValidator] for the current platform.
 ///

--- a/mobile/lib/providers/upload_media_providers.dart
+++ b/mobile/lib/providers/upload_media_providers.dart
@@ -302,6 +302,7 @@ ApiService apiService(Ref ref) {
   final service = ApiService(
     authService: authService,
     relayManagerBaseUrl: environment.relayManagerApiUrl,
+    client: ref.watch(instrumentedHttpClientFactoryProvider)(),
   );
   // Close the owned http.Client on rebuild (env switch) — in-flight requests
   // on the old instance fail over, which switchEnvironment's cache/sub reset
@@ -315,9 +316,12 @@ ApiService apiService(Ref ref) {
 CrosspostApiClient crosspostApiClient(Ref ref) {
   final oauthClient = ref.watch(oauthClientProvider);
   final config = ref.watch(oauthConfigProvider);
+  final httpClient = ref.watch(instrumentedHttpClientFactoryProvider)();
+  ref.onDispose(httpClient.close);
   return CrosspostApiClient(
     oauthClient: oauthClient,
     serverUrl: config.serverUrl,
+    httpClient: httpClient,
   );
 }
 
@@ -338,7 +342,10 @@ BlueskyCrosspostRepository blueskyCrosspostRepository(Ref ref) {
 @riverpod
 CrossposterApiClient crossposterApiClient(Ref ref) {
   final oauthClient = ref.watch(oauthClientProvider);
-  final client = CrossposterApiClient(oauthClient: oauthClient);
+  final client = CrossposterApiClient(
+    oauthClient: oauthClient,
+    httpClient: ref.watch(instrumentedHttpClientFactoryProvider)(),
+  );
   ref.onDispose(client.close);
   return client;
 }

--- a/mobile/lib/providers/upload_media_providers.g.dart
+++ b/mobile/lib/providers/upload_media_providers.g.dart
@@ -260,7 +260,7 @@ final class ApiServiceProvider
   }
 }
 
-String _$apiServiceHash() => r'f03345aebc453113d4b58bfa22a1e0455a85603d';
+String _$apiServiceHash() => r'8458d1d89858efc01eebb86ecf93b5f974d856fe';
 
 /// Crosspost API client for Bluesky toggle settings
 
@@ -313,7 +313,7 @@ final class CrosspostApiClientProvider
 }
 
 String _$crosspostApiClientHash() =>
-    r'b1bd6e7666b565c069cd7eaf6c24108366887124';
+    r'3c3771a323baade67d52ed7de2882fb42406ba56';
 
 /// Repository for Bluesky toggle settings
 
@@ -420,7 +420,7 @@ final class CrossposterApiClientProvider
 }
 
 String _$crossposterApiClientHash() =>
-    r'35226f862d4164690f286e8eba7b02da8ca1bc15';
+    r'aa560f29562e64ced8c08c2e203abfa6858cd2ee';
 
 /// Audio playback service for sound playback during recording and preview
 ///

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -5,7 +5,6 @@ import 'dart:async';
 
 import 'package:db_client/db_client.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart' show Provider;
-import 'package:http/http.dart' as http;
 import 'package:likes_repository/likes_repository.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
@@ -265,7 +264,7 @@ VideoEventPublisher videoEventPublisher(Ref ref) {
   // HTTP origin rather than production's FunnelCake API host.
   final environmentConfig = ref.watch(currentEnvironmentProvider);
   final nip98AuthService = ref.watch(nip98AuthServiceProvider);
-  final eventApiHttpClient = http.Client();
+  final eventApiHttpClient = ref.watch(instrumentedHttpClientFactoryProvider)();
   ref.onDispose(eventApiHttpClient.close);
   final eventApiClient = EventApiClient(
     httpClient: eventApiHttpClient,

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -334,7 +334,7 @@ final class VideoEventPublisherProvider
 }
 
 String _$videoEventPublisherHash() =>
-    r'039c03fe27691e0767d8d19af6ee60b2dee10551';
+    r'b163567fe547e3985218090e9b85e73de862317f';
 
 /// View event publisher for kind 22236 ephemeral analytics events
 ///

--- a/mobile/lib/services/performance_monitoring_service.dart
+++ b/mobile/lib/services/performance_monitoring_service.dart
@@ -138,6 +138,13 @@ class PerformanceMonitoringService implements PerformanceTraceMonitor {
   late final FirebasePerformance _performance;
   bool _initialized = false;
 
+  /// Whether [initialize] has completed and Firebase Performance is usable.
+  ///
+  /// Sampled per operation by consumers built before startup finishes — an
+  /// instrumented HTTP client is constructed with the provider graph, well
+  /// before [initialize] resolves.
+  bool get isEnabled => _initialized;
+
   /// Active traces for custom performance tracking
   final Map<String, Trace> _activeTraces = {};
 
@@ -321,15 +328,6 @@ class PerformanceMonitoringService implements PerformanceTraceMonitor {
         name: 'PerformanceMonitoring',
       );
     }
-  }
-
-  /// Create an HTTP metric for tracking network performance
-  Future<HttpMetric> newHttpMetric(String url, HttpMethod httpMethod) async {
-    if (!_initialized) {
-      throw StateError('Performance monitoring not initialized');
-    }
-
-    return _performance.newHttpMetric(url, httpMethod);
   }
 
   /// Convenience method to track an async operation with automatic start/stop

--- a/mobile/lib/services/video_moderation_status_service.dart
+++ b/mobile/lib/services/video_moderation_status_service.dart
@@ -6,13 +6,16 @@ import 'dart:convert';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
+import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/utils/blossom_blob_hash.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Service provider for moderation status lookups.
 final videoModerationStatusServiceProvider =
     Provider<VideoModerationStatusService>((ref) {
-      final service = VideoModerationStatusService();
+      final service = VideoModerationStatusService(
+        httpClient: ref.watch(instrumentedHttpClientFactoryProvider)(),
+      );
       ref.onDispose(service.dispose);
       return service;
     });

--- a/mobile/test/observability/network/firebase_http_metric_recorder_test.dart
+++ b/mobile/test/observability/network/firebase_http_metric_recorder_test.dart
@@ -1,0 +1,238 @@
+// ABOUTME: Tests the Firebase-backed HttpMetricRecorder implementation.
+// ABOUTME: Method mapping, the start/stop race guard, and disabled behaviour.
+
+import 'dart:async';
+
+import 'package:firebase_performance/firebase_performance.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/observability/network/firebase_http_metric_recorder.dart';
+
+/// Stands in for a platform-backed [HttpMetric].
+class _FakeHttpMetric implements HttpMetric {
+  _FakeHttpMetric({Completer<void>? startGate}) : _startGate = startGate;
+
+  final Completer<void>? _startGate;
+
+  int startCalls = 0;
+  int stopCalls = 0;
+
+  @override
+  int? httpResponseCode;
+
+  @override
+  int? requestPayloadSize;
+
+  @override
+  int? responsePayloadSize;
+
+  @override
+  String? responseContentType;
+
+  @override
+  Future<void> start() {
+    startCalls++;
+    return _startGate?.future ?? Future<void>.value();
+  }
+
+  @override
+  Future<void> stop() async {
+    stopCalls++;
+  }
+
+  final Map<String, String> _attributes = {};
+
+  @override
+  void putAttribute(String name, String value) => _attributes[name] = value;
+
+  @override
+  void removeAttribute(String name) => _attributes.remove(name);
+
+  @override
+  String? getAttribute(String name) => _attributes[name];
+
+  @override
+  Map<String, String> getAttributes() => Map.of(_attributes);
+}
+
+void main() {
+  group(FirebaseHttpMetricRecorder, () {
+    late List<(String, HttpMethod)> created;
+    late _FakeHttpMetric metric;
+
+    FirebaseHttpMetricRecorder buildRecorder({
+      bool enabled = true,
+      _FakeHttpMetric? withMetric,
+      Object? factoryError,
+    }) {
+      metric = withMetric ?? _FakeHttpMetric();
+      return FirebaseHttpMetricRecorder(
+        isEnabled: () => enabled,
+        newHttpMetric: (url, httpMethod) {
+          created.add((url, httpMethod));
+          if (factoryError != null) throw factoryError;
+          return metric;
+        },
+      );
+    }
+
+    setUp(() {
+      created = [];
+    });
+
+    test('opens and starts a metric for the reported pattern', () {
+      final recorder = buildRecorder();
+
+      final span = recorder.start(
+        urlPattern: 'https://api.divine.video/api/videos',
+        method: 'get',
+      );
+
+      expect(span, isNotNull);
+      expect(created, [
+        ('https://api.divine.video/api/videos', HttpMethod.Get),
+      ]);
+      expect(metric.startCalls, 1);
+    });
+
+    test('maps every HTTP verb the API accepts', () {
+      final recorder = buildRecorder();
+
+      for (final method in [
+        'CONNECT',
+        'DELETE',
+        'GET',
+        'HEAD',
+        'OPTIONS',
+        'PATCH',
+        'POST',
+        'PUT',
+        'TRACE',
+      ]) {
+        recorder.start(
+          urlPattern: 'https://api.divine.video/x',
+          method: method,
+        );
+      }
+
+      expect(created.map((entry) => entry.$2), [
+        HttpMethod.Connect,
+        HttpMethod.Delete,
+        HttpMethod.Get,
+        HttpMethod.Head,
+        HttpMethod.Options,
+        HttpMethod.Patch,
+        HttpMethod.Post,
+        HttpMethod.Put,
+        HttpMethod.Trace,
+      ]);
+    });
+
+    test('declines an unsupported verb instead of guessing one', () {
+      final recorder = buildRecorder();
+
+      final span = recorder.start(
+        urlPattern: 'https://api.divine.video/x',
+        method: 'PROPFIND',
+      );
+
+      expect(span, isNull);
+      expect(created, isEmpty);
+    });
+
+    test('records nothing until monitoring has initialised', () {
+      final recorder = buildRecorder(enabled: false);
+
+      final span = recorder.start(
+        urlPattern: 'https://api.divine.video/api/videos',
+        method: 'GET',
+      );
+
+      expect(span, isNull);
+      expect(created, isEmpty);
+    });
+
+    test('declines rather than throwing when the metric cannot be made', () {
+      final recorder = buildRecorder(factoryError: StateError('no app'));
+
+      final span = recorder.start(
+        urlPattern: 'https://api.divine.video/api/videos',
+        method: 'GET',
+      );
+
+      expect(span, isNull);
+    });
+
+    test('writes the outcome onto the metric before stopping it', () async {
+      final recorder = buildRecorder();
+      final span = recorder.start(
+        urlPattern: 'https://api.divine.video/api/events',
+        method: 'POST',
+      )!;
+
+      span.setRequestPayloadSize(128);
+      span.complete(
+        statusCode: 201,
+        responsePayloadSize: 64,
+        responseContentType: 'application/json',
+      );
+      await pumpEventQueue();
+
+      expect(metric.requestPayloadSize, 128);
+      expect(metric.httpResponseCode, 201);
+      expect(metric.responsePayloadSize, 64);
+      expect(metric.responseContentType, 'application/json');
+      expect(metric.stopCalls, 1);
+    });
+
+    test('waits for the start round-trip before stopping', () async {
+      final startGate = Completer<void>();
+      final recorder = buildRecorder(
+        withMetric: _FakeHttpMetric(startGate: startGate),
+      );
+      final span = recorder.start(
+        urlPattern: 'https://api.divine.video/api/videos',
+        method: 'GET',
+      )!;
+
+      // A cache hit can finish before the platform hands back a handle; the
+      // plugin drops a stop that arrives first and leaks the native metric.
+      span.complete(statusCode: 304);
+      await pumpEventQueue();
+      expect(metric.stopCalls, 0);
+
+      startGate.complete();
+      await pumpEventQueue();
+      expect(metric.stopCalls, 1);
+    });
+
+    test('stops once even when completed repeatedly', () async {
+      final recorder = buildRecorder();
+      final span = recorder.start(
+        urlPattern: 'https://api.divine.video/api/videos',
+        method: 'GET',
+      )!;
+
+      span.complete(statusCode: 200, responsePayloadSize: 10);
+      span.complete(statusCode: 500, responsePayloadSize: 20);
+      await pumpEventQueue();
+
+      expect(metric.stopCalls, 1);
+      expect(metric.httpResponseCode, 200);
+      expect(metric.responsePayloadSize, 10);
+    });
+
+    test('ignores a payload size reported after completion', () async {
+      final recorder = buildRecorder();
+      final span = recorder.start(
+        urlPattern: 'https://api.divine.video/api/videos',
+        method: 'GET',
+      )!;
+
+      span.complete(statusCode: 200);
+      span.setRequestPayloadSize(999);
+      await pumpEventQueue();
+
+      expect(metric.requestPayloadSize, isNull);
+    });
+  });
+}

--- a/mobile/test/observability/network/http_url_pattern_test.dart
+++ b/mobile/test/observability/network/http_url_pattern_test.dart
@@ -19,7 +19,7 @@ void main() {
         Uri.parse('https://api.divine.video/api/users/$eventId/videos'),
       );
 
-      expect(videos, 'https://api.divine.video/api/users/{id}/videos');
+      expect(videos, 'https://api.divine.video/api/users/:id/videos');
       expect(otherUser, videos);
     });
 
@@ -54,13 +54,13 @@ void main() {
     test('keeps a file extension while collapsing the sha256 stem', () {
       expect(
         httpMetricUrlPattern(Uri.parse('https://media.divine.video/$eventId')),
-        'https://media.divine.video/{id}',
+        'https://media.divine.video/:id',
       );
       expect(
         httpMetricUrlPattern(
           Uri.parse('https://media.divine.video/$eventId.MP4'),
         ),
-        'https://media.divine.video/{id}.mp4',
+        'https://media.divine.video/:id.mp4',
       );
     });
 
@@ -72,7 +72,7 @@ void main() {
             'npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6',
           ),
         ),
-        'https://names.divine.video/api/username/by-pubkey/{npub}',
+        'https://names.divine.video/api/username/by-pubkey/:npub',
       );
       expect(
         httpMetricUrlPattern(
@@ -81,7 +81,7 @@ void main() {
             'nevent1qqstna2yrezu5wghjvswqqwuzqqqqqqqzq3thd',
           ),
         ),
-        'https://api.divine.video/api/events/{nevent}',
+        'https://api.divine.video/api/events/:nevent',
       );
     });
 
@@ -90,7 +90,7 @@ void main() {
         httpMetricUrlPattern(
           Uri.parse('https://api.divine.video/api/leaderboard/2026/7'),
         ),
-        'https://api.divine.video/api/leaderboard/{n}/{n}',
+        'https://api.divine.video/api/leaderboard/:n/:n',
       );
       expect(
         httpMetricUrlPattern(
@@ -99,7 +99,7 @@ void main() {
             '4b2f9c1e-3a6d-4f80-9c1a-7e5b8d2f0a13',
           ),
         ),
-        'https://api.divine.video/api/uploads/{uuid}',
+        'https://api.divine.video/api/uploads/:uuid',
       );
     });
 
@@ -113,7 +113,7 @@ void main() {
 
       expect(
         alice,
-        'https://names.divine.video/api/username/check/{username}',
+        'https://names.divine.video/api/username/check/:username',
       );
       expect(bob, alice);
     });
@@ -131,7 +131,7 @@ void main() {
             'https://api.divine.video/api/users/$pubkey/notifications/read',
           ),
         ),
-        'https://api.divine.video/api/users/{id}/notifications/read',
+        'https://api.divine.video/api/users/:id/notifications/read',
       );
     });
 
@@ -147,6 +147,45 @@ void main() {
         httpMetricUrlPattern(Uri.parse('https://API.Divine.Video/api/videos')),
         'https://api.divine.video/api/videos',
       );
+    });
+
+    test('emits only characters a URI parser accepts', () {
+      // Both Firebase SDKs parse the reported URL before recording it, and
+      // neither is lenient: Android runs it through `java.net.URI.create`
+      // and drops the metric when that throws, iOS 16 gets nil from
+      // `NSURL(string:)`. A placeholder built from excluded characters —
+      // `{id}` was the first attempt — reports nothing at all, silently.
+      // Dart's own `Uri.parse` accepts braces, so it cannot stand in for
+      // this check.
+      const uuid = '4b2f9c1e-3a6d-4f80-9c1a-7e5b8d2f0a13';
+      const npub =
+          'npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6';
+      const opaque = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9';
+      final patterns = [
+        for (final url in [
+          'https://api.divine.video/api/users/$pubkey/videos',
+          'https://api.divine.video/api/videos/$eventId/stats',
+          'https://media.divine.video/$eventId.mp4',
+          'https://api.divine.video/api/leaderboard/2026/7',
+          'https://api.divine.video/api/uploads/$uuid',
+          'https://names.divine.video/api/username/by-pubkey/$npub',
+          'https://names.divine.video/api/username/check/alice',
+          'https://api.divine.video/api/auth/$opaque',
+          'http://10.0.2.2:43001/api/users/$pubkey',
+        ])
+          httpMetricUrlPattern(Uri.parse(url)),
+      ];
+
+      // RFC 2396 + RFC 2732, the grammar `java.net.URI` enforces. Excludes
+      // `{`, `}`, space, `<`, `>`, `"`, `\`, `^`, `` ` `` and `|`.
+      final legal = RegExp(r"^[A-Za-z0-9\-._~!$&'()*+,;=:@/?#%\[\]]+$");
+      for (final pattern in patterns) {
+        expect(
+          legal.hasMatch(pattern),
+          isTrue,
+          reason: 'reported URL is not parseable by the SDKs: $pattern',
+        );
+      }
     });
   });
 

--- a/mobile/test/observability/network/http_url_pattern_test.dart
+++ b/mobile/test/observability/network/http_url_pattern_test.dart
@@ -118,6 +118,40 @@ void main() {
       expect(bob, alice);
     });
 
+    test('collapses free-form video ids that are not hex/uuid/opaque', () {
+      const shortcode = '5gITeYOlL7g';
+      final byId = httpMetricUrlPattern(
+        Uri.parse('https://api.divine.video/api/videos/$shortcode'),
+      );
+      final stats = httpMetricUrlPattern(
+        Uri.parse('https://api.divine.video/api/videos/$shortcode/stats'),
+      );
+      final views = httpMetricUrlPattern(
+        Uri.parse('https://api.divine.video/api/videos/$shortcode/views'),
+      );
+      final comments = httpMetricUrlPattern(
+        Uri.parse(
+          'https://api.divine.video/api/v2/videos/$shortcode/comments',
+        ),
+      );
+      final bulk = httpMetricUrlPattern(
+        Uri.parse('https://api.divine.video/api/videos/stats/bulk'),
+      );
+
+      expect(byId, 'https://api.divine.video/api/videos/:id');
+      expect(stats, 'https://api.divine.video/api/videos/:id/stats');
+      expect(views, 'https://api.divine.video/api/videos/:id/views');
+      expect(comments, 'https://api.divine.video/api/v2/videos/:id/comments');
+      expect(bulk, 'https://api.divine.video/api/videos/stats/bulk');
+    });
+
+    test('brackets IPv6 loopback so the reported URL stays parseable', () {
+      expect(
+        httpMetricUrlPattern(Uri.parse('http://[::1]:43001/api/videos')),
+        'http://[::1]:43001/api/videos',
+      );
+    });
+
     test('leaves route words alone, however long', () {
       expect(
         httpMetricUrlPattern(

--- a/mobile/test/observability/network/http_url_pattern_test.dart
+++ b/mobile/test/observability/network/http_url_pattern_test.dart
@@ -1,0 +1,179 @@
+// ABOUTME: Tests the reported-URL policy for network-request metrics.
+// ABOUTME: Identifier segments must collapse so Firebase aggregates them.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/observability/network/http_url_pattern.dart';
+
+void main() {
+  const pubkey =
+      '32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245';
+  const eventId =
+      'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90';
+
+  group('httpMetricUrlPattern', () {
+    test('collapses a pubkey path segment so one endpoint is one pattern', () {
+      final videos = httpMetricUrlPattern(
+        Uri.parse('https://api.divine.video/api/users/$pubkey/videos'),
+      );
+      final otherUser = httpMetricUrlPattern(
+        Uri.parse('https://api.divine.video/api/users/$eventId/videos'),
+      );
+
+      expect(videos, 'https://api.divine.video/api/users/{id}/videos');
+      expect(otherUser, videos);
+    });
+
+    test('drops the query string', () {
+      expect(
+        httpMetricUrlPattern(
+          Uri.parse(
+            'https://api.divine.video/api/videos'
+            '?limit=20&cursor=$eventId&moderation_profile=default',
+          ),
+        ),
+        'https://api.divine.video/api/videos',
+      );
+    });
+
+    test('drops userinfo and the fragment', () {
+      expect(
+        httpMetricUrlPattern(
+          Uri.parse('https://token@api.divine.video/api/videos#top'),
+        ),
+        'https://api.divine.video/api/videos',
+      );
+    });
+
+    test('keeps an explicit non-default port so local runs stay distinct', () {
+      expect(
+        httpMetricUrlPattern(Uri.parse('http://localhost:47777/api/videos')),
+        'http://localhost:47777/api/videos',
+      );
+    });
+
+    test('keeps a file extension while collapsing the sha256 stem', () {
+      expect(
+        httpMetricUrlPattern(Uri.parse('https://media.divine.video/$eventId')),
+        'https://media.divine.video/{id}',
+      );
+      expect(
+        httpMetricUrlPattern(
+          Uri.parse('https://media.divine.video/$eventId.MP4'),
+        ),
+        'https://media.divine.video/{id}.mp4',
+      );
+    });
+
+    test('collapses NIP-19 entities to their type', () {
+      expect(
+        httpMetricUrlPattern(
+          Uri.parse(
+            'https://names.divine.video/api/username/by-pubkey/'
+            'npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6',
+          ),
+        ),
+        'https://names.divine.video/api/username/by-pubkey/{npub}',
+      );
+      expect(
+        httpMetricUrlPattern(
+          Uri.parse(
+            'https://api.divine.video/api/events/'
+            'nevent1qqstna2yrezu5wghjvswqqwuzqqqqqqqzq3thd',
+          ),
+        ),
+        'https://api.divine.video/api/events/{nevent}',
+      );
+    });
+
+    test('collapses numeric and uuid segments', () {
+      expect(
+        httpMetricUrlPattern(
+          Uri.parse('https://api.divine.video/api/leaderboard/2026/7'),
+        ),
+        'https://api.divine.video/api/leaderboard/{n}/{n}',
+      );
+      expect(
+        httpMetricUrlPattern(
+          Uri.parse(
+            'https://api.divine.video/api/uploads/'
+            '4b2f9c1e-3a6d-4f80-9c1a-7e5b8d2f0a13',
+          ),
+        ),
+        'https://api.divine.video/api/uploads/{uuid}',
+      );
+    });
+
+    test('collapses free-text segments on registered routes', () {
+      final alice = httpMetricUrlPattern(
+        Uri.parse('https://names.divine.video/api/username/check/alice'),
+      );
+      final bob = httpMetricUrlPattern(
+        Uri.parse('https://names.divine.video/api/username/check/bob'),
+      );
+
+      expect(
+        alice,
+        'https://names.divine.video/api/username/check/{username}',
+      );
+      expect(bob, alice);
+    });
+
+    test('leaves route words alone, however long', () {
+      expect(
+        httpMetricUrlPattern(
+          Uri.parse('https://api.divine.video/api/hashtags/trending'),
+        ),
+        'https://api.divine.video/api/hashtags/trending',
+      );
+      expect(
+        httpMetricUrlPattern(
+          Uri.parse(
+            'https://api.divine.video/api/users/$pubkey/notifications/read',
+          ),
+        ),
+        'https://api.divine.video/api/users/{id}/notifications/read',
+      );
+    });
+
+    test('preserves a trailing slash rather than merging two routes', () {
+      expect(
+        httpMetricUrlPattern(Uri.parse('https://api.divine.video/api/videos/')),
+        'https://api.divine.video/api/videos/',
+      );
+    });
+
+    test('lower-cases the host so casing does not split a pattern', () {
+      expect(
+        httpMetricUrlPattern(Uri.parse('https://API.Divine.Video/api/videos')),
+        'https://api.divine.video/api/videos',
+      );
+    });
+  });
+
+  group('isInstrumentedHost', () {
+    test('accepts Divine-operated hosts and their subdomains', () {
+      expect(isInstrumentedHost('api.divine.video'), isTrue);
+      expect(isInstrumentedHost('media.divine.video'), isTrue);
+      expect(isInstrumentedHost('divine.video'), isTrue);
+      expect(isInstrumentedHost('relay.poc.dvines.org'), isTrue);
+      expect(isInstrumentedHost('API.DIVINE.VIDEO'), isTrue);
+    });
+
+    test('accepts local-stack hosts so a local run can be verified', () {
+      expect(isInstrumentedHost('localhost'), isTrue);
+      expect(isInstrumentedHost('10.0.2.2'), isTrue);
+    });
+
+    test('rejects third-party hosts', () {
+      expect(isInstrumentedHost('api.github.com'), isFalse);
+      expect(isInstrumentedHost('nos.lol'), isFalse);
+      expect(isInstrumentedHost('app-ads-services.com'), isFalse);
+      expect(isInstrumentedHost(''), isFalse);
+    });
+
+    test('rejects a look-alike host that merely ends in our name', () {
+      expect(isInstrumentedHost('notdivine.video'), isFalse);
+      expect(isInstrumentedHost('divine.video.evil.com'), isFalse);
+    });
+  });
+}

--- a/mobile/test/observability/network/performance_http_client_test.dart
+++ b/mobile/test/observability/network/performance_http_client_test.dart
@@ -124,7 +124,7 @@ void main() {
 
       expect(
         recorder.only.urlPattern,
-        'https://api.divine.video/api/videos/{id}/stats',
+        'https://api.divine.video/api/videos/:id/stats',
       );
       expect(recorder.only.method, 'GET');
     });

--- a/mobile/test/observability/network/performance_http_client_test.dart
+++ b/mobile/test/observability/network/performance_http_client_test.dart
@@ -1,0 +1,276 @@
+// ABOUTME: Tests the http.Client decorator that opens a metric per request.
+// ABOUTME: Covers host filtering, payload sizes, failures and cancellation.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:openvine/observability/network/http_metric_recorder.dart';
+import 'package:openvine/observability/network/performance_http_client.dart';
+
+class _RecordedSpan implements HttpMetricSpan {
+  _RecordedSpan(this.urlPattern, this.method);
+
+  final String urlPattern;
+  final String method;
+
+  int? requestPayloadSize;
+  int? statusCode;
+  int? responsePayloadSize;
+  String? responseContentType;
+  int completions = 0;
+
+  bool get isCompleted => completions > 0;
+
+  @override
+  void setRequestPayloadSize(int bytes) => requestPayloadSize = bytes;
+
+  @override
+  void complete({
+    int? statusCode,
+    int? responsePayloadSize,
+    String? responseContentType,
+  }) {
+    completions++;
+    if (completions > 1) return;
+    this.statusCode = statusCode;
+    this.responsePayloadSize = responsePayloadSize;
+    this.responseContentType = responseContentType;
+  }
+}
+
+class _FakeRecorder implements HttpMetricRecorder {
+  _FakeRecorder({this.enabled = true});
+
+  final bool enabled;
+  final List<_RecordedSpan> spans = [];
+
+  _RecordedSpan get only => spans.single;
+
+  @override
+  HttpMetricSpan? start({required String urlPattern, required String method}) {
+    if (!enabled) return null;
+    final span = _RecordedSpan(urlPattern, method);
+    spans.add(span);
+    return span;
+  }
+}
+
+/// Inner client under the decorator: answers with a caller-supplied stream (or
+/// error) and records what it was asked to send.
+class _FakeInnerClient extends http.BaseClient {
+  _FakeInnerClient({
+    this.responder,
+    this.error,
+    this.headers = const {'content-type': 'application/json'},
+    this.statusCode = 200,
+  });
+
+  final Stream<List<int>> Function()? responder;
+  final Object? error;
+  final Map<String, String> headers;
+  final int statusCode;
+
+  final List<http.BaseRequest> sent = [];
+  bool closed = false;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    sent.add(request);
+    final failure = error;
+    if (failure != null) throw failure;
+    final body =
+        responder?.call() ??
+        Stream<List<int>>.fromIterable([utf8.encode('{}')]);
+    return http.StreamedResponse(
+      body,
+      statusCode,
+      request: request,
+      headers: headers,
+      reasonPhrase: 'OK',
+    );
+  }
+
+  @override
+  void close() {
+    closed = true;
+    super.close();
+  }
+}
+
+void main() {
+  group(PerformanceHttpClient, () {
+    late _FakeRecorder recorder;
+
+    setUp(() {
+      recorder = _FakeRecorder();
+    });
+
+    test('reports the route pattern and method for a Divine host', () async {
+      final client = PerformanceHttpClient(
+        inner: _FakeInnerClient(),
+        recorder: recorder,
+      );
+      addTearDown(client.close);
+
+      await client.get(
+        Uri.parse(
+          'https://api.divine.video/api/videos/'
+          'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90'
+          '/stats?limit=5',
+        ),
+      );
+
+      expect(
+        recorder.only.urlPattern,
+        'https://api.divine.video/api/videos/{id}/stats',
+      );
+      expect(recorder.only.method, 'GET');
+    });
+
+    test('records status, content type and transferred sizes', () async {
+      final client = PerformanceHttpClient(
+        inner: _FakeInnerClient(
+          responder: () => Stream<List<int>>.fromIterable([
+            utf8.encode('{"videos":'),
+            utf8.encode('[]}'),
+          ]),
+        ),
+        recorder: recorder,
+      );
+      addTearDown(client.close);
+
+      final response = await client.post(
+        Uri.parse('https://api.divine.video/api/events'),
+        body: '{"kind":34236}',
+      );
+
+      expect(response.body, '{"videos":[]}');
+      final span = recorder.only;
+      expect(span.statusCode, 200);
+      expect(span.requestPayloadSize, 14);
+      expect(span.responsePayloadSize, 13);
+      expect(span.responseContentType, 'application/json');
+    });
+
+    test('records an error status, and tolerates no content type', () async {
+      final client = PerformanceHttpClient(
+        inner: _FakeInnerClient(statusCode: 404, headers: const {}),
+        recorder: recorder,
+      );
+      addTearDown(client.close);
+
+      await client.get(Uri.parse('https://api.divine.video/api/videos'));
+
+      final span = recorder.only;
+      expect(span.statusCode, 404);
+      expect(span.responseContentType, isNull);
+    });
+
+    test('does not report requests to third-party hosts', () async {
+      final inner = _FakeInnerClient();
+      final client = PerformanceHttpClient(inner: inner, recorder: recorder);
+      addTearDown(client.close);
+
+      await client.get(Uri.parse('https://api.github.com/repos/divine/app'));
+
+      expect(recorder.spans, isEmpty);
+      expect(inner.sent, hasLength(1));
+    });
+
+    test('still sends the request when the recorder declines it', () async {
+      final inner = _FakeInnerClient();
+      final client = PerformanceHttpClient(
+        inner: inner,
+        recorder: _FakeRecorder(enabled: false),
+      );
+      addTearDown(client.close);
+
+      final response = await client.get(
+        Uri.parse('https://api.divine.video/api/videos'),
+      );
+
+      expect(response.statusCode, 200);
+      expect(inner.sent, hasLength(1));
+    });
+
+    test('completes the span without a status when the send fails', () async {
+      final client = PerformanceHttpClient(
+        inner: _FakeInnerClient(error: http.ClientException('offline')),
+        recorder: recorder,
+      );
+      addTearDown(client.close);
+
+      await expectLater(
+        client.get(Uri.parse('https://api.divine.video/api/videos')),
+        throwsA(isA<http.ClientException>()),
+      );
+
+      final span = recorder.only;
+      expect(span.isCompleted, isTrue);
+      expect(span.statusCode, isNull);
+    });
+
+    test(
+      'completes the span when the response body errors mid-stream',
+      () async {
+        final client = PerformanceHttpClient(
+          inner: _FakeInnerClient(
+            responder: () => Stream<List<int>>.fromIterable([
+              utf8.encode('partial'),
+            ]).followedBy(Stream.error(http.ClientException('reset'))),
+          ),
+          recorder: recorder,
+        );
+        addTearDown(client.close);
+
+        final response = await client.send(
+          http.Request('GET', Uri.parse('https://media.divine.video/abc')),
+        );
+
+        await expectLater(
+          response.stream.drain<void>(),
+          throwsA(isA<http.ClientException>()),
+        );
+        expect(recorder.only.isCompleted, isTrue);
+      },
+    );
+
+    test('completes the span once when the body is cancelled', () async {
+      final client = PerformanceHttpClient(
+        inner: _FakeInnerClient(
+          responder: () => Stream<List<int>>.periodic(
+            const Duration(milliseconds: 5),
+            (_) => utf8.encode('chunk'),
+          ),
+        ),
+        recorder: recorder,
+      );
+      addTearDown(client.close);
+
+      final response = await client.send(
+        http.Request('GET', Uri.parse('https://media.divine.video/abc.mp4')),
+      );
+      final subscription = response.stream.listen(null);
+      await subscription.cancel();
+
+      expect(recorder.only.completions, 1);
+    });
+
+    test('closing the wrapper closes the client it wraps', () {
+      final inner = _FakeInnerClient();
+
+      PerformanceHttpClient(inner: inner, recorder: recorder).close();
+
+      expect(inner.closed, isTrue);
+    });
+  });
+}
+
+extension _FollowedBy on Stream<List<int>> {
+  Stream<List<int>> followedBy(Stream<List<int>> next) async* {
+    yield* this;
+    yield* next;
+  }
+}

--- a/mobile/test/services/performance_monitoring_service_test.dart
+++ b/mobile/test/services/performance_monitoring_service_test.dart
@@ -19,6 +19,17 @@ void main() {
       expect(true, true);
     });
 
+    test('isEnabled stays false while Firebase is unavailable', () async {
+      // The flag gates the instrumented HTTP client (#7122): it must only
+      // turn true once Firebase Performance actually came up, never merely
+      // because initialize() was called and swallowed a failure.
+      expect(service.isEnabled, isFalse);
+
+      await service.initialize();
+
+      expect(service.isEnabled, isFalse);
+    });
+
     test('should handle trace start and stop without error', () async {
       await service.initialize();
 


### PR DESCRIPTION
## Description

Firebase Performance auto-instruments network traffic by swizzling the *native* HTTP stacks, so nothing the app issues from Dart ever reached the **Network Requests** tab. The export showed zero `NETWORK_REQUEST` events on Android, and on iOS 24,843 events of which essentially all were Apple/Google SDK telemetry — the only Divine host present was `media.divine.video` (414 events), which is native video-player traffic rather than anything Dart sent. Relay, API, CDN and upload behaviour were all absent from a tab that looked like it covered them.

This adds the missing `HttpMetric` instrumentation at **one boundary** — a `PerformanceHttpClient` decorator over `http.Client` — and wires it into the clients that talk to our own hosts, so new callers are covered by using the shared factory rather than by remembering to instrument each call.

**Related Issue:** Closes #7122

### Why it is built this way

**The span covers the whole transfer, not time-to-first-byte.** `send()` wraps the response stream and ends the metric when the body completes, errors, or its subscription is cancelled. Stopping awaits the start round-trip, because the plugin drops a stop that arrives before the platform handed back a handle — the metric is then never reported *and* leaks natively. That is the same race the existing custom-trace handle already guards against (`_FirebasePerformanceTrace`), and a 304 or cache hit is exactly what would hit it.

**Paths are reported as route patterns.** Firebase aggregates by URL and drops high-cardinality patterns, so `/api/users/<64-hex>/videos` would give one pattern per user. `httpMetricUrlPattern` collapses long hex ids, NIP-19 bech32 entities (kept as `{npub}` / `{nevent}` so the type stays readable), UUIDs, all-digit segments and opaque base64url tokens, and drops query strings, fragments and userinfo. Identifiers are replaced **whole** — a truncated Nostr id is still a Nostr id, and emitting one is banned repo-wide, so aggregating by route is the sanctioned answer. Free-text path segments (`/api/username/check/<username>`) cannot be recognised by any generic rule, so those routes carry an explicit entry in a small override table.

**Reporting is limited to Divine-operated hosts plus local-stack loopback** (`isInstrumentedHost`). Filtering at runtime rather than trusting the wiring means a client that *can* be pointed at a user-configured relay, Blossom server or avatar host stays safe to wrap. It also protects Firebase's per-app URL-pattern cap from being spent on hosts we cannot act on.

**The provider hands out a factory, not a shared client.** Each call site keeps owning and closing its own client, so one consumer's `close()` cannot cancel another's in-flight requests. Injecting a client flips several callees from owner to borrower (their `dispose()` only closes a client they created themselves), so those providers now close it — called out inline at each site.

**A port, not a direct Firebase dependency.** `HttpMetricRecorder` / `HttpMetricSpan` keep the decorator testable without a Firebase app and mirror the existing `BlossomPerformanceMonitor` precedent. The now-superseded, never-called `PerformanceMonitoringService.newHttpMetric` (which threw when uninitialised) is removed rather than left as a second, dead way to open a metric.

### What is instrumented

Funnelcake REST API (feeds, search, profiles, notifications, video stats) · event publish · product-analytics ingest · username claim/release/check (`names.divine.video`) · Keycast OAuth (`login.divine.video`) · relay-manager · invite server · apps-directory listing + audit · NIP-39 and CAWG verification · crossposting (settings + manual) · supporter worker · subtitle/VTT fetch · moderation check-result · NIP-11 relay capability probe · the login-path following pre-fetch.

### Deliberate exclusions

Recorded with reasons in [`mobile/docs/NETWORK_PERFORMANCE_MONITORING.md`](mobile/docs/NETWORK_PERFORMANCE_MONITORING.md), since the issue asked for the decision to be explicit:

- **Relay WebSockets** — not HTTP requests; `HttpMetric` cannot express them. Relay latency needs its own custom trace.
- **Blossom uploads** — Dio-based, and the shipped path runs through the OS background transport that Firebase *does* auto-instrument natively. Upload timing is already reported as custom traces via `BlossomPerformanceMonitor`, which measures the whole chunked/resumable operation instead of fragmenting it per chunk.
- **Video/image byte traffic** — one or more events per feed item for little value beyond the native `media.divine.video` events; throughput is already tracked by `BandwidthTrackerService`.
- **Third-party hosts** — GitHub releases, Zendesk, the `workers.dev` geo-blocker, NIP-05 resolution, remote avatar SVGs, and `nostr_sdk`'s legacy Dio uploaders.

The judgment call most worth a second opinion: feed queries **are** instrumented. They were the traffic that was completely dark, but they are also the highest-volume events here. Narrowing that is a one-line change in the wiring list if we'd rather not pay for it.

## Out of Scope

- A custom trace for relay WebSocket latency — the other half of the visibility gap, and a separate piece of work.
- Draining the pre-existing client leaks these call sites already had (`ProfileRepository` is rebuilt on every auth flip and its client was never closed before either; closing it now would abort an in-flight username claim mid-flow, so behaviour is left as it was, with a comment).

## Verification

- `flutter analyze lib test integration_test` — clean.
- `dart format --set-exit-if-changed lib test` — clean.
- `dart run build_runner build --delete-conflicting-outputs` — rerun; the only generated churn is Riverpod's provider-hash lines for the touched providers.
- `flutter test test/observability` — 62 tests, covering pattern collapsing, host filtering, payload sizes, non-2xx statuses, transport failure, mid-stream error, cancellation, single-stop idempotency, verb mapping and the start/stop race guard.
- `flutter test test/providers` — 654 tests. `flutter test test/services` — 3,944 tests. Plus the affected screen tests (relay settings, Bluesky settings) and `main_*` shell tests.
- `check_untested_services_floor.sh`, `check_test_unit_structure.sh` — pass.
- **Device verification on a real Samsung Galaxy: pending** — console confirmation still needs a shipped build; not a code blocker on this head.
- **Console confirmation is pending by nature:** Firebase surfaces network data within ~12h, so the acceptance criterion "our own hosts appear in `NETWORK_REQUEST` on both platforms" can only be closed after a build ships. Loopback hosts are instrumented on purpose so a LOCAL `local_stack/` run exercises the identical path first.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore

