### PR TITLE
ci(shorebird): move code push to the Divine org and wire it into Codemagic

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -31,7 +31,7 @@ Generic Flutter and Dart standards live in `.claude/rules/`:
 ## Project Rules
 
 - Most app work happens in `mobile/`. Key entry points are `mobile/lib/main.dart` and `mobile/lib/router/app_router.dart`.
-- Use current code plus focused docs as source of truth: `docs/STATE_MANAGEMENT.md`, `docs/BLOC_UI_MIGRATION_PRD.md`, `docs/NOSTR_EVENT_TYPES.md`, `mobile/docs/NOSTR_VIDEO_EVENTS.md`, `mobile/docs/DESIGN_SYSTEM_COMPONENTS.md`, `mobile/docs/GOLDEN_TESTING_GUIDE.md`, and `mobile/docs/PEOPLE_SEARCH.md`.
+- Use current code plus focused docs as source of truth: `docs/STATE_MANAGEMENT.md`, `docs/BLOC_UI_MIGRATION_PRD.md`, `docs/NOSTR_EVENT_TYPES.md`, `mobile/docs/NOSTR_VIDEO_EVENTS.md`, `mobile/docs/DESIGN_SYSTEM_COMPONENTS.md`, `mobile/docs/GOLDEN_TESTING_GUIDE.md`, `mobile/docs/PEOPLE_SEARCH.md`, and `mobile/docs/SHOREBIRD_CODE_PUSH.md`.
 - Older docs can drift. If documentation disagrees with code, trust the current implementation, targeted tests, and the newest focused doc.
 
 ## Architecture And State

