### PR TITLE
refactor(profile): inject username and NIP-05 service endpoints

### DIFF
--- a/mobile/lib/models/environment_config.dart
+++ b/mobile/lib/models/environment_config.dart
@@ -140,6 +140,11 @@ class EnvironmentConfig {
   /// service is not part of local_stack.
   String get verifierBaseUrl => 'https://verifier.divine.video';
 
+  /// Origin of the divine-name-server that owns `@divine.video` usernames
+  /// (names.divine.video). Single host across all environments — the service
+  /// has no staging deployment and is not part of local_stack.
+  String get nameServerBaseUrl => 'https://names.divine.video';
+
   /// Get blossom media server URL
   String get blossomUrl {
     if (environment == AppEnvironment.local) {

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -373,6 +373,10 @@ ProfileRepository _buildProfileRepository(Ref ref, {required bool warmCache}) {
     httpClient: ref.watch(instrumentedHttpClientFactoryProvider)(),
     funnelcakeApiClient: funnelcakeClient,
     indexerRelays: env.indexerRelays,
+    nameServerBaseUrl: env.nameServerBaseUrl,
+    // Keycast keys its username namespace on the request Host, so the
+    // availability probe must name the same tenant the app signs in against.
+    keycastNip05Url: ref.watch(oauthConfigProvider).nip05Url,
     profileSearchFilter: (query, profiles) =>
         SearchUtils.searchProfiles(query, profiles, limit: 50),
     blockFilter: blockFilter,

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_config.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_config.dart
@@ -16,4 +16,10 @@ class OAuthConfig {
   String get authorizeUrl => '$serverUrl/api/oauth/authorize';
   String get tokenUrl => '$serverUrl/api/oauth/token';
   String get nostrApiUrl => '$serverUrl/api/nostr';
+
+  /// NIP-05 document for this Keycast tenant.
+  ///
+  /// Keycast derives the tenant from the request Host, so this resolves to
+  /// whichever tenant [serverUrl] names. Callers append `?name=<username>`.
+  String get nip05Url => '$serverUrl/.well-known/nostr.json';
 }

--- a/mobile/packages/keycast_flutter/test/oauth_config_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_config_test.dart
@@ -1,0 +1,53 @@
+// ABOUTME: Tests OAuthConfig endpoint derivation from serverUrl.
+// ABOUTME: Covers the NIP-05 document consumed by username availability.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:keycast_flutter/keycast_flutter.dart';
+
+void main() {
+  group(OAuthConfig, () {
+    const config = OAuthConfig(
+      serverUrl: 'https://login.divine.video',
+      clientId: 'divine-mobile',
+      redirectUri: 'divine://auth',
+    );
+
+    test('derives every endpoint from serverUrl', () {
+      expect(
+        config.authorizeUrl,
+        equals('https://login.divine.video/api/oauth/authorize'),
+      );
+      expect(
+        config.tokenUrl,
+        equals('https://login.divine.video/api/oauth/token'),
+      );
+      expect(
+        config.nostrApiUrl,
+        equals('https://login.divine.video/api/nostr'),
+      );
+    });
+
+    // Consumed by ProfileRepository as the second username-availability
+    // source. Keycast resolves the tenant from the request Host, so the
+    // origin must carry through unchanged.
+    test('nip05Url points at the tenant named by serverUrl', () {
+      expect(
+        config.nip05Url,
+        equals('https://login.divine.video/.well-known/nostr.json'),
+      );
+    });
+
+    test('nip05Url follows a non-production origin', () {
+      const local = OAuthConfig(
+        serverUrl: 'http://localhost:43000',
+        clientId: 'divine-mobile',
+        redirectUri: 'divine://auth',
+      );
+
+      expect(
+        local.nip05Url,
+        equals('http://localhost:43000/.well-known/nostr.json'),
+      );
+    });
+  });
+}

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -17,15 +17,6 @@ import 'package:profile_repository/profile_repository.dart';
 import 'package:profile_repository/src/identity_event_selection.dart';
 import 'package:unified_logger/unified_logger.dart';
 
-// TODO(e2e): Add divine-name-server to local_stack Docker dependencies
-// so username check/claim flows can be tested against it in E2E tests.
-const _usernameClaimUrl = 'https://names.divine.video/api/username/claim';
-const _usernameCheckUrl = 'https://names.divine.video/api/username/check';
-const _usernameReleaseUrl = 'https://names.divine.video/api/username/release';
-const _usernameByPubkeyUrl =
-    'https://names.divine.video/api/username/by-pubkey';
-const _keycastNip05Url = 'https://login.divine.video/.well-known/nostr.json';
-
 // How long a Divine-identity determination is trusted before re-querying.
 //
 // Kept equal to ModerationLabelService._resolvedPubkeyTtl (24h) so the app
@@ -76,6 +67,30 @@ const defaultProfileIndexerRelays = [
   'wss://relay.nos.social',
 ];
 
+/// Origin of the divine-name-server that owns `@divine.video` usernames.
+///
+/// Production wiring overrides this via
+/// `EnvironmentConfig.nameServerBaseUrl`. There is no staging deployment of
+/// divine-name-server today, so every environment resolves to this host; the
+/// parameter exists so tests can substitute a fake.
+const defaultNameServerBaseUrl = 'https://names.divine.video';
+
+/// Keycast NIP-05 document consulted as a second username-availability
+/// source.
+///
+/// Production wiring overrides this via `OAuthConfig.nip05Url`, which follows
+/// the environment's Keycast origin. Keycast keys its username namespace on
+/// the request Host, so this must name the same tenant the app signs in
+/// against or availability answers describe a different registry.
+const defaultKeycastNip05Url =
+    'https://login.divine.video/.well-known/nostr.json';
+
+/// Normalizes an injected endpoint so path composition cannot double the
+/// separator. `'$base/name'` on a base ending in `/` yields `//name`, which
+/// the name server routes to a 404 rather than the intended handler.
+String _stripTrailingSlash(String url) =>
+    url.endsWith('/') ? url.substring(0, url.length - 1) : url;
+
 /// Repository for fetching and publishing user profiles (Kind 0 metadata).
 class ProfileRepository implements ProfileReader {
   /// Creates a new profile repository.
@@ -91,7 +106,11 @@ class ProfileRepository implements ProfileReader {
     IdentityEventsDao? identityEventsDao,
     VanishedProfilesDao? vanishedProfilesDao,
     List<String> indexerRelays = defaultProfileIndexerRelays,
-  }) : _nostrClient = nostrClient,
+    String nameServerBaseUrl = defaultNameServerBaseUrl,
+    String keycastNip05Url = defaultKeycastNip05Url,
+  }) : _nameServerBaseUrl = _stripTrailingSlash(nameServerBaseUrl),
+       _keycastNip05Url = _stripTrailingSlash(keycastNip05Url),
+       _nostrClient = nostrClient,
        _userProfilesDao = userProfilesDao,
        _httpClient = httpClient,
        _profileStatsDao = profileStatsDao,
@@ -134,6 +153,22 @@ class ProfileRepository implements ProfileReader {
   final VanishedProfilesDao? _vanishedProfilesDao;
 
   final List<String> _indexerRelays;
+
+  final String _nameServerBaseUrl;
+  final String _keycastNip05Url;
+
+  /// NIP-98 signs the absolute request URL and the server compares it by
+  /// exact string equality, so these getters are the single source for both
+  /// the signed string and the requested string. Never rebuild either at a
+  /// call site.
+  String get _usernameClaimUrl => '$_nameServerBaseUrl/api/username/claim';
+
+  String get _usernameCheckUrl => '$_nameServerBaseUrl/api/username/check';
+
+  String get _usernameReleaseUrl => '$_nameServerBaseUrl/api/username/release';
+
+  String get _usernameByPubkeyUrl =>
+      '$_nameServerBaseUrl/api/username/by-pubkey';
 
   /// In-flight relay fetches keyed by pubkey. Concurrent callers for the
   /// same pubkey share the same future instead of firing duplicate requests.

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -1913,7 +1913,7 @@ class ProfileRepository implements ProfileReader {
       final profiles = restResults
           .map((result) => result.toUserProfile())
           .where((p) => !(_blockFilter?.call(p.pubkey) ?? false));
-      return _enrichFromCache(profiles.toList());
+      return await _enrichFromCache(profiles.toList());
     } on Exception catch (e) {
       Log.warning(
         'REST profile search failed: $e',

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -1469,7 +1469,7 @@ class ProfileRepository implements ProfileReader {
 
   /// Claims a username via NIP-98 authenticated request.
   ///
-  /// Makes a POST request to `names.divine.video/api/username/claim` with the
+  /// Makes a POST request to the name server's `/api/username/claim` with the
   /// username. The pubkey is extracted from the NIP-98 auth header by the
   /// server.
   ///
@@ -1559,7 +1559,7 @@ class ProfileRepository implements ProfileReader {
   }
 
   /// Permanently burns the caller's own `@divine.video` username via a NIP-98
-  /// authenticated request to `names.divine.video/api/username/release`.
+  /// authenticated request to the name server's `/api/username/release`.
   ///
   /// The server verifies the authenticated pubkey owns [name] as an active
   /// username before burning it. Returns a [UsernameReleaseResult]; never
@@ -1799,8 +1799,8 @@ class ProfileRepository implements ProfileReader {
         final code = data['code'] as String?;
 
         if (available) {
-          // Also check keycast (login.divine.video) — username must be
-          // available on both the name server and the login server.
+          // Also check keycast — username must be available on both the name
+          // server and the login server.
           try {
             final keycastResponse = await _httpClient
                 .get(Uri.parse('$_keycastNip05Url?name=$normalizedUsername'))

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -17,6 +17,11 @@ import 'package:profile_repository/profile_repository.dart';
 import 'package:profile_repository/src/identity_event_selection.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+// TODO(e2e): Add divine-name-server to local_stack Docker dependencies
+// so username check/claim flows can be tested against it in E2E tests.
+// Tracked by #3367 while this repository still uses the production name
+// server in local builds.
+
 // How long a Divine-identity determination is trusted before re-querying.
 //
 // Kept equal to ModerationLabelService._resolvedPubkeyTtl (24h) so the app

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -90,9 +90,10 @@ const defaultNameServerBaseUrl = 'https://names.divine.video';
 const defaultKeycastNip05Url =
     'https://login.divine.video/.well-known/nostr.json';
 
-/// Normalizes an injected endpoint so path composition cannot double the
-/// separator. `'$base/name'` on a base ending in `/` yields `//name`, which
-/// the name server routes to a 404 rather than the intended handler.
+/// Normalizes an injected endpoint so composition cannot leave a stray
+/// separator. `'$base/name'` on a base ending in `/` yields `//name`, and
+/// `'$url?name='` yields `nostr.json/?name=`; both are paths the origin
+/// routes to a 404 rather than the intended handler.
 String _stripTrailingSlash(String url) =>
     url.endsWith('/') ? url.substring(0, url.length - 1) : url;
 

--- a/mobile/packages/profile_repository/test/src/profile_repository_endpoints_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_endpoints_test.dart
@@ -67,30 +67,6 @@ void main() {
           equals('https://login.divine.video/.well-known/nostr.json'),
         );
       });
-
-      // NIP-98 binds the absolute request URL by exact string equality and
-      // the unsigned endpoints interpolate onto the base, so a shipped value
-      // that is not already its own canonical form silently 401s or 404s.
-      // Dot segments are the worst case: they route fine on the unsigned
-      // GETs and reject on claim/release.
-      for (final url in const [
-        defaultNameServerBaseUrl,
-        defaultKeycastNip05Url,
-      ]) {
-        test('$url is already canonical', () {
-          expect(
-            Uri.parse(url).toString(),
-            equals(url),
-            reason: 'not a fixed point of Uri normalization',
-          );
-          expect(url, isNot(endsWith('/')), reason: 'would double a slash');
-          expect(url, isNot(contains('?')), reason: 'would corrupt ?name=');
-          expect(Uri.parse(url).userInfo, isEmpty);
-          expect(Uri.parse(url).hasPort, isFalse, reason: 'explicit port');
-          expect(Uri.parse(url).pathSegments, isNot(contains('.')));
-          expect(Uri.parse(url).pathSegments, isNot(contains('..')));
-        });
-      }
     });
 
     group('injection', () {

--- a/mobile/packages/profile_repository/test/src/profile_repository_endpoints_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_endpoints_test.dart
@@ -1,0 +1,273 @@
+// ABOUTME: Pins the injectable name-server / Keycast endpoints on
+// ABOUTME: ProfileRepository — production defaults, per-endpoint injection,
+// ABOUTME: and the NIP-98 signed-URL-equals-requested-URL coupling.
+
+import 'dart:convert';
+
+import 'package:db_client/db_client.dart' hide Filter, ProfileStats;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:profile_repository/profile_repository.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockUserProfilesDao extends Mock implements UserProfilesDao {}
+
+class _MockHttpClient extends Mock implements Client {}
+
+/// Deliberately distinct per endpoint, and deliberately NOT the production
+/// host, so a call site that reads a neighbouring endpoint fails loudly.
+const _testNameServer = 'https://names.test.example';
+const _testKeycastNip05 = 'https://login.test.example/.well-known/nostr.json';
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(Uri.parse('https://fallback.test.example'));
+  });
+
+  group('ProfileRepository endpoints', () {
+    late _MockNostrClient nostrClient;
+    late _MockUserProfilesDao userProfilesDao;
+    late _MockHttpClient httpClient;
+
+    setUp(() {
+      nostrClient = _MockNostrClient();
+      userProfilesDao = _MockUserProfilesDao();
+      httpClient = _MockHttpClient();
+    });
+
+    ProfileRepository buildRepository({
+      String? nameServerBaseUrl,
+      String? keycastNip05Url,
+    }) {
+      return ProfileRepository(
+        nostrClient: nostrClient,
+        userProfilesDao: userProfilesDao,
+        httpClient: httpClient,
+        nameServerBaseUrl: nameServerBaseUrl ?? defaultNameServerBaseUrl,
+        keycastNip05Url: keycastNip05Url ?? defaultKeycastNip05Url,
+      );
+    }
+
+    group('production defaults', () {
+      // Bound to the shipped constants, not to literals restated here, so a
+      // change to either default is what turns these red.
+      test('name server origin is unchanged', () {
+        expect(
+          defaultNameServerBaseUrl,
+          equals('https://names.divine.video'),
+        );
+      });
+
+      test('keycast NIP-05 document is unchanged', () {
+        expect(
+          defaultKeycastNip05Url,
+          equals('https://login.divine.video/.well-known/nostr.json'),
+        );
+      });
+
+      // NIP-98 binds the absolute request URL by exact string equality and
+      // the unsigned endpoints interpolate onto the base, so a shipped value
+      // that is not already its own canonical form silently 401s or 404s.
+      // Dot segments are the worst case: they route fine on the unsigned
+      // GETs and reject on claim/release.
+      for (final url in const [
+        defaultNameServerBaseUrl,
+        defaultKeycastNip05Url,
+      ]) {
+        test('$url is already canonical', () {
+          expect(
+            Uri.parse(url).toString(),
+            equals(url),
+            reason: 'not a fixed point of Uri normalization',
+          );
+          expect(url, isNot(endsWith('/')), reason: 'would double a slash');
+          expect(url, isNot(contains('?')), reason: 'would corrupt ?name=');
+          expect(Uri.parse(url).userInfo, isEmpty);
+          expect(Uri.parse(url).hasPort, isFalse, reason: 'explicit port');
+          expect(Uri.parse(url).pathSegments, isNot(contains('.')));
+          expect(Uri.parse(url).pathSegments, isNot(contains('..')));
+        });
+      }
+    });
+
+    group('injection', () {
+      test(
+        'checkUsernameAvailability requests the injected name server',
+        () async {
+          when(() => httpClient.get(any())).thenAnswer(
+            (_) async => Response(jsonEncode({'available': true}), 200),
+          );
+
+          await buildRepository(
+            nameServerBaseUrl: _testNameServer,
+          ).checkUsernameAvailability(username: 'alice');
+
+          verify(
+            () => httpClient.get(
+              Uri.parse('$_testNameServer/api/username/check/alice'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'checkUsernameAvailability probes the injected keycast URL',
+        () async {
+          when(
+            () => httpClient.get(
+              Uri.parse('$_testNameServer/api/username/check/alice'),
+            ),
+          ).thenAnswer(
+            (_) async => Response(jsonEncode({'available': true}), 200),
+          );
+          when(
+            () => httpClient.get(Uri.parse('$_testKeycastNip05?name=alice')),
+          ).thenAnswer(
+            (_) async =>
+                Response(jsonEncode({'names': <String, String>{}}), 200),
+          );
+
+          await buildRepository(
+            nameServerBaseUrl: _testNameServer,
+            keycastNip05Url: _testKeycastNip05,
+          ).checkUsernameAvailability(username: 'alice');
+
+          verify(
+            () => httpClient.get(Uri.parse('$_testKeycastNip05?name=alice')),
+          ).called(1);
+        },
+      );
+
+      test('getUsernameByPubkey requests the injected name server', () async {
+        const pubkey =
+            '0000000000000000000000000000000000000000000000000000000000000001';
+        when(() => httpClient.get(any())).thenAnswer(
+          (_) async => Response('{}', 404),
+        );
+
+        await buildRepository(
+          nameServerBaseUrl: _testNameServer,
+        ).getUsernameByPubkey(pubkeyHex: pubkey);
+
+        verify(
+          () => httpClient.get(
+            Uri.parse('$_testNameServer/api/username/by-pubkey/$pubkey'),
+          ),
+        ).called(1);
+      });
+
+      test(
+        'a trailing slash on the base does not double the separator',
+        () async {
+          when(() => httpClient.get(any())).thenAnswer(
+            (_) async => Response(jsonEncode({'available': true}), 200),
+          );
+
+          await buildRepository(
+            nameServerBaseUrl: '$_testNameServer/',
+          ).checkUsernameAvailability(username: 'alice');
+
+          verify(
+            () => httpClient.get(
+              Uri.parse('$_testNameServer/api/username/check/alice'),
+            ),
+          ).called(1);
+        },
+      );
+    });
+
+    group('NIP-98 signed URL equals requested URL', () {
+      // The signed 'u' tag and the wire URL must be the same string: the name
+      // server compares them byte-for-byte. Nothing else in the suite covers
+      // this coupling, and a divergence 401s every claim and release.
+      test('claimUsername signs exactly the URL it posts to', () async {
+        when(
+          () => nostrClient.createNip98AuthHeader(
+            url: any(named: 'url'),
+            method: any(named: 'method'),
+            payload: any(named: 'payload'),
+          ),
+        ).thenAnswer((_) async => 'Nostr fake');
+        when(
+          () => httpClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer((_) async => Response('{}', 500));
+
+        await buildRepository(
+          nameServerBaseUrl: _testNameServer,
+        ).claimUsername(username: 'alice');
+
+        final signed =
+            verify(
+                  () => nostrClient.createNip98AuthHeader(
+                    url: captureAny(named: 'url'),
+                    method: any(named: 'method'),
+                    payload: any(named: 'payload'),
+                  ),
+                ).captured.single
+                as String;
+        final posted =
+            verify(
+                  () => httpClient.post(
+                    captureAny(),
+                    headers: any(named: 'headers'),
+                    body: any(named: 'body'),
+                  ),
+                ).captured.single
+                as Uri;
+
+        expect(signed, equals(posted.toString()));
+        expect(signed, equals('$_testNameServer/api/username/claim'));
+      });
+
+      test('releaseUsername signs exactly the URL it posts to', () async {
+        when(
+          () => nostrClient.createNip98AuthHeader(
+            url: any(named: 'url'),
+            method: any(named: 'method'),
+            payload: any(named: 'payload'),
+          ),
+        ).thenAnswer((_) async => 'Nostr fake');
+        when(
+          () => httpClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer((_) async => Response('{}', 500));
+
+        await buildRepository(
+          nameServerBaseUrl: _testNameServer,
+        ).releaseUsername(name: 'alice');
+
+        final signed =
+            verify(
+                  () => nostrClient.createNip98AuthHeader(
+                    url: captureAny(named: 'url'),
+                    method: any(named: 'method'),
+                    payload: any(named: 'payload'),
+                  ),
+                ).captured.single
+                as String;
+        final posted =
+            verify(
+                  () => httpClient.post(
+                    captureAny(),
+                    headers: any(named: 'headers'),
+                    body: any(named: 'body'),
+                  ),
+                ).captured.single
+                as Uri;
+
+        expect(signed, equals(posted.toString()));
+        expect(signed, equals('$_testNameServer/api/username/release'));
+      });
+    });
+  });
+}

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -3615,6 +3615,51 @@ void main() {
       );
 
       test(
+        'searchUsersFromApi returns empty when cache enrichment throws',
+        () async {
+          // Arrange: the REST call succeeds, then the cache lookup fails.
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.searchProfiles(
+              query: 'ga',
+              limit: 10,
+              offset: any(named: 'offset'),
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              ProfileSearchResult(
+                pubkey: 'd' * 64,
+                displayName: 'GaryVee',
+                createdAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+              ),
+            ],
+          );
+          final throwingDao = MockUserProfilesDao();
+          when(
+            () => throwingDao.getProfile(any()),
+          ).thenThrow(Exception('cache read failed'));
+
+          final repoWithFunnelcake = ProfileRepository(
+            nostrClient: mockNostrClient,
+            userProfilesDao: throwingDao,
+            httpClient: mockHttpClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          // Act & Assert: the enrichment failure is absorbed by the same
+          // fallback that covers a failed REST call, per this method's
+          // documented contract. Without the `await` on _enrichFromCache the
+          // future escapes the `on Exception` and this call throws instead.
+          await expectLater(
+            repoWithFunnelcake.searchUsersFromApi(query: 'ga', limit: 10),
+            completion(isEmpty),
+          );
+        },
+      );
+
+      test(
         'uses Funnelcake first then WebSocket when both available',
         () async {
           // Arrange

--- a/mobile/test/models/environment_config_test.dart
+++ b/mobile/test/models/environment_config_test.dart
@@ -278,6 +278,25 @@ void main() {
       });
     });
 
+    group('nameServerBaseUrl', () {
+      test('production returns the divine-name-server host', () {
+        const config = EnvironmentConfig(
+          environment: AppEnvironment.production,
+        );
+        expect(config.nameServerBaseUrl, equals('https://names.divine.video'));
+      });
+
+      test('is the same across environments (no local stub)', () {
+        for (final env in AppEnvironment.values) {
+          final config = EnvironmentConfig(environment: env);
+          expect(
+            config.nameServerBaseUrl,
+            equals('https://names.divine.video'),
+          );
+        }
+      });
+    });
+
     group('inviteBaseUrl', () {
       // These exercise the no-define path. The
       // `bool.hasEnvironment('INVITE_SERVER_URL')` override branch cannot be

--- a/mobile/test/providers/oauth_config_provider_test.dart
+++ b/mobile/test/providers/oauth_config_provider_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/environment_provider.dart';
+import 'package:profile_repository/profile_repository.dart';
 
 void main() {
   group('oauthConfigProvider', () {
@@ -27,6 +28,14 @@ void main() {
         'https://login.divine.video/api/oauth/authorize',
       );
       expect(config.tokenUrl, 'https://login.divine.video/api/oauth/token');
+      // Feeds ProfileRepository.keycastNip05Url. The availability probe is
+      // fail-open, so a malformed value here yields silently-claimable
+      // usernames rather than a visible error.
+      expect(
+        config.nip05Url,
+        equals(defaultKeycastNip05Url),
+        reason: 'production must keep the shipped repository default',
+      );
     });
 
     test('keeps local oauth on the emulator localhost endpoint', () {
@@ -49,6 +58,14 @@ void main() {
       expect(
         config.tokenUrl,
         'http://$localHost:$localKeycastPort/api/oauth/token',
+      );
+      // LOCAL now checks username availability against the local_stack
+      // Keycast rather than production. Keycast keys its username namespace
+      // on the request Host and rejects 127.0.0.1, so this must resolve
+      // through localHost.
+      expect(
+        config.nip05Url,
+        'http://$localHost:$localKeycastPort/.well-known/nostr.json',
       );
     });
   });


### PR DESCRIPTION
Part of #3367.

## What

`ProfileRepository` hardcoded five endpoint URLs spanning two independent backends. They are now injectable with production defaults.

| Constant | Backend | Signed? |
|---|---|---|
| claim / check / release / by-pubkey | `names.divine.video` (divine-name-server) | claim + release are NIP-98 signed |
| `.well-known/nostr.json` | `login.divine.video` (Keycast) | no |

The name-server origin and the Keycast NIP-05 document became optional constructor parameters with package-level defaults, mirroring the `indexerRelays` / `defaultProfileIndexerRelays` pair already in the same class. The four name-server paths derive from one base, following `VerifierClient` - which already solves exactly this for a NIP-98-signed endpoint and documents why the URL is exposed as a getter rather than rebuilt at the call site.

## Scope note - the issue's premise is only half true

The issue frames this as unblocking "staging, local stack, test servers". That holds for **one** of the five endpoints.

**divine-name-server has no non-production deployment and never has** - `wrangler.toml` has never contained an `[env.*]` block across its entire history, the deploy workflow has a single target, the org's own staging-worker convention (`workers_dev = true`) is absent, the IaC URL registry lists exactly one URL for it, live DNS/TLS probes fail for every plausible staging hostname, and a maintainer said so in writing in divine-name-server#13 back in March. So for those four, injection buys **test substitution and future-proofing, not environment switching** - and a per-environment getter would be five branches returning one value. It is documented as a single host, exactly like `verifierBaseUrl`.

**Keycast is the opposite case** and is the one behavior change here. It has live staging and poc hosts, and the app already resolves a Keycast origin per environment in `oauthConfigProvider`. Today a LOCAL run signs in against local Keycast but checks username availability against **production** Keycast. That is now consistent with the local Keycast tenant.

**LOCAL tradeoff:** local username availability now probes local_stack Keycast, while claim/release still use production `names.divine.video` because divine-name-server is not in local_stack. That means LOCAL can still straddle two registries until #3367's remaining local-stack/test cleanup is finished. Production, staging, poc and test are byte-identical - `oauthConfigProvider` branches only on `AppEnvironment.local`.

## Why the NIP-98 test matters

NIP-98 binds the absolute request URL by **exact string equality**, and nothing in the repo covered that coupling. Verified against production and a local `workerd` (they agree 8/8): a config value carrying a dot segment returns **200 on `/check` and 401 on every claim and release** - a smoke test against the check endpoint would have proved nothing. The signed string and the requested string now come from a single getter, and a regression test pins that for both signed endpoints.

The injected base is normalized for a trailing slash, since `'$base/name'` on a base ending in `/` composes a double slash the name server routes to a 404.

## Verification

- `profile_repository`: **434 tests, 100.0000 % (1160/1160)** - the package is gated at 100 with zero headroom (count reflects the reviewer commits below)
- `keycast_flutter`: 264 tests, 88.21 % (gate 44)
- `flutter analyze lib test integration_test` clean; `dart analyze lib test` clean in both packages; format clean
- **Mutation-tested** - each new test was proven able to fail: a dot segment in the shipped default, claim signing the release URL, and removing the trailing-slash normalization each turn the suite red
- Existing `ProfileRepository` construction sites compile unchanged because the parameters are optional. Existing username tests are not all migrated to injected URLs yet, so #3367 remains open.

## Not in scope

A sixth hardcoded protocol value exists that the issue does not mention - the `.divine.video` NIP-05 identifier domain (`profile_repository.dart`, `user_profile.dart`). It is the one value NIP-05 genuinely binds, and it deserves its own issue rather than riding along here.

---

## Reviewer commits (hm21)

Two mechanical fixes pushed on top, each its own commit so they can be reverted independently:

- `5c4e981b16` - `docs(profile)`: the claim/release dartdoc and the keycast availability comment still named `names.divine.video` / `login.divine.video` after those hosts became injectable.
- `e4136255a3` - `test(profile)`: removed the `'<url> is already canonical'` case; every property it asserted is implied by the two sibling tests that pin each default to its literal, so it could not fail on its own. Coverage stays at 100 % (1160/1160).

## Takeover commit (NotThatKindOfDrLiz)

- `6b7b99f1b3` - `test(profile)`: restored the local_stack divine-name-server TODO with #3367 as the tracker and added `EnvironmentConfig.nameServerBaseUrl` tests beside the verifier coverage.
