### PR TITLE
feat(library): drag a selection across the clips grid with a long press

### DIFF
--- a/mobile/lib/blocs/clips_library/clips_library_bloc.dart
+++ b/mobile/lib/blocs/clips_library/clips_library_bloc.dart
@@ -42,6 +42,9 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
     on<ClipsLibraryLoadRequested>(_onLoadRequested, transformer: droppable());
     on<ClipsLibraryToggleSelection>(_onToggleSelection);
     on<ClipsLibraryClearSelection>(_onClearSelection);
+    on<ClipsLibraryDragSelectionStarted>(_onDragSelectionStarted);
+    on<ClipsLibraryDragSelectionExtended>(_onDragSelectionExtended);
+    on<ClipsLibraryDragSelectionEnded>(_onDragSelectionEnded);
     on<ClipsLibraryDeleteSelected>(_onDeleteSelected, transformer: droppable());
     on<ClipsLibraryDeleteClip>(_onDeleteClip, transformer: droppable());
     on<ClipsLibrarySaveToGallery>(_onSaveToGallery, transformer: droppable());
@@ -268,6 +271,100 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
         selectedClipIds: selectedIds,
         selectedDuration: selectedDuration,
       ),
+    );
+  }
+
+  void _onDragSelectionStarted(
+    ClipsLibraryDragSelectionStarted event,
+    Emitter<ClipsLibraryState> emit,
+  ) {
+    final clip = event.clip;
+    // Disabled clips (already in the editor) cannot be toggled, so they are
+    // no anchor either.
+    if (state.disabledClipIds.contains(clip.id)) return;
+
+    final next = _withDragRange(
+      ClipsLibraryDragSelection(
+        anchorClipId: clip.id,
+        // A press that lands while the selection is out of sight cannot be
+        // toggling it — it is the one that brings the selection up.
+        selecting:
+            !event.selectionEnabled || !state.selectedClipIds.contains(clip.id),
+        baseSelectedClipIds: state.selectedClipIds,
+        targetAspectRatio: event.targetAspectRatio,
+      ),
+      focusClipId: clip.id,
+    );
+
+    emit(
+      event.selectionEnabled
+          ? next
+          : next.copyWith(
+              isLibrarySelectionMode: true,
+              didAutoOpenSelectionMode: false,
+            ),
+    );
+  }
+
+  void _onDragSelectionExtended(
+    ClipsLibraryDragSelectionExtended event,
+    Emitter<ClipsLibraryState> emit,
+  ) {
+    final drag = state.dragSelection;
+    if (drag == null) return;
+    emit(_withDragRange(drag, focusClipId: event.clip.id));
+  }
+
+  void _onDragSelectionEnded(
+    ClipsLibraryDragSelectionEnded event,
+    Emitter<ClipsLibraryState> emit,
+  ) {
+    if (state.dragSelection == null) return;
+    emit(state.copyWith(clearDragSelection: true));
+  }
+
+  /// The state a drag reaching [focusClipId] leaves behind.
+  ///
+  /// Runs the range from the anchor to the clip under the finger over the
+  /// selection the drag started from, so clips the finger has moved back past
+  /// return to whatever they were before it.
+  ClipsLibraryState _withDragRange(
+    ClipsLibraryDragSelection drag, {
+    required String focusClipId,
+  }) {
+    final clips = state.sortedClips;
+    final anchorIndex = clips.indexWhere((c) => c.id == drag.anchorClipId);
+    final focusIndex = clips.indexWhere((c) => c.id == focusClipId);
+    if (anchorIndex < 0 || focusIndex < 0) return state;
+
+    final selectedIds = Set<String>.from(drag.baseSelectedClipIds);
+    // Both constraints tighten as the range grows: with nothing selected yet,
+    // the first clip the drag picks up is what the rest has to match.
+    var isStopMotion = state.stopMotionTypeOf(drag.baseSelectedClipIds);
+    var aspectRatio = drag.targetAspectRatio;
+    final step = focusIndex >= anchorIndex ? 1 : -1;
+
+    for (var i = anchorIndex; ; i += step) {
+      final clip = clips[i];
+      if (!state.disabledClipIds.contains(clip.id)) {
+        if (!drag.selecting) {
+          selectedIds.remove(clip.id);
+        } else if ((isStopMotion == null ||
+                clip.isStopMotion == isStopMotion) &&
+            (aspectRatio == null ||
+                aspectRatio == clip.targetAspectRatio.value)) {
+          selectedIds.add(clip.id);
+          isStopMotion ??= clip.isStopMotion;
+          aspectRatio ??= clip.targetAspectRatio.value;
+        }
+      }
+      if (i == focusIndex) break;
+    }
+
+    return state.copyWith(
+      selectedClipIds: selectedIds,
+      selectedDuration: state.durationOf(selectedIds),
+      dragSelection: drag,
     );
   }
 

--- a/mobile/lib/blocs/clips_library/clips_library_bloc.dart
+++ b/mobile/lib/blocs/clips_library/clips_library_bloc.dart
@@ -832,6 +832,10 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
         selectedClipIds: crossesTrashBoundary ? const {} : null,
         selectedDuration: crossesTrashBoundary ? Duration.zero : null,
         clearOrganizeResult: true,
+        // A drag resolves its range against `sortedClips`. The list the
+        // finger started on is gone, so end the drag rather than run the
+        // anchor's range over positions the user never dragged across.
+        clearDragSelection: true,
       ),
     );
 

--- a/mobile/lib/blocs/clips_library/clips_library_event.dart
+++ b/mobile/lib/blocs/clips_library/clips_library_event.dart
@@ -47,6 +47,55 @@ final class ClipsLibraryClearSelection extends ClipsLibraryEvent {
   const ClipsLibraryClearSelection();
 }
 
