### PR TITLE
fix(bookmarks): make the share-sheet save affordance reflect the existing bookmark

### DIFF
--- a/mobile/lib/blocs/share_sheet/reportable_sites.dart
+++ b/mobile/lib/blocs/share_sheet/reportable_sites.dart
@@ -7,6 +7,7 @@
 abstract class ShareSheetBlocReportableSites {
   static const String onContactsLoadRequested = '_onContactsLoadRequested';
   static const String onSendRequested = '_onSendRequested';
+  static const String onBookmarkStatusRequested = '_onBookmarkStatusRequested';
   static const String onSaveRequested = '_onSaveRequested';
   static const String onAddVideoToClipsRequested =
       '_onAddVideoToClipsRequested';

--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -315,7 +315,11 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
 
     try {
       final reconciled = await bookmarkService.syncGlobalBookmarks();
-      if (isClosed || !reconciled) return;
+      if (isClosed ||
+          !reconciled ||
+          state.bookmarkStatus != ShareSheetBookmarkStatus.unknown) {
+        return;
+      }
 
       emit(
         state.copyWith(
@@ -325,10 +329,11 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
         ),
       );
     } catch (e, stackTrace) {
-      // Expected on a flaky network: the affordance stays `unknown` and reads
-      // as plain "Save", which is exactly the pre-existing behaviour. Not
-      // reportable, and deliberately not surfaced — the sheet's other actions
-      // are unaffected.
+      _addUnexpectedError(
+        e,
+        stackTrace,
+        ShareSheetBlocReportableSites.onBookmarkStatusRequested,
+      );
       Log.warning(
         'Could not resolve bookmark status: $e',
         name: 'ShareSheetBloc',

--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -56,6 +56,10 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
     on<ShareSheetRecipientToggled>(_onRecipientToggled);
     on<ShareSheetSendRequested>(_onSendRequested, transformer: droppable());
     on<ShareSheetSaveRequested>(_onSaveRequested, transformer: droppable());
+    on<ShareSheetBookmarkStatusRequested>(
+      _onBookmarkStatusRequested,
+      transformer: droppable(),
+    );
     on<ShareSheetAddVideoToClipsRequested>(
       _onAddVideoToClipsRequested,
       transformer: droppable(),
@@ -287,6 +291,58 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
   }
 
   // --------------------------------------------------------------------------
+  // Bookmark status (labels the Save affordance before it is tapped)
+  // --------------------------------------------------------------------------
+
+  /// Resolves [ShareSheetState.bookmarkStatus] from a relay-reconciled read.
+  ///
+  /// Uses the non-authoritative [BookmarkService.syncGlobalBookmarks] rather
+  /// than the full-settlement form the toggle pays for. `requireAuthoritative`
+  /// exists to stop a partially-read list from becoming the base of a
+  /// replacing publish; a label publishes nothing, and the toggle reconciles
+  /// authoritatively again before it acts. `ProfileSavedVideosBloc` reads
+  /// bookmark state for display the same way.
+  ///
+  /// The status is left [ShareSheetBookmarkStatus.unknown] when the read is
+  /// inconclusive. Claiming "not saved" on a failed read is the mislabel this
+  /// handler exists to remove.
+  Future<void> _onBookmarkStatusRequested(
+    ShareSheetBookmarkStatusRequested event,
+    Emitter<ShareSheetState> emit,
+  ) async {
+    final bookmarkService = await _bookmarkServiceFuture;
+    if (bookmarkService == null || isClosed) return;
+
+    try {
+      final reconciled = await bookmarkService.syncGlobalBookmarks();
+      if (isClosed || !reconciled) return;
+
+      emit(
+        state.copyWith(
+          bookmarkStatus: bookmarkService.isVideoBookmarkedGlobally(_video.id)
+              ? ShareSheetBookmarkStatus.saved
+              : ShareSheetBookmarkStatus.notSaved,
+        ),
+      );
+    } catch (e, stackTrace) {
+      // Expected on a flaky network: the affordance stays `unknown` and reads
+      // as plain "Save", which is exactly the pre-existing behaviour. Not
+      // reportable, and deliberately not surfaced — the sheet's other actions
+      // are unaffected.
+      Log.warning(
+        'Could not resolve bookmark status: $e',
+        name: 'ShareSheetBloc',
+        category: LogCategory.ui,
+      );
+      Log.debug(
+        'Bookmark status stack trace: $stackTrace',
+        name: 'ShareSheetBloc',
+        category: LogCategory.ui,
+      );
+    }
+  }
+
+  // --------------------------------------------------------------------------
   // Save to bookmarks
   // --------------------------------------------------------------------------
 
@@ -335,6 +391,14 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
       emit(
         state.copyWith(
           isSaving: false,
+          // Only a succeeded toggle reconciled with the relay. On failure
+          // `isBookmarked` falls back to the pre-toggle guess, so adopting it
+          // would launder a stale local read into a confident label.
+          bookmarkStatus: result.succeeded
+              ? (result.isBookmarked
+                    ? ShareSheetBookmarkStatus.saved
+                    : ShareSheetBookmarkStatus.notSaved)
+              : state.bookmarkStatus,
           actionResult: ShareSheetSaveResult(
             succeeded: result.succeeded,
             removed: result.succeeded && result.wasBookmarked,

--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -291,7 +291,7 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
   }
 
   // --------------------------------------------------------------------------
-  // Bookmark status (labels the Save affordance before it is tapped)
+  // Bookmark status (picks the save/remove row before it is tapped)
   // --------------------------------------------------------------------------
 
   /// Resolves [ShareSheetState.bookmarkStatus] from a relay-reconciled read.

--- a/mobile/lib/blocs/share_sheet/share_sheet_event.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_event.dart
@@ -49,10 +49,11 @@ class ShareSheetSaveRequested extends ShareSheetEvent {
 
 /// Resolve whether this video is already globally bookmarked.
 ///
-/// Dispatched on sheet open so the Save row can name the direction its tap
-/// will take. The toggle decides its direction from its own authoritative
-/// reconcile, so this read only labels the affordance — it never becomes the
-/// base of a replacing publish.
+/// Dispatched on sheet open so the row can name the direction its tap will
+/// take — "Save" when it adds, "Remove from saved" when it removes. The
+/// toggle decides its direction from its own authoritative reconcile, so this
+/// read only labels the affordance — it never becomes the base of a replacing
+/// publish.
 class ShareSheetBookmarkStatusRequested extends ShareSheetEvent {
   const ShareSheetBookmarkStatusRequested();
 }

--- a/mobile/lib/blocs/share_sheet/share_sheet_event.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_event.dart
@@ -47,6 +47,16 @@ class ShareSheetSaveRequested extends ShareSheetEvent {
   const ShareSheetSaveRequested();
 }
 
+/// Resolve whether this video is already globally bookmarked.
+///
+/// Dispatched on sheet open so the Save row can name the direction its tap
+/// will take. The toggle decides its direction from its own authoritative
+/// reconcile, so this read only labels the affordance — it never becomes the
+/// base of a replacing publish.
+class ShareSheetBookmarkStatusRequested extends ShareSheetEvent {
+  const ShareSheetBookmarkStatusRequested();
+}
+
 /// Add a video (classic Vine or own video) to the local clip library.
 class ShareSheetAddVideoToClipsRequested extends ShareSheetEvent {
   const ShareSheetAddVideoToClipsRequested({this.libraryTitle});

--- a/mobile/lib/blocs/share_sheet/share_sheet_state.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_state.dart
@@ -82,10 +82,7 @@ class ShareSheetSaveResult extends ShareSheetActionResult {
 }
 
 class ShareSheetVideoClipImportResult extends ShareSheetActionResult {
-  ShareSheetVideoClipImportResult({
-    required this.succeeded,
-    this.libraryTitle,
-  });
+  ShareSheetVideoClipImportResult({required this.succeeded, this.libraryTitle});
 
   final bool succeeded;
   final String? libraryTitle;
@@ -132,6 +129,15 @@ class ShareSheetShareViaTriggered extends ShareSheetActionResult {
   final String? subject;
 }
 
+/// Whether the video is already in the user's global (kind 10003) bookmarks.
+///
+/// Starts [unknown] and stays there until a relay-reconciled read resolves it.
+/// [unknown] must render as the plain "Save" affordance rather than as
+/// [notSaved]: the two are indistinguishable to a reader, but conflating them
+/// would let an unresolved read claim the video is not bookmarked — which is
+/// exactly the mislabel this state exists to prevent.
+enum ShareSheetBookmarkStatus { unknown, saved, notSaved }
+
 /// State for the share sheet.
 class ShareSheetState extends Equatable {
   const ShareSheetState({
@@ -140,6 +146,7 @@ class ShareSheetState extends Equatable {
     this.selectedRecipients = const [],
     this.isSending = false,
     this.isSaving = false,
+    this.bookmarkStatus = ShareSheetBookmarkStatus.unknown,
     this.actionResult,
   });
 
@@ -162,6 +169,9 @@ class ShareSheetState extends Equatable {
   /// show that it is working rather than sitting inert (#7073).
   final bool isSaving;
 
+  /// Whether this video is already globally bookmarked, per a reconciled read.
+  final ShareSheetBookmarkStatus bookmarkStatus;
+
   /// One-shot action result for BlocListener consumption.
   /// Cleared on next state emission.
   final ShareSheetActionResult? actionResult;
@@ -179,6 +189,7 @@ class ShareSheetState extends Equatable {
     List<ShareableUser>? selectedRecipients,
     bool? isSending,
     bool? isSaving,
+    ShareSheetBookmarkStatus? bookmarkStatus,
     ShareSheetActionResult? actionResult,
     bool clearActionResult = false,
   }) {
@@ -188,6 +199,7 @@ class ShareSheetState extends Equatable {
       selectedRecipients: selectedRecipients ?? this.selectedRecipients,
       isSending: isSending ?? this.isSending,
       isSaving: isSaving ?? this.isSaving,
+      bookmarkStatus: bookmarkStatus ?? this.bookmarkStatus,
       actionResult: clearActionResult
           ? null
           : (actionResult ?? this.actionResult),
@@ -201,6 +213,7 @@ class ShareSheetState extends Equatable {
     selectedRecipients,
     isSending,
     isSaving,
+    bookmarkStatus,
     actionResult,
   ];
 }

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -1655,6 +1655,7 @@
     "authInviteErrorTemporary": "ግብዣህን አሁን ማረጋገጥ አልቻልንም። ወደ የግብዣ ኮድዎ ይመለሱ እና እንደገና ይሞክሩ፣ ወይም ድጋፍን ያግኙ።",
     "authInviteErrorUnknown": "ግብዣህን ማግበር አልቻልንም። ወደ የግብዣ ኮድዎ ይመለሱ፣ የተጠባባቂ ዝርዝሩን ይቀላቀሉ ወይም ድጋፍ ሰጪን ያግኙ።",
     "shareSheetSave": "አስቀምጥ",
+    "shareSheetSaved": "ተቀምጧል",
     "shareSheetSaveToGallery": "ወደ ማዕከለ-ስዕላት አስቀምጥ",
     "shareSheetSaveWithWatermark": "በውሃ ምልክት አስቀምጥ",
     "shareSheetSaveVideo": "ቪዲዮ አስቀምጥ",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -1655,7 +1655,7 @@
     "authInviteErrorTemporary": "ግብዣህን አሁን ማረጋገጥ አልቻልንም። ወደ የግብዣ ኮድዎ ይመለሱ እና እንደገና ይሞክሩ፣ ወይም ድጋፍን ያግኙ።",
     "authInviteErrorUnknown": "ግብዣህን ማግበር አልቻልንም። ወደ የግብዣ ኮድዎ ይመለሱ፣ የተጠባባቂ ዝርዝሩን ይቀላቀሉ ወይም ድጋፍ ሰጪን ያግኙ።",
     "shareSheetSave": "አስቀምጥ",
-    "shareSheetSaved": "ተቀምጧል",
+    "shareSheetRemoveFromSaved": "ከዕልባቶች አስወግድ",
     "shareSheetSaveToGallery": "ወደ ማዕከለ-ስዕላት አስቀምጥ",
     "shareSheetSaveWithWatermark": "በውሃ ምልክት አስቀምጥ",
     "shareSheetSaveVideo": "ቪዲዮ አስቀምጥ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1383,7 +1383,7 @@
     "authInviteErrorTemporary": "لم نتمكّن من تأكيد دعوتك الآن. عد إلى رمز دعوتك وحاول مرّة أخرى، أو تواصل مع الدعم.",
     "authInviteErrorUnknown": "لم نتمكّن من تفعيل دعوتك. عد إلى رمز دعوتك، انضم لقائمة الانتظار، أو تواصل مع الدعم.",
     "shareSheetSave": "حفظ",
-    "shareSheetSaved": "محفوظ",
+    "shareSheetRemoveFromSaved": "إزالة المحفوظ",
     "shareSheetSaveToGallery": "حفظ في المعرض",
     "shareSheetSaveWithWatermark": "حفظ مع العلامة المائية",
     "shareSheetSaveVideo": "حفظ الفيديو",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1383,6 +1383,7 @@
     "authInviteErrorTemporary": "لم نتمكّن من تأكيد دعوتك الآن. عد إلى رمز دعوتك وحاول مرّة أخرى، أو تواصل مع الدعم.",
     "authInviteErrorUnknown": "لم نتمكّن من تفعيل دعوتك. عد إلى رمز دعوتك، انضم لقائمة الانتظار، أو تواصل مع الدعم.",
     "shareSheetSave": "حفظ",
+    "shareSheetSaved": "محفوظ",
     "shareSheetSaveToGallery": "حفظ في المعرض",
     "shareSheetSaveWithWatermark": "حفظ مع العلامة المائية",
     "shareSheetSaveVideo": "حفظ الفيديو",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -1469,7 +1469,7 @@
     "authInviteErrorTemporary": "Не можахме да потвърдим поканата ти в момента. Върни се към кода за покана и опитай пак или се свържи с поддръжката.",
     "authInviteErrorUnknown": "Не успяхме да активираме поканата ти. Върни се към кода за покана, присъедини се към списъка с чакащи или се свържи с поддръжката.",
     "shareSheetSave": "Запази",
-    "shareSheetSaved": "Запазено",
+    "shareSheetRemoveFromSaved": "Премахни от запазени",
     "shareSheetSaveToGallery": "Запази в галерията",
     "shareSheetSaveWithWatermark": "Запази с воден знак",
     "shareSheetSaveVideo": "Запази видео",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -1469,6 +1469,7 @@
     "authInviteErrorTemporary": "Не можахме да потвърдим поканата ти в момента. Върни се към кода за покана и опитай пак или се свържи с поддръжката.",
     "authInviteErrorUnknown": "Не успяхме да активираме поканата ти. Върни се към кода за покана, присъедини се към списъка с чакащи или се свържи с поддръжката.",
     "shareSheetSave": "Запази",
+    "shareSheetSaved": "Запазено",
     "shareSheetSaveToGallery": "Запази в галерията",
     "shareSheetSaveWithWatermark": "Запази с воден знак",
     "shareSheetSaveVideo": "Запази видео",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1393,6 +1393,7 @@
     "authInviteErrorTemporary": "Wir konnten deine Einladung gerade nicht bestätigen. Geh zurück zu deinem Einladungscode und versuch es nochmal oder kontaktier den Support.",
     "authInviteErrorUnknown": "Wir konnten deine Einladung nicht aktivieren. Geh zurück zu deinem Einladungscode, tritt der Warteliste bei oder kontaktier den Support.",
     "shareSheetSave": "Speichern",
+    "shareSheetSaved": "Gespeichert",
     "shareSheetSaveToGallery": "In Galerie speichern",
     "shareSheetSaveWithWatermark": "Mit Wasserzeichen speichern",
     "shareSheetSaveVideo": "Video speichern",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1393,7 +1393,7 @@
     "authInviteErrorTemporary": "Wir konnten deine Einladung gerade nicht bestätigen. Geh zurück zu deinem Einladungscode und versuch es nochmal oder kontaktier den Support.",
     "authInviteErrorUnknown": "Wir konnten deine Einladung nicht aktivieren. Geh zurück zu deinem Einladungscode, tritt der Warteliste bei oder kontaktier den Support.",
     "shareSheetSave": "Speichern",
-    "shareSheetSaved": "Gespeichert",
+    "shareSheetRemoveFromSaved": "Lesezeichen entfernen",
     "shareSheetSaveToGallery": "In Galerie speichern",
     "shareSheetSaveWithWatermark": "Mit Wasserzeichen speichern",
     "shareSheetSaveVideo": "Video speichern",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2084,6 +2084,10 @@
   "authInviteErrorTemporary": "We couldn't confirm your invite right now. Go back to your invite code and try again, or contact support.",
   "authInviteErrorUnknown": "We couldn't activate your invite. Go back to your invite code, join the waitlist, or contact support.",
   "shareSheetSave": "Save",
+  "shareSheetSaved": "Saved",
+  "@shareSheetSaved": {
+    "description": "Share-sheet action label shown when the video is already in the user's global bookmarks; tapping it removes the bookmark."
+  },
   "shareSheetSaveToGallery": "Save to Gallery",
   "shareSheetSaveWithWatermark": "Save with Watermark",
   "shareSheetSaveVideo": "Save Video",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2084,9 +2084,9 @@
   "authInviteErrorTemporary": "We couldn't confirm your invite right now. Go back to your invite code and try again, or contact support.",
   "authInviteErrorUnknown": "We couldn't activate your invite. Go back to your invite code, join the waitlist, or contact support.",
   "shareSheetSave": "Save",
-  "shareSheetSaved": "Saved",
-  "@shareSheetSaved": {
-    "description": "Share-sheet action label shown when the video is already in the user's global bookmarks; tapping it removes the bookmark."
+  "shareSheetRemoveFromSaved": "Remove from saved",
+  "@shareSheetRemoveFromSaved": {
+    "description": "Share-sheet action label shown in place of \"Save\" once a relay-reconciled read confirms the video is already in the user's global bookmarks. It names the direction of the tap, which removes the bookmark."
   },
   "shareSheetSaveToGallery": "Save to Gallery",
   "shareSheetSaveWithWatermark": "Save with Watermark",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1397,7 +1397,7 @@
     "authInviteErrorTemporary": "No pudimos confirmar tu invitación ahora. Volvé a tu código y probá de nuevo, o contactá a soporte.",
     "authInviteErrorUnknown": "No pudimos activar tu invitación. Volvé a tu código, unite a la lista de espera o contactá a soporte.",
     "shareSheetSave": "Guardar",
-    "shareSheetSaved": "Guardado",
+    "shareSheetRemoveFromSaved": "Quitar de guardados",
     "shareSheetSaveToGallery": "Guardar en la galería",
     "shareSheetSaveWithWatermark": "Guardar con marca de agua",
     "shareSheetSaveVideo": "Guardar video",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1397,6 +1397,7 @@
     "authInviteErrorTemporary": "No pudimos confirmar tu invitación ahora. Volvé a tu código y probá de nuevo, o contactá a soporte.",
     "authInviteErrorUnknown": "No pudimos activar tu invitación. Volvé a tu código, unite a la lista de espera o contactá a soporte.",
     "shareSheetSave": "Guardar",
+    "shareSheetSaved": "Guardado",
     "shareSheetSaveToGallery": "Guardar en la galería",
     "shareSheetSaveWithWatermark": "Guardar con marca de agua",
     "shareSheetSaveVideo": "Guardar video",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -929,7 +929,7 @@
     "authInviteErrorTemporary": "Hindi namin ma-confirm ang iyong invite ngayon. Bumalik sa iyong invite code at subukang ulit, o makipag-ugnayan sa support.",
     "authInviteErrorUnknown": "Hindi namin na-activate ang iyong invite. Bumalik sa iyong invite code, sumali sa waitlist, o makipag-ugnayan sa support.",
     "shareSheetSave": "I-save",
-    "shareSheetSaved": "Naka-save",
+    "shareSheetRemoveFromSaved": "Alisin sa naka-save",
     "shareSheetSaveToGallery": "I-save sa Gallery",
     "shareSheetSaveWithWatermark": "I-save na may Watermark",
     "shareSheetSaveVideo": "I-save ang Video",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -929,6 +929,7 @@
     "authInviteErrorTemporary": "Hindi namin ma-confirm ang iyong invite ngayon. Bumalik sa iyong invite code at subukang ulit, o makipag-ugnayan sa support.",
     "authInviteErrorUnknown": "Hindi namin na-activate ang iyong invite. Bumalik sa iyong invite code, sumali sa waitlist, o makipag-ugnayan sa support.",
     "shareSheetSave": "I-save",
+    "shareSheetSaved": "Naka-save",
     "shareSheetSaveToGallery": "I-save sa Gallery",
     "shareSheetSaveWithWatermark": "I-save na may Watermark",
     "shareSheetSaveVideo": "I-save ang Video",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1393,7 +1393,7 @@
     "authInviteErrorTemporary": "On n'a pas pu confirmer ton invitation pour l'instant. Retourne à ton code d'invitation et réessaie, ou contacte le support.",
     "authInviteErrorUnknown": "On n'a pas pu activer ton invitation. Retourne à ton code d'invitation, rejoins la liste d'attente, ou contacte le support.",
     "shareSheetSave": "Enregistrer",
-    "shareSheetSaved": "Enregistré",
+    "shareSheetRemoveFromSaved": "Retirer des favoris",
     "shareSheetSaveToGallery": "Enregistrer dans la galerie",
     "shareSheetSaveWithWatermark": "Enregistrer avec filigrane",
     "shareSheetSaveVideo": "Enregistrer la vidéo",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1393,6 +1393,7 @@
     "authInviteErrorTemporary": "On n'a pas pu confirmer ton invitation pour l'instant. Retourne à ton code d'invitation et réessaie, ou contacte le support.",
     "authInviteErrorUnknown": "On n'a pas pu activer ton invitation. Retourne à ton code d'invitation, rejoins la liste d'attente, ou contacte le support.",
     "shareSheetSave": "Enregistrer",
+    "shareSheetSaved": "Enregistré",
     "shareSheetSaveToGallery": "Enregistrer dans la galerie",
     "shareSheetSaveWithWatermark": "Enregistrer avec filigrane",
     "shareSheetSaveVideo": "Enregistrer la vidéo",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1390,6 +1390,7 @@
     "authInviteErrorTemporary": "Kami tidak bisa mengkonfirmasi undanganmu sekarang. Kembali ke kode undanganmu dan coba lagi, atau hubungi dukungan.",
     "authInviteErrorUnknown": "Kami tidak bisa mengaktifkan undanganmu. Kembali ke kode undanganmu, gabung daftar tunggu, atau hubungi dukungan.",
     "shareSheetSave": "Simpan",
+    "shareSheetSaved": "Tersimpan",
     "shareSheetSaveToGallery": "Simpan ke Galeri",
     "shareSheetSaveWithWatermark": "Simpan dengan Watermark",
     "shareSheetSaveVideo": "Simpan Video",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1390,7 +1390,7 @@
     "authInviteErrorTemporary": "Kami tidak bisa mengkonfirmasi undanganmu sekarang. Kembali ke kode undanganmu dan coba lagi, atau hubungi dukungan.",
     "authInviteErrorUnknown": "Kami tidak bisa mengaktifkan undanganmu. Kembali ke kode undanganmu, gabung daftar tunggu, atau hubungi dukungan.",
     "shareSheetSave": "Simpan",
-    "shareSheetSaved": "Tersimpan",
+    "shareSheetRemoveFromSaved": "Hapus dari tersimpan",
     "shareSheetSaveToGallery": "Simpan ke Galeri",
     "shareSheetSaveWithWatermark": "Simpan dengan Watermark",
     "shareSheetSaveVideo": "Simpan Video",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1393,7 +1393,7 @@
     "authInviteErrorTemporary": "Non siamo riusciti a confermare il tuo invito in questo momento. Torna al tuo codice invito e riprova, oppure contatta l'assistenza.",
     "authInviteErrorUnknown": "Non siamo riusciti ad attivare il tuo invito. Torna al tuo codice invito, entra nella lista d'attesa o contatta l'assistenza.",
     "shareSheetSave": "Salva",
-    "shareSheetSaved": "Salvato",
+    "shareSheetRemoveFromSaved": "Rimuovi dai salvati",
     "shareSheetSaveToGallery": "Salva in galleria",
     "shareSheetSaveWithWatermark": "Salva con filigrana",
     "shareSheetSaveVideo": "Salva video",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1393,6 +1393,7 @@
     "authInviteErrorTemporary": "Non siamo riusciti a confermare il tuo invito in questo momento. Torna al tuo codice invito e riprova, oppure contatta l'assistenza.",
     "authInviteErrorUnknown": "Non siamo riusciti ad attivare il tuo invito. Torna al tuo codice invito, entra nella lista d'attesa o contatta l'assistenza.",
     "shareSheetSave": "Salva",
+    "shareSheetSaved": "Salvato",
     "shareSheetSaveToGallery": "Salva in galleria",
     "shareSheetSaveWithWatermark": "Salva con filigrana",
     "shareSheetSaveVideo": "Salva video",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1383,6 +1383,7 @@
     "authInviteErrorTemporary": "今は招待を確認できなかった。招待コードに戻ってもう一回試すか、サポートに連絡してね。",
     "authInviteErrorUnknown": "招待を有効にできなかった。招待コードに戻るか、ウェイトリストに参加するか、サポートに連絡してね。",
     "shareSheetSave": "保存",
+    "shareSheetSaved": "保存済み",
     "shareSheetSaveToGallery": "ギャラリーに保存",
     "shareSheetSaveWithWatermark": "ウォーターマーク付きで保存",
     "shareSheetSaveVideo": "動画を保存",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1383,7 +1383,7 @@
     "authInviteErrorTemporary": "今は招待を確認できなかった。招待コードに戻ってもう一回試すか、サポートに連絡してね。",
     "authInviteErrorUnknown": "招待を有効にできなかった。招待コードに戻るか、ウェイトリストに参加するか、サポートに連絡してね。",
     "shareSheetSave": "保存",
-    "shareSheetSaved": "保存済み",
+    "shareSheetRemoveFromSaved": "保存を外す",
     "shareSheetSaveToGallery": "ギャラリーに保存",
     "shareSheetSaveWithWatermark": "ウォーターマーク付きで保存",
     "shareSheetSaveVideo": "動画を保存",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -854,6 +854,7 @@
     "authInviteErrorTemporary": "지금은 초대 코드를 확인할 수 없어요. 초대 코드로 돌아가서 다시 시도하거나 고객센터에 문의해주세요.",
     "authInviteErrorUnknown": "초대를 활성화할 수 없어요. 초대 코드로 돌아가거나, 대기자 명단에 등록하거나, 고객센터에 문의해주세요.",
     "shareSheetSave": "저장",
+    "shareSheetSaved": "저장됨",
     "shareSheetSaveToGallery": "갤러리에 저장",
     "shareSheetSaveWithWatermark": "워터마크와 함께 저장",
     "shareSheetSaveVideo": "영상 저장",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -854,7 +854,7 @@
     "authInviteErrorTemporary": "지금은 초대 코드를 확인할 수 없어요. 초대 코드로 돌아가서 다시 시도하거나 고객센터에 문의해주세요.",
     "authInviteErrorUnknown": "초대를 활성화할 수 없어요. 초대 코드로 돌아가거나, 대기자 명단에 등록하거나, 고객센터에 문의해주세요.",
     "shareSheetSave": "저장",
-    "shareSheetSaved": "저장됨",
+    "shareSheetRemoveFromSaved": "저장 취소",
     "shareSheetSaveToGallery": "갤러리에 저장",
     "shareSheetSaveWithWatermark": "워터마크와 함께 저장",
     "shareSheetSaveVideo": "영상 저장",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -1894,6 +1894,7 @@
   "authInviteErrorTemporary": "Kami tidak dapat mengesahkan jemputan anda sekarang. Kembali ke kod jemputan anda dan cuba lagi, atau hubungi sokongan.",
   "authInviteErrorUnknown": "Kami tidak dapat mengaktifkan jemputan anda. Kembali ke kod jemputan anda, sertai senarai menunggu, atau hubungi sokongan.",
   "shareSheetSave": "Simpan",
+  "shareSheetSaved": "Disimpan",
   "shareSheetSaveToGallery": "Simpan ke Galeri",
   "shareSheetSaveWithWatermark": "Simpan dengan Tera Air",
   "shareSheetSaveVideo": "Simpan Video",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -1894,7 +1894,7 @@
   "authInviteErrorTemporary": "Kami tidak dapat mengesahkan jemputan anda sekarang. Kembali ke kod jemputan anda dan cuba lagi, atau hubungi sokongan.",
   "authInviteErrorUnknown": "Kami tidak dapat mengaktifkan jemputan anda. Kembali ke kod jemputan anda, sertai senarai menunggu, atau hubungi sokongan.",
   "shareSheetSave": "Simpan",
-  "shareSheetSaved": "Disimpan",
+  "shareSheetRemoveFromSaved": "Alih keluar simpanan",
   "shareSheetSaveToGallery": "Simpan ke Galeri",
   "shareSheetSaveWithWatermark": "Simpan dengan Tera Air",
   "shareSheetSaveVideo": "Simpan Video",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1393,6 +1393,7 @@
     "authInviteErrorTemporary": "We konden je invite nu niet bevestigen. Ga terug naar je invite-code en probeer het opnieuw, of neem contact op met support.",
     "authInviteErrorUnknown": "We konden je invite niet activeren. Ga terug naar je invite-code, kom op de wachtlijst of neem contact op met support.",
     "shareSheetSave": "Opslaan",
+    "shareSheetSaved": "Opgeslagen",
     "shareSheetSaveToGallery": "Opslaan in galerij",
     "shareSheetSaveWithWatermark": "Opslaan met watermerk",
     "shareSheetSaveVideo": "Video opslaan",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1393,7 +1393,7 @@
     "authInviteErrorTemporary": "We konden je invite nu niet bevestigen. Ga terug naar je invite-code en probeer het opnieuw, of neem contact op met support.",
     "authInviteErrorUnknown": "We konden je invite niet activeren. Ga terug naar je invite-code, kom op de wachtlijst of neem contact op met support.",
     "shareSheetSave": "Opslaan",
-    "shareSheetSaved": "Opgeslagen",
+    "shareSheetRemoveFromSaved": "Verwijder bladwijzer",
     "shareSheetSaveToGallery": "Opslaan in galerij",
     "shareSheetSaveWithWatermark": "Opslaan met watermerk",
     "shareSheetSaveVideo": "Video opslaan",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1393,6 +1393,7 @@
     "authInviteErrorTemporary": "Nie mogliśmy teraz potwierdzić twojego zaproszenia. Wróć do kodu zaproszenia i spróbuj ponownie, lub skontaktuj się z pomocą.",
     "authInviteErrorUnknown": "Nie mogliśmy aktywować twojego zaproszenia. Wróć do kodu zaproszenia, dołącz do listy oczekujących lub skontaktuj się z pomocą.",
     "shareSheetSave": "Zapisz",
+    "shareSheetSaved": "Zapisano",
     "shareSheetSaveToGallery": "Zapisz w galerii",
     "shareSheetSaveWithWatermark": "Zapisz ze znakiem wodnym",
     "shareSheetSaveVideo": "Zapisz film",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1393,7 +1393,7 @@
     "authInviteErrorTemporary": "Nie mogliśmy teraz potwierdzić twojego zaproszenia. Wróć do kodu zaproszenia i spróbuj ponownie, lub skontaktuj się z pomocą.",
     "authInviteErrorUnknown": "Nie mogliśmy aktywować twojego zaproszenia. Wróć do kodu zaproszenia, dołącz do listy oczekujących lub skontaktuj się z pomocą.",
     "shareSheetSave": "Zapisz",
-    "shareSheetSaved": "Zapisano",
+    "shareSheetRemoveFromSaved": "Usuń z zapisanych",
     "shareSheetSaveToGallery": "Zapisz w galerii",
     "shareSheetSaveWithWatermark": "Zapisz ze znakiem wodnym",
     "shareSheetSaveVideo": "Zapisz film",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1393,6 +1393,7 @@
     "authInviteErrorTemporary": "Não conseguimos confirmar seu convite agora. Volte para o seu código de convite e tente novamente ou contate o suporte.",
     "authInviteErrorUnknown": "Não conseguimos ativar seu convite. Volte para o seu código de convite, entre na lista de espera ou contate o suporte.",
     "shareSheetSave": "Salvar",
+    "shareSheetSaved": "Salvo",
     "shareSheetSaveToGallery": "Salvar na galeria",
     "shareSheetSaveWithWatermark": "Salvar com marca d'água",
     "shareSheetSaveVideo": "Salvar vídeo",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1393,7 +1393,7 @@
     "authInviteErrorTemporary": "Não conseguimos confirmar seu convite agora. Volte para o seu código de convite e tente novamente ou contate o suporte.",
     "authInviteErrorUnknown": "Não conseguimos ativar seu convite. Volte para o seu código de convite, entre na lista de espera ou contate o suporte.",
     "shareSheetSave": "Salvar",
-    "shareSheetSaved": "Salvo",
+    "shareSheetRemoveFromSaved": "Remover dos salvos",
     "shareSheetSaveToGallery": "Salvar na galeria",
     "shareSheetSaveWithWatermark": "Salvar com marca d'água",
     "shareSheetSaveVideo": "Salvar vídeo",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1393,6 +1393,7 @@
     "authInviteErrorTemporary": "N-am putut confirma invitația ta acum. Întoarce-te la codul tău și încearcă din nou, sau contactează asistența.",
     "authInviteErrorUnknown": "N-am putut activa invitația ta. Întoarce-te la codul tău, alătură-te listei de așteptare sau contactează asistența.",
     "shareSheetSave": "Salvează",
+    "shareSheetSaved": "Salvat",
     "shareSheetSaveToGallery": "Salvează în galerie",
     "shareSheetSaveWithWatermark": "Salvează cu filigran",
     "shareSheetSaveVideo": "Salvează videoclipul",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1393,7 +1393,7 @@
     "authInviteErrorTemporary": "N-am putut confirma invitația ta acum. Întoarce-te la codul tău și încearcă din nou, sau contactează asistența.",
     "authInviteErrorUnknown": "N-am putut activa invitația ta. Întoarce-te la codul tău, alătură-te listei de așteptare sau contactează asistența.",
     "shareSheetSave": "Salvează",
-    "shareSheetSaved": "Salvat",
+    "shareSheetRemoveFromSaved": "Elimină din salvate",
     "shareSheetSaveToGallery": "Salvează în galerie",
     "shareSheetSaveWithWatermark": "Salvează cu filigran",
     "shareSheetSaveVideo": "Salvează videoclipul",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1393,7 +1393,7 @@
     "authInviteErrorTemporary": "Vi kunde inte bekräfta din inbjudan just nu. Gå tillbaka till din inbjudningskod och försök igen, eller kontakta supporten.",
     "authInviteErrorUnknown": "Vi kunde inte aktivera din inbjudan. Gå tillbaka till din inbjudningskod, gå med i väntelistan eller kontakta supporten.",
     "shareSheetSave": "Spara",
-    "shareSheetSaved": "Sparad",
+    "shareSheetRemoveFromSaved": "Ta bort från sparade",
     "shareSheetSaveToGallery": "Spara i galleriet",
     "shareSheetSaveWithWatermark": "Spara med vattenmärke",
     "shareSheetSaveVideo": "Spara video",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1393,6 +1393,7 @@
     "authInviteErrorTemporary": "Vi kunde inte bekräfta din inbjudan just nu. Gå tillbaka till din inbjudningskod och försök igen, eller kontakta supporten.",
     "authInviteErrorUnknown": "Vi kunde inte aktivera din inbjudan. Gå tillbaka till din inbjudningskod, gå med i väntelistan eller kontakta supporten.",
     "shareSheetSave": "Spara",
+    "shareSheetSaved": "Sparad",
     "shareSheetSaveToGallery": "Spara i galleriet",
     "shareSheetSaveWithWatermark": "Spara med vattenmärke",
     "shareSheetSaveVideo": "Spara video",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1390,7 +1390,7 @@
     "authInviteErrorTemporary": "Davetini şu anda doğrulayamadık. Davet koduna geri dönüp tekrar dene veya destekle iletişime geç.",
     "authInviteErrorUnknown": "Davetini etkinleştiremedik. Davet koduna geri dön, bekleme listesine katıl veya destekle iletişime geç.",
     "shareSheetSave": "Kaydet",
-    "shareSheetSaved": "Kaydedildi",
+    "shareSheetRemoveFromSaved": "Kaydı kaldır",
     "shareSheetSaveToGallery": "Galeriye Kaydet",
     "shareSheetSaveWithWatermark": "Filigranlı Kaydet",
     "shareSheetSaveVideo": "Videoyu Kaydet",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1390,6 +1390,7 @@
     "authInviteErrorTemporary": "Davetini şu anda doğrulayamadık. Davet koduna geri dönüp tekrar dene veya destekle iletişime geç.",
     "authInviteErrorUnknown": "Davetini etkinleştiremedik. Davet koduna geri dön, bekleme listesine katıl veya destekle iletişime geç.",
     "shareSheetSave": "Kaydet",
+    "shareSheetSaved": "Kaydedildi",
     "shareSheetSaveToGallery": "Galeriye Kaydet",
     "shareSheetSaveWithWatermark": "Filigranlı Kaydet",
     "shareSheetSaveVideo": "Videoyu Kaydet",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -1894,7 +1894,7 @@
   "authInviteErrorTemporary": "ہم فی الحال آپ کی دعوت کی تصدیق نہیں کر سکے۔ اپنے دعوتی کوڈ پر واپس جا کر دوبارہ کوشش کریں، یا سپورٹ سے رابطہ کریں۔",
   "authInviteErrorUnknown": "ہم آپ کی دعوت فعال نہیں کر سکے۔ اپنے دعوتی کوڈ پر واپس جائیں، ویٹ لسٹ میں شامل ہوں، یا سپورٹ سے رابطہ کریں۔",
   "shareSheetSave": "محفوظ کریں",
-  "shareSheetSaved": "محفوظ",
+  "shareSheetRemoveFromSaved": "محفوظات سے ہٹائیں",
   "shareSheetSaveToGallery": "گیلری میں محفوظ کریں",
   "shareSheetSaveWithWatermark": "واٹر مارک کے ساتھ محفوظ کریں",
   "shareSheetSaveVideo": "ویڈیو محفوظ کریں",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -1894,6 +1894,7 @@
   "authInviteErrorTemporary": "ہم فی الحال آپ کی دعوت کی تصدیق نہیں کر سکے۔ اپنے دعوتی کوڈ پر واپس جا کر دوبارہ کوشش کریں، یا سپورٹ سے رابطہ کریں۔",
   "authInviteErrorUnknown": "ہم آپ کی دعوت فعال نہیں کر سکے۔ اپنے دعوتی کوڈ پر واپس جائیں، ویٹ لسٹ میں شامل ہوں، یا سپورٹ سے رابطہ کریں۔",
   "shareSheetSave": "محفوظ کریں",
+  "shareSheetSaved": "محفوظ",
   "shareSheetSaveToGallery": "گیلری میں محفوظ کریں",
   "shareSheetSaveWithWatermark": "واٹر مارک کے ساتھ محفوظ کریں",
   "shareSheetSaveVideo": "ویڈیو محفوظ کریں",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -1894,6 +1894,7 @@
   "authInviteErrorTemporary": "Bọn mình chưa xác nhận được mã mời của bạn. Quay lại mã mời và thử lại, hoặc liên hệ hỗ trợ.",
   "authInviteErrorUnknown": "Bọn mình không kích hoạt được mã mời của bạn. Quay lại mã mời, tham gia danh sách chờ, hoặc liên hệ hỗ trợ.",
   "shareSheetSave": "Lưu",
+  "shareSheetSaved": "Đã lưu",
   "shareSheetSaveToGallery": "Lưu vào thư viện ảnh",
   "shareSheetSaveWithWatermark": "Lưu kèm watermark",
   "shareSheetSaveVideo": "Lưu video",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -1894,7 +1894,7 @@
   "authInviteErrorTemporary": "Bọn mình chưa xác nhận được mã mời của bạn. Quay lại mã mời và thử lại, hoặc liên hệ hỗ trợ.",
   "authInviteErrorUnknown": "Bọn mình không kích hoạt được mã mời của bạn. Quay lại mã mời, tham gia danh sách chờ, hoặc liên hệ hỗ trợ.",
   "shareSheetSave": "Lưu",
-  "shareSheetSaved": "Đã lưu",
+  "shareSheetRemoveFromSaved": "Xóa khỏi mục đã lưu",
   "shareSheetSaveToGallery": "Lưu vào thư viện ảnh",
   "shareSheetSaveWithWatermark": "Lưu kèm watermark",
   "shareSheetSaveVideo": "Lưu video",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -1894,7 +1894,7 @@
   "authInviteErrorTemporary": "暂时无法确认你的邀请。返回你的邀请码页面重试，或联系客服。",
   "authInviteErrorUnknown": "无法激活你的邀请。返回你的邀请码页面、加入等候名单，或联系客服。",
   "shareSheetSave": "保存",
-  "shareSheetSaved": "已保存",
+  "shareSheetRemoveFromSaved": "移除收藏",
   "shareSheetSaveToGallery": "保存到相册",
   "shareSheetSaveWithWatermark": "保存（带水印）",
   "shareSheetSaveVideo": "保存视频",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -1894,6 +1894,7 @@
   "authInviteErrorTemporary": "暂时无法确认你的邀请。返回你的邀请码页面重试，或联系客服。",
   "authInviteErrorUnknown": "无法激活你的邀请。返回你的邀请码页面、加入等候名单，或联系客服。",
   "shareSheetSave": "保存",
+  "shareSheetSaved": "已保存",
   "shareSheetSaveToGallery": "保存到相册",
   "shareSheetSaveWithWatermark": "保存（带水印）",
   "shareSheetSaveVideo": "保存视频",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -6062,11 +6062,11 @@ abstract class AppLocalizations {
   /// **'Save'**
   String get shareSheetSave;
 
-  /// Share-sheet action label shown when the video is already in the user's global bookmarks; tapping it removes the bookmark.
+  /// Share-sheet action label shown in place of "Save" once a relay-reconciled read confirms the video is already in the user's global bookmarks. It names the direction of the tap, which removes the bookmark.
   ///
   /// In en, this message translates to:
-  /// **'Saved'**
-  String get shareSheetSaved;
+  /// **'Remove from saved'**
+  String get shareSheetRemoveFromSaved;
 
   /// No description provided for @shareSheetSaveToGallery.
   ///

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -6062,6 +6062,12 @@ abstract class AppLocalizations {
   /// **'Save'**
   String get shareSheetSave;
 
+  /// Share-sheet action label shown when the video is already in the user's global bookmarks; tapping it removes the bookmark.
+  ///
+  /// In en, this message translates to:
+  /// **'Saved'**
+  String get shareSheetSaved;
+
   /// No description provided for @shareSheetSaveToGallery.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -3421,6 +3421,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get shareSheetSave => 'አስቀምጥ';
 
   @override
+  String get shareSheetSaved => 'ተቀምጧል';
+
+  @override
   String get shareSheetSaveToGallery => 'ወደ ማዕከለ-ስዕላት አስቀምጥ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -3421,7 +3421,7 @@ class AppLocalizationsAm extends AppLocalizations {
   String get shareSheetSave => 'አስቀምጥ';
 
   @override
-  String get shareSheetSaved => 'ተቀምጧል';
+  String get shareSheetRemoveFromSaved => 'ከዕልባቶች አስወግድ';
 
   @override
   String get shareSheetSaveToGallery => 'ወደ ማዕከለ-ስዕላት አስቀምጥ';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3453,7 +3453,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get shareSheetSave => 'حفظ';
 
   @override
-  String get shareSheetSaved => 'محفوظ';
+  String get shareSheetRemoveFromSaved => 'إزالة المحفوظ';
 
   @override
   String get shareSheetSaveToGallery => 'حفظ في المعرض';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3453,6 +3453,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get shareSheetSave => 'حفظ';
 
   @override
+  String get shareSheetSaved => 'محفوظ';
+
+  @override
   String get shareSheetSaveToGallery => 'حفظ في المعرض';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -3534,6 +3534,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get shareSheetSave => 'Запази';
 
   @override
+  String get shareSheetSaved => 'Запазено';
+
+  @override
   String get shareSheetSaveToGallery => 'Запази в галерията';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -3534,7 +3534,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get shareSheetSave => 'Запази';
 
   @override
-  String get shareSheetSaved => 'Запазено';
+  String get shareSheetRemoveFromSaved => 'Премахни от запазени';
 
   @override
   String get shareSheetSaveToGallery => 'Запази в галерията';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -3525,6 +3525,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get shareSheetSave => 'Speichern';
 
   @override
+  String get shareSheetSaved => 'Gespeichert';
+
+  @override
   String get shareSheetSaveToGallery => 'In Galerie speichern';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -3525,7 +3525,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get shareSheetSave => 'Speichern';
 
   @override
-  String get shareSheetSaved => 'Gespeichert';
+  String get shareSheetRemoveFromSaved => 'Lesezeichen entfernen';
 
   @override
   String get shareSheetSaveToGallery => 'In Galerie speichern';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3485,6 +3485,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get shareSheetSave => 'Save';
 
   @override
+  String get shareSheetSaved => 'Saved';
+
+  @override
   String get shareSheetSaveToGallery => 'Save to Gallery';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3485,7 +3485,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get shareSheetSave => 'Save';
 
   @override
-  String get shareSheetSaved => 'Saved';
+  String get shareSheetRemoveFromSaved => 'Remove from saved';
 
   @override
   String get shareSheetSaveToGallery => 'Save to Gallery';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -3526,6 +3526,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get shareSheetSave => 'Guardar';
 
   @override
+  String get shareSheetSaved => 'Guardado';
+
+  @override
   String get shareSheetSaveToGallery => 'Guardar en la galería';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -3526,7 +3526,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get shareSheetSave => 'Guardar';
 
   @override
-  String get shareSheetSaved => 'Guardado';
+  String get shareSheetRemoveFromSaved => 'Quitar de guardados';
 
   @override
   String get shareSheetSaveToGallery => 'Guardar en la galería';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -3540,6 +3540,9 @@ class AppLocalizationsFil extends AppLocalizations {
   String get shareSheetSave => 'I-save';
 
   @override
+  String get shareSheetSaved => 'Naka-save';
+
+  @override
   String get shareSheetSaveToGallery => 'I-save sa Gallery';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -3540,7 +3540,7 @@ class AppLocalizationsFil extends AppLocalizations {
   String get shareSheetSave => 'I-save';
 
   @override
-  String get shareSheetSaved => 'Naka-save';
+  String get shareSheetRemoveFromSaved => 'Alisin sa naka-save';
 
   @override
   String get shareSheetSaveToGallery => 'I-save sa Gallery';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -3536,6 +3536,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get shareSheetSave => 'Enregistrer';
 
   @override
+  String get shareSheetSaved => 'Enregistré';
+
+  @override
   String get shareSheetSaveToGallery => 'Enregistrer dans la galerie';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -3536,7 +3536,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get shareSheetSave => 'Enregistrer';
 
   @override
-  String get shareSheetSaved => 'Enregistré';
+  String get shareSheetRemoveFromSaved => 'Retirer des favoris';
 
   @override
   String get shareSheetSaveToGallery => 'Enregistrer dans la galerie';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3449,6 +3449,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get shareSheetSave => 'Simpan';
 
   @override
+  String get shareSheetSaved => 'Tersimpan';
+
+  @override
   String get shareSheetSaveToGallery => 'Simpan ke Galeri';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3449,7 +3449,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get shareSheetSave => 'Simpan';
 
   @override
-  String get shareSheetSaved => 'Tersimpan';
+  String get shareSheetRemoveFromSaved => 'Hapus dari tersimpan';
 
   @override
   String get shareSheetSaveToGallery => 'Simpan ke Galeri';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -3526,7 +3526,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get shareSheetSave => 'Salva';
 
   @override
-  String get shareSheetSaved => 'Salvato';
+  String get shareSheetRemoveFromSaved => 'Rimuovi dai salvati';
 
   @override
   String get shareSheetSaveToGallery => 'Salva in galleria';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -3526,6 +3526,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get shareSheetSave => 'Salva';
 
   @override
+  String get shareSheetSaved => 'Salvato';
+
+  @override
   String get shareSheetSaveToGallery => 'Salva in galleria';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3300,7 +3300,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get shareSheetSave => '保存';
 
   @override
-  String get shareSheetSaved => '保存済み';
+  String get shareSheetRemoveFromSaved => '保存を外す';
 
   @override
   String get shareSheetSaveToGallery => 'ギャラリーに保存';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3300,6 +3300,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get shareSheetSave => '保存';
 
   @override
+  String get shareSheetSaved => '保存済み';
+
+  @override
   String get shareSheetSaveToGallery => 'ギャラリーに保存';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3318,6 +3318,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get shareSheetSave => '저장';
 
   @override
+  String get shareSheetSaved => '저장됨';
+
+  @override
   String get shareSheetSaveToGallery => '갤러리에 저장';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3318,7 +3318,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get shareSheetSave => '저장';
 
   @override
-  String get shareSheetSaved => '저장됨';
+  String get shareSheetRemoveFromSaved => '저장 취소';
 
   @override
   String get shareSheetSaveToGallery => '갤러리에 저장';

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -3514,7 +3514,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get shareSheetSave => 'Simpan';
 
   @override
-  String get shareSheetSaved => 'Disimpan';
+  String get shareSheetRemoveFromSaved => 'Alih keluar simpanan';
 
   @override
   String get shareSheetSaveToGallery => 'Simpan ke Galeri';

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -3514,6 +3514,9 @@ class AppLocalizationsMs extends AppLocalizations {
   String get shareSheetSave => 'Simpan';
 
   @override
+  String get shareSheetSaved => 'Disimpan';
+
+  @override
   String get shareSheetSaveToGallery => 'Simpan ke Galeri';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3499,6 +3499,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get shareSheetSave => 'Opslaan';
 
   @override
+  String get shareSheetSaved => 'Opgeslagen';
+
+  @override
   String get shareSheetSaveToGallery => 'Opslaan in galerij';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3499,7 +3499,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get shareSheetSave => 'Opslaan';
 
   @override
-  String get shareSheetSaved => 'Opgeslagen';
+  String get shareSheetRemoveFromSaved => 'Verwijder bladwijzer';
 
   @override
   String get shareSheetSaveToGallery => 'Opslaan in galerij';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -3570,6 +3570,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get shareSheetSave => 'Zapisz';
 
   @override
+  String get shareSheetSaved => 'Zapisano';
+
+  @override
   String get shareSheetSaveToGallery => 'Zapisz w galerii';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -3570,7 +3570,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get shareSheetSave => 'Zapisz';
 
   @override
-  String get shareSheetSaved => 'Zapisano';
+  String get shareSheetRemoveFromSaved => 'Usuń z zapisanych';
 
   @override
   String get shareSheetSaveToGallery => 'Zapisz w galerii';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3513,7 +3513,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get shareSheetSave => 'Salvar';
 
   @override
-  String get shareSheetSaved => 'Salvo';
+  String get shareSheetRemoveFromSaved => 'Remover dos salvos';
 
   @override
   String get shareSheetSaveToGallery => 'Salvar na galeria';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3513,6 +3513,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get shareSheetSave => 'Salvar';
 
   @override
+  String get shareSheetSaved => 'Salvo';
+
+  @override
   String get shareSheetSaveToGallery => 'Salvar na galeria';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -3586,7 +3586,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get shareSheetSave => 'Salvează';
 
   @override
-  String get shareSheetSaved => 'Salvat';
+  String get shareSheetRemoveFromSaved => 'Elimină din salvate';
 
   @override
   String get shareSheetSaveToGallery => 'Salvează în galerie';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -3586,6 +3586,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get shareSheetSave => 'Salvează';
 
   @override
+  String get shareSheetSaved => 'Salvat';
+
+  @override
   String get shareSheetSaveToGallery => 'Salvează în galerie';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3482,7 +3482,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get shareSheetSave => 'Spara';
 
   @override
-  String get shareSheetSaved => 'Sparad';
+  String get shareSheetRemoveFromSaved => 'Ta bort från sparade';
 
   @override
   String get shareSheetSaveToGallery => 'Spara i galleriet';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3482,6 +3482,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get shareSheetSave => 'Spara';
 
   @override
+  String get shareSheetSaved => 'Sparad';
+
+  @override
   String get shareSheetSaveToGallery => 'Spara i galleriet';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3455,6 +3455,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get shareSheetSave => 'Kaydet';
 
   @override
+  String get shareSheetSaved => 'Kaydedildi';
+
+  @override
   String get shareSheetSaveToGallery => 'Galeriye Kaydet';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3455,7 +3455,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get shareSheetSave => 'Kaydet';
 
   @override
-  String get shareSheetSaved => 'Kaydedildi';
+  String get shareSheetRemoveFromSaved => 'Kaydı kaldır';
 
   @override
   String get shareSheetSaveToGallery => 'Galeriye Kaydet';

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -3486,7 +3486,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get shareSheetSave => 'محفوظ کریں';
 
   @override
-  String get shareSheetSaved => 'محفوظ';
+  String get shareSheetRemoveFromSaved => 'محفوظات سے ہٹائیں';
 
   @override
   String get shareSheetSaveToGallery => 'گیلری میں محفوظ کریں';

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -3486,6 +3486,9 @@ class AppLocalizationsUr extends AppLocalizations {
   String get shareSheetSave => 'محفوظ کریں';
 
   @override
+  String get shareSheetSaved => 'محفوظ';
+
+  @override
   String get shareSheetSaveToGallery => 'گیلری میں محفوظ کریں';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -3493,6 +3493,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get shareSheetSave => 'Lưu';
 
   @override
+  String get shareSheetSaved => 'Đã lưu';
+
+  @override
   String get shareSheetSaveToGallery => 'Lưu vào thư viện ảnh';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -3493,7 +3493,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get shareSheetSave => 'Lưu';
 
   @override
-  String get shareSheetSaved => 'Đã lưu';
+  String get shareSheetRemoveFromSaved => 'Xóa khỏi mục đã lưu';
 
   @override
   String get shareSheetSaveToGallery => 'Lưu vào thư viện ảnh';

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -3298,6 +3298,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get shareSheetSave => '保存';
 
   @override
+  String get shareSheetSaved => '已保存';
+
+  @override
   String get shareSheetSaveToGallery => '保存到相册';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -3298,7 +3298,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get shareSheetSave => '保存';
 
   @override
-  String get shareSheetSaved => '已保存';
+  String get shareSheetRemoveFromSaved => '移除收藏';
 
   @override
   String get shareSheetSaveToGallery => '保存到相册';

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -145,16 +145,19 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
         eventId: widget.video.id,
       )..loadConnections();
     }
-    _shareSheetBloc = ShareSheetBloc(
-      video: widget.video,
-      relayUrl: ref.read(currentEnvironmentProvider).relayUrl,
-      videoSharingService: widget.videoSharingService,
-      profileRepository: widget.profileRepository,
-      followRepository: ref.read(followRepositoryProvider),
-      bookmarkServiceFuture: ref.read(bookmarkServiceProvider.future),
-      cacheManager: openVineImageCache,
-      videoClipImportService: ref.read(videoClipImportServiceProvider),
-    )..add(const ShareSheetContactsLoadRequested());
+    _shareSheetBloc =
+        ShareSheetBloc(
+            video: widget.video,
+            relayUrl: ref.read(currentEnvironmentProvider).relayUrl,
+            videoSharingService: widget.videoSharingService,
+            profileRepository: widget.profileRepository,
+            followRepository: ref.read(followRepositoryProvider),
+            bookmarkServiceFuture: ref.read(bookmarkServiceProvider.future),
+            cacheManager: openVineImageCache,
+            videoClipImportService: ref.read(videoClipImportServiceProvider),
+          )
+          ..add(const ShareSheetContactsLoadRequested())
+          ..add(const ShareSheetBookmarkStatusRequested());
   }
 
   @override
@@ -729,6 +732,7 @@ class _UnifiedShareSheetView extends StatelessWidget {
                         video: video,
                         isOwnContent: isOwnContent,
                         isSavePending: state.isSaving,
+                        bookmarkStatus: state.bookmarkStatus,
                         onCrosspost: onCrosspost,
                         onSave: () => bloc.add(const ShareSheetSaveRequested()),
                         onSaveOriginal: onSaveOriginal,

--- a/mobile/lib/widgets/video_feed_item/actions/share_sheet_more_actions.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_sheet_more_actions.dart
@@ -78,11 +78,10 @@ class _MoreActionsSection extends ConsumerWidget {
       _ActionData(
         icon: DivineIconName.bookmarkSimple,
         label: isSaved
-            ? context.l10n.shareSheetSaved
+            ? context.l10n.shareSheetRemoveFromSaved
             : context.l10n.shareSheetSave,
         onTap: onSave,
         isPending: isSavePending,
-        isActive: isSaved,
       ),
       if (onSaveOriginal != null)
         _ActionData(
@@ -170,7 +169,6 @@ class _MoreActionsSection extends ConsumerWidget {
                   label: action.label,
                   onTap: action.onTap,
                   isPending: action.isPending,
-                  isActive: action.isActive,
                 );
               },
             ),
@@ -187,7 +185,6 @@ class _ActionData {
     required this.label,
     required this.onTap,
     this.isPending = false,
-    this.isActive = false,
   });
 
   final DivineIconName icon;
@@ -197,10 +194,6 @@ class _ActionData {
   /// Whether the action is mid-flight, so the circle shows a spinner and stops
   /// responding to taps.
   final bool isPending;
-
-  /// Renders the circle as an on-state. Used by Save to show the video is
-  /// already bookmarked, so the tap reads as a removal rather than an add.
-  final bool isActive;
 }
 
 class _ActionCircle extends StatelessWidget {
@@ -209,31 +202,20 @@ class _ActionCircle extends StatelessWidget {
     required this.label,
     required this.onTap,
     this.isPending = false,
-    this.isActive = false,
   });
 
   final DivineIconName icon;
   final String label;
   final VoidCallback onTap;
   final bool isPending;
-  final bool isActive;
 
   static const double _circleSize = 48;
   static const double _iconSize = 22;
 
   @override
   Widget build(BuildContext context) {
-    // Every action already tints vineGreen, so an on-state cannot be another
-    // green tint. Inverting the fill — solid green with a surface-coloured
-    // glyph — is the same colour-swap idiom LikeActionButton uses, and needs
-    // no filled bookmark asset (none exists; bookmark_plus and bookmark_simple
-    // are byte-identical outlines).
-    final bgColor = isActive
-        ? VineTheme.vineGreen
-        : VineTheme.vineGreen.withValues(alpha: 0.15);
-    final iconColor = isActive
-        ? context.vineColors.surface
-        : VineTheme.vineGreen;
+    final bgColor = VineTheme.vineGreen.withValues(alpha: 0.15);
+    const iconColor = VineTheme.vineGreen;
 
     return Semantics(
       button: true,

--- a/mobile/lib/widgets/video_feed_item/actions/share_sheet_more_actions.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_sheet_more_actions.dart
@@ -8,6 +8,7 @@ class _MoreActionsSection extends ConsumerWidget {
   const _MoreActionsSection({
     required this.video,
     required this.isOwnContent,
+    required this.bookmarkStatus,
     required this.onSave,
     required this.onSaveWithWatermark,
     required this.onAddToList,
@@ -28,6 +29,7 @@ class _MoreActionsSection extends ConsumerWidget {
 
   /// Whether the bookmark toggle is mid-flight (#7073).
   final bool isSavePending;
+  final ShareSheetBookmarkStatus bookmarkStatus;
   final VoidCallback onSave;
   final Future<void> Function()? onSaveOriginal;
   final Future<void> Function() onSaveWithWatermark;
@@ -46,6 +48,8 @@ class _MoreActionsSection extends ConsumerWidget {
     final showDebugTools = ref.watch(
       isFeatureEnabledProvider(FeatureFlag.debugTools),
     );
+
+    final isSaved = bookmarkStatus == ShareSheetBookmarkStatus.saved;
 
     // The crosspost action only appears once the connections fetch
     // reports at least one connected platform.
@@ -69,11 +73,16 @@ class _MoreActionsSection extends ConsumerWidget {
           label: context.l10n.shareMenuDeleteVideo,
           onTap: onDeleteVideo!,
         ),
+      // `unknown` deliberately renders as "Save": an unresolved read must not
+      // claim the video is unsaved, and "Save" is the pre-existing wording.
       _ActionData(
         icon: DivineIconName.bookmarkSimple,
-        label: context.l10n.shareSheetSave,
+        label: isSaved
+            ? context.l10n.shareSheetSaved
+            : context.l10n.shareSheetSave,
         onTap: onSave,
         isPending: isSavePending,
+        isActive: isSaved,
       ),
       if (onSaveOriginal != null)
         _ActionData(
@@ -161,6 +170,7 @@ class _MoreActionsSection extends ConsumerWidget {
                   label: action.label,
                   onTap: action.onTap,
                   isPending: action.isPending,
+                  isActive: action.isActive,
                 );
               },
             ),
@@ -177,6 +187,7 @@ class _ActionData {
     required this.label,
     required this.onTap,
     this.isPending = false,
+    this.isActive = false,
   });
 
   final DivineIconName icon;
@@ -186,6 +197,10 @@ class _ActionData {
   /// Whether the action is mid-flight, so the circle shows a spinner and stops
   /// responding to taps.
   final bool isPending;
+
+  /// Renders the circle as an on-state. Used by Save to show the video is
+  /// already bookmarked, so the tap reads as a removal rather than an add.
+  final bool isActive;
 }
 
 class _ActionCircle extends StatelessWidget {
@@ -194,20 +209,31 @@ class _ActionCircle extends StatelessWidget {
     required this.label,
     required this.onTap,
     this.isPending = false,
+    this.isActive = false,
   });
 
   final DivineIconName icon;
   final String label;
   final VoidCallback onTap;
   final bool isPending;
+  final bool isActive;
 
   static const double _circleSize = 48;
   static const double _iconSize = 22;
 
   @override
   Widget build(BuildContext context) {
-    final bgColor = VineTheme.vineGreen.withValues(alpha: 0.15);
-    const iconColor = VineTheme.vineGreen;
+    // Every action already tints vineGreen, so an on-state cannot be another
+    // green tint. Inverting the fill — solid green with a surface-coloured
+    // glyph — is the same colour-swap idiom LikeActionButton uses, and needs
+    // no filled bookmark asset (none exists; bookmark_plus and bookmark_simple
+    // are byte-identical outlines).
+    final bgColor = isActive
+        ? VineTheme.vineGreen
+        : VineTheme.vineGreen.withValues(alpha: 0.15);
+    final iconColor = isActive
+        ? context.vineColors.surface
+        : VineTheme.vineGreen;
 
     return Semantics(
       button: true,

--- a/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
+++ b/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
@@ -418,11 +418,10 @@ void main() {
                 'selected pubkeys',
                 [testRecipient.pubkey],
               )
-              .having(
-                (s) => s.contacts.map((c) => c.pubkey),
-                'contacts',
-                [testRecipient.pubkey, otherRecipient.pubkey],
-              ),
+              .having((s) => s.contacts.map((c) => c.pubkey), 'contacts', [
+                testRecipient.pubkey,
+                otherRecipient.pubkey,
+              ]),
         ],
       );
     });
@@ -471,11 +470,7 @@ void main() {
           ),
           isA<ShareSheetState>()
               .having((s) => s.isSending, 'isSending', isFalse)
-              .having(
-                (s) => s.selectedRecipients,
-                'selection cleared',
-                isEmpty,
-              )
+              .having((s) => s.selectedRecipients, 'selection cleared', isEmpty)
               .having(
                 (s) => s.actionResult,
                 'actionResult',
@@ -514,24 +509,13 @@ void main() {
             isTrue,
           ),
           isA<ShareSheetState>()
-              .having(
-                (s) => s.selectedRecipients,
-                'selection cleared',
-                isEmpty,
-              )
+              .having((s) => s.selectedRecipients, 'selection cleared', isEmpty)
               .having(
                 (s) => s.actionResult,
                 'actionResult',
                 isA<ShareSheetSendSuccess>()
-                    .having((r) => r.recipientNames, 'names', [
-                      'Alice',
-                      'Bob',
-                    ])
-                    .having(
-                      (r) => r.conversationId,
-                      'conversationId',
-                      isNull,
-                    )
+                    .having((r) => r.recipientNames, 'names', ['Alice', 'Bob'])
+                    .having((r) => r.conversationId, 'conversationId', isNull)
                     .having(
                       (r) => r.recipientPubkey,
                       'recipientPubkey',
@@ -576,11 +560,7 @@ void main() {
           ),
           isA<ShareSheetState>()
               .having((s) => s.isSending, 'isSending', isFalse)
-              .having(
-                (s) => s.selectedRecipients,
-                'selection cleared',
-                isEmpty,
-              )
+              .having((s) => s.selectedRecipients, 'selection cleared', isEmpty)
               .having(
                 (s) => s.actionResult,
                 'actionResult',
@@ -1082,9 +1062,8 @@ void main() {
               libraryTitle: any(named: 'libraryTitle'),
             ),
           ).thenAnswer(
-            (_) async => VideoClipImportSuccess(
-              _clip(libraryTitle: 'My local cut'),
-            ),
+            (_) async =>
+                VideoClipImportSuccess(_clip(libraryTitle: 'My local cut')),
           );
         },
         build: () => createBloc(videoClipImportService: mockImporter),
@@ -1098,11 +1077,7 @@ void main() {
             (state) => state.actionResult,
             'actionResult',
             isA<ShareSheetVideoClipImportResult>()
-                .having(
-                  (result) => result.succeeded,
-                  'succeeded',
-                  isTrue,
-                )
+                .having((result) => result.succeeded, 'succeeded', isTrue)
                 .having(
                   (result) => result.libraryTitle,
                   'libraryTitle',
@@ -1223,11 +1198,7 @@ void main() {
                   'text',
                   'https://divine.video/video/test-id',
                 )
-                .having(
-                  (r) => r.kind,
-                  'kind',
-                  ShareSheetCopiedKind.postLink,
-                ),
+                .having((r) => r.kind, 'kind', ShareSheetCopiedKind.postLink),
           ),
         ],
       );
@@ -1416,11 +1387,7 @@ void main() {
             (s) => s.actionResult,
             'actionResult',
             isA<ShareSheetCopiedToClipboard>()
-                .having(
-                  (r) => r.kind,
-                  'kind',
-                  ShareSheetCopiedKind.eventJson,
-                )
+                .having((r) => r.kind, 'kind', ShareSheetCopiedKind.eventJson)
                 .having(
                   (r) => r.text.contains('"id"'),
                   'text contains id field',
@@ -1471,11 +1438,7 @@ void main() {
             (s) => s.actionResult,
             'actionResult',
             isA<ShareSheetCopiedToClipboard>()
-                .having(
-                  (r) => r.kind,
-                  'kind',
-                  ShareSheetCopiedKind.eventId,
-                )
+                .having((r) => r.kind, 'kind', ShareSheetCopiedKind.eventId)
                 .having(
                   (r) => r.text.startsWith('nevent'),
                   'text starts with nevent',
@@ -1513,6 +1476,8 @@ void main() {
     });
 
     group('ShareSheetBookmarkStatusRequested', () {
+      late Completer<bool> bookmarkStatusSyncCompleter;
+
       blocTest<ShareSheetBloc, ShareSheetState>(
         'resolves saved when the reconciled list contains the video',
         setUp: () {
@@ -1552,6 +1517,58 @@ void main() {
             'bookmarkStatus',
             ShareSheetBookmarkStatus.notSaved,
           ),
+        ],
+      );
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'does not let a late status read overwrite a successful toggle',
+        setUp: () {
+          bookmarkStatusSyncCompleter = Completer<bool>();
+          when(
+            () => mockBookmarkService.syncGlobalBookmarks(),
+          ).thenAnswer((_) => bookmarkStatusSyncCompleter.future);
+          when(
+            () => mockBookmarkService.isVideoBookmarkedGlobally(any()),
+          ).thenReturn(false);
+          when(
+            () => mockBookmarkService.toggleVideoInGlobalBookmarks(any()),
+          ).thenAnswer(
+            (_) async => const BookmarkToggleResult(
+              succeeded: true,
+              wasBookmarked: false,
+              isBookmarked: true,
+            ),
+          );
+          addTearDown(() {
+            if (!bookmarkStatusSyncCompleter.isCompleted) {
+              bookmarkStatusSyncCompleter.complete(false);
+            }
+          });
+        },
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const ShareSheetBookmarkStatusRequested());
+          await Future<void>.delayed(Duration.zero);
+          bloc.add(const ShareSheetSaveRequested());
+          await Future<void>.delayed(Duration.zero);
+          bookmarkStatusSyncCompleter.complete(true);
+        },
+        expect: () => [
+          isA<ShareSheetState>()
+              .having(
+                (s) => s.bookmarkStatus,
+                'bookmarkStatus',
+                ShareSheetBookmarkStatus.saved,
+              )
+              .having(
+                (s) => s.actionResult,
+                'actionResult',
+                isA<ShareSheetSaveResult>().having(
+                  (r) => r.succeeded,
+                  'succeeded',
+                  isTrue,
+                ),
+              ),
         ],
       );
 

--- a/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
+++ b/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
@@ -1554,7 +1554,17 @@ void main() {
           bookmarkStatusSyncCompleter.complete(true);
         },
         expect: () => [
+          // The in-flight save (#7073) emits before the toggle resolves; the
+          // label must not commit to a direction while it is pending.
           isA<ShareSheetState>()
+              .having((s) => s.isSaving, 'isSaving', isTrue)
+              .having(
+                (s) => s.bookmarkStatus,
+                'bookmarkStatus',
+                ShareSheetBookmarkStatus.unknown,
+              ),
+          isA<ShareSheetState>()
+              .having((s) => s.isSaving, 'isSaving', isFalse)
               .having(
                 (s) => s.bookmarkStatus,
                 'bookmarkStatus',
@@ -1617,11 +1627,20 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(const ShareSheetSaveRequested()),
         expect: () => [
-          isA<ShareSheetState>().having(
-            (s) => s.bookmarkStatus,
-            'bookmarkStatus',
-            ShareSheetBookmarkStatus.notSaved,
-          ),
+          isA<ShareSheetState>()
+              .having((s) => s.isSaving, 'isSaving', isTrue)
+              .having(
+                (s) => s.bookmarkStatus,
+                'bookmarkStatus',
+                ShareSheetBookmarkStatus.unknown,
+              ),
+          isA<ShareSheetState>()
+              .having((s) => s.isSaving, 'isSaving', isFalse)
+              .having(
+                (s) => s.bookmarkStatus,
+                'bookmarkStatus',
+                ShareSheetBookmarkStatus.notSaved,
+              ),
         ],
       );
 
@@ -1648,11 +1667,20 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(const ShareSheetSaveRequested()),
         expect: () => [
-          isA<ShareSheetState>().having(
-            (s) => s.bookmarkStatus,
-            'bookmarkStatus',
-            ShareSheetBookmarkStatus.saved,
-          ),
+          isA<ShareSheetState>()
+              .having((s) => s.isSaving, 'isSaving', isTrue)
+              .having(
+                (s) => s.bookmarkStatus,
+                'bookmarkStatus',
+                ShareSheetBookmarkStatus.saved,
+              ),
+          isA<ShareSheetState>()
+              .having((s) => s.isSaving, 'isSaving', isFalse)
+              .having(
+                (s) => s.bookmarkStatus,
+                'bookmarkStatus',
+                ShareSheetBookmarkStatus.saved,
+              ),
         ],
       );
     });

--- a/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
+++ b/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
@@ -147,6 +147,10 @@ void main() {
       expect(bloc.state.selectedRecipients, isEmpty);
       expect(bloc.state.isSending, isFalse);
       expect(bloc.state.actionResult, isNull);
+      expect(
+        bloc.state.bookmarkStatus,
+        equals(ShareSheetBookmarkStatus.unknown),
+      );
       bloc.close();
     });
 
@@ -1503,6 +1507,134 @@ void main() {
             (s) => s.actionResult,
             'actionResult',
             isA<ShareSheetActionFailure>(),
+          ),
+        ],
+      );
+    });
+
+    group('ShareSheetBookmarkStatusRequested', () {
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'resolves saved when the reconciled list contains the video',
+        setUp: () {
+          when(
+            () => mockBookmarkService.syncGlobalBookmarks(),
+          ).thenAnswer((_) async => true);
+          when(
+            () => mockBookmarkService.isVideoBookmarkedGlobally(any()),
+          ).thenReturn(true);
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ShareSheetBookmarkStatusRequested()),
+        expect: () => [
+          isA<ShareSheetState>().having(
+            (s) => s.bookmarkStatus,
+            'bookmarkStatus',
+            ShareSheetBookmarkStatus.saved,
+          ),
+        ],
+      );
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'resolves notSaved when the reconciled list omits the video',
+        setUp: () {
+          when(
+            () => mockBookmarkService.syncGlobalBookmarks(),
+          ).thenAnswer((_) async => true);
+          when(
+            () => mockBookmarkService.isVideoBookmarkedGlobally(any()),
+          ).thenReturn(false);
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ShareSheetBookmarkStatusRequested()),
+        expect: () => [
+          isA<ShareSheetState>().having(
+            (s) => s.bookmarkStatus,
+            'bookmarkStatus',
+            ShareSheetBookmarkStatus.notSaved,
+          ),
+        ],
+      );
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'stays unknown when the reconcile is inconclusive, and never reads '
+        'the stale local cache',
+        setUp: () {
+          when(
+            () => mockBookmarkService.syncGlobalBookmarks(),
+          ).thenAnswer((_) async => false);
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ShareSheetBookmarkStatusRequested()),
+        expect: () => <ShareSheetState>[],
+        verify: (_) {
+          verifyNever(
+            () => mockBookmarkService.isVideoBookmarkedGlobally(any()),
+          );
+        },
+      );
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'stays unknown when the bookmark service is unavailable',
+        build: () =>
+            createBloc(bookmarkServiceFuture: Future<BookmarkService?>.value()),
+        act: (bloc) => bloc.add(const ShareSheetBookmarkStatusRequested()),
+        expect: () => <ShareSheetState>[],
+      );
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'a successful remove flips the status to notSaved',
+        setUp: () {
+          when(
+            () => mockBookmarkService.isVideoBookmarkedGlobally(any()),
+          ).thenReturn(true);
+          when(
+            () => mockBookmarkService.toggleVideoInGlobalBookmarks(any()),
+          ).thenAnswer(
+            (_) async => const BookmarkToggleResult(
+              succeeded: true,
+              wasBookmarked: true,
+              isBookmarked: false,
+            ),
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ShareSheetSaveRequested()),
+        expect: () => [
+          isA<ShareSheetState>().having(
+            (s) => s.bookmarkStatus,
+            'bookmarkStatus',
+            ShareSheetBookmarkStatus.notSaved,
+          ),
+        ],
+      );
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'a failed toggle leaves the status untouched rather than adopting the '
+        'pre-toggle guess',
+        seed: () => const ShareSheetState(
+          bookmarkStatus: ShareSheetBookmarkStatus.saved,
+        ),
+        setUp: () {
+          when(
+            () => mockBookmarkService.isVideoBookmarkedGlobally(any()),
+          ).thenReturn(false);
+          when(
+            () => mockBookmarkService.toggleVideoInGlobalBookmarks(any()),
+          ).thenAnswer(
+            (_) async => const BookmarkToggleResult(
+              succeeded: false,
+              wasBookmarked: false,
+              isBookmarked: false,
+            ),
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ShareSheetSaveRequested()),
+        expect: () => [
+          isA<ShareSheetState>().having(
+            (s) => s.bookmarkStatus,
+            'bookmarkStatus',
+            ShareSheetBookmarkStatus.saved,
           ),
         ],
       );

--- a/mobile/test/widgets/share_video_menu_comprehensive_test.dart
+++ b/mobile/test/widgets/share_video_menu_comprehensive_test.dart
@@ -203,6 +203,49 @@ void main() {
       expect(find.text('Save'), findsOneWidget);
     });
 
+    testWidgets(
+      'More actions row shows Saved once the reconciled read finds the video',
+      (tester) async {
+        when(
+          () => mockBookmarkService.syncGlobalBookmarks(),
+        ).thenAnswer((_) async => true);
+        when(
+          () => mockBookmarkService.isVideoBookmarkedGlobally(any()),
+        ).thenReturn(true);
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        await tester.pumpWidget(buildSubject());
+        await tester.tap(find.byType(ShareActionButton));
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.shareSheetSaved), findsOneWidget);
+        expect(find.text(l10n.shareSheetSave), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'More actions row keeps Save when the reconcile is inconclusive',
+      (tester) async {
+        // The stale local cache says "bookmarked", but the relay read failed.
+        // Believing the cache here is the #7072 mislabel, so the row must not
+        // claim a saved state it could not confirm.
+        when(
+          () => mockBookmarkService.syncGlobalBookmarks(),
+        ).thenAnswer((_) async => false);
+        when(
+          () => mockBookmarkService.isVideoBookmarkedGlobally(any()),
+        ).thenReturn(true);
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        await tester.pumpWidget(buildSubject());
+        await tester.tap(find.byType(ShareActionButton));
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.shareSheetSave), findsOneWidget);
+        expect(find.text(l10n.shareSheetSaved), findsNothing);
+      },
+    );
+
     testWidgets('More actions row shows Copy action', (tester) async {
       await tester.pumpWidget(buildSubject());
       await tester.tap(find.byType(ShareActionButton));

--- a/mobile/test/widgets/share_video_menu_comprehensive_test.dart
+++ b/mobile/test/widgets/share_video_menu_comprehensive_test.dart
@@ -204,7 +204,8 @@ void main() {
     });
 
     testWidgets(
-      'More actions row shows Saved once the reconciled read finds the video',
+      'More actions row offers Remove from saved once the reconciled read '
+      'finds the video',
       (tester) async {
         when(
           () => mockBookmarkService.syncGlobalBookmarks(),
@@ -218,7 +219,7 @@ void main() {
         await tester.tap(find.byType(ShareActionButton));
         await tester.pumpAndSettle();
 
-        expect(find.text(l10n.shareSheetSaved), findsOneWidget);
+        expect(find.text(l10n.shareSheetRemoveFromSaved), findsOneWidget);
         expect(find.text(l10n.shareSheetSave), findsNothing);
       },
     );
@@ -242,7 +243,7 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text(l10n.shareSheetSave), findsOneWidget);
-        expect(find.text(l10n.shareSheetSaved), findsNothing);
+        expect(find.text(l10n.shareSheetRemoveFromSaved), findsNothing);
       },
     );
 

--- a/mobile/test/widgets/share_video_menu_comprehensive_test.dart
+++ b/mobile/test/widgets/share_video_menu_comprehensive_test.dart
@@ -117,6 +117,9 @@ void main() {
       () => mockBookmarkService.isVideoBookmarkedGlobally(any()),
     ).thenReturn(false);
     when(
+      () => mockBookmarkService.syncGlobalBookmarks(),
+    ).thenAnswer((_) async => true);
+    when(
       () => mockBookmarkService.toggleVideoInGlobalBookmarks(any()),
     ).thenAnswer(
       (_) async => const BookmarkToggleResult(
@@ -202,6 +205,24 @@ void main() {
 
       expect(find.text('Save'), findsOneWidget);
     });
+
+    testWidgets(
+      'More actions row keeps Save when the reconciled read omits the video',
+      (tester) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        await tester.pumpWidget(buildSubject());
+        await tester.tap(find.byType(ShareActionButton));
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.shareSheetSave), findsOneWidget);
+        expect(find.text(l10n.shareSheetRemoveFromSaved), findsNothing);
+        verify(() => mockBookmarkService.syncGlobalBookmarks()).called(1);
+        verify(
+          () => mockBookmarkService.isVideoBookmarkedGlobally(testVideo.id),
+        ).called(1);
+      },
+    );
 
     testWidgets(
       'More actions row offers Remove from saved once the reconciled read '
@@ -403,6 +424,7 @@ void main() {
       await tester.pumpWidget(buildSubject());
       await tester.tap(find.byType(ShareActionButton));
       await tester.pumpAndSettle();
+      clearInteractions(mockBookmarkService);
 
       await tester.tap(find.text('Save'));
       await tester.pumpAndSettle();


### PR DESCRIPTION
Closes #7072.

## Problem

The share-sheet Save row rendered a constant label and icon, so it read `Save` even when the video was already bookmarked. After #6966 the toggle decides its direction from an authoritative relay reconcile, so a cold cache plus a relay-held bookmark turns a row labelled `Save` into a **removal**.

This is already pinned as intended *service* behaviour — `bookmark_service_test.dart`'s "removes a video bookmarked on another device", whose comment reads *"Local cache knows nothing, so a pre-read would have said 'add'."* That comment is this issue.

Reproduced on device against a real kind 10003:

```
Synced 2 global bookmarks from relay
Published global bookmarks to Nostr: afa867dd… (accepted by all 1 relay)
Removed item from global bookmarks: 87020fae…
```

The service is correct — the video *is* bookmarked, so removing it is the right toggle. Only the affordance lied. The fix is confined to the UI/BLoC layer; `BookmarkService` is untouched except for separately tracked follow-up work.

## Approach

`ShareSheetBloc` resolves the state on sheet open, so the row can say `Remove from saved` before the tap instead of `Save`.

**The read is deliberately the cheap, non-authoritative `syncGlobalBookmarks()`.** `requireAuthoritative` exists to stop a partially-read list from becoming the base of a replacing publish; a label publishes nothing, and the toggle still reconciles authoritatively before it acts. `ProfileSavedVideosBloc:171` already reads bookmark state for display the same way.

**An inconclusive read stays `unknown` and renders as plain `Save`** — the pre-existing wording — so a failed reconcile is never worse than today, and a stale local cache is never laundered into a confident label. This path is real, not theoretical: the same device session logged `Bookmark sync inconclusive (timedOut=true, requireAuthoritative=false)`.

**A late sheet-open read cannot overwrite a completed toggle's label.** The status handler now returns after the await if the sheet already has a resolved bookmark status. This keeps a stale display-only read from flipping the row back after the user has just saved or removed the video. The broader service-level serialization problem is tracked in #7163.

**A separate row, not a state-dependent label.** When the read resolves to saved, the row becomes `Remove from saved` — it names the direction rather than relying on the reader noticing the `d` in `Saved`. Because the label carries the direction, no on-state colour is needed: this branch adds no field to `_ActionData` or `_ActionCircle` — their `isPending` flag arrives from #7141, already on `main` — so the entire affordance change is one label ternary. The icon stays `bookmarkSimple` — no remove-bookmark asset exists (`bookmark_plus.svg` and `bookmark_simple.svg` are byte-identical outlines) and `trash` already means delete-video two circles away. `_ActionCircle` already wraps its content in `Semantics(button: true, label:)`, so the screen reader now announces an action rather than a state.

## Product decision — resolved

#7072 named **two** shapes without choosing between them: a state-dependent label, or a separate `Remove from saved` row. Reviewed in-thread and settled on the separate row; this PR implements that.

**Copy is not a literal translation.** Every literal rendering of "Remove from saved" overflows the 68px / fontSize-11 / 2-line label slot and ellipsizes — de `Aus Gespeicherten entfernen`, fr `Retirer des enregistrements`, nl `Verwijderen uit opgeslagen`. Each locale instead reuses the verb it already applies to bookmark removal (de `Lesezeichen entfernen`, fr `Retirer des favoris`, ja `保存を外す`), anchored on the existing `peopleListsRemove` / `soundsRemoveSavedSound` / `shareRemovedFromBookmarks` values. All 22 were measured against the real slot under both Roboto and San Francisco; none clips, with `pt` / `bg` / `vi` tightest at 1–3px of headroom. For scale, the slot already truncates the shipping `Mit Wasserzeichen speichern` and `Enregistrer avec filigrane` today.

**What this does not close.** `unknown` still renders `Save` while the tap may remove. A failed reconcile cannot name a direction, and asserting either one would be the #7072 mislabel again — so a destructive tap labelled additively survives exactly where the read is inconclusive. A non-authoritative `notSaved` answer can also be wrong if a newer list only exists on a mute relay. This PR narrows the common confirmed-saved case; #7163 tracks the service-level coordination risk found during review.

## Testing

- 7 BLoC tests (resolves saved / notSaved; late status read cannot overwrite a successful toggle; stays `unknown` on an inconclusive read **and** never touches the stale cache; stays `unknown` with no service; post-toggle refresh; failed toggle leaves status untouched)
- 3 widget tests (keeps `Save` when reconciled not-saved; offers `Remove from saved` when reconciled saved; keeps `Save` when the reconcile fails **even though the stale cache says bookmarked**)
- Mutation-checked twice: removing the `!reconciled` guard turns the "stays unknown" test red; inverting the label ternary turns **both** original widget tests red
- `shareSheetSaved` replaced by `shareSheetRemoveFromSaved` in **all 22 locales** with `@description`
- Rebased onto #7141, which added an in-flight `isSaving` emission ahead of the toggle result. The three bookmark-status BLoC tests now assert both emissions instead of only the last, pinning that the label does not commit to a direction while the save is still pending.

Local:

- `flutter test test/blocs/share_sheet/share_sheet_bloc_test.dart`
- `flutter test test/widgets/share_video_menu_comprehensive_test.dart`
- `dart format --set-exit-if-changed lib/blocs/share_sheet/reportable_sites.dart lib/blocs/share_sheet/share_sheet_bloc.dart test/blocs/share_sheet/share_sheet_bloc_test.dart test/widgets/share_video_menu_comprehensive_test.dart`
- `flutter analyze lib/blocs/share_sheet test/blocs/share_sheet/share_sheet_bloc_test.dart test/widgets/share_video_menu_comprehensive_test.dart`

Verified on an iPhone 17 Pro Max simulator against a real signed-in account and its real kind 10003. That run predates the label swap and exercised the resolution path; the swap itself is covered by widget tests.

## Follow-ups found while investigating

- #7163 — serialize global bookmark syncs so stale overlapping reads cannot overwrite newer local/persisted bookmark state
- non-item tags are dropped on every kind-10003 republish (`title`/`description`/`image`/`alt`) — real for anyone who also uses another Nostr client
- `BookmarkItem` truncates tags to 4 positions
- privately-bookmarked videos read as not-bookmarked, and saving one appends a public `e` tag
- bookmarks key on event id while kind 34236 is addressable, so an edit strands them

