### PR TITLE
fix(video): play classic Vine originals on iOS

### DIFF
--- a/mobile/lib/extensions/video_event_extensions.dart
+++ b/mobile/lib/extensions/video_event_extensions.dart
@@ -169,10 +169,7 @@ extension VideoEventAppExtensions on VideoEvent {
   /// - A developer format override (Developer Options) forces that server
   ///   format on any Divine video for A/B testing, ahead of every heuristic
   ///   below.
-  /// - Classic Vine originals use the raw blob directly (/{hash}) because the
-  ///   source is already 480p or lower — transcoded variants are upscales at
-  ///   best and may not exist, causing needless 404s.
-  /// - All other Divine videos default to progressive MP4 720p (faststart,
+  /// - All Divine videos default to progressive MP4 720p (faststart,
   ///   moov at front) for fastest startup with short videos (1 request, no
   ///   manifest overhead) — it is 3-8x smaller than the raw blob. This covers
   ///   raw-only uploads too: their `imeta` lists only the raw blob because it
@@ -209,15 +206,19 @@ extension VideoEventAppExtensions on VideoEvent {
           videoUrl;
     }
 
-    // Classic Vine originals are 480p or lower — serve the raw blob directly.
-    // Transcoded 720p variants are pointless upscales and may not exist.
-    if (isOriginalVine) return '$_divineMediaBase/$hash';
-
     // Production default: progressive MP4 720p (faststart). Fastest startup
     // (1 request, moov at front), correct colors on all platforms, and 3-8x
     // smaller than the raw blob. Raw-only uploads take this path too; the
     // runtime fallback chain drops to the raw blob if the 720p.mp4 is not
     // transcoded yet.
+    //
+    // Classic Vine originals take this path as well. They must never be sent
+    // to the extensionless raw blob: iOS AVURLAsset picks its container parser
+    // from the URL path extension and ignores the Content-Type header, so
+    // `/{hash}` fails to parse with AVFoundation -11828/-11829 "Cannot Open"
+    // and never plays. The transcoder caps at the source resolution,
+    // so the "720p" variant of a 480x480 Vine is still 480x480 — smaller than
+    // the raw blob, not an upscale.
     return '$_divineMediaBase/$hash/720p.mp4';
   }
 

