### PR TITLE
fix(divine_ui): align the snackbar with its Figma spec

### DIFF
--- a/mobile/lib/screens/comments/widgets/comment_options_modal.dart
+++ b/mobile/lib/screens/comments/widgets/comment_options_modal.dart
@@ -169,8 +169,8 @@ class _OptionTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final color = isDestructive
         // The sheet surface follows the palette now, and fixed `likeRed` only
-        // holds 4.13:1 on the light one. The palette token is `likeRed`
-        // verbatim on dark, so that rendering is unchanged.
+        // holds 4.13:1 on the light one. #7147 moved the dark token off
+        // `likeRed` onto `error/error`, lifting dark from 4.57:1 to 5.12:1.
         ? context.vineColors.onErrorContainer
         : context.vineColors.onSurface;
 

--- a/mobile/packages/divine_ui/lib/src/divine_snackbar_container.dart
+++ b/mobile/packages/divine_ui/lib/src/divine_snackbar_container.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 
@@ -14,6 +16,8 @@ class DivineSnackbarContainer extends StatelessWidget {
     this.onActionPressed,
     this.secondaryActionLabel,
     this.onSecondaryActionPressed,
+    this.onDismissPressed,
+    this.dismissSemanticLabel = 'Dismiss',
     super.key,
   });
 
@@ -26,6 +30,8 @@ class DivineSnackbarContainer extends StatelessWidget {
     VoidCallback? onActionPressed,
     String? secondaryActionLabel,
     VoidCallback? onSecondaryActionPressed,
+    VoidCallback? onDismissPressed,
+    String dismissSemanticLabel = 'Dismiss',
     Duration? duration,
     EdgeInsetsGeometry? margin,
     EdgeInsetsGeometry? padding,
@@ -44,8 +50,29 @@ class DivineSnackbarContainer extends StatelessWidget {
       onActionPressed: onActionPressed,
       secondaryActionLabel: secondaryActionLabel,
       onSecondaryActionPressed: onSecondaryActionPressed,
+      onDismissPressed: onDismissPressed,
+      dismissSemanticLabel: dismissSemanticLabel,
     ),
   );
+
+  /// Widest the banner grows before it stops tracking the screen
+  /// (`component/snackbar/max-width`). Wider viewports centre it instead.
+  static const double maxWidth = 480;
+
+  /// Shortest the banner can be (`size/interactive/48`), so a single-line
+  /// message still clears the standard touch-target height.
+  static const double minHeight = 48;
+
+  static const double _radius = 16;
+  static const double _sideEdge = 16;
+
+  /// Trailing inset when a dismiss button is present. The button carries 4px
+  /// of transparent padding of its own, which makes up the rest of the edge.
+  static const double _dismissEdge = 4;
+
+  static const double _gap = 4;
+  static const double _labelVerticalPadding = 12;
+  static const double _stackedActionBottom = 4;
 
   /// The label of the snackbar.
   final String label;
@@ -76,62 +103,247 @@ class DivineSnackbarContainer extends StatelessWidget {
   /// Callback when the secondary action button is pressed.
   final VoidCallback? onSecondaryActionPressed;
 
-  /// Label colour that stays legible on the resolved surface.
+  /// Callback when the trailing dismiss (✕) button is pressed. The button is
+  /// rendered only when this is non-null.
   ///
-  /// A [backgroundColor] comes from the caller, not from the theme, so a light
-  /// one (the yellow staging indicator, say) would leave the theme's
-  /// white-on-dark label unreadable — those flip to dark ink instead.
-  Color _labelColor(VineThemeColors colors) {
+  /// Inside a [SnackBar] the usual wiring is
+  /// `() => ScaffoldMessenger.of(context).hideCurrentSnackBar()`.
+  final VoidCallback? onDismissPressed;
+
+  /// Screen-reader label for the dismiss button.
+  ///
+  /// `divine_ui` carries no localizations, so callers pass a translated
+  /// string; the default is the English fallback.
+  final String dismissSemanticLabel;
+
+  bool get _hasAction => actionLabel != null && onActionPressed != null;
+
+  bool get _hasSecondaryAction =>
+      secondaryActionLabel != null && onSecondaryActionPressed != null;
+
+  bool get _hasDismiss => onDismissPressed != null;
+
+  /// Whether [backgroundColor] is a light surface the theme's white-on-dark
+  /// content would disappear on.
+  bool get _hasLightSurface {
     final surface = backgroundColor;
-    if (surface != null &&
-        ThemeData.estimateBrightnessForColor(surface) == Brightness.light) {
-      return VineTheme.primaryDarkGreen;
+    return surface != null &&
+        ThemeData.estimateBrightnessForColor(surface) == Brightness.light;
+  }
+
+  double get _endInset => _hasDismiss ? _dismissEdge : _sideEdge;
+
+  Color _surfaceColor(VineThemeColors colors) =>
+      backgroundColor ??
+      (error ? colors.errorContainer : colors.surfaceContainerHigh);
+
+  /// Label colour that stays legible on the resolved surface.
+  Color _labelColor(VineThemeColors colors) {
+    if (_hasLightSurface) return VineTheme.primaryDarkGreen;
+    return error ? VineTheme.error : colors.primaryText;
+  }
+
+  /// Colour of an affirmative action.
+  Color get _affirmativeColor =>
+      _hasLightSurface ? VineTheme.primaryDarkGreen : VineTheme.vineGreen;
+
+  /// Accent shared by a lone action button and the dismiss icon: the error
+  /// red on an error banner, the brand green otherwise.
+  Color get _accentColor =>
+      error && !_hasLightSurface ? VineTheme.error : _affirmativeColor;
+
+  /// Whether the action row has to move below the message.
+  ///
+  /// The design keeps action and message on one line while they both fit, and
+  /// drops the action onto its own right-aligned row once they stop fitting —
+  /// otherwise a long action label squeezes the message into a column of
+  /// single words.
+  bool _stacksActions(
+    BuildContext context,
+    double availableWidth,
+    TextStyle labelStyle,
+    TextStyle actionStyle,
+  ) {
+    if (!_hasAction) return false;
+
+    final textScaler = MediaQuery.textScalerOf(context);
+    final textDirection = Directionality.of(context);
+
+    double measure(String text, TextStyle style) {
+      final painter = TextPainter(
+        text: TextSpan(text: text, style: style),
+        textDirection: textDirection,
+        textScaler: textScaler,
+        maxLines: 1,
+      )..layout();
+      final width = painter.width;
+      painter.dispose();
+      return width;
     }
-    return error ? colors.onErrorContainer : colors.primaryText;
+
+    double actionWidth(String text) =>
+        math.max(_ActionButton.minWidth, measure(text, actionStyle));
+
+    var used = actionWidth(actionLabel!) + _gap;
+    if (_hasSecondaryAction) {
+      used += actionWidth(secondaryActionLabel!) + _gap;
+    }
+    if (_hasDismiss) used += _DismissButton.width + _gap;
+
+    return measure(label, labelStyle) + used >
+        availableWidth - _sideEdge - _endInset;
   }
 
   @override
   Widget build(BuildContext context) {
     final colors = context.vineColors;
-    final textStyle = VineTheme.labelLargeFont(color: _labelColor(colors));
-    final hasSecondary =
-        secondaryActionLabel != null && onSecondaryActionPressed != null;
-    final bannerText = Text(label, style: textStyle);
+    final labelStyle = VineTheme.labelLargeFont(color: _labelColor(colors));
+    final actionStyle = VineTheme.titleMediumFont();
 
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: backgroundColor ?? (error ? colors.errorContainer : colors.card),
-        borderRadius: const BorderRadius.all(Radius.circular(16)),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Expanded(child: bannerText),
-            if (actionLabel != null && onActionPressed != null)
-              _ActionButton(
-                label: actionLabel!,
-                onPressed: onActionPressed!,
-                // With a destructive secondary action present, the primary is
-                // the affirmative choice (green) even in an error snackbar;
-                // a lone action follows the error flag (red on error).
-                color: (hasSecondary || !error)
-                    ? VineTheme.vineGreen
-                    : VineTheme.likeRed,
-                textStyle: textStyle,
+    final actions = <Widget>[
+      if (_hasAction)
+        _ActionButton(
+          label: actionLabel!,
+          onPressed: onActionPressed!,
+          // With a destructive secondary action present, the primary is the
+          // affirmative choice (green) even in an error snackbar; a lone
+          // action follows the banner's own accent.
+          color: _hasSecondaryAction ? _affirmativeColor : _accentColor,
+          textStyle: actionStyle,
+        ),
+      if (_hasSecondaryAction)
+        _ActionButton(
+          label: secondaryActionLabel!,
+          onPressed: onSecondaryActionPressed!,
+          // Secondary is the destructive choice (e.g. Delete).
+          color: VineTheme.error,
+          textStyle: actionStyle,
+        ),
+      if (_hasDismiss)
+        _DismissButton(
+          onPressed: onDismissPressed!,
+          color: _accentColor,
+          semanticLabel: dismissSemanticLabel,
+        ),
+    ];
+
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: maxWidth),
+        child: SizedBox(
+          width: double.infinity,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: _surfaceColor(colors),
+              borderRadius: const BorderRadius.all(Radius.circular(_radius)),
+              boxShadow: VineTheme.depth1,
+            ),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(minHeight: minHeight),
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final text = Text(label, style: labelStyle);
+                  final stacked = _stacksActions(
+                    context,
+                    constraints.maxWidth,
+                    labelStyle,
+                    actionStyle,
+                  );
+                  return stacked
+                      ? _StackedLayout(
+                          label: text,
+                          actions: actions,
+                          endInset: _endInset,
+                        )
+                      : _InlineLayout(
+                          label: text,
+                          actions: actions,
+                          endInset: _endInset,
+                        );
+                },
               ),
-            if (hasSecondary)
-              _ActionButton(
-                label: secondaryActionLabel!,
-                onPressed: onSecondaryActionPressed!,
-                // Secondary is the destructive choice (e.g. Delete).
-                color: VineTheme.likeRed,
-                textStyle: textStyle,
-              ),
-          ],
+            ),
+          ),
         ),
       ),
