### PR TITLE
fix(feed): recover from a feed load the relay never answered

### DIFF
--- a/mobile/lib/services/feed_retry_scheduler.dart
+++ b/mobile/lib/services/feed_retry_scheduler.dart
@@ -86,6 +86,16 @@ class FeedRetryScheduler {
     _consecutiveTimeouts.remove(type);
   }
 
+  /// Clears the consecutive-timeout budget for [type].
+  ///
+  /// Call when the user (or another explicit path) starts a fresh subscribe
+  /// for that feed. Without this, a type that exhausted [maxAttempts] stays
+  /// latched until a load is actually served or [resetBudgets] runs — so a
+  /// navigate-back after give-up would never re-arm auto-retry.
+  void clearTimeoutBudget(SubscriptionType type) {
+    _consecutiveTimeouts.remove(type);
+  }
+
   /// Resets every timeout budget, for an explicit user-driven retry.
   void resetBudgets() {
     _consecutiveTimeouts.clear();

--- a/mobile/lib/services/feed_retry_scheduler.dart
+++ b/mobile/lib/services/feed_retry_scheduler.dart
@@ -1,0 +1,191 @@
+// ABOUTME: Bounded re-issue policy for feed subscriptions the relay never served.
+// ABOUTME: Owns the online-retry cycle and the consecutive-timeout budget.
+
+import 'dart:async';
+
+import 'package:openvine/services/connection_status_service.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Re-issues the relay subscription for [type] using its last-known
+/// parameters.
+typedef FeedResubscribe = Future<void> Function(SubscriptionType type);
+
+/// Hands [type] to the relay-ready retry, which owns the wait for a usable
+/// relay rather than a usable network.
+typedef FeedRelayNotReady = void Function(SubscriptionType type);
+
+/// Re-issues feed subscriptions that failed, a few times, while online.
+///
+/// Serves two callers: a subscribe attempted while offline, and a feed load
+/// whose relay never answered (#7124). Both need the same thing — re-issue
+/// these filters a few times, but only while there is a network to issue them
+/// on — and both need it to stop rather than run for the life of the process.
+///
+/// The two budgets are deliberately separate. [scheduleWhenOnline] counts
+/// re-subscribe *calls that threw*, which bounds a subscribe that cannot even
+/// be issued. Writing a REQ to a relay that then stays silent does not throw,
+/// so that budget resets on every attempt and cannot bound a silent relay;
+/// [recordFeedLoadTimeout] counts consecutive unanswered loads instead and is
+/// what stops that loop.
+class FeedRetryScheduler {
+  FeedRetryScheduler({
+    required ConnectionStatusService connectionService,
+    required FeedResubscribe resubscribe,
+    required FeedRelayNotReady onRelayNotReady,
+    this.maxAttempts = 3,
+    this.retryDelay = const Duration(seconds: 10),
+  }) : _connectionService = connectionService,
+       _resubscribe = resubscribe,
+       _onRelayNotReady = onRelayNotReady;
+
+  static const _logName = 'FeedRetryScheduler';
+
+  final ConnectionStatusService _connectionService;
+  final FeedResubscribe _resubscribe;
+  final FeedRelayNotReady _onRelayNotReady;
+
+  /// How many re-issues one cycle may attempt, and how many unanswered loads
+  /// in a row a feed may cost before it is left alone.
+  final int maxAttempts;
+
+  /// Gap between attempts within a cycle.
+  final Duration retryDelay;
+
+  Timer? _retryTimer;
+  final Set<SubscriptionType> _typesAwaitingRetry = {};
+  int _attempts = 0;
+
+  /// Feed loads that hit the deadline in a row without the relay ever
+  /// answering, per type.
+  final Map<SubscriptionType, int> _consecutiveTimeouts = {};
+
+  /// Attempts spent in the current cycle, for diagnostics.
+  int get attempts => _attempts;
+
+  /// Records a feed load that hit its deadline unanswered, and reports whether
+  /// the feed still has budget to be re-issued.
+  ///
+  /// Cleared by [recordFeedServed], so a relay that recovers starts over with
+  /// a full budget.
+  bool recordFeedLoadTimeout(SubscriptionType type) {
+    final consecutive = (_consecutiveTimeouts[type] ?? 0) + 1;
+    _consecutiveTimeouts[type] = consecutive;
+    if (consecutive <= maxAttempts) return true;
+    Log.warning(
+      'Giving up on ${type.name} after $consecutive consecutive timed-out '
+      'loads; the next explicit subscribe starts over',
+      name: _logName,
+      category: LogCategory.video,
+    );
+    return false;
+  }
+
+  /// Records that [type] was actually served — a first event or an EOSE.
+  void recordFeedServed(SubscriptionType type) {
+    _consecutiveTimeouts.remove(type);
+  }
+
+  /// Resets every timeout budget, for an explicit user-driven retry.
+  void resetBudgets() {
+    _consecutiveTimeouts.clear();
+    _attempts = 0;
+  }
+
+  /// Schedule a retry of [subscriptionType] once the device is online.
+  ///
+  /// The failed type is recorded so the retry re-establishes the feed that
+  /// actually broke (with its original parameters) — previously the retry
+  /// hardcoded the discovery feed, so home/hashtag/profile feeds never
+  /// recovered through this path.
+  void scheduleWhenOnline(SubscriptionType subscriptionType) {
+    _typesAwaitingRetry.add(subscriptionType);
+
+    // An active cycle keeps its attempt budget. A fresh cycle starts
+    // over — previously an exhausted counter was never reset, leaving
+    // retries dead for the rest of the session.
+    if (_retryTimer?.isActive ?? false) return;
+    _attempts = 0;
+
+    _retryTimer = Timer.periodic(retryDelay, (timer) {
+      if (!_connectionService.isOnline) {
+        Log.debug(
+          '⏳ Still offline, waiting for connection...',
+          name: _logName,
+          category: LogCategory.video,
+        );
+        return;
+      }
+      if (_typesAwaitingRetry.isEmpty || _attempts >= maxAttempts) {
+        _typesAwaitingRetry.clear();
+        timer.cancel();
+        return;
+      }
+
+      _attempts++;
+      Log.warning(
+        'Attempting to resubscribe to '
+        '${_typesAwaitingRetry.map((t) => t.name).join(", ")} '
+        '(attempt $_attempts/$maxAttempts)',
+        name: _logName,
+        category: LogCategory.video,
+      );
+
+      for (final type in Set<SubscriptionType>.of(_typesAwaitingRetry)) {
+        _retrySubscription(type, timer);
+      }
+    });
+  }
+
+  /// Re-issue the relay subscription for [type] using its last-known
+  /// parameters, forcing past duplicate detection (the dead subscription
+  /// is still registered after an onError, so a non-forced call no-ops).
+  void _retrySubscription(SubscriptionType type, Timer timer) {
+    unawaited(
+      _resubscribe(type)
+          .then((_) {
+            _typesAwaitingRetry.remove(type);
+            Log.info(
+              'Successfully resubscribed to ${type.name} feed',
+              name: _logName,
+              category: LogCategory.video,
+            );
+            if (_typesAwaitingRetry.isEmpty) {
+              timer.cancel();
+              _attempts = 0;
+            }
+          })
+          .catchError((Object e) {
+            Log.error(
+              'Retry attempt $_attempts for ${type.name} failed: $e',
+              name: _logName,
+              category: LogCategory.video,
+            );
+            if (e is RelayNotReadyException) {
+              _typesAwaitingRetry.remove(type);
+              if (_typesAwaitingRetry.isEmpty) {
+                timer.cancel();
+                _attempts = 0;
+              }
+              _onRelayNotReady(type);
+              return;
+            }
+            if (_attempts >= maxAttempts) {
+              _typesAwaitingRetry.clear();
+              timer.cancel();
+              Log.warning(
+                'Max retry attempts reached for video feed subscription',
+                name: _logName,
+                category: LogCategory.video,
+              );
+            }
+          }),
+    );
+  }
+
+  void dispose() {
+    _retryTimer?.cancel();
+    _retryTimer = null;
+    _typesAwaitingRetry.clear();
+  }
+}

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -2298,16 +2298,22 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
               category: LogCategory.video,
             );
 
-            // Clean up subscription state so retry is possible
+            // Clean up subscription state so retry is possible.
+            // The stored params are deliberately kept: they are the only
+            // record of the filters this feed was built from, and the retry
+            // scheduled below cannot re-issue the REQ without them. Dropping
+            // them made a timed-out feed unrecoverable until the user
+            // navigated away and back (#7124).
             Log.info(
               '🧹 Cleaning up timed-out subscription state for $subscriptionType',
               name: 'VideoEventService',
               category: LogCategory.video,
             );
             _activeSubscriptions.remove(subscriptionType);
-            _subscriptionParams.remove(subscriptionType);
 
-            // Cancel the subscription to prevent leaks
+            // Cancel the subscription to prevent leaks. This also releases the
+            // REQ in the SDK, which force-cycles the relay if the socket
+            // swallowed it — so the retry below runs on a live connection.
             final sub = _subscriptions.remove(subscriptionId);
             sub?.cancel();
 
@@ -2324,6 +2330,10 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             );
 
             completeFeedLoadTrace('timeout');
+            // Every other completion path notifies; without this the loading
+            // state flips silently and no listener re-evaluates the feed.
+            notifyListeners();
+            _scheduleRetryWhenOnline(subscriptionType);
           }
         });
 
@@ -4762,12 +4772,17 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     _relayReadyRetrySubscription = null;
   }
 
-  /// Schedule retry of [subscriptionType] when the device is back online.
+  /// Schedule a bounded retry of [subscriptionType] once the device is online.
   ///
   /// The failed type is recorded so the retry re-establishes the feed
   /// that actually broke (with its original parameters) — previously the
   /// retry hardcoded the discovery feed, so home/hashtag/profile feeds
   /// never recovered through this path.
