### PR TITLE
docs(video): clarify bare blob playback failure

### DIFF
--- a/mobile/lib/extensions/video_event_extensions.dart
+++ b/mobile/lib/extensions/video_event_extensions.dart
@@ -191,9 +191,11 @@ extension VideoEventAppExtensions on VideoEvent {
 
     // Developer format override takes priority over every heuristic below so
     // A/B testing can force a specific server format on any Divine video,
-    // including classic Vine originals and raw-only uploads. If the forced
-    // variant does not exist yet the runtime fallback chain recovers, and
-    // seeing that is the point of the test switch.
+    // including classic Vine originals and raw-only uploads. Forcing `raw`
+    // intentionally exposes the bare blob path, which currently fails for
+    // range-requesting players until divine-blossom#198 is fixed. If any other
+    // forced variant does not exist yet the runtime fallback chain recovers,
+    // and seeing that is the point of the test switch.
     final override = videoFormatPreference.format;
     if (override != null) {
       return switch (override) {
@@ -217,12 +219,12 @@ extension VideoEventAppExtensions on VideoEvent {
     // transcoded yet.
     //
     // Classic Vine originals take this path as well. They must never be sent
-    // to the extensionless raw blob: iOS AVURLAsset picks its container parser
-    // from the URL path extension and ignores the Content-Type header, so
-    // `/{hash}` fails to parse with AVFoundation -11828/-11829 "Cannot Open"
-    // and never plays. The transcoder caps at the source resolution,
-    // so the "720p" variant of a 480x480 Vine is still 480x480 — smaller than
-    // the raw blob, not an upscale.
+    // to the bare blob: every Range request to `/{hash}` comes back as a
+    // cached `NoSuchKey` XML body dressed up as a 206, so AVFoundation - which
+    // always range-requests - fails with -11829 "Cannot Open" and the video
+    // never plays (divine-blossom#198). The transcoder caps at the source
+    // resolution, so the "720p" variant of a 480x480 Vine is still 480x480 -
+    // smaller than the raw blob, not an upscale.
     return '$_divineMediaBase/$hash/720p.mp4';
   }
 
@@ -231,9 +233,11 @@ extension VideoEventAppExtensions on VideoEvent {
   /// Older desktop Chrome (< 150) and Firefox lack native HLS, so an HLS
   /// `.m3u8` won't play there. Resolve HLS to the progressive variant — the
   /// same [getOptimalVideoUrlForPlatform] selection the feed already uses on
-  /// every platform. Resolve extensionless Divine raw blobs too, because iOS
-  /// AVURLAsset cannot parse them. Progressive URLs pass through unchanged, so
-  /// the common case (and its transcode readiness) is never touched.
+  /// every platform. Resolve bare Divine blobs too: every Range request to
+  /// `/{hash}` comes back as a cached `NoSuchKey` body dressed up as a 206
+  /// (divine-blossom#198), and a range-requesting player gets that instead of
+  /// video. Progressive URLs pass through unchanged, so the common case (and
+  /// its transcode readiness) is never touched.
   String? get inlinePlayerVideoUrl {
     final url = videoUrl;
     if (url == null) return null;

--- a/mobile/packages/divine_video_player/test/src/apple_hls_direct_item_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/apple_hls_direct_item_contract_test.dart
@@ -29,8 +29,9 @@ void main() {
         source,
         contains('pathExtension.lowercased() == "m3u8"'),
         reason:
-            'AVURLAsset itself picks its parser from the URL path extension, '
-            'so the same signal must decide which builder runs.',
+            'Every app-constructed HLS URL ends in .m3u8, so the path '
+            'extension is the cheap deterministic signal for which builder '
+            'runs - no extra load to discover the asset has no tracks.',
       );
       expect(
         source,

--- a/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
@@ -56,9 +56,11 @@ List<String> resolvePlaybackSources(
 
     final isRawBlob = resolvedSource == rawUrl;
     // Progressive first, HLS last. For a quality variant (e.g. 720p.mp4) the
-    // guaranteed raw blob comes before HLS: if the variant is not transcoded
-    // yet, the raw blob plays immediately, whereas HLS may also be mid-encode
-    // and only pays the manifest-round-trip cost. HLS stays the last resort.
+    // guaranteed raw blob still comes before HLS so the fallback order
+    // preserves the existing "try another progressive source before paying HLS
+    // startup" behavior. The bare blob currently fails for range-requesting
+    // players until divine-blossom#198 is fixed, so HLS remains behind it as
+    // the final recovery source.
     return isRawBlob
         ? orderedUniqueSources([resolvedSource, hlsUrl, originalUrl])
         : orderedUniqueSources([resolvedSource, rawUrl, hlsUrl, originalUrl]);

--- a/mobile/test/extensions/video_event_divine_server_test.dart
+++ b/mobile/test/extensions/video_event_divine_server_test.dart
@@ -303,10 +303,10 @@ void main() {
       );
     });
 
-    // Regression test for classic Vines being unplayable on iOS. The
-    // extensionless raw blob (`/{hash}`) cannot be parsed by AVURLAsset,
-    // which selects its container parser from the URL path extension and
-    // ignores the Content-Type header.
+    // Regression test for classic Vines being unplayable on iOS. Every Range
+    // request to the bare blob (`/{hash}`) returns a cached `NoSuchKey` XML
+    // body as a 206, and AVFoundation always range-requests, so it never gets
+    // video back (divine-blossom#198).
     test('uses MP4 720p for classic Vine originals', () {
       final video = _createVideoWithUrl(
         'https://media.divine.video/$hash',


### PR DESCRIPTION

## Summary

- correct the remaining bare-blob playback comments from the old AVURLAsset path-extension theory to the measured Range-response failure
- document that the raw Developer Options override intentionally exposes the currently broken bare blob path
- update the infinite feed fallback rationale so it no longer claims the raw blob plays immediately
- tighten the HLS source-contract reason to app-constructed HLS URLs

## Follow-up

Refs #7184 for the post-divine-blossom#198 revisit hook.

## Verification

- `dart format --set-exit-if-changed lib/extensions/video_event_extensions.dart packages/infinite_video_feed/lib/src/utils/playback_sources.dart packages/divine_video_player/test/src/apple_hls_direct_item_contract_test.dart test/extensions/video_event_divine_server_test.dart` (0 changed; package-resolution warnings before `mise trust`)
- `mise exec -- dart format lib test integration_test` (0 changed)
- pre-push hook: analyzer passed; changed-file tests passed (33 tests)