--- a/.github/ci-timing-budgets.json
+++ b/.github/ci-timing-budgets.json
@@ -24,6 +24,7 @@
   "jobs": {
     "Detect App CI Scope": { "warn": 40, "fail": 90 },
     "Codemagic Variable Groups": { "warn": 30, "fail": 90 },
+    "CI Configuration Tests": { "warn": 30, "fail": 90 },
     "Tests": { "warn": 600, "fail": 780 },
     "Generated Files": { "warn": 260, "fail": 420 },
     "Analyze": { "warn": 150, "fail": 300 },

--- a/.github/scripts/tests/test_codemagic_android_build_number.py
+++ b/.github/scripts/tests/test_codemagic_android_build_number.py
@@ -6,23 +6,84 @@ CODEMAGIC_PATH = Path(__file__).resolve().parents[3] / "codemagic.yaml"
 
 
 class CodemagicAndroidBuildNumberTest(unittest.TestCase):
-    def test_android_aab_build_uses_google_play_floor(self) -> None:
-        contents = CODEMAGIC_PATH.read_text()
+    def setUp(self) -> None:
+        self.contents = CODEMAGIC_PATH.read_text()
 
+    def test_android_aab_build_uses_google_play_floor(self) -> None:
         self.assertIn(
             'google-play get-latest-build-number --package-name "co.openvine.app"',
-            contents,
+            self.contents,
         )
-        self.assertIn("BUILD_NUMBER=$PROJECT_BUILD_NUMBER", contents)
+        self.assertIn("BUILD_NUMBER=$PROJECT_BUILD_NUMBER", self.contents)
         self.assertIn(
             'NEXT_PLAY_BUILD_NUMBER=$((LATEST_GOOGLE_PLAY_BUILD_NUMBER + 1))',
-            contents,
+            self.contents,
         )
         self.assertIn(
             'if [ "$NEXT_PLAY_BUILD_NUMBER" -gt "$BUILD_NUMBER" ]; then',
-            contents,
+            self.contents,
         )
-        self.assertNotIn("PROJECT_BUILD_NUMBER + 8", contents)
+        self.assertNotIn("PROJECT_BUILD_NUMBER + 8", self.contents)
+
+    def test_shorebird_supporters_defines_are_optional(self) -> None:
+        self.assertIn("optional_names = %w[", self.contents)
+        self.assertIn("SUPPORTERS_API_BASE_URL", self.contents)
+        self.assertIn("FF_DIVINE_SUPPORTERS", self.contents)
+        self.assertIn("defines[name] = ENV.fetch(name, '')", self.contents)
+
+    def test_shorebird_release_commands_are_signed_and_preflighted(self) -> None:
+        self.assertIn("*preflight_shorebird_ios_release", self.contents)
+        self.assertIn("*preflight_shorebird_android_release", self.contents)
+        self.assertIn("--build-name=$BUILD_NAME", self.contents)
+        self.assertIn("--public-key-path=build/shorebird/patch_public_key.pem", self.contents)
+        self.assertIn("already exists and is active", self.contents)
+
+    def test_shorebird_patch_commands_publish_to_staging_and_are_signed(self) -> None:
+        self.assertIn(
+            "shorebird patch android --release-version=${{ inputs.RELEASE_VERSION }} --track=staging",
+            self.contents,
+        )
+        self.assertIn(
+            "shorebird patch ios --release-version=${{ inputs.RELEASE_VERSION }} --track=staging",
+            self.contents,
+        )
+        self.assertIn("--private-key-path=build/shorebird/patch_private_key.pem", self.contents)
+        self.assertNotIn("--track=stable", self.contents)
+
+    def test_shorebird_patch_workflows_gate_branch_and_release_commit(self) -> None:
+        self.assertIn('if [ "$CM_BRANCH" != "main" ]; then', self.contents)
+        self.assertIn("RELEASE_COMMIT:", self.contents)
+        self.assertIn("git merge-base --is-ancestor", self.contents)
+        self.assertIn("git diff --name-only", self.contents)
+        self.assertIn("*prepare_patch_source", self.contents)
+
+    def test_shorebird_cache_is_enabled_for_release_and_patch_workflows(self) -> None:
+        self.assertEqual(self.contents.count("- $HOME/.shorebird"), 4)
+
+    def test_shorebird_install_runs_before_ios_dependency_resolution(self) -> None:
+        ios_build = self.contents.index("ios-build:")
+        ios_patch = self.contents.index("ios-patch:")
+        android_build = self.contents.index("android-build:")
+        android_patch = self.contents.index("android-patch:")
+        macos_build = self.contents.index("macos-build:")
+
+        self.assertLess(
+            self.contents.index("- *shorebird_install", ios_build),
+            self.contents.index("- *prepare_ios_spm_packages", ios_build),
+        )
+        self.assertLess(
+            self.contents.index("- *shorebird_install", ios_patch),
+            self.contents.index("- *prepare_ios_spm_packages", ios_patch),
+        )
+        self.assertLess(
+            self.contents.index("- *shorebird_install", android_build),
+            self.contents.index("- *setup_local_properties", android_build),
+        )
+        self.assertLess(
+            self.contents.index("- *shorebird_install", android_patch),
+            self.contents.index("- *setup_local_properties", android_patch),
+        )
+        self.assertLess(android_patch, macos_build)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/test_codemagic_android_build_number.py
+++ b/.github/scripts/tests/test_codemagic_android_build_number.py
@@ -39,6 +39,11 @@ class CodemagicAndroidBuildNumberTest(unittest.TestCase):
         self.assertIn("--public-key-path=build/shorebird/patch_public_key.pem", self.contents)
         self.assertIn("already exists and is active", self.contents)
 
+    def test_shorebird_flutter_version_uses_current_supported_engine(self) -> None:
+        self.assertIn("flutter: 3.44.9", self.contents)
+        self.assertIn("FLUTTER_VERSION: 3.44.9", self.contents)
+        self.assertNotIn("3.44.0", self.contents)
+
     def test_shorebird_patch_commands_publish_to_staging_and_are_signed(self) -> None:
         self.assertIn(
             "shorebird patch android --release-version=${{ inputs.RELEASE_VERSION }} --track=staging",

--- a/.github/scripts/tests/test_codemagic_android_build_number.py
+++ b/.github/scripts/tests/test_codemagic_android_build_number.py
@@ -44,6 +44,9 @@ class CodemagicAndroidBuildNumberTest(unittest.TestCase):
         self.assertIn("FLUTTER_VERSION: 3.44.9", self.contents)
         self.assertNotIn("3.44.0", self.contents)
 
+    def test_shorebird_preserves_codemagic_flutter_root_for_android_plugins(self) -> None:
+        self.assertIn('echo CODEMAGIC_FLUTTER_ROOT="$FLUTTER_ROOT" >> $CM_ENV', self.contents)
+
     def test_shorebird_patch_commands_publish_to_staging_and_are_signed(self) -> None:
         self.assertIn(
             "shorebird patch android --release-version=${{ inputs.RELEASE_VERSION }} --track=staging",

--- a/.github/scripts/tests/test_codemagic_android_build_number.py
+++ b/.github/scripts/tests/test_codemagic_android_build_number.py
@@ -9,6 +9,7 @@ MISE_PATH = Path(__file__).resolve().parents[3] / "mobile" / "mise.toml"
 MOBILE_CI_PATH = (
     Path(__file__).resolve().parents[3] / ".github" / "workflows" / "mobile_ci.yaml"
 )
+WORKFLOWS_PATH = Path(__file__).resolve().parents[2] / "workflows"
 
 
 class CodemagicAndroidBuildNumberTest(unittest.TestCase):
@@ -87,6 +88,15 @@ class CodemagicAndroidBuildNumberTest(unittest.TestCase):
         self.assertEqual({expected}, mobile_ci_versions)
         self.assertEqual({expected}, codemagic_flutter_versions)
         self.assertEqual({expected}, shorebird_release_versions)
+        stale_workflows = []
+        for workflow in WORKFLOWS_PATH.glob("*.y*ml"):
+            versions = re.findall(
+                r"flutter(?:-|_)version:\s*[\"']?([^\"'\s]+)",
+                workflow.read_text(),
+            )
+            if any(version != expected for version in versions):
+                stale_workflows.append(workflow.name)
+        self.assertEqual([], stale_workflows)
 
     def test_shorebird_patch_commands_publish_to_staging_and_are_signed(self) -> None:
         self.assertIn(
@@ -115,10 +125,25 @@ class CodemagicAndroidBuildNumberTest(unittest.TestCase):
         self.assertIn("'pubspec.yaml'", self.contents)
         self.assertIn("'pubspec.lock'", self.contents)
         self.assertIn("'packages/**/android/**'", self.contents)
+        self.assertIn("'packages/**/assets/**'", self.contents)
         self.assertIn("'packages/**/darwin/**'", self.contents)
         self.assertIn("Cut a normal store release instead of a Shorebird patch.", self.contents)
         for command in self._shorebird_patch_commands():
             self.assertNotRegex(command, r"--allow-native-diffs|--allow-asset-diffs")
+
+    def test_store_artifacts_are_built_by_shorebird_release(self) -> None:
+        self.assertIn("*build_aab", self._workflow_block("android-build"))
+        self.assertIn("*build_ios", self._workflow_block("ios-build"))
+        self.assertRegex(self.contents, r"(?m)^\s+shorebird release android ")
+        self.assertRegex(self.contents, r"(?m)^\s+shorebird release ios ")
+        self.assertNotRegex(self.contents, r"(?m)^\s+flutter build appbundle ")
+        self.assertNotRegex(self.contents, r"(?m)^\s+flutter build ipa ")
+
+    def test_release_jobs_never_materialize_patch_private_key(self) -> None:
+        self.assertIn("*write_shorebird_public_key", self._workflow_block("ios-build"))
+        self.assertIn("*write_shorebird_public_key", self._workflow_block("android-build"))
+        self.assertNotIn("*write_shorebird_private_key", self._workflow_block("ios-build"))
+        self.assertNotIn("*write_shorebird_private_key", self._workflow_block("android-build"))
 
     def test_shorebird_cache_is_enabled_for_release_and_patch_workflows(self) -> None:
         for workflow in ("ios-build", "android-build", "ios-patch", "android-patch"):

--- a/.github/scripts/tests/test_codemagic_android_build_number.py
+++ b/.github/scripts/tests/test_codemagic_android_build_number.py
@@ -10,6 +10,9 @@ MOBILE_CI_PATH = (
     Path(__file__).resolve().parents[3] / ".github" / "workflows" / "mobile_ci.yaml"
 )
 WORKFLOWS_PATH = Path(__file__).resolve().parents[2] / "workflows"
+SHOREBIRD_DOC_PATH = (
+    Path(__file__).resolve().parents[3] / "mobile" / "docs" / "SHOREBIRD_CODE_PUSH.md"
+)
 
 
 class CodemagicAndroidBuildNumberTest(unittest.TestCase):
@@ -17,6 +20,7 @@ class CodemagicAndroidBuildNumberTest(unittest.TestCase):
         self.contents = CODEMAGIC_PATH.read_text()
         self.mobile_ci_contents = MOBILE_CI_PATH.read_text()
         self.mise_contents = MISE_PATH.read_text()
+        self.shorebird_doc_contents = SHOREBIRD_DOC_PATH.read_text()
 
     def test_codemagic_yaml_parses_with_aliases(self) -> None:
         result = subprocess.run(
@@ -60,12 +64,27 @@ class CodemagicAndroidBuildNumberTest(unittest.TestCase):
         self.assertIn("FF_DIVINE_SUPPORTERS", self.contents)
         self.assertIn("defines[name] = ENV.fetch(name, '')", self.contents)
 
+    def test_shorebird_required_defines_reject_empty_values(self) -> None:
+        self.assertIn(
+            "required_names.reject { |name| ENV.key?(name) && !ENV.fetch(name).empty? }",
+            self.contents,
+        )
+
+    def test_shorebird_install_reuses_only_the_expected_cached_version(self) -> None:
+        self.assertIn('EXPECTED_SHOREBIRD_VERSION="Shorebird 1.6.117"', self.contents)
+        self.assertIn('if [ -x "$SHOREBIRD_BIN" ]; then', self.contents)
+        self.assertIn("bash -s -- --force", self.contents)
+        self.assertRegex(
+            self.contents,
+            r"(?s)&shorebird_install.*?script: \|\n\s+set -euo pipefail\n",
+        )
+
     def test_shorebird_release_commands_are_signed_and_preflighted(self) -> None:
         self.assertIn("*preflight_shorebird_ios_release", self.contents)
         self.assertIn("*preflight_shorebird_android_release", self.contents)
         self.assertIn("shorebird releases list --platform=android --json", self.contents)
         self.assertIn("shorebird releases list --platform=ios --json", self.contents)
-        self.assertIn("shorebird_release_preflight.rb", self.contents)
+        self.assertEqual(2, self.contents.count("shorebird_release_preflight.rb"))
         self.assertNotIn("shorebird releases info", self.contents)
         self.assertIn("--build-name=$BUILD_NAME", self.contents)
         self.assertIn("--public-key-path=build/shorebird/patch_public_key.pem", self.contents)
@@ -90,11 +109,19 @@ class CodemagicAndroidBuildNumberTest(unittest.TestCase):
         self.assertEqual({expected}, shorebird_release_versions)
         stale_workflows = []
         for workflow in WORKFLOWS_PATH.glob("*.y*ml"):
+            workflow_contents = workflow.read_text()
+            uses_flutter = re.search(
+                r"flutter_package\.yml|subosito/flutter-action|"
+                r"\bflutter\s+(?:analyze|build|drive|pub|test)\b",
+                workflow_contents,
+            )
+            if uses_flutter is None:
+                continue
             versions = re.findall(
                 r"flutter(?:-|_)version:\s*[\"']?([^\"'\s]+)",
-                workflow.read_text(),
+                workflow_contents,
             )
-            if any(version != expected for version in versions):
+            if set(versions) != {expected}:
                 stale_workflows.append(workflow.name)
         self.assertEqual([], stale_workflows)
 
@@ -122,10 +149,12 @@ class CodemagicAndroidBuildNumberTest(unittest.TestCase):
         self.assertIn("'android/**'", self.contents)
         self.assertIn("'ios/**'", self.contents)
         self.assertIn("'assets/**'", self.contents)
+        self.assertIn("'shaders/**'", self.contents)
         self.assertIn("'pubspec.yaml'", self.contents)
         self.assertIn("'pubspec.lock'", self.contents)
         self.assertIn("'packages/**/android/**'", self.contents)
         self.assertIn("'packages/**/assets/**'", self.contents)
+        self.assertIn("'packages/**/shaders/**'", self.contents)
         self.assertIn("'packages/**/darwin/**'", self.contents)
         self.assertIn("Cut a normal store release instead of a Shorebird patch.", self.contents)
         for command in self._shorebird_patch_commands():
@@ -150,27 +179,46 @@ class CodemagicAndroidBuildNumberTest(unittest.TestCase):
             self.assertIn("- $HOME/.shorebird", self._workflow_block(workflow))
 
     def test_shorebird_install_runs_before_ios_dependency_resolution(self) -> None:
-        ios_build = self.contents.index("ios-build:")
-        ios_patch = self.contents.index("ios-patch:")
-        android_build = self.contents.index("android-build:")
-        android_patch = self.contents.index("android-patch:")
+        for workflow_name in ("ios-build", "ios-patch"):
+            workflow = self._workflow_block(workflow_name)
+            self.assertLess(
+                workflow.index("- *shorebird_install"),
+                workflow.index("- *prepare_ios_spm_packages"),
+            )
+        for workflow_name in ("android-build", "android-patch"):
+            workflow = self._workflow_block(workflow_name)
+            self.assertLess(
+                workflow.index("- *shorebird_install"),
+                workflow.index("- *setup_local_properties"),
+            )
 
-        self.assertLess(
-            self.contents.index("- *shorebird_install", ios_build),
-            self.contents.index("- *prepare_ios_spm_packages", ios_build),
+    def test_shorebird_release_preflight_runs_before_store_build(self) -> None:
+        for workflow_name, preflight, build in (
+            ("ios-build", "- *preflight_shorebird_ios_release", "- *build_ios"),
+            ("android-build", "- *preflight_shorebird_android_release", "- *build_aab"),
+        ):
+            workflow = self._workflow_block(workflow_name)
+            self.assertLess(workflow.index(preflight), workflow.index(build))
+
+    def test_shorebird_release_builds_fail_on_missing_preflight_output(self) -> None:
+        for anchor in ("build_aab", "build_ios"):
+            self.assertRegex(
+                self.contents,
+                rf"(?s)&{anchor}.*?script: \|\n\s+set -euo pipefail\n",
+            )
+
+    def test_runbook_uses_current_patch_promotion_and_reporting(self) -> None:
+        set_track = (
+            "shorebird patches set-track --release <version> --patch <n> "
+            "--track stable"
         )
+        self.assertIn(set_track, self.shorebird_doc_contents)
         self.assertLess(
-            self.contents.index("- *shorebird_install", ios_patch),
-            self.contents.index("- *prepare_ios_spm_packages", ios_patch),
+            self.shorebird_doc_contents.index(set_track),
+            self.shorebird_doc_contents.index("shorebird patches promote"),
         )
-        self.assertLess(
-            self.contents.index("- *shorebird_install", android_build),
-            self.contents.index("- *setup_local_properties", android_build),
-        )
-        self.assertLess(
-            self.contents.index("- *shorebird_install", android_patch),
-            self.contents.index("- *setup_local_properties", android_patch),
-        )
+        self.assertIn("`shorebird_code_push` is a runtime dependency", self.shorebird_doc_contents)
+        self.assertIn("Crashlytics", self.shorebird_doc_contents)
 
     def _workflow_block(self, workflow_name: str) -> str:
         start = self.contents.index(f"  {workflow_name}:")

--- a/.github/scripts/tests/test_codemagic_android_build_number.py
+++ b/.github/scripts/tests/test_codemagic_android_build_number.py
@@ -1,14 +1,41 @@
 import re
+import subprocess
 import unittest
 from pathlib import Path
 
 
 CODEMAGIC_PATH = Path(__file__).resolve().parents[3] / "codemagic.yaml"
+MISE_PATH = Path(__file__).resolve().parents[3] / "mobile" / "mise.toml"
+MOBILE_CI_PATH = (
+    Path(__file__).resolve().parents[3] / ".github" / "workflows" / "mobile_ci.yaml"
+)
 
 
 class CodemagicAndroidBuildNumberTest(unittest.TestCase):
     def setUp(self) -> None:
         self.contents = CODEMAGIC_PATH.read_text()
+        self.mobile_ci_contents = MOBILE_CI_PATH.read_text()
+        self.mise_contents = MISE_PATH.read_text()
+
+    def test_codemagic_yaml_parses_with_aliases(self) -> None:
+        result = subprocess.run(
+            [
+                "ruby",
+                "-e",
+                (
+                    "require 'yaml'; "
+                    "data = YAML.safe_load(File.read(ARGV[0]), aliases: true); "
+                    "abort 'missing workflows' unless data.fetch('workflows').is_a?(Hash); "
+                    "abort 'missing definitions' unless data.fetch('definitions').is_a?(Hash)"
+                ),
+                str(CODEMAGIC_PATH),
+            ],
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_android_aab_build_uses_google_play_floor(self) -> None:
         self.assertIn(
@@ -35,14 +62,31 @@ class CodemagicAndroidBuildNumberTest(unittest.TestCase):
     def test_shorebird_release_commands_are_signed_and_preflighted(self) -> None:
         self.assertIn("*preflight_shorebird_ios_release", self.contents)
         self.assertIn("*preflight_shorebird_android_release", self.contents)
+        self.assertIn("shorebird releases list --platform=android --json", self.contents)
+        self.assertIn("shorebird releases list --platform=ios --json", self.contents)
+        self.assertIn("shorebird_release_preflight.rb", self.contents)
+        self.assertNotIn("shorebird releases info", self.contents)
         self.assertIn("--build-name=$BUILD_NAME", self.contents)
         self.assertIn("--public-key-path=build/shorebird/patch_public_key.pem", self.contents)
-        self.assertIn("already exists and is active", self.contents)
 
-    def test_shorebird_flutter_version_uses_current_supported_engine(self) -> None:
-        self.assertIn("flutter: 3.44.9", self.contents)
-        self.assertIn("FLUTTER_VERSION: 3.44.9", self.contents)
-        self.assertNotIn("3.44.0", self.contents)
+    def test_flutter_pins_match_current_shorebird_engine(self) -> None:
+        mise_version = re.search(r'^flutter = "([^"]+)"$', self.mise_contents, re.MULTILINE)
+        self.assertIsNotNone(mise_version)
+        expected = mise_version.group(1)
+
+        mobile_ci_versions = set(
+            re.findall(r'flutter-version: "([^"]+)"', self.mobile_ci_contents)
+        )
+        codemagic_flutter_versions = set(
+            re.findall(r"^\s+flutter: ([0-9]+\.[0-9]+\.[0-9]+)$", self.contents, re.MULTILINE)
+        )
+        shorebird_release_versions = set(
+            re.findall(r"^\s+FLUTTER_VERSION: ([0-9]+\.[0-9]+\.[0-9]+)$", self.contents, re.MULTILINE)
+        )
+
+        self.assertEqual({expected}, mobile_ci_versions)
+        self.assertEqual({expected}, codemagic_flutter_versions)
+        self.assertEqual({expected}, shorebird_release_versions)
 
     def test_shorebird_patch_commands_publish_to_staging_and_are_signed(self) -> None:
         self.assertIn(
@@ -73,19 +117,18 @@ class CodemagicAndroidBuildNumberTest(unittest.TestCase):
         self.assertIn("'packages/**/android/**'", self.contents)
         self.assertIn("'packages/**/darwin/**'", self.contents)
         self.assertIn("Cut a normal store release instead of a Shorebird patch.", self.contents)
-        self.assertIsNone(
-            re.search(r"shorebird patch .*(--allow-native-diffs|--allow-asset-diffs)", self.contents)
-        )
+        for command in self._shorebird_patch_commands():
+            self.assertNotRegex(command, r"--allow-native-diffs|--allow-asset-diffs")
 
     def test_shorebird_cache_is_enabled_for_release_and_patch_workflows(self) -> None:
-        self.assertEqual(self.contents.count("- $HOME/.shorebird"), 4)
+        for workflow in ("ios-build", "android-build", "ios-patch", "android-patch"):
+            self.assertIn("- $HOME/.shorebird", self._workflow_block(workflow))
 
     def test_shorebird_install_runs_before_ios_dependency_resolution(self) -> None:
         ios_build = self.contents.index("ios-build:")
         ios_patch = self.contents.index("ios-patch:")
         android_build = self.contents.index("android-build:")
         android_patch = self.contents.index("android-patch:")
-        macos_build = self.contents.index("macos-build:")
 
         self.assertLess(
             self.contents.index("- *shorebird_install", ios_build),
@@ -103,7 +146,27 @@ class CodemagicAndroidBuildNumberTest(unittest.TestCase):
             self.contents.index("- *shorebird_install", android_patch),
             self.contents.index("- *setup_local_properties", android_patch),
         )
-        self.assertLess(android_patch, macos_build)
+
+    def _workflow_block(self, workflow_name: str) -> str:
+        start = self.contents.index(f"  {workflow_name}:")
+        next_workflow = re.search(r"^  [a-z0-9-]+:", self.contents[start + 1 :], re.MULTILINE)
+        if next_workflow is None:
+            return self.contents[start:]
+        return self.contents[start : start + 1 + next_workflow.start()]
+
+    def _shorebird_patch_commands(self) -> list[str]:
+        commands = []
+        lines = self.contents.splitlines()
+        for index, line in enumerate(lines):
+            if "shorebird patch " not in line:
+                continue
+            command_lines = [line]
+            cursor = index
+            while command_lines[-1].rstrip().endswith("\\"):
+                cursor += 1
+                command_lines.append(lines[cursor])
+            commands.append("\n".join(command_lines))
+        return commands
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/test_codemagic_android_build_number.py
+++ b/.github/scripts/tests/test_codemagic_android_build_number.py
@@ -89,6 +89,19 @@ class CodemagicAndroidBuildNumberTest(unittest.TestCase):
         self.assertIn("--build-name=$BUILD_NAME", self.contents)
         self.assertIn("--public-key-path=build/shorebird/patch_public_key.pem", self.contents)
 
+    def test_ios_release_rejects_closed_app_store_version_before_shorebird(self) -> None:
+        workflow = self._workflow_block("ios-build")
+        self.assertIn(
+            "app-store-connect get-latest-app-store-build-number",
+            self.contents,
+        )
+        self.assertIn("--include-version --json", self.contents)
+        self.assertEqual(1, self.contents.count("ios_store_version_preflight.rb"))
+        self.assertLess(
+            workflow.index("- *preflight_shorebird_ios_release"),
+            workflow.index("- *build_ios"),
+        )
+
     def test_flutter_pins_match_current_shorebird_engine(self) -> None:
         mise_version = re.search(r'^flutter = "([^"]+)"$', self.mise_contents, re.MULTILINE)
         self.assertIsNotNone(mise_version)

--- a/.github/scripts/tests/test_codemagic_android_build_number.py
+++ b/.github/scripts/tests/test_codemagic_android_build_number.py
@@ -44,9 +44,6 @@ class CodemagicAndroidBuildNumberTest(unittest.TestCase):
         self.assertIn("FLUTTER_VERSION: 3.44.9", self.contents)
         self.assertNotIn("3.44.0", self.contents)
 
-    def test_shorebird_preserves_codemagic_flutter_root_for_android_plugins(self) -> None:
-        self.assertIn('echo CODEMAGIC_FLUTTER_ROOT="$FLUTTER_ROOT" >> $CM_ENV', self.contents)
-
     def test_shorebird_patch_commands_publish_to_staging_and_are_signed(self) -> None:
         self.assertIn(
             "shorebird patch android --release-version=${{ inputs.RELEASE_VERSION }} --track=staging",

--- a/.github/scripts/tests/test_codemagic_android_build_number.py
+++ b/.github/scripts/tests/test_codemagic_android_build_number.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 from pathlib import Path
 
@@ -56,6 +57,20 @@ class CodemagicAndroidBuildNumberTest(unittest.TestCase):
         self.assertIn("git merge-base --is-ancestor", self.contents)
         self.assertIn("git diff --name-only", self.contents)
         self.assertIn("*prepare_patch_source", self.contents)
+
+    def test_shorebird_patch_workflows_block_native_asset_and_dependency_changes(self) -> None:
+        self.assertIn("BLOCKED_PATCH_PATHS=$(git diff --name-only", self.contents)
+        self.assertIn("'android/**'", self.contents)
+        self.assertIn("'ios/**'", self.contents)
+        self.assertIn("'assets/**'", self.contents)
+        self.assertIn("'pubspec.yaml'", self.contents)
+        self.assertIn("'pubspec.lock'", self.contents)
+        self.assertIn("'packages/**/android/**'", self.contents)
+        self.assertIn("'packages/**/darwin/**'", self.contents)
+        self.assertIn("Cut a normal store release instead of a Shorebird patch.", self.contents)
+        self.assertIsNone(
+            re.search(r"shorebird patch .*(--allow-native-diffs|--allow-asset-diffs)", self.contents)
+        )
 
     def test_shorebird_cache_is_enabled_for_release_and_patch_workflows(self) -> None:
         self.assertEqual(self.contents.count("- $HOME/.shorebird"), 4)

--- a/.github/scripts/tests/test_ios_store_version_preflight.py
+++ b/.github/scripts/tests/test_ios_store_version_preflight.py
@@ -1,0 +1,89 @@
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "mobile"
+    / "scripts"
+    / "ios_store_version_preflight.rb"
+)
+
+
+class IosStoreVersionPreflightTest(unittest.TestCase):
+    def run_preflight(
+        self,
+        payload: dict | list | str,
+        candidate_version: str = "1.0.21",
+    ) -> subprocess.CompletedProcess[str]:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as file:
+            json.dump(payload, file)
+            file.flush()
+            return subprocess.run(
+                ["ruby", str(SCRIPT_PATH), file.name, candidate_version],
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+
+    def test_allows_version_above_latest_approved_version(self) -> None:
+        result = self.run_preflight(
+            {"buildId": "build-id", "version": "1.0.20", "buildNumber": "848"}
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("newer than approved App Store version 1.0.20", result.stdout)
+
+    def test_blocks_same_version_as_latest_approved_version(self) -> None:
+        result = self.run_preflight(
+            {"buildId": "build-id", "version": "1.0.20", "buildNumber": "848"},
+            candidate_version="1.0.20",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must be newer than approved App Store version 1.0.20", result.stderr)
+
+    def test_blocks_version_below_latest_approved_version(self) -> None:
+        result = self.run_preflight(
+            {"buildId": "build-id", "version": "1.2.0", "buildNumber": "848"},
+            candidate_version="1.1.99",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must be newer than approved App Store version 1.2.0", result.stderr)
+
+    def test_compares_numeric_components_instead_of_lexically(self) -> None:
+        result = self.run_preflight(
+            {"buildId": "build-id", "version": "1.9.9", "buildNumber": "848"},
+            candidate_version="1.10.0",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_fails_closed_on_missing_version(self) -> None:
+        result = self.run_preflight({"buildId": "build-id", "buildNumber": "848"})
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("missing version", result.stderr)
+
+    def test_fails_closed_on_invalid_json_shape(self) -> None:
+        result = self.run_preflight([])
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("expected a JSON object", result.stderr)
+
+    def test_fails_closed_on_invalid_version(self) -> None:
+        result = self.run_preflight(
+            {"buildId": "build-id", "version": "1.0.20", "buildNumber": "848"},
+            candidate_version="next",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid candidate version", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_shorebird_release_preflight.py
+++ b/.github/scripts/tests/test_shorebird_release_preflight.py
@@ -52,7 +52,7 @@ class ShorebirdReleasePreflightTest(unittest.TestCase):
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("No existing active Shorebird ios release", result.stdout)
+        self.assertIn("No existing Shorebird ios release", result.stdout)
 
     def test_blocks_active_platform_release(self) -> None:
         result = self.run_preflight(
@@ -70,7 +70,25 @@ class ShorebirdReleasePreflightTest(unittest.TestCase):
         )
 
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("already exists and is active", result.stderr)
+        self.assertIn("already exists with status active", result.stderr)
+
+    def test_blocks_non_active_platform_release(self) -> None:
+        result = self.run_preflight(
+            {
+                "status": "success",
+                "data": {
+                    "releases": [
+                        {
+                            "version": "1.0.20+841",
+                            "platform_statuses": {"ios": "failed"},
+                        }
+                    ]
+                },
+            }
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("already exists with status failed", result.stderr)
 
     def test_allows_same_version_for_different_platform(self) -> None:
         result = self.run_preflight(
@@ -110,6 +128,24 @@ class ShorebirdReleasePreflightTest(unittest.TestCase):
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("missing releases array", result.stderr)
+
+    def test_fails_closed_on_unreadable_platform_statuses(self) -> None:
+        result = self.run_preflight(
+            {
+                "status": "success",
+                "data": {
+                    "releases": [
+                        {
+                            "version": "1.0.20+841",
+                            "platform_statuses": ["ios", "active"],
+                        }
+                    ]
+                },
+            }
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unreadable platform_statuses", result.stderr)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/test_shorebird_release_preflight.py
+++ b/.github/scripts/tests/test_shorebird_release_preflight.py
@@ -1,0 +1,116 @@
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "mobile"
+    / "scripts"
+    / "shorebird_release_preflight.rb"
+)
+
+
+class ShorebirdReleasePreflightTest(unittest.TestCase):
+    def run_preflight(
+        self,
+        payload: dict,
+        platform: str = "ios",
+        release_version: str = "1.0.20+841",
+    ) -> subprocess.CompletedProcess[str]:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as file:
+            json.dump(payload, file)
+            file.flush()
+            return subprocess.run(
+                [
+                    "ruby",
+                    str(SCRIPT_PATH),
+                    file.name,
+                    platform,
+                    release_version,
+                ],
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+
+    def test_allows_missing_release(self) -> None:
+        result = self.run_preflight(
+            {
+                "status": "success",
+                "data": {
+                    "releases": [
+                        {
+                            "version": "1.0.20+840",
+                            "platform_statuses": {"ios": "active"},
+                        }
+                    ]
+                },
+            }
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("No existing active Shorebird ios release", result.stdout)
+
+    def test_blocks_active_platform_release(self) -> None:
+        result = self.run_preflight(
+            {
+                "status": "success",
+                "data": {
+                    "releases": [
+                        {
+                            "version": "1.0.20+841",
+                            "platform_statuses": {"ios": "active"},
+                        }
+                    ]
+                },
+            }
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("already exists and is active", result.stderr)
+
+    def test_allows_same_version_for_different_platform(self) -> None:
+        result = self.run_preflight(
+            {
+                "status": "success",
+                "data": {
+                    "releases": [
+                        {
+                            "version": "1.0.20+841",
+                            "platform_statuses": {"android": "active"},
+                        }
+                    ]
+                },
+            },
+            platform="ios",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_fails_closed_on_error_envelope(self) -> None:
+        result = self.run_preflight(
+            {
+                "status": "error",
+                "error": {
+                    "code": "fetch_failed",
+                    "message": "Insufficient permissions.",
+                },
+            }
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("fetch_failed", result.stderr)
+        self.assertIn("Insufficient permissions", result.stderr)
+
+    def test_fails_closed_on_unexpected_shape(self) -> None:
+        result = self.run_preflight({"status": "success", "data": {}})
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("missing releases array", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/analytics.yaml
+++ b/.github/workflows/analytics.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/analytics"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 73

--- a/.github/workflows/app_update_repository.yaml
+++ b/.github/workflows/app_update_repository.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/app_update_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 89

--- a/.github/workflows/app_version_client.yaml
+++ b/.github/workflows/app_version_client.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/app_version_client"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 76

--- a/.github/workflows/background_uploader.yaml
+++ b/.github/workflows/background_uploader.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/background_uploader"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 69

--- a/.github/workflows/badge_repository.yaml
+++ b/.github/workflows/badge_repository.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/badge_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/blossom_upload_service.yaml
+++ b/.github/workflows/blossom_upload_service.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/blossom_upload_service"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 100

--- a/.github/workflows/blurhash_service.yaml
+++ b/.github/workflows/blurhash_service.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/blurhash_service"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/cache_sync.yml
+++ b/.github/workflows/cache_sync.yml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/cache_sync"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       coverage_excludes: "**/*.g.dart"

--- a/.github/workflows/caption_generator.yaml
+++ b/.github/workflows/caption_generator.yaml
@@ -24,7 +24,7 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/caption_generator"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
 
   # The Dart workflow above never compiles the native Kotlin, so a compile
   # error would pass green until the package is wired into an app build.
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.44.0"
+          flutter-version: "3.44.9"
           channel: "stable"
           cache: true
       - name: Setup Gradle

--- a/.github/workflows/categories_repository.yaml
+++ b/.github/workflows/categories_repository.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/categories_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/collaborator_repository.yaml
+++ b/.github/workflows/collaborator_repository.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/collaborator_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 96

--- a/.github/workflows/comments_repository.yaml
+++ b/.github/workflows/comments_repository.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/comments_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 80

--- a/.github/workflows/content_blocklist_repository.yaml
+++ b/.github/workflows/content_blocklist_repository.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/content_blocklist_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/content_policy.yaml
+++ b/.github/workflows/content_policy.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/content_policy"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/count_formatter.yaml
+++ b/.github/workflows/count_formatter.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/count_formatter"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/creator_sync.yaml
+++ b/.github/workflows/creator_sync.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/creator_sync"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/curated_list_repository.yaml
+++ b/.github/workflows/curated_list_repository.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/curated_list_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/curation_repository.yaml
+++ b/.github/workflows/curation_repository.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/curation_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/db_client.yaml
+++ b/.github/workflows/db_client.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/db_client"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 40

--- a/.github/workflows/divine_blurhash.yaml
+++ b/.github/workflows/divine_blurhash.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/divine_blurhash"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/divine_camera.yaml
+++ b/.github/workflows/divine_camera.yaml
@@ -24,7 +24,7 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/divine_camera"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
 
   android-unit-tests:
     name: Android Unit Tests
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.44.0"
+          flutter-version: "3.44.9"
           channel: "stable"
           cache: true
       - name: Setup Gradle

--- a/.github/workflows/divine_quick_actions.yaml
+++ b/.github/workflows/divine_quick_actions.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/divine_quick_actions"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 76

--- a/.github/workflows/divine_status_client.yaml
+++ b/.github/workflows/divine_status_client.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/divine_status_client"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/divine_ui.yml
+++ b/.github/workflows/divine_ui.yml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/divine_ui"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/divine_video_player.yaml
+++ b/.github/workflows/divine_video_player.yaml
@@ -24,7 +24,7 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/divine_video_player"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
 
   android-unit-tests:
     name: Android Unit Tests
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.44.0"
+          flutter-version: "3.44.9"
           channel: "stable"
           cache: true
       - name: Setup Gradle

--- a/.github/workflows/dm_repository.yaml
+++ b/.github/workflows/dm_repository.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/dm_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 93

--- a/.github/workflows/feed_repository.yaml
+++ b/.github/workflows/feed_repository.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/feed_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 64

--- a/.github/workflows/feed_tuning_repository.yaml
+++ b/.github/workflows/feed_tuning_repository.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/feed_tuning_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/follow_repository.yaml
+++ b/.github/workflows/follow_repository.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/follow_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/funnelcake_api_client.yaml
+++ b/.github/workflows/funnelcake_api_client.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/funnelcake_api_client"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 44

--- a/.github/workflows/hashtag_repository.yaml
+++ b/.github/workflows/hashtag_repository.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/hashtag_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 30

--- a/.github/workflows/iap_repository.yaml
+++ b/.github/workflows/iap_repository.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/iap_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 90

--- a/.github/workflows/image_metadata_stripper.yaml
+++ b/.github/workflows/image_metadata_stripper.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/image_metadata_stripper"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/infinite_video_feed.yaml
+++ b/.github/workflows/infinite_video_feed.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/infinite_video_feed"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/invite_api_client.yaml
+++ b/.github/workflows/invite_api_client.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/invite_api_client"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 89

--- a/.github/workflows/keycast_flutter.yaml
+++ b/.github/workflows/keycast_flutter.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/keycast_flutter"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 44

--- a/.github/workflows/likes_repository.yaml
+++ b/.github/workflows/likes_repository.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/likes_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 62

--- a/.github/workflows/media_cache.yml
+++ b/.github/workflows/media_cache.yml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/media_cache"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 98

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -83,6 +83,13 @@ jobs:
         # undeclared group fails every workflow in the file and no in-script
         # guard can catch it (#7203).
         run: bash mobile/scripts/check_codemagic_groups.sh
+  ci-config-tests:
+    name: CI Configuration Tests
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run CI configuration unit tests
+        run: python3 -m unittest discover -s .github/scripts/tests
 
   generated-files:
     name: Generated Files
@@ -542,6 +549,7 @@ jobs:
     needs:
       - changes
       - codemagic-groups
+      - ci-config-tests
       - generated-files
       - format
       - analyze
@@ -554,6 +562,7 @@ jobs:
         env:
           CODEMAGIC_GROUPS_RESULT: ${{ needs.codemagic-groups.result }}
           GENERATED_FILES_RESULT: ${{ needs.generated-files.result }}
+          CI_CONFIG_TESTS_RESULT: ${{ needs.ci-config-tests.result }}
           FORMAT_RESULT: ${{ needs.format.result }}
           ANALYZE_RESULT: ${{ needs.analyze.result }}
           TESTS_RESULT: ${{ needs.tests.result }}
@@ -565,6 +574,7 @@ jobs:
           echo "app-ci-required: ${APP_CI_REQUIRED}"
           echo "codemagic-groups: ${CODEMAGIC_GROUPS_RESULT}"
           echo "generated-files: ${GENERATED_FILES_RESULT}"
+          echo "ci-config-tests: ${CI_CONFIG_TESTS_RESULT}"
           echo "format: ${FORMAT_RESULT}"
           echo "analyze: ${ANALYZE_RESULT}"
           echo "tests: ${TESTS_RESULT}"
@@ -593,6 +603,7 @@ jobs:
           fi
 
           results=(
+            "${CI_CONFIG_TESTS_RESULT}"
             "${GENERATED_FILES_RESULT}"
             "${FORMAT_RESULT}"
             "${ANALYZE_RESULT}"

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -87,7 +87,7 @@ jobs:
     name: CI Configuration Tests
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Run CI configuration unit tests
         run: python3 -m unittest discover -s .github/scripts/tests
 
@@ -109,7 +109,7 @@ jobs:
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.44.0"
+          flutter-version: "3.44.9"
           channel: "stable"
           cache: true
       - name: 📦 Install dependencies
@@ -322,7 +322,7 @@ jobs:
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.44.0"
+          flutter-version: "3.44.9"
           channel: "stable"
           cache: true
       - name: 📦 Install dependencies
@@ -346,7 +346,7 @@ jobs:
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.44.0"
+          flutter-version: "3.44.9"
           channel: "stable"
           cache: true
       - name: 📦 Install dependencies
@@ -372,7 +372,7 @@ jobs:
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.44.0"
+          flutter-version: "3.44.9"
           channel: "stable"
           cache: true
       - name: 📦 Install dependencies

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -498,7 +498,7 @@ jobs:
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.44.0"
+          flutter-version: "3.44.9"
           channel: "stable"
           cache: true
       - name: 📦 Install dependencies

--- a/.github/workflows/mobile_pr_preview_build.yml
+++ b/.github/workflows/mobile_pr_preview_build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.44.0"
+          flutter-version: "3.44.9"
           channel: stable
           cache: true
 

--- a/.github/workflows/mobile_service_integration_tests.yaml
+++ b/.github/workflows/mobile_service_integration_tests.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.44.0"
+          flutter-version: "3.44.9"
           channel: "stable"
           cache: true
       # `flutter test integration_test/...` runs in integration-test mode, which

--- a/.github/workflows/mobile_web_production_deploy.yml
+++ b/.github/workflows/mobile_web_production_deploy.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.44.0"
+          flutter-version: "3.44.9"
           channel: stable
           cache: true
 

--- a/.github/workflows/models_ci.yaml
+++ b/.github/workflows/models_ci.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/models"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 25

--- a/.github/workflows/nostr_app_bridge_repository.yaml
+++ b/.github/workflows/nostr_app_bridge_repository.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/nostr_app_bridge_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 78

--- a/.github/workflows/nostr_client.yaml
+++ b/.github/workflows/nostr_client.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/nostr_client"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 82

--- a/.github/workflows/nostr_key_manager.yml
+++ b/.github/workflows/nostr_key_manager.yml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/nostr_key_manager"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 52

--- a/.github/workflows/nostr_sdk.yaml
+++ b/.github/workflows/nostr_sdk.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/nostr_sdk"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 20

--- a/.github/workflows/notification_repository.yaml
+++ b/.github/workflows/notification_repository.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/notification_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 94

--- a/.github/workflows/people_lists_repository.yaml
+++ b/.github/workflows/people_lists_repository.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/people_lists_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 95

--- a/.github/workflows/permissions_service.yaml
+++ b/.github/workflows/permissions_service.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/permissions_service"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 22

--- a/.github/workflows/profile_repository.yaml
+++ b/.github/workflows/profile_repository.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/profile_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/reposts_repository.yaml
+++ b/.github/workflows/reposts_repository.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/reposts_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/sound_service.yaml
+++ b/.github/workflows/sound_service.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/sound_service"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/sounds_repository.yaml
+++ b/.github/workflows/sounds_repository.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/sounds_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/text_sanitizer.yaml
+++ b/.github/workflows/text_sanitizer.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/text_sanitizer"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/time_formatter.yaml
+++ b/.github/workflows/time_formatter.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/time_formatter"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 100

--- a/.github/workflows/tv_static_effect.yaml
+++ b/.github/workflows/tv_static_effect.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/tv_static_effect"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/.github/workflows/unified_logger.yaml
+++ b/.github/workflows/unified_logger.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/unified_logger"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 40

--- a/.github/workflows/verifier_client.yaml
+++ b/.github/workflows/verifier_client.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/verifier_client"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 76

--- a/.github/workflows/video_event_cache.yaml
+++ b/.github/workflows/video_event_cache.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/video_event_cache"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"
       min_coverage: 0

--- a/.github/workflows/videos_repository.yaml
+++ b/.github/workflows/videos_repository.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/videos_repository"
-      flutter_version: "3.44.0"
+      flutter_version: "3.44.9"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 - Most implementation work is in `mobile/`. The main Flutter entry points are `mobile/lib/main.dart` and `mobile/lib/router/app_router.dart`.
 - Shared reusable logic belongs in the owning package under `mobile/packages/`, not as app-layer duplication.
-- Start with current code and focused docs, especially `CONTRIBUTING.md`, `docs/STATE_MANAGEMENT.md`, `docs/BLOC_UI_MIGRATION_PRD.md`, `docs/NOSTR_EVENT_TYPES.md`, `mobile/docs/NOSTR_VIDEO_EVENTS.md`, `mobile/docs/DESIGN_SYSTEM_COMPONENTS.md`, and `mobile/docs/GOLDEN_TESTING_GUIDE.md`.
+- Start with current code and focused docs, especially `CONTRIBUTING.md`, `docs/STATE_MANAGEMENT.md`, `docs/BLOC_UI_MIGRATION_PRD.md`, `docs/NOSTR_EVENT_TYPES.md`, `mobile/docs/NOSTR_VIDEO_EVENTS.md`, `mobile/docs/DESIGN_SYSTEM_COMPONENTS.md`, `mobile/docs/GOLDEN_TESTING_GUIDE.md`, and `mobile/docs/SHOREBIRD_CODE_PUSH.md`.
 - Older docs can drift. If documentation conflicts, trust the current implementation, targeted tests, and the newest focused doc over historical notes.
 
 ## Divine Context And Brain
@@ -157,6 +157,21 @@ If a Divine Brain search or ask tool is available, you may use it for company me
 - Web resolves local endpoints to `localhost`, but nothing wires a LOCAL web run: `AppEnvironment.local` is absent from the environment picker in `mobile/lib/screens/developer_options_screen.dart`, and neither web build selects it — `mobile_web_production_deploy.yml` pins `DEFAULT_ENV=PRODUCTION`, and the PR-preview build pins no `DEFAULT_ENV` at all, so it inherits the compiled `PRODUCTION` default. CORS is not the obstacle — funnelcake, the relay, and Blossom all send `Access-Control-Allow-Origin: *`, Keycast allows any `http://localhost:<port>` origin before consulting `ALLOWED_ORIGINS`, and a WebSocket handshake is not subject to CORS at all.
 - User-installed CAs are not trusted in any build. If you need to proxy-debug with Charles or mitmproxy, add a single `<certificates src="user" />` line to `<trust-anchors>` in `mobile/android/app/src/main/res/xml/network_security_config.xml` in your working copy and don't commit it; CI's transport-security guard will block any commit that re-enables user-CA trust. (For iOS and macOS, plist-edit `NSAppTransportSecurity` similarly and revert before commit.)
 - If you add a new exception to any native config, update `mobile/scripts/check_native_transport_security.sh` so the guard recognises the allowance. It covers four files: the Android XML plus the `Runner` plists for iOS and macOS and the iOS notification-service extension.
+
+## Shorebird Code Push
+
+- The Play AAB and App Store IPA are built by `shorebird release`, not
+  `flutter build`. That command links the Shorebird updater into the engine —
+  a store artifact built with plain `flutter build` is **permanently
+  unpatchable**. Never swap those steps back in `codemagic.yaml`.
+- Never add `--allow-native-diffs` or `--allow-asset-diffs`. Shorebird's
+  refusal to patch across native or asset changes is a correctness guard; a fix
+  needing native changes needs a store release.
+- Patches are manual-only and gated behind `CONFIRM_PATCH`. A patch reaches
+  production users within about one app launch, with no store review and no
+  rollback. Treat it as a production deploy.
+- Full detail, including the patch runbook and known gotchas:
+  `mobile/docs/SHOREBIRD_CODE_PUSH.md`.
 
 ## Zapstore Publishing Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,9 +167,10 @@ If a Divine Brain search or ask tool is available, you may use it for company me
 - Never add `--allow-native-diffs` or `--allow-asset-diffs`. Shorebird's
   refusal to patch across native or asset changes is a correctness guard; a fix
   needing native changes needs a store release.
-- Patches are manual-only and gated behind `CONFIRM_PATCH`. A patch reaches
-  production users within about one app launch, with no store review and no
-  rollback. Treat it as a production deploy.
+- Patches are manual-only, gated behind `CONFIRM_PATCH`, and published to the
+  Shorebird `staging` track first. Validate the staged patch, then promote it
+  to `stable`. Rollback exists, but it is emergency recovery rather than a
+  substitute for staging and review.
 - Full detail, including the patch runbook and known gotchas:
   `mobile/docs/SHOREBIRD_CODE_PUSH.md`.
 

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -164,6 +164,12 @@ definitions:
     - &shorebird_install
       name: Install Shorebird
       script: |
+        # Shorebird swaps FLUTTER_ROOT to its managed engine checkout during
+        # release builds. Keep Codemagic's Flutter SDK path available for local
+        # Android plugins that need compile-only Flutter embedding classes.
+        if [ -n "${FLUTTER_ROOT:-}" ]; then
+          echo CODEMAGIC_FLUTTER_ROOT="$FLUTTER_ROOT" >> $CM_ENV
+        fi
         curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | bash
         echo PATH="$HOME/.shorebird/bin:$PATH" >> $CM_ENV
     - &write_shorebird_dart_defines

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -164,6 +164,36 @@ definitions:
       script: |
         curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | bash
         echo PATH="$HOME/.shorebird/bin:$PATH" >> $CM_ENV
+    - &write_shorebird_dart_defines
+      name: Write Shorebird dart-defines
+      script: |
+        mkdir -p build/shorebird
+        DEFAULT_ENV="${{ inputs.DEFAULT_ENV }}" ruby <<'RUBY'
+        require 'json'
+
+        names = %w[
+          ZENDESK_APP_ID
+          ZENDESK_CLIENT_ID
+          ZENDESK_URL
+          PROOFMODE_SIGNING_SERVER_ENDPOINT
+          PROOFMODE_SIGNING_SERVER_TOKEN
+          SUPPORTERS_API_BASE_URL
+          FF_DIVINE_SUPPORTERS
+        ]
+
+        missing = names.reject { |name| ENV.key?(name) }
+        unless missing.empty?
+          abort("missing Shorebird dart-define environment variables: #{missing.join(', ')}")
+        end
+
+        defines = names.to_h { |name| [name, ENV.fetch(name)] }
+        defines['DEFAULT_ENV'] = ENV.fetch('DEFAULT_ENV')
+
+        File.write(
+          'build/shorebird/dart_defines.json',
+          JSON.pretty_generate(defines) + "\n",
+        )
+        RUBY
     - &build_apk
       name: Build Android APK
       script: |
@@ -200,14 +230,7 @@ definitions:
         # release carries the updater. A plain `flutter build` here would ship
         # a permanently unpatchable version to Play.
         shorebird release android --flutter-version=$FLUTTER_VERSION --build-number=$BUILD_NUMBER \
-          --dart-define=ZENDESK_APP_ID=$ZENDESK_APP_ID \
-          --dart-define=ZENDESK_CLIENT_ID=$ZENDESK_CLIENT_ID \
-          --dart-define=ZENDESK_URL=$ZENDESK_URL \
-          --dart-define=DEFAULT_ENV=${{ inputs.DEFAULT_ENV }} \
-          --dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT=$PROOFMODE_SIGNING_SERVER_ENDPOINT \
-          --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN \
-          --dart-define=SUPPORTERS_API_BASE_URL=$SUPPORTERS_API_BASE_URL \
-          --dart-define=FF_DIVINE_SUPPORTERS=$FF_DIVINE_SUPPORTERS
+          --dart-define-from-file=build/shorebird/dart_defines.json
     - &confirm_patch
       name: Confirm patch to production
       script: |
@@ -223,6 +246,11 @@ definitions:
           echo "Re-run with CONFIRM_PATCH=YES if that is what you intend."
           exit 1
         fi
+        if ! printf '%s\n' "${{ inputs.RELEASE_VERSION }}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+\+[0-9]+$'; then
+          echo "Refusing to patch: RELEASE_VERSION must look like 1.0.9+247."
+          echo "Got: '${{ inputs.RELEASE_VERSION }}'"
+          exit 1
+        fi
         echo "Patching release ${{ inputs.RELEASE_VERSION }} with DEFAULT_ENV=${{ inputs.DEFAULT_ENV }}."
     - &patch_android
       name: Patch Android (Shorebird)
@@ -234,14 +262,7 @@ definitions:
         # detects native or asset diffs; do NOT add --allow-native-diffs or
         # --allow-asset-diffs to force past that — cut a new release instead.
         shorebird patch android --release-version=${{ inputs.RELEASE_VERSION }} \
-          --dart-define=ZENDESK_APP_ID=$ZENDESK_APP_ID \
-          --dart-define=ZENDESK_CLIENT_ID=$ZENDESK_CLIENT_ID \
-          --dart-define=ZENDESK_URL=$ZENDESK_URL \
-          --dart-define=DEFAULT_ENV=${{ inputs.DEFAULT_ENV }} \
-          --dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT=$PROOFMODE_SIGNING_SERVER_ENDPOINT \
-          --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN \
-          --dart-define=SUPPORTERS_API_BASE_URL=$SUPPORTERS_API_BASE_URL \
-          --dart-define=FF_DIVINE_SUPPORTERS=$FF_DIVINE_SUPPORTERS
+          --dart-define-from-file=build/shorebird/dart_defines.json
     - &build_macos
       name: Build macOS app
       script: |
@@ -345,14 +366,7 @@ definitions:
         # carries the updater. A plain `flutter build` here would ship a
         # permanently unpatchable version to TestFlight and the App Store.
         shorebird release ios --flutter-version=$FLUTTER_VERSION --build-number=$BUILD_NUMBER \
-          --dart-define=ZENDESK_APP_ID=$ZENDESK_APP_ID \
-          --dart-define=ZENDESK_CLIENT_ID=$ZENDESK_CLIENT_ID \
-          --dart-define=ZENDESK_URL=$ZENDESK_URL \
-          --dart-define=DEFAULT_ENV=${{ inputs.DEFAULT_ENV }} \
-          --dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT=$PROOFMODE_SIGNING_SERVER_ENDPOINT \
-          --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN \
-          --dart-define=SUPPORTERS_API_BASE_URL=$SUPPORTERS_API_BASE_URL \
-          --dart-define=FF_DIVINE_SUPPORTERS=$FF_DIVINE_SUPPORTERS \
+          --dart-define-from-file=build/shorebird/dart_defines.json \
           --export-options-plist=/Users/builder/export_options.plist
     - &patch_ios
       name: Patch iOS (Shorebird)
@@ -360,14 +374,7 @@ definitions:
         # See the Android patch step for why there is no --flutter-version and
         # why the dart-defines must match the release's.
         shorebird patch ios --release-version=${{ inputs.RELEASE_VERSION }} \
-          --dart-define=ZENDESK_APP_ID=$ZENDESK_APP_ID \
-          --dart-define=ZENDESK_CLIENT_ID=$ZENDESK_CLIENT_ID \
-          --dart-define=ZENDESK_URL=$ZENDESK_URL \
-          --dart-define=DEFAULT_ENV=${{ inputs.DEFAULT_ENV }} \
-          --dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT=$PROOFMODE_SIGNING_SERVER_ENDPOINT \
-          --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN \
-          --dart-define=SUPPORTERS_API_BASE_URL=$SUPPORTERS_API_BASE_URL \
-          --dart-define=FF_DIVINE_SUPPORTERS=$FF_DIVINE_SUPPORTERS \
+          --dart-define-from-file=build/shorebird/dart_defines.json \
           --export-options-plist=/Users/builder/export_options.plist
     - &upload_dsyms_to_crashlytics
       name: Upload dSYMs to Firebase Crashlytics
@@ -688,6 +695,7 @@ workflows:
       - *prepare_ios_spm_packages
       - *pod_install
       - *shorebird_install
+      - *write_shorebird_dart_defines
       - *build_ios
       - *upload_dsyms_to_crashlytics
       - *publish_github_release
@@ -798,6 +806,7 @@ workflows:
       - *setup_local_properties
       - *configure_gradle_memory
       - *shorebird_install
+      - *write_shorebird_dart_defines
       - *build_apk
       - *build_aab
       - *publish_github_release
@@ -829,6 +838,8 @@ workflows:
     working_directory: mobile
     max_build_duration: 60
     instance_type: mac_mini_m2
+    integrations:
+      app_store_connect: API key for Codemagic # Setup in Codemagic UI
     inputs:
       CONFIRM_PATCH:
         description: >-
@@ -865,7 +876,6 @@ workflows:
         - proofmode_credentials
         - shorebird_credentials
       vars:
-        FLUTTER_VERSION: 3.44.0
         BUNDLE_ID: co.openvine.app
         IOS_EXTENSION_BUNDLE_IDS: >-
           co.openvine.app.NotificationServiceExtension
@@ -890,6 +900,7 @@ workflows:
       - *prepare_ios_spm_packages
       - *pod_install
       - *shorebird_install
+      - *write_shorebird_dart_defines
       - *patch_ios
 
   android-patch:
@@ -931,8 +942,6 @@ workflows:
         - zendesk_credentials
         - proofmode_credentials
         - shorebird_credentials
-      vars:
-        FLUTTER_VERSION: 3.44.0
       android_signing:
         - divine_keystore
     cache:
@@ -948,6 +957,7 @@ workflows:
       - *setup_local_properties
       - *configure_gradle_memory
       - *shorebird_install
+      - *write_shorebird_dart_defines
       - *patch_android
 
   macos-build:

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -796,7 +796,7 @@ workflows:
           - "NO"
           - "YES"
     environment:
-      flutter: 3.44.0
+      flutter: 3.44.9
       xcode: latest
       cocoapods: default
       groups:
@@ -808,7 +808,7 @@ workflows:
         # Must match `flutter:` above. Shorebird ships its own Flutter, so the
         # release is only reproducible if we pin it to the same version
         # Codemagic provisioned.
-        FLUTTER_VERSION: 3.44.0
+        FLUTTER_VERSION: 3.44.9
         BUNDLE_ID: co.openvine.app
         IOS_EXTENSION_BUNDLE_IDS: >-
           co.openvine.app.NotificationServiceExtension
@@ -871,7 +871,7 @@ workflows:
           - TEST
           - POC
     environment:
-      flutter: 3.44.0
+      flutter: 3.44.9
       xcode: latest
       cocoapods: default
       groups:
@@ -920,7 +920,7 @@ workflows:
           - "NO"
           - "YES"
     environment:
-      flutter: 3.44.0
+      flutter: 3.44.9
       java: 17
       groups:
         - zendesk_credentials
@@ -930,7 +930,7 @@ workflows:
         - shorebird_credentials
       vars:
         # Must match `flutter:` above — see the iOS workflow for why.
-        FLUTTER_VERSION: 3.44.0
+        FLUTTER_VERSION: 3.44.9
       android_signing:
         - divine_keystore
     cache:
@@ -1019,7 +1019,7 @@ workflows:
           - TEST
           - POC
     environment:
-      flutter: 3.44.0
+      flutter: 3.44.9
       xcode: latest
       cocoapods: default
       groups:
@@ -1097,7 +1097,7 @@ workflows:
           - TEST
           - POC
     environment:
-      flutter: 3.44.0
+      flutter: 3.44.9
       java: 17
       groups:
         - zendesk_credentials
@@ -1147,7 +1147,7 @@ workflows:
           - "NO"
           - "YES"
     environment:
-      flutter: 3.44.0
+      flutter: 3.44.9
       xcode: latest
       cocoapods: default
       groups:
@@ -1185,7 +1185,7 @@ workflows:
     max_build_duration: 25
     instance_type: mac_mini_m2
     environment:
-      flutter: 3.44.0
+      flutter: 3.44.9
       # Pinned alongside MAESTRO_VERSION. The compatibility contract has two
       # sides: 2.1.0 cannot drive Xcode 26.x, and `latest` floating means a
       # Codemagic image bump can break the suite with no commit on our side —
@@ -1257,7 +1257,7 @@ workflows:
     max_build_duration: 60
     instance_type: linux_x2
     environment:
-      flutter: 3.44.0
+      flutter: 3.44.9
       java: 17
       groups:
         - zendesk_credentials

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -208,6 +208,22 @@ definitions:
           --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN \
           --dart-define=SUPPORTERS_API_BASE_URL=$SUPPORTERS_API_BASE_URL \
           --dart-define=FF_DIVINE_SUPPORTERS=$FF_DIVINE_SUPPORTERS
+    - &confirm_patch
+      name: Confirm patch to production
+      script: |
+        # Runs first so a mis-clicked workflow fails in seconds rather than
+        # after pod install / Gradle setup.
+        if [ "${{ inputs.CONFIRM_PATCH }}" != "YES" ]; then
+          echo "Refusing to patch: CONFIRM_PATCH is '${{ inputs.CONFIRM_PATCH }}', expected YES."
+          echo
+          echo "A patch reaches every install of release ${{ inputs.RELEASE_VERSION }}"
+          echo "within about one app launch, including App Store and Play"
+          echo "production users. There is no store review and no rollback window."
+          echo
+          echo "Re-run with CONFIRM_PATCH=YES if that is what you intend."
+          exit 1
+        fi
+        echo "Patching release ${{ inputs.RELEASE_VERSION }} with DEFAULT_ENV=${{ inputs.DEFAULT_ENV }}."
     - &patch_android
       name: Patch Android (Shorebird)
       script: |
@@ -814,6 +830,15 @@ workflows:
     max_build_duration: 60
     instance_type: mac_mini_m2
     inputs:
+      CONFIRM_PATCH:
+        description: >-
+          Must be YES to proceed. Guards against a mis-clicked workflow — a
+          patch ships to production users with no review and no rollback.
+        type: choice
+        default: "NO"
+        options:
+          - "NO"
+          - "YES"
       RELEASE_VERSION:
         description: >-
           Release to patch, exactly as Shorebird lists it, including the build
@@ -855,6 +880,7 @@ workflows:
     triggering:
       events: []
     scripts:
+      - *confirm_patch
       - *check_signing_endpoint
       - *check_supporters_config
       - *check_ios_extension_signing_contract
@@ -872,6 +898,15 @@ workflows:
     max_build_duration: 60
     instance_type: mac_mini_m4
     inputs:
+      CONFIRM_PATCH:
+        description: >-
+          Must be YES to proceed. Guards against a mis-clicked workflow — a
+          patch ships to production users with no review and no rollback.
+        type: choice
+        default: "NO"
+        options:
+          - "NO"
+          - "YES"
       RELEASE_VERSION:
         description: >-
           Release to patch, exactly as Shorebird lists it, including the build
@@ -907,6 +942,7 @@ workflows:
     triggering:
       events: []
     scripts:
+      - *confirm_patch
       - *check_signing_endpoint
       - *check_supporters_config
       - *setup_local_properties

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -304,15 +304,17 @@ definitions:
           echo "SHOREBIRD_RELEASE_VERSION=$RELEASE_VERSION"
         } > build/shorebird/android_release.env
         echo "Android Shorebird release version: $RELEASE_VERSION"
-        if shorebird releases info --release-version="$RELEASE_VERSION" --json > build/shorebird/release_info.json 2> build/shorebird/release_info.err; then
-          if ruby -rjson -e 'release = JSON.parse(File.read(ARGV[0])).fetch("release"); exit(release.fetch("platform_statuses", {}).fetch(ARGV[1], nil) == "active" ? 0 : 1)' build/shorebird/release_info.json android; then
-            echo "ERROR: Android Shorebird release $RELEASE_VERSION already exists and is active."
-            echo "Bump the build number/version or delete the failed Shorebird release before retrying."
-            exit 1
+        if ! shorebird releases list --platform=android --json > build/shorebird/release_info.json 2> build/shorebird/release_info.err; then
+          echo "ERROR: could not list existing Shorebird releases."
+          if [ -s build/shorebird/release_info.err ]; then
+            sed 's/^/stderr: /' build/shorebird/release_info.err
           fi
-        else
-          echo "No existing Shorebird release found for $RELEASE_VERSION; continuing."
+          if [ -s build/shorebird/release_info.json ]; then
+            sed 's/^/stdout: /' build/shorebird/release_info.json
+          fi
+          exit 1
         fi
+        ruby scripts/shorebird_release_preflight.rb build/shorebird/release_info.json android "$RELEASE_VERSION"
     - &preflight_shorebird_ios_release
       name: Preflight iOS Shorebird release
       script: |
@@ -348,15 +350,17 @@ definitions:
           echo "SHOREBIRD_RELEASE_VERSION=$RELEASE_VERSION"
         } > build/shorebird/ios_release.env
         echo "iOS Shorebird release version: $RELEASE_VERSION"
-        if shorebird releases info --release-version="$RELEASE_VERSION" --json > build/shorebird/release_info.json 2> build/shorebird/release_info.err; then
-          if ruby -rjson -e 'release = JSON.parse(File.read(ARGV[0])).fetch("release"); exit(release.fetch("platform_statuses", {}).fetch(ARGV[1], nil) == "active" ? 0 : 1)' build/shorebird/release_info.json ios; then
-            echo "ERROR: iOS Shorebird release $RELEASE_VERSION already exists and is active."
-            echo "Bump the build number/version or delete the failed Shorebird release before retrying."
-            exit 1
+        if ! shorebird releases list --platform=ios --json > build/shorebird/release_info.json 2> build/shorebird/release_info.err; then
+          echo "ERROR: could not list existing Shorebird releases."
+          if [ -s build/shorebird/release_info.err ]; then
+            sed 's/^/stderr: /' build/shorebird/release_info.err
           fi
-        else
-          echo "No existing Shorebird release found for $RELEASE_VERSION; continuing."
+          if [ -s build/shorebird/release_info.json ]; then
+            sed 's/^/stdout: /' build/shorebird/release_info.json
+          fi
+          exit 1
         fi
+        ruby scripts/shorebird_release_preflight.rb build/shorebird/release_info.json ios "$RELEASE_VERSION"
     - &build_apk
       name: Build Android APK
       script: |

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -367,6 +367,7 @@ definitions:
     - &preflight_shorebird_ios_release
       name: Preflight iOS Shorebird release
       script: |
+        set -euo pipefail
         BUILD_NAME=$(ruby -ne 'if $_ =~ /^version:\s*([0-9]+\.[0-9]+\.[0-9]+)\+/; puts $1; exit; end' pubspec.yaml)
         if [ -z "$BUILD_NAME" ]; then
           echo "ERROR: could not read build name from pubspec.yaml version."
@@ -374,7 +375,20 @@ definitions:
         fi
         APP_STORE_APP_ID=6747959501 # co.openvine.app
         ASC_LOOKUP_LOG=$(mktemp)
-        trap 'rm -f "$ASC_LOOKUP_LOG"' EXIT
+        ASC_STORE_VERSION_JSON=$(mktemp)
+        trap 'rm -f "$ASC_LOOKUP_LOG" "$ASC_STORE_VERSION_JSON"' EXIT
+        if ! app-store-connect get-latest-app-store-build-number "$APP_STORE_APP_ID" \
+          --platform=IOS --include-version --json > "$ASC_STORE_VERSION_JSON" 2>"$ASC_LOOKUP_LOG"; then
+          echo "ERROR: could not read the latest approved App Store version."
+          if [ -s "$ASC_LOOKUP_LOG" ]; then
+            echo "       App Store Connect lookup output:"
+            sed 's/^/       /' "$ASC_LOOKUP_LOG"
+          fi
+          echo "       Refusing to create a Shorebird release that Apple may reject after the build."
+          exit 1
+        fi
+        ruby scripts/ios_store_version_preflight.rb "$ASC_STORE_VERSION_JSON" "$BUILD_NAME"
+        : > "$ASC_LOOKUP_LOG"
         if ! LATEST_IOS_BUILD_NUMBER=$(app-store-connect get-latest-build-number "$APP_STORE_APP_ID" 2>"$ASC_LOOKUP_LOG"); then
           LATEST_IOS_BUILD_NUMBER=
         fi

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -35,6 +35,8 @@
 #     CI authenticates with API keys only.
 #   - SHOREBIRD_PATCH_PUBLIC_KEY (public PEM used by `shorebird release`)
 #   - SHOREBIRD_PATCH_PRIVATE_KEY (secure private PEM used by `shorebird patch`)
+#     Store each PEM as a single-line value whose newlines are written as
+#     literal `\n` sequences. The CI step validates the decoded PEM envelope.
 #   The key must belong to an account with access to the app_id in
 #   mobile/shorebird.yaml, which lives in the Divine organization.
 #
@@ -166,6 +168,12 @@ definitions:
       script: |
         curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | bash
         echo PATH="$HOME/.shorebird/bin:$PATH" >> $CM_ENV
+        SHOREBIRD_VERSION_OUTPUT=$("$HOME/.shorebird/bin/shorebird" --version)
+        echo "$SHOREBIRD_VERSION_OUTPUT"
+        if ! printf '%s\n' "$SHOREBIRD_VERSION_OUTPUT" | grep -Fq 'Shorebird 1.6.117'; then
+          echo "ERROR: expected Shorebird 1.6.117; update and validate the pinned version before continuing."
+          exit 1
+        fi
     - &write_shorebird_dart_defines
       name: Write Shorebird dart-defines
       script: |
@@ -201,15 +209,15 @@ definitions:
           'build/shorebird/dart_defines.json',
           JSON.pretty_generate(defines) + "\n",
         )
+        File.chmod(0o600, 'build/shorebird/dart_defines.json')
         RUBY
-    - &write_shorebird_signing_keys
-      name: Write Shorebird patch signing keys
+    - &write_shorebird_public_key
+      name: Write Shorebird patch public key
       script: |
         mkdir -p build/shorebird
         ruby <<'RUBY'
         keys = {
           'SHOREBIRD_PATCH_PUBLIC_KEY' => 'build/shorebird/patch_public_key.pem',
-          'SHOREBIRD_PATCH_PRIVATE_KEY' => 'build/shorebird/patch_private_key.pem',
         }
 
         missing = keys.keys.reject { |name| ENV.key?(name) && !ENV.fetch(name).empty? }
@@ -218,9 +226,30 @@ definitions:
         end
 
         keys.each do |name, path|
-          File.write(path, ENV.fetch(name).gsub('\\n', "\n"))
-          File.chmod(name.end_with?('PRIVATE_KEY') ? 0o600 : 0o644, path)
+          pem = ENV.fetch(name).gsub('\\n', "\n")
+          unless pem.match?(/\A-----BEGIN PUBLIC KEY-----\n.+\n-----END PUBLIC KEY-----\n?\z/m)
+            abort("invalid PEM encoding for #{name}; use literal \\n sequences")
+          end
+          File.write(path, pem)
+          File.chmod(0o644, path)
         end
+        RUBY
+    - &write_shorebird_private_key
+      name: Write Shorebird patch private key
+      script: |
+        mkdir -p build/shorebird
+        ruby <<'RUBY'
+        name = 'SHOREBIRD_PATCH_PRIVATE_KEY'
+        path = 'build/shorebird/patch_private_key.pem'
+        unless ENV.key?(name) && !ENV.fetch(name).empty?
+          abort("missing Shorebird patch signing variable: #{name}")
+        end
+        pem = ENV.fetch(name).gsub('\\n', "\n")
+        unless pem.match?(/\A-----BEGIN (?:EC |RSA )?PRIVATE KEY-----\n.+\n-----END (?:EC |RSA )?PRIVATE KEY-----\n?\z/m)
+          abort("invalid PEM encoding for #{name}; use literal \\n sequences")
+        end
+        File.write(path, pem)
+        File.chmod(0o600, path)
         RUBY
     - &prepare_patch_source
       name: Verify patch source
@@ -235,7 +264,15 @@ definitions:
           echo "Use the git commit that produced the target store release."
           exit 1
         fi
-        git fetch --quiet origin main
+        if ! printf '%s\n' "${{ inputs.RELEASE_COMMIT }}" | grep -Eq '^[0-9a-fA-F]{40}$'; then
+          echo "Refusing to patch: RELEASE_COMMIT must be a full 40-character commit SHA."
+          exit 1
+        fi
+        if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+          git fetch --quiet --unshallow origin main
+        else
+          git fetch --quiet origin main
+        fi
         if ! git cat-file -e "${{ inputs.RELEASE_COMMIT }}^{commit}" 2>/dev/null; then
           echo "Refusing to patch: RELEASE_COMMIT '${{ inputs.RELEASE_COMMIT }}' is not a commit in this checkout."
           exit 1
@@ -256,6 +293,7 @@ definitions:
           'pubspec.lock' \
           'shorebird.yaml' \
           'packages/**/android/**' \
+          'packages/**/assets/**' \
           'packages/**/darwin/**' \
           'packages/**/ios/**' \
           'packages/**/macos/**' \
@@ -369,14 +407,7 @@ definitions:
         # universal APK. These per-ABI APKs go to Zapstore / direct download,
         # so those installs are not patchable. Play (the AAB below) is.
         flutter build apk --release --split-per-abi --build-number=$PROJECT_BUILD_NUMBER \
-          --dart-define=ZENDESK_APP_ID=$ZENDESK_APP_ID \
-          --dart-define=ZENDESK_CLIENT_ID=$ZENDESK_CLIENT_ID \
-          --dart-define=ZENDESK_URL=$ZENDESK_URL \
-          --dart-define=DEFAULT_ENV=${{ inputs.DEFAULT_ENV }} \
-          --dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT=$PROOFMODE_SIGNING_SERVER_ENDPOINT \
-          --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN \
-          --dart-define=SUPPORTERS_API_BASE_URL=$SUPPORTERS_API_BASE_URL \
-          --dart-define=FF_DIVINE_SUPPORTERS=$FF_DIVINE_SUPPORTERS
+          --dart-define-from-file=build/shorebird/dart_defines.json
     - &build_aab
       name: Build Android AAB (Shorebird release)
       script: |
@@ -832,7 +863,7 @@ workflows:
       - *check_signing_endpoint
       - *check_supporters_config
       - *check_ios_extension_signing_contract
-      - *write_shorebird_signing_keys
+      - *write_shorebird_public_key
       - *preflight_shorebird_ios_release
       - *setup_code_signing_xcode
       - *clean_ios_workspace_state
@@ -951,7 +982,7 @@ workflows:
       - *enable_spm
       - *setup_local_properties
       - *configure_gradle_memory
-      - *write_shorebird_signing_keys
+      - *write_shorebird_public_key
       - *preflight_shorebird_android_release
       - *write_shorebird_dart_defines
       - *build_apk
@@ -1052,7 +1083,7 @@ workflows:
       - *check_signing_endpoint
       - *check_supporters_config
       - *check_ios_extension_signing_contract
-      - *write_shorebird_signing_keys
+      - *write_shorebird_private_key
       - *setup_code_signing_xcode
       - *clean_ios_workspace_state
       - *enable_spm
@@ -1124,7 +1155,7 @@ workflows:
       - *check_supporters_config
       - *setup_local_properties
       - *configure_gradle_memory
-      - *write_shorebird_signing_keys
+      - *write_shorebird_private_key
       - *write_shorebird_dart_defines
       - *patch_android
 

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -246,6 +246,28 @@ definitions:
           echo "current head:    $(git rev-parse HEAD)"
           exit 1
         fi
+        BLOCKED_PATCH_PATHS=$(git diff --name-only "${{ inputs.RELEASE_COMMIT }}..HEAD" -- \
+          'android/**' \
+          'ios/**' \
+          'macos/**' \
+          'web/**' \
+          'assets/**' \
+          'pubspec.yaml' \
+          'pubspec.lock' \
+          'shorebird.yaml' \
+          'packages/**/android/**' \
+          'packages/**/darwin/**' \
+          'packages/**/ios/**' \
+          'packages/**/macos/**' \
+          'packages/**/pubspec.yaml')
+        if [ -n "$BLOCKED_PATCH_PATHS" ]; then
+          echo "Refusing to patch: this diff contains native, asset, dependency, or Shorebird config changes."
+          echo
+          echo "$BLOCKED_PATCH_PATHS"
+          echo
+          echo "Cut a normal store release instead of a Shorebird patch."
+          exit 1
+        fi
         echo "Patch source diff from release commit to current HEAD:"
         git log --oneline --no-merges "${{ inputs.RELEASE_COMMIT }}..HEAD"
         if git diff --quiet "${{ inputs.RELEASE_COMMIT }}..HEAD" -- '*.dart'; then

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -29,6 +29,12 @@
 # 9 - Android publishing reads the service account from environment variable
 #     group "google_play_credentials":
 #   - GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
+# 10 - Create environment variable group "shorebird_credentials" with:
+#   - SHOREBIRD_TOKEN (mark as secure) — an API key from the Shorebird
+#     console under Account > API Keys. `shorebird login:ci` is removed;
+#     CI authenticates with API keys only.
+#   The key must belong to an account with access to the app_id in
+#   mobile/shorebird.yaml, which lives in the Divine organization.
 #
 # Every group named under a workflow's `groups:` key must appear in this
 # checklist. Codemagic validates this whole file before it provisions a machine,
@@ -153,9 +159,18 @@ definitions:
         } >> "$GRADLE_HOME/gradle.properties"
         echo "Effective $GRADLE_HOME/gradle.properties:"
         cat "$GRADLE_HOME/gradle.properties"
+    - &shorebird_install
+      name: Install Shorebird
+      script: |
+        curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | bash
+        echo PATH="$HOME/.shorebird/bin:$PATH" >> $CM_ENV
     - &build_apk
       name: Build Android APK
       script: |
+        # Deliberately NOT a Shorebird release. Shorebird has no
+        # --split-per-abi; its Android artifact is either an AAB or one
+        # universal APK. These per-ABI APKs go to Zapstore / direct download,
+        # so those installs are not patchable. Play (the AAB below) is.
         flutter build apk --release --split-per-abi --build-number=$PROJECT_BUILD_NUMBER \
           --dart-define=ZENDESK_APP_ID=$ZENDESK_APP_ID \
           --dart-define=ZENDESK_CLIENT_ID=$ZENDESK_CLIENT_ID \
@@ -166,7 +181,7 @@ definitions:
           --dart-define=SUPPORTERS_API_BASE_URL=$SUPPORTERS_API_BASE_URL \
           --dart-define=FF_DIVINE_SUPPORTERS=$FF_DIVINE_SUPPORTERS
     - &build_aab
-      name: Build Android AAB
+      name: Build Android AAB (Shorebird release)
       script: |
         # Use the latest Play versionCode as the primary source of truth.
         LATEST_GOOGLE_PLAY_BUILD_NUMBER=$(google-play get-latest-build-number --package-name "co.openvine.app" 2>/dev/null || true)
@@ -181,7 +196,28 @@ definitions:
             fi
             ;;
         esac
-        flutter build appbundle --release --build-number=$BUILD_NUMBER \
+        # Shorebird wraps `flutter build appbundle` with its own engine so the
+        # release carries the updater. A plain `flutter build` here would ship
+        # a permanently unpatchable version to Play.
+        shorebird release android --flutter-version=$FLUTTER_VERSION --build-number=$BUILD_NUMBER \
+          --dart-define=ZENDESK_APP_ID=$ZENDESK_APP_ID \
+          --dart-define=ZENDESK_CLIENT_ID=$ZENDESK_CLIENT_ID \
+          --dart-define=ZENDESK_URL=$ZENDESK_URL \
+          --dart-define=DEFAULT_ENV=${{ inputs.DEFAULT_ENV }} \
+          --dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT=$PROOFMODE_SIGNING_SERVER_ENDPOINT \
+          --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN \
+          --dart-define=SUPPORTERS_API_BASE_URL=$SUPPORTERS_API_BASE_URL \
+          --dart-define=FF_DIVINE_SUPPORTERS=$FF_DIVINE_SUPPORTERS
+    - &patch_android
+      name: Patch Android (Shorebird)
+      script: |
+        # No --flutter-version: a patch is compiled against the Flutter version
+        # its release was built with, which Shorebird resolves from the release.
+        # The dart-defines must match the release's or the patch changes app
+        # behaviour beyond the code fix. Shorebird refuses to patch when it
+        # detects native or asset diffs; do NOT add --allow-native-diffs or
+        # --allow-asset-diffs to force past that — cut a new release instead.
+        shorebird patch android --release-version=${{ inputs.RELEASE_VERSION }} \
           --dart-define=ZENDESK_APP_ID=$ZENDESK_APP_ID \
           --dart-define=ZENDESK_CLIENT_ID=$ZENDESK_CLIENT_ID \
           --dart-define=ZENDESK_URL=$ZENDESK_URL \
@@ -260,7 +296,7 @@ definitions:
             "${ARTIFACTS[@]}"
         fi
     - &build_ios
-      name: Build and sign iOS
+      name: Build and sign iOS (Shorebird release)
       script: |
         # App Store Connect is the source of truth, mirroring the Play lookup in
         # the AAB step. Apple rejects any upload whose build number does not
@@ -289,7 +325,25 @@ definitions:
             ;;
         esac
         echo "iOS build number: $BUILD_NUMBER (App Store Connect latest: ${LATEST_IOS_BUILD_NUMBER:-unknown})"
-        flutter build ipa --release --build-number=$BUILD_NUMBER \
+        # Shorebird wraps `flutter build ipa` with its own engine so the release
+        # carries the updater. A plain `flutter build` here would ship a
+        # permanently unpatchable version to TestFlight and the App Store.
+        shorebird release ios --flutter-version=$FLUTTER_VERSION --build-number=$BUILD_NUMBER \
+          --dart-define=ZENDESK_APP_ID=$ZENDESK_APP_ID \
+          --dart-define=ZENDESK_CLIENT_ID=$ZENDESK_CLIENT_ID \
+          --dart-define=ZENDESK_URL=$ZENDESK_URL \
+          --dart-define=DEFAULT_ENV=${{ inputs.DEFAULT_ENV }} \
+          --dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT=$PROOFMODE_SIGNING_SERVER_ENDPOINT \
+          --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN \
+          --dart-define=SUPPORTERS_API_BASE_URL=$SUPPORTERS_API_BASE_URL \
+          --dart-define=FF_DIVINE_SUPPORTERS=$FF_DIVINE_SUPPORTERS \
+          --export-options-plist=/Users/builder/export_options.plist
+    - &patch_ios
+      name: Patch iOS (Shorebird)
+      script: |
+        # See the Android patch step for why there is no --flutter-version and
+        # why the dart-defines must match the release's.
+        shorebird patch ios --release-version=${{ inputs.RELEASE_VERSION }} \
           --dart-define=ZENDESK_APP_ID=$ZENDESK_APP_ID \
           --dart-define=ZENDESK_CLIENT_ID=$ZENDESK_CLIENT_ID \
           --dart-define=ZENDESK_URL=$ZENDESK_URL \
@@ -589,7 +643,12 @@ workflows:
         - zendesk_credentials
         - proofmode_credentials
         - github_credentials
+        - shorebird_credentials
       vars:
+        # Must match `flutter:` above. Shorebird ships its own Flutter, so the
+        # release is only reproducible if we pin it to the same version
+        # Codemagic provisioned.
+        FLUTTER_VERSION: 3.44.0
         BUNDLE_ID: co.openvine.app
         IOS_EXTENSION_BUNDLE_IDS: >-
           co.openvine.app.NotificationServiceExtension
@@ -612,6 +671,7 @@ workflows:
       - *enable_spm
       - *prepare_ios_spm_packages
       - *pod_install
+      - *shorebird_install
       - *build_ios
       - *upload_dsyms_to_crashlytics
       - *publish_github_release
@@ -703,6 +763,10 @@ workflows:
         - google_play_credentials
         - proofmode_credentials
         - github_credentials
+        - shorebird_credentials
+      vars:
+        # Must match `flutter:` above — see the iOS workflow for why.
+        FLUTTER_VERSION: 3.44.0
       android_signing:
         - divine_keystore
     cache:
@@ -717,6 +781,7 @@ workflows:
       - *enable_spm
       - *setup_local_properties
       - *configure_gradle_memory
+      - *shorebird_install
       - *build_apk
       - *build_aab
       - *publish_github_release
@@ -734,6 +799,120 @@ workflows:
         # on every track). A draft upload succeeds; promote it to a live
         # release in the Play Console after completing that declaration.
         submit_as_draft: true
+
+  # Patch workflows ship a Dart-only fix to an already-released build over the
+  # air. They publish to Shorebird, not to Play or the App Store, and are
+  # manual-trigger only — a patch reaches users within one app launch, so it
+  # should be a deliberate act, never a side effect of a push.
+  #
+  # A patch can only target a release that was cut by `shorebird release`
+  # (the AAB and IPA steps above). Per-ABI APKs from the Zapstore path are
+  # plain flutter builds and cannot be patched.
+  ios-patch:
+    name: iOS Patch (Shorebird)
+    working_directory: mobile
+    max_build_duration: 60
+    instance_type: mac_mini_m2
+    inputs:
+      RELEASE_VERSION:
+        description: >-
+          Release to patch, exactly as Shorebird lists it, including the build
+          number (e.g. 1.0.9+247). Get it from `shorebird releases list` or the
+          Shorebird console — a value with no matching release fails the build.
+        type: string
+      DEFAULT_ENV:
+        description: >-
+          Must match the value the target release was built with. A mismatch
+          silently repoints patched installs at a different environment.
+        type: choice
+        default: PRODUCTION
+        options:
+          - PRODUCTION
+          - STAGING
+          - TEST
+          - POC
+    environment:
+      flutter: 3.44.0
+      xcode: latest
+      cocoapods: default
+      groups:
+        - zendesk_credentials
+        - proofmode_credentials
+        - shorebird_credentials
+      vars:
+        FLUTTER_VERSION: 3.44.0
+        BUNDLE_ID: co.openvine.app
+        IOS_EXTENSION_BUNDLE_IDS: >-
+          co.openvine.app.NotificationServiceExtension
+          co.openvine.app.CameraQuickActionWidget
+      ios_signing:
+        distribution_type: app_store
+        bundle_identifier: co.openvine.app
+    cache:
+      cache_paths:
+        - $HOME/Library/Caches/CocoaPods
+        - $HOME/.pub-cache
+    triggering:
+      events: []
+    scripts:
+      - *check_signing_endpoint
+      - *check_supporters_config
+      - *check_ios_extension_signing_contract
+      - *setup_code_signing_xcode
+      - *clean_ios_workspace_state
+      - *enable_spm
+      - *prepare_ios_spm_packages
+      - *pod_install
+      - *shorebird_install
+      - *patch_ios
+
+  android-patch:
+    name: Android Patch (Shorebird)
+    working_directory: mobile
+    max_build_duration: 60
+    instance_type: mac_mini_m4
+    inputs:
+      RELEASE_VERSION:
+        description: >-
+          Release to patch, exactly as Shorebird lists it, including the build
+          number (e.g. 1.0.9+247). Get it from `shorebird releases list` or the
+          Shorebird console — a value with no matching release fails the build.
+        type: string
+      DEFAULT_ENV:
+        description: >-
+          Must match the value the target release was built with. A mismatch
+          silently repoints patched installs at a different environment.
+        type: choice
+        default: PRODUCTION
+        options:
+          - PRODUCTION
+          - STAGING
+          - TEST
+          - POC
+    environment:
+      flutter: 3.44.0
+      java: 17
+      groups:
+        - zendesk_credentials
+        - proofmode_credentials
+        - shorebird_credentials
+      vars:
+        FLUTTER_VERSION: 3.44.0
+      android_signing:
+        - divine_keystore
+    cache:
+      cache_paths:
+        - $HOME/.gradle/caches
+        - $HOME/.pub-cache
+    triggering:
+      events: []
+    scripts:
+      - *check_signing_endpoint
+      - *check_supporters_config
+      - *setup_local_properties
+      - *configure_gradle_memory
+      - *shorebird_install
+      - *patch_android
 
   macos-build:
     name: macOS Build

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -164,12 +164,6 @@ definitions:
     - &shorebird_install
       name: Install Shorebird
       script: |
-        # Shorebird swaps FLUTTER_ROOT to its managed engine checkout during
-        # release builds. Keep Codemagic's Flutter SDK path available for local
-        # Android plugins that need compile-only Flutter embedding classes.
-        if [ -n "${FLUTTER_ROOT:-}" ]; then
-          echo CODEMAGIC_FLUTTER_ROOT="$FLUTTER_ROOT" >> $CM_ENV
-        fi
         curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | bash
         echo PATH="$HOME/.shorebird/bin:$PATH" >> $CM_ENV
     - &write_shorebird_dart_defines

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -166,12 +166,21 @@ definitions:
     - &shorebird_install
       name: Install Shorebird
       script: |
-        curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | bash
+        set -euo pipefail
+        SHOREBIRD_BIN="$HOME/.shorebird/bin/shorebird"
+        EXPECTED_SHOREBIRD_VERSION="Shorebird 1.6.117"
+        SHOREBIRD_VERSION_OUTPUT=""
+        if [ -x "$SHOREBIRD_BIN" ]; then
+          SHOREBIRD_VERSION_OUTPUT=$("$SHOREBIRD_BIN" --version 2>/dev/null || true)
+        fi
+        if ! printf '%s\n' "$SHOREBIRD_VERSION_OUTPUT" | grep -Fq "$EXPECTED_SHOREBIRD_VERSION"; then
+          curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | bash -s -- --force
+          SHOREBIRD_VERSION_OUTPUT=$("$SHOREBIRD_BIN" --version)
+        fi
         echo PATH="$HOME/.shorebird/bin:$PATH" >> $CM_ENV
-        SHOREBIRD_VERSION_OUTPUT=$("$HOME/.shorebird/bin/shorebird" --version)
         echo "$SHOREBIRD_VERSION_OUTPUT"
-        if ! printf '%s\n' "$SHOREBIRD_VERSION_OUTPUT" | grep -Fq 'Shorebird 1.6.117'; then
-          echo "ERROR: expected Shorebird 1.6.117; update and validate the pinned version before continuing."
+        if ! printf '%s\n' "$SHOREBIRD_VERSION_OUTPUT" | grep -Fq "$EXPECTED_SHOREBIRD_VERSION"; then
+          echo "ERROR: expected $EXPECTED_SHOREBIRD_VERSION; update and validate the pinned version before continuing."
           exit 1
         fi
     - &write_shorebird_dart_defines
@@ -194,7 +203,7 @@ definitions:
           FF_DIVINE_SUPPORTERS
         ]
 
-        missing = required_names.reject { |name| ENV.key?(name) }
+        missing = required_names.reject { |name| ENV.key?(name) && !ENV.fetch(name).empty? }
         unless missing.empty?
           abort("missing Shorebird dart-define environment variables: #{missing.join(', ')}")
         end
@@ -289,11 +298,13 @@ definitions:
           'macos/**' \
           'web/**' \
           'assets/**' \
+          'shaders/**' \
           'pubspec.yaml' \
           'pubspec.lock' \
           'shorebird.yaml' \
           'packages/**/android/**' \
           'packages/**/assets/**' \
+          'packages/**/shaders/**' \
           'packages/**/darwin/**' \
           'packages/**/ios/**' \
           'packages/**/macos/**' \
@@ -411,6 +422,7 @@ definitions:
     - &build_aab
       name: Build Android AAB (Shorebird release)
       script: |
+        set -euo pipefail
         # Use the latest Play versionCode as the primary source of truth.
         . build/shorebird/android_release.env
         BUILD_NAME=$SHOREBIRD_BUILD_NAME
@@ -528,6 +540,7 @@ definitions:
     - &build_ios
       name: Build and sign iOS (Shorebird release)
       script: |
+        set -euo pipefail
         . build/shorebird/ios_release.env
         BUILD_NAME=$SHOREBIRD_BUILD_NAME
         BUILD_NUMBER=$SHOREBIRD_BUILD_NUMBER

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -33,6 +33,8 @@
 #   - SHOREBIRD_TOKEN (mark as secure) — an API key from the Shorebird
 #     console under Account > API Keys. `shorebird login:ci` is removed;
 #     CI authenticates with API keys only.
+#   - SHOREBIRD_PATCH_PUBLIC_KEY (public PEM used by `shorebird release`)
+#   - SHOREBIRD_PATCH_PRIVATE_KEY (secure private PEM used by `shorebird patch`)
 #   The key must belong to an account with access to the app_id in
 #   mobile/shorebird.yaml, which lives in the Divine organization.
 #
@@ -171,22 +173,28 @@ definitions:
         DEFAULT_ENV="${{ inputs.DEFAULT_ENV }}" ruby <<'RUBY'
         require 'json'
 
-        names = %w[
+        required_names = %w[
           ZENDESK_APP_ID
           ZENDESK_CLIENT_ID
           ZENDESK_URL
           PROOFMODE_SIGNING_SERVER_ENDPOINT
           PROOFMODE_SIGNING_SERVER_TOKEN
+        ]
+
+        optional_names = %w[
           SUPPORTERS_API_BASE_URL
           FF_DIVINE_SUPPORTERS
         ]
 
-        missing = names.reject { |name| ENV.key?(name) }
+        missing = required_names.reject { |name| ENV.key?(name) }
         unless missing.empty?
           abort("missing Shorebird dart-define environment variables: #{missing.join(', ')}")
         end
 
-        defines = names.to_h { |name| [name, ENV.fetch(name)] }
+        defines = required_names.to_h { |name| [name, ENV.fetch(name)] }
+        optional_names.each do |name|
+          defines[name] = ENV.fetch(name, '')
+        end
         defines['DEFAULT_ENV'] = ENV.fetch('DEFAULT_ENV')
 
         File.write(
@@ -194,6 +202,139 @@ definitions:
           JSON.pretty_generate(defines) + "\n",
         )
         RUBY
+    - &write_shorebird_signing_keys
+      name: Write Shorebird patch signing keys
+      script: |
+        mkdir -p build/shorebird
+        ruby <<'RUBY'
+        keys = {
+          'SHOREBIRD_PATCH_PUBLIC_KEY' => 'build/shorebird/patch_public_key.pem',
+          'SHOREBIRD_PATCH_PRIVATE_KEY' => 'build/shorebird/patch_private_key.pem',
+        }
+
+        missing = keys.keys.reject { |name| ENV.key?(name) && !ENV.fetch(name).empty? }
+        unless missing.empty?
+          abort("missing Shorebird patch signing variables: #{missing.join(', ')}")
+        end
+
+        keys.each do |name, path|
+          File.write(path, ENV.fetch(name).gsub('\\n', "\n"))
+          File.chmod(name.end_with?('PRIVATE_KEY') ? 0o600 : 0o644, path)
+        end
+        RUBY
+    - &prepare_patch_source
+      name: Verify patch source
+      script: |
+        if [ "$CM_BRANCH" != "main" ]; then
+          echo "Refusing to patch from branch '$CM_BRANCH'."
+          echo "Patch workflows must run from main after the fix has merged."
+          exit 1
+        fi
+        if [ -z "${{ inputs.RELEASE_COMMIT }}" ]; then
+          echo "Refusing to patch: RELEASE_COMMIT is required."
+          echo "Use the git commit that produced the target store release."
+          exit 1
+        fi
+        git fetch --quiet origin main
+        if ! git cat-file -e "${{ inputs.RELEASE_COMMIT }}^{commit}" 2>/dev/null; then
+          echo "Refusing to patch: RELEASE_COMMIT '${{ inputs.RELEASE_COMMIT }}' is not a commit in this checkout."
+          exit 1
+        fi
+        if ! git merge-base --is-ancestor "${{ inputs.RELEASE_COMMIT }}" HEAD; then
+          echo "Refusing to patch: RELEASE_COMMIT must be an ancestor of HEAD."
+          echo "release commit: ${{ inputs.RELEASE_COMMIT }}"
+          echo "current head:    $(git rev-parse HEAD)"
+          exit 1
+        fi
+        echo "Patch source diff from release commit to current HEAD:"
+        git log --oneline --no-merges "${{ inputs.RELEASE_COMMIT }}..HEAD"
+        if git diff --quiet "${{ inputs.RELEASE_COMMIT }}..HEAD" -- '*.dart'; then
+          echo "No Dart changes found between release commit and HEAD."
+        else
+          echo
+          echo "Dart files changed since the release commit:"
+          git diff --name-only "${{ inputs.RELEASE_COMMIT }}..HEAD" -- '*.dart'
+        fi
+    - &preflight_shorebird_android_release
+      name: Preflight Android Shorebird release
+      script: |
+        BUILD_NAME=$(ruby -ne 'if $_ =~ /^version:\s*([0-9]+\.[0-9]+\.[0-9]+)\+/; puts $1; exit; end' pubspec.yaml)
+        if [ -z "$BUILD_NAME" ]; then
+          echo "ERROR: could not read build name from pubspec.yaml version."
+          exit 1
+        fi
+        LATEST_GOOGLE_PLAY_BUILD_NUMBER=$(google-play get-latest-build-number --package-name "co.openvine.app" 2>/dev/null || true)
+        BUILD_NUMBER=$PROJECT_BUILD_NUMBER
+        case "$LATEST_GOOGLE_PLAY_BUILD_NUMBER" in
+          ''|*[!0-9]*)
+            ;;
+          *)
+            NEXT_PLAY_BUILD_NUMBER=$((LATEST_GOOGLE_PLAY_BUILD_NUMBER + 1))
+            if [ "$NEXT_PLAY_BUILD_NUMBER" -gt "$BUILD_NUMBER" ]; then
+              BUILD_NUMBER=$NEXT_PLAY_BUILD_NUMBER
+            fi
+            ;;
+        esac
+        RELEASE_VERSION="$BUILD_NAME+$BUILD_NUMBER"
+        {
+          echo "SHOREBIRD_BUILD_NAME=$BUILD_NAME"
+          echo "SHOREBIRD_BUILD_NUMBER=$BUILD_NUMBER"
+          echo "SHOREBIRD_RELEASE_VERSION=$RELEASE_VERSION"
+        } > build/shorebird/android_release.env
+        echo "Android Shorebird release version: $RELEASE_VERSION"
+        if shorebird releases info --release-version="$RELEASE_VERSION" --json > build/shorebird/release_info.json 2> build/shorebird/release_info.err; then
+          if ruby -rjson -e 'release = JSON.parse(File.read(ARGV[0])).fetch("release"); exit(release.fetch("platform_statuses", {}).fetch(ARGV[1], nil) == "active" ? 0 : 1)' build/shorebird/release_info.json android; then
+            echo "ERROR: Android Shorebird release $RELEASE_VERSION already exists and is active."
+            echo "Bump the build number/version or delete the failed Shorebird release before retrying."
+            exit 1
+          fi
+        else
+          echo "No existing Shorebird release found for $RELEASE_VERSION; continuing."
+        fi
+    - &preflight_shorebird_ios_release
+      name: Preflight iOS Shorebird release
+      script: |
+        BUILD_NAME=$(ruby -ne 'if $_ =~ /^version:\s*([0-9]+\.[0-9]+\.[0-9]+)\+/; puts $1; exit; end' pubspec.yaml)
+        if [ -z "$BUILD_NAME" ]; then
+          echo "ERROR: could not read build name from pubspec.yaml version."
+          exit 1
+        fi
+        APP_STORE_APP_ID=6747959501 # co.openvine.app
+        ASC_LOOKUP_LOG=$(mktemp)
+        trap 'rm -f "$ASC_LOOKUP_LOG"' EXIT
+        if ! LATEST_IOS_BUILD_NUMBER=$(app-store-connect get-latest-build-number "$APP_STORE_APP_ID" 2>"$ASC_LOOKUP_LOG"); then
+          LATEST_IOS_BUILD_NUMBER=
+        fi
+        case "$LATEST_IOS_BUILD_NUMBER" in
+          ''|*[!0-9]*)
+            echo "ERROR: could not read the latest App Store Connect build number."
+            if [ -s "$ASC_LOOKUP_LOG" ]; then
+              echo "       App Store Connect lookup output:"
+              sed 's/^/       /' "$ASC_LOOKUP_LOG"
+            fi
+            echo "       Refusing to guess a build number Apple may reject after upload."
+            exit 1
+            ;;
+          *)
+            BUILD_NUMBER=$((LATEST_IOS_BUILD_NUMBER + 1))
+            ;;
+        esac
+        RELEASE_VERSION="$BUILD_NAME+$BUILD_NUMBER"
+        {
+          echo "SHOREBIRD_BUILD_NAME=$BUILD_NAME"
+          echo "SHOREBIRD_BUILD_NUMBER=$BUILD_NUMBER"
+          echo "SHOREBIRD_RELEASE_VERSION=$RELEASE_VERSION"
+        } > build/shorebird/ios_release.env
+        echo "iOS Shorebird release version: $RELEASE_VERSION"
+        if shorebird releases info --release-version="$RELEASE_VERSION" --json > build/shorebird/release_info.json 2> build/shorebird/release_info.err; then
+          if ruby -rjson -e 'release = JSON.parse(File.read(ARGV[0])).fetch("release"); exit(release.fetch("platform_statuses", {}).fetch(ARGV[1], nil) == "active" ? 0 : 1)' build/shorebird/release_info.json ios; then
+            echo "ERROR: iOS Shorebird release $RELEASE_VERSION already exists and is active."
+            echo "Bump the build number/version or delete the failed Shorebird release before retrying."
+            exit 1
+          fi
+        else
+          echo "No existing Shorebird release found for $RELEASE_VERSION; continuing."
+        fi
     - &build_apk
       name: Build Android APK
       script: |
@@ -214,23 +355,16 @@ definitions:
       name: Build Android AAB (Shorebird release)
       script: |
         # Use the latest Play versionCode as the primary source of truth.
-        LATEST_GOOGLE_PLAY_BUILD_NUMBER=$(google-play get-latest-build-number --package-name "co.openvine.app" 2>/dev/null || true)
-        BUILD_NUMBER=$PROJECT_BUILD_NUMBER
-        case "$LATEST_GOOGLE_PLAY_BUILD_NUMBER" in
-          ''|*[!0-9]*)
-            ;;
-          *)
-            NEXT_PLAY_BUILD_NUMBER=$((LATEST_GOOGLE_PLAY_BUILD_NUMBER + 1))
-            if [ "$NEXT_PLAY_BUILD_NUMBER" -gt "$BUILD_NUMBER" ]; then
-              BUILD_NUMBER=$NEXT_PLAY_BUILD_NUMBER
-            fi
-            ;;
-        esac
+        . build/shorebird/android_release.env
+        BUILD_NAME=$SHOREBIRD_BUILD_NAME
+        BUILD_NUMBER=$SHOREBIRD_BUILD_NUMBER
+        echo "Android build number: $BUILD_NUMBER (release: $SHOREBIRD_RELEASE_VERSION)"
         # Shorebird wraps `flutter build appbundle` with its own engine so the
         # release carries the updater. A plain `flutter build` here would ship
         # a permanently unpatchable version to Play.
-        shorebird release android --flutter-version=$FLUTTER_VERSION --build-number=$BUILD_NUMBER \
-          --dart-define-from-file=build/shorebird/dart_defines.json
+        shorebird release android --flutter-version=$FLUTTER_VERSION --build-name=$BUILD_NAME --build-number=$BUILD_NUMBER \
+          --dart-define-from-file=build/shorebird/dart_defines.json \
+          --public-key-path=build/shorebird/patch_public_key.pem
     - &confirm_patch
       name: Confirm patch to production
       script: |
@@ -241,7 +375,8 @@ definitions:
           echo
           echo "A patch reaches every install of release ${{ inputs.RELEASE_VERSION }}"
           echo "within about one app launch, including App Store and Play"
-          echo "production users. There is no store review and no rollback window."
+          echo "production users. There is no store review; rollback exists but"
+          echo "is an emergency mitigation, not a substitute for validation."
           echo
           echo "Re-run with CONFIRM_PATCH=YES if that is what you intend."
           exit 1
@@ -261,8 +396,9 @@ definitions:
         # behaviour beyond the code fix. Shorebird refuses to patch when it
         # detects native or asset diffs; do NOT add --allow-native-diffs or
         # --allow-asset-diffs to force past that — cut a new release instead.
-        shorebird patch android --release-version=${{ inputs.RELEASE_VERSION }} \
-          --dart-define-from-file=build/shorebird/dart_defines.json
+        shorebird patch android --release-version=${{ inputs.RELEASE_VERSION }} --track=staging \
+          --dart-define-from-file=build/shorebird/dart_defines.json \
+          --private-key-path=build/shorebird/patch_private_key.pem
     - &build_macos
       name: Build macOS app
       script: |
@@ -335,46 +471,25 @@ definitions:
     - &build_ios
       name: Build and sign iOS (Shorebird release)
       script: |
-        # App Store Connect is the source of truth, mirroring the Play lookup in
-        # the AAB step. Apple rejects any upload whose build number does not
-        # exceed the last one accepted for the version train, and it does so
-        # *after* the upload succeeds — so a stale number costs a full build and
-        # an emailed rejection rather than a fast failure.
-        APP_STORE_APP_ID=6747959501 # co.openvine.app
-        ASC_LOOKUP_LOG=$(mktemp)
-        trap 'rm -f "$ASC_LOOKUP_LOG"' EXIT
-        if ! LATEST_IOS_BUILD_NUMBER=$(app-store-connect get-latest-build-number "$APP_STORE_APP_ID" 2>"$ASC_LOOKUP_LOG"); then
-          LATEST_IOS_BUILD_NUMBER=
-        fi
-        case "$LATEST_IOS_BUILD_NUMBER" in
-          ''|*[!0-9]*)
-            echo "ERROR: could not read the latest App Store Connect build number."
-            if [ -s "$ASC_LOOKUP_LOG" ]; then
-              echo "       App Store Connect lookup output:"
-              sed 's/^/       /' "$ASC_LOOKUP_LOG"
-            fi
-            echo "       Refusing to guess a build number Apple may reject after upload."
-            exit 1
-            ;;
-          *)
-            NEXT_IOS_BUILD_NUMBER=$((LATEST_IOS_BUILD_NUMBER + 1))
-            BUILD_NUMBER=$NEXT_IOS_BUILD_NUMBER
-            ;;
-        esac
-        echo "iOS build number: $BUILD_NUMBER (App Store Connect latest: ${LATEST_IOS_BUILD_NUMBER:-unknown})"
+        . build/shorebird/ios_release.env
+        BUILD_NAME=$SHOREBIRD_BUILD_NAME
+        BUILD_NUMBER=$SHOREBIRD_BUILD_NUMBER
+        echo "iOS build number: $BUILD_NUMBER (release: $SHOREBIRD_RELEASE_VERSION)"
         # Shorebird wraps `flutter build ipa` with its own engine so the release
         # carries the updater. A plain `flutter build` here would ship a
         # permanently unpatchable version to TestFlight and the App Store.
-        shorebird release ios --flutter-version=$FLUTTER_VERSION --build-number=$BUILD_NUMBER \
+        shorebird release ios --flutter-version=$FLUTTER_VERSION --build-name=$BUILD_NAME --build-number=$BUILD_NUMBER \
           --dart-define-from-file=build/shorebird/dart_defines.json \
+          --public-key-path=build/shorebird/patch_public_key.pem \
           --export-options-plist=/Users/builder/export_options.plist
     - &patch_ios
       name: Patch iOS (Shorebird)
       script: |
         # See the Android patch step for why there is no --flutter-version and
         # why the dart-defines must match the release's.
-        shorebird patch ios --release-version=${{ inputs.RELEASE_VERSION }} \
+        shorebird patch ios --release-version=${{ inputs.RELEASE_VERSION }} --track=staging \
           --dart-define-from-file=build/shorebird/dart_defines.json \
+          --private-key-path=build/shorebird/patch_private_key.pem \
           --export-options-plist=/Users/builder/export_options.plist
     - &upload_dsyms_to_crashlytics
       name: Upload dSYMs to Firebase Crashlytics
@@ -682,19 +797,22 @@ workflows:
     cache:
       cache_paths:
         - $HOME/Library/Caches/CocoaPods
+        - $HOME/.shorebird
         - $HOME/.pub-cache
     triggering:
       events: []
     scripts:
+      - *shorebird_install
       - *check_signing_endpoint
       - *check_supporters_config
       - *check_ios_extension_signing_contract
+      - *write_shorebird_signing_keys
+      - *preflight_shorebird_ios_release
       - *setup_code_signing_xcode
       - *clean_ios_workspace_state
       - *enable_spm
       - *prepare_ios_spm_packages
       - *pod_install
-      - *shorebird_install
       - *write_shorebird_dart_defines
       - *build_ios
       - *upload_dsyms_to_crashlytics
@@ -796,16 +914,19 @@ workflows:
     cache:
       cache_paths:
         - $HOME/.gradle/caches
+        - $HOME/.shorebird
         - $HOME/.pub-cache
     triggering:
       events: []
     scripts:
+      - *shorebird_install
       - *check_signing_endpoint
       - *check_supporters_config
       - *enable_spm
       - *setup_local_properties
       - *configure_gradle_memory
-      - *shorebird_install
+      - *write_shorebird_signing_keys
+      - *preflight_shorebird_android_release
       - *write_shorebird_dart_defines
       - *build_apk
       - *build_aab
@@ -827,8 +948,9 @@ workflows:
 
   # Patch workflows ship a Dart-only fix to an already-released build over the
   # air. They publish to Shorebird, not to Play or the App Store, and are
-  # manual-trigger only — a patch reaches users within one app launch, so it
-  # should be a deliberate act, never a side effect of a push.
+  # manual-trigger only. The workflows publish to the Shorebird staging track;
+  # promoting to stable reaches users within one app launch, so it should be a
+  # deliberate act, never a side effect of a push.
   #
   # A patch can only target a release that was cut by `shorebird release`
   # (the AAB and IPA steps above). Per-ABI APKs from the Zapstore path are
@@ -844,7 +966,8 @@ workflows:
       CONFIRM_PATCH:
         description: >-
           Must be YES to proceed. Guards against a mis-clicked workflow — a
-          patch ships to production users with no review and no rollback.
+          patch ships with no store review and rollback is only an emergency
+          mitigation.
         type: choice
         default: "NO"
         options:
@@ -855,6 +978,12 @@ workflows:
           Release to patch, exactly as Shorebird lists it, including the build
           number (e.g. 1.0.9+247). Get it from `shorebird releases list` or the
           Shorebird console — a value with no matching release fails the build.
+        type: string
+      RELEASE_COMMIT:
+        description: >-
+          Git commit that produced the target store release. The workflow
+          prints every commit and Dart file that will be included in the patch
+          beyond this release commit.
         type: string
       DEFAULT_ENV:
         description: >-
@@ -886,20 +1015,23 @@ workflows:
     cache:
       cache_paths:
         - $HOME/Library/Caches/CocoaPods
+        - $HOME/.shorebird
         - $HOME/.pub-cache
     triggering:
       events: []
     scripts:
       - *confirm_patch
+      - *prepare_patch_source
+      - *shorebird_install
       - *check_signing_endpoint
       - *check_supporters_config
       - *check_ios_extension_signing_contract
+      - *write_shorebird_signing_keys
       - *setup_code_signing_xcode
       - *clean_ios_workspace_state
       - *enable_spm
       - *prepare_ios_spm_packages
       - *pod_install
-      - *shorebird_install
       - *write_shorebird_dart_defines
       - *patch_ios
 
@@ -912,7 +1044,8 @@ workflows:
       CONFIRM_PATCH:
         description: >-
           Must be YES to proceed. Guards against a mis-clicked workflow — a
-          patch ships to production users with no review and no rollback.
+          patch ships with no store review and rollback is only an emergency
+          mitigation.
         type: choice
         default: "NO"
         options:
@@ -923,6 +1056,12 @@ workflows:
           Release to patch, exactly as Shorebird lists it, including the build
           number (e.g. 1.0.9+247). Get it from `shorebird releases list` or the
           Shorebird console — a value with no matching release fails the build.
+        type: string
+      RELEASE_COMMIT:
+        description: >-
+          Git commit that produced the target store release. The workflow
+          prints every commit and Dart file that will be included in the patch
+          beyond this release commit.
         type: string
       DEFAULT_ENV:
         description: >-
@@ -947,16 +1086,19 @@ workflows:
     cache:
       cache_paths:
         - $HOME/.gradle/caches
+        - $HOME/.shorebird
         - $HOME/.pub-cache
     triggering:
       events: []
     scripts:
       - *confirm_patch
+      - *prepare_patch_source
+      - *shorebird_install
       - *check_signing_endpoint
       - *check_supporters_config
       - *setup_local_properties
       - *configure_gradle_memory
-      - *shorebird_install
+      - *write_shorebird_signing_keys
       - *write_shorebird_dart_defines
       - *patch_android
 

--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -57,6 +57,9 @@ installation identifier to Divine account data. In Google Play, disclose Device
 or other IDs, App interactions, and Diagnostics as required collection for App
 functionality and Analytics. Mark the Google Play data as not shared only while
 Shorebird is contractually acting as Divine's service provider or processor.
+Do not finalize that answer until the DPA is executed and the privacy review
+confirms that its terms cover data relating to every intended user, including
+minor users.
 
 | Artifact | Built by | Patchable |
 |---|---|---|
@@ -71,8 +74,10 @@ sideload user. Those installs cannot receive patches. Play and App Store
 installs can.
 
 `auto_update` is left at its default (on), so patches apply in the background
-on launch. `shorebird_code_push` is not a dependency — there is no in-app UI
-for controlling or reporting patch state.
+on launch. `shorebird_code_push` is a runtime dependency. There is no in-app UI
+for controlling patch state, but startup records patch availability and the
+current patch number in logs and Crashlytics custom keys. Use those values when
+triaging crashes that may be specific to a code-push patch.
 
 ### Flutter version
 
@@ -133,11 +138,12 @@ be retrofitted later; cut a new store release instead.
 1. Promote the exact patch after validation:
 
    ```
-   shorebird patches promote --release-version <version> --patch-number <n>
+   shorebird patches set-track --release <version> --patch <n> --track stable
    ```
 
-   `shorebird patches set-track --release <version> --patch <n> --track stable`
-   is equivalent when you need the lower-level command form.
+   `shorebird patches promote --release-version <version> --patch-number <n>`
+   is the deprecated legacy shorthand in the pinned CLI. Do not use it in new
+   automation.
 1. Both platforms need their own patch run. There is no combined workflow.
 
 `DEFAULT_ENV` is the easiest thing to get wrong. A mismatch does not fail the
@@ -185,8 +191,14 @@ Divine service identity is tracked in #7200.
 Installing the CLI:
 
 ```
-curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | bash
+if [ ! -x "$HOME/.shorebird/bin/shorebird" ]; then
+  curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | bash
+fi
 ```
+
+The installer refuses to overwrite an existing installation. Existing installs
+do not need to rerun it; use `bash -s -- --force` only when deliberately
+replacing the installed CLI.
 
 Then `shorebird login`. You need access to the Divine organization; membership
 is managed in the Shorebird console.

--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -95,6 +95,8 @@ be retrofitted later; cut a new store release instead.
    checkout, then prints every commit and Dart file included after that commit.
    Read that list before treating the patch as safe: pure Dart merged since the
    release is exactly what Shorebird can ship.
+   If the diff includes native, asset, dependency, or Shorebird config changes,
+   the workflow refuses to patch and tells you to cut a normal store release.
 1. Run `ios-patch` or `android-patch` in Codemagic with:
    - `CONFIRM_PATCH` = `YES` (defaults to `NO`; the build aborts otherwise)
    - `RELEASE_VERSION` = the exact release string, e.g. `1.0.9+247`

--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -101,6 +101,12 @@ Run `ios-build` or `android-build` in Codemagic as usual. They now produce
 Shorebird releases as a side effect of building the store artifact — no extra
 step, no change to how you ship.
 
+Before starting a store build, update `mobile/pubspec.yaml` to the intended
+marketing version. The iOS preflight reads the latest approved App Store
+version and refuses a candidate that is equal or lower before Shorebird builds
+or records a release. Increasing only the build number cannot reopen a closed
+App Store version train.
+
 Publishing behaviour is unchanged: iOS stops at TestFlight
 (`submit_to_app_store: false`, internal groups), Android uploads to Play as a
 draft. Promotion to production stays manual in both stores.
@@ -221,6 +227,11 @@ later upload or symbol step fails, the store build-number lookup can derive the
 same version again, but Shorebird will refuse to create it twice. The preflight
 stops that retry before the long build. Delete the failed Shorebird release or
 bump the store build number before rerunning; do not bypass the preflight.
+
+**App Store Connect rejects builds for an approved marketing version.** Once
+Apple approves a version such as `1.0.20`, its pre-release train is closed and
+a higher build number does not reopen it. Bump the version in
+`mobile/pubspec.yaml`; the iOS preflight checks this before invoking Shorebird.
 
 **`shorebird init` fails with "Unable to initialize gradlew".** `gradlew` is
 gitignored, so a fresh worktree has no wrapper, and `init` calls it directly

--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -39,6 +39,25 @@ them. If a fix needs native changes, it needs a store release.
 The app is `mobile/shorebird.yaml` → `app_id`, owned by the **Divine**
 organization in Shorebird (not an individual's account).
 
+### Privacy disclosure
+
+Shorebird checks for patches when the app launches. The request includes a
+random identifier unique to that app installation, the app, release, and patch
+versions, update channel, platform, and device architecture. Shorebird also
+records patch download, installation, and failure status. This information is
+used to deliver updates, diagnose update failures, and produce aggregated
+update and active-install analytics. The installation identifier is not an
+advertising identifier and is not used for advertising or cross-app tracking.
+
+Keep the public privacy policy and store disclosures aligned with this
+behavior. In App Store Connect, disclose Device ID, Product Interaction, and
+Other Diagnostic Data for App Functionality and Analytics, without tracking.
+Mark them as not linked only while neither Divine nor Shorebird joins the
+installation identifier to Divine account data. In Google Play, disclose Device
+or other IDs, App interactions, and Diagnostics as required collection for App
+functionality and Analytics. Mark the Google Play data as not shared only while
+Shorebird is contractually acting as Divine's service provider or processor.
+
 | Artifact | Built by | Patchable |
 |---|---|---|
 | Play AAB | `shorebird release android` | Yes |

--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -63,6 +63,11 @@ duplicates the workflow's `flutter:` setting and is passed to
 bumping Flutter, confirm the target is in `shorebird flutter versions list`
 first — Shorebird supports a subset.
 
+The current 3.44.9 pin is deliberate. Shorebird's 3.44.0 engine crashed at
+launch in the Dart async FFI path used by `cupertino_http`, so the repo and all
+CI workflows moved together to the refreshed 3.44.9 Shorebird engine. Do not
+move the pin back independently in one workflow.
+
 Patch commands take no `--flutter-version`. A patch is compiled against
 whatever version its release used, which Shorebird resolves from the release.
 
@@ -148,6 +153,11 @@ The same group holds patch-signing key material:
 - `SHOREBIRD_PATCH_PUBLIC_KEY` — public PEM passed to `shorebird release`
 - `SHOREBIRD_PATCH_PRIVATE_KEY` — secure private PEM passed to `shorebird patch`
 
+Store both keys as single-line values with literal `\n` sequences between PEM
+lines. CI decodes and validates that envelope before invoking Shorebird. Release
+jobs only materialize the public key; patch jobs only materialize the private
+key.
+
 The token is currently generated from an individual's account. Moving it to a
 Divine service identity is tracked in #7200.
 
@@ -174,6 +184,12 @@ for them: a patch should be compiled in the same environment as the release it
 targets.
 
 ### Known gotchas
+
+**A release build is not idempotent after `shorebird release` succeeds.** If a
+later upload or symbol step fails, the store build-number lookup can derive the
+same version again, but Shorebird will refuse to create it twice. The preflight
+stops that retry before the long build. Delete the failed Shorebird release or
+bump the store build number before rerunning; do not bypass the preflight.
 
 **`shorebird init` fails with "Unable to initialize gradlew".** `gradlew` is
 gitignored, so a fresh worktree has no wrapper, and `init` calls it directly

--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -76,21 +76,43 @@ Publishing behaviour is unchanged: iOS stops at TestFlight
 (`submit_to_app_store: false`, internal groups), Android uploads to Play as a
 draft. Promotion to production stays manual in both stores.
 
+Release commands pass `--public-key-path`, so every new store binary only
+accepts signed Shorebird patches. A release built without the public key cannot
+be retrofitted later; cut a new store release instead.
+
 **Record the version and build number of every release you promote** — e.g.
-`1.0.9+247`. That exact string is what a future patch targets.
+`1.0.9+247` — and the git commit that produced it. A future patch needs both.
 
 ## Shipping a patch
 
 1. Land the Dart fix on `main` through the normal PR process. A patch is built
    from the current checkout, so the fix must be merged first.
-2. Identify the target release: `shorebird patch` needs the version of the
+1. Identify the target release: `shorebird patch` needs the version of the
    build that is actually live. `shorebird releases list`, or the Shorebird
    console, shows what exists.
-3. Run `ios-patch` or `android-patch` in Codemagic with:
+1. Identify the `RELEASE_COMMIT` that produced that store release. The patch
+   workflow refuses a release commit that is not an ancestor of the current
+   checkout, then prints every commit and Dart file included after that commit.
+   Read that list before treating the patch as safe: pure Dart merged since the
+   release is exactly what Shorebird can ship.
+1. Run `ios-patch` or `android-patch` in Codemagic with:
    - `CONFIRM_PATCH` = `YES` (defaults to `NO`; the build aborts otherwise)
    - `RELEASE_VERSION` = the exact release string, e.g. `1.0.9+247`
+   - `RELEASE_COMMIT` = the git commit that produced the target release
    - `DEFAULT_ENV` = **the same value the release was built with**
-4. Both platforms need their own patch run. There is no combined workflow.
+1. The workflow publishes to Shorebird's `staging` track, not directly to
+   `stable`.
+1. Validate the staged patch with `shorebird preview --track staging
+   --release-version <version>` or the Shorebird console.
+1. Promote the exact patch after validation:
+
+   ```
+   shorebird patches promote --release-version <version> --patch-number <n>
+   ```
+
+   `shorebird patches set-track --release <version> --patch <n> --track stable`
+   is equivalent when you need the lower-level command form.
+1. Both platforms need their own patch run. There is no combined workflow.
 
 `DEFAULT_ENV` is the easiest thing to get wrong. A mismatch does not fail the
 build — it silently repoints patched installs at a different environment.
@@ -100,9 +122,17 @@ build — it silently repoints patched installs at a different environment.
 TestFlight build `1.0.9+247` and App Store build `1.0.9+247` are the same
 Shorebird release. There is no way to patch "just the TestFlight build". If
 that version was promoted to the App Store, patching it reaches production
-users too, within about one app launch, with no store review and no rollback.
+users too once the patch is promoted to `stable`, within about one app launch,
+with no store review.
 
 Treat every patch as a production deploy.
+
+### Rollback is recovery, not validation
+
+Shorebird supports patch rollback and on-device rollback from failed patches.
+That reduces the worst-case blast radius, but it does not make patching casual:
+users can still receive the bad patch before rollback, and rollback does not
+replace review, staging validation, signing, or source-diff checks.
 
 ## Credentials
 
@@ -110,6 +140,11 @@ CI authenticates with `SHOREBIRD_TOKEN`, held in the `shorebird_credentials`
 environment variable group in Codemagic and marked Secret. It is an API key
 from the Shorebird console (**Account → API Keys**); `shorebird login:ci` no
 longer exists.
+
+The same group holds patch-signing key material:
+
+- `SHOREBIRD_PATCH_PUBLIC_KEY` — public PEM passed to `shorebird release`
+- `SHOREBIRD_PATCH_PRIVATE_KEY` — secure private PEM passed to `shorebird patch`
 
 The token is currently generated from an individual's account. Moving it to a
 Divine service identity is tracked in #7200.

--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -1,0 +1,162 @@
+# Shorebird Code Push
+
+Shorebird ships Dart-only fixes to already-released builds over the air. A
+patch reaches users on their next app launch without a store submission.
+
+Read this before changing anything in `codemagic.yaml` that touches a store
+artifact, and before shipping a patch.
+
+## The one rule that matters
+
+**A build is patchable only if it was produced by `shorebird release`.** That
+command links the Shorebird updater into the engine; a plain `flutter build`
+does not. If a store-bound artifact is ever built with `flutter build`, that
+version is permanently unpatchable — there is no way to fix it after the fact
+short of shipping a new store release.
+
+This is why the Play AAB and App Store IPA steps in `codemagic.yaml` call
+`shorebird release`. Do not "simplify" them back to `flutter build`.
+
+## What can and cannot be patched
+
+| Change | Patchable |
+|---|---|
+| Dart code — logic, UI, strings | Yes |
+| Native code (Kotlin/Swift, plugins with native parts) | No |
+| Assets bundled at build time | No |
+| Adding or upgrading a dependency with native code | No |
+| Flutter or engine version | No |
+
+Shorebird detects native and asset diffs and **refuses** to build the patch.
+That refusal is a correctness guard: a patch that disagrees with the binary it
+lands on produces crashes that are extremely hard to diagnose in the field.
+
+`--allow-native-diffs` and `--allow-asset-diffs` override the guard. Do not add
+them. If a fix needs native changes, it needs a store release.
+
+## How Divine is set up
+
+The app is `mobile/shorebird.yaml` → `app_id`, owned by the **Divine**
+organization in Shorebird (not an individual's account).
+
+| Artifact | Built by | Patchable |
+|---|---|---|
+| Play AAB | `shorebird release android` | Yes |
+| App Store IPA | `shorebird release ios` | Yes |
+| Zapstore / GitHub per-ABI APKs | `flutter build apk --split-per-abi` | **No** — deliberate |
+| macOS DMG | `flutter build macos` | No — not wired |
+
+The Zapstore APKs are an intentional exception: Shorebird has no
+`--split-per-abi`, and its universal APK would inflate the download for every
+sideload user. Those installs cannot receive patches. Play and App Store
+installs can.
+
+`auto_update` is left at its default (on), so patches apply in the background
+on launch. `shorebird_code_push` is not a dependency — there is no in-app UI
+for controlling or reporting patch state.
+
+### Flutter version
+
+Shorebird ships its own Flutter, so `FLUTTER_VERSION` in `codemagic.yaml`
+duplicates the workflow's `flutter:` setting and is passed to
+`shorebird release --flutter-version`. **Keep the two in sync**, and when
+bumping Flutter, confirm the target is in `shorebird flutter versions list`
+first — Shorebird supports a subset.
+
+Patch commands take no `--flutter-version`. A patch is compiled against
+whatever version its release used, which Shorebird resolves from the release.
+
+## Cutting a release
+
+Run `ios-build` or `android-build` in Codemagic as usual. They now produce
+Shorebird releases as a side effect of building the store artifact — no extra
+step, no change to how you ship.
+
+Publishing behaviour is unchanged: iOS stops at TestFlight
+(`submit_to_app_store: false`, internal groups), Android uploads to Play as a
+draft. Promotion to production stays manual in both stores.
+
+**Record the version and build number of every release you promote** — e.g.
+`1.0.9+247`. That exact string is what a future patch targets.
+
+## Shipping a patch
+
+1. Land the Dart fix on `main` through the normal PR process. A patch is built
+   from the current checkout, so the fix must be merged first.
+2. Identify the target release: `shorebird patch` needs the version of the
+   build that is actually live. `shorebird releases list`, or the Shorebird
+   console, shows what exists.
+3. Run `ios-patch` or `android-patch` in Codemagic with:
+   - `CONFIRM_PATCH` = `YES` (defaults to `NO`; the build aborts otherwise)
+   - `RELEASE_VERSION` = the exact release string, e.g. `1.0.9+247`
+   - `DEFAULT_ENV` = **the same value the release was built with**
+4. Both platforms need their own patch run. There is no combined workflow.
+
+`DEFAULT_ENV` is the easiest thing to get wrong. A mismatch does not fail the
+build — it silently repoints patched installs at a different environment.
+
+### A patch targets a release version, not a channel
+
+TestFlight build `1.0.9+247` and App Store build `1.0.9+247` are the same
+Shorebird release. There is no way to patch "just the TestFlight build". If
+that version was promoted to the App Store, patching it reaches production
+users too, within about one app launch, with no store review and no rollback.
+
+Treat every patch as a production deploy.
+
+## Credentials
+
+CI authenticates with `SHOREBIRD_TOKEN`, held in the `shorebird_credentials`
+environment variable group in Codemagic and marked Secret. It is an API key
+from the Shorebird console (**Account → API Keys**); `shorebird login:ci` no
+longer exists.
+
+The token is currently generated from an individual's account. Moving it to a
+Divine service identity is tracked in #7200.
+
+## Local setup
+
+Installing the CLI:
+
+```
+curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | bash
+```
+
+Then `shorebird login`. You need access to the Divine organization; membership
+is managed in the Shorebird console.
+
+`shorebird doctor` from `mobile/` reports one known issue —
+`ios/Podfile.lock` is not tracked in source control (`mobile/.gitignore`).
+It is worth revisiting, since patches cannot change native code and a release
+and its patches should resolve identical pods.
+
+You cannot run `shorebird release android` or `shorebird patch android` on a
+machine without a JDK and a complete Android SDK. Android release and patch
+builds run on Codemagic, which provisions both. That is also the correct place
+for them: a patch should be compiled in the same environment as the release it
+targets.
+
+### Known gotchas
+
+**`shorebird init` fails with "Unable to initialize gradlew".** `gradlew` is
+gitignored, so a fresh worktree has no wrapper, and `init` calls it directly
+rather than through `flutter build`. See #7201. Workaround:
+
+```
+echo "flutter.sdk=$HOME/flutter" > mobile/android/local.properties
+cd mobile && flutter build apk --config-only   # injects the wrapper
+```
+
+`init` also needs a JDK for that call, which a machine set up only for iOS
+work will not have.
+
+**`shorebird init` invents a `divineuitests` flavor.** Its iOS detection treats
+every shared Xcode scheme that is not `Runner` as a product flavor, and picks up
+the `DivineUITests` test target. The app has no product flavors — if a re-init
+ever writes a `flavors:` block into `shorebird.yaml`, delete it.
+
+## Reference
+
+- [Shorebird docs](https://docs.shorebird.dev)
+- [Codemagic integration](https://docs.shorebird.dev/code-push/ci/codemagic/)
+- `codemagic.yaml` — release and patch workflows, setup steps in the header

--- a/mobile/mise.toml
+++ b/mobile/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-flutter = "3.44.0"
+flutter = "3.44.9"
 
 [tasks.local_up]
 description = "Start all local E2E services"

--- a/mobile/packages/caption_generator/android/build.gradle.kts
+++ b/mobile/packages/caption_generator/android/build.gradle.kts
@@ -11,6 +11,13 @@ repositories {
     mavenCentral()
 }
 
+val flutterRoot = providers.environmentVariable("FLUTTER_ROOT")
+    .orElse(providers.environmentVariable("FLUTTER_HOME"))
+    .orNull
+    ?: throw GradleException("FLUTTER_ROOT must be set to test caption_generator")
+val flutterDebugEmbeddingJar =
+    file("$flutterRoot/bin/cache/artifacts/engine/android-arm64/flutter.jar")
+
 android {
     namespace = "co.openvine.caption_generator"
 
@@ -42,6 +49,8 @@ android {
 }
 
 dependencies {
+    add("debugCompileOnly", files(flutterDebugEmbeddingJar))
+    add("debugUnitTestImplementation", files(flutterDebugEmbeddingJar))
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.mockito:mockito-core:5.0.0")
     testImplementation("org.robolectric:robolectric:4.14.1")

--- a/mobile/packages/caption_generator/android/build.gradle.kts
+++ b/mobile/packages/caption_generator/android/build.gradle.kts
@@ -11,30 +11,6 @@ repositories {
     mavenCentral()
 }
 
-val flutterRootCandidates = listOf(
-    providers.environmentVariable("FLUTTER_ROOT").orNull,
-    providers.environmentVariable("FLUTTER_HOME").orNull,
-    providers.environmentVariable("CODEMAGIC_FLUTTER_ROOT").orNull,
-).filterNotNull().distinct()
-
-if (flutterRootCandidates.isEmpty()) {
-    throw GradleException(
-        "FLUTTER_ROOT, FLUTTER_HOME, or CODEMAGIC_FLUTTER_ROOT must be set to compile caption_generator",
-    )
-}
-
-val flutterEmbeddingJarCandidates = flutterRootCandidates.flatMap { root ->
-    listOf(
-        file("$root/bin/cache/artifacts/engine/android-arm64/flutter.jar"),
-        file("$root/bin/cache/artifacts/engine/android-arm64-release/flutter.jar"),
-    )
-}
-val flutterEmbeddingJar = flutterEmbeddingJarCandidates.firstOrNull { it.isFile }
-    ?: throw GradleException(
-        "Could not find Flutter Android embedding jar. Checked: " +
-            flutterEmbeddingJarCandidates.joinToString { it.absolutePath },
-    )
-
 android {
     namespace = "co.openvine.caption_generator"
 
@@ -66,8 +42,6 @@ android {
 }
 
 dependencies {
-    compileOnly(files(flutterEmbeddingJar))
-    testImplementation(files(flutterEmbeddingJar))
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.mockito:mockito-core:5.0.0")
     testImplementation("org.robolectric:robolectric:4.14.1")

--- a/mobile/packages/caption_generator/android/build.gradle.kts
+++ b/mobile/packages/caption_generator/android/build.gradle.kts
@@ -50,7 +50,7 @@ android {
 
 dependencies {
     add("debugCompileOnly", files(flutterDebugEmbeddingJar))
-    add("debugUnitTestImplementation", files(flutterDebugEmbeddingJar))
+    testImplementation(files(flutterDebugEmbeddingJar))
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.mockito:mockito-core:5.0.0")
     testImplementation("org.robolectric:robolectric:4.14.1")

--- a/mobile/packages/caption_generator/android/build.gradle.kts
+++ b/mobile/packages/caption_generator/android/build.gradle.kts
@@ -11,12 +11,29 @@ repositories {
     mavenCentral()
 }
 
-val flutterRoot = providers.environmentVariable("FLUTTER_ROOT")
-    .orElse(providers.environmentVariable("FLUTTER_HOME"))
-    .orNull
-    ?: throw GradleException("FLUTTER_ROOT must be set to compile caption_generator")
-val flutterEmbeddingJar =
-    file("$flutterRoot/bin/cache/artifacts/engine/android-arm64/flutter.jar")
+val flutterRootCandidates = listOf(
+    providers.environmentVariable("FLUTTER_ROOT").orNull,
+    providers.environmentVariable("FLUTTER_HOME").orNull,
+    providers.environmentVariable("CODEMAGIC_FLUTTER_ROOT").orNull,
+).filterNotNull().distinct()
+
+if (flutterRootCandidates.isEmpty()) {
+    throw GradleException(
+        "FLUTTER_ROOT, FLUTTER_HOME, or CODEMAGIC_FLUTTER_ROOT must be set to compile caption_generator",
+    )
+}
+
+val flutterEmbeddingJarCandidates = flutterRootCandidates.flatMap { root ->
+    listOf(
+        file("$root/bin/cache/artifacts/engine/android-arm64/flutter.jar"),
+        file("$root/bin/cache/artifacts/engine/android-arm64-release/flutter.jar"),
+    )
+}
+val flutterEmbeddingJar = flutterEmbeddingJarCandidates.firstOrNull { it.isFile }
+    ?: throw GradleException(
+        "Could not find Flutter Android embedding jar. Checked: " +
+            flutterEmbeddingJarCandidates.joinToString { it.absolutePath },
+    )
 
 android {
     namespace = "co.openvine.caption_generator"

--- a/mobile/packages/caption_generator/android/build.gradle.kts
+++ b/mobile/packages/caption_generator/android/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 val flutterRoot = providers.environmentVariable("FLUTTER_ROOT")
     .orElse(providers.environmentVariable("FLUTTER_HOME"))
     .orNull
-    ?: throw GradleException("FLUTTER_ROOT must be set to test caption_generator")
+    ?: throw GradleException("FLUTTER_ROOT must be set to compile caption_generator")
 val flutterDebugEmbeddingJar =
     file("$flutterRoot/bin/cache/artifacts/engine/android-arm64/flutter.jar")
 
@@ -49,7 +49,7 @@ android {
 }
 
 dependencies {
-    add("debugCompileOnly", files(flutterDebugEmbeddingJar))
+    compileOnly(files(flutterDebugEmbeddingJar))
     testImplementation(files(flutterDebugEmbeddingJar))
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.mockito:mockito-core:5.0.0")

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.20+820
+version: 1.0.21+820
 
 environment:
   sdk: ^3.12.0

--- a/mobile/scripts/ios_store_version_preflight.rb
+++ b/mobile/scripts/ios_store_version_preflight.rb
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+
+json_path, candidate_version = ARGV
+unless json_path && candidate_version
+  abort('usage: ios_store_version_preflight.rb <latest-app-store-build-json> <candidate-version>')
+end
+
+def numeric_version(value, label)
+  unless value.is_a?(String) && value.match?(/\A\d+(?:\.\d+){0,2}\z/)
+    abort("ERROR: invalid #{label} #{value.inspect}; expected one to three numeric components.")
+  end
+
+  value.split('.').map(&:to_i).fill(0, value.count('.') + 1...3)
+end
+
+payload = JSON.parse(File.read(json_path))
+unless payload.is_a?(Hash)
+  abort('ERROR: expected a JSON object from App Store Connect.')
+end
+
+approved_version = payload['version']
+abort('ERROR: App Store Connect response is missing version.') unless approved_version
+
+candidate_parts = numeric_version(candidate_version, 'candidate version')
+approved_parts = numeric_version(approved_version, 'approved App Store version')
+
+unless (candidate_parts <=> approved_parts) == 1
+  abort(
+    "ERROR: candidate version #{candidate_version} must be newer than approved App Store version " \
+    "#{approved_version}. Bump mobile/pubspec.yaml before cutting a Shorebird release.",
+  )
+end
+
+puts "Candidate version #{candidate_version} is newer than approved App Store version #{approved_version}."

--- a/mobile/scripts/shorebird_release_preflight.rb
+++ b/mobile/scripts/shorebird_release_preflight.rb
@@ -24,14 +24,23 @@ unless releases.is_a?(Array)
 end
 
 release = releases.find { |item| item['version'] == release_version }
-platform_statuses = release && release['platform_statuses']
-status = platform_statuses[platform] if platform_statuses.is_a?(Hash)
-
-if status == 'active'
-  abort(
-    "ERROR: #{platform} Shorebird release #{release_version} already exists and is active.\n" \
-    'Bump the build number/version or delete the failed Shorebird release before retrying.',
-  )
+unless release
+  puts "No existing Shorebird #{platform} release found for #{release_version}; continuing."
+  exit 0
 end
 
-puts "No existing active Shorebird #{platform} release found for #{release_version}; continuing."
+platform_statuses = release['platform_statuses']
+unless platform_statuses.is_a?(Hash)
+  abort("ERROR: Shorebird release #{release_version} has unreadable platform_statuses.")
+end
+
+status = platform_statuses[platform]
+unless status
+  puts "No existing Shorebird #{platform} release found for #{release_version}; continuing."
+  exit 0
+end
+
+abort(
+  "ERROR: #{platform} Shorebird release #{release_version} already exists with status #{status}.\n" \
+  'Bump the build number/version or delete the failed Shorebird release before retrying.',
+)

--- a/mobile/scripts/shorebird_release_preflight.rb
+++ b/mobile/scripts/shorebird_release_preflight.rb
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+
+json_path, platform, release_version = ARGV
+unless json_path && platform && release_version
+  abort('usage: shorebird_release_preflight.rb <releases-json> <platform> <release-version>')
+end
+
+payload = JSON.parse(File.read(json_path))
+
+unless payload['status'] == 'success'
+  error = payload['error'] || {}
+  code = error['code'] || 'unknown_error'
+  message = error['message'] || 'no error message'
+  abort("ERROR: Shorebird releases list failed (#{code}): #{message}")
+end
+
+data = payload['data']
+releases = data && data['releases']
+unless releases.is_a?(Array)
+  abort('ERROR: Shorebird releases list JSON is missing releases array at data.releases.')
+end
+
+release = releases.find { |item| item['version'] == release_version }
+platform_statuses = release && release['platform_statuses']
+status = platform_statuses[platform] if platform_statuses.is_a?(Hash)
+
+if status == 'active'
+  abort(
+    "ERROR: #{platform} Shorebird release #{release_version} already exists and is active.\n" \
+    'Bump the build number/version or delete the failed Shorebird release before retrying.',
+  )
+end
+
+puts "No existing active Shorebird #{platform} release found for #{release_version}; continuing."

--- a/mobile/shorebird.yaml
+++ b/mobile/shorebird.yaml
@@ -5,7 +5,7 @@
 # Your app_id is the unique identifier assigned to your app.
 # It is used to identify your app when requesting patches from Shorebird's servers.
 # It is not a secret and can be shared publicly.
-app_id: 5a90f08c-3325-4805-aa02-9f056115b49b
+app_id: 73254661-21d7-4df0-90f3-265c044d7c9a
 
 # auto_update controls if Shorebird should automatically update in the background on launch.
 # If auto_update: false, you will need to use package:shorebird_code_push to trigger updates.


### PR DESCRIPTION
## Description

Moves Shorebird code push to an app owned by the **Divine organization** and wires it into Codemagic. Store-bound Android and iOS artifacts are now built by `shorebird release`, so future Play and App Store releases can receive signed Dart-only patches.

The previous Shorebird app belonged to a personal-account experiment that was never used by CI and had no releases. Nothing already shipped was patchable, so there is no release migration.

## What changes

| Artifact | Build command | Patchable |
|---|---|---|
| Play AAB | `shorebird release android` | Yes |
| App Store IPA | `shorebird release ios` | Yes |
| Zapstore/GitHub per-ABI APKs | `flutter build apk --split-per-abi` | No, by decision |
| macOS DMG | `flutter build macos` | No |

- Adds manual `ios-patch` and `android-patch` workflows.
- Requires `CONFIRM_PATCH=YES`, `main`, an exact release version, and the full release commit SHA.
- Prints the complete commit/Dart diff since the release and blocks native, asset, dependency, or Shorebird-config changes.
- Publishes patches to `staging`; promotion to `stable` remains a separate manual action.
- Signs releases with the public key and patches with the private key. Release jobs never materialize the private key.
- Fails closed when Shorebird release state cannot be read or the target version already exists.
- Keeps patch/release dart-defines in one mode-`0600` JSON file so the AAB, APK, IPA, and patches cannot silently diverge.
- Pins Shorebird CLI behavior to the validated `1.6.117` version.

## Flutter 3.44.9

This PR deliberately moves every repository and CI workflow pin from Flutter 3.44.0 to 3.44.9. The move is forced by the Shorebird engine: the 3.44.0 build crashed at launch in the Dart async FFI path used by `cupertino_http`, while Shorebird 1.6.117 ships the validated 3.44.9 engine. A repo-wide parity test now prevents local, package-CI, GitHub, Codemagic, and Shorebird release pins from drifting apart.

## Release and patch safety

- Store release commands are pinned by tests so they cannot be swapped back to plain Flutter builds unnoticed.
- A release preflight rejects every existing status for the same platform/version before the long build. If `shorebird release` succeeds and a later upload step fails, delete that failed Shorebird release or bump the store build number before retrying.
- Patch workflows fetch full history when necessary and reject anything except a full 40-character release commit SHA.
- Shorebird signing variables must be stored as single-line PEM values with literal `\n` separators; CI validates the decoded envelope.
- `auto_update` remains enabled, so installed store builds contact Shorebird at launch with app/release/patch state. The DPA is in flight; store data-sharing answers must not be finalized until it is executed and privacy review confirms coverage for all intended users, including minor users.

## Merge sequencing

Divine 1.0.20 has been submitted on the previous release path. The sequencing gate is satisfied: the first store build after this merges is intentionally the Shorebird cutover.

## Codemagic prerequisite

The `shorebird_credentials` group must contain:

- `SHOREBIRD_TOKEN` (secure)
- `SHOREBIRD_PATCH_PUBLIC_KEY`
- `SHOREBIRD_PATCH_PRIVATE_KEY` (secure)

Setup and PEM encoding are documented as step 10 in `codemagic.yaml` and in `mobile/docs/SHOREBIRD_CODE_PUSH.md`.

## Verification

- Two real Codemagic release builds completed on the Shorebird 3.44.9 engine: iOS and Android.
- Hardware smoke tests passed on both platforms.
- `python3 -m unittest discover -s .github/scripts/tests` — 26 passed after the final hardening update.
- `mobile/scripts/check_codemagic_groups.sh` — all five referenced groups documented.
- `codemagic.yaml` parses with YAML aliases enabled.
- No `3.44.0` workflow/release pin remains.
- Patch commands, release listing, staging promotion, and preview flags were verified against Shorebird 1.6.117.
- All Codemagic release and patch validation runs pass, including the patch dry-run path.

Relates to #7200.

## Out of scope

- Moving `SHOREBIRD_TOKEN` from an individual account to a Divine service identity remains tracked in #7200.
- `gradlew` being gitignored is tracked in #7201.
- `ios/Podfile.lock` remains untracked and is called out by `shorebird doctor`.
- macOS code push is not enabled.
