### PR TITLE
fix(perf): give each upload leg its own operation-scoped trace

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -672,8 +672,8 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
   );
 
   // Critical phase: traces started before this completes are dropped on the
-  // floor — `startTrace` early-returns and `startOperationTrace` hands back a
-  // no-op handle. In `deferred` that silently cost every cold-start
+  // floor — `startOperationTrace` hands back a no-op handle. In `deferred`
+  // that silently cost every cold-start
   // measurement, including the `feed_load_homeFeed` and `feed_load_discovery`
   // traces, which mount while the later phases are still working through their
   // queue (#7118). Cost here is a single platform round-trip that runs in

--- a/mobile/lib/providers/upload_media_providers.dart
+++ b/mobile/lib/providers/upload_media_providers.dart
@@ -165,14 +165,27 @@ class _FirebasePerformanceAdapter implements BlossomPerformanceMonitor {
   final PerformanceTraceMonitor _monitor;
 
   @override
-  Future<void> startTrace(String traceName) => _monitor.startTrace(traceName);
+  BlossomPerformanceTrace startOperationTrace(String traceName) =>
+      _BlossomTraceAdapter(_monitor.startOperationTrace(traceName));
+}
+
+/// Adapts an app-layer [PerformanceTrace] handle to the package-level
+/// [BlossomPerformanceTrace] handle.
+class _BlossomTraceAdapter implements BlossomPerformanceTrace {
+  _BlossomTraceAdapter(this._trace);
+
+  final PerformanceTrace _trace;
 
   @override
-  Future<void> stopTrace(String traceName) => _monitor.stopTrace(traceName);
+  void setMetric(String metricName, int value) =>
+      _trace.setMetric(metricName, value);
 
   @override
-  void setMetric(String traceName, String metricName, int value) =>
-      _monitor.setMetric(traceName, metricName, value);
+  void putAttribute(String attribute, String value) =>
+      _trace.putAttribute(attribute, value);
+
+  @override
+  Future<void> stop() => _trace.stop();
 }
 
 /// Blossom BUD-01 authentication service for age-restricted content

--- a/mobile/lib/services/performance_monitoring_service.dart
+++ b/mobile/lib/services/performance_monitoring_service.dart
@@ -25,22 +25,19 @@ abstract class PerformanceTrace {
 }
 
 /// Minimal trace API used by services that need testable performance spans.
+///
+/// Deliberately handle-only. The name-keyed API this replaced treated the
+/// trace *name* as the identity of a measurement, so starting a second trace
+/// of the same name reported the first one wherever it happened to be —
+/// truncating it — and a trace that was never stopped stayed open until some
+/// later start reported it, which is how a 23.6-hour `feed_load_profile`
+/// sample reached the console (#7119).
 abstract class PerformanceTraceMonitor {
-  Future<void> startTrace(String traceName);
-
-  Future<void> stopTrace(String traceName);
-
-  /// Starts a trace and returns an operation-scoped [PerformanceTrace] handle.
-  /// Prefer this over [startTrace] for any operation that can overlap another
-  /// of the same name or complete before its trace round-trip settles. Returns
-  /// a no-op handle when monitoring is unavailable.
+  /// Starts a trace and returns the handle that owns it.
+  ///
+  /// Returns a no-op handle when monitoring is unavailable, so callers never
+  /// need to null-check.
   PerformanceTrace startOperationTrace(String traceName);
-
-  void incrementMetric(String traceName, String metricName, int value);
-
-  void setMetric(String traceName, String metricName, int value);
-
-  void putAttribute(String traceName, String attribute, String value);
 }
 
 /// No-op [PerformanceTrace] returned when monitoring is unavailable.
@@ -112,23 +109,8 @@ class NoOpPerformanceTraceMonitor implements PerformanceTraceMonitor {
   const NoOpPerformanceTraceMonitor();
 
   @override
-  Future<void> startTrace(String traceName) async {}
-
-  @override
-  Future<void> stopTrace(String traceName) async {}
-
-  @override
   PerformanceTrace startOperationTrace(String traceName) =>
       const _NoOpPerformanceTrace();
-
-  @override
-  void incrementMetric(String traceName, String metricName, int value) {}
-
-  @override
-  void setMetric(String traceName, String metricName, int value) {}
-
-  @override
-  void putAttribute(String traceName, String attribute, String value) {}
 }
 
 /// Performance monitoring service for tracking app performance
@@ -144,9 +126,6 @@ class PerformanceMonitoringService implements PerformanceTraceMonitor {
   /// instrumented HTTP client is constructed with the provider graph, well
   /// before [initialize] resolves.
   bool get isEnabled => _initialized;
-
-  /// Active traces for custom performance tracking
-  final Map<String, Trace> _activeTraces = {};
 
   /// Initialize performance monitoring
   Future<void> initialize() async {
@@ -172,36 +151,11 @@ class PerformanceMonitoringService implements PerformanceTraceMonitor {
     }
   }
 
-  /// Start a custom trace for tracking operation performance
-  @override
-  Future<void> startTrace(String traceName) async {
-    if (!_initialized) return;
-
-    try {
-      // Stop existing trace with same name if it exists
-      await stopTrace(traceName);
-
-      final trace = _performance.newTrace(traceName);
-      await trace.start();
-      _activeTraces[traceName] = trace;
-
-      Log.debug(
-        'Started performance trace: $traceName',
-        name: 'PerformanceMonitoring',
-      );
-    } catch (e) {
-      Log.error(
-        'Failed to start trace $traceName: $e',
-        name: 'PerformanceMonitoring',
-      );
-    }
-  }
-
   /// Start an operation-scoped trace and return its handle.
   ///
-  /// Unlike [startTrace], nothing is stored in [_activeTraces]: the caller
-  /// owns the returned [PerformanceTrace] and tags/stops it directly, so
-  /// overlapping operations of the same name keep independent traces. Start is
+  /// The caller owns the returned [PerformanceTrace] and tags/stops it
+  /// directly, so overlapping operations of the same name keep independent
+  /// traces and a handle that is never stopped simply never reports. Start is
   /// fire-and-forget so callers stay synchronous; attributes and metrics are
   /// buffered until stop, and stop itself waits for the start round-trip so a
   /// short operation cannot end its trace before the platform opened it.
@@ -224,122 +178,6 @@ class PerformanceMonitoringService implements PerformanceTraceMonitor {
         name: 'PerformanceMonitoring',
       );
       return const _NoOpPerformanceTrace();
-    }
-  }
-
-  /// Stop a custom trace and record the duration
-  @override
-  Future<void> stopTrace(String traceName) async {
-    if (!_initialized) return;
-
-    try {
-      final trace = _activeTraces.remove(traceName);
-      if (trace != null) {
-        await trace.stop();
-        Log.debug(
-          'Stopped performance trace: $traceName',
-          name: 'PerformanceMonitoring',
-        );
-      }
-    } catch (e) {
-      Log.error(
-        'Failed to stop trace $traceName: $e',
-        name: 'PerformanceMonitoring',
-      );
-    }
-  }
-
-  /// Add a metric to an active trace
-  @override
-  void incrementMetric(String traceName, String metricName, int value) {
-    if (!_initialized) return;
-
-    try {
-      final trace = _activeTraces[traceName];
-      if (trace != null) {
-        trace.incrementMetric(metricName, value);
-        Log.debug(
-          'Incremented metric $metricName by $value for trace $traceName',
-          name: 'PerformanceMonitoring',
-        );
-      } else {
-        Log.warning(
-          'Trace $traceName not found for metric $metricName',
-          name: 'PerformanceMonitoring',
-        );
-      }
-    } catch (e) {
-      Log.error(
-        'Failed to increment metric $metricName: $e',
-        name: 'PerformanceMonitoring',
-      );
-    }
-  }
-
-  /// Set a metric value on an active trace
-  @override
-  void setMetric(String traceName, String metricName, int value) {
-    if (!_initialized) return;
-
-    try {
-      final trace = _activeTraces[traceName];
-      if (trace != null) {
-        trace.setMetric(metricName, value);
-        Log.debug(
-          'Set metric $metricName to $value for trace $traceName',
-          name: 'PerformanceMonitoring',
-        );
-      } else {
-        Log.warning(
-          'Trace $traceName not found for metric $metricName',
-          name: 'PerformanceMonitoring',
-        );
-      }
-    } catch (e) {
-      Log.error(
-        'Failed to set metric $metricName: $e',
-        name: 'PerformanceMonitoring',
-      );
-    }
-  }
-
-  /// Add an attribute to an active trace for filtering in Firebase Console
-  @override
-  void putAttribute(String traceName, String attribute, String value) {
-    if (!_initialized) return;
-
-    try {
-      final trace = _activeTraces[traceName];
-      if (trace != null) {
-        trace.putAttribute(attribute, value);
-        Log.debug(
-          'Set attribute $attribute=$value for trace $traceName',
-          name: 'PerformanceMonitoring',
-        );
-      } else {
-        Log.warning(
-          'Trace $traceName not found for attribute $attribute',
-          name: 'PerformanceMonitoring',
-        );
-      }
-    } catch (e) {
-      Log.error(
-        'Failed to put attribute $attribute: $e',
-        name: 'PerformanceMonitoring',
-      );
-    }
-  }
-
-  /// Convenience method to track an async operation with automatic start/stop
-  Future<T> trace<T>(String traceName, Future<T> Function() operation) async {
-    await startTrace(traceName);
-    try {
-      final result = await operation();
-      await stopTrace(traceName);
-      return result;
-    } catch (e) {
-      await stopTrace(traceName);
-      rethrow;
     }
   }
 }

--- a/mobile/lib/services/performance_monitoring_service.dart
+++ b/mobile/lib/services/performance_monitoring_service.dart
@@ -8,10 +8,10 @@ import 'package:unified_logger/unified_logger.dart';
 ///
 /// Callers capture the handle returned by
 /// [PerformanceTraceMonitor.startOperationTrace] and tag/stop *that* handle, so
