### PR TITLE
fix(perf): keep developer builds out of the production Firebase Performance dataset

### DIFF
--- a/mobile/android/app/src/debug/AndroidManifest.xml
+++ b/mobile/android/app/src/debug/AndroidManifest.xml
@@ -40,7 +40,11 @@
              Consequence, and the reason this is the right trade here: runtime
              re-enabling is impossible while this is set. To collect
              performance data from a local build - e.g. to verify new
-             instrumentation - comment this block out for that run. -->
+             instrumentation - comment this block out for that run AND flip
+             `PerformanceMonitoringService.collectionEnabled` to `true`.
+             Commenting this out alone does nothing: that gate re-asserts
+             `false` on every launch and the SDK persists it, so resolution
+             just falls through to the cache it wrote. -->
         <meta-data
             android:name="firebase_performance_collection_deactivated"
             android:value="true" />

--- a/mobile/android/app/src/debug/AndroidManifest.xml
+++ b/mobile/android/app/src/debug/AndroidManifest.xml
@@ -22,5 +22,27 @@
         <meta-data
             android:name="io.flutter.embedding.android.EnableImpeller"
             android:value="false" />
+
+        <!-- Keep debug builds out of the production Firebase Performance
+             dataset (#7123).
+
+             Deliberately `_deactivated` rather than `_enabled=false`.
+             ConfigResolver.getIsPerformanceCollectionEnabled resolves in this
+             order: deactivated (early return) -> the persisted device cache ->
+             this manifest. `_enabled=false` sits on the bottom rung, so it
+             loses to the cache - and every developer device that ran a build
+             before #7123 has `true` cached there, which is exactly the
+             population this needs to silence. `_deactivated` wins outright and
+             takes effect on the first launch, which also covers `_app_start`:
+             that trace is captured natively before Dart runs, so the Dart gate
+             alone cannot suppress it.
+
+             Consequence, and the reason this is the right trade here: runtime
+             re-enabling is impossible while this is set. To collect
+             performance data from a local build - e.g. to verify new
+             instrumentation - comment this block out for that run. -->
+        <meta-data
+            android:name="firebase_performance_collection_deactivated"
+            android:value="true" />
     </application>
 </manifest>

--- a/mobile/android/app/src/profile/AndroidManifest.xml
+++ b/mobile/android/app/src/profile/AndroidManifest.xml
@@ -4,4 +4,17 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+
+    <!-- Keep profile builds out of the production Firebase Performance dataset
+         (#7123). A profile build runs on a developer device and is not a real
+         user, but its timings are indistinguishable from one once they land.
+
+         See the debug manifest for why this is `_deactivated` rather than
+         `_enabled=false`, and for how to collect locally when you actually
+         want to. -->
+    <application>
+        <meta-data
+            android:name="firebase_performance_collection_deactivated"
+            android:value="true" />
+    </application>
 </manifest>

--- a/mobile/docs/NETWORK_PERFORMANCE_MONITORING.md
+++ b/mobile/docs/NETWORK_PERFORMANCE_MONITORING.md
@@ -135,10 +135,18 @@ slow; check the cheap things first.
 
 1. Unit level: `flutter test test/observability/network`.
 2. Local stack: loopback hosts are instrumented on purpose, so a LOCAL run
-   against `local_stack/` exercises the same path end to end. The cost is that
-   debug runs report `http://localhost:<port>/…` patterns into the same
-   project — a handful of extra patterns, the same routes on a different
-   authority. That is the same trade the existing custom traces already make.
+   against `local_stack/` exercises the same path end to end. Nothing reaches
+   the console from it by default, though — developer builds are deactivated
+   natively and gated in Dart (#7123), so this step only proves the client
+   builds a metric, not that Firebase accepted it. To take it all the way,
+   opt that one run back in: undo the native deactivation for your platform
+   (`android/app/src/debug/AndroidManifest.xml`, or
+   `FIREBASE_PERFORMANCE_COLLECTION_DEACTIVATED=NO` in `ios/Flutter/Debug.xcconfig`)
+   **and** flip `PerformanceMonitoringService.collectionEnabled` to `true` —
+   either alone leaves collection off. Revert both before committing; a debug
+   run that reports lands `http://localhost:<port>/…` patterns in the
+   production project under a build number no store build uses — exactly the
+   contamination that skewed #7123.
 3. Console: **Performance → Network Requests**, filtered to `divine.video` /
    `dvines.org`. Confirm requests appear from **both** platforms and that each
    endpoint shows as one aggregated pattern with placeholders — a list of

--- a/mobile/ios/Flutter/Debug.xcconfig
+++ b/mobile/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,10 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"
+
+// Keep debug builds out of the production Firebase Performance dataset
+// (#7123). Read via Info.plist's firebase_performance_collection_deactivated.
+// This outranks the persisted collection preference, so it silences developer
+// devices that already cached "enabled" from a build predating that fix, and
+// it applies from the first launch - which is what `_app_start` needs, since
+// that trace is captured natively before Dart runs.
+FIREBASE_PERFORMANCE_COLLECTION_DEACTIVATED=YES

--- a/mobile/ios/Flutter/Debug.xcconfig
+++ b/mobile/ios/Flutter/Debug.xcconfig
@@ -7,4 +7,9 @@
 // devices that already cached "enabled" from a build predating that fix, and
 // it applies from the first launch - which is what `_app_start` needs, since
 // that trace is captured natively before Dart runs.
+//
+// To collect from a local build, set this to NO AND flip
+// `PerformanceMonitoringService.collectionEnabled` to `true`. Changing this
+// alone does nothing: that gate re-asserts `false` on every launch and the SDK
+// persists it, so resolution just falls through to the cache it wrote.
 FIREBASE_PERFORMANCE_COLLECTION_DEACTIVATED=YES

--- a/mobile/ios/Flutter/Profile.xcconfig
+++ b/mobile/ios/Flutter/Profile.xcconfig
@@ -1,2 +1,10 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"
 #include "Generated.xcconfig"
+
+// Keep profile builds out of the production Firebase Performance dataset
+// (#7123). Profile.xcconfig is the base for the Runner Profile configuration
+// (wired in Runner.xcodeproj); without that wiring the Profile configuration
+// falls through to Release.xcconfig and cannot be told apart from a store
+// build natively. See Debug.xcconfig for why this is `_deactivated` and how
+// to opt a single local run back in.
+FIREBASE_PERFORMANCE_COLLECTION_DEACTIVATED=YES

--- a/mobile/ios/Flutter/Release.xcconfig
+++ b/mobile/ios/Flutter/Release.xcconfig
@@ -1,3 +1,11 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"
 #include "Generated.xcconfig"
+
+// Production reports performance data (#7123). Note this file backs BOTH the
+// Release and Profile configurations - Profile.xcconfig is not referenced by
+// Runner.xcodeproj at all - so a profile build cannot be told apart from a
+// release build here, and is instead kept out of the dataset by the release
+// only gate in PerformanceMonitoringService. Android has no such limit and
+// deactivates profile builds outright in its profile manifest.
+FIREBASE_PERFORMANCE_COLLECTION_DEACTIVATED=NO

--- a/mobile/ios/Flutter/Release.xcconfig
+++ b/mobile/ios/Flutter/Release.xcconfig
@@ -1,11 +1,7 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
-#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"
 #include "Generated.xcconfig"
 
-// Production reports performance data (#7123). Note this file backs BOTH the
-// Release and Profile configurations - Profile.xcconfig is not referenced by
-// Runner.xcodeproj at all - so a profile build cannot be told apart from a
-// release build here, and is instead kept out of the dataset by the release
-// only gate in PerformanceMonitoringService. Android has no such limit and
-// deactivates profile builds outright in its profile manifest.
+// Production reports performance data (#7123). Profile builds use
+// Profile.xcconfig instead; do not fold the profile Pods include back in here
+// or a profile run silently inherits release settings again.
 FIREBASE_PERFORMANCE_COLLECTION_DEACTIVATED=NO

--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		7724038FFA9E1FC6C1CB27D0 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		7B0F1A2B3C4D5E6F708192A3 /* Profile.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Profile.xcconfig; path = Flutter/Profile.xcconfig; sourceTree = "<group>"; };
 		82B841000000000000334401 /* AppVersion.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = AppVersion.xcconfig; path = Flutter/AppVersion.xcconfig; sourceTree = "<group>"; };
 		8CE07D4A15ABF6932C18302C /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		8E202EC5FED8AC0BD1454DD8 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -225,6 +226,7 @@
 				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
+				7B0F1A2B3C4D5E6F708192A3 /* Profile.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
 				82B841000000000000334401 /* AppVersion.xcconfig */,
 				9740EEB31CF90195004384FC /* Generated.xcconfig */,
@@ -841,7 +843,7 @@
 		};
 		249021D4217E4FDB00AE95B9 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
+			baseConfigurationReference = 7B0F1A2B3C4D5E6F708192A3 /* Profile.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -52,12 +52,12 @@
 	<key>FirebaseCrashlyticsCollectionEnabled</key>
 	<true/>
 	<!-- Keep developer builds out of the production Firebase Performance
-	     dataset (#7123). Set to YES by Debug.xcconfig and NO by
-	     Release.xcconfig; a string is fine because FPRConfigurations reads
-	     this through -boolValue. If the setting is ever missing the value
-	     expands to an empty string, which -boolValue reads as NO, so the
-	     failure mode is "production keeps reporting" rather than a silent
-	     loss of production data. -->
+	     dataset (#7123). Set to YES by Debug.xcconfig and Profile.xcconfig,
+	     and NO by Release.xcconfig; a string is fine because
+	     FPRConfigurations reads this through -boolValue. If the setting is
+	     ever missing the value expands to an empty string, which -boolValue
+	     reads as NO, so the failure mode is "production keeps reporting"
+	     rather than a silent loss of production data. -->
 	<key>firebase_performance_collection_deactivated</key>
 	<string>$(FIREBASE_PERFORMANCE_COLLECTION_DEACTIVATED)</string>
 	<key>FirebaseAutomaticScreenReportingEnabled</key>

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -51,6 +51,15 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>FirebaseCrashlyticsCollectionEnabled</key>
 	<true/>
+	<!-- Keep developer builds out of the production Firebase Performance
+	     dataset (#7123). Set to YES by Debug.xcconfig and NO by
+	     Release.xcconfig; a string is fine because FPRConfigurations reads
+	     this through -boolValue. If the setting is ever missing the value
+	     expands to an empty string, which -boolValue reads as NO, so the
+	     failure mode is "production keeps reporting" rather than a silent
+	     loss of production data. -->
+	<key>firebase_performance_collection_deactivated</key>
+	<string>$(FIREBASE_PERFORMANCE_COLLECTION_DEACTIVATED)</string>
 	<key>FirebaseAutomaticScreenReportingEnabled</key>
 	<false/>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/mobile/lib/services/performance_monitoring_service.dart
+++ b/mobile/lib/services/performance_monitoring_service.dart
@@ -153,10 +153,9 @@ class PerformanceMonitoringService implements PerformanceTraceMonitor {
   /// build.
   ///
   /// Paired with a native deactivation in the debug and profile Android
-  /// manifests and in `Debug.xcconfig`, which is what actually suppresses
-  /// `_app_start` — that trace is captured natively before Dart runs. This
-  /// gate is what covers an iOS profile build, which shares `Release.xcconfig`
-  /// and so cannot be deactivated natively.
+  /// manifests and in iOS `Debug.xcconfig` / `Profile.xcconfig`, which is what
+  /// actually suppresses `_app_start` — that trace is captured natively before
+  /// Dart runs.
   @visibleForTesting
   static const bool collectionEnabled = kReleaseMode;
 

--- a/mobile/lib/services/performance_monitoring_service.dart
+++ b/mobile/lib/services/performance_monitoring_service.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Uses Firebase Performance Monitoring to track screen transitions, network requests, and custom operations
 
 import 'package:firebase_performance/firebase_performance.dart';
+import 'package:flutter/foundation.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// A handle to a single started performance trace.
@@ -135,6 +136,30 @@ class NoOpPerformanceTraceMonitor implements PerformanceTraceMonitor {
 class PerformanceMonitoringService implements PerformanceTraceMonitor {
   PerformanceMonitoringService();
 
+  /// Whether this build may report to the production Firebase Performance
+  /// dataset.
+  ///
+  /// Release-only, which is stricter than the `!kDebugMode` gate
+  /// `CrashReportingService` uses: a profile build is a developer device too,
+  /// and its timings land in the same dataset as real users rather than in a
+  /// separate bucket.
+  ///
+  /// Debug and profile builds are excluded because they are far slower than
+  /// release and there is no way to tell them apart once the data has landed.
+  /// In #7123 this skewed the release comparison it was being read for: local
+  /// builds — identifiable only because they carry the `pubspec.yaml` build
+  /// number, which store builds never use — were 9.5% of the 1.0.19 sample at
+  /// a p50 of 919 ms, against ~100 ms for the same phone model on a store
+  /// build.
+  ///
+  /// Paired with a native deactivation in the debug and profile Android
+  /// manifests and in `Debug.xcconfig`, which is what actually suppresses
+  /// `_app_start` — that trace is captured natively before Dart runs. This
+  /// gate is what covers an iOS profile build, which shares `Release.xcconfig`
+  /// and so cannot be deactivated natively.
+  @visibleForTesting
+  static const bool collectionEnabled = kReleaseMode;
+
   late final FirebasePerformance _performance;
   bool _initialized = false;
 
@@ -155,12 +180,16 @@ class PerformanceMonitoringService implements PerformanceTraceMonitor {
     try {
       _performance = FirebasePerformance.instance;
 
-      // Enable performance collection
-      await _performance.setPerformanceCollectionEnabled(true);
+      // Always assert the flag rather than skipping the call when collection
+      // is off: the SDK persists it across launches, so a device that ran an
+      // earlier build — which enabled collection unconditionally — keeps
+      // reporting until something actively sets it back to false.
+      await _performance.setPerformanceCollectionEnabled(collectionEnabled);
 
       _initialized = true;
       Log.info(
-        'Performance monitoring initialized successfully',
+        'Performance monitoring initialized successfully '
+        '(collection enabled: $collectionEnabled)',
         name: 'PerformanceMonitoring',
       );
     } catch (e) {

--- a/mobile/test/services/performance_monitoring_service_test.dart
+++ b/mobile/test/services/performance_monitoring_service_test.dart
@@ -1,10 +1,27 @@
 // ABOUTME: Tests for Firebase Performance Monitoring service
 // ABOUTME: Verifies trace creation, metrics, and attributes
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
 
 void main() {
+  group('PerformanceMonitoringService.collectionEnabled', () {
+    test('stays off outside release builds', () {
+      // Premise: the test runner is not a release build, so this asserts the
+      // same branch a developer's `flutter run` takes.
+      expect(kReleaseMode, isFalse, reason: 'tests must run in non-release');
+
+      // #7123: collection was enabled unconditionally, so developer devices
+      // reported into the production dataset alongside real users. Local
+      // builds were 9.5% of the 1.0.19 `_app_start` sample at a p50 of 919 ms
+      // against ~100 ms for the same phone on a store build — enough to
+      // manufacture a release-over-release regression that the release code
+      // did not contain.
+      expect(PerformanceMonitoringService.collectionEnabled, isFalse);
+    });
+  });
+
   group('PerformanceMonitoringService', () {
     late PerformanceMonitoringService service;
 

--- a/mobile/test/services/performance_monitoring_service_test.dart
+++ b/mobile/test/services/performance_monitoring_service_test.dart
@@ -99,11 +99,34 @@ void main() {
     });
 
     test('sets that build setting per iOS configuration', () {
-      // Release.xcconfig also backs the Profile configuration —
-      // Profile.xcconfig is not referenced by Runner.xcodeproj — so an iOS
-      // profile build is covered by the release-only Dart gate instead.
       expect(_deactivationSetting('ios/Flutter/Debug.xcconfig'), 'YES');
+      expect(_deactivationSetting('ios/Flutter/Profile.xcconfig'), 'YES');
       expect(_deactivationSetting('ios/Flutter/Release.xcconfig'), 'NO');
+    });
+
+    test('wires the iOS Profile configuration to Profile.xcconfig', () {
+      // Without this, Profile falls through to Release.xcconfig and inherits
+      // FIREBASE_PERFORMANCE_COLLECTION_DEACTIVATED=NO, so `_app_start` still
+      // reports from the first launch of an iOS profile build.
+      final pbxproj = File(
+        'ios/Runner.xcodeproj/project.pbxproj',
+      ).readAsStringSync();
+
+      expect(
+        pbxproj,
+        contains('path = Flutter/Profile.xcconfig'),
+        reason: 'Profile.xcconfig must be a project file reference.',
+      );
+      expect(
+        RegExp(
+          r'249021D4217E4FDB00AE95B9 /\* Profile \*/ = \{'
+          r'[\s\S]*?'
+          r'baseConfigurationReference = [0-9A-F]+ /\* Profile\.xcconfig \*/;',
+        ).hasMatch(pbxproj),
+        isTrue,
+        reason:
+            'Runner target Profile configuration must point at Profile.xcconfig.',
+      );
     });
   });
 