+/// Event dispatched when a long press on [clip] opens a drag selection.
+///
+/// The clip is toggled right away, and whether it went into or out of the
+/// selection decides what the rest of the drag does — see
+/// [ClipsLibraryDragSelection.selecting].
+final class ClipsLibraryDragSelectionStarted extends ClipsLibraryEvent {
+  const ClipsLibraryDragSelectionStarted(
+    this.clip, {
+    this.targetAspectRatio,
+    this.selectionEnabled = true,
+  });
+
+  /// The clip under the finger when the long press was recognized.
+  final DivineVideoClip clip;
+
+  /// Aspect ratio the drag is confined to, e.g. the one the editor's timeline
+  /// is already committed to. `null` lets the first picked clip decide it.
+  final double? targetAspectRatio;
+
+  /// Whether the grid was already picking clips when the press landed.
+  ///
+  /// A long press while browsing opens selection mode, and always picks the
+  /// clip up rather than toggling it: the selection it would toggle against
+  /// is one the user cannot see, since clips already in the editor arrive
+  /// pre-selected with their badges hidden.
+  final bool selectionEnabled;
+
+  @override
+  List<Object?> get props => [clip, targetAspectRatio, selectionEnabled];
+}
+
+/// Event dispatched while a drag selection moves, once per clip the finger
+/// reaches. Selects everything between the anchor and [clip] — and only that,
+/// so dragging back over a clip takes it out again.
+final class ClipsLibraryDragSelectionExtended extends ClipsLibraryEvent {
+  const ClipsLibraryDragSelectionExtended(this.clip);
+
+  /// The clip currently under the finger.
+  final DivineVideoClip clip;
+
+  @override
+  List<Object?> get props => [clip];
+}
+
+/// Event dispatched when the finger lifts and the drag selection is over.
+final class ClipsLibraryDragSelectionEnded extends ClipsLibraryEvent {
+  const ClipsLibraryDragSelectionEnded();
+}
+
 /// Event to delete all selected clips.
 final class ClipsLibraryDeleteSelected extends ClipsLibraryEvent {
   const ClipsLibraryDeleteSelected();

--- a/mobile/lib/blocs/clips_library/clips_library_state.dart
+++ b/mobile/lib/blocs/clips_library/clips_library_state.dart
@@ -166,6 +166,44 @@ final class ClipsLibraryOrganizeResult extends Equatable {
   List<Object?> get props => [action, clipIds, categoryName];
 }
 
+/// A long-press-and-drag range selection running on the clips grid.
+///
+/// Held for the length of the gesture so every move can be resolved against
+/// the same starting point: the range always runs from [anchorClipId] to the
+/// clip under the finger, and everything outside it falls back to
+/// [baseSelectedClipIds]. That is what lets the user drag back over a clip to
+/// undo it.
+final class ClipsLibraryDragSelection extends Equatable {
+  const ClipsLibraryDragSelection({
+    required this.anchorClipId,
+    required this.selecting,
+    required this.baseSelectedClipIds,
+    this.targetAspectRatio,
+  });
+
+  /// The clip the drag started on. One end of the range.
+  final String anchorClipId;
+
+  /// Whether the drag selects or deselects. Decided by the anchor: starting
+  /// on an unselected clip selects, starting on a selected one deselects.
+  final bool selecting;
+
+  /// The selection as it stood when the drag started.
+  final Set<String> baseSelectedClipIds;
+
+  /// Aspect ratio every clip the drag picks up has to match, or `null` while
+  /// the selection is still empty and the first clip decides it.
+  final double? targetAspectRatio;
+
+  @override
+  List<Object?> get props => [
+    anchorClipId,
+    selecting,
+    baseSelectedClipIds,
+    targetAspectRatio,
+  ];
+}
+
 /// Operation status for clips library actions.
 enum ClipsLibraryStatus {
   /// Initial state, no operation in progress.
@@ -255,6 +293,7 @@ final class ClipsLibraryState extends Equatable {
     this.categories = const [],
     this.filter = const ClipLibraryAllFilter(),
     this.lastOrganizeResult,
+    this.dragSelection,
   });
 
   /// Current operation status.
@@ -324,6 +363,10 @@ final class ClipsLibraryState extends Equatable {
   /// feedback), or `null` when there is nothing to report.
   final ClipsLibraryOrganizeResult? lastOrganizeResult;
 
+  /// The long-press-and-drag range selection in progress, or `null` when the
+  /// user is not dragging across the grid.
+  final ClipsLibraryDragSelection? dragSelection;
+
   /// The category the [filter] is showing, or `null` for the built-in
   /// filters and for a category that no longer exists.
   ClipCategory? get activeCategory {
@@ -358,12 +401,26 @@ final class ClipsLibraryState extends Equatable {
   /// selected. Drives the no-mixing rule — stop-motion stills and normal
   /// clips cannot coexist in one editor timeline, so once one type is
   /// selected the other becomes non-selectable.
-  bool? get selectedIsStopMotion {
-    if (selectedClipIds.isEmpty) return null;
+  bool? get selectedIsStopMotion => stopMotionTypeOf(selectedClipIds);
+
+  /// Type of the clips [clipIds] names — `true` when they are stop-motion,
+  /// `false` for normal video clips, `null` when the set names none of the
+  /// loaded clips. See [selectedIsStopMotion] for the current selection.
+  bool? stopMotionTypeOf(Set<String> clipIds) {
+    if (clipIds.isEmpty) return null;
     for (final clip in clips) {
-      if (selectedClipIds.contains(clip.id)) return clip.isStopMotion;
+      if (clipIds.contains(clip.id)) return clip.isStopMotion;
     }
     return null;
+  }
+
+  /// Combined duration of the clips [clipIds] names.
+  Duration durationOf(Set<String> clipIds) {
+    var total = Duration.zero;
+    for (final clip in clips) {
+      if (clipIds.contains(clip.id)) total += clip.duration;
+    }
+    return total;
   }
 
   /// Creates a copy of this state with the given fields replaced.
@@ -386,6 +443,8 @@ final class ClipsLibraryState extends Equatable {
     List<ClipCategory>? categories,
     ClipLibraryFilter? filter,
     ClipsLibraryOrganizeResult? lastOrganizeResult,
+    ClipsLibraryDragSelection? dragSelection,
+    bool clearDragSelection = false,
     bool clearOrganizeResult = false,
     bool clearGallerySaveResult = false,
     bool clearDeletedCount = false,
@@ -420,6 +479,9 @@ final class ClipsLibraryState extends Equatable {
       lastOrganizeResult: clearOrganizeResult
           ? null
           : (lastOrganizeResult ?? this.lastOrganizeResult),
+      dragSelection: clearDragSelection
+          ? null
+          : (dragSelection ?? this.dragSelection),
     );
   }
 
@@ -443,5 +505,6 @@ final class ClipsLibraryState extends Equatable {
     categories,
     filter,
     lastOrganizeResult,
+    dragSelection,
   ];
 }

--- a/mobile/lib/widgets/library/clips_tab.dart
+++ b/mobile/lib/widgets/library/clips_tab.dart
@@ -492,9 +492,11 @@ class _MasonryLayout extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Walked rather than indexed: `Set.elementAt` restarts the iterator every
+    // time, and a drag selection is large enough for that to cost frames.
+    var selectionIndex = 0;
     final selectionIndexById = <String, int>{
-      for (var i = 0; i < selectedClipIds.length; i++)
-        selectedClipIds.elementAt(i): i + 1,
+      for (final id in selectedClipIds) id: ++selectionIndex,
     };
     return PinchZoomGrid(
       columnCount: columnCount,

--- a/mobile/lib/widgets/library/clips_tab.dart
+++ b/mobile/lib/widgets/library/clips_tab.dart
@@ -14,6 +14,7 @@ import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/library/clip_category_actions.dart';
 import 'package:openvine/widgets/library/clip_category_chips.dart';
+import 'package:openvine/widgets/library/drag_select_region.dart';
 import 'package:openvine/widgets/library/empty_library_state.dart';
 import 'package:openvine/widgets/library/pinch_zoom_grid.dart';
 import 'package:openvine/widgets/library/trashed_clips_list.dart';
@@ -270,7 +271,7 @@ class _FilterContent extends StatelessWidget {
       columnCount: state.gridColumnCount,
       backgroundColor: backgroundColor,
       selectedClipIds: state.selectedClipIds,
-      showSelectionIndicator: selectionEnabled,
+      selectionEnabled: selectionEnabled,
       disabledClipIds: state.disabledClipIds,
       selectedIsStopMotion: state.selectedIsStopMotion,
       scrollController: scrollController,
@@ -285,7 +286,6 @@ class _FilterContent extends StatelessWidget {
         }
         _showClipPreview(context, clip);
       },
-      onLongPressClip: (clip) => _showClipPreview(context, clip),
     );
   }
 
@@ -460,9 +460,8 @@ class _MasonryLayout extends StatelessWidget {
     required this.columnCount,
     required this.backgroundColor,
     required this.selectedClipIds,
-    required this.showSelectionIndicator,
+    required this.selectionEnabled,
     required this.onTapClip,
-    required this.onLongPressClip,
     this.disabledClipIds = const {},
     this.scrollController,
     this.targetAspectRatio,
@@ -474,11 +473,15 @@ class _MasonryLayout extends StatelessWidget {
   final int columnCount;
   final Color backgroundColor;
   final Set<String> selectedClipIds;
-  final bool showSelectionIndicator;
+
+  /// Whether the grid is picking clips rather than browsing them: tiles carry
+  /// a selection badge, a tap toggles one, and a long press drags a range of
+  /// them out.
+  final bool selectionEnabled;
+
   final Set<String> disabledClipIds;
   final ScrollController? scrollController;
   final ValueChanged<DivineVideoClip> onTapClip;
-  final ValueChanged<DivineVideoClip> onLongPressClip;
   final double? targetAspectRatio;
   final double topPadding;
 
@@ -509,35 +512,57 @@ class _MasonryLayout extends StatelessWidget {
           Directionality.of(context),
         );
       },
-      builder: (context, columns, controller) => MasonryGridView.count(
-        controller: controller,
-        padding: .only(
-          top: topPadding,
-          bottom: MediaQuery.viewPaddingOf(context).bottom,
+      builder: (context, columns, controller) => DragSelectRegion(
+        scrollController: controller,
+        onStarted: (index) => context.read<ClipsLibraryBloc>().add(
+          ClipsLibraryDragSelectionStarted(
+            clips[index],
+            targetAspectRatio: targetAspectRatio,
+            selectionEnabled: selectionEnabled,
+          ),
         ),
-        crossAxisCount: columns,
-        mainAxisSpacing: 4,
-        crossAxisSpacing: 4,
-        cacheExtent: MediaQuery.sizeOf(context).height * 2,
-        itemCount: clips.length,
-        itemBuilder: (context, index) {
-          final clip = clips[index];
-          final selectionIndex = selectionIndexById[clip.id] ?? -1;
-
-          return VideoClipThumbnailCard(
-            clip: clip,
-            selectionIndex: selectionIndex,
-            showSelectionIndicator: showSelectionIndicator,
-            disabled:
+        onExtended: (index) => context.read<ClipsLibraryBloc>().add(
+          ClipsLibraryDragSelectionExtended(clips[index]),
+        ),
+        onEnded: () => context.read<ClipsLibraryBloc>().add(
+          const ClipsLibraryDragSelectionEnded(),
+        ),
+        child: MasonryGridView.count(
+          controller: controller,
+          padding: .only(
+            top: topPadding,
+            bottom: MediaQuery.viewPaddingOf(context).bottom,
+          ),
+          crossAxisCount: columns,
+          mainAxisSpacing: 4,
+          crossAxisSpacing: 4,
+          cacheExtent: MediaQuery.sizeOf(context).height * 2,
+          itemCount: clips.length,
+          itemBuilder: (context, index) {
+            final clip = clips[index];
+            final selectionIndex = selectionIndexById[clip.id] ?? -1;
+            final disabled =
                 disabledClipIds.contains(clip.id) ||
                 (targetAspectRatio != null &&
                     targetAspectRatio != clip.targetAspectRatio.value) ||
                 (selectedIsStopMotion != null &&
-                    clip.isStopMotion != selectedIsStopMotion),
-            onTap: () => onTapClip(clip),
-            onLongPress: () => onLongPressClip(clip),
-          );
-        },
+                    clip.isStopMotion != selectedIsStopMotion);
+
+            return DragSelectSlot(
+              index: index,
+              enabled: !disabled,
+              child: VideoClipThumbnailCard(
+                clip: clip,
+                selectionIndex: selectionIndex,
+                showSelectionIndicator: selectionEnabled,
+                disabled: disabled,
+                onTap: () => onTapClip(clip),
+                // No long press here: it belongs to the drag selection above,
+                // and a handler at this depth would win the arena from it.
+              ),
+            );
+          },
+        ),
       ),
     );
   }

--- a/mobile/lib/widgets/library/drag_select_region.dart
+++ b/mobile/lib/widgets/library/drag_select_region.dart
@@ -79,6 +79,15 @@ class _DragSelectRegionState extends State<DragSelectRegion>
   /// offset: negative moves towards the top of the list.
   double _autoScrollVelocity = 0;
 
+  /// Height the edge band was last measured against, so a region that is
+  /// resized mid-drag can be told apart from a finger that moved.
+  double? _bandHeight;
+
+  /// Which edge's band arrived under the finger rather than the other way
+  /// round — `-1` for the top, `1` for the bottom, `0` when auto-scroll is
+  /// free to run. Held until the finger leaves that band.
+  int _disarmedBand = 0;
+
   Duration? _lastTick;
 
   bool get _isDragging => _focusSlot >= 0;
@@ -100,6 +109,8 @@ class _DragSelectRegionState extends State<DragSelectRegion>
     if (slot == null) return;
     _focusSlot = slot;
     _fingerPosition = details.globalPosition;
+    _bandHeight = _renderBox?.size.height;
+    _disarmedBand = 0;
     unawaited(HapticFeedback.selectionClick());
     widget.onStarted(slot);
   }
@@ -122,6 +133,8 @@ class _DragSelectRegionState extends State<DragSelectRegion>
   void _finishDrag() {
     _stopAutoScroll();
     _fingerPosition = null;
+    _bandHeight = null;
+    _disarmedBand = 0;
     if (!_isDragging) return;
     _focusSlot = -1;
     widget.onEnded();
@@ -180,6 +193,24 @@ class _DragSelectRegionState extends State<DragSelectRegion>
       depth = (dy - edge) / edge;
     } else if (dy > height - edge) {
       depth = (dy - (height - edge)) / edge;
+    }
+
+    // The band sits at the region's own edges, so it moves whenever the
+    // region is resized under the gesture — the create-video bar rising on
+    // the very press that opened the selection, above all. Scrolling is the
+    // finger's to ask for, so a band that comes to it is held off until it
+    // leaves again.
+    final band = depth == 0 ? 0 : depth.sign.toInt();
+    if (height != _bandHeight) {
+      _bandHeight = height;
+      if (band != 0) _disarmedBand = band;
+    }
+    if (_disarmedBand != 0) {
+      if (band == _disarmedBand) {
+        _stopAutoScroll();
+        return;
+      }
+      _disarmedBand = 0;
     }
 
     _autoScrollVelocity = depth.clamp(-1.0, 1.0) * _autoScrollMaxVelocity;

--- a/mobile/lib/widgets/library/drag_select_region.dart
+++ b/mobile/lib/widgets/library/drag_select_region.dart
@@ -1,0 +1,273 @@
+// ABOUTME: Long-press-and-drag range selection across a scrollable grid
+// ABOUTME: Hit-tests the slot under the finger and auto-scrolls at the edges
+
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart' show HapticFeedback;
+import 'package:flutter/widgets.dart';
+
+/// Wraps a scrollable grid and turns a long press followed by a drag into a
+/// range selection, the way a device photo gallery does.
+///
+/// The long press picks out the slot under the finger — the anchor — and every
+/// further move reports the slot the finger has reached. The owner is expected
+/// to select everything between the two, so dragging back shrinks the range
+/// again rather than piling more onto it.
+///
+/// Items opt in by wrapping themselves in a [DragSelectSlot], which is what
+/// this region hit-tests for; anything else under the finger is ignored and
+/// leaves the range where it was. Items must not take the long press for
+/// themselves — a handler of their own sits deeper in the tree and would win
+/// the gesture arena from this one.
+///
+/// While the finger sits near the top or bottom edge the grid scrolls itself,
+/// and the range keeps growing into whatever scrolls into view.
+class DragSelectRegion extends StatefulWidget {
+  const DragSelectRegion({
+    required this.scrollController,
+    required this.onStarted,
+    required this.onExtended,
+    required this.onEnded,
+    required this.child,
+    super.key,
+  });
+
+  /// Controller of the scroll view in [child], used for the edge auto-scroll.
+  final ScrollController scrollController;
+
+  /// Called with the anchor slot when a long press opens a drag selection.
+  final ValueChanged<int> onStarted;
+
+  /// Called with the slot the finger has moved onto, once per slot.
+  final ValueChanged<int> onExtended;
+
+  /// Called when the finger lifts or the gesture is cancelled.
+  final VoidCallback onEnded;
+
+  /// The scroll view this region covers.
+  final Widget child;
+
+  @override
+  State<DragSelectRegion> createState() => _DragSelectRegionState();
+}
+
+class _DragSelectRegionState extends State<DragSelectRegion>
+    with SingleTickerProviderStateMixin {
+  /// How close to an edge the finger has to be for the grid to scroll itself.
+  ///
+  /// Clamped against the viewport further down, so a short grid keeps a
+  /// usable band in the middle where nothing scrolls.
+  static const _autoScrollEdge = 72.0;
+
+  /// Speed of the edge auto-scroll with the finger right at the edge, in
+  /// logical pixels per second. Ramps up from zero across the edge band.
+  static const _autoScrollMaxVelocity = 900.0;
+
+  late final Ticker _autoScrollTicker;
+
+  /// Slot the range currently ends on, or `-1` while no drag is running.
+  int _focusSlot = -1;
+
+  /// Where the finger is, in global coordinates. The auto-scroll re-reads the
+  /// slot under it as the grid moves beneath a finger that is holding still.
+  Offset? _fingerPosition;
+
+  /// Pixels per second the grid is scrolling itself at, signed like a scroll
+  /// offset: negative moves towards the top of the list.
+  double _autoScrollVelocity = 0;
+
+  Duration? _lastTick;
+
+  bool get _isDragging => _focusSlot >= 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _autoScrollTicker = createTicker(_onAutoScrollTick);
+  }
+
+  @override
+  void dispose() {
+    _autoScrollTicker.dispose();
+    super.dispose();
+  }
+
+  void _onLongPressStart(LongPressStartDetails details) {
+    final slot = _slotAt(details.globalPosition);
+    if (slot == null) return;
+    _focusSlot = slot;
+    _fingerPosition = details.globalPosition;
+    unawaited(HapticFeedback.selectionClick());
+    widget.onStarted(slot);
+  }
+
+  void _onLongPressMoveUpdate(LongPressMoveUpdateDetails details) {
+    if (!_isDragging) return;
+    _fingerPosition = details.globalPosition;
+    _updateAutoScroll(details.globalPosition);
+    _extendTo(details.globalPosition);
+  }
+
+  void _onLongPressEnd(LongPressEndDetails details) => _finishDrag();
+
+  /// Also fires for a press that was released before it became a long press,
+  /// which is why this is a no-op unless a drag actually opened.
+  void _onLongPressCancel() {
+    if (_isDragging) _finishDrag();
+  }
+
+  void _finishDrag() {
+    _stopAutoScroll();
+    _fingerPosition = null;
+    if (!_isDragging) return;
+    _focusSlot = -1;
+    widget.onEnded();
+  }
+
+  /// Reports the slot under [globalPosition], if the finger has moved onto a
+  /// different one. Positions between slots, over an item that cannot be
+  /// selected, or outside the grid leave the range where it is.
+  void _extendTo(Offset globalPosition) {
+    final slot = _slotAt(globalPosition);
+    if (slot == null || slot == _focusSlot) return;
+    _focusSlot = slot;
+    unawaited(HapticFeedback.selectionClick());
+    widget.onExtended(slot);
+  }
+
+  int? _slotAt(Offset globalPosition) {
+    final box = _renderBox;
+    if (box == null || box.size.isEmpty) return null;
+    // A finger that has wandered off the grid — past the bottom edge and onto
+    // whatever sits below it, most of all — is still dragging the range along
+    // the nearest column, so the search runs from the closest point inside.
+    final local = box.globalToLocal(globalPosition);
+    final inside = Offset(
+      local.dx.clamp(0.0, box.size.width - 1),
+      local.dy.clamp(0.0, box.size.height - 1),
+    );
+    final result = BoxHitTestResult();
+    if (!box.hitTest(result, position: inside)) return null;
+    for (final entry in result.path) {
+      final target = entry.target;
+      if (target is! RenderMetaData) continue;
+      final slot = target.metaData;
+      if (slot is _DragSelectSlotData) return slot.enabled ? slot.index : null;
+    }
+    return null;
+  }
+
+  RenderBox? get _renderBox {
+    final box = context.findRenderObject();
+    return box is RenderBox && box.hasSize ? box : null;
+  }
+
+  void _updateAutoScroll(Offset globalPosition) {
+    final box = _renderBox;
+    if (box == null) {
+      _stopAutoScroll();
+      return;
+    }
+
+    final height = box.size.height;
+    final edge = math.min(_autoScrollEdge, height / 4);
+    final dy = box.globalToLocal(globalPosition).dy;
+    var depth = 0.0;
+    if (dy < edge) {
+      depth = (dy - edge) / edge;
+    } else if (dy > height - edge) {
+      depth = (dy - (height - edge)) / edge;
+    }
+
+    _autoScrollVelocity = depth.clamp(-1.0, 1.0) * _autoScrollMaxVelocity;
+    if (_autoScrollVelocity == 0) {
+      _stopAutoScroll();
+    } else if (!_autoScrollTicker.isActive) {
+      _lastTick = null;
+      _autoScrollTicker.start();
+    }
+  }
+
+  void _stopAutoScroll() {
+    if (!_autoScrollTicker.isActive) return;
+    _autoScrollTicker.stop();
+    _autoScrollVelocity = 0;
+  }
+
+  void _onAutoScrollTick(Duration elapsed) {
+    // Last tick's scroll has been laid out by now, so this is the first
+    // moment the grid can report a new slot under a finger holding still.
+    final finger = _fingerPosition;
+    if (finger != null) _extendTo(finger);
+
+    final last = _lastTick;
+    _lastTick = elapsed;
+    if (last == null) return;
+    final seconds =
+        (elapsed - last).inMicroseconds / Duration.microsecondsPerSecond;
+    if (seconds <= 0) return;
+
+    final controller = widget.scrollController;
+    if (!controller.hasClients) return;
+    final position = controller.position;
+    final target = (position.pixels + _autoScrollVelocity * seconds).clamp(
+      position.minScrollExtent,
+      position.maxScrollExtent,
+    );
+    if (target == position.pixels) return;
+    position.jumpTo(target);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      excludeFromSemantics: true,
+      onLongPressStart: _onLongPressStart,
+      onLongPressMoveUpdate: _onLongPressMoveUpdate,
+      onLongPressEnd: _onLongPressEnd,
+      onLongPressCancel: _onLongPressCancel,
+      child: widget.child,
+    );
+  }
+}
+
+/// Marks [child] as the item at [index] for an enclosing [DragSelectRegion].
+class DragSelectSlot extends StatelessWidget {
+  const DragSelectSlot({
+    required this.index,
+    required this.child,
+    this.enabled = true,
+    super.key,
+  });
+
+  /// Position of this item in the list the region reports slots from.
+  final int index;
+
+  /// Whether a drag may start on or run onto this item. A disabled slot reads
+  /// as a gap: the range simply stays where it was.
+  final bool enabled;
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return MetaData(
+      metaData: _DragSelectSlotData(index: index, enabled: enabled),
+      // Opaque so the whole tile answers for the slot, whatever part of its
+      // content the finger happens to be over.
+      behavior: HitTestBehavior.opaque,
+      child: child,
+    );
+  }
+}
+
+@immutable
+class _DragSelectSlotData {
+  const _DragSelectSlotData({required this.index, required this.enabled});
+
+  final int index;
+  final bool enabled;
+}

