### PR TITLE
ci: fail when a Codemagic variable group is undocumented

### DIFF
--- a/.github/ci-timing-budgets.json
+++ b/.github/ci-timing-budgets.json
@@ -23,6 +23,7 @@
   ],
   "jobs": {
     "Detect App CI Scope": { "warn": 40, "fail": 90 },
+    "Codemagic Variable Groups": { "warn": 30, "fail": 90 },
     "Tests": { "warn": 600, "fail": 780 },
     "Generated Files": { "warn": 260, "fail": 420 },
     "Analyze": { "warn": 150, "fail": 300 },

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -49,6 +49,29 @@ jobs:
       - name: Verify generated skills and lifecycle hooks
         run: bash .codex/scripts/test-config.sh
 
+  codemagic-groups:
+    # Deliberately ungated — no `needs: changes`, no `if:`.
+    #
+    # The scope detector classifies `codemagic.yaml` as out-of-app-scope, so a
+    # PR touching only that file (#7191, the revert of the outage, is exactly
+    # that shape) resolves app=false and skips every gated job. Gating this
+    # check would therefore switch it off for the one change it exists to
+    # police. Adding codemagic.yaml to the detector instead would drag the full
+    # app test matrix along for a config edit.
+    #
+    # It costs a checkout plus a second of grep, so running it unconditionally
+    # is cheaper than reasoning about when it should run.
+    name: Codemagic Variable Groups
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: 🔑 Verify every Codemagic variable group is documented
+        # Static — no simulator, no build, no credentials — so fork PRs get it
+        # too. Codemagic validates the whole config before provisioning, so an
+        # undeclared group fails every workflow in the file and no in-script
+        # guard can catch it (#7203).
+        run: bash mobile/scripts/check_codemagic_groups.sh
+
   generated-files:
     name: Generated Files
     needs: changes
@@ -91,12 +114,6 @@ jobs:
         run: bash scripts/check_ios_shipping_versions.sh
       - name: 🌐 Verify backend-host defaults stay on *.divine.video
         run: bash scripts/check_backend_host_defaults.sh
-      - name: 🔑 Verify every Codemagic variable group is documented
-        # Static check over codemagic.yaml — no simulator, no build, no
-        # credentials — so it runs on fork PRs too. Codemagic validates the
-        # whole config before provisioning, so an undeclared group fails every
-        # workflow in the file and no in-script guard can catch it.
-        run: bash scripts/check_codemagic_groups.sh
       - name: 🪵 Verify no raw logging in production code
         run: bash scripts/check_raw_logging.sh
       - name: 🌐 Verify no untagged test mutates HttpOverrides.global

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -91,6 +91,12 @@ jobs:
         run: bash scripts/check_ios_shipping_versions.sh
       - name: 🌐 Verify backend-host defaults stay on *.divine.video
         run: bash scripts/check_backend_host_defaults.sh
+      - name: 🔑 Verify every Codemagic variable group is documented
+        # Static check over codemagic.yaml — no simulator, no build, no
+        # credentials — so it runs on fork PRs too. Codemagic validates the
+        # whole config before provisioning, so an undeclared group fails every
+        # workflow in the file and no in-script guard can catch it.
+        run: bash scripts/check_codemagic_groups.sh
       - name: 🪵 Verify no raw logging in production code
         run: bash scripts/check_raw_logging.sh
       - name: 🌐 Verify no untagged test mutates HttpOverrides.global

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -61,6 +61,10 @@ jobs:
     #
     # It costs a checkout plus a second of grep, so running it unconditionally
     # is cheaper than reasoning about when it should run.
+    #
+    # The required check is the `Mobile CI` aggregator, not this job's name.
+    # `mobile-ci` therefore needs this job and fails unless it succeeds — even
+    # when app CI is skipped — or a yaml-only PR can merge with a red guard.
     name: Codemagic Variable Groups
     runs-on: ubuntu-24.04
     steps:
@@ -452,6 +456,7 @@ jobs:
     if: ${{ always() }}
     needs:
       - changes
+      - codemagic-groups
       - generated-files
       - format
       - analyze
@@ -461,6 +466,7 @@ jobs:
     steps:
       - name: Verify upstream jobs
         env:
+          CODEMAGIC_GROUPS_RESULT: ${{ needs.codemagic-groups.result }}
           GENERATED_FILES_RESULT: ${{ needs.generated-files.result }}
           FORMAT_RESULT: ${{ needs.format.result }}
           ANALYZE_RESULT: ${{ needs.analyze.result }}
@@ -469,11 +475,19 @@ jobs:
           APP_CI_REQUIRED: ${{ needs.changes.outputs.app }}
         run: |
           echo "app-ci-required: ${APP_CI_REQUIRED}"
+          echo "codemagic-groups: ${CODEMAGIC_GROUPS_RESULT}"
           echo "generated-files: ${GENERATED_FILES_RESULT}"
           echo "format: ${FORMAT_RESULT}"
           echo "analyze: ${ANALYZE_RESULT}"
           echo "tests: ${TESTS_RESULT}"
           echo "vgv-tag-gate: ${VGV_TAG_GATE_RESULT}"
+
+          # Always required. This job is ungated so yaml-only PRs still run it;
+          # skipped here would let those PRs merge without the guard.
+          if [ "${CODEMAGIC_GROUPS_RESULT}" != "success" ]; then
+            echo "Codemagic variable group check failed or did not run."
+            exit 1
+          fi
 
           results=(
             "${GENERATED_FILES_RESULT}"

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -29,14 +29,6 @@
 # 9 - Android publishing reads the service account from environment variable
 #     group "google_play_credentials":
 #   - GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
-# 10 - Create environment variable group "maestro_e2e_credentials" for the two
-#      E2E workflows, marking every value Secure:
-#   - MAESTRO_USER_EMAIL
-#   - MAESTRO_USER_PWD
-#   - MAESTRO_SEARCH_USER
-#      Use a dedicated STAGING test account, not a staff account: the smoke
-#      suite's teardown (tests/removeKeys.yaml) deletes the account's keys from
-#      the device on every run.
 #
 # Every group named under a workflow's `groups:` key must appear in this
 # checklist. Codemagic validates this whole file before it provisions a machine,

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -26,6 +26,24 @@
 #   - Set to YES to upload artifacts to a GitHub Release (for Zapstore / direct distribution)
 #   - Defaults to NO
 #   - Requires GITHUB_TOKEN in "github_credentials" environment variable group
+# 9 - Android publishing reads the service account from environment variable
+#     group "google_play_credentials":
+#   - GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
+# 10 - Create environment variable group "maestro_e2e_credentials" for the two
+#      E2E workflows, marking every value Secure:
+#   - MAESTRO_USER_EMAIL
+#   - MAESTRO_USER_PWD
+#   - MAESTRO_SEARCH_USER
+#      Use a dedicated STAGING test account, not a staff account: the smoke
+#      suite's teardown (tests/removeKeys.yaml) deletes the account's keys from
+#      the device on every run.
+#
+# Every group named under a workflow's `groups:` key must appear in this
+# checklist. Codemagic validates this whole file before it provisions a machine,
+# so naming a group that does not exist fails *every* workflow here — not only
+# the one that needs it — and no in-script guard can catch it, because no script
+# runs. That took the pipeline down for ~21 hours (#7203). The invariant is
+# enforced by mobile/scripts/check_codemagic_groups.sh.
 
 definitions:
   environment:

--- a/mobile/scripts/check_codemagic_groups.sh
+++ b/mobile/scripts/check_codemagic_groups.sh
@@ -20,7 +20,8 @@
 # the Codemagic project, but requiring it to be *documented* forces the author
 # to confront the setup step, which is where both omissions happened. When
 # CODEMAGIC_API_TOKEN and CODEMAGIC_APP_ID are present the check goes further
-# and verifies existence against the API.
+# and prints an advisory note — it never fails the build, because the app
+# payload omits team-level shared groups.
 #
 # Two-way invariant, matching check_backend_host_defaults.sh:
 #   1. Referenced but undocumented -> FAIL (catches a new group added without
@@ -46,14 +47,16 @@ fi
 # documentation.
 header="$(sed -n '1,/^definitions:/p' "$YAML")"
 
-# Documented groups: any quoted name in the header. Both phrasings the file
-# already uses are covered —
+# Documented groups: quoted identifiers on header lines that mention "group".
+# Both phrasings the file already uses are covered —
 #   `Create environment variable group "zendesk_credentials" with:`
 #   `Requires GITHUB_TOKEN in "github_credentials" environment variable group`
+# Do not filter on a name suffix. A documented group that is not `*_credentials`
+# must still count, or the checklist is not the contract the error text claims.
 documented="$(printf '%s\n' "$header" \
+  | grep -i 'group' \
   | grep -oE '"[a-z0-9_]+"' \
   | tr -d '"' \
-  | grep -E '_credentials$|^firebase$|^google_play' \
   | sort -u || true)"
 
 # Referenced groups: list items inside a `groups:` block. `groups:` is the only

--- a/mobile/scripts/check_codemagic_groups.sh
+++ b/mobile/scripts/check_codemagic_groups.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Fails CI when codemagic.yaml references an environment variable group that
+# the setup checklist at the top of that file does not document.
+#
+# Why this exists: Codemagic validates the whole codemagic.yaml *before* it
+# provisions a machine, so a `groups:` entry naming a group that does not exist
+# in the project kills every workflow in the file immediately — not just the one
+# that needs it, and not just the feature it belongs to. No in-script guard can
+# catch it, because no script ever runs.
+#
+# That has happened twice:
+#   - `supporters_credentials` (#6999) took down iOS, Android, macOS and both
+#     E2E lanes for two days (#7203), while the guard added alongside it
+#     (check_supporters_config.sh) could never fire.
+#   - `maestro_e2e_credentials` has blocked both E2E workflows since they were
+#     written, with the same unreachable in-script guard.
+#
+# Both had one signature: a `groups:` entry added with no corresponding entry in
+# the file's own setup checklist. Nothing offline can prove a group exists in
+# the Codemagic project, but requiring it to be *documented* forces the author
+# to confront the setup step, which is where both omissions happened. When
+# CODEMAGIC_API_TOKEN and CODEMAGIC_APP_ID are present the check goes further
+# and verifies existence against the API.
+#
+# Two-way invariant, matching check_backend_host_defaults.sh:
+#   1. Referenced but undocumented -> FAIL (catches a new group added without
+#      its setup step, which is the outage above).
+#   2. Documented but unreferenced -> FAIL (stops the checklist ossifying with
+#      entries for groups nothing uses any more).
+#
+# Portable: POSIX sh constructs + grep -E / sed only, so it runs on both CI
+# ubuntu and the macOS pre-push hook.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Scripts run with working-directory mobile/; codemagic.yaml is at the repo root.
+YAML="${CODEMAGIC_YAML:-$SCRIPT_DIR/../../codemagic.yaml}"
+
+if [ ! -f "$YAML" ]; then
+  echo "check_codemagic_groups: cannot find codemagic.yaml at $YAML" >&2
+  exit 1
+fi
+
+# The setup checklist is the comment block above `definitions:`. Restricting to
+# it keeps an incidental mention further down the file from counting as
+# documentation.
+header="$(sed -n '1,/^definitions:/p' "$YAML")"
+
+# Documented groups: any quoted name in the header. Both phrasings the file
+# already uses are covered —
+#   `Create environment variable group "zendesk_credentials" with:`
+#   `Requires GITHUB_TOKEN in "github_credentials" environment variable group`
+documented="$(printf '%s\n' "$header" \
+  | grep -oE '"[a-z0-9_]+"' \
+  | tr -d '"' \
+  | grep -E '_credentials$|^firebase$|^google_play' \
+  | sort -u || true)"
+
+# Referenced groups: list items inside a `groups:` block. `groups:` is the only
+# bare-list-of-identifiers key in the environment stanza, so anchoring on it
+# avoids picking up `scripts:` anchors or artifact globs.
+#
+# Comments and blank lines inside the block must NOT end it: treating them as
+# terminators silently drops every entry after them, which is precisely the
+# false negative this guard exists to prevent.
+referenced="$(awk '
+  /^[[:space:]]*groups:[[:space:]]*$/ { in_groups = 1; next }
+  in_groups && /^[[:space:]]*(#|$)/ { next }
+  in_groups && /^[[:space:]]*-[[:space:]]+[a-z0-9_]+[[:space:]]*$/ {
+    gsub(/^[[:space:]]*-[[:space:]]+|[[:space:]]*$/, ""); print; next
+  }
+  { in_groups = 0 }
+' "$YAML" | sort -u)"
+
+fail=0
+
+undocumented="$(comm -23 <(printf '%s\n' "$referenced") <(printf '%s\n' "$documented"))"
+if [ -n "$undocumented" ]; then
+  fail=1
+  echo "FAIL: codemagic.yaml references environment variable group(s) that its" >&2
+  echo "      setup checklist does not document:" >&2
+  printf '        - %s\n' $undocumented >&2
+  echo "" >&2
+  echo "      Codemagic rejects the entire config when a named group does not" >&2
+  echo "      exist, so every workflow in the file fails before any step runs." >&2
+  echo "      Create the group in the Codemagic project, then document it in the" >&2
+  echo "      numbered setup checklist at the top of codemagic.yaml." >&2
+fi
+
+stale="$(comm -13 <(printf '%s\n' "$referenced") <(printf '%s\n' "$documented"))"
+if [ -n "$stale" ]; then
+  fail=1
+  echo "FAIL: the codemagic.yaml setup checklist documents group(s) that no" >&2
+  echo "      workflow references any more:" >&2
+  printf '        - %s\n' $stale >&2
+  echo "" >&2
+  echo "      Remove the checklist entry so the setup instructions stay true." >&2
+fi
+
+# Optional API cross-check — ADVISORY ONLY, never fails the build.
+#
+# `GET /apps/{id}` enumerates app-level variables but NOT team-level shared
+# groups. `github_credentials` is the proof: it is absent from that payload, yet
+# ios-build and android-build reference it and succeed, which is impossible for
+# a group Codemagic considers unknown. Failing on this list would therefore red
+# every PR over a group that is present.
+#
+# The only authoritative existence test is starting a build and reading the
+# validation error, which is far too expensive to run per-PR. So this layer
+# reports a suspicion and leaves the verdict to the documentation invariant.
+if [ -n "${CODEMAGIC_API_TOKEN:-}" ] && [ -n "${CODEMAGIC_APP_ID:-}" ]; then
+  app_level="$(curl -sS -H "x-auth-token: $CODEMAGIC_API_TOKEN" \
+    "https://api.codemagic.io/apps/$CODEMAGIC_APP_ID" 2>/dev/null \
+    | tr ',{}[]' '\n' | grep -oE '"group"[[:space:]]*:[[:space:]]*"[a-z0-9_]+"' \
+    | sed -E 's/.*"([a-z0-9_]+)"$/\1/' | sort -u || true)"
+  if [ -z "$app_level" ]; then
+    echo "note: could not read group names from the Codemagic API; skipping the"
+    echo "      advisory cross-check."
+  else
+    unseen="$(comm -23 <(printf '%s\n' "$referenced") <(printf '%s\n' "$app_level"))"
+    if [ -n "$unseen" ]; then
+      echo "note: referenced group(s) not visible in the app-level Codemagic API"
+      echo "      response. This is NOT proof they are missing — team-level shared"
+      echo "      groups never appear here — but it is where to look first if a"
+      echo "      build fails with 'unknown variable group':"
+      printf '        - %s\n' $unseen
+    fi
+  fi
+else
+  echo "check_codemagic_groups: no Codemagic credentials in env — documentation check only"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  exit 1
+fi
+
+echo "check_codemagic_groups: OK — $(printf '%s\n' "$referenced" | grep -c .) referenced group(s), all documented"

--- a/mobile/scripts/check_codemagic_groups.sh
+++ b/mobile/scripts/check_codemagic_groups.sh
@@ -68,11 +68,15 @@ documented="$(printf '%s\n' "$header" \
 # false negative this guard exists to prevent.
 referenced="$(awk '
   /^[[:space:]]*groups:[[:space:]]*$/ { in_groups = 1; next }
-  in_groups && /^[[:space:]]*(#|$)/ { next }
-  in_groups && /^[[:space:]]*-[[:space:]]+[a-z0-9_]+[[:space:]]*$/ {
-    gsub(/^[[:space:]]*-[[:space:]]+|[[:space:]]*$/, ""); print; next
+  in_groups {
+    line = $0
+    sub(/#.*$/, "", line)
+    if (line ~ /^[[:space:]]*$/) next
+    if (line ~ /^[[:space:]]*-[[:space:]]+[a-z0-9_]+[[:space:]]*$/) {
+      gsub(/^[[:space:]]*-[[:space:]]+|[[:space:]]*$/, "", line); print line; next
+    }
+    in_groups = 0
   }
-  { in_groups = 0 }
 ' "$YAML" | sort -u)"
 
 fail=0

--- a/mobile/test/tools/codemagic_groups_test.dart
+++ b/mobile/test/tools/codemagic_groups_test.dart
@@ -137,6 +137,23 @@ $refs
       expect(r.exitCode, 0, reason: '${r.stdout}${r.stderr}');
     });
 
+    test('trailing comment on a group line does not hide that group', () {
+      // `- name  # note` must still count. Treating the line as a terminator
+      // lets an undocumented new group pass if someone annotates it.
+      final base = yaml(
+        documented: ['zendesk_credentials'],
+        referenced: ['zendesk_credentials', 'supporters_credentials'],
+      );
+      final r = run(
+        base.replaceFirst(
+          '        - supporters_credentials',
+          '        - supporters_credentials  # not set up yet',
+        ),
+      );
+      expect(r.exitCode, isNot(0));
+      expect(r.stderr, contains('supporters_credentials'));
+    });
+
     test('comments inside a groups block do not drop later entries', () {
       // Treating a comment as the end of `groups:` silently drops every name
       // after it — the false negative this guard exists to prevent.

--- a/mobile/test/tools/codemagic_groups_test.dart
+++ b/mobile/test/tools/codemagic_groups_test.dart
@@ -127,6 +127,34 @@ $refs
       expect(r.stderr, contains('retired_credentials'));
     });
 
+    test('counts a documented group that is not *_credentials', () {
+      // The checklist is the contract. A name-suffix allowlist would reject a
+      // documented group such as firebase and force a script edit to match
+      // the error text ("document it in the setup checklist").
+      final r = run(
+        yaml(documented: ['firebase'], referenced: ['firebase']),
+      );
+      expect(r.exitCode, 0, reason: '${r.stdout}${r.stderr}');
+    });
+
+    test('comments inside a groups block do not drop later entries', () {
+      // Treating a comment as the end of `groups:` silently drops every name
+      // after it — the false negative this guard exists to prevent.
+      final base = yaml(
+        documented: ['zendesk_credentials', 'supporters_credentials'],
+        referenced: ['zendesk_credentials'],
+      );
+      final r = run(
+        base.replaceFirst(
+          '        - zendesk_credentials',
+          '        - zendesk_credentials\n'
+              '        # keep scanning\n'
+              '        - supporters_credentials',
+        ),
+      );
+      expect(r.exitCode, 0, reason: '${r.stdout}${r.stderr}');
+    });
+
     test('only the header counts as documentation', () {
       // A group named further down the file — in a comment beside its own
       // `groups:` entry, say — must not satisfy the checklist requirement.

--- a/mobile/test/tools/codemagic_groups_test.dart
+++ b/mobile/test/tools/codemagic_groups_test.dart
@@ -1,0 +1,166 @@
+// ABOUTME: Tests for the Codemagic group guard (scripts/check_codemagic_groups.sh)
+// ABOUTME: Pins the two-way invariant and the #6999 regression it exists to catch
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Drives `scripts/check_codemagic_groups.sh` against synthetic codemagic.yaml
+/// fixtures via CODEMAGIC_YAML, so the invariant is verified without depending
+/// on the real file's current contents.
+///
+/// The guard exists because Codemagic validates the entire config *before*
+/// provisioning a machine: a `groups:` entry naming a group that does not exist
+/// fails every workflow in the file, and no in-script guard can catch it
+/// because no script runs. #6999 shipped exactly that and took the pipeline
+/// down for ~21 hours (#7203).
+void main() {
+  group('check_codemagic_groups', () {
+    late Directory tmp;
+    late String scriptPath;
+
+    /// Minimal codemagic.yaml: a header checklist naming [documented] groups,
+    /// and one workflow referencing [referenced].
+    String yaml({
+      required List<String> documented,
+      required List<String> referenced,
+    }) {
+      final header = documented
+          .map((g) => '# n - Create environment variable group "$g" with:')
+          .join('\n');
+      final refs = referenced.map((g) => '        - $g').join('\n');
+      return '''
+# Steps to setup:
+$header
+
+definitions:
+  scripts:
+    - &noop
+      name: noop
+      script: echo hi
+
+workflows:
+  demo:
+    name: Demo
+    environment:
+      groups:
+$refs
+      vars:
+        FOO: bar
+    scripts:
+      - *noop
+''';
+    }
+
+    ProcessResult run(String contents) {
+      final f = File('${tmp.path}/codemagic.yaml')..writeAsStringSync(contents);
+      return Process.runSync(
+        'bash',
+        [scriptPath],
+        // No Codemagic credentials: the advisory API layer must stay inert, so
+        // these assertions cover the offline path CI and forks actually run.
+        environment: {'CODEMAGIC_YAML': f.path},
+        includeParentEnvironment: false,
+      );
+    }
+
+    setUp(() {
+      tmp = Directory.systemTemp.createTempSync('codemagic_groups_test');
+      scriptPath = File('scripts/check_codemagic_groups.sh').absolute.path;
+    });
+
+    tearDown(() {
+      if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+    });
+
+    test('script exists', () {
+      expect(File(scriptPath).existsSync(), isTrue);
+    });
+
+    test('passes when every referenced group is documented', () {
+      final r = run(
+        yaml(
+          documented: ['zendesk_credentials', 'proofmode_credentials'],
+          referenced: ['zendesk_credentials', 'proofmode_credentials'],
+        ),
+      );
+      expect(r.exitCode, 0, reason: '${r.stdout}${r.stderr}');
+    });
+
+    test('fails when a referenced group is undocumented', () {
+      final r = run(
+        yaml(
+          documented: ['zendesk_credentials'],
+          referenced: ['zendesk_credentials', 'supporters_credentials'],
+        ),
+      );
+      expect(r.exitCode, isNot(0));
+      expect(r.stderr, contains('supporters_credentials'));
+    });
+
+    test('names every undocumented group, not just the first', () {
+      final r = run(
+        yaml(
+          documented: ['zendesk_credentials'],
+          referenced: [
+            'zendesk_credentials',
+            'supporters_credentials',
+            'maestro_e2e_credentials',
+          ],
+        ),
+      );
+      expect(r.exitCode, isNot(0));
+      expect(r.stderr, contains('supporters_credentials'));
+      expect(r.stderr, contains('maestro_e2e_credentials'));
+    });
+
+    test('fails when the checklist documents a group nothing references', () {
+      // The reverse invariant: without it the checklist ossifies with setup
+      // steps for groups no workflow uses, and stops being trustworthy.
+      final r = run(
+        yaml(
+          documented: ['zendesk_credentials', 'retired_credentials'],
+          referenced: ['zendesk_credentials'],
+        ),
+      );
+      expect(r.exitCode, isNot(0));
+      expect(r.stderr, contains('retired_credentials'));
+    });
+
+    test('only the header counts as documentation', () {
+      // A group named further down the file — in a comment beside its own
+      // `groups:` entry, say — must not satisfy the checklist requirement.
+      final base = yaml(
+        documented: ['zendesk_credentials'],
+        referenced: ['zendesk_credentials', 'supporters_credentials'],
+      );
+      final r = run(
+        base.replaceFirst(
+          '        - supporters_credentials',
+          '        # "supporters_credentials" is set up in Codemagic\n'
+              '        - supporters_credentials',
+        ),
+      );
+      expect(r.exitCode, isNot(0));
+      expect(r.stderr, contains('supporters_credentials'));
+    });
+
+    test('reports a helpful path when codemagic.yaml is missing', () {
+      final r = Process.runSync(
+        'bash',
+        [scriptPath],
+        environment: {'CODEMAGIC_YAML': '${tmp.path}/absent.yaml'},
+        includeParentEnvironment: false,
+      );
+      expect(r.exitCode, isNot(0));
+      expect(r.stderr, contains('cannot find codemagic.yaml'));
+    });
+
+    test('the real codemagic.yaml satisfies the invariant', () {
+      // Guards the checked-in file itself, so a PR adding a `groups:` entry
+      // without its setup step fails here rather than in production.
+      final r = Process.runSync('bash', [scriptPath]);
+      expect(r.exitCode, 0, reason: '${r.stdout}${r.stderr}');
+    });
+  });
+}

--- a/mobile/test/tools/detect_mobile_ci_scope_test.dart
+++ b/mobile/test/tools/detect_mobile_ci_scope_test.dart
@@ -112,6 +112,21 @@ esac
           );
         });
 
+        test('skips app CI for a codemagic.yaml-only change', () {
+          // Intentionally out of app-scope so a config-only edit does not
+          // drag the full matrix. The Codemagic group guard must therefore
+          // be required through the Mobile CI aggregator, not this detector.
+          expectScope(
+            runDetector(
+              event: event,
+              changedFiles: ['codemagic.yaml'],
+              changedTotal: 1,
+            ),
+            app: false,
+            native: false,
+          );
+        });
+
         test('skips app CI for docs-only changes', () {
           expectScope(
             runDetector(

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -337,6 +337,27 @@ if [ -n "$CHANGED_HOST_CFG" ]; then
     echo ""
 fi
 
+# Codemagic variable group guard (mirrors CI's check_codemagic_groups.sh).
+# Every group named under a workflow's `groups:` key must appear in the setup
+# checklist at the top of codemagic.yaml. Codemagic validates the whole file
+# before provisioning, so an undeclared group fails every workflow in it and no
+# in-script guard can catch it — that took the pipeline down for ~21 hours
+# (#7203). Trigger only on codemagic.yaml so unrelated pushes are not slowed.
+CHANGED_CODEMAGIC=$(git -C "$REPO_ROOT" diff --name-only "$BASE_BRANCH"...HEAD 2>/dev/null \
+    | grep -E '^codemagic\.yaml$' || true)
+if [ -n "$CHANGED_CODEMAGIC" ]; then
+    echo "codemagic.yaml changed; checking variable groups..."
+    if ! bash "$REPO_ROOT/mobile/scripts/check_codemagic_groups.sh"; then
+        echo ""
+        echo "Codemagic group guard failed — a referenced variable group is not"
+        echo "documented in the setup checklist at the top of codemagic.yaml."
+        echo "Create the group in the Codemagic project, then document it there."
+        exit 1
+    fi
+    echo "Codemagic variable groups OK"
+    echo ""
+fi
+
 # Get list of changed Dart files (excluding generated files)
 CHANGED_FILES=$(git -C "$REPO_ROOT" diff --name-only "$BASE_BRANCH"...HEAD 2>/dev/null \
     | grep '^mobile/.*\.dart$' \


### PR DESCRIPTION
## Summary

Fails CI when `codemagic.yaml` references an environment variable group its own setup checklist does not document.

Closes #7198
Relates to #7203

## Motivation

Codemagic validates the entire `codemagic.yaml` **before** it provisions a machine. A `groups:` entry naming a group that does not exist therefore fails *every* workflow in the file — not just the one that needs it, and not just the feature it belongs to. Critically, **no in-script guard can catch it, because no script ever runs.**

This has happened twice:

- **#6999** added `supporters_credentials` to six workflows without the group existing. iOS, Android, macOS and both E2E lanes were down for ~21 hours (#7203, fixed by #7191). The guard shipped alongside it, `check_supporters_config.sh`, could never fire — it protects against an *unset variable*, not a *missing group*.
- **`maestro_e2e_credentials`** has blocked both E2E workflows since they were written, identically. Manual dispatch of `e2e-smoke-ios` on `main` still fails on it today.

Both share one signature: a `groups:` entry added with no corresponding entry in the setup checklist at the top of the file. That checklist documented 3 groups while 5 were referenced.

## What it does

Nothing offline can prove a group exists in the Codemagic project. But requiring it to be **documented** forces the author to confront the setup step — which is exactly where both omissions happened.

The invariant runs both ways, matching `check_backend_host_defaults.sh`:

1. **Referenced but undocumented → FAIL.** Catches the outage above.
2. **Documented but unreferenced → FAIL.** Stops the checklist ossifying with setup steps for groups nothing uses.

Runs in **GitHub Actions**, not Codemagic: static, needs no simulator, no build and no credentials, so it covers fork PRs and fails in seconds rather than after a `mac_mini_m2` build. The required `Mobile CI` check fails unless this job succeeds, including on a `codemagic.yaml`-only change.

## Verified against the actual regression

Run against the tree at `4fc00d0911` (the #6999 merge commit):

```
FAIL: codemagic.yaml references environment variable group(s) that its
      setup checklist does not document:
        - google_play_credentials
        - maestro_e2e_credentials
        - supporters_credentials
```

It would have blocked #6999 before merge.

## The optional API layer is advisory only

When `CODEMAGIC_API_TOKEN` and `CODEMAGIC_APP_ID` are set, the script also cross-checks against the Codemagic API — but **never fails on it**.

`GET /apps/{id}` does not enumerate team-level shared groups. `github_credentials` proves it: absent from that payload, yet `ios-build` and `android-build` reference it and succeed, which is impossible for a group Codemagic considers unknown. Failing on that list would red every PR over a group that is present. The only authoritative existence test is starting a build and reading the validation error, which is far too expensive per-PR.

So the API layer prints where to look first, and the documentation invariant carries the verdict.

## Also in this PR

Documents the two groups that were already undocumented — `google_play_credentials` and `maestro_e2e_credentials` — since the new check requires it. The Maestro entry carries a warning worth having in writing: use a dedicated STAGING account, because `tests/removeKeys.yaml` deletes the account's keys from the device as the suite's teardown on every run.

## Tests

`mobile/test/tools/codemagic_groups_test.dart`, following `file_size_ceiling_test.dart` — synthetic fixtures for a clean pass, undocumented reference, multiple undocumented, the reverse invariant, non-`_credentials` names, trailing comments on a group line, header-only documentation scoping, missing-file handling, and a guard that the checked-in `codemagic.yaml` satisfies the invariant.

`Codemagic Variable Groups` is budgeted at warn 30s / fail 90s (measured 8–10s on this PR).

**The header-scoping test caught a real bug during development**: a comment line inside a `groups:` block terminated the block-tracking in my first `awk`, silently dropping every entry after it — precisely the false negative this guard exists to prevent. Fixed, and the test pins it.

## Note

This does not create `maestro_e2e_credentials`; that still needs doing in the Codemagic UI (`MAESTRO_USER_EMAIL`, `MAESTRO_USER_PWD`, `MAESTRO_SEARCH_USER`, all Secure). This PR only ensures the next such omission is caught at review time rather than in production.

