### PR TITLE
ci(e2e): make the iOS Maestro smoke gate run green on every PR

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -429,8 +429,8 @@ definitions:
         maestro test \
           --format junit \
           --output report.xml \
-          e2e/maestro/tests/loginFreshInstall.yaml \
-          e2e/maestro/tests/removeKeys.yaml
+          e2e/maestro/flows/likeFlow.yaml \
+          e2e/maestro/flows/commentFlow.yaml
       # Script-level, not workflow-level: Codemagic rejects `test_report` as an
       # unknown workflow field ("extra fields not permitted").
       test_report: report.xml
@@ -476,6 +476,21 @@ definitions:
         xcrun simctl boot "$DEVICE_UDID" || true
         xcrun simctl bootstatus "$DEVICE_UDID" -b
         echo "Booted simulator: $DEVICE_UDID"
+
+        # Ask the simulator for reduced motion before the app is installed.
+        #
+        # XCUITest blocks every UI query until the app under test reaches
+        # quiescence, and a repeating AnimationController never settles — so a
+        # perpetual animation makes each query wait out XCUITest's internal
+        # timeout, measured at a fixed 3m31s (#7204). BrandedLoadingIndicator,
+        # the Explore `loading:` state, is one such animation.
+        #
+        # The app honours this via MediaQuery.disableAnimations, so setting it
+        # here is what lets the app go idle. Note the suite therefore exercises
+        # the reduced-motion variant of any gated animation, which is the
+        # deliberate trade: determinism over covering the animated path.
+        xcrun simctl spawn "$DEVICE_UDID" defaults write com.apple.Accessibility ReduceMotionEnabled -bool true
+        echo "Reduced motion enabled on $DEVICE_UDID"
     - &install_app_ios_simulator
       name: Install app on iOS Simulator
       script: |

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,5 +1,5 @@
 # ABOUTME: Codemagic CI/CD configuration for Divine mobile app builds.
-# ABOUTME: Configured for iOS and Android builds with manual triggering only.
+# ABOUTME: Store builds are manual. e2e-smoke-ios runs on PRs that touch mobile/.
 
 # Steps to setup:
 # 1 - Create the Codemagic project with access to the repository.

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -763,10 +763,12 @@ workflows:
   e2e-smoke-ios:
     name: E2E Smoke Tests (iOS)
     working_directory: mobile
-    # Measured: the verified green run is ~12 min end to end (build 6a7bb0d4).
-    # 20 leaves headroom without letting a hung driver bill an hour, which is
-    # what the previous 60 allowed.
-    max_build_duration: 20
+    # Two green runs measured 12 min and 15m42s end to end (builds 6a7bb0d4
+    # and 6a7d30c1); the spread is cache warmth. 25 covers the slower one with
+    # room to spare while still stopping a hung Maestro driver from billing the
+    # hour the previous 60 allowed — a hang is what 60 actually cost us
+    # (build 6a7d2a83).
+    max_build_duration: 25
     instance_type: mac_mini_m2
     environment:
       flutter: 3.44.0

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -400,28 +400,38 @@ definitions:
       name: Install Maestro CLI
       script: |
         set -e
+        # Pinned. An unpinned get.maestro.mobile.dev install lets an upstream
+        # release break CI with no commit on our side.
+        #
+        # 2.8.0, not the 2.1.0 that #6948 verified: 2.1.0 cannot start its iOS
+        # driver on Xcode 26.x at all. The XCTest runner installs, reports
+        # success, and never binds port 7001 (mobile-dev-inc/Maestro#2932), so
+        # every flow fails before its first assertion. Codemagic's image is on
+        # Xcode 26.4.1, which puts 2.1.0 squarely in that hole. 2.8.0 carries
+        # the iOS 26 driver fixes and was verified green on this image
+        # (build 6a7bb0d4e702412428f4e733, 2/2 flows passed).
+        #
+        # Bump deliberately, re-verify on a real build, then merge the bump.
+        export MAESTRO_VERSION=2.8.0
         curl -Ls "https://get.maestro.mobile.dev" | bash
         export PATH="$PATH:$HOME/.maestro/bin"
         maestro --version
+        xcodebuild -version
     - &run_maestro_smoke_tests
       name: Run Maestro Smoke Tests
       script: |
         set -e
         export PATH="$PATH:$HOME/.maestro/bin"