--- a/mobile/lib/widgets/video_clip/video_clip_thumbnail_card.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_thumbnail_card.dart
@@ -17,7 +17,6 @@ class VideoClipThumbnailCard extends StatefulWidget {
   const VideoClipThumbnailCard({
     required this.clip,
     this.onTap,
-    this.onLongPress,
     this.selectionIndex = -1,
     this.showSelectionIndicator = true,
     this.disabled = false,
@@ -41,10 +40,6 @@ class VideoClipThumbnailCard extends StatefulWidget {
   /// is non-interactive (e.g. in the trash bin view where restore /
   /// delete-now actions live outside the thumbnail).
   final VoidCallback? onTap;
-
-  /// Callback invoked when the card is long-pressed. When `null`, no
-  /// long-press handler is registered.
-  final VoidCallback? onLongPress;
 
   /// Whether to show the duration badge at the bottom-left corner.
   final bool showDurationBadge;
@@ -105,7 +100,6 @@ class _VideoClipThumbnailCardState extends State<VideoClipThumbnailCard> {
       selected: _isSelected,
       enabled: !widget.disabled,
       onTap: widget.disabled ? null : widget.onTap,
-      onLongPress: widget.disabled ? null : widget.onLongPress,
       hint: widget.disabled
           ? l10n.videoClipSemanticHintDisabled
           : _isSelected
@@ -117,7 +111,6 @@ class _VideoClipThumbnailCardState extends State<VideoClipThumbnailCard> {
         child: GestureDetector(
           excludeFromSemantics: true,
           onTap: widget.disabled ? null : widget.onTap,
-          onLongPress: widget.disabled ? null : widget.onLongPress,
           child: ClipRRect(
             borderRadius: .circular(4),
             child: AspectRatio(

--- a/mobile/test/blocs/clips_library/clips_library_bloc_test.dart
+++ b/mobile/test/blocs/clips_library/clips_library_bloc_test.dart
@@ -478,6 +478,7 @@ void main() {
         String id, {
         Duration duration = const Duration(seconds: 1),
         model.AspectRatio aspectRatio = .vertical,
+        String? categoryId,
       }) => DivineVideoClip(
         id: id,
         video: EditorVideo.file('/path/to/$id.mp4'),
@@ -486,6 +487,7 @@ void main() {
         recordedAt: DateTime(2026),
         targetAspectRatio: aspectRatio,
         originalAspectRatio: 9 / 16,
+        categoryId: categoryId,
       );
 
       final a = gridClip('a', duration: const Duration(seconds: 5));
@@ -733,6 +735,35 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(ClipsLibraryDragSelectionStarted(a)),
         expect: () => <ClipsLibraryState>[],
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'forgets the drag when the filter swaps the list under it',
+        seed: () => seedWith([a, b, gridClip('e', categoryId: 'cat')]),
+        build: createBloc,
+        // The chip row sits outside the drag region, so a second finger can
+        // change the filter mid-drag. Without this the range would be walked
+        // over the new list, covering clips the finger never crossed.
+        act: (bloc) => bloc
+          ..add(ClipsLibraryDragSelectionStarted(a))
+          ..add(
+            const ClipsLibraryFilterChanged(ClipLibraryCategoryFilter('cat')),
+          )
+          ..add(ClipsLibraryDragSelectionExtended(gridClip('e'))),
+        expect: () => [
+          isA<ClipsLibraryState>().having(
+            (s) => s.dragSelection,
+            'dragSelection',
+            isNotNull,
+          ),
+          isA<ClipsLibraryState>()
+              .having((s) => s.dragSelection, 'dragSelection', isNull)
+              .having(
+                (s) => s.selectedClipIds.toList(),
+                'selectedClipIds',
+                equals(['a']),
+              ),
+        ],
       );
 
       blocTest<ClipsLibraryBloc, ClipsLibraryState>(

--- a/mobile/test/blocs/clips_library/clips_library_bloc_test.dart
+++ b/mobile/test/blocs/clips_library/clips_library_bloc_test.dart
@@ -8,6 +8,7 @@ import 'package:bloc/bloc.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' as model show AspectRatio;
 import 'package:openvine/blocs/clips_library/clips_library_bloc.dart';
 import 'package:openvine/models/clip_category.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -468,6 +469,292 @@ void main() {
             'selectedClipIds',
             equals({'sm1', 'sm2'}),
           ),
+        ],
+      );
+    });
+
+    group('drag selection', () {
+      DivineVideoClip gridClip(
+        String id, {
+        Duration duration = const Duration(seconds: 1),
+        model.AspectRatio aspectRatio = .vertical,
+      }) => DivineVideoClip(
+        id: id,
+        video: EditorVideo.file('/path/to/$id.mp4'),
+        thumbnailPath: '/path/to/$id.jpg',
+        duration: duration,
+        recordedAt: DateTime(2026),
+        targetAspectRatio: aspectRatio,
+        originalAspectRatio: 9 / 16,
+      );
+
+      final a = gridClip('a', duration: const Duration(seconds: 5));
+      final b = gridClip('b', duration: const Duration(seconds: 3));
+      final c = gridClip('c', duration: const Duration(seconds: 2));
+      final d = gridClip('d', duration: const Duration(seconds: 4));
+
+      ClipsLibraryState seedWith(
+        List<DivineVideoClip> clips, {
+        Set<String> selectedClipIds = const {},
+        Set<String> disabledClipIds = const {},
+      }) => ClipsLibraryState(
+        status: ClipsLibraryStatus.loaded,
+        clips: clips,
+        sortedClips: clips,
+        selectedClipIds: selectedClipIds,
+        disabledClipIds: disabledClipIds,
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'selects every clip between the anchor and the one under the finger',
+        seed: () => seedWith([a, b, c, d]),
+        build: createBloc,
+        act: (bloc) => bloc
+          ..add(ClipsLibraryDragSelectionStarted(a))
+          ..add(ClipsLibraryDragSelectionExtended(c)),
+        expect: () => [
+          isA<ClipsLibraryState>().having(
+            (s) => s.selectedClipIds.toList(),
+            'selectedClipIds',
+            equals(['a']),
+          ),
+          isA<ClipsLibraryState>()
+              .having(
+                (s) => s.selectedClipIds.toList(),
+                'selectedClipIds',
+                equals(['a', 'b', 'c']),
+              )
+              .having(
+                (s) => s.selectedDuration,
+                'selectedDuration',
+                equals(const Duration(seconds: 10)),
+              ),
+        ],
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'numbers the range from the anchor outwards when dragging back up',
+        seed: () => seedWith([a, b, c, d]),
+        build: createBloc,
+        act: (bloc) => bloc
+          ..add(ClipsLibraryDragSelectionStarted(d))
+          ..add(ClipsLibraryDragSelectionExtended(b)),
+        expect: () => [
+          isA<ClipsLibraryState>(),
+          isA<ClipsLibraryState>().having(
+            (s) => s.selectedClipIds.toList(),
+            'selectedClipIds',
+            equals(['d', 'c', 'b']),
+          ),
+        ],
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'drops the clips the finger has moved back past',
+        seed: () => seedWith([a, b, c, d]),
+        build: createBloc,
+        act: (bloc) => bloc
+          ..add(ClipsLibraryDragSelectionStarted(a))
+          ..add(ClipsLibraryDragSelectionExtended(d))
+          ..add(ClipsLibraryDragSelectionExtended(b)),
+        expect: () => [
+          isA<ClipsLibraryState>(),
+          isA<ClipsLibraryState>().having(
+            (s) => s.selectedClipIds.toList(),
+            'selectedClipIds',
+            equals(['a', 'b', 'c', 'd']),
+          ),
+          isA<ClipsLibraryState>()
+              .having(
+                (s) => s.selectedClipIds.toList(),
+                'selectedClipIds',
+                equals(['a', 'b']),
+              )
+              .having(
+                (s) => s.selectedDuration,
+                'selectedDuration',
+                equals(const Duration(seconds: 8)),
+              ),
+        ],
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'keeps what was selected before the drag',
+        seed: () => seedWith([a, b, c, d], selectedClipIds: const {'d'}),
+        build: createBloc,
+        act: (bloc) => bloc
+          ..add(ClipsLibraryDragSelectionStarted(a))
+          ..add(ClipsLibraryDragSelectionExtended(b)),
+        expect: () => [
+          isA<ClipsLibraryState>(),
+          isA<ClipsLibraryState>().having(
+            (s) => s.selectedClipIds.toList(),
+            'selectedClipIds',
+            equals(['d', 'a', 'b']),
+          ),
+        ],
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'deselects the range when the drag starts on a selected clip',
+        seed: () =>
+            seedWith([a, b, c, d], selectedClipIds: const {'a', 'b', 'c'}),
+        build: createBloc,
+        act: (bloc) => bloc
+          ..add(ClipsLibraryDragSelectionStarted(a))
+          ..add(ClipsLibraryDragSelectionExtended(b)),
+        expect: () => [
+          isA<ClipsLibraryState>().having(
+            (s) => s.selectedClipIds.toList(),
+            'selectedClipIds',
+            equals(['b', 'c']),
+          ),
+          isA<ClipsLibraryState>()
+              .having(
+                (s) => s.selectedClipIds.toList(),
+                'selectedClipIds',
+                equals(['c']),
+              )
+              .having(
+                (s) => s.selectedDuration,
+                'selectedDuration',
+                equals(const Duration(seconds: 2)),
+              ),
+        ],
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'passes over clips that would mix stop-motion into the selection',
+        seed: () => seedWith([a, createStopMotionClip(id: 'sm1'), c]),
+        build: createBloc,
+        act: (bloc) => bloc
+          ..add(ClipsLibraryDragSelectionStarted(a))
+          ..add(ClipsLibraryDragSelectionExtended(c)),
+        expect: () => [
+          isA<ClipsLibraryState>(),
+          isA<ClipsLibraryState>().having(
+            (s) => s.selectedClipIds.toList(),
+            'selectedClipIds',
+            equals(['a', 'c']),
+          ),
+        ],
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'passes over clips of another aspect ratio than the editor holds',
+        seed: () => seedWith([a, gridClip('sq', aspectRatio: .square), c]),
+        build: createBloc,
+        act: (bloc) => bloc
+          ..add(
+            // The editor's timeline is vertical, so the square clip in the
+            // middle of the range cannot join it.
+            ClipsLibraryDragSelectionStarted(a, targetAspectRatio: 9 / 16),
+          )
+          ..add(ClipsLibraryDragSelectionExtended(c)),
+        expect: () => [
+          isA<ClipsLibraryState>(),
+          isA<ClipsLibraryState>().having(
+            (s) => s.selectedClipIds.toList(),
+            'selectedClipIds',
+            equals(['a', 'c']),
+          ),
+        ],
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'leaves clips already in the editor alone',
+        seed: () => seedWith(
+          [a, b, c],
+          selectedClipIds: const {'b'},
+          disabledClipIds: const {'b'},
+        ),
+        build: createBloc,
+        act: (bloc) => bloc
+          ..add(ClipsLibraryDragSelectionStarted(a))
+          ..add(ClipsLibraryDragSelectionExtended(c)),
+        expect: () => [
+          isA<ClipsLibraryState>(),
+          isA<ClipsLibraryState>().having(
+            (s) => s.selectedClipIds.toList(),
+            'selectedClipIds',
+            equals(['b', 'a', 'c']),
+          ),
+        ],
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'opens selection mode when the press lands while browsing',
+        seed: () => seedWith([a, b]),
+        build: createBloc,
+        act: (bloc) => bloc.add(
+          ClipsLibraryDragSelectionStarted(a, selectionEnabled: false),
+        ),
+        expect: () => [
+          isA<ClipsLibraryState>()
+              .having(
+                (s) => s.isLibrarySelectionMode,
+                'isLibrarySelectionMode',
+                isTrue,
+              )
+              .having(
+                (s) => s.selectedClipIds.toList(),
+                'selectedClipIds',
+                equals(['a']),
+              ),
+        ],
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'picks up a clip the editor pre-selected out of sight',
+        // Opening the library from the editor pre-selects its clips with the
+        // badges hidden, so this press has nothing visible to toggle off.
+        seed: () => seedWith([a, b], selectedClipIds: const {'a'}),
+        build: createBloc,
+        act: (bloc) => bloc
+          ..add(ClipsLibraryDragSelectionStarted(a, selectionEnabled: false))
+          ..add(ClipsLibraryDragSelectionExtended(b)),
+        expect: () => [
+          isA<ClipsLibraryState>().having(
+            (s) => s.selectedClipIds.toList(),
+            'selectedClipIds',
+            equals(['a']),
+          ),
+          isA<ClipsLibraryState>().having(
+            (s) => s.selectedClipIds.toList(),
+            'selectedClipIds',
+            equals(['a', 'b']),
+          ),
+        ],
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'starts no drag on a clip already in the editor',
+        seed: () => seedWith([a, b], disabledClipIds: const {'a'}),
+        build: createBloc,
+        act: (bloc) => bloc.add(ClipsLibraryDragSelectionStarted(a)),
+        expect: () => <ClipsLibraryState>[],
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'forgets the drag once the finger lifts',
+        seed: () => seedWith([a, b]),
+        build: createBloc,
+        act: (bloc) => bloc
+          ..add(ClipsLibraryDragSelectionStarted(a))
+          ..add(const ClipsLibraryDragSelectionEnded()),
+        expect: () => [
+          isA<ClipsLibraryState>().having(
+            (s) => s.dragSelection,
+            'dragSelection',
+            isNotNull,
+          ),
+          isA<ClipsLibraryState>()
+              .having((s) => s.dragSelection, 'dragSelection', isNull)
+              .having(
+                (s) => s.selectedClipIds.toList(),
+                'selectedClipIds',
+                equals(['a']),
+              ),
         ],
       );
     });

--- a/mobile/test/blocs/clips_library/clips_library_state_test.dart
+++ b/mobile/test/blocs/clips_library/clips_library_state_test.dart
@@ -232,6 +232,7 @@ void main() {
         const <ClipCategory>[],
         const ClipLibraryAllFilter(),
         null,
+        null,
       ]);
     });
   });

