### PR TITLE
docs: record pre-change baseline for view and loop metrics

### DIFF
--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-baseline.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-baseline.md
@@ -16,10 +16,14 @@ any figure can be re-derived or extended.
 **Reader's key for the client tag.** Mobile view reporters appear in
 `view_interactions.client` as `Divine`. A second stream, `divine-mobile/1.0`,
 carries 1–6 viewers/day and is a legacy or dev build, not the shipping app.
-The #917 detector's "mobile" series is the `Divine` bucket — its backtest
-figures (578 on 2026-08-05, 263 on 2026-08-12) match `Divine` exactly. Any
-change to what the shipping app sends as its client tag silently re-keys the
-detector; the two-phase start event must carry the same tag.
+The #917 detector's "mobile" series is the `Divine` bucket alone — its
+backtest figures (578 on 2026-08-05, 263 on 2026-08-12) match `Divine`
+exactly. **§1's Mobile columns are the union `client IN ('Divine',
+'divine-mobile/1.0')`, so they run 0–6 viewers/day above the detector's
+series** (2026-08-05: 582 union vs 578 `Divine`). Reconcile a #917 alert
+against `Divine` only. Any change to what the shipping app sends as its
+client tag silently re-keys the detector; the redefined playback-start
+event must carry the same tag.
 
 ## 1. The outage, as a series
 
@@ -52,8 +56,10 @@ current definition per event: `ceil(loops)` clamped to ≥1 (see §3).
 
 What to hold onto:
 
-- **Mobile reporters fell 680 → 263 (–61%) over twelve days; events fell
-  28.5k → 8.8k (–69%).** Matches the design doc's 60–69% decline claim.
+- **Mobile reporters fell 676 → 263 (–61%) over twelve days; events fell
+  28.5k → 8.8k (–69%).** Stated on the `Divine` bucket so it matches the
+  two merged specs and the #917 detector; the union column above reads
+  680 → 263 for the same span.
 - **Web was flat throughout** (36–56 viewers every day, no trend). The
   regression is mobile-only — the property the #917 detector keys on.
 - **The #7210 recovery is not yet visible at capture time.** 2026-08-13 is a
@@ -171,12 +177,13 @@ Ten most-reacted videos, 2026-08-09..13:
 | a5c0a43c8bc2b418d6863c15699d924b43bfca044c5b71756b73968fab4711b3 | 30 | 41 | 14 | 53.3% |
 | 63c1b5cab350f3ef9e353b0682d1e7302e4ce1037a46057c4558ff20b9cd0347 | 30 | 49 | 22 | 26.7% |
 
-**Weighted: 164 of 366 provable watchers registered a view — 55.2% are
-absent.** Median across videos 53.9%, range 26.7–73.8%. The design doc's
-single-video measurement (event a3092dfc… above, 10-of-37 at the time)
-reproduces at 11-of-42 — same video, more interactions accrued since, same
-direction. The 73% figure was the high end of a real distribution, not an
-outlier.
+**Weighted: 174 of 366 provable watchers registered a view — 52.5% are
+absent.** Median across videos 53.8%, range 26.7–73.8%. The design doc's
+single-video measurement (event
+a3092dfc8d36d15583d0866ae4312fd32b96a8eb59d79a7f23028c1ffc6d5503 above,
+10-of-37 at the time) reproduces at 11-of-42 — same video, more
+interactions accrued since, same direction. The 73% figure was the high end
+of a real distribution, not an outlier.
 
 Caveats, stated so the number is not over-read:
 
@@ -190,25 +197,62 @@ Caveats, stated so the number is not over-read:
 
 ## 5. The display floor, restated on current numbers
 
-`publicLoopCountFloor` = 1000, applied to public counts:
+**This section corrects the design doc, which measures the wrong column.**
+`video_card_meta.dart:79` defines the gated quantity as
+`video.isOriginalVine ? video.originalLoops ?? 0 : video.totalLoops` —
+i.e. the archival `loops` tag for classic Vines (98% of the catalogue),
+and `originalLoops + views` for native ones. The design doc's table
+measures `video_total_views_data.total_views`, which the floor is never
+applied to, and lands three orders of magnitude off.
 
-| Threshold | Videos at or above | Share of 2,201,986 |
+`publicLoopCountFloor` = 1000, measured against the quantity the code
+actually gates:
+
+| Threshold | Videos at or above | Share of 2,203,822 |
 |---|---|---|
-| 1000 (today's floor) | 961 | 0.044% |
-| 333 | 2,441 | 0.111% |
-| 100 | 12,573 | 0.571% |
+| 1000 (today's floor) | 1,152,593 | **52.30%** |
+| 333 | 1,375,711 | 62.42% |
+| 100 | 1,621,923 | 73.60% |
 
-Unchanged from the design doc to within a few videos. The public count is
-effectively never shown; the card's date-first presentation is doing the
-work the doc attributes to it.
+Median public count across the catalogue: **1,417**.
+
+So a public count renders on about **half** the catalogue, not on 0.044%
+of it. The design doc's conclusion — "the public count is effectively
+never shown; 9,996 videos in 10,000 render a date" — does not hold, and
+the same wrong table is live on `main` in
+[the design doc](2026-08-13-view-and-loop-metrics-design.md) §"The display
+floor, and why most cards show a date". It needs the same correction.
+
+**The floor decision survives the correction; only its stated rationale
+changes.** The design doc argued the floor was harmless because almost
+nobody ever sees a count. The real argument is the one on the constant
+itself (`video_card_meta.dart:9`): a number below the floor "tells a
+viewer not to bother", and a wall of small counts on *other people's*
+videos discourages posting. On the real distribution the floor is doing
+that job well — visitors see a count on ~52% of videos, every one of them
+≥1000, and a date on the rest instead of a discouraging 47. Creators are
+never gated: `_resolveLoopCount` returns `video.totalLoops` unconditionally
+when `isOwnVideo`, and `totalLoops` is additive
+(`originalLoops + views`), so a creator sees the larger number.
+
+One unreconciled discrepancy, stated rather than smoothed over: the
+constant's own doc comment reports "roughly 64% of the archive" hidden
+with "p50 is 298 loops", measured against a 1,000-Vine sample. The
+full-catalogue measurement above gives 47.7% hidden at p50 1,417. Both are
+the same order of magnitude and both contradict the design doc's 0.044%,
+but the sample and the census disagree by enough that the sample was
+probably not representative. Re-tuning the floor should use the census.
 
 ## 6. Context figures
 
-- `daily_active_users`: 7,679 on 2026-08-12 (7–10k across the window).
+- `daily_active_users`: 7,679 on 2026-08-12 **as read at 2026-08-13 09:15
+  UTC**. This table accrues after the day closes — the same row read on
+  2026-08-14 returns 8,043 — so treat 7,679 as a partial read, not a
+  settled daily figure, and the derived share below as approximate.
   Signed-in view reporters that day were 303 (263 mobile + 40 web) — ~4% of
-  DAU. The table has no auth split, so the "anonymous are roughly half of
-  daily users" claim cannot be checked here; the CDN channel (§2) is the
-  only anonymous evidence.
+  DAU on the partial read, ~3.8% on the settled one. The table has no auth
+  split, so the "anonymous are roughly half of daily users" claim cannot be
+  checked here; the CDN channel (§2) is the only anonymous evidence.
 - The API's trending surface reads `trending_videos_snapshot`
   (`crates/clickhouse/src/client.rs:3541`); a second, separate path queries
   `trending_videos` (`client.rs:7606`). Both are live code at capture time —
@@ -219,16 +263,34 @@ work the doc attributes to it.
 When each change from the design lands, re-run the appendix queries and
 compare against the matching section:
 
-| Change | Watch |
-|---|---|
-| #7210 client fix rollout | §1 mobile reporters returning toward ~600/day; expect a one-day backlog-replay spike at publish-time timestamps — recovered history, not growth |
-| View = playback start (two-phase 22236) | §1 events rising toward sessions; `views_today_def` decoupling from loops |
-| CDN-derived loops | §2's zero-loop gap closing; §3 aggregate loops/view rising past 1.0 for the first time |
-| Ranking unification | §6's duplicate trending paths reduced to one |
+| Change | Status at capture | Watch |
+|---|---|---|
+| #7210 client fix rollout | merged, not yet visible | §1 mobile reporters returning toward ~600/day; expect a one-day backlog-replay spike at publish-time timestamps — recovered history, not growth |
+| View = playback start | **landed — #7217, merged 2026-08-13 10:08 UTC** | §1 events rising toward sessions; `views_today_def` decoupling from loops |
+| Same-video session restart | **landed — #7231, merged 2026-08-14 04:20 UTC** | §1 events rising for re-watches without §1 viewers rising |
+| CDN-derived loops | not started | §2's zero-loop gap closing; §3 aggregate loops/view rising past 1.0 for the first time |
+| Ranking unification | not started | §6's duplicate trending paths reduced to one |
 
-Every figure here is a floor measured on a pipeline whose known errors all
-run downward. Compare like for like: same UTC day boundaries, same client
-buckets, same TTL windows.
+**Changes since capture.** #7217 and #7231 both merged between this
+snapshot and this document landing, so the first two rows are already
+"after" rather than "before". #7217 implements the design's single
+kind-22236 event per session — there is no two-phase start/end event in
+either merged spec, and #7231 documents one-event-per-session as the
+current mobile-emitted contract.
+
+**Most** figures here are floors measured on a pipeline whose known errors
+run downward — but not all of them, so do not apply that blanket:
+
+- **View counts are floors.** Every known error drops views.
+- **Loop figures are not.** The findings doc §3.4 records a `_handleState`
+  early-return defect that *inflates* watch time when a route is pushed,
+  and stored `loops` is `watched_seconds / duration`, so §1's loop sums and
+  §3's 0.733 loops/view ratio are inflated by it.
+- **§4's missing share is not.** Its own caveat admits the 90-day window
+  falsely counts a late-reacting interactor as missing.
+
+Compare like for like: same UTC day boundaries, same client buckets, same
+TTL windows.
 
 ## Appendix: exact queries
 
@@ -342,11 +404,39 @@ ORDER BY ia.interactors DESC;
 <details>
 <summary>§5 — display floor distribution</summary>
 
+Mirrors `_publicCount` in `video_card_meta.dart`: the archival `loops` tag
+for classic Vines, `originalLoops + views` otherwise. Do **not** measure
+this against `video_total_views_data.total_views` — the floor is never
+applied to that column, and doing so is the error this section corrects.
+
 ```sql