-/// each operation owns its own trace. This avoids the name-keyed pitfalls of
-/// the legacy [PerformanceTraceMonitor.startTrace] API: a fast operation can't
-/// tag/stop before a shared registration completes, and two overlapping
-/// operations can't stop or re-attribute each other's trace.
+/// each operation owns its own trace. This avoids the pitfalls of the removed
+/// name-keyed API: a fast operation can't tag/stop before a shared
+/// registration completes, and two overlapping operations can't stop or
+/// re-attribute each other's trace.
 abstract class PerformanceTrace {
   /// Adds an attribute for filtering in the Firebase console.
   void putAttribute(String attribute, String value);

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -2262,22 +2262,25 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         bool eoseReceived = false;
         bool timeoutReported = false;
 
-        // Start performance trace for feed loading
-        final traceName = 'feed_load_${subscriptionType.name}';
+        // Operation-scoped so two loads of the same subscription type keep
+        // independent traces. Under the name-keyed API a load that never
+        // reached a completion path — the service is disposed before the 30s
+        // timeout fires — stayed open until the next load of that type
+        // reported it, which is how a 23.6-hour `feed_load_profile` sample
+        // reached the console. A leaked handle now simply never reports
+        // (#7119).
+        final trace = _performanceMonitor.startOperationTrace(
+          'feed_load_${subscriptionType.name}',
+        );
         var traceCompleted = false;
         void completeFeedLoadTrace(String completion, {int? eventTotal}) {
           if (traceCompleted) return;
           traceCompleted = true;
-          _performanceMonitor.setMetric(
-            traceName,
-            'event_count',
-            eventTotal ?? eventCount,
-          );
-          _performanceMonitor.putAttribute(traceName, 'completion', completion);
-          unawaited(_performanceMonitor.stopTrace(traceName));
+          trace
+            ..setMetric('event_count', eventTotal ?? eventCount)
+            ..putAttribute('completion', completion);
+          unawaited(trace.stop());
         }
-
-        await _performanceMonitor.startTrace(traceName);
 
         Log.info(
           '📡 Creating subscription for $subscriptionType at ${subscriptionStartTime.toIso8601String()}',

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_performance_monitor.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_performance_monitor.dart
@@ -4,10 +4,16 @@
 /// Trace name for the in-process transfer run by
 /// `BlossomUploadService.uploadVideo`.
 ///
-/// Spans the whole upload, so it is comparable to the publish timeline's
-/// `transfer_ms`. Deliberately *not* shared with [enqueueTraceName]: the two
-/// measure different things, and reporting both under one name blends two
-/// incompatible distributions into a number nobody can read (#7119).
+/// Spans the whole in-process transfer. Deliberately *not* shared with
+/// [enqueueTraceName]: the two measure different things, and reporting both
+/// under one name blends two incompatible distributions into a number nobody
+/// can read (#7119).
+///
+/// Not comparable to the publish timeline's `transfer_ms`, which stopwatches
+/// the whole `uploadVideoWithResume` call — OS attempt plus any fallback — on
+/// every publish. This trace only opens once the in-process leg actually runs,
+/// which in the shipping config means the OS attempt did not succeed first
+/// try. Its population is that biased-slow subset, not all publishes.
 const String uploadTraceName = 'video_upload';
 
 /// Trace name for the setup-and-enqueue leg of

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_performance_monitor.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_performance_monitor.dart
@@ -1,19 +1,68 @@
 // ABOUTME: Abstract performance monitoring interface for upload metrics.
 // ABOUTME: Decouples the package from Firebase Performance or any APM tool.
 
+/// Trace name for the in-process transfer run by
+/// `BlossomUploadService.uploadVideo`.
+///
+/// Spans the whole upload, so it is comparable to the publish timeline's
+/// `transfer_ms`. Deliberately *not* shared with [enqueueTraceName]: the two
+/// measure different things, and reporting both under one name blends two
+/// incompatible distributions into a number nobody can read (#7119).
+const String uploadTraceName = 'video_upload';
+
+/// Trace name for the setup-and-enqueue leg of
+/// `BlossomUploadService.uploadVideoInBackground`.
+///
+/// Covers only the in-process work that hands the transfer to the OS. The
+/// transfer itself is owned by the OS, can span an app suspension, and is not
+/// measured here.
+const String enqueueTraceName = 'video_upload_enqueue';
+
+/// A handle to a single started trace.
+///
+/// The handle — not a trace name — is the identity of the measurement, so two
+/// overlapping uploads keep independent traces. The name-keyed API this
+/// replaced reported an in-flight trace whenever a second one of the same name
+/// started, which truncated the first and left multi-hour samples in the tail
+/// whenever one was never stopped (#7119).
+abstract class BlossomPerformanceTrace {
+  /// Sets a metric value on this trace.
+  void setMetric(String metricName, int value);
+
+  /// Adds an attribute for filtering in the APM console.
+  void putAttribute(String attribute, String value);
+
+  /// Stops the trace and records its duration.
+  Future<void> stop();
+}
+
 /// Optional performance monitoring interface for tracking upload metrics.
 ///
 /// Provide a custom implementation to integrate with Firebase Performance
 /// or another APM tool. If not provided, [NoOpPerformanceMonitor] is used.
+///
+// Kept as a named port rather than the bare function `one_member_abstracts`
+// suggests: the call sites read as `startOperationTrace(uploadTraceName)`, and
+// the app-layer adapter and the test doubles are classes that implement it.
+// ignore: one_member_abstracts
 abstract class BlossomPerformanceMonitor {
-  /// Start a named performance trace.
-  Future<void> startTrace(String traceName);
+  /// Starts a trace and returns the handle that owns it.
+  BlossomPerformanceTrace startOperationTrace(String traceName);
+}
 
-  /// Stop a named performance trace.
-  Future<void> stopTrace(String traceName);
+/// A no-op [BlossomPerformanceTrace] that silently discards every call.
+class NoOpPerformanceTrace implements BlossomPerformanceTrace {
+  /// Creates a [NoOpPerformanceTrace].
+  const NoOpPerformanceTrace();
 
-  /// Set a metric value on an active trace.
-  void setMetric(String traceName, String metricName, int value);
+  @override
+  void setMetric(String metricName, int value) {}
+
+  @override
+  void putAttribute(String attribute, String value) {}
+
+  @override
+  Future<void> stop() async {}
 }
 
 /// A no-op implementation that silently discards all performance calls.
@@ -22,11 +71,6 @@ class NoOpPerformanceMonitor implements BlossomPerformanceMonitor {
   const NoOpPerformanceMonitor();
 
   @override
-  Future<void> startTrace(String traceName) async {}
-
-  @override
-  Future<void> stopTrace(String traceName) async {}
-
-  @override
-  void setMetric(String traceName, String metricName, int value) {}
+  BlossomPerformanceTrace startOperationTrace(String traceName) =>
+      const NoOpPerformanceTrace();
 }

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -630,20 +630,13 @@ class BlossomUploadService {
   /// Size of the uploaded file, reported on both upload traces.
   static const String _fileSizeMetric = 'file_size_bytes';
 
-  /// Trace attribute separating completed uploads from the ones that failed or
-  /// were cancelled. Without it a two-minute timeout and an eight-second
-  /// success sit in the same duration distribution (#7121).
+  /// Trace attribute separating completed uploads from the ones that failed.
+  /// Without it a two-minute timeout and an eight-second success sit in the
+  /// same duration distribution (#7121).
   static const String _outcomeAttribute = 'outcome';
 
   /// Attribute value for an upload that reached its terminal success state.
   static const String _outcomeSuccess = 'success';
-
-  /// Attribute value for an upload the user deliberately stopped.
-  ///
-  /// Kept apart from the `error:*` values rather than folded in: a cancel is
-  /// terminal but not a failure, and grouping it with timeouts would inflate
-  /// the error rate with user intent.
-  static const String _outcomeCancelled = 'cancelled';
 
   /// Attribute value for a trace whose operation threw instead of returning a
   /// result. Distinct from a returned failure, which carries its own reason.
@@ -934,19 +927,19 @@ class BlossomUploadService {
   /// Maps an upload result onto the trace's `outcome` attribute value.
   ///
   /// A null [result] means the operation threw instead of returning, which is
-  /// otherwise indistinguishable from a returned failure. A user cancellation
-  /// reports [_outcomeCancelled] rather than an `error:*` value — it is
-  /// terminal but not a failure. Every other failure is `error:<reason>`, so
-  /// the attribute's cardinality stays bounded by
+  /// otherwise indistinguishable from a returned failure. Failure values are
+  /// `error:<reason>`, so the attribute's cardinality is bounded by
   /// [BlossomUploadFailureReason]; an unclassified failure reports `unknown`,
   /// matching how callers are told to treat a null reason.
+  ///
+  /// [BlossomUploadFailureReason.cancelled] needs no special case: it is only
+  /// ever produced by [_backgroundTransferResult] from an OS terminal event,
+  /// which arrives after the enqueue trace has already been tagged and
+  /// stopped. No traced result can carry it.
   static String _traceOutcome(BlossomUploadResult? result) {
     if (result == null) return _outcomeThrew;
     if (result.success) return _outcomeSuccess;
     final reason = result.failureReason ?? BlossomUploadFailureReason.unknown;
-    if (reason == BlossomUploadFailureReason.cancelled) {
-      return _outcomeCancelled;
-    }
     return 'error:${reason.name}';
   }
 

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -638,6 +638,13 @@ class BlossomUploadService {
   /// Attribute value for an upload that reached its terminal success state.
   static const String _outcomeSuccess = 'success';
 
+  /// Attribute value for an upload the user deliberately stopped.
+  ///
+  /// Kept apart from the `error:*` values rather than folded in: a cancel is
+  /// terminal but not a failure, and grouping it with timeouts would inflate
+  /// the error rate with user intent.
+  static const String _outcomeCancelled = 'cancelled';
+
   /// Attribute value for a trace whose operation threw instead of returning a
   /// result. Distinct from a returned failure, which carries its own reason.
   static const String _outcomeThrew = 'error:threw';
@@ -912,20 +919,6 @@ class BlossomUploadService {
   ///     [BlossomUploadFailureReason.unknown].
   ///
   /// Anything else falls through to [BlossomUploadFailureReason.unknown].
-  /// Maps an upload result onto the trace's `outcome` attribute value.
-  ///
-  /// A null [result] means the operation threw instead of returning, which is
-  /// otherwise indistinguishable from a returned failure. Failure values are
-  /// `error:<reason>`, so the attribute's cardinality is bounded by
-  /// [BlossomUploadFailureReason]; an unclassified failure reports `unknown`,
-  /// matching how callers are told to treat a null reason.
-  static String _traceOutcome(BlossomUploadResult? result) {
-    if (result == null) return _outcomeThrew;
-    if (result.success) return _outcomeSuccess;
-    final reason = result.failureReason ?? BlossomUploadFailureReason.unknown;
-    return 'error:${reason.name}';
-  }
-
   static BlossomUploadFailureReason _classifyUploadException(Object error) {
     if (error is DioException) {
       return BlossomUploadFailureReason.fromDioException(error);
@@ -936,6 +929,25 @@ class BlossomUploadService {
           BlossomUploadFailureReason.unknown;
     }
     return BlossomUploadFailureReason.unknown;
+  }
+
+  /// Maps an upload result onto the trace's `outcome` attribute value.
+  ///
+  /// A null [result] means the operation threw instead of returning, which is
+  /// otherwise indistinguishable from a returned failure. A user cancellation
+  /// reports [_outcomeCancelled] rather than an `error:*` value — it is
+  /// terminal but not a failure. Every other failure is `error:<reason>`, so
+  /// the attribute's cardinality stays bounded by
+  /// [BlossomUploadFailureReason]; an unclassified failure reports `unknown`,
+  /// matching how callers are told to treat a null reason.
+  static String _traceOutcome(BlossomUploadResult? result) {
+    if (result == null) return _outcomeThrew;
+    if (result.success) return _outcomeSuccess;
+    final reason = result.failureReason ?? BlossomUploadFailureReason.unknown;
+    if (reason == BlossomUploadFailureReason.cancelled) {
+      return _outcomeCancelled;
+    }
+    return 'error:${reason.name}';
   }
 
   /// Whether a [BlossomUploadResult] failure is transient and worth retrying.

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -627,6 +627,25 @@ class BlossomUploadService {
   /// killed mid-transfer.
   static const Duration _backgroundUploadTimeout = Duration(minutes: 30);
 
+  /// Size of the uploaded file, reported on both upload traces.
+  static const String _fileSizeMetric = 'file_size_bytes';
+
+  /// Trace attribute separating completed uploads from the ones that failed or
+  /// were cancelled. Without it a two-minute timeout and an eight-second
+  /// success sit in the same duration distribution (#7121).
+  static const String _outcomeAttribute = 'outcome';
+
+  /// Attribute value for an upload that reached its terminal success state.
+  static const String _outcomeSuccess = 'success';
+
+  /// Attribute value for a trace whose operation threw instead of returning a
+  /// result. Distinct from a returned failure, which carries its own reason.
+  static const String _outcomeThrew = 'error:threw';
+
+  /// Attribute value for an enqueue that never happened because the OS had
+  /// already completed the transfer while the app was dead.
+  static const String _outcomeReused = 'reused';
+
   /// The authentication provider for signing Blossom events.
   final BlossomAuthProvider authProvider;
 
@@ -893,6 +912,20 @@ class BlossomUploadService {
   ///     [BlossomUploadFailureReason.unknown].
   ///
   /// Anything else falls through to [BlossomUploadFailureReason.unknown].
+  /// Maps an upload result onto the trace's `outcome` attribute value.
+  ///
+  /// A null [result] means the operation threw instead of returning, which is
+  /// otherwise indistinguishable from a returned failure. Failure values are
+  /// `error:<reason>`, so the attribute's cardinality is bounded by
+  /// [BlossomUploadFailureReason]; an unclassified failure reports `unknown`,
+  /// matching how callers are told to treat a null reason.
+  static String _traceOutcome(BlossomUploadResult? result) {
+    if (result == null) return _outcomeThrew;
+    if (result.success) return _outcomeSuccess;
+    final reason = result.failureReason ?? BlossomUploadFailureReason.unknown;
+    return 'error:${reason.name}';
+  }
+
   static BlossomUploadFailureReason _classifyUploadException(Object error) {
     if (error is DioException) {
       return BlossomUploadFailureReason.fromDioException(error);
@@ -1921,24 +1954,32 @@ class BlossomUploadService {
     void Function(BlossomResumableUploadSession)? onResumableSessionUpdated,
     void Function(double)? onProgress,
   }) async {
-    // Start performance trace for video upload
-    await _performanceMonitor.startTrace('video_upload');
+    // Check authentication before attempting any uploads. Deliberately ahead
+    // of the trace: an attempt that never reaches the network has no transfer
+    // duration to report, and timing it only adds near-zero samples to the
+    // distribution for the work itself (#7119).
+    if (!authProvider.isAuthenticated) {
+      Log.error(
+        'User not authenticated - cannot sign Blossom requests',
+        name: 'BlossomUploadService',
+        category: LogCategory.video,
+      );
+      return const BlossomUploadResult(
+        success: false,
+        errorMessage: 'User not authenticated - please sign in to upload',
+        failureReason: BlossomUploadFailureReason.auth,
+      );
+    }
+
+    // Operation-scoped: this upload owns the handle, so a concurrent upload
+    // gets its own trace instead of truncating this one.
+    final trace = _performanceMonitor.startOperationTrace(uploadTraceName);
+
+    // Set on every exit so the `finally` can tag the outcome. Stays null only
+    // when the body threw, which the tag distinguishes from a returned failure.
+    BlossomUploadResult? tracedResult;
 
     try {
-      // Check authentication before attempting any uploads
-      if (!authProvider.isAuthenticated) {
-        Log.error(
-          'User not authenticated - cannot sign Blossom requests',
-          name: 'BlossomUploadService',
-          category: LogCategory.video,
-        );
-        return const BlossomUploadResult(
-          success: false,
-          errorMessage: 'User not authenticated - please sign in to upload',
-          failureReason: BlossomUploadFailureReason.auth,
-        );
-      }
-
       Log.info(
         'User is authenticated, can create signed events',
         name: 'BlossomUploadService',
@@ -1955,12 +1996,7 @@ class BlossomUploadService {
       final fileSize = hashResult.size;
       final fileHash = hashResult.hash;
 
-      // Add file size metric to performance trace
-      _performanceMonitor.setMetric(
-        'video_upload',
-        'file_size_bytes',
-        fileSize,
-      );
+      trace.setMetric(_fileSizeMetric, fileSize);
 
       Log.info(
         'File hash: $fileHash, size: $fileSize bytes',
@@ -2081,7 +2117,7 @@ class BlossomUploadService {
 
             // Return with canonical URL to ensure we never publish
             // a non-HTTP URL (e.g. local file path)
-            return BlossomUploadResult(
+            return tracedResult = BlossomUploadResult(
               success: true,
               url: canonicalUrl,
               fallbackUrl: canonicalUrl,
@@ -2127,7 +2163,8 @@ class BlossomUploadService {
         category: LogCategory.video,
       );
 
-      return lastError ??
+      return tracedResult =
+          lastError ??
           const BlossomUploadResult(
             success: false,
             errorMessage: 'All servers failed',
@@ -2140,14 +2177,14 @@ class BlossomUploadService {
         category: LogCategory.video,
       );
 
-      return BlossomUploadResult(
+      return tracedResult = BlossomUploadResult(
         success: false,
         errorMessage: 'Blossom upload failed: $e',
         failureReason: _classifyUploadException(e),
       );
     } finally {
-      // Stop performance trace
-      await _performanceMonitor.stopTrace('video_upload');
+      trace.putAttribute(_outcomeAttribute, _traceOutcome(tracedResult));
+      await trace.stop();
     }
   }
 
@@ -2188,25 +2225,25 @@ class BlossomUploadService {
       );
     }
 
-    var traceRunning = false;
-    Future<void> stopTraceOnce() async {
+    // Reports under [enqueueTraceName], not [uploadTraceName]: this trace
+    // covers only the in-process handoff, while `uploadVideo` times a whole
+    // transfer. Sharing one name blended the two into a distribution that
+    // described neither (#7119).
+    final trace = _performanceMonitor.startOperationTrace(enqueueTraceName);
+    var traceRunning = true;
+    Future<void> stopTraceOnce(String outcome) async {
       if (!traceRunning) return;
       traceRunning = false;
-      await _performanceMonitor.stopTrace('video_upload');
+      trace.putAttribute(_outcomeAttribute, outcome);
+      await trace.stop();
     }
 
-    await _performanceMonitor.startTrace('video_upload');
-    traceRunning = true;
     try {
       onProgress?.call(0.1);
       final hashResult = await HashUtil.sha256File(videoFile);
       final fileSize = hashResult.size;
       final fileHash = hashResult.hash;
-      _performanceMonitor.setMetric(
-        'video_upload',
-        'file_size_bytes',
-        fileSize,
-      );
+      trace.setMetric(_fileSizeMetric, fileSize);
       onProgress?.call(0.2);
 
       final serverUrl = (await _getServerUrlsForUpload()).first;
@@ -2225,6 +2262,10 @@ class BlossomUploadService {
         );
         if (result.success) {
           onProgress?.call(1);
+          // The OS finished this transfer while the app was dead, so no
+          // handoff happened. Tagged rather than reported as a fast enqueue,
+          // which would understate the real distribution.
+          await stopTraceOnce(_outcomeReused);
           return result;
         }
       }
@@ -2239,11 +2280,13 @@ class BlossomUploadService {
         authTtl: _backgroundAuthTtl,
       );
       if (authHeader == null) {
-        return const BlossomUploadResult(
+        const result = BlossomUploadResult(
           success: false,
           errorMessage: 'Failed to create Blossom authentication',
           failureReason: BlossomUploadFailureReason.authUnavailable,
         );
+        await stopTraceOnce(_traceOutcome(result));
+        return result;
       }
 
       final headers = <String, dynamic>{
@@ -2280,6 +2323,7 @@ class BlossomUploadService {
       // event, enqueue failure, or the safety timeout below — so we never leak
       // a listener on the shared broadcast stream.
       try {
+        BlossomUploadResult? enqueueFailure;
         try {
           await transport.enqueue(
             taskId: taskId,
@@ -2289,21 +2333,27 @@ class BlossomUploadService {
             filePath: videoFile.path,
           );
         } on Object catch (e) {
+          enqueueFailure = BlossomUploadResult(
+            success: false,
+            errorMessage: 'Failed to enqueue background upload: $e',
+            failureReason: _classifyUploadException(e),
+          );
           if (!completer.isCompleted) {
-            completer.complete(
-              BlossomUploadResult(
-                success: false,
-                errorMessage: 'Failed to enqueue background upload: $e',
-                failureReason: _classifyUploadException(e),
-              ),
-            );
+            completer.complete(enqueueFailure);
           }
         }
 
         // Setup + enqueue are the only in-process work; stop the trace here so
         // it doesn't span the OS-owned transfer wait (which can include a long
         // app suspension and would otherwise pollute the perf metric).
-        await stopTraceOnce();
+        //
+        // `success` therefore means the transfer reached the OS, not that it
+        // finished — the OS leg is not measured by this trace at all.
+        await stopTraceOnce(
+          enqueueFailure == null
+              ? _outcomeSuccess
+              : _traceOutcome(enqueueFailure),
+        );
         return await completer.future.timeout(
           timeout,
           onTimeout: () => BlossomUploadResult(
@@ -2319,7 +2369,9 @@ class BlossomUploadService {
         await sub.cancel();
       }
     } finally {
-      await stopTraceOnce();
+      // Only reached with the trace still running when the body threw before
+      // the enqueue stop above; every deliberate exit tags its own outcome.
+      await stopTraceOnce(_outcomeThrew);
     }
   }
 

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -1960,9 +1960,12 @@ class BlossomUploadService {
     void Function(double)? onProgress,
   }) async {
     // Check authentication before attempting any uploads. Deliberately ahead
-    // of the trace: an attempt that never reaches the network has no transfer
-    // duration to report, and timing it only adds near-zero samples to the
-    // distribution for the work itself (#7119).
+    // of the trace: a signed-out attempt is rejected without a single await,
+    // and timing it only adds near-zero samples to the distribution for the
+    // work itself (#7119). This buys nothing for the other pre-network exits —
+    // a missing file still throws out of `HashUtil.sha256File` below and
+    // reports a few-millisecond trace tagged `error:unknown`. The `outcome`
+    // attribute is what keeps those filterable.
     if (!authProvider.isAuthenticated) {
       Log.error(
         'User not authenticated - cannot sign Blossom requests',
@@ -1980,8 +1983,11 @@ class BlossomUploadService {
     // gets its own trace instead of truncating this one.
     final trace = _performanceMonitor.startOperationTrace(uploadTraceName);
 
-    // Set on every exit so the `finally` can tag the outcome. Stays null only
-    // when the body threw, which the tag distinguishes from a returned failure.
+    // Set on every exit so the `finally` can tag the outcome. The catch-all
+    // below converts every throw into an assigned return, so on this path it
+    // is never actually null — the null branch of [_traceOutcome] is carried
+    // for `uploadVideoInBackground`, whose outer `finally` can be reached with
+    // no result at all.
     BlossomUploadResult? tracedResult;
 
     try {

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_with_resume_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_with_resume_test.dart
@@ -101,28 +101,58 @@ class _FakeTransport implements BlossomBackgroundTransport {
   ) async => null;
 }
 
-/// A performance monitor whose [startTrace] throws on the first call and
-/// succeeds thereafter. The first call is from uploadVideoInBackground (the
+/// A performance monitor whose [startOperationTrace] throws on the first call
+/// and succeeds thereafter. The first call is from uploadVideoInBackground (the
 /// OS-first attempt); the throw makes it propagate out of that method before
 /// its internal try/catch, exercising the defensive catch in
 /// uploadVideoWithResume. The subsequent resumable uploadVideo path then gets
 /// a working trace so it can complete normally.
+/// Records every trace handed out, so a test can assert which trace names were
+/// used and how each one was tagged.
+class _RecordingPerformanceMonitor implements BlossomPerformanceMonitor {
+  final traces = <_RecordedTrace>[];
+
+  _RecordedTrace? named(String traceName) =>
+      traces.where((t) => t.name == traceName).firstOrNull;
+
+  @override
+  BlossomPerformanceTrace startOperationTrace(String traceName) {
+    final trace = _RecordedTrace(traceName);
+    traces.add(trace);
+    return trace;
+  }
+}
+
+class _RecordedTrace implements BlossomPerformanceTrace {
+  _RecordedTrace(this.name);
+
+  final String name;
+  final attributes = <String, String>{};
+  final metrics = <String, int>{};
+  bool stopped = false;
+
+  @override
+  void putAttribute(String attribute, String value) =>
+      attributes[attribute] = value;
+
+  @override
+  void setMetric(String metricName, int value) => metrics[metricName] = value;
+
+  @override
+  Future<void> stop() async => stopped = true;
+}
+
 class _ThrowingPerformanceMonitor implements BlossomPerformanceMonitor {
   var _calls = 0;
 
   @override
-  Future<void> startTrace(String traceName) async {
+  BlossomPerformanceTrace startOperationTrace(String traceName) {
     _calls++;
     if (_calls == 1) {
       throw Exception('perf monitor unavailable');
     }
+    return const NoOpPerformanceTrace();
   }
-
-  @override
-  Future<void> stopTrace(String traceName) async {}
-
-  @override
-  void setMetric(String traceName, String metricName, int value) {}
 }
 
 const _testServer = 'https://media.divine.video';
@@ -335,6 +365,162 @@ void main() {
             onSendProgress: any(named: 'onSendProgress'),
           ),
         ).called(2);
+      },
+    );
+
+    test('OS-first success reports only the enqueue trace', () async {
+      final monitor = _RecordingPerformanceMonitor();
+      final transport = _FakeTransport();
+      final service = BlossomUploadService(
+        authProvider: auth,
+        dio: dio,
+        defaultServerUrl: _testServer,
+        backgroundTransport: transport,
+        performanceMonitor: monitor,
+      );
+
+      final result = await service.uploadVideoWithResume(
+        videoFile: videoFile,
+        nostrPubkey: _testPublicKey,
+        taskId: 'task-trace-os',
+        title: 'OS-first success',
+        description: null,
+        hashtags: null,
+        proofManifestJson: null,
+      );
+
+      expect(result.success, isTrue);
+
+      // The OS leg measures the handoff only, so it must not report under the
+      // whole-transfer name — that blend is what made the old distribution
+      // unreadable (#7119).
+      expect(monitor.traces.map((t) => t.name), equals([enqueueTraceName]));
+
+      final enqueue = monitor.named(enqueueTraceName)!;
+      expect(enqueue.stopped, isTrue);
+      expect(enqueue.attributes['outcome'], 'success');
+      expect(enqueue.metrics['file_size_bytes'], 8);
+    });
+
+    test(
+      'OS-first failure reports the enqueue trace and a separate upload trace',
+      () async {
+        final monitor = _RecordingPerformanceMonitor();
+        final transport = _FakeTransport(completeSuccessfully: false);
+        final service = BlossomUploadService(
+          authProvider: auth,
+          dio: dio,
+          defaultServerUrl: _testServer,
+          backgroundTransport: transport,
+          performanceMonitor: monitor,
+        );
+
+        stubResumableControlPlane(uploadId: 'up_trace');
+        when(
+          () => dio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((invocation) async {
+          final options = invocation.namedArguments[#options] as Options;
+          final contentRange = options.headers?['Content-Range'] as String;
+          final nextOffset = switch (contentRange) {
+            'bytes 0-3/8' => '4',
+            'bytes 4-7/8' => '8',
+            _ => throw StateError('Unexpected range: $contentRange'),
+          };
+          return Response(
+            requestOptions: RequestOptions(path: '/sessions/up_trace'),
+            statusCode: 204,
+            headers: Headers.fromMap({
+              DivineUploadHeaders.uploadOffset: [nextOffset],
+            }),
+          );
+        });
+
+        final result = await service.uploadVideoWithResume(
+          videoFile: videoFile,
+          nostrPubkey: _testPublicKey,
+          taskId: 'task-trace-fallback',
+          title: 'OS-first fails, resumable fallback',
+          description: null,
+          hashtags: null,
+          proofManifestJson: null,
+        );
+
+        expect(result.success, isTrue);
+
+        // Two legs ran, so two independently named traces are reported. Under
+        // the name-keyed API these shared one name and one bucket.
+        expect(
+          monitor.traces.map((t) => t.name),
+          equals([enqueueTraceName, uploadTraceName]),
+        );
+
+        // The enqueue itself succeeded — the OS transfer failed afterwards,
+        // which this trace deliberately does not span.
+        expect(
+          monitor.named(enqueueTraceName)!.attributes['outcome'],
+          'success',
+        );
+
+        final upload = monitor.named(uploadTraceName)!;
+        expect(upload.stopped, isTrue);
+        expect(upload.attributes['outcome'], 'success');
+      },
+    );
+
+    test(
+      'a failed in-process upload is tagged with its failure reason',
+      () async {
+        final monitor = _RecordingPerformanceMonitor();
+        final service = BlossomUploadService(
+          authProvider: auth,
+          dio: dio,
+          defaultServerUrl: _testServer,
+          performanceMonitor: monitor,
+        );
+
+        when(
+          () => dio.head<dynamic>(any(), options: any(named: 'options')),
+        ).thenThrow(
+          DioException(
+            requestOptions: RequestOptions(path: '/'),
+            type: DioExceptionType.connectionTimeout,
+          ),
+        );
+        when(
+          () => dio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenThrow(
+          DioException(
+            requestOptions: RequestOptions(path: '/'),
+            type: DioExceptionType.connectionTimeout,
+          ),
+        );
+
+        final result = await service.uploadVideo(
+          videoFile: videoFile,
+          nostrPubkey: _testPublicKey,
+          title: 'doomed',
+          description: null,
+          hashtags: null,
+          proofManifestJson: null,
+        );
+
+        expect(result.success, isFalse);
+
+        // Without this attribute a two-minute timeout and an eight-second
+        // success sit in the same duration distribution (#7121).
+        final upload = monitor.named(uploadTraceName)!;
+        expect(upload.stopped, isTrue);
+        expect(upload.attributes['outcome'], 'error:network');
       },
     );
 

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_with_resume_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_with_resume_test.dart
@@ -532,7 +532,7 @@ void main() {
       },
     );
 
-    test('a user cancellation is not tagged as an error', () async {
+    test('a cancelled OS transfer keeps its enqueue tagged success', () async {
       final monitor = _RecordingPerformanceMonitor();
       final transport = _FakeTransport(outcome: _FakeOutcome.cancelled);
       final service = BlossomUploadService(
@@ -554,8 +554,10 @@ void main() {
       );
 
       expect(result.success, isFalse);
-      // A cancel is terminal but deliberate. Folding it into `error:*` would
-      // inflate the error rate with user intent.
+      // The hand-off itself succeeded; the cancel lands on the OS leg, which
+      // this trace deliberately does not span. A cancel therefore never
+      // reaches the `outcome` attribute at all — it cannot inflate the error
+      // rate, so it needs no value of its own.
       expect(monitor.named(enqueueTraceName)!.attributes['outcome'], 'success');
       // The cancel is terminal, so no fallback leg runs and no second trace
       // is opened.
@@ -981,9 +983,10 @@ void main() {
       'OS-first attempt that throws still falls back to chunked resumable',
       () async {
         // uploadVideoInBackground normally returns failures rather than
-        // throwing, so to exercise the catch-guard we make startTrace throw
-        // (it runs before uploadVideoInBackground's internal try/catch). The
-        // publish must still get a resumable retry rather than dying.
+        // throwing, so to exercise the catch-guard we make
+        // startOperationTrace throw (it runs before uploadVideoInBackground's
+        // internal try/catch). The publish must still get a resumable retry
+        // rather than dying.
         final transport = _FakeTransport();
         final service = BlossomUploadService(
           authProvider: auth,
@@ -1030,8 +1033,8 @@ void main() {
         );
 
         expect(result.success, isTrue);
-        // The OS attempt never reached enqueue (startTrace threw first), but
-        // the resumable fallback still completed successfully.
+        // The OS attempt never reached enqueue (startOperationTrace threw
+        // first), but the resumable fallback still completed successfully.
         expect(transport.enqueuedTaskIds, isEmpty);
         verify(
           () => dio.put<dynamic>(

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_with_resume_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_with_resume_test.dart
@@ -103,18 +103,22 @@ class _FakeTransport implements BlossomBackgroundTransport {
   /// Makes [enqueue] throw, modelling a transport that rejects the hand-off.
   bool throwOnEnqueue = false;
 
+  /// Makes [takeBufferedTerminalEvent] throw, modelling a platform channel
+  /// that fails during startup reconciliation — before the hand-off, so the
+  /// throw escapes the whole method instead of becoming a result.
+  bool throwOnTakeBuffered = false;
+
   @override
   Future<BlossomBackgroundTransferEvent?> takeBufferedTerminalEvent(
     String taskId,
-  ) async => bufferedTerminalEvent;
+  ) async {
+    if (throwOnTakeBuffered) {
+      throw StateError('transport channel failed');
+    }
+    return bufferedTerminalEvent;
+  }
 }
 
-/// A performance monitor whose [startOperationTrace] throws on the first call
-/// and succeeds thereafter. The first call is from uploadVideoInBackground (the
-/// OS-first attempt); the throw makes it propagate out of that method before
-/// its internal try/catch, exercising the defensive catch in
-/// uploadVideoWithResume. The subsequent resumable uploadVideo path then gets
-/// a working trace so it can complete normally.
 /// Records every trace handed out, so a test can assert which trace names were
 /// used and how each one was tagged.
 class _RecordingPerformanceMonitor implements BlossomPerformanceMonitor {
@@ -150,6 +154,12 @@ class _RecordedTrace implements BlossomPerformanceTrace {
   Future<void> stop() async => stopped = true;
 }
 
+/// A performance monitor whose [startOperationTrace] throws on the first call
+/// and succeeds thereafter. The first call is from uploadVideoInBackground (the
+/// OS-first attempt); the throw makes it propagate out of that method before
+/// its internal try/catch, exercising the defensive catch in
+/// uploadVideoWithResume. The subsequent resumable uploadVideo path then gets
+/// a working trace so it can complete normally.
 class _ThrowingPerformanceMonitor implements BlossomPerformanceMonitor {
   var _calls = 0;
 
@@ -669,6 +679,36 @@ void main() {
       },
     );
 
+    test('a throw before the hand-off is tagged error:threw', () async {
+      // The one outcome value no other test reaches. It is only produced by
+      // the outer `finally`, which needs the body to escape with no result at
+      // all — every deliberate exit assigns one and tags itself. A transport
+      // that fails during startup reconciliation does exactly that.
+      final monitor = _RecordingPerformanceMonitor();
+      final transport = _FakeTransport()..throwOnTakeBuffered = true;
+      final service = BlossomUploadService(
+        authProvider: auth,
+        dio: dio,
+        defaultServerUrl: _testServer,
+        backgroundTransport: transport,
+        performanceMonitor: monitor,
+      );
+
+      await expectLater(
+        service.uploadVideoInBackground(
+          videoFile: videoFile,
+          taskId: 'task-throws',
+          proofManifestJson: null,
+        ),
+        throwsA(isA<StateError>()),
+      );
+
+      final enqueue = monitor.named(enqueueTraceName)!;
+      expect(enqueue.stopped, isTrue);
+      expect(enqueue.attributes['outcome'], 'error:threw');
+      expect(transport.enqueuedTaskIds, isEmpty);
+    });
+
     test('an unreachable signer is tagged on the enqueue trace', () async {
       // Signing fails, so no auth header can be built and the hand-off never
       // happens. Called directly rather than through uploadVideoWithResume so
@@ -697,10 +737,7 @@ void main() {
         proofManifestJson: null,
       );
 
-      expect(
-        result.failureReason,
-        BlossomUploadFailureReason.authUnavailable,
-      );
+      expect(result.failureReason, BlossomUploadFailureReason.authUnavailable);
       expect(
         monitor.named(enqueueTraceName)!.attributes['outcome'],
         'error:authUnavailable',
@@ -1047,45 +1084,42 @@ void main() {
       },
     );
 
-    test(
-      'resumableTimeout does NOT bound the OS-first leg',
-      () async {
-        // The OS PUT succeeds only after a delay that far exceeds the tiny
-        // resumableTimeout. If a regression wrapped the OS leg in
-        // `.timeout(resumableTimeout)`, that timeout would fire first and this
-        // upload would fail / fall through to the resumable path. Because the
-        // OS leg is deliberately unbounded by resumableTimeout, the delayed OS
-        // success is returned and the resumable control plane is never touched.
-        final transport = _FakeTransport(
-          completionDelay: const Duration(milliseconds: 150),
-        );
-        final service = BlossomUploadService(
-          authProvider: auth,
-          dio: dio,
-          defaultServerUrl: _testServer,
-          backgroundTransport: transport,
-        );
+    test('resumableTimeout does NOT bound the OS-first leg', () async {
+      // The OS PUT succeeds only after a delay that far exceeds the tiny
+      // resumableTimeout. If a regression wrapped the OS leg in
+      // `.timeout(resumableTimeout)`, that timeout would fire first and this
+      // upload would fail / fall through to the resumable path. Because the
+      // OS leg is deliberately unbounded by resumableTimeout, the delayed OS
+      // success is returned and the resumable control plane is never touched.
+      final transport = _FakeTransport(
+        completionDelay: const Duration(milliseconds: 150),
+      );
+      final service = BlossomUploadService(
+        authProvider: auth,
+        dio: dio,
+        defaultServerUrl: _testServer,
+        backgroundTransport: transport,
+      );
 
-        final result = await service.uploadVideoWithResume(
-          videoFile: videoFile,
-          nostrPubkey: _testPublicKey,
-          taskId: 'task-os-slow',
-          title: 'slow OS success under short resumable timeout',
-          description: null,
-          hashtags: null,
-          proofManifestJson: null,
-          resumableTimeout: const Duration(milliseconds: 5),
-        );
+      final result = await service.uploadVideoWithResume(
+        videoFile: videoFile,
+        nostrPubkey: _testPublicKey,
+        taskId: 'task-os-slow',
+        title: 'slow OS success under short resumable timeout',
+        description: null,
+        hashtags: null,
+        proofManifestJson: null,
+        resumableTimeout: const Duration(milliseconds: 5),
+      );
 
-        expect(result.success, isTrue);
-        expect(transport.enqueuedTaskIds, equals(['task-os-slow']));
-        // Resumable leg never reached: the OS leg outlived resumableTimeout and
-        // still won, proving resumableTimeout did not cut it.
-        verifyNever(
-          () => dio.head<dynamic>(any(), options: any(named: 'options')),
-        );
-      },
-    );
+      expect(result.success, isTrue);
+      expect(transport.enqueuedTaskIds, equals(['task-os-slow']));
+      // Resumable leg never reached: the OS leg outlived resumableTimeout and
+      // still won, proving resumableTimeout did not cut it.
+      verifyNever(
+        () => dio.head<dynamic>(any(), options: any(named: 'options')),
+      );
+    });
 
     test(
       'resumableTimeout bounds the in-process resumable leg when reached',
@@ -1113,9 +1147,7 @@ void main() {
             options: any(named: 'options'),
             onSendProgress: any(named: 'onSendProgress'),
           ),
-        ).thenAnswer(
-          (_) => Completer<Response<dynamic>>().future,
-        );
+        ).thenAnswer((_) => Completer<Response<dynamic>>().future);
 
         await expectLater(
           service.uploadVideoWithResume(

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_with_resume_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_with_resume_test.dart
@@ -50,6 +50,7 @@ class _FakeTransport implements BlossomBackgroundTransport {
     required Map<String, String> headers,
     required String filePath,
   }) async {
+    if (throwOnEnqueue) throw StateError('transport rejected the hand-off');
     enqueuedTaskIds.add(taskId);
     void emit() {
       if (_controller.isClosed) return;
@@ -95,10 +96,17 @@ class _FakeTransport implements BlossomBackgroundTransport {
     cancelledTaskIds.add(taskId);
   }
 
+  /// Terminal event the OS finished while the app was dead, handed back on
+  /// the next launch instead of re-uploading. `null` means nothing buffered.
+  BlossomBackgroundTransferEvent? bufferedTerminalEvent;
+
+  /// Makes [enqueue] throw, modelling a transport that rejects the hand-off.
+  bool throwOnEnqueue = false;
+
   @override
   Future<BlossomBackgroundTransferEvent?> takeBufferedTerminalEvent(
     String taskId,
-  ) async => null;
+  ) async => bufferedTerminalEvent;
 }
 
 /// A performance monitor whose [startOperationTrace] throws on the first call
@@ -523,6 +531,168 @@ void main() {
         expect(upload.attributes['outcome'], 'error:network');
       },
     );
+
+    test('a user cancellation is not tagged as an error', () async {
+      final monitor = _RecordingPerformanceMonitor();
+      final transport = _FakeTransport(outcome: _FakeOutcome.cancelled);
+      final service = BlossomUploadService(
+        authProvider: auth,
+        dio: dio,
+        defaultServerUrl: _testServer,
+        backgroundTransport: transport,
+        performanceMonitor: monitor,
+      );
+
+      final result = await service.uploadVideoWithResume(
+        videoFile: videoFile,
+        nostrPubkey: _testPublicKey,
+        taskId: 'task-cancel',
+        title: 'cancelled',
+        description: null,
+        hashtags: null,
+        proofManifestJson: null,
+      );
+
+      expect(result.success, isFalse);
+      // A cancel is terminal but deliberate. Folding it into `error:*` would
+      // inflate the error rate with user intent.
+      expect(monitor.named(enqueueTraceName)!.attributes['outcome'], 'success');
+      // The cancel is terminal, so no fallback leg runs and no second trace
+      // is opened.
+      expect(monitor.traces.map((t) => t.name), equals([enqueueTraceName]));
+    });
+
+    test(
+      'a claimed buffered transfer is tagged as reused, not enqueued',
+      () async {
+        final monitor = _RecordingPerformanceMonitor();
+        final transport = _FakeTransport()
+          ..bufferedTerminalEvent = const BlossomBackgroundTransferEvent(
+            taskId: 'task-buffered',
+            status: BlossomBackgroundTransferStatus.completed,
+            progress: 1,
+            httpStatusCode: 200,
+            responseBody:
+                '{"url":"https://media.divine.video/buffered",'
+                '"fallbackUrl":"https://media.divine.video/buffered"}',
+          );
+        final service = BlossomUploadService(
+          authProvider: auth,
+          dio: dio,
+          defaultServerUrl: _testServer,
+          backgroundTransport: transport,
+          performanceMonitor: monitor,
+        );
+
+        final result = await service.uploadVideoWithResume(
+          videoFile: videoFile,
+          nostrPubkey: _testPublicKey,
+          taskId: 'task-buffered',
+          title: 'reclaimed after relaunch',
+          description: null,
+          hashtags: null,
+          proofManifestJson: null,
+        );
+
+        expect(result.success, isTrue);
+        // No hand-off happened — the OS finished it while the app was dead.
+        // Reporting it as a fast enqueue would understate the real
+        // distribution.
+        expect(
+          monitor.named(enqueueTraceName)!.attributes['outcome'],
+          'reused',
+        );
+        expect(transport.enqueuedTaskIds, isEmpty);
+      },
+    );
+
+    test(
+      'a transport that rejects the hand-off is tagged as a failure',
+      () async {
+        final monitor = _RecordingPerformanceMonitor();
+        final transport = _FakeTransport()..throwOnEnqueue = true;
+        final service = BlossomUploadService(
+          authProvider: auth,
+          dio: dio,
+          defaultServerUrl: _testServer,
+          backgroundTransport: transport,
+          performanceMonitor: monitor,
+        );
+
+        stubResumableControlPlane(uploadId: 'up_throw');
+        when(
+          () => dio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((invocation) async {
+          final options = invocation.namedArguments[#options] as Options;
+          final contentRange = options.headers?['Content-Range'] as String;
+          final nextOffset = switch (contentRange) {
+            'bytes 0-3/8' => '4',
+            'bytes 4-7/8' => '8',
+            _ => throw StateError('Unexpected range: $contentRange'),
+          };
+          return Response(
+            requestOptions: RequestOptions(path: '/sessions/up_throw'),
+            statusCode: 204,
+            headers: Headers.fromMap({
+              DivineUploadHeaders.uploadOffset: [nextOffset],
+            }),
+          );
+        });
+
+        final result = await service.uploadVideoWithResume(
+          videoFile: videoFile,
+          nostrPubkey: _testPublicKey,
+          taskId: 'task-enqueue-throws',
+          title: 'hand-off rejected',
+          description: null,
+          hashtags: null,
+          proofManifestJson: null,
+        );
+
+        expect(result.success, isTrue, reason: 'the fallback leg carries it');
+
+        // The throw is caught and converted to a result, so this is a
+        // returned failure with an unclassifiable reason — not `error:threw`,
+        // which is reserved for an operation that produced no result at all.
+        expect(
+          monitor.named(enqueueTraceName)!.attributes['outcome'],
+          'error:unknown',
+        );
+        expect(monitor.named(enqueueTraceName)!.stopped, isTrue);
+      },
+    );
+
+    test('an unauthenticated in-process upload opens no trace', () async {
+      when(() => auth.isAuthenticated).thenReturn(false);
+
+      final monitor = _RecordingPerformanceMonitor();
+      final service = BlossomUploadService(
+        authProvider: auth,
+        dio: dio,
+        defaultServerUrl: _testServer,
+        performanceMonitor: monitor,
+      );
+
+      final result = await service.uploadVideo(
+        videoFile: videoFile,
+        nostrPubkey: _testPublicKey,
+        title: 'signed out',
+        description: null,
+        hashtags: null,
+        proofManifestJson: null,
+      );
+
+      expect(result.failureReason, BlossomUploadFailureReason.auth);
+      // An attempt that never reaches the network has no transfer duration to
+      // report; timing it would only add near-zero samples to the
+      // distribution for the work itself.
+      expect(monitor.traces, isEmpty);
+    });
 
     test(
       'when a resumable session already exists, skips the OS PUT and resumes',

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_with_resume_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_with_resume_test.dart
@@ -667,6 +667,45 @@ void main() {
       },
     );
 
+    test('an unreachable signer is tagged on the enqueue trace', () async {
+      // Signing fails, so no auth header can be built and the hand-off never
+      // happens. Called directly rather than through uploadVideoWithResume so
+      // the fallback leg does not open a second trace over the same failure.
+      when(
+        () => auth.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer((_) async => null);
+
+      final monitor = _RecordingPerformanceMonitor();
+      final transport = _FakeTransport();
+      final service = BlossomUploadService(
+        authProvider: auth,
+        dio: dio,
+        defaultServerUrl: _testServer,
+        backgroundTransport: transport,
+        performanceMonitor: monitor,
+      );
+
+      final result = await service.uploadVideoInBackground(
+        videoFile: videoFile,
+        taskId: 'task-no-signer',
+        proofManifestJson: null,
+      );
+
+      expect(
+        result.failureReason,
+        BlossomUploadFailureReason.authUnavailable,
+      );
+      expect(
+        monitor.named(enqueueTraceName)!.attributes['outcome'],
+        'error:authUnavailable',
+      );
+      expect(transport.enqueuedTaskIds, isEmpty);
+    });
+
     test('an unauthenticated in-process upload opens no trace', () async {
       when(() => auth.isAuthenticated).thenReturn(false);
 

--- a/mobile/scripts/baseline/future_delayed_tests.txt
+++ b/mobile/scripts/baseline/future_delayed_tests.txt
@@ -23,7 +23,6 @@ test/services/curated_list_service_crud_test.dart
 test/services/curated_list_service_playlist_test.dart
 test/services/curated_list_service_query_test.dart
 test/services/curated_list_service_video_management_test.dart
-test/services/performance_monitoring_service_test.dart
 test/services/reactive_pagination_test.dart
 test/services/relay_capability_service_test.dart
 test/services/seen_videos_service_test.dart

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -64,21 +64,6 @@ class _RecordingTraceMonitor implements PerformanceTraceMonitor {
     traces.add(trace);
     return trace;
   }
-
-  @override
-  Future<void> startTrace(String traceName) async {}
-
-  @override
-  Future<void> stopTrace(String traceName) async {}
-
-  @override
-  void putAttribute(String traceName, String attribute, String value) {}
-
-  @override
-  void incrementMetric(String traceName, String metricName, int value) {}
-
-  @override
-  void setMetric(String traceName, String metricName, int value) {}
 }
 
 class _MockClipManager extends Mock implements ClipManagerNotifier {}

--- a/mobile/test/services/performance_monitoring_service_test.dart
+++ b/mobile/test/services/performance_monitoring_service_test.dart
@@ -30,63 +30,6 @@ void main() {
       expect(service.isEnabled, isFalse);
     });
 
-    test('should handle trace start and stop without error', () async {
-      await service.initialize();
-
-      // These should not throw even if Firebase isn't configured
-      await service.startTrace('test_trace');
-      await service.stopTrace('test_trace');
-
-      expect(true, true);
-    });
-
-    test('should handle metrics without error', () async {
-      await service.initialize();
-      await service.startTrace('test_trace');
-
-      // These should not throw even if Firebase isn't configured
-      service.setMetric('test_trace', 'test_metric', 100);
-      service.incrementMetric('test_trace', 'counter', 1);
-
-      await service.stopTrace('test_trace');
-      expect(true, true);
-    });
-
-    test('should handle attributes without error', () async {
-      await service.initialize();
-      await service.startTrace('test_trace');
-
-      // This should not throw even if Firebase isn't configured
-      service.putAttribute('test_trace', 'test_attr', 'test_value');
-
-      await service.stopTrace('test_trace');
-      expect(true, true);
-    });
-
-    test('trace convenience method should work', () async {
-      await service.initialize();
-
-      // Test the trace wrapper
-      final result = await service.trace('test_operation', () async {
-        await Future.delayed(const Duration(milliseconds: 10));
-        return 'success';
-      });
-
-      expect(result, 'success');
-    });
-
-    test('trace convenience method should handle errors', () async {
-      await service.initialize();
-
-      // Test that errors are propagated
-      expect(
-        () => service.trace('error_operation', () async {
-          throw Exception('Test error');
-        }),
-        throwsException,
-      );
-    });
-
     test(
       'startOperationTrace returns a handle that tags and stops cleanly',
       () async {

--- a/mobile/test/services/video_event_service_online_retry_test.dart
+++ b/mobile/test/services/video_event_service_online_retry_test.dart
@@ -97,17 +97,8 @@ void main() {
       when(() => mockNostrService.unsubscribe(any())).thenAnswer((_) async {});
 
       when(
-        () => mockPerformanceMonitor.startTrace(any()),
-      ).thenAnswer((_) async {});
-      when(
-        () => mockPerformanceMonitor.stopTrace(any()),
-      ).thenAnswer((_) async {});
-      when(
-        () => mockPerformanceMonitor.setMetric(any(), any(), any()),
-      ).thenReturn(null);
-      when(
-        () => mockPerformanceMonitor.putAttribute(any(), any(), any()),
-      ).thenReturn(null);
+        () => mockPerformanceMonitor.startOperationTrace(any()),
+      ).thenReturn(const NoOpPerformanceTraceMonitor().startOperationTrace(''));
 
       service = VideoEventService(
         mockNostrService,

--- a/mobile/test/services/video_event_service_startup_contract_test.dart
+++ b/mobile/test/services/video_event_service_startup_contract_test.dart
@@ -33,35 +33,35 @@ class _RecordingPerformanceMonitor implements PerformanceTraceMonitor {
   final attributes = <String, Map<String, String>>{};
 
   @override
-  void incrementMetric(String traceName, String metricName, int value) {
-    metrics.putIfAbsent(traceName, () => {})[metricName] =
-        (metrics[traceName]?[metricName] ?? 0) + value;
-  }
-
-  @override
-  void putAttribute(String traceName, String attribute, String value) {
-    attributes.putIfAbsent(traceName, () => {})[attribute] = value;
-  }
-
-  @override
-  void setMetric(String traceName, String metricName, int value) {
-    metrics.putIfAbsent(traceName, () => {})[metricName] = value;
-  }
-
-  @override
-  Future<void> startTrace(String traceName) async {
+  PerformanceTrace startOperationTrace(String traceName) {
     startedTraces.add(traceName);
+    return _RecordingTrace(this, traceName);
+  }
+}
+
+/// Records a single handle's calls back into its [_RecordingPerformanceMonitor]
+/// under the trace name, so the assertions stay keyed by name even though the
+/// production code now addresses traces by handle.
+class _RecordingTrace implements PerformanceTrace {
+  _RecordingTrace(this._monitor, this._traceName);
+
+  final _RecordingPerformanceMonitor _monitor;
+  final String _traceName;
+
+  @override
+  void putAttribute(String attribute, String value) {
+    _monitor.attributes.putIfAbsent(_traceName, () => {})[attribute] = value;
   }
 
   @override
-  Future<void> stopTrace(String traceName) async {
-    stoppedTraces.add(traceName);
+  void setMetric(String metric, int value) {
+    _monitor.metrics.putIfAbsent(_traceName, () => {})[metric] = value;
   }
 
   @override
-  PerformanceTrace startOperationTrace(String traceName) =>
-      // VideoEventService uses the name-keyed trace API, not the handle API.
-      throw UnimplementedError();
+  Future<void> stop() async {
+    _monitor.stoppedTraces.add(_traceName);
+  }
 }
 
 /// Asserts a feed-load trace was started once, stopped exactly once, and closed

--- a/mobile/test/services/video_event_service_subscribe_race_test.dart
+++ b/mobile/test/services/video_event_service_subscribe_race_test.dart
@@ -3,12 +3,13 @@
 
 import 'dart:async';
 
+import 'package:db_client/db_client.dart' hide Filter;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
-import 'package:openvine/services/performance_monitoring_service.dart';
+import 'package:openvine/services/event_router.dart';
 import 'package:openvine/services/subscription_manager.dart';
 import 'package:openvine/services/video_event_service.dart';
 
@@ -16,8 +17,9 @@ class _MockNostrClient extends Mock implements NostrClient {}
 
 class _MockSubscriptionManager extends Mock implements SubscriptionManager {}
 
-class _MockPerformanceTraceMonitor extends Mock
-    implements PerformanceTraceMonitor {}
+class _MockAppDatabase extends Mock implements AppDatabase {}
+
+class _MockNostrEventsDao extends Mock implements NostrEventsDao {}
 
 class _FakeFilter extends Fake implements Filter {}
 
@@ -25,18 +27,28 @@ void main() {
   setUpAll(() {
     registerFallbackValue(_FakeFilter());
     registerFallbackValue(<Filter>[]);
+    registerFallbackValue(<Event>[]);
   });
 
   group('subscribeToVideoFeed concurrency', () {
     late _MockNostrClient mockNostrService;
     late _MockSubscriptionManager mockSubscriptionManager;
-    late _MockPerformanceTraceMonitor mockPerformanceMonitor;
+    late _MockAppDatabase mockDatabase;
+    late _MockNostrEventsDao mockNostrEventsDao;
     late VideoEventService service;
+
+    /// Parks the first cached-events read so the caller that claimed the
+    /// subscription id sits inside its async gap while the next call races
+    /// through. This is the only `await` between the synchronous claim and the
+    /// relay `subscribe`, so it is the seam that opens the window under test.
+    late Completer<List<Event>> firstCacheReadGate;
 
     setUp(() {
       mockNostrService = _MockNostrClient();
       mockSubscriptionManager = _MockSubscriptionManager();
-      mockPerformanceMonitor = _MockPerformanceTraceMonitor();
+      mockDatabase = _MockAppDatabase();
+      mockNostrEventsDao = _MockNostrEventsDao();
+      firstCacheReadGate = Completer<List<Event>>();
 
       when(() => mockNostrService.isInitialized).thenReturn(true);
       when(() => mockNostrService.publicKey).thenReturn('');
@@ -45,20 +57,30 @@ void main() {
         () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
       ).thenAnswer((_) => StreamController<Event>.broadcast().stream);
 
+      when(() => mockDatabase.nostrEventsDao).thenReturn(mockNostrEventsDao);
       when(
-        () => mockPerformanceMonitor.stopTrace(any()),
+        () => mockNostrEventsDao.upsertEventsBatch(
+          any(),
+          expireAt: any(named: 'expireAt'),
+        ),
       ).thenAnswer((_) async {});
+
+      var cacheReads = 0;
       when(
-        () => mockPerformanceMonitor.setMetric(any(), any(), any()),
-      ).thenReturn(null);
-      when(
-        () => mockPerformanceMonitor.putAttribute(any(), any(), any()),
-      ).thenReturn(null);
+        () => mockNostrEventsDao.getEventsByFilter(
+          any(),
+          sortBy: any(named: 'sortBy'),
+        ),
+      ).thenAnswer((_) {
+        cacheReads++;
+        if (cacheReads == 1) return firstCacheReadGate.future;
+        return Future<List<Event>>.value([]);
+      });
 
       service = VideoEventService(
         mockNostrService,
         subscriptionManager: mockSubscriptionManager,
-        performanceMonitor: mockPerformanceMonitor,
+        eventRouter: EventRouter(mockDatabase),
       );
     });
 
@@ -69,32 +91,20 @@ void main() {
     test(
       'concurrent identical subscribes create exactly one relay subscription',
       () async {
-        // Hold the FIRST subscribe call inside its async gap (between the
-        // duplicate-id check and subscription registration) by blocking its
-        // performance-trace await; later calls proceed immediately.
-        final firstTraceGate = Completer<void>();
-        var startTraceCalls = 0;
-        when(() => mockPerformanceMonitor.startTrace(any())).thenAnswer((_) {
-          startTraceCalls++;
-          if (startTraceCalls == 1) return firstTraceGate.future;
-          return Future<void>.value();
-        });
-
-        // First call enters the async gap and parks on the trace gate.
+        // First call claims the id, then parks on the cached-events read.
         final first = service.subscribeToVideoFeed(
           subscriptionType: SubscriptionType.discovery,
           limit: 10,
         );
 
-        // Second identical call races through while the first is parked.
-        final second = service.subscribeToVideoFeed(
+        // Second identical call races through while the first is parked, and
+        // must reuse the pending claim rather than open a second REQ.
+        await service.subscribeToVideoFeed(
           subscriptionType: SubscriptionType.discovery,
           limit: 10,
         );
-        await second;
 
-        // Release the first call and let it finish.
-        firstTraceGate.complete();
+        firstCacheReadGate.complete([]);
         await first;
 
         verify(
@@ -103,42 +113,42 @@ void main() {
       },
     );
 
-    test(
-      'pending reuse does not block retry if first setup fails',
-      () async {
-        final firstTraceGate = Completer<void>();
-        var startTraceCalls = 0;
-        when(() => mockPerformanceMonitor.startTrace(any())).thenAnswer((_) {
-          startTraceCalls++;
-          if (startTraceCalls == 1) return firstTraceGate.future;
-          return Future<void>.value();
-        });
+    test('pending reuse does not block retry if first setup fails', () async {
+      // The first call's relay subscribe throws, so its `catch` must release
+      // the pending claim; otherwise the id stays claimed forever and every
+      // later attempt is silently swallowed as a duplicate.
+      var subscribeCalls = 0;
+      when(
+        () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+      ).thenAnswer((_) {
+        subscribeCalls++;
+        if (subscribeCalls == 1) throw StateError('relay subscribe failed');
+        return StreamController<Event>.broadcast().stream;
+      });
 
-        final first = service.subscribeToVideoFeed(
-          subscriptionType: SubscriptionType.discovery,
-          limit: 10,
-        );
+      final first = service.subscribeToVideoFeed(
+        subscriptionType: SubscriptionType.discovery,
+        limit: 10,
+      );
 
-        await service.subscribeToVideoFeed(
-          subscriptionType: SubscriptionType.discovery,
-          limit: 10,
-        );
+      // Races in while the first is parked: reuses the claim, no REQ.
+      await service.subscribeToVideoFeed(
+        subscriptionType: SubscriptionType.discovery,
+        limit: 10,
+      );
 
-        firstTraceGate.completeError(
-          StateError('trace failed'),
-          StackTrace.current,
-        );
-        await first;
+      firstCacheReadGate.complete([]);
+      await first;
 
-        await service.subscribeToVideoFeed(
-          subscriptionType: SubscriptionType.discovery,
-          limit: 10,
-        );
+      // The claim is released, so this retry gets through to the relay.
+      await service.subscribeToVideoFeed(
+        subscriptionType: SubscriptionType.discovery,
+        limit: 10,
+      );
 
-        verify(
-          () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
-        ).called(1);
-      },
-    );
+      // Twice: the throwing first attempt plus the successful retry. The
+      // racing second call contributed none.
+      expect(subscribeCalls, 2);
+    });
   });
 }

--- a/mobile/test/services/video_event_service_subscribe_race_test.dart
+++ b/mobile/test/services/video_event_service_subscribe_race_test.dart
@@ -37,18 +37,25 @@ void main() {
     late _MockNostrEventsDao mockNostrEventsDao;
     late VideoEventService service;
 
-    /// Parks the first cached-events read so the caller that claimed the
-    /// subscription id sits inside its async gap while the next call races
-    /// through. This is the only `await` between the synchronous claim and the
-    /// relay `subscribe`, so it is the seam that opens the window under test.
-    late Completer<List<Event>> firstCacheReadGate;
+    /// Parks *every* cached-events read until the test releases it, so the
+    /// caller that claimed the subscription id is guaranteed to sit inside its
+    /// async gap while the next call races through. This is the only `await`
+    /// between the synchronous claim and the relay `subscribe`, so it is the
+    /// seam that opens the window under test.
+    ///
+    /// Gating every read rather than only the first: a counted gate silently
+    /// stops parking anyone if some other reader reaches the DAO first, and
+    /// the test then degenerates into two sequential subscribes that pass for
+    /// the wrong reason. A caller that is supposed to return at the claim
+    /// check never reaches this stub at all.
+    late Completer<List<Event>> cacheReadGate;
 
     setUp(() {
       mockNostrService = _MockNostrClient();
       mockSubscriptionManager = _MockSubscriptionManager();
       mockDatabase = _MockAppDatabase();
       mockNostrEventsDao = _MockNostrEventsDao();
-      firstCacheReadGate = Completer<List<Event>>();
+      cacheReadGate = Completer<List<Event>>();
 
       when(() => mockNostrService.isInitialized).thenReturn(true);
       when(() => mockNostrService.publicKey).thenReturn('');
@@ -65,17 +72,12 @@ void main() {
         ),
       ).thenAnswer((_) async {});
 
-      var cacheReads = 0;
       when(
         () => mockNostrEventsDao.getEventsByFilter(
           any(),
           sortBy: any(named: 'sortBy'),
         ),
-      ).thenAnswer((_) {
-        cacheReads++;
-        if (cacheReads == 1) return firstCacheReadGate.future;
-        return Future<List<Event>>.value([]);
-      });
+      ).thenAnswer((_) => cacheReadGate.future);
 
       service = VideoEventService(
         mockNostrService,
@@ -97,14 +99,23 @@ void main() {
           limit: 10,
         );
 
-        // Second identical call races through while the first is parked, and
-        // must reuse the pending claim rather than open a second REQ.
-        await service.subscribeToVideoFeed(
-          subscriptionType: SubscriptionType.discovery,
-          limit: 10,
+        // Pin the seam itself: the first call must still be inside its async
+        // gap. If it ever ran to completion here the two calls would be
+        // sequential, and a green result would say nothing about the race.
+        verifyNever(
+          () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
         );
 
-        firstCacheReadGate.complete([]);
+        // Second identical call races through while the first is parked, and
+        // must reuse the pending claim rather than open a second REQ.
+        await _expectReusesClaim(
+          service.subscribeToVideoFeed(
+            subscriptionType: SubscriptionType.discovery,
+            limit: 10,
+          ),
+        );
+
+        cacheReadGate.complete([]);
         await first;
 
         verify(
@@ -132,12 +143,14 @@ void main() {
       );
 
       // Races in while the first is parked: reuses the claim, no REQ.
-      await service.subscribeToVideoFeed(
-        subscriptionType: SubscriptionType.discovery,
-        limit: 10,
+      await _expectReusesClaim(
+        service.subscribeToVideoFeed(
+          subscriptionType: SubscriptionType.discovery,
+          limit: 10,
+        ),
       );
 
-      firstCacheReadGate.complete([]);
+      cacheReadGate.complete([]);
       await first;
 
       // The claim is released, so this retry gets through to the relay.
@@ -152,3 +165,17 @@ void main() {
     });
   });
 }
+
+/// Awaits a subscribe that is expected to return at the pending-claim check.
+///
+/// Such a call never reaches the gated cached-events read, so it completes
+/// promptly. One that regresses past the claim parks on the gate forever;
+/// bound it here so the failure names the broken invariant instead of
+/// surfacing as an unexplained suite timeout.
+Future<void> _expectReusesClaim(Future<void> subscribe) => subscribe.timeout(
+  const Duration(seconds: 5),
+  onTimeout: () => fail(
+    'subscribe reached the cached-events read instead of reusing the '
+    'pending claim',
+  ),
+);

--- a/mobile/test/services/video_publish/publish_timeline_test.dart
+++ b/mobile/test/services/video_publish/publish_timeline_test.dart
@@ -32,21 +32,6 @@ class _FakePerformanceMonitor implements PerformanceTraceMonitor {
     startedOperations.add(traceName);
     return trace;
   }
-
-  @override
-  Future<void> startTrace(String traceName) async {}
-
-  @override
-  Future<void> stopTrace(String traceName) async {}
-
-  @override
-  void incrementMetric(String traceName, String metricName, int value) {}
-
-  @override
-  void setMetric(String traceName, String metricName, int value) {}
-
-  @override
-  void putAttribute(String traceName, String attribute, String value) {}
 }
 
 void main() {

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -72,21 +72,6 @@ class _FakePerformanceMonitor implements PerformanceTraceMonitor {
     startedOperations.add(traceName);
     return trace;
   }
-
-  @override
-  Future<void> startTrace(String traceName) async {}
-
-  @override
-  Future<void> stopTrace(String traceName) async {}
-
-  @override
-  void incrementMetric(String traceName, String metricName, int value) {}
-
-  @override
-  void setMetric(String traceName, String metricName, int value) {}
-
-  @override
-  void putAttribute(String traceName, String attribute, String value) {}
 }
 
 void main() {


### PR DESCRIPTION
## Description

The `video_upload` distribution was unreadable. 94% of iOS samples came in under a second for a payload whose median size is 6.16 MB — 31 MB/s — while the same uploads reported `transfer_ms` p50 = 7,396 ms on `video_publish`. The tail held a 2.2-hour sample, and `feed_load_profile` held a 23.6-hour one.

Two separate defects produced that, and only the second one is what #7119 originally described.

**The two upload paths measured different things under one name.** `uploadVideoWithResume` tries `uploadVideoInBackground` first for every fresh publish and only falls back to `uploadVideo` when that fails. `uploadVideoInBackground` deliberately stops its trace right after enqueue so it does not span the OS-owned transfer, which can include an app suspension — sound on its own, but it reported under `video_upload`, the name `uploadVideo` uses for a whole transfer. So a normal successful publish emitted a `video_upload` trace measuring only enqueue latency, and the actual transfer was never instrumented. That is what the 100 ms–1 s bucket is; the >30 s Android outliers are the cases where the OS path failed and the in-process path took over. The OS leg now reports as `video_upload_enqueue`, leaving `video_upload` to mean one thing.

A caveat that the first version of this description got wrong: `video_upload` is still *not* comparable to `transfer_ms`. `transfer_ms` stopwatches the whole `uploadVideoWithResume` call — OS attempt plus any fallback — on every publish, while `video_upload` only opens once the in-process leg actually runs. In the shipping config that means the OS attempt did not win first try, so its population is a biased-slow subset. The two are not interchangeable p50s; `video_upload` answers "how long does the fallback take", not "how long does an upload take".

**The name-keyed API treated the trace name as the identity of a measurement.** `startTrace` began by calling `stopTrace`, which does not discard the in-flight trace but reports it wherever it happens to be. An overlapping operation therefore truncated its predecessor, and a trace that was never stopped stayed open until some later start reported it — the 23.6-hour sample is a feed load whose service was disposed before its 30 s timeout could fire. Both call sites now take an operation-scoped handle, and a leaked handle simply never reports.

With those migrated the name-keyed API had no production callers left. Leaving both paths live is what `agent_workflow.md` §4 forbids, so `startTrace`, `stopTrace`, `incrementMetric`, `setMetric`, `putAttribute`, the `_activeTraces` map and the `trace<T>()` convenience are gone. That is why the diff touches thirteen files — seven are test doubles that implemented the old interface. `newHttpMetric` is gone too: #7131 removed it from this class on `main` and closed #7122 through a different entry point (`FirebaseHttpMetricRecorder`), so the rebase takes main's deletion and keeps its `isEnabled` getter.

**Related Issue:** Closes #7119, Closes #7121

## Relationship to #7128

#7128 reached the outcome attribute independently and found the same enqueue-versus-transfer problem, solving it with an `outcome: enqueued` value on a single trace name rather than by splitting the name. One thing is adopted from it:

- **Test coverage** from its outcome-trace suite that the three trace tests here did not already reach: the cancel path, a buffered terminal event claimed after a relaunch, a transport that rejects the hand-off, and an unauthenticated upload.

Three deliberate divergences:

- **Separate names rather than one name plus a filter.** Firebase shows an aggregated distribution per trace name by default. Sharing a name keeps the default view a blend of enqueue latency and transfer duration that you have to remember to filter on every visit; separate names make the correct reading the default. Historical continuity is not an argument against it — the historical `video_upload` data is the blend this PR exists to end.
- **No `cancelled` outcome value.** #7128 tags a user cancellation `error:cancelled`, and this PR briefly carried a dedicated `cancelled` value to keep deliberate stops out of the error rate. Both are unreachable. The only producer of `BlossomUploadFailureReason.cancelled` is `_backgroundTransferResult`, from an OS terminal event that arrives through the completer in `uploadVideoInBackground` — after `stopTraceOnce` has already tagged and stopped the enqueue trace. `uploadVideo` cannot produce it either (no `CancelToken` in the package; a Dio cancel classifies as `unknown`), and `uploadVideoWithResume` short-circuits on `cancelled` before the in-process leg starts. Verified by mutation: deleting the branch left the package suite green at 100% coverage. A cancel simply never reaches `outcome`, so no value is needed to keep it out of the error rate.
- **An unauthenticated in-process upload opens no trace at all**, where #7128 tags it `error:auth`. The auth check now sits ahead of the trace: an attempt that never reaches the network has no transfer duration to report, and timing it only adds near-zero samples to the distribution for the work itself.

#7128 also leaves #7119 untouched and extends the name-keyed interface it removes, so landing both would mean reshaping the same interface twice. Recommend closing it as superseded.

## Out of Scope

On the OS path the transfer itself is still unmeasured — instrumenting it means spanning a wait that can include an app suspension, which is exactly what the early stop avoids. It needs its own trace with a `suspended` attribute to filter on; worth a separate issue rather than smuggling it in here.

#7127 (#7120) touches `publish_timeline_test.dart`, where this PR removes 15 lines of dead overrides. Independently mergeable in either order; whichever lands second resolves a small textual conflict.

## Verification

- `dart format` — clean
- `flutter analyze lib test integration_test packages/blossom_upload_service` — no issues
- `flutter test --coverage` in `packages/blossom_upload_service` — 243 passing, 100% line coverage (the package's CI gate)
- `flutter test test/services/ test/blocs/video_recorder/ test/providers/video_editor_provider_test.dart` — 4,162 passing, re-run twice with `--test-randomize-ordering-seed random`
- Seven new tests pin the split names, the outcome values (`success`, `error:<reason>`, `reused`), and the no-trace-when-signed-out contract
- Manually verified on a real Samsung Galaxy: a video published end to end over the OS path with no regression

Rebased onto `main` after #7131 landed; both conflicts are in `performance_monitoring_service.dart` and its test, resolved by taking main's `newHttpMetric` deletion and `isEnabled` getter while keeping this PR's removal of the legacy name-keyed tests. Main's `isEnabled stays false while Firebase is unavailable` test sits inside the deleted range and is preserved.

The fallback path — OS attempt fails, in-process chunked resumable takes over — was not exercised on device. It is covered by the pre-existing `fresh upload whose OS PUT fails falls back to chunked resumable` plus a new trace assertion over the same flow, both of which run the real service control flow with only HTTP mocked.

Review reported both tests in `video_event_service_subscribe_race_test.dart` failing under heavy parallel load (`Expected: <1> Actual: <2>`) and green 15/15 idle. Not reproduced here in 72 runs — 12 idle, 40 parallel, 20 sequential under 14-way CPU saturation — and it stays unexplained: with the test's stubs there is no `await` between entering `subscribeToVideoFeed` and the synchronous pending-claim add, so the racing caller cannot pass that check.

What was fixable is fixed. The gate parked only the *first* cached-events read, so any other reader reaching the DAO first silently turned the test into two sequential subscribes that pass for the wrong reason. It now gates every read, asserts the first caller is genuinely inside its async gap, and bounds the racing call so a regression names the broken invariant rather than hanging. Mutation-checked: removing the pending-claim reuse fails both tests with that message.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


