### PR TITLE
fix(db): fail closed when the local database is damaged past classification

### DIFF
--- a/mobile/docs/sqlcipher_at_rest_plan.md
+++ b/mobile/docs/sqlcipher_at_rest_plan.md
@@ -65,7 +65,12 @@ migration path is replaced with a safe side-file flow:
    neither — a legible header over a damaged page classifies the same way on
    every launch, so it fails startup closed rather than retrying forever (#6897).
 2. For populated plaintext DBs, copy the source to
-   `divine_db.db.sqlcipher_migrating` with `VACUUM INTO`.
+   `divine_db.db.sqlcipher_migrating` with `VACUUM INTO`. The classification in
+   step 1 reads only `sqlite_master`, so damage anywhere past page 1 reaches
+   here looking like healthy plaintext; this copy walks every b-tree and is the
+   first thing to see it. `SQLITE_CORRUPT` here takes the same fail-closed path
+   as step 1, and for the same reason — it is a property of the bytes, so the
+   retry never comes out differently.
 3. Open the side file, select `cipher='sqlcipher'` + `legacy=4`, then
    `PRAGMA rekey = "x'<key>'"`.
 4. Verify the encrypted copy opens with the raw key and that `user_version` plus
@@ -75,10 +80,10 @@ migration path is replaced with a safe side-file flow:
 
 On any failure, the plaintext source is left intact and migration retries next
 launch. That deferral opens the database unkeyed in the meantime, which is only
-safe because the source is readable plaintext — a database damaged past
-classification takes the fail-closed path above instead. After a later successful
-keyed open, old pre-cipher plaintext backups are deleted so plaintext does not
-remain at rest.
+safe because the source is readable plaintext — a structurally corrupt one takes
+the fail-closed path above instead, from whichever of the two steps first sees
+the damage. After a later successful keyed open, old pre-cipher plaintext backups
+are deleted so plaintext does not remain at rest.
 
 ## Key-loss recovery
 

--- a/mobile/docs/sqlcipher_at_rest_plan.md
+++ b/mobile/docs/sqlcipher_at_rest_plan.md
@@ -60,8 +60,10 @@ database instead of silently writing plaintext.
 migration path is replaced with a safe side-file flow:
 
 1. Classify the existing `divine_db.db` by opening it unkeyed. Only
-   `SQLITE_NOTADB` is treated as already encrypted; transient read failures stay
-   indeterminate and retry later.
+   `SQLITE_NOTADB` is treated as already encrypted; transient read failures
+   (busy, locked, I/O) stay indeterminate and retry later. `SQLITE_CORRUPT` is
+   neither — a legible header over a damaged page classifies the same way on
+   every launch, so it fails startup closed rather than retrying forever (#6897).
 2. For populated plaintext DBs, copy the source to
    `divine_db.db.sqlcipher_migrating` with `VACUUM INTO`.
 3. Open the side file, select `cipher='sqlcipher'` + `legacy=4`, then
@@ -72,8 +74,11 @@ migration path is replaced with a safe side-file flow:
    promote the verified encrypted artifact into place.
 
 On any failure, the plaintext source is left intact and migration retries next
-launch. After a later successful keyed open, old pre-cipher plaintext backups are
-deleted so plaintext does not remain at rest.
+launch. That deferral opens the database unkeyed in the meantime, which is only
+safe because the source is readable plaintext — a database damaged past
+classification takes the fail-closed path above instead. After a later successful
+keyed open, old pre-cipher plaintext backups are deleted so plaintext does not
+remain at rest.
 
 ## Key-loss recovery
 

--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -124,10 +124,10 @@ class DatabaseEncryptionBootstrap {
   ///   the cipher key cannot be read or written, most often a launch before
   ///   the device's first unlock. Raised by the Keychain backends only — see
   ///   the platform note on that class.
-  /// * [DatabaseUnreadableError] when the database file is damaged past
-  ///   classification. Distinct from the deferral above: that one hands back a
-  ///   `null` key for a database that genuinely is readable plaintext, this one
-  ///   has no readable database to hand a key for.
+  /// * [DatabaseUnreadableError] when the database file is structurally
+  ///   corrupt. Distinct from the deferral above: that one hands back a `null`
+  ///   key for a database that genuinely is readable plaintext, this one has no
+  ///   readable database to hand a key for.
   ///
   /// Must run before the first `AppDatabase` open.
   Future<String?> resolveCipherKey() async {
@@ -234,12 +234,12 @@ class DatabaseEncryptionBootstrap {
         // file as encrypted.
         return (null, false);
       case CipherMigrationOutcome.unreadable:
-        // Deliberately NOT the deferral above: the file cannot be classified,
-        // so returning `null` would open an unusable database and break every
-        // statement for the whole session — the exact silent-null-key state
-        // #5301 forbids — and the classification is deterministic, so no later
-        // launch recovers on its own. Fail closed instead; the startup failure
-        // screen offers the reset. See #6897.
+        // Deliberately NOT the deferral above: the file is structurally
+        // corrupt, so returning `null` would open an unusable database and
+        // break every statement for the whole session — the exact
+        // silent-null-key state #5301 forbids — and the outcome is a property
+        // of the bytes, so no later launch recovers on its own. Fail closed
+        // instead; the startup failure screen offers the reset. See #6897.
         throw const DatabaseUnreadableError();
     }
   }
@@ -362,28 +362,34 @@ class DatabaseCipherStorageUnavailableException implements Exception {
       'secure storage is unavailable ($cause)';
 }
 
-/// Thrown when the local database file exists but cannot be classified: the
-/// keyless probe read a legible SQLite header and then failed with
-/// `SQLITE_CORRUPT`, so the file is neither usable plaintext nor recognizably
-/// encrypted.
+/// Thrown when the local database file exists but is structurally corrupt: a
+/// legible SQLite header over pages that fail with `SQLITE_CORRUPT`, so the file
+/// is neither usable plaintext nor recognizably encrypted.
 ///
 /// Not a key problem — an encrypted file reports `SQLITE_NOTADB` and takes the
-/// salvage/recreate path instead. The stored cipher key is fine and is
-/// deliberately kept, so the backup a reset leaves behind stays readable.
+/// salvage/recreate path instead. The stored cipher key is nonetheless kept:
+/// the damaged file itself is plaintext-shaped and needs no key to read, but any
+/// `.pre_key_loss_wipe_backup` / `.pre_corruption_recovery_backup` beside it is
+/// encrypted under that key, and rotating it would strand them.
 ///
 /// Fails startup on purpose. The alternative the bootstrap used to take was to
 /// hand back a `null` key and let the app open the damaged file anyway, which
 /// looked like a normal launch and then failed every statement in the session
-/// (#6897). Because the classification depends only on the bytes on disk, the
-/// "retry next launch" that the deferral promises never arrives.
+/// (#6897). Because the outcome depends only on the bytes on disk, the "retry
+/// next launch" that the deferral promises never arrives.
 class DatabaseUnreadableError implements Exception {
   const DatabaseUnreadableError();
 
+  /// Names `SQLITE_CORRUPT` so a Crashlytics reader sees the underlying result
+  /// code without the statement that raised it. That also puts this message
+  /// inside the corruption allowlist in
+  /// [shouldRepairLocalDatabaseCacheAfterBootstrapError], which is why that
+  /// function has to deny this type before it reaches the message match.
   @override
   String toString() =>
       'DatabaseUnreadableError: the local database is damaged beyond '
-      'classification; it is neither readable plaintext nor an encrypted '
-      'database.';
+      'classification (SQLITE_CORRUPT under a legible SQLite header); it is '
+      'neither readable plaintext nor an encrypted database.';
 }
 
 class DatabaseCipherUnavailableError extends StateError {
@@ -439,12 +445,14 @@ bool shouldRepairLocalDatabaseCacheAfterBootstrapError(Object error) {
   // The database is fine; only the keystore holding its key was unreachable.
   // Repairing would delete that key and strand a recoverable database.
   if (error is DatabaseCipherStorageUnavailableException) return false;
-  // The database really is unusable, but the repair below also rotates the
-  // cipher key, and nothing here proves the stored one is stale. Rotating it
-  // would orphan the backup the repair leaves behind — the user's only copy of
-  // their local-only drafts and clips. The failure screen offers the same reset
-  // with the key retained, so the user chooses the data loss instead of a
-  // silent wipe on a launch that looked normal.
+  // Load-bearing: this message names SQLITE_CORRUPT, so it would otherwise
+  // match the allowlist below and auto-repair. The database really is unusable,
+  // but the repair rotates the cipher key, and nothing here proves the stored
+  // one is stale — rotating it would strand any encrypted backup already beside
+  // the damaged file, which holds the user's local-only drafts and clips. The
+  // failure screen offers the same reset with the key retained, so the user
+  // chooses the data loss instead of a silent wipe on a launch that looked
+  // normal.
   if (error is DatabaseUnreadableError) return false;
 
   final message = error.toString();

--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -124,6 +124,10 @@ class DatabaseEncryptionBootstrap {
   ///   the cipher key cannot be read or written, most often a launch before
   ///   the device's first unlock. Raised by the Keychain backends only — see
   ///   the platform note on that class.
+  /// * [DatabaseUnreadableError] when the database file is damaged past
+  ///   classification. Distinct from the deferral above: that one hands back a
+  ///   `null` key for a database that genuinely is readable plaintext, this one
+  ///   has no readable database to hand a key for.
   ///
   /// Must run before the first `AppDatabase` open.
   Future<String?> resolveCipherKey() async {
@@ -229,6 +233,14 @@ class DatabaseEncryptionBootstrap {
         // signal that forces the salvage once the retry finally classifies the
         // file as encrypted.
         return (null, false);
+      case CipherMigrationOutcome.unreadable:
+        // Deliberately NOT the deferral above: the file cannot be classified,
+        // so returning `null` would open an unusable database and break every
+        // statement for the whole session — the exact silent-null-key state
+        // #5301 forbids — and the classification is deterministic, so no later
+        // launch recovers on its own. Fail closed instead; the startup failure
+        // screen offers the reset. See #6897.
+        throw const DatabaseUnreadableError();
     }
   }
 
@@ -350,6 +362,30 @@ class DatabaseCipherStorageUnavailableException implements Exception {
       'secure storage is unavailable ($cause)';
 }
 
+/// Thrown when the local database file exists but cannot be classified: the
+/// keyless probe read a legible SQLite header and then failed with
+/// `SQLITE_CORRUPT`, so the file is neither usable plaintext nor recognizably
+/// encrypted.
+///
+/// Not a key problem — an encrypted file reports `SQLITE_NOTADB` and takes the
+/// salvage/recreate path instead. The stored cipher key is fine and is
+/// deliberately kept, so the backup a reset leaves behind stays readable.
+///
+/// Fails startup on purpose. The alternative the bootstrap used to take was to
+/// hand back a `null` key and let the app open the damaged file anyway, which
+/// looked like a normal launch and then failed every statement in the session
+/// (#6897). Because the classification depends only on the bytes on disk, the
+/// "retry next launch" that the deferral promises never arrives.
+class DatabaseUnreadableError implements Exception {
+  const DatabaseUnreadableError();
+
+  @override
+  String toString() =>
+      'DatabaseUnreadableError: the local database is damaged beyond '
+      'classification; it is neither readable plaintext nor an encrypted '
+      'database.';
+}
+
 class DatabaseCipherUnavailableError extends StateError {
   DatabaseCipherUnavailableError()
     : super(
@@ -365,7 +401,9 @@ class DatabaseCipherUnavailableError extends StateError {
 /// secure-storage or cipher bootstrap failure: an existing encrypted DB
 /// would be opened as plaintext and repeatedly surface SQLITE_NOTADB. Web and
 /// intentional plaintext migration deferrals still return `null` from
-/// [resolveCipherKey].
+/// [resolveCipherKey] — but only when the plaintext database is actually
+/// readable; a damaged one throws [DatabaseUnreadableError] rather than
+/// inheriting that carve-out (#6897).
 Future<String?> resolveStartupDatabaseCipherKey({
   required Future<String?> Function() resolveCipherKey,
   required Future<void> Function(Object error, StackTrace stack) recordError,
@@ -401,6 +439,13 @@ bool shouldRepairLocalDatabaseCacheAfterBootstrapError(Object error) {
   // The database is fine; only the keystore holding its key was unreachable.
   // Repairing would delete that key and strand a recoverable database.
   if (error is DatabaseCipherStorageUnavailableException) return false;
+  // The database really is unusable, but the repair below also rotates the
+  // cipher key, and nothing here proves the stored one is stale. Rotating it
+  // would orphan the backup the repair leaves behind — the user's only copy of
+  // their local-only drafts and clips. The failure screen offers the same reset
+  // with the key retained, so the user chooses the data loss instead of a
+  // silent wipe on a launch that looked normal.
+  if (error is DatabaseUnreadableError) return false;
 
   final message = error.toString();
   return message.contains('SqliteException($_sqliteNotADb)') ||

--- a/mobile/lib/startup/database_bootstrap_failure_app.dart
+++ b/mobile/lib/startup/database_bootstrap_failure_app.dart
@@ -433,6 +433,10 @@ enum DatabaseBootstrapDiagnosis {
   /// The key no longer opens the database file.
   cipherMismatch('db-cipher-mismatch'),
 
+  /// The database file is damaged past classification — neither readable
+  /// plaintext nor recognizably encrypted.
+  databaseUnreadable('db-unreadable'),
+
   /// Anything else. Read the exception from Crashlytics for this one.
   bootstrapFailed('db-bootstrap-failed');
 
@@ -445,10 +449,11 @@ enum DatabaseBootstrapDiagnosis {
   /// Whether the screen may offer the destructive local-database reset.
   ///
   /// [cipherMismatch] is provably unusable — the key no longer opens the file.
-  /// [bootstrapFailed] is only presumed unusable: the cause is unknown, though
-  /// startup did fail on it. The reset keeps the cipher key for exactly that
-  /// reason, so the backup it leaves behind stays readable if the presumption
-  /// was wrong.
+  /// [databaseUnreadable] is too: the file is damaged past classification, and
+  /// no key or retry changes that. [bootstrapFailed] is only presumed unusable:
+  /// the cause is unknown, though startup did fail on it. The reset keeps the
+  /// cipher key for exactly that reason, so the backup it leaves behind stays
+  /// readable if the presumption was wrong.
   ///
   /// [secureStorage] must never reach it: the database is intact and only its
   /// keystore was unreachable, so clearing it would trade a restart-and-retry
@@ -459,7 +464,7 @@ enum DatabaseBootstrapDiagnosis {
   /// Switched exhaustively on purpose: a future diagnosis has to make this
   /// choice deliberately instead of defaulting into a destructive offer.
   bool get allowsLocalDatabaseReset => switch (this) {
-    cipherMismatch || bootstrapFailed => true,
+    cipherMismatch || databaseUnreadable || bootstrapFailed => true,
     cipherUnavailable || secureStorage => false,
   };
 }
@@ -479,6 +484,9 @@ DatabaseBootstrapDiagnosis databaseBootstrapDiagnosis(Object error) {
   }
   if (error is DatabaseCipherStorageUnavailableException) {
     return DatabaseBootstrapDiagnosis.secureStorage;
+  }
+  if (error is DatabaseUnreadableError) {
+    return DatabaseBootstrapDiagnosis.databaseUnreadable;
   }
 
   final message = error.toString();

--- a/mobile/lib/startup/database_bootstrap_failure_app.dart
+++ b/mobile/lib/startup/database_bootstrap_failure_app.dart
@@ -433,8 +433,8 @@ enum DatabaseBootstrapDiagnosis {
   /// The key no longer opens the database file.
   cipherMismatch('db-cipher-mismatch'),
 
-  /// The database file is damaged past classification — neither readable
-  /// plaintext nor recognizably encrypted.
+  /// The database file is structurally corrupt — neither readable plaintext nor
+  /// recognizably encrypted.
   databaseUnreadable('db-unreadable'),
 
   /// Anything else. Read the exception from Crashlytics for this one.
@@ -449,8 +449,8 @@ enum DatabaseBootstrapDiagnosis {
   /// Whether the screen may offer the destructive local-database reset.
   ///
   /// [cipherMismatch] is provably unusable — the key no longer opens the file.
-  /// [databaseUnreadable] is too: the file is damaged past classification, and
-  /// no key or retry changes that. [bootstrapFailed] is only presumed unusable:
+  /// [databaseUnreadable] is too: the file is structurally corrupt, and no key
+  /// or retry changes that. [bootstrapFailed] is only presumed unusable:
   /// the cause is unknown, though startup did fail on it. The reset keeps the
   /// cipher key for exactly that reason, so the backup it leaves behind stays
   /// readable if the presumption was wrong.

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -481,9 +481,18 @@ enum CipherMigrationOutcome {
   /// A populated plaintext database was rekeyed into an encrypted file.
   migrated,
 
-  /// Migration was attempted but could not complete; the plaintext source is
-  /// left intact and the caller should retry on the next launch.
+  /// Migration was attempted on a **readable plaintext** database but could not
+  /// complete; the source is left intact and the caller should retry on the
+  /// next launch. Opening it with a null key in the meantime is safe — the file
+  /// really is plaintext.
   failed,
+
+  /// The database file exists but could not be classified or read: a legible
+  /// SQLite header over a structurally corrupt page. Unlike [failed] this is
+  /// deterministic for a given file, so retrying next launch never recovers,
+  /// and opening it with a null key yields SQLITE_CORRUPT on every statement
+  /// for the whole session. The caller must fail closed. See #6897.
+  unreadable,
 }
 
 /// One-time in-place rekey of the existing **plaintext** `divine_db.db` into a
@@ -498,6 +507,10 @@ enum CipherMigrationOutcome {
 /// Wipe-and-resync is intentionally rejected: `divine_db.db` is shared with
 /// drafts, pending uploads/actions, reactions, reposts, etc., which cannot be
 /// re-fetched. See `mobile/docs/sqlcipher_at_rest_plan.md`.
+///
+/// Returns [CipherMigrationOutcome.unreadable] when the existing file is
+/// neither readable plaintext nor recognizably encrypted, which no retry can
+/// fix — the caller must fail closed rather than open it unkeyed.
 ///
 /// Requires SQLite3MultipleCiphers; returns [CipherMigrationOutcome.failed]
 /// when it is not linked, leaving the source intact.
@@ -538,11 +551,13 @@ Future<CipherMigrationOutcome> migratePlaintextToEncrypted({
   switch (_classifyDatabase(dbPath)) {
     case _DbClassification.encrypted:
       return CipherMigrationOutcome.alreadyEncrypted;
+    case _DbClassification.corrupt:
+      return CipherMigrationOutcome.unreadable;
     case _DbClassification.indeterminate:
-      // A transient or unreadable error (busy, locked, I/O, corrupt) — do NOT
-      // assume "encrypted", which would trigger the key-loss recovery path
-      // on a readable plaintext DB. Leave everything intact and retry next
-      // launch.
+      // A transient error (busy, locked, I/O) — do NOT assume "encrypted",
+      // which would trigger the key-loss recovery path on a readable plaintext
+      // DB. Leave everything intact and retry next launch, when the contention
+      // or the I/O fault is likely gone.
       return CipherMigrationOutcome.failed;
     case _DbClassification.emptyPlaintext:
       _deleteDatabaseAndSidecars(dbPath);
@@ -591,20 +606,33 @@ enum _DbClassification {
   encrypted,
   emptyPlaintext,
   populatedPlaintext,
+
+  /// Structurally damaged: the keyless open read a legible SQLite header and
+  /// then failed with `SQLITE_CORRUPT` rather than `SQLITE_NOTADB`. An
+  /// encrypted file cannot land here — its page 1 starts with the cipher salt,
+  /// not `SQLite format 3`, so it always reports `SQLITE_NOTADB` — which makes
+  /// this a plaintext-shaped file that no key can rescue.
+  corrupt,
+
+  /// Something transient stopped the classification (busy, locked, I/O).
   indeterminate,
 }
 
 /// Classifies [dbPath] by opening it **without** a key. A plaintext database
-/// reads its schema fine. Only `SQLITE_NOTADB` is treated as a positive
-/// "encrypted" signal; any other error is [_DbClassification.indeterminate] so
-/// a transient failure on a readable plaintext DB never masquerades as
-/// encrypted (which would trigger the destructive key-loss path).
+/// reads its schema fine.
+///
+/// Only `SQLITE_NOTADB` is treated as a positive "encrypted" signal, so a
+/// transient failure on a readable plaintext DB never masquerades as encrypted
+/// (which would trigger the destructive key-loss path). `SQLITE_CORRUPT` is
+/// split out from the transient errors: it is a property of the file, not of
+/// the moment, so it repeats on every launch and needs the caller to fail
+/// closed rather than defer.
 _DbClassification _classifyDatabase(String dbPath) {
   Database db;
   try {
     db = sqlite3.open(dbPath, mode: OpenMode.readOnly);
   } on SqliteException catch (e) {
-    return _encryptedOrIndeterminate(e);
+    return _classifyKeylessFailure(e);
   }
 
   try {
@@ -617,16 +645,18 @@ _DbClassification _classifyDatabase(String dbPath) {
         ? _DbClassification.emptyPlaintext
         : _DbClassification.populatedPlaintext;
   } on SqliteException catch (e) {
-    return _encryptedOrIndeterminate(e);
+    return _classifyKeylessFailure(e);
   } finally {
     db.close();
   }
 }
 
-_DbClassification _encryptedOrIndeterminate(SqliteException e) =>
-    e.resultCode == _sqliteNotADb
-    ? _DbClassification.encrypted
-    : _DbClassification.indeterminate;
+_DbClassification _classifyKeylessFailure(SqliteException e) =>
+    switch (e.resultCode) {
+      _sqliteNotADb => _DbClassification.encrypted,
+      _sqliteCorrupt => _DbClassification.corrupt,
+      _ => _DbClassification.indeterminate,
+    };
 
 CipherMigrationOutcome _rekeyPlaintextInPlace({
   required String dbPath,

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -487,11 +487,15 @@ enum CipherMigrationOutcome {
   /// really is plaintext.
   failed,
 
-  /// The database file exists but could not be classified or read: a legible
-  /// SQLite header over a structurally corrupt page. Unlike [failed] this is
+  /// The database file exists but could not be classified or copied: a legible
+  /// SQLite header over structurally corrupt pages. Unlike [failed] this is
   /// deterministic for a given file, so retrying next launch never recovers,
   /// and opening it with a null key yields SQLITE_CORRUPT on every statement
   /// for the whole session. The caller must fail closed. See #6897.
+  ///
+  /// Reached from either place the damage can surface: the keyless
+  /// classification, which sees only page 1, and the `VACUUM INTO` copy that
+  /// walks every remaining b-tree.
   unreadable,
 }
 
@@ -509,8 +513,9 @@ enum CipherMigrationOutcome {
 /// re-fetched. See `mobile/docs/sqlcipher_at_rest_plan.md`.
 ///
 /// Returns [CipherMigrationOutcome.unreadable] when the existing file is
-/// neither readable plaintext nor recognizably encrypted, which no retry can
-/// fix — the caller must fail closed rather than open it unkeyed.
+/// structurally corrupt — whether that surfaces while classifying page 1 or
+/// while copying the rest of it — which no retry can fix, so the caller must
+/// fail closed rather than open it unkeyed.
 ///
 /// Requires SQLite3MultipleCiphers; returns [CipherMigrationOutcome.failed]
 /// when it is not linked, leaving the source intact.
@@ -658,6 +663,24 @@ _DbClassification _classifyKeylessFailure(SqliteException e) =>
       _ => _DbClassification.indeterminate,
     };
 
+/// Maps a rekey failure to an outcome, on the same result-code split
+/// [_classifyKeylessFailure] applies one step earlier.
+///
+/// [_classifyDatabase] reads only `sqlite_master`, so it can only ever see
+/// damage on page 1; everything past it classifies as readable plaintext and
+/// first surfaces here, where `VACUUM INTO` copies the whole database and walks
+/// every b-tree. That is the larger share of a real database, and the same
+/// permanent condition: the bytes classify identically on every launch, so
+/// deferring retries them forever while the app runs unkeyed against a file
+/// that throws on the damaged pages. Fail closed for it too (#6897).
+///
+/// Everything else — busy, locked, I/O, a missing SQLite3MultipleCiphers — is
+/// genuinely transient and keeps deferring.
+CipherMigrationOutcome _rekeyFailureOutcome(SqliteException e) =>
+    e.resultCode == _sqliteCorrupt
+    ? CipherMigrationOutcome.unreadable
+    : CipherMigrationOutcome.failed;
+
 CipherMigrationOutcome _rekeyPlaintextInPlace({
   required String dbPath,
   required String rawKeyHex,
@@ -671,8 +694,8 @@ CipherMigrationOutcome _rekeyPlaintextInPlace({
     // The source must be opened UNKEYED. It remains untouched until a verified
     // encrypted side-file is ready to promote.
     source = sqlite3.open(dbPath);
-  } on SqliteException {
-    return CipherMigrationOutcome.failed;
+  } on SqliteException catch (e) {
+    return _rekeyFailureOutcome(e);
   }
 
   try {
@@ -682,9 +705,9 @@ CipherMigrationOutcome _rekeyPlaintextInPlace({
       return CipherMigrationOutcome.failed;
     }
     source.execute('VACUUM INTO ?;', [encryptedPath]);
-  } on SqliteException {
+  } on SqliteException catch (e) {
     _deleteDatabaseAndSidecars(encryptedPath);
-    return CipherMigrationOutcome.failed;
+    return _rekeyFailureOutcome(e);
   } finally {
     source.close();
   }

--- a/mobile/packages/db_client/lib/src/database/connection/connection_stub.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_stub.dart
@@ -53,6 +53,7 @@ enum CipherMigrationOutcome {
   removedEmptyPlaintext,
   migrated,
   failed,
+  unreadable,
 }
 
 /// Stub implementation - will be replaced by conditional imports

--- a/mobile/packages/db_client/lib/src/database/connection/connection_web.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_web.dart
@@ -78,6 +78,7 @@ enum CipherMigrationOutcome {
   removedEmptyPlaintext,
   migrated,
   failed,
+  unreadable,
 }
 
 /// Native plaintext→encrypted migration does not apply on web. Never reached

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -1293,6 +1293,38 @@ void main() {
       );
     });
 
+    test('reports corruption past the schema page as unreadable, not a '
+        'deferrable failure', () async {
+      // The other door onto the same #6897 state, and the wider one: the
+      // classification reads only sqlite_master, so damage anywhere past page 1
+      // looks like healthy plaintext and first surfaces in the VACUUM INTO copy
+      // below. Deferring there retried the identical bytes on every launch just
+      // as forever as the schema-page case did.
+      _createMultiPageDatabase(dbPath);
+      _corruptPagesAfterSchema(dbPath);
+
+      expect(
+        await migratePlaintextToEncrypted(
+          rawKeyHex: validKey,
+          databasePath: dbPath,
+        ),
+        equals(CipherMigrationOutcome.unreadable),
+        reason:
+            'the schema page is intact, so only the whole-database copy '
+            'can see this damage',
+      );
+      expect(
+        File(dbPath).existsSync(),
+        isTrue,
+        reason: 'the damaged file is left for the caller to back up',
+      );
+      expect(
+        File('$dbPath.sqlcipher_migrating').existsSync(),
+        isFalse,
+        reason: 'the half-written side file is cleaned up',
+      );
+    });
+
     test(
       'migrates a populated plaintext DB to encrypted raw-key storage',
       () async {

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -1266,6 +1266,33 @@ void main() {
       );
     });
 
+    test('reports a legible header over a corrupt schema page as unreadable, '
+        'not a deferrable failure', () async {
+      // The shape that starts the app with a null cipher key (#6897): the
+      // 100-byte header survives, so the keyless open succeeds and only the
+      // sqlite_master read trips — on SQLITE_CORRUPT, not the SQLITE_NOTADB
+      // that would classify the file as encrypted. Whole-file garbage does NOT
+      // reproduce it; that reads as encrypted and self-heals.
+      _createSqliteDatabase(dbPath, draftCount: 3);
+      _corruptSchemaPageKeepingHeader(dbPath);
+
+      expect(
+        await migratePlaintextToEncrypted(
+          rawKeyHex: validKey,
+          databasePath: dbPath,
+        ),
+        equals(CipherMigrationOutcome.unreadable),
+        reason:
+            'CipherMigrationOutcome.failed would defer to a next launch that '
+            'classifies the same bytes the same way, forever',
+      );
+      expect(
+        File(dbPath).existsSync(),
+        isTrue,
+        reason: 'the damaged file is left for the caller to back up',
+      );
+    });
+
     test(
       'migrates a populated plaintext DB to encrypted raw-key storage',
       () async {
@@ -1528,6 +1555,23 @@ void _corruptPagesAfterSchema(String path) {
   final bytes = file.readAsBytesSync();
   // page_size is 512, so bytes [0, 1024) cover pages 1-2 (header + schema).
   for (var i = 1024; i < bytes.length; i += 1) {
+    bytes[i] = 0xFF;
+  }
+  file.writeAsBytesSync(bytes);
+}
+
+/// Overwrites page 1 from the end of the 100-byte file header onwards, leaving
+/// the `SQLite format 3` magic (and the page size it declares) intact.
+///
+/// The magic is what SQLite checks before reporting `SQLITE_NOTADB`, so keeping
+/// it forces the damage to surface as `SQLITE_CORRUPT` instead — the case that
+/// the keyless classification cannot label. Byte 100 is the b-tree page type;
+/// `0xFF` is not one of the four legal values.
+void _corruptSchemaPageKeepingHeader(String path) {
+  final file = File(path);
+  final bytes = file.readAsBytesSync();
+  final pageSize = (bytes[16] << 8) | bytes[17];
+  for (var i = 100; i < pageSize; i += 1) {
     bytes[i] = 0xFF;
   }
   file.writeAsBytesSync(bytes);

--- a/mobile/test/services/database_encryption_bootstrap_test.dart
+++ b/mobile/test/services/database_encryption_bootstrap_test.dart
@@ -354,6 +354,27 @@ void main() {
           );
         },
       );
+
+      test('keeps the flag when the database is unreadable', () async {
+        store[dbCipherKeyStorageKey] = existing;
+        var cleared = false;
+        final bootstrap = buildBootstrap(
+          outcome: CipherMigrationOutcome.unreadable,
+          onDelete: () {},
+          hasPendingCorruptionRecovery: true,
+          onClearPendingCorruptionRecovery: () => cleared = true,
+        );
+
+        await expectLater(
+          bootstrap.resolveCipherKey(),
+          throwsA(isA<DatabaseUnreadableError>()),
+        );
+        expect(
+          cleared,
+          isFalse,
+          reason: 'startup failed on the database, so it recovered nothing',
+        );
+      });
     });
 
     test('backs up the unrecoverable DB on key loss (generated key + '
@@ -582,6 +603,52 @@ void main() {
       );
 
       expect(await bootstrap.resolveCipherKey(), isNull);
+    });
+
+    test('fails closed instead of handing back a null key for an unreadable '
+        'database', () async {
+      // The gap #6897 closes: this used to share the plaintext deferral's
+      // enum case, so startup continued on a null key, opened the damaged file
+      // anyway, and failed every statement for the rest of the session.
+      var deleted = false;
+      final bootstrap = buildBootstrap(
+        outcome: CipherMigrationOutcome.unreadable,
+        onDelete: () => deleted = true,
+      );
+
+      await expectLater(
+        bootstrap.resolveCipherKey(),
+        throwsA(isA<DatabaseUnreadableError>()),
+      );
+      expect(
+        deleted,
+        isFalse,
+        reason:
+            'the damaged file is preserved for the user-confirmed reset on '
+            'the failure screen, not wiped behind their back',
+      );
+    });
+
+    test('keeps the cipher key when the database is unreadable', () async {
+      const existing =
+          '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+      store[dbCipherKeyStorageKey] = existing;
+      final bootstrap = buildBootstrap(
+        outcome: CipherMigrationOutcome.unreadable,
+        onDelete: () {},
+      );
+
+      await expectLater(
+        bootstrap.resolveCipherKey(),
+        throwsA(isA<DatabaseUnreadableError>()),
+      );
+      expect(
+        store[dbCipherKeyStorageKey],
+        equals(existing),
+        reason:
+            'nothing here proves the key is stale, and it is the only thing '
+            'that can still read a backup of the damaged file',
+      );
     });
 
     test('regenerates a key when the stored value is malformed', () async {

--- a/mobile/test/startup/database_bootstrap_failure_app_test.dart
+++ b/mobile/test/startup/database_bootstrap_failure_app_test.dart
@@ -319,6 +319,13 @@ void main() {
       );
     });
 
+    test('classifies a database damaged past classification', () {
+      expect(
+        databaseBootstrapDiagnosticCode(const DatabaseUnreadableError()),
+        equals('db-unreadable'),
+      );
+    });
+
     test('falls back to the catch-all for unrecognized failures', () {
       expect(
         databaseBootstrapDiagnosticCode(StateError('something else entirely')),
@@ -552,6 +559,7 @@ void main() {
             .toSet(),
         equals({
           DatabaseBootstrapDiagnosis.cipherMismatch,
+          DatabaseBootstrapDiagnosis.databaseUnreadable,
           DatabaseBootstrapDiagnosis.bootstrapFailed,
         }),
       );
@@ -593,6 +601,19 @@ void main() {
       expect(
         shouldRepairLocalDatabaseCacheAfterBootstrapError(
           DatabaseCipherStorageUnavailableException(_lockedKeychainFailure()),
+        ),
+        isFalse,
+      );
+    });
+
+    test('excludes an unreadable database despite it being unusable', () {
+      // Unusable, but the automatic repair also rotates the cipher key, and
+      // nothing proves the stored one is stale — rotating it would orphan the
+      // backup the repair leaves behind. The failure screen offers the same
+      // reset with the key kept, so the user chooses the data loss.
+      expect(
+        shouldRepairLocalDatabaseCacheAfterBootstrapError(
+          const DatabaseUnreadableError(),
         ),
         isFalse,
       );

--- a/mobile/test/startup/database_bootstrap_failure_app_test.dart
+++ b/mobile/test/startup/database_bootstrap_failure_app_test.dart
@@ -606,17 +606,22 @@ void main() {
       );
     });
 
-    test('excludes an unreadable database despite it being unusable', () {
+    test('excludes an unreadable database despite its message matching the '
+        'corruption allowlist', () {
       // Unusable, but the automatic repair also rotates the cipher key, and
-      // nothing proves the stored one is stale — rotating it would orphan the
-      // backup the repair leaves behind. The failure screen offers the same
-      // reset with the key kept, so the user chooses the data loss.
+      // nothing proves the stored one is stale — rotating it would strand any
+      // encrypted backup beside the damaged file. The failure screen offers the
+      // same reset with the key kept, so the user chooses the data loss.
+      const error = DatabaseUnreadableError();
       expect(
-        shouldRepairLocalDatabaseCacheAfterBootstrapError(
-          const DatabaseUnreadableError(),
-        ),
-        isFalse,
+        error.toString(),
+        contains('SQLITE_CORRUPT'),
+        reason:
+            'the type check is only load-bearing while the message would '
+            'otherwise match the allowlist below it — without this the '
+            'expectation that follows passes no matter what the function does',
       );
+      expect(shouldRepairLocalDatabaseCacheAfterBootstrapError(error), isFalse);
     });
   });
 }


### PR DESCRIPTION
## Description

A local database with a legible SQLite header over corrupt pages started the app with a **null cipher key**. The app rendered normally, then every database-backed feature failed with `SqliteException(11)` for the rest of the session.

`_classifyDatabase` opens the file unkeyed and treated only `SQLITE_NOTADB` as a positive "encrypted" signal — everything else, including `SQLITE_CORRUPT`, became `_DbClassification.indeterminate` and mapped to `CipherMigrationOutcome.failed`. That is the same enum case that means "plaintext rekey deferred, retry next launch", which the bootstrap answers by returning `null` rather than throwing, so the fail-closed machinery from #5301 never engaged. The two situations need opposite handling: a deferred rekey leaves a genuinely readable plaintext file behind, while a corrupt one leaves nothing safe to open. And because the outcome depends only on the bytes on disk, the "retry next launch" it promises never arrives — the device never recovers on its own.

**The split.** `SQLITE_CORRUPT` now leaves the transient bucket. Busy, locked and I/O really do heal on a later launch and keep deferring exactly as before; a corrupt file yields the new `CipherMigrationOutcome.unreadable`, which the bootstrap turns into a thrown `DatabaseUnreadableError`. That reaches the existing `DatabaseBootstrapFailureApp` through the diagnosis it already routes on, under a new `db-unreadable` code that permits the reset affordance.

**Both doors, not one.** The classification reads only `sqlite_master`, so it can only ever see damage on page 1. Corruption anywhere past it — the larger share of a real database — classifies as healthy plaintext and first surfaces in the `VACUUM INTO` copy that walks every b-tree, which also mapped to `failed` and produced the identical null-key session. That variant is the worse of the two in practice: the runtime corruption gate fires and tells the user to restart because the next launch repairs it, a promise the byte-deterministic classification guarantees it cannot keep. `_rekeyFailureOutcome` applies the same result-code split one step down, so both doors fail closed and only the genuinely transient codes keep deferring.

Failing closed on *every* indeterminate case would have been simpler but wrong: it would turn transient contention on an intact database into a failure screen. The result code is the signal that separates "this file will never classify" from "ask again later", so that is where the split goes.

**Why the screen and not the automatic repair.** `DatabaseUnreadableError.toString()` names `SQLITE_CORRUPT` — a Crashlytics reader gets the result code without the statement that raised it — which puts the message inside the corruption allowlist in `shouldRepairLocalDatabaseCacheAfterBootstrapError`, so the type check has to deny it before the match. The repair passes `deleteCipherKey: true` and nothing here proves the stored key is stale. The damaged file itself is plaintext-shaped and needs no key to read, but any `.pre_key_loss_wipe_backup` / `.pre_corruption_recovery_backup` already beside it is encrypted under that key, and rotating it strands them. The failure screen offers the same reset with the key retained, so the user chooses the data loss instead of getting a silent wipe on a launch that looked normal.

**Related Issue:** Closes #6897

## Out of Scope

No salvage attempt before the failure screen. A `SQLITE_CORRUPT` classification means the file carries a legible `SQLite format 3` header, which an encrypted database never does — its page 1 starts with the cipher salt — so the file is plaintext-shaped and `salvageCorruptEncryptedDatabase` is the wrong tool for it, being keyed. A plaintext salvage path would be new machinery well beyond this fix. The damaged file is preserved either way: the reset backs it up rather than deleting it.

## Verification

- `flutter test` — full `db_client` package suite, 926 tests green, including a regression test per door. Both build a real SQLite database and damage it: bytes 100..`page_size` overwritten with the header intact (page 1, caught by the classification), and every page after the schema overwritten (past page 1, caught only by the `VACUUM INTO` copy). Each pins to `unreadable` rather than `failed`. Whole-file garbage deliberately does *not* reproduce either shape; that reads as encrypted and already self-heals.
- `flutter test test/startup test/services/database_encryption_bootstrap_test.dart test/services/database_corruption_service_test.dart` — 106 tests green, covering the throw, the cipher key being kept, the pending-corruption flag surviving, the new diagnostic code, and the repair deny-list entry.
- Both new tests were mutation-checked rather than assumed. Reverting the `_rekeyFailureOutcome` split fails the migration-copy test; deleting the type guard makes `shouldRepairLocalDatabaseCacheAfterBootstrapError` return `true`, which would wipe the database and rotate the key.
- `flutter analyze lib test integration_test` — clean, app and package. Note `db_client` enables `lines_longer_than_80_chars`, which the app layer disables, so package-local doc comments are checked more strictly than an app-only analyze pass would show.
- `dart format` — clean.

Not yet verified on a real Samsung Galaxy device — reproducing it needs a deliberately corrupted `divine_db.db` planted in the app container (the repro script is in the issue). Marked draft until that pass is done.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