-SELECT countIf(total_views>=1000) AS ge_1000,
-       countIf(total_views>=333)  AS ge_333,
-       countIf(total_views>=100)  AS ge_100,
-       count() AS videos
-FROM nostr.video_total_views_data;
+WITH
+  arrayExists(t -> t[1] = 'platform' AND t[2] = 'vine', tags)  AS is_vine,
+  toUInt64OrZero(arrayFirst(t -> t[1] = 'views', tags)[2])     AS views_tag,
+  if(is_vine, loops, loops + views_tag)                        AS public_count
+SELECT count()                       AS catalogue,
+       countIf(public_count >= 1000) AS ge_1000,
+       countIf(public_count >= 333)  AS ge_333,
+       countIf(public_count >= 100)  AS ge_100,
+       median(public_count)          AS p50
+FROM nostr.videos;
+```
+
+`nostr.videos.loops` is the `loops` tag, verified over a 200,000-row Vine
+sample: 198,061 rows carry the tag and the column equals it in all 198,061,
+with zero mismatches.
+</details>
+
+<details>
+<summary>§6 — daily active users</summary>
+
+`daily_active_users` accrues after the day closes, so a same-day or
+next-morning read is partial. Record the read time alongside the value.
+
+```sql
+SELECT date, active_users
+FROM nostr.daily_active_users
+WHERE date >= toDate('2026-08-08')
+ORDER BY date;
 ```
 </details>

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-baseline.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-baseline.md
@@ -1,0 +1,352 @@
+# View and loop metrics: pre-change baseline
+
+**Date:** 2026-08-13, measured 08:30–09:15 UTC
+**Status:** Snapshot — read-only measurement, no code change
+**Companion to:** [View and loop metrics design](2026-08-13-view-and-loop-metrics-design.md)
+
+## Why this exists
+
+The design's open risk section: the redefinition and the #7210 outage recovery
+land close together, and without a recorded pre-change state their effects
+become unattributable. This is that record. Every number here was measured
+read-only against production ClickHouse (`agent_readonly_user`, ClickHouse
+Cloud 26.4.1.2163) on the date above, with the exact SQL in the appendix so
+any figure can be re-derived or extended.
+
+**Reader's key for the client tag.** Mobile view reporters appear in
+`view_interactions.client` as `Divine`. A second stream, `divine-mobile/1.0`,
+carries 1–6 viewers/day and is a legacy or dev build, not the shipping app.
+The #917 detector's "mobile" series is the `Divine` bucket — its backtest
+figures (578 on 2026-08-05, 263 on 2026-08-12) match `Divine` exactly. Any
+change to what the shipping app sends as its client tag silently re-keys the
+detector; the two-phase start event must carry the same tag.
+
+## 1. The outage, as a series
+
+Signed-in reporting per day, UTC. `views_today_def` reconstructs the server's
+current definition per event: `ceil(loops)` clamped to ≥1 (see §3).
+
+| Day | Mobile events | Mobile viewers | Mobile loops | Mobile views (today's def) | Web events | Web viewers |
+|---|---|---|---|---|---|---|
+| 2026-07-24 | 28,022 | 621 | 28,323.1 | 44,027 | 11,967 | 39 |
+| 2026-07-25 | 27,967 | 656 | 28,303.4 | 44,117 | 7,415 | 37 |
+| 2026-07-26 | 27,710 | 630 | 27,869.1 | 43,628 | 196 | 26 |
+| 2026-07-27 | 28,823 | 666 | 26,927.2 | 43,409 | 2,436 | 56 |
+| 2026-07-28 | 30,269 | 641 | 33,278.1 | 50,483 | 2,126 | 46 |
+| 2026-07-29 | 30,144 | 591 | 32,376.2 | 49,541 | 3,514 | 40 |
+| 2026-07-30 | 23,788 | 597 | 27,753.4 | 40,753 | 2,069 | 42 |
+| 2026-07-31 | 26,558 | 566 | 28,895.8 | 43,554 | 1,098 | 45 |
+| 2026-08-01 | 27,351 | 680 | 27,476.4 | 42,672 | 10,739 | 42 |
+| 2026-08-02 | 28,301 | 625 | 27,736.6 | 43,762 | 3,557 | 50 |
+| 2026-08-03 | 28,523 | 628 | 28,488.8 | 44,582 | 484 | 41 |
+| 2026-08-04 | 29,067 | 612 | 27,448.8 | 44,089 | 1,345 | 56 |
+| 2026-08-05 | 25,043 | 582 | 26,140.5 | 40,202 | 925 | 51 |
+| 2026-08-06 | 28,252 | 580 | 28,995.7 | 44,907 | 903 | 36 |
+| 2026-08-07 | 24,062 | 572 | 26,286.7 | 39,702 | 758 | 42 |
+| 2026-08-08 | 21,083 | 499 | 22,249.3 | 34,456 | 2,265 | 39 |
+| 2026-08-09 | 21,653 | 415 | 22,838.2 | 34,962 | 3,999 | 46 |
+| 2026-08-10 | 16,870 | 366 | 17,931.6 | 27,300 | 1,287 | 51 |
+| 2026-08-11 | 15,050 | 350 | 14,439.2 | 23,147 | 1,545 | 42 |
+| 2026-08-12 | 8,833 | 263 | 9,197.5 | 14,182 | 2,517 | 40 |
+| 2026-08-13 (partial, to 09:15 UTC) | 2,861 | 116 | 3,544.6 | 5,141 | 2,253 | 24 |
+
+What to hold onto:
+
+- **Mobile reporters fell 680 → 263 (–61%) over twelve days; events fell
+  28.5k → 8.8k (–69%).** Matches the design doc's 60–69% decline claim.
+- **Web was flat throughout** (36–56 viewers every day, no trend). The
+  regression is mobile-only — the property the #917 detector keys on.
+- **The #7210 recovery is not yet visible at capture time.** 2026-08-13 is a
+  partial day but tracks below 2026-08-12's full day. The client fix
+  (#7182, persist the addressable d tag on queued view events) is merged but
+  its reporters have not arrived in production numbers. When they do, this
+  table is the "before".
+- Loops-per-event sits at ~1.0–1.1 for mobile throughout, outage or not —
+  the outage removed *reporters*, not engagement depth per reporter.
+
+## 2. Anonymous coverage: the CDN side
+
+`cdn_view_counts` holds one row per media delivery (sha256, viewed_at, pop,
+bytes_sent). Daily, UTC:
+
+| Day | Deliveries | Distinct videos | GB served |
+|---|---|---|---|
+| 2026-07-24 | 62,939 | 44,239 | 82.97 |
+| 2026-07-25 | 46,165 | 25,690 | 68.50 |
+| 2026-07-26 | 28,514 | 15,580 | 47.95 |
+| 2026-07-27 | 37,149 | 22,470 | 53.05 |
+| 2026-07-28 | 98,027 | 67,253 | 126.66 |
+| 2026-07-29 | 115,191 | 78,120 | 150.03 |
+| 2026-07-30 | 78,905 | 55,092 | 103.90 |
+| 2026-07-31 | 54,012 | 36,279 | 73.41 |
+| 2026-08-01 | 21,523 | 8,601 | 33.43 |
+| 2026-08-02 | 32,802 | 19,734 | 48.59 |
+| 2026-08-03 | 28,398 | 14,325 | 44.20 |
+| 2026-08-04 | 25,383 | 12,299 | 38.04 |
+| 2026-08-05 | 55,444 | 39,299 | 68.69 |
+| 2026-08-06 | 49,968 | 35,327 | 65.41 |
+| 2026-08-07 | 34,529 | 23,071 | 50.28 |
+| 2026-08-08 | 35,932 | 25,314 | 54.13 |
+| 2026-08-09 | 27,276 | 13,198 | 42.62 |
+| 2026-08-10 | 35,480 | 24,929 | 54.67 |
+| 2026-08-11 | 39,609 | 18,781 | 63.96 |
+| 2026-08-12 | 110,791 | 68,035 | 150.15 |
+| 2026-08-13 (partial) | 32,666 | 22,034 | 48.86 |
+
+- **Daily deliveries swing 21.5k–115.2k with no weekly pattern** — cache
+  behaviour and range requests, not audience. The design doc's noise warning
+  (21k–110k) reproduces. Ranking must not treat a CDN-derived loop as
+  equivalent in confidence to an observed one.
+- **CDN deliveries do not visibly dip during the outage window** (the dip
+  2026-08-01..04 and the spike 2026-08-12 both sit inside ordinary variance).
+  Anonymous demand kept flowing while signed-in reporting collapsed — the
+  two channels measure different things and only one was broken.
+
+Totals across the catalogue (`video_total_views_data`, refreshed
+2026-08-13 08:30 UTC):
+
+| Measure | Value |
+|---|---|
+| Videos | 2,201,986 |
+| CDN views | 4,709,947 |
+| Auth views | 6,441,545 |
+| Total views | 11,151,492 |
+| CDN share | **42.24%** |
+| Rows where `total ≠ cdn + auth` | **0** |
+
+The design doc's identity holds exactly on all 2.2M rows. CDN-derived
+viewing is already 42% of reported views and contributes **zero** loops
+today — that gap is the single largest correction the design makes.
+
+## 3. Today's definitional conflation, measured
+
+The server computes, per kind-22236 event
+(`crates/relay/src/view_handler.rs:74-83`):
+
+```
+loops      = max(watched_seconds, 1) / video_duration_seconds   (Float)
+view_count = ceil(loops) clamped to ≥ 1
+```
+
+So today's "views" are not playback starts and not sessions — they are
+**loops rounded up**. A 30-second watch of a 6-second video is 5 "views"
+from one session; a 0.75-pass watch is 1. The client-sent `loops` tag is
+never parsed (`ViewEventData`, same file) — every fractional loop in the
+database is server-derived. Aggregate state:
+
+| Measure | Value |
+|---|---|
+| `view_counts` rows (per-video aggregates) | 2,106,714 |
+| Σ view_count | 6,542,283 |
+| Σ total_loops | 4,796,635.2 |
+| Loops per view, aggregate | **0.733** |
+| Rows with loops < views | **91%** |
+
+The design doc's 0.63–0.71 ratio and 91% row share reproduce. This is the
+ratio measured on the broken pipeline — the argument for deferring the
+"which metric leads" call until both are measured properly.
+
+## 4. Ground truth: interactors who never registered a view
+
+Method: a like, repost, or comment is proof of viewing. For each sampled
+video, the set of distinct pubkeys interacting in the last 4 days (kinds
+6, 7, 16, 1111 via `event_tags_flat`, plus `comments`) is compared against
+the set of distinct pubkeys in `view_interactions` for that video (full
+90-day TTL window). Candidates were restricted to events present in
+`videos` — an earlier unrestricted pass returned kind-1 text notes from the
+wider relay network, which trivially have no view rows.
+
+Ten most-reacted videos, 2026-08-09..13:
+
+| Video event id | Interactors | Registered viewers | Interactors with a view | Missing |
+|---|---|---|---|---|
+| dbd2c6f133ec35f41375c02353c4d4247efa96dccede953436a959af51dd4d34 | 46 | 55 | 17 | 63.0% |
+| 63cc7c3942a6d447d3a6fc8e3caaadfd34d23b5b69d8a8b7c5ce9d5a02087aef | 42 | 53 | 22 | 47.6% |
+| a3092dfc8d36d15583d0866ae4312fd32b96a8eb59d79a7f23028c1ffc6d5503 | 42 | 29 | 11 | 73.8% |
+| ae8b149c8a350a6b46b60fd52eac70643a48557cfad58122ab429e4ea17df40c | 39 | 77 | 27 | 30.8% |
+| a68e53502c5ac41bf36e2e89a0116171be69a52e4b7119eb959c9c3bc9081d2a | 38 | 52 | 20 | 47.4% |
+| 87d463ee481daa5c974a3cf77f326e9821cfeff596bf83d945b4ab336c84389b | 35 | 35 | 16 | 54.3% |
+| 5a269949a378ac87dd1e4ae646dd41b67da37068858cd03b3ec54d7f1a1822b0 | 33 | 55 | 14 | 57.6% |
+| 30af2b523e454672316cba2193beee835e20a0f04438244d1c7144ccde6e7019 | 31 | 41 | 11 | 64.5% |
+| a5c0a43c8bc2b418d6863c15699d924b43bfca044c5b71756b73968fab4711b3 | 30 | 41 | 14 | 53.3% |
+| 63c1b5cab350f3ef9e353b0682d1e7302e4ce1037a46057c4558ff20b9cd0347 | 30 | 49 | 22 | 26.7% |
+
+**Weighted: 164 of 366 provable watchers registered a view — 55.2% are
+absent.** Median across videos 53.9%, range 26.7–73.8%. The design doc's
+single-video measurement (event a3092dfc… above, 10-of-37 at the time)
+reproduces at 11-of-42 — same video, more interactions accrued since, same
+direction. The 73% figure was the high end of a real distribution, not an
+outlier.
+
+Caveats, stated so the number is not over-read:
+
+- An interactor who watched >90 days ago and reacted late would be falsely
+  counted as missing. For videos interacted with this month this is rare —
+  reaction follows viewing closely — and the 4-day-window variant of the
+  query produced near-identical overlap.
+- This samples *signed-in* viewing only, by construction: anonymous viewers
+  sign no events, so they appear in neither set. It is a floor on the
+  signed-in loss, not a measure of the anonymous share.
+
+## 5. The display floor, restated on current numbers
+
+`publicLoopCountFloor` = 1000, applied to public counts:
+
+| Threshold | Videos at or above | Share of 2,201,986 |
+|---|---|---|
+| 1000 (today's floor) | 961 | 0.044% |
+| 333 | 2,441 | 0.111% |
+| 100 | 12,573 | 0.571% |
+
+Unchanged from the design doc to within a few videos. The public count is
+effectively never shown; the card's date-first presentation is doing the
+work the doc attributes to it.
+
+## 6. Context figures
+
+- `daily_active_users`: 7,679 on 2026-08-12 (7–10k across the window).
+  Signed-in view reporters that day were 303 (263 mobile + 40 web) — ~4% of
+  DAU. The table has no auth split, so the "anonymous are roughly half of
+  daily users" claim cannot be checked here; the CDN channel (§2) is the
+  only anonymous evidence.
+- The API's trending surface reads `trending_videos_snapshot`
+  (`crates/clickhouse/src/client.rs:3541`); a second, separate path queries
+  `trending_videos` (`client.rs:7606`). Both are live code at capture time —
+  the duplicate-formula situation the design removes.
+
+## 7. How to use this document
+
+When each change from the design lands, re-run the appendix queries and
+compare against the matching section:
+
+| Change | Watch |
+|---|---|
+| #7210 client fix rollout | §1 mobile reporters returning toward ~600/day; expect a one-day backlog-replay spike at publish-time timestamps — recovered history, not growth |
+| View = playback start (two-phase 22236) | §1 events rising toward sessions; `views_today_def` decoupling from loops |
+| CDN-derived loops | §2's zero-loop gap closing; §3 aggregate loops/view rising past 1.0 for the first time |
+| Ranking unification | §6's duplicate trending paths reduced to one |
+
+Every figure here is a floor measured on a pipeline whose known errors all
+run downward. Compare like for like: same UTC day boundaries, same client
+buckets, same TTL windows.
+
+## Appendix: exact queries
+
+All run read-only against production ClickHouse, database `nostr`, on
+2026-08-13. `CH()` is the HTTPS endpoint with the readonly credential.
+
+<details>
+<summary>§1 — daily signed-in series</summary>
+
+```sql
+SELECT toDate(created_at,'UTC') AS day,
+       multiIf(client IN ('Divine','divine-mobile/1.0'),'mobile',
+               client='divine-web/1.0','web','other') AS platform,
+       count() AS events,
+       uniqExact(viewer_pubkey) AS viewers,
+       round(sum(view_interactions.loops),1) AS loops_sum,
+       sum(greatest(ceiling(view_interactions.loops),1)) AS views_today_def
+FROM nostr.view_interactions
+WHERE created_at >= toDate('2026-07-24','UTC')
+GROUP BY day, platform
+ORDER BY day, platform;
+```
+(The `view_interactions.` qualifier on `loops` is load-bearing: an unqualified
+`sum(loops) AS loops` alias shadows the column and ClickHouse 26 rejects the
+later `ceiling(loops)` as a nested aggregate.)
+</details>
+
+<details>
+<summary>§2 — CDN deliveries and totals split</summary>
+
+```sql
+SELECT toDate(viewed_at,'UTC') AS day, count() AS deliveries,
+       uniqExact(sha256) AS videos, round(sum(bytes_sent)/1e9,2) AS GB
+FROM nostr.cdn_view_counts
+WHERE viewed_at >= toDate('2026-07-24','UTC')
+GROUP BY day ORDER BY day;
+
+SELECT count() AS videos, sum(cdn_views) AS cdn, sum(auth_views) AS auth,
+       sum(total_views) AS total,
+       round(sum(cdn_views)/sum(total_views)*100,2) AS cdn_pct,
+       countIf(total_views != cdn_views + auth_views) AS sum_breaks,
+       max(refreshed_at) AS last_refresh
+FROM nostr.video_total_views_data;
+```
+</details>
+
+<details>
+<summary>§3 — loops vs views aggregate</summary>
+
+```sql
+SELECT count() AS rows, sum(view_count) AS views,
+       round(sum(total_loops),1) AS loops,
+       round(sum(total_loops)/sum(view_count),3) AS loops_per_view,
+       round(countIf(total_loops < view_count)/count()*100,1) AS pct_rows_loops_lt_views
+FROM nostr.view_counts;
+```
+</details>
+
+<details>
+<summary>§4 — ground-truth interactor overlap</summary>
+
+Candidates (must be restricted to catalogue videos, or relay-network text
+notes dominate the reaction sample):
+
+```sql
+SELECT f.tag_value_primary AS vid, uniqExact(f.pubkey) AS reactors
+FROM nostr.event_tags_flat f
+INNER JOIN (SELECT toString(id) AS id FROM nostr.videos) v
+  ON f.tag_value_primary = v.id
+WHERE f.kind = 7 AND f.tag_name = 'e'
+  AND f.created_at >= now() - INTERVAL 4 DAY
+GROUP BY vid HAVING reactors >= 10
+ORDER BY reactors DESC LIMIT 10;
+```
+
+Overlap per candidate set:
+
+```sql
+WITH videos AS (SELECT arrayJoin([ '<event id>', ... ]) AS vid),
+interactors AS (
+  SELECT DISTINCT vid, toString(pubkey) AS pk FROM (
+    SELECT tag_value_primary AS vid, pubkey FROM nostr.event_tags_flat
+    WHERE kind IN (6,7,16,1111) AND tag_name = 'e'
+      AND tag_value_primary IN (SELECT vid FROM videos)
+      AND created_at >= now() - INTERVAL 4 DAY
+    UNION ALL
+    SELECT root_event_id AS vid, pubkey FROM nostr.comments
+    WHERE root_event_id IN (SELECT vid FROM videos)
+      AND created_at >= now() - INTERVAL 4 DAY
+  )
+),
+viewersall AS (
+  SELECT DISTINCT target_event_id AS vid, toString(viewer_pubkey) AS pk
+  FROM nostr.view_interactions
+  WHERE target_event_id IN (SELECT vid FROM videos)
+)
+SELECT ia.vid, ia.interactors, va.viewers_90d, oa.interactors_with_view,
+       round(100 - oa.interactors_with_view / ia.interactors * 100, 1)
+         AS pct_interactors_missing
+FROM (SELECT vid, uniqExact(pk) AS interactors FROM interactors GROUP BY vid) ia
+LEFT JOIN (SELECT vid, uniqExact(pk) AS viewers_90d
+           FROM viewersall GROUP BY vid) va ON ia.vid = va.vid
+LEFT JOIN (SELECT i.vid, uniqExact(i.pk) AS interactors_with_view
+           FROM interactors i
+           INNER JOIN viewersall v ON i.vid = v.vid AND i.pk = v.pk
+           GROUP BY i.vid) oa ON ia.vid = oa.vid
+ORDER BY ia.interactors DESC;
+```
+</details>
+
+<details>
+<summary>§5 — display floor distribution</summary>
+
+```sql
+SELECT countIf(total_views>=1000) AS ge_1000,
+       countIf(total_views>=333)  AS ge_333,
+       countIf(total_views>=100)  AS ge_100,
+       count() AS videos
+FROM nostr.video_total_views_data;
+```
+</details>

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-baseline.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-baseline.md
@@ -9,9 +9,8 @@
 The design's open risk section: the redefinition and the #7210 outage recovery
 land close together, and without a recorded pre-change state their effects
 become unattributable. This is that record. Every number here was measured
-read-only against production ClickHouse (`agent_readonly_user`, ClickHouse
-Cloud 26.4.1.2163) on the date above, with the exact SQL in the appendix so
-any figure can be re-derived or extended.
+read-only against production ClickHouse Cloud on the date above, with the exact
+SQL in the appendix so any figure can be re-derived or extended.
 
 **Reader's key for the client tag.** Mobile view reporters appear in
 `view_interactions.client` as `Divine`, emitted by
@@ -138,6 +137,9 @@ Totals across the catalogue (`video_total_views_data`, refreshed
 The design doc's identity holds exactly on all 2.2M rows. CDN-derived
 viewing is already 42% of reported views and contributes **zero** loops
 today — that gap is the single largest correction the design makes.
+This denominator comes from `video_total_views_data`, the aggregate table
+behind the CDN/auth split; §5 uses `nostr.videos`, which has a slightly larger
+catalogue row count because it is the source table for the public-count gate.
 
 ## 3. Today's definitional conflation, measured
 
@@ -180,28 +182,28 @@ the set of distinct pubkeys in `view_interactions` for that video (full
 `videos` — an earlier unrestricted pass returned kind-1 text notes from the
 wider relay network, which trivially have no view rows.
 
-Ten most-reacted videos, 2026-08-09..13:
+Ten most-reacted videos, 2026-08-09..13. Sample labels stand in for the real
+event ids so this public doc keeps the aggregate result without publishing
+content-level internal measurement rows.
 
-| Video event id | Interactors | Registered viewers | Interactors with a view | Missing |
+| Sample | Interactors | Registered viewers | Interactors with a view | Missing |
 |---|---|---|---|---|
-| dbd2c6f133ec35f41375c02353c4d4247efa96dccede953436a959af51dd4d34 | 46 | 55 | 17 | 63.0% |
-| 63cc7c3942a6d447d3a6fc8e3caaadfd34d23b5b69d8a8b7c5ce9d5a02087aef | 42 | 53 | 22 | 47.6% |
-| a3092dfc8d36d15583d0866ae4312fd32b96a8eb59d79a7f23028c1ffc6d5503 | 42 | 29 | 11 | 73.8% |
-| ae8b149c8a350a6b46b60fd52eac70643a48557cfad58122ab429e4ea17df40c | 39 | 77 | 27 | 30.8% |
-| a68e53502c5ac41bf36e2e89a0116171be69a52e4b7119eb959c9c3bc9081d2a | 38 | 52 | 20 | 47.4% |
-| 87d463ee481daa5c974a3cf77f326e9821cfeff596bf83d945b4ab336c84389b | 35 | 35 | 16 | 54.3% |
-| 5a269949a378ac87dd1e4ae646dd41b67da37068858cd03b3ec54d7f1a1822b0 | 33 | 55 | 14 | 57.6% |
-| 30af2b523e454672316cba2193beee835e20a0f04438244d1c7144ccde6e7019 | 31 | 41 | 11 | 64.5% |
-| a5c0a43c8bc2b418d6863c15699d924b43bfca044c5b71756b73968fab4711b3 | 30 | 41 | 14 | 53.3% |
-| 63c1b5cab350f3ef9e353b0682d1e7302e4ce1037a46057c4558ff20b9cd0347 | 30 | 49 | 22 | 26.7% |
+| sample_01 | 46 | 55 | 17 | 63.0% |
+| sample_02 | 42 | 53 | 22 | 47.6% |
+| sample_03 | 42 | 29 | 11 | 73.8% |
+| sample_04 | 39 | 77 | 27 | 30.8% |
+| sample_05 | 38 | 52 | 20 | 47.4% |
+| sample_06 | 35 | 35 | 16 | 54.3% |
+| sample_07 | 33 | 55 | 14 | 57.6% |
+| sample_08 | 31 | 41 | 11 | 64.5% |
+| sample_09 | 30 | 41 | 14 | 53.3% |
+| sample_10 | 30 | 49 | 22 | 26.7% |
 
 **Weighted: 174 of 366 provable watchers registered a view — 52.5% are
 absent.** Median across videos 53.8%, range 26.7–73.8%. The design doc's
-single-video measurement (event
-a3092dfc8d36d15583d0866ae4312fd32b96a8eb59d79a7f23028c1ffc6d5503 above,
-10-of-37 at the time) reproduces at 11-of-42 — same video, more
-interactions accrued since, same direction. The 73% figure was the high end
-of a real distribution, not an outlier.
+single-video measurement reproduces as `sample_03` at 11-of-42 — same video,
+more interactions accrued since, same direction. The 73% figure was the high
+end of a real distribution, not an outlier.
 
 Caveats, stated so the number is not over-read:
 
@@ -218,10 +220,11 @@ Caveats, stated so the number is not over-read:
 **This section corrects the design doc, which measures the wrong column.**
 `mobile/lib/widgets/video_feed_item/video_card_meta.dart:79` defines the gated
 quantity as `video.isOriginalVine ? video.originalLoops ?? 0 :
