### PR TITLE
fix(ci): drop the supporters variable group that does not exist yet

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -550,7 +550,6 @@ workflows:
       groups:
         - zendesk_credentials
         - proofmode_credentials
-        - supporters_credentials
         - github_credentials
       vars:
         BUNDLE_ID: co.openvine.app
@@ -616,7 +615,6 @@ workflows:
       groups:
         - zendesk_credentials
         - proofmode_credentials
-        - supporters_credentials
     cache:
       cache_paths:
         - $HOME/Library/Caches/CocoaPods
@@ -666,7 +664,6 @@ workflows:
         - zendesk_credentials
         - google_play_credentials
         - proofmode_credentials
-        - supporters_credentials
         - github_credentials
       android_signing:
         - divine_keystore
@@ -729,7 +726,6 @@ workflows:
       groups:
         - zendesk_credentials
         - proofmode_credentials
-        - supporters_credentials
         - github_credentials
     cache:
       cache_paths:
@@ -763,7 +759,6 @@ workflows:
       groups:
         - zendesk_credentials
         - proofmode_credentials
-        - supporters_credentials
         - maestro_e2e_credentials
       vars:
         DEFAULT_ENV: STAGING
@@ -803,7 +798,6 @@ workflows:
       groups:
         - zendesk_credentials
         - proofmode_credentials
-        - supporters_credentials
         - maestro_e2e_credentials
       vars:
         DEFAULT_ENV: STAGING

--- a/mobile/scripts/check_supporters_config.sh
+++ b/mobile/scripts/check_supporters_config.sh
@@ -39,9 +39,8 @@ if [ "$flag" = "true" ] && [ -z "$base_url" ]; then
   echo "ERROR: FF_DIVINE_SUPPORTERS=true but SUPPORTERS_API_BASE_URL is empty." >&2
   echo "  supporterApiClientProvider returns null when the URL is empty, so the" >&2
   echo "  supporter screen would render with no way to claim a purchase or read" >&2
-  echo "  entitlement. Set SUPPORTERS_API_BASE_URL in the Codemagic" >&2
-  echo "  'supporters_credentials' environment variable group, or turn the flag" >&2
-  echo "  off for this build." >&2
+  echo "  entitlement. Configure SUPPORTERS_API_BASE_URL for this build, or" >&2
+  echo "  turn the flag off." >&2
   exit 1
 fi
 


### PR DESCRIPTION
Closes #7192

## Description

Codemagic is currently rejecting the entire config with:

> Codemagic.yaml references to unknown variable group(s): supporters_credentials

This fails **all six workflows** - `ios-build`, `ios-simulator-build`, `android-build`, `macos-build`, `e2e-smoke-ios`, `e2e-smoke-android` - before any step runs. Config validation happens up front, so nothing builds.

#6999 added `supporters_credentials` to those six workflows alongside the supporter `--dart-define`s, but the group was never created in Codemagic. That ordering was backwards, and it was flagged on that PR as unverifiable from GitHub CI: no GitHub workflow parses `codemagic.yaml`, so this could only ever surface on the first Codemagic run after merge.

It was also premature rather than merely out of order. `supporter_providers.dart` describes the URL as one the build supplies *"once divine-supporters exists"* - it doesn't exist yet, so there is nothing to put in the group.

## What this does

- Removes the six `- supporters_credentials` lines.
- Keeps the existing `--dart-define=SUPPORTERS_API_BASE_URL` / `FF_DIVINE_SUPPORTERS` lines.
- Updates `check_supporters_config.sh` so the failure message no longer tells operators to configure a removed Codemagic group.

With both supporter variables unset, the defines interpolate to empty, which is the same state every build has been in since #6999 merged:

- `supporterApiBaseUrl.isEmpty` -> `supporterApiClientProvider` returns `null` -> the feature is inert
- `check_supporters_config.sh` exits 0

So this restores the pre-#6999 build behaviour without reverting the plumbing or the guard, both of which are correct and will be wanted the moment the Worker ships.

## Verification

`check_supporters_config.sh` run against the two inactive states a build can now be in:

| Environment | Exit |
|---|---|
| both variables unset | `0` |
| both set to empty string (what the build steps actually emit) | `0` |

Also verified:

- `FF_DIVINE_SUPPORTERS=true` with an empty `SUPPORTERS_API_BASE_URL` still exits `1` and prints the updated guidance.
- `codemagic.yaml` parses with YAML anchors enabled.
- Every workflow still has a non-empty `environment.groups` list.
- No `supporters_credentials` references remain in `codemagic.yaml` or the supporter config guard.

GitHub CI cannot verify the actual Codemagic fix yet - no workflow here validates Codemagic variable groups. **The real check is the next Codemagic run**, which should get past config validation instead of failing immediately.

## Follow-up

When `divine-supporters` is deployed, re-add the group **in the same change that populates it**, rather than ahead of it.

Follow-up prevention issue: #7198

**Related:** #6999
