### PR TITLE
fix(view-events): restore kind 22236 publishing from the durable queue

### DIFF
--- a/mobile/lib/models/view_event_drop_reason.dart
+++ b/mobile/lib/models/view_event_drop_reason.dart
@@ -1,0 +1,59 @@
+// ABOUTME: Why a kind-22236 view event was not published to the relay.
+// ABOUTME: Separates expected skips from defects so only defects alarm.
+
+/// Why a kind-22236 view event was not published.
+///
+/// `publishViewEvent` returning `false` on its own cannot distinguish a view
+/// that was correctly skipped from one the client failed to build. Both are
+/// silent, but only the second is a bug — so the two must be told apart at
+/// the point of the drop rather than inferred from log volume later.
+enum ViewEventDropReason {
+  /// The watched segment was shorter than the minimum for a view.
+  belowMinimumWatchTime,
+
+  /// No signed-in identity, so nothing could sign the event.
+  notAuthenticated,
+
+  /// The video carried no addressable `d` tag, so no `a` tag could be built.
+  missingAddressableDTag,
+
+  /// Signing returned no event.
+  signingFailed,
+
+  /// The event was built and signed but the relay publish did not succeed.
+  relayRejected;
+
+  /// Whether this drop indicates a defect rather than an expected skip.
+  ///
+  /// Structural drops should never occur: by the time they are reached the
+  /// caller has already decided this view is worth publishing, so failing to
+  /// build or sign the event means the client is broken. They are reported.
+  ///
+  /// Expected skips are high-volume and routine. Reporting them would bury
+  /// the defects, so they stay silent — see `.claude/rules/error_handling.md`.
+  /// [relayRejected] is deliberately not structural: the event was well
+  /// formed and the failure is a network or relay condition, which the
+  /// durable queue already retries.
+  bool get isStructural => switch (this) {
+    ViewEventDropReason.belowMinimumWatchTime => false,
+    ViewEventDropReason.notAuthenticated => false,
+    ViewEventDropReason.missingAddressableDTag => true,
+    ViewEventDropReason.signingFailed => true,
+    ViewEventDropReason.relayRejected => false,
+  };
+}
+
+/// A view event the client decided to publish but could not construct.
+///
+/// Wrap with `Reportable` at the call site so Crashlytics groups on this type
+/// and the identifier sanitiser runs.
+class ViewEventInvariantException implements Exception {
+  /// Creates an invariant violation for [reason].
+  const ViewEventInvariantException(this.reason);
+
+  /// The structural reason the event could not be published.
+  final ViewEventDropReason reason;
+
+  @override
+  String toString() => 'ViewEventInvariantException(${reason.name})';
+}

--- a/mobile/lib/models/view_event_drop_reason.dart
+++ b/mobile/lib/models/view_event_drop_reason.dart
@@ -20,6 +20,9 @@ enum ViewEventDropReason {
   /// Signing returned no event.
   signingFailed,
 
+  /// An unexpected exception interrupted event construction or publishing.
+  unexpectedError,
+
   /// The event was built and signed but the relay publish did not succeed.
   relayRejected;
 
@@ -39,6 +42,7 @@ enum ViewEventDropReason {
     ViewEventDropReason.notAuthenticated => false,
     ViewEventDropReason.missingAddressableDTag => true,
     ViewEventDropReason.signingFailed => true,
+    ViewEventDropReason.unexpectedError => true,
     ViewEventDropReason.relayRejected => false,
   };
 }

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -10,6 +10,8 @@ import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/current_app_l10n.dart';
+import 'package:openvine/models/view_event_drop_reason.dart';
+import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/creator_sync_provider.dart';
 import 'package:openvine/providers/curation_providers.dart';
@@ -305,6 +307,17 @@ ViewEventPublisher viewEventPublisher(Ref ref) {
   return ViewEventPublisher(
     nostrService: nostrService,
     authService: authService,
+    onDrop: (reason, {required String videoId}) {
+      if (!reason.isStructural) return;
+      CrashReportingService.instance.recordError(
+        Reportable(
+          ViewEventInvariantException(reason),
+          context: 'ViewEventPublisher.publishViewEvent',
+        ),
+        StackTrace.current,
+        reason: 'ViewEventPublisher.${reason.name}',
+      );
+    },
   );
 }
 

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -307,15 +307,15 @@ ViewEventPublisher viewEventPublisher(Ref ref) {
   return ViewEventPublisher(
     nostrService: nostrService,
     authService: authService,
-    onDrop: (reason, {required String videoId}) {
+    onDrop: (reason, {required String videoId, required String method}) {
       if (!reason.isStructural) return;
       CrashReportingService.instance.recordError(
         Reportable(
           ViewEventInvariantException(reason),
-          context: 'ViewEventPublisher.publishViewEvent',
+          context: 'ViewEventPublisher.$method',
         ),
         StackTrace.current,
-        reason: 'ViewEventPublisher.${reason.name}',
+        reason: 'ViewEventPublisher.$method.${reason.name}.videoId=$videoId',
       );
     },
   );

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -396,7 +396,7 @@ final class ViewEventPublisherProvider
 }
 
 String _$viewEventPublisherHash() =>
-    r'3bd713d924c727d7fb5ce56bd247ed307ae1d0e5';
+    r'506c5f1f86589ad3aa99e9f3673c31952e31f3c3';
 
 /// Subscribed list video cache for merging subscribed list videos into home feed
 /// Depends on CuratedListService which is async, so watch the state provider

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -396,7 +396,7 @@ final class ViewEventPublisherProvider
 }
 
 String _$viewEventPublisherHash() =>
-    r'33477998370aad03ce25bb4beff38a28da291d64';
+    r'3bd713d924c727d7fb5ce56bd247ed307ae1d0e5';
 
 /// Subscribed list video cache for merging subscribed list videos into home feed
 /// Depends on CuratedListService which is async, so watch the state provider

