### PR TITLE
docs: design view and loop as two distinct metrics

### DIFF
--- a/docs/superpowers/specs/2026-08-13-view-and-loop-findings.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-findings.md
@@ -1,0 +1,296 @@
+# View and loop metrics — investigation findings
+
+**Date:** 2026-08-13
+**Status:** Findings record. Companion to
+[the design spec](2026-08-13-view-and-loop-metrics-design.md).
+
+Everything established during the 2026-08-13 investigation, with sources, so
+none of it has to be rediscovered. Claims are marked **measured**, **read from
+code**, **sourced**, or **inferred**. Where an earlier conclusion was wrong it
+is recorded as wrong rather than deleted, because several of them were
+confidently stated and may have been repeated elsewhere.
+
+---
+
+## 1. The outage (resolved)
+
+**Measured.** Daily mobile viewers fell 676 (Aug 1) → 263 (Aug 12) while
+`divine-web/1.0` stayed flat at ~40 through the same ingest and tables. GA4
+daily users were flat at ~1,450. The decline tracked 1.0.19 adoption.
+
+**Read from code.** Root cause: #6722 changed `publishViewEvent` to require
+`video.addressableId`, which derives strictly from `addressableDTag`.
+`ViewEventRetryService._toVideoEvent` rebuilds a `VideoEvent` from stored queue
+columns and never set that field, so every swept row hit the guard and returned
+before the event was constructed. **The event was never sent** — not rejected
+by the relay.
+
+The durable queue is the *primary* path: `AnalyticsService` enqueues first and
+only direct-publishes if enqueueing fails, and the sole caller always passes a
+non-null pubkey. So for any signed-in user on 1.0.19 the loss was total. That
+predicts Aug 12 survivors at ~45% of baseline (the 1.0.17 remainder) ≈ 272
+against 263 observed.
+
+Fixed and merged in **#7210** (`625b12f277`). The reviewer's follow-up commit
+correctly guarded against `videoVineId == videoId`, which would otherwise mint
+bogus addressable coordinates for videos with no real `d` tag.
+
+**Not recoverable:** the stranded on-device backlogs replay at *publish* time,
+so they land on rollout day rather than the days they happened. Historical
+daily leaderboards for Aug 8–13 stay wrong permanently.
+
+Detection added in **divine-funnelcake#917** — per-client daily volume against
+each client's own trailing 7-day median. Backtested: no ordinary-day alerts
+across 24 days, fires on 2026-08-08, the first day of the outage.
+
+---
+
+## 2. The undercount is much larger than the outage
+
+### 2.1 Interaction-overlap: the best instrument available
+
+**Measured.** A like, comment, or repost proves the person watched. Comparing
+interactors against reporting viewers gives a per-video floor on the loss with
+no benchmarks or assumptions.
+
+Event `a3092dfc8d36d15583d0866ae4312fd32b96a8eb59d79a7f23028c1ffc6d5503`
+(posted 2026-08-13):
+
+| Measure | Count |
+|---|---|
+| Distinct people who liked / commented / reposted | 37 |
+| Distinct people who registered a view | 26 |
+| Interactors who registered a view | **10 of 37** |
+
+**73% of provably-real viewers are absent from the view count.** Displayed 108;
+implied floor above 400. A floor twice over — it counts only people who
+interacted, and silent viewers are missing on top.
+
+This method works on any video, any day. It should replace the indirect
+estimates below.
+
+### 2.2 Weaker corroborating estimates
+
+**Measured, but indirect.** Both agree in direction:
+
+- Recorded views imply an 8–18% per-user interaction rate against a 1–5%
+  short-form industry norm.
+- Recorded views run at ~1.0 per CDN download, for a format where one download
+  serves many playthroughs.
+
+### 2.3 Every known cause subtracts
+
+**Read from code.** None of these inflate:
+
+- A view requires ≥1s of *actual playback* — `_totalWatchDuration` accumulates
+  only while playing, so a still-buffering video that is scrolled past records
+  nothing.
+- Anonymous viewers contribute **zero loops** (§3.2).
+- The relay discards the client's real playthrough count (§3.1).
+- The queue regression dropped signed-in reporting entirely for six days.
+
+**This is not a choice between accurate and flattering. It is a choice between
+wrong-low and less-wrong.**
+
+---
+
+## 3. What the metrics actually are
+
+### 3.1 `loops` is a watch-time ratio, and the real count is discarded
+
+**Read from code.** `crates/relay/src/view_handler.rs`:
+
+```rust
+fn watch_loops(watched_seconds: u32, video_duration_seconds: f64) -> f64 {
+    let watched_seconds = f64::from(watched_seconds.max(1));
+    watched_seconds / effective_duration_seconds(video_duration_seconds)
+}
+```
+
+So a stored "loop" is `watched_seconds / duration` — a fraction, not a count.
+Observed range 0 to 218.2, mean 0.99, median 0.75.
+
+**The mobile client already computes the Vine-correct number and it is thrown
+away.** `divine_video_metrics_tracker.dart` increments an integer `_loopCount`
+on wrap detection, and `view_event_publisher.dart` emits it:
+
+```dart
+if (loopCount != null && loopCount > 0) ['loops', loopCount.toString()],
+```
+
+The relay's tag parser matches `a`, `e`, `viewed`, `source`, `client`, and
+`_ => {}` for everything else. **The `loops` tag falls through and is
+discarded.** Wiring it up is a small change with large consequences.
+
+Caveat on the client counter: wrap detection requires the last sampled position
+to be within 1000 ms of the end (`_lastPosition!.inMilliseconds >
+duration.inMilliseconds - 1000`). If position updates are sparse or jittery,
+wraps are missed. Unquantified.
+
+### 3.2 Anonymous viewers reach views but never loops
+
+**Measured.** `total_views = cdn_views + auth_views` holds exactly, zero
+exceptions across 2,201,983 videos. CDN is 42% of all views (4.70M of 11.14M).
+
+But loops derive from `view_interactions`, which is signed-only. So anonymous
+viewers — 42% of the audience — contribute **no loops at all**. Loops is the
+worse-measured metric, not the smaller one.
+
+### 3.3 The card shows views under a loops label
+
+**Read from code.** `mobile/packages/models/lib/src/video_event.dart`:
+
+```dart
+/// Total loops combining archived Vine loops and live diVine views.
+int get totalLoops =>
+    (originalLoops ?? 0) + (int.tryParse(rawTags['views'] ?? '') ?? 0);
+```
+
+For a video with no archive history the first term is zero, so the card's
+"N Loops" renders the **view** count. The sampled video displayed "108 Loops"
+against a real stored loop value of 42.
+
+**The actual loop number is displayed nowhere in the app.** Independent of the
+outage; survives the #7210 fix. Note the trap: pointing the card at the current
+loop metric would *cut* every Divine-native card by roughly a third, so the
+label fix and the counting fix must ship together.
+
+### 3.4 Loop tracking has a state bug
+
+**Read from code.** `_handleState` returns on its first line when
+`!widget.isActive`. Opening a route (e.g. the comment sheet) sets
+`_routeAllowsPlayback = false` → `isFeedActive` false → the **pause event is
+never processed**. `_isPlaying` stays true and `_lastPlayStartTime` stays set,
+so `_finalizeAndPublish` later adds the entire span including the paused
+period. Direction of error: **inflates** watch time for users who open
+comments. The only known error in that direction.
+
+---
+
+## 4. What Vine actually did
+
+**Sourced** — 2014 trade press, listed at the end.
+
+- **Loops counted every playthrough, not viewers.** "If one person watches a
+  video on loop 10 times in a row, this will count as 10 loops — it's not
+  per-click, or per-viewer."
+- **Autoplay counted, and Vine was criticised for it.** Loops accrued "even if
+  the video is not actually being watched"; an embedded Vine incremented as
+  long as the tab stayed open. Vine shipped it anyway.
+- **Embeds counted**, on Vine and across the web, in real time.
+- **Tracking began 3 April 2014.** Older videos showed `+` beside the count,
+  meaning the true number is higher than displayed.
+- **Calibration:** contemporary commentary treated ~3 loops per viewer as a
+  marker of strong engagement.
+
+**Unresolved:** sources conflict on whether the *first* play counted as a loop
+or only replays. Needs a better source than 2014 trade press.
+
+### Divine versus Vine
+
+| | Vine | Divine today |
+|---|---|---|
+| Unit | one playthrough = 1 loop | `watched_seconds / duration`, fractional |
+| Autoplay | counted | only if ≥1s and signed in |
+| Unattended playback | counted | not counted |
+| Anonymous viewers | counted | contribute zero loops |
+| Incomplete data | shown as `N+` | silently undercounted |
+| Engagement benchmark | ~3 loops/viewer = strong | **0.65 loops/view measured** |
+
+Divine measures ~4.6× below what Vine considered a good video, on a metric
+carrying Vine's name.
+
+**The framing that matters:** the word "loops" already carries Vine's meaning.
+Printing "108 Loops" for a number computed under stricter-than-Vine rules is
+the *misleading* option. Adopting Vine semantics is not inflation — it makes
+the number mean what the label already promises. Divine is read as Vine 2.0, so
+an undercounted loop number reads as failure rather than as caution.
+
+---
+
+## 5. Ranking archaeology
+
+**Read from deployed `system.tables`**, not migrations — migrations drift.
+
+| Date | Event |
+|---|---|
+| 2026-01-05 | Trending formula written: `engagement × decay`, no views term |
+| 2026-01-16 | Kind-22236 view ingestion ships — 11 days *later* |
+| 2026-04-13 | Leaderboard rebuilt, uses `views + unique_viewers × 2` |
+| 2026-06-15 | A **second** trending formula added, view-velocity |
+| 2026-08-05 | Popular rebuilt, uses views as a linear term |
+
+Nobody chose this. Each surface encoded whatever data existed the day it was
+written, and old formulas were carried forward by refactors.
+
+**Two contradictory trending formulas are live at once.** The API serves
+`trending_videos_snapshot` (`crates/clickhouse/src/client.rs:3541`), populated
+by a **view-velocity** MV (`period_views / prior_period_views`).
+`trending_videos_base_snapshot` uses engagement-decay. The naming does not
+indicate which is which.
+
+Formulas, verified:
+
+- `engagement_score = reactions + comments×2 + reposts×3` — **no views term**.
+  Verified across 74,205 rows, zero mismatches.
+- `popular_score = (views + log1p(loops)×0.5 + engagement_score×4) × decay`
+- `leaderboard rank_score = views + unique_viewers×2 + log1p(loops)×0.5 +
+  reactions×4 + comments×8 + reposts×12`
+
+So Popular and Leaderboard rank on views directly; the served Trending ranks on
+view *velocity*. All three were moved by the outage.
+
+**Also affected:** Gorse recommendations consume view feedback with distinct
+scores for completed vs extended watches. Extent unmeasured.
+
+---
+
+## 6. Corrections to earlier conclusions
+
+Recorded because each was stated confidently and may have been repeated.
+
+1. **"Trending is corrupted"** → then **"trending is clean, no views term"** →
+   **finally: the served trending object *is* view-based.** The middle claim
+   came from reading `trending_videos` and `trending_videos_base_snapshot`,
+   neither of which is what the API serves.
+2. **"Loops is the biggest number, lead with it"** — wrong on today's data
+   (0.65 per view). But the ratio comes from a pipeline where 42% of the
+   audience contributes zero loops, so it cannot settle the question either.
+3. **"`loops >= views` is an invariant"** — false. 91% of `view_counts` rows
+   have loops below views.
+4. **"The display floor is mis-set and starves creators"** — wrong. Creators
+   always see their own count (`isOwnVideo`), so the floor never gated the
+   retention effect. Only 0.04% of videos reach 1000; that is deliberate.
+5. **"Loops are lost behind the comment sheet"** — wrong. The video pauses on
+   route push. The real defect is the opposite (§3.4).
+6. **Persistent bias toward conservatism.** Framing the view-definition
+   question with "completed loop" among the options, calling a flat number
+   "true rather than bigger," repeatedly appending inflation caveats. Every
+   measured error runs one way; adding caution on top compounds it.
+
+---
+
+## 7. Open questions
+
+- Does the first play count as a loop under Vine semantics? (§4)
+- How much has Gorse skewed since Aug 8? (§5)
+- How many wraps does the client's detector miss? (§3.1)
+- Integer playthroughs vs fractional ratio as the stored value — and whether
+  the fraction survives as a ranking-only signal.
+- Whether to fix §3.4, which is correct but reduces loops for engaged users.
+
+## 8. Related work
+
+| Item | Status |
+|---|---|
+| divine-mobile #7210 — outage fix | **merged**, `625b12f277` |
+| divine-funnelcake #917 — volume detector | open, green, awaiting review |
+| divine-mobile #7211 — no-release-freezes policy | open, green, awaiting review |
+| divine-mobile #7212 — this design spec | open, awaiting review |
+
+## Sources
+
+- [Vine's New "Loop Counts" May Cause Video Marketing Deception — ClickZ](https://www.clickz.com/vines-new-loop-counts-may-cause-video-marketing-deception/30719/)
+- [Vine Adds Loop Count, Updating Video Views in Realtime — The Realtime Report](https://therealtimereport.com/2014/07/08/vine-adds-loop-count-updating-video-views-in-realtime/)
+- [Vine adds loop counts to reveal how many times people watched a video — TNW](https://thenextweb.com/news/vine-adds-loop-counts-reveal-many-times-people-watched-video)
+- [Vine Update Introduces Loop Counts — TechCrunch](https://techcrunch.com/2014/07/01/vine-update-introduces-loop-counts-so-you-know-how-great-you-are/)

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
@@ -242,7 +242,7 @@ where size matters. Loops gains most in *relative* terms, because it is the
 metric that has been missing 42% of its audience entirely — but it starts from
 ~0.65x views and does not overtake it.
 
-### The display floor is set far too high
+### The display floor, and why most cards show a date
 
 `publicLoopCountFloor` is 1000. Measured against the catalogue:
 
@@ -252,22 +252,29 @@ metric that has been missing 42% of its audience entirely — but it starts from
 | 333 (floor reached at ×3) | 2,441 | 0.11% |
 | 100 (floor reached at ×10) | 12,571 | 0.57% |
 
-So the public count is effectively **never** shown — 9,996 videos in 10,000
-render a date instead. And correcting the metrics does not fix that: an
-order-of-magnitude improvement moves it from 0.04% to 0.57%, a 13× increase in
-how many cards show a number and still under one percent of the catalogue.
+So the public count is effectively never shown — 9,996 videos in 10,000 render
+a date instead. Correcting the metrics does not change that: an
+order-of-magnitude improvement moves it from 0.04% to 0.57%.
 
-An earlier draft of this document claimed the correction would move "a large
-share of the catalogue" above the floor. That is false, and the real conclusion
-is the opposite: **1000 is mis-set by roughly two orders of magnitude** for
-Divine's actual volumes, and no plausible metrics correction reaches it.
+**This is intended, and it is not a defect.** Two reasons it holds:
 
-This matters because of what the floor was for. The video-card spec suppressed
-small counts to stop them discouraging viewers, citing that crossing ~100 views
-roughly doubles new-creator retention. At a floor of 1000, essentially no
-creator ever sees the encouraging version. Re-tuning the constant is a
-one-line change and is likely worth more than any measurement work in this
-document.
+- **Creator retention does not run through the public count.** The video-card
+  spec's `isOwnVideo` case shows a creator their own number *always, however
+  small*. The retention effect it cites — crossing ~100 views roughly doubling
+  the chance a new creator keeps posting — operates on the creator's own view,
+  which has no floor. The public floor never gated it.
+- **A date is the better default for this catalogue.** With ~2.2M archived
+  vines from 2013–16, "Apr 22, 2014" reframes a clip as an artifact in a way a
+  view count does not. Suppression is not a fallback here; it is often the
+  stronger presentation.
+
+Two earlier drafts of this document got this wrong in opposite directions:
+first claiming the correction would lift "a large share of the catalogue" above
+the floor, then claiming the floor was mis-set by two orders of magnitude and
+was starving creators of encouragement. Neither holds. The floor governs public
+display only, the constant is deliberately one line, and re-tuning it is a
+product call to make on its own evidence rather than a consequence of this
+work.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
@@ -1,7 +1,7 @@
 # View and loop metrics
 
 **Date:** 2026-08-13
-**Status:** Design — decisions settled
+**Status:** Design — one open decision (integral vs fractional loops)
 **Target:** No freeze applies; ships on the normal release path
 
 ## Problem
@@ -44,8 +44,9 @@ Anonymous coverage is split, and the split is the confusing part. Because view
 events are Nostr-signed, anonymous viewers appear in `total_views` via CDN
 delivery — 42% of all views — but are entirely absent from everything derived
 from `view_interactions`: `unique_viewers`, `loops`, and the daily stats that
-feed the leaderboard. So the headline view count sees them and the hero loop
-metric does not.
+feed the leaderboard. So the view count sees them and the loop count does not —
+which is why loops, the metric unique to Divine, is the worse-measured of the
+two.
 
 Numbers are not cosmetic here.
 [The video-card view-count spec](2026-08-08-video-card-view-count-display-design.md)
@@ -73,9 +74,27 @@ comparable to nothing).
 viewers are roughly half of daily users and are currently invisible. This is the
 single largest correction available and every other platform already does it.
 
-**4. Loops is the hero number.** Largest, Vine-native, and unique to Divine —
-no other platform can quote a loop count. It is already what the video card
-renders.
+**4. Loops is the signature number; views is the largest number.** These are
+not the same claim, and conflating them was an error in an earlier draft of
+this document.
+
+Loops runs at **0.63–0.71 per view** in current data, and 91% of
+`view_counts` rows carry fewer loops than views. That is inherent to the
+definitions rather than a measurement artefact: a view is a playback start, a
+loop is a *completed* playthrough, so every viewer who scrolls away mid-play
+contributes a view and no loop. Rewatching does not close the gap, because
+most sessions never finish one pass.
+
+So:
+
+- **Views is the headline** where size and comparability matter — it is the
+  bigger number and the one other platforms report.
+- **Loops is the signature** — Vine-native, unique to Divine, and the only
+  metric no competitor can quote. It is what the video card already renders
+  and it should stay there.
+
+Publishing loops as "the big number" would understate Divine by roughly a
+third against its own view count.
 
 **5. A displayed number is never reduced — but it may be withheld.** These are
 different acts and only one of them is a lie.
@@ -121,12 +140,25 @@ view   := one playback start, deduplicated per viewing session
 session:= a continuous period of engagement with one video by one viewer
 ```
 
-`loops >= views` always holds. Both are emitted per viewing session, so one
-session reports one view and N loops.
+One session reports one view and N loops, where **N is frequently zero** — a
+viewer who starts playback and leaves before the video completes produces a
+view and no loop. `loops >= views` does **not** hold, at either the row or the
+aggregate level: 91% of current `view_counts` rows carry fewer loops than
+views, and the aggregate ratio sits at 0.63–0.71 loops per view.
 
-The existing `view_interactions.loops` column already stores a fractional
-playthrough count (observed range 0 to 218.2, mean 0.99), so the loop metric is
-derivable from data collected today. It is `views` that changes definition.
+**Open: is a loop integral or fractional?** The existing
+`view_counts.total_loops` is a `Float64` and `view_interactions.loops` a
+`Float32` (observed range 0 to 218.2, mean 0.99), so today a partial pass
+contributes a fraction. The definition above says a loop is a *completed*
+playthrough, which implies integer semantics. Flooring would drop the reported
+figure — the median view event sits at 0.75 of a pass and would round to zero.
+
+Keeping the fractional value is recommended: it is what already ships, it is
+strictly larger, and "2.4 loops" is defensible for a format where partial
+replays are real viewing. But the word "loop" then means *playthrough
+fraction*, not *completed playthrough*, and the definition block must say so
+rather than leaving the two in conflict. This needs a decision before
+implementation.
 
 ### Display versus ranking
 
@@ -199,33 +231,52 @@ Stacked against today's reported numbers:
 | #7210 view-event fix (merged) | ×1.7 recovery on the signed-in share | ×1.7 recovery |
 | View = playback start | ×2–3 on the signed-in share | — |
 | Anonymous counted | already counted (42% of views) | **new — CDN deliveries begin contributing** |
-| Loops promoted as headline | — | larger again than views |
+| Loops as signature metric | — | stays ~0.65x views; not a multiplier |
 
 Views grow mostly from the redefinition, since anonymous views already flow into
 `total_views`. Loops grow mostly from anonymous, since loops are currently
 signed-in only and CDN deliveries have never contributed one.
 
-The compounding matters more than either figure: loops is the hero number, and
-it is the metric that has been missing 42% of its audience entirely.
+Views is the larger figure and grows fastest, so it is the number to lead with
+where size matters. Loops gains most in *relative* terms, because it is the
+metric that has been missing 42% of its audience entirely — but it starts from
+~0.65x views and does not overtake it.
 
-The effect compounds with the display floor. `publicLoopCountFloor` is 1000, and
-today most videos fall below it — which is why the video-card spec had to
-suppress counts in the first place. An order-of-magnitude correction moves a
-large share of the catalogue above the floor, so counts start appearing on cards
-that currently show only a date. The suppression rule stops being load-bearing
-because fewer numbers are embarrassing, rather than because the rule changed.
+### The display floor is set far too high
 
-That is the same lever from both ends: the Aug 8 spec hid small numbers because
-small numbers were suppressing adoption; this work makes the numbers correct, so
-there are fewer to hide. The floor should be re-examined after rollout — at
-truthful volumes 1000 may be set too low or too high, and it is deliberately a
-one-line constant.
+`publicLoopCountFloor` is 1000. Measured against the catalogue:
+
+| Threshold | Videos at or above | Share of 2,201,983 |
+|---|---|---|
+| 1000 (today's floor) | 961 | **0.04%** |
+| 333 (floor reached at ×3) | 2,441 | 0.11% |
+| 100 (floor reached at ×10) | 12,571 | 0.57% |
+
+So the public count is effectively **never** shown — 9,996 videos in 10,000
+render a date instead. And correcting the metrics does not fix that: an
+order-of-magnitude improvement moves it from 0.04% to 0.57%, a 13× increase in
+how many cards show a number and still under one percent of the catalogue.
+
+An earlier draft of this document claimed the correction would move "a large
+share of the catalogue" above the floor. That is false, and the real conclusion
+is the opposite: **1000 is mis-set by roughly two orders of magnitude** for
+Divine's actual volumes, and no plausible metrics correction reaches it.
+
+This matters because of what the floor was for. The video-card spec suppressed
+small counts to stop them discouraging viewers, citing that crossing ~100 views
+roughly doubles new-creator retention. At a floor of 1000, essentially no
+creator ever sees the encouraging version. Re-tuning the constant is a
+one-line change and is likely worth more than any measurement work in this
+document.
 
 ## Testing
 
 - Unit tests pinning `view`/`loop`/`session` boundaries: a scroll-past with no
   playback start emits nothing; one session with N playthroughs emits one view
-  and N loops; `loops >= views` holds as an invariant.
+  and N loops, including the N=0 case where playback starts and never
+  completes a pass. Do **not** assert `loops >= views`; it is false in
+  production data and the test should pin that a view with zero loops is
+  valid.
 - A test asserting the display path applies no filtering — the property most
   likely to be broken later by someone adding a well-meant cap.
 - Ranking-path tests over adversarial input: a single session with hundreds of

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
@@ -1,7 +1,7 @@
 # View and loop metrics
 
 **Date:** 2026-08-13
-**Status:** Design — one open decision (anonymous signal transport)
+**Status:** Design — decisions settled
 **Target:** No freeze applies; ships on the normal release path
 
 ## Problem
@@ -37,9 +37,15 @@ put recorded views at roughly a third of reality:
 - Recorded views run at ~1.0 per CDN download, for a format where one download
   serves many playthroughs.
 
-Causes are definitional, not defects: a view today requires **≥1s of actual
-playback** by a **signed-in** user. Anonymous viewers — roughly half of daily
-users — emit nothing at all, because view events are Nostr-signed.
+Causes are definitional, not defects. A view today requires **≥1s of actual
+playback**, which excludes the scroll-past and the still-buffering.
+
+Anonymous coverage is split, and the split is the confusing part. Because view
+events are Nostr-signed, anonymous viewers appear in `total_views` via CDN
+delivery — 42% of all views — but are entirely absent from everything derived
+from `view_interactions`: `unique_viewers`, `loops`, and the daily stats that
+feed the leaderboard. So the headline view count sees them and the hero loop
+metric does not.
 
 Numbers are not cosmetic here.
 [The video-card view-count spec](2026-08-08-video-card-view-count-display-design.md)
@@ -151,51 +157,56 @@ Anonymous events carry weaker identity guarantees than signed ones and should
 therefore weigh less in ranking than signed-in events. They still count fully
 for display. The exact weighting is a tuning question, not an architectural one.
 
-### Anonymous signal — the open decision
+### Anonymous signal: CDN-derived, one loop assumed
 
-Counting anonymous viewers requires a client-side signal that does not depend on
-a Nostr key. Two options, with materially different properties:
+**Decision: each CDN delivery without a matching signed view event counts as one
+view and one loop.**
 
-**A. CDN-derived.** Infer views and loops from media delivery logs, which
-already flow to `cdn_view_counts`.
+This is not new machinery — it is already how the platform reports. Every
+`video_total_views_data` row satisfies `total_views = cdn_views + auth_views`
+exactly, with zero exceptions across 2,201,983 videos, and CDN accounts for 42%
+of all views (4.70M of 11.14M). The decision is to make the existing behaviour
+the stated definition rather than an undocumented accident, and to extend the
+same treatment to loops.
 
-- No client work, no new endpoint, no new abuse surface.
-- Cannot see loops: one download serves many playthroughs, so replays are
-  invisible. Undercounts exactly the metric chosen as the hero.
-- Cache hits and range requests distort counts; observed daily totals swing
-  21k–110k, which is not the shape of a trustworthy signal.
+It needs no client work, no new ingest endpoint, no unsigned-write abuse
+surface, and no privacy decision on a device identifier. An unsigned client
+beacon was considered and rejected on that basis: it would measure anonymous
+loop depth accurately, but every one of those costs is real and the accuracy
+gain does not carry them.
 
-**B. Unsigned client beacon.** The client posts view/loop events without a Nostr
-signature, identified by an ephemeral device-scoped id.
+Two limits, stated so nobody later mistakes them for defects:
 
-- Measures the real thing: playback starts and completed loops as the player
-  observed them, identically to the signed path.
-- Requires a new ingest endpoint and rate limiting; an unsigned endpoint is a
-  new abuse surface, which is precisely why decision 6 keeps anti-spam in
-  ranking rather than display.
-- Needs a privacy decision on the ephemeral identifier's lifetime and scope.
+- **Anonymous loop depth is assumed, not measured.** One delivery serves many
+  playthroughs, so an anonymous viewer who loops a video twenty times reports
+  one loop. Anonymous engagement depth is therefore systematically conservative
+  against signed-in depth. This understates the hero metric rather than
+  inflating it, which is the safe direction to be wrong in.
+- **CDN counts are noisy.** Observed daily totals swing between 21k and 110k,
+  driven by cache behaviour and range requests rather than by audience. Ranking
+  should not treat a CDN-derived loop as equivalent in confidence to an observed
+  one.
 
-**Recommendation: B.** Option A structurally cannot count loops, and loops is
-the hero metric. A signal that cannot measure the headline number is not a
-candidate. B should reuse the existing client-side counting logic so signed and
-anonymous paths cannot drift apart in definition.
-
-This decision is deferred, not assumed. Everything else in this design holds
-under either choice.
+If anonymous loop depth later proves worth measuring properly, the beacon
+remains available as an additive change; nothing in this design forecloses it.
 
 ### Expected movement
 
 Stacked against today's reported numbers:
 
-| Change | Effect |
-|---|---|
-| #7210 view-event fix (merged) | ×1.7 recovery of the outage loss |
-| View = playback start | ×2–3 |
-| Count anonymous viewers | ×2 |
-| Loops promoted as headline | Larger again than views |
+| Change | Effect on views | Effect on loops |
+|---|---|---|
+| #7210 view-event fix (merged) | ×1.7 recovery on the signed-in share | ×1.7 recovery |
+| View = playback start | ×2–3 on the signed-in share | — |
+| Anonymous counted | already counted (42% of views) | **new — CDN deliveries begin contributing** |
+| Loops promoted as headline | — | larger again than views |
 
-Roughly an order of magnitude over what is reported today, with every step
-explainable to a partner, a creator, or a journalist.
+Views grow mostly from the redefinition, since anonymous views already flow into
+`total_views`. Loops grow mostly from anonymous, since loops are currently
+signed-in only and CDN deliveries have never contributed one.
+
+The compounding matters more than either figure: loops is the hero number, and
+it is the metric that has been missing 42% of its audience entirely.
 
 The effect compounds with the display floor. `publicLoopCountFloor` is 1000, and
 today most videos fall below it — which is why the video-card spec had to
@@ -246,8 +257,14 @@ recovery land close together, so a jump will be hard to attribute. Ship the
 detector and record a pre-change baseline first, or the effect of each becomes
 unrecoverable.
 
-**An unsigned ingest endpoint is a new abuse surface.** Decision 6 contains the
-blast radius — inflated anonymous traffic cannot move rankings — but it can move
-*displayed* counts, which decision 5 says are never reduced. If displayed
-anonymous counts are successfully inflated, the only remedies are at ingest.
-This tension is real and should be settled before B ships.
+**Anonymous loop depth is assumed rather than measured.** One CDN delivery
+counts as one loop, so anonymous viewers who rewatch report a single loop. The
+hero metric is therefore conservative for 42% of the audience. That is the safe
+direction to be wrong in, but it should be stated wherever the number is
+published rather than discovered later by someone reconciling it.
+
+**CDN delivery is inflatable without an account.** Repeated media requests raise
+displayed counts, and decision 5 says displayed numbers are never reduced, so
+the only remedy is at ingest — deduplication and rate limiting on delivery
+logging. Decision 6 keeps the blast radius out of ranking, but it does not
+protect the public number.

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
@@ -90,11 +90,27 @@ So:
 - **Views is the headline** where size and comparability matter — it is the
   bigger number and the one other platforms report.
 - **Loops is the signature** — Vine-native, unique to Divine, and the only
-  metric no competitor can quote. It is what the video card already renders
-  and it should stay there.
+  metric no competitor can quote. The video card is the right home for it and
+  it should stay there.
 
 Publishing loops as "the big number" would understate Divine by roughly a
 third against its own view count.
+
+**The card does not render this metric today, despite the label.**
+`VideoEvent.totalLoops`
+(`mobile/packages/models/lib/src/video_event.dart:1149`) is:
+
+```dart
+int get totalLoops =>
+    (originalLoops ?? 0) + (int.tryParse(rawTags['views'] ?? '') ?? 0);
+```
+
+Archival Vine loops plus the Divine **`views`** tag. For a Divine-native video
+the number under the label "loops" is the *view* count. Pointing the card at
+the real loop metric therefore cuts every Divine-native card by roughly a
+third — which decision 5 forbids. Reconciling the label with the metric is a
+prerequisite for this work, not a follow-up, and it is tracked as an open risk
+below.
 
 **5. A displayed number is never reduced — but it may be withheld.** These are
 different acts and only one of them is a lie.
@@ -315,9 +331,17 @@ recovery land close together, so a jump will be hard to attribute. Ship the
 detector and record a pre-change baseline first, or the effect of each becomes
 unrecoverable.
 
+**The card's "loops" label does not name the loop metric.** `totalLoops` sums
+archival Vine loops with the Divine `views` tag, so a Divine-native card shows
+a view count under a loop label. Because loops run at ~0.65x views, correcting
+the card reduces a displayed number, which decision 5 forbids. The two rules
+cannot both be satisfied by pointing the existing card at the new metric;
+which one gives — the label, the floor, or a one-time restatement — is
+unresolved and blocks the client half of this work.
+
 **Anonymous loop depth is assumed rather than measured.** One CDN delivery
 counts as one loop, so anonymous viewers who rewatch report a single loop. The
-hero metric is therefore conservative for 42% of the audience. That is the safe
+loop count is therefore conservative for 42% of the audience. That is the safe
 direction to be wrong in, but it should be stated wherever the number is
 published rather than discovered later by someone reconciling it.
 

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
@@ -1,0 +1,253 @@
+# View and loop metrics
+
+**Date:** 2026-08-13
+**Status:** Design — one open decision (anonymous signal transport)
+**Target:** No freeze applies; ships on the normal release path
+
+## Problem
+
+Divine has no shared definition of a view, and three discovery surfaces that
+each rank on a different theory of merit. None of it was decided — it accreted
+as data became available, and old formulas were carried forward by refactors
+rather than revisited.
+
+| Date | Event |
+|---|---|
+| 2026-01-05 | Trending formula written: `engagement × decay`, **no views term** |
+| 2026-01-16 | Kind-22236 view ingestion ships — 11 days *later* |
+| 2026-04-13 | Leaderboard rebuilt, uses `views + unique_viewers × 2` |
+| 2026-06-15 | A **second** trending formula added, view-velocity |
+| 2026-08-05 | Popular rebuilt, uses views as a linear term |
+
+Two contradictory trending formulas are live simultaneously on
+near-identically-named objects. The one the API serves
+(`trending_videos_snapshot`, via `client.rs:3541`) is the view-velocity one —
+not the one the object naming suggests.
+
+The kind-22236 outage (#7210) exposed this. When mobile view reporting stopped,
+`views`, `unique_viewers` and `loops` all fell ~60–69% in six days, which moved
+Trending, Popular and the creator Leaderboard while Divine had no way to notice.
+Detection is being added separately (divine-funnelcake#917).
+
+Underneath the outage sits a permanent undercount. Two independent estimates
+put recorded views at roughly a third of reality:
+
+- Recorded views imply an 8–18% per-user interaction rate against a 1–5%
+  short-form industry norm.
+- Recorded views run at ~1.0 per CDN download, for a format where one download
+  serves many playthroughs.
+
+Causes are definitional, not defects: a view today requires **≥1s of actual
+playback** by a **signed-in** user. Anonymous viewers — roughly half of daily
+users — emit nothing at all, because view events are Nostr-signed.
+
+Numbers are not cosmetic here.
+[The video-card view-count spec](2026-08-08-video-card-view-count-display-design.md)
+measured that crossing ~100 views roughly doubles the chance a new creator keeps
+posting (31% → 61%), and that 80% of new creators never reach it. Understated
+counts suppress the behaviour the product depends on.
+
+## Decisions
+
+**1. Two metrics, not one.** Views and loops answer different questions and
+must stop being conflated.
+
+- **Loops** — every playthrough. Depth. Unbounded by nature.
+- **Views** — one per playback start, per session. Reach. Bounded per person.
+
+**2. A view is a playback start.** Not ≥1s, not a completed loop. This matches
+TikTok and Reels, so a creator arriving from either reads Divine's numbers in
+familiar units. It is also the largest defensible definition.
+
+Rejected: *completed loop* (strictest option; 60.3% of current view events never
+complete one, so it would cut recorded views to ~40%) and *≥1s* (today's rule,
+comparable to nothing).
+
+**3. Both metrics count everyone.** Signed-in and anonymous alike. Anonymous
+viewers are roughly half of daily users and are currently invisible. This is the
+single largest correction available and every other platform already does it.
+
+**4. Loops is the hero number.** Largest, Vine-native, and unique to Divine —
+no other platform can quote a loop count. It is already what the video card
+renders.
+
+**5. A displayed number is never reduced — but it may be withheld.** These are
+different acts and only one of them is a lie.
+
+- **Never reduce.** No damping, capping, or silent dedup on any number that is
+  shown. A creator can count their own loops; a shaved number is a trust
+  violation and a discoverable one.
+- **Withholding is legitimate.** Showing nothing is an editorial choice, not a
+  false statement.
+  [The video-card spec](2026-08-08-video-card-view-count-display-design.md)
+  already establishes this: a public count renders only at or above
+  `publicLoopCountFloor` (1000), because below that it reads as a warning rather
+  than a recommendation, and small numbers were themselves suppressing adoption.
+- **A creator always sees their own true number**, however small — correcting a
+  creator's underestimate of their audience is what keeps them posting
+  (Bernstein et al., CHI 2013).
+
+The three rules compose: raw counts everywhere they appear, a floor governing
+whether a *public* count appears at all, and no floor on a creator's own view of
+their own work.
+
+**6. Anti-spam lives entirely in ranking.** Nobody is owed a slot on Popular, so
+ranking can be as aggressive as it needs to be. Because public counts never
+move, aggressive filtering produces no creator-facing complaint — which makes it
+easier to be strict, not harder.
+
+**7. Each surface gets one stated job and one formula.** The duplicate and
+contradictory ranking objects are removed, not left alongside.
+
+| Surface | Job, in words a user could repeat |
+|---|---|
+| Trending | Rising fastest right now |
+| Popular | Most-watched over a window |
+| Leaderboard | Best creators over a period |
+
+## Design
+
+### Metric definitions
+
+```
+loop   := one completed playthrough of the video
+view   := one playback start, deduplicated per viewing session
+session:= a continuous period of engagement with one video by one viewer
+```
+
+`loops >= views` always holds. Both are emitted per viewing session, so one
+session reports one view and N loops.
+
+The existing `view_interactions.loops` column already stores a fractional
+playthrough count (observed range 0 to 218.2, mean 0.99), so the loop metric is
+derivable from data collected today. It is `views` that changes definition.
+
+### Display versus ranking
+
+Two pipelines from one event stream, and they must not be collapsed:
+
+- **Display path** — raw sums. What a viewer or creator sees on a video, a
+  profile, or in analytics. No filtering of any kind. Whether a public count is
+  *shown* is governed separately by `publicLoopCountFloor`; that gate decides
+  visibility, never magnitude.
+- **Ranking path** — the same events, then anti-spam, then damping. Feeds
+  Trending, Popular, Leaderboard, and recommendations.
+
+A single event contributes fully to display and conditionally to ranking. The
+divergence is intentional and should be documented wherever both appear, so a
+creator asking "why am I not on Popular with 50k loops" gets a real answer.
+
+### Ranking inputs
+
+Ranking damps loops and trusts views, because views are bounded per person and
+loops are not — one observed session already carries 218 loops, which under raw
+weighting outranks 218 distinct viewers.
+
+Retained from current behaviour: `log1p(loops) × 0.5`, already used by
+`popular_score` and the leaderboard. This is not a new brake; it is the existing
+one, kept deliberately rather than by accident.
+
+Anonymous events carry weaker identity guarantees than signed ones and should
+therefore weigh less in ranking than signed-in events. They still count fully
+for display. The exact weighting is a tuning question, not an architectural one.
+
+### Anonymous signal — the open decision
+
+Counting anonymous viewers requires a client-side signal that does not depend on
+a Nostr key. Two options, with materially different properties:
+
+**A. CDN-derived.** Infer views and loops from media delivery logs, which
+already flow to `cdn_view_counts`.
+
+- No client work, no new endpoint, no new abuse surface.
+- Cannot see loops: one download serves many playthroughs, so replays are
+  invisible. Undercounts exactly the metric chosen as the hero.
+- Cache hits and range requests distort counts; observed daily totals swing
+  21k–110k, which is not the shape of a trustworthy signal.
+
+**B. Unsigned client beacon.** The client posts view/loop events without a Nostr
+signature, identified by an ephemeral device-scoped id.
+
+- Measures the real thing: playback starts and completed loops as the player
+  observed them, identically to the signed path.
+- Requires a new ingest endpoint and rate limiting; an unsigned endpoint is a
+  new abuse surface, which is precisely why decision 6 keeps anti-spam in
+  ranking rather than display.
+- Needs a privacy decision on the ephemeral identifier's lifetime and scope.
+
+**Recommendation: B.** Option A structurally cannot count loops, and loops is
+the hero metric. A signal that cannot measure the headline number is not a
+candidate. B should reuse the existing client-side counting logic so signed and
+anonymous paths cannot drift apart in definition.
+
+This decision is deferred, not assumed. Everything else in this design holds
+under either choice.
+
+### Expected movement
+
+Stacked against today's reported numbers:
+
+| Change | Effect |
+|---|---|
+| #7210 view-event fix (merged) | ×1.7 recovery of the outage loss |
+| View = playback start | ×2–3 |
+| Count anonymous viewers | ×2 |
+| Loops promoted as headline | Larger again than views |
+
+Roughly an order of magnitude over what is reported today, with every step
+explainable to a partner, a creator, or a journalist.
+
+The effect compounds with the display floor. `publicLoopCountFloor` is 1000, and
+today most videos fall below it — which is why the video-card spec had to
+suppress counts in the first place. An order-of-magnitude correction moves a
+large share of the catalogue above the floor, so counts start appearing on cards
+that currently show only a date. The suppression rule stops being load-bearing
+because fewer numbers are embarrassing, rather than because the rule changed.
+
+That is the same lever from both ends: the Aug 8 spec hid small numbers because
+small numbers were suppressing adoption; this work makes the numbers correct, so
+there are fewer to hide. The floor should be re-examined after rollout — at
+truthful volumes 1000 may be set too low or too high, and it is deliberately a
+one-line constant.
+
+## Testing
+
+- Unit tests pinning `view`/`loop`/`session` boundaries: a scroll-past with no
+  playback start emits nothing; one session with N playthroughs emits one view
+  and N loops; `loops >= views` holds as an invariant.
+- A test asserting the display path applies no filtering — the property most
+  likely to be broken later by someone adding a well-meant cap.
+- Ranking-path tests over adversarial input: a single session with hundreds of
+  loops must not outrank many distinct viewers.
+- Parity test between the signed and anonymous paths, so the two cannot drift to
+  different definitions of the same word.
+- The divine-funnelcake#917 detector already covers per-client reporting
+  collapse and should stay green through the rollout.
+
+## Out of scope
+
+- Recomputing historical rankings for 2026-08-08 onward. The events were never
+  sent and cannot be recovered; the on-device backlog replays with publish-time
+  timestamps, so it lands on rollout day rather than the days it happened.
+  Historical daily leaderboards for that window stay wrong permanently.
+- Gorse recommendation retraining. Recommendations consumed the biased sample
+  during the outage; the extent is unmeasured and is its own piece of work.
+- The sybil-shaped reaction traffic since 2026-08-06. It inflates engagement
+  terms rather than view terms and is tracked separately.
+
+## Open risk
+
+**Rollout-day spike.** The #7210 fix replays every stranded on-device backlog at
+publish time. Expect a one-day artificial peak that is recovered history, not
+growth, and do not read any view metric on that day without accounting for it.
+
+**Numbers move for two reasons at once.** The redefinition and the outage
+recovery land close together, so a jump will be hard to attribute. Ship the
+detector and record a pre-change baseline first, or the effect of each becomes
+unrecoverable.
+
+**An unsigned ingest endpoint is a new abuse surface.** Decision 6 contains the
+blast radius — inflated anonymous traffic cannot move rankings — but it can move
+*displayed* counts, which decision 5 says are never reduced. If displayed
+anonymous counts are successfully inflated, the only remedies are at ingest.
+This tension is real and should be settled before B ships.

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
@@ -244,10 +244,17 @@ Stacked against today's reported numbers:
 
 | Change | Effect on views | Effect on loops |
 |---|---|---|
-| #7210 view-event fix (merged) | ×1.7 recovery on the signed-in share | ×1.7 recovery |
+| #7210 view-event fix (merged) | ×2.6 ceiling, actual unmeasured | same ceiling |
 | View = playback start | ×2–3 on the signed-in share | — |
 | Anonymous counted | already counted (42% of views) | **new — CDN deliveries begin contributing** |
 | Loops as signature metric | — | stays ~0.65x views; not a multiplier |
+
+The #7210 ceiling is the full reporter population coming back: daily mobile
+view reporters fell 676 → 263 over the window, so restoring all of them is
+×2.6. The realised figure is lower and not yet measured, because that fix only
+restores queued rows carrying a real `d` tag — rows where `videoVineId ==
+videoId` still drop as `missingAddressableDTag`. Treat ×2.6 as a bound, not a
+forecast, and read the actual number off the post-rollout baseline.
 
 Views grow mostly from the redefinition, since anonymous views already flow into
 `total_views`. Loops grow mostly from anonymous, since loops are currently

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
@@ -29,24 +29,66 @@ The kind-22236 outage (#7210) exposed this. When mobile view reporting stopped,
 Trending, Popular and the creator Leaderboard while Divine had no way to notice.
 Detection is being added separately (divine-funnelcake#917).
 
-Underneath the outage sits a permanent undercount. Two independent estimates
-put recorded views at roughly a third of reality:
+Underneath the outage sits a permanent undercount, and it is measurable
+directly rather than by inference.
 
-- Recorded views imply an 8–18% per-user interaction rate against a 1–5%
-  short-form industry norm.
-- Recorded views run at ~1.0 per CDN download, for a format where one download
-  serves many playthroughs.
+### Ground truth: anyone who interacts provably watched
 
-Causes are definitional, not defects. A view today requires **≥1s of actual
-playback**, which excludes the scroll-past and the still-buffering.
+A like, comment, or repost is proof of viewing. Comparing the set of people who
+interacted with a video against the set who registered a view gives a floor on
+the loss, per video, with no benchmarks or assumptions.
 
-Anonymous coverage is split, and the split is the confusing part. Because view
-events are Nostr-signed, anonymous viewers appear in `total_views` via CDN
-delivery — 42% of all views — but are entirely absent from everything derived
-from `view_interactions`: `unique_viewers`, `loops`, and the daily stats that
-feed the leaderboard. So the view count sees them and the loop count does not —
-which is why loops, the metric unique to Divine, is the worse-measured of the
-two.
+Worked example — event
+`a3092dfc8d36d15583d0866ae4312fd32b96a8eb59d79a7f23028c1ffc6d5503`, posted
+2026-08-13:
+
+| Measure | Count |
+|---|---|
+| Distinct people who liked / commented / reposted | 37 |
+| Distinct people who registered a view | 26 |
+| **Interactors who registered a view** | **10 of 37** |
+
+**27 of 37 people who provably watched are absent from the view count** — 73%
+missing. The card showed 108; the implied floor is above 400. It is a floor
+twice over: it counts only people who bothered to interact, and silent viewers
+are missing on top of them.
+
+The same method shows engagement tracks looping, as expected for the format.
+Interactors returned 4.5 times each against 1.06 for non-interactors, giving
+~4.8 loops per interactor versus ~1.7. But the largest single interactor
+session recorded **3.3 loops** — nobody writes a comment on a six-second video
+in 3.3 passes, which suggests loop accumulation stops when the comment sheet
+opens while the video keeps playing behind it. Unconfirmed, and worth finding.
+
+Two weaker estimates agree in direction: recorded views imply an 8–18% per-user
+interaction rate against a 1–5% short-form norm, and run at ~1.0 per CDN
+download for a format where one download serves many playthroughs.
+
+### Every known error runs the same way
+
+Every cause identified so far *subtracts*:
+
+- A view requires ≥1s of playback, excluding the scroll-past and the
+  still-buffering.
+- Anonymous viewers contribute no loops at all.
+- Loop accumulation appears to stop during interaction.
+- The queue regression dropped signed-in reporting entirely for six days.
+
+None of them inflate. **So this is not a choice between accurate and
+flattering — it is a choice between wrong-low and less-wrong.** Where a
+definition is a genuine judgment call, this design takes the inclusive reading,
+because every measured error is in one direction and adding caution on top of a
+fourfold undercount compounds it rather than correcting it.
+
+The constraint that remains is honesty, not conservatism: publish nothing that
+could not be explained if audited. That rules out fabrication. It does not rule
+out counting what is actually being watched.
+
+Anonymous coverage is split, which is the confusing part. Because view events
+are Nostr-signed, anonymous viewers reach `total_views` through CDN delivery —
+42% of all views — but are absent from everything derived from
+`view_interactions`: `unique_viewers`, `loops`, and the daily stats feeding the
+leaderboard.
 
 Numbers are not cosmetic here.
 [The video-card view-count spec](2026-08-08-video-card-view-count-display-design.md)
@@ -74,27 +116,25 @@ comparable to nothing).
 viewers are roughly half of daily users and are currently invisible. This is the
 single largest correction available and every other platform already does it.
 
-**4. Loops is the signature number; views is the largest number.** These are
-not the same claim, and conflating them was an error in an earlier draft of
-this document.
+**4. Loops stays the signature metric. Which number is larger is not yet
+known.**
 
-Loops runs at **0.63–0.71 per view** in current data, and 91% of
-`view_counts` rows carry fewer loops than views. That is inherent to the
-definitions rather than a measurement artefact: a view is a playback start, a
-loop is a *completed* playthrough, so every viewer who scrolls away mid-play
-contributes a view and no loop. Rewatching does not close the gap, because
-most sessions never finish one pass.
+Loops currently measures 0.63–0.71 per view, and an earlier draft concluded
+from that that views should be the headline. **That conclusion does not
+survive, because the ratio is measured on a broken pipeline.** Anonymous
+viewers are 42% of all views and contribute *zero* loops; the signed-in half
+was dropping data for six days; and loop accumulation appears to stop during
+interaction. Every one of those depresses loops specifically.
 
-So:
+Loops is the *worse-measured* of the two metrics, not the smaller one. Counting
+anonymous loops alone moves it close to parity, and if real looping runs above
+what today's pipeline captures — which the 3.3-loop ceiling on commenter
+sessions suggests — it passes views.
 
-- **Views is the headline** where size and comparability matter — it is the
-  bigger number and the one other platforms report.
-- **Loops is the signature** — Vine-native, unique to Divine, and the only
-  metric no competitor can quote. The video card is the right home for it and
-  it should stay there.
-
-Publishing loops as "the big number" would understate Divine by roughly a
-third against its own view count.
+So loops keeps its claim on the video card and stays the metric no competitor
+can quote. **Which metric leads is deferred until both are measured properly**,
+rather than settled now on an instrument known to be broken in exactly the
+direction that decides it.
 
 **The card does not render this metric today, despite the label.**
 `VideoEvent.totalLoops`
@@ -247,7 +287,7 @@ Stacked against today's reported numbers:
 | #7210 view-event fix (merged) | ×2.6 ceiling, actual unmeasured | same ceiling |
 | View = playback start | ×2–3 on the signed-in share | — |
 | Anonymous counted | already counted (42% of views) | **new — CDN deliveries begin contributing** |
-| Loops as signature metric | — | stays ~0.65x views; not a multiplier |
+| Loop accumulation during interaction | — | unquantified; suspected undercount |
 
 The #7210 ceiling is the full reporter population coming back: daily mobile
 view reporters fell 676 → 263 over the window, so restoring all of them is
@@ -260,10 +300,10 @@ Views grow mostly from the redefinition, since anonymous views already flow into
 `total_views`. Loops grow mostly from anonymous, since loops are currently
 signed-in only and CDN deliveries have never contributed one.
 
-Views is the larger figure and grows fastest, so it is the number to lead with
-where size matters. Loops gains most in *relative* terms, because it is the
-metric that has been missing 42% of its audience entirely — but it starts from
-~0.65x views and does not overtake it.
+Both remain floors. The interaction-overlap measurement puts real views for a
+sampled video above 400 against a displayed 108, which is a larger correction
+than this table accounts for, and it counts only viewers who interacted.
+Treat every figure here as the least the number should move, not the most.
 
 ### The display floor, and why most cards show a date
 

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
@@ -228,7 +228,7 @@ Two limits, stated so nobody later mistakes them for defects:
 - **Anonymous loop depth is assumed, not measured.** One delivery serves many
   playthroughs, so an anonymous viewer who loops a video twenty times reports
   one loop. Anonymous engagement depth is therefore systematically conservative
-  against signed-in depth. This understates the hero metric rather than
+  against signed-in depth. This understates the loop count rather than
   inflating it, which is the safe direction to be wrong in.
 - **CDN counts are noisy.** Observed daily totals swing between 21k and 110k,
   driven by cache behaviour and range requests rather than by audience. Ranking


### PR DESCRIPTION
## Description

Design spec for what a view and a loop should mean on Divine, and how the discovery surfaces should rank.

Written because the kind-22236 outage (#7210) exposed that there is no shared definition of a view, and that Trending, Popular and Leaderboard each rank on a different formula that nobody chose. Two contradictory trending formulas are live simultaneously on near-identically-named objects, and the one the API actually serves is the one the naming does *not* suggest.

Key decisions:

- **Views and loops are different metrics.** Loops measure depth; views measure reach. Conflating them is what made the ranking formulas incoherent.
- **A view is a playback start** — matching TikTok and Reels, so creators read Divine's numbers in familiar units.
- **Views is the headline, loops is the signature.** Loops runs at 0.63–0.71 per view in current data and does not overtake it, so loops is the Vine-native number rather than the big one. `loops >= views` does not hold at row or aggregate level.
- **Both count anonymous viewers**, roughly half of daily users, currently absent from every `view_interactions`-derived metric because view events are Nostr-signed.
- **Anonymous arrives CDN-derived**, one view and one loop per delivery — the model already in production (`total_views = cdn_views + auth_views` holds exactly across 2,201,983 videos). An unsigned client beacon was considered and rejected: it measures anonymous loop depth accurately, but costs a new unsigned-write abuse surface and a privacy call on a device identifier.
- **A displayed number is never reduced, but may be withheld.** Builds on the existing `publicLoopCountFloor` rule from the Aug 8 video-card spec — hiding a small number is editorial, shaving one a creator can count themselves is not.
- **Anti-spam lives entirely in ranking**, which makes it easier to be strict, because no public count ever moves.

**Open decisions**, both recorded in the spec:

- **Integral vs fractional loops.** The stored columns are `Float64`/`Float32` and the median view event sits at 0.75 of a pass, so flooring to "completed playthroughs" would round most sessions to zero. Keeping the fractional value is recommended, but then the definition block has to say *playthrough fraction* rather than *completed playthrough*.
- **The card's "loops" label does not name the loop metric.** `VideoEvent.totalLoops` is `originalLoops + rawTags['views']`, so a Divine-native card shows a view count under a loop label. Because loops run at ~0.65x views, pointing the card at the real metric reduces a displayed number — which decision 5 forbids. Which rule gives is unresolved and blocks the client half of this work.

**Related Issue:** Relates to #7210, divinevideo/divine-funnelcake#917

## Out of Scope

Called out in the spec: recomputing historical rankings for Aug 8 onward (the events were never sent and cannot be recovered), Gorse retraining after the biased-sample window, and the sybil-shaped reaction traffic since Aug 6.

## Verification

Docs-only — no code, tests, or generated files. Claims in the spec are sourced rather than asserted: the formula archaeology is read from deployed `system.tables` objects rather than migration files, which drift; the 60.3% / 8-18% / ~1.0-per-download figures are measured against production; the loop-per-view ratio and the display-floor table are measured against the catalogue; the creator-retention figures are cited from the existing Aug 8 spec.

## Type of Change

- [x] 📝 Documentation