+  ///
+  /// Serves two callers: a subscribe attempted while offline, and a feed load
+  /// whose relay never answered (#7124). Both need the same thing — re-issue
+  /// these filters a few times, but only while there is a network to issue
+  /// them on.
   void _scheduleRetryWhenOnline(SubscriptionType subscriptionType) {
     _typesAwaitingRetry.add(subscriptionType);
 

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -253,6 +253,17 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   static const Duration _retryDelay = Duration(seconds: 10);
   static const int _eventDeletionKind = 5;
 
+  /// Feed loads that hit the deadline in a row without the relay ever
+  /// answering, per type.
+  ///
+  /// [_scheduleRetryWhenOnline] resets its budget whenever a re-subscribe
+  /// *call* succeeds, and issuing a REQ always succeeds — so a relay that
+  /// stays silent would otherwise re-arm the cycle on every timeout and
+  /// re-issue the same feed every ~40s for the life of the process. Cleared
+  /// the moment the feed is actually served (first event or EOSE), so a
+  /// recovered relay gets the full budget back.
+  final Map<SubscriptionType, int> _consecutiveFeedTimeouts = {};
+
   // Optional services for enhanced functionality
   ContentBlocklistRepository? _blocklistRepository;
   StreamSubscription<BlocklistChange>? _blocklistChangesSubscription;
@@ -2333,7 +2344,21 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             // Every other completion path notifies; without this the loading
             // state flips silently and no listener re-evaluates the feed.
             notifyListeners();
-            _scheduleRetryWhenOnline(subscriptionType);
+
+            final consecutive =
+                (_consecutiveFeedTimeouts[subscriptionType] ?? 0) + 1;
+            _consecutiveFeedTimeouts[subscriptionType] = consecutive;
+            if (consecutive <= _maxRetryAttempts) {
+              _scheduleRetryWhenOnline(subscriptionType);
+            } else {
+              Log.warning(
+                'Giving up on $subscriptionType after $consecutive '
+                'consecutive timed-out loads; the next explicit subscribe '
+                'starts over',
+                name: 'VideoEventService',
+                category: LogCategory.video,
+              );
+            }
           }
         });
 
@@ -2403,6 +2428,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             eoseReceived = true;
             feedLoadingTimeout
                 ?.cancel(); // Cancel timeout - EOSE received successfully
+            _consecutiveFeedTimeouts.remove(subscriptionType);
             final eoseDuration = DateTime.now().difference(
               subscriptionStartTime,
             );
@@ -2500,6 +2526,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
               firstEventTime = DateTime.now();
               feedLoadingTimeout
                   ?.cancel(); // Cancel timeout - events are arriving successfully
+              _consecutiveFeedTimeouts.remove(subscriptionType);
               final firstEventLatency = firstEventTime!.difference(
                 subscriptionStartTime,
               );
@@ -4783,6 +4810,11 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   /// whose relay never answered (#7124). Both need the same thing — re-issue
   /// these filters a few times, but only while there is a network to issue
   /// them on.
+  ///
+  /// The attempt budget here counts re-subscribe *calls* that threw, and a
+  /// REQ that reaches a silent relay does not throw — so the budget cannot
+  /// bound a relay that keeps timing out. [_consecutiveFeedTimeouts] is what
+  /// stops that loop, on the timeout side.
   void _scheduleRetryWhenOnline(SubscriptionType subscriptionType) {
     _typesAwaitingRetry.add(subscriptionType);
 

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -42,6 +42,7 @@ import 'package:openvine/services/divine_host_filter_service.dart';
 import 'package:openvine/services/effective_content_labels.dart';
 import 'package:openvine/services/event_router.dart';
 import 'package:openvine/services/feed_aspect_ratio_preference_service.dart';
+import 'package:openvine/services/feed_retry_scheduler.dart';
 import 'package:openvine/services/moderation_label_service.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/repost_resolver.dart';
@@ -190,15 +191,18 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   // Global state
   bool _isLoading = false;
   String? _error;
-  Timer? _retryTimer;
   StreamSubscription<Map<String, RelayConnectionStatus>>?
   _relayReadyRetrySubscription;
 
-  // Feed types whose relay subscription failed on a connection error and
-  // should be re-established by the online-retry cycle.
-  final Set<SubscriptionType> _typesAwaitingRetry = {};
+  // Feed types whose relay subscription failed because no relay was usable
+  // yet, and should be re-established once one is.
   final Set<SubscriptionType> _typesAwaitingRelayReady = {};
-  int _retryAttempts = 0;
+
+  late final FeedRetryScheduler _retryScheduler = FeedRetryScheduler(
+    connectionService: _connectionService,
+    resubscribe: _resubscribeWithStoredParams,
+    onRelayNotReady: _scheduleRetryWhenRelayReady,
+  );
 
   // Track subscription parameters per type
   final Map<SubscriptionType, Map<String, dynamic>> _subscriptionParams = {};
@@ -249,20 +253,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   final StreamController<String> _removedVideoIdsController =
       StreamController<String>.broadcast();
 
-  static const int _maxRetryAttempts = 3;
-  static const Duration _retryDelay = Duration(seconds: 10);
   static const int _eventDeletionKind = 5;
-
-  /// Feed loads that hit the deadline in a row without the relay ever
-  /// answering, per type.
-  ///
-  /// [_scheduleRetryWhenOnline] resets its budget whenever a re-subscribe
-  /// *call* succeeds, and issuing a REQ always succeeds — so a relay that
-  /// stays silent would otherwise re-arm the cycle on every timeout and
-  /// re-issue the same feed every ~40s for the life of the process. Cleared
-  /// the moment the feed is actually served (first event or EOSE), so a
-  /// recovered relay gets the full budget back.
-  final Map<SubscriptionType, int> _consecutiveFeedTimeouts = {};
 
   // Optional services for enhanced functionality
   ContentBlocklistRepository? _blocklistRepository;
@@ -1837,7 +1828,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           sortBy: sortBy,
           nip50Sort: nip50Sort,
         );
-        _scheduleRetryWhenOnline(subscriptionType);
+        _retryScheduler.scheduleWhenOnline(subscriptionType);
       }
       throw const VideoEventServiceException('Device is offline');
     }
@@ -2345,19 +2336,8 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             // state flips silently and no listener re-evaluates the feed.
             notifyListeners();
 
-            final consecutive =
-                (_consecutiveFeedTimeouts[subscriptionType] ?? 0) + 1;
-            _consecutiveFeedTimeouts[subscriptionType] = consecutive;
-            if (consecutive <= _maxRetryAttempts) {
-              _scheduleRetryWhenOnline(subscriptionType);
-            } else {
-              Log.warning(
-                'Giving up on $subscriptionType after $consecutive '
-                'consecutive timed-out loads; the next explicit subscribe '
-                'starts over',
-                name: 'VideoEventService',
-                category: LogCategory.video,
-              );
+            if (_retryScheduler.recordFeedLoadTimeout(subscriptionType)) {
+              _retryScheduler.scheduleWhenOnline(subscriptionType);
             }
           }
         });
@@ -2428,7 +2408,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             eoseReceived = true;
             feedLoadingTimeout
                 ?.cancel(); // Cancel timeout - EOSE received successfully
-            _consecutiveFeedTimeouts.remove(subscriptionType);
+            _retryScheduler.recordFeedServed(subscriptionType);
             final eoseDuration = DateTime.now().difference(
               subscriptionStartTime,
             );
@@ -2526,7 +2506,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
               firstEventTime = DateTime.now();
               feedLoadingTimeout
                   ?.cancel(); // Cancel timeout - events are arriving successfully
-              _consecutiveFeedTimeouts.remove(subscriptionType);
+              _retryScheduler.recordFeedServed(subscriptionType);
               final firstEventLatency = firstEventTime!.difference(
                 subscriptionStartTime,
               );
@@ -2669,7 +2649,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           category: LogCategory.video,
         );
         if (scheduleOnlineRetry) {
-          _scheduleRetryWhenOnline(subscriptionType);
+          _retryScheduler.scheduleWhenOnline(subscriptionType);
         } else {
           rethrow;
         }
@@ -3331,7 +3311,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         name: 'VideoEventService',
         category: LogCategory.video,
       );
-      _scheduleRetryWhenOnline(subscriptionType);
+      _retryScheduler.scheduleWhenOnline(subscriptionType);
     }
   }
 
@@ -4730,7 +4710,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
   /// Schedule retry of [subscriptionType] when at least one relay reconnects.
   ///
-  /// This is intentionally separate from [_scheduleRetryWhenOnline]: the device
+  /// This is intentionally separate from [FeedRetryScheduler.scheduleWhenOnline]: the device
   /// can have network connectivity while every Nostr relay is disconnected.
   void _scheduleRetryWhenRelayReady(SubscriptionType subscriptionType) {
     _typesAwaitingRelayReady.add(subscriptionType);
@@ -4799,107 +4779,6 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     _relayReadyRetrySubscription = null;
   }
 
