### PR TITLE
fix(video-editor): scale the sound layer's waveform against its own peak

### DIFF
--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
@@ -106,6 +106,15 @@ class TimelineOverlayBloc
           item.id: item.waveformRightChannel!,
     };
 
+    // Same for a source duration the extractor measured (see
+    // _onWaveformLoaded). A track that reaches _soundItem without a duration
+    // would otherwise drop that basis on every rebuild and re-flatten its
+    // waveform.
+    final sourceDurationCache = <String, Duration>{
+      for (final item in state.items)
+        if (item.sourceDuration != null) item.id: item.sourceDuration!,
+    };
+
     // Clips may not be measured yet during a draft load, surfacing a transient
     // totalVideoDuration of zero. Clamping every item's end to zero would
     // collapse the whole timeline — sounds, layers, filters and markers — and
@@ -124,6 +133,7 @@ class TimelineOverlayBloc
           total: total,
           leftChannel: leftCache[track.id],
           rightChannel: rightCache[track.id],
+          measuredSourceDuration: sourceDurationCache[track.id],
         ),
     ];
 
@@ -260,22 +270,29 @@ class TimelineOverlayBloc
   /// [TimelineOverlayItem.sourceDuration] so the two never drift — the same
   /// `sourceDuration - startOffset` relationship [_onItemTrimmed] applies
   /// live during a trim drag.
+  ///
+  /// [measuredSourceDuration] is the basis the waveform extractor reported for
+  /// this track (see [_onWaveformLoaded]). It only fills in for a track whose
+  /// own duration never resolved; a track that carries one keeps it, so the
+  /// item's basis stays the same value the trim clamps read.
   static TimelineOverlayItem _soundItem(
     AudioEvent track, {
     required Duration total,
     Float32List? leftChannel,
     Float32List? rightChannel,
+    Duration? measuredSourceDuration,
   }) {
     // Treat a non-positive duration as "unknown" — matching
     // _resolveSoundDurationSecs / _healMissingAudioDurations, which key off
     // `(duration ?? 0) <= 0`. A persisted-but-zero duration must NOT become a
     // zero-length sourceDuration: that would drive maxDuration to <= 0 and let
     // a trim gesture immediately collapse the now-visible bar back to nothing.
-    // Falling through to null gives it the maxDuration fallback below instead.
+    // Falling through to the measured basis (or null) gives it the maxDuration
+    // fallback below instead.
     final hasDuration = (track.duration ?? 0) > 0;
     final sourceDuration = hasDuration
         ? Duration(milliseconds: (track.duration! * 1000).round())
-        : null;
+        : _positiveOrNull(measuredSourceDuration);
 
     // A persisted track can carry an invalid composition window — e.g. a sound
     // added before its duration was known ends up with endTime=0 (see
@@ -787,6 +804,34 @@ class TimelineOverlayBloc
     return endTime != null && endTime > track.startTime ? endTime : total;
   }
 
