### PR TITLE
test(router): stop the NIP-05 navigation test depending on test order

### DIFF
--- a/mobile/test/router/nip05_settings_navigation_test.dart
+++ b/mobile/test/router/nip05_settings_navigation_test.dart
@@ -94,6 +94,29 @@ void main() {
       ).thenAnswer((_) async {});
     });
 
+    // `scrollUntilVisible` stops once the row is *built*, which inside a
+    // ListView's cache extent can still leave it below the viewport edge, so
+    // the tap lands on nothing. How close the row gets to that edge is not
+    // stable: VineTheme's `GoogleFonts.inter` registers its asset
+    // process-globally, so the first widget test to render this screen lays it
+    // out with the wider fallback font and every later one with real Inter
+    // metrics. Randomized ordering picks which test pays that cost, so every
+    // tap here goes through `ensureVisible` first (#7179).
+    Future<void> tapNip05Tile(WidgetTester tester) async {
+      final nip05Tile = find.text(
+        lookupAppLocalizations(const Locale('en')).nostrSettingsNip05Address,
+      );
+      await tester.scrollUntilVisible(
+        nip05Tile,
+        250,
+        scrollable: find.byType(Scrollable),
+      );
+      await tester.ensureVisible(nip05Tile);
+      await tester.pumpAndSettle();
+      await tester.tap(nip05Tile);
+      await tester.pumpAndSettle();
+    }
+
     ProviderContainer buildContainer() {
       final container = ProviderContainer(
         overrides: [
@@ -139,18 +162,7 @@ void main() {
       router.go(NostrSettingsScreen.path);
       await tester.pumpAndSettle();
 
-      final nip05Tile = find.text(l10n.nostrSettingsNip05Address);
-      await tester.scrollUntilVisible(
-        nip05Tile,
-        250,
-        scrollable: find.byType(Scrollable),
-      );
-      // scrollUntilVisible stops once the row is built, which in a ListView
-      // can still leave it below the viewport edge.
-      await tester.ensureVisible(nip05Tile);
-      await tester.pumpAndSettle();
-      await tester.tap(nip05Tile);
-      await tester.pumpAndSettle();
+      await tapNip05Tile(tester);
 
       expect(find.text(l10n.nostrSettingsNip05Address), findsWidgets);
       expect(find.byType(Nip05SettingsView), findsOneWidget);
@@ -208,14 +220,7 @@ void main() {
         router.go(NostrSettingsScreen.path);
         await tester.pumpAndSettle();
 
-        final nip05Tile = find.text(l10n.nostrSettingsNip05Address);
-        await tester.scrollUntilVisible(
-          nip05Tile,
-          250,
-          scrollable: find.byType(Scrollable),
-        );
-        await tester.tap(nip05Tile);
-        await tester.pumpAndSettle();
+        await tapNip05Tile(tester);
 
         expect(find.byType(Nip05SettingsView), findsOneWidget);
         expect(router.canPop(), isTrue);


### PR DESCRIPTION
## Description

`test/router/nip05_settings_navigation_test.dart` passed or failed on Mobile CI depending only on the `--test-randomize-ordering-seed` the run picked. Root cause, measured rather than guessed:

`tester.scrollUntilVisible` returns as soon as the target row is **built**, and inside a `ListView`'s cache extent that can still leave it below the viewport edge. The `tap` that follows then lands on nothing — `warnIfMissed` only prints a warning, it does not fail — so the route never changes and the next assertion reports zero `Nip05SettingsView` widgets.

Whether the row lands on or off the fold is not stable within a single run. `VineTheme`'s font helpers are `GoogleFonts.inter(...)`, and google_fonts registers `assets/fonts/Inter-Regular.ttf` into the **process-global** font collection asynchronously. Instrumenting the same screen across consecutive tests in one isolate:

| render | intro text height | NIP-05 row rect | maxScrollExtent | tap |
|---|---|---|---|---|
| first in the isolate | 80px (fallback test font, wide glyphs) | y 600–624, viewport ends at 600 | 336 | **misses** |
| every later one | 40px (real Inter) | y 512–536 | 168 | hits |

So the first widget test in an isolate to render this screen lays it out with the fallback font — the intro copy and the client-attribution subtitle wrap to twice the lines, content grows ~256px, and the row is pushed past the fold.

In declaration order that first test is `tapping the NIP-05 tile opens the NIP-05 settings route`, which has carried an `ensureVisible` since #6599 and therefore survives. Randomized ordering shuffles tests *within* a group, so any seed that sorts the pop test first hands **it** the cold layout — and that test had no `ensureVisible`. Same mechanism under `very_good test --optimization`, where the whole shard shares one isolate.

The fix routes both tap sites through one helper that scrolls, `ensureVisible`s, then taps, and documents the mechanism once instead of leaving it as a partial note on whichever test happened to hit it first.

The issue notes the test passes locally in isolation. That held only for unshuffled order — it reproduces on macOS in isolation once a seed is passed.

**Related Issue:** Closes #7179

## Out of Scope

Eight other scroll-then-tap sites carry the same latent pattern with no `ensureVisible` (`settings_screen_test.dart`, `content_filters_screen_test.dart`, `safety_settings_screen_test.dart`, `discover_lists_screen_test.dart`, `app_language_screen_test.dart`, `minor_account_review_parent_consent_screen_test.dart`). Left out to keep this diff scoped to #7179; tracked in #7195.

Making font metrics deterministic for the whole unit suite (preloading fonts in `flutter_test_config.dart`) would remove the underlying instability, but it changes layout for every existing widget and golden test and slows every run — a much larger change than this issue warrants.

## Verification

No app code changed; this is a test-harness fix, so there is nothing to verify on device.

Before the fix, from `mobile/`:

- seeds `1105091160` (the failing CI seed from the issue), `1`, `2`, `4`, `5` — **fail** at the `Nip05SettingsView` assertion
- seeds `3`, `6`, `7`, `8` and default order — pass

After the fix, all 18 seeds pass, including both seeds named in the issue:

```
for s in 1105091160 1129702722 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
  flutter test test/router/nip05_settings_navigation_test.dart --test-randomize-ordering-seed=$s
done
```

Plus default order, `dart format` (no changes) and `flutter analyze` (no issues) on the touched file.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