--- a/mobile/lib/services/view_event_publisher.dart
+++ b/mobile/lib/services/view_event_publisher.dart
@@ -16,7 +16,11 @@ const int viewEventKind = 22236;
 /// Wired in the app layer to Crashlytics for structural drops. Injected
 /// rather than reached for statically so tests can assert on drops.
 typedef ViewEventDropReporter =
-    void Function(ViewEventDropReason reason, {required String videoId});
+    void Function(
+      ViewEventDropReason reason, {
+      required String videoId,
+      required String method,
+    });
 
 /// Service for publishing video view events to Nostr relays.
 ///
@@ -43,13 +47,13 @@ class ViewEventPublisher {
   ///
   /// Every early return in this class routes through here, so a new skip
   /// path cannot be added without declaring whether it is a defect.
-  bool _drop(ViewEventDropReason reason, String videoId) {
+  bool _drop(ViewEventDropReason reason, String videoId, String method) {
     Log.debug(
       'View event dropped (${reason.name}) for video $videoId',
       name: 'ViewEventPublisher',
       category: LogCategory.video,
     );
-    _onDrop?.call(reason, videoId: videoId);
+    _onDrop?.call(reason, videoId: videoId, method: method);
     return false;
   }
 
@@ -69,19 +73,24 @@ class ViewEventPublisher {
     String? sourceDetail,
     int? loopCount,
   }) async {
+    const method = 'publishViewEvent';
     if (endSeconds - startSeconds < 1) {
-      return _drop(ViewEventDropReason.belowMinimumWatchTime, video.id);
+      return _drop(ViewEventDropReason.belowMinimumWatchTime, video.id, method);
     }
 
     if (!_authService.isAuthenticated) {
-      return _drop(ViewEventDropReason.notAuthenticated, video.id);
+      return _drop(ViewEventDropReason.notAuthenticated, video.id, method);
     }
 
     try {
       // View events require an addressable video reference.
       final aTag = video.addressableId;
       if (aTag == null) {
-        return _drop(ViewEventDropReason.missingAddressableDTag, video.id);
+        return _drop(
+          ViewEventDropReason.missingAddressableDTag,
+          video.id,
+          method,
+        );
       }
 
       // Get relay hint
@@ -126,7 +135,7 @@ class ViewEventPublisher {
       );
 
       if (event == null) {
-        return _drop(ViewEventDropReason.signingFailed, video.id);
+        return _drop(ViewEventDropReason.signingFailed, video.id, method);
       }
 
       // Publish to relays (fire-and-forget for ephemeral events)
@@ -140,7 +149,7 @@ class ViewEventPublisher {
         );
         return true;
       } else {
-        return _drop(ViewEventDropReason.relayRejected, video.id);
+        return _drop(ViewEventDropReason.relayRejected, video.id, method);
       }
     } catch (e) {
       Log.error(
@@ -148,7 +157,7 @@ class ViewEventPublisher {
         name: 'ViewEventPublisher',
         category: LogCategory.video,
       );
-      return _drop(ViewEventDropReason.relayRejected, video.id);
+      return _drop(ViewEventDropReason.unexpectedError, video.id, method);
     }
   }
 
@@ -162,23 +171,28 @@ class ViewEventPublisher {
     ViewTrafficSource source = ViewTrafficSource.unknown,
     String? sourceDetail,
   }) async {
+    const method = 'publishViewEventWithSegments';
     // Filter out invalid segments
     final validSegments = segments
         .where((s) => s.$2 > s.$1 && s.$2 - s.$1 >= 1)
         .toList();
 
     if (validSegments.isEmpty) {
-      return _drop(ViewEventDropReason.belowMinimumWatchTime, video.id);
+      return _drop(ViewEventDropReason.belowMinimumWatchTime, video.id, method);
     }
 
     if (!_authService.isAuthenticated) {
-      return _drop(ViewEventDropReason.notAuthenticated, video.id);
+      return _drop(ViewEventDropReason.notAuthenticated, video.id, method);
     }
 
     try {
       final aTag = video.addressableId;
       if (aTag == null) {
-        return _drop(ViewEventDropReason.missingAddressableDTag, video.id);
+        return _drop(
+          ViewEventDropReason.missingAddressableDTag,
+          video.id,
+          method,
+        );
       }
 
       String relayHint = _defaultRelayHint;
@@ -206,7 +220,7 @@ class ViewEventPublisher {
       );
 
       if (event == null) {
-        return _drop(ViewEventDropReason.signingFailed, video.id);
+        return _drop(ViewEventDropReason.signingFailed, video.id, method);
       }
 
       final sentEvent = await _nostrService.publishEvent(event);
@@ -223,14 +237,14 @@ class ViewEventPublisher {
         );
         return true;
       }
-      return _drop(ViewEventDropReason.relayRejected, video.id);
+      return _drop(ViewEventDropReason.relayRejected, video.id, method);
     } catch (e) {
       Log.error(
         'Error publishing multi-segment view event: $e',
         name: 'ViewEventPublisher',
         category: LogCategory.video,
       );
-      return _drop(ViewEventDropReason.relayRejected, video.id);
+      return _drop(ViewEventDropReason.unexpectedError, video.id, method);
     }
   }
 }

--- a/mobile/lib/services/view_event_publisher.dart
+++ b/mobile/lib/services/view_event_publisher.dart
@@ -3,12 +3,20 @@
 
 import 'package:models/models.dart' hide LogCategory;
 import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/models/view_event_drop_reason.dart';
 import 'package:openvine/models/view_traffic_source.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Kind 22236 - Ephemeral video view event (NIP-71 extension)
 const int viewEventKind = 22236;