-video.totalLoops` — i.e. the archival `loops` tag for classic Vines (98% of the
-catalogue), and `originalLoops + views` for native ones. The design doc's table
-measures `video_total_views_data.total_views`, which the floor is never applied
-to, and lands three orders of magnitude off.
+video.totalLoops` — i.e. the archival `loops` tag for classic Vines (about 98%
+of the `nostr.videos` catalogue; derived by the appendix query), and
+`originalLoops + views` for native ones. The design doc's table measures
+`video_total_views_data.total_views`, which the floor is never applied to, and
+lands three orders of magnitude off.
 
 `publicLoopCountFloor` = 1000, measured against the quantity the code
 actually gates:
@@ -234,25 +237,26 @@ actually gates:
 
 Median public count across the catalogue: **1,417**.
 
-So a public count renders on about **half** the catalogue, not on 0.044%
-of it. The design doc's conclusion — "the public count is effectively
-never shown; 9,996 videos in 10,000 render a date" — does not hold, and
-the same wrong table is live on `main` in
-[the design doc](2026-08-13-view-and-loop-metrics-design.md) §"The display
-floor, and why most cards show a date". It needs the same correction.
+When the post-date/count-hiding feature is enabled, a public count renders on
+about **half** the catalogue, not on 0.044% of it. The design doc's prior
+conclusion — "the public count is effectively never shown; 9,996 videos in
+10,000 render a date" — does not hold under the feature-gated code path.
+Production remains unchanged while `FeatureFlag.videoCardPostDate` is off:
+`resolveVideoCardMeta` returns `video.totalLoops` directly, so every card keeps
+today's count-only behavior until the flag is enabled.
 
 **The floor decision survives the correction; only its stated rationale
 changes.** The design doc argued the floor was harmless because almost
 nobody ever sees a count. The real argument is the one on the constant
 itself (`mobile/lib/widgets/video_feed_item/video_card_meta.dart:9`): a number
 below the floor "tells a viewer not to bother", and a wall of small counts on