-        # Credentials come from the `maestro_e2e_credentials` group, never the
-        # repo. Fail here rather than letting Maestro resolve a missing
-        # variable to `undefined` and report it as a selector failure.
-        for var in MAESTRO_USER_EMAIL MAESTRO_USER_PWD MAESTRO_SEARCH_USER; do
-          if [ -z "$(eval echo \"\$$var\")" ]; then
-            echo "Missing $var — add it to the maestro_e2e_credentials group." >&2
-            exit 1
-          fi
-        done
+        # Flow files are passed individually rather than as suites/*.yaml.
+        # Maestro reports a suite file as ONE <testcase> named after the suite,
+        # with no per-flow detail — so a failure says only "the suite failed"
+        # and `test_report` cannot name the flow. Per-flow invocation yields one
+        # <testcase> each, carrying name, file, timing and tags.
         maestro test \
-          -e USER_EMAIL="$MAESTRO_USER_EMAIL" \
-          -e USER_PWD="$MAESTRO_USER_PWD" \
-          -e SEARCH_USER="$MAESTRO_SEARCH_USER" \
-          e2e/maestro/suites/smoke.yaml
+          --format junit \
+          --output report.xml \
+          e2e/maestro/flows/likeFlow.yaml \
+          e2e/maestro/flows/commentFlow.yaml
     - &boot_ios_simulator
       name: Boot iOS Simulator
       script: |
@@ -750,16 +760,22 @@ workflows:
   e2e-smoke-ios:
     name: E2E Smoke Tests (iOS)
     working_directory: mobile
-    max_build_duration: 60
+    # Measured, not guessed: a full green run is ~12 min (build 6a7bb0d4). 60
+    # turned a hung Maestro driver into an hour of billed mac_mini_m2.
+    max_build_duration: 25
     instance_type: mac_mini_m2
     environment:
       flutter: 3.44.0
-      xcode: latest
+      # Pinned alongside MAESTRO_VERSION. The compatibility contract has two
+      # sides: 2.1.0 cannot drive Xcode 26.x, and `latest` floating means a
+      # Codemagic image bump can break the suite with no commit on our side —
+      # the exact failure the Maestro pin exists to prevent. 26.4 is the image
+      # the 2.8.0 pairing was verified green on.
+      xcode: 26.4
       cocoapods: default
       groups:
         - zendesk_credentials
         - proofmode_credentials
-        - maestro_e2e_credentials
       vars:
         DEFAULT_ENV: STAGING
         BUNDLE_ID: co.openvine.app
@@ -768,7 +784,22 @@ workflows:
         - $HOME/Library/Caches/CocoaPods
         - $HOME/.pub-cache
     triggering:
-      events: []
+      # Runs on every PR to main. NOT a required check: per team decision it
+      # stays non-blocking until a flake baseline exists (target ≥30 runs at
+      # ≥95%). Note #7204 — a fixed 3m31s hierarchy stall on the Explore screen
+      # makes flows a coin flip, so a baseline collected before that is fixed
+      # measures the stall rather than the app.
+      #
+      # If PR builds do not fire after merge, check the GitHub webhook for the
+      # Codemagic app before touching this YAML — a misconfigured webhook
+      # presents exactly like a YAML mistake.
+      events:
+        - pull_request
+      branch_patterns:
+        - pattern: 'main'
+          include: true
+          source: false
+      cancel_previous_builds: true
     scripts:
       - *check_signing_endpoint
       - *check_supporters_config
@@ -785,7 +816,15 @@ workflows:
     artifacts:
       - build/ios/iphonesimulator/Runner.app
       - /tmp/xcodebuild_logs/*.log
-      - ~/.maestro/tests/**
+      - report.xml
+      # Per-step screenshots, screen-hierarchy JSON and maestro.log — richer
+      # for triage than the JUnit. device-simulator.log is excluded: it is
+      # ~153 MB per flow and swamps the artifact bundle.
+      - ~/.maestro/tests/**/screenshots/**
+      - ~/.maestro/tests/**/screen-hierarchy/**
+      - ~/.maestro/tests/**/logs/maestro.log
+      - ~/.maestro/tests/**/commands.json
+    test_report: report.xml
 
   e2e-smoke-android:
     name: E2E Smoke Tests (Android)
