### PR TITLE
test(widget-tests): pump a frame between scrolling and tapping

### DIFF
--- a/mobile/test/helpers/scroll.dart
+++ b/mobile/test/helpers/scroll.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+
+/// Scrolls [target] into view and settles the frame before returning.
+///
+/// Use this instead of a bare `tester.scrollUntilVisible` wherever a tap or
+/// another viewport-sensitive interaction follows.
+///
+/// `scrollUntilVisible` ends by calling `Scrollable.ensureVisible` on [target]
+/// itself, so the target is positioned correctly — but it does not pump a
+/// frame afterwards. Tapping straight away reads the target's centre from the
+/// not-yet-settled layout, which can sit at or past the viewport edge on a
+/// screen whose content happens to be tall. The tap then lands on nothing:
+/// `warnIfMissed` only prints a warning, so the failure surfaces later as an
+/// unrelated assertion (#7179).
+///
+/// Whether a row lands near that edge is not stable across a run. `VineTheme`'s
+/// font helpers are `GoogleFonts.inter(...)`, and google_fonts registers its
+/// asset into the process-global font collection asynchronously, so the first
+/// widget test in an isolate to render a screen lays it out with the wider
+/// fallback test font and every later one with real Inter metrics. Randomized
+/// ordering decides which test pays that cost.
+///
+/// [delta] and [scrollable] pass straight through to `scrollUntilVisible`.
+Future<void> scrollUntilTappable(
+  WidgetTester tester,
+  Finder target,
+  double delta, {
+  Finder? scrollable,
+}) async {
+  await tester.scrollUntilVisible(target, delta, scrollable: scrollable);
+  await tester.pumpAndSettle();
+}

--- a/mobile/test/helpers/scroll.dart
+++ b/mobile/test/helpers/scroll.dart
@@ -1,3 +1,6 @@
+// ABOUTME: Scroll helper that settles the frame before a tap reads coordinates.
+// ABOUTME: Guards the #7179 class where a tap uses the pre-scroll layout and misses.
+
 import 'package:flutter_test/flutter_test.dart';
 
 /// Scrolls [target] into view and settles the frame before returning.
@@ -20,13 +23,25 @@ import 'package:flutter_test/flutter_test.dart';
 /// fallback test font and every later one with real Inter metrics. Randomized
 /// ordering decides which test pays that cost.
 ///
-/// [delta] and [scrollable] pass straight through to `scrollUntilVisible`.
+/// Every parameter besides [tester] passes straight through to
+/// `scrollUntilVisible` with its own defaults, so this is a drop-in
+/// replacement.
 Future<void> scrollUntilTappable(
   WidgetTester tester,
   Finder target,
   double delta, {
   Finder? scrollable,
+  int maxScrolls = 50,
+  Duration duration = const Duration(milliseconds: 50),
+  bool continuous = false,
 }) async {
-  await tester.scrollUntilVisible(target, delta, scrollable: scrollable);
+  await tester.scrollUntilVisible(
+    target,
+    delta,
+    scrollable: scrollable,
+    maxScrolls: maxScrolls,
+    duration: duration,
+    continuous: continuous,
+  );
   await tester.pumpAndSettle();
 }

