### PR TITLE
fix(video-editor): stop the sound preview ring from rewinding

### DIFF
--- a/mobile/lib/widgets/video_editor/audio_editor/audio_editor_selection_overlay.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_editor_selection_overlay.dart
@@ -100,7 +100,7 @@ class AudioEditorSelectionOverlay extends StatelessWidget {
   }
 }
 
-class _AudioPlaybackProgressButton extends StatelessWidget {
+class _AudioPlaybackProgressButton extends StatefulWidget {
   const _AudioPlaybackProgressButton({
     required this.audioService,
     required this.onPressed,
@@ -111,35 +111,86 @@ class _AudioPlaybackProgressButton extends StatelessWidget {
   final VoidCallback onPressed;
   final bool isLoading;
 
+  @override
+  State<_AudioPlaybackProgressButton> createState() =>
+      _AudioPlaybackProgressButtonState();
+}
+
+class _AudioPlaybackProgressButtonState
+    extends State<_AudioPlaybackProgressButton> {
   static const double _buttonVisualSize = 42;
   static const double _buttonBorderRadius = 16;
+
+  /// Last rendered progress, never rewound while playback continues.
+  ///
+  /// just_audio advances the position from the moment `play()` is requested,
+  /// but the platform only starts rendering audio a moment later and then
+  /// reports the true — smaller — position. Painting that correction rewinds
+  /// the ring, so the last value is held until playback catches up. A position
+  /// back at the start (pause, restart, another sound) resets it.
+  double _progress = 0;
+
+  // The player rebuilds these stream views on every access, so they are bound
+  // once instead of per build to avoid resubscribing on each rebuild.
+  late Stream<bool> _playingStream;
+  late Stream<Duration?> _durationStream;
+  late Stream<Duration> _positionStream;
+
+  @override
+  void initState() {
+    super.initState();
+    _bindStreams();
+  }
+
+  @override
+  void didUpdateWidget(covariant _AudioPlaybackProgressButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.audioService != widget.audioService) {
+      _progress = 0;
+      _bindStreams();
+    } else if (widget.isLoading && !oldWidget.isLoading) {
+      _progress = 0;
+    }
+  }
+
+  void _bindStreams() {
+    _playingStream = widget.audioService.playingStream;
+    _durationStream = widget.audioService.durationStream;
+    _positionStream = widget.audioService.positionStream;
+  }
+
+  double _resolveProgress(Duration? duration, Duration? position) {
+    final durationMs = duration?.inMilliseconds ?? 0;
+    final positionMs = position?.inMilliseconds ?? 0;
+    if (durationMs <= 0 || positionMs <= 0) return _progress = 0;
+
+    final progress = (positionMs / durationMs).clamp(0.0, 1.0);
+    return progress > _progress ? _progress = progress : _progress;
+  }
 
   @override
   Widget build(BuildContext context) {
     return AnimatedSwitcher(
       duration: VineTheme.defaultAnimationDuration,
-      child: isLoading
+      child: widget.isLoading
           ? const BrandedLoadingIndicator(size: _buttonVisualSize)
           : StreamBuilder<bool>(
-              stream: audioService.playingStream,
-              initialData: audioService.isPlaying,
+              stream: _playingStream,
+              initialData: widget.audioService.isPlaying,
               builder: (context, playingSnapshot) {
                 final isPlaying = playingSnapshot.data ?? false;
                 return StreamBuilder<Duration?>(
-                  stream: audioService.durationStream,
-                  initialData: audioService.duration,
+                  stream: _durationStream,
+                  initialData: widget.audioService.duration,
                   builder: (context, durationSnapshot) {
                     return StreamBuilder<Duration>(
-                      stream: audioService.positionStream,
+                      stream: _positionStream,
                       initialData: Duration.zero,
                       builder: (context, positionSnapshot) {
-                        final durationMs =
-                            durationSnapshot.data?.inMilliseconds ?? 0;
-                        final positionMs =
-                            positionSnapshot.data?.inMilliseconds ?? 0;
-                        final progress = durationMs <= 0
-                            ? 0.0
-                            : (positionMs / durationMs).clamp(0.0, 1.0);
+                        final progress = _resolveProgress(
+                          durationSnapshot.data,
+                          positionSnapshot.data,
+                        );
 
                         return SizedBox.square(
                           dimension: _buttonVisualSize,
@@ -159,7 +210,7 @@ class _AudioPlaybackProgressButton extends StatelessWidget {
                                     : context
                                           .l10n
                                           .videoEditorAudioPlayPreviewSemanticLabel,
-                                onPressed: onPressed,
+                                onPressed: widget.onPressed,
                               ),
                             ),
                           ),

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_editor_selection_overlay.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_editor_selection_overlay.dart
@@ -148,8 +148,6 @@ class _AudioPlaybackProgressButtonState
     if (oldWidget.audioService != widget.audioService) {
       _progress = 0;
       _bindStreams();
-    } else if (widget.isLoading && !oldWidget.isLoading) {
-      _progress = 0;
     }
   }
 

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_editor_selection_overlay.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_editor_selection_overlay.dart
@@ -162,10 +162,14 @@ class _AudioPlaybackProgressButtonState
   double _resolveProgress(Duration? duration, Duration? position) {
     final durationMs = duration?.inMilliseconds ?? 0;
     final positionMs = position?.inMilliseconds ?? 0;
-    if (durationMs <= 0 || positionMs <= 0) return _progress = 0;
+    final next = durationMs <= 0 || positionMs <= 0
+        ? 0.0
+        : (positionMs / durationMs).clamp(0.0, 1.0);
 
-    final progress = (positionMs / durationMs).clamp(0.0, 1.0);
-    return progress > _progress ? _progress = progress : _progress;
+    if (next == 0 || next > _progress) {
+      _progress = next;
+    }
+    return _progress;
   }
 
   @override

--- a/mobile/test/widgets/video_editor/audio_editor/audio_editor_selection_overlay_test.dart
+++ b/mobile/test/widgets/video_editor/audio_editor/audio_editor_selection_overlay_test.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 import 'dart:ui' show Tristate;
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -294,6 +295,33 @@ void main() {
 
         await emitPosition(tester, const Duration(milliseconds: 800));
         expect(progressPainter(tester).shouldRepaint(ahead), isTrue);
+      });
+
+      // Loading swaps the ring out for the spinner, so the position
+      // StreamBuilder remounts on the way back and its `initialData` of
+      // `Duration.zero` is what clears the previous sound's progress. Nothing
+      // else resets it on this path, so a change to that initial value would
+      // silently leave the old ring on screen while the next sound loads.
+      // pumpAndSettle is unusable here — the spinner animates forever.
+      testWidgets('resets after a loading round-trip', (tester) async {
+        await tester.pumpWidget(buildWidget(audio: _createTestAudio()));
+        await tester.pump();
+        final atStart = progressPainter(tester);
+
+        await emitPosition(tester, const Duration(seconds: 5));
+        expect(progressPainter(tester).shouldRepaint(atStart), isTrue);
+
+        await tester.pumpWidget(
+          buildWidget(audio: _createTestAudio(), isLoading: true),
+        );
+        await tester.pump();
+        await tester.pump(VineTheme.defaultAnimationDuration);
+
+        await tester.pumpWidget(buildWidget(audio: _createTestAudio()));
+        await tester.pump();
+        await tester.pump(VineTheme.defaultAnimationDuration);
+
+        expect(progressPainter(tester).shouldRepaint(atStart), isFalse);
       });
 
       testWidgets('rewinds when playback restarts at the beginning', (

--- a/mobile/test/widgets/video_editor/audio_editor/audio_editor_selection_overlay_test.dart
+++ b/mobile/test/widgets/video_editor/audio_editor/audio_editor_selection_overlay_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for AudioEditorSelectionOverlay widget
 // ABOUTME: Validates rendering of audio metadata, play/pause toggle, and done.
 
+import 'dart:async';
 import 'dart:ui' show Tristate;
 
 import 'package:flutter/material.dart';
@@ -232,6 +233,81 @@ void main() {
           find.bySemanticsLabel(l10n.videoEditorAudioPausePreviewSemanticLabel),
           findsOneWidget,
         );
+      });
+    });
+
+    group('Progress ring', () {
+      late StreamController<Duration> positionController;
+
+      setUp(() {
+        positionController = StreamController<Duration>.broadcast();
+        when(
+          () => audioService.positionStream,
+        ).thenAnswer((_) => positionController.stream);
+        when(
+          () => audioService.duration,
+        ).thenReturn(const Duration(seconds: 10));
+      });
+
+      tearDown(() => positionController.close());
+
+      // The ring is painted as the foreground of the box holding the
+      // play/pause button, so it is the outermost paint in that subtree.
+      CustomPainter progressPainter(WidgetTester tester) {
+        final paint = tester.widget<CustomPaint>(
+          find
+              .descendant(
+                of: find.byWidgetPredicate(
+                  (widget) =>
+                      widget is SizedBox &&
+                      widget.width == 42 &&
+                      widget.height == 42,
+                ),
+                matching: find.byType(CustomPaint),
+              )
+              .first,
+        );
+        return paint.foregroundPainter!;
+      }
+
+      Future<void> emitPosition(WidgetTester tester, Duration position) async {
+        positionController.add(position);
+        await tester.idle();
+        await tester.pump();
+      }
+
+      // just_audio advances the position from the moment play() is requested,
+      // while the platform reports the true — smaller — position once it
+      // actually starts rendering audio. Painting that correction rewinds the
+      // ring at the start of every preview.
+      testWidgets('holds while the player corrects the position backwards', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget(audio: _createTestAudio()));
+        await tester.pump();
+
+        await emitPosition(tester, const Duration(milliseconds: 500));
+        final ahead = progressPainter(tester);
+
+        await emitPosition(tester, const Duration(milliseconds: 200));
+        expect(progressPainter(tester).shouldRepaint(ahead), isFalse);
+
+        await emitPosition(tester, const Duration(milliseconds: 800));
+        expect(progressPainter(tester).shouldRepaint(ahead), isTrue);
+      });
+
+      testWidgets('rewinds when playback restarts at the beginning', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget(audio: _createTestAudio()));
+        await tester.pump();
+        final atStart = progressPainter(tester);
+
+        await emitPosition(tester, const Duration(milliseconds: 500));
+        expect(progressPainter(tester).shouldRepaint(atStart), isTrue);
+
+        await emitPosition(tester, Duration.zero);
+        expect(progressPainter(tester).shouldRepaint(atStart), isFalse);
       });
     });
 


### PR DESCRIPTION
Closes #7150

## Description

Selecting a sound in the audio picker made the circular progress ring around the play button run forward and then visibly jump backwards once, right after playback started, before running through normally.

just_audio flips `playing` to true and starts extrapolating the position from the wall clock the moment `play()` is requested — before the audio session is activated and before the platform actually renders audio (`AudioPlayer.play()` / `_getPositionFor`). Once the renderer really starts, the platform reports the true, smaller position (`ObserverRenderer` → `updatePositionIfChanged()` → broadcast), and the ring rewinds by exactly that startup latency. On a short clip such as the 6.3 s bundled sound, ~200 ms of latency is ~3 % of the ring and moves fast enough to be obvious.

The true position is only knowable once the platform reports it, so this cannot be fixed at the source. Instead the ring holds its last painted progress until playback catches up — a hold of a few hundred milliseconds at the very start is imperceptible, a backwards jump is not. A position back at the start (pause, restart, another sound) still rewinds it, and a loading round-trip clears it because the position `StreamBuilder` remounts on its `initialData` of `Duration.zero`. The clamp is monotonic for the whole preview, so a backwards correction after a mid-playback stall also freezes the ring rather than rewinding it; that is the accepted tradeoff.

That same commit binds the three player streams once in `initState` instead of on every build. `playingStream` / `durationStream` / `positionStream` hand out a fresh stream view on each access, so every rebuild made the `StreamBuilder` resubscribe; that orphans just_audio's cached position subject together with its timer and can leave the ring stalled. Not the cause of the reported bug, but the same code path.

A second commit is readability only: the hold was written as assignments inside a `return` expression and a ternary, which hid a state write in the middle of `build`. Same behaviour, expressed as a plain reset-or-advance clamp.

A third commit answers review feedback. `didUpdateWidget` also zeroed the progress on the `isLoading` rising edge, which turned out to be unable to change any observable behaviour — the remount described above already clears it before the first paint, so the branch was untestable by construction. It is gone, and the reset it was guarding is now pinned by a test at the place that actually provides it.

## Out of Scope

A residual lead remains — the ring still starts a moment before audio is audible, it just no longer snaps back. Removing that would mean pre-activating the audio session (the sheet never calls `configureForMixedPlayback()`, even though it previews audio next to the editor's video). Left out deliberately to keep this diff on the reported symptom.

## Verification

- `flutter test test/widgets/video_editor/audio_editor/` — 74 tests green, including three new regression tests: the ring holds when the player corrects the position backwards, it rewinds when playback restarts at zero, and it resets across a loading round-trip. The first fails against `main`; the third fails if the position `StreamBuilder`'s `initialData` stops being zero.
- `flutter analyze lib/widgets/video_editor/audio_editor test/widgets/video_editor/audio_editor` — clean.
- `dart format` — clean.
- Manually verified on a real Samsung Galaxy: selected sounds in the video editor's audio picker and confirmed the progress ring now advances smoothly without the backwards jump.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