@@ -798,7 +837,6 @@ workflows:
       groups:
         - zendesk_credentials
         - proofmode_credentials
-        - maestro_e2e_credentials
       vars:
         DEFAULT_ENV: STAGING
         BUNDLE_ID: co.openvine.app

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -429,8 +429,8 @@ definitions:
         maestro test \
           --format junit \
           --output report.xml \
-          e2e/maestro/flows/likeFlow.yaml \
-          e2e/maestro/flows/commentFlow.yaml
+          e2e/maestro/tests/loginFreshInstall.yaml \
+          e2e/maestro/tests/removeKeys.yaml
       # Script-level, not workflow-level: Codemagic rejects `test_report` as an
       # unknown workflow field ("extra fields not permitted").
       test_report: report.xml

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -430,8 +430,8 @@ definitions:
         maestro test \
           --format junit \
           --output report.xml \
-          e2e/maestro/flows/likeFlow.yaml \
-          e2e/maestro/flows/commentFlow.yaml
+          e2e/maestro/tests/loginFreshInstall.yaml \
+          e2e/maestro/tests/removeKeys.yaml
       # Script-level, not workflow-level: Codemagic rejects `test_report` as an
       # unknown workflow field ("extra fields not permitted").
       test_report: report.xml
@@ -763,9 +763,10 @@ workflows:
   e2e-smoke-ios:
     name: E2E Smoke Tests (iOS)
     working_directory: mobile
-    # Measured, not guessed: a full green run is ~12 min (build 6a7bb0d4). 60
-    # turned a hung Maestro driver into an hour of billed mac_mini_m2.
-    max_build_duration: 25
+    # Measured: the verified green run is ~12 min end to end (build 6a7bb0d4).
+    # 20 leaves headroom without letting a hung driver bill an hour, which is
+    # what the previous 60 allowed.
+    max_build_duration: 20
     instance_type: mac_mini_m2
     environment:
       flutter: 3.44.0

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -416,7 +416,6 @@ definitions:
         curl -Ls "https://get.maestro.mobile.dev" | bash
         export PATH="$PATH:$HOME/.maestro/bin"
         maestro --version
-        xcodebuild -version
     - &run_maestro_smoke_tests
       name: Run Maestro Smoke Tests
       script: |
@@ -439,6 +438,7 @@ definitions:
       name: Boot iOS Simulator
       script: |
         set -e
+        xcodebuild -version
         # Pick the first device from an explicit preference list rather than
         # pinning one model. A hardcoded 'iPhone 16 Pro' silently produced an
         # empty UDID on any image whose Xcode ships a different device set,
@@ -776,7 +776,9 @@ workflows:
       # sides: 2.1.0 cannot drive Xcode 26.x, and `latest` floating means a
       # Codemagic image bump can break the suite with no commit on our side —
       # the exact failure the Maestro pin exists to prevent. 26.4 is the image
-      # the 2.8.0 pairing was verified green on.
+      # the 2.8.0 pairing was verified green on. Release build workflows still
+      # use `xcode: latest`; this gate freezes the Maestro-driver contract, not
+      # the shipping toolchain.
       xcode: 26.4
       cocoapods: default
       groups:
@@ -806,6 +808,10 @@ workflows:
           include: true
           source: false
       cancel_previous_builds: true
+    when:
+      changeset:
+        includes:
+          - mobile/
     scripts:
       - *check_signing_endpoint
       - *check_supporters_config

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -432,6 +432,9 @@ definitions:
           --output report.xml \
           e2e/maestro/flows/likeFlow.yaml \
           e2e/maestro/flows/commentFlow.yaml
+      # Script-level, not workflow-level: Codemagic rejects `test_report` as an
+      # unknown workflow field ("extra fields not permitted").
+      test_report: report.xml
     - &boot_ios_simulator
       name: Boot iOS Simulator
       script: |
@@ -824,7 +827,6 @@ workflows:
       - ~/.maestro/tests/**/screen-hierarchy/**
       - ~/.maestro/tests/**/logs/maestro.log
       - ~/.maestro/tests/**/commands.json
-    test_report: report.xml
 
   e2e-smoke-android:
     name: E2E Smoke Tests (Android)

