### PR TITLE
test: stop two widget tests depending on test order

### DIFF
--- a/mobile/test/screens/profile_setup/bio_field_test.dart
+++ b/mobile/test/screens/profile_setup/bio_field_test.dart
@@ -93,7 +93,9 @@ void main() {
       // The counter is painted over the field's top-right corner. Left
       // hit-testable it wins that rectangle, and the tap escapes to the
       // screen's dismiss-the-keyboard gesture instead of reaching the input.
-      await tester.tap(find.text('0/1000'));
+      // Missing the counter is the point — it sits behind an IgnorePointer,
+      // so the tap is meant to fall through to the field underneath.
+      await tester.tap(find.text('0/1000'), warnIfMissed: false);
       await tester.pump();
 
       expect(focusNode.hasFocus, isTrue);

--- a/mobile/test/screens/welcome_screen_test.dart
+++ b/mobile/test/screens/welcome_screen_test.dart
@@ -165,9 +165,22 @@ void main() {
 
   group(WelcomeScreen, () {
     group('default variant', () {
-      testWidgets('displays $AuthHeroSection', (tester) async {
+      // The fresh-install hero column overflows the default 800x600 test
+      // surface by 13px, but only when it lays out with the wide fallback
+      // font: VineTheme's GoogleFonts.inter registers its asset into the
+      // process-global font collection asynchronously, so the first test in
+      // an isolate to render this screen misses real Inter metrics. Under
+      // randomized ordering that is whichever test the seed sorts first, so
+      // every test here takes the headroom rather than the four that
+      // happened to hit it. Width stays 800 so nothing re-wraps. This cannot
+      // move into setUp — setSurfaceSize asserts it runs inside a test.
+      Future<void> useTallSurface(WidgetTester tester) async {
         await tester.binding.setSurfaceSize(const Size(800, 1200));
         addTearDown(() => tester.binding.setSurfaceSize(null));
+      }
+
+      testWidgets('displays $AuthHeroSection', (tester) async {
+        await useTallSurface(tester);
         await tester.pumpWidget(createTestWidget());
         await tester.pumpAndSettle();
 
@@ -175,6 +188,7 @@ void main() {
       });
 
       testWidgets('displays create account button', (tester) async {
+        await useTallSurface(tester);
         await tester.pumpWidget(createTestWidget());
         await tester.pumpAndSettle();
 
@@ -182,6 +196,7 @@ void main() {
       });
 
       testWidgets('displays login button', (tester) async {
+        await useTallSurface(tester);
         await tester.pumpWidget(createTestWidget());
         await tester.pumpAndSettle();
 
@@ -189,14 +204,9 @@ void main() {
       });
 
       testWidgets('primary actions carry stable test anchors', (tester) async {
-        // The default 800x600 surface overflows the hero column by 13px on
-        // the fresh-install variant. That is pre-existing on origin/main and
-        // out of scope here; size the surface so this test fails only for
-        // its own reason.
-        tester.view.physicalSize = const Size(390, 844);
-        tester.view.devicePixelRatio = 1;
-        addTearDown(tester.view.resetPhysicalSize);
-        addTearDown(tester.view.resetDevicePixelRatio);
+        // This one wants a phone viewport rather than the headroom above.
+        await tester.binding.setSurfaceSize(const Size(390, 844));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
 
         await tester.pumpWidget(createTestWidget());
         await tester.pumpAndSettle();
@@ -214,6 +224,7 @@ void main() {
       });
 
       testWidgets('displays terms notice with legal links', (tester) async {
+        await useTallSurface(tester);
         await tester.pumpWidget(createTestWidget());
         await tester.pumpAndSettle();
 
@@ -233,8 +244,7 @@ void main() {
         'renders Greenlight label, under-16 link, and terms above the auth buttons',
         (tester) async {
           final l10n = lookupAppLocalizations(const Locale('en'));
-          await tester.binding.setSurfaceSize(const Size(800, 1200));
-          addTearDown(() => tester.binding.setSurfaceSize(null));
+          await useTallSurface(tester);
           await tester.pumpWidget(createTestWidget());
           await tester.pumpAndSettle();
 
@@ -290,6 +300,7 @@ void main() {
       testWidgets('tapping create account calls acceptTerms and navigates', (
         tester,
       ) async {
+        await useTallSurface(tester);
         await tester.pumpWidget(createTestWidget());
         await tester.pumpAndSettle();
 
@@ -324,6 +335,7 @@ void main() {
       testWidgets('tapping login button calls acceptTerms and navigates', (
         tester,
       ) async {
+        await useTallSurface(tester);
         await tester.pumpWidget(createTestWidget());
         await tester.pumpAndSettle();
 
@@ -337,6 +349,7 @@ void main() {
       testWidgets(
         'tapping "Divine age authorization" navigates to the public family guide',
         (tester) async {
+          await useTallSurface(tester);
           await tester.pumpWidget(createTestWidget());
           await tester.pumpAndSettle();
 
@@ -377,6 +390,7 @@ void main() {
       testWidgets(
         'tapping "Here are your choices." navigates to the public family guide',
         (tester) async {
+          await useTallSurface(tester);
           await tester.pumpWidget(createTestWidget());
           await tester.pumpAndSettle();
 
@@ -400,8 +414,7 @@ void main() {
       );
 
       testWidgets('shows error when lastError is set', (tester) async {
-        await tester.binding.setSurfaceSize(const Size(800, 1200));
-        addTearDown(() => tester.binding.setSurfaceSize(null));
+        await useTallSurface(tester);
         when(() => mockAuthService.lastError).thenReturn('Auth failed');
 
         await tester.pumpWidget(createTestWidget());
@@ -412,6 +425,7 @@ void main() {
       });
 
       testWidgets('does not show error when lastError is null', (tester) async {
+        await useTallSurface(tester);
         await tester.pumpWidget(createTestWidget());
         await tester.pumpAndSettle();
 

--- a/mobile/test/screens/welcome_screen_test.dart
+++ b/mobile/test/screens/welcome_screen_test.dart
@@ -314,6 +314,7 @@ void main() {
       testWidgets(
         'tapping create account skips the invite gate when invites are disabled',
         (tester) async {
+          await useTallSurface(tester);
           final availabilityCubit = seededInviteAvailabilityCubit(
             serverMode: OnboardingMode.open,
           );


### PR DESCRIPTION
Closes #7187

## Description

Two order-dependent widget-test defects, found while auditing `scrollUntilVisible` call sites for the #7179 follow-up. They are independent of each other and of #7179; both are test-only.

**1. `welcome_screen_test.dart` — fails on some seeds.** The fresh-install hero column overflows the default 800x600 test surface by 13px, which throws a `RenderFlex` layout assertion. It only overflows when the column lays out with the wide fallback font: `VineTheme`'s helpers are `GoogleFonts.inter`, and google_fonts registers `Inter-Regular.ttf` into the process-global font collection asynchronously, so the first test in an isolate to render this screen misses real Inter metrics and every later one gets them.

Four tests in the group already sized the surface up to dodge this, and one carried a comment calling the overflow pre-existing and out of scope. That left the other eight exposed, and randomized ordering picks which of them pays the cold-font cost — so the failure moved between seeds instead of belonging to any one test. Fixing only the test that happened to fail would have moved the flake, not removed it, so every fresh-install test now goes through one `useTallSurface` helper. Width stays 800, so nothing re-wraps and no layout-order assertion changes.

Two secondary notes on that file: the helper can't move into `setUp`, because `setSurfaceSize` asserts it runs inside a test. And the phone-viewport test switches from `tester.view.physicalSize` to `setSurfaceSize`, because a binding surface size overrides `view.physicalSize` — mixing both mechanisms in one group makes which one wins depend on call order.

**2. `bio_field_test.dart` — noisy but passing.** The test taps the character counter to prove the tap reaches the field underneath, since the counter is painted over the field's top-right corner behind an `IgnorePointer`. Missing the counter is the assertion. `tester.tap` warns anyway and dumps a full `HitTestResult` into CI logs on every run, which reads like a real failure when scanning a red shard. Now `warnIfMissed: false`.

**Related Issue:** 

## Out of Scope

The underlying 13px overflow in the welcome hero column is untouched — it is still there on an 800x600 viewport. This PR only stops the tests depending on which one renders first. Worth its own issue if the layout should actually fit that viewport.

## Verification

- `welcome_screen_test.dart`: failed on seeds 2, 3, 9, 10 before; passes on seeds 1–24 after.
- `bio_field_test.dart`: passes on seeds 1–8; the `would not hit test` warning is gone from the output.
- Merged-isolate reproduction via `very_good test test/screens --optimization` (the CI shard shape): seeds 2 and 3 failed before, seeds 1–3 all pass after.
- `dart format` clean, `flutter analyze` on both files reports no issues.

Not verified on a device: both changes are test-only and touch no app code.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)