### PR TITLE
feat(notifications): open grouped engagement lists

### DIFF
--- a/mobile/lib/blocs/video_engagement/video_engagement_bloc.dart
+++ b/mobile/lib/blocs/video_engagement/video_engagement_bloc.dart
@@ -1,6 +1,5 @@
 // ABOUTME: BLoC for fetching the list of users who liked or reposted a video.
-// ABOUTME: Backs the engagement list screens shown when the video owner taps
-// ABOUTME: the like or repost button on their own video.
+// ABOUTME: Backs engagement list screens opened from feed buttons/notifications.
 
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';

--- a/mobile/lib/notifications/routing/avatar_stack_tap_target.dart
+++ b/mobile/lib/notifications/routing/avatar_stack_tap_target.dart
@@ -1,0 +1,85 @@
+// ABOUTME: In-app-only decision for notification avatar-stack taps.
+// ABOUTME: Keeps avatar affordances separate from row/push notification taps.
+
+import 'package:equatable/equatable.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/video_engagement/video_engagement_bloc.dart'
+    show VideoEngagementType;
+
+/// Destination for tapping the avatar stack on a rendered notification row.
+///
+/// Unlike [NotificationTapTarget], this contract is only for the in-app avatar
+/// affordance. Push/local payloads do not have an avatar stack.
+sealed class AvatarStackTapTarget extends Equatable {
+  const AvatarStackTapTarget();
+}
+
+/// Open the full video engagement list behind a grouped like/repost row.
+class OpenEngagementListTarget extends AvatarStackTapTarget {
+  const OpenEngagementListTarget({
+    required this.eventId,
+    required this.type,
+    this.addressableId,
+  });
+
+  /// Hex id of the target video event.
+  final String eventId;
+
+  /// Optional `kind:pubkey:d-tag` for addressable video events.
+  final String? addressableId;
+
+  /// Whether to open likers or reposters.
+  final VideoEngagementType type;
+
+  @override
+  List<Object?> get props => [eventId, addressableId, type];
+}
+
+/// Open the actor profile represented by the avatar.
+class OpenActorProfileTarget extends AvatarStackTapTarget {
+  const OpenActorProfileTarget(this.pubkey);
+
+  /// Hex pubkey of the actor whose profile should open.
+  final String pubkey;
+
+  @override
+  List<Object?> get props => [pubkey];
+}
+
+/// Resolves the avatar-stack tap target for [notification].
+///
+/// Grouped video likes/reposts open their engagement list. Single-actor rows
+/// and all non-engagement notification kinds keep the historical behavior:
+/// open the visible actor's profile.
+AvatarStackTapTarget? resolveAvatarStackTapTarget(
+  NotificationItem notification,
+) {
+  return switch (notification) {
+    VideoNotification(
+      type: NotificationKind.like,
+      totalCount: > 1,
+      :final videoEventId,
+      :final videoAddressableId,
+    ) =>
+      OpenEngagementListTarget(
+        eventId: videoEventId,
+        addressableId: videoAddressableId,
+        type: VideoEngagementType.likers,
+      ),
+    VideoNotification(
+      type: NotificationKind.repost,
+      totalCount: > 1,
+      :final videoEventId,
+      :final videoAddressableId,
+    ) =>
+      OpenEngagementListTarget(
+        eventId: videoEventId,
+        addressableId: videoAddressableId,
+        type: VideoEngagementType.reposters,
+      ),
+    VideoNotification(:final actors) when actors.isNotEmpty =>
+      OpenActorProfileTarget(actors.first.pubkey),
+    ActorNotification(:final actor) => OpenActorProfileTarget(actor.pubkey),
+    VideoNotification() => null,
+  };
+}

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -7,9 +7,12 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/video_engagement/video_engagement_bloc.dart'
+    show VideoEngagementType;
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/notifications/bloc/notification_feed_bloc.dart';
+import 'package:openvine/notifications/routing/avatar_stack_tap_target.dart';
 import 'package:openvine/notifications/routing/notification_tap_target.dart';
 import 'package:openvine/notifications/widgets/widgets.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -17,6 +20,7 @@ import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/screens/curated_list_by_author_screen.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