--- a/mobile/test/widgets/library/clips_tab_test.dart
+++ b/mobile/test/widgets/library/clips_tab_test.dart
@@ -4,6 +4,7 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:divine_video_player/divine_video_player.dart';
+import 'package:flutter/gestures.dart' show kLongPressTimeout;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -613,8 +614,174 @@ void main() {
         ).called(1);
       });
 
+      testWidgets('long-pressing a clip opens a drag selection', (
+        tester,
+      ) async {
+        when(() => mockBloc.state).thenReturn(
+          ClipsLibraryState(
+            status: ClipsLibraryStatus.loaded,
+            clips: [clip1, clip2],
+            sortedClips: [clip1, clip2],
+          ),
+        );
+
+        await tester.pumpWidget(buildWidget());
+
+        final gesture = await tester.startGesture(
+          tester.getCenter(find.byType(VideoClipThumbnailCard).first),
+        );
+        await tester.pump(kLongPressTimeout + const Duration(milliseconds: 10));
+
+        verify(
+          () => mockBloc.add(ClipsLibraryDragSelectionStarted(clip1)),
+        ).called(1);
+
+        await gesture.up();
+        await tester.pump();
+
+        verify(
+          () => mockBloc.add(const ClipsLibraryDragSelectionEnded()),
+        ).called(1);
+      });
+
+      testWidgets('dragging on from the long press reaches the next clip', (
+        tester,
+      ) async {
+        when(() => mockBloc.state).thenReturn(
+          ClipsLibraryState(
+            status: ClipsLibraryStatus.loaded,
+            clips: [clip1, clip2],
+            sortedClips: [clip1, clip2],
+          ),
+        );
+
+        await tester.pumpWidget(buildWidget());
+
+        final cards = find.byType(VideoClipThumbnailCard);
+        final gesture = await tester.startGesture(
+          tester.getCenter(cards.first),
+        );
+        await tester.pump(kLongPressTimeout + const Duration(milliseconds: 10));
+        await gesture.moveTo(tester.getCenter(cards.at(1)));
+        await tester.pump();
+
+        // The whole range is the bloc's to work out; the grid only reports
+        // which clip the finger has reached.
+        verify(
+          () => mockBloc.add(ClipsLibraryDragSelectionExtended(clip2)),
+        ).called(1);
+
+        await gesture.up();
+        await tester.pump();
+      });
+
+      testWidgets('holding the finger at the bottom scrolls on into the grid', (
+        tester,
+      ) async {
+        // Four rows of three, so most of the grid starts off screen and the
+        // range can only reach it by way of the edge auto-scroll.
+        final clips = [
+          for (var i = 0; i < 12; i++)
+            DivineVideoClip(
+              id: 'clip$i',
+              video: EditorVideo.file('/path/to/clip$i.mp4'),
+              duration: const Duration(seconds: 1),
+              recordedAt: DateTime(2026),
+              targetAspectRatio: .vertical,
+              originalAspectRatio: 9 / 16,
+            ),
+        ];
+        when(() => mockBloc.state).thenReturn(
+          ClipsLibraryState(
+            status: ClipsLibraryStatus.loaded,
+            clips: clips,
+            sortedClips: clips,
+          ),
+        );
+
+        await tester.pumpWidget(buildWidget());
+
+        final grid = tester.getRect(find.byType(MasonryGridView));
+        final gesture = await tester.startGesture(
+          tester.getCenter(find.byType(VideoClipThumbnailCard).at(1)),
+        );
+        await tester.pump(kLongPressTimeout + const Duration(milliseconds: 10));
+        await gesture.moveTo(Offset(grid.center.dx, grid.bottom - 8));
+        await tester.pump();
+
+        // Long enough for the auto-scroll to run out of grid, which parks the
+        // finger over the last clip in the middle column.
+        for (var i = 0; i < 20; i++) {
+          await tester.pump(const Duration(milliseconds: 100));
+        }
+
+        verify(
+          () => mockBloc.add(ClipsLibraryDragSelectionExtended(clips[10])),
+        ).called(1);
+
+        await gesture.up();
+        await tester.pump();
+      });
+
+      testWidgets('a clip that cannot join the selection starts no drag', (
+        tester,
+      ) async {
+        when(() => mockBloc.state).thenReturn(
+          ClipsLibraryState(
+            status: ClipsLibraryStatus.loaded,
+            clips: [clip1],
+            sortedClips: [clip1],
+          ),
+        );
+
+        // The editor's timeline is square, so the vertical clip is disabled.
+        await tester.pumpWidget(buildWidget(targetAspectRatio: 1));
+
+        final gesture = await tester.startGesture(
+          tester.getCenter(find.byType(VideoClipThumbnailCard).first),
+        );
+        await tester.pump(kLongPressTimeout + const Duration(milliseconds: 10));
+        await gesture.up();
+        await tester.pump();
+
+        verifyNever(
+          () => mockBloc.add(
+            ClipsLibraryDragSelectionStarted(clip1, targetAspectRatio: 1),
+          ),
+        );
+      });
+
+      testWidgets('long-pressing while browsing starts a selection too', (
+        tester,
+      ) async {
+        when(() => mockBloc.state).thenReturn(
+          ClipsLibraryState(
+            status: ClipsLibraryStatus.loaded,
+            clips: [clip1, clip2],
+            sortedClips: [clip1, clip2],
+          ),
+        );
+
+        await tester.pumpWidget(buildWidget(selectionEnabled: false));
+
+        final gesture = await tester.startGesture(
+          tester.getCenter(find.byType(VideoClipThumbnailCard).first),
+        );
+        await tester.pump(kLongPressTimeout + const Duration(milliseconds: 10));
+        await gesture.up();
+        await tester.pump();
+
+        // Browsing has no selection on screen to toggle against, which the
+        // bloc needs to know — it is the press that opens selection mode.
+        verify(
+          () => mockBloc.add(
+            ClipsLibraryDragSelectionStarted(clip1, selectionEnabled: false),
+          ),
+        ).called(1);
+      });
+
       testWidgets(
-        'long-press → trash closes preview and soft-deletes the clip',
+        'tap → trash closes preview and soft-deletes the clip',
         (tester) async {
           DivineVideoPlayerController.resetIdCounterForTesting();
           final messenger =
@@ -660,16 +827,16 @@ void main() {
             ProviderScope(
               child: MockGoRouterProvider(
                 goRouter: mockGoRouter,
-                child: buildWidget(),
+                child: buildWidget(selectionEnabled: false),
               ),
             ),
           );
 
-          // Long-press opens the VideoClipPreview overlay; tapping
-          // (default selectionEnabled=true) would only toggle selection.
-          // pumpAndSettle never settles here because the preview shows a
-          // CircularProgressIndicator while the player initializes.
-          await tester.longPress(find.byType(VideoClipThumbnailCard).first);
+          // Browsing, so a tap opens the VideoClipPreview overlay; the long
+          // press belongs to the drag selection. pumpAndSettle never settles
+          // here because the preview shows a CircularProgressIndicator while
+          // the player initializes.
+          await tester.tap(find.byType(VideoClipThumbnailCard).first);
           await tester.pump();
           await tester.pump(const Duration(milliseconds: 300));
 

--- a/mobile/test/widgets/library/drag_select_region_test.dart
+++ b/mobile/test/widgets/library/drag_select_region_test.dart
@@ -1,0 +1,174 @@
+// ABOUTME: Tests for the long-press-and-drag range selection region
+// ABOUTME: Covers slot reporting and the edge auto-scroll
+
+import 'package:flutter/gestures.dart' show kLongPressTimeout;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/widgets/library/drag_select_region.dart';
+
+void main() {
+  group(DragSelectRegion, () {
+    const rowHeight = 100.0;
+    const slotCount = 20;
+
+    late ScrollController controller;
+    late List<int> started;
+    late List<int> extended;
+    late int endedCount;
+
+    setUp(() {
+      controller = ScrollController();
+      started = [];
+      extended = [];
+      endedCount = 0;
+    });
+
+    tearDown(() => controller.dispose());
+
+    /// A grid of [slotCount] full-width rows inside a box of [height], with
+    /// [footerHeight] taken off the bottom the way the create-video bar does.
+    Widget buildWidget({double height = 600, double footerHeight = 0}) {
+      return MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: [
+              SizedBox(
+                height: height - footerHeight,
+                child: DragSelectRegion(
+                  scrollController: controller,
+                  onStarted: started.add,
+                  onExtended: extended.add,
+                  onEnded: () => endedCount++,
+                  child: ListView.builder(
+                    controller: controller,
+                    itemCount: slotCount,
+                    itemBuilder: (context, index) => DragSelectSlot(
+                      index: index,
+                      child: SizedBox(
+                        height: rowHeight,
+                        child: Text('slot $index'),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              SizedBox(height: footerHeight),
+            ],
+          ),
+        ),
+      );
+    }
+
+    testWidgets('reports the slot the long press lands on', (tester) async {
+      await tester.pumpWidget(buildWidget());
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.text('slot 1')),
+      );
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 10));
+
+      expect(started, equals([1]));
+
+      await gesture.up();
+      await tester.pump();
+      expect(endedCount, equals(1));
+    });
+
+    testWidgets('reports each further slot the finger reaches', (tester) async {
+      await tester.pumpWidget(buildWidget());
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.text('slot 0')),
+      );
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 10));
+      await gesture.moveTo(tester.getCenter(find.text('slot 2')));
+      await tester.pump();
+
+      expect(extended, equals([2]));
+
+      await gesture.up();
+      await tester.pump();
+    });
+
+    testWidgets('scrolls the grid on while the finger sits at the edge', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildWidget());
+
+      final region = tester.getRect(find.byType(DragSelectRegion));
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.text('slot 0')),
+      );
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 10));
+      await gesture.moveTo(Offset(region.center.dx, region.bottom - 4));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(controller.offset, greaterThan(0));
+
+      await gesture.up();
+      await tester.pump();
+    });
+
+    testWidgets(
+      'a footer appearing under the finger does not scroll the grid',
+      (tester) async {
+        // The press that opens the selection is also what raises the
+        // create-video bar, which takes its height off the bottom of the
+        // grid. A finger the user put well clear of the edge must not end up
+        // scrolling just because the edge moved up to meet it.
+        const footerHeight = 80.0;
+        await tester.pumpWidget(buildWidget());
+
+        final region = tester.getRect(find.byType(DragSelectRegion));
+        final gesture = await tester.startGesture(
+          Offset(region.center.dx, region.bottom - 100),
+        );
+        await tester.pump(kLongPressTimeout + const Duration(milliseconds: 10));
+
+        await tester.pumpWidget(buildWidget(footerHeight: footerHeight));
+
+        // The same 2pt of travel the finger makes just holding still.
+        await gesture.moveTo(Offset(region.center.dx, region.bottom - 102));
+        await tester.pump();
+        for (var i = 0; i < 8; i++) {
+          await tester.pump(const Duration(milliseconds: 20));
+        }
+
+        expect(controller.offset, equals(0));
+
+        await gesture.up();
+        await tester.pump();
+      },
+    );
+
+    testWidgets('the edge still scrolls once the finger leaves and returns', (
+      tester,
+    ) async {
+      const footerHeight = 80.0;
+      await tester.pumpWidget(buildWidget());
+
+      final region = tester.getRect(find.byType(DragSelectRegion));
+      final gesture = await tester.startGesture(
+        Offset(region.center.dx, region.bottom - 100),
+      );
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 10));
+      await tester.pumpWidget(buildWidget(footerHeight: footerHeight));
+
+      // Out of the band the footer pushed onto the finger...
+      await gesture.moveTo(Offset(region.center.dx, region.center.dy));
+      await tester.pump();
+      // ...and deliberately back down onto the new edge.
+      await gesture.moveTo(
+        Offset(region.center.dx, region.bottom - footerHeight - 4),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(controller.offset, greaterThan(0));
+
+      await gesture.up();
+      await tester.pump();
+    });
+  });
+}