-  /// Schedule a bounded retry of [subscriptionType] once the device is online.
-  ///
-  /// The failed type is recorded so the retry re-establishes the feed
-  /// that actually broke (with its original parameters) — previously the
-  /// retry hardcoded the discovery feed, so home/hashtag/profile feeds
-  /// never recovered through this path.
-  ///
-  /// Serves two callers: a subscribe attempted while offline, and a feed load
-  /// whose relay never answered (#7124). Both need the same thing — re-issue
-  /// these filters a few times, but only while there is a network to issue
-  /// them on.
-  ///
-  /// The attempt budget here counts re-subscribe *calls* that threw, and a
-  /// REQ that reaches a silent relay does not throw — so the budget cannot
-  /// bound a relay that keeps timing out. [_consecutiveFeedTimeouts] is what
-  /// stops that loop, on the timeout side.
-  void _scheduleRetryWhenOnline(SubscriptionType subscriptionType) {
-    _typesAwaitingRetry.add(subscriptionType);
-
-    // An active cycle keeps its attempt budget. A fresh cycle starts
-    // over — previously an exhausted counter was never reset, leaving
-    // retries dead for the rest of the session.
-    if (_retryTimer?.isActive ?? false) return;
-    _retryAttempts = 0;
-
-    _retryTimer = Timer.periodic(_retryDelay, (timer) {
-      if (!_connectionService.isOnline) {
-        Log.debug(
-          '⏳ Still offline, waiting for connection...',
-          name: 'VideoEventService',
-          category: LogCategory.video,
-        );
-        return;
-      }
-      if (_typesAwaitingRetry.isEmpty || _retryAttempts >= _maxRetryAttempts) {
-        _typesAwaitingRetry.clear();
-        timer.cancel();
-        return;
-      }
-
-      _retryAttempts++;
-      Log.warning(
-        'Attempting to resubscribe to '
-        '${_typesAwaitingRetry.map((t) => t.name).join(", ")} '
-        '(attempt $_retryAttempts/$_maxRetryAttempts)',
-        name: 'VideoEventService',
-        category: LogCategory.video,
-      );
-
-      for (final type in Set<SubscriptionType>.of(_typesAwaitingRetry)) {
-        _retrySubscription(type, timer);
-      }
-    });
-  }
-
-  /// Re-issue the relay subscription for [type] using its last-known
-  /// parameters, forcing past duplicate detection (the dead subscription
-  /// is still registered after an onError, so a non-forced call no-ops).
-  void _retrySubscription(SubscriptionType type, Timer timer) {
-    unawaited(
-      _resubscribeWithStoredParams(type)
-          .then((_) {
-            _typesAwaitingRetry.remove(type);
-            Log.info(
-              'Successfully resubscribed to ${type.name} feed',
-              name: 'VideoEventService',
-              category: LogCategory.video,
-            );
-            if (_typesAwaitingRetry.isEmpty) {
-              timer.cancel();
-              _retryAttempts = 0;
-            }
-          })
-          .catchError((Object e) {
-            Log.error(
-              'Retry attempt $_retryAttempts for ${type.name} failed: $e',
-              name: 'VideoEventService',
-              category: LogCategory.video,
-            );
-            if (e is RelayNotReadyException) {
-              _typesAwaitingRetry.remove(type);
-              if (_typesAwaitingRetry.isEmpty) {
-                timer.cancel();
-                _retryAttempts = 0;
-              }
-              _scheduleRetryWhenRelayReady(type);
-              return;
-            }
-            if (_retryAttempts >= _maxRetryAttempts) {
-              _typesAwaitingRetry.clear();
-              timer.cancel();
-              Log.warning(
-                'Max retry attempts reached for video feed subscription',
-                name: 'VideoEventService',
-                category: LogCategory.video,
-              );
-            }
-          }),
-    );
-  }
-
   Future<void> _resubscribeWithStoredParams(SubscriptionType type) {
     final params = _subscriptionParams[type];
     return subscribeToVideoFeed(
@@ -4929,7 +4808,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       ),
     ),
     'isLoading': _isLoading,
-    'retryAttempts': _retryAttempts,
+    'retryAttempts': _retryScheduler.attempts,
     'hasError': _error != null,
     'lastError': _error,
     'connectionInfo': _connectionService.getConnectionInfo(),
@@ -4942,7 +4821,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       name: 'VideoEventService',
       category: LogCategory.video,
     );
-    _retryAttempts = 0;
+    _retryScheduler.resetBudgets();
     _error = null;
 
     try {
@@ -5923,7 +5802,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   void dispose() {
     _isDisposed = true;
 
-    _retryTimer?.cancel();
+    _retryScheduler.dispose();
     _cancelRelayReadyRetrySubscription();
     _likeCountBatchTimer?.cancel();
     _authStateSubscription?.cancel();

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -204,6 +204,11 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     onRelayNotReady: _scheduleRetryWhenRelayReady,
   );
 
+  /// Per-type 30s feed-load fuses. Cancelled on replace/teardown so a
+  /// subscription the user already left cannot fire recovery against a later
+  /// live feed of the same type.
+  final Map<SubscriptionType, Timer> _feedLoadTimeouts = {};
+
   // Track subscription parameters per type
   final Map<SubscriptionType, Map<String, dynamic>> _subscriptionParams = {};
 
@@ -1791,6 +1796,13 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     _isLoading = true;
     _error = null;
 
+    // Explicit subscribe paths re-arm the consecutive-timeout budget. The
+    // auto-retry cycle passes scheduleOnlineRetry: false so it keeps counting
+    // toward the give-up ceiling instead of resetting itself every attempt.
+    if (scheduleOnlineRetry) {
+      _retryScheduler.clearTimeoutBudget(subscriptionType);
+    }
+
     if (!_nostrService.isInitialized) {
       _isLoading = false;
 
@@ -2287,10 +2299,27 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           category: LogCategory.video,
         );
 
-        // Set up timeout to detect feed loading failures (30 seconds)
-        Timer? feedLoadingTimeout;
+        // Set up timeout to detect feed loading failures (30 seconds).
+        // Tracked on the service so replace/cancel can kill it — a local-only
+        // Timer kept firing after the user left and could unmap a later live
+        // sub of the same type, then auto-retry with stale/null filters.
+        _cancelFeedLoadTimeout(subscriptionType);
+        late final Timer feedLoadingTimeout;
         feedLoadingTimeout = Timer(const Duration(seconds: 30), () {
           if (_isDisposed) return;
+          if (!identical(
+            _feedLoadTimeouts[subscriptionType],
+            feedLoadingTimeout,
+          )) {
+            return;
+          }
+          _feedLoadTimeouts.remove(subscriptionType);
+
+          // Subscription already torn down or replaced — do not recover.
+          if (_activeSubscriptions[subscriptionType] != subscriptionId ||
+              !_subscriptions.containsKey(subscriptionId)) {
+            return;
+          }
 
           if (!eoseReceived && eventCount == 0 && !timeoutReported) {
             timeoutReported = true;
@@ -2341,6 +2370,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             }
           }
         });
+        _feedLoadTimeouts[subscriptionType] = feedLoadingTimeout;
 
         // Phase 3.3: Cache-first strategy - load cached events BEFORE relay subscription
         // This provides instant UI feedback while relay fetches fresh data
