### PR TITLE
fix(recorder): discard the recording session when leaving the camera

### DIFF
--- a/mobile/lib/screens/video_recorder_screen.dart
+++ b/mobile/lib/screens/video_recorder_screen.dart
@@ -24,7 +24,6 @@ import 'package:openvine/providers/overlay_visibility_provider.dart';
 import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
-import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/widgets/camera_permission_gate.dart';
 import 'package:openvine/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart';
 import 'package:openvine/widgets/video_recorder/modes/capture/video_recorder_stop_motion_budget.dart';
@@ -185,8 +184,6 @@ class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
   OverlayVisibility? _overlayVisibilityNotifier;
   late final CreationAnalyticsTracker _creationAnalyticsTracker;
   VideoRecorderMode? _lastRecorderMode;
-
-  bool get _isAutosavedDraft => ref.read(videoEditorProvider).isAutosavedDraft;
 
   @override
   void initState() {
@@ -402,10 +399,8 @@ class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
         },
         child: PopScope(
           onPopInvokedWithResult: (didPop, value) {
-            if (didPop && !widget.fromEditor && !_isAutosavedDraft) {
-              ref
-                  .read(videoPublishProvider.notifier)
-                  .clearAll(keepAutosavedDraft: true);
+            if (didPop && !widget.fromEditor) {
+              discardRecorderSession(ref);
             }
           },
           child: AnnotatedRegion<SystemUiOverlayStyle>(

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_main_overlay_actions.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_main_overlay_actions.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Top overlay actions for the video editor with close and done buttons.
 // ABOUTME: Hides when the music sub-editor is open.
 
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -191,10 +193,19 @@ class _TopActions extends ConsumerWidget {
     if (draftSaved) {
       // The draft now owns the session, so end it here like the discard path
       // does — otherwise its clips stay selected behind the editor and the
-      // next camera open inherits them, aspect ratio included. The saved
-      // draft references the same files, so only the redundant autosave copy
-      // is reaped.
-      ref.read(videoPublishProvider.notifier).clearAll();
+      // next camera open inherits them, aspect ratio included.
+      //
+      // `keepAutosavedDraft` because `saveAsDraft` already awaited
+      // `removeAutosavedDraft()`: there is nothing left to reap, and re-issuing
+      // that delete unawaited is the hazard its own doc warns about — it
+      // targets the fixed autosave id, so landing late would wipe the recovery
+      // point of whatever session is active by then (adding a clip back on the
+      // recorder writes one).
+      unawaited(
+        ref
+            .read(videoPublishProvider.notifier)
+            .clearAll(keepAutosavedDraft: true),
+      );
       // Success: close prompt + close editor.
       context.pop();
       context.pop();

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_main_overlay_actions.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_main_overlay_actions.dart
@@ -189,6 +189,12 @@ class _TopActions extends ConsumerWidget {
     final draftSaved = outcome == DraftSaveOutcome.saved;
 
     if (draftSaved) {
+      // The draft now owns the session, so end it here like the discard path
+      // does — otherwise its clips stay selected behind the editor and the
+      // next camera open inherits them, aspect ratio included. The saved
+      // draft references the same files, so only the redundant autosave copy
+      // is reaped.
+      ref.read(videoPublishProvider.notifier).clearAll();
       // Success: close prompt + close editor.
       context.pop();
       context.pop();

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_top_bar.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_top_bar.dart
@@ -74,7 +74,7 @@ class VideoRecorderCaptureTopBar extends ConsumerWidget {
                       type: .ghostOverMedia,
                       onPressed: () => fromEditor
                           ? context.pop(false)
-                          : closeVideoRecorder(context),
+                          : closeVideoRecorder(context, ref),
                     ),
                     ?center,
                     AnimatedOpacity(

--- a/mobile/lib/widgets/video_recorder/modes/classic/video_recorder_classic_top_bar.dart
+++ b/mobile/lib/widgets/video_recorder/modes/classic/video_recorder_classic_top_bar.dart
@@ -39,7 +39,7 @@ class VideoRecorderClassicTopBar extends ConsumerWidget {
                   type: .ghostSecondary,
                   onPressed: isRecording
                       ? null
-                      : () => closeVideoRecorder(context),
+                      : () => closeVideoRecorder(context, ref),
                 ),
                 DivineIconButton(
                   icon: .caretRight,

--- a/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
@@ -18,6 +18,7 @@ import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/library_screen.dart';
@@ -30,12 +31,38 @@ import 'package:unified_logger/unified_logger.dart';
 ///
 /// Pops if there is a route to pop to, otherwise navigates home (the recorder
 /// was reached via `go`, so there is nothing on the stack).
-void closeVideoRecorder(BuildContext context) {
+void closeVideoRecorder(BuildContext context, WidgetRef ref) {
   if (context.canPop()) {
+    // The recorder's `PopScope` discards the session on the way out; a `go`
+    // never reaches it, so that branch has to do it here.
     context.pop();
-  } else {
-    context.go(VideoFeedPage.pathForIndex(0));
+    return;
   }
+  discardRecorderSession(ref);
+  context.go(VideoFeedPage.pathForIndex(0));
+}
+
+/// Ends the recording session the user is walking away from.
+///
+/// Every recorded clip is already saved to the persistent clip library, so
+/// this only drops the session — which is what keeps the camera from
+/// reopening on the previous session's settings. The aspect ratio is derived
+/// from the clips in the session and its toggle is disabled while any exist
+/// (mixing ratios in one video isn't supported), so a surviving 1:1 clip
+/// pinned the next camera open to 1:1 until the selection was cleared in the
+/// library.
+///
+/// An autosaved session's recovery point *is* the autosave draft, so
+/// discarding the session takes that draft with it. A named draft holds its
+/// own file and the autosave draft then belongs to some other session — leave
+/// it alone.
+void discardRecorderSession(WidgetRef ref) {
+  final isAutosavedDraft = ref.read(videoEditorProvider).isAutosavedDraft;
+  unawaited(
+    ref
+        .read(videoPublishProvider.notifier)
+        .clearAll(keepAutosavedDraft: !isAutosavedDraft),
+  );
 }
 
 /// Navigates to the video editor (or the metadata screen, depending on mode),

--- a/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
@@ -56,6 +56,17 @@ void closeVideoRecorder(BuildContext context, WidgetRef ref) {
 /// discarding the session takes that draft with it. A named draft holds its
 /// own file and the autosave draft then belongs to some other session — leave
 /// it alone.
+///
+/// Deleting it here loses nothing the user could miss: at the camera the
+/// autosave draft only ever holds the selected clips, and those are already in
+/// the persistent clip library. Editor state cannot be in it, because the
+/// editor refuses to close on an autosaved session without a decision
+/// (`canPop: !isAutosavedDraft`) — save turns it into a named draft, discard
+/// ends the session, and an unedited close has nothing to keep. Keeping the
+/// draft would instead have the next camera open offer a "continue?" prompt
+/// whose only payload is the clip selection that pinned the aspect ratio in
+/// the first place. An OS kill still leaves the draft intact, which is the
+/// case recovery is for.
 void discardRecorderSession(WidgetRef ref) {
   final isAutosavedDraft = ref.read(videoEditorProvider).isAutosavedDraft;
   unawaited(

--- a/mobile/lib/widgets/video_recorder/video_recorder_top_bar.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_top_bar.dart
@@ -52,7 +52,7 @@ class _VideoRecorderTopBarState extends ConsumerState<VideoRecorderTopBar> {
                   doneSemanticLabel:
                       context.l10n.videoRecorderContinueToEditorLabel,
                   doneIcon: DivineIconName.caretRight,
-                  onClose: () => closeVideoRecorder(context),
+                  onClose: () => closeVideoRecorder(context, ref),
                   onDone: hasClips
                       ? () => openVideoEditorFromRecorder(context, ref)
                       : null,

--- a/mobile/test/providers/clip_manager_provider_test.dart
+++ b/mobile/test/providers/clip_manager_provider_test.dart
@@ -332,6 +332,47 @@ void main() {
       expect(state.isProcessing, isFalse);
     });
 
+    group('clearAll autosave draft handling', () {
+      // The recorder and editor exits differ only in this flag, and the
+      // widget-level suites drive it through a fake `VideoPublishNotifier`
+      // that records the boolean without running the chain — so these are the
+      // assertions that fail if the delete stops reaching storage.
+      void addClip(ClipManagerNotifier notifier) => notifier.addClip(
+        limitClipDuration: false,
+        video: EditorVideo.file('/path/to/video1.mp4'),
+        duration: const Duration(seconds: 1),
+        targetAspectRatio: .vertical,
+        originalAspectRatio: 9 / 16,
+      );
+
+      test('deletes the autosave draft by default', () async {
+        final notifier = container.read(clipManagerProvider.notifier);
+        addClip(notifier);
+
+        await notifier.clearAll();
+
+        verify(
+          () => mockDraftStorageService.deleteDraft(
+            VideoEditorConstants.autoSaveId,
+          ),
+        ).called(greaterThanOrEqualTo(1));
+      });
+
+      test('leaves the autosave draft untouched when keeping it', () async {
+        final notifier = container.read(clipManagerProvider.notifier);
+        addClip(notifier);
+
+        await notifier.clearAll(keepAutosavedDraft: true);
+
+        // The shared `draft_autosave` slot is never touched — the editor's
+        // save path relies on that, having already reaped it itself.
+        verifyNever(() => mockDraftStorageService.deleteDraft(any()));
+        // ...and the session still empties, which is what cures the inherited
+        // aspect ratio. The flag only decides the draft's fate.
+        expect(container.read(clipManagerProvider).clips, isEmpty);
+      });
+    });
+
     test('canRecordMore is true when under limit', () {
       final notifier = container.read(clipManagerProvider.notifier);
 

--- a/mobile/test/screens/video_recorder_screen_test.dart
+++ b/mobile/test/screens/video_recorder_screen_test.dart
@@ -521,7 +521,7 @@ void main() {
         expect(fakeVideoPublishNotifier.keepAutosavedDraftValues, isEmpty);
       });
 
-      testWidgets('does not clear video publish state for autosaved draft', (
+      testWidgets('discards the autosaved session when the route pops', (
         tester,
       ) async {
         SharedPreferences.setMockInitialValues({
@@ -553,8 +553,11 @@ void main() {
         Navigator.of(tester.element(find.byType(VideoRecorderView))).pop();
         await tester.pumpAndSettle();
 
-        expect(fakeVideoPublishNotifier.clearAllCalls, isZero);
-        expect(fakeVideoPublishNotifier.keepAutosavedDraftValues, isEmpty);
+        // The autosave draft is this session's own recovery point, so leaving
+        // the recorder takes it with the session — otherwise the next camera
+        // open inherits its aspect ratio.
+        expect(fakeVideoPublishNotifier.clearAllCalls, equals(1));
+        expect(fakeVideoPublishNotifier.keepAutosavedDraftValues, [isFalse]);
       });
     });
 

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_main_overlay_actions_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_main_overlay_actions_test.dart
@@ -63,6 +63,7 @@ class _FakeVideoEditorNotifier extends VideoEditorNotifier {
 
 class _FakeVideoPublishNotifier extends VideoPublishNotifier {
   int clearAllCalls = 0;
+  final keepAutosavedDraftValues = <bool>[];
 
   @override
   VideoPublishProviderState build() => const VideoPublishProviderState();
@@ -70,6 +71,7 @@ class _FakeVideoPublishNotifier extends VideoPublishNotifier {
   @override
   Future<void> clearAll({bool keepAutosavedDraft = false}) async {
     clearAllCalls++;
+    keepAutosavedDraftValues.add(keepAutosavedDraft);
   }
 }
 
@@ -320,6 +322,10 @@ void main() {
           // The draft owns the session now; leaving it selected would carry
           // its clips — and their aspect ratio — into the next camera open.
           expect(fakeVideoPublishNotifier.clearAllCalls, equals(1));
+          // `saveAsDraft` already awaited the autosave delete, so this clear
+          // must not re-issue it: a late fixed-id delete would wipe whatever
+          // session is active by the time it lands.
+          expect(fakeVideoPublishNotifier.keepAutosavedDraftValues, [isTrue]);
         },
       );
 

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_main_overlay_actions_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_main_overlay_actions_test.dart
@@ -317,6 +317,9 @@ void main() {
           expect(fakeVideoEditorNotifier.saveAsDraftCalls, equals(1));
           verify(() => mockGoRouter.pop<Object?>(any())).called(2);
           expect(find.text('Saved to library'), findsOneWidget);
+          // The draft owns the session now; leaving it selected would carry
+          // its clips — and their aspect ratio — into the next camera open.
+          expect(fakeVideoPublishNotifier.clearAllCalls, equals(1));
         },
       );
 
@@ -358,6 +361,8 @@ void main() {
           verify(() => mockGoRouter.pop<Object?>(any())).called(1);
           expect(find.text('Failed to save'), findsOneWidget);
           expect(find.bySemanticsLabel(closeLabel), findsOneWidget);
+          // Nothing was saved, so the session is all the user has left.
+          expect(fakeVideoPublishNotifier.clearAllCalls, isZero);
         },
       );
 

--- a/mobile/test/widgets/video_recorder/video_recorder_navigation_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_navigation_test.dart
@@ -17,11 +17,14 @@ import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
+import 'package:openvine/models/video_publish/video_publish_provider_state.dart';
 import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
+import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/library_screen.dart';
 import 'package:openvine/screens/video_editor/video_editor_screen.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_screen.dart';
@@ -41,6 +44,18 @@ class _MockVideoRecorderBloc
 class _MockAudioSessionService extends Mock implements AudioSessionService {}
 
 class _MockDraftStorageService extends Mock implements DraftStorageService {}
+
+class _FakeVideoPublishNotifier extends VideoPublishNotifier {
+  final keepAutosavedDraftValues = <bool>[];
+
+  @override
+  VideoPublishProviderState build() => const VideoPublishProviderState();
+
+  @override
+  Future<void> clearAll({bool keepAutosavedDraft = false}) async {
+    keepAutosavedDraftValues.add(keepAutosavedDraft);
+  }
+}
 
 class _FakeVideoEditorNotifier extends VideoEditorNotifier {
   bool saveAsDraftCalled = false;
@@ -91,6 +106,7 @@ void main() {
   late _MockVideoRecorderBloc recorderBloc;
   late _MockAudioSessionService audioSessionService;
   late _FakeVideoEditorNotifier fakeEditor;
+  late _FakeVideoPublishNotifier fakePublish;
   late _FakeClipManagerNotifier fakeClipManager;
   late _MockDraftStorageService mockDraftStorageService;
 
@@ -103,6 +119,7 @@ void main() {
     recorderBloc = _MockVideoRecorderBloc();
     audioSessionService = _MockAudioSessionService();
     fakeEditor = _FakeVideoEditorNotifier();
+    fakePublish = _FakeVideoPublishNotifier();
     fakeClipManager = _FakeClipManagerNotifier();
     mockDraftStorageService = _MockDraftStorageService();
     when(
@@ -156,6 +173,10 @@ void main() {
           path: WelcomeScreen.path,
           builder: (_, _) => const _StubScreen(label: 'welcome'),
         ),
+        GoRoute(
+          path: VideoFeedPage.pathForIndex(0),
+          builder: (_, _) => const _StubScreen(label: 'feed'),
+        ),
       ],
     );
 
@@ -163,6 +184,7 @@ void main() {
       overrides: [
         authServiceProvider.overrideWithValue(mockAuthService),
         videoEditorProvider.overrideWith(() => fakeEditor),
+        videoPublishProvider.overrideWith(() => fakePublish),
         clipManagerProvider.overrideWith(() => fakeClipManager),
         audioSessionServiceProvider.overrideWithValue(audioSessionService),
         draftStorageServiceProvider.overrideWithValue(mockDraftStorageService),
@@ -174,6 +196,24 @@ void main() {
       ),
     );
   }
+
+  group('closeVideoRecorder', () {
+    testWidgets('discards the session when it has to leave via go', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildHarness());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('close-recorder')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('feed'), findsOneWidget);
+      // Nothing to pop means the recorder's PopScope never runs, so this exit
+      // has to end the session itself — otherwise its clips (and with them the
+      // aspect ratio they lock in) survive into the next camera open.
+      expect(fakePublish.keepAutosavedDraftValues, [isFalse]);
+    });
+  });
 
   group('recorder-exit auth gate', () {
     group('when already authenticated', () {
@@ -516,6 +556,11 @@ class _RecorderHarness extends ConsumerWidget {
             key: const Key('show-delete-snackbar'),
             onPressed: () => showClipDeleteSnackbar(context, ref),
             child: const Text('show delete snackbar'),
+          ),
+          ElevatedButton(
+            key: const Key('close-recorder'),
+            onPressed: () => closeVideoRecorder(context, ref),
+            child: const Text('close recorder'),
           ),
         ],
       ),


### PR DESCRIPTION
Closes #7143

## Description

Recording a 1:1 clip pinned the camera to 1:1 on every later open — the only way back to vertical was clearing the selection in the library.

The aspect ratio isn't a remembered setting: the recorder derives it from the clips of the running session (`clips.first.targetAspectRatio` on init) and disables the toggle while any clip exists, because clips of mixed ratios can't share one video. That is correct — the actual bug is that the session outlived the screen. Its cleanup sat behind `!_isAutosavedDraft` in the recorder's `PopScope`, and `isAutosavedDraft` defaults to `true`, so it effectively never ran.

Two exits now end the session:

- **Leaving the camera** — new `discardRecorderSession(ref)`, called from the recorder's `PopScope` (back gesture, X button) and from the `go` branch of `closeVideoRecorder` (quick action / deep link entry, where there is nothing to pop and `PopScope` never fires). An autosaved session takes its autosave draft with it, since that draft *is* the session being walked away from. A named draft keeps its own file, and the then-unrelated autosave draft is left alone.
- **Saving the draft in the editor** — the discard branch of the save/discard prompt already cleared the session; the save branch didn't, so the clips stayed selected behind the editor. It clears now too, passing `keepAutosavedDraft: true`. A *failed* save keeps the session, because it is all the user has left. The metadata screen's "Save for later" already did this.

The two exits pass opposite `keepAutosavedDraft` values on purpose. `clearAll` empties the in-memory clips either way — that alone cures the inherited aspect ratio — so the flag decides only the fate of the saved `draft_autosave` row:

- **Camera exit discards it, and loses nothing the user could miss.** At the camera that draft holds only the clip selection, and every one of those clips is already in the persistent clip library. Editor state cannot be in it: the editor refuses to close on an autosaved session without a decision (`canPop: !isAutosavedDraft`) — save turns it into a named draft, discard ends the session, and an unedited close has nothing to keep. Keeping the draft would only have the next camera open offer a "continue?" prompt whose entire payload is the clip selection that pinned the ratio in the first place. An OS kill leaves the draft intact, which is the case that recovery prompt exists for, and it never runs this path.
- **The editor save keeps it, because `saveAsDraft` has already reaped it.** It awaits `removeAutosavedDraft()` before reporting success, so there is nothing left to delete — and re-issuing that delete fire-and-forget is the hazard its own doc comment forbids: the id is fixed, so one that lands late wipes the recovery point of whatever session is active by then. `removeAutosavedDraft` swallows its own failure while `saveAsDraft` still returns `saved`, so the row can genuinely still be live when it does.

No footage is lost either way: every take is written to the persistent clip library as it is recorded, and draft file cleanup skips anything the clip library or another draft still references.

**Related Issue:** 

## Out of Scope

Opening a **named** draft from the library and leaving the editor with back pops straight out without the save/discard prompt (`canPop: !isAutosavedDraft`), so its clips stay selected and the first camera open after that still inherits their aspect ratio. It heals itself as soon as that camera is closed. Left alone here because it is a different entry point than the two reported; happy to cover it in a follow-up.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test test/widgets/video_editor/main_editor/ test/widgets/video_recorder/ test/screens/video_recorder_screen_test.dart test/providers/clip_manager_provider_test.dart test/providers/video_editor_provider_test.dart` — 576 passed
- Manually verified on a real Samsung Galaxy: record 1:1 → leave the camera → reopen — the camera comes back on the default ratio with the toggle usable, and the clip is still in the library. Same for editor → "Save draft".

Test coverage: the recorder-screen test that asserted an autosaved session is *not* cleared on pop now asserts the opposite (and that the autosave draft goes with it); a new navigation test covers the `go` exit; the editor's save-draft tests assert the session is cleared on success and kept on failure, and now pin `keepAutosavedDraft` too. Those suites all drive the flag through a fake `VideoPublishNotifier` that records the boolean and stops there, so `clip_manager_provider_test.dart` gained the two assertions that actually reach storage: the default deletes `draft_autosave`, and keeping it touches the slot not at all while still emptying the session.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