-*other people's* videos discourages posting. On the real distribution the floor
-is doing that job well — visitors see a count on ~52% of videos, every one of
-them ≥1000, and a date on the rest instead of a discouraging 47. Creators are
-never gated: `_resolveLoopCount` returns `video.totalLoops` unconditionally
-when `isOwnVideo`, and `totalLoops` is additive
-(`mobile/packages/models/lib/src/video_event.dart:1181-1183`), so a creator
-sees the larger number.
+*other people's* videos discourages posting. On the real distribution, once the
+feature is enabled, the floor would show visitors a count on ~52% of videos,
+every one of them ≥1000, and a date on the rest instead of a discouraging 47.
+Creators are never gated in that code path: `_resolveLoopCount` returns
+`video.totalLoops` unconditionally when `isOwnVideo`, and `totalLoops` is
+additive (`mobile/packages/models/lib/src/video_event.dart:1181-1183`), so a
+creator sees the larger number.
 
 One unreconciled discrepancy, stated rather than smoothed over: the
 constant's own doc comment reports "roughly 64% of the archive" hidden
@@ -264,14 +268,12 @@ probably not representative. Re-tuning the floor should use the census.
 
 ## 6. Context figures
 
-- `daily_active_users`: 7,679 on 2026-08-12 **as read at 2026-08-13 09:15
-  UTC**. This table accrues after the day closes — the same row read on
-  2026-08-14 returns 8,043 — so treat 7,679 as a partial read, not a
-  settled daily figure, and the derived share below as approximate.
-  Signed-in view reporters that day were 303 (263 mobile + 40 web) — ~4% of
-  DAU on the partial read, ~3.8% on the settled one. The table has no auth
-  split, so the "anonymous are roughly half of daily users" claim cannot be
-  checked here; the CDN channel (§2) is the only anonymous evidence.
+- `daily_active_users` was still accruing when this snapshot was taken, so the
+  same day read changed between 2026-08-13 and 2026-08-14. Signed-in view
+  reporters were only a low-single-digit percentage of that daily active user
+  row. Treat that as directional context, not a settled KPI. The table has no
+  auth split, so the "anonymous are roughly half of daily users" claim cannot
+  be checked here; the CDN channel (§2) is the only anonymous evidence.
 - The API's trending surface reads `trending_videos_snapshot`
   (`divinevideo/divine-funnelcake/crates/clickhouse/src/client.rs`); a second,
   separate path queries `trending_videos` in the same repo. Both are live code