+
+/// Notified every time a view event is dropped instead of published.
+///
+/// Wired in the app layer to Crashlytics for structural drops. Injected
+/// rather than reached for statically so tests can assert on drops.
+typedef ViewEventDropReporter =
+    void Function(ViewEventDropReason reason, {required String videoId});
 
 /// Service for publishing video view events to Nostr relays.
 ///
@@ -20,13 +28,30 @@ class ViewEventPublisher {
     required NostrClient nostrService,
     required AuthService authService,
     String? defaultRelayHint,
+    ViewEventDropReporter? onDrop,
   }) : _nostrService = nostrService,
        _authService = authService,
+       _onDrop = onDrop,
        _defaultRelayHint = defaultRelayHint ?? 'wss://relay.divine.video';
 
   final NostrClient _nostrService;
   final AuthService _authService;
   final String _defaultRelayHint;
+  final ViewEventDropReporter? _onDrop;
+
+  /// Records a dropped view event and returns `false` for the caller.
+  ///
+  /// Every early return in this class routes through here, so a new skip
+  /// path cannot be added without declaring whether it is a defect.
+  bool _drop(ViewEventDropReason reason, String videoId) {
+    Log.debug(
+      'View event dropped (${reason.name}) for video $videoId',
+      name: 'ViewEventPublisher',
+      category: LogCategory.video,
+    );
+    _onDrop?.call(reason, videoId: videoId);
+    return false;
+  }
 
   /// Publish a video view event.
   ///
@@ -44,46 +69,19 @@ class ViewEventPublisher {
     String? sourceDetail,
     int? loopCount,
   }) async {
-    // Skip if no meaningful watch time
-    if (endSeconds <= startSeconds) {
-      Log.debug(
-        'Skipping view event: no watch time (start=$startSeconds, end=$endSeconds)',
-        name: 'ViewEventPublisher',
-        category: LogCategory.video,
-      );
-      return false;
-    }
-
-    // Skip very short views (less than 1 second)
     if (endSeconds - startSeconds < 1) {
-      Log.debug(
-        'Skipping view event: less than 1 second watched',
-        name: 'ViewEventPublisher',
-        category: LogCategory.video,
-      );
-      return false;
+      return _drop(ViewEventDropReason.belowMinimumWatchTime, video.id);
     }
 
-    // Check authentication
     if (!_authService.isAuthenticated) {
-      Log.warning(
-        'Cannot publish view event: user not authenticated',
-        name: 'ViewEventPublisher',
-        category: LogCategory.video,
-      );
-      return false;
+      return _drop(ViewEventDropReason.notAuthenticated, video.id);
     }
 
     try {
       // View events require an addressable video reference.
       final aTag = video.addressableId;
       if (aTag == null) {
-        Log.warning(
-          'Skipping view event: video has no addressable d tag',
-          name: 'ViewEventPublisher',
-          category: LogCategory.video,
-        );
-        return false;
+        return _drop(ViewEventDropReason.missingAddressableDTag, video.id);
       }
 
       // Get relay hint
@@ -128,12 +126,7 @@ class ViewEventPublisher {
       );
 
       if (event == null) {
-        Log.error(
-          'Failed to create view event: createAndSignEvent returned null',
-          name: 'ViewEventPublisher',
-          category: LogCategory.video,
-        );
-        return false;
+        return _drop(ViewEventDropReason.signingFailed, video.id);
       }
 
       // Publish to relays (fire-and-forget for ephemeral events)
@@ -147,12 +140,7 @@ class ViewEventPublisher {
         );
         return true;
       } else {
-        Log.warning(
-          'View event publish failed for video ${video.id}',
-          name: 'ViewEventPublisher',
-          category: LogCategory.video,
-        );
-        return false;
+        return _drop(ViewEventDropReason.relayRejected, video.id);
       }
     } catch (e) {
       Log.error(
@@ -160,7 +148,7 @@ class ViewEventPublisher {
         name: 'ViewEventPublisher',
         category: LogCategory.video,
       );
-      return false;
+      return _drop(ViewEventDropReason.relayRejected, video.id);
     }
   }
 
@@ -180,32 +168,17 @@ class ViewEventPublisher {
         .toList();
 
     if (validSegments.isEmpty) {
-      Log.debug(
-        'Skipping view event: no valid segments',
-        name: 'ViewEventPublisher',
-        category: LogCategory.video,
-      );
-      return false;
+      return _drop(ViewEventDropReason.belowMinimumWatchTime, video.id);
     }
 
     if (!_authService.isAuthenticated) {
-      Log.warning(
-        'Cannot publish view event: user not authenticated',
-        name: 'ViewEventPublisher',
-        category: LogCategory.video,
-      );
-      return false;
+      return _drop(ViewEventDropReason.notAuthenticated, video.id);
     }
 
     try {
       final aTag = video.addressableId;
       if (aTag == null) {
-        Log.warning(
-          'Skipping view event: video has no addressable d tag',
-          name: 'ViewEventPublisher',
-          category: LogCategory.video,
-        );
-        return false;
+        return _drop(ViewEventDropReason.missingAddressableDTag, video.id);
       }
 
       String relayHint = _defaultRelayHint;
@@ -233,7 +206,7 @@ class ViewEventPublisher {
       );
 
       if (event == null) {
-        return false;
+        return _drop(ViewEventDropReason.signingFailed, video.id);
       }
 
       final sentEvent = await _nostrService.publishEvent(event);
@@ -250,14 +223,14 @@ class ViewEventPublisher {
         );
         return true;
       }
-      return false;
+      return _drop(ViewEventDropReason.relayRejected, video.id);
     } catch (e) {
       Log.error(
         'Error publishing multi-segment view event: $e',
         name: 'ViewEventPublisher',
         category: LogCategory.video,
       );
-      return false;
+      return _drop(ViewEventDropReason.relayRejected, video.id);
     }
   }
 }

