### PR TITLE
fix(db): delete unreadable plaintext reset source

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1244,9 +1244,10 @@ Future<void> _startOpenVineApp() async {
     ),
   );
 
-  // Both the automatic repair and the manual escape hatch below mean the same
-  // operation, so they share one definition and cannot drift apart. They differ
-  // only in whether the cipher key goes with the database.
+  // Resets preserve a backup by default because encrypted backups stay readable
+  // under the retained cipher key. The db-unreadable diagnosis is different:
+  // it proves the current file is plaintext-shaped corruption, so preserving it
+  // would leave plaintext at rest after the reset.
   Future<void> resetLocalDatabaseCache({required bool deleteCipherKey}) =>
       resetEncryptedDatabaseCache(
         secureStorage: dbCipherSecureStorage,
@@ -1300,12 +1301,19 @@ Future<void> _startOpenVineApp() async {
     // and the account with it.
     //
     // The cipher key stays: the diagnoses that reach this button cannot prove
-    // it is stale, and it is the only thing that can still read the backup this
-    // reset leaves behind. Keeping it also means the reset never touches the
-    // keystore, which may itself be why the user is on that screen.
-    resetLocalDatabase: () async {
+    // it is stale, and encrypted reset backups remain readable under it. For
+    // db-unreadable, the damaged file is plaintext-shaped, so the reset deletes
+    // it instead of preserving a plaintext backup.
+    resetLocalDatabase: (diagnosis) async {
       try {
-        await resetLocalDatabaseCache(deleteCipherKey: false);
+        if (diagnosis == DatabaseBootstrapDiagnosis.databaseUnreadable) {
+          await resetUnreadablePlaintextDatabaseCache(
+            secureStorage: dbCipherSecureStorage,
+            onDatabaseReset: () => DmSyncState(sharedPreferences).clearAll(),
+          );
+        } else {
+          await resetLocalDatabaseCache(deleteCipherKey: false);
+        }
       } catch (error, stack) {
         // The screen keeps the user on it and says the reset failed; without
         // this the only report of a failed recovery would be that sentence.

--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -367,10 +367,9 @@ class DatabaseCipherStorageUnavailableException implements Exception {
 /// is neither usable plaintext nor recognizably encrypted.
 ///
 /// Not a key problem — an encrypted file reports `SQLITE_NOTADB` and takes the
-/// salvage/recreate path instead. The stored cipher key is nonetheless kept:
-/// the damaged file itself is plaintext-shaped and needs no key to read, but any
-/// `.pre_key_loss_wipe_backup` / `.pre_corruption_recovery_backup` beside it is
-/// encrypted under that key, and rotating it would strand them.
+/// salvage/recreate path instead. The stored cipher key is nonetheless kept
+/// because nothing here proves it stale; the reset path decides what to do with
+/// the damaged plaintext-shaped file.
 ///
 /// Fails startup on purpose. The alternative the bootstrap used to take was to
 /// hand back a `null` key and let the app open the damaged file anyway, which
@@ -448,11 +447,9 @@ bool shouldRepairLocalDatabaseCacheAfterBootstrapError(Object error) {
   // Load-bearing: this message names SQLITE_CORRUPT, so it would otherwise
   // match the allowlist below and auto-repair. The database really is unusable,
   // but the repair rotates the cipher key, and nothing here proves the stored
-  // one is stale — rotating it would strand any encrypted backup already beside
-  // the damaged file, which holds the user's local-only drafts and clips. The
-  // failure screen offers the same reset with the key retained, so the user
-  // chooses the data loss instead of a silent wipe on a launch that looked
-  // normal.
+  // one is stale. The failure screen offers a diagnosis-aware reset instead, so
+  // the user chooses the data loss instead of a silent wipe on a launch that
+  // looked normal.
   if (error is DatabaseUnreadableError) return false;
 
   final message = error.toString();
@@ -484,6 +481,23 @@ Future<void> resetEncryptedDatabaseCache({
   }
   await _runPostDatabaseReset(onDatabaseReset);
 }
+
+/// Deletes an unreadable plaintext-shaped database without preserving it.
+///
+/// [DatabaseUnreadableError] proves the current file is not an encrypted DB:
+/// it has a legible SQLite header and structural corruption. Backing it up under
+/// the key-loss suffix would leave plaintext at rest after the reset, so this
+/// path keeps the cipher key but hard-deletes the database and sidecars.
+Future<void> resetUnreadablePlaintextDatabaseCache({
+  required FlutterSecureStorage secureStorage,
+  @visibleForTesting Future<void> Function()? deleteDatabase,
+  Future<void> Function()? onDatabaseReset,
+}) => resetEncryptedDatabaseCache(
+  secureStorage: secureStorage,
+  deleteCipherKey: false,
+  deleteDatabase: deleteDatabase ?? deleteSharedDatabase,
+  onDatabaseReset: onDatabaseReset,
+);
 
 Future<void> _runPostDatabaseReset(
   Future<void> Function()? onDatabaseReset,

--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -469,6 +469,10 @@ bool shouldRepairLocalDatabaseCacheAfterBootstrapError(Object error) {
 /// is stale: the backup this call leaves behind is encrypted under that key, so
 /// deleting it makes the backup permanently unreadable — while a retained key
 /// opens a fresh database just as well as a rotated one.
+///
+/// [deleteDatabase] overrides that backup step. Callers that have proved the
+/// file is plaintext-shaped pass [deleteSharedDatabase] via
+/// [resetUnreadablePlaintextDatabaseCache], which leaves no backup at all.
 Future<void> resetEncryptedDatabaseCache({
   required FlutterSecureStorage secureStorage,
   bool deleteCipherKey = true,

--- a/mobile/lib/startup/database_bootstrap_failure_app.dart
+++ b/mobile/lib/startup/database_bootstrap_failure_app.dart
@@ -31,7 +31,8 @@ Future<DatabaseBootstrapStartupResult> resolveDatabaseBootstrapForAppStart({
   Future<void> Function(Object error, StackTrace stack)?
   repairLocalDatabaseCache,
   bool Function(Object error)? shouldRepairLocalDatabaseCache,
-  Future<void> Function()? resetLocalDatabase,
+  Future<void> Function(DatabaseBootstrapDiagnosis diagnosis)?
+  resetLocalDatabase,
 }) async {
   try {
     return DatabaseBootstrapStartupResult.ready(await resolveCipherKey());
@@ -117,7 +118,8 @@ class DatabaseBootstrapFailureApp extends StatelessWidget {
   /// `null` hides the affordance. Even when provided it is only offered for
   /// diagnoses where the database is already unusable — see
   /// [DatabaseBootstrapDiagnosis.allowsLocalDatabaseReset].
-  final Future<void> Function()? onResetLocalDatabase;
+  final Future<void> Function(DatabaseBootstrapDiagnosis diagnosis)?
+  onResetLocalDatabase;
 
   @override
   Widget build(BuildContext context) {
@@ -144,7 +146,8 @@ class _FailureScreen extends StatefulWidget {
   final Object error;
   final StackTrace stack;
   final VoidCallback onCloseApp;
-  final Future<void> Function()? onResetLocalDatabase;
+  final Future<void> Function(DatabaseBootstrapDiagnosis diagnosis)?
+  onResetLocalDatabase;
 
   @override
   State<_FailureScreen> createState() => _FailureScreenState();
@@ -157,9 +160,10 @@ class _FailureScreenState extends State<_FailureScreen> {
 
   bool get _canReset =>
       widget.onResetLocalDatabase != null &&
-      databaseBootstrapDiagnosis(
-        widget.error,
-      ).allowsLocalDatabaseReset;
+      _diagnosis.allowsLocalDatabaseReset;
+
+  DatabaseBootstrapDiagnosis get _diagnosis =>
+      databaseBootstrapDiagnosis(widget.error);
 
   /// Swaps the step in place and announces it: nothing is pushed, so assistive
   /// tech gets no route change and the focused node just disappears.
@@ -179,7 +183,7 @@ class _FailureScreenState extends State<_FailureScreen> {
       _resetFailed = false;
     });
     try {
-      await widget.onResetLocalDatabase!().timeout(_resetTimeout);
+      await widget.onResetLocalDatabase!(_diagnosis).timeout(_resetTimeout);
     } on Object {
       // The reset can fail outright, and a wedged platform channel can hang it
       // past the timeout. Stay put and say so rather than closing on a reset

--- a/mobile/lib/startup/database_bootstrap_failure_app.dart
+++ b/mobile/lib/startup/database_bootstrap_failure_app.dart
@@ -113,7 +113,12 @@ class DatabaseBootstrapFailureApp extends StatelessWidget {
   final StackTrace stack;
   final VoidCallback onCloseApp;
 
-  /// Backs up and clears the local database so the next launch rebuilds it.
+  /// Clears the local database so the next launch rebuilds it.
+  ///
+  /// Receives the diagnosis so the caller can pick the file disposition: a
+  /// reset backs the database up by default, but a plaintext-shaped
+  /// [DatabaseBootstrapDiagnosis.databaseUnreadable] file is deleted outright
+  /// rather than preserved as plaintext at rest.
   ///
   /// `null` hides the affordance. Even when provided it is only offered for
   /// diagnoses where the database is already unusable — see

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -251,7 +251,7 @@ Future<bool> salvageCorruptEncryptedDatabase({
   if (!File(dbPath).existsSync()) return false;
 
   final salvagePath = '$dbPath$_salvageSuffix';
-  _deleteDatabaseAndSidecars(salvagePath);
+  deleteDatabaseAndSidecars(salvagePath);
 
   // Build the salvage copy, then only swap it in if it is itself sound. On any
   // failure (wrong key, unbuildable, unsound copy) leave the original intact.
@@ -267,7 +267,7 @@ Future<bool> salvageCorruptEncryptedDatabase({
         databasePath: salvagePath,
       );
   if (!usable) {
-    _deleteDatabaseAndSidecars(salvagePath);
+    deleteDatabaseAndSidecars(salvagePath);
     return false;
   }
 
@@ -565,7 +565,7 @@ Future<CipherMigrationOutcome> migratePlaintextToEncrypted({
       // or the I/O fault is likely gone.
       return CipherMigrationOutcome.failed;
     case _DbClassification.emptyPlaintext:
-      _deleteDatabaseAndSidecars(dbPath);
+      deleteDatabaseAndSidecars(dbPath);
       return CipherMigrationOutcome.removedEmptyPlaintext;
     case _DbClassification.populatedPlaintext:
       return _rekeyPlaintextInPlace(dbPath: dbPath, rawKeyHex: rawKeyHex);
@@ -597,7 +597,7 @@ Future<bool> _resumeInterruptedSalvage({
     return true;
   }
 
-  _deleteDatabaseAndSidecars(salvagePath);
+  deleteDatabaseAndSidecars(salvagePath);
   return false;
 }
 
@@ -687,7 +687,7 @@ CipherMigrationOutcome _rekeyPlaintextInPlace({
 }) {
   final encryptedPath = '$dbPath$_migratingSuffix';
   // Remove any partial artifact from an interrupted previous attempt.
-  _deleteDatabaseAndSidecars(encryptedPath);
+  deleteDatabaseAndSidecars(encryptedPath);
 
   Database source;
   try {
@@ -706,7 +706,7 @@ CipherMigrationOutcome _rekeyPlaintextInPlace({
     }
     source.execute('VACUUM INTO ?;', [encryptedPath]);
   } on SqliteException catch (e) {
-    _deleteDatabaseAndSidecars(encryptedPath);
+    deleteDatabaseAndSidecars(encryptedPath);
     return _rekeyFailureOutcome(e);
   } finally {
     source.close();
@@ -716,7 +716,7 @@ CipherMigrationOutcome _rekeyPlaintextInPlace({
     encryptedPath: encryptedPath,
     rawKeyHex: rawKeyHex,
   )) {
-    _deleteDatabaseAndSidecars(encryptedPath);
+    deleteDatabaseAndSidecars(encryptedPath);
     return CipherMigrationOutcome.failed;
   }
 
@@ -725,7 +725,7 @@ CipherMigrationOutcome _rekeyPlaintextInPlace({
     encryptedPath: encryptedPath,
     rawKeyHex: rawKeyHex,
   )) {
-    _deleteDatabaseAndSidecars(encryptedPath);
+    deleteDatabaseAndSidecars(encryptedPath);
     return CipherMigrationOutcome.failed;
   }
 
@@ -1031,7 +1031,7 @@ Future<void> migrateLegacyDatabase({
       );
       return;
     } else {
-      _deleteDatabaseAndSidecars(legacyPath);
+      deleteDatabaseAndSidecars(legacyPath);
       return;
     }
   }
@@ -1111,10 +1111,6 @@ void deleteDatabaseAndSidecars(String dbPath) {
     final file = File('$dbPath$suffix');
     if (file.existsSync()) file.deleteSync();
   }
-}
-
-void _deleteDatabaseAndSidecars(String dbPath) {
-  deleteDatabaseAndSidecars(dbPath);
 }
 
 String _nextDatabaseBackupPath(String dbPath, {required String suffix}) {

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -843,6 +843,16 @@ Future<void> backUpAndRemoveSharedDatabase() async {
   _moveSidecars(fromPath: dbPath, toPath: backupPath);
 }
 
+/// Deletes the shared database and sidecars without preserving a backup.
+///
+/// Use only when the caller has already proved the file is unusable plaintext.
+/// Encrypted database resets should keep using [backUpAndRemoveSharedDatabase]
+/// so the preserved backup remains readable under the retained cipher key.
+Future<void> deleteSharedDatabase() async {
+  final dbPath = await getSharedDatabasePath();
+  deleteDatabaseAndSidecars(dbPath);
+}
+
 /// Removes plaintext backups left by a successful plaintext→encrypted
 /// migration once the encrypted database has opened with its key.
 ///
@@ -1095,11 +1105,16 @@ void _moveSidecars({
   }
 }
 
-void _deleteDatabaseAndSidecars(String dbPath) {
+@visibleForTesting
+void deleteDatabaseAndSidecars(String dbPath) {
   for (final suffix in const ['', '-wal', '-shm']) {
     final file = File('$dbPath$suffix');
     if (file.existsSync()) file.deleteSync();
   }
+}
+
+void _deleteDatabaseAndSidecars(String dbPath) {
+  deleteDatabaseAndSidecars(dbPath);
 }
 
 String _nextDatabaseBackupPath(String dbPath, {required String suffix}) {

--- a/mobile/packages/db_client/lib/src/database/connection/connection_stub.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_stub.dart
@@ -68,3 +68,8 @@ Future<CipherMigrationOutcome> migratePlaintextToEncrypted({
 Future<void> backUpAndRemoveSharedDatabase() async {
   throw UnsupportedError('No database implementation found for this platform');
 }
+
+/// Stub implementation - will be replaced by conditional imports
+Future<void> deleteSharedDatabase() async {
+  throw UnsupportedError('No database implementation found for this platform');
+}

--- a/mobile/packages/db_client/lib/src/database/connection/connection_web.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_web.dart
@@ -29,7 +29,9 @@ QueryExecutor openEncryptedConnection({
   required String rawKeyHex,
   String? databasePath,
 }) {
-  throw UnsupportedError('Native at-rest encryption is not supported on web');
+  throw UnsupportedError(
+    'Native at-rest encryption is not supported on web',
+  );
 }
 
 /// Web never opens native encrypted databases; startup skips DB encryption
@@ -38,7 +40,9 @@ Future<bool> encryptedDatabaseOpensWithKey({
   required String rawKeyHex,
   String? databasePath,
 }) async {
-  throw UnsupportedError('Native at-rest encryption is not supported on web');
+  throw UnsupportedError(
+    'Native at-rest encryption is not supported on web',
+  );
 }
 
 /// Corruption salvage is native-only; startup skips DB encryption on web.
@@ -47,7 +51,9 @@ Future<bool> encryptedDatabaseKeyDecrypts({
   required String rawKeyHex,
   String? databasePath,
 }) async {
-  throw UnsupportedError('Native at-rest encryption is not supported on web');
+  throw UnsupportedError(
+    'Native at-rest encryption is not supported on web',
+  );
 }
 
 /// Corruption salvage is native-only; startup skips DB encryption on web.
@@ -56,7 +62,9 @@ Future<bool> salvageCorruptEncryptedDatabase({
   required String rawKeyHex,
   String? databasePath,
 }) async {
-  throw UnsupportedError('Native at-rest encryption is not supported on web');
+  throw UnsupportedError(
+    'Native at-rest encryption is not supported on web',
+  );
 }
 
 /// No-op on web (key-loss recovery is native-only). Never reached at runtime.
@@ -83,5 +91,7 @@ Future<CipherMigrationOutcome> migratePlaintextToEncrypted({
   required String rawKeyHex,
   String? databasePath,
 }) async {
-  throw UnsupportedError('Native at-rest encryption is not supported on web');
+  throw UnsupportedError(
+    'Native at-rest encryption is not supported on web',
+  );
 }

--- a/mobile/packages/db_client/lib/src/database/connection/connection_web.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_web.dart
@@ -29,9 +29,7 @@ QueryExecutor openEncryptedConnection({
   required String rawKeyHex,
   String? databasePath,
 }) {
-  throw UnsupportedError(
-    'Native at-rest encryption is not supported on web',
-  );
+  throw UnsupportedError('Native at-rest encryption is not supported on web');
 }
 
 /// Web never opens native encrypted databases; startup skips DB encryption
@@ -40,9 +38,7 @@ Future<bool> encryptedDatabaseOpensWithKey({
   required String rawKeyHex,
   String? databasePath,
 }) async {
-  throw UnsupportedError(
-    'Native at-rest encryption is not supported on web',
-  );
+  throw UnsupportedError('Native at-rest encryption is not supported on web');
 }
 
 /// Corruption salvage is native-only; startup skips DB encryption on web.
@@ -51,9 +47,7 @@ Future<bool> encryptedDatabaseKeyDecrypts({
   required String rawKeyHex,
   String? databasePath,
 }) async {
-  throw UnsupportedError(
-    'Native at-rest encryption is not supported on web',
-  );
+  throw UnsupportedError('Native at-rest encryption is not supported on web');
 }
 
 /// Corruption salvage is native-only; startup skips DB encryption on web.
@@ -62,13 +56,15 @@ Future<bool> salvageCorruptEncryptedDatabase({
   required String rawKeyHex,
   String? databasePath,
 }) async {
-  throw UnsupportedError(
-    'Native at-rest encryption is not supported on web',
-  );
+  throw UnsupportedError('Native at-rest encryption is not supported on web');
 }
 
 /// No-op on web (key-loss recovery is native-only). Never reached at runtime.
 Future<void> backUpAndRemoveSharedDatabase() async {}
+
+/// No-op on web (native database deletion is native-only). Never reached at
+/// runtime.
+Future<void> deleteSharedDatabase() async {}
 
 /// Outcome of [migratePlaintextToEncrypted]. Mirrors the native enum so app
 /// code that switches on it compiles for web.
@@ -87,7 +83,5 @@ Future<CipherMigrationOutcome> migratePlaintextToEncrypted({
   required String rawKeyHex,
   String? databasePath,
 }) async {
-  throw UnsupportedError(
-    'Native at-rest encryption is not supported on web',
-  );
+  throw UnsupportedError('Native at-rest encryption is not supported on web');
 }

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -1468,6 +1468,44 @@ void main() {
       },
     );
   });
+
+  group('deleteDatabaseAndSidecars', () {
+    late Directory tempRoot;
+    late String dbPath;
+
+    setUp(() {
+      tempRoot = Directory.systemTemp.createTempSync(
+        'db_client_delete_database_sidecars_test_',
+      );
+      dbPath = p.join(tempRoot.path, 'divine_db.db');
+      File(dbPath).writeAsBytesSync(const [1]);
+      File('$dbPath-wal').writeAsBytesSync(const [2]);
+      File('$dbPath-shm').writeAsBytesSync(const [3]);
+      File('$dbPath.pre_key_loss_wipe_backup').writeAsBytesSync(const [4]);
+    });
+
+    tearDown(() {
+      if (tempRoot.existsSync()) {
+        tempRoot.deleteSync(recursive: true);
+      }
+    });
+
+    test(
+      'deletes the current database and sidecars without making a backup',
+      () {
+        deleteDatabaseAndSidecars(dbPath);
+
+        expect(File(dbPath).existsSync(), isFalse);
+        expect(File('$dbPath-wal').existsSync(), isFalse);
+        expect(File('$dbPath-shm').existsSync(), isFalse);
+        expect(
+          File('$dbPath.pre_key_loss_wipe_backup').existsSync(),
+          isTrue,
+          reason: 'existing encrypted backups are not part of the current DB',
+        );
+      },
+    );
+  });
 }
 
 /// Creates an encrypted database with a few local-only rows (drafts, clips) in

--- a/mobile/test/services/database_encryption_bootstrap_test.dart
+++ b/mobile/test/services/database_encryption_bootstrap_test.dart
@@ -724,6 +724,25 @@ void main() {
         verifyNever(() => storage.delete(key: any(named: 'key')));
       },
     );
+
+    test(
+      'unreadable plaintext reset deletes DB without deleting cipher key',
+      () async {
+        var deleted = false;
+        var reset = false;
+
+        await resetUnreadablePlaintextDatabaseCache(
+          secureStorage: storage,
+          deleteDatabase: () async => deleted = true,
+          onDatabaseReset: () async => reset = true,
+        );
+
+        expect(deleted, isTrue);
+        expect(reset, isTrue);
+        expect(store[dbCipherKeyStorageKey], isNotNull);
+        verifyNever(() => storage.delete(key: any(named: 'key')));
+      },
+    );
   });
 
   group('resolveStartupDatabaseCipherKey', () {

--- a/mobile/test/startup/database_bootstrap_failure_app_test.dart
+++ b/mobile/test/startup/database_bootstrap_failure_app_test.dart
@@ -170,69 +170,75 @@ void main() {
       },
     );
 
-    test('does not repair secure-storage failures', () async {
-      var removedSplash = false;
-      Widget? renderedApp;
-      var attempts = 0;
-      var repaired = false;
-      final error = DatabaseCipherStorageUnavailableException(
-        _lockedKeychainFailure(),
-      );
+    test(
+      'does not repair secure-storage failures',
+      () async {
+        var removedSplash = false;
+        Widget? renderedApp;
+        var attempts = 0;
+        var repaired = false;
+        final error = DatabaseCipherStorageUnavailableException(
+          _lockedKeychainFailure(),
+        );
 
-      final result = await resolveDatabaseBootstrapForAppStart(
-        resolveCipherKey: () async {
-          attempts += 1;
-          throw error;
-        },
-        repairLocalDatabaseCache: (error, stack) async {
-          repaired = true;
-        },
-        shouldRepairLocalDatabaseCache:
-            shouldRepairLocalDatabaseCacheAfterBootstrapError,
-        removeNativeSplash: () => removedSplash = true,
-        runApp: (app) => renderedApp = app,
-      );
+        final result = await resolveDatabaseBootstrapForAppStart(
+          resolveCipherKey: () async {
+            attempts += 1;
+            throw error;
+          },
+          repairLocalDatabaseCache: (error, stack) async {
+            repaired = true;
+          },
+          shouldRepairLocalDatabaseCache:
+              shouldRepairLocalDatabaseCacheAfterBootstrapError,
+          removeNativeSplash: () => removedSplash = true,
+          runApp: (app) => renderedApp = app,
+        );
 
-      expect(result.didRenderFailureApp, isTrue);
-      expect(attempts, equals(1));
-      expect(repaired, isFalse);
-      expect(removedSplash, isTrue);
-      expect(renderedApp, isA<DatabaseBootstrapFailureApp>());
-    });
+        expect(result.didRenderFailureApp, isTrue);
+        expect(attempts, equals(1));
+        expect(repaired, isFalse);
+        expect(removedSplash, isTrue);
+        expect(renderedApp, isA<DatabaseBootstrapFailureApp>());
+      },
+    );
 
-    test('repairs allowlisted sqlite corruption failures', () async {
-      var removedSplash = false;
-      Widget? renderedApp;
-      var attempts = 0;
-      var repaired = false;
+    test(
+      'repairs allowlisted sqlite corruption failures',
+      () async {
+        var removedSplash = false;
+        Widget? renderedApp;
+        var attempts = 0;
+        var repaired = false;
 
-      final result = await resolveDatabaseBootstrapForAppStart(
-        resolveCipherKey: () async {
-          attempts += 1;
-          if (attempts == 1) {
-            throw SqliteException(
-              extendedResultCode: 26,
-              message: 'file is not a database',
-            );
-          }
-          return 'c' * 64;
-        },
-        repairLocalDatabaseCache: (error, stack) async {
-          repaired = true;
-        },
-        shouldRepairLocalDatabaseCache:
-            shouldRepairLocalDatabaseCacheAfterBootstrapError,
-        removeNativeSplash: () => removedSplash = true,
-        runApp: (app) => renderedApp = app,
-      );
+        final result = await resolveDatabaseBootstrapForAppStart(
+          resolveCipherKey: () async {
+            attempts += 1;
+            if (attempts == 1) {
+              throw SqliteException(
+                extendedResultCode: 26,
+                message: 'file is not a database',
+              );
+            }
+            return 'c' * 64;
+          },
+          repairLocalDatabaseCache: (error, stack) async {
+            repaired = true;
+          },
+          shouldRepairLocalDatabaseCache:
+              shouldRepairLocalDatabaseCacheAfterBootstrapError,
+          removeNativeSplash: () => removedSplash = true,
+          runApp: (app) => renderedApp = app,
+        );
 
-      expect(result.didRenderFailureApp, isFalse);
-      expect(result.cipherKey, equals('c' * 64));
-      expect(attempts, equals(2));
-      expect(repaired, isTrue);
-      expect(removedSplash, isFalse);
-      expect(renderedApp, isNull);
-    });
+        expect(result.didRenderFailureApp, isFalse);
+        expect(result.cipherKey, equals('c' * 64));
+        expect(attempts, equals(2));
+        expect(repaired, isTrue);
+        expect(removedSplash, isFalse);
+        expect(renderedApp, isNull);
+      },
+    );
   });
 
   group('resolveDatabaseBootstrapForAppStart reset wiring', () {
@@ -270,7 +276,10 @@ void main() {
         ),
       );
 
-      expect(find.text("couldn't unlock your local database"), findsOneWidget);
+      expect(
+        find.text("couldn't unlock your local database"),
+        findsOneWidget,
+      );
       expect(find.textContaining('Restart Divine'), findsOneWidget);
       // The rendered code is what a support report is triaged from, so pin the
       // value rather than just the label.
@@ -282,7 +291,9 @@ void main() {
 
     test('classifies cipher availability failures for release diagnostics', () {
       expect(
-        databaseBootstrapDiagnosticCode(DatabaseCipherUnavailableError()),
+        databaseBootstrapDiagnosticCode(
+          DatabaseCipherUnavailableError(),
+        ),
         equals('db-cipher-unavailable'),
       );
     });

--- a/mobile/test/startup/database_bootstrap_failure_app_test.dart
+++ b/mobile/test/startup/database_bootstrap_failure_app_test.dart
@@ -170,81 +170,75 @@ void main() {
       },
     );
 
-    test(
-      'does not repair secure-storage failures',
-      () async {
-        var removedSplash = false;
-        Widget? renderedApp;
-        var attempts = 0;
-        var repaired = false;
-        final error = DatabaseCipherStorageUnavailableException(
-          _lockedKeychainFailure(),
-        );
+    test('does not repair secure-storage failures', () async {
+      var removedSplash = false;
+      Widget? renderedApp;
+      var attempts = 0;
+      var repaired = false;
+      final error = DatabaseCipherStorageUnavailableException(
+        _lockedKeychainFailure(),
+      );
 
-        final result = await resolveDatabaseBootstrapForAppStart(
-          resolveCipherKey: () async {
-            attempts += 1;
-            throw error;
-          },
-          repairLocalDatabaseCache: (error, stack) async {
-            repaired = true;
-          },
-          shouldRepairLocalDatabaseCache:
-              shouldRepairLocalDatabaseCacheAfterBootstrapError,
-          removeNativeSplash: () => removedSplash = true,
-          runApp: (app) => renderedApp = app,
-        );
+      final result = await resolveDatabaseBootstrapForAppStart(
+        resolveCipherKey: () async {
+          attempts += 1;
+          throw error;
+        },
+        repairLocalDatabaseCache: (error, stack) async {
+          repaired = true;
+        },
+        shouldRepairLocalDatabaseCache:
+            shouldRepairLocalDatabaseCacheAfterBootstrapError,
+        removeNativeSplash: () => removedSplash = true,
+        runApp: (app) => renderedApp = app,
+      );
 
-        expect(result.didRenderFailureApp, isTrue);
-        expect(attempts, equals(1));
-        expect(repaired, isFalse);
-        expect(removedSplash, isTrue);
-        expect(renderedApp, isA<DatabaseBootstrapFailureApp>());
-      },
-    );
+      expect(result.didRenderFailureApp, isTrue);
+      expect(attempts, equals(1));
+      expect(repaired, isFalse);
+      expect(removedSplash, isTrue);
+      expect(renderedApp, isA<DatabaseBootstrapFailureApp>());
+    });
 
-    test(
-      'repairs allowlisted sqlite corruption failures',
-      () async {
-        var removedSplash = false;
-        Widget? renderedApp;
-        var attempts = 0;
-        var repaired = false;
+    test('repairs allowlisted sqlite corruption failures', () async {
+      var removedSplash = false;
+      Widget? renderedApp;
+      var attempts = 0;
+      var repaired = false;
 
-        final result = await resolveDatabaseBootstrapForAppStart(
-          resolveCipherKey: () async {
-            attempts += 1;
-            if (attempts == 1) {
-              throw SqliteException(
-                extendedResultCode: 26,
-                message: 'file is not a database',
-              );
-            }
-            return 'c' * 64;
-          },
-          repairLocalDatabaseCache: (error, stack) async {
-            repaired = true;
-          },
-          shouldRepairLocalDatabaseCache:
-              shouldRepairLocalDatabaseCacheAfterBootstrapError,
-          removeNativeSplash: () => removedSplash = true,
-          runApp: (app) => renderedApp = app,
-        );
+      final result = await resolveDatabaseBootstrapForAppStart(
+        resolveCipherKey: () async {
+          attempts += 1;
+          if (attempts == 1) {
+            throw SqliteException(
+              extendedResultCode: 26,
+              message: 'file is not a database',
+            );
+          }
+          return 'c' * 64;
+        },
+        repairLocalDatabaseCache: (error, stack) async {
+          repaired = true;
+        },
+        shouldRepairLocalDatabaseCache:
+            shouldRepairLocalDatabaseCacheAfterBootstrapError,
+        removeNativeSplash: () => removedSplash = true,
+        runApp: (app) => renderedApp = app,
+      );
 
-        expect(result.didRenderFailureApp, isFalse);
-        expect(result.cipherKey, equals('c' * 64));
-        expect(attempts, equals(2));
-        expect(repaired, isTrue);
-        expect(removedSplash, isFalse);
-        expect(renderedApp, isNull);
-      },
-    );
+      expect(result.didRenderFailureApp, isFalse);
+      expect(result.cipherKey, equals('c' * 64));
+      expect(attempts, equals(2));
+      expect(repaired, isTrue);
+      expect(removedSplash, isFalse);
+      expect(renderedApp, isNull);
+    });
   });
 
   group('resolveDatabaseBootstrapForAppStart reset wiring', () {
     test('hands the reset hook to the failure app', () async {
       Widget? renderedApp;
-      Future<void> reset() async {}
+      Future<void> reset(DatabaseBootstrapDiagnosis diagnosis) async {}
 
       await resolveDatabaseBootstrapForAppStart(
         resolveCipherKey: () async => throw StateError('bootstrap failed'),
@@ -276,10 +270,7 @@ void main() {
         ),
       );
 
-      expect(
-        find.text("couldn't unlock your local database"),
-        findsOneWidget,
-      );
+      expect(find.text("couldn't unlock your local database"), findsOneWidget);
       expect(find.textContaining('Restart Divine'), findsOneWidget);
       // The rendered code is what a support report is triaged from, so pin the
       // value rather than just the label.
@@ -291,9 +282,7 @@ void main() {
 
     test('classifies cipher availability failures for release diagnostics', () {
       expect(
-        databaseBootstrapDiagnosticCode(
-          DatabaseCipherUnavailableError(),
-        ),
+        databaseBootstrapDiagnosticCode(DatabaseCipherUnavailableError()),
         equals('db-cipher-unavailable'),
       );
     });
@@ -355,7 +344,7 @@ void main() {
             _lockedKeychainFailure(),
           ),
           stack: StackTrace.current,
-          onResetLocalDatabase: () async {},
+          onResetLocalDatabase: (_) async {},
         ),
       );
 
@@ -372,7 +361,7 @@ void main() {
         DatabaseBootstrapFailureApp(
           error: StateError('something else entirely'),
           stack: StackTrace.current,
-          onResetLocalDatabase: () async {},
+          onResetLocalDatabase: (_) async {},
         ),
       );
 
@@ -387,7 +376,7 @@ void main() {
     });
 
     testWidgets('resets and closes once the user confirms', (tester) async {
-      var resets = 0;
+      DatabaseBootstrapDiagnosis? resetDiagnosis;
       var closed = false;
 
       await tester.pumpWidget(
@@ -395,7 +384,7 @@ void main() {
           error: StateError('something else entirely'),
           stack: StackTrace.current,
           onCloseApp: () => closed = true,
-          onResetLocalDatabase: () async => resets++,
+          onResetLocalDatabase: (diagnosis) async => resetDiagnosis = diagnosis,
         ),
       );
 
@@ -404,13 +393,34 @@ void main() {
 
       expect(find.text('reset your local database?'), findsOneWidget);
       expect(find.textContaining('Your account stays'), findsOneWidget);
-      expect(resets, isZero, reason: 'confirmation must gate the wipe');
+      expect(resetDiagnosis, isNull, reason: 'confirmation must gate the wipe');
 
       await tester.tap(find.text('reset and close'));
       await tester.pump();
 
-      expect(resets, equals(1));
+      expect(resetDiagnosis, DatabaseBootstrapDiagnosis.bootstrapFailed);
       expect(closed, isTrue);
+    });
+
+    testWidgets('passes the database-unreadable diagnosis to reset', (
+      tester,
+    ) async {
+      DatabaseBootstrapDiagnosis? resetDiagnosis;
+
+      await tester.pumpWidget(
+        DatabaseBootstrapFailureApp(
+          error: const DatabaseUnreadableError(),
+          stack: StackTrace.current,
+          onResetLocalDatabase: (diagnosis) async => resetDiagnosis = diagnosis,
+        ),
+      );
+
+      await tester.tap(find.text('reset local database'));
+      await tester.pump();
+      await tester.tap(find.text('reset and close'));
+      await tester.pump();
+
+      expect(resetDiagnosis, DatabaseBootstrapDiagnosis.databaseUnreadable);
     });
 
     testWidgets('returns to the failure screen on cancel', (tester) async {
@@ -420,7 +430,7 @@ void main() {
         DatabaseBootstrapFailureApp(
           error: StateError('something else entirely'),
           stack: StackTrace.current,
-          onResetLocalDatabase: () async => resets++,
+          onResetLocalDatabase: (_) async => resets++,
         ),
       );
 
@@ -443,7 +453,7 @@ void main() {
           error: StateError('something else entirely'),
           stack: StackTrace.current,
           onCloseApp: () => closed = true,
-          onResetLocalDatabase: () async =>
+          onResetLocalDatabase: (_) async =>
               throw StateError('keystore delete failed'),
         ),
       );
@@ -473,7 +483,7 @@ void main() {
           error: StateError('something else entirely'),
           stack: StackTrace.current,
           onCloseApp: () => closes++,
-          onResetLocalDatabase: () async {},
+          onResetLocalDatabase: (_) async {},
         ),
       );
 
@@ -501,7 +511,7 @@ void main() {
         DatabaseBootstrapFailureApp(
           error: StateError('something else entirely'),
           stack: StackTrace.current,
-          onResetLocalDatabase: () => Completer<void>().future,
+          onResetLocalDatabase: (_) => Completer<void>().future,
         ),
       );
 
@@ -528,7 +538,7 @@ void main() {
         DatabaseBootstrapFailureApp(
           error: StateError('something else entirely'),
           stack: StackTrace.current,
-          onResetLocalDatabase: () async => throw StateError('nope'),
+          onResetLocalDatabase: (_) async => throw StateError('nope'),
         ),
       );
 


### PR DESCRIPTION
## Summary

Follow-up to #7157. The new db-unreadable reset path now deletes the proven plaintext-shaped corrupt database instead of routing through the key-loss backup path, which would preserve a plaintext .pre_key_loss_wipe_backup beside the fresh encrypted DB.

Related Issue: Refs #6897

## Changes

- Pass the bootstrap diagnosis into the manual reset callback so db-unreadable can choose a different file disposition.
- Add a resetUnreadablePlaintextDatabaseCache helper that keeps the cipher key but hard-deletes the unreadable plaintext database and sidecars.
- Keep the existing backup-preserving reset behavior for encrypted/key-loss-style diagnoses.
- Update comments that implied encrypted backups could sit beside the plaintext-shaped unreadable DB.

## Verification

- flutter analyze lib/main.dart lib/services/database_encryption_bootstrap.dart lib/startup/database_bootstrap_failure_app.dart test/startup/database_bootstrap_failure_app_test.dart test/services/database_encryption_bootstrap_test.dart
- flutter analyze lib/src/database/connection/connection_native.dart lib/src/database/connection/connection_stub.dart lib/src/database/connection/connection_web.dart test/src/database/connection/connection_native_test.dart (from mobile/packages/db_client)
- flutter test test/startup/database_bootstrap_failure_app_test.dart test/services/database_encryption_bootstrap_test.dart
- flutter test test/src/database/connection/connection_native_test.dart (from mobile/packages/db_client)

## Review

@hm21, please review since this remediates the post-merge reset disposition from #7157.