--- a/mobile/test/helpers/scroll_test.dart
+++ b/mobile/test/helpers/scroll_test.dart
@@ -1,0 +1,104 @@
+// ABOUTME: Regression tests for scroll helpers used by widget tests.
+// ABOUTME: Pins the settled-frame guarantee before viewport-sensitive actions.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'scroll.dart';
+
+void main() {
+  testWidgets(
+    'scrollUntilTappable pumps the post-scroll frame before returning',
+    (
+      tester,
+    ) async {
+      const targetKey = Key('target');
+
+      await tester.pumpWidget(
+        const _ScrollProbe(targetKey: targetKey),
+      );
+
+      await tester.scrollUntilVisible(
+        find.byKey(targetKey),
+        240,
+        scrollable: find.byType(Scrollable),
+      );
+      expect(find.text('post-scroll frame pending'), findsOneWidget);
+
+      await tester.pumpWidget(
+        const _ScrollProbe(targetKey: targetKey),
+      );
+      await tester.pumpAndSettle();
+
+      await scrollUntilTappable(
+        tester,
+        find.byKey(targetKey),
+        240,
+        scrollable: find.byType(Scrollable),
+      );
+
+      expect(find.text('post-scroll frame settled'), findsOneWidget);
+    },
+  );
+}
+
+class _ScrollProbe extends StatefulWidget {
+  const _ScrollProbe({required this.targetKey});
+
+  final Key targetKey;
+
+  @override
+  State<_ScrollProbe> createState() => _ScrollProbeState();
+}
+
+class _ScrollProbeState extends State<_ScrollProbe> {
+  bool _settledAfterScroll = true;
+  bool _settleScheduled = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          height: 320,
+          child: NotificationListener<ScrollEndNotification>(
+            onNotification: (_) {
+              if (_settleScheduled) {
+                return false;
+              }
+              setState(() {
+                _settledAfterScroll = false;
+                _settleScheduled = true;
+              });
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                if (!mounted) {
+                  return;
+                }
+                setState(() {
+                  _settledAfterScroll = true;
+                  _settleScheduled = false;
+                });
+              });
+              return false;
+            },
+            child: ListView(
+              children: [
+                for (var index = 0; index < 20; index++)
+                  SizedBox(height: 80, child: Text('before $index')),
+                SizedBox(
+                  key: widget.targetKey,
+                  height: 80,
+                  child: Text(
+                    _settledAfterScroll
+                        ? 'post-scroll frame settled'
+                        : 'post-scroll frame pending',
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/test/router/nip05_settings_navigation_test.dart
+++ b/mobile/test/router/nip05_settings_navigation_test.dart
@@ -19,6 +19,8 @@ import 'package:openvine/services/auth_service.dart'
 import 'package:profile_repository/profile_repository.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../helpers/scroll.dart';
+
 class _MockAuthService extends Mock implements AuthService {}
 
 class _MockProfileRepository extends Mock implements ProfileRepository {}
@@ -94,25 +96,16 @@ void main() {
       ).thenAnswer((_) async {});
     });
 
-    // `scrollUntilVisible` stops once the row is *built*, which inside a
-    // ListView's cache extent can still leave it below the viewport edge, so
-    // the tap lands on nothing. How close the row gets to that edge is not
-    // stable: VineTheme's `GoogleFonts.inter` registers its asset
-    // process-globally, so the first widget test to render this screen lays it
-    // out with the wider fallback font and every later one with real Inter
-    // metrics. Randomized ordering picks which test pays that cost, so every
-    // tap here goes through `ensureVisible` first (#7179).
     Future<void> tapNip05Tile(WidgetTester tester) async {
       final nip05Tile = find.text(
         lookupAppLocalizations(const Locale('en')).nostrSettingsNip05Address,
       );
-      await tester.scrollUntilVisible(
+      await scrollUntilTappable(
+        tester,
         nip05Tile,
         250,
         scrollable: find.byType(Scrollable),
       );
-      await tester.ensureVisible(nip05Tile);
-      await tester.pumpAndSettle();
       await tester.tap(nip05Tile);
       await tester.pumpAndSettle();
     }

--- a/mobile/test/screens/content_filters_screen_test.dart
+++ b/mobile/test/screens/content_filters_screen_test.dart
@@ -12,6 +12,7 @@ import 'package:openvine/screens/content_filters_screen.dart';
 import 'package:openvine/services/age_verification_service.dart';
 import 'package:openvine/services/content_filter_service.dart';
 
+import '../helpers/scroll.dart';
 import '../helpers/test_provider_overrides.dart';
 
 class _MockContentFilterService extends Mock implements ContentFilterService {}
@@ -137,14 +138,12 @@ void main() {
 
         Future<void> tapShowFor(ContentLabel label) async {
           final row = find.byKey(ValueKey('content-filter-${label.value}'));
-          await tester.scrollUntilVisible(row, 80);
-          await tester.pumpAndSettle();
-          await tester.tap(
-            find.descendant(
-              of: row,
-              matching: find.text(l10nOf(tester).contentFiltersShow),
-            ),
+          final showButton = find.descendant(
+            of: row,
+            matching: find.text(l10nOf(tester).contentFiltersShow),
           );
+          await scrollUntilTappable(tester, row, 80);
+          await tester.tap(showButton);
           await tester.pump();
         }
 

--- a/mobile/test/screens/developer_options_screen_test.dart
+++ b/mobile/test/screens/developer_options_screen_test.dart
@@ -17,6 +17,7 @@ import 'package:openvine/services/environment_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../helpers/invite_availability_harness.dart';
+import '../helpers/scroll.dart';
 
 Future<SharedPreferences> mockPrefs() async {
   SharedPreferences.setMockInitialValues({});
@@ -52,17 +53,12 @@ Future<InviteAvailabilityCubit> pumpScreen(
 }
 
 Future<void> tapTile(WidgetTester tester, String title) async {
-  // Tap the whole ListTile (not just the text) and ensure it is fully in view
-  // first: scrollUntilVisible can leave the row clipped at a viewport edge, so
-  // a tap on the text's centre lands off-target on some layouts (this is what
-  // failed on Linux CI but passed on macOS). hitTestWarningShouldBeFatal
-  // (set in main) turns any such miss into a hard failure so it can't pass
-  // locally again.
+  // Tap the whole ListTile rather than just its text: a tap on the text's
+  // centre lands off-target on some layouts (this is what failed on Linux CI
+  // but passed on macOS). hitTestWarningShouldBeFatal (set in main) turns any
+  // such miss into a hard failure so it can't pass locally again.
   final tile = find.widgetWithText(ListTile, title);
-  await tester.scrollUntilVisible(tile, 300);
-  await tester.pumpAndSettle();
-  await tester.ensureVisible(tile);
-  await tester.pumpAndSettle();
+  await scrollUntilTappable(tester, tile, 300);
   await tester.tap(tile);
   await tester.pumpAndSettle();
 }

--- a/mobile/test/screens/developer_options_screen_test.dart
+++ b/mobile/test/screens/developer_options_screen_test.dart
@@ -55,8 +55,8 @@ Future<InviteAvailabilityCubit> pumpScreen(
 Future<void> tapTile(WidgetTester tester, String title) async {
   // Tap the whole ListTile rather than just its text: a tap on the text's
   // centre lands off-target on some layouts (this is what failed on Linux CI
-  // but passed on macOS). hitTestWarningShouldBeFatal (set in main) turns any
-  // such miss into a hard failure so it can't pass locally again.
+  // but passed on macOS). Some groups below make hit-test warnings fatal so
+  // this cannot slip through their local runs again.
   final tile = find.widgetWithText(ListTile, title);
   await scrollUntilTappable(tester, tile, 300);
   await tester.tap(tile);

--- a/mobile/test/screens/minor_account_review_parent_consent_screen_test.dart
+++ b/mobile/test/screens/minor_account_review_parent_consent_screen_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/screens/minor_account_review_parent_consent_screen.dart';
 
+import '../helpers/scroll.dart';
+
 void main() {
   group('MinorAccountReviewParentConsentScreen', () {
     testWidgets('opens support email with prepared subject and body', (
@@ -33,12 +35,12 @@ void main() {
       );
 
       await tester.pumpAndSettle();
-      await tester.scrollUntilVisible(
+      await scrollUntilTappable(
+        tester,
         find.text(l10n.minorAccountReviewParentConsentEmailCta),
         200,
         scrollable: find.byType(Scrollable),
       );
-      await tester.pumpAndSettle();
       await tester.tap(find.text(l10n.minorAccountReviewParentConsentEmailCta));
       await tester.pumpAndSettle();
 

--- a/mobile/test/screens/minor_account_review_screen_test.dart
+++ b/mobile/test/screens/minor_account_review_screen_test.dart
@@ -11,6 +11,8 @@ import 'package:openvine/screens/minor_account_review_parent_consent_screen.dart
 import 'package:openvine/screens/minor_account_review_screen.dart';
 import 'package:openvine/screens/minor_account_review_under13_screen.dart';
 
+import '../helpers/scroll.dart';
+
 void main() {
   group('MinorAccountReviewScreen', () {
     testWidgets('shows the welcome-entry family guidance copy', (
@@ -374,7 +376,8 @@ void main() {
         await tester.pumpAndSettle();
         expect(protectedFetches, 1);
 
-        await tester.scrollUntilVisible(
+        await scrollUntilTappable(
+          tester,
           find.text('Check Again'),
           200,
           scrollable: find.byType(Scrollable),

--- a/mobile/test/screens/notification_settings_screen_test.dart
+++ b/mobile/test/screens/notification_settings_screen_test.dart
@@ -17,6 +17,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/notification_settings_screen.dart';
 import 'package:openvine/services/notification_preferences_service.dart';
 
+import '../helpers/scroll.dart';
 import '../helpers/test_provider_overrides.dart';
 
 class _MockNotificationRepository extends Mock
@@ -76,15 +77,12 @@ void main() {
           tester.element(find.byType(NotificationSettingsScreen)),
         );
 
-        await tester.scrollUntilVisible(
+        await scrollUntilTappable(
+          tester,
           find.text(l10n.notificationSettingsMarkAllAsRead),
           200,
           scrollable: find.byType(Scrollable).first,
         );
-        await tester.ensureVisible(
-          find.text(l10n.notificationSettingsMarkAllAsRead),
-        );
-        await tester.pumpAndSettle();
 
         await tester.tap(find.text(l10n.notificationSettingsMarkAllAsRead));
         await tester.pump();
@@ -114,15 +112,12 @@ void main() {
           tester.element(find.byType(NotificationSettingsScreen)),
         );
 
-        await tester.scrollUntilVisible(
+        await scrollUntilTappable(
+          tester,
           find.text(l10n.notificationSettingsMarkAllAsRead),
           200,
           scrollable: find.byType(Scrollable).first,
         );
-        await tester.ensureVisible(
-          find.text(l10n.notificationSettingsMarkAllAsRead),
-        );
-        await tester.pumpAndSettle();
 
         await tester.tap(find.text(l10n.notificationSettingsMarkAllAsRead));
         await tester.pump();
@@ -214,7 +209,7 @@ void main() {
         ),
         matching: find.byType(Switch),
       );
-      await tester.scrollUntilVisible(newPostsSwitch, 100);
+      await scrollUntilTappable(tester, newPostsSwitch, 100);
 
       await tester.tap(newPostsSwitch);
       await tester.pump();

--- a/mobile/test/screens/settings/app_language_screen_test.dart
+++ b/mobile/test/screens/settings/app_language_screen_test.dart
@@ -11,6 +11,8 @@ import 'package:openvine/blocs/locale/locale_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/screens/settings/app_language_screen.dart';
 
+import '../../helpers/scroll.dart';
+
 class _MockLocaleCubit extends MockCubit<LocaleState> implements LocaleCubit {}
 
 void main() {
@@ -39,12 +41,12 @@ void main() {
       String nativeName,
     ) async {
       final tileFinder = find.widgetWithText(ListTile, nativeName);
-      await tester.scrollUntilVisible(
+      await scrollUntilTappable(
+        tester,
         tileFinder,
         160,
         scrollable: find.byType(Scrollable),
       );
-      await tester.pumpAndSettle();
       return tester.widget<ListTile>(tileFinder);
     }
 

--- a/mobile/test/screens/settings/settings_taxonomy_test.dart
+++ b/mobile/test/screens/settings/settings_taxonomy_test.dart
@@ -35,6 +35,8 @@ import 'package:openvine/services/moderation_label_service.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../helpers/scroll.dart';
+
 class _MockAuthService extends Mock implements AuthService {}
 
 class _MockLocaleCubit extends MockCubit<LocaleState> implements LocaleCubit {}
@@ -320,6 +322,14 @@ void main() {
       isTrue,
     );
 
+    // The scroll above targeted a different row, so bring the toggle itself
+    // back into view — and pump — before reading its centre.
+    await scrollUntilTappable(
+      tester,
+      captionsToggle,
+      120,
+      scrollable: find.byType(Scrollable),
+    );
     await tester.tap(captionsToggle);
     await tester.pumpAndSettle();
 

--- a/mobile/test/screens/settings/storage/storage_management_view_test.dart
+++ b/mobile/test/screens/settings/storage/storage_management_view_test.dart
@@ -14,6 +14,8 @@ import 'package:openvine/screens/settings/storage/storage_management_page.dart';
 import 'package:openvine/services/storage_management_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart' as editor;
 
+import '../../../helpers/scroll.dart';
+
 class _MockService extends Mock implements StorageManagementService {}
 
 DivineVideoClip _clip(String id) => DivineVideoClip(
@@ -149,9 +151,7 @@ void main() {
   /// Scrolls the repair button into view and opens its confirmation sheet.
   Future<void> openRepairSheet(WidgetTester tester) async {
     final repair = find.text(l10n.settingsStorageRepairButton);
-    await tester.scrollUntilVisible(repair, 200);
-    await tester.ensureVisible(repair);
-    await tester.pumpAndSettle();
+    await scrollUntilTappable(tester, repair, 200);
     await tester.tap(repair);
     await tester.pumpAndSettle();
   }

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -23,6 +23,7 @@ import 'package:openvine/services/content_reporting_service.dart';
 import 'package:openvine/services/moderation_label_service.dart';
 import 'package:openvine/widgets/report_content_dialog.dart';
 
+import '../helpers/scroll.dart';
 import '../helpers/test_provider_overrides.dart';
 import '../helpers/test_pubkeys.dart';
 
@@ -786,6 +787,18 @@ void main() {
       );
     }
 
+    /// Scrolls the reason list to [reasonLabel] and selects it.
+    Future<void> selectReason(WidgetTester tester, String reasonLabel) async {
+      await scrollUntilTappable(
+        tester,
+        find.text(reasonLabel),
+        100,
+        scrollable: find.byType(Scrollable).last,
+      );
+      await tester.tap(find.text(reasonLabel));
+      await tester.pumpAndSettle();
+    }
+
     Future<void> openAndSubmitReport(
       WidgetTester tester, {
       String? reasonLabel,
@@ -795,14 +808,7 @@ void main() {
       await tester.tap(find.text('Open Report'));
       await tester.pumpAndSettle();
 
-      final reason = reasonLabel ?? l10n.reportReasonSpam;
-      await tester.scrollUntilVisible(
-        find.text(reason),
-        100,
-        scrollable: find.byType(Scrollable).last,
-      );
-      await tester.tap(find.text(reason));
-      await tester.pumpAndSettle();
+      await selectReason(tester, reasonLabel ?? l10n.reportReasonSpam);
 
       await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
       await tester.pumpAndSettle();
@@ -1555,14 +1561,10 @@ void main() {
       await openAndSubmitReport(tester);
       expect(find.text(l10n.reportNotSent), findsOneWidget);
 
-      final csam = l10n.reportReasonTitle(ContentFilterReason.csam);
-      await tester.scrollUntilVisible(
-        find.text(csam),
-        100,
-        scrollable: find.byType(Scrollable).last,
+      await selectReason(
+        tester,
+        l10n.reportReasonTitle(ContentFilterReason.csam),
       );
-      await tester.tap(find.text(csam));
-      await tester.pumpAndSettle();
       await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
       await tester.pumpAndSettle();
 
@@ -1616,14 +1618,10 @@ void main() {
 
       // Change of mind: spam -> csam. NIP-56 collapses csam to 'illegal'
       // while spam stays 'spam', so a stale re-drive is visible in both tags.
-      final csam = l10n.reportReasonTitle(ContentFilterReason.csam);
-      await tester.scrollUntilVisible(
-        find.text(csam),
-        100,
-        scrollable: find.byType(Scrollable).last,
+      await selectReason(
+        tester,
+        l10n.reportReasonTitle(ContentFilterReason.csam),
       );
-      await tester.tap(find.text(csam));
-      await tester.pumpAndSettle();
       await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
       await tester.pumpAndSettle();
 
@@ -1687,14 +1685,10 @@ void main() {
         await setLargeSurface(tester);
         await openAndSubmitReport(tester);
 
-        final csam = l10n.reportReasonTitle(ContentFilterReason.csam);
-        await tester.scrollUntilVisible(
-          find.text(csam),
-          100,
-          scrollable: find.byType(Scrollable).last,
+        await selectReason(
+          tester,
+          l10n.reportReasonTitle(ContentFilterReason.csam),
         );
-        await tester.tap(find.text(csam));
-        await tester.pumpAndSettle();
 
         await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
         await tester.pumpAndSettle();
@@ -1762,14 +1756,10 @@ void main() {
       await openAndSubmitReport(tester);
 
       // The send is still pending here — change the reason before it parks.
-      final csam = l10n.reportReasonTitle(ContentFilterReason.csam);
-      await tester.scrollUntilVisible(
-        find.text(csam),
-        100,
-        scrollable: find.byType(Scrollable).last,
+      await selectReason(
+        tester,
+        l10n.reportReasonTitle(ContentFilterReason.csam),
       );
-      await tester.tap(find.text(csam));
-      await tester.pumpAndSettle();
 
       firstSend.complete(
         const NIP17SendResult.failure(
@@ -1853,14 +1843,10 @@ void main() {
       await setLargeSurface(tester);
       await openAndSubmitReport(tester);
 
-      final csam = l10n.reportReasonTitle(ContentFilterReason.csam);
-      await tester.scrollUntilVisible(
-        find.text(csam),
-        100,
-        scrollable: find.byType(Scrollable).last,
+      await selectReason(
+        tester,
+        l10n.reportReasonTitle(ContentFilterReason.csam),
       );
-      await tester.tap(find.text(csam));
-      await tester.pumpAndSettle();
 
       // Resubmit BEFORE the first send settles.
       await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));

--- a/mobile/test/widgets/settings_screen_test.dart
+++ b/mobile/test/widgets/settings_screen_test.dart
@@ -39,6 +39,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../helpers/go_router.dart';
 import '../helpers/invite_availability_harness.dart';
+import '../helpers/scroll.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
 
@@ -468,12 +469,12 @@ void main() {
       await tester.pumpAndSettle();
 
       final scrollable = find.byType(Scrollable);
-      await tester.scrollUntilVisible(
+      await scrollUntilTappable(
+        tester,
         find.text('Integration Permissions'),
         300,
         scrollable: scrollable,
       );
-      await tester.pumpAndSettle();
       await tester.tap(find.text('Integration Permissions'));
       await tester.pumpAndSettle();
 
@@ -530,12 +531,12 @@ void main() {
       await tester.pumpAndSettle();
 
       final scrollable = find.byType(Scrollable);
-      await tester.scrollUntilVisible(
+      await scrollUntilTappable(
+        tester,
         find.text(l10n.settingsIntegratedApps),
         200,
         scrollable: scrollable,
       );
-      await tester.pumpAndSettle();
       await tester.tap(find.text(l10n.settingsIntegratedApps));
       await tester.pumpAndSettle();
 
@@ -553,12 +554,12 @@ void main() {
       await tester.pumpAndSettle();
 
       final scrollable = find.byType(Scrollable);
-      await tester.scrollUntilVisible(
+      await scrollUntilTappable(
+        tester,
         find.text(l10n.settingsBadgesTitle),
         200,
         scrollable: scrollable,
       );
-      await tester.pumpAndSettle();
       await tester.tap(find.text(l10n.settingsBadgesTitle));
       await tester.pumpAndSettle();
 
@@ -919,12 +920,12 @@ void main() {
         await tester.pumpAndSettle();
 
         final scrollable = find.byType(Scrollable);
-        await tester.scrollUntilVisible(
+        await scrollUntilTappable(
+          tester,
           find.text(l10n.settingsDeveloperOptions),
           200,
           scrollable: scrollable,
         );
-        await tester.pumpAndSettle();
 
         expect(find.text(l10n.settingsDeveloperOptions), findsOneWidget);
 


### PR DESCRIPTION
## Summary

Audits every `scrollUntilVisible` call site that is followed by a tap or another viewport-sensitive interaction and routes it through one shared `scrollUntilTappable` helper. Scroll-only assertions are left untouched.

19 call sites across 15 files; 16 needed the fix.

## The mechanism in #7181 does not hold, so the fix changed shape

#7181 and this issue both say `scrollUntilVisible` stops once the row is *built* and can leave it below the viewport, so a following tap needs `ensureVisible`. That is not what happens:

- `scrollUntilVisible` delegates to `dragUntilVisible`, which **ends with `await Scrollable.ensureVisible(element(finder))`** — and has done since flutter/flutter#62097 introduced it in 2020. `tester.ensureVisible(sameFinder)` right afterwards is exactly the same call on the same element, so it is a no-op. Measured: identical resulting position with and without it.
- What the failing tests were missing is a **pumped frame**. Reading a target's centre straight after the scroll returned `y=548` where the settled layout put it at `y=12`. The tap is dispatched against a layout that has not been applied yet; on a screen whose content happens to be tall that lands at or past the viewport edge, `warnIfMissed` only prints a warning, and the miss surfaces later as an unrelated assertion.

Whether a row lands near that edge is not stable across a run — which is the seed dependency in #7179. `VineTheme`'s font helpers are `GoogleFonts.inter(...)`, google_fonts registers its asset into the process-global font collection asynchronously, so the first widget test in an isolate to render a screen gets the wider fallback metrics and every later one gets real Inter. Randomized ordering picks who pays.

So the helper is `scrollUntilVisible` + `pumpAndSettle`, and the four sites that already carried a redundant `ensureVisible` — including #7181's own helper — drop it, rather than eleven more sites gaining one. #7181's comment documented the disproven mechanism and is rewritten; the font-metrics half of it is correct and moves into the helper's doc.

Caveat worth stating plainly: I could not build a synthetic case where the tap actually *misses* on Flutter 3.44, so "stale coordinates cause the miss" is inference from the measurements above rather than a red-to-green reproduction. The change is correct either way — the pump is required and the `ensureVisible` was doing nothing.

## Left alone deliberately

- **Scroll-only assertions** (`discover_lists` pagination triggers, `minor_account_review` copy checks, `login_options`, four of `settings_taxonomy`'s five call sites, and others) — no interaction follows, no risk.
- **`safety_settings_screen_test.dart`** calls `switchTile.onChanged!(true)` directly rather than tapping, so it never hit-tests.
- **`app_detail_screen_test.dart`** keeps its `ensureVisible`: it scrolls to a text and then taps a *different* widget (`DivineButton`). That is the case where the call does carry weight.

`settings_taxonomy_test.dart` is the one case where the tap target is a *different* widget from the scroll target and the fix still applies: it scrolls to the hold-to-record row, then taps the Closed Captions toggle 14 lines later with no frame in between. Scrolling to the toggle itself is what fixes it — `scrollUntilVisible` short-circuits its drag loop when the target is already built and goes straight to `Scrollable.ensureVisible`, which brings it back into view in whichever direction is needed.

`report_content_dialog_test.dart` repeated the same scroll-and-select block six times; that collapses into a local `selectReason` helper.

## Test plan

Test-only change — no app code touched, so there is nothing to verify on device.

- `flutter analyze test` — clean.
- All 11 changed files plus the 4 audited-but-unchanged ones, `--test-randomize-ordering-seed=random`: 189 tests, green.
- Same run with `WidgetController.hitTestWarningShouldBeFatal = true` forced on globally (temporary local patch to `flutter_test_config.dart`, not committed) so any tap landing on nothing becomes a hard failure: green.
- Pre-push hook re-ran the affected suites: green.

Closes #7195