@@ -2406,8 +2436,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           filters,
           onEose: () {
             eoseReceived = true;
-            feedLoadingTimeout
-                ?.cancel(); // Cancel timeout - EOSE received successfully
+            _cancelFeedLoadTimeout(subscriptionType);
             _retryScheduler.recordFeedServed(subscriptionType);
             final eoseDuration = DateTime.now().difference(
               subscriptionStartTime,
@@ -2504,8 +2533,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             // Track first event arrival time
             if (firstEventTime == null) {
               firstEventTime = DateTime.now();
-              feedLoadingTimeout
-                  ?.cancel(); // Cancel timeout - events are arriving successfully
+              _cancelFeedLoadTimeout(subscriptionType);
               _retryScheduler.recordFeedServed(subscriptionType);
               final firstEventLatency = firstEventTime!.difference(
                 subscriptionStartTime,
@@ -2553,7 +2581,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             );
           },
           onError: (error) {
-            feedLoadingTimeout?.cancel();
+            _cancelFeedLoadTimeout(subscriptionType);
             Log.error(
               '❌ Subscription error for $subscriptionType after $eventCount events: $error',
               name: 'VideoEventService',
@@ -2563,7 +2591,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             _handleSubscriptionError(error, subscriptionType);
           },
           onDone: () {
-            feedLoadingTimeout?.cancel();
+            _cancelFeedLoadTimeout(subscriptionType);
             final totalDuration = DateTime.now().difference(
               subscriptionStartTime,
             );
@@ -5429,8 +5457,16 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         includeReposts == currentIncludeReposts;
   }
 
+  void _cancelFeedLoadTimeout(SubscriptionType subscriptionType) {
+    _feedLoadTimeouts.remove(subscriptionType)?.cancel();
+  }
+
   /// Cancel subscription for a specific type
   Future<void> _cancelSubscription(SubscriptionType subscriptionType) async {
+    // Kill the fuse before tearing down state so a later fire cannot unmap a
+    // replacement subscription or schedule a retry for a feed the user left.
+    _cancelFeedLoadTimeout(subscriptionType);
+
     final subscriptionId = _activeSubscriptions[subscriptionType];
     if (subscriptionId != null) {
       Log.info(
@@ -5802,6 +5838,10 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   void dispose() {
     _isDisposed = true;
 
+    for (final timer in _feedLoadTimeouts.values) {
+      timer.cancel();
+    }
+    _feedLoadTimeouts.clear();
     _retryScheduler.dispose();
     _cancelRelayReadyRetrySubscription();
     _likeCountBatchTimer?.cancel();

--- a/mobile/packages/nostr_sdk/lib/relay/relay.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay.dart
@@ -63,17 +63,28 @@ abstract class Relay {
   /// The method implement by different relays to do some real when it connecting.
   Future<bool> doConnect();
 
+  /// Whether the socket this [onConnected] runs on is a new one.
+  ///
+  /// [connect] short-circuits when the connection is already live, so it can
+  /// reach [onConnected] without anything having been cycled. Such a socket
+  /// still holds every REQ it was sent, and re-issuing them would only make
+  /// the relay replay its stored window again.
+  bool get connectionIsFresh => true;
+
   /// The medhod called after relay connect success.
   ///
-  /// Flushes whatever was queued while the socket was down, then re-issues
-  /// every saved subscription and pending one-shot query. The re-issue is what
-  /// makes a reconnect recoverable: a REQ written to a socket that later died
-  /// is gone, and the relay keeps no record of it, so without this a live
-  /// subscription goes permanently silent after any reconnect and its caller
-  /// can only fall back to a timeout. Mirrors the post-AUTH replay and the
-  /// zombie reconnect in `RelayPool`.
+  /// Flushes whatever was queued while the socket was down, then — when the
+  /// connection is actually new — re-issues every saved subscription and
+  /// pending one-shot query. The re-issue is what makes a reconnect
+  /// recoverable: a REQ written to a socket that later died is gone, and the
+  /// relay keeps no record of it, so without this a live subscription goes
+  /// permanently silent after any reconnect and its caller can only fall back
+  /// to a timeout. Mirrors the post-AUTH replay and the zombie reconnect in
+  /// `RelayPool`.
   Future onConnected({String? source}) async {
-    final saved = [..._subscriptions.values, ..._queries.values];
+    final saved = connectionIsFresh
+        ? [..._subscriptions.values, ..._queries.values]
+        : const <Subscription>[];
     await _flushPendingMessages(source, {for (final s in saved) s.id});
     await _reissueSavedRequests(source, saved);
   }
@@ -126,6 +137,11 @@ abstract class Relay {
       message.length > 1 && message[0] == 'REQ' && ids.contains(message[1]);
 
   /// Re-sends every REQ this relay is still holding on the fresh socket.
+  ///
+  /// `skipReconnect` matches how these REQs were sent the first time
+  /// (`RelayPool.relayDoSubscribe`): re-issuing onto a socket that dies again
+  /// must queue the frame, not drive a nested reconnect out of the reconnect
+  /// handler that is already running.
   Future<void> _reissueSavedRequests(
     String? source,
     List<Subscription> saved,
@@ -136,7 +152,7 @@ abstract class Relay {
     );
     for (final subscription in saved) {
       try {
-        await send(subscription.toJson());
+        await send(subscription.toJson(), skipReconnect: true);
       } catch (e) {
         log('subscription re-issue exception onConnected');
         log('$e');

--- a/mobile/packages/nostr_sdk/lib/relay/relay.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay.dart
@@ -64,7 +64,29 @@ abstract class Relay {
   Future<bool> doConnect();
 
   /// The medhod called after relay connect success.
+  ///
+  /// Flushes whatever was queued while the socket was down, then re-issues
+  /// every saved subscription and pending one-shot query. The re-issue is what
+  /// makes a reconnect recoverable: a REQ written to a socket that later died
+  /// is gone, and the relay keeps no record of it, so without this a live
+  /// subscription goes permanently silent after any reconnect and its caller
+  /// can only fall back to a timeout. Mirrors the post-AUTH replay and the
+  /// zombie reconnect in `RelayPool`.
   Future onConnected({String? source}) async {
+    final saved = [..._subscriptions.values, ..._queries.values];
+    await _flushPendingMessages(source, {for (final s in saved) s.id});
+    await _reissueSavedRequests(source, saved);
+  }
+
+  /// Sends the frames that failed while the socket was down.
+  ///
+  /// REQ frames naming one of [reissuedIds] are dropped instead of sent: the
+  /// saved subscription carries the same REQ and is re-issued right after, and
+  /// sending both makes the relay replay its whole stored window twice.
+  Future<void> _flushPendingMessages(
+    String? source,
+    Set<String> reissuedIds,
+  ) async {
     log(
       '[Relay] onConnected[${source ?? "unknown"}]: ${relayStatus.addr} - sending ${pendingMessages.length} pending messages',
     );
@@ -78,6 +100,7 @@ abstract class Relay {
     pendingMessages.clear();
 
     for (var message in messagesToSend) {
+      if (_isReqNaming(message, reissuedIds)) continue;
       try {
         final result = await send(message, queueIfFailed: false);
         if (!result) {
@@ -97,6 +120,28 @@ abstract class Relay {
     log(
       '[Relay] onConnected[${source ?? "unknown"}]: ${relayStatus.addr} - replay complete, remaining pending messages=${pendingMessages.length}',
     );
+  }
+
+  bool _isReqNaming(List<dynamic> message, Set<String> ids) =>
+      message.length > 1 && message[0] == 'REQ' && ids.contains(message[1]);
+
+  /// Re-sends every REQ this relay is still holding on the fresh socket.
+  Future<void> _reissueSavedRequests(
+    String? source,
+    List<Subscription> saved,
+  ) async {
+    if (saved.isEmpty) return;
+    log(
+      '[Relay] onConnected[${source ?? "unknown"}]: ${relayStatus.addr} - re-issuing ${saved.length} saved REQs',
+    );
+    for (final subscription in saved) {
+      try {
+        await send(subscription.toJson());
+      } catch (e) {
+        log('subscription re-issue exception onConnected');
+        log('$e');
+      }
+    }
   }
 
   Future<void> getRelayInfo(String url) async {

--- a/mobile/packages/nostr_sdk/lib/relay/relay_base.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_base.dart
@@ -28,13 +28,20 @@ class RelayBase extends Relay {
   /// Tracks whether doConnect is in progress to avoid duplicate onConnected calls
   bool _isConnecting = false;
 
+  bool _connectionIsFresh = true;
+
+  @override
+  bool get connectionIsFresh => _connectionIsFresh;
+
   @override
   Future<bool> doConnect() async {
     // If already connected, return true
     if (_connectionManager != null && _connectionManager!.isConnected) {
       log("connect break: $url - already connected");
+      _connectionIsFresh = false;
       return true;
     }
+    _connectionIsFresh = true;
 
     try {
       _isConnecting = true;
@@ -89,6 +96,10 @@ class RelayBase extends Relay {
           // Flush pending messages on reconnection, but NOT during initial connect
           // (relay.connect() will call onConnected after doConnect returns)
           if (wasDisconnected && !_isConnecting) {
+            // A disconnected -> connected transition is a new socket by
+            // definition, including the one `forceReconnect` drives without
+            // going through `doConnect`.
+            _connectionIsFresh = true;
             onConnected(source: 'stateStream-reconnect');
           }
         case ConnectionState.connecting:

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -184,6 +184,11 @@ class RelayPool {
   /// quiet altogether. Dropped when the query settles or is unsubscribed.
   final Map<String, DateTime> _querySentAt = {};
 
+  /// The [_querySentAt] equivalent for live subscriptions, so a subscription
+  /// its caller tore down without ever being served can ask the same question.
+  /// Dropped when the subscription is unsubscribed.
+  final Map<String, DateTime> _subscriptionSentAt = {};
+
   /// One-shot queries at least one relay has already answered.
   ///
   /// Sticky for the query's lifetime rather than a property of the call that
@@ -1051,6 +1056,30 @@ class RelayPool {
     _repairSilentRelays(silent, sentAt);
   }
 
+  /// [_repairRelaysThatNeverAnswered] for live subscriptions.
+  ///
+  /// A live subscription has no terminal frame, so "the relay still holds it"
+  /// is true right up to the CLOSE — silence since the REQ is the whole signal,
+  /// and [_repairSilentRelays] is what applies it. A relay that streamed events
+  /// or EOSE'd stamped its activity clock and is therefore left alone; one that
+  /// swallowed the REQ into a half-open socket is not, which is the case the
+  /// feed loads hit. Without this a zombie charges every subsequent feed load
+  /// the caller's full timeout until something else happens to cycle it.
+  void _repairRelaysThatNeverServedSubscription(String subId) {
+    final sentAt = _subscriptionSentAt.remove(subId);
+    if (sentAt == null) return;
+    final silent = [
+      for (final relay in [
+        ..._relaysSnapshot(),
+        ..._tempRelaysSnapshot(),
+        ..._cacheRelaysSnapshot(),
+      ])
+        if (relay.hasSubscriptionById(subId)) relay.url,
+    ];
+    if (silent.isEmpty) return;
+    _repairSilentRelays(silent, sentAt);
+  }
+
   /// Releases the one-shot queries [relay] is parked on once it can no longer
   /// answer them.
   ///
@@ -1548,6 +1577,7 @@ class RelayPool {
       onEose: onEose,
     );
     _subscriptions[subscription.id] = subscription;
+    _subscriptionSentAt[subscription.id] = DateTime.now();
     log(
       '📋 subscribe: id=${subscription.id}, '
       'relays=${_relays.length}, filters=$filters',
@@ -1656,6 +1686,9 @@ class RelayPool {
     // Clean up EOSE tracking for this subscription
     _subscriptionEoseRelays.remove(id);
     if (subscription != null) {
+      // A relay that still holds this REQ never served it, so offer it to the
+      // zombie repair before the CLOSE sweep below drops that evidence.
+      _repairRelaysThatNeverServedSubscription(id);
       // check query and send close
       var it = _relaysSnapshot();
       for (var relay in it) {
@@ -2247,19 +2280,20 @@ class RelayPool {
   /// so a brownout relay isn't force-cycled on every timed-out publish.
   final Map<String, DateTime> _lastSilentRepairAt = {};
 
-  /// Repair pass for OK-awaiting publishes that timed out in silence.
+  /// Repair pass for frames that were written and answered with silence.
   ///
   /// A relay lands in [PublishOutcome.noResponseFrom] when its WebSocket sink
   /// accepted the EVENT frame but no OK of either polarity came back within
-  /// the confirm window. When the same connection ALSO received no inbound
-  /// frame of any kind since the publish was written, the socket is a
-  /// half-open zombie (typically left behind by a connectivity flap). Nothing
-  /// else repairs it: publish sends pass `skipReconnect`, the idle heartbeat
-  /// needs 90s+ of silence, and a zombie still reports `connected` to every
-  /// health gate — so every retry inside that window would deterministically
-  /// time out again. Force-cycle the connection and re-send the relay's
-  /// subscriptions (mirroring [add]'s autoSubscribe and the post-AUTH replay)
-  /// so the next attempt runs on a live socket.
+  /// the confirm window; the query and subscription paths feed the same check
+  /// with the relays still holding an abandoned REQ. When the same connection
+  /// ALSO received no inbound frame of any kind since that frame was written,
+  /// the socket is a half-open zombie (typically left behind by a connectivity
+  /// flap). Nothing else repairs it: publish and REQ sends pass
+  /// `skipReconnect`, the idle heartbeat needs 90s+ of silence, and a zombie
+  /// still reports `connected` to every health gate — so every retry inside
+  /// that window would deterministically time out again. Force-cycle the
+  /// connection so the next attempt runs on a live socket; the reconnect
+  /// re-issues the relay's saved REQs (see [Relay.onConnected]).
   void _repairSilentRelays(List<String> silentRelayUrls, DateTime sentAt) {
     final now = DateTime.now();
     for (final url in silentRelayUrls) {
@@ -2285,19 +2319,12 @@ class RelayPool {
     }
   }
 
+  /// Force-cycles [relay]'s socket. [Relay.onConnected] re-issues the saved
+  /// subscriptions and pending one-shot queries on the fresh connection, so an
+  /// in-flight REQ that the closed socket swallowed still runs.
   Future<void> _reconnectAndResubscribe(RelayBase relay) async {
     try {
-      if (!await relay.forceReconnect()) return;
-      for (final subscription in relay.getSubscriptions()) {
-        await relay.send(subscription.toJson());
-      }
-      // Replay pending one-shot queries too: forceReconnect closed the old
-      // socket, so an in-flight REQ that had not yet EOSE'd is gone. Without
-      // re-issuing it the relay never EOSEs on the fresh socket and the
-      // pool-level completion can only resolve via the caller's timeout.
-      for (final query in relay.getQueries()) {
-        await relay.send(query.toJson());
-      }
+      await relay.forceReconnect();
     } catch (e) {
       log('OK-timeout reconnect failed for ${relay.url}: $e');
     }

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -228,6 +228,7 @@ class RelayPool {
     this.onNotice,
     this.signatureVerificationPolicy = SignatureVerificationPolicy.all,
     this.silentRepairCooldown = const Duration(seconds: 60),
+    this.minSubscriptionAgeBeforeRepair = const Duration(seconds: 10),
     this.tempRelayIdleTimeout = const Duration(seconds: 120),
     this.tempRelaySweepInterval = const Duration(seconds: 60),
   });
@@ -266,6 +267,19 @@ class RelayPool {
   /// tests that need to exercise the post-cooldown re-repair without a
   /// wall-clock wait.
   Duration silentRepairCooldown;
+
+  /// How long a live subscription must have gone unanswered before its
+  /// teardown is treated as evidence against the socket.
+  ///
+  /// Unlike a one-shot query, which is only released once its caller gave up
+  /// waiting, [unsubscribe] is the ordinary teardown every screen runs — so
+  /// without a floor, a feed the user left inside the relay's round-trip time
+  /// would force-cycle a perfectly healthy connection and make it replay its
+  /// stored window for every other subscription it carries. The default sits
+  /// far above navigation-speed teardowns and well below the app's own feed
+  /// deadline, so a caller that actually waited still gets the repair.
+  /// Injectable so tests need no wall-clock wait.
+  Duration minSubscriptionAgeBeforeRepair;
 
   /// Controls whether [_dispatchTypedFrame] performs expensive Schnorr
   /// verification. The event id is always recomputed first; policy skips only
@@ -1065,9 +1079,16 @@ class RelayPool {
   /// swallowed the REQ into a half-open socket is not, which is the case the
   /// feed loads hit. Without this a zombie charges every subsequent feed load
   /// the caller's full timeout until something else happens to cycle it.
+  ///
+  /// A subscription torn down before [minSubscriptionAgeBeforeRepair] proves
+  /// nothing about the socket — the relay may simply not have answered yet —
+  /// so it is ignored rather than charged against the connection.
   void _repairRelaysThatNeverServedSubscription(String subId) {
     final sentAt = _subscriptionSentAt.remove(subId);
     if (sentAt == null) return;
+    if (DateTime.now().difference(sentAt) < minSubscriptionAgeBeforeRepair) {
+      return;
+    }
     final silent = [
       for (final relay in [
         ..._relaysSnapshot(),
@@ -2308,11 +2329,11 @@ class RelayPool {
       if (!_silentRelayRepairsInFlight.add(url)) continue;
       _lastSilentRepairAt[url] = now;
       log(
-        '📡 $url accepted a publish frame but sent nothing back for the '
-        'whole OK window; reconnecting the stale connection',
+        '📡 $url accepted a frame but sent nothing back for the whole window '
+        'the caller waited; reconnecting the stale connection',
       );
       unawaited(
-        _reconnectAndResubscribe(
+        _reconnectSilentRelay(
           relay,
         ).whenComplete(() => _silentRelayRepairsInFlight.remove(url)),
       );
@@ -2322,11 +2343,11 @@ class RelayPool {
   /// Force-cycles [relay]'s socket. [Relay.onConnected] re-issues the saved
   /// subscriptions and pending one-shot queries on the fresh connection, so an
   /// in-flight REQ that the closed socket swallowed still runs.
-  Future<void> _reconnectAndResubscribe(RelayBase relay) async {
+  Future<void> _reconnectSilentRelay(RelayBase relay) async {
     try {
       await relay.forceReconnect();
     } catch (e) {
-      log('OK-timeout reconnect failed for ${relay.url}: $e');
+      log('silent-relay reconnect failed for ${relay.url}: $e');
     }
   }
 

--- a/mobile/packages/nostr_sdk/test/unit/relay_pending_messages_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pending_messages_test.dart
@@ -81,4 +81,72 @@ void main() {
       },
     );
   });
+
+  group('Relay saved-REQ re-issue on reconnect', () {
+    Subscription subscriptionWith(String id) => Subscription(
+      [
+        {
+          'kinds': [34236],
+        },
+      ],
+      (_) {},
+      id: id,
+    );
+
+    test('re-issues saved subscriptions so a dropped socket does not leave the '
+        'caller waiting forever', () async {
+      final relay = _RequeueingRelay('wss://relay.example', failedMessage: [])
+        ..saveSubscription(subscriptionWith('feed'));
+
+      await relay.onConnected(source: 'stateStream-reconnect');
+
+      expect(relay.sentMessages, [
+        [
+          'REQ',
+          'feed',
+          {
+            'kinds': [34236],
+          },
+        ],
+      ]);
+    });
+
+    test('re-issues pending one-shot queries too', () async {
+      final relay = _RequeueingRelay('wss://relay.example', failedMessage: [])
+        ..saveQuery(subscriptionWith('author-page'));
+
+      await relay.onConnected(source: 'stateStream-reconnect');
+
+      expect(relay.sentMessages.single[1], 'author-page');
+    });
+
+    test(
+      'sends a queued REQ once when its subscription is also saved — a '
+      'double REQ makes the relay replay the whole stored window twice',
+      () async {
+        final subscription = subscriptionWith('feed');
+        final relay = _RequeueingRelay('wss://relay.example', failedMessage: [])
+          ..saveSubscription(subscription)
+          ..pendingMessages.add(subscription.toJson());
+
+        await relay.onConnected(source: 'stateStream-reconnect');
+
+        expect(relay.sentMessages, hasLength(1));
+        expect(relay.pendingMessages, isEmpty);
+      },
+    );
+
+    test('still replays queued frames that are not re-issued REQs', () async {
+      final relay = _RequeueingRelay('wss://relay.example', failedMessage: [])
+        ..saveSubscription(subscriptionWith('feed'))
+        ..pendingMessages.add([
+          'EVENT',
+          {'id': 'queued-while-down'},
+        ]);
+
+      await relay.onConnected(source: 'stateStream-reconnect');
+
+      expect(relay.sentMessages.map((m) => m.first), ['EVENT', 'REQ']);
+    });
+  });
 }

--- a/mobile/packages/nostr_sdk/test/unit/relay_pending_messages_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pending_messages_test.dart
@@ -5,11 +5,17 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 
 class _RequeueingRelay extends Relay {
-  _RequeueingRelay(String url, {required this.failedMessage})
-    : super(url, RelayStatus(url));
+  _RequeueingRelay(
+    String url, {
+    required this.failedMessage,
+    this.connectionIsFresh = true,
+  }) : super(url, RelayStatus(url));
 
   final List<dynamic> failedMessage;
   final List<List<dynamic>> sentMessages = [];
+
+  @override
+  final bool connectionIsFresh;
 
   @override
   Future<bool> doConnect() async => true;
@@ -147,6 +153,43 @@ void main() {
       await relay.onConnected(source: 'stateStream-reconnect');
 
       expect(relay.sentMessages.map((m) => m.first), ['EVENT', 'REQ']);
+    });
+
+    test('leaves saved REQs alone when the connection was only reused — the '
+        'live socket still holds them', () async {
+      final subscription = subscriptionWith('feed');
+      final relay =
+          _RequeueingRelay(
+              'wss://relay.example',
+              failedMessage: [],
+              connectionIsFresh: false,
+            )
+            ..saveSubscription(subscription)
+            ..pendingMessages.add([
+              'EVENT',
+              {'id': 'queued-while-down'},
+            ]);
+
+      await relay.onConnected(source: 'connect()');
+
+      expect(relay.sentMessages.map((m) => m.first), ['EVENT']);
+    });
+
+    test('replays a queued REQ when the connection was only reused — nothing '
+        're-issues it otherwise', () async {
+      final subscription = subscriptionWith('feed');
+      final relay =
+          _RequeueingRelay(
+              'wss://relay.example',
+              failedMessage: [],
+              connectionIsFresh: false,
+            )
+            ..saveSubscription(subscription)
+            ..pendingMessages.add(subscription.toJson());
+
+      await relay.onConnected(source: 'connect()');
+
+      expect(relay.sentMessages.map((m) => m.first), ['REQ']);
     });
   });
 }

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_subscription_zombie_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_subscription_zombie_test.dart
@@ -30,6 +30,9 @@ void main() {
       await nostr.relayPool.add(
         RelayBase(relayUrl, RelayStatus(relayUrl), channelFactory: factory),
       );
+      // These tests tear the subscription down immediately; the age floor
+      // that protects navigation-speed teardowns has its own test below.
+      nostr.relayPool.minSubscriptionAgeBeforeRepair = Duration.zero;
     });
 
     String subscribeToFeed() => nostr.subscribe([
@@ -93,6 +96,28 @@ void main() {
         factory.createdChannels,
         hasLength(1),
         reason: 'an inbound-active connection must not be cycled',
+      );
+    });
+
+    test('a subscription dropped before the age floor is not charged against '
+        'the socket', () async {
+      nostr.relayPool.minSubscriptionAgeBeforeRepair = const Duration(
+        minutes: 1,
+      );
+
+      final subId = subscribeToFeed();
+      await Future<void>.delayed(Duration.zero);
+
+      // The user left the screen inside the relay's round-trip time.
+      nostr.unsubscribe(subId);
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(
+        factory.createdChannels,
+        hasLength(1),
+        reason:
+            'a teardown faster than the relay could answer proves nothing '
+            'about the connection',
       );
     });
 

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_subscription_zombie_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_subscription_zombie_test.dart
@@ -1,0 +1,125 @@
+// ABOUTME: Regression tests for zombie-socket remediation driven by a live
+// ABOUTME: subscription its caller tore down without ever being served.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+import '../support/fake_web_socket.dart';
+
+List<List<dynamic>> _reqFrames(FakeWebSocketChannel channel) => channel
+    .sentMessages
+    .map((m) => jsonDecode(m as String) as List<dynamic>)
+    .where((m) => m.first == 'REQ')
+    .toList();
+
+void main() {
+  group('RelayPool zombie-socket remediation on subscription teardown', () {
+    const relayUrl = 'wss://relay.divine.video';
+    late Nostr nostr;
+    late FakeWebSocketChannelFactory factory;
+
+    setUp(() async {
+      final signer = LocalNostrSigner(
+        '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+      );
+      nostr = Nostr(signer, [], (url) => RelayBase(url, RelayStatus(url)));
+      await nostr.refreshPublicKey();
+      factory = FakeWebSocketChannelFactory();
+      await nostr.relayPool.add(
+        RelayBase(relayUrl, RelayStatus(relayUrl), channelFactory: factory),
+      );
+    });
+
+    String subscribeToFeed() => nostr.subscribe([
+      {
+        'kinds': [34236],
+      },
+    ], (_) {});
+
+    test('a relay that swallows the REQ and never sends a frame is '
+        'force-reconnected when the caller gives up', () async {
+      expect(factory.createdChannels, hasLength(1));
+      final zombieChannel = factory.createdChannels.single;
+
+      final subId = subscribeToFeed();
+      await Future<void>.delayed(Duration.zero);
+      expect(_reqFrames(zombieChannel), hasLength(1));
+
+      // The feed-load deadline expired with no EVENT and no EOSE.
+      nostr.unsubscribe(subId);
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(
+        factory.createdChannels,
+        hasLength(2),
+        reason: 'a socket that swallowed the REQ must be cycled',
+      );
+    });
+
+    test('a relay that answered the subscription is left alone', () async {
+      final channel = factory.createdChannels.single;
+
+      final subId = subscribeToFeed();
+      await Future<void>.delayed(Duration.zero);
+      channel.simulateMessage(jsonEncode(['EOSE', subId]));
+      await Future<void>.delayed(Duration.zero);
+
+      nostr.unsubscribe(subId);
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(
+        factory.createdChannels,
+        hasLength(1),
+        reason: 'an EOSE-ing relay is healthy and must not be cycled',
+      );
+    });
+
+    test('a relay that stays inbound-active is left alone — silence '
+        'discriminates zombie from slow', () async {
+      final channel = factory.createdChannels.single;
+
+      final subId = subscribeToFeed();
+      await Future<void>.delayed(Duration.zero);
+      // Nothing for our REQ, but the connection is demonstrably alive.
+      channel.simulateMessage(jsonEncode(['NOTICE', 'busy']));
+      await Future<void>.delayed(Duration.zero);
+
+      nostr.unsubscribe(subId);
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(
+        factory.createdChannels,
+        hasLength(1),
+        reason: 'an inbound-active connection must not be cycled',
+      );
+    });
+
+    test('the reconnect re-issues the REQs the relay still holds', () async {
+      final zombieChannel = factory.createdChannels.single;
+
+      final abandoned = subscribeToFeed();
+      final survivor = nostr.subscribe([
+        {
+          'kinds': [1],
+        },
+      ], (_) {});
+      await Future<void>.delayed(Duration.zero);
+      expect(_reqFrames(zombieChannel), hasLength(2));
+
+      nostr.unsubscribe(abandoned);
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(factory.createdChannels, hasLength(2));
+      final freshChannel = factory.createdChannels.last;
+      expect(
+        _reqFrames(freshChannel).map((frame) => frame[1]),
+        [survivor],
+        reason:
+            'the surviving subscription runs again on the live socket, '
+            'the abandoned one does not',
+      );
+    });
+  });
+}

--- a/mobile/test/services/feed_retry_scheduler_test.dart
+++ b/mobile/test/services/feed_retry_scheduler_test.dart
@@ -90,6 +90,29 @@ void main() {
           [true, true, true, false],
         );
       });
+
+      test('clearTimeoutBudget re-arms a type that had given up', () {
+        final scheduler = build();
+        addTearDown(scheduler.dispose);
+
+        for (var i = 0; i < 4; i++) {
+          scheduler.recordFeedLoadTimeout(SubscriptionType.discovery);
+        }
+        expect(
+          scheduler.recordFeedLoadTimeout(SubscriptionType.discovery),
+          isFalse,
+        );
+
+        scheduler.clearTimeoutBudget(SubscriptionType.discovery);
+
+        expect(
+          scheduler.recordFeedLoadTimeout(SubscriptionType.discovery),
+          isTrue,
+          reason:
+              'an explicit subscribe must start over; otherwise navigate-back '
+              'after give-up never re-arms auto-retry',
+        );
+      });
     });
 
     group('scheduleWhenOnline', () {

--- a/mobile/test/services/feed_retry_scheduler_test.dart
+++ b/mobile/test/services/feed_retry_scheduler_test.dart
@@ -1,0 +1,183 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/connection_status_service.dart';
+import 'package:openvine/services/feed_retry_scheduler.dart';
+import 'package:openvine/services/video_event_service.dart';
+
+class _FakeConnectionStatusService extends ConnectionStatusService {
+  bool online = true;
+
+  @override
+  bool get isOnline => online;
+
+  @override
+  bool get isConnected => online;
+}
+
+void main() {
+  group(FeedRetryScheduler, () {
+    late _FakeConnectionStatusService connectionService;
+    late List<SubscriptionType> resubscribed;
+    late List<SubscriptionType> relayNotReady;
+    late Future<void> Function(SubscriptionType) resubscribe;
+
+    FeedRetryScheduler build() => FeedRetryScheduler(
+      connectionService: connectionService,
+      resubscribe: (type) {
+        resubscribed.add(type);
+        return resubscribe(type);
+      },
+      onRelayNotReady: relayNotReady.add,
+    );
+
+    setUp(() {
+      connectionService = _FakeConnectionStatusService();
+      resubscribed = [];
+      relayNotReady = [];
+      resubscribe = (_) async {};
+    });
+
+    tearDown(() => connectionService.dispose());
+
+    group('recordFeedLoadTimeout', () {
+      test('allows a retry until the budget is spent', () {
+        final scheduler = build();
+        addTearDown(scheduler.dispose);
+
+        expect(
+          [
+            for (var i = 0; i < 5; i++)
+              scheduler.recordFeedLoadTimeout(SubscriptionType.discovery),
+          ],
+          [true, true, true, false, false],
+        );
+      });
+
+      test('counts each feed type on its own budget', () {
+        final scheduler = build();
+        addTearDown(scheduler.dispose);
+
+        for (var i = 0; i < 4; i++) {
+          scheduler.recordFeedLoadTimeout(SubscriptionType.discovery);
+        }
+
+        expect(
+          scheduler.recordFeedLoadTimeout(SubscriptionType.hashtag),
+          isTrue,
+          reason: 'a hashtag feed is not charged for the discovery feed',
+        );
+      });
+
+      test('a served feed starts over with a full budget', () {
+        final scheduler = build();
+        addTearDown(scheduler.dispose);
+
+        for (var i = 0; i < 4; i++) {
+          scheduler.recordFeedLoadTimeout(SubscriptionType.discovery);
+        }
+        expect(
+          scheduler.recordFeedLoadTimeout(SubscriptionType.discovery),
+          isFalse,
+        );
+
+        scheduler.recordFeedServed(SubscriptionType.discovery);
+
+        expect(
+          [
+            for (var i = 0; i < 4; i++)
+              scheduler.recordFeedLoadTimeout(SubscriptionType.discovery),
+          ],
+          [true, true, true, false],
+        );
+      });
+    });
+
+    group('scheduleWhenOnline', () {
+      test('re-issues the feed after the retry delay', () {
+        fakeAsync((fake) {
+          final scheduler = build();
+          addTearDown(scheduler.dispose);
+
+          scheduler.scheduleWhenOnline(SubscriptionType.profile);
+          expect(resubscribed, isEmpty);
+
+          fake
+            ..elapse(const Duration(seconds: 10))
+            ..flushMicrotasks();
+
+          expect(resubscribed, [SubscriptionType.profile]);
+        });
+      });
+
+      test('waits for the network instead of spending attempts offline', () {
+        fakeAsync((fake) {
+          final scheduler = build();
+          addTearDown(scheduler.dispose);
+
+          connectionService.online = false;
+          scheduler.scheduleWhenOnline(SubscriptionType.profile);
+          fake
+            ..elapse(const Duration(minutes: 5))
+            ..flushMicrotasks();
+          expect(resubscribed, isEmpty);
+
+          connectionService.online = true;
+          fake
+            ..elapse(const Duration(seconds: 10))
+            ..flushMicrotasks();
+          expect(resubscribed, [SubscriptionType.profile]);
+        });
+      });
+
+      test('stops after maxAttempts when every re-issue fails', () {
+        fakeAsync((fake) {
+          resubscribe = (_) async => throw StateError('no relay');
+          final scheduler = build();
+          addTearDown(scheduler.dispose);
+
+          scheduler.scheduleWhenOnline(SubscriptionType.profile);
+          fake
+            ..elapse(const Duration(minutes: 5))
+            ..flushMicrotasks();
+
+          expect(resubscribed, hasLength(3));
+        });
+      });
+
+      test('hands a relay-not-ready failure to the relay-ready retry', () {
+        fakeAsync((fake) {
+          resubscribe = (_) async =>
+              throw const RelayNotReadyException('no relay');
+          final scheduler = build();
+          addTearDown(scheduler.dispose);
+
+          scheduler.scheduleWhenOnline(SubscriptionType.profile);
+          fake
+            ..elapse(const Duration(minutes: 5))
+            ..flushMicrotasks();
+
+          expect(relayNotReady, [SubscriptionType.profile]);
+          expect(
+            resubscribed,
+            hasLength(1),
+            reason: 'the online cycle hands the type over instead of retrying',
+          );
+        });
+      });
+
+      test('dispose stops a cycle already in flight', () {
+        fakeAsync((fake) {
+          build()
+            ..scheduleWhenOnline(SubscriptionType.profile)
+            ..dispose();
+
+          fake
+            ..elapse(const Duration(minutes: 5))
+            ..flushMicrotasks();
+
+          expect(resubscribed, isEmpty);
+        });
+      });
+    });
+  });
+}

--- a/mobile/test/services/video_event_service_timeout_test.dart
+++ b/mobile/test/services/video_event_service_timeout_test.dart
@@ -5,12 +5,26 @@ import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/services/connection_status_service.dart';
 import 'package:openvine/services/subscription_manager.dart';
 import 'package:openvine/services/video_event_service.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
 
 class _MockSubscriptionManager extends Mock implements SubscriptionManager {}
+
+class _FakeConnectionStatusService extends ConnectionStatusService {
+  bool online = true;
+
+  @override
+  bool get isOnline => online;
+
+  @override
+  bool get isConnected => online;
+
+  @override
+  Map<String, dynamic> getConnectionInfo() => {'isConnected': online};
+}
 
 void main() {
   setUpAll(() {
@@ -143,5 +157,171 @@ void main() {
         });
       },
     );
+  });
+
+  // A relay that answers with nothing at all used to be terminal: the timeout
+  // dropped the stored filters and scheduled no retry, so the feed stayed empty
+  // until the user navigated away and back (#7124).
+  group('VideoEventService timeout recovery', () {
+    const author =
+        '385c3a6ec0b9d57a4330dbd6284989be5bd00e41c535f9ca39b6ae7c521b81cd';
+
+    late VideoEventService service;
+    late _MockNostrClient mockNostrService;
+    late _MockSubscriptionManager mockSubscriptionManager;
+    late _FakeConnectionStatusService connectionService;
+    late List<List<Filter>> subscribeCalls;
+
+    setUp(() {
+      mockNostrService = _MockNostrClient();
+      mockSubscriptionManager = _MockSubscriptionManager();
+      connectionService = _FakeConnectionStatusService();
+      subscribeCalls = [];
+
+      when(() => mockNostrService.isInitialized).thenReturn(true);
+      when(() => mockNostrService.connectedRelayCount).thenReturn(1);
+      when(
+        () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+      ).thenAnswer((invocation) {
+        subscribeCalls.add(
+          (invocation.positionalArguments.first as List<Filter>).toList(),
+        );
+        // Never emits and never EOSEs: the relay that swallowed the REQ.
+        final controller = StreamController<Event>(onCancel: () async {});
+        addTearDown(controller.close);
+        return controller.stream;
+      });
+
+      service = VideoEventService(
+        mockNostrService,
+        subscriptionManager: mockSubscriptionManager,
+        connectionService: connectionService,
+      );
+    });
+
+    tearDown(() {
+      service.dispose();
+      connectionService.dispose();
+    });
+
+    test('re-issues the timed-out feed with its original filters', () {
+      fakeAsync((fake) {
+        unawaited(
+          service.subscribeToVideoFeed(
+            subscriptionType: SubscriptionType.profile,
+            authors: [author],
+          ),
+        );
+        fake.flushMicrotasks();
+        expect(subscribeCalls, hasLength(1));
+
+        fake
+          ..elapse(const Duration(seconds: 31))
+          ..flushMicrotasks();
+        expect(
+          subscribeCalls,
+          hasLength(1),
+          reason: 'the timeout itself must not re-subscribe',
+        );
+
+        fake
+          ..elapse(const Duration(seconds: 10))
+          ..flushMicrotasks();
+
+        expect(subscribeCalls, hasLength(2));
+        expect(
+          subscribeCalls.last.any(
+            (filter) => filter.authors?.contains(author) ?? false,
+          ),
+          isTrue,
+          reason:
+              'the retry must re-establish the feed that timed out, which is '
+              'only possible if the timeout kept its stored parameters',
+        );
+      });
+    });
+
+    test('stops retrying once a re-issued subscription is established', () {
+      fakeAsync((fake) {
+        unawaited(
+          service.subscribeToVideoFeed(
+            subscriptionType: SubscriptionType.profile,
+            authors: [author],
+          ),
+        );
+        fake
+          ..flushMicrotasks()
+          ..elapse(const Duration(seconds: 31))
+          ..flushMicrotasks()
+          ..elapse(const Duration(seconds: 10))
+          ..flushMicrotasks();
+        expect(subscribeCalls, hasLength(2));
+
+        fake
+          ..elapse(const Duration(seconds: 30))
+          ..flushMicrotasks();
+        expect(
+          subscribeCalls,
+          hasLength(2),
+          reason: 'a successful re-subscribe ends the retry cycle',
+        );
+      });
+    });
+
+    test('does not re-issue while the device is offline', () {
+      fakeAsync((fake) {
+        unawaited(
+          service.subscribeToVideoFeed(
+            subscriptionType: SubscriptionType.profile,
+            authors: [author],
+          ),
+        );
+        fake
+          ..flushMicrotasks()
+          ..elapse(const Duration(seconds: 31))
+          ..flushMicrotasks();
+
+        connectionService.online = false;
+        fake
+          ..elapse(const Duration(seconds: 30))
+          ..flushMicrotasks();
+        expect(subscribeCalls, hasLength(1));
+
+        connectionService.online = true;
+        fake
+          ..elapse(const Duration(seconds: 10))
+          ..flushMicrotasks();
+        expect(subscribeCalls, hasLength(2));
+      });
+    });
+
+    test('notifies listeners when the load times out', () {
+      fakeAsync((fake) {
+        unawaited(
+          service.subscribeToVideoFeed(
+            subscriptionType: SubscriptionType.profile,
+            authors: [author],
+          ),
+        );
+        fake.flushMicrotasks();
+
+        var notifications = 0;
+        void onChange() => notifications++;
+        service.addListener(onChange);
+        addTearDown(() => service.removeListener(onChange));
+
+        fake
+          ..elapse(const Duration(seconds: 31))
+          ..flushMicrotasks();
+
+        expect(
+          notifications,
+          greaterThan(0),
+          reason:
+              'every other completion path notifies; without this the loading '
+              'state flips with nothing re-reading it',
+        );
+      });
+    });
   });
 }

--- a/mobile/test/services/video_event_service_timeout_test.dart
+++ b/mobile/test/services/video_event_service_timeout_test.dart
@@ -171,12 +171,14 @@ void main() {
     late _MockSubscriptionManager mockSubscriptionManager;
     late _FakeConnectionStatusService connectionService;
     late List<List<Filter>> subscribeCalls;
+    late List<void Function()> eoseCallbacks;
 
     setUp(() {
       mockNostrService = _MockNostrClient();
       mockSubscriptionManager = _MockSubscriptionManager();
       connectionService = _FakeConnectionStatusService();
       subscribeCalls = [];
+      eoseCallbacks = [];
 
       when(() => mockNostrService.isInitialized).thenReturn(true);
       when(() => mockNostrService.connectedRelayCount).thenReturn(1);
@@ -186,6 +188,8 @@ void main() {
         subscribeCalls.add(
           (invocation.positionalArguments.first as List<Filter>).toList(),
         );
+        final onEose = invocation.namedArguments[#onEose] as void Function()?;
+        if (onEose != null) eoseCallbacks.add(onEose);
         // Never emits and never EOSEs: the relay that swallowed the REQ.
         final controller = StreamController<Event>(onCancel: () async {});
         addTearDown(controller.close);
@@ -241,7 +245,35 @@ void main() {
       });
     });
 
-    test('stops retrying once a re-issued subscription is established', () {
+    test('gives up after the retry budget instead of re-issuing forever', () {
+      fakeAsync((fake) {
+        unawaited(
+          service.subscribeToVideoFeed(
+            subscriptionType: SubscriptionType.profile,
+            authors: [author],
+          ),
+        );
+        fake.flushMicrotasks();
+
+        for (var i = 0; i < 30; i++) {
+          fake
+            ..elapse(const Duration(seconds: 10))
+            ..flushMicrotasks();
+        }
+
+        expect(
+          subscribeCalls,
+          hasLength(4),
+          reason:
+              'the initial load plus three retries. Issuing a REQ always '
+              'succeeds, so the retry cycle re-arms its own budget on every '
+              'attempt — without a cap on consecutive timeouts a silent relay '
+              'is re-subscribed every ~40s for the life of the process',
+        );
+      });
+    });
+
+    test('a load the relay answers restores the retry budget', () {
       fakeAsync((fake) {
         unawaited(
           service.subscribeToVideoFeed(
@@ -251,19 +283,35 @@ void main() {
         );
         fake
           ..flushMicrotasks()
-          ..elapse(const Duration(seconds: 31))
-          ..flushMicrotasks()
-          ..elapse(const Duration(seconds: 10))
+          ..elapse(const Duration(seconds: 41))
           ..flushMicrotasks();
         expect(subscribeCalls, hasLength(2));
 
-        fake
-          ..elapse(const Duration(seconds: 30))
-          ..flushMicrotasks();
+        // The retry is served, so the feed is healthy again.
+        eoseCallbacks.last();
+        fake.flushMicrotasks();
+
+        // A later load onto a relay that has gone silent again gets the whole
+        // budget, not the remainder of the one that timed out before.
+        final servedCalls = subscribeCalls.length;
+        unawaited(
+          service.subscribeToVideoFeed(
+            subscriptionType: SubscriptionType.profile,
+            authors: [author],
+            force: true,
+          ),
+        );
+        fake.flushMicrotasks();
+        for (var i = 0; i < 30; i++) {
+          fake
+            ..elapse(const Duration(seconds: 10))
+            ..flushMicrotasks();
+        }
+
         expect(
-          subscribeCalls,
-          hasLength(2),
-          reason: 'a successful re-subscribe ends the retry cycle',
+          subscribeCalls.length - servedCalls,
+          4,
+          reason: 'the second load plus a full three retries',
         );
       });
     });

--- a/mobile/test/services/video_event_service_timeout_test.dart
+++ b/mobile/test/services/video_event_service_timeout_test.dart
@@ -371,5 +371,108 @@ void main() {
         );
       });
     });
+
+    test(
+      'cancelling before the fuse expires does not resubscribe or unmap a '
+      'replacement',
+      () {
+        fakeAsync((fake) {
+          const authorB =
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+          unawaited(
+            service.subscribeToVideoFeed(
+              subscriptionType: SubscriptionType.profile,
+              authors: [author],
+            ),
+          );
+          fake.flushMicrotasks();
+          expect(subscribeCalls, hasLength(1));
+
+          // User leaves / replaces the feed well inside the 30s window.
+          unawaited(
+            service.subscribeToVideoFeed(
+              subscriptionType: SubscriptionType.profile,
+              authors: [authorB],
+              force: true,
+            ),
+          );
+          fake.flushMicrotasks();
+          expect(subscribeCalls, hasLength(2));
+          expect(service.isSubscribed(SubscriptionType.profile), isTrue);
+
+          // Stay inside B's fuse so only a leaked A fuse could fire recovery.
+          fake
+            ..elapse(const Duration(seconds: 29))
+            ..flushMicrotasks();
+
+          expect(
+            subscribeCalls,
+            hasLength(2),
+            reason:
+                "A's cancelled fuse must not schedule a retry after replace",
+          );
+          expect(
+            service.isSubscribed(SubscriptionType.profile),
+            isTrue,
+            reason: "A's cancelled fuse must not unmap B's live subscription",
+          );
+          expect(
+            subscribeCalls.last.any(
+              (filter) => filter.authors?.contains(authorB) ?? false,
+            ),
+            isTrue,
+          );
+        });
+      },
+    );
+
+    test(
+      'an explicit subscribe after give-up re-arms the timeout retry budget',
+      () {
+        fakeAsync((fake) {
+          unawaited(
+            service.subscribeToVideoFeed(
+              subscriptionType: SubscriptionType.profile,
+              authors: [author],
+            ),
+          );
+          fake.flushMicrotasks();
+
+          // Exhaust the consecutive-timeout budget (initial + 3 retries).
+          for (var i = 0; i < 30; i++) {
+            fake
+              ..elapse(const Duration(seconds: 10))
+              ..flushMicrotasks();
+          }
+          expect(subscribeCalls, hasLength(4));
+
+          // User comes back with an explicit subscribe — must not stay latched.
+          unawaited(
+            service.subscribeToVideoFeed(
+              subscriptionType: SubscriptionType.profile,
+              authors: [author],
+              force: true,
+            ),
+          );
+          fake.flushMicrotasks();
+          final afterExplicit = subscribeCalls.length;
+
+          for (var i = 0; i < 30; i++) {
+            fake
+              ..elapse(const Duration(seconds: 10))
+              ..flushMicrotasks();
+          }
+
+          expect(
+            subscribeCalls.length - afterExplicit,
+            3,
+            reason:
+                'explicit subscribe clears the latch so the new load gets a '
+                'full three retries again',
+          );
+        });
+      },
+    );
   });
 }


### PR DESCRIPTION
Closes #7124

Addresses the timeout half of #7124 (eose_empty remains open)

## What

A feed load that the relay never answers no longer ends in an empty screen. Two gaps at two layers produced the same failure, so both are fixed here.

**The REQ was lost and never re-sent.** `Relay.onConnected` replayed only `pendingMessages` — the frames that had *failed* to send while the socket was down. A REQ that was successfully written to a socket that later died was simply gone: the relay keeps no record of it, `WebSocketConnectionManager` does no automatic reconnection, and nothing re-issued it. A live subscription that lost its socket went silent for the rest of the session. `onConnected` now re-issues the relay's saved subscriptions and pending one-shot queries whenever it runs on a genuinely new socket.

**Nothing repaired a half-open socket for subscriptions.** `RelayPool` already force-cycles a zombie connection for publishes (`_repairSilentRelays`) and for one-shot queries (`_repairRelaysThatNeverAnswered`), but the live `subscribe()` path — the one every feed load runs on — had no equivalent. A socket that reports `connected` while swallowing everything written to it charged every subsequent feed load the full client-side timeout. Abandoning a live subscription now offers its relay to the same repair, provided the caller actually waited on it.

**The app-layer deadline was terminal.** `VideoEventService`'s 30s feed-load timeout dropped `_subscriptionParams` — the only record of the filters that feed was built from — scheduled no retry, and never called `notifyListeners()` (every other completion path does). The feed stayed empty until the user navigated away and back. It now keeps the params, notifies, and hands the type to the existing online-retry cycle under a cap on consecutive unanswered loads.

## Why these choices

**The deadline stays at 30s.** The issue frames the 30s wait as the problem, but shortening it would regress the loads it is meant to help: hashtag feeds have a p90 of 21.9s on iOS, so a 10s fuse would tear down subscriptions that were about to be served, and the retry would restart their clock from zero. The harm is "shows nothing", not "waits 30s" — so this makes the outcome recoverable rather than making the fuse shorter. Revisiting the number needs the p50/p75 that #7118 now produces for the cold-start feeds.

**Cancel-then-retry, in that order.** Cancelling the timed-out subscription releases the REQ in the SDK, which is what triggers the zombie repair. The retry fires ten seconds later, by which point the force-cycled socket is live again — so the retry is not just a second shot at the same dead connection.

**The retry is capped on consecutive timeouts, not on re-subscribe failures.** `_scheduleRetryWhenOnline`'s existing budget counts re-subscribe *calls* that threw, and writing a REQ to a silent relay does not throw — so a successful call resets the budget and the next timeout re-arms the whole cycle. Left at that, a relay that never answers is re-subscribed every ~40s for the life of the process. `_consecutiveFeedTimeouts` bounds it at the timeout side instead, and is cleared the moment the feed is actually served (first event or EOSE) so a recovered relay starts over with a full budget.

**The subscription repair needs a minimum wait.** A one-shot query is only released once its caller gave up, but `unsubscribe` is the ordinary teardown every screen runs. Without a floor, a feed the user left inside the relay's round-trip time would force-cycle a perfectly healthy socket, which then replays its stored window for every other subscription it carries. `minSubscriptionAgeBeforeRepair` defaults to 10s — far above navigation-speed teardowns, well below the 30s feed deadline the repair exists to serve.

**The re-issue is gated on a genuinely new socket.** `Relay.connect()` short-circuits when the connection is already live but still reaches `onConnected`, so an unconditional re-issue would make a healthy relay replay its whole stored window on every such call. `connectionIsFresh` is set from `doConnect` and from the disconnected→connected transition that `forceReconnect` drives, so only a real reconnect re-issues. The re-issued REQs go out with `skipReconnect`, matching how `relayDoSubscribe` sent them the first time.

**`_reconnectAndResubscribe`'s explicit replay loops are removed.** `onConnected` now covers every reconnect path rather than just that one, so keeping them would send each REQ twice and make the relay replay its whole stored window twice. The pending-message flush skips REQ frames the re-issue already covers, for the same reason. What is left is a plain force-cycle, renamed `_reconnectSilentRelay` since it no longer resubscribes.

**Reusing the online-retry cycle.** A timed-out load and a subscribe attempted while offline need the same thing — re-issue these filters a few times, only while there is a network. It already carries the attempt budget, per-type dedup, and the `RelayNotReadyException` hand-off to the relay-ready retry.

**The retry cycle moves into `FeedRetryScheduler`.** #6932 landed on `main` after this branch was cut and freezes `lib/services/video_event_service.dart` at its line count, which this work grows. The cycle is the responsibility this PR is about and is self-contained, so it moves out whole — the timer, both budgets, and the per-type dedup — with `resubscribe` and the relay-not-ready hand-off injected as callbacks. The service drops ~120 lines and lands back under the ceiling, and the policy gets direct unit tests instead of only being reachable through a 6.5k-line service.

## Scope

Only the `timeout` half of #7124. The issue asks for `eose_empty` — a relay that answers promptly with nothing — to be separated and given its own UI treatment; that is a distinct problem and is not touched here.

## Test plan

- `packages/nostr_sdk/test/unit/relay_pending_messages_test.dart` — saved subscriptions and pending queries are re-issued on reconnect; a queued REQ the re-issue covers is sent once, not twice; unrelated queued frames still replay; a reused connection re-issues nothing but still flushes its queue, including a queued REQ nothing else would send.
- `packages/nostr_sdk/test/unit/relay_pool_subscription_zombie_test.dart` (new) — a relay that swallows the REQ is force-cycled when the caller gives up; one that EOSE'd or is otherwise inbound-active is left alone; a subscription dropped before the age floor is not charged against the socket; the fresh socket re-runs the surviving subscriptions but not the abandoned one.
- `test/services/video_event_service_timeout_test.dart` — the timed-out feed is re-issued with its original filters, the cycle stops after the budget instead of re-issuing forever, a load the relay answers restores that budget, nothing is re-issued while offline, and the timeout notifies listeners.
- `test/services/feed_retry_scheduler_test.dart` (new) — the timeout budget is spent, per-type, and restored by a served load; the cycle waits for the network rather than spending attempts offline, stops after `maxAttempts` when every re-issue throws, hands a `RelayNotReadyException` over instead of retrying it, and `dispose` stops a cycle in flight.
- All app-layer tests and the SDK tests covering these paths fail on `main` without these changes.
- `flutter analyze lib test integration_test` clean; `packages/nostr_sdk/test` (503), `packages/nostr_client/test` (338), `test/services` (3972), and `test/blocs/profile_feed` + `test/providers` (694) green.
- Manual verification on a real Samsung Galaxy (SM-S942B): feed loads, navigation between feeds, and reconnect behaviour confirmed on device, before the `FeedRetryScheduler` extraction — that move is behaviour-preserving and covered by the suites above.
