### PR TITLE
fix(notifications): keep mid-sentence mentions in comment previews

### DIFF
--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -2535,7 +2535,15 @@ class NotificationRepository {
       // The `break` above already guarantees `match.start < limit`, so
       // ending after it is exactly the straddling case.
       if (match.end <= limit) continue;
-      return (match.end - match.start) <= _maxKeptReferenceLength
+      // Measure the decodable payload only. The optional `nostr:` scheme is
+      // stripped before Nip19.decode in the UI, so counting it here would
+      // drop a still-decodable 85–90 char bech32 that merely carries the
+      // NIP-21 prefix.
+      final referenceLength =
+          match.group(_bech32ReferenceGroup)?.length ??
+          match.group(_hexReferenceGroup)?.length ??
+          (match.end - match.start);
+      return referenceLength <= _maxKeptReferenceLength
           ? match.end
           : match.start;
     }

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -10,6 +10,8 @@ import 'package:db_client/db_client.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:meta/meta.dart';
 import 'package:models/models.dart';
+import 'package:nostr_sdk/nip19/nip19.dart';
+import 'package:nostr_sdk/nip19/nip19_tlv.dart';
 import 'package:notification_repository/src/blocked_notification_filter.dart';
 import 'package:notification_repository/src/notification_page.dart';
 import 'package:profile_repository/profile_repository.dart';
@@ -43,13 +45,18 @@ typedef AuthHeadersProvider =
 /// exists only to keep remote-controlled content finite, not for layout.
 const _maxCommentLength = 120;
 
-/// Longest reference that may be kept whole when it straddles the cap.
+/// Longest raw reference that may be kept whole when it straddles the cap.
 ///
-/// bech32's `maxInputLength` is 90, so `Nip19.decode` cannot decode anything
-/// longer; the UI would render such a token raw rather than as a resolved
-/// label, which is the #6346 defect. Keeping only decodable-length references
-/// bounds the preview without ever splitting one.
-const _maxKeptReferenceLength = 90;
+/// `NotificationCommentQuote` renders valid profile references as `@label`
+/// and video/event references as the localized "View video" label, so the
+/// source token can be longer than its visible text. This bound keeps
+/// remote-controlled source content finite while still admitting normal
+/// `nprofile`/`nevent`/`naddr` references with relay hints.
+const _maxKeptResolvedReferenceLength = 512;
+
+/// If an unbounded reference starts before this point, use the plain cap
+/// instead of returning an empty quote body such as `...`.
+const _minPreviewBeforeDroppingReference = 12;
 
 /// Maximum number of actor avatars shown in a grouped notification.
 const _maxGroupActors = 3;
@@ -2513,14 +2520,14 @@ class NotificationRepository {
   /// Returns a bounded cut index that does not split a decodable Nostr
   /// reference — bech32 or bare 64-char hex.
   ///
-  /// A reference that straddles [limit] is kept whole when it is short enough
-  /// to be decodable ([_maxKeptReferenceLength]); the UI then resolves it to
-  /// `@<name>` or a "view video" label, which renders *shorter* than the raw
-  /// token, so keeping it costs nothing the reader can see. Dropping it
-  /// instead deleted mid-sentence mentions outright (#6763).
+  /// A reference that straddles [limit] is kept whole when the notification
+  /// quote UI renders it as bounded display text: a decoded profile label, a
+  /// video label, or a 64-char hex reference. Dropping those instead deleted
+  /// mid-sentence mentions outright (#6763).
   ///
-  /// A longer run cannot decode and would render raw, so the cut falls back to
-  /// the reference's start and omits it rather than splitting it (#6346).
+  /// A token-shaped run that would render raw is omitted rather than split
+  /// (#6346), unless it starts too early to leave a useful preview; in that
+  /// case the plain cap is clearer than a bare `...`.
   ///
   /// A token the UI resolves as a URL or hashtag is skipped even when a
   /// bech32 or hex run sits inside it — the UI does not link that run, so
@@ -2535,19 +2542,37 @@ class NotificationRepository {
       // The `break` above already guarantees `match.start < limit`, so
       // ending after it is exactly the straddling case.
       if (match.end <= limit) continue;
-      // Measure the decodable payload only. The optional `nostr:` scheme is
-      // stripped before Nip19.decode in the UI, so counting it here would
-      // drop a still-decodable 85–90 char bech32 that merely carries the
-      // NIP-21 prefix.
-      final referenceLength =
-          match.group(_bech32ReferenceGroup)?.length ??
-          match.group(_hexReferenceGroup)?.length ??
-          (match.end - match.start);
-      return referenceLength <= _maxKeptReferenceLength
-          ? match.end
+      if (_referenceRendersAsBoundedLabel(match)) return match.end;
+      return match.start < _minPreviewBeforeDroppingReference
+          ? limit
           : match.start;
     }
     return limit;
+  }
+
+  static bool _referenceRendersAsBoundedLabel(RegExpMatch match) {
+    final hexReference = match.group(_hexReferenceGroup);
+    if (hexReference != null) return true;
+
+    final bech32Reference = match.group(_bech32ReferenceGroup);
+    if (bech32Reference == null ||
+        bech32Reference.length > _maxKeptResolvedReferenceLength) {
+      return false;
+    }
+
+    final lower = bech32Reference.toLowerCase();
+    if (lower.startsWith('npub1')) {
+      return Nip19.decode(bech32Reference).length == 64;
+    }
+
+    if (lower.startsWith('nprofile1')) {
+      final pubkey = NIP19Tlv.decodeNprofile(bech32Reference)?.pubkey;
+      return pubkey != null && pubkey.length == 64;
+    }
+
+    return lower.startsWith('note1') ||
+        lower.startsWith('nevent1') ||
+        lower.startsWith('naddr1');
   }
 
   /// Moves [cut] back one code unit when it would split a surrogate pair.

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -35,7 +35,21 @@ typedef AuthHeadersProvider =
     });
 
 /// Maximum length for comment preview text before truncation.