@@ -449,6 +451,8 @@ WITH
   toUInt64OrZero(arrayFirst(t -> t[1] = 'views', tags)[2])    AS views_tag,
   if(is_vine, loops, loops + views_tag)                       AS public_count
 SELECT count()                       AS catalogue,
+       countIf(is_vine)              AS vine_catalogue,
+       round(countIf(is_vine) / count() * 100, 1) AS vine_catalogue_pct,
        countIf(public_count >= 1000) AS ge_1000,
        countIf(public_count >= 333)  AS ge_333,
        countIf(public_count >= 100)  AS ge_100,

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-baseline.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-baseline.md
@@ -14,16 +14,28 @@ Cloud 26.4.1.2163) on the date above, with the exact SQL in the appendix so
 any figure can be re-derived or extended.
 
 **Reader's key for the client tag.** Mobile view reporters appear in
-`view_interactions.client` as `Divine`. A second stream, `divine-mobile/1.0`,
-carries 1–6 viewers/day and is a legacy or dev build, not the shipping app.
-The #917 detector's "mobile" series is the `Divine` bucket alone — its
-backtest figures (578 on 2026-08-05, 263 on 2026-08-12) match `Divine`
-exactly. **§1's Mobile columns are the union `client IN ('Divine',
-'divine-mobile/1.0')`, so they run 0–6 viewers/day above the detector's
-series** (2026-08-05: 582 union vs 578 `Divine`). Reconcile a #917 alert
-against `Divine` only. Any change to what the shipping app sends as its
-client tag silently re-keys the detector; the redefined playback-start
-event must carry the same tag.
+`view_interactions.client` as `Divine`, emitted by
+`mobile/packages/nostr_client/lib/src/nip89_client_tag.dart:11`. A second
+stream, `divine-mobile/1.0`, carries 1-6 viewers/day and is a legacy or dev
+build, not the shipping app. The divinevideo/divine-funnelcake#917 detector's
+"mobile" series is the `Divine` bucket alone — its backtest figures (578 on
+2026-08-05, 263 on 2026-08-12) match `Divine` exactly. **§1's Mobile columns
+are the union `client IN ('Divine', 'divine-mobile/1.0')`, so they run 0-6
+viewers/day above the detector's series** (2026-08-05: 582 union vs 578
+`Divine`). Reconcile a divinevideo/divine-funnelcake#917 alert against
+`Divine` only.
+
+One caveat is load-bearing: the mobile client tag is user-disablable from
+Nostr settings (`mobile/lib/screens/settings/nostr_settings_screen.dart:241`),
+and `Nip89ClientTag.applyToEvent` returns without adding the tag when disabled
+(`mobile/packages/nostr_client/lib/src/nip89_client_tag.dart:75-82`). Kind
+22236 is not excluded from tagging, so a user who opts out still publishes view
+events, but they land with a null or non-Divine client. That means §1's mobile
+columns and divinevideo/divine-funnelcake#917's detector series are biased low
+by an unmeasured opt-out population; a large opt-out wave can present as a
+mobile reporting collapse. Any change to what the shipping app sends as its
+client tag silently re-keys the detector; the redefined playback-start event
+must keep the same tag when attribution is enabled.
 
 ## 1. The outage, as a series
 
@@ -58,10 +70,13 @@ What to hold onto:
 
 - **Mobile reporters fell 676 → 263 (–61%) over twelve days; events fell
   28.5k → 8.8k (–69%).** Stated on the `Divine` bucket so it matches the
-  two merged specs and the #917 detector; the union column above reads
-  680 → 263 for the same span.
+  two merged specs and the divinevideo/divine-funnelcake#917 detector; the
+  union column above reads 680 → 263 for the same span. Re-run the client
+  breakdown query in the appendix to derive the 676 detector peak; the platform
+  rollup query derives the table.
 - **Web was flat throughout** (36–56 viewers every day, no trend). The
-  regression is mobile-only — the property the #917 detector keys on.
+  regression is mobile-only — the property the divinevideo/divine-funnelcake#917
+  detector keys on.
 - **The #7210 recovery is not yet visible at capture time.** 2026-08-13 is a
   partial day but tracks below 2026-08-12's full day. The client fix
   (#7182, persist the addressable d tag on queued view events) is merged but
@@ -127,10 +142,11 @@ today — that gap is the single largest correction the design makes.
 ## 3. Today's definitional conflation, measured
 
 The server computes, per kind-22236 event
-(`crates/relay/src/view_handler.rs:74-83`):
+(`divinevideo/divine-funnelcake/crates/relay/src/view_handler.rs:62-82`):
 
 ```