--- a/mobile/lib/extensions/video_event_extensions.dart
+++ b/mobile/lib/extensions/video_event_extensions.dart
@@ -143,6 +143,10 @@ extension VideoEventAppExtensions on VideoEvent {
       isFromDivineServer && videoFormatPreference.isHlsFormat;
 
   /// Whether background file caching should be skipped for this video.
+  ///
+  /// Classic Vine originals already dominate the cache through feed prefetching;
+  /// skip this single-file cache path so inline/background callers do not widen
+  /// storage use further.
   bool get shouldSkipFileCaching => isOriginalVine;
 
   /// Get HLS URL with optional quality override.
@@ -227,14 +231,24 @@ extension VideoEventAppExtensions on VideoEvent {
   /// Older desktop Chrome (< 150) and Firefox lack native HLS, so an HLS
   /// `.m3u8` won't play there. Resolve HLS to the progressive variant — the
   /// same [getOptimalVideoUrlForPlatform] selection the feed already uses on
-  /// every platform. Progressive URLs pass through unchanged, so the common
-  /// case (and its transcode readiness) is never touched.
+  /// every platform. Resolve extensionless Divine raw blobs too, because iOS
+  /// AVURLAsset cannot parse them. Progressive URLs pass through unchanged, so
+  /// the common case (and its transcode readiness) is never touched.
   String? get inlinePlayerVideoUrl {
     final url = videoUrl;
     if (url == null) return null;
     final isHls = url.toLowerCase().contains('.m3u8');
-    if (!isHls) return url;
-    return getOptimalVideoUrlForPlatform() ?? url;
+    final uri = Uri.tryParse(url);
+    final pathSegments = uri?.pathSegments ?? const <String>[];
+    final lastSegment = pathSegments.isEmpty ? '' : pathSegments.last;
+    final isExtensionlessDivineBlob =
+        isFromDivineServer &&
+        _extractVideoHash(url) != null &&
+        !lastSegment.contains('.');
+    if (isHls || isExtensionlessDivineBlob) {
+      return getOptimalVideoUrlForPlatform() ?? url;
+    }
+    return url;
   }
 
   /// HLS URL selected by bandwidth tracker quality.

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -231,19 +231,26 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
 
         armSetClipsTimeout()
 
-        // Build the composition asynchronously.
+        // Build the player item asynchronously.
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                let (composition, videoComposition, offsets, durations, audioMix) = try await self.buildComposition(
-                    from: clipsRaw)
+                let playerItem: AVPlayerItem
+                let offsets: [Double]
+                let durations: [Double]
+                if let hlsClip = Self.soleHlsClip(in: clipsRaw) {
+                    (playerItem, offsets, durations) =
+                        try await self.makeHlsPlayerItem(from: hlsClip)
+                } else {
+                    (playerItem, offsets, durations) =
+                        try await self.makeCompositionPlayerItem(from: clipsRaw)
+                }
                 self.clipOffsets = offsets
                 self.clipDurations = durations
                 self.clipCount = offsets.count
                 self.totalDuration = offsets.last.map { $0 + (durations.last ?? 0) } ?? 0
                 self.firstFrameRendered = false
 
-                let playerItem = AVPlayerItem(asset: composition)
                 // Prevent pitch distortion when clips play at a speed other
                 // than 1×. .timeDomain preserves pitch across the editor's
                 // 0.25×–3× range at a fraction of .spectral's (phase vocoder)
@@ -251,23 +258,6 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 // cycles from video decode/render on weaker devices, showing up
                 // as dropped or stuttering frames during sped-up preview.
                 playerItem.audioTimePitchAlgorithm = .timeDomain
-                // Validate BEFORE assigning. -[AVPlayerItem setVideoComposition:]
-                // throws an Objective-C NSInvalidArgumentException on an invalid
-                // composition (zero render size or zero/invalid frame duration).
-                // That exception is not a Swift Error, so the enclosing do/catch
-                // can't catch it and the process aborts (SIGABRT). Rejecting the
-                // bad values here surfaces the failure as a FlutterError instead.
-                guard (videoComposition?.renderSize ?? composition.naturalSize).isPositive else {
-                    throw CompositionError.invalidRenderSize
-                }
-                if let videoComposition {
-                    let frameDuration = videoComposition.frameDuration
-                    guard frameDuration.isNumeric, frameDuration.seconds > 0 else {
-                        throw CompositionError.invalidFrameDuration
-                    }
-                    playerItem.videoComposition = videoComposition
-                }
-                if let audioMix { playerItem.audioMix = audioMix }
                 self.templateItem = playerItem
 
                 let requestedStartPositionMs = (args["startPositionMs"] as? NSNumber)?.int64Value
@@ -352,6 +342,109 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 )
             }
         }