+    );
+  }
+}
+
+/// Message and actions sharing a single row.
+class _InlineLayout extends StatelessWidget {
+  const _InlineLayout({
+    required this.label,
+    required this.actions,
+    required this.endInset,
+  });
+
+  final Widget label;
+  final List<Widget> actions;
+  final double endInset;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        left: DivineSnackbarContainer._sideEdge,
+        right: endInset,
+      ),
+      child: Row(
+        spacing: DivineSnackbarContainer._gap,
+        children: [
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                vertical: DivineSnackbarContainer._labelVerticalPadding,
+              ),
+              child: label,
+            ),
+          ),
+          ...actions,
+        ],
+      ),
+    );
+  }
+}
+
+/// Message on top, actions right-aligned on their own row below.
+class _StackedLayout extends StatelessWidget {
+  const _StackedLayout({
+    required this.label,
+    required this.actions,
+    required this.endInset,
+  });
+
+  final Widget label;
+  final List<Widget> actions;
+  final double endInset;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: DivineSnackbarContainer._sideEdge,
+            vertical: DivineSnackbarContainer._labelVerticalPadding,
+          ),
+          child: label,
+        ),
+        Padding(
+          padding: EdgeInsets.only(
+            left: DivineSnackbarContainer._sideEdge,
+            right: endInset,
+            bottom: DivineSnackbarContainer._stackedActionBottom,
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            spacing: DivineSnackbarContainer._gap,
+            children: actions,
+          ),
+        ),
+      ],
     );
   }
 }
@@ -144,6 +356,13 @@ class _ActionButton extends StatelessWidget {
     required this.textStyle,
   });
 
+  /// `component/button/min-width` — a short label still gets a comfortable
+  /// target rather than shrinking to the width of the word.
+  static const double minWidth = 72;
+
+  /// `size/interactive/48`.
+  static const double height = 48;
+
   final String label;
   final VoidCallback onPressed;
   final Color color;
@@ -154,14 +373,46 @@ class _ActionButton extends StatelessWidget {
     return TextButton(
       onPressed: onPressed,
       style: TextButton.styleFrom(
-        padding: const EdgeInsets.symmetric(horizontal: 12),
-        minimumSize: const Size(48, 36),
+        padding: EdgeInsets.zero,
+        minimumSize: const Size(minWidth, height),
         tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(16)),
+        ),
       ),
       child: Text(
         label,
-        style: textStyle.copyWith(fontWeight: FontWeight.w800, color: color),
+        textAlign: TextAlign.center,
+        style: textStyle.copyWith(color: color),
       ),
+    );
+  }
+}
+
+class _DismissButton extends StatelessWidget {
+  const _DismissButton({
+    required this.onPressed,
+    required this.color,
+    required this.semanticLabel,
+  });
+
+  /// Total width including the button's own transparent outer padding.
+  static const double width = 48;
+
+  final VoidCallback onPressed;
+  final Color color;
+  final String semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return DivineIconButton(
+      icon: DivineIconName.x,
+      onPressed: onPressed,
+      type: DivineIconButtonType.ghostSecondary,
+      size: DivineIconButtonSize.small,
+      foregroundColor: color,
+      tooltip: semanticLabel,
+      semanticLabel: semanticLabel,
     );
   }
 }

