### PR TITLE
fix(db): unblock db_client analyze on newer Dart stable

### DIFF
--- a/mobile/packages/db_client/lib/src/db_client.dart
+++ b/mobile/packages/db_client/lib/src/db_client.dart
@@ -226,7 +226,10 @@ class DbClient {
 
       final result = await countExp.getSingle();
 
-      return result.read(countAll()) ?? 0;
+      // The type argument is explicit because inference through `??` leaves
+      // `read`'s return unresolved for `unawaited_return_in_try_block`, which
+      // then reports this `int` as an unawaited `Future`.
+      return result.read<int>(countAll()) ?? 0;
     } on Exception {
       rethrow;
     }


### PR DESCRIPTION
Closes #7189

## Description

`main` has been red on **DB Client CI** since b10b92044 (#7173), and every PR touching `mobile/packages/db_client/**` inherits the failure — including #7182.

The failing step is the package analyze:

```
warning • Returning a 'Future' without 'await' inside a try block. Try adding an 'await'
        • lib/src/db_client.dart:229:7 • unawaited_return_in_try_block
```

Two things combined to produce it:

1. **`DB Client CI` floats on the latest Flutter `stable`.** `db_client.yaml` calls the VeryGood `flutter_package` workflow without a `flutter_version`, so it resolves whatever stable is that day rather than the repo's pinned 3.44.0 (Dart 3.12.0). Dart 3.13 added the `unawaited_return_in_try_block` diagnostic.
2. **The diagnostic misreads the line.** `DbClient.count` returns `result.read(countAll()) ?? 0`, which is an `int` — `TypedResult.read<D extends Object>(Expression<D>)` returns `D?`, and `countAll()` is `Expression<int>`. But inference through `??` leaves the generic call's return unresolved when the check runs, so it conservatively reports the `int` as an unawaited `Future`.

#7173 never touched `db_client.dart`. It changed `connection_native.dart` / `connection_stub.dart` / `connection_web.dart`, which matched the workflow's path filter and ran the package analyze over pre-existing code for the first time under the newer SDK.

Pinning the type argument resolves `read` up front and silences the false positive. It is also more precise about the column type at the read site. Hoisting to a local works equally well; the explicit type argument keeps the diff to one line, and the comment exists so the seemingly-redundant `<int>` is not "simplified" away — a local run on the pinned 3.44.0 would stay green while CI went red again.

**Related Issue:** 

## Out of Scope

- **The same diagnostic is latent in 6 other packages.** Analyzing `mobile/packages` under Dart 3.13 reports 13 more hits: `media_cache` (6), `blossom_upload_service` (2), `invite_api_client` (2), `blurhash_service` (1), `nostr_sdk` (1), `profile_repository` (1). None are failing today because their workflows only run on path changes, but each will go red the moment someone touches that package. **Unlike this one, the three I sampled are all genuine, not false positives** — the returned expression really is a `Future`:
  - `media_cache_image_provider.dart:108` returns `_decodeFile(...)` (`Future<ui.Codec>`) from a `try` whose `catch` evicts the failed key from the image cache — a decode failure escapes that cleanup.
  - `profile_repository.dart:1875` returns `_enrichFromCache(...)` from a `try` whose `on Exception` logs and falls back — an enrichment failure escapes the fallback.
  - `invite_api_client.dart:220` and `:242` return `_consumeInvite(..., signer: signer)` from a `try` with `finally { signer.close(); }`, so the signer is closed before the returned future completes.

  These want real `await`s, not a type argument, and each deserves its own look.
- **54 of 57 package workflows float on `stable`.** Only `creator_sync`, `models_ci`, and `sounds_repository` pass `flutter_version: "3.44.0"`. That gap is why a toolchain roll can turn `main` red with no code change, and why it is invisible to a local run on the pinned SDK. Deciding whether to pin the rest is a CI-policy call, not something to slip into an unblock PR.

## Verification

Run from `mobile/packages/db_client`:

- `dart analyze lib test` under **Dart 3.13.0** (what CI resolves today) — `No issues found!` (fails on `main`)
- `dart analyze lib test` under **Dart 3.12.0** (repo pin, Flutter 3.44.0) — `No issues found!`
- `dart format --output=none --set-exit-if-changed lib test` — 0 changed
- `flutter test --coverage` — **927 tests pass**, line coverage 43.86% (gate: `min_coverage: 40`)
- Pre-push hook analyze — `Analysis OK`

The root cause was confirmed rather than guessed: a `Never`-typed probe on the expression reports `A value of type 'int' can't be assigned to a variable of type 'Never'`, proving the value is an `int`; and a minimal repro shows the diagnostic fires for `r.read(countAll()) ?? 0` but not for `r.read<int>(countAll()) ?? 0` nor for the same expression hoisted to a local.

No behaviour change — `count` returns exactly what it did before.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