--- a/mobile/test/widgets/video_clip/video_clip_thumbnail_card_test.dart
+++ b/mobile/test/widgets/video_clip/video_clip_thumbnail_card_test.dart
@@ -46,7 +46,6 @@ void main() {
       int selectionIndex = -1,
       bool disabled = false,
       VoidCallback? onTap,
-      VoidCallback? onLongPress,
     }) {
       return MaterialApp(
         theme: VineTheme.theme,
@@ -58,7 +57,6 @@ void main() {
             selectionIndex: selectionIndex,
             disabled: disabled,
             onTap: onTap ?? () {},
-            onLongPress: onLongPress ?? () {},
           ),
         ),
       );
@@ -174,16 +172,6 @@ void main() {
         expect(tapped, isTrue);
       });
 
-      testWidgets('calls onLongPress when long-pressed', (tester) async {
-        var longPressed = false;
-        await tester.pumpWidget(
-          buildWidget(onLongPress: () => longPressed = true),
-        );
-
-        await tester.longPress(find.byType(VideoClipThumbnailCard));
-        expect(longPressed, isTrue);
-      });
-
       testWidgets('does not call onTap when disabled', (tester) async {
         var tapped = false;
         await tester.pumpWidget(
@@ -192,16 +180,6 @@ void main() {
 
         await tester.tap(find.byType(VideoClipThumbnailCard));
         expect(tapped, isFalse);
-      });
-
-      testWidgets('does not call onLongPress when disabled', (tester) async {
-        var longPressed = false;
-        await tester.pumpWidget(
-          buildWidget(disabled: true, onLongPress: () => longPressed = true),
-        );
-
-        await tester.longPress(find.byType(VideoClipThumbnailCard));
-        expect(longPressed, isFalse);
       });
     });
 