-loops      = max(watched_seconds, 1) / video_duration_seconds   (Float)
+duration   = video_duration_seconds, else 6.3s when missing/non-finite/<=0
+loops      = max(watched_seconds, 1) / duration   (Float)
 view_count = ceil(loops) clamped to ≥ 1
 ```
 
@@ -138,7 +154,9 @@ So today's "views" are not playback starts and not sessions — they are
 **loops rounded up**. A 30-second watch of a 6-second video is 5 "views"
 from one session; a 0.75-pass watch is 1. The client-sent `loops` tag is
 never parsed (`ViewEventData`, same file) — every fractional loop in the
-database is server-derived. Aggregate state:
+database is server-derived. Unknown or invalid durations use the 6.3-second
+fallback, so the 0.733 aggregate ratio includes fallback-derived loops rather
+than treating those rows as undefined. Aggregate state:
 
 | Measure | Value |
 |---|---|
@@ -198,12 +216,12 @@ Caveats, stated so the number is not over-read:
 ## 5. The display floor, restated on current numbers
 
 **This section corrects the design doc, which measures the wrong column.**
-`video_card_meta.dart:79` defines the gated quantity as
-`video.isOriginalVine ? video.originalLoops ?? 0 : video.totalLoops` —
-i.e. the archival `loops` tag for classic Vines (98% of the catalogue),
-and `originalLoops + views` for native ones. The design doc's table
-measures `video_total_views_data.total_views`, which the floor is never
-applied to, and lands three orders of magnitude off.
+`mobile/lib/widgets/video_feed_item/video_card_meta.dart:79` defines the gated
+quantity as `video.isOriginalVine ? video.originalLoops ?? 0 :
+video.totalLoops` — i.e. the archival `loops` tag for classic Vines (98% of the
+catalogue), and `originalLoops + views` for native ones. The design doc's table
+measures `video_total_views_data.total_views`, which the floor is never applied
+to, and lands three orders of magnitude off.
 
 `publicLoopCountFloor` = 1000, measured against the quantity the code
 actually gates:
@@ -226,14 +244,15 @@ floor, and why most cards show a date". It needs the same correction.
 **The floor decision survives the correction; only its stated rationale
 changes.** The design doc argued the floor was harmless because almost
 nobody ever sees a count. The real argument is the one on the constant
-itself (`video_card_meta.dart:9`): a number below the floor "tells a
-viewer not to bother", and a wall of small counts on *other people's*
-videos discourages posting. On the real distribution the floor is doing
-that job well — visitors see a count on ~52% of videos, every one of them
-≥1000, and a date on the rest instead of a discouraging 47. Creators are
+itself (`mobile/lib/widgets/video_feed_item/video_card_meta.dart:9`): a number
+below the floor "tells a viewer not to bother", and a wall of small counts on
+*other people's* videos discourages posting. On the real distribution the floor
+is doing that job well — visitors see a count on ~52% of videos, every one of
+them ≥1000, and a date on the rest instead of a discouraging 47. Creators are
 never gated: `_resolveLoopCount` returns `video.totalLoops` unconditionally
 when `isOwnVideo`, and `totalLoops` is additive
-(`originalLoops + views`), so a creator sees the larger number.
+(`mobile/packages/models/lib/src/video_event.dart:1181-1183`), so a creator
+sees the larger number.
 
 One unreconciled discrepancy, stated rather than smoothed over: the
 constant's own doc comment reports "roughly 64% of the archive" hidden
@@ -254,9 +273,9 @@ probably not representative. Re-tuning the floor should use the census.
   split, so the "anonymous are roughly half of daily users" claim cannot be
   checked here; the CDN channel (§2) is the only anonymous evidence.
 - The API's trending surface reads `trending_videos_snapshot`
-  (`crates/clickhouse/src/client.rs:3541`); a second, separate path queries
-  `trending_videos` (`client.rs:7606`). Both are live code at capture time —
-  the duplicate-formula situation the design removes.
+  (`divinevideo/divine-funnelcake/crates/clickhouse/src/client.rs`); a second,
+  separate path queries `trending_videos` in the same repo. Both are live code
+  at capture time — the duplicate-formula situation the design removes.
 
 ## 7. How to use this document
 
@@ -316,6 +335,21 @@ ORDER BY day, platform;
 (The `view_interactions.` qualifier on `loops` is load-bearing: an unqualified
 `sum(loops) AS loops` alias shadows the column and ClickHouse 26 rejects the
 later `ceiling(loops)` as a nested aggregate.)
+
+Client breakdown for reconciling §1's `mobile` union with the
+divinevideo/divine-funnelcake#917 detector's `Divine` bucket:
+
+```sql
+SELECT toDate(created_at,'UTC') AS day,
+       client,
+       count() AS events,
+       uniqExact(viewer_pubkey) AS viewers
+FROM nostr.view_interactions
+WHERE created_at >= toDate('2026-07-24','UTC')
+  AND client IN ('Divine','divine-mobile/1.0','divine-web/1.0')
+GROUP BY day, client
+ORDER BY day, client;
+```
 </details>
 
 <details>
@@ -411,9 +445,9 @@ applied to that column, and doing so is the error this section corrects.
 
 ```sql
 WITH