--- a/mobile/lib/services/view_event_retry_service.dart
+++ b/mobile/lib/services/view_event_retry_service.dart
@@ -12,13 +12,13 @@ import 'package:openvine/services/view_event_publisher.dart';
 /// Backoff configuration for [ViewEventRetryService].
 class ViewEventRetryConfig {
   const ViewEventRetryConfig({
-    this.maxRetries = 5,
+    this.maxEventsPerSweep = 25,
     this.initialDelay = const Duration(seconds: 2),
     this.maxDelay = const Duration(minutes: 5),
     this.backoffMultiplier = 2.0,
   });
 
-  final int maxRetries;
+  final int maxEventsPerSweep;
   final Duration initialDelay;
   final Duration maxDelay;
   final double backoffMultiplier;
@@ -91,7 +91,7 @@ class ViewEventRetryService {
     try {
       final retryable = await _dao.getRetryableForUser(
         userPubkey: _userPubkey,
-        maxRetries: _retryConfig.maxRetries,
+        limit: _retryConfig.maxEventsPerSweep,
       );
 
       for (final row in retryable) {
@@ -133,6 +133,13 @@ class ViewEventRetryService {
   }
 
   VideoEvent _toVideoEvent(PendingViewEvent row) {
+    final addressableDTag =
+        row.videoVineId != null &&
+            row.videoVineId!.isNotEmpty &&
+            row.videoVineId != row.videoId
+        ? row.videoVineId
+        : null;
+
     return VideoEvent(
       id: row.videoId,
       pubkey: row.videoPubkey,
@@ -140,10 +147,9 @@ class ViewEventRetryService {
       content: '',
       timestamp: row.createdAt,
       vineId: row.videoVineId,
-      // The queue stores the video's `d` tag in videoVineId. Without this the
-      // rebuilt event has no addressable coordinate and every swept row is
-      // dropped before it reaches a relay (#6722).
-      addressableDTag: row.videoVineId,
+      // Older queued rows only have videoVineId. Trust it as a d tag when it
+      // differs from videoId; equality is the known event-id fallback shape.
+      addressableDTag: addressableDTag,
     );
   }
 }

--- a/mobile/lib/services/view_event_retry_service.dart
+++ b/mobile/lib/services/view_event_retry_service.dart
@@ -140,6 +140,10 @@ class ViewEventRetryService {
       content: '',
       timestamp: row.createdAt,
       vineId: row.videoVineId,
+      // The queue stores the video's `d` tag in videoVineId. Without this the
+      // rebuilt event has no addressable coordinate and every swept row is
+      // dropped before it reaches a relay (#6722).
+      addressableDTag: row.videoVineId,
     );
   }
 }

--- a/mobile/packages/db_client/lib/src/database/daos/pending_view_events_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/pending_view_events_dao.dart
@@ -7,11 +7,7 @@ import 'package:meta/meta.dart';
 
 part 'pending_view_events_dao.g.dart';
 
-enum PendingViewEventStatus {
-  pending,
-  publishing,
-  failed,
-}
+enum PendingViewEventStatus { pending, publishing, failed }
 
 class UnknownPendingViewEventStatusException implements Exception {
   const UnknownPendingViewEventStatusException(this.rawValue);
@@ -161,10 +157,9 @@ class PendingViewEventsDao extends DatabaseAccessor<AppDatabase>
   }
 
   Future<void> enqueue(PendingViewEvent event) async {
-    await into(pendingViewEvents).insert(
-      _modelToCompanion(event),
-      mode: InsertMode.insertOrIgnore,
-    );
+    await into(
+      pendingViewEvents,
+    ).insert(_modelToCompanion(event), mode: InsertMode.insertOrIgnore);
   }
 
   Future<bool> markPublishing(String id) async {
@@ -226,7 +221,7 @@ class PendingViewEventsDao extends DatabaseAccessor<AppDatabase>
 
   Future<List<PendingViewEvent>> getRetryableForUser({
     required String userPubkey,
-    required int maxRetries,
+    int? limit,
   }) async {
     final query = select(pendingViewEvents)
       ..where(
@@ -236,6 +231,9 @@ class PendingViewEventsDao extends DatabaseAccessor<AppDatabase>
                 t.status.equals(PendingViewEventStatus.failed.name)),
       )
       ..orderBy([(t) => OrderingTerm(expression: t.createdAt)]);
+    if (limit != null) {
+      query.limit(limit);
+    }
     final rows = await query.get();
     return rows.map(_rowToModel).toList();
   }

--- a/mobile/packages/db_client/test/src/database/daos/pending_view_events_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/pending_view_events_dao_test.dart
@@ -159,58 +159,68 @@ void main() {
     });
 
     group('getRetryableForUser', () {
-      test(
-        'returns retryable pending, failed, and exhausted rows oldest first',
-        () async {
-          await dao.enqueue(
-            makeEvent(
-              id: 'publishing',
-              status: PendingViewEventStatus.publishing,
-              createdAt: DateTime.utc(2026, 5),
-            ),
-          );
-          await dao.enqueue(
-            makeEvent(
-              id: 'failed-old',
-              status: PendingViewEventStatus.failed,
-              retryCount: 2,
-              createdAt: DateTime.utc(2026, 5, 2),
-            ),
-          );
-          await dao.enqueue(
-            makeEvent(
-              id: 'pending-new',
-              createdAt: DateTime.utc(2026, 5, 3),
-            ),
-          );
-          await dao.enqueue(
-            makeEvent(
-              id: 'exhausted',
-              status: PendingViewEventStatus.failed,
-              retryCount: 5,
-              createdAt: DateTime.utc(2026, 5, 4),
-            ),
-          );
-          await dao.enqueue(
-            makeEvent(
-              id: 'other-user',
-              userPubkey: userB,
-              createdAt: DateTime.utc(2026, 5, 5),
-            ),
-          );
+      test('returns retryable pending and failed rows oldest first', () async {
+        await dao.enqueue(
+          makeEvent(
+            id: 'publishing',
+            status: PendingViewEventStatus.publishing,
+            createdAt: DateTime.utc(2026, 5),
+          ),
+        );
+        await dao.enqueue(
+          makeEvent(
+            id: 'failed-old',
+            status: PendingViewEventStatus.failed,
+            retryCount: 2,
+            createdAt: DateTime.utc(2026, 5, 2),
+          ),
+        );
+        await dao.enqueue(
+          makeEvent(id: 'pending-new', createdAt: DateTime.utc(2026, 5, 3)),
+        );
+        await dao.enqueue(
+          makeEvent(
+            id: 'exhausted',
+            status: PendingViewEventStatus.failed,
+            retryCount: 5,
+            createdAt: DateTime.utc(2026, 5, 4),
+          ),
+        );
+        await dao.enqueue(
+          makeEvent(
+            id: 'other-user',
+            userPubkey: userB,
+            createdAt: DateTime.utc(2026, 5, 5),
+          ),
+        );
 
-          final retryable = await dao.getRetryableForUser(
-            userPubkey: userA,
-            maxRetries: 5,
-          );
+        final retryable = await dao.getRetryableForUser(userPubkey: userA);
 
-          expect(retryable.map((event) => event.id), [
-            'failed-old',
-            'pending-new',
-            'exhausted',
-          ]);
-        },
-      );
+        expect(retryable.map((event) => event.id), [
+          'failed-old',
+          'pending-new',
+          'exhausted',
+        ]);
+      });
+
+      test('limits the oldest retryable rows when requested', () async {
+        await dao.enqueue(
+          makeEvent(id: 'oldest', createdAt: DateTime.utc(2026, 5)),
+        );
+        await dao.enqueue(
+          makeEvent(id: 'middle', createdAt: DateTime.utc(2026, 5, 2)),
+        );
+        await dao.enqueue(
+          makeEvent(id: 'newest', createdAt: DateTime.utc(2026, 5, 3)),
+        );
+
+        final retryable = await dao.getRetryableForUser(
+          userPubkey: userA,
+          limit: 2,
+        );
+
+        expect(retryable.map((event) => event.id), ['oldest', 'middle']);
+      });
     });
 
     group('resetPublishingToPending', () {

--- a/mobile/test/models/view_event_drop_reason_test.dart
+++ b/mobile/test/models/view_event_drop_reason_test.dart
@@ -15,6 +15,7 @@ void main() {
     test('failures to build a publishable event are structural', () {
       expect(ViewEventDropReason.missingAddressableDTag.isStructural, isTrue);
       expect(ViewEventDropReason.signingFailed.isStructural, isTrue);
+      expect(ViewEventDropReason.unexpectedError.isStructural, isTrue);
     });
 
     test('every reason states its reportability', () {

--- a/mobile/test/models/view_event_drop_reason_test.dart
+++ b/mobile/test/models/view_event_drop_reason_test.dart
@@ -1,0 +1,42 @@
+// ABOUTME: Tests the reportability policy for kind-22236 view-event drops.
+// ABOUTME: Structural drops must alarm; expected skips must stay silent.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/models/view_event_drop_reason.dart';
+
+void main() {
+  group(ViewEventDropReason, () {
+    test('expected skips are not structural', () {
+      expect(ViewEventDropReason.belowMinimumWatchTime.isStructural, isFalse);
+      expect(ViewEventDropReason.notAuthenticated.isStructural, isFalse);
+      expect(ViewEventDropReason.relayRejected.isStructural, isFalse);
+    });
+
+    test('failures to build a publishable event are structural', () {
+      expect(ViewEventDropReason.missingAddressableDTag.isStructural, isTrue);
+      expect(ViewEventDropReason.signingFailed.isStructural, isTrue);
+    });
+
+    test('every reason states its reportability', () {
+      for (final reason in ViewEventDropReason.values) {
+        expect(
+          () => reason.isStructural,
+          returnsNormally,
+          reason: '$reason must declare whether it is a defect',
+        );
+      }
+    });
+  });
+
+  group(ViewEventInvariantException, () {
+    test('names the reason without leaking viewer identity', () {
+      const exception = ViewEventInvariantException(
+        ViewEventDropReason.missingAddressableDTag,
+      );
+
+      expect(exception.toString(), contains('missingAddressableDTag'));
+      expect(exception.toString(), isNot(contains('npub1')));
+      expect(exception.toString(), isNot(contains('nsec1')));
+    });
+  });
+}

--- a/mobile/test/services/analytics_service_test.dart
+++ b/mobile/test/services/analytics_service_test.dart
@@ -164,9 +164,7 @@ void main() {
       );
 
       final captured =
-          verify(
-                () => queue.enqueue(captureAny()),
-              ).captured.single
+          verify(() => queue.enqueue(captureAny())).captured.single
               as ProductAnalyticsEvent;
       expect(captured.eventId, '018ff7d7-2ef5-7000-8000-000000000003');
       expect(captured.eventName, 'screen_time');
@@ -228,7 +226,6 @@ void main() {
       final retryable = await database!.pendingViewEventsDao.getRetryableForUser(
         userPubkey:
             '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
-        maxRetries: 5,
       );
       expect(retryable, hasLength(1));
       expect(retryable.single.videoId, video.id);
@@ -280,7 +277,6 @@ void main() {
       final retryable = await database!.pendingViewEventsDao.getRetryableForUser(
         userPubkey:
             '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
-        maxRetries: 5,
       );
       expect(retryable, isEmpty);
       expect(flushCount, 0);
@@ -365,10 +361,7 @@ void main() {
       );
 
       final retryable = await database!.pendingViewEventsDao
-          .getRetryableForUser(
-            userPubkey: userPubkey,
-            maxRetries: 5,
-          );
+          .getRetryableForUser(userPubkey: userPubkey);
       expect(retryable, hasLength(1));
       verifyNever(
         () => publisher.publishViewEvent(

--- a/mobile/test/services/view_event_publisher_test.dart
+++ b/mobile/test/services/view_event_publisher_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
+import 'package:openvine/models/view_event_drop_reason.dart';
 import 'package:openvine/models/view_traffic_source.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/view_event_publisher.dart';
@@ -225,31 +226,31 @@ void main() {
         expect(tags.where((t) => t[0] == 'client'), isEmpty);
       });
 
-      test('falls back to event ID when vineId is null', () async {
-        final video = createTestVideoEvent(
-          id: 'event_id_fallback',
-          pubkey: creatorPubkey,
-        );
+      test(
+        'does not fall back to event ID when the real d tag is absent',
+        () async {
+          final video = createTestVideoEvent(
+            id: 'event_id_fallback',
+            pubkey: creatorPubkey,
+            clearAddressableDTag: true,
+          );
 
-        await publisher.publishViewEvent(
-          video: video,
-          startSeconds: 0,
-          endSeconds: 5,
-        );
+          final result = await publisher.publishViewEvent(
+            video: video,
+            startSeconds: 0,
+            endSeconds: 5,
+          );
 
-        final captured = verify(
-          () => mockAuth.createAndSignEvent(
-            kind: any(named: 'kind'),
-            content: any(named: 'content'),
-            tags: captureAny(named: 'tags'),
-          ),
-        ).captured;
-
-        final tags = captured[0] as List<List<String>>;
-        final aTag = tags.firstWhere((t) => t[0] == 'a');
-        // When vineId is null, should fall back to event ID
-        expect(aTag[1], equals('34236:$creatorPubkey:event_id_fallback'));
-      });
+          expect(result, isFalse);
+          verifyNever(
+            () => mockAuth.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          );
+        },
+      );
 
       test('returns false when createAndSignEvent returns null', () async {
         when(
@@ -269,6 +270,49 @@ void main() {
         expect(result, isFalse);
         verifyNever(() => mockNostr.publishEvent(any()));
       });
+
+      test(
+        'reports thrown signing errors as unexpected structural drops',
+        () async {
+          final drops =
+              <({ViewEventDropReason reason, String videoId, String method})>[];
+          publisher = ViewEventPublisher(
+            nostrService: mockNostr,
+            authService: mockAuth,
+            onDrop:
+                (reason, {required String videoId, required String method}) {
+                  drops.add((reason: reason, videoId: videoId, method: method));
+                },
+          );
+          when(
+            () => mockAuth.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenThrow(StateError('signer unavailable'));
+
+          final result = await publisher.publishViewEvent(
+            video: createTestVideoEvent(
+              id: 'throwing_sign_video',
+              pubkey: creatorPubkey,
+              vineId: 'throwing_sign_d_tag',
+            ),
+            startSeconds: 0,
+            endSeconds: 5,
+          );
+
+          expect(result, isFalse);
+          expect(drops, [
+            (
+              reason: ViewEventDropReason.unexpectedError,
+              videoId: 'throwing_sign_video',
+              method: 'publishViewEvent',
+            ),
+          ]);
+          verifyNever(() => mockNostr.publishEvent(any()));
+        },
+      );
 
       test(
         'returns false when publishEvent does not return PublishSuccess',

--- a/mobile/test/services/view_event_queue_publish_repro_test.dart
+++ b/mobile/test/services/view_event_queue_publish_repro_test.dart
@@ -1,0 +1,156 @@
+// ABOUTME: End-to-end guard for the kind-22236 view-event outage in 1.0.19.
+// ABOUTME: Sweeps a real queue row through the real publisher to the relay.
+
+import 'dart:io';
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:openvine/models/view_event_drop_reason.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/view_event_publisher.dart';
+import 'package:openvine/services/view_event_retry_service.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _FakeEvent extends Fake implements Event {}
+
+void main() {
+  setUpAll(() => registerFallbackValue(_FakeEvent()));
+
+  // The retry service rebuilds a VideoEvent from a handful of stored columns.
+  // Wiring the *real* publisher to that reconstruction is the only way to
+  // catch a new required field silently emptying the queue — the pre-existing
+  // suite mocks ViewEventPublisher, which is why #6722 shipped green.
+  group('a queued view event survives the sweep', () {
+    late AppDatabase database;
+    late PendingViewEventsDao dao;
+    late _MockNostrClient mockNostr;
+    late _MockAuthService mockAuth;
+    late ViewEventPublisher publisher;
+    late Directory tempDir;
+    final drops = <ViewEventDropReason>[];
+
+    const userPubkey =
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    const videoPubkey =
+        'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+
+    setUp(() async {
+      drops.clear();
+      tempDir = Directory.systemTemp.createTempSync('view_event_queue_repro_');
+      database = AppDatabase.test(
+        NativeDatabase(File('${tempDir.path}/test.db')),
+      );
+      dao = database.pendingViewEventsDao;
+
+      mockNostr = _MockNostrClient();
+      mockAuth = _MockAuthService();
+
+      when(() => mockAuth.isAuthenticated).thenReturn(true);
+      when(() => mockNostr.connectedRelays).thenReturn([]);
+      when(
+        () => mockAuth.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer(
+        (invocation) async => Event.fromJson({
+          'id': 'c' * 64,
+          'pubkey': userPubkey,
+          'created_at': 1786587097,
+          'kind': invocation.namedArguments[#kind] as int,
+          'tags': invocation.namedArguments[#tags],
+          'content': '',
+          'sig': 'sig',
+        }),
+      );
+      when(() => mockNostr.publishEvent(any())).thenAnswer(
+        (invocation) async => PublishSuccess(
+          event: invocation.positionalArguments.first as Event,
+        ),
+      );
+
+      publisher = ViewEventPublisher(
+        nostrService: mockNostr,
+        authService: mockAuth,
+        onDrop: (reason, {required String videoId}) => drops.add(reason),
+      );
+
+      await dao.enqueue(
+        PendingViewEvent(
+          id: 'queued-view',
+          videoId: 'a' * 64,
+          videoPubkey: videoPubkey,
+          videoVineId: 'vine-id-from-queue-row',
+          userPubkey: userPubkey,
+          watchDurationMs: 6000,
+          totalDurationMs: 6000,
+          loopCount: 1,
+          trafficSource: 'home',
+          status: PendingViewEventStatus.pending,
+          createdAt: DateTime.utc(2026, 8, 12),
+        ),
+      );
+    });
+
+    tearDown(() async {
+      await database.close();
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('publishes a kind 22236 event and clears the row', () async {
+      final service = ViewEventRetryService(
+        viewEventPublisher: publisher,
+        pendingViewEventsDao: dao,
+        userPubkey: userPubkey,
+        appForegroundStream: const Stream<bool>.empty(),
+      );
+
+      await service.sweep();
+
+      final published = verify(
+        () => mockNostr.publishEvent(captureAny()),
+      ).captured;
+      expect(
+        published,
+        hasLength(1),
+        reason: 'every queued view event must reach the relay',
+      );
+      expect((published.single as Event).kind, equals(viewEventKind));
+      expect(
+        drops,
+        isEmpty,
+        reason: 'a well-formed queue row must not be dropped',
+      );
+      expect(
+        await dao.getById('queued-view'),
+        isNull,
+        reason: 'a delivered row is removed from the queue',
+      );
+    });
+
+    test('carries the addressable a tag the relay indexes views by', () async {
+      final service = ViewEventRetryService(
+        viewEventPublisher: publisher,
+        pendingViewEventsDao: dao,
+        userPubkey: userPubkey,
+        appForegroundStream: const Stream<bool>.empty(),
+      );
+
+      await service.sweep();
+
+      final event =
+          verify(() => mockNostr.publishEvent(captureAny())).captured.single
+              as Event;
+      final aTag = event.tags.firstWhere((tag) => tag.first == 'a');
+      expect(aTag[1], endsWith(':vine-id-from-queue-row'));
+    });
+  });
+}

--- a/mobile/test/services/view_event_queue_publish_repro_test.dart
+++ b/mobile/test/services/view_event_queue_publish_repro_test.dart
@@ -80,7 +80,8 @@ void main() {
       publisher = ViewEventPublisher(
         nostrService: mockNostr,
         authService: mockAuth,
-        onDrop: (reason, {required String videoId}) => drops.add(reason),
+        onDrop: (reason, {required String videoId, required String method}) =>
+            drops.add(reason),
       );
 
       await dao.enqueue(
@@ -152,5 +153,41 @@ void main() {
       final aTag = event.tags.firstWhere((tag) => tag.first == 'a');
       expect(aTag[1], endsWith(':vine-id-from-queue-row'));
     });
+
+    test(
+      'drops a queued event-id fallback instead of fabricating an a tag',
+      () async {
+        await dao.deleteById('queued-view');
+        await dao.enqueue(
+          PendingViewEvent(
+            id: 'queued-view-without-d',
+            videoId: 'b' * 64,
+            videoPubkey: videoPubkey,
+            videoVineId: 'b' * 64,
+            userPubkey: userPubkey,
+            watchDurationMs: 6000,
+            totalDurationMs: 6000,
+            loopCount: 1,
+            trafficSource: 'home',
+            status: PendingViewEventStatus.pending,
+            createdAt: DateTime.utc(2026, 8, 12),
+          ),
+        );
+        final service = ViewEventRetryService(
+          viewEventPublisher: publisher,
+          pendingViewEventsDao: dao,
+          userPubkey: userPubkey,
+          appForegroundStream: const Stream<bool>.empty(),
+        );
+
+        await service.sweep();
+
+        verifyNever(() => mockNostr.publishEvent(any()));
+        expect(drops, [ViewEventDropReason.missingAddressableDTag]);
+        final row = await dao.getById('queued-view-without-d');
+        expect(row, isNotNull);
+        expect(row!.status, PendingViewEventStatus.failed);
+      },
+    );
   });
 }

--- a/mobile/test/services/view_event_retry_service_test.dart
+++ b/mobile/test/services/view_event_retry_service_test.dart
@@ -42,6 +42,7 @@ void main() {
       int retryCount = 0,
       DateTime? lastAttemptAt,
       String eventVideoPubkey = videoPubkey,
+      DateTime? createdAt,
     }) {
       return PendingViewEvent(
         id: id,
@@ -57,16 +58,20 @@ void main() {
         status: status,
         retryCount: retryCount,
         lastAttemptAt: lastAttemptAt,
-        createdAt: DateTime.utc(2026, 5),
+        createdAt: createdAt ?? DateTime.utc(2026, 5),
       );
     }
 
-    ViewEventRetryService makeService({Stream<bool>? foregroundStream}) {
+    ViewEventRetryService makeService({
+      Stream<bool>? foregroundStream,
+      ViewEventRetryConfig retryConfig = const ViewEventRetryConfig(),
+    }) {
       return ViewEventRetryService(
         viewEventPublisher: publisher,
         pendingViewEventsDao: dao,
         userPubkey: userPubkey,
         appForegroundStream: foregroundStream ?? const Stream<bool>.empty(),
+        retryConfig: retryConfig,
         now: () => now,
       );
     }
@@ -126,6 +131,7 @@ void main() {
       expect(video.id, 'video-view-a');
       expect(video.pubkey, videoPubkey);
       expect(video.vineId, 'vine-view-a');
+      expect(video.addressableDTag, 'vine-view-a');
       expect(captured[1], 0);
       expect(captured[2], 2);
       expect(captured[3], ViewTrafficSource.home);
@@ -216,6 +222,37 @@ void main() {
         ).called(1);
       },
     );
+
+    test('limits each sweep to the configured batch size', () async {
+      await dao.enqueue(
+        makeEvent(id: 'oldest', createdAt: DateTime.utc(2026, 5)),
+      );
+      await dao.enqueue(
+        makeEvent(id: 'middle', createdAt: DateTime.utc(2026, 5, 2)),
+      );
+      await dao.enqueue(
+        makeEvent(id: 'newest', createdAt: DateTime.utc(2026, 5, 3)),
+      );
+      final service = makeService(
+        retryConfig: const ViewEventRetryConfig(maxEventsPerSweep: 2),
+      );
+
+      await service.sweep();
+
+      expect(await dao.getById('oldest'), isNull);
+      expect(await dao.getById('middle'), isNull);
+      expect(await dao.getById('newest'), isNotNull);
+      verify(
+        () => publisher.publishViewEvent(
+          video: any(named: 'video'),
+          startSeconds: any(named: 'startSeconds'),
+          endSeconds: any(named: 'endSeconds'),
+          source: any(named: 'source'),
+          sourceDetail: any(named: 'sourceDetail'),
+          loopCount: any(named: 'loopCount'),
+        ),
+      ).called(2);
+    });
 
     test(
       'skips high-retry failed rows before capped backoff elapses',


### PR DESCRIPTION
## Description

Kind-22236 view events stopped being recorded for a large and growing share of users. Daily mobile viewers in ClickHouse fell from 676 (Aug 1) to 263 (Aug 12) while `divine-web/1.0`, which publishes through the same relay ingest into the same tables, stayed flat at ~40. The decline tracks 1.0.19 adoption, not user loss — GA4 daily users were flat at ~1,450 across the window.

**Root cause.** #6722 changed `publishViewEvent` to require `video.addressableId`, which derives strictly from the new `addressableDTag` field. `ViewEventRetryService._toVideoEvent` rebuilds a `VideoEvent` from a handful of stored queue columns and never set that field, so `addressableId` was always `null` and every swept row hit the guard and returned before the event was ever constructed. The event is not rejected by the relay — it is never sent.

The durable queue is the **primary** path: `AnalyticsService` enqueues first and only direct-publishes if enqueueing fails, and the sole caller always passes a non-null pubkey. So for any signed-in user on 1.0.19 the loss is total, not partial. That predicts Aug 12 survivors at ~45% of baseline (the 1.0.17 remainder), ≈272 against 263 observed.

Before #6722 the publisher computed its own coordinate as `video.vineId ?? video.id`, which could never be null, so the same reconstruction worked.

### The fix

The queue's legacy `videoVineId` column stores `video.vineId`, which may be either the real `d` tag or the event-id fallback used for videos with no `d`. Reconstruction now carries `videoVineId` as `addressableDTag` only when it is non-empty and differs from `videoId`. That restores queued publishing for rows with a real d tag without fabricating coordinates for videos that never had one.

Queued rows are still retried indefinitely so stranded backlogs drain once this ships, but each foreground sweep now fetches a bounded batch to avoid serially replaying a multi-day backlog in one foreground pass.

### Making the next one loud

`publishViewEvent` returned a bare `bool`, which conflated "correctly skipped, too short" (expected, high volume) with "could not build the event" (a defect). No amount of log volume separates those. Drops are now typed:

| Reason | Reports to Crashlytics |
|---|---|
| `belowMinimumWatchTime` | no — expected, high volume |
| `notAuthenticated` | no — expected |
| `relayRejected` | no — explicit relay/publish failure; the queue retries |
| `missingAddressableDTag` | **yes** — structural |
| `signingFailed` | **yes** — structural |
| `unexpectedError` | **yes** — structural |

Every early return routes through one `_drop()` helper, so a new skip path cannot be added without declaring whether it is a defect. Expected volume for the structural reasons is zero; any signal is an alarm. Reporting is injected via `ViewEventDropReporter` rather than reached for statically, so tests can assert on drops; Crashlytics context now includes the publisher method and full video id.

**Related Issue:** Relates to #6722

## Out of Scope

- **A broader undercount.** Even before this regression, recorded views imply an 8–18% per-user interaction rate against a 1–5% industry norm, and views run at ~1.0 per CDN download for a looping format. Two independent estimates put the baseline undercount at roughly 3–5x. That is a definitional problem — a view requires ≥1s of *actual playback* by a *signed-in* user — and is not addressed here.
- **Server-side detection.** A volume check on the mobile/web split would have caught this in a day without waiting on a client release. Not in this PR.

## Verification

- `dart run build_runner build --delete-conflicting-outputs` — regenerated `video_providers.g.dart`
- `flutter test test/models/view_event_drop_reason_test.dart test/services/view_event_publisher_test.dart test/services/view_event_queue_publish_repro_test.dart test/services/view_event_retry_service_test.dart test/services/analytics_service_test.dart` — passing
- `flutter test test/src/database/daos/pending_view_events_dao_test.dart` from `mobile/packages/db_client` — passing
- `flutter analyze lib test integration_test` from `mobile` — no issues
- `flutter analyze lib test` from `mobile/packages/db_client` — no issues
- Pre-push hook reran analyzer, generated-file verification, and changed-file tests — passing

The new guard sweeps a real queue row through the *real* publisher. The suite now covers both queue shapes: a row with a real d tag publishes and clears, while a row where `videoVineId == videoId` drops as `missingAddressableDTag` instead of publishing a fabricated `a` tag.

### Rollout note

Because queued rows are never discarded, every 1.0.19 device still holds its stranded backlog. On rollout those replay with publish-time timestamps in bounded foreground sweeps, producing recovered history rather than new traffic. Worth accounting for before reading any view metric on release day.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
