### PR TITLE
fix(bookmarks): read NIP-51 private items so saving cannot leak them

### DIFF
--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -321,6 +321,11 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
         return;
       }
 
+      // A list whose private items stayed encrypted cannot answer this: the
+      // video may well be bookmarked inside `content`. Leaving the status
+      // unresolved is the same call the inconclusive-read path makes above.
+      if (bookmarkService.hasUnreadablePrivateItems) return;
+
       emit(
         state.copyWith(
           bookmarkStatus: bookmarkService.isVideoBookmarkedGlobally(_video.id)

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -109,8 +109,29 @@ enum BookmarkToggleFailure {
   /// There is no signed-in identity to read or publish as.
   notAuthenticated,
 
+  /// The list carries NIP-51 private items this client could not read, so the
+  /// current state is unknown and any write could disclose one of them.
+  privateItemsUnreadable,
+
   /// Anything else, including an unexpected throw.
   unknown,
+}
+
+/// What this client managed to make of a kind-10003's `content`.
+enum _PrivateItemsState {
+  /// There is nothing encrypted to read.
+  none,
+
+  /// The private item array was decrypted and parsed.
+  readable,
+
+  /// `content` is non-empty but did not yield items — a deprecated NIP-04
+  /// payload, a signer that declined, or malformed plaintext.
+  ///
+  /// Distinct from [none] on purpose: treating it as "no private items" is
+  /// what lets the write path publish a public duplicate of an item it cannot
+  /// see (#7136).
+  unreadable,
 }
 
 /// Service for the user's NIP-51 global bookmark list (kind 10003).
@@ -147,16 +168,31 @@ class BookmarkService {
   /// bookmark on an older build.
   static const String _legacyProseContent = 'Divine global bookmarks';
 
-  // Global bookmarks (Kind 10003)
+  /// The list's **public** items — the ones carried in `tags`.
+  ///
+  /// Kept separate from [_privateBookmarks] because this is the sole input to
+  /// the published `tags`. A private item that leaked in here would be
+  /// republished in the clear, which is the disclosure #7136 is about.
   final List<BookmarkItem> _globalBookmarks = [];
+
+  /// The list's **private** items, decrypted from `content`.
+  ///
+  /// Never persisted. [SharedPreferences] is unencrypted, so caching these
+  /// would move the user's private bookmarks into plaintext local storage —
+  /// a disclosure of its own. They are re-read on every sync instead.
+  final List<BookmarkItem> _privateBookmarks = [];
+
+  /// What became of the newest `content` we saw. Drives the write path's
+  /// refusal to act on a list it cannot fully see.
+  _PrivateItemsState _privateItemsState = _PrivateItemsState.none;
 
   /// The `content` of the newest kind-10003 we have seen for this user.
   ///
   /// NIP-51 reserves `.content` for the NIP-44-encrypted private item array.
-  /// Divine cannot read those items yet, so it carries the ciphertext through
-  /// untouched instead of overwriting another client's private bookmarks —
-  /// except for [_legacyProseContent], which is Divine's own malformed output
-  /// and is dropped rather than propagated.
+  /// Carried through untouched whenever the private items are not the thing
+  /// being changed, so a public-item write can never disturb them — except for
+  /// [_legacyProseContent], which is Divine's own malformed output and is
+  /// dropped rather than propagated.
   String _lastKnownRemoteContent = '';
 
   /// How long a full-settlement "this user has no list" answer is reused
@@ -190,7 +226,20 @@ class BookmarkService {
         _now().difference(confirmedAt) >= absenceConfirmationTtl;
   }
 
-  List<BookmarkItem> get globalBookmarks => List.unmodifiable(_globalBookmarks);
+  /// Every bookmark on the list — public items first, then private ones.
+  ///
+  /// A set literal, so an item held both publicly and privately appears once
+  /// ([BookmarkItem] compares on type and id).
+  List<BookmarkItem> get globalBookmarks =>
+      List.unmodifiable({..._globalBookmarks, ..._privateBookmarks});
+
+  /// Whether the list carries private items this client could not read.
+  ///
+  /// While true the bookmark state is genuinely unknown: callers must not
+  /// render "not saved", and the write path refuses rather than publishing a
+  /// public copy of an item it cannot see.
+  bool get hasUnreadablePrivateItems =>
+      _privateItemsState == _PrivateItemsState.unreadable;
 
   /// Reconciles [globalBookmarks] against the user's kind-10003 on the relay.
   ///
@@ -272,7 +321,8 @@ class BookmarkService {
         if (events == null) {
           Log.warning(
             'Empty bookmark answer not confirmed by every relay - keeping '
-            'the ${_globalBookmarks.length} bookmarks this device has',
+            'the ${_globalBookmarks.length + _privateBookmarks.length} '
+            'bookmarks this device has',
             name: 'BookmarkService',
             category: LogCategory.system,
           );
@@ -291,6 +341,8 @@ class BookmarkService {
         // session that opens Saved often enough would never re-confirm.
         if (answeredAuthoritatively) _absenceConfirmedAt = _now();
         _globalBookmarks.clear();
+        _privateBookmarks.clear();
+        _privateItemsState = _PrivateItemsState.none;
         _lastKnownRemoteContent = '';
       } else {
         // Seeing the event disproves the absence, so the stamp cannot stand.
@@ -301,13 +353,14 @@ class BookmarkService {
         _absenceConfirmedAt = null;
         final newestFirst = [...events]
           ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
-        _adoptGlobalBookmarksFromEvent(newestFirst.first);
+        await _adoptGlobalBookmarksFromEvent(newestFirst.first);
       }
 
       await _saveBookmarksToSharedPreferences();
 
       Log.info(
-        'Synced ${_globalBookmarks.length} global bookmarks from relay',
+        'Synced ${_globalBookmarks.length + _privateBookmarks.length} global '
+        'bookmarks from relay (${_privateBookmarks.length} private)',
         name: 'BookmarkService',
         category: LogCategory.system,
       );
@@ -395,6 +448,18 @@ class BookmarkService {
       );
     }
 
+    // The list reconciled, but part of it stayed encrypted. Either direction
+    // would be a guess: adding could publish an item already held privately,
+    // and removing could report "Removed" for one that survives in `content`.
+    if (hasUnreadablePrivateItems) {
+      return BookmarkToggleResult(
+        succeeded: false,
+        wasBookmarked: wasBookmarked,
+        isBookmarked: wasBookmarked,
+        failure: BookmarkToggleFailure.privateItemsUnreadable,
+      );
+    }
+
     final succeeded = wasBookmarked
         ? await removeFromGlobalBookmarks(
             BookmarkItem(type: 'e', id: videoEventId),
@@ -445,8 +510,19 @@ class BookmarkService {
         return false;
       }
 
-      // Check if already bookmarked
-      if (_globalBookmarks.contains(item)) {
+      if (hasUnreadablePrivateItems) {
+        Log.warning(
+          'Not adding to global bookmarks: the list has private items this '
+          'client could not read, so a public tag could disclose one',
+          name: 'BookmarkService',
+          category: LogCategory.system,
+        );
+        return false;
+      }
+
+      // Already bookmarked either way. Adding a public tag for an item held
+      // privately would publish a bookmark the user chose to keep encrypted.
+      if (_globalBookmarks.contains(item) || _privateBookmarks.contains(item)) {
         Log.debug(
           'Item already in global bookmarks: ${item.id}',
           name: 'BookmarkService',
@@ -498,6 +574,35 @@ class BookmarkService {
         return false;
       }
 
+      if (hasUnreadablePrivateItems) {
+        Log.warning(
+          'Not removing from global bookmarks: the list has private items this '
+          'client could not read, so the result could not be reported honestly',
+          name: 'BookmarkService',
+          category: LogCategory.system,
+        );
+        return false;
+      }
+
+      // A private item is removed from the encrypted array, leaving the public
+      // tags alone. Dropping only a public copy would report "Removed" while
+      // every conforming client still shows it bookmarked (#7136).
+      if (_privateBookmarks.contains(item)) {
+        final privateCandidate = [..._privateBookmarks]..remove(item);
+        final published = await _publishGlobalBookmarks(
+          [..._globalBookmarks],
+          privateCandidate: privateCandidate,
+        );
+        if (!published) return false;
+
+        Log.info(
+          'Removed private item from global bookmarks: ${item.id}',
+          name: 'BookmarkService',
+          category: LogCategory.system,
+        );
+        return true;
+      }
+
       final candidate = [..._globalBookmarks];
       if (!candidate.remove(item)) {
         Log.warning(
@@ -528,11 +633,13 @@ class BookmarkService {
     }
   }
 
-  /// Check if an item is in global bookmarks
+  /// Check if an item is in global bookmarks, public or private.
+  ///
+  /// Consulting only the public tags is what made a privately-bookmarked video
+  /// read as unsaved, and then let a save publish it in the clear (#7136).
   bool isInGlobalBookmarks(String itemId, String type) {
-    return _globalBookmarks.any(
-      (item) => item.id == itemId && item.type == type,
-    );
+    bool matches(BookmarkItem item) => item.id == itemId && item.type == type;
+    return _globalBookmarks.any(matches) || _privateBookmarks.any(matches);
   }
 
   /// Check if a video event is bookmarked globally
@@ -555,7 +662,14 @@ class BookmarkService {
   /// share sheet turns into "Saved" — a relay-policy rejection has to be able
   /// to say the save did not stick. It is still breadth, not durability: the
   /// relay acknowledges from an in-memory queue and commits afterwards.
-  Future<bool> _publishGlobalBookmarks(List<BookmarkItem> candidate) async {
+  /// Pass [privateCandidate] only when the private items are the thing being
+  /// changed; it is re-encrypted and replaces `content`. Leaving it null keeps
+  /// the ciphertext byte-for-byte, which is what makes a public-item write
+  /// incapable of disturbing another client's private bookmarks.
+  Future<bool> _publishGlobalBookmarks(
+    List<BookmarkItem> candidate, {
+    List<BookmarkItem>? privateCandidate,
+  }) async {
     try {
       if (!_authService.isAuthenticated) {
         Log.warning(
@@ -566,11 +680,20 @@ class BookmarkService {
         return false;
       }
 
+      // NIP-51 reserves `content` for the encrypted private item array, so it
+      // is either ciphertext or empty — never prose.
+      final String content;
+      if (privateCandidate == null) {
+        content = _lastKnownRemoteContent;
+      } else {
+        final encrypted = await _encryptPrivateItems(privateCandidate);
+        if (encrypted == null) return false;
+        content = encrypted;
+      }
+
       final event = await _authService.createAndSignEvent(
         kind: globalBookmarksKind,
-        // NIP-51 reserves `content` for the encrypted private item array, so
-        // it is either the ciphertext we read back or empty — never prose.
-        content: _lastKnownRemoteContent,
+        content: content,
         tags: [for (final item in candidate) item.toTag()],
       );
 
@@ -590,6 +713,15 @@ class BookmarkService {
       _globalBookmarks
         ..clear()
         ..addAll(candidate);
+      if (privateCandidate != null) {
+        _privateBookmarks
+          ..clear()
+          ..addAll(privateCandidate);
+        _lastKnownRemoteContent = content;
+        _privateItemsState = privateCandidate.isEmpty
+            ? _PrivateItemsState.none
+            : _PrivateItemsState.readable;
+      }
       await _saveBookmarksToSharedPreferences();
 
       Log.debug(
@@ -609,23 +741,157 @@ class BookmarkService {
     }
   }
 
+  /// Encrypts [items] as the NIP-51 private array, or `null` if the payload
+  /// could not be produced **or did not read back**.
+  ///
+  /// The verification round trip is the point. Kind 10003 is replaceable, so a
+  /// re-encryption that silently produced the wrong bytes would destroy
+  /// private bookmarks this client cannot reconstruct. Everything else keeps
+  /// carrying the original ciphertext untouched.
+  Future<String?> _encryptPrivateItems(List<BookmarkItem> items) async {
+    // A list with no private items left carries no payload at all, rather than
+    // the ciphertext of an empty array.
+    if (items.isEmpty) return '';
+
+    final pubkey = _authService.currentPublicKeyHex;
+    final identity = _authService.currentIdentity;
+    if (pubkey == null || identity == null) return null;
+
+    final plaintext = jsonEncode([for (final item in items) item.toTag()]);
+    try {
+      final ciphertext = await identity.nip44Encrypt(pubkey, plaintext);
+      if (ciphertext == null || ciphertext.isEmpty) {
+        Log.warning(
+          'Signer returned no ciphertext for the private bookmark items',
+          name: 'BookmarkService',
+          category: LogCategory.system,
+        );
+        return null;
+      }
+
+      if (await identity.nip44Decrypt(pubkey, ciphertext) != plaintext) {
+        Log.error(
+          'Re-encrypted private bookmark items did not read back - '
+          'refusing to publish',
+          name: 'BookmarkService',
+          category: LogCategory.system,
+        );
+        return null;
+      }
+      return ciphertext;
+    } catch (e) {
+      Log.error(
+        'Failed to encrypt private bookmark items: $e',
+        name: 'BookmarkService',
+        category: LogCategory.system,
+      );
+      return null;
+    }
+  }
+
   // === NOSTR LOADING ===
 
-  /// Replace the in-memory list with the contents of a kind-10003 [event].
+  /// Replace the in-memory lists with the contents of a kind-10003 [event].
   ///
-  /// Also captures `event.content`. Divine cannot decrypt NIP-51 private
-  /// items, so carrying the ciphertext through unchanged is what keeps a
-  /// republish from deleting bookmarks another client stored privately.
-  void _adoptGlobalBookmarksFromEvent(Event event) {
+  /// Reads both halves NIP-51 defines: the public items in `tags`, and the
+  /// private items in `content` — a stringified tag array encrypted to the
+  /// author's own key. The ciphertext is still captured verbatim so a
+  /// public-item write can republish it untouched.
+  Future<void> _adoptGlobalBookmarksFromEvent(Event event) async {
     _lastKnownRemoteContent = event.content == _legacyProseContent
         ? ''
         : event.content;
-    _globalBookmarks.clear();
+    _globalBookmarks
+      ..clear()
+      ..addAll(_itemsFromTags(event.tags));
 
-    for (final tag in event.tags) {
-      if (tag.length >= 2 && ['e', 'a', 't', 'r'].contains(tag[0])) {
-        _globalBookmarks.add(BookmarkItem.fromTag(tag));
+    _privateBookmarks.clear();
+    _privateItemsState = await _readPrivateItems(_lastKnownRemoteContent);
+  }
+
+  /// The bookmark items among [tags], in order.
+  static List<BookmarkItem> _itemsFromTags(List<List<String>> tags) => [
+    for (final tag in tags)
+      if (tag.length >= 2 && ['e', 'a', 't', 'r'].contains(tag[0]))
+        BookmarkItem.fromTag(tag),
+  ];
+
+  /// Decrypts [content] into [_privateBookmarks] and reports what happened.
+  ///
+  /// NIP-51 encrypts private items to the author's own key, so this needs only
+  /// the signer this device already has — every identity that can publish a
+  /// bookmark can also decrypt one.
+  Future<_PrivateItemsState> _readPrivateItems(String content) async {
+    if (content.isEmpty) return _PrivateItemsState.none;
+
+    // NIP-51 deprecated NIP-04 for this field and tells clients to detect it by
+    // the `iv` marker. Divine does not read that scheme; reporting it as
+    // unreadable is what stops the write path from guessing "not bookmarked".
+    if (content.contains('?iv=')) {
+      Log.warning(
+        'Bookmark list uses the deprecated NIP-04 private-item scheme - '
+        'private items left unread',
+        name: 'BookmarkService',
+        category: LogCategory.system,
+      );
+      return _PrivateItemsState.unreadable;
+    }
+
+    final pubkey = _authService.currentPublicKeyHex;
+    final identity = _authService.currentIdentity;
+    if (pubkey == null || identity == null) {
+      return _PrivateItemsState.unreadable;
+    }
+
+    try {
+      final plaintext = await identity.nip44Decrypt(pubkey, content);
+      if (plaintext == null) {
+        Log.warning(
+          'Signer could not decrypt the private bookmark items',
+          name: 'BookmarkService',
+          category: LogCategory.system,
+        );
+        return _PrivateItemsState.unreadable;
       }
+
+      final tags = _tagsFromPrivatePayload(plaintext);
+      if (tags == null) return _PrivateItemsState.unreadable;
+
+      _privateBookmarks.addAll(_itemsFromTags(tags));
+      Log.debug(
+        'Read ${_privateBookmarks.length} private bookmark items',
+        name: 'BookmarkService',
+        category: LogCategory.system,
+      );
+      return _PrivateItemsState.readable;
+    } catch (e) {
+      Log.error(
+        'Failed to read private bookmark items: $e',
+        name: 'BookmarkService',
+        category: LogCategory.system,
+      );
+      return _PrivateItemsState.unreadable;
+    }
+  }
+
+  /// Parses a NIP-51 private payload — a stringified tag array — or `null`
+  /// when it is not one.
+  static List<List<String>>? _tagsFromPrivatePayload(String plaintext) {
+    try {
+      final decoded = jsonDecode(plaintext);
+      if (decoded is! List) return null;
+
+      final tags = <List<String>>[];
+      for (final entry in decoded) {
+        if (entry is! List) return null;
+        tags.add([
+          for (final value in entry)
+            if (value is String) value,
+        ]);
+      }
+      return tags;
+    } catch (_) {
+      return null;
     }
   }
 

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -627,8 +627,12 @@ class BookmarkService {
         return true;
       }
 
-      final candidate = [..._globalBookmarks];
-      if (!candidate.remove(item)) {
+      // `removeWhere` for the same reason the private path uses it: another
+      // client is free to write the same tag twice, and `List.remove` would
+      // drop one copy and republish the other while reporting "Removed".
+      final candidate = [..._globalBookmarks]
+        ..removeWhere((existing) => existing == item);
+      if (candidate.length == _globalBookmarks.length) {
         Log.warning(
           'Item not found in global bookmarks: ${item.id}',
           name: 'BookmarkService',

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -929,10 +929,13 @@ class BookmarkService {
       final tags = <List<String>>[];
       for (final entry in decoded) {
         if (entry is! List) return null;
-        tags.add([
-          for (final value in entry)
-            if (value is String) value,
-        ]);
+        // Rejected rather than filtered. Dropping a non-string would shift
+        // every position after it — `['e', id, null, petname]` re-encrypts as
+        // `['e', id, petname]`, promoting the label to the relay hint — and
+        // silently rewriting an entry is exactly what carrying the array
+        // verbatim exists to prevent.
+        if (entry.any((value) => value is! String)) return null;
+        tags.add([for (final value in entry) value as String]);
       }
       return tags;
     } catch (_) {

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -339,8 +339,7 @@ class BookmarkService {
         if (events == null) {
           Log.warning(
             'Empty bookmark answer not confirmed by every relay - keeping '
-            'the ${_globalBookmarks.length + _privateBookmarks.length} '
-            'bookmarks this device has',
+            'the ${globalBookmarks.length} bookmarks this device has',
             name: 'BookmarkService',
             category: LogCategory.system,
           );
@@ -378,8 +377,8 @@ class BookmarkService {
       await _saveBookmarksToSharedPreferences();
 
       Log.info(
-        'Synced ${_globalBookmarks.length + _privateBookmarks.length} global '
-        'bookmarks from relay (${_privateBookmarks.length} private)',
+        'Synced ${globalBookmarks.length} global bookmarks from relay '
+        '(${_privateBookmarks.length} private)',
         name: 'BookmarkService',
         category: LogCategory.system,
       );

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -584,13 +584,14 @@ class BookmarkService {
         return false;
       }
 
-      // A private item is removed from the encrypted array, leaving the public
-      // tags alone. Dropping only a public copy would report "Removed" while
-      // every conforming client still shows it bookmarked (#7136).
+      // A private item is removed from the encrypted array. Dropping only a
+      // public copy would report "Removed" while every conforming client still
+      // shows it bookmarked (#7136) — and the reverse is just as untrue, so an
+      // item the pre-fix leak left in *both* halves loses both.
       if (_privateBookmarks.contains(item)) {
         final privateCandidate = [..._privateBookmarks]..remove(item);
         final published = await _publishGlobalBookmarks(
-          [..._globalBookmarks],
+          [..._globalBookmarks]..removeWhere((candidate) => candidate == item),
           privateCandidate: privateCandidate,
         );
         if (!published) return false;

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -134,6 +134,15 @@ enum _PrivateItemsState {
   unreadable,
 }
 
+/// The outcome of reading a kind-10003's `content`, returned rather than
+/// stored so the caller can apply it without suspending mid-update.
+class _PrivateItemsRead {
+  const _PrivateItemsRead({required this.state, required this.items});
+
+  final _PrivateItemsState state;
+  final List<BookmarkItem> items;
+}
+
 /// Service for the user's NIP-51 global bookmark list (kind 10003).
 class BookmarkService {
   BookmarkService({
@@ -798,16 +807,23 @@ class BookmarkService {
   /// private items in `content` — a stringified tag array encrypted to the
   /// author's own key. The ciphertext is still captured verbatim so a
   /// public-item write can republish it untouched.
+  /// Nothing here mutates state until every await has resolved. Decryption
+  /// suspends, and syncs are not serialized (#7163), so a `clear()` before the
+  /// await and an `addAll` after it would let two adopts interleave into a
+  /// duplicated item — which `List.remove` then only half removes, leaving the
+  /// relay holding a bookmark the user was told was gone.
   Future<void> _adoptGlobalBookmarksFromEvent(Event event) async {
-    _lastKnownRemoteContent = event.content == _legacyProseContent
-        ? ''
-        : event.content;
+    final content = event.content == _legacyProseContent ? '' : event.content;
+    final private = await _readPrivateItems(content);
+
+    _lastKnownRemoteContent = content;
     _globalBookmarks
       ..clear()
       ..addAll(_itemsFromTags(event.tags));
-
-    _privateBookmarks.clear();
-    _privateItemsState = await _readPrivateItems(_lastKnownRemoteContent);
+    _privateBookmarks
+      ..clear()
+      ..addAll(private.items);
+    _privateItemsState = private.state;
   }
 
   /// The bookmark items among [tags], in order.
@@ -817,13 +833,23 @@ class BookmarkService {
         BookmarkItem.fromTag(tag),
   ];
 
-  /// Decrypts [content] into [_privateBookmarks] and reports what happened.
+  /// Decrypts [content] into private items, and reports what happened.
+  ///
+  /// Returns the items rather than storing them, so the caller can apply the
+  /// whole read in one synchronous step.
   ///
   /// NIP-51 encrypts private items to the author's own key, so this needs only
   /// the signer this device already has — every identity that can publish a
   /// bookmark can also decrypt one.
-  Future<_PrivateItemsState> _readPrivateItems(String content) async {
-    if (content.isEmpty) return _PrivateItemsState.none;
+  Future<_PrivateItemsRead> _readPrivateItems(String content) async {
+    const unreadable = _PrivateItemsRead(
+      state: _PrivateItemsState.unreadable,
+      items: [],
+    );
+
+    if (content.isEmpty) {
+      return const _PrivateItemsRead(state: _PrivateItemsState.none, items: []);
+    }
 
     // NIP-51 deprecated NIP-04 for this field and tells clients to detect it by
     // the `iv` marker. Divine does not read that scheme; reporting it as
@@ -835,14 +861,12 @@ class BookmarkService {
         name: 'BookmarkService',
         category: LogCategory.system,
       );
-      return _PrivateItemsState.unreadable;
+      return unreadable;
     }
 
     final pubkey = _authService.currentPublicKeyHex;
     final identity = _authService.currentIdentity;
-    if (pubkey == null || identity == null) {
-      return _PrivateItemsState.unreadable;
-    }
+    if (pubkey == null || identity == null) return unreadable;
 
     try {
       final plaintext = await identity.nip44Decrypt(pubkey, content);
@@ -852,26 +876,29 @@ class BookmarkService {
           name: 'BookmarkService',
           category: LogCategory.system,
         );
-        return _PrivateItemsState.unreadable;
+        return unreadable;
       }
 
       final tags = _tagsFromPrivatePayload(plaintext);
-      if (tags == null) return _PrivateItemsState.unreadable;
+      if (tags == null) return unreadable;
 
-      _privateBookmarks.addAll(_itemsFromTags(tags));
+      final items = _itemsFromTags(tags);
       Log.debug(
-        'Read ${_privateBookmarks.length} private bookmark items',
+        'Read ${items.length} private bookmark items',
         name: 'BookmarkService',
         category: LogCategory.system,
       );
-      return _PrivateItemsState.readable;
+      return _PrivateItemsRead(
+        state: _PrivateItemsState.readable,
+        items: items,
+      );
     } catch (e) {
       Log.error(
         'Failed to read private bookmark items: $e',
         name: 'BookmarkService',
         category: LogCategory.system,
       );
-      return _PrivateItemsState.unreadable;
+      return unreadable;
     }
   }
 

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -137,10 +137,14 @@ enum _PrivateItemsState {
 /// The outcome of reading a kind-10003's `content`, returned rather than
 /// stored so the caller can apply it without suspending mid-update.
 class _PrivateItemsRead {
-  const _PrivateItemsRead({required this.state, required this.items});
+  const _PrivateItemsRead({required this.state, required this.tags});
 
   final _PrivateItemsState state;
-  final List<BookmarkItem> items;
+
+  /// The decrypted array verbatim, not just the entries this client models.
+  /// Re-encrypting from parsed items would silently drop another client's
+  /// non-item tags and any tag position past the fourth.
+  final List<List<String>> tags;
 }
 
 /// Service for the user's NIP-51 global bookmark list (kind 10003).
@@ -190,6 +194,11 @@ class BookmarkService {
   /// would move the user's private bookmarks into plaintext local storage —
   /// a disclosure of its own. They are re-read on every sync instead.
   final List<BookmarkItem> _privateBookmarks = [];
+
+  /// [_privateBookmarks]' source array, kept verbatim so a re-encryption
+  /// rewrites only the entry being removed. Never persisted, for the same
+  /// reason [_privateBookmarks] is not.
+  List<List<String>> _privateTags = const [];
 
   /// What became of the newest `content` we saw. Drives the write path's
   /// refusal to act on a list it cannot fully see.
@@ -351,6 +360,7 @@ class BookmarkService {
         if (answeredAuthoritatively) _absenceConfirmedAt = _now();
         _globalBookmarks.clear();
         _privateBookmarks.clear();
+        _privateTags = const [];
         _privateItemsState = _PrivateItemsState.none;
         _lastKnownRemoteContent = '';
       } else {
@@ -596,9 +606,14 @@ class BookmarkService {
       // A private item is removed from the encrypted array. Dropping only a
       // public copy would report "Removed" while every conforming client still
       // shows it bookmarked (#7136) — and the reverse is just as untrue, so an
-      // item the pre-fix leak left in *both* halves loses both.
+      // item the pre-fix leak left in *both* halves loses both. `removeWhere`
+      // rather than `remove`, which drops only the first of a duplicate pair.
       if (_privateBookmarks.contains(item)) {
-        final privateCandidate = [..._privateBookmarks]..remove(item);
+        final privateCandidate = [..._privateTags]
+          ..removeWhere(
+            (tag) =>
+                tag.length >= 2 && tag[0] == item.type && tag[1] == item.id,
+          );
         final published = await _publishGlobalBookmarks(
           [..._globalBookmarks]..removeWhere((candidate) => candidate == item),
           privateCandidate: privateCandidate,
@@ -678,7 +693,7 @@ class BookmarkService {
   /// incapable of disturbing another client's private bookmarks.
   Future<bool> _publishGlobalBookmarks(
     List<BookmarkItem> candidate, {
-    List<BookmarkItem>? privateCandidate,
+    List<List<String>>? privateCandidate,
   }) async {
     try {
       if (!_authService.isAuthenticated) {
@@ -724,9 +739,10 @@ class BookmarkService {
         ..clear()
         ..addAll(candidate);
       if (privateCandidate != null) {
+        _privateTags = privateCandidate;
         _privateBookmarks
           ..clear()
-          ..addAll(privateCandidate);
+          ..addAll(_itemsFromTags(privateCandidate));
         _lastKnownRemoteContent = content;
         _privateItemsState = privateCandidate.isEmpty
             ? _PrivateItemsState.none
@@ -758,7 +774,7 @@ class BookmarkService {
   /// re-encryption that silently produced the wrong bytes would destroy
   /// private bookmarks this client cannot reconstruct. Everything else keeps
   /// carrying the original ciphertext untouched.
-  Future<String?> _encryptPrivateItems(List<BookmarkItem> items) async {
+  Future<String?> _encryptPrivateItems(List<List<String>> items) async {
     // A list with no private items left carries no payload at all, rather than
     // the ciphertext of an empty array.
     if (items.isEmpty) return '';
@@ -767,7 +783,7 @@ class BookmarkService {
     final identity = _authService.currentIdentity;
     if (pubkey == null || identity == null) return null;
 
-    final plaintext = jsonEncode([for (final item in items) item.toTag()]);
+    final plaintext = jsonEncode(items);
     try {
       final ciphertext = await identity.nip44Encrypt(pubkey, plaintext);
       if (ciphertext == null || ciphertext.isEmpty) {
@@ -807,6 +823,7 @@ class BookmarkService {
   /// private items in `content` — a stringified tag array encrypted to the
   /// author's own key. The ciphertext is still captured verbatim so a
   /// public-item write can republish it untouched.
+  ///
   /// Nothing here mutates state until every await has resolved. Decryption
   /// suspends, and syncs are not serialized (#7163), so a `clear()` before the
   /// await and an `addAll` after it would let two adopts interleave into a
@@ -820,9 +837,10 @@ class BookmarkService {
     _globalBookmarks
       ..clear()
       ..addAll(_itemsFromTags(event.tags));
+    _privateTags = private.tags;
     _privateBookmarks
       ..clear()
-      ..addAll(private.items);
+      ..addAll(_itemsFromTags(private.tags));
     _privateItemsState = private.state;
   }
 
@@ -844,11 +862,11 @@ class BookmarkService {
   Future<_PrivateItemsRead> _readPrivateItems(String content) async {
     const unreadable = _PrivateItemsRead(
       state: _PrivateItemsState.unreadable,
-      items: [],
+      tags: [],
     );
 
     if (content.isEmpty) {
-      return const _PrivateItemsRead(state: _PrivateItemsState.none, items: []);
+      return const _PrivateItemsRead(state: _PrivateItemsState.none, tags: []);
     }
 
     // NIP-51 deprecated NIP-04 for this field and tells clients to detect it by
@@ -882,16 +900,12 @@ class BookmarkService {
       final tags = _tagsFromPrivatePayload(plaintext);
       if (tags == null) return unreadable;
 
-      final items = _itemsFromTags(tags);
       Log.debug(
-        'Read ${items.length} private bookmark items',
+        'Read ${_itemsFromTags(tags).length} private bookmark items',
         name: 'BookmarkService',
         category: LogCategory.system,
       );
-      return _PrivateItemsRead(
-        state: _PrivateItemsState.readable,
-        items: items,
-      );
+      return _PrivateItemsRead(state: _PrivateItemsState.readable, tags: tags);
     } catch (e) {
       Log.error(
         'Failed to read private bookmark items: $e',

--- a/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
+++ b/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
@@ -113,6 +113,9 @@ void main() {
       when(
         () => mockBookmarkService.isVideoBookmarkedGlobally(any()),
       ).thenReturn(false);
+      when(
+        () => mockBookmarkService.hasUnreadablePrivateItems,
+      ).thenReturn(false);
       when(() => mockSharingService.recentlySharedWith).thenReturn([]);
       when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
       when(
@@ -1518,6 +1521,31 @@ void main() {
             ShareSheetBookmarkStatus.notSaved,
           ),
         ],
+      );
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'stays unknown when the list has private items it could not read',
+        setUp: () {
+          when(
+            () => mockBookmarkService.syncGlobalBookmarks(),
+          ).thenAnswer((_) async => true);
+          when(
+            () => mockBookmarkService.hasUnreadablePrivateItems,
+          ).thenReturn(true);
+          // The public half says "not bookmarked", but the encrypted half is
+          // exactly where the video might be — claiming notSaved here is the
+          // mislabel that precedes the disclosure (#7136).
+          when(
+            () => mockBookmarkService.isVideoBookmarkedGlobally(any()),
+          ).thenReturn(false);
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ShareSheetBookmarkStatusRequested()),
+        expect: () => <ShareSheetState>[],
+        verify: (bloc) => expect(
+          bloc.state.bookmarkStatus,
+          ShareSheetBookmarkStatus.unknown,
+        ),
       );
 
       blocTest<ShareSheetBloc, ShareSheetState>(

--- a/mobile/test/services/bookmark_service_test.dart
+++ b/mobile/test/services/bookmark_service_test.dart
@@ -1092,6 +1092,31 @@ void main() {
         },
       );
 
+      test('counts an item held in both halves once', () async {
+        const inBoth = 'in-both';
+        stubRelay(
+          events: [
+            bookmarkListEvent(
+              [inBoth],
+              content: await encryptToSelf([
+                ['e', inBoth],
+              ]),
+            ),
+          ],
+        );
+        final service = createService();
+
+        await service.syncGlobalBookmarks();
+
+        expect(
+          service.globalBookmarks,
+          hasLength(1),
+          reason:
+              'one bookmarked video, so summing the two halves would report '
+              'two - the count the sync log reads from',
+        );
+      });
+
       test('removing an item held in both halves drops both copies', () async {
         const inBoth = 'in-both';
         stubRelay(

--- a/mobile/test/services/bookmark_service_test.dart
+++ b/mobile/test/services/bookmark_service_test.dart
@@ -6,10 +6,12 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:nostr_sdk/client_utils/keys.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
 import 'package:nostr_sdk/relay/publish_outcome.dart';
+import 'package:openvine/services/auth/nostr_identity.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/bookmark_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -31,6 +33,12 @@ void main() {
     late _MockAuthService authService;
     late SharedPreferences prefs;
     late String pubkey;
+
+    /// A real local identity, so NIP-44 in these tests is the actual crypto
+    /// rather than a stub. `NostrIdentity` is sealed and cannot be mocked, and
+    /// using the real signer is what makes the private-item fixtures genuine
+    /// NIP-51 payloads.
+    late LocalNostrIdentity identity;
 
     /// The tags of the last kind-10003 handed to the signer.
     List<List<String>>? signedTags;
@@ -127,8 +135,27 @@ void main() {
       ),
     ).captured;
 
+    /// A genuine NIP-51 private payload: a stringified tag array, NIP-44
+    /// encrypted to the author's own key.
+    Future<String> encryptToSelf(List<List<String>> items) async {
+      final ciphertext = await identity.nip44Encrypt(pubkey, jsonEncode(items));
+      return ciphertext!;
+    }
+
+    Future<List<List<String>>> decryptToSelf(String ciphertext) async {
+      final plaintext = await identity.nip44Decrypt(pubkey, ciphertext);
+      return [
+        for (final entry in jsonDecode(plaintext!) as List)
+          [for (final value in entry as List) value as String],
+      ];
+    }
+
     setUp(() async {
-      pubkey = getPublicKey(generatePrivateKey());
+      final privateKeyHex = generatePrivateKey();
+      pubkey = getPublicKey(privateKeyHex);
+      identity = LocalNostrIdentity(
+        keyContainer: SecureKeyContainer.fromPrivateKeyHex(privateKeyHex),
+      );
       nostrClient = _MockNostrClient();
       authService = _MockAuthService();
       signedTags = null;
@@ -139,6 +166,7 @@ void main() {
 
       when(() => authService.isAuthenticated).thenReturn(true);
       when(() => authService.currentPublicKeyHex).thenReturn(pubkey);
+      when(() => authService.currentIdentity).thenReturn(identity);
 
       // Capture what the service asks to sign, and hand back a real event.
       when(
@@ -422,6 +450,9 @@ void main() {
           // leaves the bookmark list empty while holding another client's
           // ciphertext. A stamp from before it existed must not let a later
           // partial empty answer through unconfirmed and wipe that content.
+          final ciphertext = await encryptToSelf([
+            ['e', 'their-private-one'],
+          ]);
           var clock = DateTime(2026);
           final service = createService(now: () => clock);
 
@@ -429,7 +460,7 @@ void main() {
           await service.syncGlobalBookmarks();
 
           clock = clock.add(const Duration(minutes: 1));
-          stubRelay(events: [bookmarkListEvent([], content: 'ciphertext')]);
+          stubRelay(events: [bookmarkListEvent([], content: ciphertext)]);
           await service.syncGlobalBookmarks();
 
           clock = clock.add(const Duration(minutes: 1));
@@ -443,13 +474,13 @@ void main() {
 
           // The unconfirmed empty must not have reached the content, so a
           // publish still carries the other client's private items.
-          stubRelay(events: [bookmarkListEvent([], content: 'ciphertext')]);
+          stubRelay(events: [bookmarkListEvent([], content: ciphertext)]);
           await service.addToGlobalBookmarks(
             const BookmarkItem(type: 'e', id: 'mine'),
           );
           expect(
             signedContent,
-            equals('ciphertext'),
+            equals(ciphertext),
             reason: 'a stale absence must not strip private bookmarks',
           );
         },
@@ -763,7 +794,9 @@ void main() {
       test(
         "carries another client's encrypted content through untouched",
         () async {
-          const ciphertext = 'AhjoBRIcKJZSgAGz/y0uYsggKpn6dgeRHYs=';
+          final ciphertext = await encryptToSelf([
+            ['e', 'their-private-one'],
+          ]);
           stubRelay(
             events: [
               bookmarkListEvent(['relay-a'], content: ciphertext),
@@ -779,8 +812,8 @@ void main() {
             signedContent,
             equals(ciphertext),
             reason:
-                'overwriting it would delete the private bookmarks that '
-                'Divine cannot yet decrypt',
+                'a public-item write must re-emit the payload byte-for-byte '
+                'rather than re-encrypting it',
           );
         },
       );
@@ -943,6 +976,273 @@ void main() {
 
         expect(result.succeeded, isTrue);
         expect(result.failure, isNull);
+      });
+    });
+
+    group('NIP-51 private items', () {
+      const privateVideo = 'privately-bookmarked-video';
+
+      test('reads a list whose items are all private', () async {
+        stubRelay(
+          events: [
+            bookmarkListEvent(
+              [],
+              content: await encryptToSelf([
+                ['e', privateVideo],
+              ]),
+            ),
+          ],
+        );
+        final service = createService();
+
+        await service.syncGlobalBookmarks();
+
+        expect(
+          service.isVideoBookmarkedGlobally(privateVideo),
+          isTrue,
+          reason: 'a private item is still a bookmark',
+        );
+        expect(
+          service.globalBookmarks.map((item) => item.id),
+          contains(privateVideo),
+          reason: 'Saved must list it, not render an empty state',
+        );
+      });
+
+      test('merges public and private items without duplicating', () async {
+        stubRelay(
+          events: [
+            bookmarkListEvent(
+              ['public-one', 'in-both'],
+              content: await encryptToSelf([
+                ['e', privateVideo],
+                ['e', 'in-both'],
+              ]),
+            ),
+          ],
+        );
+        final service = createService();
+
+        await service.syncGlobalBookmarks();
+
+        expect(
+          service.globalBookmarks.map((item) => item.id),
+          equals(['public-one', 'in-both', privateVideo]),
+        );
+      });
+
+      test(
+        'saving a privately-bookmarked video does not publish a public tag',
+        () async {
+          final ciphertext = await encryptToSelf([
+            ['e', privateVideo],
+          ]);
+          stubRelay(events: [bookmarkListEvent([], content: ciphertext)]);
+          final service = createService();
+
+          final result = await service.toggleVideoInGlobalBookmarks(
+            privateVideo,
+          );
+
+          expect(
+            result.wasBookmarked,
+            isTrue,
+            reason: 'the private item decides the direction',
+          );
+          expect(
+            signedEventIds(),
+            isNot(contains(privateVideo)),
+            reason:
+                'publishing it as a public tag would disclose a bookmark the '
+                'user chose to keep private (#7136)',
+          );
+        },
+      );
+
+      test(
+        'removing a private item drops it from the encrypted array',
+        () async {
+          final ciphertext = await encryptToSelf([
+            ['e', privateVideo],
+            ['e', 'keep-me'],
+          ]);
+          stubRelay(events: [bookmarkListEvent([], content: ciphertext)]);
+          final service = createService();
+
+          final result = await service.toggleVideoInGlobalBookmarks(
+            privateVideo,
+          );
+
+          expect(result.succeeded, isTrue);
+          expect(result.isBookmarked, isFalse);
+          expect(
+            await decryptToSelf(signedContent!),
+            equals([
+              ['e', 'keep-me'],
+            ]),
+            reason:
+                'leaving it in `content` would make the reported removal a lie '
+                'for every conforming client (#7136)',
+          );
+          expect(
+            service.isVideoBookmarkedGlobally(privateVideo),
+            isFalse,
+            reason: 'and the local read must agree with what was published',
+          );
+        },
+      );
+
+      test('clears content once the last private item is removed', () async {
+        stubRelay(
+          events: [
+            bookmarkListEvent(
+              [],
+              content: await encryptToSelf([
+                ['e', privateVideo],
+              ]),
+            ),
+          ],
+        );
+        final service = createService();
+
+        await service.toggleVideoInGlobalBookmarks(privateVideo);
+
+        expect(
+          signedContent,
+          isEmpty,
+          reason: 'an empty private array carries no payload at all',
+        );
+      });
+
+      test('never writes private items into SharedPreferences', () async {
+        stubRelay(
+          events: [
+            bookmarkListEvent(
+              ['public-one'],
+              content: await encryptToSelf([
+                ['e', privateVideo],
+              ]),
+            ),
+          ],
+        );
+        final service = createService();
+
+        await service.syncGlobalBookmarks();
+
+        expect(
+          prefs.getString(BookmarkService.globalBookmarksStorageKey),
+          allOf(contains('public-one'), isNot(contains(privateVideo))),
+          reason:
+              'SharedPreferences is unencrypted, so caching private items '
+              'would move them into plaintext local storage',
+        );
+      });
+
+      group('unreadable content', () {
+        test('refuses to publish when the payload is NIP-04', () async {
+          // NIP-51 deprecated NIP-04 here but tells clients to detect it by
+          // the `iv` marker; one such list is live on relay.divine.video.
+          stubRelay(
+            events: [
+              bookmarkListEvent([], content: 'c29tZQ==?iv=aXY='),
+            ],
+          );
+          final service = createService();
+
+          final result = await service.toggleVideoInGlobalBookmarks('wanted');
+
+          expect(result.succeeded, isFalse);
+          expect(
+            result.failure,
+            equals(BookmarkToggleFailure.privateItemsUnreadable),
+          );
+          expect(signedTags, isNull, reason: 'nothing may be published');
+        });
+
+        test('refuses to publish when the signer cannot decrypt', () async {
+          // Content encrypted to a different identity: real ciphertext this
+          // signer will never read.
+          final stranger = LocalNostrIdentity(
+            keyContainer: SecureKeyContainer.fromPrivateKeyHex(
+              generatePrivateKey(),
+            ),
+          );
+          final foreign = await stranger.nip44Encrypt(
+            stranger.pubkey,
+            jsonEncode([
+              ['e', privateVideo],
+            ]),
+          );
+          stubRelay(events: [bookmarkListEvent([], content: foreign!)]);
+          final service = createService();
+
+          final result = await service.toggleVideoInGlobalBookmarks('wanted');
+
+          expect(result.succeeded, isFalse);
+          expect(
+            result.failure,
+            equals(BookmarkToggleFailure.privateItemsUnreadable),
+          );
+          expect(signedTags, isNull);
+        });
+
+        test(
+          'refuses to publish when the plaintext is not a tag array',
+          () async {
+            stubRelay(
+              events: [
+                bookmarkListEvent(
+                  [],
+                  content: (await identity.nip44Encrypt(pubkey, 'not json'))!,
+                ),
+              ],
+            );
+            final service = createService();
+
+            final result = await service.toggleVideoInGlobalBookmarks('wanted');
+
+            expect(result.succeeded, isFalse);
+            expect(
+              result.failure,
+              equals(BookmarkToggleFailure.privateItemsUnreadable),
+            );
+            expect(signedTags, isNull);
+          },
+        );
+
+        test(
+          'reports the blind spot so callers can stay indeterminate',
+          () async {
+            stubRelay(
+              events: [
+                bookmarkListEvent([], content: 'c29tZQ==?iv=aXY='),
+              ],
+            );
+            final service = createService();
+
+            await service.syncGlobalBookmarks();
+
+            expect(service.hasUnreadablePrivateItems, isTrue);
+          },
+        );
+
+        test('stays false for a list Divine can read end to end', () async {
+          stubRelay(
+            events: [
+              bookmarkListEvent(
+                [],
+                content: await encryptToSelf([
+                  ['e', privateVideo],
+                ]),
+              ),
+            ],
+          );
+          final service = createService();
+
+          await service.syncGlobalBookmarks();
+
+          expect(service.hasUnreadablePrivateItems, isFalse);
+        });
       });
     });
   });

--- a/mobile/test/services/bookmark_service_test.dart
+++ b/mobile/test/services/bookmark_service_test.dart
@@ -1092,6 +1092,38 @@ void main() {
         },
       );
 
+      test('removing an item held in both halves drops both copies', () async {
+        const inBoth = 'in-both';
+        stubRelay(
+          events: [
+            bookmarkListEvent(
+              [inBoth],
+              content: await encryptToSelf([
+                ['e', inBoth],
+              ]),
+            ),
+          ],
+        );
+        final service = createService();
+
+        final result = await service.toggleVideoInGlobalBookmarks(inBoth);
+
+        expect(result.succeeded, isTrue);
+        expect(result.isBookmarked, isFalse);
+        expect(
+          signedEventIds(),
+          isNot(contains(inBoth)),
+          reason:
+              'a surviving public tag makes the reported removal a lie - the '
+              'pre-fix leak (#7136) is what puts an item in both halves',
+        );
+        expect(
+          service.isVideoBookmarkedGlobally(inBoth),
+          isFalse,
+          reason: 'and the local read must agree with what was published',
+        );
+      });
+
       test('clears content once the last private item is removed', () async {
         stubRelay(
           events: [

--- a/mobile/test/services/bookmark_service_test.dart
+++ b/mobile/test/services/bookmark_service_test.dart
@@ -1259,6 +1259,36 @@ void main() {
         );
       });
 
+      test('refuses a private tag carrying a non-string value', () async {
+        // Dropping the offending value instead would shift every position
+        // after it: `['e', id, null, petname]` re-encrypts as
+        // `['e', id, petname]`, promoting the label to the relay hint. The
+        // verbatim carry-through exists precisely to make losses like that
+        // impossible, so a payload this client cannot represent is unreadable.
+        stubRelay(
+          events: [
+            bookmarkListEvent(
+              [],
+              content: (await identity.nip44Encrypt(
+                pubkey,
+                jsonEncode([
+                  ['e', privateVideo, null, 'a petname'],
+                ]),
+              ))!,
+            ),
+          ],
+        );
+        final service = createService();
+
+        final result = await service.toggleVideoInGlobalBookmarks('wanted');
+
+        expect(
+          result.failure,
+          equals(BookmarkToggleFailure.privateItemsUnreadable),
+        );
+        expect(signedTags, isNull, reason: 'nothing may be published');
+      });
+
       test('never writes private items into SharedPreferences', () async {
         stubRelay(
           events: [

--- a/mobile/test/services/bookmark_service_test.dart
+++ b/mobile/test/services/bookmark_service_test.dart
@@ -1124,6 +1124,39 @@ void main() {
         );
       });
 
+      test(
+        'a sync racing the toggle cannot duplicate a private item',
+        () async {
+          stubRelay(
+            events: [
+              bookmarkListEvent(
+                [],
+                content: await encryptToSelf([
+                  ['e', privateVideo],
+                ]),
+              ),
+            ],
+          );
+          final service = createService();
+
+          // The display read and the toggle share one service instance and
+          // neither is serialized, so both reach the decrypt await together.
+          final racingSync = service.syncGlobalBookmarks();
+          final toggle = service.toggleVideoInGlobalBookmarks(privateVideo);
+          await racingSync;
+          final result = await toggle;
+
+          expect(result.succeeded, isTrue);
+          expect(
+            signedContent,
+            isEmpty,
+            reason:
+                'a private item adopted twice survives List.remove, so the '
+                'relay keeps the bookmark the user was told was removed',
+          );
+        },
+      );
+
       test('clears content once the last private item is removed', () async {
         stubRelay(
           events: [

--- a/mobile/test/services/bookmark_service_test.dart
+++ b/mobile/test/services/bookmark_service_test.dart
@@ -1157,6 +1157,36 @@ void main() {
         },
       );
 
+      test('a removal rewrites only the entry it removes', () async {
+        stubRelay(
+          events: [
+            bookmarkListEvent(
+              [],
+              content: await encryptToSelf([
+                ['title', 'Reading list'],
+                ['e', privateVideo],
+                ['e', 'keep-me', 'wss://relay.example', 'a petname', 'extra'],
+              ]),
+            ),
+          ],
+        );
+        final service = createService();
+
+        await service.toggleVideoInGlobalBookmarks(privateVideo);
+
+        expect(
+          await decryptToSelf(signedContent!),
+          equals([
+            ['title', 'Reading list'],
+            ['e', 'keep-me', 'wss://relay.example', 'a petname', 'extra'],
+          ]),
+          reason:
+              're-encrypting from parsed items would drop another client tag '
+              'this one does not model, and truncate the fifth position - '
+              'losses the byte-for-byte carry-through could never cause',
+        );
+      });
+
       test('clears content once the last private item is removed', () async {
         stubRelay(
           events: [

--- a/mobile/test/services/bookmark_service_test.dart
+++ b/mobile/test/services/bookmark_service_test.dart
@@ -836,6 +836,31 @@ void main() {
         expect(signedEventIds(), equals(['keep-a', 'keep-b']));
       });
 
+      test('drops every public copy of a duplicated tag', () async {
+        // Nothing stops another client from writing the same `e` tag twice.
+        // `List.remove` drops only the first, so the republished list would
+        // still carry the video while the sheet reports "Removed" — the same
+        // lie the private path already uses `removeWhere` to avoid.
+        stubRelay(
+          events: [
+            bookmarkListEvent(['keep', 'drop', 'drop']),
+          ],
+        );
+        final service = createService();
+
+        final removed = await service.removeFromGlobalBookmarks(
+          const BookmarkItem(type: 'e', id: 'drop'),
+        );
+
+        expect(removed, isTrue);
+        expect(signedEventIds(), equals(['keep']));
+        expect(
+          service.isVideoBookmarkedGlobally('drop'),
+          isFalse,
+          reason: 'a surviving duplicate makes the reported removal a lie',
+        );
+      });
+
       test('does not publish when the relay could not be reached', () async {
         stubRelay(events: [], timedOut: true);
         final service = createService();

--- a/mobile/test/widgets/share_video_menu_comprehensive_test.dart
+++ b/mobile/test/widgets/share_video_menu_comprehensive_test.dart
@@ -117,6 +117,9 @@ void main() {
       () => mockBookmarkService.isVideoBookmarkedGlobally(any()),
     ).thenReturn(false);
     when(
+      () => mockBookmarkService.hasUnreadablePrivateItems,
+    ).thenReturn(false);
+    when(
       () => mockBookmarkService.syncGlobalBookmarks(),
     ).thenAnswer((_) async => true);
     when(


### PR DESCRIPTION
## Description

`BookmarkService` consulted only the **public** tags of the user's NIP-51 kind 10003. NIP-51 also puts **private** items in `.content` — a stringified tag array, NIP-44 encrypted to the author's own key — and Divine never read them.

Three defects followed, all reproduced before the fix:

1. A video bookmarked privately in another client read as **unsaved**, and Saved rendered its empty state.
2. Tapping **Save** on it appended a plaintext `e` tag while the ciphertext passed through unchanged — storing the item twice and **publishing a bookmark the user chose to keep private**.
3. Tapping again dropped only the public copy and reported **"Removed"** while the private one survived, so every conforming client still showed it bookmarked.

This is not hypothetical. A census of `wss://relay.divine.video` (416 kind-10003 events, one per author) found **66** users carrying private items — **24** of them with zero public tags, so Divine showed them nothing at all.

### What changed

- **Read** — `content` is decrypted on adopt and reads answer from the union of both halves. `globalBookmarks` and `isInGlobalBookmarks` now see private items, so both consumers (share sheet, Saved tab) are fixed without any UI change.
- **Write** — an item keeps the privacy class it already had. A private item is removed from the encrypted array rather than shadowed by a public tag. **New saves still go to public tags, unchanged.**
- **Unreadable content** — the deprecated NIP-04 scheme (NIP-51 mandates sniffing `?iv=`; one such list is live), a signer that declines, or malformed plaintext are reported as *unreadable* rather than as "no private items", and the write path refuses instead of guessing. The share sheet leaves its label at `unknown` rather than claiming "not saved".

### Safety properties

- **Private items are never persisted.** `SharedPreferences` is unencrypted; caching them would move private bookmarks into plaintext local storage — a disclosure of its own. They are re-read on each sync.
- **`_globalBookmarks` stays public-only** and remains the sole input to the published `tags`, so a private item cannot reach the clear.
- **Re-encryption is verified before publishing.** It only happens when the private array is the thing being changed, and the payload must decrypt back to the intended array first — kind 10003 is replaceable, so an unverified re-encryption would destroy private bookmarks this client cannot reconstruct. Every other write re-emits the original ciphertext byte-for-byte, preserving #6966's guarantee.

Capability was never the blocker: every `NostrIdentity` that can publish can also `nip44Decrypt`, and every Keycast permission variant permits it — including the strictest, `encrypt_to_self`, whose predicate is literally `sender == recipient`, which is exactly this case.

**Related Issue:** Closes #7136, Closes #6967

## Out of Scope

Deliberately not touched — separate blast radii, each with its own issue:

- #7134 non-item tags (`title`/`description`/`image`/`alt`) dropped on republish
- #7135 bookmark by coordinate so an edit does not strand the item
- #7137 `BookmarkItem` truncates tags to four positions
- #7163 serialize global bookmark syncs
- #6969 extract a `bookmarks_repository` package

A dedicated user-facing string for the unreadable case is also out of scope — the existing failure copy is honest, and a new key would drag 16+ locales into this PR.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test` on all four affected suites — **153 passing** (`bookmark_service`, `share_sheet_bloc`, `profile_saved_videos_bloc`, `share_video_menu_comprehensive`)
- Ratchets: `check_service_god_file_ceiling`, `check_untested_services_floor`, `check_test_unit_structure` — all pass
- Test fixtures use the **real** signer (`LocalNostrIdentity` + `SecureKeyContainer`), so the private payloads under test are genuine NIP-44 encrypt-to-self round trips rather than stubs. `NostrIdentity` is sealed and cannot be mocked, which makes this the only option — and the better one.
- 11 new service tests cover: private-only read, public+private merge without duplicates, no public tag on saving a private item, removal from the encrypted array, content cleared when the last private item goes, private items absent from `SharedPreferences`, and four unreadable-content refusals.

### On device

Built for iOS and run against the local `funnelcake` relay stack, signed in by importing an nsec through the real UI, driven via `idb`'s accessibility tree.

**Before** — relay holds a kind 10003 with one NIP-44 private item and zero public tags:

```
[SYSTEM] Synced 0 global bookmarks from relay      →  screen: "Nothing saved yet"
```

**After** — same seed, same screen:

```
[SYSTEM] Read 1 private bookmark items
[SYSTEM] Synced 1 global bookmarks from relay (1 private)
```

The device run also caught a defect in this diff that the unit tests could not: the sync log counted only the public half, so it still read `Synced 0` while holding a private item. Both count-reporting log lines now include private items.

A control run with a *public* bookmark reaches the same screen state, which confirms the remaining empty Saved list is the local stack's video-resolution behaviour and not this change — private items now behave exactly like public ones.

Separately verified on device: reading an all-private list does **not** republish or destroy it. The relay copy came back byte-identical — same event id, same `created_at`, private item still decrypting.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