+    }
+
+    /// The single clip of [clipsRaw] when it is an HLS source the direct-item
+    /// path can represent exactly, otherwise nil.
+    ///
+    /// An HLS `AVURLAsset` exposes **no** tracks — `loadTracks` returns an
+    /// empty array — so a composition built from one always ends in
+    /// [CompositionError.noPlayableVideoTracks] and can never play. Such
+    /// clips take the direct-item path in [makeHlsPlayerItem] instead.
+    ///
+    /// The diversion is deliberately narrow. A composition can start a clip
+    /// part-way in and rescale it; an `AVPlayerItem` carries the whole asset
+    /// from zero, so a non-zero `startMs` or an off-speed clip has no exact
+    /// representation here and would report a timeline that does not match
+    /// what plays. Those keep failing on the composition path exactly as they
+    /// do today rather than playing something subtly wrong. Multi-clip
+    /// timelines likewise still need a composition to stitch — the editor's
+    /// multi-clip sources are local files, never HLS.
+    private static func soleHlsClip(
+        in clipsRaw: [[String: Any]]
+    ) -> [String: Any]? {
+        guard clipsRaw.count == 1, let clip = clipsRaw.first,
+            let uri = clip["uri"] as? String,
+            URL(string: uri)?.pathExtension.lowercased() == "m3u8",
+            (clip["startMs"] as? NSNumber)?.int64Value ?? 0 == 0,
+            (clip["playbackSpeed"] as? NSNumber)?.doubleValue ?? 1.0 == 1.0
+        else { return nil }
+        return clip
+    }
+
+    /// Builds a player item straight from an HLS asset, bypassing the
+    /// composition.
+    ///
+    /// Trimming is applied with `forwardPlaybackEndTime` rather than a
+    /// composition time range. Orientation needs no video composition because
+    /// HLS renditions are already upright, and per-clip volume needs no audio
+    /// mix because there is exactly one clip — `volume` covers it. The cost is
+    /// that the audio-mix edge de-click fades do not apply, so an HLS loop
+    /// seam can click; HLS is only ever reached as a last-resort fallback
+    /// source, which does not justify rebuilding those ramps here.
+    private func makeHlsPlayerItem(
+        from clipMap: [String: Any]
+    ) async throws -> (AVPlayerItem, [Double], [Double]) {
+        guard let uri = clipMap["uri"] as? String, let url = URL(string: uri) else {
+            throw CompositionError.noPlayableVideoTracks
+        }
+        let httpHeaders = clipMap["httpHeaders"] as? [String: String]
+        let assetOptions: [String: Any]? = httpHeaders.map {
+            [Self.avURLAssetHTTPHeaderFieldsKey: $0]
+        }
+        let asset = AVURLAsset(url: url, options: assetOptions)
+        let assetDuration = try await asset.load(.duration)
+
+        // soleHlsClip guarantees startMs == 0, so the item's timeline is
+        // [0, endTime] and the reported duration is endTime itself.
+        var endTime = assetDuration
+        if let endMs = clipMap["endMs"] as? NSNumber {
+            // Clamp to the asset the same way the composition path does: the
+            // feed caps every clip at maxFeedPlaybackDuration without knowing
+            // the source length up front.
+            let requestedEnd = CMTime(value: endMs.int64Value, timescale: 1000)
+            endTime =
+                (assetDuration.isNumeric && CMTimeCompare(requestedEnd, assetDuration) > 0)
+                ? assetDuration
+                : requestedEnd
+        }
+        guard endTime.isNumeric, endTime.seconds > 0 else {
+            throw CompositionError.noPlayableVideoTracks
+        }
+
+        let playerItem = AVPlayerItem(asset: asset)
+        if CMTimeCompare(endTime, assetDuration) < 0 {
+            playerItem.forwardPlaybackEndTime = endTime
+        }
+        return (playerItem, [0], [endTime.seconds])
+    }
+
+    /// Builds a player item backed by an AVMutableComposition of every clip.
+    private func makeCompositionPlayerItem(
+        from clipsRaw: [[String: Any]]
+    ) async throws -> (AVPlayerItem, [Double], [Double]) {
+        let (composition, videoComposition, offsets, durations, audioMix) =
+            try await buildComposition(from: clipsRaw)
+
+        let playerItem = AVPlayerItem(asset: composition)
+        // Validate BEFORE assigning. -[AVPlayerItem setVideoComposition:]
+        // throws an Objective-C NSInvalidArgumentException on an invalid
+        // composition (zero render size or zero/invalid frame duration).
+        // That exception is not a Swift Error, so the enclosing do/catch
+        // can't catch it and the process aborts (SIGABRT). Rejecting the
+        // bad values here surfaces the failure as a FlutterError instead.
+        guard (videoComposition?.renderSize ?? composition.naturalSize).isPositive else {
+            throw CompositionError.invalidRenderSize
+        }
+        if let videoComposition {
+            let frameDuration = videoComposition.frameDuration
+            guard frameDuration.isNumeric, frameDuration.seconds > 0 else {
+                throw CompositionError.invalidFrameDuration
+            }
+            playerItem.videoComposition = videoComposition
+        }
+        if let audioMix { playerItem.audioMix = audioMix }
+        return (playerItem, offsets, durations)
     }
 
     /// Builds an AVMutableComposition that stitches all clips into a

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -367,6 +367,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             let uri = clip["uri"] as? String,
             URL(string: uri)?.pathExtension.lowercased() == "m3u8",
             (clip["startMs"] as? NSNumber)?.int64Value ?? 0 == 0,