+import 'package:openvine/screens/video_engagement/video_engagement_list_screen.dart';
 import 'package:openvine/services/notification_target_resolver.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -112,8 +116,8 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
                         .add(const NotificationFeedRefreshed()),
                     onItemTap: (notification) =>
                         _onItemTap(context, notification),
-                    onProfileTap: (pubkey) =>
-                        _navigateToProfile(context, pubkey),
+                    onProfileTap: (notification) =>
+                        _onAvatarStackTap(context, notification),
                     onFollowBack: (pubkey) => context
                         .read<NotificationFeedBloc>()
                         .add(NotificationFeedFollowBack(pubkey)),
@@ -268,6 +272,45 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
             break;
         }
     }
+  }
+
+  void _onAvatarStackTap(BuildContext context, NotificationItem notification) {
+    final target = resolveAvatarStackTapTarget(notification);
+    switch (target) {
+      case OpenEngagementListTarget(
+        :final eventId,
+        :final addressableId,
+        :final type,
+      ):
+        _navigateToEngagementList(
+          context,
+          eventId: eventId,
+          addressableId: addressableId,
+          type: type,
+        );
+      case OpenActorProfileTarget(:final pubkey):
+        _navigateToProfile(context, pubkey);
+      case null:
+        break;
+    }
+  }
+
+  void _navigateToEngagementList(
+    BuildContext context, {
+    required String eventId,
+    required String? addressableId,
+    required VideoEngagementType type,
+  }) {
+    final routeName = switch (type) {
+      VideoEngagementType.likers => VideoEngagementListScreen.likersRouteName,
+      VideoEngagementType.reposters =>
+        VideoEngagementListScreen.repostersRouteName,
+    };
+    context.pushNamed(
+      routeName,
+      pathParameters: {'eventId': eventId},
+      queryParameters: addressableId == null ? const {} : {'a': addressableId},
+    );
   }
 
   void _navigateToList(
@@ -503,7 +546,7 @@ class _NotificationList extends StatelessWidget {
   final bool hasMore;
   final ScrollController scrollController;
   final void Function(NotificationItem notification) onItemTap;
-  final void Function(String pubkey) onProfileTap;
+  final void Function(NotificationItem notification) onProfileTap;
   final void Function(String pubkey) onFollowBack;
 
   /// When `true`, renders [_RefreshErrorBanner] as the list's first item so
@@ -566,10 +609,7 @@ class _NotificationList extends StatelessWidget {
             NotificationListItem(
               notification: notification,
               onTap: () => onItemTap(notification),
-              onProfileTap: () {
-                final pubkey = _profilePubkey(notification);
-                if (pubkey != null) onProfileTap(pubkey);
-              },
+              onProfileTap: () => onProfileTap(notification),
               onFollowBack: () {
                 final pubkey = _profilePubkey(notification);
                 if (pubkey != null) onFollowBack(pubkey);

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -116,7 +116,7 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
                         .add(const NotificationFeedRefreshed()),
                     onItemTap: (notification) =>
                         _onItemTap(context, notification),
-                    onProfileTap: (notification) =>
+                    onAvatarStackTap: (notification) =>
                         _onAvatarStackTap(context, notification),
                     onFollowBack: (pubkey) => context
                         .read<NotificationFeedBloc>()
@@ -535,7 +535,7 @@ class _NotificationList extends StatelessWidget {
     required this.hasMore,
     required this.scrollController,
     required this.onItemTap,
-    required this.onProfileTap,
+    required this.onAvatarStackTap,
     required this.onFollowBack,
     required this.showRefreshErrorBanner,
     required this.onRetryRefresh,
@@ -546,7 +546,11 @@ class _NotificationList extends StatelessWidget {
   final bool hasMore;
   final ScrollController scrollController;
   final void Function(NotificationItem notification) onItemTap;
-  final void Function(NotificationItem notification) onProfileTap;
+
+  /// Called when the row's avatar stack is tapped. Resolves to the engagement
+  /// list for grouped like/repost rows and to a profile otherwise, so this is
+  /// deliberately not named `onProfileTap`.
+  final void Function(NotificationItem notification) onAvatarStackTap;
   final void Function(String pubkey) onFollowBack;
 
   /// When `true`, renders [_RefreshErrorBanner] as the list's first item so
@@ -609,7 +613,7 @@ class _NotificationList extends StatelessWidget {
             NotificationListItem(
               notification: notification,
               onTap: () => onItemTap(notification),
-              onProfileTap: () => onProfileTap(notification),
+              onProfileTap: () => onAvatarStackTap(notification),
               onFollowBack: () {
                 final pubkey = _profilePubkey(notification);
                 if (pubkey != null) onFollowBack(pubkey);

--- a/mobile/lib/router/routes/video_routes.dart
+++ b/mobile/lib/router/routes/video_routes.dart
@@ -192,9 +192,8 @@ List<RouteBase> videoRoutes() {
       ),
       builder: buildPooledFullscreenFeed,
     ),
-    // Engagement lists for own videos: who liked / reposted this video.
-    // Reached when the video owner taps the Like or Repost button on
-    // their own video.
+    // Engagement lists: who liked / reposted this video.
+    // Reached from feed action buttons and grouped notification avatar stacks.
     GoRoute(
       path: '/video/:eventId/likers',
       name: VideoEngagementListScreen.likersRouteName,

--- a/mobile/test/notifications/routing/avatar_stack_tap_target_test.dart
+++ b/mobile/test/notifications/routing/avatar_stack_tap_target_test.dart
@@ -1,0 +1,117 @@
+// ABOUTME: Tests for in-app notification avatar-stack tap routing.
+// ABOUTME: Pins grouped like/repost list routing and profile fallback behavior.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/video_engagement/video_engagement_bloc.dart'
+    show VideoEngagementType;
+import 'package:openvine/notifications/routing/avatar_stack_tap_target.dart';
+
+void main() {
+  group('resolveAvatarStackTapTarget', () {
+    const firstActor = ActorInfo(pubkey: 'actor_1', displayName: 'Alice');
+    const secondActor = ActorInfo(pubkey: 'actor_2', displayName: 'Bob');
+
+    VideoNotification videoNotification(
+      NotificationKind kind, {
+      int totalCount = 3,
+      List<ActorInfo> actors = const [firstActor, secondActor],
+    }) {
+      return VideoNotification(
+        id: 'notification_${kind.name}',
+        type: kind,
+        videoEventId: 'video_event_${kind.name}',
+        videoAddressableId: '34236:author:${kind.name}',
+        actors: actors,
+        totalCount: totalCount,
+        timestamp: DateTime(2026),
+      );
+    }
+
+    test('grouped like opens the likers list', () {
+      expect(
+        resolveAvatarStackTapTarget(videoNotification(NotificationKind.like)),
+        const OpenEngagementListTarget(
+          eventId: 'video_event_like',
+          addressableId: '34236:author:like',
+          type: VideoEngagementType.likers,
+        ),
+      );
+    });
+
+    test('grouped repost opens the reposters list', () {
+      expect(
+        resolveAvatarStackTapTarget(videoNotification(NotificationKind.repost)),
+        const OpenEngagementListTarget(
+          eventId: 'video_event_repost',
+          addressableId: '34236:author:repost',
+          type: VideoEngagementType.reposters,
+        ),
+      );
+    });
+
+    test('single like keeps opening the actor profile', () {
+      expect(
+        resolveAvatarStackTapTarget(
+          videoNotification(
+            NotificationKind.like,
+            totalCount: 1,
+            actors: const [firstActor],
+          ),
+        ),
+        const OpenActorProfileTarget('actor_1'),
+      );
+    });
+
+    test('single repost keeps opening the actor profile', () {
+      expect(
+        resolveAvatarStackTapTarget(
+          videoNotification(
+            NotificationKind.repost,
+            totalCount: 1,
+            actors: const [firstActor],
+          ),
+        ),
+        const OpenActorProfileTarget('actor_1'),
+      );
+    });
+
+    for (final kind in const [
+      NotificationKind.likeComment,
+      NotificationKind.comment,
+      NotificationKind.mention,
+      NotificationKind.newPost,
+      NotificationKind.listAdd,
+    ]) {
+      test('$kind keeps opening the first visible actor profile', () {
+        expect(
+          resolveAvatarStackTapTarget(videoNotification(kind)),
+          const OpenActorProfileTarget('actor_1'),
+        );
+      });
+    }
+
+    for (final kind in const [
+      NotificationKind.follow,
+      NotificationKind.like,
+      NotificationKind.mention,
+      NotificationKind.system,
+      NotificationKind.likeComment,
+      NotificationKind.reply,
+    ]) {
+      test('actor notification $kind opens the actor profile', () {
+        expect(
+          resolveAvatarStackTapTarget(
+            ActorNotification(
+              id: 'actor_${kind.name}',
+              type: kind,
+              actor: firstActor,
+              timestamp: DateTime(2026),
+            ),
+          ),
+          const OpenActorProfileTarget('actor_1'),
+        );
+      });
+    }
+  });
+}

--- a/mobile/test/notifications/routing/avatar_stack_tap_target_test.dart
+++ b/mobile/test/notifications/routing/avatar_stack_tap_target_test.dart
@@ -91,27 +91,20 @@ void main() {
       });
     }
 
-    for (final kind in const [
-      NotificationKind.follow,
-      NotificationKind.like,
-      NotificationKind.mention,
-      NotificationKind.system,
-      NotificationKind.likeComment,
-      NotificationKind.reply,
-    ]) {
-      test('actor notification $kind opens the actor profile', () {
-        expect(
-          resolveAvatarStackTapTarget(
-            ActorNotification(
-              id: 'actor_${kind.name}',
-              type: kind,
-              actor: firstActor,
-              timestamp: DateTime(2026),
-            ),
+    // Kind never participates in the ActorNotification branch — it always
+    // resolves to the actor's profile — so one case pins the whole branch.
+    test('actor notification opens the actor profile', () {
+      expect(
+        resolveAvatarStackTapTarget(
+          ActorNotification(
+            id: 'actor_follow',
+            type: NotificationKind.follow,
+            actor: firstActor,
+            timestamp: DateTime(2026),
           ),
-          const OpenActorProfileTarget('actor_1'),
-        );
-      });
-    }
+        ),
+        const OpenActorProfileTarget('actor_1'),
+      );
+    });
   });
 }

--- a/mobile/test/notifications/view/notifications_view_test.dart
+++ b/mobile/test/notifications/view/notifications_view_test.dart
@@ -26,6 +26,7 @@ import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
+import 'package:openvine/screens/video_engagement/video_engagement_list_screen.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:videos_repository/videos_repository.dart';
 
@@ -63,6 +64,8 @@ Future<void> _pumpView(WidgetTester tester, NotificationFeedBloc bloc) async {
 typedef _RoutedViewResult = ({
   List<PooledFullscreenVideoFeedArgs> videoArgs,
   List<({String videoId, VideoDetailRouteExtra? extra})> videoDetailRoutes,
+  List<({String routeName, String eventId, String? addressableId})>
+  engagementRoutes,
   List<String> profileNpubs,
 });
 
@@ -77,6 +80,8 @@ Future<_RoutedViewResult> _pumpRoutedViewFull(
   final capturedVideoArgs = <PooledFullscreenVideoFeedArgs>[];
   final capturedVideoDetailRoutes =
       <({String videoId, VideoDetailRouteExtra? extra})>[];
+  final capturedEngagementRoutes =
+      <({String routeName, String eventId, String? addressableId})>[];
   final capturedProfileNpubs = <String>[];
   final router = GoRouter(
     initialLocation: '/',
@@ -98,6 +103,30 @@ Future<_RoutedViewResult> _pumpRoutedViewFull(
           capturedVideoDetailRoutes.add((
             videoId: state.pathParameters['id']!,
             extra: state.extra as VideoDetailRouteExtra?,
+          ));
+          return const Scaffold(body: SizedBox.shrink());
+        },
+      ),
+      GoRoute(
+        path: '/video/:eventId/likers',
+        name: VideoEngagementListScreen.likersRouteName,
+        builder: (context, state) {
+          capturedEngagementRoutes.add((
+            routeName: VideoEngagementListScreen.likersRouteName,
+            eventId: state.pathParameters['eventId']!,
+            addressableId: state.uri.queryParameters['a'],
+          ));
+          return const Scaffold(body: SizedBox.shrink());
+        },
+      ),
+      GoRoute(
+        path: '/video/:eventId/reposters',
+        name: VideoEngagementListScreen.repostersRouteName,
+        builder: (context, state) {
+          capturedEngagementRoutes.add((
+            routeName: VideoEngagementListScreen.repostersRouteName,
+            eventId: state.pathParameters['eventId']!,
+            addressableId: state.uri.queryParameters['a'],
           ));
           return const Scaffold(body: SizedBox.shrink());
         },
@@ -136,6 +165,7 @@ Future<_RoutedViewResult> _pumpRoutedViewFull(
   return (
     videoArgs: capturedVideoArgs,
     videoDetailRoutes: capturedVideoDetailRoutes,
+    engagementRoutes: capturedEngagementRoutes,
     profileNpubs: capturedProfileNpubs,
   );
 }
@@ -1330,6 +1360,171 @@ void main() {
           expect(result.profileNpubs.single, startsWith('npub'));
         },
       );
+    });
+
+    group('avatar stack routing', () {
+      testWidgets('grouped like avatar stack opens the likers list', (
+        tester,
+      ) async {
+        final videoService = _MockVideoEventService();
+        final nostrClient = _MockNostrClient();
+        final videosRepository = _MockVideosRepository();
+        const addressableId =
+            '34236:'
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+            ':grouped-like';
+
+        when(() => mockBloc.state).thenReturn(
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [
+              VideoNotification(
+                id: 'grouped-like',
+                type: NotificationKind.like,
+                videoEventId: 'grouped_like_video_event',
+                videoAddressableId: addressableId,
+                actors: const [
+                  ActorInfo(pubkey: 'liker_1', displayName: 'Alice'),
+                  ActorInfo(pubkey: 'liker_2', displayName: 'Bob'),
+                  ActorInfo(pubkey: 'liker_3', displayName: 'Charlie'),
+                ],
+                totalCount: 4,
+                timestamp: DateTime(2026),
+              ),
+            ],
+          ),
+        );
+
+        final result = await _pumpRoutedViewFull(
+          tester,
+          mockBloc,
+          videoEventService: videoService,
+          nostrClient: nostrClient,
+          videosRepository: videosRepository,
+        );
+
+        await tester.tap(
+          find.bySemanticsLabel(_l10n.notificationsViewProfilesSemanticLabel),
+        );
+        await tester.pumpAndSettle();
+
+        expect(result.videoArgs, isEmpty);
+        expect(result.videoDetailRoutes, isEmpty);
+        expect(result.profileNpubs, isEmpty);
+        expect(result.engagementRoutes, hasLength(1));
+        expect(
+          result.engagementRoutes.single.routeName,
+          VideoEngagementListScreen.likersRouteName,
+        );
+        expect(
+          result.engagementRoutes.single.eventId,
+          'grouped_like_video_event',
+        );
+        expect(result.engagementRoutes.single.addressableId, addressableId);
+      });
+
+      testWidgets('grouped repost avatar stack opens the reposters list', (
+        tester,
+      ) async {
+        final videoService = _MockVideoEventService();
+        final nostrClient = _MockNostrClient();
+        final videosRepository = _MockVideosRepository();
+        const addressableId =
+            '34236:'
+            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+            ':grouped-repost';
+
+        when(() => mockBloc.state).thenReturn(
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [
+              VideoNotification(
+                id: 'grouped-repost',
+                type: NotificationKind.repost,
+                videoEventId: 'grouped_repost_video_event',
+                videoAddressableId: addressableId,
+                actors: const [
+                  ActorInfo(pubkey: 'reposter_1', displayName: 'Alice'),
+                  ActorInfo(pubkey: 'reposter_2', displayName: 'Bob'),
+                ],
+                totalCount: 2,
+                timestamp: DateTime(2026),
+              ),
+            ],
+          ),
+        );
+
+        final result = await _pumpRoutedViewFull(
+          tester,
+          mockBloc,
+          videoEventService: videoService,
+          nostrClient: nostrClient,
+          videosRepository: videosRepository,
+        );
+
+        await tester.tap(
+          find.bySemanticsLabel(_l10n.notificationsViewProfilesSemanticLabel),
+        );
+        await tester.pumpAndSettle();
+
+        expect(result.videoArgs, isEmpty);
+        expect(result.videoDetailRoutes, isEmpty);
+        expect(result.profileNpubs, isEmpty);
+        expect(result.engagementRoutes, hasLength(1));
+        expect(
+          result.engagementRoutes.single.routeName,
+          VideoEngagementListScreen.repostersRouteName,
+        );
+        expect(
+          result.engagementRoutes.single.eventId,
+          'grouped_repost_video_event',
+        );
+        expect(result.engagementRoutes.single.addressableId, addressableId);
+      });
+
+      testWidgets('single like avatar stack still opens the actor profile', (
+        tester,
+      ) async {
+        final videoService = _MockVideoEventService();
+        final nostrClient = _MockNostrClient();
+        final videosRepository = _MockVideosRepository();
+        final likerPubkey = 'a' * 64;
+
+        when(() => mockBloc.state).thenReturn(
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [
+              VideoNotification(
+                id: 'single-like',
+                type: NotificationKind.like,
+                videoEventId: 'single_like_video_event',
+                actors: [ActorInfo(pubkey: likerPubkey, displayName: 'Alice')],
+                totalCount: 1,
+                timestamp: DateTime(2026),
+              ),
+            ],
+          ),
+        );
+
+        final result = await _pumpRoutedViewFull(
+          tester,
+          mockBloc,
+          videoEventService: videoService,
+          nostrClient: nostrClient,
+          videosRepository: videosRepository,
+        );
+
+        await tester.tap(
+          find.bySemanticsLabel(_l10n.notificationsViewProfilesSemanticLabel),
+        );
+        await tester.pumpAndSettle();
+
+        expect(result.videoArgs, isEmpty);
+        expect(result.videoDetailRoutes, isEmpty);
+        expect(result.engagementRoutes, isEmpty);
+        expect(result.profileNpubs, hasLength(1));
+        expect(result.profileNpubs.single, startsWith('npub'));
+      });
     });
 
     group('date headers', () {


### PR DESCRIPTION
## Summary
- add an in-app avatar-stack tap resolver for grouped notification rows
- route grouped likes to the likers list and grouped reposts to the reposters list
- keep single-actor and non-engagement avatar taps opening the actor profile
- update stale engagement-list comments now that notifications can open the routes

Closes #7180

## Verification
- flutter analyze
- flutter test test/notifications/routing/avatar_stack_tap_target_test.dart test/notifications/view/notifications_view_test.dart
- pre-push changed-file checks: analyzer plus test/blocs/video_engagement/video_engagement_bloc_test.dart test/notifications/routing/avatar_stack_tap_target_test.dart test/notifications/view/notifications_view_test.dart