--- a/mobile/packages/divine_ui/lib/src/divine_snackbar_container.dart
+++ b/mobile/packages/divine_ui/lib/src/divine_snackbar_container.dart
@@ -74,6 +74,10 @@ class DivineSnackbarContainer extends StatelessWidget {
   static const double _labelVerticalPadding = 12;
   static const double _stackedActionBottom = 4;
 
+  /// How many lines the message may take while it still shares its row with
+  /// the actions — the design's two-line banner.
+  static const int _inlineLabelMaxLines = 2;
+
   /// The label of the snackbar.
   final String label;
 
@@ -140,24 +144,36 @@ class DivineSnackbarContainer extends StatelessWidget {
   /// Label colour that stays legible on the resolved surface.
   Color _labelColor(VineThemeColors colors) {
     if (_hasLightSurface) return VineTheme.primaryDarkGreen;
-    return error ? VineTheme.error : colors.primaryText;
+    return error ? colors.onErrorContainer : colors.primaryText;
   }
 
   /// Colour of an affirmative action.
-  Color get _affirmativeColor =>
-      _hasLightSurface ? VineTheme.primaryDarkGreen : VineTheme.vineGreen;
+  ///
+  /// [VineTheme.vineGreen] holds 9:1 on the dark surface but only 1.76:1 on
+  /// the light one, so a light appearance — the theme's own or a
+  /// caller-supplied [backgroundColor] — takes the dark green instead.
+  Color _affirmativeColor(VineThemeColors colors) =>
+      _hasLightSurface || colors.isLight
+      ? VineTheme.primaryDarkGreen
+      : VineTheme.vineGreen;
 
   /// Accent shared by a lone action button and the dismiss icon: the error
   /// red on an error banner, the brand green otherwise.
-  Color get _accentColor =>
-      error && !_hasLightSurface ? VineTheme.error : _affirmativeColor;
+  ///
+  /// The red resolves through the palette rather than [VineTheme.error], which
+  /// is the dark value and reads 3.1:1 on the light error container.
+  Color _accentColor(VineThemeColors colors) => error && !_hasLightSurface
+      ? colors.onErrorContainer
+      : _affirmativeColor(colors);
 
   /// Whether the action row has to move below the message.
   ///
-  /// The design keeps action and message on one line while they both fit, and
-  /// drops the action onto its own right-aligned row once they stop fitting —
+  /// The design's own threshold is its two-line banner: the action keeps the
+  /// message's row while the message still fits in [_inlineLabelMaxLines]
+  /// beside it, and drops onto its own right-aligned row once it does not —
   /// otherwise a long action label squeezes the message into a column of
-  /// single words.
+  /// single words. So a long message with a short action still wraps inline
+  /// rather than spending a third row on an "Undo".
   bool _stacksActions(
     BuildContext context,
     double availableWidth,
@@ -188,10 +204,20 @@ class DivineSnackbarContainer extends StatelessWidget {
     if (_hasSecondaryAction) {
       used += actionWidth(secondaryActionLabel!) + _gap;
     }
-    if (_hasDismiss) used += _DismissButton.width + _gap;
+    if (_hasDismiss) used += _DismissButton.widthOf(context) + _gap;
 
-    return measure(label, labelStyle) + used >
-        availableWidth - _sideEdge - _endInset;
+    final labelWidth = availableWidth - _sideEdge - _endInset - used;
+    if (labelWidth <= 0) return true;
+
+    final painter = TextPainter(
+      text: TextSpan(text: label, style: labelStyle),
+      textDirection: textDirection,
+      textScaler: textScaler,
+      maxLines: _inlineLabelMaxLines,
+    )..layout(maxWidth: labelWidth);
+    final overflows = painter.didExceedMaxLines;
+    painter.dispose();
+    return overflows;
   }
 
   @override
@@ -200,7 +226,8 @@ class DivineSnackbarContainer extends StatelessWidget {
     final labelStyle = VineTheme.labelLargeFont(color: _labelColor(colors));
     // The banner's accent is what a lone action wears; the buttons below
     // re-resolve it when a destructive secondary changes the pairing.
-    final actionStyle = VineTheme.titleMediumFont(color: _accentColor);
+    final accent = _accentColor(colors);
+    final actionStyle = VineTheme.titleMediumFont(color: accent);
 
     final actions = <Widget>[
       if (_hasAction)
@@ -210,7 +237,7 @@ class DivineSnackbarContainer extends StatelessWidget {
           // With a destructive secondary action present, the primary is the
           // affirmative choice (green) even in an error snackbar; a lone
           // action follows the banner's own accent.
-          color: _hasSecondaryAction ? _affirmativeColor : _accentColor,
+          color: _hasSecondaryAction ? _affirmativeColor(colors) : accent,
           textStyle: actionStyle,
         ),
       if (_hasSecondaryAction)
@@ -218,13 +245,13 @@ class DivineSnackbarContainer extends StatelessWidget {
           label: secondaryActionLabel!,
           onPressed: onSecondaryActionPressed!,
           // Secondary is the destructive choice (e.g. Delete).
-          color: VineTheme.error,
+          color: colors.onErrorContainer,
           textStyle: actionStyle,
         ),
       if (_hasDismiss)
         _DismissButton(
           onPressed: onDismissPressed!,
-          color: _accentColor,
+          color: accent,
           semanticLabel: dismissSemanticLabel,
         ),
     ];
@@ -339,10 +366,12 @@ class _StackedLayout extends StatelessWidget {
             right: endInset,
             bottom: DivineSnackbarContainer._stackedActionBottom,
           ),
+          // Flexible so an action too wide even for the full banner wraps
+          // inside it rather than running off the edge.
           child: Row(
             mainAxisAlignment: MainAxisAlignment.end,
             spacing: DivineSnackbarContainer._gap,
-            children: actions,
+            children: [for (final action in actions) Flexible(child: action)],
           ),
         ),
       ],
@@ -379,7 +408,9 @@ class _ActionButton extends StatelessWidget {
         minimumSize: const Size(minWidth, height),
         tapTargetSize: MaterialTapTargetSize.shrinkWrap,
         shape: const RoundedRectangleBorder(
-          borderRadius: BorderRadius.all(Radius.circular(16)),
+          borderRadius: BorderRadius.all(
+            Radius.circular(DivineSnackbarContainer._radius),
+          ),
         ),
       ),
       child: Text(
@@ -398,8 +429,17 @@ class _DismissButton extends StatelessWidget {
     required this.semanticLabel,
   });
 
-  /// Total width including the button's own transparent outer padding.
-  static const double width = 48;
+  /// The 48px tap target [DivineIconButton] centres its 40px pill in.
+  static const double tapTarget = 48;
+
+  /// Transparent outer padding [DivineIconButton] adds on each side when it
+  /// has no border, which `ghostSecondary` does not.
+  static const double outerPadding = 2;
+
+  /// Total rendered width, scaler included — the tap target scales with text,
+  /// the transparent padding around it does not.
+  static double widthOf(BuildContext context) =>
+      DivineIcon.scaleSize(context, tapTarget) + outerPadding * 2;
 
   final VoidCallback onPressed;
   final Color color;

--- a/mobile/packages/divine_ui/lib/src/divine_snackbar_container.dart
+++ b/mobile/packages/divine_ui/lib/src/divine_snackbar_container.dart
@@ -198,7 +198,9 @@ class DivineSnackbarContainer extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.vineColors;
     final labelStyle = VineTheme.labelLargeFont(color: _labelColor(colors));
-    final actionStyle = VineTheme.titleMediumFont();
+    // The banner's accent is what a lone action wears; the buttons below
+    // re-resolve it when a destructive secondary changes the pairing.
+    final actionStyle = VineTheme.titleMediumFont(color: _accentColor);
 
     final actions = <Widget>[
       if (_hasAction)

--- a/mobile/packages/divine_ui/lib/src/divine_snackbar_container.dart
+++ b/mobile/packages/divine_ui/lib/src/divine_snackbar_container.dart
@@ -436,8 +436,12 @@ class _DismissButton extends StatelessWidget {
   /// has no border, which `ghostSecondary` does not.
   static const double outerPadding = 2;
 
-  /// Total rendered width, scaler included — the tap target scales with text,
-  /// the transparent padding around it does not.
+  /// Width the placement measurement reserves: the tap target, which scales
+  /// with text, plus the transparent padding around it, which does not.
+  ///
+  /// Whether that padding reaches the rendered box has moved between Flutter
+  /// versions, so this deliberately reserves the upper bound — over-reserving
+  /// stacks a borderline banner one notch early, under-reserving overflows it.
   static double widthOf(BuildContext context) =>
       DivineIcon.scaleSize(context, tapTarget) + outerPadding * 2;
 

--- a/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
+++ b/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
@@ -1025,7 +1025,10 @@ class VineTheme {
     disabled: onSurfaceDisabled,
     skeleton: skeletonBase,
     errorContainer: errorContainer,
-    onErrorContainer: likeRed,
+    // Was `likeRed` — a like-button colour the error surfaces had borrowed,
+    // frozen there so the constant-to-token migration stayed pixel-neutral.
+    // Figma's `error/error` lifts the pairing from 4.15:1 to 4.65:1.
+    onErrorContainer: error,
     accentPositive: vineGreen,
     accentWarning: accentOrange,
     inverseSurface: inverseSurface,
@@ -1112,9 +1115,7 @@ class VineTheme {
       primarySwatch: _createMaterialColor(vineGreen),
       primaryColor: vineGreen,
       colorScheme: scheme,
-      progressIndicatorTheme: ProgressIndicatorThemeData(
-        color: scheme.primary,
-      ),
+      progressIndicatorTheme: ProgressIndicatorThemeData(color: scheme.primary),
       scaffoldBackgroundColor: colors.background,
       extensions: <ThemeExtension<dynamic>>[colors],
       appBarTheme: AppBarTheme(

--- a/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
+++ b/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
@@ -900,6 +900,26 @@ class VineTheme {
   /// video content (caption pills, floating popups, etc.).
   static const Color shadow25 = Color(0x40000000);
 
+  /// Figma `effects/shadow-15` drop-shadow color (15% black), the softer
+  /// half of the [depth1] pair.
+  static const Color shadow15 = Color(0x26000000);
+
+  /// Figma `depth 1` elevation: the drop-shadow pair that lifts a floating
+  /// surface (snackbar, popup) off the page.
+  ///
+  /// Unlike [buttonBoxShadows] — an inward emboss — this is a genuine outward
+  /// shadow, so it must be painted on a [DecoratedBox] outside any [Material]
+  /// that would clip it.
+  static const List<BoxShadow> depth1 = [
+    BoxShadow(color: shadow25, offset: Offset(0, 1), blurRadius: 3),
+    BoxShadow(
+      color: shadow15,
+      offset: Offset(0, 4),
+      blurRadius: 8,
+      spreadRadius: 3,
+    ),
+  ];
+
   /// Figma `effects/shadow-10` drop-shadow pair, for use in
   /// [TextStyle.shadows] on text overlaid on video content or other
   /// bright surfaces (caption block, action-button labels, feed-mode

--- a/mobile/packages/divine_ui/test/src/divine_snackbar_container_test.dart
+++ b/mobile/packages/divine_ui/test/src/divine_snackbar_container_test.dart
@@ -1,6 +1,35 @@
+import 'dart:math' as math;
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+/// Size [text] takes on one unconstrained line, in the style it actually
+/// rendered with.
+///
+/// The placement tests size their viewport from this rather than hardcoding
+/// pixel widths. This suite runs in two font contexts: from the package it
+/// falls back to a test font, and from `mobile/` — which is how the pre-push
+/// hook runs it — it gets the bundled Inter. The same string measures about
+/// twice as wide in one as the other, so any fixed viewport puts the two on
+/// opposite sides of the wrap threshold.
+Size _renderedTextSize(WidgetTester tester, String text) {
+  final painter = TextPainter(
+    text: TextSpan(
+      text: text,
+      style: tester.widget<Text>(find.text(text)).style,
+    ),
+    textDirection: TextDirection.ltr,
+  )..layout();
+  final size = painter.size;
+  painter.dispose();
+  return size;
+}
+
+/// Viewport width that leaves the message exactly [labelWidth] to wrap in,
+/// once the action column and the two 16px edge insets are accounted for.
+double _viewportFor(double labelWidth, double actionWidth) =>
+    labelWidth + math.max(72, actionWidth) + 4 + 16 + 16;
 
 void main() {
   group('DivineSnackbarContainer', () {
@@ -538,24 +567,35 @@ void main() {
       testWidgets('drops a long action onto its own right-aligned row', (
         tester,
       ) async {
-        tester.view.physicalSize = const Size(360, 800);
+        const message = 'We could not reach the relay just now';
+        const action = 'Try that again';
+        final widget = buildTestWidget(
+          label: message,
+          actionLabel: action,
+          onActionPressed: () {},
+        );
+
         tester.view.devicePixelRatio = 1;
         addTearDown(tester.view.resetPhysicalSize);
         addTearDown(tester.view.resetDevicePixelRatio);
+        await tester.pumpWidget(widget);
 
-        await tester.pumpWidget(
-          buildTestWidget(
-            label: 'We could not reach the relay just now',
-            actionLabel: 'Try that again',
-            onActionPressed: () {},
+        // A third of the message's own width leaves it needing four lines,
+        // which is past the two it may take while sharing the row.
+        final message1Line = _renderedTextSize(tester, message);
+        tester.view.physicalSize = Size(
+          _viewportFor(
+            message1Line.width / 3,
+            _renderedTextSize(tester, action).width,
           ),
+          800,
         );
+        await tester.pumpWidget(widget);
 
-        final label = tester.getRect(
-          find.text('We could not reach the relay just now'),
+        expect(
+          tester.getRect(find.text(action)).top,
+          greaterThanOrEqualTo(tester.getRect(find.text(message)).bottom),
         );
-        final action = tester.getRect(find.text('Try that again'));
-        expect(action.top, greaterThanOrEqualTo(label.bottom));
 
         final banner = tester.getRect(find.byType(DecoratedBox));
         final button = tester.getRect(find.byType(TextButton));
@@ -567,27 +607,37 @@ void main() {
       // it rather than spending a third row on an "Undo".
       testWidgets('keeps a short action beside a message that wraps to two '
           'lines', (tester) async {
-        tester.view.physicalSize = const Size(360, 800);
+        const message = 'We could not reach the relay just now';
+        const action = 'Undo';
+        final widget = buildTestWidget(
+          label: message,
+          actionLabel: action,
+          onActionPressed: () {},
+        );
+
         tester.view.devicePixelRatio = 1;
         addTearDown(tester.view.resetPhysicalSize);
         addTearDown(tester.view.resetDevicePixelRatio);
+        await tester.pumpWidget(widget);
 
-        // Wide enough to need a second line beside the action, not a third:
-        // the old one-line measurement stacked this, the two-line rule keeps
-        // it inline.
-        const message = 'We could not reach the relay';
-        await tester.pumpWidget(
-          buildTestWidget(
-            label: message,
-            actionLabel: 'Undo',
-            onActionPressed: () {},
+        // Three quarters of the message's own width: too narrow for one line,
+        // wide enough for two. The old one-line measurement stacked this.
+        final message1Line = _renderedTextSize(tester, message);
+        tester.view.physicalSize = Size(
+          _viewportFor(
+            message1Line.width * 0.75,
+            _renderedTextSize(tester, action).width,
           ),
+          800,
         );
+        await tester.pumpWidget(widget);
 
         final label = tester.getRect(find.text(message));
-        final action = tester.getRect(find.text('Undo'));
-        expect(label.height, greaterThan(24));
-        expect(action.left, greaterThan(label.right));
+        expect(label.height, greaterThan(message1Line.height));
+        expect(
+          tester.getRect(find.text(action)).left,
+          greaterThan(label.right),
+        );
       });
 
       // On its own row the actions are Flexible, so one too wide even for the
@@ -595,18 +645,25 @@ void main() {
       testWidgets('wraps an over-wide action inside the banner', (
         tester,
       ) async {
-        tester.view.physicalSize = const Size(360, 800);
+        const action = 'Try reconnecting to the relay one more time now';
+        final widget = buildTestWidget(
+          label: 'We could not reach the relay just now',
+          actionLabel: action,
+          onActionPressed: () {},
+        );
+
         tester.view.devicePixelRatio = 1;
         addTearDown(tester.view.resetPhysicalSize);
         addTearDown(tester.view.resetDevicePixelRatio);
+        await tester.pumpWidget(widget);
 
-        await tester.pumpWidget(
-          buildTestWidget(
-            label: 'We could not reach the relay just now',
-            actionLabel: 'Try reconnecting to the relay one more time now',
-            onActionPressed: () {},
-          ),
+        // Narrower than the action label alone, so it cannot fit on one line
+        // even with the whole banner to itself.
+        tester.view.physicalSize = Size(
+          _renderedTextSize(tester, action).width * 0.7,
+          800,
         );
+        await tester.pumpWidget(widget);
 
         expect(tester.takeException(), isNull);
         final banner = tester.getRect(find.byType(DecoratedBox));

--- a/mobile/packages/divine_ui/test/src/divine_snackbar_container_test.dart
+++ b/mobile/packages/divine_ui/test/src/divine_snackbar_container_test.dart
@@ -693,7 +693,7 @@ void main() {
       );
 
       final box = tester.widget<DecoratedBox>(
-        find.byType(DecoratedBox).first,
+        find.byType(DecoratedBox),
       );
       expect(
         (box.decoration as BoxDecoration).color,
@@ -716,7 +716,7 @@ void main() {
       );
 
       final box = tester.widget<DecoratedBox>(
-        find.byType(DecoratedBox).first,
+        find.byType(DecoratedBox),
       );
       expect(
         (box.decoration as BoxDecoration).color,

--- a/mobile/packages/divine_ui/test/src/divine_snackbar_container_test.dart
+++ b/mobile/packages/divine_ui/test/src/divine_snackbar_container_test.dart
@@ -41,11 +41,12 @@ void main() {
       );
       final decoration = decoratedBox.decoration as BoxDecoration;
 
-      expect(decoration.color, VineTheme.cardBackground);
+      expect(decoration.color, VineTheme.surfaceContainerHigh);
       expect(
         decoration.borderRadius,
         const BorderRadius.all(Radius.circular(16)),
       );
+      expect(decoration.boxShadow, VineTheme.depth1);
     });
 
     testWidgets('renders error state correctly', (tester) async {
@@ -67,14 +68,14 @@ void main() {
       );
 
       final text = tester.widget<Text>(find.text('Error message'));
-      expect(text.style?.color, VineTheme.likeRed);
+      expect(text.style?.color, VineTheme.error);
     });
 
     testWidgets('renders non-error text without red color', (tester) async {
       await tester.pumpWidget(buildTestWidget(label: 'Info message'));
 
       final text = tester.widget<Text>(find.text('Info message'));
-      expect(text.style?.color, isNot(VineTheme.likeRed));
+      expect(text.style?.color, isNot(VineTheme.error));
     });
 
     testWidgets('does not render action button when actionLabel is null', (
@@ -150,7 +151,45 @@ void main() {
       );
 
       final actionText = tester.widget<Text>(find.text('Retry'));
-      expect(actionText.style?.color, VineTheme.likeRed);
+      expect(actionText.style?.color, VineTheme.error);
+    });
+
+    testWidgets('action label uses the title/medium type ramp', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          label: 'Test message',
+          actionLabel: 'Retry',
+          onActionPressed: () {},
+        ),
+      );
+
+      final actionStyle = tester.widget<Text>(find.text('Retry')).style;
+      final reference = VineTheme.titleMediumFont();
+      expect(actionStyle?.fontFamily, reference.fontFamily);
+      expect(actionStyle?.fontSize, 16);
+      expect(actionStyle?.fontWeight, FontWeight.w800);
+      expect(actionStyle?.letterSpacing, 0.15);
+    });
+
+    testWidgets('a light custom surface darkens the action too', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: VineTheme.theme,
+          home: Scaffold(
+            body: DivineSnackbarContainer(
+              label: 'Switched to Staging',
+              backgroundColor: const Color(0xFFFFF140),
+              actionLabel: 'Undo',
+              onActionPressed: () {},
+            ),
+          ),
+        ),
+      );
+
+      final actionText = tester.widget<Text>(find.text('Undo'));
+      expect(actionText.style?.color, VineTheme.primaryDarkGreen);
     });
 
     group('secondary action', () {
@@ -191,7 +230,7 @@ void main() {
         );
         expect(
           tester.widget<Text>(find.text('Delete')).style?.color,
-          VineTheme.likeRed,
+          VineTheme.error,
         );
       });
 
@@ -273,21 +312,169 @@ void main() {
       });
     });
 
-    testWidgets('has correct padding', (tester) async {
-      await tester.pumpWidget(buildTestWidget(label: 'Test message'));
+    group('sizing', () {
+      testWidgets('a one-line banner still clears the 48px touch target', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildTestWidget(label: 'Test message'));
 
-      final padding = tester.widget<Padding>(find.byType(Padding));
-      expect(
-        padding.padding,
-        const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-      );
+        final banner = tester.getRect(find.byType(DecoratedBox));
+        expect(banner.height, DivineSnackbarContainer.minHeight);
+      });
+
+      testWidgets('insets the label by 16px from the leading edge', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildTestWidget(label: 'Test message'));
+
+        final banner = tester.getRect(find.byType(DecoratedBox));
+        final label = tester.getRect(find.text('Test message'));
+        expect(label.left - banner.left, 16);
+      });
+
+      testWidgets('stops growing at the max width on a wide viewport', (
+        tester,
+      ) async {
+        tester.view.physicalSize = const Size(1600, 900);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await tester.pumpWidget(buildTestWidget(label: 'Test message'));
+
+        final banner = tester.getRect(find.byType(DecoratedBox));
+        expect(banner.width, DivineSnackbarContainer.maxWidth);
+        // …and stays centred rather than pinned to the leading edge.
+        expect(banner.center.dx, 800);
+      });
+
+      testWidgets('tracks the viewport when it is narrower than the max', (
+        tester,
+      ) async {
+        tester.view.physicalSize = const Size(360, 800);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await tester.pumpWidget(buildTestWidget(label: 'Test message'));
+
+        final banner = tester.getRect(find.byType(DecoratedBox));
+        expect(banner.width, 360);
+      });
     });
 
-    testWidgets('uses Row with spaceBetween alignment', (tester) async {
-      await tester.pumpWidget(buildTestWidget(label: 'Test message'));
+    group('dismiss button', () {
+      testWidgets('is absent when onDismissPressed is null', (tester) async {
+        await tester.pumpWidget(buildTestWidget(label: 'Test message'));
 
-      final row = tester.widget<Row>(find.byType(Row));
-      expect(row.mainAxisAlignment, MainAxisAlignment.spaceBetween);
+        expect(find.byType(DivineIconButton), findsNothing);
+      });
+
+      testWidgets('renders and calls back when tapped', (tester) async {
+        var dismissed = false;
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: VineTheme.theme,
+            home: Scaffold(
+              body: DivineSnackbarContainer(
+                label: 'Test message',
+                onDismissPressed: () => dismissed = true,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(DivineIconButton), findsOneWidget);
+        await tester.tap(find.byType(DivineIconButton));
+        expect(dismissed, isTrue);
+      });
+
+      testWidgets('carries the accent colour and semantic label', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: VineTheme.theme,
+            home: Scaffold(
+              body: DivineSnackbarContainer(
+                label: 'Error message',
+                error: true,
+                dismissSemanticLabel: 'Close',
+                onDismissPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        final button = tester.widget<DivineIconButton>(
+          find.byType(DivineIconButton),
+        );
+        expect(button.icon, DivineIconName.x);
+        expect(button.foregroundColor, VineTheme.error);
+        expect(button.semanticLabel, 'Close');
+      });
+
+      testWidgets('sits beside the label rather than below it', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: VineTheme.theme,
+            home: Scaffold(
+              body: DivineSnackbarContainer(
+                label: 'Test message',
+                onDismissPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        final label = tester.getRect(find.text('Test message'));
+        final button = tester.getRect(find.byType(DivineIconButton));
+        expect(button.left, greaterThan(label.right));
+      });
+    });
+
+    group('action placement', () {
+      testWidgets('keeps a short action on the message row', (tester) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            label: 'Copied',
+            actionLabel: 'Undo',
+            onActionPressed: () {},
+          ),
+        );
+
+        final label = tester.getRect(find.text('Copied'));
+        final action = tester.getRect(find.text('Undo'));
+        expect(action.left, greaterThan(label.right));
+        expect(action.center.dy, closeTo(label.center.dy, 1));
+      });
+
+      testWidgets('drops a long action onto its own right-aligned row', (
+        tester,
+      ) async {
+        tester.view.physicalSize = const Size(360, 800);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            label: 'We could not reach the relay just now',
+            actionLabel: 'Try that again',
+            onActionPressed: () {},
+          ),
+        );
+
+        final label = tester.getRect(
+          find.text('We could not reach the relay just now'),
+        );
+        final action = tester.getRect(find.text('Try that again'));
+        expect(action.top, greaterThanOrEqualTo(label.bottom));
+
+        final banner = tester.getRect(find.byType(DecoratedBox));
+        final button = tester.getRect(find.byType(TextButton));
+        expect(banner.right - button.right, 16);
+      });
     });
 
     testWidgets('paints a custom surface colour when given one', (

--- a/mobile/packages/divine_ui/test/src/divine_snackbar_container_test.dart
+++ b/mobile/packages/divine_ui/test/src/divine_snackbar_container_test.dart
@@ -478,17 +478,21 @@ void main() {
         expect(button.left, greaterThan(label.right));
       });
 
-      // The placement measurement reserves a fixed width for this button, so
-      // the two drift apart silently if the button's own geometry changes.
-      // 48px tap target + the 2px transparent padding it carries on each side.
-      testWidgets('renders at the width the placement measurement reserves', (
-        tester,
-      ) async {
+      // The trailing inset drops from 16 to 4 when the dismiss button is
+      // present, because the button carries the rest of the edge itself.
+      //
+      // This pins the inset rather than the button's absolute width: that
+      // width is Flutter-version-dependent (3.44 renders the ghostSecondary
+      // small variant at 52, current stable at 48), so asserting it here
+      // pins the SDK rather than this component's contract.
+      testWidgets('sits 4px inside the trailing edge', (tester) async {
         await tester.pumpWidget(
           buildTestWidget(label: 'Test message', onDismissPressed: () {}),
         );
 
-        expect(tester.getRect(find.byType(DivineIconButton)).width, 52);
+        final banner = tester.getRect(find.byType(DecoratedBox));
+        final button = tester.getRect(find.byType(DivineIconButton));
+        expect(banner.right - button.right, 4);
       });
 
       testWidgets('sits after the action when both are present', (

--- a/mobile/packages/divine_ui/test/src/divine_snackbar_container_test.dart
+++ b/mobile/packages/divine_ui/test/src/divine_snackbar_container_test.dart
@@ -11,9 +11,11 @@ void main() {
       VoidCallback? onActionPressed,
       String? secondaryActionLabel,
       VoidCallback? onSecondaryActionPressed,
+      VoidCallback? onDismissPressed,
+      ThemeData? theme,
     }) {
       return MaterialApp(
-        theme: VineTheme.theme,
+        theme: theme ?? VineTheme.theme,
         home: Scaffold(
           body: DivineSnackbarContainer(
             label: label,
@@ -22,6 +24,7 @@ void main() {
             onActionPressed: onActionPressed,
             secondaryActionLabel: secondaryActionLabel,
             onSecondaryActionPressed: onSecondaryActionPressed,
+            onDismissPressed: onDismissPressed,
           ),
         ),
       );
@@ -310,6 +313,20 @@ void main() {
         expect(container.secondaryActionLabel, 'Delete');
         expect(container.onSecondaryActionPressed, equals(onDelete));
       });
+
+      testWidgets('passes the dismiss parameters through', (tester) async {
+        void onDismiss() {}
+
+        final snackBar = DivineSnackbarContainer.snackBar(
+          'Saved',
+          onDismissPressed: onDismiss,
+          dismissSemanticLabel: 'Close',
+        );
+
+        final container = snackBar.content as DivineSnackbarContainer;
+        expect(container.onDismissPressed, equals(onDismiss));
+        expect(container.dismissSemanticLabel, 'Close');
+      });
     });
 
     group('sizing', () {
@@ -431,6 +448,75 @@ void main() {
         final button = tester.getRect(find.byType(DivineIconButton));
         expect(button.left, greaterThan(label.right));
       });
+
+      // The placement measurement reserves a fixed width for this button, so
+      // the two drift apart silently if the button's own geometry changes.
+      // 48px tap target + the 2px transparent padding it carries on each side.
+      testWidgets('renders at the width the placement measurement reserves', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(label: 'Test message', onDismissPressed: () {}),
+        );
+
+        expect(tester.getRect(find.byType(DivineIconButton)).width, 52);
+      });
+
+      testWidgets('sits after the action when both are present', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            label: 'Copied',
+            actionLabel: 'Undo',
+            onActionPressed: () {},
+            onDismissPressed: () {},
+          ),
+        );
+
+        final action = tester.getRect(find.text('Undo'));
+        final dismiss = tester.getRect(find.byType(DivineIconButton));
+        expect(dismiss.left, greaterThanOrEqualTo(action.right));
+      });
+    });
+
+    group('light appearance', () {
+      // The error label resolves through `onErrorContainer` rather than the
+      // `VineTheme.error` constant, which is the dark value and holds only
+      // 3.1:1 on the light error container — under the 4.5:1 floor its
+      // Inter 14/600 needs as normal text.
+      testWidgets('error label uses the light error token', (tester) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            label: 'Error message',
+            error: true,
+            theme: VineTheme.lightTheme,
+          ),
+        );
+
+        final text = tester.widget<Text>(find.text('Error message'));
+        expect(text.style?.color, VineTheme.lightColors.onErrorContainer);
+        expect(text.style?.color, isNot(VineTheme.error));
+      });
+
+      // `vineGreen` reads 1.76:1 on the light surface, so a light appearance
+      // takes the dark green even without a caller-supplied background.
+      testWidgets('action darkens its green on the light surface', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            label: 'Copied',
+            actionLabel: 'Undo',
+            onActionPressed: () {},
+            theme: VineTheme.lightTheme,
+          ),
+        );
+
+        final text = tester.widget<Text>(find.text('Undo'));
+        expect(text.style?.color, VineTheme.primaryDarkGreen);
+        expect(text.style?.color, isNot(VineTheme.vineGreen));
+      });
     });
 
     group('action placement', () {
@@ -474,6 +560,59 @@ void main() {
         final banner = tester.getRect(find.byType(DecoratedBox));
         final button = tester.getRect(find.byType(TextButton));
         expect(banner.right - button.right, 16);
+      });
+
+      // The threshold is the design's two-line banner, not "the message fits
+      // on one line" — a long message with a short action still wraps beside
+      // it rather than spending a third row on an "Undo".
+      testWidgets('keeps a short action beside a message that wraps to two '
+          'lines', (tester) async {
+        tester.view.physicalSize = const Size(360, 800);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        // Wide enough to need a second line beside the action, not a third:
+        // the old one-line measurement stacked this, the two-line rule keeps
+        // it inline.
+        const message = 'We could not reach the relay';
+        await tester.pumpWidget(
+          buildTestWidget(
+            label: message,
+            actionLabel: 'Undo',
+            onActionPressed: () {},
+          ),
+        );
+
+        final label = tester.getRect(find.text(message));
+        final action = tester.getRect(find.text('Undo'));
+        expect(label.height, greaterThan(24));
+        expect(action.left, greaterThan(label.right));
+      });
+
+      // On its own row the actions are Flexible, so one too wide even for the
+      // full banner wraps inside it rather than running off the edge.
+      testWidgets('wraps an over-wide action inside the banner', (
+        tester,
+      ) async {
+        tester.view.physicalSize = const Size(360, 800);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            label: 'We could not reach the relay just now',
+            actionLabel: 'Try reconnecting to the relay one more time now',
+            onActionPressed: () {},
+          ),
+        );
+
+        expect(tester.takeException(), isNull);
+        final banner = tester.getRect(find.byType(DecoratedBox));
+        final button = tester.getRect(find.byType(TextButton));
+        expect(button.right, lessThanOrEqualTo(banner.right));
+        expect(button.left, greaterThanOrEqualTo(banner.left));
       });
     });
 

--- a/mobile/test/screens/comments/widgets/comment_options_modal_test.dart
+++ b/mobile/test/screens/comments/widgets/comment_options_modal_test.dart
@@ -56,14 +56,17 @@ void main() {
       expect(color, isNot(VineTheme.likeRed));
     });
 
