### PR TITLE
docs: record that Divine does not run release freezes

### DIFF
--- a/docs/ANALYTICS_OBSERVABILITY.md
+++ b/docs/ANALYTICS_OBSERVABILITY.md
@@ -162,7 +162,7 @@ does not make them queryable as dimensions retroactively.
 The GA4 reporting identity setting does not gate the BigQuery `user_id` field;
 use BigQuery as the campaign source of truth.
 
-## Pre-Freeze End-To-End Check
+## Pre-Release-Candidate End-To-End Check
 
 Publish from a test account and query the streaming export within minutes:
 

--- a/docs/P1_LAUNCH_HUB.md
+++ b/docs/P1_LAUNCH_HUB.md
@@ -34,7 +34,7 @@ window, do not hold a change for one, and do not frame a fix as needing a
 "freeze exception". If you are told a freeze is in effect, treat that as stale
 and confirm before planning around it.
 
-`## 1. Freeze The Candidate` in [docs/RELEASE_CHECKLIST.md](RELEASE_CHECKLIST.md)
+`## 1. Pin The Release Candidate` in [docs/RELEASE_CHECKLIST.md](RELEASE_CHECKLIST.md)
 is unrelated — it means pin the target commit for a build, not stop merging.
 
 ## Current Release Path

--- a/docs/P1_LAUNCH_HUB.md
+++ b/docs/P1_LAUNCH_HUB.md
@@ -22,6 +22,21 @@ P1 launch is the milestone for submitting Divine to the App Store for review and
 - [mobile/docs/ENCRYPTION_EXPORT_COMPLIANCE.md](../mobile/docs/ENCRYPTION_EXPORT_COMPLIANCE.md) - export compliance record
 - [mobile/docs/ANDROID_DEPLOYMENT.md](../mobile/docs/ANDROID_DEPLOYMENT.md) - Play Console upload flow
 
+## Release Policy: No Freezes
+
+Divine does not run a release freeze before launch. Fixes land through normal
+review and ship on the normal release path, including in the days immediately
+before a launch.
+
+A freeze blocks corrections for exactly the bugs that launch traffic is most
+likely to expose, which gets the risk backwards. Do not plan around a freeze
+window, do not hold a change for one, and do not frame a fix as needing a
+"freeze exception". If you are told a freeze is in effect, treat that as stale
+and confirm before planning around it.
+
+`## 1. Freeze The Candidate` in [docs/RELEASE_CHECKLIST.md](RELEASE_CHECKLIST.md)
+is unrelated — it means pin the target commit for a build, not stop merging.
+
 ## Current Release Path
 
 From `mobile/`:

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -5,7 +5,7 @@ Validated against: `mobile/pubspec.yaml`, `mobile/build_ios.sh`, `mobile/build_a
 
 Use this checklist for P1 release prep and store submission. This replaces older package-release and legacy deployment checklists.
 
-## 1. Freeze The Candidate
+## 1. Pin The Release Candidate
 
 "Freeze" here means pin the commit you are about to build. It is not a merge
 freeze — Divine does not run release freezes, including before launch. See

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -7,6 +7,10 @@ Use this checklist for P1 release prep and store submission. This replaces older
 
 ## 1. Freeze The Candidate
 
+"Freeze" here means pin the commit you are about to build. It is not a merge
+freeze — Divine does not run release freezes, including before launch. See
+[Release Policy: No Freezes](P1_LAUNCH_HUB.md#release-policy-no-freezes).
+
 - [ ] Confirm the target commit is on `main` or the intended release branch.
 - [ ] Confirm `mobile/pubspec.yaml` has the release version and build number you expect.
 - [ ] Review `git status` and remove temporary files, logs, or unfinished work.


### PR DESCRIPTION
Closes #7461

## Description

Records the standing decision that Divine does not run release freezes, including before launch. Fixes land through normal review and ship on the normal release path.

A freeze blocks corrections for exactly the bugs that launch traffic is most likely to expose, which inverts the risk it is meant to reduce.

Written down because a task brief asserted a freeze was already in effect, and work was planned around holding a fix back for it — specifically the kind-22236 view-event outage in #7210, where the client fix was framed as needing a "freeze exception" it did not need.

Also disambiguates `## 1. Pin The Release Candidate` in the release checklist, which means pin the commit you are about to build, not stop merging. That naming collision is part of why the assumption went unchallenged.

Renames the analytics docs heading from `Pre-Freeze End-To-End Check` to `Pre-Release-Candidate End-To-End Check` so launch-adjacent observability docs do not preserve the same false release-freeze framing.

**Related Issue:** Relates to #7210

## Out of Scope

No process or tooling changes — this records an existing decision so it stops being re-litigated. None otherwise.

## Verification

Docs-only. No code, tests, or generated files touched. All three edited files render as valid Markdown and the cross-links between them resolve (`P1_LAUNCH_HUB.md#release-policy-no-freezes` matches the new heading; `RELEASE_CHECKLIST.md` link is relative within `docs/`). `docs/ANALYTICS_OBSERVABILITY.md` only renames a heading and has no inbound anchor references in this PR.

## Type of Change

- [x] 📝 Documentation