-const _maxCommentLength = 50;
+///
+/// Sized just above the widest measured two-line capacity of
+/// `NotificationCommentQuote` — 112 Latin code units at 440pt, 99 at 393pt,
+/// 76 at 320pt — so the cap never truncates text the row could otherwise have
+/// shown. The row clamps itself with `maxLines: 2` + ellipsis, so this bound
+/// exists only to keep remote-controlled content finite, not for layout.
+const _maxCommentLength = 120;
+
+/// Longest reference that may be kept whole when it straddles the cap.
+///
+/// bech32's `maxInputLength` is 90, so `Nip19.decode` cannot decode anything
+/// longer; the UI would render such a token raw rather than as a resolved
+/// label, which is the #6346 defect. Keeping only decodable-length references
+/// bounds the preview without ever splitting one.
+const _maxKeptReferenceLength = 90;
 
 /// Maximum number of actor avatars shown in a grouped notification.
 const _maxGroupActors = 3;
@@ -82,15 +96,6 @@ const _bech32ReferenceGroup = 3;
 
 /// [_uiTokenPattern] group holding a bare 64-char hex pubkey / event id.
 const _hexReferenceGroup = 4;
-
-/// Any letter or digit in any script.
-///
-/// The preview's "is this token the leading content?" test must treat
-/// Cyrillic, CJK, and accented text as content. Testing only ASCII
-/// `[0-9A-Za-z]` classified every non-Latin script as punctuation, which let
-/// a straddling token qualify as leading and silently raised the preview cap
-/// from [_maxCommentLength] to four times that for most locales.
-final RegExp _letterOrDigitPattern = RegExp(r'[\p{L}\p{N}]', unicode: true);
 
 /// Retry policy for the first-page notifications fetch.
 ///
