### PR TITLE
fix(bookmarks): show save progress while relay reconcile and publish are in flight

### DIFF
--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -294,6 +294,12 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
     ShareSheetSaveRequested event,
     Emitter<ShareSheetState> emit,
   ) async {
+    // Emitted above the await deliberately: resolving the bookmark service is
+    // itself a wait on a cold start, and the toggle below is a relay
+    // reconcile + sign + publish. Emitting after it would leave the sheet
+    // inert for the whole window, which is the bug (#7073).
+    emit(state.copyWith(isSaving: true, clearActionResult: true));
+
     final bookmarkService = await _bookmarkServiceFuture;
     if (bookmarkService == null) {
       Log.warning(
@@ -302,7 +308,10 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
         category: LogCategory.ui,
       );
       emit(
-        state.copyWith(actionResult: ShareSheetSaveResult(succeeded: false)),
+        state.copyWith(
+          isSaving: false,
+          actionResult: ShareSheetSaveResult(succeeded: false),
+        ),
       );
       return;
     }
@@ -321,10 +330,12 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
       wasBookmarked = result.wasBookmarked;
       emit(
         state.copyWith(
+          isSaving: false,
           actionResult: ShareSheetSaveResult(
             succeeded: result.succeeded,
             removed: result.succeeded && result.wasBookmarked,
             wasBookmarkedBeforeToggle: result.wasBookmarked,
+            failure: result.failure,
           ),
         ),
       );
@@ -341,6 +352,7 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
       );
       emit(
         state.copyWith(
+          isSaving: false,
           actionResult: ShareSheetSaveResult(
             succeeded: false,
             wasBookmarkedBeforeToggle: wasBookmarked,

--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -301,6 +301,8 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
     emit(state.copyWith(isSaving: true, clearActionResult: true));
 
     final bookmarkService = await _bookmarkServiceFuture;
+    if (isClosed) return;
+
     if (bookmarkService == null) {
       Log.warning(
         'Bookmark service unavailable — cannot save',
@@ -327,6 +329,8 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
       final result = await bookmarkService.toggleVideoInGlobalBookmarks(
         _video.id,
       );
+      if (isClosed) return;
+
       wasBookmarked = result.wasBookmarked;
       emit(
         state.copyWith(
@@ -350,6 +354,8 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
         name: 'ShareSheetBloc',
         category: LogCategory.ui,
       );
+      if (isClosed) return;
+
       emit(
         state.copyWith(
           isSaving: false,

--- a/mobile/lib/blocs/share_sheet/share_sheet_state.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_state.dart
@@ -65,6 +65,7 @@ class ShareSheetSaveResult extends ShareSheetActionResult {
     required this.succeeded,
     this.removed = false,
     this.wasBookmarkedBeforeToggle = false,
+    this.failure,
   });
 
   final bool succeeded;
@@ -74,6 +75,10 @@ class ShareSheetSaveResult extends ShareSheetActionResult {
 
   /// Whether the video was already globally bookmarked before this toggle.
   final bool wasBookmarkedBeforeToggle;
+
+  /// Why the toggle failed, so the sheet can say "couldn't reach the network"
+  /// instead of a generic error. `null` when [succeeded] is true.
+  final BookmarkToggleFailure? failure;
 }
 
 class ShareSheetVideoClipImportResult extends ShareSheetActionResult {
@@ -134,6 +139,7 @@ class ShareSheetState extends Equatable {
     this.contacts = const [],
     this.selectedRecipients = const [],
     this.isSending = false,
+    this.isSaving = false,
     this.actionResult,
   });
 
@@ -148,6 +154,13 @@ class ShareSheetState extends Equatable {
 
   /// Whether a send operation is in progress.
   final bool isSending;
+
+  /// Whether a bookmark save/remove is in progress.
+  ///
+  /// The toggle reconciles kind 10003 with the relay, signs, and waits for the
+  /// publish to be accepted before it can report anything, so the sheet has to
+  /// show that it is working rather than sitting inert (#7073).
+  final bool isSaving;
 
   /// One-shot action result for BlocListener consumption.
   /// Cleared on next state emission.
@@ -165,6 +178,7 @@ class ShareSheetState extends Equatable {
     List<ShareableUser>? contacts,
     List<ShareableUser>? selectedRecipients,
     bool? isSending,
+    bool? isSaving,
     ShareSheetActionResult? actionResult,
     bool clearActionResult = false,
   }) {
@@ -173,6 +187,7 @@ class ShareSheetState extends Equatable {
       contacts: contacts ?? this.contacts,
       selectedRecipients: selectedRecipients ?? this.selectedRecipients,
       isSending: isSending ?? this.isSending,
+      isSaving: isSaving ?? this.isSaving,
       actionResult: clearActionResult
           ? null
           : (actionResult ?? this.actionResult),
@@ -185,6 +200,7 @@ class ShareSheetState extends Equatable {
     contacts,
     selectedRecipients,
     isSending,
+    isSaving,
     actionResult,
   ];
 }

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -73,6 +73,7 @@ class BookmarkToggleResult {
     required this.succeeded,
     required this.wasBookmarked,
     required this.isBookmarked,
+    this.failure,
   });
 
   /// Whether the change reconciled and a relay accepted the new list.
@@ -84,6 +85,32 @@ class BookmarkToggleResult {
   /// Whether the video is bookmarked now. Equals [wasBookmarked] when the
   /// toggle failed, since no relay accepted a new list.
   final bool isBookmarked;
+
+  /// Why the toggle failed, or `null` when [succeeded] is true. Lets the UI
+  /// tell "we could not reach the network" apart from "the relay said no".
+  final BookmarkToggleFailure? failure;
+}
+
+/// Why a bookmark mutation did not complete.
+///
+/// Deliberately does not name a member "offline": `noRelays` is also reported
+/// for a disposed client, so [couldNotReachRelays] describes what was observed
+/// rather than guessing at the device's connectivity.
+enum BookmarkToggleFailure {
+  /// No relay could be reached, so the current list could not be read.
+  couldNotReachRelays,
+
+  /// Relays were reachable but did not answer before the query deadline.
+  timedOut,
+
+  /// The list reconciled, but no relay accepted the new version.
+  relayDidNotAccept,
+
+  /// There is no signed-in identity to read or publish as.
+  notAuthenticated,
+
+  /// Anything else, including an unexpected throw.
+  unknown,
 }
 
 /// Service for the user's NIP-51 global bookmark list (kind 10003).
@@ -196,7 +223,20 @@ class BookmarkService {
   /// missing is re-confirmed each time rather than once per window. An answer
   /// that stays unconfirmed changes nothing. A read that finds a list keeps
   /// the fast trade and pays for none of this.
-  Future<bool> syncGlobalBookmarks({bool requireAuthoritative = false}) async {
+  Future<bool> syncGlobalBookmarks({bool requireAuthoritative = false}) async =>
+      // Equality to success, never `!= someFailure`: a blacklist would let any
+      // failure member added later fall through as "reconciled" and publish
+      // kind 10003 from an inconclusive read — the #6966 regression.
+      await _syncGlobalBookmarks(requireAuthoritative: requireAuthoritative) ==
+      null;
+
+  /// [syncGlobalBookmarks], but reporting *why* it failed.
+  ///
+  /// Returns `null` on success. Only [toggleVideoInGlobalBookmarks] needs the
+  /// reason, so the public surface stays a bool.
+  Future<BookmarkToggleFailure?> _syncGlobalBookmarks({
+    required bool requireAuthoritative,
+  }) async {
     final pubkey = _authService.currentPublicKeyHex;
     if (!_authService.isAuthenticated || pubkey == null) {
       Log.warning(
@@ -204,15 +244,16 @@ class BookmarkService {
         name: 'BookmarkService',
         category: LogCategory.system,
       );
-      return false;
+      return BookmarkToggleFailure.notAuthenticated;
     }
 
     try {
-      var events = await _readRemoteGlobalBookmarks(
+      final read = await _readRemoteGlobalBookmarks(
         pubkey,
         requireAuthoritative: requireAuthoritative,
       );
-      if (events == null) return false;
+      var events = read.events;
+      if (events == null) return read.failure;
       var answeredAuthoritatively = requireAuthoritative;
 
       if (events.isEmpty && !requireAuthoritative && _mustConfirmAbsence) {
@@ -223,10 +264,11 @@ class BookmarkService {
         // — the reinstall #6627 is about, where the cache is empty too — or
         // overwrites the snapshot Saved falls back to offline. Confirm it
         // against every relay before believing it.
-        events = await _readRemoteGlobalBookmarks(
+        final confirmation = await _readRemoteGlobalBookmarks(
           pubkey,
           requireAuthoritative: true,
         );
+        events = confirmation.events;
         if (events == null) {
           Log.warning(
             'Empty bookmark answer not confirmed by every relay - keeping '
@@ -234,7 +276,7 @@ class BookmarkService {
             name: 'BookmarkService',
             category: LogCategory.system,
           );
-          return false;
+          return confirmation.failure;
         }
         answeredAuthoritatively = true;
       }
@@ -269,14 +311,14 @@ class BookmarkService {
         name: 'BookmarkService',
         category: LogCategory.system,
       );
-      return true;
+      return null;
     } catch (e) {
       Log.error(
         'Failed to sync global bookmarks from relay: $e',
         name: 'BookmarkService',
         category: LogCategory.system,
       );
-      return false;
+      return BookmarkToggleFailure.unknown;
     }
   }
 
@@ -289,7 +331,8 @@ class BookmarkService {
   /// regardless of settlement, so leaving it on would let a stale locally-held
   /// kind-10003 stand in for a relay answer — and the next publish would
   /// resurrect a list the user had already emptied.
-  Future<List<Event>?> _readRemoteGlobalBookmarks(
+  Future<({List<Event>? events, BookmarkToggleFailure? failure})>
+  _readRemoteGlobalBookmarks(
     String pubkey, {
     required bool requireAuthoritative,
   }) async {
@@ -310,12 +353,22 @@ class BookmarkService {
         name: 'BookmarkService',
         category: LogCategory.system,
       );
-      return null;
+      // A device with no reachable relay sets *both* flags, so noRelays has to
+      // be tested first or offline would always report as a timeout.
+      return (
+        events: null,
+        failure: result.noRelays
+            ? BookmarkToggleFailure.couldNotReachRelays
+            : BookmarkToggleFailure.timedOut,
+      );
     }
 
-    return result.events
-        .where((event) => event.kind == globalBookmarksKind)
-        .toList();
+    return (
+      events: result.events
+          .where((event) => event.kind == globalBookmarksKind)
+          .toList(),
+      failure: null,
+    );
   }
 
   /// If [videoEventId] is globally bookmarked, removes it; otherwise adds it.
@@ -330,14 +383,15 @@ class BookmarkService {
     String? relay,
     String? petname,
   }) async {
-    final reconciled = await syncGlobalBookmarks(requireAuthoritative: true);
+    final failure = await _syncGlobalBookmarks(requireAuthoritative: true);
     final wasBookmarked = isVideoBookmarkedGlobally(videoEventId);
 
-    if (!reconciled) {
+    if (failure != null) {
       return BookmarkToggleResult(
         succeeded: false,
         wasBookmarked: wasBookmarked,
         isBookmarked: wasBookmarked,
+        failure: failure,
       );
     }
 
@@ -360,6 +414,9 @@ class BookmarkService {
       succeeded: succeeded,
       wasBookmarked: wasBookmarked,
       isBookmarked: succeeded ? !wasBookmarked : wasBookmarked,
+      // The read already reconciled, so anything failing past this point is
+      // the publish leg.
+      failure: succeeded ? null : BookmarkToggleFailure.relayDidNotAccept,
     );
   }
 

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -87,7 +87,7 @@ class BookmarkToggleResult {
   final bool isBookmarked;
 
   /// Why the toggle failed, or `null` when [succeeded] is true. Lets the UI
-  /// tell "we could not reach the network" apart from "the relay said no".
+  /// tell "we could not reach the network" apart from publish-leg failures.
   final BookmarkToggleFailure? failure;
 }
 
@@ -103,8 +103,8 @@ enum BookmarkToggleFailure {
   /// Relays were reachable but did not answer before the query deadline.
   timedOut,
 
-  /// The list reconciled, but no relay accepted the new version.
-  relayDidNotAccept,
+  /// The list reconciled, but the new version was not published.
+  publishDidNotComplete,
 
   /// There is no signed-in identity to read or publish as.
   notAuthenticated,
@@ -253,7 +253,7 @@ class BookmarkService {
         requireAuthoritative: requireAuthoritative,
       );
       var events = read.events;
-      if (events == null) return read.failure;
+      if (events == null) return read.failure ?? BookmarkToggleFailure.unknown;
       var answeredAuthoritatively = requireAuthoritative;
 
       if (events.isEmpty && !requireAuthoritative && _mustConfirmAbsence) {
@@ -276,7 +276,7 @@ class BookmarkService {
             name: 'BookmarkService',
             category: LogCategory.system,
           );
-          return confirmation.failure;
+          return confirmation.failure ?? BookmarkToggleFailure.unknown;
         }
         answeredAuthoritatively = true;
       }
@@ -415,8 +415,9 @@ class BookmarkService {
       wasBookmarked: wasBookmarked,
       isBookmarked: succeeded ? !wasBookmarked : wasBookmarked,
       // The read already reconciled, so anything failing past this point is
-      // the publish leg.
-      failure: succeeded ? null : BookmarkToggleFailure.relayDidNotAccept,
+      // the publish leg: auth disappeared, signing failed, relay OK never came
+      // back true, or the publish path threw.
+      failure: succeeded ? null : BookmarkToggleFailure.publishDidNotComplete,
     );
   }
 

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -24,6 +24,7 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/providers/video_clip_import_provider.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart';
+import 'package:openvine/services/bookmark_service.dart';
 import 'package:openvine/services/video_clip_import_service.dart';
 import 'package:openvine/services/video_sharing_service.dart';
 import 'package:openvine/utils/delete_result_localization.dart';
@@ -290,11 +291,18 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
         :final succeeded,
         :final removed,
         :final wasBookmarkedBeforeToggle,
+        :final failure,
       ):
+        // "Failed to add bookmark" names no recovery for the state the user is
+        // almost certainly in, and after a long blocking wait that matters
+        // more, not less. Only the unreachable-relay case is worded
+        // separately; the rest keep today's copy.
         final snackText = succeeded
             ? (removed
                   ? context.l10n.shareRemovedFromBookmarks
                   : context.l10n.shareAddedToBookmarks)
+            : failure == BookmarkToggleFailure.couldNotReachRelays
+            ? context.l10n.profileSetupNoRelaysConnected
             : (wasBookmarkedBeforeToggle
                   ? context.l10n.shareFailedToRemoveBookmark
                   : context.l10n.shareFailedToAddBookmark);
@@ -714,6 +722,7 @@ class _UnifiedShareSheetView extends StatelessWidget {
                       _MoreActionsSection(
                         video: video,
                         isOwnContent: isOwnContent,
+                        isSavePending: state.isSaving,
                         onCrosspost: onCrosspost,
                         onSave: () => bloc.add(const ShareSheetSaveRequested()),
                         onSaveOriginal: onSaveOriginal,

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -295,17 +295,23 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
       ):
         // "Failed to add bookmark" names no recovery for the state the user is
         // almost certainly in, and after a long blocking wait that matters
-        // more, not less. Only the unreachable-relay case is worded
-        // separately; the rest keep today's copy.
+        // more, not less. Both network-shaped failures are worded that way:
+        // the read runs with requireAllRelaysSettled, so a single slow relay
+        // reports timedOut while the device is merely degraded, not offline.
+        // Everything else keeps today's copy.
         final snackText = succeeded
             ? (removed
                   ? context.l10n.shareRemovedFromBookmarks
                   : context.l10n.shareAddedToBookmarks)
-            : failure == BookmarkToggleFailure.couldNotReachRelays
-            ? context.l10n.profileSetupNoRelaysConnected
-            : (wasBookmarkedBeforeToggle
-                  ? context.l10n.shareFailedToRemoveBookmark
-                  : context.l10n.shareFailedToAddBookmark);
+            : switch (failure) {
+                BookmarkToggleFailure.couldNotReachRelays ||
+                BookmarkToggleFailure.timedOut =>
+                  context.l10n.profileSetupNoRelaysConnected,
+                _ =>
+                  wasBookmarkedBeforeToggle
+                      ? context.l10n.shareFailedToRemoveBookmark
+                      : context.l10n.shareFailedToAddBookmark,
+              };
         _safePop(context);
         messenger.showSnackBar(
           DivineSnackbarContainer.snackBar(snackText, error: !succeeded),

--- a/mobile/lib/widgets/video_feed_item/actions/share_sheet_more_actions.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_sheet_more_actions.dart
@@ -15,6 +15,7 @@ class _MoreActionsSection extends ConsumerWidget {
     required this.onShareVia,
     required this.onCopyEventJson,
     required this.onCopyEventId,
+    this.isSavePending = false,
     this.onEditVideo,
     this.onDeleteVideo,
     this.onAddVideoToClips,
@@ -24,6 +25,9 @@ class _MoreActionsSection extends ConsumerWidget {
 
   final VideoEvent video;
   final bool isOwnContent;
+
+  /// Whether the bookmark toggle is mid-flight (#7073).
+  final bool isSavePending;
   final VoidCallback onSave;
   final Future<void> Function()? onSaveOriginal;
   final Future<void> Function() onSaveWithWatermark;
@@ -69,6 +73,7 @@ class _MoreActionsSection extends ConsumerWidget {
         icon: DivineIconName.bookmarkSimple,
         label: context.l10n.shareSheetSave,
         onTap: onSave,
+        isPending: isSavePending,
       ),
       if (onSaveOriginal != null)
         _ActionData(
@@ -155,6 +160,7 @@ class _MoreActionsSection extends ConsumerWidget {
                   icon: action.icon,
                   label: action.label,
                   onTap: action.onTap,
+                  isPending: action.isPending,
                 );
               },
             ),
@@ -170,11 +176,16 @@ class _ActionData {
     required this.icon,
     required this.label,
     required this.onTap,
+    this.isPending = false,
   });
 
   final DivineIconName icon;
   final String label;
   final VoidCallback onTap;
+
+  /// Whether the action is mid-flight, so the circle shows a spinner and stops
+  /// responding to taps.
+  final bool isPending;
 }
 
 class _ActionCircle extends StatelessWidget {
@@ -182,13 +193,16 @@ class _ActionCircle extends StatelessWidget {
     required this.icon,
     required this.label,
     required this.onTap,
+    this.isPending = false,
   });
 
   final DivineIconName icon;
   final String label;
   final VoidCallback onTap;
+  final bool isPending;
 
   static const double _circleSize = 48;
+  static const double _iconSize = 22;
 
   @override
   Widget build(BuildContext context) {
@@ -198,9 +212,10 @@ class _ActionCircle extends StatelessWidget {
     return Semantics(
       button: true,
       label: label,
+      enabled: !isPending,
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
-        onTap: onTap,
+        onTap: isPending ? null : onTap,
         child: SizedBox(
           width: 68,
           child: Column(
@@ -215,7 +230,24 @@ class _ActionCircle extends StatelessWidget {
                   shape: BoxShape.circle,
                 ),
                 child: Center(
-                  child: DivineIcon(icon: icon, size: 22, color: iconColor),
+                  child: isPending
+                      // Same footprint as the icon it replaces, so the row does
+                      // not reflow while the save is in flight. Mirrors the
+                      // send button in share_sheet_message_input.dart.
+                      ? const SizedBox.square(
+                          dimension: _iconSize,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            valueColor: AlwaysStoppedAnimation<Color>(
+                              iconColor,
+                            ),
+                          ),
+                        )
+                      : DivineIcon(
+                          icon: icon,
+                          size: _iconSize,
+                          color: iconColor,
+                        ),
                 ),
               ),
               Text(

--- a/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
+++ b/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
@@ -1031,6 +1031,31 @@ void main() {
           () => mockBookmarkService.toggleVideoInGlobalBookmarks(any()),
         ).called(1),
       );
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'does not emit after close when save completes late',
+        setUp: () {
+          saveGate = Completer<BookmarkToggleResult>();
+          when(
+            () => mockBookmarkService.toggleVideoInGlobalBookmarks(any()),
+          ).thenAnswer((_) => saveGate.future);
+        },
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const ShareSheetSaveRequested());
+          await Future<void>.delayed(Duration.zero);
+          await bloc.close();
+          saveGate.complete(
+            const BookmarkToggleResult(
+              succeeded: true,
+              wasBookmarked: false,
+              isBookmarked: true,
+            ),
+          );
+          await Future<void>.delayed(Duration.zero);
+        },
+        expect: () => [savePending],
+      );
     });
 
     // -----------------------------------------------------------------------

--- a/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
+++ b/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Verifies contact loading, recipient selection, send-with-message,
 // ABOUTME: save, copy, and share-via action flows
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:file/file.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
@@ -700,6 +702,15 @@ void main() {
     // -----------------------------------------------------------------------
 
     group('ShareSheetSaveRequested', () {
+      // The save handler emits a pending state before it touches the
+      // network, then the terminal result, so every expectation below opens
+      // with this one and asserts the flag is cleared on the way out.
+      final savePending = isA<ShareSheetState>()
+          .having((s) => s.isSaving, 'isSaving', isTrue)
+          .having((s) => s.actionResult, 'actionResult', isNull);
+
+      late Completer<BookmarkToggleResult> saveGate;
+
       blocTest<ShareSheetBloc, ShareSheetState>(
         'emits $ShareSheetSaveResult with succeeded=true, removed=false when adding bookmark',
         setUp: () {
@@ -716,18 +727,21 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(const ShareSheetSaveRequested()),
         expect: () => [
-          isA<ShareSheetState>().having(
-            (s) => s.actionResult,
-            'actionResult',
-            isA<ShareSheetSaveResult>()
-                .having((r) => r.succeeded, 'succeeded', isTrue)
-                .having((r) => r.removed, 'removed', isFalse)
-                .having(
-                  (r) => r.wasBookmarkedBeforeToggle,
-                  'wasBookmarkedBeforeToggle',
-                  isFalse,
-                ),
-          ),
+          savePending,
+          isA<ShareSheetState>()
+              .having((s) => s.isSaving, 'isSaving', isFalse)
+              .having(
+                (s) => s.actionResult,
+                'actionResult',
+                isA<ShareSheetSaveResult>()
+                    .having((r) => r.succeeded, 'succeeded', isTrue)
+                    .having((r) => r.removed, 'removed', isFalse)
+                    .having(
+                      (r) => r.wasBookmarkedBeforeToggle,
+                      'wasBookmarkedBeforeToggle',
+                      isFalse,
+                    ),
+              ),
         ],
       );
 
@@ -747,18 +761,21 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(const ShareSheetSaveRequested()),
         expect: () => [
-          isA<ShareSheetState>().having(
-            (s) => s.actionResult,
-            'actionResult',
-            isA<ShareSheetSaveResult>()
-                .having((r) => r.succeeded, 'succeeded', isTrue)
-                .having((r) => r.removed, 'removed', isTrue)
-                .having(
-                  (r) => r.wasBookmarkedBeforeToggle,
-                  'wasBookmarkedBeforeToggle',
-                  isTrue,
-                ),
-          ),
+          savePending,
+          isA<ShareSheetState>()
+              .having((s) => s.isSaving, 'isSaving', isFalse)
+              .having(
+                (s) => s.actionResult,
+                'actionResult',
+                isA<ShareSheetSaveResult>()
+                    .having((r) => r.succeeded, 'succeeded', isTrue)
+                    .having((r) => r.removed, 'removed', isTrue)
+                    .having(
+                      (r) => r.wasBookmarkedBeforeToggle,
+                      'wasBookmarkedBeforeToggle',
+                      isTrue,
+                    ),
+              ),
         ],
       );
 
@@ -778,18 +795,21 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(const ShareSheetSaveRequested()),
         expect: () => [
-          isA<ShareSheetState>().having(
-            (s) => s.actionResult,
-            'actionResult',
-            isA<ShareSheetSaveResult>()
-                .having((r) => r.succeeded, 'succeeded', isFalse)
-                .having((r) => r.removed, 'removed', isFalse)
-                .having(
-                  (r) => r.wasBookmarkedBeforeToggle,
-                  'wasBookmarkedBeforeToggle',
-                  isFalse,
-                ),
-          ),
+          savePending,
+          isA<ShareSheetState>()
+              .having((s) => s.isSaving, 'isSaving', isFalse)
+              .having(
+                (s) => s.actionResult,
+                'actionResult',
+                isA<ShareSheetSaveResult>()
+                    .having((r) => r.succeeded, 'succeeded', isFalse)
+                    .having((r) => r.removed, 'removed', isFalse)
+                    .having(
+                      (r) => r.wasBookmarkedBeforeToggle,
+                      'wasBookmarkedBeforeToggle',
+                      isFalse,
+                    ),
+              ),
         ],
       );
 
@@ -810,18 +830,21 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(const ShareSheetSaveRequested()),
         expect: () => [
-          isA<ShareSheetState>().having(
-            (s) => s.actionResult,
-            'actionResult',
-            isA<ShareSheetSaveResult>()
-                .having((r) => r.succeeded, 'succeeded', isFalse)
-                .having((r) => r.removed, 'removed', isFalse)
-                .having(
-                  (r) => r.wasBookmarkedBeforeToggle,
-                  'wasBookmarkedBeforeToggle',
-                  isTrue,
-                ),
-          ),
+          savePending,
+          isA<ShareSheetState>()
+              .having((s) => s.isSaving, 'isSaving', isFalse)
+              .having(
+                (s) => s.actionResult,
+                'actionResult',
+                isA<ShareSheetSaveResult>()
+                    .having((r) => r.succeeded, 'succeeded', isFalse)
+                    .having((r) => r.removed, 'removed', isFalse)
+                    .having(
+                      (r) => r.wasBookmarkedBeforeToggle,
+                      'wasBookmarkedBeforeToggle',
+                      isTrue,
+                    ),
+              ),
         ],
       );
 
@@ -836,18 +859,21 @@ void main() {
         act: (bloc) => bloc.add(const ShareSheetSaveRequested()),
         errors: () => [isA<Exception>()],
         expect: () => [
-          isA<ShareSheetState>().having(
-            (s) => s.actionResult,
-            'actionResult',
-            isA<ShareSheetSaveResult>()
-                .having((r) => r.succeeded, 'succeeded', isFalse)
-                .having((r) => r.removed, 'removed', isFalse)
-                .having(
-                  (r) => r.wasBookmarkedBeforeToggle,
-                  'wasBookmarkedBeforeToggle',
-                  isFalse,
-                ),
-          ),
+          savePending,
+          isA<ShareSheetState>()
+              .having((s) => s.isSaving, 'isSaving', isFalse)
+              .having(
+                (s) => s.actionResult,
+                'actionResult',
+                isA<ShareSheetSaveResult>()
+                    .having((r) => r.succeeded, 'succeeded', isFalse)
+                    .having((r) => r.removed, 'removed', isFalse)
+                    .having(
+                      (r) => r.wasBookmarkedBeforeToggle,
+                      'wasBookmarkedBeforeToggle',
+                      isFalse,
+                    ),
+              ),
         ],
       );
 
@@ -866,18 +892,21 @@ void main() {
         act: (bloc) => bloc.add(const ShareSheetSaveRequested()),
         errors: () => [isA<Exception>()],
         expect: () => [
-          isA<ShareSheetState>().having(
-            (s) => s.actionResult,
-            'actionResult',
-            isA<ShareSheetSaveResult>()
-                .having((r) => r.succeeded, 'succeeded', isFalse)
-                .having((r) => r.removed, 'removed', isFalse)
-                .having(
-                  (r) => r.wasBookmarkedBeforeToggle,
-                  'wasBookmarkedBeforeToggle',
-                  isTrue,
-                ),
-          ),
+          savePending,
+          isA<ShareSheetState>()
+              .having((s) => s.isSaving, 'isSaving', isFalse)
+              .having(
+                (s) => s.actionResult,
+                'actionResult',
+                isA<ShareSheetSaveResult>()
+                    .having((r) => r.succeeded, 'succeeded', isFalse)
+                    .having((r) => r.removed, 'removed', isFalse)
+                    .having(
+                      (r) => r.wasBookmarkedBeforeToggle,
+                      'wasBookmarkedBeforeToggle',
+                      isTrue,
+                    ),
+              ),
         ],
       );
 
@@ -887,18 +916,21 @@ void main() {
             createBloc(bookmarkServiceFuture: Future<BookmarkService?>.value()),
         act: (bloc) => bloc.add(const ShareSheetSaveRequested()),
         expect: () => [
-          isA<ShareSheetState>().having(
-            (s) => s.actionResult,
-            'actionResult',
-            isA<ShareSheetSaveResult>()
-                .having((r) => r.succeeded, 'succeeded', isFalse)
-                .having((r) => r.removed, 'removed', isFalse)
-                .having(
-                  (r) => r.wasBookmarkedBeforeToggle,
-                  'wasBookmarkedBeforeToggle',
-                  isFalse,
-                ),
-          ),
+          savePending,
+          isA<ShareSheetState>()
+              .having((s) => s.isSaving, 'isSaving', isFalse)
+              .having(
+                (s) => s.actionResult,
+                'actionResult',
+                isA<ShareSheetSaveResult>()
+                    .having((r) => r.succeeded, 'succeeded', isFalse)
+                    .having((r) => r.removed, 'removed', isFalse)
+                    .having(
+                      (r) => r.wasBookmarkedBeforeToggle,
+                      'wasBookmarkedBeforeToggle',
+                      isFalse,
+                    ),
+              ),
         ],
       );
 
@@ -925,29 +957,79 @@ void main() {
           bloc.add(const ShareSheetSaveRequested());
         },
         expect: () => [
-          isA<ShareSheetState>().having(
-            (s) => s.actionResult,
-            'actionResult',
-            isA<ShareSheetSaveResult>()
-                .having((r) => r.removed, 'removed', isFalse)
-                .having(
-                  (r) => r.wasBookmarkedBeforeToggle,
-                  'wasBookmarkedBeforeToggle',
-                  isFalse,
-                ),
-          ),
-          isA<ShareSheetState>().having(
-            (s) => s.actionResult,
-            'actionResult',
-            isA<ShareSheetSaveResult>()
-                .having((r) => r.removed, 'removed', isTrue)
-                .having(
-                  (r) => r.wasBookmarkedBeforeToggle,
-                  'wasBookmarkedBeforeToggle',
+          savePending,
+          isA<ShareSheetState>()
+              .having((s) => s.isSaving, 'isSaving', isFalse)
+              .having(
+                (s) => s.actionResult,
+                'actionResult',
+                isA<ShareSheetSaveResult>()
+                    .having((r) => r.removed, 'removed', isFalse)
+                    .having(
+                      (r) => r.wasBookmarkedBeforeToggle,
+                      'wasBookmarkedBeforeToggle',
+                      isFalse,
+                    ),
+              ),
+          savePending,
+          isA<ShareSheetState>()
+              .having((s) => s.isSaving, 'isSaving', isFalse)
+              .having(
+                (s) => s.actionResult,
+                'actionResult',
+                isA<ShareSheetSaveResult>()
+                    .having((r) => r.removed, 'removed', isTrue)
+                    .having(
+                      (r) => r.wasBookmarkedBeforeToggle,
+                      'wasBookmarkedBeforeToggle',
+                      isTrue,
+                    ),
+              ),
+        ],
+      );
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'swallows a repeat save while the first is still in flight',
+        setUp: () {
+          saveGate = Completer<BookmarkToggleResult>();
+          when(
+            () => mockBookmarkService.toggleVideoInGlobalBookmarks(any()),
+          ).thenAnswer((_) => saveGate.future);
+        },
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const ShareSheetSaveRequested());
+          await Future<void>.delayed(Duration.zero);
+          // Still reconciling. The sheet is showing the pending affordance and
+          // this second tap must not start another reconcile-and-publish of a
+          // replaceable list.
+          bloc.add(const ShareSheetSaveRequested());
+          await Future<void>.delayed(Duration.zero);
+          saveGate.complete(
+            const BookmarkToggleResult(
+              succeeded: true,
+              wasBookmarked: false,
+              isBookmarked: true,
+            ),
+          );
+        },
+        expect: () => [
+          savePending,
+          isA<ShareSheetState>()
+              .having((s) => s.isSaving, 'isSaving', isFalse)
+              .having(
+                (s) => s.actionResult,
+                'actionResult',
+                isA<ShareSheetSaveResult>().having(
+                  (r) => r.succeeded,
+                  'succeeded',
                   isTrue,
                 ),
-          ),
+              ),
         ],
+        verify: (_) => verify(
+          () => mockBookmarkService.toggleVideoInGlobalBookmarks(any()),
+        ).called(1),
       );
     });
 

--- a/mobile/test/services/bookmark_service_test.dart
+++ b/mobile/test/services/bookmark_service_test.dart
@@ -887,6 +887,60 @@ void main() {
         expect(result.isBookmarked, equals(result.wasBookmarked));
         verifyNever(() => nostrClient.publishEventAwaitOk(any()));
       });
+
+      test(
+        'reports couldNotReachRelays, not timedOut, when the device is '
+        'offline and the query sets both flags',
+        () async {
+          // An offline device reports noRelays *and* timedOut. Testing
+          // timedOut first would route offline to the wrong message, so the
+          // precedence is pinned here.
+          stubRelay(events: [], timedOut: true, noRelays: true);
+          final service = createService();
+
+          final result = await service.toggleVideoInGlobalBookmarks('wanted');
+
+          expect(
+            result.failure,
+            equals(BookmarkToggleFailure.couldNotReachRelays),
+          );
+          verifyNever(() => nostrClient.publishEventAwaitOk(any()));
+        },
+      );
+
+      test('reports timedOut when relays were reachable but silent', () async {
+        stubRelay(events: [], timedOut: true);
+        final service = createService();
+
+        final result = await service.toggleVideoInGlobalBookmarks('wanted');
+
+        expect(result.failure, equals(BookmarkToggleFailure.timedOut));
+        verifyNever(() => nostrClient.publishEventAwaitOk(any()));
+      });
+
+      test('reports relayDidNotAccept when the publish is rejected', () async {
+        stubRelay(events: []);
+        stubPublishRejected();
+        final service = createService();
+
+        final result = await service.toggleVideoInGlobalBookmarks('wanted');
+
+        expect(result.succeeded, isFalse);
+        expect(
+          result.failure,
+          equals(BookmarkToggleFailure.relayDidNotAccept),
+        );
+      });
+
+      test('carries no failure reason when the toggle succeeds', () async {
+        stubRelay(events: []);
+        final service = createService();
+
+        final result = await service.toggleVideoInGlobalBookmarks('wanted');
+
+        expect(result.succeeded, isTrue);
+        expect(result.failure, isNull);
+      });
     });
   });
 }

--- a/mobile/test/services/bookmark_service_test.dart
+++ b/mobile/test/services/bookmark_service_test.dart
@@ -918,19 +918,22 @@ void main() {
         verifyNever(() => nostrClient.publishEventAwaitOk(any()));
       });
 
-      test('reports relayDidNotAccept when the publish is rejected', () async {
-        stubRelay(events: []);
-        stubPublishRejected();
-        final service = createService();
+      test(
+        'reports publishDidNotComplete when the publish is rejected',
+        () async {
+          stubRelay(events: []);
+          stubPublishRejected();
+          final service = createService();
 
-        final result = await service.toggleVideoInGlobalBookmarks('wanted');
+          final result = await service.toggleVideoInGlobalBookmarks('wanted');
 
-        expect(result.succeeded, isFalse);
-        expect(
-          result.failure,
-          equals(BookmarkToggleFailure.relayDidNotAccept),
-        );
-      });
+          expect(result.succeeded, isFalse);
+          expect(
+            result.failure,
+            equals(BookmarkToggleFailure.publishDidNotComplete),
+          );
+        },
+      );
 
       test('carries no failure reason when the toggle succeeds', () async {
         stubRelay(events: []);

--- a/mobile/test/widgets/share_video_menu_comprehensive_test.dart
+++ b/mobile/test/widgets/share_video_menu_comprehensive_test.dart
@@ -2,6 +2,9 @@
 // ABOUTME: sheet rendering, feature flags, save/bookmark, copy link, share via,
 // ABOUTME: and quick-send behavior.
 
+import 'dart:async';
+import 'dart:ui' show Tristate;
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -374,6 +377,62 @@ void main() {
         () => mockBookmarkService.toggleVideoInGlobalBookmarks(testVideo.id),
       ).called(1);
     });
+
+    testWidgets(
+      'Save shows a spinner and stops accepting taps while in flight',
+      (tester) async {
+        // The real toggle reconciles kind 10003 with the relay, signs, then
+        // waits for the publish to be accepted — 3.9s on a healthy production
+        // connection. Holding the future open is the only way a test can see
+        // that window; the other Save tests resolve in a microtask and the
+        // handler finishes before the first rebuild.
+        final gate = Completer<BookmarkToggleResult>();
+        when(
+          () => mockBookmarkService.isVideoBookmarkedGlobally(any()),
+        ).thenReturn(false);
+        when(
+          () => mockBookmarkService.toggleVideoInGlobalBookmarks(any()),
+        ).thenAnswer((_) => gate.future);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.tap(find.byType(ShareActionButton));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Save'));
+        // Never pumpAndSettle here: the spinner animates forever and the pump
+        // budget runs out instead of settling.
+        await tester.pump();
+
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+        final saveSemantics = tester.getSemantics(
+          find
+              .ancestor(of: find.text('Save'), matching: find.byType(Semantics))
+              .first,
+        );
+        expect(
+          saveSemantics.flagsCollection.isEnabled,
+          equals(Tristate.isFalse),
+        );
+
+        await tester.tap(find.text('Save'));
+        await tester.pump();
+
+        gate.complete(
+          const BookmarkToggleResult(
+            succeeded: true,
+            wasBookmarked: false,
+            isBookmarked: true,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Added to bookmarks'), findsOneWidget);
+        verify(
+          () => mockBookmarkService.toggleVideoInGlobalBookmarks(testVideo.id),
+        ).called(1);
+      },
+    );
 
     testWidgets('tapping Save shows failure snackbar on error', (tester) async {
       when(

--- a/mobile/test/widgets/share_video_menu_comprehensive_test.dart
+++ b/mobile/test/widgets/share_video_menu_comprehensive_test.dart
@@ -363,7 +363,8 @@ void main() {
       await tester.tap(find.text('Save'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Added to bookmarks'), findsOneWidget);
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.shareAddedToBookmarks), findsOneWidget);
       verify(
         () => mockBookmarkService.isVideoBookmarkedGlobally(testVideo.id),
       ).called(1);
@@ -421,7 +422,8 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('Added to bookmarks'), findsOneWidget);
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.shareAddedToBookmarks), findsOneWidget);
         verify(
           () => mockBookmarkService.toggleVideoInGlobalBookmarks(testVideo.id),
         ).called(1);

--- a/mobile/test/widgets/share_video_menu_comprehensive_test.dart
+++ b/mobile/test/widgets/share_video_menu_comprehensive_test.dart
@@ -112,9 +112,7 @@ void main() {
         any(),
         libraryTitle: any(named: 'libraryTitle'),
       ),
-    ).thenAnswer(
-      (_) async => VideoClipImportSuccess(_FakeDivineVideoClip()),
-    );
+    ).thenAnswer((_) async => VideoClipImportSuccess(_FakeDivineVideoClip()));
     when(
       () => mockBookmarkService.isVideoBookmarkedGlobally(any()),
     ).thenReturn(false);
@@ -260,9 +258,7 @@ void main() {
           () => authService.currentPublicKeyHex,
         ).thenReturn(testVideo.pubkey);
 
-        await tester.pumpWidget(
-          buildSubject(mockAuthService: authService),
-        );
+        await tester.pumpWidget(buildSubject(mockAuthService: authService));
         await tester.tap(find.byType(ShareActionButton));
         await tester.pumpAndSettle();
 
@@ -296,9 +292,7 @@ void main() {
     ) async {
       final authService = createMockAuthService();
       when(() => authService.isAuthenticated).thenReturn(true);
-      when(
-        () => authService.currentPublicKeyHex,
-      ).thenReturn(testVideo.pubkey);
+      when(() => authService.currentPublicKeyHex).thenReturn(testVideo.pubkey);
 
       await tester.pumpWidget(buildSubject(mockAuthService: authService));
       await tester.tap(find.byType(ShareActionButton));
@@ -477,6 +471,44 @@ void main() {
 
       expect(find.text('Failed to add bookmark'), findsOneWidget);
     });
+
+    // Both network-shaped failures share the "couldn't reach the network"
+    // wording. timedOut is the one a degraded connection actually produces:
+    // the read runs with requireAllRelaysSettled, so one slow relay times the
+    // query out while connectedRelays is non-empty and noRelays stays false.
+    for (final (name, failure) in const [
+      ('couldNotReachRelays', BookmarkToggleFailure.couldNotReachRelays),
+      ('timedOut', BookmarkToggleFailure.timedOut),
+    ]) {
+      testWidgets('tapping Save reports $name as a network failure', (
+        tester,
+      ) async {
+        when(
+          () => mockBookmarkService.isVideoBookmarkedGlobally(any()),
+        ).thenReturn(false);
+        when(
+          () => mockBookmarkService.toggleVideoInGlobalBookmarks(any()),
+        ).thenAnswer(
+          (_) async => BookmarkToggleResult(
+            succeeded: false,
+            wasBookmarked: false,
+            isBookmarked: false,
+            failure: failure,
+          ),
+        );
+
+        await tester.pumpWidget(buildSubject());
+        await tester.tap(find.byType(ShareActionButton));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Save'));
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.profileSetupNoRelaysConnected), findsOneWidget);
+        expect(find.text(l10n.shareFailedToAddBookmark), findsNothing);
+      });
+    }
 
     testWidgets('share sheet has correct DivineIcons', (tester) async {
       await tester.pumpWidget(buildSubject());


### PR DESCRIPTION
## Description

Since #6966 the share-sheet **Save** is a blocking network round trip — an authoritative kind-10003 reconcile, then a signature, then a publish awaiting relay `OK` — and the sheet rendered nothing for the whole window. `transformer: droppable()` swallowed repeat taps with no feedback, so the sheet read as broken.

Measured on the iOS simulator against `wss://relay.divine.video` with a Keycast identity, from a 60 fps screen recording: the More-actions row is **pixel-identical from t=1.2 s to t=5.2 s** with the tap landing at ~2.0 s, then the sheet abruptly vanishes. **3.86 s of inert UI.** Four toggles measured 1.19 s – 3.86 s end to end; in the slowest, the reconcile read alone consumed **3.15 s of its 5 s budget**.

Three commits:

1. **`BookmarkToggleFailure` on `BookmarkToggleResult`**, sourced only from the existing inconclusive detector in `_readRemoteGlobalBookmarks`. An offline device sets `noRelays` **and** `timedOut`, so `noRelays` is tested first — otherwise offline always reports as a timeout. The member is not named "offline" because `noRelays` is also returned for a *disposed* client. `syncGlobalBookmarks` keeps its `bool` signature over a private reason-returning body, written as **equality-to-success**, never `!= someFailure`: a blacklist would let any failure member added later fall through as "reconciled" and publish from an inconclusive read — the regression #6966 exists to prevent. `addToGlobalBookmarks` / `removeFromGlobalBookmarks` are untouched, since the toggle always reconciles authoritatively first.
2. **`isSaving` on `ShareSheetState`**, emitted at the very top of `_onSaveRequested` — above the bookmark-service await, which is itself a cold-start wait — and cleared on all three exits.
3. **`isPending` on `_ActionData` / `_ActionCircle`**: the circle swaps its icon for a same-sized spinner, stops accepting taps, and reports `enabled: false` to assistive tech. The unreachable-relay failure is worded with the existing `profileSetupNoRelaysConnected` rather than "Failed to add bookmark".

**Related Issue:** Closes #7073

### Two things reviewers should look at deliberately

**This ships a spinner where #3408/#3409 name bookmarks as debt to convert to *optimistic*.** #3408 line 67 — *"The same pattern needs to be applied to reposts, … curated lists, DM send, and bookmarks"* — and #3409 line 58 lists **Bookmarks** under its deferred set. That pattern is unavailable here, for two reasons:

- **There is no trusted pre-state to flip.** `toggleVideoInGlobalBookmarks` reconciles at `bookmark_service.dart:333` *before* reading direction at `:334`, and the result doc at `:66-70` makes that the contract. #3408's step 1, "snapshot pre-mutation state", has nothing to snapshot — which is also why #7072 exists.
- **`BookmarkService` has no publish serialization.** `NotifySubscriptionsRepository:35` *documents* "Implementations must serialize mutations", and that contract is why `NotifyBellCubit` can flip optimistically. Grepping `_publishLock|synchronized|Mutex|_inFlight` in `BookmarkService` returns nothing, so an unserialized read-modify-write of a replaceable list would be a lost-update race.

The issue itself closes with "Product decision needed" — happy to be overruled in one comment.

**The failure-reason enum is not what #7073 asked for.** The issue asks for the pending affordance; the enum is an unrequested addition. It is here because a spinner changes the cost of a bad message: "Failed to add bookmark" is forgettable after 1 s and useless after 30 s of held attention. Only the unreachable-relay case is worded differently; everything else keeps today's copy.

## Out of Scope

Not folded in here:

- **Timeout caps across all 8 blocking sites.** The dominant term is the **signer**, not the relay — the sign leg is ≤30 s, and ≤90 s across the 401 refresh+retry stack (`keycast_rpc.dart:96/111/117`) — so a publish cap alone would trim little. Capping is also a user-visible behaviour change (some saves that succeed today would report failure) with an unmeasured false-failure rate.
- **`OwnerVideoActionsCubit` emits `OwnerVideoDeleteStatus.deleting` and nothing renders it.** All three consumers test only `== success`, and the cubit has no `BlocProvider`/`BlocBuilder`/`BlocListener` anywhere — the status is unobservable by construction. Worse than this issue.
- **Bookmarks store addressable kind-34236 videos as bare `e` ids.** NIP-51 references addressable targets by `a` coordinate, so a revised video takes a new event id under the same `d` tag and silently stops reading as bookmarked. Lands on #7072.
- The offline read burning its full 5 s while the publish leg one function above short-circuits (`nostr_client.dart:894-896` vs `:769-781`) — a package change.
- `_safePop` firing on failure as well as success, so a failed save closes the sheet and retry needs a reopen.
- **#7072** — blocked on whether the sheet should do a *mutating* network read on open (`syncGlobalBookmarks` rewrites SharedPreferences), and on a missing filled-bookmark icon.

## Verification

- `flutter analyze lib test` — no issues.
- `flutter test` on the 4 affected suites — **126 passing**.
- Every new assertion mutation-tested rather than assumed:
  - flipping the `noRelays`/`timedOut` precedence → the offline test fails with `Actual: timedOut`;
  - dropping `enabled: !isPending` → `Actual: Tristate.none`;
  - never rendering the spinner → `Found 0 widgets with type "CircularProgressIndicator"`.
- All six CI ratchets green: 4 design-system ceilings, untested-services floor, test-unit structure.
- No new ARB keys, so no locale churn.
- Verified on the iOS simulator against the production relay.

Two harness notes for anyone extending these tests: `pumpAndSettle` cannot be used while the spinner is mounted (it animates forever), and `flagsCollection.isEnabled` is a `Tristate` that must be imported from `dart:ui`. The three existing "tapping Save" tests resolve the toggle in a microtask, so the handler completes before the first rebuild and they cannot observe this window at all — the Completer-gated test is the only one that can.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

