### PR TITLE
fix(video-editor): report why a render produced no video

### DIFF
--- a/mobile/lib/blocs/clips_library/clips_library_bloc.dart
+++ b/mobile/lib/blocs/clips_library/clips_library_bloc.dart
@@ -10,6 +10,8 @@ import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/services/clip_library_service.dart';
 import 'package:openvine/services/gallery_save_service.dart';
 import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
+import 'package:pro_video_editor/pro_video_editor.dart'
+    show RenderCanceledException;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -358,7 +360,11 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
       DivineVideoClip? materialized;
       try {
         // Stop-motion clips render their mp4 on demand before saving.
-        materialized = await StopMotionRenderService.materialize(clip);
+        try {
+          materialized = await StopMotionRenderService.materialize(clip);
+        } on RenderCanceledException {
+          materialized = null;
+        }
         if (materialized == null) {
           failureCount++;
           continue;

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -1239,20 +1239,6 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         return;
       }
 
-      if (result == null) {
-        // A user cancel bumps the generation and is caught above, so reaching
-        // here with a matching generation is a genuine render failure — surface
-        // the retry affordance (#6058).
-        tagOutcome('failed');
-        Log.warning(
-          '⚠️ Video render failed',
-          name: 'VideoEditorNotifier',
-          category: .video,
-        );
-        state = state.copyWith(isProcessing: false, renderFailed: true);
-        return;
-      }
-
       tagOutcome('success');
 
       final (finalRenderedClip, proofManifestJson) = result;
@@ -1285,6 +1271,28 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         proofManifestJson: proofManifestJson,
       );
       autosaveChanges();