@@ -2476,19 +2481,18 @@ class NotificationRepository {
 
   static bool _isEventId(String id) => _parseAddressableId(id) == null;
 
-  /// Truncates comment text to [_maxCommentLength] characters, except for
-  /// bounded leading Nostr references that the UI can resolve.
+  /// Truncates comment text to [_maxCommentLength] characters, keeping any
+  /// Nostr reference that straddles the cut intact.
   ///
   /// Only applies to the kinds that render a quote: comment, reply, and
   /// likeComment. Pair it with [_commentQuoteSource], which picks the text
   /// each kind should quote.
   ///
-  /// The cut avoids splitting a Nostr reference the UI can decode — bech32
+  /// The cut never splits a Nostr reference the UI can decode — bech32
   /// (`npub1...`, `nprofile1...`, `note1...`, `nevent1...`, `naddr1...`) or a
-  /// bare 64-char hex pubkey / event id — mid-token. A sliced token can no
-  /// longer be decoded, so the row widget falls back to rendering the raw
-  /// string verbatim instead of resolving it. Keeping a bounded leading token
-  /// intact lets the UI linkifier resolve it to `@<name>`.
+  /// bare 64-char hex pubkey / event id. A sliced token can no longer be
+  /// decoded, so the row widget falls back to rendering the raw string
+  /// verbatim instead of resolving it.
   static String? _truncateComment(String? content, NotificationKind kind) {
     if (content == null) return null;
     if (kind != NotificationKind.comment &&
@@ -2498,7 +2502,10 @@ class NotificationRepository {
     }
     if (content.length <= _maxCommentLength) return content;
 
-    final cut = _referenceAwareCut(content, _maxCommentLength);
+    final cut = _surrogateSafeCut(
+      content,
+      _referenceAwareCut(content, _maxCommentLength),
+    );
     if (cut >= content.length) return content;
     return '${content.substring(0, cut).trimRight()}...';
   }
@@ -2506,17 +2513,19 @@ class NotificationRepository {
   /// Returns a bounded cut index that does not split a decodable Nostr
   /// reference — bech32 or bare 64-char hex.
   ///
-  /// If a reference straddles [limit], the cut is pulled back to the
-  /// reference's start so the token is omitted from the preview rather than
-  /// split. If the content before that token is only whitespace or
-  /// punctuation, and keeping the full token stays within the preview bound,
-  /// the token's end is returned so the UI can resolve it.
+  /// A reference that straddles [limit] is kept whole when it is short enough
+  /// to be decodable ([_maxKeptReferenceLength]); the UI then resolves it to
+  /// `@<name>` or a "view video" label, which renders *shorter* than the raw
+  /// token, so keeping it costs nothing the reader can see. Dropping it
+  /// instead deleted mid-sentence mentions outright (#6763).
+  ///
+  /// A longer run cannot decode and would render raw, so the cut falls back to
+  /// the reference's start and omits it rather than splitting it (#6346).
   ///
   /// A token the UI resolves as a URL or hashtag is skipped even when a
   /// bech32 or hex run sits inside it — the UI does not link that run, so
   /// pulling the cut back to it only shortens the preview.
   static int _referenceAwareCut(String content, int limit) {
-    final maxReferencePreviewLength = limit * 4;
     for (final match in _uiTokenPattern.allMatches(content)) {
       if (match.start >= limit) break;
       final isReference =
@@ -2525,19 +2534,25 @@ class NotificationRepository {
       if (!isReference) continue;
       // The `break` above already guarantees `match.start < limit`, so
       // ending after it is exactly the straddling case.
-      final straddlesLimit = match.end > limit;
-      if (!straddlesLimit) continue;
-      final canKeepLeadingToken =
-          match.end <= maxReferencePreviewLength &&
-          _hasOnlyWhitespaceOrPunctuationBefore(content, match.start);
-      if (canKeepLeadingToken) return match.end;
-      return match.start;
+      if (match.end <= limit) continue;
+      return (match.end - match.start) <= _maxKeptReferenceLength
+          ? match.end
+          : match.start;
     }
     return limit;
   }
 
-  static bool _hasOnlyWhitespaceOrPunctuationBefore(String content, int end) =>
-      !_letterOrDigitPattern.hasMatch(content.substring(0, end));
+  /// Moves [cut] back one code unit when it would split a surrogate pair.
+  ///
+  /// [_maxCommentLength] counts UTF-16 code units, so a cut can land between
+  /// the halves of an astral character (emoji). The lone high surrogate left
+  /// behind renders as U+FFFD once the span builder sanitizes it.
+  static int _surrogateSafeCut(String content, int cut) {
+    if (cut <= 0 || cut >= content.length) return cut;
+    final previous = content.codeUnitAt(cut - 1);
+    final isHighSurrogate = previous >= 0xD800 && previous <= 0xDBFF;
+    return isHighSurrogate ? cut - 1 : cut;
+  }
 }
 
 @immutable

--- a/mobile/packages/notification_repository/pubspec.yaml
+++ b/mobile/packages/notification_repository/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   meta: ^1.14.0
   models:
   nostr_client:
+  nostr_sdk:
   profile_repository:
   rxdart: ^0.28.0
   text_sanitizer:

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -3327,6 +3327,32 @@ void main() {
       );
 
       test(
+        'keeps a straddling nostr:-prefixed bech32 near the decode cap',
+        () async {
+          // The UI strips `nostr:` before Nip19.decode. An 85-char bech32 is
+          // still decodable; counting the scheme in the keep-length check
+          // would make the full match 91 and drop a still-valid reference.
+          final bech32 = 'nprofile1${'q' * 76}';
+          expect(bech32.length, 85);
+          final content = '${'word ' * 20}nostr:$bech32 tail';
+          stubNotifications([
+            makeNotification(
+              notificationType: 'comment',
+              sourceKind: 1,
+              content: content,
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as VideoNotification;
+          expect(item.commentText, contains(bech32));
+          expect(item.commentText, contains('nostr:'));
+          expect(item.commentText, endsWith('...'));
+        },
+      );
+
+      test(
         'does not preserve unbounded leading token-shaped content',
         () async {
           final content = 'npub1${'a' * 5000}';

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -8,6 +8,8 @@ import 'package:db_client/db_client.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:nostr_sdk/nip19/nip19.dart';
+import 'package:nostr_sdk/nip19/nip19_tlv.dart';
 import 'package:notification_repository/notification_repository.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:test/test.dart';
@@ -27,6 +29,9 @@ void main() {
   const userPubkey = 'user1234567890abcdef';
   const stableCursorId =
       '1122334411223344112233441122334411223344112233441122334411223344';
+  const validPubkey =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+  final validNpub = Nip19.encodePubKey(validPubkey);
 
   NotificationRepository buildRepository({
     BlockedNotificationFilter? blockFilter,
@@ -3125,15 +3130,14 @@ void main() {
       );
 
       test(
-        'keeps a bounded leading bech32 npub intact when it spans the cut',
+        'keeps a valid bech32 npub intact',
         () async {
           // Regression: a reply whose content begins with a raw npub longer
           // than the 50-char preview cap must keep the token intact so the
           // row widget can decode it to a display name. Slicing it
           // mid-bech32 destroyed the checksum and the row fell back to
           // rendering a raw "npub1..." fragment verbatim.
-          const npub =
-              'npub180cvv07tjdrrgpa9jzd0cdkej42kwsaxq9rz7gvdpjx6nz004f9uulstw6';
+          final npub = validNpub;
           stubNotifications([
             makeNotification(
               notificationType: 'comment',
@@ -3152,9 +3156,8 @@ void main() {
       test(
         'keeps a bech32 npub after leading whitespace or punctuation',
         () async {
-          const npub =
-              'npub180cvv07tjdrrgpa9jzd0cdkej42kwsaxq9rz7gvdpjx6nz004f9uulstw6';
-          const content = ' @$npub';
+          final npub = validNpub;
+          final content = ' @$npub';
           stubNotifications([
             makeNotification(
               notificationType: 'comment',
@@ -3170,31 +3173,28 @@ void main() {
         },
       );
 
-      test(
-        "keeps the mention in #6763's reported example",
-        () async {
-          // The issue's own example. It no longer straddles the cap at 120, so
-          // this guards the cap; the straddle POLICY is guarded separately
-          // below. Previously this rendered as 'Reply to...' — the mention,
-          // the only meaningful part of the preview, was deleted.
-          const npub =
-              'npub180cvv07tjdrrgpa9jzd0cdkej42kwsaxq9rz7gvdpjx6nz004f9uulstw6';
-          const content = 'Reply to $npub more';
-          stubNotifications([
-            makeNotification(
-              notificationType: 'comment',
-              sourceKind: 1,
-              content: content,
-            ),
-          ]);
-          stubProfiles({});
+      test("keeps the mention in #6763's reported example", () async {
+        // The issue's own example. It no longer straddles the cap at 120, so
+        // this guards the cap; the straddle POLICY is guarded separately
+        // below. Previously this rendered as 'Reply to...' — the mention,
+        // the only meaningful part of the preview, was deleted.
+        const npub =
+            'npub180cvv07tjdrrgpa9jzd0cdkej42kwsaxq9rz7gvdpjx6nz004f9uulstw6';
+        const content = 'Reply to $npub more';
+        stubNotifications([
+          makeNotification(
+            notificationType: 'comment',
+            sourceKind: 1,
+            content: content,
+          ),
+        ]);
+        stubProfiles({});
 
-          final page = await repository.getNotifications();
-          final item = page.items.single as VideoNotification;
-          expect(item.commentText, equals(content));
-          expect(item.commentText, contains(npub));
-        },
-      );
+        final page = await repository.getNotifications();
+        final item = page.items.single as VideoNotification;
+        expect(item.commentText, equals(content));
+        expect(item.commentText, contains(npub));
+      });
 
       test('keeps the mention in the production #6763 comment', () async {
         // Real comment from api.divine.video, event
@@ -3225,8 +3225,7 @@ void main() {
           // Guards the straddle POLICY, not the cap number: 100 chars of
           // lead-in push the npub past the 120-char cap, so the token is only
           // preserved because a straddling reference is now kept whole.
-          const npub =
-              'npub180cvv07tjdrrgpa9jzd0cdkej42kwsaxq9rz7gvdpjx6nz004f9uulstw6';
+          final npub = validNpub;
           final content = '${'word ' * 20}$npub tail';
           stubNotifications([
             makeNotification(
@@ -3305,11 +3304,8 @@ void main() {
       });
 
       test(
-        'omits a reference too long to decode rather than keeping it',
+        'uses the plain cap for a leading unbounded token-shaped run',
         () async {
-          // bech32 caps decodable input at 90 chars, so a longer run would only
-          // ever render raw. Keeping it let a comment that merely STARTS with a
-          // token-shaped run put ~200 raw characters into the row.
           final content = 'nprofile1${'q' * 180} tail';
           stubNotifications([
             makeNotification(
@@ -3322,19 +3318,21 @@ void main() {
 
           final page = await repository.getNotifications();
           final item = page.items.single as VideoNotification;
-          expect(item.commentText, isNot(contains('nprofile1')));
+          expect(item.commentText, equals('${content.substring(0, 120)}...'));
         },
       );
 
       test(
-        'keeps a straddling nostr:-prefixed bech32 near the decode cap',
+        'keeps a straddling nostr:-prefixed profile reference with relay hints',
         () async {
-          // The UI strips `nostr:` before Nip19.decode. An 85-char bech32 is
-          // still decodable; counting the scheme in the keep-length check
-          // would make the full match 91 and drop a still-valid reference.
-          final bech32 = 'nprofile1${'q' * 76}';
-          expect(bech32.length, 85);
-          final content = '${'word ' * 20}nostr:$bech32 tail';
+          final nprofile = NIP19Tlv.encodeNprofile(
+            Nprofile(
+              pubkey: validPubkey,
+              relays: const ['wss://relay.damus.io'],
+            ),
+          );
+          expect(nprofile.length, greaterThan(90));
+          final content = '${'word ' * 20}nostr:$nprofile tail';
           stubNotifications([
             makeNotification(
               notificationType: 'comment',
@@ -3346,14 +3344,46 @@ void main() {
 
           final page = await repository.getNotifications();
           final item = page.items.single as VideoNotification;
-          expect(item.commentText, contains(bech32));
+          expect(item.commentText, contains(nprofile));
           expect(item.commentText, contains('nostr:'));
           expect(item.commentText, endsWith('...'));
         },
       );
 
       test(
-        'does not preserve unbounded leading token-shaped content',
+        'keeps a leading naddr that the quote UI renders as a video label',
+        () async {
+          final naddr = NIP19Tlv.encodeNaddr(
+            Naddr(
+              id: 'stable-video-reference',
+              author:
+                  'abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+                  '0123456789',
+              kind: 34236,
+              relays: const ['wss://relay.divine.video'],
+            ),
+          );
+          expect(naddr.length, greaterThan(120));
+          final content = 'nostr:$naddr tail';
+          stubNotifications([
+            makeNotification(
+              notificationType: 'comment',
+              sourceKind: 1,
+              content: content,
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as VideoNotification;
+          expect(item.commentText, contains(naddr));
+          expect(item.commentText, isNot(equals('...')));
+          expect(item.commentText, endsWith('...'));
+        },
+      );
+
+      test(
+        'caps unbounded leading token-shaped content',
         () async {
           final content = 'npub1${'a' * 5000}';
           stubNotifications([
@@ -3367,8 +3397,8 @@ void main() {
 
           final page = await repository.getNotifications();
           final item = page.items.single as VideoNotification;
-          expect(item.commentText, equals('...'));
-          expect(item.commentText!.length, lessThanOrEqualTo(53));
+          expect(item.commentText, equals('${content.substring(0, 120)}...'));
+          expect(item.commentText!.length, lessThanOrEqualTo(123));
         },
       );
 
@@ -3421,8 +3451,7 @@ void main() {
           // silently regress to being locale-sensitive. Lead-in is long
           // enough that the npub straddles the 120-char cap (not only
           // fits under it).
-          const npub =
-              'npub180cvv07tjdrrgpa9jzd0cdkej42kwsaxq9rz7gvdpjx6nz004f9uulstw6';
+          final npub = validNpub;
           const cyrillic = 'Привет всем друзьям сегодня';
           final content = '$cyrillic ${'слово ' * 14}nostr:$npub tail';
           stubNotifications([
@@ -3444,14 +3473,15 @@ void main() {
       );
 
       test(
-        'still treats punctuation-only lead-in as leading for a bech32 token',
+        'keeps a punctuation-prefixed profile reference that straddles the cut',
         () async {
-          // Guards the other side of the non-Latin fix: real punctuation and
-          // whitespace must keep qualifying as "leading", including
-          // non-ASCII punctuation such as guillemets and an em dash.
-          const npub =
-              'npub180cvv07tjdrrgpa9jzd0cdkej42kwsaxq9rz7gvdpjx6nz004f9uulstw6';
-          const content = '«— » $npub';
+          final nprofile = NIP19Tlv.encodeNprofile(
+            Nprofile(
+              pubkey: validPubkey,
+              relays: const ['wss://relay.divine.video'],
+            ),
+          );
+          final content = '«— » ${'— ' * 45}nostr:$nprofile tail';
           stubNotifications([
             makeNotification(
               notificationType: 'comment',
@@ -3463,7 +3493,9 @@ void main() {
 
           final page = await repository.getNotifications();
           final item = page.items.single as VideoNotification;
-          expect(item.commentText, equals(content));
+          expect(content.length, greaterThan(120));
+          expect(item.commentText, contains(nprofile));
+          expect(item.commentText, endsWith('...'));
         },
       );
 

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -2268,7 +2268,7 @@ void main() {
       });
 
       test('likeComment truncates a long liked comment body', () async {
-        final body = 'a' * 120;
+        final body = 'a' * 200;
         stubNotifications([
           makeNotification(
             targetCommentId: 'comment_event_xyz',
@@ -2280,7 +2280,7 @@ void main() {
 
         final page = await repository.getNotifications();
         final item = page.items.single as ActorNotification;
-        expect(item.commentText, equals('${'a' * 50}...'));
+        expect(item.commentText, equals('${'a' * 120}...'));
       });
 
       test(
@@ -3104,9 +3104,9 @@ void main() {
       );
 
       test(
-        'truncates a long comment on $VideoNotification (50 chars + ellipsis)',
+        'truncates a long comment on $VideoNotification (120 chars + ellipsis)',
         () async {
-          final longComment = 'A' * 60;
+          final longComment = 'A' * 200;
           stubNotifications([
             makeNotification(
               notificationType: 'comment',
@@ -3118,9 +3118,9 @@ void main() {
 
           final page = await repository.getNotifications();
           final item = page.items.single as VideoNotification;
-          // Reuses _truncateComment: caps at 50 chars and appends "..."
+          // Reuses _truncateComment: caps at 120 chars and appends "..."
           // so the row never tries to render an unbounded comment body.
-          expect(item.commentText, equals('${'A' * 50}...'));
+          expect(item.commentText, equals('${'A' * 120}...'));
         },
       );
 
@@ -3171,12 +3171,12 @@ void main() {
       );
 
       test(
-        'omits a bech32 reference straddling the cut instead of splitting it',
+        "keeps the mention in #6763's reported example",
         () async {
-          // 'Reply to ' (9 chars) + npub (63) + ' more' straddles the
-          // 50-char limit: the npub starts at index 9 and ends at 72. The
-          // cut pulls back to the token's start so the preview shows only
-          // the leading text, never a sliced npub fragment.
+          // The issue's own example. It no longer straddles the cap at 120, so
+          // this guards the cap; the straddle POLICY is guarded separately
+          // below. Previously this rendered as 'Reply to...' — the mention,
+          // the only meaningful part of the preview, was deleted.
           const npub =
               'npub180cvv07tjdrrgpa9jzd0cdkej42kwsaxq9rz7gvdpjx6nz004f9uulstw6';
           const content = 'Reply to $npub more';
@@ -3191,8 +3191,138 @@ void main() {
 
           final page = await repository.getNotifications();
           final item = page.items.single as VideoNotification;
-          expect(item.commentText, equals('Reply to...'));
-          expect(item.commentText, isNot(contains('npub1')));
+          expect(item.commentText, equals(content));
+          expect(item.commentText, contains(npub));
+        },
+      );
+
+      test('keeps the mention in the production #6763 comment', () async {
+        // Real comment from api.divine.video, event
+        // 65e5c466b0c722ce3eccfe11fe65d07dbc7f42d1e3e21f2f1148a238772bbc32.
+        // 82 code units, so it now survives whole; it used to render as
+        // 'The big guy....' with the mention deleted.
+        const npub =
+            'npub1m9d23lqwl78y3z2jf9dcqeyer5nlh9hdsef0ztx7m3dyaz'
+            '66u4qq4stysk';
+        const content = 'The big guy. nostr:$npub';
+        stubNotifications([
+          makeNotification(
+            notificationType: 'comment',
+            sourceKind: 1,
+            content: content,
+          ),
+        ]);
+        stubProfiles({});
+
+        final page = await repository.getNotifications();
+        final item = page.items.single as VideoNotification;
+        expect(item.commentText, equals(content));
+      });
+
+      test(
+        'keeps a mid-sentence mention straddling the cap, not just the limit',
+        () async {
+          // Guards the straddle POLICY, not the cap number: 100 chars of
+          // lead-in push the npub past the 120-char cap, so the token is only
+          // preserved because a straddling reference is now kept whole.
+          const npub =
+              'npub180cvv07tjdrrgpa9jzd0cdkej42kwsaxq9rz7gvdpjx6nz004f9uulstw6';
+          final content = '${'word ' * 20}$npub tail';
+          stubNotifications([
+            makeNotification(
+              notificationType: 'comment',
+              sourceKind: 1,
+              content: content,
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as VideoNotification;
+          expect(item.commentText, contains(npub));
+          expect(item.commentText, endsWith('...'));
+        },
+      );
+
+      test('keeps a 64-hex reference straddling the cap', () async {
+        // The lead-in pushes the hex past the 120-char cap so the straddle
+        // branch is actually exercised — a shorter string would return early
+        // from _truncateComment and pass without testing anything.
+        const hex =
+            'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90';
+        final content = '${'word ' * 20}$hex tail';
+        stubNotifications([
+          makeNotification(
+            notificationType: 'comment',
+            sourceKind: 1,
+            content: content,
+          ),
+        ]);
+        stubProfiles({});
+
+        final page = await repository.getNotifications();
+        final item = page.items.single as VideoNotification;
+        expect(item.commentText, contains(hex));
+        expect(item.commentText, endsWith('...'));
+      });
+
+      test('never splits a surrogate pair at the cut', () async {
+        // The cap counts UTF-16 code units, so a naive cut lands between the
+        // halves of an astral emoji and strands a lone high surrogate.
+        final content = '${'b' * 119}\u{1F600} and a good deal more text here';
+        stubNotifications([
+          makeNotification(
+            notificationType: 'comment',
+            sourceKind: 1,
+            content: content,
+          ),
+        ]);
+        stubProfiles({});
+
+        final page = await repository.getNotifications();
+        final item = page.items.single as VideoNotification;
+        final units = item.commentText!.codeUnits;
+        for (var i = 0; i < units.length; i++) {
+          final unit = units[i];
+          final isHigh = unit >= 0xD800 && unit <= 0xDBFF;
+          final isLow = unit >= 0xDC00 && unit <= 0xDFFF;
+          if (isHigh) {
+            expect(
+              i + 1 < units.length &&
+                  units[i + 1] >= 0xDC00 &&
+                  units[i + 1] <= 0xDFFF,
+              isTrue,
+              reason: 'unpaired high surrogate at $i',
+            );
+          } else if (isLow) {
+            expect(
+              i > 0 && units[i - 1] >= 0xD800 && units[i - 1] <= 0xDBFF,
+              isTrue,
+              reason: 'unpaired low surrogate at $i',
+            );
+          }
+        }
+      });
+
+      test(
+        'omits a reference too long to decode rather than keeping it',
+        () async {
+          // bech32 caps decodable input at 90 chars, so a longer run would only
+          // ever render raw. Keeping it let a comment that merely STARTS with a
+          // token-shaped run put ~200 raw characters into the row.
+          final content = 'nprofile1${'q' * 180} tail';
+          stubNotifications([
+            makeNotification(
+              notificationType: 'comment',
+              sourceKind: 1,
+              content: content,
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as VideoNotification;
+          expect(item.commentText, isNot(contains('nprofile1')));
         },
       );
 
@@ -3219,7 +3349,7 @@ void main() {
       test(
         'does not treat embedded alphanumeric bech32-looking text as a token',
         () async {
-          final content = 'prefixnpub1${'a' * 60}';
+          final content = 'prefixnpub1${'a' * 130}';
           stubNotifications([
             makeNotification(
               notificationType: 'comment',
@@ -3231,19 +3361,18 @@ void main() {
 
           final page = await repository.getNotifications();
           final item = page.items.single as VideoNotification;
-          expect(item.commentText, equals('${content.substring(0, 50)}...'));
+          // No token boundary here, so the plain cap applies.
+          expect(item.commentText, equals('${content.substring(0, 120)}...'));
         },
       );
 
       test('keeps a bounded leading 64-hex reference intact', () async {
         // LinkifiedTextSpanBuilder decodes a bare 64-char hex pubkey / event
-        // id the same way it decodes bech32. A hex reference is always
-        // longer than the 50-char cap, so before it was protected the cut
-        // sliced it every time and the row rendered raw hex.
+        // id the same way it decodes bech32, so the cut must never slice one.
         const hex64 =
             'a1b2c3d4e5f60718293a4b5c6d7e8f90'
             'a1b2c3d4e5f60718293a4b5c6d7e8f90';
-        const content = '$hex64 and some trailing words';
+        final content = '$hex64 ${'and some trailing words ' * 4}';
         stubNotifications([
           makeNotification(
             notificationType: 'comment',
@@ -3255,16 +3384,21 @@ void main() {
 
         final page = await repository.getNotifications();
         final item = page.items.single as VideoNotification;
-        expect(item.commentText, equals('$hex64...'));
+        expect(item.commentText, contains(hex64));
+        expect(item.commentText, endsWith('...'));
       });
 
       test(
-        'omits a 64-hex reference straddling the cut instead of splitting it',
+        'keeps a non-Latin lead-in mention that straddles the cut',
         () async {
-          const hex64 =
-              'a1b2c3d4e5f60718293a4b5c6d7e8f90'
-              'a1b2c3d4e5f60718293a4b5c6d7e8f90';
-          const content = 'Reply to $hex64 more';
+          // Post-#6839 the lead-in test is Unicode-aware, so this case behaved
+          // exactly like the Latin one — the mention was deleted in every
+          // locale. #6763 asks for both to be asserted so the fix cannot
+          // silently regress to being locale-sensitive again.
+          const npub =
+              'npub180cvv07tjdrrgpa9jzd0cdkej42kwsaxq9rz7gvdpjx6nz004f9uulstw6';
+          const cyrillic = 'Привет всем друзьям сегодня';
+          const content = '$cyrillic nostr:$npub и ещё немного текста';
           stubNotifications([
             makeNotification(
               notificationType: 'comment',
@@ -3276,37 +3410,10 @@ void main() {
 
           final page = await repository.getNotifications();
           final item = page.items.single as VideoNotification;
-          expect(item.commentText, equals('Reply to...'));
-          expect(item.commentText, isNot(contains(hex64.substring(0, 16))));
+          expect(item.commentText, contains(npub));
+          expect(item.commentText, startsWith(cyrillic));
         },
       );
-
-      test('applies the preview cap to non-Latin lead-in text', () async {
-        // The leading-token allowance is bounded at four times the cap, and
-        // is only meant to fire when nothing but whitespace or punctuation
-        // precedes the token. Testing only ASCII letters classified every
-        // non-Latin script as punctuation, so Cyrillic / CJK / accented
-        // lead-ins silently got a 200-char preview of remote-controlled
-        // content while the Latin equivalent got 50.
-        const npub =
-            'npub180cvv07tjdrrgpa9jzd0cdkej42kwsaxq9rz7gvdpjx6nz004f9uulstw6';
-        const cyrillic = 'Привет всем друзьям сегодня';
-        const content = '$cyrillic nostr:$npub и ещё немного текста';
-        stubNotifications([
-          makeNotification(
-            notificationType: 'comment',
-            sourceKind: 1,
-            content: content,
-          ),
-        ]);
-        stubProfiles({});
-
-        final page = await repository.getNotifications();
-        final item = page.items.single as VideoNotification;
-        expect(item.commentText, equals('$cyrillic...'));
-        expect(item.commentText!.length, lessThanOrEqualTo(53));
-        expect(item.commentText, isNot(contains('npub1')));
-      });
 
       test(
         'still treats punctuation-only lead-in as leading for a bech32 token',
@@ -3355,10 +3462,7 @@ void main() {
 
         final page = await repository.getNotifications();
         final item = page.items.single as VideoNotification;
-        expect(
-          item.commentText,
-          equals('Look at this https://blossom.divine.video/a1b2c3d4...'),
-        );
+        expect(item.commentText, equals('${content.substring(0, 120)}...'));
       });
 
       test('leaves a bech32 token inside a URL to the plain cut', () async {
@@ -3366,7 +3470,9 @@ void main() {
         // so the npub in its path is not a reference either.
         const npub =
             'npub180cvv07tjdrrgpa9jzd0cdkej42kwsaxq9rz7gvdpjx6nz004f9uulstw6';
-        const content = 'Follow https://divine.video/$npub please';
+        const content =
+            'Follow https://divine.video/$npub please '
+            'and then keep reading well past the preview cap';
         stubNotifications([
           makeNotification(
             notificationType: 'comment',
@@ -3378,7 +3484,7 @@ void main() {
 
         final page = await repository.getNotifications();
         final item = page.items.single as VideoNotification;
-        expect(item.commentText, equals('${content.substring(0, 50)}...'));
+        expect(item.commentText, equals('${content.substring(0, 120)}...'));
         expect(
           item.commentText,
           startsWith('Follow https://divine.video/npub1'),
@@ -3390,7 +3496,9 @@ void main() {
         const hex64 =
             'a1b2c3d4e5f60718293a4b5c6d7e8f90'
             'a1b2c3d4e5f60718293a4b5c6d7e8f90';
-        const content = 'nice one #$hex64 keep going with more words here';
+        const content =
+            'nice one #$hex64 keep going with more words here '
+            'so the plain cut is actually exercised';
         stubNotifications([
           makeNotification(
             notificationType: 'comment',
@@ -3404,7 +3512,7 @@ void main() {
         final item = page.items.single as VideoNotification;
         expect(
           item.commentText,
-          equals('nice one #a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4...'),
+          equals('${content.substring(0, 120).trimRight()}...'),
         );
       });
 

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -3417,14 +3417,13 @@ void main() {
       test(
         'keeps a non-Latin lead-in mention that straddles the cut',
         () async {
-          // Post-#6839 the lead-in test is Unicode-aware, so this case behaved
-          // exactly like the Latin one — the mention was deleted in every
-          // locale. #6763 asks for both to be asserted so the fix cannot
-          // silently regress to being locale-sensitive again.
+          // #6763 asks for Latin and non-Latin lead-in so the fix cannot
+          // silently regress to being locale-sensitive. Lead-in is long enough
+          // that the npub straddles the 120-char cap (not merely fits under it).
           const npub =
               'npub180cvv07tjdrrgpa9jzd0cdkej42kwsaxq9rz7gvdpjx6nz004f9uulstw6';
           const cyrillic = 'Привет всем друзьям сегодня';
-          const content = '$cyrillic nostr:$npub и ещё немного текста';
+          final content = '$cyrillic ${'слово ' * 14}nostr:$npub tail';
           stubNotifications([
             makeNotification(
               notificationType: 'comment',
@@ -3436,8 +3435,10 @@ void main() {
 
           final page = await repository.getNotifications();
           final item = page.items.single as VideoNotification;
+          expect(content.length, greaterThan(120));
           expect(item.commentText, contains(npub));
           expect(item.commentText, startsWith(cyrillic));
+          expect(item.commentText, endsWith('...'));
         },
       );
 

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -3418,8 +3418,9 @@ void main() {
         'keeps a non-Latin lead-in mention that straddles the cut',
         () async {
           // #6763 asks for Latin and non-Latin lead-in so the fix cannot
-          // silently regress to being locale-sensitive. Lead-in is long enough
-          // that the npub straddles the 120-char cap (not merely fits under it).
+          // silently regress to being locale-sensitive. Lead-in is long
+          // enough that the npub straddles the 120-char cap (not only
+          // fits under it).
           const npub =
               'npub180cvv07tjdrrgpa9jzd0cdkej42kwsaxq9rz7gvdpjx6nz004f9uulstw6';
           const cyrillic = 'Привет всем друзьям сегодня';


### PR DESCRIPTION
Fixes #6763
Refs #7166

## Problem

A notification comment preview deleted a Nostr mention outright whenever the
reference straddled the raw preview cap and useful text preceded it. Reproduced
against production with a real comment on event
`65e5c466b0c722ce3eccfe11fe65d07dbc7f42d1e3e21f2f1148a238772bbc32`:

```
content (82 chars): 'The big guy. nostr:npub1m9d23lqwl78y3z2jf9dcqeyer5nlh9hdsef0ztx7m3dyaz66u4qq4stysk'
rendered          : "The big guy...."
```

## Changes

The straddle policy now keeps references that the notification quote UI renders
as bounded display text:

- valid `npub` / `nprofile` profile references, rendered as `@label`
- `note` / `nevent` / `naddr` video references, rendered as the localized
  "View video" label
- bare 64-character hex references

The previous length proxy was wrong for TLV references with relay hints:
`nprofile`, `nevent`, and `naddr` are not limited by the bare bech32
90-character path. The repository now validates profile references with the
same NIP-19 decode helpers the UI path depends on, and keeps video references
under a finite raw-source bound because the quote UI renders them as a fixed
label.

The preview cap remains 120 code units. Invalid or unbounded token-shaped runs
still do not get special preservation, but leading invalid runs now fall back
to the plain cap instead of producing a blank quote body of just `...`.

The cut remains surrogate-safe so it cannot split an astral character.

## Scope note for reviewers

The issue title says "mention previews", but `NotificationKind.mention` renders
no quote at all (`commentText` is null). This is about a mention inside the
body of a `comment` / `reply` / `likeComment` row.

## Follow-up tracked

#7166 tracks the pre-existing tokenizer-parity and synthetic-link follow-up:
notification preview truncation mirrors `LinkifiedTextSpanBuilder` behavior,
and truncation can still synthesize a new URL-shaped token around `www`-style
text. That is not left as untracked PR-body debt.

## Testing

- `flutter test test/src/notification_repository_test.dart --name "comment text truncation"`
- `flutter test`
- `flutter analyze lib test`