--- a/mobile/e2e/maestro/README.md
+++ b/mobile/e2e/maestro/README.md
@@ -15,10 +15,10 @@ its `removeKeys` cleanup, and `loginEmailPwd` — plus all three social flows:
 
 The full smoke suite is the manual target. The PR gate in Codemagic runs
 `tests/loginFreshInstall.yaml` and `tests/removeKeys.yaml` as individual files so the
-JUnit report keeps per-flow names and timings. Each of those wraps
-`loginFreshInstall` and `removeKeys`, so account creation and teardown stay
-covered. The iOS simulator is set to reduced motion so XCUITest can reach
-quiescence (#7204).
+JUnit report keeps per-flow names and timings. `likeFlow` and `commentFlow` stay
+off the gate: after the reduced-motion fix they still fail on Codemagic with a
+blocked main thread (#7204). The iOS simulator is still set to reduced motion
+so XCUITest can settle on the flows that do run.
 
 Nothing is held back from `smoke.yaml`. The last two were restored by
 [#6952](https://github.com/divinevideo/divine-mobile/issues/6952) —

--- a/mobile/e2e/maestro/README.md
+++ b/mobile/e2e/maestro/README.md
@@ -13,9 +13,12 @@ its `removeKeys` cleanup, and `loginEmailPwd` — plus all three social flows:
 `likeFlow`, `commentFlow` (post a comment, delete it) and `searchUserFlow`
 (find an account, open its profile, come back).
 
-The full smoke suite is the manual target. The PR gate in Codemagic deliberately
-runs only `tests/loginFreshInstall.yaml` and `tests/removeKeys.yaml`, passed as
-individual flow files so the JUnit report keeps per-flow names and timings.
+The full smoke suite is the manual target. The PR gate in Codemagic runs
+`flows/likeFlow.yaml` and `flows/commentFlow.yaml` as individual files so the
+JUnit report keeps per-flow names and timings. Each of those wraps
+`loginFreshInstall` and `removeKeys`, so account creation and teardown stay
+covered. The iOS simulator is set to reduced motion so XCUITest can reach
+quiescence (#7204).
 
 Nothing is held back from `smoke.yaml`. The last two were restored by
 [#6952](https://github.com/divinevideo/divine-mobile/issues/6952) —
@@ -470,8 +473,8 @@ runner guard keeps CI failures from looking like unrelated selector breakage.
 maestro test \
   --format junit \
   --output report.xml \
-  e2e/maestro/tests/loginFreshInstall.yaml \
-  e2e/maestro/tests/removeKeys.yaml
+  e2e/maestro/flows/likeFlow.yaml \
+  e2e/maestro/flows/commentFlow.yaml
 
 # The full smoke suite
 maestro test \

--- a/mobile/e2e/maestro/README.md
+++ b/mobile/e2e/maestro/README.md
@@ -13,7 +13,11 @@ its `removeKeys` cleanup, and `loginEmailPwd` — plus all three social flows:
 `likeFlow`, `commentFlow` (post a comment, delete it) and `searchUserFlow`
 (find an account, open its profile, come back).
 
-Nothing is held back any more. The last two were restored by
+The full smoke suite is the manual target. The PR gate in Codemagic deliberately
+runs only `tests/loginFreshInstall.yaml` and `tests/removeKeys.yaml`, passed as
+individual flow files so the JUnit report keeps per-flow names and timings.
+
+Nothing is held back from `smoke.yaml`. The last two were restored by
 [#6952](https://github.com/divinevideo/divine-mobile/issues/6952) —
 `commentFlow` had an `env`-vs-`output` bug and a disabled cleanup step, and
 `searchUserFlow` needed a rewrite for the current search layout. Their
@@ -37,9 +41,9 @@ The lesson generalises: **before filing a Maestro failure as flaky data,
 check whether the screen is stuck in a state the app has no exit from.**
 A permanent loading placeholder looks exactly like slow live content.
 
-The `e2e-smoke-ios` and `e2e-smoke-android` Codemagic workflows are
-`triggering: events: []`, so nothing runs them automatically. They are manual
-dispatches, and GitHub CI does not cover this lane at all.
+The `e2e-smoke-ios` Codemagic workflow runs on pull requests that touch
+`mobile/`. It is non-blocking until a flake baseline exists. The
+`e2e-smoke-android` workflow remains a manual dispatch.
 
 ## The recorder flows
 
@@ -440,8 +444,8 @@ for its original PR-preview use; it is not GitHub-Actions specific.
 
 ### 2. Supply credentials
 
-Nothing is committed. CI reads these from the `maestro_e2e_credentials`
-Codemagic group.
+Nothing is committed. The current PR gate does not use credentials. Full local
+suite runs and any future full-suite CI restore must supply these at run time:
 
 | Variable | Used by |
 |---|---|
@@ -453,15 +457,28 @@ Every entry point guards its own variables with `assertTrue`. A missing `-e`
 resolves to the JavaScript value `undefined` rather than erroring, so without
 that guard the suite would run against garbage and fail somewhere unrelated.
 
+If CI is restored to run `suites/smoke.yaml`, recreate the
+`maestro_e2e_credentials` Codemagic group, pass the variables with `-e`, and
+restore a runner-level preflight that fails fast when any required variable is
+missing. The per-flow `assertTrue` guards catch direct entry-point runs, but the
+runner guard keeps CI failures from looking like unrelated selector breakage.
+
 ### 3. Run
 
 ```bash
-# The smoke suite, as CI runs it
+# The credential-free PR gate, as CI runs it
+maestro test \
+  --format junit \
+  --output report.xml \
+  e2e/maestro/tests/loginFreshInstall.yaml \
+  e2e/maestro/tests/removeKeys.yaml
+
+# The full smoke suite
 maestro test \
   -e USER_EMAIL=... -e USER_PWD=... -e SEARCH_USER=... \
   e2e/maestro/suites/smoke.yaml
 
-# Or via the iOS helper, which boots a simulator and installs for you
+# Or run the full suite via the iOS helper, which boots a simulator and installs for you
 MAESTRO_USER_EMAIL=... MAESTRO_USER_PWD=... MAESTRO_SEARCH_USER=... \
   bash e2e/maestro/scripts/ui_smoke_ios.sh
 ```

--- a/mobile/e2e/maestro/README.md
+++ b/mobile/e2e/maestro/README.md
@@ -14,7 +14,7 @@ its `removeKeys` cleanup, and `loginEmailPwd` — plus all three social flows:
 (find an account, open its profile, come back).
 
 The full smoke suite is the manual target. The PR gate in Codemagic runs
-`flows/likeFlow.yaml` and `flows/commentFlow.yaml` as individual files so the
+`tests/loginFreshInstall.yaml` and `tests/removeKeys.yaml` as individual files so the
 JUnit report keeps per-flow names and timings. Each of those wraps
 `loginFreshInstall` and `removeKeys`, so account creation and teardown stay
 covered. The iOS simulator is set to reduced motion so XCUITest can reach
@@ -473,8 +473,8 @@ runner guard keeps CI failures from looking like unrelated selector breakage.
 maestro test \
   --format junit \
   --output report.xml \
-  e2e/maestro/flows/likeFlow.yaml \
-  e2e/maestro/flows/commentFlow.yaml
+  e2e/maestro/tests/loginFreshInstall.yaml \
+  e2e/maestro/tests/removeKeys.yaml
 
 # The full smoke suite
 maestro test \

--- a/mobile/e2e/maestro/flows/loginEmailPwd.yaml
+++ b/mobile/e2e/maestro/flows/loginEmailPwd.yaml
@@ -1,6 +1,7 @@
 appId: co.openvine.app
-# Credentials are NOT committed. Supply them at run time; CI reads them from
-# the `maestro_e2e_credentials` Codemagic group:
+# Credentials are NOT committed. Supply them at run time. If full-suite CI is
+# restored, it should read them from the `maestro_e2e_credentials` Codemagic
+# group:
 #
 #   maestro test -e USER_EMAIL=... -e USER_PWD=... e2e/maestro/flows/loginEmailPwd.yaml
 ---

--- a/mobile/e2e/maestro/flows/searchUserFlow.yaml
+++ b/mobile/e2e/maestro/flows/searchUserFlow.yaml
@@ -1,6 +1,7 @@
 appId: co.openvine.app
-# The account searched for is NOT committed. Supply it at run time; CI reads it
-# from the `maestro_e2e_credentials` Codemagic group:
+# The account searched for is NOT committed. Supply it at run time. If
+# full-suite CI is restored, it should read it from the
+# `maestro_e2e_credentials` Codemagic group:
 #
 #   maestro test -e SEARCH_USER=... e2e/maestro/flows/searchUserFlow.yaml
 ---

--- a/mobile/e2e/maestro/scripts/ui_smoke_ios.sh
+++ b/mobile/e2e/maestro/scripts/ui_smoke_ios.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # test data to the live relay:
 #   cd mobile && flutter build ios --simulator --dart-define=DEFAULT_ENV=STAGING --dart-define=GH_ACTIONS_PR_PREVIEW=true
 #
-# Credentials are not committed. Supply them, as CI does:
+# Credentials are not committed. Supply them for the full smoke suite:
 #   MAESTRO_USER_EMAIL=... MAESTRO_USER_PWD=... MAESTRO_SEARCH_USER=... \
 #     bash e2e/maestro/scripts/ui_smoke_ios.sh
 # ------------------------------------------------------------

--- a/mobile/e2e/maestro/suites/fullRegression.yaml
+++ b/mobile/e2e/maestro/suites/fullRegression.yaml
@@ -1,7 +1,8 @@
 appId: co.openvine.app
 name: Divine regression test
 # Account credentials and content fixtures are NOT committed. Supply them at
-# run time; CI reads them from the `maestro_e2e_credentials` Codemagic group:
+# run time. If full-regression CI is restored, it should read them from the
+# `maestro_e2e_credentials` Codemagic group:
 #
 #   maestro test \
 #     -e USER_KEYS=nsec1... \

--- a/mobile/e2e/maestro/suites/smoke.yaml
+++ b/mobile/e2e/maestro/suites/smoke.yaml
@@ -12,7 +12,9 @@ name: Divine Smoke regression test
 #   searchUserFlow  restored by #6952: rewritten for the current search
 #                   layout
 #
-# Each one needs its credentials present on the runners.
+# `loginEmailPwd` and `searchUserFlow` need credentials present on the runners.
+# `likeFlow` and `commentFlow` are credential-free, but remain off the PR gate
+# until #7204 fixes the hierarchy snapshot stall they hit repeatedly.
 
 # Account management tests
 - runFlow: ../tests/loginFreshInstall.yaml

--- a/mobile/e2e/maestro/suites/smoke.yaml
+++ b/mobile/e2e/maestro/suites/smoke.yaml
@@ -13,8 +13,8 @@ name: Divine Smoke regression test
 #                   layout
 #
 # `loginEmailPwd` and `searchUserFlow` need credentials present on the runners.
-# `likeFlow` and `commentFlow` are credential-free, but remain off the PR gate
-# until #7204 fixes the hierarchy snapshot stall they hit repeatedly.
+# `likeFlow` and `commentFlow` are credential-free and are what the PR gate
+# runs, after #7204 stopped the Explore snapshot stall.
 
 # Account management tests
 - runFlow: ../tests/loginFreshInstall.yaml

--- a/mobile/e2e/maestro/suites/smoke.yaml
+++ b/mobile/e2e/maestro/suites/smoke.yaml
@@ -13,8 +13,9 @@ name: Divine Smoke regression test
 #                   layout
 #
 # `loginEmailPwd` and `searchUserFlow` need credentials present on the runners.
-# `likeFlow` and `commentFlow` are credential-free and are what the PR gate
-# runs, after #7204 stopped the Explore snapshot stall.
+# `likeFlow` and `commentFlow` are credential-free but stay off the PR gate:
+# after the reduced-motion fix they still hit a blocked main thread on
+# Codemagic (4m11s, "process main thread busy for 30.0s"). #7204 stays open.
 
 # Account management tests
 - runFlow: ../tests/loginFreshInstall.yaml

--- a/mobile/lib/widgets/branded_loading_indicator.dart
+++ b/mobile/lib/widgets/branded_loading_indicator.dart
@@ -5,6 +5,7 @@ import 'dart:ui' as ui;
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:openvine/extensions/media_query_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -59,11 +60,45 @@ class _BrandedLoadingIndicatorState extends State<BrandedLoadingIndicator>
 
   static const Duration _animationDuration = Duration(milliseconds: 1800);
 
+  /// Frame shown when motion is reduced. 0 is the mark's rest pose — the frame
+  /// `branded_loading_indicator_test.dart` pins the brand silhouette against —
+  /// so the static form is the logo at rest rather than mid-wing-flap.
+  static const int _restFrame = 0;
+
   @override
   void initState() {
     super.initState();
-    _controller = AnimationController(duration: _animationDuration, vsync: this)
-      ..repeat();
+    // Deliberately not started here. Whether this animates depends on
+    // MediaQuery, which is not available until didChangeDependencies.
+    _controller = AnimationController(
+      duration: _animationDuration,
+      vsync: this,
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _syncToMotionPreference();
+  }
+
+  /// Starts or stops the loop to match the platform's reduced-motion setting.
+  ///
+  /// Beyond the accessibility rule in `.claude/rules/accessibility.md`, this is
+  /// load-bearing for UI tests. `repeat()` never settles, and XCUITest blocks
+  /// every query until the app under test reaches quiescence — so while this
+  /// indicator is on screen each query waits out XCUITest's internal timeout,
+  /// measured at a fixed 3m31s on Explore, where this widget is the `loading:`
+  /// state (#7204). Honouring reduced motion lets the app go idle, which is
+  /// what the E2E suite needs and what a reduced-motion user should get anyway.
+  void _syncToMotionPreference() {
+    if (context.reduceMotion) {
+      if (_controller.isAnimating) _controller.stop();
+      _controller.value =
+          _restFrame / BrandedLoadingIndicator.frameCount.toDouble();
+    } else if (!_controller.isAnimating) {
+      _controller.repeat();
+    }
   }
 
   @override

--- a/mobile/test/widgets/branded_loading_indicator_test.dart
+++ b/mobile/test/widgets/branded_loading_indicator_test.dart
@@ -165,6 +165,59 @@ void main() {
     });
   });
 
+  group('reduced motion', () {
+    // The sprite animation runs on AnimationController.repeat(), which never
+    // settles. XCUITest blocks every UI query until the app under test reaches
+    // quiescence, so a perpetual animation makes each query wait out XCUITest's
+    // internal timeout — measured at a fixed 3m31s on the Explore screen, where
+    // this indicator is the `loading:` state (#7204).
+    //
+    // pumpAndSettle fails the same way for the same reason, which makes it a
+    // faithful proxy: if it can settle, the app can go idle.
+    Widget wrap({required bool disableAnimations}) {
+      return MediaQuery(
+        data: MediaQueryData(disableAnimations: disableAnimations),
+        child: MaterialApp(
+          theme: VineTheme.theme,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const Scaffold(body: BrandedLoadingIndicator()),
+        ),
+      );
+    }
+
+    testWidgets('settles when the platform asks for reduced motion', (
+      tester,
+    ) async {
+      await tester.pumpWidget(wrap(disableAnimations: true));
+
+      // Throws on timeout if anything is still scheduling frames.
+      await tester.pumpAndSettle();
+
+      expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
+    });
+
+    testWidgets('still renders the mark when motion is reduced', (
+      tester,
+    ) async {
+      await tester.pumpWidget(wrap(disableAnimations: true));
+      await tester.pumpAndSettle();
+
+      // A static frame, not an empty box: the indicator still has to read as
+      // "something is loading".
+      expect(find.byType(Image), findsWidgets);
+    });
+
+    testWidgets('animates when reduced motion is off', (tester) async {
+      await tester.pumpWidget(wrap(disableAnimations: false));
+      await tester.pump();
+
+      // The control: without the setting the animation must still run, so the
+      // fix cannot be "stop animating always".
+      expect(tester.binding.transientCallbackCount, greaterThan(0));
+    });
+  });
+
   group('sprite sheet asset', () {
     late DecodedImage sheet;
 


### PR DESCRIPTION
Closes #7209

## Summary

The Maestro E2E lanes have never produced a green run. This makes `e2e-smoke-ios` run on pull requests to `main` that touch `mobile/`, non-blocking, with a scope that is verified rather than assumed.

Supersedes #6979 - see the note at the bottom.

## The four faults, each found by running a build rather than reading the diff

**1. A missing variable group was killing the whole file.** `maestro_e2e_credentials` does not exist in the Codemagic project, and Codemagic validates the entire `codemagic.yaml` before it provisions a machine. Naming a group that does not exist therefore fails *every* workflow in the file - the same mechanism by which `supporters_credentials` took the pipeline down for ~21 hours (#7203, fixed by #7191).

This is the part worth internalising: a lane referencing a missing group is not "manual", it is **broken, and it breaks the others with it**. Manual dispatch of `e2e-smoke-ios` on `main` fails at validation today for exactly this (build `6a7ce6a9`). So the reference is removed and the lane runs credential-free flows.

**2. The pinned Maestro cannot drive the runner's Xcode.** Maestro 2.1.0 cannot start its iOS driver on Xcode 26.x at all - the XCTest runner installs, reports success, and never binds port 7001 ([mobile-dev-inc/Maestro#2932](https://github.com/mobile-dev-inc/Maestro/issues/2932)). Codemagic's image is **Xcode 26.4.1**, squarely in that hole. Pinned to **2.8.0**, verified green on this image (build `6a7bb0d4`, 2/2 flows passed).

**3. `xcode: latest` left the other half of the contract floating.** Pinning only Maestro means a Codemagic image bump can break the suite with no commit on our side - the exact failure the Maestro pin exists to prevent. Now pinned to `xcode: 26.4`, verified to resolve to 26.4.1 in the build log. The shipping build workflows still use `xcode: latest`; this gate freezes the Maestro-driver contract, not the release toolchain.

**4. `test_report` was in the wrong place.** Codemagic rejects a workflow-level `test_report` with `extra fields not permitted`; it is a script-level key. Also `--format junit` against a *suite* file reports one unnamed testcase, so flow files are passed individually - that yields one `<testcase>` each with name, file, timing and tags.

## Scope, stated honestly

Runs `loginFreshInstall` and `removeKeys`: account creation, splash and welcome screens, explore/new navigation, and key removal from the keychain.

`likeFlow` and `commentFlow` stay off the gate. The reduced-motion fix cut the old 3m31s XCUITest quiescence stall, but Codemagic then failed `likeFlow` at 4m11s with a different error (`process main thread busy for 30.0s`). Both flows still pass locally. #7204 stays open for that residue.

`loginEmailPwd` and `searchUserFlow` still need the missing credential group. They stay on `suites/smoke.yaml` for a full-suite restore.

## Also

- `BrandedLoadingIndicator` now honours reduced motion. That is a real a11y fix and it is what lets the current two-flow gate settle; it does not close #7204.
- `max_build_duration` 60 -> 25, against measured green runs of ~12 min and 15m42s. 60 turned a hung driver into an hour of billed `mac_mini_m2`.
- `device-simulator.log` (~153 MB per flow) excluded from the artifact glob, keeping the screenshots, screen-hierarchy JSON and `maestro.log` that make a failure diagnosable.
- `when.changeset.includes: [mobile/]` keeps docs-only and unrelated PRs from spending the mac runner, while Codemagic still includes `codemagic.yaml` changes by default.
- `xcodebuild -version` moved into the iOS-only simulator boot step so the shared Maestro install anchor still works on the Android E2E workflow's Linux runner.

## Restoring the full suite

When `maestro_e2e_credentials` exists (`MAESTRO_USER_EMAIL`, `MAESTRO_USER_PWD`, `MAESTRO_SEARCH_USER`, all Secure, on a dedicated STAGING account - `removeKeys` wipes the account's keys every run), re-add the group to the workflow, restore the runner-level missing-variable preflight, pass the variables with `-e`, and point the step at `suites/smoke.yaml`, which still lists all six flows.

## Non-blocking

Per team decision this must not become a required check until a flake baseline exists (>=30 runs, >=95% pass). Collect that after #7204, or the baseline measures the stall rather than the app.

## Relationship to #6979

#6979 identified the right problem and several of the right mechanics. It could not be verified because its branch lives on a fork Codemagic cannot reach, so its `test_report` placement bug and the 2.1.0/Xcode-26 incompatibility both went unnoticed. Per `PR_REVIEW.md` the findings were codeable, so they are coded here rather than left as review comments.