+    } on VideoRenderFailedException catch (error) {
+      // A newer render owns the processing flag now — leave it alone.
+      if (generation != _renderGeneration) {
+        tagOutcome('incomplete');
+        return;
+      }
+      trace.putAttribute('failure_reason', error.traceValue);
+      // A cancel without a generation bump is teardown cancelling in-flight
+      // native tasks, not a render that could not produce a video — it belongs
+      // in the same bucket as a superseded render. The retry affordance still
+      // comes up, since the export genuinely did not finish.
+      tagOutcome(
+        error.reason == VideoRenderFailureReason.canceled
+            ? 'incomplete'
+            : 'failed',
+      );
+      Log.warning(
+        '⚠️ Video render produced no video: ${error.traceValue}',
+        name: 'VideoEditorNotifier',
+        category: .video,
+      );
+      state = state.copyWith(isProcessing: false, renderFailed: true);
     } catch (error, stackTrace) {
       // A newer render owns the processing flag now — leave it alone.
       if (generation != _renderGeneration) {
@@ -1292,6 +1300,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         return;
       }
       tagOutcome('error');
+      trace.putAttribute('failure_reason', error.runtimeType.toString());
       // Surface the failure (e.g. a hung/failed C2PA proof step) as an error +
       // retry so the user can restart the render instead of being stuck on the
       // processing overlay (#6058).

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -53,6 +53,8 @@ import 'package:openvine/services/video_editor/video_editor_render_service.dart'
 import 'package:openvine/services/video_publish/publish_error_kind.dart';
 import 'package:openvine/services/video_publish/video_publish_service.dart';
 import 'package:pro_image_editor/pro_image_editor.dart' show CompleteParameters;
+import 'package:pro_video_editor/pro_video_editor.dart'
+    show RenderCanceledException;
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -419,9 +421,14 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
           : null;
 
       if (finalRenderedClip != null && finalRenderedClip.isStopMotion) {
-        final materialized = await StopMotionRenderService.materialize(
-          finalRenderedClip,
-        );
+        DivineVideoClip? materialized;
+        try {
+          materialized = await StopMotionRenderService.materialize(
+            finalRenderedClip,
+          );
+        } on RenderCanceledException {
+          materialized = null;
+        }
         if (materialized == null) {
           setError(stopMotionFailedMessage!);
           await creationTracker.publishFailed(

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -479,20 +479,23 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
           return;
         }
 
-        final result = await VideoEditorRenderService.renderVideoToClip(
-          clips: draft.clips,
-          parameters: parameters,
-          editorStateHistory: draft.editorStateHistory,
-          taskId: draft.id,
-        );
-
-        if (result == null) {
+        final (DivineVideoClip, String?) result;
+        try {
+          result = await VideoEditorRenderService.renderVideoToClip(
+            clips: draft.clips,
+            parameters: parameters,
+            editorStateHistory: draft.editorStateHistory,
+            taskId: draft.id,
+          );
+        } on VideoRenderFailedException catch (error) {
           // `setError` alone is invisible here: nothing on screen reads the
           // error state, so the `.preparing` scrim would just vanish (#6058).
-          // A frames-only draft that got this far failed its stop-motion
-          // assembly, which has its own copy.
+          // A draft whose stop-motion assembly failed has its own copy; every
+          // other failure gets the generic one.
+          final assemblyFailed =
+              error.reason == VideoRenderFailureReason.stopMotionAssembly;
           final message =
-              stopMotionFailedMessage ??
+              (assemblyFailed ? stopMotionFailedMessage : null) ??
               currentAppL10n(
                 ref.read(sharedPreferencesProvider),
               ).publishErrorMessage(PublishErrorKind.generic);
@@ -500,7 +503,7 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
           _showPublishError(message);
           await creationTracker.publishFailed(
             mode: recorderMode,
-            reason: needsStopMotionRender
+            reason: assemblyFailed
                 ? 'stop_motion_render_failed'
                 : 'render_failed',
           );

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -459,7 +459,14 @@ class UploadManager implements BackgroundAwareService {
         <({DivineVideoClip source, DivineVideoClip materialized})>[];
     Future<DivineVideoClip> materializedSource(DivineVideoClip clip) async {
       if (!clip.isStopMotion) return clip;
-      final materialized = await StopMotionRenderService.materialize(clip);
+      final DivineVideoClip? materialized;
+      try {
+        materialized = await StopMotionRenderService.materialize(clip);
+      } on RenderCanceledException {
+        throw StateError(
+          'Stop-motion assembly cancelled for clip ${clip.id} — nothing to upload',
+        );
+      }
       if (materialized == null) {
         throw StateError(
           'Stop-motion assembly failed for clip ${clip.id} — nothing to upload',

--- a/mobile/lib/services/video_editor/stop_motion_render_service.dart
+++ b/mobile/lib/services/video_editor/stop_motion_render_service.dart
@@ -63,8 +63,15 @@ class StopMotionRenderService {
   /// When [taskId] is set, the native encoder emits its progress under that
   /// id via [ProVideoEditor.progressStreamById].
   ///
-  /// Returns the output file path, or null if rendering failed or was
-  /// cancelled. The native render path needs a device build to exercise.
+  /// Returns the output file path, or null if rendering failed.
+  ///
+  /// Throws [RenderCanceledException] when the native assembly is cancelled
+  /// (user cancel or lifecycle teardown via [NativeRenderTaskRegistry]).
+  /// Callers that only need a null-on-failure contract should catch that and
+  /// map it; the final-export path must keep cancel distinct from a failed
+  /// assembly so telemetry does not tag it `stop_motion_assembly`.
+  ///
+  /// The native render path needs a device build to exercise.
   static Future<String?> assemble({
     required List<StopMotionClipFrame> frames,
     required model.AspectRatio aspectRatio,
@@ -110,6 +117,9 @@ class StopMotionRenderService {
   /// Returns `null` only when the render fails, so callers (publish, gallery
   /// save) can surface a failure instead of proceeding with a clip that has no
   /// playable video.
+  ///
+  /// Throws [RenderCanceledException] when assembly is cancelled — see
+  /// [assemble].
   static Future<DivineVideoClip?> materialize(
     DivineVideoClip clip, {
     String? taskId,
@@ -293,7 +303,10 @@ class StopMotionRenderService {
         category: LogCategory.video,
       );
       await _deletePartialOutput(outputPath);
-      return null;
+      // Keep cancel distinct from a failed assembly: collapsing both to null
+      // made the final-export path tag detach mid-assembly as
+      // `stop_motion_assembly` / `failed` instead of `canceled` / `incomplete`.
+      rethrow;
     } catch (e, stack) {
       Log.error(
         '❌ Stop-motion assembly failed: $e',

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -487,13 +487,25 @@ class VideoEditorRenderService {
             stepCount: assemblyStepCount,
           );
           assemblyStep++;
-          final materialized = await StopMotionRenderService.materialize(
-            clip,
-            taskId: assemblyTaskId,
-          );
-          if (materialized == null) {
-            throw const VideoRenderFailedException(
-              VideoRenderFailureReason.stopMotionAssembly,
+          final DivineVideoClip materialized;
+          try {
+            final assembled = await StopMotionRenderService.materialize(
+              clip,
+              taskId: assemblyTaskId,
+            );
+            if (assembled == null) {
+              throw const VideoRenderFailedException(
+                VideoRenderFailureReason.stopMotionAssembly,
+              );
+            }
+            materialized = assembled;
+          } on RenderCanceledException catch (e) {
+            // Detach / cancelActiveNativeTasks during assembly must not land
+            // in the stop_motion_assembly bucket — same incomplete semantics
+            // as a cancelled composite render.
+            throw VideoRenderFailedException(
+              VideoRenderFailureReason.canceled,
+              cause: e,
             );
           }
           final intermediatePath = materialized.video?.file?.path;

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -25,6 +25,56 @@ import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+/// Why a render produced no output.
+///
+/// Carried by [VideoRenderFailedException] and reported as the
+/// `failure_reason` attribute on the `video_generation` trace, so a render
+/// that fails on device can be told apart from one that was superseded (#7125).
+enum VideoRenderFailureReason {
+  /// Nothing to render — the clip list was empty.
+  emptyClips('empty_clips'),
+
+  /// A stop-motion clip could not be assembled into its base video.
+  stopMotionAssembly('stop_motion_assembly'),
+
+  /// The native render pipeline threw.
+  nativeRender('native_render'),
+
+  /// The native task was cancelled — by the user, or by teardown
+  /// (`AppLifecycleState.detached`) cancelling every in-flight task.
+  canceled('canceled');
+
+  const VideoRenderFailureReason(this.traceValue);
+
+  /// Stable identifier used in telemetry. Independent of the enum name so a
+  /// rename cannot silently split a Firebase dimension.
+  final String traceValue;
+}
+
+/// Thrown when a render finished without producing a video.
+class VideoRenderFailedException implements Exception {
+  const VideoRenderFailedException(this.reason, {this.cause});
+
+  final VideoRenderFailureReason reason;
+
+  /// The underlying error, when the failure came from a throw rather than a
+  /// guard. Native failures surface here as `PlatformException`.
+  final Object? cause;
+
+  /// Compact telemetry label, e.g. `native_render:PlatformException`.
+  ///
+  /// The cause's type — never its message — so device paths and other
+  /// free-form native text stay out of the trace attribute.
+  String get traceValue => cause == null
+      ? reason.traceValue
+      : '${reason.traceValue}:${cause.runtimeType}';
+
+  @override
+  String toString() =>
+      'VideoRenderFailedException(${reason.traceValue})'
+      '${cause == null ? '' : ': $cause'}';
+}
+
 /// Result of normalizing clips to a target aspect ratio.
 class _NormalizationResult {
   const _NormalizationResult({
@@ -334,7 +384,7 @@ class VideoEditorRenderService {
   /// When set, [renderVideoToClip] delegates to this callback instead of
   /// running the real render pipeline. Reset to `null` in `tearDown`.
   @visibleForTesting
-  static Future<(DivineVideoClip, String? proofManifestJson)?> Function({
+  static Future<(DivineVideoClip, String? proofManifestJson)> Function({
     required List<DivineVideoClip> clips,
     required Map<String, dynamic> editorStateHistory,
     CompleteParameters? parameters,
@@ -370,8 +420,12 @@ class VideoEditorRenderService {
   /// - The rendered [DivineVideoClip]
   /// - The proofManifestJson (or null if ProofMode unavailable)
   ///
-  /// Returns null if rendering failed/cancelled.
-  static Future<(DivineVideoClip, String? proofManifestJson)?>
+  /// Throws:
+  ///
+  /// * [VideoRenderFailedException] if the render produced no video — the
+  ///   reason distinguishes an empty clip list, a failed stop-motion assembly,
+  ///   a native render failure, and a cancellation.
+  static Future<(DivineVideoClip, String? proofManifestJson)>
   renderVideoToClip({
     required List<DivineVideoClip> clips,
     required Map<String, dynamic> editorStateHistory,
@@ -387,7 +441,11 @@ class VideoEditorRenderService {
       );
     }
 
-    if (clips.isEmpty) return null;
+    if (clips.isEmpty) {
+      throw const VideoRenderFailedException(
+        VideoRenderFailureReason.emptyClips,
+      );
+    }
 
     final effectiveTaskId = taskId ?? clips.first.id;
     // Frames-only stop-motion clips need an assembly pass (stills → base mp4)
@@ -425,7 +483,11 @@ class VideoEditorRenderService {
             clip,
             taskId: assemblyTaskId,
           );
-          if (materialized == null) return null;
+          if (materialized == null) {
+            throw const VideoRenderFailedException(
+              VideoRenderFailureReason.stopMotionAssembly,
+            );
+          }
           final intermediatePath = materialized.video?.file?.path;
           if (intermediatePath != null) {
             intermediateStopMotionPaths.add(intermediatePath);
@@ -445,15 +507,13 @@ class VideoEditorRenderService {
         category: LogCategory.video,
       );
 
-      final outputPath = await renderVideo(
+      final outputPath = await _renderVideoOrThrow(
         clips: clips,
         aspectRatio: clips.first.targetAspectRatio,
         usePersistentStorage: true,
         parameters: parameters,
         taskId: effectiveTaskId,
       );
-
-      if (outputPath == null) return null;
 
       await progressTracker.markRenderComplete();
 
@@ -629,7 +689,35 @@ class VideoEditorRenderService {
   /// [VideoEditorConstants.maxDuration] for the final-export path; pass `null`
   /// to render the full concatenation uncapped (e.g. when merging clips into an
   /// intermediate editor clip that the user can still trim).
+  ///
+  /// Callers that need to know *why* a render produced nothing should use
+  /// [_renderVideoOrThrow] instead — this wrapper collapses every failure to
+  /// `null`.
   static Future<String?> renderVideo({
+    required List<DivineVideoClip> clips,
+    bool usePersistentStorage = false,
+    model.AspectRatio? aspectRatio,
+    CompleteParameters? parameters,
+    String? taskId,
+    Duration? maxOutputDuration = VideoEditorConstants.maxDuration,
+  }) async {
+    try {
+      return await _renderVideoOrThrow(
+        clips: clips,
+        usePersistentStorage: usePersistentStorage,
+        aspectRatio: aspectRatio,
+        parameters: parameters,
+        taskId: taskId,
+        maxOutputDuration: maxOutputDuration,
+      );
+    } on VideoRenderFailedException {
+      return null;
+    }
+  }
+
+  /// [renderVideo], but throws [VideoRenderFailedException] instead of
+  /// returning null so the caller can report why the render produced nothing.
+  static Future<String> _renderVideoOrThrow({
     required List<DivineVideoClip> clips,
     bool usePersistentStorage = false,
     model.AspectRatio? aspectRatio,
@@ -639,7 +727,7 @@ class VideoEditorRenderService {
   }) async {
     final override = renderVideoOverride;
     if (override != null) {
-      return override(
+      final overridden = await override(
         clips: clips,
         usePersistentStorage: usePersistentStorage,
         aspectRatio: aspectRatio,
@@ -647,6 +735,12 @@ class VideoEditorRenderService {
         taskId: taskId,
         maxOutputDuration: maxOutputDuration,
       );
+      if (overridden == null) {
+        throw const VideoRenderFailedException(
+          VideoRenderFailureReason.nativeRender,
+        );
+      }
+      return overridden;
     }
 
     final cacheDir = await getTemporaryDirectory();
@@ -698,28 +792,33 @@ class VideoEditorRenderService {
       );
 
       return outputPath;
-    } on RenderCanceledException {
+    } on RenderCanceledException catch (e) {
       Log.info(
         '🚫 Video render cancelled by user',
         name: _logName,
         category: .video,
       );
       unawaited(_cleanupTempFiles(tempFilePaths));
-      return null;
+      throw VideoRenderFailedException(
+        VideoRenderFailureReason.canceled,
+        cause: e,
+      );
     } catch (e, stack) {
       Log.error('❌ Video render failed: $e', name: _logName, category: .video);
       unawaited(_cleanupTempFiles(tempFilePaths));
-      // Native/IO render failures are expected; only programming-invariant
-      // violations (StateError/TypeError/RangeError — all `Error` subtypes)
-      // are worth surfacing to Crashlytics.
-      if (e is Error) {
-        CrashReportingService.instance.recordError(
-          e,
-          stack,
-          reason: 'renderVideo failed',
-        );
-      }
-      return null;
+      // Every failure is reported, not just `Error` subtypes: a failed export
+      // is a dead end for the user, and the native pipeline signals its
+      // failures as `PlatformException`, which is not an `Error`. Gating on
+      // `Error` left the entire population invisible in Crashlytics (#7125).
+      CrashReportingService.instance.recordError(
+        e,
+        stack,
+        reason: 'renderVideo failed',
+      );
+      throw VideoRenderFailedException(
+        VideoRenderFailureReason.nativeRender,
+        cause: e,
+      );
     }
   }
 

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -407,6 +407,14 @@ class VideoEditorRenderService {
   })?
   renderVideoOverride;
 
+  /// Test-only override for the Crashlytics report a failed render files.
+  ///
+  /// When set, [_reportRenderFailure] delegates to this callback instead of
+  /// [CrashReportingService]. Reset to `null` in `tearDown`.
+  @visibleForTesting
+  static void Function(Object error, StackTrace stackTrace)?
+  crashReporterOverride;
+
   // ─────────────────────────────────────────────────────────────────────────
   // Public API
   // ─────────────────────────────────────────────────────────────────────────
@@ -513,6 +521,7 @@ class VideoEditorRenderService {
         usePersistentStorage: true,
         parameters: parameters,
         taskId: effectiveTaskId,
+        reportEveryFailure: true,
       );
 
       await progressTracker.markRenderComplete();
@@ -690,9 +699,12 @@ class VideoEditorRenderService {
   /// to render the full concatenation uncapped (e.g. when merging clips into an
   /// intermediate editor clip that the user can still trim).
   ///
-  /// Callers that need to know *why* a render produced nothing should use
-  /// [_renderVideoOrThrow] instead — this wrapper collapses every failure to
-  /// `null`.
+  /// Every failure — a cancellation included — collapses to `null` here, so
+  /// callers cannot tell them apart, and only a programming-invariant
+  /// violation (an `Error` subtype) is reported to Crashlytics. The
+  /// final-export path ([renderVideoToClip]) instead surfaces a
+  /// [VideoRenderFailedException] naming the reason, and reports every
+  /// failure.
   static Future<String?> renderVideo({
     required List<DivineVideoClip> clips,
     bool usePersistentStorage = false,
@@ -717,6 +729,10 @@ class VideoEditorRenderService {
 
   /// [renderVideo], but throws [VideoRenderFailedException] instead of
   /// returning null so the caller can report why the render produced nothing.
+  ///
+  /// [reportEveryFailure] widens Crashlytics reporting from `Error` subtypes to
+  /// every failure. Only the final export ([renderVideoToClip]) passes it —
+  /// see [_reportRenderFailure].
   static Future<String> _renderVideoOrThrow({
     required List<DivineVideoClip> clips,
     bool usePersistentStorage = false,
@@ -724,32 +740,34 @@ class VideoEditorRenderService {
     CompleteParameters? parameters,
     String? taskId,
     Duration? maxOutputDuration = VideoEditorConstants.maxDuration,
+    bool reportEveryFailure = false,
   }) async {
-    final override = renderVideoOverride;
-    if (override != null) {
-      final overridden = await override(
-        clips: clips,
-        usePersistentStorage: usePersistentStorage,
-        aspectRatio: aspectRatio,
-        parameters: parameters,
-        taskId: taskId,
-        maxOutputDuration: maxOutputDuration,
-      );
-      if (overridden == null) {
-        throw const VideoRenderFailedException(
-          VideoRenderFailureReason.nativeRender,
-        );
-      }
-      return overridden;
-    }
-
-    final cacheDir = await getTemporaryDirectory();
-    final outputDir = usePersistentStorage
-        ? await getApplicationDocumentsDirectory()
-        : cacheDir;
     var tempFilePaths = <String>[];
 
     try {
+      final override = renderVideoOverride;
+      if (override != null) {
+        final overridden = await override(
+          clips: clips,
+          usePersistentStorage: usePersistentStorage,
+          aspectRatio: aspectRatio,
+          parameters: parameters,
+          taskId: taskId,
+          maxOutputDuration: maxOutputDuration,
+        );
+        if (overridden == null) {
+          throw const VideoRenderFailedException(
+            VideoRenderFailureReason.nativeRender,
+          );
+        }
+        return overridden;
+      }
+
+      final cacheDir = await getTemporaryDirectory();
+      final outputDir = usePersistentStorage
+          ? await getApplicationDocumentsDirectory()
+          : cacheDir;
+
       Log.debug(
         '🎞️ Rendering ${clips.length} clip(s) to final video',
         name: _logName,
@@ -792,6 +810,10 @@ class VideoEditorRenderService {
       );
 
       return outputPath;
+    } on VideoRenderFailedException {
+      // Already classified (the test override's null return) — re-wrapping it
+      // below would report it a second time under the wrong cause.
+      rethrow;
     } on RenderCanceledException catch (e) {
       Log.info(
         '🚫 Video render cancelled by user',
@@ -806,20 +828,44 @@ class VideoEditorRenderService {
     } catch (e, stack) {
       Log.error('❌ Video render failed: $e', name: _logName, category: .video);
       unawaited(_cleanupTempFiles(tempFilePaths));
-      // Every failure is reported, not just `Error` subtypes: a failed export
-      // is a dead end for the user, and the native pipeline signals its
-      // failures as `PlatformException`, which is not an `Error`. Gating on
-      // `Error` left the entire population invisible in Crashlytics (#7125).
-      CrashReportingService.instance.recordError(
-        e,
-        stack,
-        reason: 'renderVideo failed',
-      );
+      _reportRenderFailure(e, stack, reportEveryFailure: reportEveryFailure);
       throw VideoRenderFailedException(
         VideoRenderFailureReason.nativeRender,
         cause: e,
       );
     }
+  }
+
+  /// Files a failed render to Crashlytics, unless the caller treats a failure
+  /// as recoverable.
+  ///
+  /// The final export reports everything, not just `Error` subtypes: it is a
+  /// dead end for the user, and the native pipeline signals its failures as
+  /// `PlatformException`, which is not an `Error` — gating on `Error` left the
+  /// entire population invisible in Crashlytics (#7125).
+  ///
+  /// Every other [renderVideo] caller stays on the `Error` gate. A transition
+  /// seam falls back to a hard cut and is never negative-cached, so
+  /// `_ensureSeamsRendered` re-attempts a failing boundary on each timeline
+  /// change — reporting each attempt would bury the export failures this is
+  /// meant to surface.
+  static void _reportRenderFailure(
+    Object error,
+    StackTrace stackTrace, {
+    required bool reportEveryFailure,
+  }) {
+    if (!reportEveryFailure && error is! Error) return;
+
+    final override = crashReporterOverride;
+    if (override != null) {
+      override(error, stackTrace);
+      return;
+    }
+    CrashReportingService.instance.recordError(
+      error,
+      stackTrace,
+      reason: 'renderVideo failed',
+    );
   }
 
   /// Limits a clip's duration to a specified length.

--- a/mobile/lib/utils/gallery_save_utils.dart
+++ b/mobile/lib/utils/gallery_save_utils.dart
@@ -8,6 +8,8 @@ import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/services/gallery_save_service.dart';
 import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
 import 'package:openvine/widgets/gallery_permission_sheet.dart';
+import 'package:pro_video_editor/pro_video_editor.dart'
+    show RenderCanceledException;
 
 /// Saves the final rendered video to the device gallery.
 ///
@@ -25,9 +27,13 @@ Future<void> saveToGallery(BuildContext context, WidgetRef ref) async {
   DivineVideoClip? materialized;
   try {
     // Stop-motion clips render their mp4 on demand; a normal clip passes through.
-    materialized = await StopMotionRenderService.materialize(
-      finalRenderedClip,
-    );
+    try {
+      materialized = await StopMotionRenderService.materialize(
+        finalRenderedClip,
+      );
+    } on RenderCanceledException {
+      return;
+    }
     if (materialized == null || !context.mounted) return;
     final video = materialized.requireVideo;
 

--- a/mobile/lib/widgets/video_clip/video_clip_preview.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_preview.dart
@@ -18,6 +18,8 @@ import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
 import 'package:openvine/widgets/stop_motion/stop_motion_player.dart';
 import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
 import 'package:openvine/widgets/video_clip/video_clip_hero.dart';
+import 'package:pro_video_editor/pro_video_editor.dart'
+    show RenderCanceledException;
 import 'package:unified_logger/unified_logger.dart';
 
 class VideoClipPreview extends ConsumerStatefulWidget {
@@ -111,7 +113,11 @@ class _VideoClipPreviewSheetState extends ConsumerState<VideoClipPreview> {
       final gallerySaveService = ref.read(gallerySaveServiceProvider);
       // Stop-motion clips render their mp4 on demand; a normal clip passes
       // through unchanged.
-      materialized = await StopMotionRenderService.materialize(widget.clip);
+      try {
+        materialized = await StopMotionRenderService.materialize(widget.clip);
+      } on RenderCanceledException {
+        materialized = null;
+      }
       if (!mounted) return;
       if (materialized == null) {
         ScaffoldMessenger.of(context).showSnackBar(

--- a/mobile/scripts/check_process_global_mutations.sh
+++ b/mobile/scripts/check_process_global_mutations.sh
@@ -98,6 +98,7 @@ RESET_TO_DEFAULT_GLOBALS=(
   'debugUsesAppleAppStoreTipPolicyOverride:null'
   'VideoEditorRenderService\.renderVideoOverride:null'
   'VideoEditorRenderService\.renderVideoToClipOverride:null'
+  'VideoEditorRenderService\.crashReporterOverride:null'
   'NativeProofModeService\.proofFileOverride:null'
   'NativeProofModeService\.c2paSigningServiceFactoryOverride:null'
   'InfiniteVideoFeed\.debugIsSupportedOverride:null'

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -4,13 +4,12 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:typed_data';
-import 'dart:ui';
 
 import 'package:characters/characters.dart';
 import 'package:db_client/db_client.dart';
 import 'package:drift/native.dart';
 import 'package:fake_async/fake_async.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -604,20 +603,22 @@ void main() {
               required editorStateHistory,
               parameters,
               taskId,
-            }) async => null;
+            }) async => throw const VideoRenderFailedException(
+              VideoRenderFailureReason.nativeRender,
+            );
 
         await notifier.startRenderVideo();
 
         final state = container.read(videoEditorProvider);
         expect(state.isProcessing, isFalse);
         expect(state.finalRenderedClip, isNull);
-        // The null-return path is the primary way a genuine render failure
+        // A render that produced no video is the primary way a genuine failure
         // surfaces the retry overlay — a regression that drops this flag would
         // leave the user stuck with no way to retry (#6058).
         expect(
           state.renderFailed,
           isTrue,
-          reason: 'a null render result surfaces the retry affordance',
+          reason: 'a failed render surfaces the retry affordance',
         );
       });
 
@@ -692,8 +693,8 @@ void main() {
               duration: const Duration(seconds: 2),
             );
 
-        final slowCompleter = Completer<(DivineVideoClip, String?)?>();
-        final fastCompleter = Completer<(DivineVideoClip, String?)?>();
+        final slowCompleter = Completer<(DivineVideoClip, String?)>();
+        final fastCompleter = Completer<(DivineVideoClip, String?)>();
 
         var callCount = 0;
         VideoEditorRenderService.renderVideoToClipOverride =
@@ -765,8 +766,8 @@ void main() {
               duration: const Duration(seconds: 2),
             );
 
-        final slowCompleter = Completer<(DivineVideoClip, String?)?>();
-        final fastCompleter = Completer<(DivineVideoClip, String?)?>();
+        final slowCompleter = Completer<(DivineVideoClip, String?)>();
+        final fastCompleter = Completer<(DivineVideoClip, String?)>();
 
         var callCount = 0;
         VideoEditorRenderService.renderVideoToClipOverride =
@@ -784,15 +785,18 @@ void main() {
 
         // Start first (slow) render
         final render1 = notifier.startRenderVideo();
-        // Start second render — will complete with null (cancelled)
+        // Start second render — will fail
         final render2 = notifier.startRenderVideo();
 
-        // Second render returns null (simulating cancellation)
-        fastCompleter.complete(null);
+        // Second render produces no video (simulating a native failure)
+        fastCompleter.completeError(
+          const VideoRenderFailedException(
+            VideoRenderFailureReason.nativeRender,
+          ),
+        );
         await render2;
 
-        // isProcessing should be false after the latest render
-        // returned null
+        // isProcessing should be false after the latest render failed
         expect(container.read(videoEditorProvider).isProcessing, isFalse);
 
         // Now the stale render completes — should be silently
@@ -841,7 +845,9 @@ void main() {
               taskId,
             }) async {
               capturedTaskId = taskId;
-              return null;
+              throw const VideoRenderFailedException(
+                VideoRenderFailureReason.nativeRender,
+              );
             };
 
         await notifier.startRenderVideo();
@@ -875,7 +881,9 @@ void main() {
               taskId,
             }) async {
               capturedTaskId = taskId;
-              return null;
+              throw const VideoRenderFailedException(
+                VideoRenderFailureReason.nativeRender,
+              );
             };
 
         await notifier.startRenderVideo();
@@ -1041,7 +1049,9 @@ void main() {
               taskId,
             }) async {
               reRendered = true;
-              return null;
+              throw const VideoRenderFailedException(
+                VideoRenderFailureReason.nativeRender,
+              );
             };
         NativeProofModeService.proofFileOverride =
             (
@@ -1339,8 +1349,8 @@ void main() {
           final notifier = container.read(videoEditorProvider.notifier);
           addOneClip();
 
-          final slowCompleter = Completer<(DivineVideoClip, String?)?>();
-          final fastCompleter = Completer<(DivineVideoClip, String?)?>();
+          final slowCompleter = Completer<(DivineVideoClip, String?)>();
+          final fastCompleter = Completer<(DivineVideoClip, String?)>();
           var callCount = 0;
           VideoEditorRenderService.renderVideoToClipOverride =
               ({
@@ -1397,25 +1407,77 @@ void main() {
         },
       );
 
-      test('tags outcome=failed when the render returns null', () async {
-        final notifier = container.read(videoEditorProvider.notifier);
-        addOneClip();
+      void failRenderWith(VideoRenderFailedException failure) {
         VideoEditorRenderService.renderVideoToClipOverride =
             ({
               required clips,
               required editorStateHistory,
               parameters,
               taskId,
-            }) async => null;
+            }) async => throw failure;
+      }
+
+      test('tags outcome=failed with the reason behind a render that produced '
+          'no video (#7125)', () async {
+        final notifier = container.read(videoEditorProvider.notifier);
+        addOneClip();
+        failRenderWith(
+          const VideoRenderFailedException(
+            VideoRenderFailureReason.stopMotionAssembly,
+          ),
+        );
 
         await notifier.startRenderVideo();
+        final trace = performanceMonitor.traces.single;
+        expect(trace.attributes['outcome'], 'failed');
+        expect(trace.attributes['failure_reason'], 'stop_motion_assembly');
+      });
+
+      test('carries the native cause type in the reason, not its message '
+          '(#7125)', () async {
+        final notifier = container.read(videoEditorProvider.notifier);
+        addOneClip();
+        failRenderWith(
+          VideoRenderFailedException(
+            VideoRenderFailureReason.nativeRender,
+            cause: PlatformException(
+              code: 'RENDER_ERROR',
+              message: '/var/mobile/Containers/Data/Application/x/clip.mp4',
+            ),
+          ),
+        );
+
+        await notifier.startRenderVideo();
+        final reason =
+            performanceMonitor.traces.single.attributes['failure_reason'];
+        expect(reason, 'native_render:PlatformException');
         expect(
-          performanceMonitor.traces.single.attributes['outcome'],
-          'failed',
+          reason,
+          isNot(contains('/var/mobile')),
+          reason: 'device paths must not ride into a trace attribute',
         );
       });
 
-      test('tags outcome=error when the render throws', () async {
+      test('tags a cancelled render incomplete, not failed (#7125)', () async {
+        final notifier = container.read(videoEditorProvider.notifier);
+        addOneClip();
+        failRenderWith(
+          const VideoRenderFailedException(VideoRenderFailureReason.canceled),
+        );
+
+        await notifier.startRenderVideo();
+        final trace = performanceMonitor.traces.single;
+        expect(
+          trace.attributes['outcome'],
+          'incomplete',
+          reason:
+              'teardown cancelling in-flight native tasks is not a render that '
+              'could not produce a video',
+        );
+        expect(trace.attributes['failure_reason'], 'canceled');
+      });
+
+      test('tags outcome=error with the type when the render throws', () async {
         final notifier = container.read(videoEditorProvider.notifier);
         addOneClip();
         VideoEditorRenderService.renderVideoToClipOverride =
@@ -1424,13 +1486,12 @@ void main() {
               required editorStateHistory,
               parameters,
               taskId,
-            }) async => throw Exception('render boom');
+            }) async => throw StateError('render boom');
 
         await notifier.startRenderVideo();
-        expect(
-          performanceMonitor.traces.single.attributes['outcome'],
-          'error',
-        );
+        final trace = performanceMonitor.traces.single;
+        expect(trace.attributes['outcome'], 'error');
+        expect(trace.attributes['failure_reason'], 'StateError');
       });
     });
 
@@ -1523,7 +1584,7 @@ void main() {
                 limitClipDuration: false,
               );
 
-          final renderCompleter = Completer<(DivineVideoClip, String?)?>();
+          final renderCompleter = Completer<(DivineVideoClip, String?)>();
           VideoEditorRenderService.renderVideoToClipOverride =
               ({
                 required clips,
@@ -1548,7 +1609,11 @@ void main() {
                 'until the active render future has released native resources',
           );
 
-          renderCompleter.complete(null);
+          renderCompleter.completeError(
+            const VideoRenderFailedException(
+              VideoRenderFailureReason.canceled,
+            ),
+          );
           await cancel;
           await render;
 

--- a/mobile/test/providers/video_publish_provider_test.dart
+++ b/mobile/test/providers/video_publish_provider_test.dart
@@ -558,7 +558,10 @@ void main() {
               taskId,
             }) async {
               renderCalls++;
-              return null; // stop the publish here; the render is the assertion
+              // Stop the publish here; the render call is the assertion.
+              throw const VideoRenderFailedException(
+                VideoRenderFailureReason.nativeRender,
+              );
             };
 
         final context = tester.element(find.byType(SizedBox));
@@ -583,7 +586,9 @@ void main() {
               required editorStateHistory,
               parameters,
               taskId,
-            }) async => null;
+            }) async => throw const VideoRenderFailedException(
+              VideoRenderFailureReason.nativeRender,
+            );
 
         final context = tester.element(find.byType(SizedBox));
         await container
@@ -615,7 +620,9 @@ void main() {
               required editorStateHistory,
               parameters,
               taskId,
-            }) async => null;
+            }) async => throw const VideoRenderFailedException(
+              VideoRenderFailureReason.stopMotionAssembly,
+            );
 
         final context = tester.element(find.byType(SizedBox));
         await container
@@ -666,7 +673,9 @@ void main() {
               taskId,
             }) async {
               renderCalls++;
-              return null;
+              throw const VideoRenderFailedException(
+                VideoRenderFailureReason.nativeRender,
+              );
             };
 
         final context = tester.element(find.byType(SizedBox));

--- a/mobile/test/services/video_editor/video_editor_render_service_progress_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_progress_test.dart
@@ -263,13 +263,12 @@ void main() {
         );
         await _flushStreamEvents();
 
-        expect(result, isNotNull);
-        expect(result?.$2, isNotNull);
+        expect(result.$2, isNotNull);
         // Cover extraction cannot succeed here (the render output is never
         // written), so the clip must fall back to the first source clip's
         // thumbnail rather than being left without a preview.
         expect(
-          result?.$1.thumbnailPath,
+          result.$1.thumbnailPath,
           equals('${Directory.systemTemp.path}/clip-0-thumb.jpg'),
         );
         expect(
@@ -374,14 +373,12 @@ void main() {
           originalAspectRatio: 9 / 16,
         );
 
-        final result = await VideoEditorRenderService.renderVideoToClip(
+        await VideoEditorRenderService.renderVideoToClip(
           clips: [stopMotionClip],
           editorStateHistory: const {},
           taskId: taskId,
         );
         await _flushStreamEvents();
-
-        expect(result, isNotNull);
 
         // One clip → 5% proof budget; the remaining 95% splits evenly
         // between the assembly pass and the composite render.

--- a/mobile/test/services/video_editor/video_editor_render_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_test.dart
@@ -503,4 +503,56 @@ void main() {
       });
     });
   });
+
+  group('render failure reporting (#7125)', () {
+    tearDown(() {
+      VideoEditorRenderService.renderVideoOverride = null;
+    });
+
+    test('renderVideoToClip names an empty clip list as the reason', () async {
+      await expectLater(
+        VideoEditorRenderService.renderVideoToClip(
+          clips: const [],
+          editorStateHistory: const {},
+        ),
+        throwsA(
+          isA<VideoRenderFailedException>().having(
+            (e) => e.reason,
+            'reason',
+            VideoRenderFailureReason.emptyClips,
+          ),
+        ),
+      );
+    });
+
+    test('renderVideo keeps returning null so callers that only need the '
+        'path are unaffected', () async {
+      VideoEditorRenderService.renderVideoOverride =
+          ({
+            required clips,
+            required usePersistentStorage,
+            aspectRatio,
+            parameters,
+            taskId,
+            maxOutputDuration,
+          }) async => null;
+
+      expect(
+        await VideoEditorRenderService.renderVideo(
+          clips: [clip('a', const Duration(seconds: 1))],
+        ),
+        isNull,
+      );
+    });
+
+    test('traceValue carries the cause type, never its message', () {
+      const failure = VideoRenderFailedException(
+        VideoRenderFailureReason.nativeRender,
+        cause: FormatException('/var/mobile/Containers/Data/x/clip.mp4'),
+      );
+
+      expect(failure.traceValue, 'native_render:FormatException');
+      expect(failure.toString(), contains('/var/mobile'));
+    });
+  });
 }

--- a/mobile/test/services/video_editor/video_editor_render_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_test.dart
@@ -15,7 +15,9 @@ import 'package:models/models.dart' as model;
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/extensions/aspect_ratio_extensions.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/models/video_editor/transition_geometry.dart';
+import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:pro_image_editor/pro_image_editor.dart' as pie;
 import 'package:pro_video_editor/pro_video_editor.dart'
@@ -508,8 +510,17 @@ void main() {
   });
 
   group('render failure reporting (#7125)', () {
+    late ProVideoEditor originalProVideoEditor;
+
+    setUp(() {
+      originalProVideoEditor = ProVideoEditor.instance;
+      ProVideoEditor.instance = _StubProVideoEditor();
+    });
+
     tearDown(() {
+      ProVideoEditor.instance = originalProVideoEditor;
       VideoEditorRenderService.renderVideoOverride = null;
+      StopMotionRenderService.assembleOverride = null;
     });
 
     test('renderVideoToClip names an empty clip list as the reason', () async {
@@ -524,6 +535,51 @@ void main() {
             'reason',
             VideoRenderFailureReason.emptyClips,
           ),
+        ),
+      );
+    });
+
+    test('renderVideoToClip maps a cancelled stop-motion assembly to canceled, '
+        'not stop_motion_assembly', () async {
+      StopMotionRenderService.assembleOverride =
+          ({
+            required frames,
+            required aspectRatio,
+            frameRate = StopMotionRenderService.defaultFrameRate,
+            String? taskId,
+          }) async => throw const RenderCanceledException();
+
+      final stopMotionClip = DivineVideoClip(
+        id: 'sm-clip',
+        stopMotionFrames: const [
+          StopMotionClipFrame(
+            path: '/frames/f0.jpg',
+            duration: Duration(milliseconds: 83),
+          ),
+        ],
+        duration: const Duration(milliseconds: 83),
+        recordedAt: DateTime(2026),
+        targetAspectRatio: model.AspectRatio.vertical,
+        originalAspectRatio: 9 / 16,
+      );
+
+      await expectLater(
+        VideoEditorRenderService.renderVideoToClip(
+          clips: [stopMotionClip],
+          editorStateHistory: const {},
+        ),
+        throwsA(
+          isA<VideoRenderFailedException>()
+              .having(
+                (e) => e.reason,
+                'reason',
+                VideoRenderFailureReason.canceled,
+              )
+              .having(
+                (e) => e.cause,
+                'cause',
+                isA<RenderCanceledException>(),
+              ),
         ),
       );
     });

--- a/mobile/test/services/video_editor/video_editor_render_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_test.dart
@@ -9,6 +9,7 @@ import 'dart:typed_data';
 import 'dart:ui' show Offset, Size;
 
 import 'package:fake_async/fake_async.dart';
+import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as model;
 import 'package:openvine/constants/video_editor_constants.dart';
@@ -22,6 +23,8 @@ import 'package:pro_video_editor/pro_video_editor.dart'
         ClipTransition,
         ClipTransitionType,
         EditorVideo,
+        ProVideoEditor,
+        ProgressModel,
         RenderCanceledException,
         RenderEncoderException,
         VideoQualityConfig,
@@ -555,4 +558,105 @@ void main() {
       expect(failure.toString(), contains('/var/mobile'));
     });
   });
+
+  // The invisibility #7125 reports: the native pipeline signals its failures as
+  // PlatformException, which is not an `Error`, so the old `e is Error` gate
+  // dropped the entire population before it reached Crashlytics. Widening it
+  // for the export must not drag in the recoverable callers of renderVideo —
+  // a failing transition seam falls back to a hard cut and is re-attempted on
+  // every timeline change, so reporting each attempt would bury the export
+  // failures this is meant to surface.
+  group('crash reporting gate (#7125)', () {
+    late List<Object> reported;
+    late ProVideoEditor originalProVideoEditor;
+
+    setUp(() {
+      reported = [];
+      originalProVideoEditor = ProVideoEditor.instance;
+      ProVideoEditor.instance = _StubProVideoEditor();
+      VideoEditorRenderService.crashReporterOverride = (error, _) =>
+          reported.add(error);
+    });
+
+    tearDown(() {
+      ProVideoEditor.instance = originalProVideoEditor;
+      VideoEditorRenderService.crashReporterOverride = null;
+      VideoEditorRenderService.renderVideoOverride = null;
+    });
+
+    void failRenderWith(Object error) {
+      VideoEditorRenderService.renderVideoOverride =
+          ({
+            required clips,
+            required usePersistentStorage,
+            aspectRatio,
+            parameters,
+            taskId,
+            maxOutputDuration,
+          }) async => throw error;
+    }
+
+    Future<void> exportClip() => expectLater(
+      VideoEditorRenderService.renderVideoToClip(
+        clips: [clip('a', const Duration(seconds: 1))],
+        editorStateHistory: const {},
+      ),
+      throwsA(isA<VideoRenderFailedException>()),
+    );
+
+    Future<String?> renderClipPath() => VideoEditorRenderService.renderVideo(
+      clips: [clip('a', const Duration(seconds: 1))],
+    );
+
+    test('the export reports a native failure that is not an Error', () async {
+      final failure = PlatformException(code: 'RENDER_ERROR');
+      failRenderWith(failure);
+
+      await exportClip();
+
+      expect(reported, [same(failure)]);
+    });
+
+    test('a recoverable caller does not report a native failure', () async {
+      failRenderWith(PlatformException(code: 'RENDER_ERROR'));
+
+      expect(await renderClipPath(), isNull);
+      expect(
+        reported,
+        isEmpty,
+        reason:
+            'a seam re-attempted on every timeline change would flood the '
+            'dashboard',
+      );
+    });
+
+    test('a recoverable caller still reports a programming-invariant '
+        'violation', () async {
+      final failure = StateError('boom');
+      failRenderWith(failure);
+
+      expect(await renderClipPath(), isNull);
+      expect(reported, [same(failure)]);
+    });
+
+    test('a cancellation is never reported', () async {
+      failRenderWith(const RenderCanceledException());
+
+      await exportClip();
+
+      expect(reported, isEmpty);
+    });
+  });
+}
+
+/// Satisfies the composite-progress subscription that
+/// [VideoEditorRenderService.renderVideoToClip] opens; the render itself is
+/// stubbed out through `renderVideoOverride`.
+class _StubProVideoEditor extends ProVideoEditor {
+  @override
+  void initializeStream() {}
+
+  @override
+  Stream<ProgressModel> progressStreamById(String taskId) =>
+      const Stream<ProgressModel>.empty();
 }


### PR DESCRIPTION
Closes #7139

## Description

Investigating #7125 turned up that the failure it reports cannot be diagnosed at all: the `failed` path is silent by construction.

`renderVideo` catches every exception, logs locally, returns `null`, and forwards to Crashlytics only when `e is Error`. The native pipeline signals its failures as `PlatformException`, which is not an `Error` — so nothing reaches the dashboard. The telemetry agrees: over 2026-08-04..12, **all 20 `failed` renders across both platforms** came through that null return (zero `outcome=error`), and Crashlytics holds no render-related event for any of them. `renderVideoToClip` compounds it with three separate `return null` paths that the trace cannot tell apart.

This PR makes a render that produced no video say why.

- `renderVideoToClip` throws `VideoRenderFailedException` instead of returning `null`, carrying a `VideoRenderFailureReason` — `empty_clips`, `stop_motion_assembly`, `native_render`, `canceled` — plus the cause's **type**. The message never travels: native failure text embeds device paths, so only `runtimeType` goes into telemetry (`native_render:PlatformException`).
- The `video_generation` trace carries it as `failure_reason`, alongside the existing `outcome`, `clip_count` and `aspect_ratio` — four of Firebase's five attributes. The `error` outcome gets the same treatment via `runtimeType`.
- Crashlytics reporting widens from `Error` subtypes to every failure — **on the final export only**. `AGENTS.md`'s decision matrix says expected IO failures stay out of Crashlytics, and that is the right default; a failed final export is a user-visible dead end, not a transient, and the observed volume is ~20 events per 8 days, not a flood. That deviation is deliberate, and deliberately narrow: `renderVideo`'s other three callers keep the `Error` gate, because the ~20/8d figure comes from the `video_generation` trace and therefore describes the export path alone. A transition seam that fails falls back to a hard cut, is never negative-cached, and is re-attempted from five sites in `video_editor_canvas` on every timeline change — reporting each attempt would bury the export failures this is for.
- `renderVideo` keeps its `String?` contract as a thin wrapper, so the three callers that only need the output path (`video_editor_clip_library_save_service`, `video_editor_merge_service`, `transition_seam_render_service`) are untouched.

**This does not fix the iOS failures** — it makes the next occurrence attributable. #7125 stays open until the reason data lands in the export.

### Two behaviour changes, called out separately

Neither was requested by the issue; both are corrections the reason data made visible.

1. **A cancelled render is no longer tagged `failed`.** `cancelActiveNativeTasks()` at `AppLifecycleState.detached` cancels in-flight tasks without bumping the render generation, so the resulting `RenderCanceledException` was recorded as a genuine failure. It is a cancelled render, which is what `incomplete` already means. The retry affordance still comes up — the export genuinely did not finish.
2. **Publish failure copy now follows the actual failure.** It was picked by `needsStopMotionRender`, a pre-check on whether the draft holds stop-motion clips, so a stop-motion draft whose *native* render failed got the assembly copy and the `stop_motion_render_failed` analytics reason. It now uses `error.reason`.

### What the issue's numbers actually say

Not part of this diff, but it belongs with the review: the 6× gap does not survive deduplication. The 18 iOS failures are 4 devices in 5 bursts — one iPhone 14 Plus produced 11 of them in 4 seconds, each failing in 63–94 ms. Android's 2 are one device, 6 s apart. Per affected device model that is 4/32 against 1/55. The `clip_count=7` cluster in the issue's follow-up query is that same burst, not a clip-count effect.

Worth noting for whoever picks up the root cause: the burst carries **no** `incomplete` traces, so those 11 renders each ran to completion before the next started — a deterministic sub-100 ms failure, not codec contention or a timeout. The 4 failures on the iPhone 15 Pro are the opposite shape: ~20.5 s every time, so they die inside the native encode. At least two distinct bugs.

**Related Issue:** Relates to #7125, 

## Out of Scope

- **The root cause of the iOS failures.** Unknowable until a build carrying `failure_reason` is in the field.
- **Debouncing the retry button**, which I proposed and then dropped: it would not have suppressed the observed burst (each render completed in <100 ms, so the taps never overlapped), and an in-flight guard would contradict the supersede semantics that `_renderGeneration` and three provider tests deliberately pin.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test test/services/video_editor test/providers test/widgets/video_editor test/widgets/video_metadata` — 1964 passed
- New tests: reason plumbing per failure path, cancel mapped to `incomplete`, the cause type reaching the trace without its message, `renderVideo` still returning `null` for its path-only callers, and all four sides of the reporting gate — export reports a non-`Error`, a recoverable caller does not, a recoverable caller still reports an `Error`, a cancel is never reported. Both halves of the gate are mutation-checked: reporting always, or keeping the `Error` gate, each fails exactly one of those tests.
- Not verified on a real Samsung Galaxy — this changes no UI and no rendering behaviour; the exercised paths are failure paths that need a device that reproduces them

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
