### PR TITLE
ci: reuse dart hook downloads so merge-queue jobs skip the fetch

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -10,7 +10,9 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # merge_group refs are the queue's only signal. Cancelling that run ejects
+  # the PR even when the replacement job never starts (#7197).
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   changes:
@@ -296,6 +298,26 @@ jobs:
           cache: true
       - name: 📦 Install dependencies
         run: flutter pub get
+      - name: Restore sqlite3mc hook cache
+        # The sqlite3 hook stores libsqlite3mc under this tree. flutter-action
+        # cache: true does not keep it. merge_group can restore but not save
+        # (#7197), so only push-to-main warms the cache.
+        uses: actions/cache/restore@v4
+        with:
+          path: mobile/.dart_tool/hooks_runner/shared/sqlite3
+          key: ${{ runner.os }}-sqlite3mc-${{ hashFiles('mobile/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-sqlite3mc-
+      - name: Warm sqlite3mc native assets
+        # Retries the hook download. A cache hit makes the hook skip GitHub
+        # Releases; a miss still gets five attempts instead of one.
+        run: bash scripts/ci/warmup_sqlite3mc.sh
+      - name: Save sqlite3mc hook cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v4
+        with:
+          path: mobile/.dart_tool/hooks_runner/shared/sqlite3
+          key: ${{ runner.os }}-sqlite3mc-${{ hashFiles('mobile/pubspec.lock') }}
       - name: 🛠️ Install Very Good CLI
         # Pinned so the optimizer's bundle mechanics don't float under CI. 1.3.0
         # is the current latest; 1.1.1≡1.2.0≡1.3.0 for all test/optimizer

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -298,26 +298,27 @@ jobs:
           cache: true
       - name: 📦 Install dependencies
         run: flutter pub get
-      - name: Restore sqlite3mc hook cache
-        # The sqlite3 hook stores libsqlite3mc under this tree. flutter-action
-        # cache: true does not keep it. merge_group can restore but not save
-        # (#7197), so only push-to-main warms the cache.
+      - name: Restore dart hook downloads
+        # Native-asset hooks store downloaded libs under this tree (sqlite3,
+        # cupertino_http, objective_c, …). flutter-action cache: true does not
+        # keep it. merge_group can restore but not save (#7197), so only
+        # push-to-main warms the cache.
         uses: actions/cache/restore@v4
         with:
-          path: mobile/.dart_tool/hooks_runner/shared/sqlite3
-          key: ${{ runner.os }}-sqlite3mc-${{ hashFiles('mobile/pubspec.lock') }}
+          path: mobile/.dart_tool/hooks_runner/shared
+          key: ${{ runner.os }}-dart-hooks-${{ hashFiles('mobile/pubspec.lock') }}
           restore-keys: |
-            ${{ runner.os }}-sqlite3mc-
+            ${{ runner.os }}-dart-hooks-
       - name: Warm sqlite3mc native assets
-        # Retries the hook download. A cache hit makes the hook skip GitHub
-        # Releases; a miss still gets five attempts instead of one.
+        # Retries the one hook that does an unretried GitHub Releases GET.
+        # A cache hit skips that download; a miss still gets five attempts.
         run: bash scripts/ci/warmup_sqlite3mc.sh
-      - name: Save sqlite3mc hook cache
+      - name: Save dart hook downloads
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/cache/save@v4
         with:
-          path: mobile/.dart_tool/hooks_runner/shared/sqlite3
-          key: ${{ runner.os }}-sqlite3mc-${{ hashFiles('mobile/pubspec.lock') }}
+          path: mobile/.dart_tool/hooks_runner/shared
+          key: ${{ runner.os }}-dart-hooks-${{ hashFiles('mobile/pubspec.lock') }}
       - name: 🛠️ Install Very Good CLI
         # Pinned so the optimizer's bundle mechanics don't float under CI. 1.3.0
         # is the current latest; 1.1.1≡1.2.0≡1.3.0 for all test/optimizer

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -253,7 +253,7 @@ jobs:
         # back to its defaults, reformatting 529 files.
         run: flutter pub get
       - name: ✨ Check formatting
-        run: dart format --output=none --set-exit-if-changed lib test integration_test
+        run: dart format --output=none --set-exit-if-changed lib test integration_test tools
   analyze:
     name: Analyze
     needs: changes
@@ -273,7 +273,7 @@ jobs:
       - name: 📦 Install dependencies
         run: flutter pub get
       - name: 🕵️ Analyze code
-        run: flutter analyze lib test integration_test
+        run: flutter analyze lib test integration_test tools
   tests:
     name: Tests (shard ${{ strategy.job-index }}/${{ strategy.job-total }})
     needs: changes
@@ -299,10 +299,9 @@ jobs:
       - name: 📦 Install dependencies
         run: flutter pub get
       - name: Restore dart hook downloads
-        # Native-asset hooks store downloaded libs under this tree (sqlite3,
-        # cupertino_http, objective_c, …). flutter-action cache: true does not
-        # keep it. merge_group can restore but not save (#7197), so only
-        # push-to-main warms the cache.
+        # Native-asset hooks store downloaded libs under this tree.
+        # flutter-action cache: true does not keep it. merge_group can restore
+        # but not save (#7197), so only push-to-main warms the cache.
         uses: actions/cache/restore@v4
         with:
           path: mobile/.dart_tool/hooks_runner/shared
@@ -314,7 +313,7 @@ jobs:
         # A cache hit skips that download; a miss still gets five attempts.
         run: bash scripts/ci/warmup_sqlite3mc.sh
       - name: Save dart hook downloads
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && strategy.job-index == 0
         uses: actions/cache/save@v4
         with:
           path: mobile/.dart_tool/hooks_runner/shared

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -2333,10 +2333,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqlite3
-      sha256: "37356bcb56ce0d9404d602c41e4bdb7765e7e9732a3e47adb3d98c556a6abdad"
+      sha256: "752d9d746052359a2022f588bb979f2e7c4e0f9e4b6a1c3121f7626a1574974b"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.3"
+    version: "3.3.4"
   sqlparser:
     dependency: transitive
     description:

--- a/mobile/scripts/ci/warmup_sqlite3mc.sh
+++ b/mobile/scripts/ci/warmup_sqlite3mc.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# ABOUTME: Retries the sqlite3mc native-asset hook before Mobile CI tests.
+# ABOUTME: A single dropped GitHub Releases GET must not fail the shard (#7197).
+
+# package:sqlite3 3.3.3 downloads libsqlite3mc.*.so from GitHub Releases in
+# one unretried GET. Linux test shards do that on a fresh VM. A truncated
+# connection fails the hook and GitHub's merge queue ejects the PR.
+#
+# This script runs the hook through `dart run tools/warmup_sqlite3mc.dart`
+# and retries. Pair it with actions/cache on
+# .dart_tool/hooks_runner/shared/sqlite3 so later jobs skip the download.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+ATTEMPTS="${SQLITE3MC_WARMUP_ATTEMPTS:-5}"
+SLEEP_SECS="${SQLITE3MC_WARMUP_SLEEP_SECS:-2}"
+WARMUP_CMD="${SQLITE3MC_WARMUP_CMD:-dart run tools/warmup_sqlite3mc.dart}"
+
+if ! [[ "$ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "SQLITE3MC_WARMUP_ATTEMPTS must be a positive integer, got: ${ATTEMPTS}" >&2
+  exit 2
+fi
+
+if ! [[ "$SLEEP_SECS" =~ ^[0-9]+$ ]]; then
+  echo "SQLITE3MC_WARMUP_SLEEP_SECS must be a non-negative integer, got: ${SLEEP_SECS}" >&2
+  exit 2
+fi
+
+attempt=1
+while (( attempt <= ATTEMPTS )); do
+  echo "sqlite3mc warmup attempt ${attempt}/${ATTEMPTS}"
+  if bash -c "$WARMUP_CMD"; then
+    echo "sqlite3mc warmup succeeded on attempt ${attempt}"
+    exit 0
+  fi
+  if (( attempt == ATTEMPTS )); then
+    echo "sqlite3mc warmup failed after ${ATTEMPTS} attempts" >&2
+    exit 1
+  fi
+  sleep "$SLEEP_SECS"
+  attempt=$((attempt + 1))
+done

--- a/mobile/scripts/ci/warmup_sqlite3mc.sh
+++ b/mobile/scripts/ci/warmup_sqlite3mc.sh
@@ -8,7 +8,7 @@
 #
 # This script runs the hook through `dart run tools/warmup_sqlite3mc.dart`
 # and retries. Pair it with actions/cache on
-# .dart_tool/hooks_runner/shared/sqlite3 so later jobs skip the download.
+# .dart_tool/hooks_runner/shared so later jobs skip hook downloads.
 
 set -euo pipefail
 

--- a/mobile/scripts/ci/warmup_sqlite3mc.sh
+++ b/mobile/scripts/ci/warmup_sqlite3mc.sh
@@ -2,8 +2,8 @@
 # ABOUTME: Retries the sqlite3mc native-asset hook before Mobile CI tests.
 # ABOUTME: A single dropped GitHub Releases GET must not fail the shard (#7197).
 
-# package:sqlite3 3.3.3 downloads libsqlite3mc.*.so from GitHub Releases in
-# one unretried GET. Linux test shards do that on a fresh VM. A truncated
+# package:sqlite3 downloads libsqlite3mc.*.so from GitHub Releases in one
+# unretried GET. Linux test shards do that on a fresh VM. A truncated
 # connection fails the hook and GitHub's merge queue ejects the PR.
 #
 # This script runs the hook through `dart run tools/warmup_sqlite3mc.dart`

--- a/mobile/test/tools/warmup_sqlite3mc_test.dart
+++ b/mobile/test/tools/warmup_sqlite3mc_test.dart
@@ -17,8 +17,7 @@ void main() {
         p.join(Directory.current.path, 'scripts', 'ci', 'warmup_sqlite3mc.sh'),
       );
       expect(realScript.existsSync(), isTrue);
-      scriptPath = p.join(sandbox.path, 'warmup_sqlite3mc.sh');
-      File(scriptPath).writeAsStringSync(realScript.readAsStringSync());
+      scriptPath = realScript.path;
     });
 
     tearDown(() {
@@ -26,21 +25,60 @@ void main() {
     });
 
     ProcessResult runWarmup({
-      required String command,
+      String? command,
       String attempts = '5',
       String sleepSecs = '0',
+      Map<String, String> environment = const {},
     }) {
+      final processEnvironment = {
+        ...Platform.environment,
+        'SQLITE3MC_WARMUP_ATTEMPTS': attempts,
+        'SQLITE3MC_WARMUP_SLEEP_SECS': sleepSecs,
+        ...environment,
+      };
+      if (command != null) {
+        processEnvironment['SQLITE3MC_WARMUP_CMD'] = command;
+      }
+
       return Process.runSync(
         'bash',
         [scriptPath],
-        environment: {
-          ...Platform.environment,
-          'SQLITE3MC_WARMUP_CMD': command,
-          'SQLITE3MC_WARMUP_ATTEMPTS': attempts,
-          'SQLITE3MC_WARMUP_SLEEP_SECS': sleepSecs,
-        },
+        environment: processEnvironment,
       );
     }
+
+    test('runs the default warmup command from the real project root', () {
+      final fakeBin = Directory(p.join(sandbox.path, 'bin'))..createSync();
+      final capture = File(p.join(sandbox.path, 'capture.txt'));
+      final fakeDart = File(p.join(fakeBin.path, 'dart'))
+        ..writeAsStringSync('''
+#!/usr/bin/env bash
+set -euo pipefail
+{
+  pwd
+  printf '%s\\n' "\$@"
+} > "${capture.path}"
+''');
+      final chmod = Process.runSync('chmod', ['755', fakeDart.path]);
+      expect(chmod.exitCode, equals(0), reason: chmod.stderr.toString());
+
+      final result = runWarmup(
+        attempts: '1',
+        environment: {
+          'PATH': '${fakeBin.path}:${Platform.environment['PATH']}',
+        },
+      );
+
+      expect(result.exitCode, equals(0), reason: result.stderr.toString());
+      expect(
+        capture.readAsLinesSync(),
+        equals([
+          Directory.current.path,
+          'run',
+          'tools/warmup_sqlite3mc.dart',
+        ]),
+      );
+    });
 
     test('succeeds on the first attempt without retrying', () {
       final result = runWarmup(command: 'true', attempts: '3');
@@ -100,6 +138,15 @@ test "$n" -ge 2
       expect(
         result.stderr.toString(),
         contains('SQLITE3MC_WARMUP_ATTEMPTS must be a positive integer'),
+      );
+    });
+
+    test('rejects an invalid sleep duration', () {
+      final result = runWarmup(command: 'true', sleepSecs: '-1');
+      expect(result.exitCode, equals(2));
+      expect(
+        result.stderr.toString(),
+        contains('SQLITE3MC_WARMUP_SLEEP_SECS must be a non-negative integer'),
       );
     });
   });

--- a/mobile/test/tools/warmup_sqlite3mc_test.dart
+++ b/mobile/test/tools/warmup_sqlite3mc_test.dart
@@ -1,0 +1,106 @@
+// ABOUTME: Tests the sqlite3mc warmup retry wrapper used by Mobile CI (#7197).
+// ABOUTME: Pins retry-on-failure and fail-closed after the last attempt.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('warmup_sqlite3mc.sh', () {
+    late Directory sandbox;
+    late String scriptPath;
+
+    setUp(() {
+      sandbox = Directory.systemTemp.createTempSync('warmup_sqlite3mc_');
+      final realScript = File(
+        p.join(Directory.current.path, 'scripts', 'ci', 'warmup_sqlite3mc.sh'),
+      );
+      expect(realScript.existsSync(), isTrue);
+      scriptPath = p.join(sandbox.path, 'warmup_sqlite3mc.sh');
+      File(scriptPath).writeAsStringSync(realScript.readAsStringSync());
+    });
+
+    tearDown(() {
+      if (sandbox.existsSync()) sandbox.deleteSync(recursive: true);
+    });
+
+    ProcessResult runWarmup({
+      required String command,
+      String attempts = '5',
+      String sleepSecs = '0',
+    }) {
+      return Process.runSync(
+        'bash',
+        [scriptPath],
+        environment: {
+          ...Platform.environment,
+          'SQLITE3MC_WARMUP_CMD': command,
+          'SQLITE3MC_WARMUP_ATTEMPTS': attempts,
+          'SQLITE3MC_WARMUP_SLEEP_SECS': sleepSecs,
+        },
+      );
+    }
+
+    test('succeeds on the first attempt without retrying', () {
+      final result = runWarmup(command: 'true', attempts: '3');
+      expect(result.exitCode, equals(0), reason: result.stderr.toString());
+      expect(
+        result.stdout.toString(),
+        contains('sqlite3mc warmup succeeded on attempt 1'),
+      );
+      expect(result.stdout.toString(), isNot(contains('attempt 2/')));
+    });
+
+    test('retries a failing command and succeeds later', () {
+      final marker = File(p.join(sandbox.path, 'tries'));
+      final flaky = File(p.join(sandbox.path, 'flaky.sh'))
+        ..writeAsStringSync(r'''
+#!/usr/bin/env bash
+set -euo pipefail
+n=0
+if [ -f "$MARKER" ]; then
+  n=$(wc -l < "$MARKER")
+fi
+echo x >> "$MARKER"
+test "$n" -ge 2
+''');
+      final result = Process.runSync(
+        'bash',
+        [scriptPath],
+        environment: {
+          ...Platform.environment,
+          'MARKER': marker.path,
+          'SQLITE3MC_WARMUP_CMD': 'bash ${flaky.path}',
+          'SQLITE3MC_WARMUP_ATTEMPTS': '4',
+          'SQLITE3MC_WARMUP_SLEEP_SECS': '0',
+        },
+      );
+      expect(result.exitCode, equals(0), reason: result.stderr.toString());
+      expect(
+        result.stdout.toString(),
+        contains('sqlite3mc warmup succeeded on attempt 3'),
+      );
+      expect(marker.readAsLinesSync(), hasLength(3));
+    });
+
+    test('fails closed after the last attempt', () {
+      final result = runWarmup(command: 'false', attempts: '3');
+      expect(result.exitCode, equals(1));
+      expect(
+        result.stderr.toString(),
+        contains('sqlite3mc warmup failed after 3 attempts'),
+      );
+      expect(result.stdout.toString(), contains('attempt 3/3'));
+    });
+
+    test('rejects a non-positive attempt count', () {
+      final result = runWarmup(command: 'true', attempts: '0');
+      expect(result.exitCode, equals(2));
+      expect(
+        result.stderr.toString(),
+        contains('SQLITE3MC_WARMUP_ATTEMPTS must be a positive integer'),
+      );
+    });
+  });
+}