-    testWidgets('destructive row is byte-identical on dark', (tester) async {
+    testWidgets('destructive row tracks the dark error token', (tester) async {
       await openOwnCommentSheet(tester, VineTheme.theme);
 
-      // The dark palette defines onErrorContainer as likeRed itself, so dark
-      // rendering must not move.
+      // This pinned `likeRed` byte-for-byte while the constant-to-token
+      // migration needed dark to stay pixel-neutral. #7147 retired that
+      // invariant by moving `onErrorContainer` onto Figma's `error/error`,
+      // so what is worth holding now is that the row follows the token
+      // rather than a constant of its own.
       final color = deleteLabelColor(tester);
-      expect(color, VineTheme.likeRed);
       expect(color, VineTheme.darkColors.onErrorContainer);
+      expect(color, isNot(VineTheme.likeRed));
     });
   });
 }


### PR DESCRIPTION
Closes #7148

## Description

`DivineSnackbarContainer` had drifted from its Figma spec ([UI Design → Snackbar](https://www.figma.com/design/rp1DsDEUuCaicW0lk6I2aZ/UI-Design?node-id=729-48413&m=dev&focus-id=7606-68408)) on nine points. This aligns all of them.

**Colour and type**

- Surface was `colors.card` (#1A1A1A, a neutral grey); the design calls for `bg/surface-container-high` (#000A06). This was the most visible one — the banner read as a Material default rather than as Divine chrome.
- Error label and action used the like-red (#E53E3E) they had borrowed. Both now resolve through `colors.onErrorContainer`, whose dark value moves onto the `error/error` token (#F44336) — see [Palette](#palette) below, which is the one change here that reaches beyond the snackbar.
- Action labels used `labelLargeFont` with an overridden weight (Inter 14/20) instead of the `title/medium` ramp they are specified in (Bricolage Grotesque 800, 16/24, 0.15).
- The affirmative action's green was a raw `VineTheme.vineGreen`, which reads 1.76:1 on the light `surface-container-high`. It now takes `primaryDarkGreen` on a light appearance — the theme's own, not just a caller-supplied `backgroundColor` — for 12.98:1. This was originally filed under Out of Scope for want of a light-mode green token; asking `colors.isLight` at the call site turned out to be enough.
- The `depth 1` drop shadow was missing entirely. Added to `VineTheme` as `shadow15` + `depth1`, next to the existing `shadow25` / `buttonBoxShadows` tokens, since it is a shared elevation token rather than a snackbar detail.

**Geometry** — off in both directions. A one-line banner rendered 44px where the design floors it at the 48px touch target, while a banner with an action grew to 60px, because the container padded 12px vertically around a 36px button instead of letting a 48px button set the height. The action button also gets its specified `min-width: 72` (`component/button/min-width`). The banner itself grew without limit; it now stops at the 480px max-width (`component/snackbar/max-width`) and centres beyond that, tracking the viewport below it.

**Two missing variants**

- **Dismissable.** A trailing ✕ is now available via `onDismissPressed`. It maps onto `DivineIconButton(ghostSecondary, small)`, which already matches the design exactly — 15% black scrim, 16px radius, 8px inner padding, 24px icon, 48px tap target. The trailing container inset drops to 4px when it is present, because the button carries 2px of transparent padding itself plus the 4px that centres its 40px pill in the 48px tap target. That outer padding also means the placement measurement below reserves 52px rather than 48; the rendered width is SDK-dependent, so a test pins the 4px trailing inset instead — see the note on the placement tests below. No call site opts in yet; adding one per screen is a separate decision and needs an l10n key for the semantic label (`divine_ui` stays l10n-free, so it takes a string param with an English default).
- **Longer action.** A long action label now drops onto its own right-aligned row instead of squeezing the message into a column of single words. Whether it fits depends on the rendered width of both strings, so this is measured with a `TextPainter` inside a `LayoutBuilder` rather than exposed as a caller-set flag — Figma models it as a boolean variant, but pushing that judgment to ~40 call sites would be layout logic in the wrong layer. The threshold is the design's own two-line banner: the action keeps the message's row while the message still fits in two lines beside it, and moves below once it does not, so a long message with a short action still wraps inline instead of spending a third row on an "Undo". On its own row the actions are `Flexible`, so an action too wide even for the full banner wraps inside it rather than running off the edge.

### Palette

`darkColors.onErrorContainer` was `likeRed` (#E53E3E) — a like-button colour the error surfaces had borrowed, frozen there so the constant-to-token migration stayed pixel-neutral. It now carries Figma's `error/error` (#F44336).

The snackbar reads that token rather than the `VineTheme.error` constant, because only the token resolves per appearance mode. The constant is the dark value, and on the light `errorContainer` it reads 3.1:1 — under the 4.5:1 the label's Inter 14/600 needs as normal text, and outside the `onErrorContainer` / `errorContainer` pairing that `vine_theme_light_palette_test.dart` holds. Through the token the error label is 7.7:1 on light and 4.65:1 on dark, up from 4.15:1.

One other screen reads the same token: the comment options sheet's destructive row shifts #E53E3E → #F44336 on dark, in the direction of more contrast. Its guard test `destructive row is byte-identical on dark` existed to pin the migration invariant this change deliberately retires, so it is rewritten to assert the row tracks the palette instead.

## Out of Scope

Two deliberate deviations from the Figma file, both noted rather than silently applied:

- **The secondary-action rule stays as it was.** "Primary turns green when a destructive secondary is present" has no Figma counterpart, but the alternative is two identical red buttons. Only its red moved onto the error token.
- **Text still wraps freely.** The Figma instances are set to `nowrap` / ellipsis, but every component description in the file reads "2-line snackbar", and truncating real messages would hide information users need. Happy to hard-cap at two lines if design confirms that is the intent.

**Related Issue:** 

## Verification

- `dart format` clean, `flutter analyze lib test integration_test` clean
- `divine_ui`: 891 tests green, and the package's 100% coverage gate passes (`very_good test --coverage --min-coverage 100`, 2189/2189 lines)
- Snackbar tests extended from 25 to 41, covering min height, max width, leading inset, the dismiss button (including its 4px trailing inset), the light-mode error colour and action green, dismiss alongside an action, inline vs. stacked placement, and the over-wide action wrap
- The placement tests are green from both `packages/divine_ui` and `mobile/` — see the note below on why that distinction matters
- The app-level suites that touch `DivineSnackbarContainer` or `onErrorContainer` pass, including the comment options sheet
- `mobile/scripts/golden.sh verify` clean
- All 12 Figma variants rendered locally and diffed against the design
- Manually verified on a real Samsung Galaxy device

### A note on the placement tests

The action-placement tests originally hardcoded a 360px viewport and asserted that a given string landed on a given side of the wrap threshold. That holds in only one of the two font contexts this suite runs in: from `packages/divine_ui` the tests fall back to a test font and `"We could not reach the relay"` measures 394.8px, while from `mobile/` the bundled Inter loads and the same string is 195.5px. The pre-push hook runs `divine_ui` tests from `mobile/`, so the suite was green from the package directory and red from the app root.

Each placement test now pumps once, measures the string in the style it actually rendered with, and derives its viewport from that.

The same class of problem bit the dismiss button from the other direction. The review asked for a test pinning its rendered width, and 52 is right on the Flutter 3.44 this repo pins locally — but CI's `divine_ui` job goes through the VeryGood package workflow, which resolves current stable, and there the ghostSecondary small variant renders 48. Asserting the number pinned the SDK rather than the component, so the test pins the design's actual claim instead: the trailing inset drops to 4px when the dismiss button is present. `widthOf` still reserves the upper bound, because over-reserving stacks a borderline banner one notch early while under-reserving overflows it.

Both are worth knowing for any future `divine_ui` test that asserts on text layout or component geometry.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)