+            (clip["volume"] as? NSNumber)?.doubleValue ?? 1.0 == 1.0,
             (clip["playbackSpeed"] as? NSNumber)?.doubleValue ?? 1.0 == 1.0
         else { return nil }
         return clip
@@ -377,11 +378,11 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     ///
     /// Trimming is applied with `forwardPlaybackEndTime` rather than a
     /// composition time range. Orientation needs no video composition because
-    /// HLS renditions are already upright, and per-clip volume needs no audio
-    /// mix because there is exactly one clip — `volume` covers it. The cost is
-    /// that the audio-mix edge de-click fades do not apply, so an HLS loop
-    /// seam can click; HLS is only ever reached as a last-resort fallback
-    /// source, which does not justify rebuilding those ramps here.
+    /// HLS renditions are already upright. Per-clip volume changes stay on the
+    /// composition path because a direct item has no audio mix. The cost is that
+    /// the audio-mix edge de-click fades do not apply, so an HLS loop seam can
+    /// click; HLS is only ever reached as a last-resort fallback source, which
+    /// does not justify rebuilding those ramps here.
     private func makeHlsPlayerItem(
         from clipMap: [String: Any]
     ) async throws -> (AVPlayerItem, [Double], [Double]) {
@@ -397,17 +398,10 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
 
         // soleHlsClip guarantees startMs == 0, so the item's timeline is
         // [0, endTime] and the reported duration is endTime itself.
-        var endTime = assetDuration
-        if let endMs = clipMap["endMs"] as? NSNumber {
-            // Clamp to the asset the same way the composition path does: the
-            // feed caps every clip at maxFeedPlaybackDuration without knowing
-            // the source length up front.
-            let requestedEnd = CMTime(value: endMs.int64Value, timescale: 1000)
-            endTime =
-                (assetDuration.isNumeric && CMTimeCompare(requestedEnd, assetDuration) > 0)
-                ? assetDuration
-                : requestedEnd
-        }
+        let endTime = Self.clampedEndTime(
+            requestedEndMs: clipMap["endMs"] as? NSNumber,
+            assetDuration: assetDuration
+        )
         guard endTime.isNumeric, endTime.seconds > 0 else {
             throw CompositionError.noPlayableVideoTracks
         }
@@ -445,6 +439,22 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         }
         if let audioMix { playerItem.audioMix = audioMix }
         return (playerItem, offsets, durations)
+    }
+
+    /// Clamps a requested end time to the media that exists in the asset.
+    ///
+    /// `insertTimeRange` silently inserts only existing media, so an end past the
+    /// source would otherwise leave reported duration longer than playback. The
+    /// feed relies on this because it caps clips before knowing the source length.
+    private static func clampedEndTime(
+        requestedEndMs: NSNumber?,
+        assetDuration: CMTime
+    ) -> CMTime {
+        guard let requestedEndMs else { return assetDuration }
+        let requestedEnd = CMTime(value: requestedEndMs.int64Value, timescale: 1000)
+        return (assetDuration.isNumeric && CMTimeCompare(requestedEnd, assetDuration) > 0)
+            ? assetDuration
+            : requestedEnd
     }
 
     /// Builds an AVMutableComposition that stitches all clips into a
@@ -538,23 +548,10 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             let standardizedTransform = transform.standardized(for: naturalSize)
 
             let startTime = CMTime(value: startMs, timescale: 1000)