--- a/mobile/test/services/performance_monitoring_service_test.dart
+++ b/mobile/test/services/performance_monitoring_service_test.dart
@@ -1,9 +1,30 @@
 // ABOUTME: Tests for Firebase Performance Monitoring service
-// ABOUTME: Verifies trace creation, metrics, and attributes
+// ABOUTME: Verifies trace creation, metrics, attributes, and the native and
+// ABOUTME: Dart switches that keep developer builds out of the dataset
+
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
+
+/// The value `FIREBASE_PERFORMANCE_COLLECTION_DEACTIVATED` resolves to in the
+/// xcconfig at [path], or `null` when it is never assigned.
+///
+/// Skips `//` comment lines and takes the last assignment, as xcconfig does.
+String? _deactivationSetting(String path) {
+  final assignment = RegExp(
+    r'^\s*FIREBASE_PERFORMANCE_COLLECTION_DEACTIVATED\s*=\s*(\S+)\s*$',
+  );
+
+  String? value;
+  for (final line in File(path).readAsLinesSync()) {
+    if (line.trimLeft().startsWith('//')) continue;
+    final match = assignment.firstMatch(line);
+    if (match != null) value = match.group(1);
+  }
+  return value;
+}
 
 void main() {
   group('PerformanceMonitoringService.collectionEnabled', () {
@@ -19,6 +40,70 @@ void main() {
       // manufacture a release-over-release regression that the release code
       // did not contain.
       expect(PerformanceMonitoringService.collectionEnabled, isFalse);
+    });
+  });
+
+  group('native performance collection config', () {
+    // The Dart gate above cannot suppress `_app_start` — that trace is
+    // captured natively before Dart runs — so these switches are what actually
+    // keep developer builds out of the dataset. They are also the fragile
+    // half: `Debug.xcconfig` and `Release.xcconfig` are Flutter template files
+    // that a scaffolding repair overwrites without saying so.
+    final deactivatesCollection = RegExp(
+      r'<meta-data\b'
+      r'(?=[^>]*\bandroid:name\s*=\s*'
+      '"firebase_performance_collection_deactivated")'
+      r'(?=[^>]*\bandroid:value\s*=\s*"true")'
+      r'[^>]*/\s*>',
+    );
+
+    for (final buildType in ['debug', 'profile']) {
+      test('deactivates collection in the Android $buildType manifest', () {
+        final manifest = File(
+          'android/app/src/$buildType/AndroidManifest.xml',
+        ).readAsStringSync();
+        final applicationBlock = RegExp(
+          r'<application\b[\s\S]*?</application>',
+        ).firstMatch(manifest);
+
+        expect(
+          applicationBlock,
+          isNotNull,
+          reason: 'meta-data is only read inside an <application> block.',
+        );
+        expect(applicationBlock!.group(0), matches(deactivatesCollection));
+      });
+    }
+
+    test('leaves the Android release manifest reporting', () {
+      final manifest = File(
+        'android/app/src/main/AndroidManifest.xml',
+      ).readAsStringSync();
+
+      expect(deactivatesCollection.hasMatch(manifest), isFalse);
+    });
+
+    test('reads the iOS switch from the build setting', () {
+      final plist = File('ios/Runner/Info.plist').readAsStringSync();
+
+      expect(
+        plist,
+        matches(
+          RegExp(
+            r'<key>\s*firebase_performance_collection_deactivated\s*</key>\s*'
+            r'<string>\s*\$\(FIREBASE_PERFORMANCE_COLLECTION_DEACTIVATED\)\s*'
+            '</string>',
+          ),
+        ),
+      );
+    });
+
+    test('sets that build setting per iOS configuration', () {
+      // Release.xcconfig also backs the Profile configuration —
+      // Profile.xcconfig is not referenced by Runner.xcodeproj — so an iOS
+      // profile build is covered by the release-only Dart gate instead.
+      expect(_deactivationSetting('ios/Flutter/Debug.xcconfig'), 'YES');
+      expect(_deactivationSetting('ios/Flutter/Release.xcconfig'), 'NO');
     });
   });
 


