### PR TITLE
docs(video): correct the root cause of bare-blob playback failure

### DIFF
--- a/mobile/lib/extensions/video_event_extensions.dart
+++ b/mobile/lib/extensions/video_event_extensions.dart
@@ -217,12 +217,12 @@ extension VideoEventAppExtensions on VideoEvent {
     // transcoded yet.
     //
     // Classic Vine originals take this path as well. They must never be sent
-    // to the extensionless raw blob: iOS AVURLAsset picks its container parser
-    // from the URL path extension and ignores the Content-Type header, so
-    // `/{hash}` fails to parse with AVFoundation -11828/-11829 "Cannot Open"
-    // and never plays. The transcoder caps at the source resolution,
-    // so the "720p" variant of a 480x480 Vine is still 480x480 — smaller than
-    // the raw blob, not an upscale.
+    // to the bare blob: every Range request to `/{hash}` comes back as a
+    // cached `NoSuchKey` XML body dressed up as a 206, so AVFoundation — which
+    // always range-requests — fails with -11829 "Cannot Open" and the video
+    // never plays (divine-blossom#198). The transcoder caps at the source
+    // resolution, so the "720p" variant of a 480x480 Vine is still 480x480 —
+    // smaller than the raw blob, not an upscale.
     return '$_divineMediaBase/$hash/720p.mp4';
   }
 
@@ -231,9 +231,11 @@ extension VideoEventAppExtensions on VideoEvent {
   /// Older desktop Chrome (< 150) and Firefox lack native HLS, so an HLS
   /// `.m3u8` won't play there. Resolve HLS to the progressive variant — the
   /// same [getOptimalVideoUrlForPlatform] selection the feed already uses on
-  /// every platform. Resolve extensionless Divine raw blobs too, because iOS
-  /// AVURLAsset cannot parse them. Progressive URLs pass through unchanged, so
-  /// the common case (and its transcode readiness) is never touched.
+  /// every platform. Resolve bare Divine blobs too: every Range request to
+  /// `/{hash}` comes back as a cached `NoSuchKey` body dressed up as a 206
+  /// (divine-blossom#198), and a range-requesting player gets that instead of
+  /// video. Progressive URLs pass through unchanged, so the common case (and
+  /// its transcode readiness) is never touched.
   String? get inlinePlayerVideoUrl {
     final url = videoUrl;
     if (url == null) return null;

--- a/mobile/packages/divine_video_player/test/src/apple_hls_direct_item_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/apple_hls_direct_item_contract_test.dart
@@ -29,8 +29,9 @@ void main() {
         source,
         contains('pathExtension.lowercased() == "m3u8"'),
         reason:
-            'AVURLAsset itself picks its parser from the URL path extension, '
-            'so the same signal must decide which builder runs.',
+            'Every HLS URL the app resolves ends in .m3u8, so the path '
+            'extension is the cheap deterministic signal for which builder '
+            'runs — no extra load to discover the asset has no tracks.',
       );
       expect(
         source,

--- a/mobile/test/extensions/video_event_divine_server_test.dart
+++ b/mobile/test/extensions/video_event_divine_server_test.dart
@@ -303,10 +303,10 @@ void main() {
       );
     });
 
-    // Regression test for classic Vines being unplayable on iOS. The
-    // extensionless raw blob (`/{hash}`) cannot be parsed by AVURLAsset,
-    // which selects its container parser from the URL path extension and
-    // ignores the Content-Type header.
+    // Regression test for classic Vines being unplayable on iOS. Every Range
+    // request to the bare blob (`/{hash}`) returns a cached `NoSuchKey` XML
+    // body as a 206, and AVFoundation always range-requests, so it never gets
+    // video back (divine-blossom#198).
     test('uses MP4 720p for classic Vine originals', () {
       final video = _createVideoWithUrl(
         'https://media.divine.video/$hash',


### PR DESCRIPTION
## Description

#7171 fixed classic Vine playback on iOS, and the fix was correct — but it shipped with the **wrong explanation**, and I propagated that explanation into three comments. This corrects them. **Comments only; no behaviour changes.**

### What #7171 claimed

That iOS `AVURLAsset` selects its container parser from the URL path extension and ignores `Content-Type`, so the extensionless `/{hash}` could not be parsed.

That came from a real but misleading experiment: a **local** `file://` URL with no extension genuinely does fail, and adding `.mp4` genuinely does fix it. That behaviour is real — it just is not what production hits.

### What is actually happening

Measured against the live server:

| URL | extension | Content-Type | AVFoundation |
|---|---|---|---|
| `/{hash}` | none | `video/mp4` | **fails** `-11829` |
| `/{hash}.mp4` — same blob, byte-identical | `.mp4` | `video/mp4` | **still fails** |
| `/{hash}/720p` | none | `video/mp2t` | **loads**, 1 video + 1 audio track |
| `/{hash}/720p.mp4` | `.mp4` | `video/mp4` | loads |

A local HTTP server serving those same bytes across a 2×2 of {extension, no extension} × {`no-store`, `public`} loaded in **all four** combinations.

So neither the path extension nor `Cache-Control` explains it. The real cause is server-side:

```
$ curl -sS -H "Range: bytes=0-99" https://media.divine.video/{hash}
<Error><Code>NoSuchKey</Code><Message>The object key does not exist.</Message>...

HTTP/2 206
content-range: bytes 0-99/249      <-- object is actually 855345 bytes
content-type: video/mp4            <-- body is XML
x-content-length: 855345           <-- origin's own header disagrees
```

Every `Range` request to the bare blob returns a 249-byte S3 `NoSuchKey` XML body as a **206** with a fabricated `Content-Range`. A plain `GET` returns the real object. AVFoundation always range-requests, so it always got XML. Reproduced on three unrelated blobs. Filed with full evidence as **divinevideo/divine-blossom#198**.

This also explains what the extension theory could not: why a faststart blob failed identically to a `moov`-at-end one, and why the same clip played fine the moment it was on disk.

### Why fix comments at all

The fix in #7171 stands unchanged — routing away from the bare blob is right under either explanation. But a wrong comment about platform behaviour is worse than no comment: the next person reasons from it. It already happened here. The follow-up commit on #7171 extended the fix to `inlinePlayerVideoUrl` and carried the wrong reason forward into a fourth comment — the behaviour it added is correct and stays, only its stated justification changes.

**Related Issue:** Relates to #7168, divinevideo/divine-blossom#198

## Out of Scope

- No behaviour change. The `soleHlsClip` gate, the URL selection, and `inlinePlayerVideoUrl` all work exactly as they do on `main`.
- The server fix itself — divine-blossom#198.
- #7168 has been corrected separately: it claimed 7 of 9 Developer Options formats were broken on iOS. Measured, it is **1** (`raw`). `ts720p` and `ts480p` load fine despite being extensionless MPEG-TS, which is itself part of the evidence that the extension theory was wrong.

## Verification

- `flutter analyze lib test` — no issues.
- `flutter test test/extensions/video_event_divine_server_test.dart test/extensions/video_event_extensions_test.dart` — 31 pass.
- `flutter test` in `packages/divine_video_player` — 280 pass.
- `dart format --set-exit-if-changed` on all three changed files — clean.
- `grep` across `lib/`, `test/` and the player package confirms no remaining claim that the path extension or `Content-Type` is the cause.

Behaviour is unchanged, so the end-to-end device verification from #7171 still holds.

## Type of Change

- [x] 📝 Documentation