-            var endTime: CMTime
-            if let endMs {
-                // Clamp to the asset: insertTimeRange silently inserts only the
-                // media that exists, so an endMs past the source would leave
-                // clipDuration (and therefore the reported totalDuration)
-                // longer than what actually plays. The feed relies on this —
-                // it caps every clip at maxFeedPlaybackDuration without knowing
-                // the source length up front. ExoPlayer clamps the equivalent
-                // ClippingConfiguration itself.
-                let requestedEnd = CMTime(value: endMs.int64Value, timescale: 1000)
-                endTime =
-                    (assetDuration.isNumeric && CMTimeCompare(requestedEnd, assetDuration) > 0)
-                    ? assetDuration
-                    : requestedEnd
-            } else {
-                endTime = assetDuration
-            }
+            var endTime = Self.clampedEndTime(
+                requestedEndMs: endMs,
+                assetDuration: assetDuration
+            )
             // The asset duration is the *longest* track, so ending there leaves
             // a stretch where the shorter track has already run out — silence,
             // or a frozen frame. On a looping player that stretch is the seam.

--- a/mobile/packages/divine_video_player/test/src/apple_clip_end_clamp_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/apple_clip_end_clamp_contract_test.dart
@@ -20,16 +20,20 @@ void main() {
   group('Apple native clip-end clamp contract', () {
     test('clamps a requested clip end to the asset duration', () {
       final source = _appleSourceFile().readAsStringSync();
+      final helper = _functionBody(
+        source,
+        'private static func clampedEndTime(',
+      );
 
       expect(
-        source,
+        helper,
         contains('CMTimeCompare(requestedEnd, assetDuration) > 0'),
         reason:
             'A requested end past the asset must resolve to the asset '
             'duration, not to the requested value.',
       );
       expect(
-        source,
+        helper,
         contains('assetDuration.isNumeric'),
         reason:
             'A non-numeric asset duration (indefinite/unloaded) cannot be '
@@ -39,13 +43,10 @@ void main() {
 
     test('clamps before deriving the clip duration', () {
       final source = _appleSourceFile().readAsStringSync();
+      final body = _functionBody(source, 'private func buildComposition(');
 
-      final clamp = source.indexOf(
-        'CMTimeCompare(requestedEnd, assetDuration) > 0',
-      );
-      final clipDuration = source.indexOf(
-        'CMTimeSubtract(endTime, startTime)',
-      );
+      final clamp = body.indexOf('Self.clampedEndTime(');
+      final clipDuration = body.indexOf('CMTimeSubtract(endTime, startTime)');
 
       expect(clamp, greaterThanOrEqualTo(0));
       expect(clipDuration, greaterThanOrEqualTo(0));
@@ -58,6 +59,19 @@ void main() {
       );
     });
   });
+}
+
+/// Source text of the function opening at [signature], up to the next
+/// declaration at the same indentation.
+String _functionBody(String source, String signature) {
+  final start = source.indexOf(signature);
+  expect(
+    start,
+    greaterThanOrEqualTo(0),
+    reason: 'Expected to find `$signature` in the Apple player source.',
+  );
+  final next = source.indexOf('\n    private ', start + signature.length);
+  return source.substring(start, next == -1 ? source.length : next);
 }
 
 /// The iOS and macOS players share a single Darwin source tree

--- a/mobile/packages/divine_video_player/test/src/apple_hls_direct_item_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/apple_hls_direct_item_contract_test.dart
@@ -57,6 +57,13 @@ void main() {
             'Only the composition can rescale a clip, so an off-speed clip '
             'must keep taking that path.',
       );
+      expect(
+        source,
+        contains('(clip["volume"] as? NSNumber)?.doubleValue ?? 1.0 == 1.0'),
+        reason:
+            'Only the composition can apply per-clip volume with an audio mix, '
+            'so a clip with custom volume must keep taking that path.',
+      );
 
       final dispatch = source.indexOf('Self.soleHlsClip(in: clipsRaw)');
       final compositionCall = source.indexOf(

--- a/mobile/packages/divine_video_player/test/src/apple_hls_direct_item_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/apple_hls_direct_item_contract_test.dart
@@ -1,0 +1,141 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// An HLS `AVURLAsset` exposes no tracks — `loadTracks(withMediaType:)` returns
+/// an empty array — so an `AVMutableComposition` built from one always ends in
+/// `CompositionError.noPlayableVideoTracks` and can never play. A single HLS
+/// clip therefore has to bypass the composition entirely and be handed to
+/// `AVPlayerItem` directly.
+///
+/// None of this has a Dart runtime surface, and the package has no Swift test
+/// harness, so the invariants are pinned as a source contract the same way the
+/// composition guards are: a refactor that routes HLS back through
+/// `buildComposition` keeps every runtime test green while restoring
+/// "No playable video tracks found." for every HLS source.
+void main() {
+  group('Apple native HLS direct-item contract', () {
+    test('a single m3u8 clip is diverted away from the composition', () {
+      final source = _appleSourceFile().readAsStringSync();
+
+      expect(
+        source,
+        contains('soleHlsClip'),
+        reason:
+            'The HLS detection helper is what keeps an HLS source out of '
+            'buildComposition.',
+      );
+      expect(
+        source,
+        contains('pathExtension.lowercased() == "m3u8"'),
+        reason:
+            'AVURLAsset itself picks its parser from the URL path extension, '
+            'so the same signal must decide which builder runs.',
+      );
+      expect(
+        source,
+        contains('clipsRaw.count == 1'),
+        reason:
+            'Only a whole-timeline HLS source may skip the composition — a '
+            'multi-clip timeline still needs one to stitch.',
+      );
+      expect(
+        source,
+        contains('(clip["startMs"] as? NSNumber)?.int64Value ?? 0 == 0'),
+        reason:
+            'An AVPlayerItem carries the whole asset from zero, so a non-zero '
+            'startMs has no exact representation on this path and must not be '
+            'diverted here — it would report a timeline that does not match '
+            'what plays.',
+      );
+      expect(
+        source,
+        contains(
+          '(clip["playbackSpeed"] as? NSNumber)?.doubleValue ?? 1.0 == 1.0',
+        ),
+        reason:
+            'Only the composition can rescale a clip, so an off-speed clip '
+            'must keep taking that path.',
+      );
+
+      final dispatch = source.indexOf('Self.soleHlsClip(in: clipsRaw)');
+      final compositionCall = source.indexOf(
+        'makeCompositionPlayerItem(from: clipsRaw)',
+      );
+      expect(dispatch, greaterThanOrEqualTo(0));
+      expect(compositionCall, greaterThanOrEqualTo(0));
+      expect(
+        dispatch,
+        lessThan(compositionCall),
+        reason:
+            'The HLS check must gate the composition call, not follow it — '
+            'otherwise the composition is built first and throws.',
+      );
+    });
+
+    test('the HLS builder never asks the asset for tracks', () {
+      final body = _functionBody(
+        _appleSourceFile().readAsStringSync(),
+        'private func makeHlsPlayerItem(',
+      );
+
+      expect(
+        body,
+        isNot(contains('loadTracks')),
+        reason:
+            'loadTracks returns an empty array for HLS. Reintroducing it here '
+            'is exactly the failure this path exists to avoid.',
+      );
+      expect(
+        body,
+        contains('AVPlayerItem(asset: asset)'),
+        reason: 'The item must come straight from the AVURLAsset.',
+      );
+      expect(
+        body,
+        contains('forwardPlaybackEndTime'),
+        reason:
+            'Trimming has no composition time range to live in, so the feed '
+            'cap has to be applied as a forward playback end time.',
+      );
+      expect(
+        body,
+        contains('avURLAssetHTTPHeaderFieldsKey'),
+        reason:
+            'Gated HLS playback authenticates with a viewer-auth header, which '
+            'is lost if the asset is built without the header options.',
+      );
+    });
+  });
+}
+
+/// Source text of the function opening at [signature], up to the next
+/// declaration at the same indentation.
+String _functionBody(String source, String signature) {
+  final start = source.indexOf(signature);
+  expect(
+    start,
+    greaterThanOrEqualTo(0),
+    reason: 'Expected to find `$signature` in the Apple player source.',
+  );
+  final next = source.indexOf('\n    private ', start + signature.length);
+  return source.substring(start, next == -1 ? source.length : next);
+}
+
+/// The iOS and macOS players share a single Darwin source tree
+/// (`darwin/divine_video_player/Sources/`), so the contract is asserted once.
+File _appleSourceFile() {
+  final packageRelative = File(
+    'darwin/divine_video_player/Sources/divine_video_player/'
+    'DivineVideoPlayerInstance.swift',
+  );
+  if (packageRelative.existsSync()) {
+    return packageRelative;
+  }
+
+  return File(
+    'packages/divine_video_player/'
+    'darwin/divine_video_player/Sources/divine_video_player/'
+    'DivineVideoPlayerInstance.swift',
+  );
+}

--- a/mobile/test/extensions/video_event_divine_server_test.dart
+++ b/mobile/test/extensions/video_event_divine_server_test.dart
@@ -272,7 +272,7 @@ void main() {
       },
     );
 
-    test('mp4_480p override wins over classic Vine original', () async {
+    test('mp4_480p override applies to classic Vine originals', () async {
       const hash =
           'cfb5cf3415ec4ad3f45eff478570d898ff9a660ecea63d0c058892b22468a90d';
       final video = _createVideoWithUrl(
@@ -303,7 +303,11 @@ void main() {
       );
     });
 
-    test('skips single-file caching for original Vine raw blobs', () {
+    // Regression test for classic Vines being unplayable on iOS. The
+    // extensionless raw blob (`/{hash}`) cannot be parsed by AVURLAsset,
+    // which selects its container parser from the URL path extension and
+    // ignores the Content-Type header.
+    test('uses MP4 720p for classic Vine originals', () {
       final video = _createVideoWithUrl(
         'https://media.divine.video/$hash',
         rawTags: const {'platform': 'vine'},
@@ -312,8 +316,17 @@ void main() {
       expect(video.isOriginalVine, isTrue);
       expect(
         video.getOptimalVideoUrlForPlatform(),
-        equals('https://media.divine.video/$hash'),
+        equals('https://media.divine.video/$hash/720p.mp4'),
       );
+    });
+
+    test('skips single-file caching for classic Vine originals', () {
+      final video = _createVideoWithUrl(
+        'https://media.divine.video/$hash',
+        rawTags: const {'platform': 'vine'},
+      );
+
+      expect(video.isOriginalVine, isTrue);
       expect(video.getCacheableVideoUrlForPlatform(), isNull);
     });
 

--- a/mobile/test/extensions/video_event_extensions_test.dart
+++ b/mobile/test/extensions/video_event_extensions_test.dart
@@ -24,6 +24,13 @@ void main() {
       expect(_videoWithUrl(url).inlinePlayerVideoUrl, url);
     });
 
+    test('resolves a Divine raw blob to a progressive URL', () {
+      expect(
+        _videoWithUrl('https://media.divine.video/$hash').inlinePlayerVideoUrl,
+        'https://media.divine.video/$hash/720p.mp4',
+      );
+    });
+
     test('passes a non-Divine progressive URL through unchanged', () {
       const url = 'https://example.com/clip.mp4';
       expect(_videoWithUrl(url).inlinePlayerVideoUrl, url);


### PR DESCRIPTION

## Correction (2026-08-12)

This PR merged with the right behavior change but the wrong root-cause explanation.

Classic Vine playback was not failing because remote iOS `AVURLAsset` chose its parser from the URL path extension or ignored `Content-Type`. The measured cause is server-side: Range requests to the bare blob path `/{hash}` returned a cached S3 `NoSuchKey` XML body as `206`, so AVFoundation received XML instead of video.

The fix remains valid: routing classic Vine originals and inline Divine bare blobs away from the bare blob path avoids the broken Range behavior and uses the smaller progressive MP4 derivative where available.

Context:

- divinevideo/divine-blossom#198 tracks the server-side Range defect.
- divinevideo/divine-mobile#7175 corrected the comments that carried the stale path-extension explanation.
- divinevideo/divine-mobile#7185 cleans up the remaining mobile-side comment debt and links the revisit issue.

Related issue: #7168