### PR DESCRIPTION
## Description

Firebase Performance collection was enabled unconditionally, so every debug and profile build reported into the production dataset alongside real users. Developer builds are several times slower than release, and once the data has landed nothing distinguishes them except the `pubspec.yaml` build number — which store builds never carry, because Codemagic overrides `--build-number` with `Play latest + 1`.

That is not a theoretical concern. It is one of the three confounds that produced the headline figure in #7123: local builds were 9.5% of the 1.0.19 `_app_start` sample at a p50 of **919 ms**, against ~100 ms for the same phone model on a store build. iOS is affected the same way (build 819: 80 events, 2 devices, p50 891 ms).

Two layers, because neither is sufficient alone:

**Dart gate** — `PerformanceMonitoringService.collectionEnabled` is now `kReleaseMode`. Deliberately stricter than the `!kDebugMode` gate `CrashReportingService` uses: a profile build is a developer device too, and its timings land in the same dataset as real users rather than in a separate bucket. The flag is asserted on every launch rather than skipped when collection is off — the SDK persists it, so a device that ran an earlier build keeps reporting until something actively sets it back to `false`.

**Native deactivation** — the Dart gate cannot suppress `_app_start`, which is the trace #7123 was read from, because it is captured natively before Dart runs.

The native half is also the fragile half — `Debug.xcconfig`, `Profile.xcconfig`, and `Release.xcconfig` are Flutter template files that a scaffolding repair overwrites without saying so — so both manifests, the plist indirection, the Runner Profile → `Profile.xcconfig` wiring, and the build-setting values are pinned by tests. iOS profile builds deactivate natively via `Profile.xcconfig` (wired in `Runner.xcodeproj`); Android profile builds use the profile source-set manifest.