--- a/mobile/tools/warmup_sqlite3mc.dart
+++ b/mobile/tools/warmup_sqlite3mc.dart
@@ -1,0 +1,13 @@
+// ABOUTME: Loads sqlite3mc so the native-asset hook runs before Mobile CI tests.
+// ABOUTME: Lets warmup_sqlite3mc.sh retry a dropped GitHub Releases download (#7197).
+
+import 'package:sqlite3/sqlite3.dart';
+
+void main() {
+  final db = sqlite3.openInMemory();
+  try {
+    db.select('SELECT 1;');
+  } finally {
+    db.close();
+  }
+}


### PR DESCRIPTION
## Description

Every Mobile CI linux shard currently re-downloads Dart native-asset hook libraries because `flutter-action` cache does not keep `.dart_tool/hooks_runner/shared`. A dropped fetch fails the shard, and the merge queue ejects the PR.

This change caches that shared hook folder, retries the sqlite3mc Releases download before tests, bumps `sqlite3` from 3.3.3 to 3.3.4 so the hook download path is stable/content-addressed, and does not cancel a merge-queue run when another event starts. After the first good `main` run, later jobs restore the downloads. A flaky fetch should not kick the PR.

**Related Issue:** Closes #7197

## Out of Scope

- Switching to `url_pattern` / an artifact mirror
- Per-package warmup scripts for hooks other than sqlite3mc
- Package-only workflows (`db_client`, `cache_sync`)
- Changing merge-queue policy or bypass actors

## Verification

- `dart pub upgrade sqlite3 --offline`
- `dart format --output=none --set-exit-if-changed lib test integration_test tools`
- `flutter analyze lib test integration_test tools`
- `flutter test test/tools/warmup_sqlite3mc_test.dart`
- `bash scripts/ci/warmup_sqlite3mc.sh` (succeeded on attempt 1)
- Verified the warmup created one sqlite3mc library at `.dart_tool/hooks_runner/shared/sqlite3/build/download-60cc6905/libsqlite3mc.dylib`; rerunning the focused Flutter test did not create a second sqlite3mc library download.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