-  arrayExists(t -> t[1] = 'platform' AND t[2] = 'vine', tags)  AS is_vine,
-  toUInt64OrZero(arrayFirst(t -> t[1] = 'views', tags)[2])     AS views_tag,
-  if(is_vine, loops, loops + views_tag)                        AS public_count
+  arrayExists(t -> t[1] = 'platform' AND t[2] = 'vine', tags) AS is_vine,
+  toUInt64OrZero(arrayFirst(t -> t[1] = 'views', tags)[2])    AS views_tag,
+  if(is_vine, loops, loops + views_tag)                       AS public_count
 SELECT count()                       AS catalogue,
        countIf(public_count >= 1000) AS ge_1000,
        countIf(public_count >= 333)  AS ge_333,

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
@@ -300,10 +300,11 @@ sampled video above 400 against a displayed 108, which is a larger correction
 than this table accounts for, and it counts only viewers who interacted.
 Treat every figure here as the least the number should move, not the most.
 
-### The display floor, and why most cards show a date
+### The display floor under the post-date feature
 
 `publicLoopCountFloor` is 1000. The pre-change baseline corrected this section:
-the floor is applied to
+the floor is applied only when `FeatureFlag.videoCardPostDate` is enabled, and
+then only to
 `mobile/lib/widgets/video_feed_item/video_card_meta.dart`'s public count
 (`loops` for classic Vines, `originalLoops + views` otherwise), not to
 `video_total_views_data.total_views`. Measured against the gated quantity:
