### PR TITLE
fix(analytics): route missing-d-tag drops through ViewEventPublisher

### DIFF
--- a/mobile/lib/services/view_event_retry_service.dart
+++ b/mobile/lib/services/view_event_retry_service.dart
@@ -96,13 +96,6 @@ class ViewEventRetryService {
 
       for (final row in retryable) {
         // View = playback start per spec: any watch is valid, no ≥1s gate.
-        // A row without a d tag can never build an `a` tag, so it is dropped.
-        final addressableDTag = row.videoAddressableDTag;
-        if (addressableDTag == null || addressableDTag.isEmpty) {
-          await _dao.deleteById(row.id);
-          continue;
-        }
-
         final lastAttempt = row.lastAttemptAt;
         if (lastAttempt != null) {
           final gap = _now().difference(lastAttempt);
@@ -124,7 +117,7 @@ class ViewEventRetryService {
             fractionalLoops = row.loopCount?.toDouble();
           }
           final success = await _viewEventPublisher.publishViewEvent(
-            video: _toVideoEvent(row, addressableDTag: addressableDTag),
+            video: _toVideoEvent(row),
             startSeconds: 0,
             endSeconds: row.watchDurationMs ~/ 1000,
             source: viewTrafficSourceFromTag(row.trafficSource),
@@ -145,10 +138,7 @@ class ViewEventRetryService {
     }
   }
 
-  VideoEvent _toVideoEvent(
-    PendingViewEvent row, {
-    required String addressableDTag,
-  }) {
+  VideoEvent _toVideoEvent(PendingViewEvent row) {
     return VideoEvent(
       id: row.videoId,
       pubkey: row.videoPubkey,
@@ -156,7 +146,7 @@ class ViewEventRetryService {
       content: '',
       timestamp: row.createdAt,
       vineId: row.videoVineId,
-      addressableDTag: addressableDTag,
+      addressableDTag: row.videoAddressableDTag,
     );
   }
 }

--- a/mobile/lib/services/view_event_retry_service.dart
+++ b/mobile/lib/services/view_event_retry_service.dart
@@ -106,6 +106,7 @@ class ViewEventRetryService {
         if (!marked) continue;
 
         try {
+          final video = _toVideoEvent(row);
           // Derive fractional loops from watch/total already on the row
           // instead of the rounded IntColumn, so 0.75 does not become 1.0
           // and the queue vs direct paths agree.
@@ -117,7 +118,7 @@ class ViewEventRetryService {
             fractionalLoops = row.loopCount?.toDouble();
           }
           final success = await _viewEventPublisher.publishViewEvent(
-            video: _toVideoEvent(row),
+            video: video,
             startSeconds: 0,
             endSeconds: row.watchDurationMs ~/ 1000,
             source: viewTrafficSourceFromTag(row.trafficSource),
@@ -125,6 +126,10 @@ class ViewEventRetryService {
             loopCount: fractionalLoops,
           );
           if (success) {
+            await _dao.deleteById(row.id);
+          } else if (video.addressableId == null) {
+            // The publisher has now reported the missing d tag, and a queued
+            // snapshot can never grow one, so a retry would only re-report.
             await _dao.deleteById(row.id);
           } else {
             await _dao.markFailed(row.id, 'publish returned false');

--- a/mobile/test/services/view_event_queue_publish_repro_test.dart
+++ b/mobile/test/services/view_event_queue_publish_repro_test.dart
@@ -187,9 +187,7 @@ void main() {
 
         verifyNever(() => mockNostr.publishEvent(any()));
         expect(drops, [ViewEventDropReason.missingAddressableDTag]);
-        final row = await dao.getById('queued-view-without-d');
-        expect(row, isNotNull);
-        expect(row!.status, PendingViewEventStatus.failed);
+        expect(await dao.getById('queued-view-without-d'), isNull);
       },
     );
   });

--- a/mobile/test/services/view_event_queue_publish_repro_test.dart
+++ b/mobile/test/services/view_event_queue_publish_repro_test.dart
@@ -156,7 +156,7 @@ void main() {
     });
 
     test(
-      'discards a queued event-id fallback instead of fabricating an a tag',
+      'drops a queued event-id fallback instead of fabricating an a tag',
       () async {
         await dao.deleteById('queued-view');
         await dao.enqueue(
@@ -186,11 +186,10 @@ void main() {
         await service.sweep();
 
         verifyNever(() => mockNostr.publishEvent(any()));
-        // The sweep drops it before the publisher, so no publisher-level
-        // drop is recorded; it can never address a subject, and retrying
-        // it forever would only burn the sweep budget.
-        expect(drops, isEmpty);
-        expect(await dao.getById('queued-view-without-d'), isNull);
+        expect(drops, [ViewEventDropReason.missingAddressableDTag]);
+        final row = await dao.getById('queued-view-without-d');
+        expect(row, isNotNull);
+        expect(row!.status, PendingViewEventStatus.failed);
       },
     );
   });

--- a/mobile/test/services/view_event_retry_service_test.dart
+++ b/mobile/test/services/view_event_retry_service_test.dart
@@ -147,52 +147,35 @@ void main() {
     });
 
     test(
-      'discards a null stored d tag even when vine id is distinct',
+      'passes through a null stored d tag without deriving one from vine id',
       () async {
-        await dao.enqueue(makeEvent(id: 'legacy', addressableDTag: null));
+        await dao.enqueue(
+          makeEvent(
+            id: 'legacy',
+            addressableDTag: null,
+            videoVineId: 'vine-legacy',
+          ),
+        );
         final service = makeService();
 
         await service.sweep();
 
-        expect(await dao.getById('legacy'), isNull);
-        verifyNever(
+        // ViewEventPublisher owns the missing-d-tag drop decision (and its
+        // Crashlytics reporting) — the retry service must not fabricate a
+        // tag from vineId or short-circuit around that check.
+        final captured = verify(
           () => publisher.publishViewEvent(
-            video: any(named: 'video'),
+            video: captureAny(named: 'video'),
             startSeconds: any(named: 'startSeconds'),
             endSeconds: any(named: 'endSeconds'),
             source: any(named: 'source'),
             sourceDetail: any(named: 'sourceDetail'),
             loopCount: any(named: 'loopCount'),
           ),
-        );
+        ).captured;
+        expect((captured.single as VideoEvent).addressableDTag, isNull);
       },
     );
-
-    test('discards a legacy row whose vine id is its event id', () async {
-      await dao.enqueue(
-        makeEvent(
-          id: 'legacy',
-          addressableDTag: null,
-          eventVideoId: 'event-id',
-          videoVineId: 'event-id',
-        ),
-      );
-      final service = makeService();
-
-      await service.sweep();
-
-      expect(await dao.getById('legacy'), isNull);
-      verifyNever(
-        () => publisher.publishViewEvent(
-          video: any(named: 'video'),
-          startSeconds: any(named: 'startSeconds'),
-          endSeconds: any(named: 'endSeconds'),
-          source: any(named: 'source'),
-          sourceDetail: any(named: 'sourceDetail'),
-          loopCount: any(named: 'loopCount'),
-        ),
-      );
-    });
 
     test(
       'marks row failed and increments retry count after publish failure',

--- a/mobile/test/services/view_event_retry_service_test.dart
+++ b/mobile/test/services/view_event_retry_service_test.dart
@@ -147,8 +147,18 @@ void main() {
     });
 
     test(
-      'passes through a null stored d tag without deriving one from vine id',
+      'passes a missing d tag through the publisher then deletes the row',
       () async {
+        when(
+          () => publisher.publishViewEvent(
+            video: any(named: 'video'),
+            startSeconds: any(named: 'startSeconds'),
+            endSeconds: any(named: 'endSeconds'),
+            source: any(named: 'source'),
+            sourceDetail: any(named: 'sourceDetail'),
+            loopCount: any(named: 'loopCount'),
+          ),
+        ).thenAnswer((_) async => false);
         await dao.enqueue(
           makeEvent(
             id: 'legacy',
@@ -161,8 +171,8 @@ void main() {
         await service.sweep();
 
         // ViewEventPublisher owns the missing-d-tag drop decision (and its
-        // Crashlytics reporting) — the retry service must not fabricate a
-        // tag from vineId or short-circuit around that check.
+        // Crashlytics reporting). The queue snapshot cannot grow a d-tag
+        // later, so retrying would only re-fire the structural report.
         final captured = verify(
           () => publisher.publishViewEvent(
             video: captureAny(named: 'video'),
@@ -174,6 +184,29 @@ void main() {
           ),
         ).captured;
         expect((captured.single as VideoEvent).addressableDTag, isNull);
+        expect(await dao.getById('legacy'), isNull);
+      },
+    );
+
+    test(
+      'deletes an empty stored d tag after the publisher returns false',
+      () async {
+        when(
+          () => publisher.publishViewEvent(
+            video: any(named: 'video'),
+            startSeconds: any(named: 'startSeconds'),
+            endSeconds: any(named: 'endSeconds'),
+            source: any(named: 'source'),
+            sourceDetail: any(named: 'sourceDetail'),
+            loopCount: any(named: 'loopCount'),
+          ),
+        ).thenAnswer((_) async => false);
+        await dao.enqueue(makeEvent(id: 'empty-d', addressableDTag: ''));
+        final service = makeService();
+
+        await service.sweep();
+
+        expect(await dao.getById('empty-d'), isNull);
       },
     );
 


### PR DESCRIPTION
## Description

Small follow-up to #7182. That PR fixed the primary bug (queued kind 22236 view events silently dropped forever, #7169) by adding a real `addressableDTag` column with migration backfill. It also special-cased the "still no d-tag after backfill" row: `ViewEventRetryService.sweep()` deletes it directly, before ever calling `ViewEventPublisher`.

That skips `ViewEventPublisher`'s own `addressableId == null` check and its `onDrop` reporting, so `ViewEventDropReason.missingAddressableDTag` (marked `isStructural` in #7210's Crashlytics contract, same as every other drop reason) never fires for this path. If a future bug ever causes newly-enqueued rows to lack a d-tag, this would silently delete the evidence instead of alerting.

Every row now flows through `publishViewEvent` so that missing-d-tag drop is reported. After the report, the retry service deletes the row. A queued snapshot cannot grow a d-tag later, so leaving it `failed` would retry forever and re-fire Crashlytics. Transient publish failures still use `markFailed` and backoff.

**Related Issue:** Relates to #7169, #7210

## Out of Scope

None.

## Verification

- `flutter analyze lib test integration_test tools` — clean
- `flutter test test/services/view_event_retry_service_test.dart test/services/view_event_queue_publish_repro_test.dart` — all pass
- `dart format --set-exit-if-changed` on all changed files — clean
- Pre-push hook (analyzer + changed-file tests) — green
- Mobile CI on `5adbcf8` (rebased onto #7217 + #7223) — green

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
