### PR TITLE
fix(library): collapse library toolbar actions when the row runs out of room

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2941,7 +2941,6 @@
     "libraryDeleteSelectedClipsTooltip": "የተመረጡ ቅንጥቦችን ሰርዝ",
     "libraryCloseSemanticLabel": "ቤተ-መጻሕፍቱን ዝጋ",
     "libraryStopSelectingClipsSemanticLabel": "ቅንጥቦችን መምረጥ አቁም",
-    "librarySortClipsSemanticLabel": "ቅንጥቦችን ደርድር",
     "librarySelectClipsSemanticLabel": "ቅንጥቦችን ምረጥ",
     "libraryGridSizeLabel": "የፍርግርግ መጠን",
     "libraryDisplayOptionsLabel": "መደርደር እና የፍርግርግ መጠን",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2944,6 +2944,8 @@
     "librarySortClipsSemanticLabel": "ቅንጥቦችን ደርድር",
     "librarySelectClipsSemanticLabel": "ቅንጥቦችን ምረጥ",
     "libraryGridSizeLabel": "የፍርግርግ መጠን",
+    "libraryDisplayOptionsLabel": "መደርደር እና የፍርግርግ መጠን",
+    "libraryMoreActionsSemanticLabel": "ተጨማሪ የቤተ-መጽሐፍት እርምጃዎች",
     "libraryGridSizeColumns": "{count, plural, one{{count} አምድ} other{{count} አምዶች}}",
     "librarySelect": "ምረጥ",
     "librarySortNewestCreation": "በጣም አዲስ የተፈጠረ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2543,6 +2543,8 @@
     "librarySortClipsSemanticLabel": "فرز المقاطع",
     "librarySelectClipsSemanticLabel": "تحديد المقاطع",
     "libraryGridSizeLabel": "حجم الشبكة",
+    "libraryDisplayOptionsLabel": "الفرز وحجم الشبكة",
+    "libraryMoreActionsSemanticLabel": "المزيد من إجراءات المكتبة",
     "libraryGridSizeColumns": "{count, plural, zero{بلا أعمدة} one{عمود واحد} two{عمودان} few{{count} أعمدة} many{{count} عمودًا} other{{count} عمود}}",
     "librarySelect": "تحديد",
     "librarySortNewestCreation": "الأحدث إنشاءً",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2540,7 +2540,6 @@
     "libraryDeleteSelectedClipsTooltip": "حذف المقاطع المحددة",
     "libraryCloseSemanticLabel": "إغلاق المكتبة",
     "libraryStopSelectingClipsSemanticLabel": "إيقاف تحديد المقاطع",
-    "librarySortClipsSemanticLabel": "فرز المقاطع",
     "librarySelectClipsSemanticLabel": "تحديد المقاطع",
     "libraryGridSizeLabel": "حجم الشبكة",
     "libraryDisplayOptionsLabel": "الفرز وحجم الشبكة",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2702,7 +2702,6 @@
     "libraryDeleteSelectedClipsTooltip": "Изтрийте избраните клипове",
     "libraryCloseSemanticLabel": "Затвори библиотеката",
     "libraryStopSelectingClipsSemanticLabel": "Спри избора на клипове",
-    "librarySortClipsSemanticLabel": "Сортирай клиповете",
     "librarySelectClipsSemanticLabel": "Избери клипове",
     "libraryGridSizeLabel": "Размер на мрежата",
     "libraryDisplayOptionsLabel": "Сортиране и размер на мрежата",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2705,6 +2705,8 @@
     "librarySortClipsSemanticLabel": "Сортирай клиповете",
     "librarySelectClipsSemanticLabel": "Избери клипове",
     "libraryGridSizeLabel": "Размер на мрежата",
+    "libraryDisplayOptionsLabel": "Сортиране и размер на мрежата",
+    "libraryMoreActionsSemanticLabel": "Още действия в библиотеката",
     "libraryGridSizeColumns": "{count, plural, one{1 колона} other{{count} колони}}",
     "librarySelect": "Избери",
     "librarySortNewestCreation": "Най-ново създадени",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2558,6 +2558,8 @@
     "librarySortClipsSemanticLabel": "Clips sortieren",
     "librarySelectClipsSemanticLabel": "Clips auswählen",
     "libraryGridSizeLabel": "Rastergröße",
+    "libraryDisplayOptionsLabel": "Sortierung & Rastergröße",
+    "libraryMoreActionsSemanticLabel": "Weitere Bibliotheksaktionen",
     "libraryGridSizeColumns": "{count, plural, one{1 Spalte} other{{count} Spalten}}",
     "libraryDraftActionDelete": "Entwurf löschen",
     "libraryDraftActionEdit": "Bearbeiten",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2555,7 +2555,6 @@
     "libraryDeleteSelectedClipsTooltip": "Ausgewählte Clips löschen",
     "libraryCloseSemanticLabel": "Bibliothek schließen",
     "libraryStopSelectingClipsSemanticLabel": "Clip-Auswahl beenden",
-    "librarySortClipsSemanticLabel": "Clips sortieren",
     "librarySelectClipsSemanticLabel": "Clips auswählen",
     "libraryGridSizeLabel": "Rastergröße",
     "libraryDisplayOptionsLabel": "Sortierung & Rastergröße",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4066,6 +4066,14 @@
   "@libraryGridSizeLabel": {
     "description": "Row in the library sort menu that opens the clip grid size options. The same choice can be made by pinching the grid, which assistive technology cannot perform."
   },