+  /// [duration] when it is positive, otherwise `null`.
+  static Duration? _positiveOrNull(Duration? duration) =>
+      duration != null && duration > Duration.zero ? duration : null;
+
+  /// Adopts the extractor's measured basis for an item that has none.
+  ///
+  /// A sound whose `AudioEvent.duration` never resolved reaches the painter
+  /// without a way to map full-source samples to time, so the whole file gets
+  /// squeezed into the visible bar. The extraction covers the whole source, so
+  /// its measured duration is exactly the missing basis. [maxDuration] moves
+  /// with it to keep the `sourceDuration - startOffset` relationship
+  /// [_onItemTrimmed] and [_soundItem] rely on.
+  static TimelineOverlayItem _withMeasuredBasis(
+    TimelineOverlayItem item,
+    Duration? measured,
+  ) {
+    if (item.sourceDuration != null) return item;
+    final basis = _positiveOrNull(measured);
+    if (basis == null) return item;
+
+    return item.copyWith(
+      sourceDuration: basis,
+      // Derived exactly as [_soundItem] does, so the next rebuild recomputes
+      // the same value instead of flip-flopping the bar's trim ceiling.
+      maxDuration: basis - item.startOffset,
+    );
+  }
+
   void _onWaveformLoaded(
     TimelineOverlayWaveformLoaded event,
     Emitter<TimelineOverlayState> emit,
@@ -794,9 +839,12 @@ class TimelineOverlayBloc
     final updated = [
       for (final item in state.items)
         if (item.id == event.itemId)
-          item.copyWith(
-            waveformLeftChannel: event.leftChannel,
-            waveformRightChannel: event.rightChannel,
+          _withMeasuredBasis(
+            item.copyWith(
+              waveformLeftChannel: event.leftChannel,
+              waveformRightChannel: event.rightChannel,
+            ),
+            event.sourceDuration,
           )
         else
           item,

--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_event.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_event.dart
@@ -246,14 +246,28 @@ class TimelineOverlayWaveformLoaded extends TimelineOverlayEvent {
     required this.itemId,
     required this.leftChannel,
     this.rightChannel,
+    this.sourceDuration,
   });
 
   final String itemId;
   final Float32List leftChannel;
   final Float32List? rightChannel;
 
+  /// Duration the extractor measured while reading the samples.
+  ///
+  /// Extraction always covers the whole source, so this is the source
+  /// duration — the basis the waveform painter maps samples to time against.
+  /// Supplied so a sound whose [AudioEvent.duration] never resolved still gets
+  /// one; ignored when the item already has a basis from the track.
+  final Duration? sourceDuration;
+
   @override
-  List<Object?> get props => [itemId, leftChannel, rightChannel];
+  List<Object?> get props => [
+    itemId,
+    leftChannel,
+    rightChannel,
+    sourceDuration,
+  ];
 }
 
 /// Update the volume of a custom audio track by its [AudioEvent.id].

--- a/mobile/lib/constants/video_editor_timeline_constants.dart
+++ b/mobile/lib/constants/video_editor_timeline_constants.dart
@@ -121,10 +121,12 @@ abstract class TimelineConstants {
   /// Lower bound for the per-clip waveform normalizer. A clip whose loudest
   /// sample sits below this stays quiet on screen rather than being stretched
   /// to full scale — the difference between "quiet" and "silent" survives.
+  /// Keep in lockstep with `WaveformConstants.amplitudeNormalizerFloor`.
   static const double clipWaveformNormalizerFloor = 0.2;
 
   /// Exponent applied to the normalized amplitude. Below 1 it lifts the quiet
   /// body of the signal toward the peaks; 1 would be a linear (near-flat) band.
+  /// Keep in lockstep with `WaveformConstants.amplitudeCurve`.
   static const double clipWaveformCurve = 0.6;
 
   /// Baseline height of a clip-waveform bar. Keeps a continuous line visible

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -916,6 +916,12 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
   /// pre-windowed segment here would (a) double-window against the painter's
   /// offset and (b) restyle bar heights on every left-trim, because the
   /// painter normalizes against the loudest sample in the arrays it is given.
+  ///
+  /// The measured duration travels with the samples: covering the whole source
+  /// makes it the source duration, which is the basis the painter maps samples
+  /// to time against. Sounds whose `duration` never resolved
+  /// (see [_healMissingAudioDurations]) would otherwise reach the painter with
+  /// no basis and draw the entire file squeezed into the visible bar.
   Future<void> _extractWaveform(AudioEvent audio) async {
     final path = audio.isBundled ? audio.assetPath : audio.url;
     if (path == null) return;
@@ -935,6 +941,7 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
           itemId: audio.id,
           leftChannel: data.leftChannel,
           rightChannel: data.rightChannel,
+          sourceDuration: data.duration,
         ),
       );
     } catch (e, s) {

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -122,9 +122,6 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
   /// every playhead tick so canvas overlays track playback smoothly.
   final _playTimeNotifier = ValueNotifier<Duration>(Duration.zero);
 
-  /// Tracks the previous audio tracks to detect offset changes.
-  List<AudioEvent> _previousAudioTracks = const [];
-
   /// Track ids whose missing duration we already tried to backfill, so a
   /// failed probe isn't retried on every audio-track change.
   final Set<String> _durationHealAttempted = {};
@@ -912,6 +909,13 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
 
   /// Extracts waveform data for an audio track and updates the timeline
   /// overlay with the samples.
+  ///
+  /// Always extracts the **full source file**. Windowing to
+  /// `[startOffset, startOffset + span]` is [StereoWaveformPainter]'s job via
+  /// its `startOffset` / `maxDuration` args (see `_SoundContent`). Extracting a
+  /// pre-windowed segment here would (a) double-window against the painter's
+  /// offset and (b) restyle bar heights on every left-trim, because the
+  /// painter normalizes against the loudest sample in the arrays it is given.
   Future<void> _extractWaveform(AudioEvent audio) async {
     final path = audio.isBundled ? audio.assetPath : audio.url;
     if (path == null) return;
@@ -923,19 +927,7 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
           ? EditorVideo.file(path)
           : EditorVideo.network(path);
       final data = await ProVideoEditor.instance.getWaveform(
-        WaveformConfigs(
-          video: video,
-          startTime: audio.startOffset,
-          endTime:
-              audio.startOffset +
-              Duration(
-                milliseconds:
-                    ((audio.duration ??
-                                VideoEditorConstants.maxDuration.inSeconds) *
-                            1000)
-                        .toInt(),
-              ),
-        ),
+        WaveformConfigs(video: video),
       );
       if (!mounted) return;
       _timelineOverlayBloc.add(
@@ -985,21 +977,16 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
         listenWhen: (previous, current) =>
             previous.audioTracks != current.audioTracks,
         listener: (context, state) {
-          final previousById = {for (final a in _previousAudioTracks) a.id: a};
-          _previousAudioTracks = state.audioTracks;
-
           final existingWaveformIds = state.items
               .where((i) => i.waveformLeftChannel != null)
               .map((i) => i.id)
               .toSet();
 
           for (final audio in state.audioTracks) {
-            final hadWaveform = existingWaveformIds.contains(audio.id);
-            final prev = previousById[audio.id];
-            final offsetChanged =
-                prev != null && prev.startOffset != audio.startOffset;
-
-            if (!hadWaveform || offsetChanged) {
+            // Full-source samples are offset-invariant; the painter scrolls
+            // via startOffset. Re-extract only when this track has no samples
+            // yet (new sound, or a rebuild that dropped the cache).
+            if (!existingWaveformIds.contains(audio.id)) {
               unawaited(_extractWaveform(audio));
             }
           }

--- a/mobile/lib/widgets/stereo_waveform_painter.dart
+++ b/mobile/lib/widgets/stereo_waveform_painter.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Shared stereo waveform painter for audio visualization.
 // ABOUTME: Used by video recorder progress bar and audio timing screen.
 
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -31,6 +32,17 @@ abstract final class WaveformConstants {
   /// Scale factor for waveform amplitude (leaves headroom at edges).
   static const amplitudeScale = 0.9;
 
+  /// Lower bound for the peak the bars are normalized against. Audio whose
+  /// loudest sample sits below this stays quiet on screen rather than being
+  /// stretched to full scale — the difference between "quiet" and "silent"
+  /// survives. Mirrors `TimelineConstants.clipWaveformNormalizerFloor`.
+  static const amplitudeNormalizerFloor = 0.2;
+
+  /// Exponent applied to the normalized amplitude. Below 1 it lifts the quiet
+  /// body of the signal toward the peaks; 1 would be a linear (near-flat)
+  /// band. Mirrors `TimelineConstants.clipWaveformCurve`.
+  static const amplitudeCurve = 0.6;
+
   /// Duration for waveform entrance animation.
   static const animationDuration = Duration(milliseconds: 400);
 
@@ -49,6 +61,8 @@ abstract final class WaveformConstants {
 /// - Height animation via [heightFactor]
 /// - Automatic sample-to-bar mapping
 /// - Start offset for displaying a specific audio segment
+/// - Amplitude normalization against the source's own peak, so a quietly
+///   recorded track fills the band instead of reading as silence
 class StereoWaveformPainter extends CustomPainter {
   /// Creates a waveform progress painter.
   StereoWaveformPainter({
@@ -105,6 +119,39 @@ class StereoWaveformPainter extends CustomPainter {
 
   /// Computed step (width + spacing) for each bar.
   double get _barStep => barWidth + barSpacing;
+
+  /// The loudest sample across both channels, floored.
+  ///
+  /// Real recordings rarely approach full scale, so raw amplitudes mapped
+  /// straight onto the half-height draw as a barely-there ripple — a perfectly
+  /// audible track reads as silent. Normalizing against the whole source
+  /// rather than the visible window keeps a trim from restyling the bars.
+  late final double _normalizer = _computeNormalizer();
+
+  double _computeNormalizer() {
+    var peak = WaveformConstants.amplitudeNormalizerFloor;
+    for (final sample in leftChannel) {
+      final amplitude = sample.abs();
+      if (amplitude > peak) peak = amplitude;
+    }
+    for (final sample in rightChannel ?? const <double>[]) {
+      final amplitude = sample.abs();
+      if (amplitude > peak) peak = amplitude;
+    }
+    return peak;
+  }
+
+  /// Maps a raw sample to its share (0..1) of the available half-height.
+  ///
+  /// Audio spends most of its time far below its peak, so a linear map reads
+  /// as a flat line with occasional spikes. The curve lifts the body without
+  /// flattening the transients.
+  double _shape(double sample) => math
+      .pow(
+        (sample.abs() / _normalizer).clamp(0.0, 1.0),
+        WaveformConstants.amplitudeCurve,
+      )
+      .toDouble();
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -251,12 +298,12 @@ class StereoWaveformPainter extends CustomPainter {
       final sampleIndex =
           sampleOffset + ((i / barCount) * visibleSampleCount).floor();
 
-      // Get amplitudes (0.0-1.0)
+      // Normalize and curve the raw samples into 0.0-1.0 display amplitudes.
       final leftAmp = sampleIndex < leftSamples.length
-          ? leftSamples[sampleIndex].abs().clamp(0.0, 1.0)
+          ? _shape(leftSamples[sampleIndex])
           : 0.0;
       final rightAmp = sampleIndex < rightSamples.length
-          ? rightSamples[sampleIndex].abs().clamp(0.0, 1.0)
+          ? _shape(rightSamples[sampleIndex])
           : 0.0;
 
       // Calculate bar heights (minimum for visibility), scaled by animation

--- a/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Covers update, move, trim, select, drag, trim, collapse,
 // ABOUTME: and state helpers for the current event/state API.
 
+import 'dart:typed_data';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -45,6 +47,22 @@ AudioEvent _audioEvent({
     startTime: start,
     endTime: end,
     anchorClipId: anchorClipId,
+  );
+}
+
+/// A sound whose own duration never resolved, left-trimmed by two seconds.
+final AudioEvent _durationlessTrack = _audioEvent(
+  id: 'sound-1',
+  start: const Duration(seconds: 1),
+  end: const Duration(seconds: 4),
+).copyWith(startOffset: const Duration(seconds: 2));
+
+TimelineOverlayItemsUpdate _soundUpdate(AudioEvent track) {
+  return TimelineOverlayItemsUpdate(
+    layers: const <Layer>[],
+    filters: const <FilterState>[],
+    audioTracks: [track],
+    totalVideoDuration: const Duration(seconds: 12),
   );
 }
 
@@ -639,6 +657,118 @@ void main() {
             totalVideoDuration: const Duration(seconds: 12),
           ),
         ),
+        expect: () => [
+          isA<TimelineOverlayState>()
+              .having(
+                (s) => s.items.first.sourceDuration,
+                'sourceDuration',
+                isNull,
+              )
+              .having(
+                (s) => s.items.first.maxDuration,
+                'maxDuration',
+                VideoEditorConstants.maxDuration,
+              ),
+        ],
+      );
+
+      // The waveform extractor reads the whole source, so the duration it
+      // measures is the basis the painter maps samples to time against.
+      // Without it a duration-less sound draws the entire file squeezed into
+      // its visible bar.
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'adopts the measured source duration when the track has none',
+        build: TimelineOverlayBloc.new,
+        act: (bloc) => bloc
+          ..add(_soundUpdate(_durationlessTrack))
+          ..add(
+            TimelineOverlayWaveformLoaded(
+              itemId: 'sound-1',
+              leftChannel: Float32List(4),
+              sourceDuration: const Duration(seconds: 30),
+            ),
+          ),
+        skip: 1,
+        expect: () => [
+          isA<TimelineOverlayState>()
+              .having(
+                (s) => s.items.first.sourceDuration,
+                'sourceDuration',
+                const Duration(seconds: 30),
+              )
+              .having(
+                (s) => s.items.first.maxDuration,
+                'maxDuration',
+                const Duration(seconds: 28), // 30s source - 2s offset
+              ),
+        ],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'keeps the measured basis when the item is rebuilt',
+        build: TimelineOverlayBloc.new,
+        act: (bloc) => bloc
+          ..add(_soundUpdate(_durationlessTrack))
+          ..add(
+            TimelineOverlayWaveformLoaded(
+              itemId: 'sound-1',
+              leftChannel: Float32List(4),
+              sourceDuration: const Duration(seconds: 30),
+            ),
+          )
+          ..add(_soundUpdate(_durationlessTrack)),
+        // The rebuild emits nothing precisely because the basis survived it —
+        // dropping it would rebuild the item with a null sourceDuration and
+        // the maxDuration fallback, which is a different state.
+        skip: 2,
+        expect: () => <TimelineOverlayState>[],
+        verify: (bloc) => expect(
+          bloc.state.items.first.sourceDuration,
+          const Duration(seconds: 30),
+        ),
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'keeps the track duration when the measurement disagrees',
+        build: TimelineOverlayBloc.new,
+        act: (bloc) => bloc
+          ..add(_soundUpdate(_durationlessTrack.copyWith(duration: 8)))
+          ..add(
+            TimelineOverlayWaveformLoaded(
+              itemId: 'sound-1',
+              leftChannel: Float32List(4),
+              sourceDuration: const Duration(seconds: 30),
+            ),
+          ),
+        skip: 1,
+        expect: () => [
+          isA<TimelineOverlayState>()
+              .having(
+                (s) => s.items.first.sourceDuration,
+                'sourceDuration',
+                const Duration(seconds: 8),
+              )
+              .having(
+                (s) => s.items.first.maxDuration,
+                'maxDuration',
+                const Duration(seconds: 6), // 8s source - 2s offset
+              ),
+        ],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'ignores a non-positive measured duration',
+        build: TimelineOverlayBloc.new,
+        act: (bloc) => bloc
+          ..add(_soundUpdate(_durationlessTrack))
+          ..add(
+            TimelineOverlayWaveformLoaded(
+              itemId: 'sound-1',
+              leftChannel: Float32List(4),
+              sourceDuration: Duration.zero,
+            ),
+          ),
+        skip: 1,
         expect: () => [
           isA<TimelineOverlayState>()
               .having(

--- a/mobile/test/widgets/stereo_waveform_painter_test.dart
+++ b/mobile/test/widgets/stereo_waveform_painter_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Unit tests for StereoWaveformPainter and WaveformConstants.
 // ABOUTME: Tests shouldRepaint logic, paint with empty/valid data, and constants.
 
+import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui';
 
@@ -306,6 +307,106 @@ void main() {
           () => painter.paint(canvas, const Size(200, 72)),
           returnsNormally,
         );
+      });
+    });
+
+    group('amplitude shaping', () {
+      const size = Size(200, 72);
+      const halfHeight = 36.0;
+      const scaledHalfHeight = halfHeight * WaveformConstants.amplitudeScale;
+
+      /// The bar at [index], mirrored around the vertical centre.
+      RRect barAt(int index, double armHeight) => RRect.fromRectAndRadius(
+        Rect.fromLTWH(
+          index * WaveformConstants.barStep,
+          halfHeight - armHeight,
+          WaveformConstants.barWidth,
+          armHeight * 2,
+        ),
+        WaveformConstants.barRadius,
+      );
+
+      /// A bar at the band's ceiling — what the source's loudest sample draws.
+      RRect ceilingBar(int index) => barAt(index, scaledHalfHeight);
+
+      final waveformPaint = find.byWidgetPredicate(
+        (w) => w is CustomPaint && w.painter is StereoWaveformPainter,
+      );
+
+      Future<RenderObject> pumpPainter(
+        WidgetTester tester,
+        StereoWaveformPainter painter,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Center(
+              child: SizedBox(
+                width: size.width,
+                height: size.height,
+                child: CustomPaint(painter: painter),
+              ),
+            ),
+          ),
+        );
+        return tester.renderObject(waveformPaint);
+      }
+
+      testWidgets('fills the band for a quietly recorded source', (
+        tester,
+      ) async {
+        // Real recordings peak well below full scale — mapped linearly they
+        // draw as a barely visible ripple, so the bars normalize per source.
+        final render = await pumpPainter(
+          tester,
+          createPainter(leftChannel: Float32List.fromList([0.25, 0.25])),
+        );
+
+        expect(render, paints..rrect(rrect: ceilingBar(0)));
+      });
+
+      testWidgets('keeps a near-silent source below the band', (tester) async {
+        final render = await pumpPainter(
+          tester,
+          createPainter(leftChannel: Float32List.fromList([0.03125, 0.03125])),
+        );
+
+        // Quiet, but still audible-looking: the floor holds the bars down
+        // without collapsing them to the silent baseline or hiding them.
+        expect(render, paints..rrect());
+        expect(render, isNot(paints..rrect(rrect: ceilingBar(0))));
+        expect(
+          render,
+          isNot(
+            paints..rrect(rrect: barAt(0, WaveformConstants.minBarHeight)),
+          ),
+        );
+      });
+
+      testWidgets('scales quiet passages against the source peak', (
+        tester,
+      ) async {
+        // 40 bars fit the 200px canvas, so each sample of a two-sample source
+        // owns half of them: the loud sample the first 20, the quiet one the
+        // rest.
+        final render = await pumpPainter(
+          tester,
+          createPainter(leftChannel: Float32List.fromList([0.5, 0.25])),
+        );
+
+        // The quiet half is drawn relative to the loud one, not to itself:
+        // normalizing per passage would flatten the dynamics away.
+        final quietArm =
+            math.pow(0.5, WaveformConstants.amplitudeCurve).toDouble() *
+            scaledHalfHeight;
+        const barCount = 40;
+        final bars = paints;
+        for (var i = 0; i < barCount ~/ 2; i++) {
+          bars.rrect(rrect: ceilingBar(i));
+        }
+        for (var i = barCount ~/ 2; i < barCount; i++) {
+          bars.rrect(rrect: barAt(i, quietArm));
+        }
+        expect(render, bars);
       });
     });
 

--- a/mobile/test/widgets/stereo_waveform_painter_test.dart
+++ b/mobile/test/widgets/stereo_waveform_painter_test.dart
@@ -7,6 +7,7 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/stereo_waveform_painter.dart';
 
@@ -30,6 +31,19 @@ void main() {
     test('amplitudeScale is between 0 and 1', () {
       expect(WaveformConstants.amplitudeScale, greaterThan(0));
       expect(WaveformConstants.amplitudeScale, lessThanOrEqualTo(1));
+    });
+
+    test('amplitude shaping knobs match TimelineConstants clip waveform', () {
+      // Intentionally duplicated across packages — lock the values so a
+      // future tuning change cannot drift one site without the other.
+      expect(
+        WaveformConstants.amplitudeNormalizerFloor,
+        TimelineConstants.clipWaveformNormalizerFloor,
+      );
+      expect(
+        WaveformConstants.amplitudeCurve,
+        TimelineConstants.clipWaveformCurve,
+      );
     });
   });
 


### PR DESCRIPTION
Closes #7145

## Description

Extracting audio from a clip produced a sound layer whose waveform looked flat — as if the whole track were silent — even though the very same audio drew a clearly readable loud/quiet band on the clip strip right above it.

Both come from the same data: raw peak amplitudes returned by `ProVideoEditor.getWaveform`. The difference is in the painting. `ClipWaveformPainter` normalizes each sample against the source's loudest one and lifts the quiet body with a `pow(x, 0.6)` curve; `StereoWaveformPainter` mapped the raw amplitude straight onto the half-height. A typical recording peaks around 0.3 with a body near 0.1, which is roughly one pixel of the sound layer's ~12px half-height, so everything collapsed onto the minimum-bar baseline.

This applies the clip strip's shaping in `StereoWaveformPainter`.

Two design notes:

- **The normalizer is taken over the whole source, not the visible window.** Normalizing per visible segment would make trimming a sound item silently restyle its bars, and would flatten a quiet passage up to look as loud as the chorus. Same rationale as the clip strip, which normalizes per file so splitting a clip never changes the bars on either side of the cut.
- **The fix lives in the painter, so it lands on all four of its users** — the timeline sound layer, the audio timing screen, the recorder progress bar, and the saved-sound card. That is deliberate: the same audio file reading "loud" in the timeline and "silent" on the timing screen would be worse than the current uniform flatness.

The floor (0.2) and curve exponent (0.6) intentionally match `TimelineConstants.clipWaveformNormalizerFloor` / `clipWaveformCurve`. They are duplicated rather than shared because `lib/constants/video_editor_timeline_constants.dart` is timeline-specific and a generic widget should not import it; both doc comments cross-reference each other so a future tuning change finds both.

### Making the normalizer's "whole source" actually the whole source

That first design note was aspirational: the timeline extracted a *pre-windowed* segment, so the painter was normalizing against the window's peak, not the file's. Worse, the painter has windowed by `startOffset` itself since #5199 while the extraction still cut at `startOffset` too — the head was subtracted twice, and every left-trim re-extracted and restyled the bars. `_extractWaveform` now reads the full source and lets the painter do the windowing, which is the contract it already assumed. Re-extraction on offset change is gone with it: full-source samples are offset-invariant.

That makes the painter's basis load-bearing. It maps samples to time against `sourceDuration`, which comes from `AudioEvent.duration` — and a sound whose duration never resolved (see `_healMissingAudioDurations`) has none, so `_SoundContent` falls back to treating the visible span as the whole source. With full-source samples that fallback squeezes the entire file into the bar; the old windowed extraction happened to match it. So the duration the extractor measured now travels with the samples and fills in where the track carries none. The track's own value still wins, because the trim clamps in `audioLeftTrimResult` read it and the two must not drift; `maxDuration` moves with the adopted basis using the same formula `_soundItem` applies, so a rebuild recomputes the same trim ceiling instead of flip-flopping it.

**Related Issue:** 

## Out of Scope

The sound layer's row height is unchanged. With the amplitudes shaped correctly the existing ~25px waveform area reads fine, so growing the row was not needed.

## Verification

- `flutter test test/widgets/stereo_waveform_painter_test.dart` — 3 new tests covering the shaping: a quietly recorded source fills the band, a near-silent one stays below it without collapsing to the baseline, and a quiet passage is scaled against the source peak rather than against itself. All three fail on the pre-fix painter.
- `flutter test` for every other suite touching the painter: `video_editor_timeline_overlay_item_test.dart`, `saved_sound_card_test.dart`, `video_recorder_audio_progress_bar_test.dart`, `video_recorder_lip_sync_stack_test.dart`, `clip_waveform_overlay_test.dart`, `video_audio_editor_timing_screen_test.dart` — all green.
- `flutter test test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart` — 4 new tests on the measured basis: it is adopted when the track has no duration, it survives an item rebuild, the track's own duration wins when the two disagree, and a non-positive measurement is ignored. The first two fail without the change.
- `flutter analyze lib test` — clean.
- [x] Manual pass on a real Samsung Galaxy: extract audio from a clip and compare the layer's waveform against the clip strip above it, then left-trim the sound item and confirm the bars scroll instead of restyling.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