`mobile/docs/NETWORK_PERFORMANCE_MONITORING.md` is updated in the same change: its "Verifying a change" step 2 told you a LOCAL debug run exercises the path end to end and weighed the cost of `localhost` patterns landing in the project. Deactivating developer builds removes both halves of that, so the step now says what it actually proves and how to opt a single run back in.

### Why `_deactivated` and not `_enabled=false`

Both SDKs resolve in the same order: deactivation first (early return), then the persisted device cache, then the manifest/plist default. `_enabled=false` therefore sits on the bottom rung and loses to the cache — and every developer device that ran a build predating this PR has `true` cached there, which is exactly the population that needs silencing. `_deactivated` wins outright and takes effect on the first launch.

Verified against the actual SDK sources rather than the docs: `ConfigResolver.getIsPerformanceCollectionEnabled` in `firebase-perf` 22.0.5 (bytecode) and `FPRConfigurations.m` in `FirebasePerformance` 12.9.0.

The trade-off is that runtime re-enabling becomes impossible in those builds. To collect performance data from a local build — e.g. to verify new instrumentation — undo the native switch for that platform **and** flip `PerformanceMonitoringService.collectionEnabled` to `true`. Either one alone leaves collection off: the Dart gate re-asserts `false` on every launch and the SDK persists it, so removing the native switch just falls through to the cache that gate wrote. Noted at all three places a reader might start from — the debug manifest, `Debug.xcconfig`, and `mobile/docs/NETWORK_PERFORMANCE_MONITORING.md`.

