### PR TITLE
fix(library): scope bulk clip actions to the visible selection

### DIFF
--- a/mobile/lib/blocs/clips_library/clips_library_bloc.dart
+++ b/mobile/lib/blocs/clips_library/clips_library_bloc.dart
@@ -804,7 +804,9 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
         event.categoryId,
       );
       if (!deleted) return;
-      await _reloadAfterOrganize(emit);
+      // Deleting a category leaves its clips alone — they only lose their
+      // filing — so nothing drops out of the selection here.
+      await _reloadAfterOrganize(emit, organizedIds: const {});
     } catch (e, stackTrace) {
       _handleOrganizeFailure('delete category', e, stackTrace, emit);
     }
@@ -878,11 +880,13 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
   ///
   /// [organizedIds] leave the selection, since those clips have usually just
   /// left the view. Clips selected under another filter stay selected, the
-  /// same way switching filters keeps them.
+  /// same way switching filters keeps them. Required rather than defaulted:
+  /// an empty set keeps the whole selection, which is a decision each caller
+  /// should have to state rather than inherit.
   Future<void> _reloadAfterOrganize(
     Emitter<ClipsLibraryState> emit, {
+    required Set<String> organizedIds,
     ClipsLibraryOrganizeResult? result,
-    Set<String> organizedIds = const {},
   }) async {
     final clips = _applyTypeFilter(await _clipLibraryService.getAllClips());
     final categories = await _clipLibraryService.getCategories();

--- a/mobile/lib/blocs/clips_library/clips_library_bloc.dart
+++ b/mobile/lib/blocs/clips_library/clips_library_bloc.dart
@@ -151,24 +151,20 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
   }
 
   /// Returns the clips [filter] admits, sorted by [sort].