@@ -228,7 +206,6 @@ void main() {
         );
         final semanticsData = semantics.getSemanticsData();
         expect(semanticsData.hasAction(SemanticsAction.tap), isTrue);
-        expect(semanticsData.hasAction(SemanticsAction.longPress), isTrue);
         expect(find.bySemanticsLabel('5.00'), findsNothing);
       });
 


### PR DESCRIPTION
Closes #7220

## Description

Picking more than a handful of clips in the library meant one tap per clip. Every phone gallery solves this the same way — hold a tile and sweep — so the library does too now.

- A long press on a clip opens the selection. While browsing it also turns selection mode on, so the gesture works from either state.
- Keeping the finger down and dragging runs the range from that anchor to the tile under the finger, in grid order: starting on the first clip of row 1 and dragging to row 2 column 1 selects all of row 1 plus that one clip.
- Dragging back shrinks the range again, and a press that lands on an already selected clip deselects its range instead.
- Holding near the top or bottom edge scrolls the grid on, so a range can reach past one screenful. The range keeps following the finger even once it has wandered off the grid onto the bar below.
- Each clip the range reaches gives a haptic tick.

**Why the range lives in the bloc:** the grid only reports which tile the finger is over; the handler runs the whole range over the selection the drag started from. That snapshot is what lets a drag back over a tile undo it, and it keeps the rules a tap already obeys — clips already in the editor, clips of another aspect ratio, and stop-motion mixing are stepped over rather than picked up mid-range.