### Why iOS goes through a build setting

There is one `Info.plist` for all configurations, so the value comes from `FIREBASE_PERFORMANCE_COLLECTION_DEACTIVATED`. `FPRConfigurations` reads the key through `-boolValue`, so a string from `$(...)` substitution works — checked empirically, including that `""` reads as `NO`.

The polarity is chosen for that empty case: if the setting ever goes missing the value expands to an empty string, which reads as `NO`, so the failure mode is *production keeps reporting* rather than a silent loss of production data. The inverse key would fail the other way and we would not notice for weeks.

## Out of Scope

- **The actual regression in #7123.** That issue is now reframed: device-controlled, 1.0.19 is ~15% *faster* than 1.0.15, and the real regression is ~14% between 1.0.17 and 1.0.19 caused by the Impeller switch in #6483. That was a deliberate trade-off (the chroma-key preview needs `ui.ImageFilter.shader`, which Skia does not implement), so it needs a product call, not a revert in this PR. #7123 stays open for it.

- **Historical data is still polluted.** This stops new contamination; it cannot clean what has landed. Past comparisons need filtering to store build numbers, and the corrected query is in #7123.

- **TestFlight builds still report.** They are genuine release builds, so the release-only gate does not exclude them by design.

## Verification

- `flutter analyze lib test` — no issues
- `flutter test test/services/performance_monitoring_service_test.dart` — 16/16 pass
- Dart gate test proven able to fail: flipping the gate to `true` yields `Expected: false / Actual: <true>`
- Native-config tests proven able to fail one at a time, by mutating the file each reads: `Debug.xcconfig` to `NO`, the profile manifest to `false`, the plist to a literal instead of `$(...)`, and a deactivation added to the release manifest. Each mutation failed exactly one test.
- `plutil -lint ios/Runner/Info.plist` — OK; `plutil -extract` confirms the key resolves to the build setting
- All three touched Android manifests parse as valid XML
- `-[NSString boolValue]` semantics confirmed by compiling against Foundation: `"YES"`→YES, `"NO"`→NO, `""`→NO

**Not yet verified on a device.** The behaviour this changes is only observable in the Firebase Performance dataset, so confirming it means installing a debug build and checking that no new `_app_start` events appear under a non-store build number. Worth doing on the Galaxy before this leaves draft.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

**Related Issue:** Relates to #7123