-  ///
-  /// The trash filter yields an empty list on purpose: trashed clips are not
-  /// part of [ClipsLibraryState.clips] at all, they live in
-  /// [ClipsLibraryState.trashedClips] and the UI renders them from there.
   static List<DivineVideoClip> _visibleClips(
     List<DivineVideoClip> clips,
     ClipLibraryFilter filter,
     ClipSort sort,
-  ) {
-    final matching = switch (filter) {
-      ClipLibraryAllFilter() => clips.where((c) => c.archivedAt == null),
-      ClipLibraryArchiveFilter() => clips.where((c) => c.archivedAt != null),
-      ClipLibraryCategoryFilter(:final categoryId) => clips.where(
-        (c) => c.archivedAt == null && c.categoryId == categoryId,
-      ),
-      ClipLibraryTrashFilter() => const <DivineVideoClip>[],
-    };
-    return _applySort(matching.toList(), sort);
+  ) => _applySort(clips.where(filter.admits).toList(), sort);
+
+  /// Total duration of the clips in [ids], ignoring ids [clips] has no clip
+  /// for.
+  static Duration _totalDuration(List<DivineVideoClip> clips, Set<String> ids) {
+    var total = Duration.zero;
+    for (final clip in clips) {
+      if (ids.contains(clip.id)) total += clip.duration;
+    }
+    return total;
   }
 
   Future<void> _onLoadRequested(
@@ -287,7 +283,11 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
     ClipsLibraryDeleteSelected event,
     Emitter<ClipsLibraryState> emit,
   ) async {
-    if (state.selectedClipIds.isEmpty) return;
+    // Only what the active filter shows: the rest of the selection was made
+    // under another filter and is off screen, so a single tap here must not
+    // reach it. See [ClipsLibraryState.visibleSelectedClipIds].
+    final deletedIds = state.visibleSelectedClipIds;
+    if (deletedIds.isEmpty) return;
 
     emit(
       state.copyWith(
@@ -296,8 +296,8 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
       ),
     );
 
-    final deletedIds = Set<String>.from(state.selectedClipIds);
     final deletedCount = deletedIds.length;
+    final remainingIds = state.selectedClipIds.difference(deletedIds);
 
     try {
       Log.info(
@@ -310,7 +310,8 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
         await _clipLibraryService.softDelete(clipId);
       }
 
-      // Reload clips and clear selection
+      // Reload clips; the deleted ones drop out of the selection, anything
+      // selected under another filter stays in it.
       final clips = _applyTypeFilter(await _clipLibraryService.getAllClips());
 
       emit(
@@ -318,8 +319,8 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
           status: ClipsLibraryStatus.loaded,
           clips: clips,
           sortedClips: _visibleClips(clips, state.filter, state.clipSort),
-          selectedClipIds: const {},
-          selectedDuration: Duration.zero,
+          selectedClipIds: remainingIds,
+          selectedDuration: _totalDuration(clips, remainingIds),
           lastDeletedCount: deletedCount,
           lastDeletedClipIds: deletedIds,
         ),
@@ -762,6 +763,7 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
 
       await _reloadAfterOrganize(
         emit,
+        organizedIds: event.clipIds,
         result: event.clipIds.isEmpty
             ? null
             : ClipsLibraryOrganizeResult(
@@ -829,6 +831,7 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
 
       await _reloadAfterOrganize(
         emit,
+        organizedIds: event.clipIds,
         result: ClipsLibraryOrganizeResult(
           action: targetId == null
               ? ClipsLibraryOrganizeAction.removedFromCategory
@@ -858,6 +861,7 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
 
       await _reloadAfterOrganize(
         emit,
+        organizedIds: event.clipIds,
         result: ClipsLibraryOrganizeResult(
           action: event.archived
               ? ClipsLibraryOrganizeAction.archived
@@ -870,15 +874,20 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
     }
   }
 
-  /// Reloads clips and categories after an organization change and clears the
-  /// selection, since the affected clips have usually just left the view.
+  /// Reloads clips and categories after an organization change.
+  ///
+  /// [organizedIds] leave the selection, since those clips have usually just
+  /// left the view. Clips selected under another filter stay selected, the
+  /// same way switching filters keeps them.
   Future<void> _reloadAfterOrganize(
     Emitter<ClipsLibraryState> emit, {
     ClipsLibraryOrganizeResult? result,
+    Set<String> organizedIds = const {},
   }) async {
     final clips = _applyTypeFilter(await _clipLibraryService.getAllClips());
     final categories = await _clipLibraryService.getCategories();
     final filter = _resolveFilter(state.filter, categories);
+    final selectedIds = state.selectedClipIds.difference(organizedIds);
 
     emit(
       state.copyWith(
@@ -887,8 +896,8 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
         categories: categories,
         filter: filter,
         sortedClips: _visibleClips(clips, filter, state.clipSort),
-        selectedClipIds: const {},
-        selectedDuration: Duration.zero,
+        selectedClipIds: selectedIds,
+        selectedDuration: _totalDuration(clips, selectedIds),
         lastOrganizeResult: result,
         clearOrganizeResult: result == null,
       ),

--- a/mobile/lib/blocs/clips_library/clips_library_state.dart
+++ b/mobile/lib/blocs/clips_library/clips_library_state.dart
@@ -105,6 +105,9 @@ enum LibraryClipTypeFilter {
 sealed class ClipLibraryFilter extends Equatable {
   const ClipLibraryFilter();
 
+  /// Whether the grid shows [clip] while this filter is active.
+  bool admits(DivineVideoClip clip);
+
   @override
   List<Object?> get props => [];
 }
@@ -112,16 +115,28 @@ sealed class ClipLibraryFilter extends Equatable {
 /// Every clip that is neither archived nor trashed. The library's default.
 final class ClipLibraryAllFilter extends ClipLibraryFilter {
   const ClipLibraryAllFilter();
+
+  @override
+  bool admits(DivineVideoClip clip) => clip.archivedAt == null;
 }
 
 /// Clips the user archived out of the default view.
 final class ClipLibraryArchiveFilter extends ClipLibraryFilter {
   const ClipLibraryArchiveFilter();
+
+  @override
+  bool admits(DivineVideoClip clip) => clip.archivedAt != null;
 }
 
 /// Soft-deleted clips awaiting the 30-day purge.
 final class ClipLibraryTrashFilter extends ClipLibraryFilter {
   const ClipLibraryTrashFilter();
+
+  /// Always false: trashed clips are not part of [ClipsLibraryState.clips] at
+  /// all, they live in [ClipsLibraryState.trashedClips] and the UI renders
+  /// them from there.
+  @override
+  bool admits(DivineVideoClip clip) => false;
 }
 
 /// Clips filed under one of the user's own categories.
@@ -130,6 +145,10 @@ final class ClipLibraryCategoryFilter extends ClipLibraryFilter {
 
   /// The [ClipCategory.id] this filter shows.
   final String categoryId;
+
+  @override
+  bool admits(DivineVideoClip clip) =>
+      clip.archivedAt == null && clip.categoryId == categoryId;
 
   @override
   List<Object?> get props => [categoryId];
@@ -346,6 +365,19 @@ final class ClipsLibraryState extends Equatable {
 
   /// Whether a gallery save is in progress.
   bool get isSavingToGallery => status == ClipsLibraryStatus.savingToGallery;
+
+  /// The selected clips the active [filter] actually shows.
+  ///
+  /// A selection survives switching between the active filters so a timeline
+  /// can span categories, which leaves part of it off screen. The bulk
+  /// toolbar actions run on this set instead of [selectedClipIds]: moving or
+  /// deleting clips the user cannot see is not something one tap should do.
+  /// Bulk-organizing across categories still works from
+  /// [ClipLibraryAllFilter], which shows them all at once.
+  Set<String> get visibleSelectedClipIds => {
+    for (final clip in clips)
+      if (selectedClipIds.contains(clip.id) && filter.admits(clip)) clip.id,
+  };
 
   /// Returns the currently selected clips in selection order.
   List<DivineVideoClip> get selectedClips {

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2963,7 +2963,7 @@
     },
     "libraryDeleteClipsWarning": "ይህ እርምጃ ሊቀለበስ አይችልም። የቪዲዮ ፋይሎቹ እስከመጨረሻው ከመሣሪያዎ ይወገዳሉ።",
     "libraryPreparingVideo": "ቪዲዮ በማዘጋጀት ላይ...",
-    "libraryCreateVideo": "ቪዲዮ ፍጠር",
+    "libraryCreateVideo": "ቪዲዮ ፍጠር ({count})",
     "libraryClipsSavedToDestination": "{count, plural, =1{{count} ክሊፕ} other{{count} ክሊፖች}} ወደ {destination} ተቀምጠዋል",
     "@libraryClipsSavedToDestination": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2514,7 +2514,7 @@
     "libraryTrashAutoDeletes": "{daysLeft, plural, =0{سيُحذف تلقائيًا اليوم} =1{سيُحذف تلقائيًا غدًا} other{سيُحذف تلقائيًا خلال {daysLeft} أيام}}",
     "libraryCouldNotLoadClips": "تعذّر تحميل المقاطع",
     "libraryCouldNotLoadDrafts": "تعذّر تحميل المسودات",
-    "libraryCreateVideo": "إنشاء فيديو",
+    "libraryCreateVideo": "إنشاء فيديو ({count})",
     "libraryDeleteClipMessage": "هل تريد حذف هذا المقطع؟",
     "libraryDeleteClipTitle": "حذف المقطع",
     "libraryDeleteClipsMessage": "هل تريد حذف {count, plural, one{مقطع واحد محدد} other{# مقاطع محددة}}؟",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2724,7 +2724,7 @@
     },
     "libraryDeleteClipsWarning": "Това действие не може да бъде отменено. Видео файловете ще бъдат премахнати за постоянно от твоето устройство.",
     "libraryPreparingVideo": "Видеоклипът се подготвя...",
-    "libraryCreateVideo": "Създаване на видео",
+    "libraryCreateVideo": "Създаване на видео ({count})",
     "libraryClipsSavedToDestination": "{count, plural, =1{1 клип} other{{count} клипа}} запазен{count, plural, =1{} other{и}} в {destination}",
     "@libraryClipsSavedToDestination": {
         "placeholders": {

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2522,7 +2522,7 @@
     "libraryTrashAutoDeletes": "{daysLeft, plural, =0{Wird heute automatisch gelöscht} =1{Wird morgen automatisch gelöscht} other{Wird in {daysLeft} Tagen automatisch gelöscht}}",
     "libraryCouldNotLoadClips": "Clips konnten nicht geladen werden",
     "libraryCouldNotLoadDrafts": "Entwürfe konnten nicht geladen werden",
-    "libraryCreateVideo": "Video erstellen",
+    "libraryCreateVideo": "Video erstellen ({count})",
     "libraryDeleteClipMessage": "Diesen Clip wirklich löschen?",
     "libraryDeleteClipTitle": "Clip löschen",
     "libraryDeleteClipsMessage": "Möchtest du wirklich {count, plural, one{# ausgewählten Clip} other{# ausgewählte Clips}} löschen?",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4093,7 +4093,14 @@
   },
   "libraryDeleteClipsWarning": "This action cannot be undone. The video files will be permanently removed from your device.",
   "libraryPreparingVideo": "Preparing video...",
-  "libraryCreateVideo": "Create Video",
+  "libraryCreateVideo": "Create Video ({count})",
+  "@libraryCreateVideo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "libraryClipsSavedToDestination": "{count, plural, =1{1 clip} other{{count} clips}} saved to {destination}",
   "@libraryClipsSavedToDestination": {
     "placeholders": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2530,7 +2530,7 @@
     "libraryTrashAutoDeletes": "{daysLeft, plural, =0{Se elimina automáticamente hoy} =1{Se elimina automáticamente mañana} other{Se elimina automáticamente en {daysLeft} días}}",
     "libraryCouldNotLoadClips": "No se pudieron cargar los clips",
     "libraryCouldNotLoadDrafts": "No se pudieron cargar los borradores",
-    "libraryCreateVideo": "Crear video",
+    "libraryCreateVideo": "Crear video ({count})",
     "libraryDeleteClipMessage": "¿Seguro que quieres eliminar este clip?",
     "libraryDeleteClipTitle": "Eliminar clip",
     "libraryDeleteClipsMessage": "¿Seguro que quieres eliminar {count, plural, one{# clip seleccionado} other{# clips seleccionados}}?",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1669,7 +1669,7 @@
     "libraryDeleteClipsMessage": "Sigurado ka bang gusto mong burahin ang {count, plural, one{# napiling clip} other{# napiling clip}}?",
     "libraryDeleteClipsWarning": "Hindi na ito mababawi. Permanenteng maaalis sa device mo ang mga video file.",
     "libraryPreparingVideo": "Hinahanda ang video...",
-    "libraryCreateVideo": "Gumawa ng Video",
+    "libraryCreateVideo": "Gumawa ng Video ({count})",
     "libraryClipsSavedToDestination": "{count, plural, =1{{count} clip} other{{count} clip}} na-save sa {destination}",
     "libraryClipsSavePartialResult": "{successCount} na-save, {failureCount} ang nabigo",
     "libraryGalleryPermissionDenied": "Tinanggihan ang permission para sa {destination}",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2522,7 +2522,7 @@
     "libraryTrashAutoDeletes": "{daysLeft, plural, =0{Suppression automatique aujourd’hui} =1{Suppression automatique demain} other{Suppression automatique dans {daysLeft} jours}}",
     "libraryCouldNotLoadClips": "Impossible de charger les clips",
     "libraryCouldNotLoadDrafts": "Impossible de charger les brouillons",
-    "libraryCreateVideo": "Créer une vidéo",
+    "libraryCreateVideo": "Créer une vidéo ({count})",
     "libraryDeleteClipMessage": "Supprimer ce clip ?",
     "libraryDeleteClipTitle": "Supprimer le clip",
     "libraryDeleteClipsMessage": "Supprimer {count, plural, one{# clip sélectionné} other{# clips sélectionnés}} ?",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2521,7 +2521,7 @@
     "libraryTrashAutoDeletes": "{daysLeft, plural, =0{Akan dihapus otomatis hari ini} =1{Akan dihapus otomatis besok} other{Akan dihapus otomatis dalam {daysLeft} hari}}",
     "libraryCouldNotLoadClips": "Tidak bisa memuat klip",
     "libraryCouldNotLoadDrafts": "Tidak bisa memuat draf",
-    "libraryCreateVideo": "Buat video",
+    "libraryCreateVideo": "Buat video ({count})",
     "libraryDeleteClipMessage": "Yakin ingin menghapus klip ini?",
     "libraryDeleteClipTitle": "Hapus klip",
     "libraryDeleteClipsMessage": "Yakin ingin menghapus {count, plural, one{# klip terpilih} other{# klip terpilih}}?",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2522,7 +2522,7 @@
     "libraryTrashAutoDeletes": "{daysLeft, plural, =0{Eliminazione automatica oggi} =1{Eliminazione automatica domani} other{Eliminazione automatica tra {daysLeft} giorni}}",
     "libraryCouldNotLoadClips": "Impossibile caricare le clip",
     "libraryCouldNotLoadDrafts": "Impossibile caricare le bozze",
-    "libraryCreateVideo": "Crea video",
+    "libraryCreateVideo": "Crea video ({count})",
     "libraryDeleteClipMessage": "Eliminare questa clip?",
     "libraryDeleteClipTitle": "Elimina clip",
     "libraryDeleteClipsMessage": "Vuoi eliminare {count, plural, one{# clip selezionata} other{# clip selezionate}}?",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2514,7 +2514,7 @@
     "libraryTrashAutoDeletes": "{daysLeft, plural, =0{今日自動削除} =1{明日自動削除} other{{daysLeft}日後に自動削除}}",
     "libraryCouldNotLoadClips": "クリップを読み込めませんでした",
     "libraryCouldNotLoadDrafts": "下書きを読み込めませんでした",
-    "libraryCreateVideo": "動画を作成",
+    "libraryCreateVideo": "動画を作成 ({count})",
     "libraryDeleteClipMessage": "このクリップを削除しますか？",
     "libraryDeleteClipTitle": "クリップを削除",
     "libraryDeleteClipsMessage": "選択した{count}件のクリップを削除しますか？",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1852,7 +1852,7 @@
     "libraryTrashAutoDeletes": "{daysLeft, plural, =0{오늘 자동 삭제됨} =1{내일 자동 삭제됨} other{{daysLeft}일 후 자동 삭제됨}}",
     "libraryCouldNotLoadClips": "클립을 불러올 수 없어요",
     "libraryCouldNotLoadDrafts": "임시 저장 영상을 불러올 수 없어요",
-    "libraryCreateVideo": "동영상 만들기",
+    "libraryCreateVideo": "동영상 만들기 ({count})",
     "libraryDeleteClipMessage": "이 클립을 삭제할까요?",
     "libraryDeleteClipTitle": "클립 삭제",
     "libraryDeleteClipsMessage": "선택한 클립 {count, plural, =1{1개} other{{count}개}}를 삭제할까요?",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -3756,7 +3756,7 @@
   },
   "libraryDeleteClipsWarning": "Tindakan ini tidak boleh dibuat asal. Fail video akan dialih keluar secara kekal daripada peranti anda.",
   "libraryPreparingVideo": "Menyediakan video...",
-  "libraryCreateVideo": "Cipta Video",
+  "libraryCreateVideo": "Cipta Video ({count})",
   "libraryClipsSavedToDestination": "{count, plural, =1{1 klip} other{{count} klip}} disimpan ke {destination}",
   "@libraryClipsSavedToDestination": {
     "placeholders": {

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2522,7 +2522,7 @@
     "libraryTrashAutoDeletes": "{daysLeft, plural, =0{Wordt vandaag automatisch verwijderd} =1{Wordt morgen automatisch verwijderd} other{Wordt over {daysLeft} dagen automatisch verwijderd}}",
     "libraryCouldNotLoadClips": "Clips konden niet worden geladen",
     "libraryCouldNotLoadDrafts": "Concepten konden niet worden geladen",
-    "libraryCreateVideo": "Video maken",
+    "libraryCreateVideo": "Video maken ({count})",
     "libraryDeleteClipMessage": "Weet je zeker dat je deze clip wilt verwijderen?",
     "libraryDeleteClipTitle": "Clip verwijderen",
     "libraryDeleteClipsMessage": "Weet je zeker dat je {count, plural, one{# geselecteerde clip} other{# geselecteerde clips}} wilt verwijderen?",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2522,7 +2522,7 @@
     "libraryTrashAutoDeletes": "{daysLeft, plural, =0{Zostanie automatycznie usunięty dzisiaj} =1{Zostanie automatycznie usunięty jutro} other{Zostanie automatycznie usunięty za {daysLeft} dni}}",
     "libraryCouldNotLoadClips": "Nie udało się wczytać klipów",
     "libraryCouldNotLoadDrafts": "Nie udało się wczytać wersji roboczych",
-    "libraryCreateVideo": "Utwórz wideo",
+    "libraryCreateVideo": "Utwórz wideo ({count})",
     "libraryDeleteClipMessage": "Na pewno usunąć ten klip?",
     "libraryDeleteClipTitle": "Usuń klip",
     "libraryDeleteClipsMessage": "Na pewno usunąć {count, plural, one{# wybrany klip} few{# wybrane klipy} many{# wybranych klipów} other{# wybranych klipów}}?",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2522,7 +2522,7 @@
     "libraryTrashAutoDeletes": "{daysLeft, plural, =0{Será excluído automaticamente hoje} =1{Será excluído automaticamente amanhã} other{Será excluído automaticamente em {daysLeft} dias}}",
     "libraryCouldNotLoadClips": "Não foi possível carregar os clipes",
     "libraryCouldNotLoadDrafts": "Não foi possível carregar os rascunhos",
-    "libraryCreateVideo": "Criar vídeo",
+    "libraryCreateVideo": "Criar vídeo ({count})",
     "libraryDeleteClipMessage": "Excluir este clipe?",
     "libraryDeleteClipTitle": "Excluir clipe",
     "libraryDeleteClipsMessage": "Excluir {count, plural, one{# clipe selecionado} other{# clipes selecionados}}?",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2522,7 +2522,7 @@
     "libraryTrashAutoDeletes": "{daysLeft, plural, =0{Se șterge automat azi} =1{Se șterge automat mâine} other{Se șterge automat în {daysLeft} zile}}",
     "libraryCouldNotLoadClips": "Nu s-au putut încărca clipurile",
     "libraryCouldNotLoadDrafts": "Nu s-au putut încărca ciornele",
-    "libraryCreateVideo": "Creează video",
+    "libraryCreateVideo": "Creează video ({count})",
     "libraryDeleteClipMessage": "Ștergi acest clip?",
     "libraryDeleteClipTitle": "Șterge clipul",
     "libraryDeleteClipsMessage": "Ștergi {count, plural, one{# clip selectat} other{# clipuri selectate}}?",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2522,7 +2522,7 @@
     "libraryTrashAutoDeletes": "{daysLeft, plural, =0{Raderas automatiskt i dag} =1{Raderas automatiskt i morgon} other{Raderas automatiskt om {daysLeft} dagar}}",
     "libraryCouldNotLoadClips": "Det gick inte att ladda klipp",
     "libraryCouldNotLoadDrafts": "Det gick inte att ladda utkast",
-    "libraryCreateVideo": "Skapa video",
+    "libraryCreateVideo": "Skapa video ({count})",
     "libraryDeleteClipMessage": "Vill du ta bort det här klippet?",
     "libraryDeleteClipTitle": "Ta bort klipp",
     "libraryDeleteClipsMessage": "Vill du ta bort {count, plural, one{# valt klipp} other{# valda klipp}}?",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2521,7 +2521,7 @@
     "libraryTrashAutoDeletes": "{daysLeft, plural, =0{Bugün otomatik olarak silinir} =1{Yarın otomatik olarak silinir} other{{daysLeft} gün içinde otomatik olarak silinir}}",
     "libraryCouldNotLoadClips": "Klipler yüklenemedi",
     "libraryCouldNotLoadDrafts": "Taslaklar yüklenemedi",
-    "libraryCreateVideo": "Video oluştur",
+    "libraryCreateVideo": "Video oluştur ({count})",
     "libraryDeleteClipMessage": "Bu klibi silmek istiyor musun?",
     "libraryDeleteClipTitle": "Klibi sil",
     "libraryDeleteClipsMessage": "{count, plural, one{# seçili klibi} other{# seçili klibi}} silmek istiyor musun?",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -3756,7 +3756,7 @@
   },
   "libraryDeleteClipsWarning": "یہ کارروائی واپس نہیں ہو سکتی۔ ویڈیو فائلیں آپ کی ڈیوائس سے مستقل طور پر ہٹا دی جائیں گی۔",
   "libraryPreparingVideo": "ویڈیو تیار ہو رہی ہے...",
-  "libraryCreateVideo": "ویڈیو بنائیں",
+  "libraryCreateVideo": "ویڈیو بنائیں ({count})",
   "libraryClipsSavedToDestination": "{count, plural, =1{1 کلپ} other{{count} کلپس}} {destination} میں محفوظ ہو گئیں",
   "@libraryClipsSavedToDestination": {
     "placeholders": {

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -3756,7 +3756,7 @@
   },
   "libraryDeleteClipsWarning": "Không thể hoàn tác thao tác này. Các tệp video sẽ bị xóa vĩnh viễn khỏi thiết bị của bạn.",
   "libraryPreparingVideo": "Đang chuẩn bị video...",
-  "libraryCreateVideo": "Tạo video",
+  "libraryCreateVideo": "Tạo video ({count})",
   "libraryClipsSavedToDestination": "Đã lưu {count, plural, =1{1 clip} other{{count} clip}} vào {destination}",
   "@libraryClipsSavedToDestination": {
     "placeholders": {

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -3756,7 +3756,7 @@
   },
   "libraryDeleteClipsWarning": "此操作无法撤销。视频文件将从你的设备上永久删除。",
   "libraryPreparingVideo": "正在准备视频...",
-  "libraryCreateVideo": "创作视频",
+  "libraryCreateVideo": "创作视频 ({count})",
   "libraryClipsSavedToDestination": "{count, plural, =1{1 个片段} other{{count} 个片段}}已保存到{destination}",
   "@libraryClipsSavedToDestination": {
     "placeholders": {

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -11420,8 +11420,8 @@ abstract class AppLocalizations {
   /// No description provided for @libraryCreateVideo.
   ///
   /// In en, this message translates to:
-  /// **'Create Video'**
-  String get libraryCreateVideo;
+  /// **'Create Video ({count})'**
+  String libraryCreateVideo(int count);
 
   /// No description provided for @libraryClipsSavedToDestination.
   ///

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -6399,7 +6399,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get libraryPreparingVideo => 'ቪዲዮ በማዘጋጀት ላይ...';
 
   @override
-  String get libraryCreateVideo => 'ቪዲዮ ፍጠር';
+  String libraryCreateVideo(int count) {
+    return 'ቪዲዮ ፍጠር ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -6487,7 +6487,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get libraryPreparingVideo => 'جاري تجهيز الفيديو...';
 
   @override
-  String get libraryCreateVideo => 'إنشاء فيديو';
+  String libraryCreateVideo(int count) {
+    return 'إنشاء فيديو ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -6585,7 +6585,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get libraryPreparingVideo => 'Видеоклипът се подготвя...';
 
   @override
-  String get libraryCreateVideo => 'Създаване на видео';
+  String libraryCreateVideo(int count) {
+    return 'Създаване на видео ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -6606,7 +6606,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get libraryPreparingVideo => 'Video wird vorbereitet …';
 
   @override
-  String get libraryCreateVideo => 'Video erstellen';
+  String libraryCreateVideo(int count) {
+    return 'Video erstellen ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -6524,7 +6524,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get libraryPreparingVideo => 'Preparing video...';
 
   @override
-  String get libraryCreateVideo => 'Create Video';
+  String libraryCreateVideo(int count) {
+    return 'Create Video ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -6581,7 +6581,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get libraryPreparingVideo => 'Preparando video...';
 
   @override
-  String get libraryCreateVideo => 'Crear video';
+  String libraryCreateVideo(int count) {
+    return 'Crear video ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -6606,7 +6606,9 @@ class AppLocalizationsFil extends AppLocalizations {
   String get libraryPreparingVideo => 'Hinahanda ang video...';
 
   @override
-  String get libraryCreateVideo => 'Gumawa ng Video';
+  String libraryCreateVideo(int count) {
+    return 'Gumawa ng Video ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -6609,7 +6609,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get libraryPreparingVideo => 'Préparation de la vidéo...';
 
   @override
-  String get libraryCreateVideo => 'Créer une vidéo';
+  String libraryCreateVideo(int count) {
+    return 'Créer une vidéo ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -6493,7 +6493,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get libraryPreparingVideo => 'Menyiapkan video...';
 
   @override
-  String get libraryCreateVideo => 'Buat video';
+  String libraryCreateVideo(int count) {
+    return 'Buat video ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -6587,7 +6587,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get libraryPreparingVideo => 'Preparazione video...';
 
   @override
-  String get libraryCreateVideo => 'Crea video';
+  String libraryCreateVideo(int count) {
+    return 'Crea video ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -6245,7 +6245,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get libraryPreparingVideo => '動画を準備しています…';
 
   @override
-  String get libraryCreateVideo => '動画を作成';
+  String libraryCreateVideo(int count) {
+    return '動画を作成 ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -6273,7 +6273,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get libraryPreparingVideo => '동영상 준비 중...';
 
   @override
-  String get libraryCreateVideo => '동영상 만들기';
+  String libraryCreateVideo(int count) {
+    return '동영상 만들기 ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -6576,7 +6576,9 @@ class AppLocalizationsMs extends AppLocalizations {
   String get libraryPreparingVideo => 'Menyediakan video...';
 
   @override
-  String get libraryCreateVideo => 'Cipta Video';
+  String libraryCreateVideo(int count) {
+    return 'Cipta Video ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -6558,7 +6558,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get libraryPreparingVideo => 'Video voorbereiden...';
 
   @override
-  String get libraryCreateVideo => 'Video maken';
+  String libraryCreateVideo(int count) {
+    return 'Video maken ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6685,7 +6685,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get libraryPreparingVideo => 'Przygotowywanie wideo...';
 
   @override
-  String get libraryCreateVideo => 'Utwórz wideo';
+  String libraryCreateVideo(int count) {
+    return 'Utwórz wideo ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -6571,7 +6571,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get libraryPreparingVideo => 'Preparando vídeo...';
 
   @override
-  String get libraryCreateVideo => 'Criar vídeo';
+  String libraryCreateVideo(int count) {
+    return 'Criar vídeo ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6686,7 +6686,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get libraryPreparingVideo => 'Se pregătește videoclipul...';
 
   @override
-  String get libraryCreateVideo => 'Creează video';
+  String libraryCreateVideo(int count) {
+    return 'Creează video ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -6523,7 +6523,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get libraryPreparingVideo => 'Förbereder video...';
 
   @override
-  String get libraryCreateVideo => 'Skapa video';
+  String libraryCreateVideo(int count) {
+    return 'Skapa video ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -6493,7 +6493,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get libraryPreparingVideo => 'Video hazırlanıyor...';
 
   @override
-  String get libraryCreateVideo => 'Video oluştur';
+  String libraryCreateVideo(int count) {
+    return 'Video oluştur ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -6535,7 +6535,9 @@ class AppLocalizationsUr extends AppLocalizations {
   String get libraryPreparingVideo => 'ویڈیو تیار ہو رہی ہے...';
 
   @override
-  String get libraryCreateVideo => 'ویڈیو بنائیں';
+  String libraryCreateVideo(int count) {
+    return 'ویڈیو بنائیں ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -6536,7 +6536,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get libraryPreparingVideo => 'Đang chuẩn bị video...';
 
   @override
-  String get libraryCreateVideo => 'Tạo video';
+  String libraryCreateVideo(int count) {
+    return 'Tạo video ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -6223,7 +6223,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get libraryPreparingVideo => '正在准备视频...';
 
   @override
-  String get libraryCreateVideo => '创作视频';
+  String libraryCreateVideo(int count) {
+    return '创作视频 ($count)';
+  }
 
   @override
   String libraryClipsSavedToDestination(int count, String destination) {

--- a/mobile/lib/screens/library_screen.dart
+++ b/mobile/lib/screens/library_screen.dart
@@ -637,6 +637,12 @@ class _LibraryViewState extends ConsumerState<_LibraryView>
           // point of a selection that survives a filter switch.
           final visibleSelectedClipIds = clipsState.visibleSelectedClipIds;
           final hasVisibleSelection = visibleSelectedClipIds.isNotEmpty;
+          // The create-video bar tracks the whole selection instead, so a
+          // selection that outlived the filter it was made under still has
+          // something on screen accounting for it. Without that the grid
+          // shows no marked clip and the state is indistinguishable from
+          // having selected nothing at all.
+          final selectedCount = clipsState.selectedClipIds.length;
           final targetAspectRatio = libraryTargetAspectRatioForSelection(
             selectionMode: widget.selectionMode,
             editorClips: editorClips,
@@ -733,7 +739,8 @@ class _LibraryViewState extends ConsumerState<_LibraryView>
                               !widget.selectionMode &&
                               selectionEnabled &&
                               isClipsTabActive &&
-                              hasVisibleSelection,
+                              selectedCount > 0,
+                          selectedCount: selectedCount,
                           onPressed: () => _createVideoFromSelected(
                             context,
                             selectedClips: clipsState.selectedClips,
@@ -898,9 +905,19 @@ class _LibraryContent extends StatelessWidget {
 }
 
 class _CreateVideoBar extends StatelessWidget {
-  const _CreateVideoBar({required this.visible, required this.onPressed});
+  const _CreateVideoBar({
+    required this.visible,
+    required this.selectedCount,
+    required this.onPressed,
+  });
 
   final bool visible;
+
+  /// How many clips the button would build the video from. Shown on the
+  /// label because a selection can outlive the filter it was made under, so
+  /// the grid alone does not always account for it.
+  final int selectedCount;
+
   final VoidCallback onPressed;
 
   @override
@@ -924,7 +941,7 @@ class _CreateVideoBar extends StatelessWidget {
                   padding: const EdgeInsets.all(16),
                   child: DivineButton(
                     expanded: true,
-                    label: context.l10n.libraryCreateVideo,
+                    label: context.l10n.libraryCreateVideo(selectedCount),
                     onPressed: onPressed,
                   ),
                 ),

--- a/mobile/lib/screens/library_screen.dart
+++ b/mobile/lib/screens/library_screen.dart
@@ -631,9 +631,12 @@ class _LibraryViewState extends ConsumerState<_LibraryView>
           final selectionEnabled = _isSelectionEnabled(clipsState);
 
           final sortedClips = clipsState.sortedClips;
-          final hasVisibleSelection = sortedClips.any(
-            (clip) => clipsState.selectedClipIds.contains(clip.id),
-          );
+          // Bulk move and delete run on this rather than the whole selection,
+          // which can reach across filters into clips the grid is not showing.
+          // Building a video is the exception — spanning categories is the
+          // point of a selection that survives a filter switch.
+          final visibleSelectedClipIds = clipsState.visibleSelectedClipIds;
+          final hasVisibleSelection = visibleSelectedClipIds.isNotEmpty;
           final targetAspectRatio = libraryTargetAspectRatioForSelection(
             selectionMode: widget.selectionMode,
             editorClips: editorClips,
@@ -696,7 +699,7 @@ class _LibraryViewState extends ConsumerState<_LibraryView>
                                 ? () => ClipCategoryActions.runMoveFlow(
                                     context: context,
                                     bloc: clipsBloc,
-                                    clipIds: clipsState.selectedClipIds,
+                                    clipIds: visibleSelectedClipIds,
                                   )
                                 : null,
                             onDeleteSelectedClips: hasVisibleSelection

--- a/mobile/test/blocs/clips_library/clips_library_bloc_test.dart
+++ b/mobile/test/blocs/clips_library/clips_library_bloc_test.dart
@@ -592,6 +592,23 @@ void main() {
         originalAspectRatio: 9 / 16,
       );
 
+      final travel = ClipCategory(
+        id: 'cat-travel',
+        name: 'Travel',
+        createdAt: DateTime(2026),
+      );
+
+      final filedClip = DivineVideoClip(
+        id: 'filed',
+        video: EditorVideo.file('/path/to/filed.mp4'),
+        thumbnailPath: '/path/to/filed.jpg',
+        duration: const Duration(seconds: 3),
+        recordedAt: DateTime(2026),
+        targetAspectRatio: .vertical,
+        originalAspectRatio: 9 / 16,
+        categoryId: travel.id,
+      );
+
       blocTest<ClipsLibraryBloc, ClipsLibraryState>(
         'does nothing when no clips selected',
         seed: () => ClipsLibraryState(
@@ -635,6 +652,61 @@ void main() {
         ],
         verify: (_) {
           verify(() => mockClipLibraryService.softDelete('clip1')).called(1);
+        },
+      );
+
+      // A selection survives switching between active filters, so part of it
+      // can be off screen when Delete is tapped. Only what the grid shows may
+      // go to the trash.
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'deletes only the selected clips the active filter shows',
+        setUp: () {
+          when(
+            () => mockClipLibraryService.softDelete(any()),
+          ).thenAnswer((_) async => true);
+          when(
+            () => mockClipLibraryService.getAllClips(),
+          ).thenAnswer((_) async => [clip1]);
+        },
+        seed: () => ClipsLibraryState(
+          status: ClipsLibraryStatus.loaded,
+          clips: [clip1, filedClip],
+          sortedClips: [filedClip],
+          selectedClipIds: const {'clip1', 'filed'},
+          selectedDuration: const Duration(seconds: 8),
+          categories: [travel],
+          filter: ClipLibraryCategoryFilter(travel.id),
+        ),
+        build: createBloc,
+        act: (bloc) => bloc.add(const ClipsLibraryDeleteSelected()),
+        verify: (bloc) {
+          verify(() => mockClipLibraryService.softDelete('filed')).called(1);
+          verifyNever(() => mockClipLibraryService.softDelete('clip1'));
+          expect(bloc.state.lastDeletedCount, 1);
+          expect(bloc.state.lastDeletedClipIds, {'filed'});
+          // The clip picked under the other filter was never in reach, so it
+          // stays selected — and still counts towards the duration.
+          expect(bloc.state.selectedClipIds, {'clip1'});
+          expect(bloc.state.selectedDuration, clip1.duration);
+        },
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'does nothing when the whole selection is hidden by the filter',
+        seed: () => ClipsLibraryState(
+          status: ClipsLibraryStatus.loaded,
+          clips: [clip1, filedClip],
+          sortedClips: [filedClip],
+          selectedClipIds: const {'clip1'},
+          selectedDuration: const Duration(seconds: 5),
+          categories: [travel],
+          filter: ClipLibraryCategoryFilter(travel.id),
+        ),
+        build: createBloc,
+        act: (bloc) => bloc.add(const ClipsLibraryDeleteSelected()),
+        expect: () => [],
+        verify: (_) {
+          verifyNever(() => mockClipLibraryService.softDelete(any()));
         },
       );
 
@@ -1475,6 +1547,18 @@ void main() {
         createdAt: DateTime(2026, 3, 5),
       );
 
+      DivineVideoClip clipNamed(String id) => DivineVideoClip(
+        id: id,
+        video: EditorVideo.file('/path/$id.mp4'),
+        duration: const Duration(seconds: 2),
+        recordedAt: DateTime(2026, 3, 5),
+        targetAspectRatio: .vertical,
+        originalAspectRatio: 9 / 16,
+      );
+
+      final onScreen = clipNamed('on-screen');
+      final offScreen = clipNamed('off-screen');
+
       setUp(() {
         when(
           () => mockClipLibraryService.getAllClips(),
@@ -1552,6 +1636,58 @@ void main() {
         verify: (bloc) {
           expect(bloc.state.filter, const ClipLibraryAllFilter());
           expect(bloc.state.categories, isEmpty);
+        },
+      );
+
+      // The toolbar hands over only the clips the grid is showing, so the
+      // rest of a cross-filter selection has to come out the other side of
+      // the reload intact.
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'moving clips keeps a selection made under another filter',
+        setUp: () {
+          when(
+            () => mockClipLibraryService.setClipCategory(
+              clipId: any(named: 'clipId'),
+              categoryId: any(named: 'categoryId'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockClipLibraryService.getCategories(),
+          ).thenAnswer((_) async => [travel]);
+          when(
+            () => mockClipLibraryService.getAllClips(),
+          ).thenAnswer((_) async => [onScreen, offScreen]);
+        },
+        build: createBloc,
+        seed: () => ClipsLibraryState(
+          status: ClipsLibraryStatus.loaded,
+          clips: [onScreen, offScreen],
+          sortedClips: [onScreen],
+          selectedClipIds: const {'on-screen', 'off-screen'},
+          selectedDuration: const Duration(seconds: 4),
+          categories: [travel],
+        ),
+        act: (bloc) => bloc.add(
+          const ClipsLibraryClipsMovedToCategory(
+            clipIds: {'on-screen'},
+            categoryId: 'cat-travel',
+          ),
+        ),
+        verify: (bloc) {
+          verify(
+            () => mockClipLibraryService.setClipCategory(
+              clipId: 'on-screen',
+              categoryId: travel.id,
+            ),
+          ).called(1);
+          verifyNever(
+            () => mockClipLibraryService.setClipCategory(
+              clipId: 'off-screen',
+              categoryId: any(named: 'categoryId'),
+            ),
+          );
+          expect(bloc.state.selectedClipIds, {'off-screen'});
+          expect(bloc.state.selectedDuration, offScreen.duration);
         },
       );
 

--- a/mobile/test/blocs/clips_library/clips_library_bloc_test.dart
+++ b/mobile/test/blocs/clips_library/clips_library_bloc_test.dart
@@ -1639,6 +1639,38 @@ void main() {
         },
       );
 
+      // Deleting a category unfiles its clips rather than removing them, so
+      // nothing the user picked has left the library and the selection has
+      // no reason to reset.
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'deleting a category keeps the clips selected',
+        setUp: () {
+          when(
+            () => mockClipLibraryService.deleteCategory(travel.id),
+          ).thenAnswer((_) async => true);
+          when(
+            () => mockClipLibraryService.getCategories(),
+          ).thenAnswer((_) async => []);
+          when(
+            () => mockClipLibraryService.getAllClips(),
+          ).thenAnswer((_) async => [onScreen, offScreen]);
+        },
+        build: createBloc,
+        seed: () => ClipsLibraryState(
+          status: ClipsLibraryStatus.loaded,
+          clips: [onScreen, offScreen],
+          sortedClips: [onScreen, offScreen],
+          selectedClipIds: const {'on-screen', 'off-screen'},
+          selectedDuration: const Duration(seconds: 4),
+          categories: [travel],
+        ),
+        act: (bloc) => bloc.add(ClipsLibraryCategoryDeleted(travel.id)),
+        verify: (bloc) {
+          expect(bloc.state.selectedClipIds, {'on-screen', 'off-screen'});
+          expect(bloc.state.selectedDuration, const Duration(seconds: 4));
+        },
+      );
+
       // The toolbar hands over only the clips the grid is showing, so the
       // rest of a cross-filter selection has to come out the other side of
       // the reload intact.

--- a/mobile/test/blocs/clips_library/clips_library_state_test.dart
+++ b/mobile/test/blocs/clips_library/clips_library_state_test.dart
@@ -157,6 +157,59 @@ void main() {
       });
     });
 
+    group('visibleSelectedClipIds', () {
+      final archivedClip = DivineVideoClip(
+        id: 'archived',
+        video: EditorVideo.file('/path/to/archived.mp4'),
+        duration: const Duration(seconds: 4),
+        recordedAt: DateTime(2026),
+        targetAspectRatio: .vertical,
+        originalAspectRatio: 9 / 16,
+        archivedAt: DateTime(2026, 3, 6),
+      );
+      final filedClip = DivineVideoClip(
+        id: 'filed',
+        video: EditorVideo.file('/path/to/filed.mp4'),
+        duration: const Duration(seconds: 4),
+        recordedAt: DateTime(2026),
+        targetAspectRatio: .vertical,
+        originalAspectRatio: 9 / 16,
+        categoryId: 'cat-travel',
+      );
+
+      test('drops the ids the active filter hides', () {
+        final state = ClipsLibraryState(
+          status: ClipsLibraryStatus.loaded,
+          clips: [clip1, filedClip, archivedClip],
+          selectedClipIds: const {'clip1', 'filed', 'archived'},
+          filter: const ClipLibraryCategoryFilter('cat-travel'),
+        );
+
+        expect(state.visibleSelectedClipIds, {'filed'});
+      });
+
+      test('keeps every unarchived selection under All', () {
+        final state = ClipsLibraryState(
+          status: ClipsLibraryStatus.loaded,
+          clips: [clip1, filedClip, archivedClip],
+          selectedClipIds: const {'clip1', 'filed', 'archived'},
+        );
+
+        expect(state.visibleSelectedClipIds, {'clip1', 'filed'});
+      });
+
+      test('is empty in the trash, where the grid shows no active clip', () {
+        final state = ClipsLibraryState(
+          status: ClipsLibraryStatus.loaded,
+          clips: [clip1],
+          selectedClipIds: const {'clip1'},
+          filter: const ClipLibraryTrashFilter(),
+        );
+
+        expect(state.visibleSelectedClipIds, isEmpty);
+      });
+    });
+
     group('selectedIsStopMotion', () {
       final smClip = DivineVideoClip(
         id: 'sm1',

--- a/mobile/test/screens/library_screen_test.dart
+++ b/mobile/test/screens/library_screen_test.dart
@@ -13,6 +13,7 @@ import 'package:models/models.dart' as models;
 import 'package:openvine/blocs/clips_library/clips_library_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/l10n/generated/app_localizations_en.dart';
+import 'package:openvine/models/clip_category.dart';
 import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
@@ -496,6 +497,123 @@ void main() {
           );
         },
       );
+    });
+
+    // A selection deliberately survives a filter switch so a video can span
+    // categories. The bulk toolbar actions must not inherit that reach —
+    // moving or trashing clips the grid is not showing is not something the
+    // user can see coming.
+    group('bulk actions across filters', () {
+      final travel = ClipCategory(
+        id: 'cat-travel',
+        name: 'Travel',
+        createdAt: DateTime(2026),
+      );
+
+      DivineVideoClip organizedClip(String id, {String? categoryId}) =>
+          DivineVideoClip(
+            id: id,
+            video: EditorVideo.file('/test/$id.mp4'),
+            duration: const Duration(seconds: 2),
+            recordedAt: DateTime(2026),
+            targetAspectRatio: models.AspectRatio.vertical,
+            originalAspectRatio: 9 / 16,
+            thumbnailPath: '/test/$id.jpg',
+            ghostFramePath: '/test/${id}_ghost.jpg',
+            categoryId: categoryId,
+          );
+
+      final unfiled = organizedClip('unfiled');
+      final filed = organizedClip('filed', categoryId: travel.id);
+
+      /// Opens the library with `unfiled` selected under All and `filed`
+      /// selected under Travel, then leaves Travel active — so half the
+      /// selection is off screen.
+      Future<ClipsLibraryBloc> selectAcrossFilters(WidgetTester tester) async {
+        when(
+          () => mockClipLibraryService.getAllClips(),
+        ).thenAnswer((_) async => [unfiled, filed]);
+        when(
+          () => mockClipLibraryService.getCategories(),
+        ).thenAnswer((_) async => [travel]);
+
+        await tester.pumpWidget(
+          buildWidget(
+            initialTabIndex: 1,
+            tabsMode: LibraryTabsMode.withoutSounds,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final clipsBloc =
+            BlocProvider.of<ClipsLibraryBloc>(
+                tester.element(find.byType(ClipsTab)),
+              )
+              ..add(const ClipsLibraryEnterSelectionMode())
+              ..add(ClipsLibraryToggleSelection(unfiled))
+              ..add(ClipsLibraryToggleSelection(filed))
+              ..add(
+                ClipsLibraryFilterChanged(ClipLibraryCategoryFilter(travel.id)),
+              );
+        await tester.pumpAndSettle();
+
+        expect(clipsBloc.state.selectedClipIds, {'unfiled', 'filed'});
+        expect(clipsBloc.state.sortedClips.map((c) => c.id), ['filed']);
+        return clipsBloc;
+      }
+
+      testWidgets('delete trashes only the visible half of the selection', (
+        tester,
+      ) async {
+        when(
+          () => mockClipLibraryService.softDelete(any()),
+        ).thenAnswer((_) async => true);
+
+        final clipsBloc = await selectAcrossFilters(tester);
+
+        await tester.tap(
+          find.bySemanticsLabel(en.libraryDeleteSelectedClipsTooltip),
+        );
+        await tester.pumpAndSettle();
+
+        verify(() => mockClipLibraryService.softDelete('filed')).called(1);
+        verifyNever(() => mockClipLibraryService.softDelete('unfiled'));
+        expect(clipsBloc.state.selectedClipIds, {'unfiled'});
+      });
+
+      testWidgets('move files only the visible half of the selection', (
+        tester,
+      ) async {
+        when(
+          () => mockClipLibraryService.setClipCategory(
+            clipId: any(named: 'clipId'),
+            categoryId: any(named: 'categoryId'),
+          ),
+        ).thenAnswer((_) async {});
+
+        final clipsBloc = await selectAcrossFilters(tester);
+
+        await tester.tap(
+          find.bySemanticsLabel(en.libraryMoveSelectedClipsTooltip),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(en.libraryCategoryMoveNone));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => mockClipLibraryService.setClipCategory(
+            clipId: 'filed',
+            categoryId: null,
+          ),
+        ).called(1);
+        verifyNever(
+          () => mockClipLibraryService.setClipCategory(
+            clipId: 'unfiled',
+            categoryId: any(named: 'categoryId'),
+          ),
+        );
+        expect(clipsBloc.state.selectedClipIds, {'unfiled'});
+      });
     });
 
     group('empty state', () {

--- a/mobile/test/screens/library_screen_test.dart
+++ b/mobile/test/screens/library_screen_test.dart
@@ -614,6 +614,27 @@ void main() {
         );
         expect(clipsBloc.state.selectedClipIds, {'unfiled'});
       });
+
+      // What survives an action is off screen by definition, so the grid
+      // shows no marked clip. Without the create-video bar accounting for
+      // it, that is indistinguishable from having selected nothing.
+      testWidgets('the surviving selection stays visible on the create bar', (
+        tester,
+      ) async {
+        when(
+          () => mockClipLibraryService.softDelete(any()),
+        ).thenAnswer((_) async => true);
+
+        await selectAcrossFilters(tester);
+        expect(find.text(en.libraryCreateVideo(2)), findsOneWidget);
+
+        await tester.tap(
+          find.bySemanticsLabel(en.libraryDeleteSelectedClipsTooltip),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text(en.libraryCreateVideo(1)), findsOneWidget);
+      });
     });
 
     group('empty state', () {


### PR DESCRIPTION
## Description

A selection deliberately survives switching between the active library filters, so a video can be built from clips spread over several categories. Bulk move and delete inherited that reach without meaning to: the toolbar enabled them as soon as *one* selected clip was on screen, but then handed over the full `selectedClipIds` set. Deleting one visible clip could also trash three the user had picked under another filter and could no longer see. Delete is soft and offers an undo; move offers none.

#7194 left the direction open between scoping the actions to what is visible and keeping the wide reach behind an explicit visible/hidden count. This takes the first option, because nothing is actually lost by it: bulk-organizing across categories still works in one pass from the **All** filter, which shows every unarchived clip at once. The narrow filters are exactly the case where the user cannot verify what they are about to act on.

**Creating a video keeps the full selection** — spanning categories is the whole reason a selection outlives a filter switch, and that action is additive rather than destructive.

The untouched half of the selection now **stays selected** instead of the selection being cleared wholesale after the action. Clearing it would drop clips the user picked just as silently as acting on them did; keeping it means switching back to the other filter still finds them, with `selectedDuration` recomputed to match.

`ClipLibraryFilter.admits()` replaces the switch that lived inside `_visibleClips`, so "what does this filter show" has a single answer that both the grid list and the new `ClipsLibraryState.visibleSelectedClipIds` read. Deriving visibility from `clips` + `filter` rather than from `sortedClips` also means the scoping cannot drift if a future emit path forgets to keep the sorted list in sync.

Undo is unaffected: the organize events still carry their own ids, so un-archiving from the snackbar reaches clips the active filter is hiding — scoping happens at the toolbar call site, not inside the bloc's organize handlers. The trash-boundary clearing in `_onFilterChanged` is untouched.

### Keeping the surviving selection visible

What survives a scoped action is off screen by definition, so the grid marks nothing. The create-video bar was gated on `hasVisibleSelection` and vanished along with it, which left a live selection indistinguishable from an empty one until the user happened to switch filters back.

The bar already ran on the full `selectedClips`, so gating its *visibility* on the visible subset was inconsistent with its own reach. It now shows for any selection and carries the count — **Create Video (2)**. Move and delete stay scoped to what the grid shows.

This also changes the plain filter-switch case: select under Travel, switch to Food, and the bar now stays with the count instead of disappearing. That seems right — a selection outliving a filter switch is the feature, and until now nothing on screen accounted for it.

`libraryCreateVideo` takes a count in all 22 locales. The `" ({count})"` suffix is language-neutral, so every translation carries over verbatim; placeholder metadata lives in `app_en.arb`, which is where gen-l10n and `arb_consistency_test` read it from.

### Stating the selection carry-over rather than inheriting it

`_reloadAfterOrganize` took `organizedIds` with an empty default, and an empty set means "keep the whole selection". The category-delete handler got that behaviour by omission rather than by decision, and any call site added later would too. The argument is now required, so each caller has to say what leaves the selection. Behaviour is unchanged — deleting a category unfiles its clips rather than removing them, so nothing the user picked has left the library — but that case had no test, and now does.

**Related Issue:** Closes #7194

## Out of Scope

Option two from the issue in full — an explicit **visible/hidden** split before the action — is not implemented. With the actions scoped, the snackbar reports exactly what happened ("1 clip deleted") and the create-video count reports what is still selected, which covers the case that motivated it. A breakdown of where the rest of the selection lives would be a separate piece of UI.

## Verification

- `flutter analyze lib test integration_test` — clean
- `dart format --output=none --set-exit-if-changed lib test` — clean
- `flutter test test/l10n/arb_consistency_test.dart test/blocs/clips_library test/screens/library_screen_test.dart test/widgets/library` — 298 passed
- 10 new tests (4 bloc, 3 state, 3 screen), each checked against the code it guards:
  - bloc: delete trashes only the visible half and leaves the rest selected; delete is a no-op when the whole selection is hidden; a move keeps a selection made under another filter; deleting a category keeps its clips selected
  - state: `visibleSelectedClipIds` under a category, under All, and in the trash
  - screen: end-to-end through the real toolbar with a selection spanning two filters, for both delete and move, plus the create-video bar still reporting the surviving half
- The three screen tests were run against the unfixed code and fail there, which is the bug reproduced — the create-bar one fails with `Found 0 widgets with text "Create Video (1)"`. The category-delete bloc test pins behaviour this PR introduces, so it passes against this branch and fails against `main`.
- Manually verified on a real Samsung Galaxy (SM-S942B): selected clips in one category, switched to another, selected one more, then deleted and moved. Only the visible clip was affected each time, the snackbar reported 1, the create-video bar stayed on screen reporting the remaining clip, and switching back showed the earlier selections still marked.

No visual change beyond the create-video label, so no screenshots — the rest of the diff is behavioural.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