+  "libraryDisplayOptionsLabel": "Sort & grid size",
+  "@libraryDisplayOptionsLabel": {
+    "description": "Row in the library overflow menu that opens the sorting and grid size options. Used when the toolbar is too narrow to show that button."
+  },
+  "libraryMoreActionsSemanticLabel": "More library actions",
+  "@libraryMoreActionsSemanticLabel": {
+    "description": "Accessibility label for the library toolbar button that opens the actions which did not fit in the toolbar."
+  },
   "libraryGridSizeColumns": "{count, plural, =1{1 column} other{{count} columns}}",
   "@libraryGridSizeColumns": {
     "description": "Option in the library grid size menu, naming how many columns of clips the grid shows. The range is 2 to 5. English never selects the singular arm in that range, but other locales do — Filipino selects `one` at 2, 3 and 5 — so every arm must interpolate {count} rather than spell out a digit.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4064,7 +4064,7 @@
   },
   "libraryDisplayOptionsLabel": "Sort & grid size",
   "@libraryDisplayOptionsLabel": {
-    "description": "Row in the library overflow menu that opens the sorting and grid size options. Used when the toolbar is too narrow to show that button."
+    "description": "Names the library action that opens the sorting and grid size options. Used twice: as the accessibility label of the toolbar button, and as the visible label of its overflow-menu row when the toolbar is too narrow to show that button."
   },
   "libraryMoreActionsSemanticLabel": "More library actions",
   "@libraryMoreActionsSemanticLabel": {

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4054,10 +4054,6 @@
   "@libraryStopSelectingClipsSemanticLabel": {
     "description": "Accessibility label for the library toolbar button that exits clip-selection mode."
   },
-  "librarySortClipsSemanticLabel": "Sort clips",
-  "@librarySortClipsSemanticLabel": {
-    "description": "Accessibility label for the library toolbar button that opens clip sorting options."
-  },
   "librarySelectClipsSemanticLabel": "Select clips",
   "@librarySelectClipsSemanticLabel": {
     "description": "Accessibility label for the library toolbar button that enters clip-selection mode."

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2556,7 +2556,6 @@
     "libraryDeleteSelectedClipsTooltip": "Eliminar clips seleccionados",
     "libraryCloseSemanticLabel": "Cerrar biblioteca",
     "libraryStopSelectingClipsSemanticLabel": "Dejar de seleccionar clips",
-    "librarySortClipsSemanticLabel": "Ordenar clips",
     "librarySelectClipsSemanticLabel": "Seleccionar clips",
     "libraryGridSizeLabel": "Tamaño de la cuadrícula",
     "libraryDisplayOptionsLabel": "Orden y tamaño de cuadrícula",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2559,6 +2559,8 @@
     "librarySortClipsSemanticLabel": "Ordenar clips",
     "librarySelectClipsSemanticLabel": "Seleccionar clips",
     "libraryGridSizeLabel": "Tamaño de la cuadrícula",
+    "libraryDisplayOptionsLabel": "Orden y tamaño de cuadrícula",
+    "libraryMoreActionsSemanticLabel": "Más acciones de la biblioteca",
     "libraryGridSizeColumns": "{count, plural, one{1 columna} other{{count} columnas}}",
     "librarySelect": "Seleccionar",
     "librarySortNewestCreation": "Creación más reciente",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1657,6 +1657,8 @@
     "librarySortClipsSemanticLabel": "Ayusin ang mga clip",
     "librarySelectClipsSemanticLabel": "Pumili ng mga clip",
     "libraryGridSizeLabel": "Laki ng grid",
+    "libraryDisplayOptionsLabel": "Pagkakasunod-sunod at laki ng grid",
+    "libraryMoreActionsSemanticLabel": "Higit pang aksyon sa library",
     "libraryGridSizeColumns": "{count, plural, one{{count} hanay} other{{count} na hanay}}",
     "librarySelect": "Piliin",
     "librarySortNewestCreation": "Pinakabagong ginawa",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1654,7 +1654,6 @@
     "libraryDeleteSelectedClipsTooltip": "Burahin ang mga napiling clip",
     "libraryCloseSemanticLabel": "Isara ang library",
     "libraryStopSelectingClipsSemanticLabel": "Ihinto ang pagpili ng mga clip",
-    "librarySortClipsSemanticLabel": "Ayusin ang mga clip",
     "librarySelectClipsSemanticLabel": "Pumili ng mga clip",
     "libraryGridSizeLabel": "Laki ng grid",
     "libraryDisplayOptionsLabel": "Pagkakasunod-sunod at laki ng grid",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2551,6 +2551,8 @@
     "librarySortClipsSemanticLabel": "Trier les clips",
     "librarySelectClipsSemanticLabel": "Sélectionner des clips",
     "libraryGridSizeLabel": "Taille de la grille",
+    "libraryDisplayOptionsLabel": "Tri et taille de grille",
+    "libraryMoreActionsSemanticLabel": "Plus d'actions de la bibliothèque",
     "libraryGridSizeColumns": "{count, plural, one{{count} colonne} other{{count} colonnes}}",
     "librarySelect": "Sélectionner",
     "librarySortNewestCreation": "Création la plus récente",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2548,7 +2548,6 @@
     "libraryDeleteSelectedClipsTooltip": "Supprimer les clips sélectionnés",
     "libraryCloseSemanticLabel": "Fermer la bibliothèque",
     "libraryStopSelectingClipsSemanticLabel": "Arrêter de sélectionner des clips",
-    "librarySortClipsSemanticLabel": "Trier les clips",
     "librarySelectClipsSemanticLabel": "Sélectionner des clips",
     "libraryGridSizeLabel": "Taille de la grille",
     "libraryDisplayOptionsLabel": "Tri et taille de grille",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2547,7 +2547,6 @@
     "libraryDeleteSelectedClipsTooltip": "Hapus klip terpilih",
     "libraryCloseSemanticLabel": "Tutup pustaka",
     "libraryStopSelectingClipsSemanticLabel": "Berhenti memilih klip",
-    "librarySortClipsSemanticLabel": "Urutkan klip",
     "librarySelectClipsSemanticLabel": "Pilih klip",
     "libraryGridSizeLabel": "Ukuran kisi",
     "libraryDisplayOptionsLabel": "Urutan & ukuran kisi",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2550,6 +2550,8 @@
     "librarySortClipsSemanticLabel": "Urutkan klip",
     "librarySelectClipsSemanticLabel": "Pilih klip",
     "libraryGridSizeLabel": "Ukuran kisi",
+    "libraryDisplayOptionsLabel": "Urutan & ukuran kisi",
+    "libraryMoreActionsSemanticLabel": "Tindakan pustaka lainnya",
     "libraryGridSizeColumns": "{count, plural, other{{count} kolom}}",
     "librarySelect": "Pilih",
     "librarySortNewestCreation": "Paling baru dibuat",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2548,7 +2548,6 @@
     "libraryDeleteSelectedClipsTooltip": "Elimina clip selezionate",
     "libraryCloseSemanticLabel": "Chiudi libreria",
     "libraryStopSelectingClipsSemanticLabel": "Termina selezione clip",
-    "librarySortClipsSemanticLabel": "Ordina clip",
     "librarySelectClipsSemanticLabel": "Seleziona clip",
     "libraryGridSizeLabel": "Dimensioni della griglia",
     "libraryDisplayOptionsLabel": "Ordinamento e dimensione griglia",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2551,6 +2551,8 @@
     "librarySortClipsSemanticLabel": "Ordina clip",
     "librarySelectClipsSemanticLabel": "Seleziona clip",
     "libraryGridSizeLabel": "Dimensioni della griglia",
+    "libraryDisplayOptionsLabel": "Ordinamento e dimensione griglia",
+    "libraryMoreActionsSemanticLabel": "Altre azioni della libreria",
     "libraryGridSizeColumns": "{count, plural, one{1 colonna} other{{count} colonne}}",
     "librarySelect": "Seleziona",
     "librarySortNewestCreation": "Creazione più recente",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2543,6 +2543,8 @@
     "librarySortClipsSemanticLabel": "クリップを並べ替える",
     "librarySelectClipsSemanticLabel": "クリップを選択",
     "libraryGridSizeLabel": "グリッドのサイズ",
+    "libraryDisplayOptionsLabel": "並び替えとグリッドサイズ",
+    "libraryMoreActionsSemanticLabel": "ライブラリのその他の操作",
     "libraryGridSizeColumns": "{count, plural, other{{count}列}}",
     "librarySelect": "選択",
     "librarySortNewestCreation": "作成日が新しい順",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2540,7 +2540,6 @@
     "libraryDeleteSelectedClipsTooltip": "選択したクリップを削除",
     "libraryCloseSemanticLabel": "ライブラリを閉じる",
     "libraryStopSelectingClipsSemanticLabel": "クリップの選択を終了",
-    "librarySortClipsSemanticLabel": "クリップを並べ替える",
     "librarySelectClipsSemanticLabel": "クリップを選択",
     "libraryGridSizeLabel": "グリッドのサイズ",
     "libraryDisplayOptionsLabel": "並び替えとグリッドサイズ",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1878,7 +1878,6 @@
     "libraryDeleteSelectedClipsTooltip": "선택한 클립 삭제",
     "libraryCloseSemanticLabel": "라이브러리 닫기",
     "libraryStopSelectingClipsSemanticLabel": "클립 선택 종료",
-    "librarySortClipsSemanticLabel": "클립 정렬",
     "librarySelectClipsSemanticLabel": "클립 선택",
     "libraryGridSizeLabel": "그리드 크기",
     "libraryDisplayOptionsLabel": "정렬 및 그리드 크기",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1881,6 +1881,8 @@
     "librarySortClipsSemanticLabel": "클립 정렬",
     "librarySelectClipsSemanticLabel": "클립 선택",
     "libraryGridSizeLabel": "그리드 크기",
+    "libraryDisplayOptionsLabel": "정렬 및 그리드 크기",
+    "libraryMoreActionsSemanticLabel": "라이브러리 추가 작업",
     "libraryGridSizeColumns": "{count, plural, other{{count}열}}",
     "librarySelect": "선택",
     "librarySortNewestCreation": "최신 생성순",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -3737,6 +3737,8 @@
   "librarySortClipsSemanticLabel": "Isih klip",
   "librarySelectClipsSemanticLabel": "Pilih klip",
   "libraryGridSizeLabel": "Saiz grid",
+  "libraryDisplayOptionsLabel": "Susunan & saiz grid",
+  "libraryMoreActionsSemanticLabel": "Lagi tindakan pustaka",
   "libraryGridSizeColumns": "{count, plural, other{{count} lajur}}",
   "librarySelect": "Pilih",
   "librarySortNewestCreation": "Ciptaan Terbaharu",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -3734,7 +3734,6 @@
   "libraryDeleteSelectedClipsTooltip": "Padam klip dipilih",
   "libraryCloseSemanticLabel": "Tutup pustaka",
   "libraryStopSelectingClipsSemanticLabel": "Berhenti memilih klip",
-  "librarySortClipsSemanticLabel": "Isih klip",
   "librarySelectClipsSemanticLabel": "Pilih klip",
   "libraryGridSizeLabel": "Saiz grid",
   "libraryDisplayOptionsLabel": "Susunan & saiz grid",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2551,6 +2551,8 @@
     "librarySortClipsSemanticLabel": "Clips sorteren",
     "librarySelectClipsSemanticLabel": "Clips selecteren",
     "libraryGridSizeLabel": "Rastergrootte",
+    "libraryDisplayOptionsLabel": "Sortering en rastergrootte",
+    "libraryMoreActionsSemanticLabel": "Meer bibliotheekacties",
     "libraryGridSizeColumns": "{count, plural, one{1 kolom} other{{count} kolommen}}",
     "librarySelect": "Selecteren",
     "librarySortNewestCreation": "Nieuwst aangemaakt",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2548,7 +2548,6 @@
     "libraryDeleteSelectedClipsTooltip": "Geselecteerde clips verwijderen",
     "libraryCloseSemanticLabel": "Bibliotheek sluiten",
     "libraryStopSelectingClipsSemanticLabel": "Stoppen met clips selecteren",
-    "librarySortClipsSemanticLabel": "Clips sorteren",
     "librarySelectClipsSemanticLabel": "Clips selecteren",
     "libraryGridSizeLabel": "Rastergrootte",
     "libraryDisplayOptionsLabel": "Sortering en rastergrootte",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2551,6 +2551,8 @@
     "librarySortClipsSemanticLabel": "Sortuj klipy",
     "librarySelectClipsSemanticLabel": "Wybierz klipy",
     "libraryGridSizeLabel": "Rozmiar siatki",
+    "libraryDisplayOptionsLabel": "Sortowanie i rozmiar siatki",
+    "libraryMoreActionsSemanticLabel": "Więcej akcji biblioteki",
     "libraryGridSizeColumns": "{count, plural, one{1 kolumna} few{{count} kolumny} many{{count} kolumn} other{{count} kolumny}}",
     "librarySelect": "Wybierz",
     "librarySortNewestCreation": "Najnowsze utworzone",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2548,7 +2548,6 @@
     "libraryDeleteSelectedClipsTooltip": "Usuń wybrane klipy",
     "libraryCloseSemanticLabel": "Zamknij bibliotekę",
     "libraryStopSelectingClipsSemanticLabel": "Zakończ wybieranie klipów",
-    "librarySortClipsSemanticLabel": "Sortuj klipy",
     "librarySelectClipsSemanticLabel": "Wybierz klipy",
     "libraryGridSizeLabel": "Rozmiar siatki",
     "libraryDisplayOptionsLabel": "Sortowanie i rozmiar siatki",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2548,7 +2548,6 @@
     "libraryDeleteSelectedClipsTooltip": "Excluir clipes selecionados",
     "libraryCloseSemanticLabel": "Fechar biblioteca",
     "libraryStopSelectingClipsSemanticLabel": "Parar de selecionar clipes",
-    "librarySortClipsSemanticLabel": "Ordenar clipes",
     "librarySelectClipsSemanticLabel": "Selecionar clipes",
     "libraryGridSizeLabel": "Tamanho da grade",
     "libraryDisplayOptionsLabel": "Ordenação e tamanho da grade",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2551,6 +2551,8 @@
     "librarySortClipsSemanticLabel": "Ordenar clipes",
     "librarySelectClipsSemanticLabel": "Selecionar clipes",
     "libraryGridSizeLabel": "Tamanho da grade",
+    "libraryDisplayOptionsLabel": "Ordenação e tamanho da grade",
+    "libraryMoreActionsSemanticLabel": "Mais ações da biblioteca",
     "libraryGridSizeColumns": "{count, plural, one{{count} coluna} other{{count} colunas}}",
     "librarySelect": "Selecionar",
     "librarySortNewestCreation": "Criação mais recente",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2551,6 +2551,8 @@
     "librarySortClipsSemanticLabel": "Sortează clipurile",
     "librarySelectClipsSemanticLabel": "Selectează clipuri",
     "libraryGridSizeLabel": "Dimensiunea grilei",
+    "libraryDisplayOptionsLabel": "Sortare și dimensiunea grilei",
+    "libraryMoreActionsSemanticLabel": "Mai multe acțiuni în bibliotecă",
     "libraryGridSizeColumns": "{count, plural, one{1 coloană} few{{count} coloane} other{{count} de coloane}}",
     "librarySelect": "Selectează",
     "librarySortNewestCreation": "Cele mai noi create",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2548,7 +2548,6 @@
     "libraryDeleteSelectedClipsTooltip": "Șterge clipurile selectate",
     "libraryCloseSemanticLabel": "Închide biblioteca",
     "libraryStopSelectingClipsSemanticLabel": "Oprește selectarea clipurilor",
-    "librarySortClipsSemanticLabel": "Sortează clipurile",
     "librarySelectClipsSemanticLabel": "Selectează clipuri",
     "libraryGridSizeLabel": "Dimensiunea grilei",
     "libraryDisplayOptionsLabel": "Sortare și dimensiunea grilei",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2551,6 +2551,8 @@
     "librarySortClipsSemanticLabel": "Sortera klipp",
     "librarySelectClipsSemanticLabel": "Välj klipp",
     "libraryGridSizeLabel": "Rutnätets storlek",
+    "libraryDisplayOptionsLabel": "Sortering och rutnätsstorlek",
+    "libraryMoreActionsSemanticLabel": "Fler biblioteksåtgärder",
     "libraryGridSizeColumns": "{count, plural, one{1 kolumn} other{{count} kolumner}}",
     "librarySelect": "Välj",
     "librarySortNewestCreation": "Senast skapade",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2548,7 +2548,6 @@
     "libraryDeleteSelectedClipsTooltip": "Ta bort valda klipp",
     "libraryCloseSemanticLabel": "Stäng biblioteket",
     "libraryStopSelectingClipsSemanticLabel": "Sluta välja klipp",
-    "librarySortClipsSemanticLabel": "Sortera klipp",
     "librarySelectClipsSemanticLabel": "Välj klipp",
     "libraryGridSizeLabel": "Rutnätets storlek",
     "libraryDisplayOptionsLabel": "Sortering och rutnätsstorlek",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2550,6 +2550,8 @@
     "librarySortClipsSemanticLabel": "Klipleri sırala",
     "librarySelectClipsSemanticLabel": "Klip seç",
     "libraryGridSizeLabel": "Izgara boyutu",
+    "libraryDisplayOptionsLabel": "Sıralama ve ızgara boyutu",
+    "libraryMoreActionsSemanticLabel": "Diğer kütüphane işlemleri",
     "libraryGridSizeColumns": "{count, plural, other{{count} sütun}}",
     "librarySelect": "Seç",
     "librarySortNewestCreation": "En yeni oluşturulan",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2547,7 +2547,6 @@
     "libraryDeleteSelectedClipsTooltip": "Seçili klipleri sil",
     "libraryCloseSemanticLabel": "Kitaplığı kapat",
     "libraryStopSelectingClipsSemanticLabel": "Klip seçimini bitir",
-    "librarySortClipsSemanticLabel": "Klipleri sırala",
     "librarySelectClipsSemanticLabel": "Klip seç",
     "libraryGridSizeLabel": "Izgara boyutu",
     "libraryDisplayOptionsLabel": "Sıralama ve ızgara boyutu",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -3734,7 +3734,6 @@
   "libraryDeleteSelectedClipsTooltip": "منتخب کلپس حذف کریں",
   "libraryCloseSemanticLabel": "لائبریری بند کریں",
   "libraryStopSelectingClipsSemanticLabel": "کلپس منتخب کرنا بند کریں",
-  "librarySortClipsSemanticLabel": "کلپس ترتیب دیں",
   "librarySelectClipsSemanticLabel": "کلپس منتخب کریں",
   "libraryGridSizeLabel": "گرڈ کا سائز",
   "libraryDisplayOptionsLabel": "ترتیب اور گرڈ سائز",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -3737,6 +3737,8 @@
   "librarySortClipsSemanticLabel": "کلپس ترتیب دیں",
   "librarySelectClipsSemanticLabel": "کلپس منتخب کریں",
   "libraryGridSizeLabel": "گرڈ کا سائز",
+  "libraryDisplayOptionsLabel": "ترتیب اور گرڈ سائز",
+  "libraryMoreActionsSemanticLabel": "لائبریری کی مزید کارروائیاں",
   "libraryGridSizeColumns": "{count, plural, one{1 کالم} other{{count} کالم}}",
   "librarySelect": "منتخب کریں",
   "librarySortNewestCreation": "تازہ ترین تخلیق",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -3737,6 +3737,8 @@
   "librarySortClipsSemanticLabel": "Sắp xếp clip",
   "librarySelectClipsSemanticLabel": "Chọn clip",
   "libraryGridSizeLabel": "Kích thước lưới",
+  "libraryDisplayOptionsLabel": "Sắp xếp và cỡ lưới",
+  "libraryMoreActionsSemanticLabel": "Thao tác thư viện khác",
   "libraryGridSizeColumns": "{count, plural, other{{count} cột}}",
   "librarySelect": "Chọn",
   "librarySortNewestCreation": "Mới tạo nhất",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -3734,7 +3734,6 @@
   "libraryDeleteSelectedClipsTooltip": "Xóa clip đã chọn",
   "libraryCloseSemanticLabel": "Đóng thư viện",
   "libraryStopSelectingClipsSemanticLabel": "Dừng chọn clip",
-  "librarySortClipsSemanticLabel": "Sắp xếp clip",
   "librarySelectClipsSemanticLabel": "Chọn clip",
   "libraryGridSizeLabel": "Kích thước lưới",
   "libraryDisplayOptionsLabel": "Sắp xếp và cỡ lưới",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -3734,7 +3734,6 @@
   "libraryDeleteSelectedClipsTooltip": "删除选中片段",
   "libraryCloseSemanticLabel": "关闭素材库",
   "libraryStopSelectingClipsSemanticLabel": "停止选择片段",
-  "librarySortClipsSemanticLabel": "对片段排序",
   "librarySelectClipsSemanticLabel": "选择片段",
   "libraryGridSizeLabel": "网格大小",
   "libraryDisplayOptionsLabel": "排序和网格大小",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -3737,6 +3737,8 @@
   "librarySortClipsSemanticLabel": "对片段排序",
   "librarySelectClipsSemanticLabel": "选择片段",
   "libraryGridSizeLabel": "网格大小",
+  "libraryDisplayOptionsLabel": "排序和网格大小",
+  "libraryMoreActionsSemanticLabel": "更多作品库操作",
   "libraryGridSizeColumns": "{count, plural, other{{count}列}}",
   "librarySelect": "选择",
   "librarySortNewestCreation": "最新创建",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -11345,6 +11345,18 @@ abstract class AppLocalizations {
   /// **'Grid size'**
   String get libraryGridSizeLabel;
 
+  /// Row in the library overflow menu that opens the sorting and grid size options. Used when the toolbar is too narrow to show that button.
+  ///
+  /// In en, this message translates to:
+  /// **'Sort & grid size'**
+  String get libraryDisplayOptionsLabel;
+
+  /// Accessibility label for the library toolbar button that opens the actions which did not fit in the toolbar.
+  ///
+  /// In en, this message translates to:
+  /// **'More library actions'**
+  String get libraryMoreActionsSemanticLabel;
+
   /// Option in the library grid size menu, naming how many columns of clips the grid shows. The range is 2 to 5. English never selects the singular arm in that range, but other locales do — Filipino selects `one` at 2, 3 and 5 — so every arm must interpolate {count} rather than spell out a digit.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -11327,12 +11327,6 @@ abstract class AppLocalizations {
   /// **'Stop selecting clips'**
   String get libraryStopSelectingClipsSemanticLabel;
 
-  /// Accessibility label for the library toolbar button that opens clip sorting options.
-  ///
-  /// In en, this message translates to:
-  /// **'Sort clips'**
-  String get librarySortClipsSemanticLabel;
-
   /// Accessibility label for the library toolbar button that enters clip-selection mode.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -11339,7 +11339,7 @@ abstract class AppLocalizations {
   /// **'Grid size'**
   String get libraryGridSizeLabel;
 
-  /// Row in the library overflow menu that opens the sorting and grid size options. Used when the toolbar is too narrow to show that button.
+  /// Names the library action that opens the sorting and grid size options. Used twice: as the accessibility label of the toolbar button, and as the visible label of its overflow-menu row when the toolbar is too narrow to show that button.
   ///
   /// In en, this message translates to:
   /// **'Sort & grid size'**

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -6337,9 +6337,6 @@ class AppLocalizationsAm extends AppLocalizations {
   String get libraryStopSelectingClipsSemanticLabel => 'ቅንጥቦችን መምረጥ አቁም';
 
   @override
-  String get librarySortClipsSemanticLabel => 'ቅንጥቦችን ደርድር';
-
-  @override
   String get librarySelectClipsSemanticLabel => 'ቅንጥቦችን ምረጥ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -6346,6 +6346,12 @@ class AppLocalizationsAm extends AppLocalizations {
   String get libraryGridSizeLabel => 'የፍርግርግ መጠን';
 
   @override
+  String get libraryDisplayOptionsLabel => 'መደርደር እና የፍርግርግ መጠን';
+
+  @override
+  String get libraryMoreActionsSemanticLabel => 'ተጨማሪ የቤተ-መጽሐፍት እርምጃዎች';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -6430,6 +6430,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get libraryGridSizeLabel => 'حجم الشبكة';
 
   @override
+  String get libraryDisplayOptionsLabel => 'الفرز وحجم الشبكة';
+
+  @override
+  String get libraryMoreActionsSemanticLabel => 'المزيد من إجراءات المكتبة';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -6421,9 +6421,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get libraryStopSelectingClipsSemanticLabel => 'إيقاف تحديد المقاطع';
 
   @override
-  String get librarySortClipsSemanticLabel => 'فرز المقاطع';
-
-  @override
   String get librarySelectClipsSemanticLabel => 'تحديد المقاطع';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -6523,9 +6523,6 @@ class AppLocalizationsBg extends AppLocalizations {
   String get libraryStopSelectingClipsSemanticLabel => 'Спри избора на клипове';
 
   @override
-  String get librarySortClipsSemanticLabel => 'Сортирай клиповете';
-
-  @override
   String get librarySelectClipsSemanticLabel => 'Избери клипове';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -6532,6 +6532,12 @@ class AppLocalizationsBg extends AppLocalizations {
   String get libraryGridSizeLabel => 'Размер на мрежата';
 
   @override
+  String get libraryDisplayOptionsLabel => 'Сортиране и размер на мрежата';
+
+  @override
+  String get libraryMoreActionsSemanticLabel => 'Още действия в библиотеката';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -6544,9 +6544,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get libraryStopSelectingClipsSemanticLabel => 'Clip-Auswahl beenden';
 
   @override
-  String get librarySortClipsSemanticLabel => 'Clips sortieren';
-
-  @override
   String get librarySelectClipsSemanticLabel => 'Clips auswählen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -6553,6 +6553,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get libraryGridSizeLabel => 'Rastergröße';
 
   @override
+  String get libraryDisplayOptionsLabel => 'Sortierung & Rastergröße';
+
+  @override
+  String get libraryMoreActionsSemanticLabel => 'Weitere Bibliotheksaktionen';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -6462,9 +6462,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get libraryStopSelectingClipsSemanticLabel => 'Stop selecting clips';
 
   @override
-  String get librarySortClipsSemanticLabel => 'Sort clips';
-
-  @override
   String get librarySelectClipsSemanticLabel => 'Select clips';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -6471,6 +6471,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get libraryGridSizeLabel => 'Grid size';
 
   @override
+  String get libraryDisplayOptionsLabel => 'Sort & grid size';
+
+  @override
+  String get libraryMoreActionsSemanticLabel => 'More library actions';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -6519,9 +6519,6 @@ class AppLocalizationsEs extends AppLocalizations {
       'Dejar de seleccionar clips';
 
   @override
-  String get librarySortClipsSemanticLabel => 'Ordenar clips';
-
-  @override
   String get librarySelectClipsSemanticLabel => 'Seleccionar clips';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -6528,6 +6528,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get libraryGridSizeLabel => 'Tamaño de la cuadrícula';
 
   @override
+  String get libraryDisplayOptionsLabel => 'Orden y tamaño de cuadrícula';
+
+  @override
+  String get libraryMoreActionsSemanticLabel => 'Más acciones de la biblioteca';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -6553,6 +6553,12 @@ class AppLocalizationsFil extends AppLocalizations {
   String get libraryGridSizeLabel => 'Laki ng grid';
 
   @override
+  String get libraryDisplayOptionsLabel => 'Pagkakasunod-sunod at laki ng grid';
+
+  @override
+  String get libraryMoreActionsSemanticLabel => 'Higit pang aksyon sa library';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -6544,9 +6544,6 @@ class AppLocalizationsFil extends AppLocalizations {
       'Ihinto ang pagpili ng mga clip';
 
   @override
-  String get librarySortClipsSemanticLabel => 'Ayusin ang mga clip';
-
-  @override
   String get librarySelectClipsSemanticLabel => 'Pumili ng mga clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -6556,6 +6556,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get libraryGridSizeLabel => 'Taille de la grille';
 
   @override
+  String get libraryDisplayOptionsLabel => 'Tri et taille de grille';
+
+  @override
+  String get libraryMoreActionsSemanticLabel =>
+      'Plus d\'actions de la bibliothèque';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -6547,9 +6547,6 @@ class AppLocalizationsFr extends AppLocalizations {
       'Arrêter de sélectionner des clips';
 
   @override
-  String get librarySortClipsSemanticLabel => 'Trier les clips';
-
-  @override
   String get librarySelectClipsSemanticLabel => 'Sélectionner des clips';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -6432,9 +6432,6 @@ class AppLocalizationsId extends AppLocalizations {
   String get libraryStopSelectingClipsSemanticLabel => 'Berhenti memilih klip';
 
   @override
-  String get librarySortClipsSemanticLabel => 'Urutkan klip';
-
-  @override
   String get librarySelectClipsSemanticLabel => 'Pilih klip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -6441,6 +6441,12 @@ class AppLocalizationsId extends AppLocalizations {
   String get libraryGridSizeLabel => 'Ukuran kisi';
 
   @override
+  String get libraryDisplayOptionsLabel => 'Urutan & ukuran kisi';
+
+  @override
+  String get libraryMoreActionsSemanticLabel => 'Tindakan pustaka lainnya';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -6525,9 +6525,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get libraryStopSelectingClipsSemanticLabel => 'Termina selezione clip';
 
   @override
-  String get librarySortClipsSemanticLabel => 'Ordina clip';
-
-  @override
   String get librarySelectClipsSemanticLabel => 'Seleziona clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -6534,6 +6534,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get libraryGridSizeLabel => 'Dimensioni della griglia';
 
   @override
+  String get libraryDisplayOptionsLabel => 'Ordinamento e dimensione griglia';
+
+  @override
+  String get libraryMoreActionsSemanticLabel => 'Altre azioni della libreria';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -6200,6 +6200,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get libraryGridSizeLabel => 'グリッドのサイズ';
 
   @override
+  String get libraryDisplayOptionsLabel => '並び替えとグリッドサイズ';
+
+  @override
+  String get libraryMoreActionsSemanticLabel => 'ライブラリのその他の操作';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -6191,9 +6191,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get libraryStopSelectingClipsSemanticLabel => 'クリップの選択を終了';
 
   @override
-  String get librarySortClipsSemanticLabel => 'クリップを並べ替える';
-
-  @override
   String get librarySelectClipsSemanticLabel => 'クリップを選択';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -6222,6 +6222,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get libraryGridSizeLabel => '그리드 크기';
 
   @override
+  String get libraryDisplayOptionsLabel => '정렬 및 그리드 크기';
+
+  @override
+  String get libraryMoreActionsSemanticLabel => '라이브러리 추가 작업';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -6213,9 +6213,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get libraryStopSelectingClipsSemanticLabel => '클립 선택 종료';
 
   @override
-  String get librarySortClipsSemanticLabel => '클립 정렬';
-
-  @override
   String get librarySelectClipsSemanticLabel => '클립 선택';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -6515,9 +6515,6 @@ class AppLocalizationsMs extends AppLocalizations {
   String get libraryStopSelectingClipsSemanticLabel => 'Berhenti memilih klip';
 
   @override
-  String get librarySortClipsSemanticLabel => 'Isih klip';
-
-  @override
   String get librarySelectClipsSemanticLabel => 'Pilih klip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -6524,6 +6524,12 @@ class AppLocalizationsMs extends AppLocalizations {
   String get libraryGridSizeLabel => 'Saiz grid';
 
   @override
+  String get libraryDisplayOptionsLabel => 'Susunan & saiz grid';
+
+  @override
+  String get libraryMoreActionsSemanticLabel => 'Lagi tindakan pustaka';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -6505,6 +6505,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get libraryGridSizeLabel => 'Rastergrootte';
 
   @override
+  String get libraryDisplayOptionsLabel => 'Sortering en rastergrootte';
+
+  @override
+  String get libraryMoreActionsSemanticLabel => 'Meer bibliotheekacties';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -6496,9 +6496,6 @@ class AppLocalizationsNl extends AppLocalizations {
       'Stoppen met clips selecteren';
 
   @override
-  String get librarySortClipsSemanticLabel => 'Clips sorteren';
-
-  @override
   String get librarySelectClipsSemanticLabel => 'Clips selecteren';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6619,9 +6619,6 @@ class AppLocalizationsPl extends AppLocalizations {
       'Zakończ wybieranie klipów';
 
   @override
-  String get librarySortClipsSemanticLabel => 'Sortuj klipy';
-
-  @override
   String get librarySelectClipsSemanticLabel => 'Wybierz klipy';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6628,6 +6628,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get libraryGridSizeLabel => 'Rozmiar siatki';
 
   @override
+  String get libraryDisplayOptionsLabel => 'Sortowanie i rozmiar siatki';
+
+  @override
+  String get libraryMoreActionsSemanticLabel => 'Więcej akcji biblioteki';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -6509,9 +6509,6 @@ class AppLocalizationsPt extends AppLocalizations {
       'Parar de selecionar clipes';
 
   @override
-  String get librarySortClipsSemanticLabel => 'Ordenar clipes';
-
-  @override
   String get librarySelectClipsSemanticLabel => 'Selecionar clipes';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -6518,6 +6518,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get libraryGridSizeLabel => 'Tamanho da grade';
 
   @override
+  String get libraryDisplayOptionsLabel => 'Ordenação e tamanho da grade';
+
+  @override
+  String get libraryMoreActionsSemanticLabel => 'Mais ações da biblioteca';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6623,9 +6623,6 @@ class AppLocalizationsRo extends AppLocalizations {
       'Oprește selectarea clipurilor';
 
   @override
-  String get librarySortClipsSemanticLabel => 'Sortează clipurile';
-
-  @override
   String get librarySelectClipsSemanticLabel => 'Selectează clipuri';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6632,6 +6632,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get libraryGridSizeLabel => 'Dimensiunea grilei';
 
   @override
+  String get libraryDisplayOptionsLabel => 'Sortare și dimensiunea grilei';
+
+  @override
+  String get libraryMoreActionsSemanticLabel =>
+      'Mai multe acțiuni în bibliotecă';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -6461,9 +6461,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get libraryStopSelectingClipsSemanticLabel => 'Sluta välja klipp';
 
   @override
-  String get librarySortClipsSemanticLabel => 'Sortera klipp';
-
-  @override
   String get librarySelectClipsSemanticLabel => 'Välj klipp';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -6470,6 +6470,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get libraryGridSizeLabel => 'Rutnätets storlek';
 
   @override
+  String get libraryDisplayOptionsLabel => 'Sortering och rutnätsstorlek';
+
+  @override
+  String get libraryMoreActionsSemanticLabel => 'Fler biblioteksåtgärder';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -6432,9 +6432,6 @@ class AppLocalizationsTr extends AppLocalizations {
   String get libraryStopSelectingClipsSemanticLabel => 'Klip seçimini bitir';
 
   @override
-  String get librarySortClipsSemanticLabel => 'Klipleri sırala';
-
-  @override
   String get librarySelectClipsSemanticLabel => 'Klip seç';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -6441,6 +6441,12 @@ class AppLocalizationsTr extends AppLocalizations {
   String get libraryGridSizeLabel => 'Izgara boyutu';
 
   @override
+  String get libraryDisplayOptionsLabel => 'Sıralama ve ızgara boyutu';
+
+  @override
+  String get libraryMoreActionsSemanticLabel => 'Diğer kütüphane işlemleri';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -6482,6 +6482,12 @@ class AppLocalizationsUr extends AppLocalizations {
   String get libraryGridSizeLabel => 'گرڈ کا سائز';
 
   @override
+  String get libraryDisplayOptionsLabel => 'ترتیب اور گرڈ سائز';
+
+  @override
+  String get libraryMoreActionsSemanticLabel => 'لائبریری کی مزید کارروائیاں';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -6473,9 +6473,6 @@ class AppLocalizationsUr extends AppLocalizations {
       'کلپس منتخب کرنا بند کریں';
 
   @override
-  String get librarySortClipsSemanticLabel => 'کلپس ترتیب دیں';
-
-  @override
   String get librarySelectClipsSemanticLabel => 'کلپس منتخب کریں';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -6484,6 +6484,12 @@ class AppLocalizationsVi extends AppLocalizations {
   String get libraryGridSizeLabel => 'Kích thước lưới';
 
   @override
+  String get libraryDisplayOptionsLabel => 'Sắp xếp và cỡ lưới';
+
+  @override
+  String get libraryMoreActionsSemanticLabel => 'Thao tác thư viện khác';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -6475,9 +6475,6 @@ class AppLocalizationsVi extends AppLocalizations {
   String get libraryStopSelectingClipsSemanticLabel => 'Dừng chọn clip';
 
   @override
-  String get librarySortClipsSemanticLabel => 'Sắp xếp clip';
-
-  @override
   String get librarySelectClipsSemanticLabel => 'Chọn clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -6163,9 +6163,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get libraryStopSelectingClipsSemanticLabel => '停止选择片段';
 
   @override
-  String get librarySortClipsSemanticLabel => '对片段排序';
-
-  @override
   String get librarySelectClipsSemanticLabel => '选择片段';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -6172,6 +6172,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get libraryGridSizeLabel => '网格大小';
 
   @override
+  String get libraryDisplayOptionsLabel => '排序和网格大小';
+
+  @override
+  String get libraryMoreActionsSemanticLabel => '更多作品库操作';
+
+  @override
   String libraryGridSizeColumns(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/widgets/library/library_toolbar.dart
+++ b/mobile/lib/widgets/library/library_toolbar.dart
@@ -95,11 +95,22 @@ class LibraryToolbar extends StatelessWidget {
   /// Around four characters and an ellipsis at the default text scale. Below
   /// that the title is ellipsis with no word left to read, which is the state
   /// #7165 reported at 320-360dp.
+  ///
+  /// Reserving it grows on [DivineIcon]'s capped curve rather than the raw
+  /// text scaler: the title is the one row child whose full text nobody needs
+  /// to read — every locale says the same word — while the actions beside it
+  /// are the reason the screen is open. Left uncapped, a 2x scale would spend
+  /// 160px holding four characters and push a button into the menu on a
+  /// phone wide enough to show it.
   static const _minTitleWidth = 72.0;
 
   /// Outer width of a `small` [DivineIconButton] — its 40px chip inside a
   /// 48px tap target. Scales with the text scaler, on [DivineIcon]'s capped
   /// curve, exactly as the button itself does.
+  ///
+  /// Type-independent: a destructive button pads by the border width that a
+  /// bordered one paints instead, so both land on the same outer bounds.
+  /// `library_toolbar_test` pins that, like [_chipChrome].
   static const _iconButtonWidth = 48.0;
 
   /// Width a `small` [DivineButton] adds around its label: 4px outer padding,
@@ -216,13 +227,20 @@ class LibraryToolbar extends StatelessWidget {
 
     final iconButtonExtent = _iconButtonExtent(context);
     final titleExtent =
-        MediaQuery.textScalerOf(context).scale(_minTitleWidth) +
-        _titlePadding * 2;
+        DivineIcon.scaleSize(context, _minTitleWidth) + _titlePadding * 2;
     final extents = [
       for (final action in actions) _actionExtent(context, action),
     ];
 
+    // The first collapse swaps the front action for a more button, so it only
+    // narrows the row by whatever that action is wider than one. An icon-only
+    // action is exactly as wide, which makes collapsing it alone a pure loss:
+    // same row, one extra tap to reach it. There the row starts narrowing at
+    // the second collapse, and the first is skipped.
+    final firstUsefulOverflow = extents.first > iconButtonExtent ? 1 : 2;
+
     for (var overflow = 0; overflow < actions.length; overflow++) {
+      if (overflow > 0 && overflow < firstUsefulOverflow) continue;
       // Leading button and title.
       var width = iconButtonExtent + titleExtent;
       var children = 2;
@@ -237,9 +255,10 @@ class LibraryToolbar extends StatelessWidget {
       if (width + _spacing * (children - 1) <= maxWidth) return overflow;
     }
 
-    // Nothing fits: keep the primary action anyway. It is capped instead —
-    // see [_primaryMaxWidth].
-    return actions.length - 1;
+    // Nothing fits: collapse everything the row can spare and keep the
+    // primary action anyway. It is capped instead — see [_primaryMaxWidth].
+    final most = actions.length - 1;
+    return most < firstUsefulOverflow ? 0 : most;
   }
 
   /// Width left for the primary action once every other row child has taken

--- a/mobile/lib/widgets/library/library_toolbar.dart
+++ b/mobile/lib/widgets/library/library_toolbar.dart
@@ -23,7 +23,7 @@ class _ClipAction {
     this.isDestructive = false,
   });
 
-  /// Icon shown in the row and in the overflow menu.
+  /// Icon shown in the overflow menu, and in the row when [chipLabel] is null.
   final DivineIconName icon;
 
   /// Visible label in the row. Null renders an icon-only button.
@@ -104,13 +104,14 @@ class LibraryToolbar extends StatelessWidget {
   /// phone wide enough to show it.
   static const _minTitleWidth = 72.0;
 
-  /// Outer width of a `small` [DivineIconButton] — its 40px chip inside a
-  /// 48px tap target. Scales with the text scaler, on [DivineIcon]'s capped
-  /// curve, exactly as the button itself does.
+  /// Outer width of a `small` [DivineIconButton] — its pill centred in a 48px
+  /// tap target. Scales with the text scaler, on [DivineIcon]'s capped curve,
+  /// exactly as the button itself does.
   ///
-  /// Type-independent: a destructive button pads by the border width that a
-  /// bordered one paints instead, so both land on the same outer bounds.
-  /// `library_toolbar_test` pins that, like [_chipChrome].
+  /// Type-independent: at `small` that tap-target box is what fixes the outer
+  /// bounds, so a bordered button and a destructive one occupy the same 48px
+  /// whatever their pills measure. `library_toolbar_test` pins that, like
+  /// [_chipChrome].
   static const _iconButtonWidth = 48.0;
 
   /// Width a `small` [DivineButton] adds around its label: 4px outer padding,
@@ -195,8 +196,10 @@ class LibraryToolbar extends StatelessWidget {
     final chipLabel = action.chipLabel;
     if (chipLabel == null) return _iconButtonExtent(context);
 
-    // Measured, never painted — the color is here because the style helper
-    // requires one, and it picks the chip's own so metrics stay honest.
+    // Measured, never painted — it carries a color at all because
+    // `check_implicit_font_color_ceiling` freezes color-less
+    // `VineTheme.*Font(` calls at zero (#6404), and the chip's own is the
+    // honest one to name.
     final painter = TextPainter(
       text: TextSpan(
         text: chipLabel,

--- a/mobile/lib/widgets/library/library_toolbar.dart
+++ b/mobile/lib/widgets/library/library_toolbar.dart
@@ -1,9 +1,49 @@
 // ABOUTME: Toolbar for the library screen with navigation and clip actions
-// ABOUTME: Keeps library header actions separate from LibraryScreen wiring
+// ABOUTME: Collapses clip actions into an overflow menu when the row is narrow
+
+import 'dart:math' as math;
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:openvine/l10n/l10n.dart';
+
+/// One trailing clip action of [LibraryToolbar].
+///
+/// The same description renders either as a row button or as a row of the
+/// overflow menu, so an action that moves out of the row keeps its icon, its
+/// callback and its disabled state.
+@immutable
+class _ClipAction {
+  const _ClipAction({
+    required this.icon,
+    required this.menuLabel,
+    required this.onPressed,
+    this.chipLabel,
+    this.semanticLabel,
+    this.isDestructive = false,
+  });
+
+  /// Icon shown in the row and in the overflow menu.
+  final DivineIconName icon;
+
+  /// Visible label in the row. Null renders an icon-only button.
+  final String? chipLabel;
+
+  /// Visible label of this action's overflow-menu row.
+  ///
+  /// Always spelled out — a menu row has room for words an icon button in the
+  /// toolbar does not.
+  final String menuLabel;
+
+  /// Announced name of the row button. Required for an icon-only action;
+  /// null on a chip whose visible label already reads as the action.
+  final String? semanticLabel;
+
+  /// Null disables the action in the row and in the menu.
+  final VoidCallback? onPressed;
+
+  final bool isDestructive;
+}
 
 class LibraryToolbar extends StatelessWidget {
   const LibraryToolbar({
@@ -44,95 +84,268 @@ class LibraryToolbar extends StatelessWidget {
 
   final VoidCallback? onDeleteSelectedClips;
 
+  /// Gap between row children.
+  static const _spacing = 8.0;
+
+  /// Inset the title carries on each side inside its slot.
+  static const _titlePadding = 8.0;
+
+  /// Narrowest title worth keeping in the row, before [_titlePadding].
+  ///
+  /// Around four characters and an ellipsis at the default text scale. Below
+  /// that the title is ellipsis with no word left to read, which is the state
+  /// #7165 reported at 320-360dp.
+  static const _minTitleWidth = 72.0;
+
+  /// Outer width of a `small` [DivineIconButton] — its 40px chip inside a
+  /// 48px tap target. Scales with the text scaler, on [DivineIcon]'s capped
+  /// curve, exactly as the button itself does.
+  static const _iconButtonWidth = 48.0;
+
+  /// Width a `small` [DivineButton] adds around its label: 4px outer padding,
+  /// 2px border and 14px inner padding, on each side.
+  ///
+  /// Estimating the row's width needs a number here because the collapse has
+  /// to be decided while building, before anything is laid out.
+  /// `library_toolbar_test` pins it against a real button so a change in
+  /// `divine_ui`'s geometry fails loudly rather than silently overflowing.
+  static const _chipChrome = 40.0;
+
+  /// Trailing clip actions, least important first.
+  ///
+  /// The overflow menu takes them from the front, so the primary action is
+  /// the last one to leave the row.
+  List<_ClipAction> _clipActions(BuildContext context) {
+    if (!isClipsTabActive) return const [];
+    final l10n = context.l10n;
+
+    // The bin is its own mode: nothing in it can be sorted, selected or
+    // filed, so emptying it is the only action on offer.
+    if (isTrashFilterActive) {
+      return [
+        if (onEmptyTrash != null)
+          _ClipAction(
+            icon: .trash,
+            chipLabel: l10n.libraryTrashEmptyAllLabel,
+            menuLabel: l10n.libraryTrashEmptyAllLabel,
+            onPressed: onEmptyTrash,
+            isDestructive: true,
+          ),
+      ];
+    }
+
+    return [
+      if (!isLibrarySelectionMode && onManageActiveCategory != null)
+        _ClipAction(
+          icon: .pencilSimple,
+          menuLabel: l10n.libraryCategoryManageSemanticLabel,
+          semanticLabel: l10n.libraryCategoryManageSemanticLabel,
+          onPressed: onManageActiveCategory,
+        ),
+      _ClipAction(
+        icon: .funnelSimple,
+        menuLabel: l10n.libraryDisplayOptionsLabel,
+        // #7129 put the grid-size control in this same menu, so the label
+        // names both jobs.
+        semanticLabel:
+            '${l10n.librarySortClipsSemanticLabel}. '
+            '${l10n.libraryGridSizeLabel}',
+        onPressed: onOpenSortMenu,
+      ),
+      if (!isLibrarySelectionMode)
+        _ClipAction(
+          icon: .selection,
+          chipLabel: l10n.librarySelect,
+          menuLabel: l10n.librarySelectClipsSemanticLabel,
+          semanticLabel: l10n.librarySelectClipsSemanticLabel,
+          onPressed: onEnterSelectionMode,
+        ),
+      if (isLibrarySelectionMode) ...[
+        _ClipAction(
+          icon: .folderOpen,
+          menuLabel: l10n.libraryMoveSelectedClipsTooltip,
+          semanticLabel: l10n.libraryMoveSelectedClipsTooltip,
+          onPressed: onMoveSelectedClips,
+        ),
+        _ClipAction(
+          icon: .trash,
+          menuLabel: l10n.libraryDeleteSelectedClipsTooltip,
+          semanticLabel: l10n.libraryDeleteSelectedClipsTooltip,
+          onPressed: onDeleteSelectedClips,
+          isDestructive: true,
+        ),
+      ],
+    ];
+  }
+
+  double _iconButtonExtent(BuildContext context) =>
+      DivineIcon.scaleSize(context, _iconButtonWidth);
+
+  double _actionExtent(BuildContext context, _ClipAction action) {
+    final chipLabel = action.chipLabel;
+    if (chipLabel == null) return _iconButtonExtent(context);
+
+    // Measured, never painted — the color is here because the style helper
+    // requires one, and it picks the chip's own so metrics stay honest.
+    final painter = TextPainter(
+      text: TextSpan(
+        text: chipLabel,
+        style: VineTheme.titleMediumFont(
+          color: context.vineColors.primaryText,
+        ),
+      ),
+      textDirection: Directionality.of(context),
+      textScaler: MediaQuery.textScalerOf(context),
+      maxLines: 1,
+    )..layout();
+    final labelWidth = painter.width;
+    painter.dispose();
+
+    return math.max(_iconButtonExtent(context), labelWidth + _chipChrome);
+  }
+
+  /// How many actions, counted from the front, do not fit and move into the
+  /// overflow menu.
+  int _overflowCount(
+    BuildContext context,
+    List<_ClipAction> actions,
+    double maxWidth,
+  ) {
+    if (actions.isEmpty) return 0;
+
+    final iconButtonExtent = _iconButtonExtent(context);
+    final titleExtent =
+        MediaQuery.textScalerOf(context).scale(_minTitleWidth) +
+        _titlePadding * 2;
+    final extents = [
+      for (final action in actions) _actionExtent(context, action),
+    ];
+
+    for (var overflow = 0; overflow < actions.length; overflow++) {
+      // Leading button and title.
+      var width = iconButtonExtent + titleExtent;
+      var children = 2;
+      if (overflow > 0) {
+        width += iconButtonExtent;
+        children++;
+      }
+      for (var i = overflow; i < actions.length; i++) {
+        width += extents[i];
+        children++;
+      }
+      if (width + _spacing * (children - 1) <= maxWidth) return overflow;
+    }
+
+    // Everything collapsed: leading, title and the overflow button always fit.
+    return actions.length;
+  }
+
+  Future<void> _openOverflowMenu(
+    BuildContext context,
+    List<_ClipAction> actions,
+  ) {
+    return VineBottomSheetActionMenu.show(
+      context: context,
+      options: [
+        // Most important first: the menu leads with the action the row would
+        // have shown last.
+        for (final action in actions.reversed)
+          VineBottomSheetActionData(
+            iconPath: action.icon.assetPath,
+            label: action.menuLabel,
+            isDestructive: action.isDestructive,
+            onTap: action.onPressed,
+          ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final showsSelectionExit =
         isClipsTabActive && isLibrarySelectionMode && canExitSelectionMode;
+    final actions = _clipActions(context);
+
     return Padding(
       padding: const EdgeInsets.all(16),
-      child: Row(
-        spacing: 8,
-        children: [
-          DivineIconButton(
-            size: .small,
-            type: .secondary,
-            icon: showsSelectionExit ? .x : .caretLeft,
-            semanticLabel: showsSelectionExit
-                ? context.l10n.libraryStopSelectingClipsSemanticLabel
-                : context.l10n.libraryCloseSemanticLabel,
-            onPressed: onLeadingPressed,
-          ),
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8),
-              child: Text(
-                context.l10n.profileMyLibraryLabel,
-                style: VineTheme.titleMediumFont(
-                  color: context.vineColors.primaryText,
-                ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-          ),
-          if (isClipsTabActive) ...[
-            if (isTrashFilterActive) ...[
-              if (onEmptyTrash != null)
-                DivineButton(
-                  size: .small,
-                  type: .error,
-                  label: context.l10n.libraryTrashEmptyAllLabel,
-                  onPressed: onEmptyTrash,
-                ),
-            ] else ...[
-              if (!isLibrarySelectionMode && onManageActiveCategory != null)
-                DivineIconButton(
-                  size: .small,
-                  type: .secondary,
-                  icon: .pencilSimple,
-                  semanticLabel:
-                      context.l10n.libraryCategoryManageSemanticLabel,
-                  onPressed: onManageActiveCategory,
-                ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final overflowCount = _overflowCount(
+            context,
+            actions,
+            constraints.maxWidth,
+          );
+          return Row(
+            spacing: _spacing,
+            children: [
               DivineIconButton(
                 size: .small,
                 type: .secondary,
-                icon: .funnelSimple,
-                // #7129 put the grid-size control in this same menu, so the
-                // label names both jobs.
-                semanticLabel:
-                    '${context.l10n.librarySortClipsSemanticLabel}. '
-                    '${context.l10n.libraryGridSizeLabel}',
-                onPressed: onOpenSortMenu,
+                icon: showsSelectionExit ? .x : .caretLeft,
+                semanticLabel: showsSelectionExit
+                    ? context.l10n.libraryStopSelectingClipsSemanticLabel
+                    : context.l10n.libraryCloseSemanticLabel,
+                onPressed: onLeadingPressed,
               ),
-              if (!isLibrarySelectionMode)
-                DivineButton(
-                  size: .small,
-                  type: .secondary,
-                  label: context.l10n.librarySelect,
-                  semanticLabel: context.l10n.librarySelectClipsSemanticLabel,
-                  onPressed: onEnterSelectionMode,
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: _titlePadding,
+                  ),
+                  child: Text(
+                    context.l10n.profileMyLibraryLabel,
+                    style: VineTheme.titleMediumFont(
+                      color: context.vineColors.primaryText,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
                 ),
-              if (isLibrarySelectionMode) ...[
+              ),
+              if (overflowCount > 0)
                 DivineIconButton(
                   size: .small,
                   type: .secondary,
-                  icon: .folderOpen,
-                  semanticLabel: context.l10n.libraryMoveSelectedClipsTooltip,
-                  onPressed: onMoveSelectedClips,
+                  icon: .dotsThree,
+                  semanticLabel: context.l10n.libraryMoreActionsSemanticLabel,
+                  onPressed: () => _openOverflowMenu(
+                    context,
+                    actions.sublist(0, overflowCount),
+                  ),
                 ),
-                DivineIconButton(
-                  size: .small,
-                  type: .error,
-                  icon: .trash,
-                  semanticLabel: context.l10n.libraryDeleteSelectedClipsTooltip,
-                  onPressed: onDeleteSelectedClips,
-                ),
-              ],
+              for (final action in actions.sublist(overflowCount))
+                _ClipActionButton(action: action),
             ],
-          ],
-        ],
+          );
+        },
       ),
+    );
+  }
+}
+
+class _ClipActionButton extends StatelessWidget {
+  const _ClipActionButton({required this.action});
+
+  final _ClipAction action;
+
+  @override
+  Widget build(BuildContext context) {
+    final chipLabel = action.chipLabel;
+    if (chipLabel != null) {
+      return DivineButton(
+        size: .small,
+        type: action.isDestructive ? .error : .secondary,
+        label: chipLabel,
+        semanticLabel: action.semanticLabel,
+        onPressed: action.onPressed,
+      );
+    }
+    return DivineIconButton(
+      size: .small,
+      type: action.isDestructive ? .error : .secondary,
+      icon: action.icon,
+      semanticLabel: action.semanticLabel,
+      onPressed: action.onPressed,
     );
   }
 }

--- a/mobile/lib/widgets/library/library_toolbar.dart
+++ b/mobile/lib/widgets/library/library_toolbar.dart
@@ -144,12 +144,11 @@ class LibraryToolbar extends StatelessWidget {
         ),
       _ClipAction(
         icon: .funnelSimple,
-        menuLabel: l10n.libraryDisplayOptionsLabel,
         // #7129 put the grid-size control in this same menu, so the label
-        // names both jobs.
-        semanticLabel:
-            '${l10n.librarySortClipsSemanticLabel}. '
-            '${l10n.libraryGridSizeLabel}',
+        // names both jobs — and names them the same way in the row as in the
+        // menu, rather than assembling a sentence out of two keys.
+        menuLabel: l10n.libraryDisplayOptionsLabel,
+        semanticLabel: l10n.libraryDisplayOptionsLabel,
         onPressed: onOpenSortMenu,
       ),
       if (!isLibrarySelectionMode)

--- a/mobile/lib/widgets/library/library_toolbar.dart
+++ b/mobile/lib/widgets/library/library_toolbar.dart
@@ -206,6 +206,8 @@ class LibraryToolbar extends StatelessWidget {
 
   /// How many actions, counted from the front, do not fit and move into the
   /// overflow menu.
+  ///
+  /// Never all of them: the primary action stays in the row at every width.
   int _overflowCount(
     BuildContext context,
     List<_ClipAction> actions,
@@ -236,8 +238,38 @@ class LibraryToolbar extends StatelessWidget {
       if (width + _spacing * (children - 1) <= maxWidth) return overflow;
     }
 
-    // Everything collapsed: leading, title and the overflow button always fit.
-    return actions.length;
+    // Nothing fits: keep the primary action anyway. It is capped instead —
+    // see [_primaryMaxWidth].
+    return actions.length - 1;
+  }
+
+  /// Width left for the primary action once every other row child has taken
+  /// its own.
+  ///
+  /// The primary action never moves into the menu, so in the tightest rows it
+  /// is the one child that has to give. Capping it lets its label ellipsize
+  /// rather than push the row past the screen. The title is not reserved for
+  /// here on purpose: at that width the title yields first.
+  double _primaryMaxWidth(
+    BuildContext context,
+    List<_ClipAction> visible, {
+    required bool hasOverflow,
+    required double maxWidth,
+  }) {
+    if (visible.isEmpty) return 0;
+
+    // Leading button, title, and the primary action itself.
+    var width = _iconButtonExtent(context);
+    var children = 3;
+    if (hasOverflow) {
+      width += _iconButtonExtent(context);
+      children++;
+    }
+    for (final action in visible.take(visible.length - 1)) {
+      width += _actionExtent(context, action);
+      children++;
+    }
+    return math.max(0, maxWidth - width - _spacing * (children - 1));
   }
 
   Future<void> _openOverflowMenu(
@@ -274,6 +306,13 @@ class LibraryToolbar extends StatelessWidget {
             context,
             actions,
             constraints.maxWidth,
+          );
+          final visible = actions.sublist(overflowCount);
+          final primaryMaxWidth = _primaryMaxWidth(
+            context,
+            visible,
+            hasOverflow: overflowCount > 0,
+            maxWidth: constraints.maxWidth,
           );
           return Row(
             spacing: _spacing,
@@ -313,8 +352,14 @@ class LibraryToolbar extends StatelessWidget {
                     actions.sublist(0, overflowCount),
                   ),
                 ),
-              for (final action in actions.sublist(overflowCount))
-                _ClipActionButton(action: action),
+              for (final (index, action) in visible.indexed)
+                if (index == visible.length - 1)
+                  ConstrainedBox(
+                    constraints: BoxConstraints(maxWidth: primaryMaxWidth),
+                    child: _ClipActionButton(action: action),
+                  )
+                else
+                  _ClipActionButton(action: action),
             ],
           );
         },

--- a/mobile/test/screens/library_screen_test.dart
+++ b/mobile/test/screens/library_screen_test.dart
@@ -95,8 +95,6 @@ List<Object?> _captureAnnouncements(WidgetTester tester) {
 
 void main() {
   final en = AppLocalizationsEn();
-  final displayOptionsLabel =
-      '${en.librarySortClipsSemanticLabel}. ${en.libraryGridSizeLabel}';
 
   group(LibraryScreen, () {
     late _MockGallerySaveService mockGallerySaveService;
@@ -241,7 +239,7 @@ void main() {
         await tester.pumpWidget(buildWidget(initialTabIndex: 1));
         await tester.pumpAndSettle();
 
-        await tester.tap(find.bySemanticsLabel(displayOptionsLabel));
+        await tester.tap(find.bySemanticsLabel(en.libraryDisplayOptionsLabel));
         await tester.pumpAndSettle();
         await tester.tap(find.text(en.libraryGridSizeLabel));
         await tester.pumpAndSettle();

--- a/mobile/test/widgets/library/library_toolbar_test.dart
+++ b/mobile/test/widgets/library/library_toolbar_test.dart
@@ -10,8 +10,6 @@ import 'package:openvine/widgets/library/library_toolbar.dart';
 
 void main() {
   final en = AppLocalizationsEn();
-  final displayOptionsLabel =
-      '${en.librarySortClipsSemanticLabel}. ${en.libraryGridSizeLabel}';
 
   /// Wide enough for every action, narrow enough to stay a phone.
   const wideWidth = 520.0;
@@ -166,7 +164,10 @@ void main() {
 
         expect(find.text(en.librarySelect), findsOneWidget);
         expect(iconButton(DivineIconName.funnelSimple), findsOneWidget);
-        expect(find.bySemanticsLabel(displayOptionsLabel), findsOneWidget);
+        expect(
+          find.bySemanticsLabel(en.libraryDisplayOptionsLabel),
+          findsOneWidget,
+        );
         expect(
           find.bySemanticsLabel(en.librarySelectClipsSemanticLabel),
           findsOneWidget,

--- a/mobile/test/widgets/library/library_toolbar_test.dart
+++ b/mobile/test/widgets/library/library_toolbar_test.dart
@@ -312,10 +312,12 @@ void main() {
       testWidgets('keeps the primary action when only part of the row fits', (
         tester,
       ) async {
-        // A large text scale eats the room the icon buttons need, but not the
-        // room for Select — the least important actions leave first.
+        // A large text scale on a small phone eats the room the icon buttons
+        // need, but not the room for Select — the least important actions
+        // leave first.
         await tester.pumpWidget(
           buildWidget(
+            width: narrowWidth,
             textScaler: const TextScaler.linear(2),
             onManageActiveCategory: () {},
           ),
@@ -413,6 +415,77 @@ void main() {
         }
       });
 
+      testWidgets('does not collapse a lone icon-only action', (tester) async {
+        // Collapsing one icon action swaps it for a more button of the same
+        // width: the row would be no narrower and sorting would cost a tap
+        // more. Below the width where both fit, the row keeps them both.
+        await tester.pumpWidget(buildWidget(width: narrowWidth));
+
+        expect(iconButton(DivineIconName.dotsThree), findsNothing);
+        expect(iconButton(DivineIconName.funnelSimple), findsOneWidget);
+        expect(find.text(en.librarySelect), findsOneWidget);
+      });
+
+      testWidgets('keeps the same actions past the icon scaling cap', (
+        tester,
+      ) async {
+        // Selecting offers only icon actions, so every width the toolbar
+        // estimates — buttons and the title it holds back for — is on
+        // DivineIcon's capped curve. Past the cap a larger text scale must
+        // not push another action into the menu.
+        for (var width = 280.0; width <= 520.0; width += 5) {
+          final visible = <int>[];
+          for (final scale in [1.3, 2.0]) {
+            await tester.pumpWidget(
+              buildWidget(
+                width: width,
+                textScaler: TextScaler.linear(scale),
+                isLibrarySelectionMode: true,
+                onMoveSelectedClips: () {},
+                onDeleteSelectedClips: () {},
+              ),
+            );
+            visible.add(
+              find
+                  .byWidgetPredicate((widget) => widget is DivineIconButton)
+                  .evaluate()
+                  .length,
+            );
+          }
+
+          expect(
+            visible.first,
+            equals(visible.last),
+            reason: 'row lost an action between 1.3x and 2x at ${width}dp',
+          );
+        }
+      });
+
+      testWidgets('estimates an icon button at the width it renders', (
+        tester,
+      ) async {
+        // Every icon action is estimated as one 48px tap target, whatever its
+        // type: a destructive button pads by the border width a secondary one
+        // paints instead, so both land on the same outer bounds. If that stops
+        // holding, the estimate goes under and the row overflows.
+        await tester.pumpWidget(
+          buildWidget(
+            isLibrarySelectionMode: true,
+            onMoveSelectedClips: () {},
+            onDeleteSelectedClips: () {},
+          ),
+        );
+
+        expect(
+          tester.getSize(iconButton(DivineIconName.folderOpen)).width,
+          equals(48),
+        );
+        expect(
+          tester.getSize(iconButton(DivineIconName.trash)).width,
+          equals(48),
+        );
+      });
+
       testWidgets('estimates a Select chip no narrower than it renders', (
         tester,
       ) async {
@@ -476,7 +549,11 @@ void main() {
       ) async {
         var pressed = false;
         await tester.pumpWidget(
-          buildWidget(width: narrowWidth, onOpenSortMenu: () => pressed = true),
+          buildWidget(
+            width: narrowWidth,
+            onOpenSortMenu: () => pressed = true,
+            onManageActiveCategory: () {},
+          ),
         );
 
         await tester.tap(iconButton(DivineIconName.dotsThree));

--- a/mobile/test/widgets/library/library_toolbar_test.dart
+++ b/mobile/test/widgets/library/library_toolbar_test.dart
@@ -492,20 +492,32 @@ void main() {
         // The toolbar decides the collapse while building, so it estimates
         // the chip as label + 40px of chrome. An estimate below the rendered
         // width would overflow the row instead of collapsing it.
+        //
+        // Both halves are measured off the rendered chip. A `TextPainter` of
+        // the test's own would resolve whichever font `google_fonts` has
+        // registered by the time it runs — a real one once an earlier test
+        // has pumped, the fallback on a cold cache — so comparing one against
+        // a rendered width makes the pin depend on what ran first.
         await tester.pumpWidget(buildWidget());
 
-        final painter = TextPainter(
-          text: TextSpan(
-            text: en.librarySelect,
-            style: VineTheme.titleMediumFont(),
-          ),
-          textDirection: TextDirection.ltr,
-        )..layout();
-        final estimate = painter.width + 40;
-        painter.dispose();
-
+        final label = tester.getSize(find.text(en.librarySelect)).width;
         final rendered = tester.getSize(find.byType(DivineButton).first).width;
-        expect(estimate, greaterThanOrEqualTo(rendered));
+        expect(rendered - label, moreOrLessEquals(40, epsilon: 0.01));
+
+        // ...and the label the toolbar measures is styled like the one it
+        // renders, so the two widths are of the same text.
+        final chipStyle = tester
+            .widget<Text>(find.text(en.librarySelect))
+            .style;
+        final measured = VineTheme.titleMediumFont();
+        expect(chipStyle?.fontFamily, equals(measured.fontFamily));
+        expect(
+          chipStyle?.fontFamilyFallback,
+          equals(measured.fontFamilyFallback),
+        );
+        expect(chipStyle?.fontSize, equals(measured.fontSize));
+        expect(chipStyle?.fontWeight, equals(measured.fontWeight));
+        expect(chipStyle?.letterSpacing, equals(measured.letterSpacing));
       });
     });
 

--- a/mobile/test/widgets/library/library_toolbar_test.dart
+++ b/mobile/test/widgets/library/library_toolbar_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for LibraryToolbar widget
-// ABOUTME: Covers title truncation, conditional actions, and button callbacks
+// ABOUTME: Covers title truncation, narrow-width overflow, and callbacks
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -13,12 +13,20 @@ void main() {
   final displayOptionsLabel =
       '${en.librarySortClipsSemanticLabel}. ${en.libraryGridSizeLabel}';
 
+  /// Wide enough for every action, narrow enough to stay a phone.
+  const wideWidth = 520.0;
+
+  /// A small phone in portrait — the width #7165 reported.
+  const narrowWidth = 320.0;
+
   group(LibraryToolbar, () {
     Finder iconButton(DivineIconName icon) => find.byWidgetPredicate(
       (widget) => widget is DivineIconButton && widget.icon == icon,
     );
 
     Widget buildWidget({
+      double width = wideWidth,
+      TextScaler textScaler = TextScaler.noScaling,
       bool isLibrarySelectionMode = false,
       bool canExitSelectionMode = true,
       bool isClipsTabActive = true,
@@ -35,19 +43,28 @@ void main() {
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         theme: VineTheme.theme,
+        builder: (context, child) => MediaQuery(
+          data: MediaQuery.of(context).copyWith(textScaler: textScaler),
+          child: child!,
+        ),
         home: Scaffold(
-          body: LibraryToolbar(
-            isLibrarySelectionMode: isLibrarySelectionMode,
-            canExitSelectionMode: canExitSelectionMode,
-            isClipsTabActive: isClipsTabActive,
-            onLeadingPressed: onLeadingPressed ?? () {},
-            onOpenSortMenu: onOpenSortMenu ?? () {},
-            onEnterSelectionMode: onEnterSelectionMode ?? () {},
-            isTrashFilterActive: isTrashFilterActive,
-            onEmptyTrash: onEmptyTrash,
-            onManageActiveCategory: onManageActiveCategory,
-            onMoveSelectedClips: onMoveSelectedClips,
-            onDeleteSelectedClips: onDeleteSelectedClips,
+          body: Center(
+            child: SizedBox(
+              width: width,
+              child: LibraryToolbar(
+                isLibrarySelectionMode: isLibrarySelectionMode,
+                canExitSelectionMode: canExitSelectionMode,
+                isClipsTabActive: isClipsTabActive,
+                onLeadingPressed: onLeadingPressed ?? () {},
+                onOpenSortMenu: onOpenSortMenu ?? () {},
+                onEnterSelectionMode: onEnterSelectionMode ?? () {},
+                isTrashFilterActive: isTrashFilterActive,
+                onEmptyTrash: onEmptyTrash,
+                onManageActiveCategory: onManageActiveCategory,
+                onMoveSelectedClips: onMoveSelectedClips,
+                onDeleteSelectedClips: onDeleteSelectedClips,
+              ),
+            ),
           ),
         ),
       );
@@ -139,6 +156,7 @@ void main() {
         expect(find.text(en.librarySelect), findsNothing);
         expect(iconButton(DivineIconName.funnelSimple), findsNothing);
         expect(iconButton(DivineIconName.trash), findsNothing);
+        expect(iconButton(DivineIconName.dotsThree), findsNothing);
       });
 
       testWidgets('shows clip actions when clips tab is active', (
@@ -148,14 +166,12 @@ void main() {
 
         expect(find.text(en.librarySelect), findsOneWidget);
         expect(iconButton(DivineIconName.funnelSimple), findsOneWidget);
-        expect(
-          find.bySemanticsLabel(displayOptionsLabel),
-          findsOneWidget,
-        );
+        expect(find.bySemanticsLabel(displayOptionsLabel), findsOneWidget);
         expect(
           find.bySemanticsLabel(en.librarySelectClipsSemanticLabel),
           findsOneWidget,
         );
+        expect(iconButton(DivineIconName.dotsThree), findsNothing);
       });
 
       testWidgets('swaps Select for move and delete in selection mode', (
@@ -190,6 +206,7 @@ void main() {
         await tester.pumpWidget(buildWidget(isTrashFilterActive: true));
 
         expect(find.text(en.libraryTrashEmptyAllLabel), findsNothing);
+        expect(iconButton(DivineIconName.dotsThree), findsNothing);
       });
 
       testWidgets('shows the manage action only for a category filter', (
@@ -198,9 +215,7 @@ void main() {
         await tester.pumpWidget(buildWidget());
         expect(iconButton(DivineIconName.pencilSimple), findsNothing);
 
-        await tester.pumpWidget(
-          buildWidget(onManageActiveCategory: () {}),
-        );
+        await tester.pumpWidget(buildWidget(onManageActiveCategory: () {}));
         expect(
           find.bySemanticsLabel(en.libraryCategoryManageSemanticLabel),
           findsOneWidget,
@@ -230,6 +245,7 @@ void main() {
           ),
           'trash empty': buildWidget(isTrashFilterActive: true),
           'drafts tab': buildWidget(isClipsTabActive: false),
+          'collapsed': buildWidget(width: narrowWidth),
         };
 
         for (final entry in cases.entries) {
@@ -244,6 +260,244 @@ void main() {
           hasLength(1),
           reason: 'toolbar height varies by action set: $heights',
         );
+      });
+    });
+
+    group('narrow widths', () {
+      testWidgets('collapses clip actions into an overflow button', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(width: narrowWidth, onManageActiveCategory: () {}),
+        );
+
+        expect(iconButton(DivineIconName.dotsThree), findsOneWidget);
+        expect(iconButton(DivineIconName.pencilSimple), findsNothing);
+        expect(iconButton(DivineIconName.funnelSimple), findsNothing);
+        expect(
+          find.bySemanticsLabel(en.libraryMoreActionsSemanticLabel),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('keeps a readable title beside the overflow button', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget(width: narrowWidth));
+
+        final titleWidth = tester
+            .getSize(find.text(en.profileMyLibraryLabel))
+            .width;
+        expect(titleWidth, greaterThanOrEqualTo(72));
+      });
+
+      testWidgets('keeps the primary action when only part of the row fits', (
+        tester,
+      ) async {
+        // A large text scale eats the room the icon buttons need, but not the
+        // room for Select — the least important actions leave first.
+        await tester.pumpWidget(
+          buildWidget(
+            textScaler: const TextScaler.linear(2),
+            onManageActiveCategory: () {},
+          ),
+        );
+
+        expect(find.text(en.librarySelect), findsOneWidget);
+        expect(iconButton(DivineIconName.dotsThree), findsOneWidget);
+        expect(iconButton(DivineIconName.pencilSimple), findsNothing);
+        expect(iconButton(DivineIconName.funnelSimple), findsNothing);
+
+        await tester.tap(iconButton(DivineIconName.dotsThree));
+        await tester.pumpAndSettle();
+
+        expect(find.text(en.libraryDisplayOptionsLabel), findsOneWidget);
+        expect(
+          find.text(en.libraryCategoryManageSemanticLabel),
+          findsOneWidget,
+        );
+        expect(find.text(en.librarySelectClipsSemanticLabel), findsNothing);
+      });
+
+      testWidgets('collapses the Empty trash chip rather than overflow it', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(
+            width: narrowWidth,
+            textScaler: const TextScaler.linear(2),
+            isTrashFilterActive: true,
+            onEmptyTrash: () {},
+          ),
+        );
+
+        expect(find.text(en.libraryTrashEmptyAllLabel), findsNothing);
+        expect(iconButton(DivineIconName.dotsThree), findsOneWidget);
+      });
+
+      testWidgets('does not overflow at any phone width', (tester) async {
+        for (var width = 280.0; width <= 520.0; width += 5) {
+          for (final build in [
+            () => buildWidget(width: width, onManageActiveCategory: () {}),
+            () => buildWidget(
+              width: width,
+              isLibrarySelectionMode: true,
+              onMoveSelectedClips: () {},
+              onDeleteSelectedClips: () {},
+            ),
+            () => buildWidget(
+              width: width,
+              isTrashFilterActive: true,
+              onEmptyTrash: () {},
+            ),
+          ]) {
+            await tester.pumpWidget(build());
+
+            expect(
+              tester.takeException(),
+              isNull,
+              reason: 'toolbar overflowed at ${width}dp',
+            );
+          }
+        }
+      });
+
+      testWidgets('estimates a Select chip no narrower than it renders', (
+        tester,
+      ) async {
+        // The toolbar decides the collapse while building, so it estimates
+        // the chip as label + 40px of chrome. An estimate below the rendered
+        // width would overflow the row instead of collapsing it.
+        await tester.pumpWidget(buildWidget());
+
+        final painter = TextPainter(
+          text: TextSpan(
+            text: en.librarySelect,
+            style: VineTheme.titleMediumFont(),
+          ),
+          textDirection: TextDirection.ltr,
+        )..layout();
+        final estimate = painter.width + 40;
+        painter.dispose();
+
+        final rendered = tester.getSize(find.byType(DivineButton).first).width;
+        expect(estimate, greaterThanOrEqualTo(rendered));
+      });
+    });
+
+    group('overflow menu', () {
+      testWidgets('lists every collapsed action', (tester) async {
+        await tester.pumpWidget(
+          buildWidget(width: narrowWidth, onManageActiveCategory: () {}),
+        );
+
+        await tester.tap(iconButton(DivineIconName.dotsThree));
+        await tester.pumpAndSettle();
+
+        expect(find.text(en.librarySelectClipsSemanticLabel), findsOneWidget);
+        expect(find.text(en.libraryDisplayOptionsLabel), findsOneWidget);
+        expect(
+          find.text(en.libraryCategoryManageSemanticLabel),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('manage row triggers onManageActiveCategory', (tester) async {
+        var pressed = false;
+        await tester.pumpWidget(
+          buildWidget(
+            width: narrowWidth,
+            onManageActiveCategory: () => pressed = true,
+          ),
+        );
+
+        await tester.tap(iconButton(DivineIconName.dotsThree));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(en.libraryCategoryManageSemanticLabel));
+        await tester.pumpAndSettle();
+
+        expect(pressed, isTrue);
+      });
+
+      testWidgets('display options row triggers onOpenSortMenu', (
+        tester,
+      ) async {
+        var pressed = false;
+        await tester.pumpWidget(
+          buildWidget(width: narrowWidth, onOpenSortMenu: () => pressed = true),
+        );
+
+        await tester.tap(iconButton(DivineIconName.dotsThree));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(en.libraryDisplayOptionsLabel));
+        await tester.pumpAndSettle();
+
+        expect(pressed, isTrue);
+      });
+
+      testWidgets('Select row triggers onEnterSelectionMode', (tester) async {
+        var pressed = false;
+        await tester.pumpWidget(
+          buildWidget(
+            width: narrowWidth,
+            onEnterSelectionMode: () => pressed = true,
+          ),
+        );
+
+        await tester.tap(iconButton(DivineIconName.dotsThree));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(en.librarySelectClipsSemanticLabel));
+        await tester.pumpAndSettle();
+
+        expect(pressed, isTrue);
+      });
+
+      testWidgets('move and delete rows trigger their callbacks', (
+        tester,
+      ) async {
+        var moved = false;
+        var deleted = false;
+        Widget build() => buildWidget(
+          width: narrowWidth,
+          textScaler: const TextScaler.linear(2),
+          isLibrarySelectionMode: true,
+          onMoveSelectedClips: () => moved = true,
+          onDeleteSelectedClips: () => deleted = true,
+        );
+
+        await tester.pumpWidget(build());
+        await tester.tap(iconButton(DivineIconName.dotsThree));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(en.libraryMoveSelectedClipsTooltip));
+        await tester.pumpAndSettle();
+
+        await tester.pumpWidget(build());
+        await tester.tap(iconButton(DivineIconName.dotsThree));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(en.libraryDeleteSelectedClipsTooltip));
+        await tester.pumpAndSettle();
+
+        expect(moved, isTrue);
+        expect(deleted, isTrue);
+      });
+
+      testWidgets('Empty trash row triggers onEmptyTrash', (tester) async {
+        var pressed = false;
+        await tester.pumpWidget(
+          buildWidget(
+            width: narrowWidth,
+            textScaler: const TextScaler.linear(2),
+            isTrashFilterActive: true,
+            onEmptyTrash: () => pressed = true,
+          ),
+        );
+
+        await tester.tap(iconButton(DivineIconName.dotsThree));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(en.libraryTrashEmptyAllLabel));
+        await tester.pumpAndSettle();
+
+        expect(pressed, isTrue);
       });
     });
 
@@ -290,6 +544,18 @@ void main() {
         );
 
         await tester.tap(find.text(en.libraryTrashEmptyAllLabel));
+        expect(pressed, isTrue);
+      });
+
+      testWidgets('manage button triggers onManageActiveCategory', (
+        tester,
+      ) async {
+        var pressed = false;
+        await tester.pumpWidget(
+          buildWidget(onManageActiveCategory: () => pressed = true),
+        );
+
+        await tester.tap(iconButton(DivineIconName.pencilSimple));
         expect(pressed, isTrue);
       });
 

--- a/mobile/test/widgets/library/library_toolbar_test.dart
+++ b/mobile/test/widgets/library/library_toolbar_test.dart
@@ -278,17 +278,34 @@ void main() {
           find.bySemanticsLabel(en.libraryMoreActionsSemanticLabel),
           findsOneWidget,
         );
+        // The primary action is not one of them.
+        expect(find.text(en.librarySelect), findsOneWidget);
       });
 
-      testWidgets('keeps a readable title beside the overflow button', (
+      testWidgets('keeps a readable title while the row has room', (
         tester,
       ) async {
-        await tester.pumpWidget(buildWidget(width: narrowWidth));
+        await tester.pumpWidget(buildWidget(width: 420));
 
         final titleWidth = tester
             .getSize(find.text(en.profileMyLibraryLabel))
             .width;
         expect(titleWidth, greaterThanOrEqualTo(72));
+      });
+
+      testWidgets('lets the title yield once the row runs out of room', (
+        tester,
+      ) async {
+        // The collapse buys the title its room back, but the primary action
+        // outranks it: past that point the title is what shrinks.
+        await tester.pumpWidget(buildWidget(width: narrowWidth));
+
+        expect(find.text(en.librarySelect), findsOneWidget);
+        expect(find.text(en.profileMyLibraryLabel), findsOneWidget);
+        expect(
+          tester.getSize(find.text(en.profileMyLibraryLabel)).width,
+          greaterThan(0),
+        );
       });
 
       testWidgets('keeps the primary action when only part of the row fits', (
@@ -319,9 +336,11 @@ void main() {
         expect(find.text(en.librarySelectClipsSemanticLabel), findsNothing);
       });
 
-      testWidgets('collapses the Empty trash chip rather than overflow it', (
+      testWidgets('shrinks the lone Empty trash chip instead of hiding it', (
         tester,
       ) async {
+        // Nothing can collapse when the bin is the only mode on offer, so the
+        // chip narrows until it fits and ellipsizes its label.
         await tester.pumpWidget(
           buildWidget(
             width: narrowWidth,
@@ -331,8 +350,12 @@ void main() {
           ),
         );
 
-        expect(find.text(en.libraryTrashEmptyAllLabel), findsNothing);
-        expect(iconButton(DivineIconName.dotsThree), findsOneWidget);
+        expect(find.text(en.libraryTrashEmptyAllLabel), findsOneWidget);
+        expect(iconButton(DivineIconName.dotsThree), findsNothing);
+        expect(
+          tester.getSize(find.byType(DivineButton)).width,
+          lessThanOrEqualTo(narrowWidth),
+        );
       });
 
       testWidgets('does not overflow at any phone width', (tester) async {
@@ -357,6 +380,33 @@ void main() {
               tester.takeException(),
               isNull,
               reason: 'toolbar overflowed at ${width}dp',
+            );
+          }
+        }
+      });
+
+      testWidgets('keeps the primary action in the row at any width', (
+        tester,
+      ) async {
+        // Select is how a user reaches every per-clip action, so it never
+        // moves behind the overflow button — however narrow the row gets.
+        for (var width = 280.0; width <= 520.0; width += 5) {
+          for (final scaler in [
+            TextScaler.noScaling,
+            const TextScaler.linear(2),
+          ]) {
+            await tester.pumpWidget(
+              buildWidget(
+                width: width,
+                textScaler: scaler,
+                onManageActiveCategory: () {},
+              ),
+            );
+
+            expect(
+              find.text(en.librarySelect),
+              findsOneWidget,
+              reason: 'Select left the row at ${width}dp, scale $scaler',
             );
           }
         }
@@ -394,12 +444,13 @@ void main() {
         await tester.tap(iconButton(DivineIconName.dotsThree));
         await tester.pumpAndSettle();
 
-        expect(find.text(en.librarySelectClipsSemanticLabel), findsOneWidget);
         expect(find.text(en.libraryDisplayOptionsLabel), findsOneWidget);
         expect(
           find.text(en.libraryCategoryManageSemanticLabel),
           findsOneWidget,
         );
+        // Select stayed in the row, so it is not repeated here.
+        expect(find.text(en.librarySelectClipsSemanticLabel), findsNothing);
       });
 
       testWidgets('manage row triggers onManageActiveCategory', (tester) async {
@@ -435,53 +486,52 @@ void main() {
         expect(pressed, isTrue);
       });
 
-      testWidgets('Select row triggers onEnterSelectionMode', (tester) async {
+      testWidgets('move row triggers onMoveSelectedClips', (tester) async {
         var pressed = false;
         await tester.pumpWidget(
           buildWidget(
             width: narrowWidth,
-            onEnterSelectionMode: () => pressed = true,
+            textScaler: const TextScaler.linear(2),
+            isLibrarySelectionMode: true,
+            onMoveSelectedClips: () => pressed = true,
+            onDeleteSelectedClips: () {},
           ),
         );
 
         await tester.tap(iconButton(DivineIconName.dotsThree));
         await tester.pumpAndSettle();
-        await tester.tap(find.text(en.librarySelectClipsSemanticLabel));
+        await tester.tap(find.text(en.libraryMoveSelectedClipsTooltip));
         await tester.pumpAndSettle();
 
         expect(pressed, isTrue);
       });
 
-      testWidgets('move and delete rows trigger their callbacks', (
+      testWidgets('never collapses the destructive primary action', (
         tester,
       ) async {
-        var moved = false;
-        var deleted = false;
-        Widget build() => buildWidget(
-          width: narrowWidth,
-          textScaler: const TextScaler.linear(2),
-          isLibrarySelectionMode: true,
-          onMoveSelectedClips: () => moved = true,
-          onDeleteSelectedClips: () => deleted = true,
+        // Delete is the primary action while selecting, so it stays on the
+        // row and out of the menu even at the narrowest width.
+        await tester.pumpWidget(
+          buildWidget(
+            width: narrowWidth,
+            textScaler: const TextScaler.linear(2),
+            isLibrarySelectionMode: true,
+            onMoveSelectedClips: () {},
+            onDeleteSelectedClips: () {},
+          ),
         );
 
-        await tester.pumpWidget(build());
+        expect(iconButton(DivineIconName.trash), findsOneWidget);
+
         await tester.tap(iconButton(DivineIconName.dotsThree));
         await tester.pumpAndSettle();
-        await tester.tap(find.text(en.libraryMoveSelectedClipsTooltip));
-        await tester.pumpAndSettle();
 
-        await tester.pumpWidget(build());
-        await tester.tap(iconButton(DivineIconName.dotsThree));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text(en.libraryDeleteSelectedClipsTooltip));
-        await tester.pumpAndSettle();
-
-        expect(moved, isTrue);
-        expect(deleted, isTrue);
+        expect(find.text(en.libraryDeleteSelectedClipsTooltip), findsNothing);
       });
 
-      testWidgets('Empty trash row triggers onEmptyTrash', (tester) async {
+      testWidgets('a shrunken Empty trash chip still triggers onEmptyTrash', (
+        tester,
+      ) async {
         var pressed = false;
         await tester.pumpWidget(
           buildWidget(
@@ -492,11 +542,7 @@ void main() {
           ),
         );
 
-        await tester.tap(iconButton(DivineIconName.dotsThree));
-        await tester.pumpAndSettle();
         await tester.tap(find.text(en.libraryTrashEmptyAllLabel));
-        await tester.pumpAndSettle();
-
         expect(pressed, isTrue);
       });
     });


### PR DESCRIPTION
Closes #7165

## Description

#7094 is what crowded this row: the trash button became a filter chip, and in its place came a pencil for the active category, a folder for filing selected clips, and an *Empty trash* button whose label is a full phrase rather than a word. At 320-360dp the title was the only flexible child, so it shrank to an ellipsis before anything else gave way — and a longer localized label (`Papierkorb leeren`, `Vider la corbeille`) or a large text scale pushed the row past the screen.

The trailing clip actions are now one list ordered least- to most-important, per mode:

| mode | actions, least important first |
|---|---|
| browsing | pencil (category), sort & grid size, **Select** |
| selecting | sort & grid size, folder (file clips), **delete** |
| bin | **Empty trash** |

The toolbar measures what fits against the width it is given and moves whatever does not fit — from the front — into an overflow menu behind a single more button. So the primary action is the last thing to leave the row, and nothing disappears: every collapsed action stays reachable one tap deeper, spelled out in words rather than as an icon.

The collapse has to be decided while building, before anything is laid out, so the widths are estimated rather than measured: icon buttons are a known 48px on `DivineIcon`'s capped scaling curve — the same for every button type, since a destructive one pads by the border width a bordered one paints instead — and a labelled chip is its label measured with a `TextPainter` plus 40px of chrome. That constant mirrors `divine_ui`'s `small` button geometry (4px outer padding, 2px border, 14px inner padding per side), so tests pin both against real rendered buttons — if the design system's geometry moves, the estimate fails loudly instead of silently overflowing the row.

An estimate is only safe in one direction: too large collapses a little early, too small overflows. Both are covered — a sweep from 280dp to 520dp across all three modes asserts the row never overflows at any phone width.

### What the row will not spend space on

Two rules keep the collapse from costing more than it buys.

**A collapse has to actually narrow the row.** Moving the first action into the menu swaps it for a more button, so it only saves whatever that action is wider than one — which for an icon-only action is nothing. Without a guard, browsing at 300-320dp produced a more button hiding a single icon behind a button of exactly the same width: the row no narrower, sorting one tap further away. That level is skipped, so the row starts collapsing at the second action.

**The title yields before the buttons do.** The width held back to keep the title readable grows on `DivineIcon`'s capped curve rather than the raw text scaler. Uncapped, a 2x text scale reserved 160px to hold four characters and pushed an action into the menu on phones wide enough to show it. The title is the one child whose full text nobody needs to read — every locale says the same word, and several say it at length — while the actions beside it are the reason the screen is open. Past the point where both cannot fit, the title is what shrinks — to an ellipsis, and on the narrowest phones at the largest accessibility sizes to nothing at all. The primary action keeps its 48dp tap target at every width.

Measured across 22 locales x 3 text scales x 280-440dp x 3 modes (8118 configurations): 204 fewer forced collapses, no row overflowing, and no primary action below 48dp.

Two new keys, translated into all 21 locales: `libraryDisplayOptionsLabel` (the menu row for sorting and grid size) and `libraryMoreActionsSemanticLabel`. The sort action now uses the first of those in the row as well as in the menu, instead of gluing `librarySortClipsSemanticLabel` and `libraryGridSizeLabel` into a sentence no locale can reorder — which leaves `librarySortClipsSemanticLabel` unreferenced, so it is removed.

## Out of Scope

- The dedicated grid-size toolbar button deferred in #7129 stays deferred. Grid size keeps sharing the display/sort affordance — this PR makes room in the row rather than spending it.
- Only the standalone library toolbar. The selection sheet renders its own header and never had the crowding problem.

## Verification

- `flutter analyze lib test integration_test`
- `flutter test test/widgets/library/ test/screens/library_screen_test.dart test/l10n/arb_consistency_test.dart`
- Ratchets: implicit font color, raw textstyle, raw colors, material button, raw dialog, raw icons
- On device: iPhone 17 Pro Max simulator at max dynamic type (@realmeylisdev) — nothing overflows, and every action stays reachable from the menu in all three modes. Not yet run on a Galaxy.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

