### PR TITLE
fix(feeds): hide blocked reposts and removed videos

### DIFF
--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -39,13 +39,13 @@ typedef OnVideoConfirmedUnavailable = void Function(VideoEvent video);
 
 /// Confirms whether a player-reported unavailable video is safe to prune.
 ///
-/// Production passes [DeadMediaFeedGuard.isConfirmedUnavailable], which first
-/// HEAD-confirms a 404 and then requires moderation to say the blob is
-/// `blocked`. Quarantined and age-restricted blobs also 404 but are reversible,
-/// so they keep their error tile instead of being pruned. Tests may inject a
-/// smaller predicate.
+/// Production passes [DeadMediaFeedGuard.isConfirmedUnavailable]. An API 404
+/// is session-only; only a HEAD-confirmed 404 plus a terminal `blocked`
+/// verdict is persisted. Quarantined and age-restricted blobs also 404 but
+/// are reversible, so they keep their error tile. Tests may inject a smaller
+/// predicate.
 typedef ConfirmVideoUnavailable =
-    Future<bool> Function({
+    Future<FeedUnavailability> Function({
       required String videoId,
       required String? videoUrl,
       String? explicitSha256,
@@ -624,7 +624,7 @@ class FullscreenFeedBloc
       videoUrl: videoUrl,
       explicitSha256: video.sha256,
     );
-    if (!unavailable) {
+    if (!unavailable.shouldRemoveFromSession) {
       Log.warning(
         'FullscreenFeedBloc: Player reported notFound for $videoId but '
         'confirmation did not allow prune — video stays.',
@@ -638,11 +638,11 @@ class FullscreenFeedBloc
     // our HEAD was in flight.
     if (state.removedVideoIds.contains(videoId)) return;
 
-    // Persist the confirmed 404 first so the video stays filtered out of
-    // every list surface (feed, profile, hashtag, grids) across restarts —
-    // not just dropped from this session's in-memory caches via
-    // [_onRemoveVideo].
-    _onVideoConfirmedUnavailable?.call(video);
+    // Persist only a terminal (HEAD 404 + blocked) verdict. An API 404 is
+    // session-only because funnelcake also 404s reversible states.
+    if (unavailable.shouldPersist) {
+      _onVideoConfirmedUnavailable?.call(video);
+    }
 
     _onRemoveVideo?.call(videoId);
 
@@ -659,11 +659,11 @@ class FullscreenFeedBloc
 
   /// Fails closed: without an injected confirmer there is no moderation
   /// verdict, and a bare 404 is not grounds for the persistent prune (#6251).
-  static Future<bool> _defaultConfirmVideoUnavailable({
+  static Future<FeedUnavailability> _defaultConfirmVideoUnavailable({
     required String videoId,
     required String? videoUrl,
     String? explicitSha256,
-  }) async => false;
+  }) async => FeedUnavailability.none;
 
   /// Handle UI acknowledgement of a pending skip signal.
   void _onSkipAcknowledged(

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -278,7 +278,9 @@ class FullscreenFeedBloc
         // (e.g. the liked-videos like-change subscription / load-more, which
         // never re-filter) can't re-introduce an author who is blocked under
         // the current blocklist. Idempotent for sources that already filter.
-        final videos = _applyUnavailableFilter(_applyHideFilter(incoming));
+        final videos = _applySessionRemovedFilter(
+          _applyUnavailableFilter(_applyHideFilter(incoming)),
+        );
 
         Log.debug(
           'FullscreenFeedBloc: Videos updated, count=${videos.length}',
@@ -647,10 +649,25 @@ class FullscreenFeedBloc
     _onRemoveVideo?.call(videoId);
 
     final updatedRemoved = {...state.removedVideoIds, videoId};
-    final nextIndex = index + 1;
+    final updatedVideos = [...state.videos]..removeAt(index);
 
+    if (updatedVideos.isEmpty) {
+      emit(
+        state.copyWith(
+          status: FullscreenFeedStatus.emptyAfterRemoval,
+          videos: const [],
+          removedVideoIds: updatedRemoved,
+          clearPendingSkipTarget: true,
+        ),
+      );
+      return;
+    }
+
+    final nextIndex = index.clamp(0, updatedVideos.length - 1);
     emit(
       state.copyWith(
+        videos: updatedVideos,
+        currentIndex: nextIndex,
         removedVideoIds: updatedRemoved,
         pendingSkipTarget: nextIndex,
       ),
@@ -753,6 +770,11 @@ class FullscreenFeedBloc
     final unavailableFilter = _unavailableFilter;
     if (unavailableFilter == null) return videos;
     return videos.where((v) => !unavailableFilter(v.id)).toList();
+  }
+
+  List<VideoEvent> _applySessionRemovedFilter(List<VideoEvent> videos) {
+    if (state.removedVideoIds.isEmpty) return videos;
+    return videos.where((v) => !state.removedVideoIds.contains(v.id)).toList();
   }
 
   /// Handle a broad blocklist change (`blocklistVersionProvider` bumped).

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -35,7 +35,7 @@ typedef OnRemoveVideo = void Function(String videoId);
 /// the current session — this persists the id so the video stays filtered out
 /// of every list surface across app restarts. A callback keeps the BLoC free
 /// of direct dependencies on concrete services.
-typedef OnVideoConfirmedUnavailable = void Function(String videoId);
+typedef OnVideoConfirmedUnavailable = void Function(VideoEvent video);
 
 /// Confirms whether a player-reported unavailable video is safe to prune.
 ///
@@ -45,15 +45,19 @@ typedef OnVideoConfirmedUnavailable = void Function(String videoId);
 /// so they keep their error tile instead of being pruned. Tests may inject a
 /// smaller predicate.
 typedef ConfirmVideoUnavailable =
-    Future<bool> Function({required String? videoUrl, String? explicitSha256});
+    Future<bool> Function({
+      required String videoId,
+      required String? videoUrl,
+      String? explicitSha256,
+    });
 
-/// Returns `true` when [pubkey]'s content must be hidden (blocked / muted /
-/// blocked-us / muted-us). Injected so the BLoC stays free of Riverpod and
-/// repository dependencies — the launching `ConsumerWidget` resolves it from
-/// `contentBlocklistRepository.shouldFilterFromFeeds`. The bound method reads
-/// live blocklist state on every call, so a captured reference stays correct
-/// across mutations.
-typedef BlockAuthorFilter = bool Function(String pubkey);
+/// Returns `true` when [video] must be hidden (blocked / muted / blocked-us /
+/// muted-us authors or reposters, plus shared feed policy). Injected so the
+/// BLoC stays free of Riverpod and repository dependencies — the launching
+/// `ConsumerWidget` resolves it from `VideoEventService.shouldHideVideo`. The
+/// bound method reads live filter state on every call, so a captured reference
+/// stays correct across mutations.
+typedef VideoHideFilter = bool Function(VideoEvent video);
 
 /// Returns `true` when [videoId] has been confirmed unavailable and persisted.
 /// Injected so the BLoC stays free of concrete service
@@ -108,7 +112,7 @@ class FullscreenFeedBloc
     OnRemoveVideo? onRemoveVideo,
     OnVideoConfirmedUnavailable? onVideoConfirmedUnavailable,
     ConfirmVideoUnavailable? confirmVideoUnavailable,
-    BlockAuthorFilter? blockFilter,
+    VideoHideFilter? hideFilter,
     UnavailableVideoFilter? unavailableFilter,
     FeedTuningRepository? feedTuningRepository,
   }) : _videosStream = videosStream,
@@ -123,7 +127,7 @@ class FullscreenFeedBloc
        _onVideoConfirmedUnavailable = onVideoConfirmedUnavailable,
        _confirmVideoUnavailable =
            confirmVideoUnavailable ?? _defaultConfirmVideoUnavailable,
-       _blockFilter = blockFilter,
+       _hideFilter = hideFilter,
        _unavailableFilter = unavailableFilter,
        _feedTuningRepository = feedTuningRepository,
        super(FullscreenFeedState(currentIndex: initialIndex)) {
@@ -164,7 +168,7 @@ class FullscreenFeedBloc
   final OnRemoveVideo? _onRemoveVideo;
   final OnVideoConfirmedUnavailable? _onVideoConfirmedUnavailable;
   final ConfirmVideoUnavailable _confirmVideoUnavailable;
-  final BlockAuthorFilter? _blockFilter;
+  final VideoHideFilter? _hideFilter;
   final UnavailableVideoFilter? _unavailableFilter;
   final FeedTuningRepository? _feedTuningRepository;
   StreamSubscription<bool>? _hasMoreSubscription;
@@ -274,7 +278,7 @@ class FullscreenFeedBloc
         // (e.g. the liked-videos like-change subscription / load-more, which
         // never re-filter) can't re-introduce an author who is blocked under
         // the current blocklist. Idempotent for sources that already filter.
-        final videos = _applyUnavailableFilter(_applyBlockFilter(incoming));
+        final videos = _applyUnavailableFilter(_applyHideFilter(incoming));
 
         Log.debug(
           'FullscreenFeedBloc: Videos updated, count=${videos.length}',
@@ -616,6 +620,7 @@ class FullscreenFeedBloc
     if (videoUrl == null || videoUrl.isEmpty) return;
 
     final unavailable = await _confirmVideoUnavailable(
+      videoId: videoId,
       videoUrl: videoUrl,
       explicitSha256: video.sha256,
     );
@@ -637,7 +642,7 @@ class FullscreenFeedBloc
     // every list surface (feed, profile, hashtag, grids) across restarts —
     // not just dropped from this session's in-memory caches via
     // [_onRemoveVideo].
-    _onVideoConfirmedUnavailable?.call(videoId);
+    _onVideoConfirmedUnavailable?.call(video);
 
     _onRemoveVideo?.call(videoId);
 
@@ -655,6 +660,7 @@ class FullscreenFeedBloc
   /// Fails closed: without an injected confirmer there is no moderation
   /// verdict, and a bare 404 is not grounds for the persistent prune (#6251).
   static Future<bool> _defaultConfirmVideoUnavailable({
+    required String videoId,
     required String? videoUrl,
     String? explicitSha256,
   }) async => false;
@@ -730,12 +736,12 @@ class FullscreenFeedBloc
     );
   }
 
-  /// Returns [videos] with blocked authors removed, or the same list
-  /// unchanged when no [BlockAuthorFilter] was injected.
-  List<VideoEvent> _applyBlockFilter(List<VideoEvent> videos) {
-    final blockFilter = _blockFilter;
-    if (blockFilter == null) return videos;
-    return videos.where((v) => !blockFilter(v.pubkey)).toList();
+  /// Returns [videos] with hidden items removed, or the same list unchanged
+  /// when no [VideoHideFilter] was injected.
+  List<VideoEvent> _applyHideFilter(List<VideoEvent> videos) {
+    final hideFilter = _hideFilter;
+    if (hideFilter == null) return videos;
+    return videos.where((v) => !hideFilter(v)).toList();
   }
 
   /// Returns [videos] with persisted unavailable videos removed, or the same
@@ -752,11 +758,11 @@ class FullscreenFeedBloc
   /// Handle a broad blocklist change (`blocklistVersionProvider` bumped).
   ///
   /// Re-filters the current [FullscreenFeedState.videos] against the injected
-  /// [BlockAuthorFilter] and drops now-blocked authors. This is the path for
+  /// [VideoHideFilter] and drops now-hidden videos. This is the path for
   /// account switch / identity adoption / external relay sync, which bump the
   /// version but emit no granular `removedVideoIds` (see #5041). It is a pure
   /// list filter — never a permanent tombstone — so an unblock re-shows the
-  /// author on the next source emit.
+  /// item on the next source emit.
   ///
   /// The cursor shifts left by the number of removed videos that preceded it,
   /// preserving the playing video when it survives and landing on the next
@@ -767,10 +773,10 @@ class FullscreenFeedBloc
     FullscreenFeedBlocklistChanged event,
     Emitter<FullscreenFeedState> emit,
   ) {
-    final blockFilter = _blockFilter;
-    if (blockFilter == null || state.videos.isEmpty) return;
+    final hideFilter = _hideFilter;
+    if (hideFilter == null || state.videos.isEmpty) return;
 
-    final kept = _applyBlockFilter(state.videos);
+    final kept = _applyHideFilter(state.videos);
     if (kept.length == state.videos.length) return; // nothing newly blocked
 
     if (kept.isEmpty) {
@@ -786,7 +792,7 @@ class FullscreenFeedBloc
 
     final removedBeforeCursor = state.videos
         .take(state.currentIndex)
-        .where((v) => blockFilter(v.pubkey))
+        .where(hideFilter)
         .length;
     final nextIndex = (state.currentIndex - removedBeforeCursor).clamp(
       0,

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -636,20 +636,27 @@ class FullscreenFeedBloc
       return;
     }
 
-    // Re-check dedupe in case another handler inserted the same id while
-    // our HEAD was in flight.
+    // Re-check dedupe and re-resolve the index after the await. A source
+    // re-push or hide-filter can shift the list while confirmation runs.
     if (state.removedVideoIds.contains(videoId)) return;
+    var currentIndex = state.videos.indexWhere((v) => v.id == videoId);
+    if (currentIndex < 0) return;
+    final currentVideo = state.videos[currentIndex];
 
     // Persist only a terminal (HEAD 404 + blocked) verdict. An API 404 is
     // session-only because funnelcake also 404s reversible states.
     if (unavailable.shouldPersist) {
-      _onVideoConfirmedUnavailable?.call(video);
+      _onVideoConfirmedUnavailable?.call(currentVideo);
     }
 
     _onRemoveVideo?.call(videoId);
 
+    if (state.removedVideoIds.contains(videoId)) return;
+    currentIndex = state.videos.indexWhere((v) => v.id == videoId);
+    if (currentIndex < 0) return;
+
     final updatedRemoved = {...state.removedVideoIds, videoId};
-    final updatedVideos = [...state.videos]..removeAt(index);
+    final updatedVideos = [...state.videos]..removeAt(currentIndex);
 
     if (updatedVideos.isEmpty) {
       emit(
@@ -663,7 +670,7 @@ class FullscreenFeedBloc
       return;
     }
 
-    final nextIndex = index.clamp(0, updatedVideos.length - 1);
+    final nextIndex = currentIndex.clamp(0, updatedVideos.length - 1);
     emit(
       state.copyWith(
         videos: updatedVideos,

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_event.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_event.dart
@@ -118,7 +118,7 @@ final class FullscreenFeedVideoRemoved extends FullscreenFeedEvent {
 /// Dispatched when `blocklistVersionProvider` changes (block / mute / account
 /// switch / identity adoption / external relay sync). The BLoC re-filters its
 /// current [FullscreenFeedState.videos] against the injected
-/// [BlockAuthorFilter], dropping now-blocked authors and shifting the cursor;
+/// [VideoHideFilter], dropping now-hidden videos and shifting the cursor;
 /// an empty result transitions to [FullscreenFeedStatus.emptyAfterRemoval].
 ///
 /// This covers BROAD blocklist changes that emit no granular `removedVideoIds`

--- a/mobile/lib/providers/classic_vines_provider.dart
+++ b/mobile/lib/providers/classic_vines_provider.dart
@@ -3,7 +3,6 @@
 
 import 'dart:async';
 
-import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/providers/curation_providers.dart';
@@ -78,7 +77,6 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
     bool skipCache = false,
   }) async {
     final videoEventService = ref.read(videoEventServiceProvider);
-    final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
     Object? restError;
 
     Future<HomeFeedResult> fetchRestPage({
@@ -98,7 +96,6 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
           final filteredResult = _filterRepositoryResult(
             result,
             videoEventService,
-            blocklistRepository,
           );
 
           if (filteredResult.videos.isNotEmpty ||
@@ -211,7 +208,6 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
         allVideos
             .where((v) => v.isOriginalVine)
             .where((v) => v.isSupportedOnCurrentPlatform)
-            .where((v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey))
             .toList(),
       ),
     )..sort((a, b) => (b.originalLoops ?? 0).compareTo(a.originalLoops ?? 0));
@@ -264,7 +260,6 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
 
     final repository = ref.read(videosRepositoryProvider);
     final videoEventService = ref.read(videoEventServiceProvider);
-    final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
     final funnelcakeAvailable =
         ref.read(funnelcakeAvailableProvider).asData?.value ?? false;
 
@@ -280,11 +275,7 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
         skipCache: true,
       );
       final filteredVideos = dedupeByFeedKey(
-        _filterRepositoryVideos(
-          page.videos,
-          videoEventService,
-          blocklistRepository,
-        ),
+        _filterRepositoryVideos(page.videos, videoEventService),
         alreadySeen: currentState.videos.map((v) => v.feedDedupKey),
       );
 
@@ -320,14 +311,9 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
   HomeFeedResult _filterRepositoryResult(
     HomeFeedResult result,
     VideoEventService videoEventService,
-    ContentBlocklistRepository blocklistRepository,
   ) {
     return HomeFeedResult(
-      videos: _filterRepositoryVideos(
-        result.videos,
-        videoEventService,
-        blocklistRepository,
-      ),
+      videos: _filterRepositoryVideos(result.videos, videoEventService),
       videoListSources: result.videoListSources,
       listOnlyVideoIds: result.listOnlyVideoIds,
       consumedItemCount: result.consumedItemCount,
@@ -340,13 +326,9 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
   List<VideoEvent> _filterRepositoryVideos(
     List<VideoEvent> videos,
     VideoEventService videoEventService,
-    ContentBlocklistRepository blocklistRepository,
   ) {
     return videoEventService.filterVideoList(
-      videos
-          .where((v) => v.isSupportedOnCurrentPlatform)
-          .where((v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey))
-          .toList(),
+      videos.where((v) => v.isSupportedOnCurrentPlatform).toList(),
     );
   }
 }

--- a/mobile/lib/providers/classic_vines_provider.dart
+++ b/mobile/lib/providers/classic_vines_provider.dart
@@ -57,7 +57,12 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
       if (state.hasValue && state.value != null) {
         final existing = state.value!;
         if (existing.videos.isNotEmpty) {
-          return existing;
+          return existing.copyWith(
+            videos: _filterRepositoryVideos(
+              existing.videos,
+              ref.read(videoEventServiceProvider),
+            ),
+          );
         }
       }
       return const VideoFeedState(videos: [], hasMoreContent: false);

--- a/mobile/lib/providers/classic_vines_provider.g.dart
+++ b/mobile/lib/providers/classic_vines_provider.g.dart
@@ -54,7 +54,7 @@ final class ClassicVinesFeedProvider
   ClassicVinesFeed create() => ClassicVinesFeed();
 }
 
-String _$classicVinesFeedHash() => r'6f76c95b5d6a28334ef844c746a798e8fafbe94f';
+String _$classicVinesFeedHash() => r'52810c18c983b92fd9ad9525bf81a707199dd318';
 
 /// ClassicVines feed provider - shows pre-2017 Vine archive sorted by loops
 ///

--- a/mobile/lib/providers/classic_vines_provider.g.dart
+++ b/mobile/lib/providers/classic_vines_provider.g.dart
@@ -54,7 +54,7 @@ final class ClassicVinesFeedProvider
   ClassicVinesFeed create() => ClassicVinesFeed();
 }
 
-String _$classicVinesFeedHash() => r'67d40a5dee41997a46756991501383af30ecffdb';
+String _$classicVinesFeedHash() => r'6f76c95b5d6a28334ef844c746a798e8fafbe94f';
 
 /// ClassicVines feed provider - shows pre-2017 Vine archive sorted by loops
 ///

--- a/mobile/lib/providers/for_you_provider.dart
+++ b/mobile/lib/providers/for_you_provider.dart
@@ -142,15 +142,9 @@ class ForYouFeed extends _$ForYouFeed {
       // users, and dedupe by addressable identity (the recommendation cursor
       // dedupes by event id, so a republished coordinate arrives twice).
       final videoEventService = ref.read(videoEventServiceProvider);
-      final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
       final filteredVideos = dedupeByFeedKey(
         videoEventService.filterVideoList(
-          resultVideos
-              .where((v) => v.isSupportedOnCurrentPlatform)
-              .where(
-                (v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey),
-              )
-              .toList(),
+          resultVideos.where((v) => v.isSupportedOnCurrentPlatform).toList(),
         ),
       );
       final seenVideosService = ref.read(seenVideosServiceProvider);
@@ -163,9 +157,7 @@ class ForYouFeed extends _$ForYouFeed {
         try {
           return ref
               .read(featureFlagServiceProvider)
-              .isEnabled(
-                FeatureFlag.clientSeenFiltering,
-              );
+              .isEnabled(FeatureFlag.clientSeenFiltering);
         } catch (_) {
           return true;
         }
@@ -256,12 +248,8 @@ class ForYouFeed extends _$ForYouFeed {
       }
 
       final videoEventService = ref.read(videoEventServiceProvider);
-      final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
       final filteredVideos = videoEventService.filterVideoList(
-        resultVideos
-            .where((v) => v.isSupportedOnCurrentPlatform)
-            .where((v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey))
-            .toList(),
+        resultVideos.where((v) => v.isSupportedOnCurrentPlatform).toList(),
       );
       final seenVideosService = ref.read(seenVideosServiceProvider);
       await seenVideosService.initialize();
@@ -271,9 +259,7 @@ class ForYouFeed extends _$ForYouFeed {
         try {
           return ref
               .read(featureFlagServiceProvider)
-              .isEnabled(
-                FeatureFlag.clientSeenFiltering,
-              );
+              .isEnabled(FeatureFlag.clientSeenFiltering);
         } catch (_) {
           return true;
         }

--- a/mobile/lib/providers/for_you_provider.dart
+++ b/mobile/lib/providers/for_you_provider.dart
@@ -62,7 +62,7 @@ class ForYouFeed extends _$ForYouFeed {
             name: 'ForYouFeedProvider',
             category: LogCategory.video,
           );
-          return existing;
+          return existing.copyWith(videos: _filterVideos(existing.videos));
         }
       }
       Log.info(
@@ -325,6 +325,13 @@ class ForYouFeed extends _$ForYouFeed {
         preserveExistingOnError: true,
         sessionSeed: generateRecommendationSessionSeed(),
       ),
+    );
+  }
+
+  List<VideoEvent> _filterVideos(List<VideoEvent> videos) {
+    final videoEventService = ref.read(videoEventServiceProvider);
+    return videoEventService.filterVideoList(
+      videos.where((v) => v.isSupportedOnCurrentPlatform).toList(),
     );
   }
 }

--- a/mobile/lib/providers/for_you_provider.g.dart
+++ b/mobile/lib/providers/for_you_provider.g.dart
@@ -48,7 +48,7 @@ final class ForYouFeedProvider
   ForYouFeed create() => ForYouFeed();
 }
 
-String _$forYouFeedHash() => r'47291b4fe60d1275b41612d39cf3f13c7fb58127';
+String _$forYouFeedHash() => r'136c51de7016debc320edc2f38d4e999d8f4960e';
 
 /// For You recommendations feed provider - ML-powered personalized videos
 ///

--- a/mobile/lib/providers/for_you_provider.g.dart
+++ b/mobile/lib/providers/for_you_provider.g.dart
@@ -48,7 +48,7 @@ final class ForYouFeedProvider
   ForYouFeed create() => ForYouFeed();
 }
 
-String _$forYouFeedHash() => r'136c51de7016debc320edc2f38d4e999d8f4960e';
+String _$forYouFeedHash() => r'3f25b28d4aef40da7165bfae885c02e35cc3f279';
 
 /// For You recommendations feed provider - ML-powered personalized videos
 ///

--- a/mobile/lib/providers/new_videos_feed_provider.dart
+++ b/mobile/lib/providers/new_videos_feed_provider.dart
@@ -45,7 +45,7 @@ class NewVideosFeed extends _$NewVideosFeed {
       if (state.hasValue && state.value != null) {
         final existing = state.value!;
         if (existing.videos.isNotEmpty) {
-          return existing;
+          return existing.copyWith(videos: _filterVideos(existing.videos));
         }
       }
       return const VideoFeedState(videos: [], hasMoreContent: true);
@@ -206,12 +206,8 @@ class NewVideosFeed extends _$NewVideosFeed {
 
   List<VideoEvent> _filterVideos(List<VideoEvent> videos) {
     final videoEventService = ref.read(videoEventServiceProvider);
-    final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
     return videoEventService.filterVideoList(
-      videos
-          .where((v) => v.isSupportedOnCurrentPlatform)
-          .where((v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey))
-          .toList(),
+      videos.where((v) => v.isSupportedOnCurrentPlatform).toList(),
     );
   }
 

--- a/mobile/lib/providers/new_videos_feed_provider.g.dart
+++ b/mobile/lib/providers/new_videos_feed_provider.g.dart
@@ -45,7 +45,7 @@ final class NewVideosFeedProvider
   NewVideosFeed create() => NewVideosFeed();
 }
 
-String _$newVideosFeedHash() => r'a6627f5b327f89d6693ba95571630ba6d80e4870';
+String _$newVideosFeedHash() => r'0aeb529696e60170bef378e6be35214d89773a36';
 
 /// New Videos feed provider - shows newest videos first.
 ///

--- a/mobile/lib/providers/popular_videos_feed_provider.dart
+++ b/mobile/lib/providers/popular_videos_feed_provider.dart
@@ -294,10 +294,9 @@ class PopularVideosFeed extends _$PopularVideosFeed {
     PopularVideosVariant variant,
   ) {
     final videoEventService = ref.read(videoEventServiceProvider);
-    final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
-    final compatibleVideos = videos
-        .where((v) => v.isSupportedOnCurrentPlatform)
-        .where((v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey));
+    final compatibleVideos = videos.where(
+      (v) => v.isSupportedOnCurrentPlatform,
+    );
     final platformVideos = variant == PopularVideosVariant.native
         ? compatibleVideos.where((v) => !v.isOriginalVine)
         : compatibleVideos;

--- a/mobile/lib/providers/popular_videos_feed_provider.dart
+++ b/mobile/lib/providers/popular_videos_feed_provider.dart
@@ -86,7 +86,9 @@ class PopularVideosFeed extends _$PopularVideosFeed {
       if (state.hasValue && state.value != null) {
         final existing = state.value!;
         if (existing.videos.isNotEmpty) {
-          return existing;
+          return existing.copyWith(
+            videos: _filterVideos(existing.videos, variant),
+          );
         }
       }
       return const VideoFeedState(videos: [], hasMoreContent: true);

--- a/mobile/lib/providers/popular_videos_feed_provider.g.dart
+++ b/mobile/lib/providers/popular_videos_feed_provider.g.dart
@@ -60,7 +60,7 @@ final class PopularVideosFeedProvider
   PopularVideosFeed create() => PopularVideosFeed();
 }
 
-String _$popularVideosFeedHash() => r'cd7d8fde9f385131dbd2c0c30257140bf2b6932c';
+String _$popularVideosFeedHash() => r'994ea44fe27de5af1d4833a03aaeced8c5983fdc';
 
 /// Popular Videos feed provider - shows trending videos by recent engagement.
 ///

--- a/mobile/lib/providers/popular_videos_feed_provider.g.dart
+++ b/mobile/lib/providers/popular_videos_feed_provider.g.dart
@@ -60,7 +60,7 @@ final class PopularVideosFeedProvider
   PopularVideosFeed create() => PopularVideosFeed();
 }
 
-String _$popularVideosFeedHash() => r'78744d8b8cc02dd4a4f03d53c9bd58421e565c53';
+String _$popularVideosFeedHash() => r'cd7d8fde9f385131dbd2c0c30257140bf2b6932c';
 
 /// Popular Videos feed provider - shows trending videos by recent engagement.
 ///

--- a/mobile/lib/providers/video_events_providers.dart
+++ b/mobile/lib/providers/video_events_providers.dart
@@ -320,13 +320,8 @@ class VideoEvents extends _$VideoEvents {
     }
 
     // Always emit current events if available (no reordering - preserve insertion order)
-    // Create defensive copy, filtering blocked users and unsupported platforms
-    final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
-    final currentEvents = service.filterVideoList(
-      service.discoveryVideos
-          .where((v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey))
-          .toList(),
-    );
+    // Create defensive copy, applying the shared feed filters.
+    final currentEvents = service.filterVideoList(service.discoveryVideos);
 
     Log.error(
       '  🔍 About to emit ${currentEvents.length} current events (canEmit: $_canEmit)',
@@ -416,14 +411,10 @@ class VideoEvents extends _$VideoEvents {
     }
 
     // Store pending events for debounced emission (no reordering - preserve order)
-    // Filter for platform support and blocked users
+    // Filter for platform support and shared hidden-video policy.
     // Create defensive copy ONLY when contents changed
-    final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
     _pendingEvents = service.filterVideoList(
-      newEvents
-          .where((v) => v.isSupportedOnCurrentPlatform)
-          .where((v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey))
-          .toList(),
+      newEvents.where((v) => v.isSupportedOnCurrentPlatform).toList(),
     );
 
     // Cancel any existing timer

--- a/mobile/lib/providers/video_events_providers.g.dart
+++ b/mobile/lib/providers/video_events_providers.g.dart
@@ -137,7 +137,7 @@ final class VideoEventsProvider
   VideoEvents create() => VideoEvents();
 }
 
-String _$videoEventsHash() => r'cc2a61f9a82df16bd01a3fae6a5b4a2c73cb8985';
+String _$videoEventsHash() => r'91f22117b9cf0bc22ad2ec3a0d2645031a947070';
 
 /// Stream provider for video events from Nostr
 

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -452,7 +452,8 @@ Future<BrokenVideoTracker> brokenVideoTracker(Ref ref) async {
 }
 
 /// Guard that HEAD-confirms a feed item's media is 404 and verifies moderation
-/// says the blob is `blocked` before marking it broken. Reuses the singleton
+/// says the blob is `blocked` before marking it broken. A canonical API 404
+/// is session-only and does not persist. Reuses the singleton
 /// [brokenVideoTrackerProvider] so a mark here is visible to every surface's
 /// `filterVideoList`. See #5953 / #6251.
 ///

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -470,10 +470,13 @@ Future<DeadMediaFeedGuard> deadMediaFeedGuard(Ref ref) async {
   final moderationStatusService = ref.watch(
     videoModerationStatusServiceProvider,
   );
+  final funnelcakeClient = ref.watch(funnelcakeApiClientProvider);
   final tracker = await ref.watch(brokenVideoTrackerProvider.future);
   return DeadMediaFeedGuard(
     brokenVideoTracker: tracker,
     moderationStatusService: moderationStatusService,
+    eventMissingChecker: (videoId) async =>
+        await funnelcakeClient.getVideoEvent(videoId) == null,
   );
 }
 

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -713,7 +713,8 @@ String _$brokenVideoTrackerHash() =>
     r'a0b2af154496e50f633f49069986b3c0ee1f5585';
 
 /// Guard that HEAD-confirms a feed item's media is 404 and verifies moderation
-/// says the blob is `blocked` before marking it broken. Reuses the singleton
+/// says the blob is `blocked` before marking it broken. A canonical API 404
+/// is session-only and does not persist. Reuses the singleton
 /// [brokenVideoTrackerProvider] so a mark here is visible to every surface's
 /// `filterVideoList`. See #5953 / #6251.
 ///
@@ -727,7 +728,8 @@ String _$brokenVideoTrackerHash() =>
 final deadMediaFeedGuardProvider = DeadMediaFeedGuardProvider._();
 
 /// Guard that HEAD-confirms a feed item's media is 404 and verifies moderation
-/// says the blob is `blocked` before marking it broken. Reuses the singleton
+/// says the blob is `blocked` before marking it broken. A canonical API 404
+/// is session-only and does not persist. Reuses the singleton
 /// [brokenVideoTrackerProvider] so a mark here is visible to every surface's
 /// `filterVideoList`. See #5953 / #6251.
 ///
@@ -748,7 +750,8 @@ final class DeadMediaFeedGuardProvider
         $FutureModifier<DeadMediaFeedGuard>,
         $FutureProvider<DeadMediaFeedGuard> {
   /// Guard that HEAD-confirms a feed item's media is 404 and verifies moderation
-  /// says the blob is `blocked` before marking it broken. Reuses the singleton
+  /// says the blob is `blocked` before marking it broken. A canonical API 404
+  /// is session-only and does not persist. Reuses the singleton
   /// [brokenVideoTrackerProvider] so a mark here is visible to every surface's
   /// `filterVideoList`. See #5953 / #6251.
   ///

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -784,7 +784,7 @@ final class DeadMediaFeedGuardProvider
 }
 
 String _$deadMediaFeedGuardHash() =>
-    r'958fa1e62ea46ed215cdc446b81e0f21b4822344';
+    r'7b590e30c5cc2dc5bdf1d136b7d671dd66c4c18c';
 
 /// Provider for VideoLocalStorage instance (SQLite-backed)
 ///

--- a/mobile/lib/repositories/feed_repository_impl.dart
+++ b/mobile/lib/repositories/feed_repository_impl.dart
@@ -9,7 +9,6 @@ import 'package:models/models.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/providers/classic_vines_provider.dart';
 import 'package:openvine/providers/for_you_provider.dart';
-import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/providers/new_videos_feed_provider.dart';
 import 'package:openvine/providers/popular_videos_feed_provider.dart';
 import 'package:openvine/providers/route_feed_providers.dart';
@@ -57,7 +56,7 @@ class RiverpodFeedRepository implements FeedRepository {
   late final StaticFeedRepository _static = StaticFeedRepository(
     // Static snapshots bypass each feed provider's `build()` filter, so apply
     // the platform boundary here. Block / mute is enforced downstream by the
-    // FullscreenFeedBloc's BlockAuthorFilter + the removedVideoIds bus.
+    // FullscreenFeedBloc's VideoHideFilter + the removedVideoIds bus.
     filter: (videos) =>
         videos.where((v) => v.isSupportedOnCurrentPlatform).toList(),
   );
@@ -73,16 +72,13 @@ class RiverpodFeedRepository implements FeedRepository {
   bool _isStatic(ViewSource source) =>
       source is SingleVideoViewSource || source is VideoListViewSource;
 
-  /// Applies the standard feed boundary filter (platform support + blocklist)
+  /// Applies the standard feed boundary filter (platform support + shared
+  /// VideoEventService policy)
   /// used by every feed surface.
   List<VideoEvent> _applyBoundaryFilter(List<VideoEvent> videos) {
     final videoEventService = _ref.read(videoEventServiceProvider);
-    final blocklist = _ref.read(contentBlocklistRepositoryProvider);
     return videoEventService.filterVideoList(
-      videos
-          .where((v) => v.isSupportedOnCurrentPlatform)
-          .where((v) => !blocklist.shouldFilterFromFeeds(v.pubkey))
-          .toList(),
+      videos.where((v) => v.isSupportedOnCurrentPlatform).toList(),
     );
   }
 

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -230,9 +230,7 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
     // doesn't flip identity on a block action. The version listener in
     // [FullscreenFeedContent] re-runs the filter when the blocklist changes
     // broadly (account switch / external sync). See #5041.
-    final blockFilter = ref
-        .read(contentBlocklistRepositoryProvider)
-        .shouldFilterFromFeeds;
+    final hideFilter = ref.read(videoEventServiceProvider).shouldHideVideo;
 
     // The removal bus is wired internally (no longer a per-caller parameter):
     // deletion / block / mute emit a removed id here and the bloc drops it,
@@ -243,16 +241,18 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
 
     // Persist permanently-unavailable ids so the video stays filtered out of
     // every list surface (feed, profile, hashtag, grids) across restarts. The
-    // bloc only fires this after DeadMediaFeedGuard confirms both a 404 and a
-    // requester-independent, terminal moderation verdict (#6251).
-    void persistConfirmedUnavailable(String videoId) {
+    // bloc only fires this after DeadMediaFeedGuard confirms either the
+    // canonical API no longer has the video, or a requester-independent,
+    // terminal moderation verdict explains the media 404 (#6251).
+    void persistConfirmedUnavailable(VideoEvent video) {
+      ref.read(videoEventServiceProvider).removeVideoEventCompletely(video);
       unawaited(
         ref
             .read(brokenVideoTrackerProvider.future)
             .then(
               (tracker) => tracker.markVideoBroken(
-                videoId,
-                'Confirmed moderation-unavailable 404 in fullscreen feed',
+                video.id,
+                'Confirmed unavailable video in fullscreen feed',
               ),
             )
             .catchError((Object error) {
@@ -283,12 +283,14 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
         );
 
     Future<bool> confirmVideoUnavailable({
+      required String videoId,
       required String? videoUrl,
       String? explicitSha256,
     }) async {
       final guard = ref.read(deadMediaFeedGuardProvider).asData?.value;
       if (guard == null) return false;
       return guard.isConfirmedUnavailable(
+        videoId: videoId,
         videoUrl: videoUrl,
         explicitSha256: explicitSha256,
       );
@@ -314,7 +316,7 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
             confirmVideoUnavailable: confirmVideoUnavailable,
             mediaCache: mediaCache,
             blossomAuthService: blossomAuthService,
-            blockFilter: blockFilter,
+            hideFilter: hideFilter,
             unavailableFilter: unavailableFilter,
             feedTuningRepository: feedTuningRepository,
           )..add(const FullscreenFeedStarted()),

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -313,6 +313,11 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
             hasMoreStream: feedRepository.watchHasMore(source),
             removedIdsStream: removedIdsStream,
             onLoadMore: () => unawaited(feedRepository.loadMore(source)),
+            onRemoveVideo: (videoId) {
+              ref
+                  .read(videoEventServiceProvider)
+                  .removeVideoCompletely(videoId);
+            },
             onVideoConfirmedUnavailable: persistConfirmedUnavailable,
             confirmVideoUnavailable: confirmVideoUnavailable,
             mediaCache: mediaCache,

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -32,6 +32,7 @@ import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
 import 'package:openvine/screens/feed/feed_immersive_cubit.dart';
 import 'package:openvine/screens/feed/feed_settings_menu.dart';
 import 'package:openvine/screens/feed/feed_tuning_snackbar.dart';
+import 'package:openvine/services/dead_media_feed_guard.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
@@ -241,9 +242,9 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
 
     // Persist permanently-unavailable ids so the video stays filtered out of
     // every list surface (feed, profile, hashtag, grids) across restarts. The
-    // bloc only fires this after DeadMediaFeedGuard confirms either the
-    // canonical API no longer has the video, or a requester-independent,
-    // terminal moderation verdict explains the media 404 (#6251).
+    // bloc only fires this after DeadMediaFeedGuard confirms a
+    // requester-independent, terminal moderation verdict explains the media
+    // 404 (#6251). An API 404 is session-only.
     void persistConfirmedUnavailable(VideoEvent video) {
       ref.read(videoEventServiceProvider).removeVideoEventCompletely(video);
       unawaited(
@@ -282,13 +283,13 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
           orElse: () => false,
         );
 
-    Future<bool> confirmVideoUnavailable({
+    Future<FeedUnavailability> confirmVideoUnavailable({
       required String videoId,
       required String? videoUrl,
       String? explicitSha256,
     }) async {
       final guard = ref.read(deadMediaFeedGuardProvider).asData?.value;
-      if (guard == null) return false;
+      if (guard == null) return FeedUnavailability.none;
       return guard.isConfirmedUnavailable(
         videoId: videoId,
         videoUrl: videoUrl,

--- a/mobile/lib/screens/hashtag_feed_screen.dart
+++ b/mobile/lib/screens/hashtag_feed_screen.dart
@@ -10,6 +10,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/extensions/safe_pop_extension.dart';
+import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/feed_repository_provider.dart';
@@ -143,20 +144,20 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
     }
   }
 
-  /// Removes videos whose author is blocked/muted (kind 30000 d=block /
-  /// kind 10000), or who has blocked/muted the current user.
+  /// Applies the shared feed filters, including blocked/muted authors and
+  /// reposters.
   ///
   /// The REST source is already parse-gated by the repository, so this
   /// seam mainly covers the WebSocket source and hides a just-blocked
-  /// author immediately (the [blocklistVersionProvider] watch in [build]
+  /// account immediately (the [blocklistVersionProvider] watch in [build]
   /// re-runs it). Unblocked authors reappear via the version-triggered
   /// REST refetch in [build]. See #4782, #948.
-  List<VideoEvent> _filterBlockedAuthors(List<VideoEvent> videos) {
+  List<VideoEvent> _applyFeedFilters(List<VideoEvent> videos) {
     if (videos.isEmpty) return videos;
-    final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
-    return videos
-        .where((v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey))
-        .toList();
+    final videoEventService = ref.read(videoEventServiceProvider);
+    return videoEventService.filterVideoList(
+      videos.where((v) => v.isSupportedOnCurrentPlatform).toList(),
+    );
   }
 
   /// Combine and sort videos from Funnelcake and WebSocket sources.
@@ -166,7 +167,7 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
     // If no Funnelcake data, just sort WebSocket videos locally
     if (_popularVideos == null || _popularVideos!.isEmpty) {
       webSocketVideos.sort(VideoEvent.compareByLoopsThenTime);
-      return _filterBlockedAuthors(webSocketVideos);
+      return _applyFeedFilters(webSocketVideos);
     }
 
     final funnelcakeIds = <String>{};
@@ -195,7 +196,7 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
 
     // Return Funnelcake videos (already sorted by API) + additional WebSocket
     // videos, with blocked/muted authors removed from both sources.
-    return _filterBlockedAuthors([..._popularVideos!, ...additionalVideos]);
+    return _applyFeedFilters([..._popularVideos!, ...additionalVideos]);
   }
 
   /// Navigate to fullscreen video feed through the hashtag [ViewSource].

--- a/mobile/lib/services/dead_media_feed_guard.dart
+++ b/mobile/lib/services/dead_media_feed_guard.dart
@@ -5,6 +5,8 @@ import 'package:openvine/services/broken_video_tracker.dart';
 import 'package:openvine/services/media_availability_checker.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
 
+typedef VideoEventMissingChecker = Future<bool> Function(String videoId);
+
 /// Decides whether a feed item whose player failed should be treated as
 /// permanently unavailable.
 ///
@@ -30,18 +32,22 @@ class DeadMediaFeedGuard {
   const DeadMediaFeedGuard({
     required BrokenVideoTracker brokenVideoTracker,
     required VideoModerationStatusService moderationStatusService,
+    VideoEventMissingChecker? eventMissingChecker,
     MediaAvailabilityChecker availabilityChecker =
         const MediaAvailabilityChecker(),
   }) : _tracker = brokenVideoTracker,
        _checker = availabilityChecker,
+       _eventMissingChecker = eventMissingChecker,
        _moderationStatusService = moderationStatusService;
 
   final BrokenVideoTracker _tracker;
   final MediaAvailabilityChecker _checker;
+  final VideoEventMissingChecker? _eventMissingChecker;
   final VideoModerationStatusService _moderationStatusService;
 
-  /// Returns `true` iff [videoUrl] is a HEAD-confirmed 404 and moderation
-  /// confirms the blob is `blocked`.
+  /// Returns `true` iff either [videoId] is missing from the canonical video
+  /// API, or [videoUrl] is a HEAD-confirmed 404 and moderation confirms the
+  /// blob is `blocked`.
   ///
   /// Returns `false` when [videoUrl] is missing, reachable, returns any status
   /// other than 404, the HEAD request fails, the blob hash cannot be resolved,
@@ -49,9 +55,20 @@ class DeadMediaFeedGuard {
   /// (quarantined / age-restricted). The caller must then keep the item
   /// recoverable.
   Future<bool> isConfirmedUnavailable({
+    required String videoId,
     required String? videoUrl,
     String? explicitSha256,
   }) async {
+    final eventMissingChecker = _eventMissingChecker;
+    if (eventMissingChecker != null && videoId.isNotEmpty) {
+      try {
+        if (await eventMissingChecker(videoId)) return true;
+      } on Exception {
+        // API confirmation is an optional prune signal. Fall through to the
+        // media/moderation path and stay conservative if that cannot confirm.
+      }
+    }
+
     if (videoUrl == null || videoUrl.isEmpty) return false;
     final missing = await _checker.isConfirmedMissing(videoUrl);
     if (!missing) return false;
@@ -78,6 +95,7 @@ class DeadMediaFeedGuard {
     String? explicitSha256,
   }) async {
     final unavailable = await isConfirmedUnavailable(
+      videoId: videoId,
       videoUrl: videoUrl,
       explicitSha256: explicitSha256,
     );

--- a/mobile/lib/services/dead_media_feed_guard.dart
+++ b/mobile/lib/services/dead_media_feed_guard.dart
@@ -7,6 +7,18 @@ import 'package:openvine/services/video_moderation_status_service.dart';
 
 typedef VideoEventMissingChecker = Future<bool> Function(String videoId);
 
+/// Why a feed item is unavailable, and whether that reason may be persisted.
+enum FeedUnavailability {
+  none,
+  sessionOnly,
+  persistent,
+}
+
+extension FeedUnavailabilityX on FeedUnavailability {
+  bool get shouldRemoveFromSession => this != FeedUnavailability.none;
+  bool get shouldPersist => this == FeedUnavailability.persistent;
+}
+
 /// Decides whether a feed item whose player failed should be treated as
 /// permanently unavailable.
 ///
@@ -45,16 +57,20 @@ class DeadMediaFeedGuard {
   final VideoEventMissingChecker? _eventMissingChecker;
   final VideoModerationStatusService _moderationStatusService;
 
-  /// Returns `true` iff either [videoId] is missing from the canonical video
-  /// API, or [videoUrl] is a HEAD-confirmed 404 and moderation confirms the
-  /// blob is `blocked`.
+  /// Classifies why [videoId] is unavailable.
   ///
-  /// Returns `false` when [videoUrl] is missing, reachable, returns any status
-  /// other than 404, the HEAD request fails, the blob hash cannot be resolved,
-  /// the moderation lookup fails, or moderation reports a reversible verdict
-  /// (quarantined / age-restricted). The caller must then keep the item
-  /// recoverable.
-  Future<bool> isConfirmedUnavailable({
+  /// A canonical API 404 is [FeedUnavailability.sessionOnly]: funnelcake's
+  /// by-id filter also 404s reversible states (quarantine, suspension,
+  /// vanished, expiry), so it must not persist a tombstone. See #6251.
+  ///
+  /// [FeedUnavailability.persistent] is only a HEAD-confirmed 404 whose
+  /// requester-independent moderation status is `blocked`.
+  ///
+  /// Returns [FeedUnavailability.none] when [videoUrl] is missing, reachable,
+  /// returns any status other than 404, the HEAD request fails, the blob hash
+  /// cannot be resolved, the moderation lookup fails, or moderation reports a
+  /// reversible verdict (quarantined / age-restricted).
+  Future<FeedUnavailability> isConfirmedUnavailable({
     required String videoId,
     required String? videoUrl,
     String? explicitSha256,
@@ -62,33 +78,36 @@ class DeadMediaFeedGuard {
     final eventMissingChecker = _eventMissingChecker;
     if (eventMissingChecker != null && videoId.isNotEmpty) {
       try {
-        if (await eventMissingChecker(videoId)) return true;
+        if (await eventMissingChecker(videoId)) {
+          return FeedUnavailability.sessionOnly;
+        }
       } on Exception {
         // API confirmation is an optional prune signal. Fall through to the
         // media/moderation path and stay conservative if that cannot confirm.
       }
     }
 
-    if (videoUrl == null || videoUrl.isEmpty) return false;
+    if (videoUrl == null || videoUrl.isEmpty) return FeedUnavailability.none;
     final missing = await _checker.isConfirmedMissing(videoUrl);
-    if (!missing) return false;
+    if (!missing) return FeedUnavailability.none;
 
     final sha256 = VideoModerationStatusService.resolveSha256(
       explicitSha256: explicitSha256,
       videoUrl: videoUrl,
     );
-    if (sha256 == null) return false;
+    if (sha256 == null) return FeedUnavailability.none;
 
     final status = await _moderationStatusService.fetchStatus(sha256);
     // `blocked` (PERMANENT_BAN) is the only terminal verdict. QUARANTINE maps
     // to blossom RESTRICT: reversible and pending review, so a quarantined
     // blob 404s now but must stay recoverable. See #6251.
-    return status?.blocked == true;
+    return status?.blocked == true
+        ? FeedUnavailability.persistent
+        : FeedUnavailability.none;
   }
 
-  /// Persists [videoId] as broken iff [isConfirmedUnavailable] returns `true`,
-  /// so [BrokenVideoTracker.isVideoBroken] (and therefore `filterVideoList`)
-  /// drops it from every list surface across restarts.
+  /// Returns `true` when the item should leave this session's feed.
+  /// Persists [videoId] as broken only for [FeedUnavailability.persistent].
   Future<bool> confirmAndMarkMissing({
     required String videoId,
     required String? videoUrl,
@@ -99,11 +118,13 @@ class DeadMediaFeedGuard {
       videoUrl: videoUrl,
       explicitSha256: explicitSha256,
     );
-    if (!unavailable) return false;
-    await _tracker.markVideoBroken(
-      videoId,
-      'Confirmed moderation-unavailable 404 in home feed',
-    );
+    if (!unavailable.shouldRemoveFromSession) return false;
+    if (unavailable.shouldPersist) {
+      await _tracker.markVideoBroken(
+        videoId,
+        'Confirmed moderation-unavailable 404 in home feed',
+      );
+    }
     return true;
   }
 }

--- a/mobile/lib/services/video_block_policy.dart
+++ b/mobile/lib/services/video_block_policy.dart
@@ -12,14 +12,24 @@ class VideoBlockPolicy {
     ContentBlocklistRepository? blocklistRepository,
   ) {
     if (blocklistRepository == null) return false;
+    if (video.pubkey.isNotEmpty &&
+        blocklistRepository.shouldFilterFromFeeds(video.pubkey)) {
+      return true;
+    }
     return [
-      video.pubkey,
       if (video.reposterPubkey != null) video.reposterPubkey!,
       ...?video.reposterPubkeys,
     ].any(
       (pubkey) =>
-          pubkey.isNotEmpty &&
-          blocklistRepository.shouldFilterFromFeeds(pubkey),
+          pubkey.isNotEmpty && _shouldHideReposter(blocklistRepository, pubkey),
     );
+  }
+
+  static bool _shouldHideReposter(
+    ContentBlocklistRepository blocklistRepository,
+    String pubkey,
+  ) {
+    return blocklistRepository.isBlocked(pubkey) ||
+        blocklistRepository.isMutedByUs(pubkey);
   }
 }

--- a/mobile/lib/services/video_block_policy.dart
+++ b/mobile/lib/services/video_block_policy.dart
@@ -1,0 +1,25 @@
+// ABOUTME: Shared video blocklist policy for feed/detail visibility decisions.
+// ABOUTME: Checks every visible account attached to a VideoEvent, not only authors.
+
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:models/models.dart';
+
+class VideoBlockPolicy {
+  const VideoBlockPolicy._();
+
+  static bool isHiddenByBlocklist(
+    VideoEvent video,
+    ContentBlocklistRepository? blocklistRepository,
+  ) {
+    if (blocklistRepository == null) return false;
+    return [
+      video.pubkey,
+      if (video.reposterPubkey != null) video.reposterPubkey!,
+      ...?video.reposterPubkeys,
+    ].any(
+      (pubkey) =>
+          pubkey.isNotEmpty &&
+          blocklistRepository.shouldFilterFromFeeds(pubkey),
+    );
+  }
+}

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -46,6 +46,7 @@ import 'package:openvine/services/moderation_label_service.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/repost_resolver.dart';
 import 'package:openvine/services/subscription_manager.dart';
+import 'package:openvine/services/video_block_policy.dart';
 import 'package:openvine/services/video_filter_builder.dart';
 import 'package:openvine/utils/log_tag_sanitizer.dart';
 import 'package:profile_repository/profile_repository.dart';
@@ -516,17 +517,9 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   bool get shouldFilterNonDivineVideos =>
       _divineHostFilterService?.showDivineHostedOnly ?? false;
 
-  /// Returns true when this video should be hidden — either because its author
-  /// is blocked/muted (the viewer blocked them, or they blocked the viewer via
-  /// kind-30000 `d=block` / muted via kind-10000), or because the viewer's
-  /// Divine-hosted-only preference is on and the video is not Divine-hosted.
-  ///
-  /// Detail/by-id surfaces (sound detail, video detail, curated lists,
-  /// notifications) resolve videos directly and bypass the reception-time
-  /// blocklist filter, so the blocklist check lives here at the shared
-  /// chokepoint rather than at each call site.
+  /// Returns true when shared feed policy hides this video.
   bool shouldHideVideo(VideoEvent video) {
-    if (_blocklistRepository?.shouldFilterFromFeeds(video.pubkey) ?? false) {
+    if (VideoBlockPolicy.isHiddenByBlocklist(video, _blocklistRepository)) {
       return true;
     }
     if (shouldFilterNonDivineVideos && !video.isFromDivineServer) {

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -115,9 +115,10 @@ void main() {
 
     ConfirmVideoUnavailable confirmerReturning(
       bool result, {
-      void Function(String? videoUrl, String? explicitSha256)? onCall,
+      void Function(String videoId, String? videoUrl, String? explicitSha256)?
+      onCall,
     }) => ({required videoId, required videoUrl, explicitSha256}) async {
-      onCall?.call(videoUrl, explicitSha256);
+      onCall?.call(videoId, videoUrl, explicitSha256);
       return result;
     };
 
@@ -1922,11 +1923,12 @@ void main() {
       );
 
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
-        'passes video URL and explicit sha256 to confirmation',
+        'passes video id, URL and explicit sha256 to confirmation',
         build: () => createBloc(
           confirmVideoUnavailable: confirmerReturning(
             true,
-            onCall: expectAsync2((videoUrl, explicitSha256) {
+            onCall: expectAsync3((videoId, videoUrl, explicitSha256) {
+              expect(videoId, equals('video1'));
               expect(videoUrl, equals('https://example.com/video_video1.mp4'));
               expect(explicitSha256, equals('a' * 64));
             }),

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -14,6 +14,7 @@ import 'package:media_cache/media_cache.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/fullscreen_feed/fullscreen_feed_bloc.dart';
+import 'package:openvine/services/dead_media_feed_guard.dart';
 
 class MockFileInfo extends Mock implements FileInfo {}
 
@@ -113,14 +114,23 @@ void main() {
       feedTuningRepository: feedTuningRepository,
     );
 
-    ConfirmVideoUnavailable confirmerReturning(
-      bool result, {
+    ConfirmVideoUnavailable confirmerWith(
+      FeedUnavailability result, {
       void Function(String videoId, String? videoUrl, String? explicitSha256)?
       onCall,
     }) => ({required videoId, required videoUrl, explicitSha256}) async {
       onCall?.call(videoId, videoUrl, explicitSha256);
       return result;
     };
+
+    ConfirmVideoUnavailable confirmerReturning(
+      bool result, {
+      void Function(String videoId, String? videoUrl, String? explicitSha256)?
+      onCall,
+    }) => confirmerWith(
+      result ? FeedUnavailability.persistent : FeedUnavailability.none,
+      onCall: onCall,
+    );
 
     test('initial state has correct values', () {
       final bloc = createBloc(initialIndex: 2);
@@ -1918,6 +1928,33 @@ void main() {
             (s) => s.pendingSkipTarget,
             'pendingSkipTarget',
             equals(2),
+          ),
+        ],
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'session-only confirmation removes without persisting',
+        build: () => createBloc(
+          onRemoveVideo: expectAsync1<void, String>((id) {
+            expect(id, equals('video1'));
+          }),
+          onVideoConfirmedUnavailable: (_) =>
+              fail('API-missing 404 must not persist'),
+          confirmVideoUnavailable: confirmerWith(
+            FeedUnavailability.sessionOnly,
+          ),
+        ),
+        seed: () => FullscreenFeedState(
+          status: FullscreenFeedStatus.ready,
+          videos: [createTestVideo('video1')],
+        ),
+        act: (bloc) => bloc.add(const FullscreenFeedVideoUnavailable('video1')),
+        wait: const Duration(milliseconds: 100),
+        expect: () => [
+          isA<FullscreenFeedState>().having(
+            (s) => s.removedVideoIds,
+            'removedVideoIds',
+            equals({'video1'}),
           ),
         ],
       );

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -93,7 +93,7 @@ void main() {
       OnRemoveVideo? onRemoveVideo,
       OnVideoConfirmedUnavailable? onVideoConfirmedUnavailable,
       ConfirmVideoUnavailable? confirmVideoUnavailable,
-      BlockAuthorFilter? blockFilter,
+      VideoHideFilter? hideFilter,
       UnavailableVideoFilter? unavailableFilter,
       FeedTuningRepository? feedTuningRepository,
     }) => FullscreenFeedBloc(
@@ -108,7 +108,7 @@ void main() {
       onRemoveVideo: onRemoveVideo,
       onVideoConfirmedUnavailable: onVideoConfirmedUnavailable,
       confirmVideoUnavailable: confirmVideoUnavailable,
-      blockFilter: blockFilter,
+      hideFilter: hideFilter,
       unavailableFilter: unavailableFilter,
       feedTuningRepository: feedTuningRepository,
     );
@@ -116,7 +116,7 @@ void main() {
     ConfirmVideoUnavailable confirmerReturning(
       bool result, {
       void Function(String? videoUrl, String? explicitSha256)? onCall,
-    }) => ({required videoUrl, explicitSha256}) async {
+    }) => ({required videoId, required videoUrl, explicitSha256}) async {
       onCall?.call(videoUrl, explicitSha256);
       return result;
     };
@@ -634,9 +634,8 @@ void main() {
       // just as effectively as one that pushes an empty list.
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
         'emits empty when every video in a later emission is filtered out',
-        build: () => createBloc(
-          unavailableFilter: (videoId) => videoId == 'video2',
-        ),
+        build: () =>
+            createBloc(unavailableFilter: (videoId) => videoId == 'video2'),
         act: (bloc) async {
           bloc.add(const FullscreenFeedStarted());
           await Future<void>.delayed(const Duration(milliseconds: 50));
@@ -899,7 +898,7 @@ void main() {
 
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
         'filters blocked authors from incoming stream lists at the boundary',
-        build: () => createBloc(blockFilter: (pk) => pk == authorB),
+        build: () => createBloc(hideFilter: (video) => video.pubkey == authorB),
         act: (bloc) async {
           bloc.add(const FullscreenFeedStarted());
           await Future<void>.delayed(const Duration(milliseconds: 50));
@@ -919,12 +918,42 @@ void main() {
         ],
       );
 
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'filters videos when a visible reposter is blocked',
+        build: () => createBloc(
+          hideFilter: (video) =>
+              video.pubkey == authorB ||
+              video.reposterPubkey == authorB ||
+              (video.reposterPubkeys?.contains(authorB) ?? false),
+        ),
+        act: (bloc) async {
+          bloc.add(const FullscreenFeedStarted());
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          videosController.add([
+            createTestVideo('a', pubkey: authorA),
+            createTestVideo('reposted', pubkey: authorC).copyWith(
+              isRepost: true,
+              reposterPubkey: authorB,
+              reposterPubkeys: [authorB],
+            ),
+          ]);
+        },
+        wait: const Duration(milliseconds: 100),
+        expect: () => [
+          isA<FullscreenFeedState>().having(
+            (s) => s.videos.map((v) => v.id).toList(),
+            'video ids',
+            ['a'],
+          ),
+        ],
+      );
+
       // The boundary filter must hold across a source re-push — the
       // liked-videos like-change subscription / load-more re-emit unfiltered
       // lists (finding N1), so a blocked author must not slip back in.
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
         'keeps blocked authors out across a source re-push',
-        build: () => createBloc(blockFilter: (pk) => pk == authorB),
+        build: () => createBloc(hideFilter: (video) => video.pubkey == authorB),
         act: (bloc) async {
           bloc.add(const FullscreenFeedStarted());
           await Future<void>.delayed(const Duration(milliseconds: 50));
@@ -960,7 +989,7 @@ void main() {
 
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
         'preserves the playing video when an earlier author is blocked',
-        build: () => createBloc(blockFilter: (pk) => pk == authorB),
+        build: () => createBloc(hideFilter: (video) => video.pubkey == authorB),
         seed: () => FullscreenFeedState(
           status: FullscreenFeedStatus.ready,
           videos: [
@@ -989,7 +1018,7 @@ void main() {
       // 'e', not 'd' — so this test fails loudly if the shift logic regresses.
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
         'shifts the cursor left by the count of blocked videos before it',
-        build: () => createBloc(blockFilter: (pk) => pk == authorA),
+        build: () => createBloc(hideFilter: (video) => video.pubkey == authorA),
         seed: () => FullscreenFeedState(
           status: FullscreenFeedStatus.ready,
           videos: [
@@ -1016,7 +1045,7 @@ void main() {
 
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
         'lands on the next survivor when the current video is blocked',
-        build: () => createBloc(blockFilter: (pk) => pk == authorB),
+        build: () => createBloc(hideFilter: (video) => video.pubkey == authorB),
         seed: () => FullscreenFeedState(
           status: FullscreenFeedStatus.ready,
           videos: [
@@ -1043,7 +1072,7 @@ void main() {
       // surface at index 0.
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
         'lands on the next survivor when the index-0 video is blocked',
-        build: () => createBloc(blockFilter: (pk) => pk == authorA),
+        build: () => createBloc(hideFilter: (video) => video.pubkey == authorA),
         seed: () => FullscreenFeedState(
           status: FullscreenFeedStatus.ready,
           videos: [
@@ -1066,7 +1095,7 @@ void main() {
 
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
         'transitions to emptyAfterRemoval when every author is blocked',
-        build: () => createBloc(blockFilter: (pk) => pk == authorA),
+        build: () => createBloc(hideFilter: (video) => video.pubkey == authorA),
         seed: () => FullscreenFeedState(
           status: FullscreenFeedStatus.ready,
           videos: [
@@ -1088,7 +1117,7 @@ void main() {
 
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
         'emits nothing when no author is blocked',
-        build: () => createBloc(blockFilter: (pk) => pk == authorB),
+        build: () => createBloc(hideFilter: (video) => video.pubkey == authorB),
         seed: () => FullscreenFeedState(
           status: FullscreenFeedStatus.ready,
           videos: [
@@ -1745,8 +1774,8 @@ void main() {
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
         'calls onVideoConfirmedUnavailable when confirmation allows prune',
         build: () => createBloc(
-          onVideoConfirmedUnavailable: expectAsync1<void, String>((id) {
-            expect(id, equals('video1'));
+          onVideoConfirmedUnavailable: expectAsync1<void, VideoEvent>((video) {
+            expect(video.id, equals('video1'));
           }),
           confirmVideoUnavailable: confirmerReturning(true),
         ),

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -1725,9 +1725,14 @@ void main() {
                 equals({'video1'}),
               )
               .having(
+                (s) => s.videos.map((v) => v.id).toList(),
+                'video ids',
+                ['video2'],
+              )
+              .having(
                 (s) => s.pendingSkipTarget,
                 'pendingSkipTarget',
-                equals(1),
+                equals(0),
               ),
         ],
       );
@@ -1861,7 +1866,7 @@ void main() {
               .having(
                 (s) => s.pendingSkipTarget,
                 'pendingSkipTarget',
-                equals(1),
+                equals(0),
               ),
         ],
       );
@@ -1907,7 +1912,7 @@ void main() {
       );
 
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
-        'skip target matches index of removed video + 1',
+        'skip target lands on the survivor now at the removed index',
         build: () => createBloc(
           onRemoveVideo: (_) {},
           confirmVideoUnavailable: confirmerReturning(true),
@@ -1924,11 +1929,18 @@ void main() {
         act: (bloc) => bloc.add(const FullscreenFeedVideoUnavailable('video2')),
         wait: const Duration(milliseconds: 100),
         expect: () => [
-          isA<FullscreenFeedState>().having(
-            (s) => s.pendingSkipTarget,
-            'pendingSkipTarget',
-            equals(2),
-          ),
+          isA<FullscreenFeedState>()
+              .having(
+                (s) => s.videos.map((v) => v.id).toList(),
+                'video ids',
+                ['video1', 'video3'],
+              )
+              .having((s) => s.currentIndex, 'currentIndex', equals(1))
+              .having(
+                (s) => s.pendingSkipTarget,
+                'pendingSkipTarget',
+                equals(1),
+              ),
         ],
       );
 
@@ -1951,12 +1963,51 @@ void main() {
         act: (bloc) => bloc.add(const FullscreenFeedVideoUnavailable('video1')),
         wait: const Duration(milliseconds: 100),
         expect: () => [
-          isA<FullscreenFeedState>().having(
-            (s) => s.removedVideoIds,
-            'removedVideoIds',
-            equals({'video1'}),
-          ),
+          isA<FullscreenFeedState>()
+              .having(
+                (s) => s.removedVideoIds,
+                'removedVideoIds',
+                equals({'video1'}),
+              )
+              .having(
+                (s) => s.status,
+                'status',
+                FullscreenFeedStatus.emptyAfterRemoval,
+              )
+              .having((s) => s.videos, 'videos', isEmpty),
         ],
+      );
+
+      test(
+        'session-only removal survives a source re-push of the same id',
+        () async {
+          final bloc = createBloc(
+            confirmVideoUnavailable: confirmerWith(
+              FeedUnavailability.sessionOnly,
+            ),
+          );
+          addTearDown(bloc.close);
+          bloc.add(const FullscreenFeedStarted());
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          videosController.add([
+            createTestVideo('video1'),
+            createTestVideo('video2'),
+          ]);
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          expect(bloc.state.videos.map((v) => v.id), ['video1', 'video2']);
+
+          bloc.add(const FullscreenFeedVideoUnavailable('video1'));
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          expect(bloc.state.videos.map((v) => v.id), ['video2']);
+          expect(bloc.state.removedVideoIds, equals({'video1'}));
+
+          videosController.add([
+            createTestVideo('video1'),
+            createTestVideo('video2'),
+          ]);
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          expect(bloc.state.videos.map((v) => v.id), ['video2']);
+        },
       );
 
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
@@ -2015,7 +2066,11 @@ void main() {
         ),
         seed: () => FullscreenFeedState(
           status: FullscreenFeedStatus.ready,
-          videos: [createTestVideo('video1'), createTestVideo('video2')],
+          videos: [
+            createTestVideo('video1'),
+            createTestVideo('video2'),
+            createTestVideo('video3'),
+          ],
         ),
         act: (bloc) async {
           bloc.add(const FullscreenFeedVideoUnavailable('video1'));
@@ -2029,7 +2084,7 @@ void main() {
           isA<FullscreenFeedState>().having(
             (s) => s.pendingSkipTarget,
             'pendingSkipTarget after first unavailable',
-            equals(1),
+            equals(0),
           ),
           isA<FullscreenFeedState>().having(
             (s) => s.pendingSkipTarget,
@@ -2039,7 +2094,7 @@ void main() {
           isA<FullscreenFeedState>().having(
             (s) => s.pendingSkipTarget,
             'pendingSkipTarget after second unavailable',
-            equals(2),
+            equals(0),
           ),
         ],
       );

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -1978,6 +1978,46 @@ void main() {
         ],
       );
 
+      test('re-resolves the video after confirm if the list shifted', () async {
+        final started = Completer<void>();
+        final release = Completer<void>();
+        final bloc = createBloc(
+          confirmVideoUnavailable:
+              ({
+                required videoId,
+                required videoUrl,
+                explicitSha256,
+              }) async {
+                started.complete();
+                await release.future;
+                return FeedUnavailability.sessionOnly;
+              },
+        );
+        addTearDown(bloc.close);
+        bloc.add(const FullscreenFeedStarted());
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        videosController.add([
+          createTestVideo('video1'),
+          createTestVideo('video2'),
+          createTestVideo('video3'),
+        ]);
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        bloc.add(const FullscreenFeedVideoUnavailable('video2'));
+        await started.future;
+        videosController.add([
+          createTestVideo('video3'),
+          createTestVideo('video1'),
+          createTestVideo('video2'),
+        ]);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        release.complete();
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        expect(bloc.state.videos.map((v) => v.id), ['video3', 'video1']);
+        expect(bloc.state.removedVideoIds, equals({'video2'}));
+      });
+
       test(
         'session-only removal survives a source re-push of the same id',
         () async {

--- a/mobile/test/providers/classic_vines_refresh_test.dart
+++ b/mobile/test/providers/classic_vines_refresh_test.dart
@@ -133,17 +133,15 @@ void main() {
           hasMore: true,
         ),
       );
-      when(
-        () => mockBlocklistRepository.shouldFilterFromFeeds('blocked-author'),
-      ).thenReturn(true);
-
       final filteredIds = <List<String>>[];
       when(() => mockVideoEventService.filterVideoList(any())).thenAnswer((
         invocation,
       ) {
         final videos = invocation.positionalArguments.first as List<VideoEvent>;
         filteredIds.add(videos.map((video) => video.id).toList());
-        return videos;
+        return videos
+            .where((video) => video.pubkey != 'blocked-author')
+            .toList();
       });
 
       final container = createContainer();
@@ -154,7 +152,7 @@ void main() {
 
       expect(state.videos.map((video) => video.id), ['classic-supported']);
       expect(filteredIds, [
-        ['classic-supported'],
+        ['classic-supported', 'classic-blocked'],
       ]);
     });
 

--- a/mobile/test/providers/feed_background_preservation_test.dart
+++ b/mobile/test/providers/feed_background_preservation_test.dart
@@ -170,6 +170,52 @@ void main() {
         );
       });
 
+      test('re-filters preserved videos when appReady is false', () async {
+        final container = createContainer(appReady: true);
+        addTearDown(container.dispose);
+
+        await container.read(funnelcakeAvailableProvider.future);
+        final initialState = await container.read(
+          classicVinesFeedProvider.future,
+        );
+        expect(initialState.videos, hasLength(5));
+
+        when(() => mockVideoEventService.filterVideoList(any())).thenAnswer((
+          inv,
+        ) {
+          final videos = List<VideoEvent>.from(
+            inv.positionalArguments.first as List,
+          );
+          return videos.where((video) => video.id != testVideos[1].id).toList();
+        });
+
+        container.updateOverrides([
+          appReadyProvider.overrideWithValue(false),
+          sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+          funnelcakeApiClientProvider.overrideWithValue(mockFunnelcakeClient),
+          videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+          contentBlocklistRepositoryProvider.overrideWithValue(
+            mockBlocklistRepository,
+          ),
+          funnelcakeAvailableProvider.overrideWith(
+            _TestFunnelcakeUnavailable.new,
+          ),
+        ]);
+
+        await container.read(funnelcakeAvailableProvider.future);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        final afterBackgroundState = await container.read(
+          classicVinesFeedProvider.future,
+        );
+        expect(
+          afterBackgroundState.videos.map((v) => v.id),
+          isNot(contains(testVideos[1].id)),
+        );
+        expect(afterBackgroundState.videos, hasLength(4));
+      });
+
       test('reloads fresh data when appReady returns to true', () async {
         final container = createContainer(appReady: true);
         addTearDown(container.dispose);

--- a/mobile/test/providers/new_videos_feed_provider_test.dart
+++ b/mobile/test/providers/new_videos_feed_provider_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/constants/app_constants.dart';
+import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/new_videos_feed_provider.dart';
 import 'package:openvine/providers/readiness_gate_providers.dart';
@@ -39,11 +40,11 @@ void main() {
       ).thenReturn(false);
     });
 
-    ProviderContainer createContainer() {
+    ProviderContainer createContainer({bool overrideAppReady = true}) {
       final container = ProviderContainer(
         overrides: [
           ...getStandardTestOverrides(),
-          appReadyProvider.overrideWithValue(true),
+          if (overrideAppReady) appReadyProvider.overrideWithValue(true),
           videosRepositoryProvider.overrideWithValue(videosRepository),
           videoEventServiceProvider.overrideWithValue(videoEventService),
           contentBlocklistRepositoryProvider.overrideWithValue(
@@ -84,9 +85,7 @@ void main() {
       test(
         'reports more content behind a page shorter than its page size',
         () async {
-          stubPages(
-            first: HomeFeedResult(videos: _videos(2), hasMore: true),
-          );
+          stubPages(first: HomeFeedResult(videos: _videos(2), hasMore: true));
 
           final state = await createContainer().read(
             newVideosFeedProvider.future,
@@ -114,6 +113,39 @@ void main() {
           expect(state.hasMoreContent, isFalse);
         },
       );
+
+      test('re-filters existing videos when appReady is false', () async {
+        var hideSecondVideo = false;
+        when(() => videoEventService.filterVideoList(any())).thenAnswer((
+          invocation,
+        ) {
+          final videos = List<VideoEvent>.from(
+            invocation.positionalArguments.first as List,
+          );
+          return hideSecondVideo
+              ? videos.where((video) => video.id != 'new-1').toList()
+              : videos;
+        });
+        stubPages(first: HomeFeedResult(videos: _videos(2), hasMore: true));
+        final container = createContainer(overrideAppReady: false);
+
+        final initial = await container.read(newVideosFeedProvider.future);
+        expect(initial.videos.map((v) => v.id), ['new-0', 'new-1']);
+
+        hideSecondVideo = true;
+        container.read(appForegroundProvider.notifier).setForeground(false);
+        await container.read(newVideosFeedProvider.future);
+
+        final backgrounded = container.read(newVideosFeedProvider).requireValue;
+        expect(backgrounded.videos.map((v) => v.id), ['new-0']);
+        verify(
+          () => videosRepository.getNewVideos(
+            limit: any(named: 'limit'),
+            until: any(named: 'until'),
+            skipCache: any(named: 'skipCache'),
+          ),
+        ).called(1);
+      });
     });
 
     group('loadMore', () {

--- a/mobile/test/providers/video_events_provider_blocklist_test.dart
+++ b/mobile/test/providers/video_events_provider_blocklist_test.dart
@@ -81,10 +81,17 @@ void main() {
       when(
         () => mockVideoEventService.addVideoUpdateListener(any()),
       ).thenReturn(() {});
-      when(() => mockVideoEventService.filterVideoList(any())).thenAnswer(
-        (invocation) =>
-            invocation.positionalArguments.first as List<VideoEvent>,
-      );
+      when(() => mockVideoEventService.filterVideoList(any())).thenAnswer((
+        invocation,
+      ) {
+        final videos = invocation.positionalArguments.first as List<VideoEvent>;
+        return videos
+            .where(
+              (video) =>
+                  !mockBlocklistRepository.shouldFilterFromFeeds(video.pubkey),
+            )
+            .toList();
+      });
       when(() => mockVideoEventService.removeListener(any())).thenReturn(null);
       when(() => mockVideoEventService.addListener(any())).thenReturn(null);
       when(
@@ -122,8 +129,10 @@ void main() {
         ],
       );
 
-      // Read the provider to trigger build
-      final notifier = container.read(videoEventsProvider.notifier);
+      final emissions = <List<VideoEvent>>[];
+      container.listen(videoEventsProvider, (prev, next) {
+        next.whenData(emissions.add);
+      });
 
       // Give time for the Future.microtask in _startSubscription to fire
       await Future<void>.delayed(Duration.zero);
@@ -137,8 +146,8 @@ void main() {
         () => mockBlocklistRepository.shouldFilterFromFeeds(allowedPubkey),
       ).called(greaterThanOrEqualTo(1));
 
-      // The notifier should exist without error
-      expect(notifier, isNotNull);
+      expect(emissions, isNotEmpty);
+      expect(emissions.last.map((video) => video.id), ['v1', 'v3']);
     });
 
     test('filters blocked users from change-triggered emission', () async {
@@ -193,16 +202,7 @@ void main() {
       // Check that emissions only contain allowed videos
       if (emissions.isNotEmpty) {
         final lastEmission = emissions.last;
-        expect(
-          lastEmission.every((v) => v.pubkey != blockedPubkey),
-          isTrue,
-          reason: 'Blocked user videos should be filtered from emissions',
-        );
-        expect(
-          lastEmission.length,
-          equals(2),
-          reason: 'Only 2 allowed videos should be emitted',
-        );
+        expect(lastEmission.map((video) => video.id), ['v1', 'v3']);
       }
 
       // Verify the blocklist was consulted during the change callback

--- a/mobile/test/screens/hashtag_feed_blocklist_filter_test.dart
+++ b/mobile/test/screens/hashtag_feed_blocklist_filter_test.dart
@@ -11,6 +11,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/hashtag_feed_screen.dart';
 import 'package:openvine/services/hashtag_service.dart';
+import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/widgets/composable_video_grid.dart';
 import 'package:videos_repository/videos_repository.dart';
 
@@ -20,6 +21,8 @@ class _MockHashtagService extends Mock implements HashtagService {}
 
 class _MockContentBlocklistRepository extends Mock
     implements ContentBlocklistRepository {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
 
 VideoEvent _video(String id, String pubkey) {
   final created = DateTime(2026, 3, 30, 12);
@@ -36,17 +39,23 @@ VideoEvent _video(String id, String pubkey) {
 }
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(<VideoEvent>[]);
+  });
+
   const blockedPubkey =
       'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 
   late _MockVideosRepository mockVideosRepository;
   late _MockHashtagService mockHashtagService;
   late _MockContentBlocklistRepository mockBlocklist;
+  late _MockVideoEventService mockVideoEventService;
 
   setUp(() {
     mockVideosRepository = _MockVideosRepository();
     mockHashtagService = _MockHashtagService();
     mockBlocklist = _MockContentBlocklistRepository();
+    mockVideoEventService = _MockVideoEventService();
 
     when(() => mockHashtagService.getVideosByHashtags(any())).thenReturn([]);
     when(() => mockHashtagService.getHashtagStats(any())).thenReturn(null);
@@ -54,6 +63,14 @@ void main() {
       () => mockHashtagService.subscribeToHashtagVideos(any()),
     ).thenAnswer((_) async {});
     when(() => mockBlocklist.shouldFilterFromFeeds(any())).thenReturn(false);
+    when(() => mockVideoEventService.filterVideoList(any())).thenAnswer((
+      invocation,
+    ) {
+      final videos = invocation.positionalArguments.first as List<VideoEvent>;
+      return videos
+          .where((video) => !mockBlocklist.shouldFilterFromFeeds(video.pubkey))
+          .toList();
+    });
   });
 
   Widget buildSubject(String hashtag) {
@@ -62,6 +79,7 @@ void main() {
         videosRepositoryProvider.overrideWithValue(mockVideosRepository),
         hashtagServiceProvider.overrideWith((ref) => mockHashtagService),
         contentBlocklistRepositoryProvider.overrideWithValue(mockBlocklist),
+        videoEventServiceProvider.overrideWithValue(mockVideoEventService),
         subscribedListVideoCacheProvider.overrideWithValue(null),
       ],
       child: MaterialApp(

--- a/mobile/test/services/dead_media_feed_guard_test.dart
+++ b/mobile/test/services/dead_media_feed_guard_test.dart
@@ -76,7 +76,7 @@ void main() {
       );
 
       test(
-        'returns true and marks broken when the canonical API no longer has the video',
+        'returns true without persisting when the canonical API no longer has the video',
         () async {
           final apiMissingGuard = DeadMediaFeedGuard(
             brokenVideoTracker: tracker,
@@ -92,7 +92,7 @@ void main() {
           );
 
           expect(result, isTrue);
-          verify(() => tracker.markVideoBroken('v1', any())).called(1);
+          verifyNever(() => tracker.markVideoBroken(any(), any()));
           verifyNever(() => checker.isConfirmedMissing(any()));
           verifyNever(() => moderationStatusService.fetchStatus(any()));
         },
@@ -299,7 +299,7 @@ void main() {
         ).thenAnswer((_) async => true);
       });
 
-      test('is true for a 404 blocked by moderation', () async {
+      test('is persistent for a 404 blocked by moderation', () async {
         when(
           () => moderationStatusService.fetchStatus(any()),
         ).thenAnswer((_) async => status(blocked: true));
@@ -310,11 +310,11 @@ void main() {
             videoUrl: url,
             explicitSha256: 'e' * 64,
           ),
-          isTrue,
+          FeedUnavailability.persistent,
         );
       });
 
-      test('is false for a 404 that is only quarantined', () async {
+      test('is none for a 404 that is only quarantined', () async {
         when(
           () => moderationStatusService.fetchStatus(any()),
         ).thenAnswer((_) async => status(quarantined: true));
@@ -325,8 +325,28 @@ void main() {
             videoUrl: url,
             explicitSha256: 'e' * 64,
           ),
-          isFalse,
+          FeedUnavailability.none,
         );
+      });
+
+      test('is session-only when the canonical API 404s the video', () async {
+        final apiMissingGuard = DeadMediaFeedGuard(
+          brokenVideoTracker: tracker,
+          moderationStatusService: moderationStatusService,
+          availabilityChecker: checker,
+          eventMissingChecker: (_) async => true,
+        );
+
+        expect(
+          await apiMissingGuard.isConfirmedUnavailable(
+            videoId: 'v1',
+            videoUrl: url,
+            explicitSha256: 'e' * 64,
+          ),
+          FeedUnavailability.sessionOnly,
+        );
+        verifyNever(() => checker.isConfirmedMissing(any()));
+        verifyNever(() => moderationStatusService.fetchStatus(any()));
       });
     });
   });

--- a/mobile/test/services/dead_media_feed_guard_test.dart
+++ b/mobile/test/services/dead_media_feed_guard_test.dart
@@ -76,6 +76,58 @@ void main() {
       );
 
       test(
+        'returns true and marks broken when the canonical API no longer has the video',
+        () async {
+          final apiMissingGuard = DeadMediaFeedGuard(
+            brokenVideoTracker: tracker,
+            moderationStatusService: moderationStatusService,
+            availabilityChecker: checker,
+            eventMissingChecker: (_) async => true,
+          );
+
+          final result = await apiMissingGuard.confirmAndMarkMissing(
+            videoId: 'v1',
+            videoUrl: 'https://media.divine.video/live',
+            explicitSha256: 'a' * 64,
+          );
+
+          expect(result, isTrue);
+          verify(() => tracker.markVideoBroken('v1', any())).called(1);
+          verifyNever(() => checker.isConfirmedMissing(any()));
+          verifyNever(() => moderationStatusService.fetchStatus(any()));
+        },
+      );
+
+      test(
+        'falls back to media confirmation when the API missing check fails',
+        () async {
+          const url = 'https://media.divine.video/deadhash';
+          final sha256 = 'a' * 64;
+          final apiFailingGuard = DeadMediaFeedGuard(
+            brokenVideoTracker: tracker,
+            moderationStatusService: moderationStatusService,
+            availabilityChecker: checker,
+            eventMissingChecker: (_) async => throw Exception('timeout'),
+          );
+          when(
+            () => checker.isConfirmedMissing(url),
+          ).thenAnswer((_) async => true);
+          when(
+            () => moderationStatusService.fetchStatus(sha256),
+          ).thenAnswer((_) async => status(blocked: true));
+
+          final result = await apiFailingGuard.confirmAndMarkMissing(
+            videoId: 'v1',
+            videoUrl: url,
+            explicitSha256: sha256,
+          );
+
+          expect(result, isTrue);
+          verify(() => tracker.markVideoBroken('v1', any())).called(1);
+        },
+      );
+
+      test(
         'returns false and does NOT mark broken when the media is reachable / non-404',
         () async {
           when(
@@ -229,6 +281,7 @@ void main() {
 
         expect(
           await guard.isConfirmedUnavailable(
+            videoId: 'v1',
             videoUrl: url,
             explicitSha256: 'e' * 64,
           ),
@@ -243,6 +296,7 @@ void main() {
 
         expect(
           await guard.isConfirmedUnavailable(
+            videoId: 'v1',
             videoUrl: url,
             explicitSha256: 'e' * 64,
           ),

--- a/mobile/test/services/dead_media_feed_guard_test.dart
+++ b/mobile/test/services/dead_media_feed_guard_test.dart
@@ -128,6 +128,31 @@ void main() {
       );
 
       test(
+        'stays recoverable when the API check throws and media cannot confirm',
+        () async {
+          const url = 'https://media.divine.video/live';
+          final apiFailingGuard = DeadMediaFeedGuard(
+            brokenVideoTracker: tracker,
+            moderationStatusService: moderationStatusService,
+            availabilityChecker: checker,
+            eventMissingChecker: (_) async => throw Exception('timeout'),
+          );
+          when(
+            () => checker.isConfirmedMissing(url),
+          ).thenAnswer((_) async => false);
+
+          final result = await apiFailingGuard.confirmAndMarkMissing(
+            videoId: 'v1',
+            videoUrl: url,
+            explicitSha256: 'a' * 64,
+          );
+
+          expect(result, isFalse);
+          verifyNever(() => tracker.markVideoBroken(any(), any()));
+        },
+      );
+
+      test(
         'returns false and does NOT mark broken when the media is reachable / non-404',
         () async {
           when(

--- a/mobile/test/services/video_block_policy_test.dart
+++ b/mobile/test/services/video_block_policy_test.dart
@@ -1,0 +1,66 @@
+// ABOUTME: Tests the shared VideoEvent blocklist policy for authors and reposters.
+// ABOUTME: Prevents feed surfaces from regressing to author-only block checks.
+
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/services/video_block_policy.dart';
+
+void main() {
+  group(VideoBlockPolicy, () {
+    late ContentBlocklistRepository blocklistRepository;
+
+    setUp(() {
+      blocklistRepository = ContentBlocklistRepository();
+    });
+
+    tearDown(() {
+      blocklistRepository.dispose();
+    });
+
+    test('hides videos from blocked authors', () async {
+      const author =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      await blocklistRepository.blockUser(author);
+
+      expect(
+        VideoBlockPolicy.isHiddenByBlocklist(
+          _video(pubkey: author),
+          blocklistRepository,
+        ),
+        isTrue,
+      );
+    });
+
+    test('hides videos from blocked visible reposters', () async {
+      const author =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const reposter =
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+      await blocklistRepository.blockUser(reposter);
+
+      final repost = _video(pubkey: author).copyWith(
+        isRepost: true,
+        reposterPubkey: reposter,
+        reposterPubkeys: [reposter],
+      );
+
+      expect(
+        VideoBlockPolicy.isHiddenByBlocklist(repost, blocklistRepository),
+        isTrue,
+      );
+    });
+  });
+}
+
+VideoEvent _video({required String pubkey}) {
+  final now = DateTime(2026);
+  return VideoEvent(
+    id: 'video-id',
+    pubkey: pubkey,
+    createdAt: now.millisecondsSinceEpoch ~/ 1000,
+    content: '',
+    timestamp: now,
+    videoUrl: 'https://example.com/video.mp4',
+  );
+}

--- a/mobile/test/services/video_block_policy_test.dart
+++ b/mobile/test/services/video_block_policy_test.dart
@@ -3,8 +3,12 @@
 
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/services/video_block_policy.dart';
+
+class _MockBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {}
 
 void main() {
   group(VideoBlockPolicy, () {
@@ -49,6 +53,71 @@ void main() {
         VideoBlockPolicy.isHiddenByBlocklist(repost, blocklistRepository),
         isTrue,
       );
+    });
+
+    test('hides videos from authors who blocked the viewer', () {
+      const author =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const reposter =
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+      final mock = _MockBlocklistRepository();
+      when(() => mock.shouldFilterFromFeeds(author)).thenReturn(true);
+      when(() => mock.shouldFilterFromFeeds(reposter)).thenReturn(false);
+      when(() => mock.isBlocked(any())).thenReturn(false);
+      when(() => mock.isMutedByUs(any())).thenReturn(false);
+
+      expect(
+        VideoBlockPolicy.isHiddenByBlocklist(
+          _video(pubkey: author),
+          mock,
+        ),
+        isTrue,
+      );
+    });
+
+    test(
+      'does not hide a non-blocked author when a blocked-us account reposted',
+      () {
+        const author =
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+        const reposter =
+            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+        final mock = _MockBlocklistRepository();
+        when(() => mock.shouldFilterFromFeeds(author)).thenReturn(false);
+        when(() => mock.shouldFilterFromFeeds(reposter)).thenReturn(true);
+        when(() => mock.isBlocked(any())).thenReturn(false);
+        when(() => mock.isMutedByUs(any())).thenReturn(false);
+
+        final repost = _video(pubkey: author).copyWith(
+          isRepost: true,
+          reposterPubkey: reposter,
+          reposterPubkeys: [reposter],
+        );
+
+        expect(VideoBlockPolicy.isHiddenByBlocklist(repost, mock), isFalse);
+      },
+    );
+
+    test('hides a video when the viewer muted the visible reposter', () {
+      const author =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const reposter =
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+      final mock = _MockBlocklistRepository();
+      when(() => mock.shouldFilterFromFeeds(author)).thenReturn(false);
+      when(() => mock.shouldFilterFromFeeds(reposter)).thenReturn(true);
+      when(() => mock.isBlocked(reposter)).thenReturn(false);
+      when(() => mock.isMutedByUs(reposter)).thenReturn(true);
+      when(() => mock.isBlocked(author)).thenReturn(false);
+      when(() => mock.isMutedByUs(author)).thenReturn(false);
+
+      final repost = _video(pubkey: author).copyWith(
+        isRepost: true,
+        reposterPubkey: reposter,
+        reposterPubkeys: [reposter],
+      );
+
+      expect(VideoBlockPolicy.isHiddenByBlocklist(repost, mock), isTrue);
     });
   });
 }

--- a/mobile/test/services/video_event_service_blocklist_sweep_test.dart
+++ b/mobile/test/services/video_event_service_blocklist_sweep_test.dart
@@ -63,35 +63,30 @@ void main() {
       blocklistRepo.dispose();
     });
 
-    test(
-      'blockUser triggers a sweep — removedVideoIds emits every cached id '
-      'for the blocked author',
-      () async {
-        const author = 'author-pubkey';
-        service.debugSeedAuthorBucket(author, [
-          _video(id: 'v1', pubkey: author),
-          _video(id: 'v2', pubkey: author),
-          _video(id: 'v3', pubkey: author),
-        ]);
+    test('blockUser triggers a sweep — removedVideoIds emits every cached id '
+        'for the blocked author', () async {
+      const author = 'author-pubkey';
+      service.debugSeedAuthorBucket(author, [
+        _video(id: 'v1', pubkey: author),
+        _video(id: 'v2', pubkey: author),
+        _video(id: 'v3', pubkey: author),
+      ]);
 
-        final emitted = <String>[];
-        final sub = service.removedVideoIds.listen(emitted.add);
-        addTearDown(sub.cancel);
+      final emitted = <String>[];
+      final sub = service.removedVideoIds.listen(emitted.add);
+      addTearDown(sub.cancel);
 
-        await blocklistRepo.blockUser(author);
-        await Future<void>.delayed(Duration.zero);
+      await blocklistRepo.blockUser(author);
+      await Future<void>.delayed(Duration.zero);
 
-        expect(emitted, containsAll(['v1', 'v2', 'v3']));
-        expect(emitted.length, 3);
-      },
-    );
+      expect(emitted, containsAll(['v1', 'v2', 'v3']));
+      expect(emitted.length, 3);
+    });
 
     test('unblockUser does NOT trigger a sweep (no-op for removals)', () async {
       const author = 'author-pubkey';
       await blocklistRepo.blockUser(author); // pre-block so unblock fires
-      service.debugSeedAuthorBucket(author, [
-        _video(id: 'v1', pubkey: author),
-      ]);
+      service.debugSeedAuthorBucket(author, [_video(id: 'v1', pubkey: author)]);
 
       // Listener after pre-block so the initial blocked emit isn't counted.
       final emitted = <String>[];
@@ -133,78 +128,71 @@ void main() {
       expect(emitted, isEmpty);
     });
 
-    test(
-      're-blocking the same author is dedupe at the repository level — no '
-      'duplicate sweep',
-      () async {
-        const author = 'author-pubkey';
-        service.debugSeedAuthorBucket(author, [
-          _video(id: 'v1', pubkey: author),
-        ]);
+    test('re-blocking the same author is dedupe at the repository level — no '
+        'duplicate sweep', () async {
+      const author = 'author-pubkey';
+      service.debugSeedAuthorBucket(author, [_video(id: 'v1', pubkey: author)]);
 
-        await blocklistRepo.blockUser(author);
-        await Future<void>.delayed(Duration.zero);
+      await blocklistRepo.blockUser(author);
+      await Future<void>.delayed(Duration.zero);
 
-        final emitted = <String>[];
-        final sub = service.removedVideoIds.listen(emitted.add);
-        addTearDown(sub.cancel);
+      final emitted = <String>[];
+      final sub = service.removedVideoIds.listen(emitted.add);
+      addTearDown(sub.cancel);
 
-        await blocklistRepo.blockUser(author); // already blocked → no-op
-        await Future<void>.delayed(Duration.zero);
+      await blocklistRepo.blockUser(author); // already blocked → no-op
+      await Future<void>.delayed(Duration.zero);
 
-        expect(emitted, isEmpty);
-      },
-    );
+      expect(emitted, isEmpty);
+    });
 
-    test(
-      'dispose cancels the blocklist subscription (further repo emits are '
-      'ignored without errors)',
-      () async {
-        // Build a separate service so the global tearDown does not double-
-        // dispose. Pre-existing helpers (`service`, `blocklistRepo`) stay
-        // owned by the outer setUp/tearDown.
-        final localNostr = _MockNostrClient();
-        when(() => localNostr.isInitialized).thenReturn(true);
-        when(() => localNostr.connectedRelayCount).thenReturn(1);
-        when(
-          () => localNostr.subscribe(any()),
-        ).thenAnswer((_) => const Stream<Event>.empty());
-        final localService = VideoEventService(
-          localNostr,
-          subscriptionManager: subscriptionManager,
-        );
-        final localRepo = ContentBlocklistRepository();
-        addTearDown(localRepo.dispose);
+    test('dispose cancels the blocklist subscription (further repo emits are '
+        'ignored without errors)', () async {
+      // Build a separate service so the global tearDown does not double-
+      // dispose. Pre-existing helpers (`service`, `blocklistRepo`) stay
+      // owned by the outer setUp/tearDown.
+      final localNostr = _MockNostrClient();
+      when(() => localNostr.isInitialized).thenReturn(true);
+      when(() => localNostr.connectedRelayCount).thenReturn(1);
+      when(
+        () => localNostr.subscribe(any()),
+      ).thenAnswer((_) => const Stream<Event>.empty());
+      final localService = VideoEventService(
+        localNostr,
+        subscriptionManager: subscriptionManager,
+      );
+      final localRepo = ContentBlocklistRepository();
+      addTearDown(localRepo.dispose);
 
-        localService.setBlocklistRepository(localRepo);
-        const author = 'author-pubkey';
-        localService.debugSeedAuthorBucket(author, [
-          _video(id: 'v1', pubkey: author),
-        ]);
+      localService.setBlocklistRepository(localRepo);
+      const author = 'author-pubkey';
+      localService.debugSeedAuthorBucket(author, [
+        _video(id: 'v1', pubkey: author),
+      ]);
 
-        final emitted = <String>[];
-        final sub = localService.removedVideoIds.listen(
-          emitted.add,
-          onError: (Object _) {},
-        );
-        addTearDown(sub.cancel);
+      final emitted = <String>[];
+      final sub = localService.removedVideoIds.listen(
+        emitted.add,
+        onError: (Object _) {},
+      );
+      addTearDown(sub.cancel);
 
-        localService.dispose();
+      localService.dispose();
 
-        // Repo is still live; emit a Blocked. The cancelled subscription
-        // means the bus does not see this event.
-        await localRepo.blockUser(author);
-        await Future<void>.delayed(Duration.zero);
+      // Repo is still live; emit a Blocked. The cancelled subscription
+      // means the bus does not see this event.
+      await localRepo.blockUser(author);
+      await Future<void>.delayed(Duration.zero);
 
-        expect(emitted, isEmpty);
-      },
-    );
+      expect(emitted, isEmpty);
+    });
   });
 
   // Regression for #4782: detail/by-id surfaces (sound detail, video detail,
   // curated lists, notifications) gate only on shouldHideVideo and bypass the
   // reception-time blocklist filter, so shouldHideVideo itself must consult the
-  // blocklist or a blocked/muted author's videos leak onto those surfaces.
+  // blocklist or a blocked/muted author's/reposter's videos leak onto those
+  // surfaces.
   group('VideoEventService.shouldHideVideo blocklist filtering', () {
     late VideoEventService service;
     late ContentBlocklistRepository blocklistRepo;
@@ -237,11 +225,27 @@ void main() {
           'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
       await blocklistRepo.blockUser(author);
 
-      expect(
-        service.shouldHideVideo(_video(id: 'v1', pubkey: author)),
-        isTrue,
-      );
+      expect(service.shouldHideVideo(_video(id: 'v1', pubkey: author)), isTrue);
     });
+
+    test(
+      'hides a repost whose visible reposter is filtered from feeds',
+      () async {
+        const author =
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+        const reposter =
+            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+        await blocklistRepo.blockUser(reposter);
+
+        final repost = _video(id: 'v1', pubkey: author).copyWith(
+          isRepost: true,
+          reposterPubkey: reposter,
+          reposterPubkeys: [reposter],
+        );
+
+        expect(service.shouldHideVideo(repost), isTrue);
+      },
+    );
 
     test('does not hide a non-blocked author (Divine-host filter off)', () {
       const author =

--- a/mobile/test/widgets/profile/profile_video_feed_view_test.dart
+++ b/mobile/test/widgets/profile/profile_video_feed_view_test.dart
@@ -116,6 +116,7 @@ void main() {
       when(
         () => videoEventService.filterVideoList(any()),
       ).thenAnswer((i) => i.positionalArguments.first as List<VideoEvent>);
+      when(() => videoEventService.shouldHideVideo(any())).thenReturn(false);
       when(
         () => videoEventService.isVideoEventKnownDeleted(any()),
       ).thenReturn(false);


### PR DESCRIPTION
Closes #7177

## Summary
- centralize feed hiding on VideoEventService.shouldHideVideo so blocked authors (full hide union) and viewer-blocked or viewer-muted visible reposters are filtered consistently
- re-filter New Videos, For You, Classic, and Popular stale state while appReady is false instead of returning blocked/hidden videos verbatim
- treat a canonical API 404 as a session-only removal; persist a tombstone only for a HEAD 404 plus a terminal moderation blocked verdict

## Verification
- flutter analyze
- flutter test test/services/video_event_service_blocklist_sweep_test.dart test/services/dead_media_feed_guard_test.dart test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart test/providers/new_videos_feed_provider_test.dart
- pre-push changed-file test suite passed