**Why a press while browsing always selects:** opening the library from the editor pre-selects its clips with the badges hidden, so a press there has nothing visible to toggle against. It picks the clip up rather than silently deselecting one the user cannot see.

**Deliberate behaviour change:** the long press now belongs to the selection everywhere, which gives up the clip preview inside selection mode — it used to open there on a long press, and there is now no gesture for it. That is the trade: once you are picking clips, the range drag is worth more than a preview, and browsing still opens it on tap. The thumbnail card's own `onLongPress` was left without a caller and is removed with it, `SemanticsAction.longPress` included.

**Why the auto-scroll band is armed by the finger:** the band sits at the grid's own edges, and the browse-mode press that opens a selection is also what raises the create-video bar — which takes its height off the bottom of the grid. Measured naively, a finger resting 100pt clear of the edge lands inside the band without moving and the grid scrolls itself. So a band that arrives under a stationary finger is held off until the finger leaves it, tracked per edge so a deliberate move into the opposite one still scrolls at once.

**Related Issue:** 

## Out of Scope

None.

## Verification

- `flutter analyze lib test` — clean
- `flutter test test/blocs/clips_library/ test/widgets/library/ test/widgets/video_clip/ test/screens/library_screen_test.dart` — all green, including new bloc tests for the range, the direction, the constraint skips, the browse-mode entry and the filter swapping the list mid-drag, plus widget tests for the gesture, the edge auto-scroll, and `drag_select_region_test.dart` for the band that must not arm itself when the grid shrinks
- Manually verified on a real Samsung Galaxy device

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