@@ -314,10 +315,12 @@ the floor is applied to
 | 333 (floor reached at ×3) | 1,375,711 | 62.42% |
 | 100 (floor reached at ×10) | 1,621,923 | 73.60% |
 
-So the public count renders on about half the catalogue, not on 0.04% of it.
-The floor still matters after the metric correction, but the reason is not that
-the count is effectively never shown; it is that the visible counts are all
-large enough to read as social proof rather than a warning.
+When that feature is enabled, the public count renders on about half the
+catalogue, not on 0.04% of it. Production remains unchanged while the flag is
+off: cards keep showing the raw count and no date. The floor still matters
+after the metric correction, but the reason is not that the count is
+effectively never shown; it is that the visible counts in the feature-gated
+path are all large enough to read as social proof rather than a warning.
 
 **This is intended, and it is not a defect.** Two reasons it holds:
 

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
@@ -27,7 +27,7 @@ not the one the object naming suggests.
 The kind-22236 outage (#7210) exposed this. When mobile view reporting stopped,
 `views`, `unique_viewers` and `loops` all fell ~60–69% in six days, which moved
 Trending, Popular and the creator Leaderboard while Divine had no way to notice.
-Detection is being added separately (divine-funnelcake#917).
+Detection is being added separately (divinevideo/divine-funnelcake#917).
 
 Underneath the outage sits a permanent undercount, and it is measurable
 directly rather than by inference.
@@ -302,17 +302,22 @@ Treat every figure here as the least the number should move, not the most.
 
 ### The display floor, and why most cards show a date
 
-`publicLoopCountFloor` is 1000. Measured against the catalogue:
+`publicLoopCountFloor` is 1000. The pre-change baseline corrected this section:
+the floor is applied to
+`mobile/lib/widgets/video_feed_item/video_card_meta.dart`'s public count
+(`loops` for classic Vines, `originalLoops + views` otherwise), not to
+`video_total_views_data.total_views`. Measured against the gated quantity:
 
-| Threshold | Videos at or above | Share of 2,201,983 |
+| Threshold | Videos at or above | Share of 2,203,822 |
 |---|---|---|
-| 1000 (today's floor) | 961 | **0.04%** |
-| 333 (floor reached at ×3) | 2,441 | 0.11% |
-| 100 (floor reached at ×10) | 12,571 | 0.57% |
+| 1000 (today's floor) | 1,152,593 | **52.30%** |
+| 333 (floor reached at ×3) | 1,375,711 | 62.42% |
+| 100 (floor reached at ×10) | 1,621,923 | 73.60% |
 
-So the public count is effectively never shown — 9,996 videos in 10,000 render
-a date instead. Correcting the metrics does not change that: an
-order-of-magnitude improvement moves it from 0.04% to 0.57%.
+So the public count renders on about half the catalogue, not on 0.04% of it.
+The floor still matters after the metric correction, but the reason is not that
+the count is effectively never shown; it is that the visible counts are all
+large enough to read as social proof rather than a warning.
 
 **This is intended, and it is not a defect.** Two reasons it holds:
 
@@ -326,12 +331,13 @@ order-of-magnitude improvement moves it from 0.04% to 0.57%.
   view count does not. Suppression is not a fallback here; it is often the
   stronger presentation.
 
-Two earlier drafts of this document got this wrong in opposite directions:
-first claiming the correction would lift "a large share of the catalogue" above
-the floor, then claiming the floor was mis-set by two orders of magnitude and
-was starving creators of encouragement. Neither holds. The floor governs public
-display only, the constant is deliberately one line, and re-tuning it is a
-product call to make on its own evidence rather than a consequence of this
+Earlier drafts of this document got the measurement wrong in opposite
+directions: first claiming the correction would lift "a large share of the
+catalogue" above the floor, then claiming the floor was mis-set by two orders of
+magnitude and was starving creators of encouragement. The corrected census says
+the public floor governs a real slice of the catalogue, but it still governs
+public display only, the constant is deliberately one line, and re-tuning it is
+a product call to make on its own evidence rather than a consequence of this
 work.
 
 ## Testing
@@ -348,7 +354,7 @@ work.
   loops must not outrank many distinct viewers.
 - Parity test between the signed and anonymous paths, so the two cannot drift to
   different definitions of the same word.
-- The divine-funnelcake#917 detector already covers per-client reporting
+- The divinevideo/divine-funnelcake#917 detector already covers per-client reporting
   collapse and should stay green through the rollout.
 
 ## Out of scope


### PR DESCRIPTION
Closes #7460

## Summary

Pre-change snapshot of production view/loop reporting, taken before the metric redefinition and the #7210 recovery land so their effects stay attributable. Companion to the design that landed in #7217.

What it records, all measured read-only against production ClickHouse on 2026-08-13 with re-runnable SQL in the appendix:

- **The outage as a series** — mobile reporters 676 → 263 in the `Divine` detector bucket, with the displayed mobile table using the `Divine` / `divine-mobile/1.0` union; web stays flat throughout and recovery is not yet visible at capture time
- **Anonymous coverage** — CDN deliveries swing 21.5k–115k/day on cache noise, not audience; CDN = 42.24% of all views, contributes zero loops today
- **The definitional conflation** — server computes `view_count = ceil(loops)` per event, using a 6.3s duration fallback when needed; aggregate 0.733 loops/view; the client-sent `loops` tag is never parsed
- **Ground truth** — across the 10 most-reacted videos of the last 4 days, 52.5% of provable watchers (liked/commented/reposted) never registered a view; reproduces the design doc's single-video finding as the high end of a real distribution
- **Display floor distribution** — 1,152,593 / 1,375,711 / 1,621,923 videos at the 1000/333/100 thresholds when measured against the feature-gated public count, correcting the design doc's earlier wrong table

Also documents a load-bearing operational fact: the shipping mobile app reports client tag `Divine`, the divinevideo/divine-funnelcake#917 detector keys on it, and user-disabled client attribution creates an unmeasured low bias / possible false collapse signal.

## Test plan

Docs-only. Every figure includes its exact query in the appendix; spot-checked identities hold (total = cdn + auth on 100% of 2.2M rows; detector backtest figures match the `Divine` bucket exactly). `git diff --check` passes.
