### PR TITLE
chore(lint): enable 18 analyzer rules and fix their violations

### DIFF
--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -14,53 +14,35 @@ analyzer:
     avoid_equals_and_hash_code_on_mutable_classes: ignore
     avoid_positional_boolean_parameters: ignore
     avoid_returning_this: ignore
-    avoid_setters_without_getters: ignore
     avoid_types_on_closure_parameters: ignore
-    avoid_web_libraries_in_flutter: ignore
     cascade_invocations: ignore
     comment_references: ignore
-    constant_identifier_names: ignore
     discarded_futures: ignore
     document_ignores: ignore
-    dot_shorthand_missing_context: ignore
-    final_not_initialized_constructor: ignore
     inference_failure_on_collection_literal: ignore
     inference_failure_on_function_invocation: ignore
     inference_failure_on_function_return_type: ignore
     inference_failure_on_instance_creation: ignore
     inference_failure_on_untyped_parameter: ignore
-    instance_member_access_from_factory: ignore
-    invalid_annotation_target: ignore
     invalid_assignment: ignore
     join_return_with_assignment: ignore
     library_annotations: ignore
     list_element_type_not_assignable: ignore
-    map_value_type_not_assignable: ignore
-    matching_super_parameters: ignore
-    non_constant_identifier_names: ignore
     only_throw_errors: ignore
-    prefer_asserts_with_message: ignore
     prefer_int_literals: ignore
-    return_of_invalid_type: ignore
-    return_of_invalid_type_from_closure: ignore
     sort_constructors_first: ignore
     strict_raw_type: ignore
-    strict_top_level_inference: ignore
     type_annotate_public_apis: ignore
     unawaited_futures: ignore
 
 linter:
   rules:
     avoid_dynamic_calls: false
-    avoid_print: true
-    cancel_subscriptions: false
     depend_on_referenced_packages: false
     flutter_style_todos: false
     lines_longer_than_80_chars: false
-    missing_code_block_language_in_doc_comment: false
     no_default_cases: false
     one_member_abstracts: false
-    parameter_assignments: false
     prefer_constructors_over_static_methods: false
     prefer_foreach: false
     # The repo convention is named-parameter constructor injection into private
@@ -68,7 +50,6 @@ linter:
     prefer_initializing_formals: false
     public_member_api_docs: false
     sort_pub_dependencies: false
-    unintended_html_in_doc_comment: false
     unreachable_from_main: false
     use_named_constants: false
     omit_local_variable_types: false

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -1483,7 +1483,7 @@ class VideoRecorderBloc
   /// the dispose (if any) happens after — so it never races the native start.
   /// The lock is cleared on the next [VideoRecorderInitializeRequested].
   void _lockRecordingForNavigation(Emitter<VideoRecorderBlocState> emit) {
-    _cameraService.onRemoteRecordTrigger = null;
+    _cameraService.setOnRemoteRecordTrigger(null);
     if (state.isRecording || state.isStartingRecording) {
       _readClipManager()
         ..stopRecording()
@@ -2032,10 +2032,10 @@ class VideoRecorderBloc
   // === Private helpers ===
 
   Future<void> _setupRemoteRecordControl() async {
-    _cameraService.onRemoteRecordTrigger = () {
+    _cameraService.setOnRemoteRecordTrigger(() {
       if (isClosed) return;
       add(const _VideoRecorderRemoteRecordTriggered());
-    };
+    });
 
     final success = await _cameraService.setRemoteRecordControlEnabled(
       enabled: true,
@@ -2069,7 +2069,7 @@ class VideoRecorderBloc
   Future<void> _disableRemoteRecordControl() async {
     if (_remoteRecordControlEnabled) {
       await _cameraService.setRemoteRecordControlEnabled(enabled: false);
-      _cameraService.onRemoteRecordTrigger = null;
+      _cameraService.setOnRemoteRecordTrigger(null);
       _remoteRecordControlEnabled = false;
       Log.debug(
         '🎮 Remote record control disabled',

--- a/mobile/lib/blocs/video_recorder/video_recorder_event.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_event.dart
@@ -320,7 +320,7 @@ final class _VideoRecorderCameraStateChanged extends VideoRecorderEvent {
 
 /// Internal event: a remote-record trigger fired (volume button /
 /// Bluetooth media key). Dispatched from the
-/// `CameraService.onRemoteRecordTrigger` callback.
+/// `CameraService.setOnRemoteRecordTrigger` callback.
 final class _VideoRecorderRemoteRecordTriggered extends VideoRecorderEvent {
   const _VideoRecorderRemoteRecordTriggered();
 }

--- a/mobile/lib/models/environment_config.dart
+++ b/mobile/lib/models/environment_config.dart
@@ -25,7 +25,7 @@ const loopbackHost = 'localhost';
 ///   - mobile/android/app/src/main/res/xml/network_security_config.xml
 ///   - mobile/ios/Runner/Info.plist (NSAllowsLocalNetworking)
 ///   - mobile/macos/Runner/Info.plist (NSAllowsLocalNetworking)
-/// Keep both constants in sync with the Android <domain-config> list.
+/// Keep both constants in sync with the Android `<domain-config>` list.
 String get localHost =>
     !kIsWeb && defaultTargetPlatform == TargetPlatform.android
     ? androidEmulatorHost

--- a/mobile/lib/observability/network/http_url_pattern.dart
+++ b/mobile/lib/observability/network/http_url_pattern.dart
@@ -101,7 +101,7 @@ final RegExp _fileExtension = RegExp(r'^[A-Za-z0-9]{1,5}$');
 /// fragment; and replaces identifier path segments with placeholders so every
 /// call to one endpoint lands on one pattern:
 ///
-/// ```
+/// ```text
 /// https://api.divine.video/api/users/<64-hex>/videos?limit=20
 ///   -> https://api.divine.video/api/users/:id/videos
 /// https://media.divine.video/<sha256>.mp4

--- a/mobile/lib/providers/route_feed_providers.dart
+++ b/mobile/lib/providers/route_feed_providers.dart
@@ -59,7 +59,7 @@ final exploreTabNameProvider = StateProvider<String>(
 final activeBranchIndexProvider = StateProvider<int>((ref) => 0);
 
 /// Explore feed state (discovery/all videos)
-/// Returns AsyncValue<VideoFeedState> for route-aware explore screen
+/// Returns `AsyncValue<VideoFeedState>` for route-aware explore screen
 /// Uses tab-specific list when in feed mode, otherwise sorted by loop count
 /// Filters out broken videos to match grid UI behavior
 final videosForExploreRouteProvider = Provider<AsyncValue<VideoFeedState>>((

--- a/mobile/lib/screens/comments/widgets/video_comment_player.dart
+++ b/mobile/lib/screens/comments/widgets/video_comment_player.dart
@@ -34,6 +34,9 @@ class VideoCommentPlayer extends StatefulWidget {
 class _VideoCommentPlayerState extends State<VideoCommentPlayer>
     with WidgetsBindingObserver {
   DivineVideoPlayerController? _controller;
+  // Cancelled in dispose through a local alias, so the field is nulled before
+  // the async teardown.
+  // ignore: cancel_subscriptions
   StreamSubscription<DivineVideoPlayerState>? _stateSubscription;
   bool _isInitializing = false;
   bool _isPlaying = false;

--- a/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
@@ -62,6 +62,9 @@ class _VideoMetadataCoverScreenState
   // dispose can clean them up even if a later batch superseded the list
   // currently held in [_stripThumbnails].
   final Set<String> _allStripThumbnailPaths = <String>{};
+  // Cancelled in _disposeStripResources through a local alias, so the field is
+  // nulled before the await.
+  // ignore: cancel_subscriptions
   StreamSubscription<List<StripThumbnail>>? _stripSubscription;
 
   Duration _selectedPosition = Duration.zero;

--- a/mobile/lib/services/account_deletion_service.dart
+++ b/mobile/lib/services/account_deletion_service.dart
@@ -103,7 +103,7 @@ class _VanishPublishConfig {
     required this.maxAttempts,
     required this.timeout,
     required this.retryDelays,
-  }) : assert(maxAttempts > 0);
+  }) : assert(maxAttempts > 0, 'maxAttempts must be at least 1');
 
   final int maxAttempts;
   final Duration timeout;

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -3,7 +3,9 @@
 
 import 'dart:convert';
 // TODO: migrate to `package:web` and `dart:js_interop`.
-// ignore: deprecated_member_use
+// The conditional import keeps `dart:html` off every non-web build, which is
+// what the lint guards against.
+// ignore: deprecated_member_use, avoid_web_libraries_in_flutter
 import 'dart:html'
     if (dart.library.io) 'package:openvine/services/bug_report_service_stub.dart'
     as html;

--- a/mobile/lib/services/c2pa_signing_service.dart
+++ b/mobile/lib/services/c2pa_signing_service.dart
@@ -101,7 +101,7 @@ class C2paSigningService {
 
   /// Whether the remote signing pipeline is configured for this build.
   ///
-  /// Signing is a network call to [SIGNING_SERVER_ENDPOINT]. The endpoint always
+  /// Signing is a network call to [signingServerEndpoint]. The endpoint always
   /// resolves to a usable URL — an override that is absent falls back to
   /// [defaultSigningServerEndpoint] — so signing is configured unless a build
   /// explicitly disables it with `PROOFMODE_SIGNING_SERVER_ENDPOINT=disabled`.
@@ -500,8 +500,8 @@ class C2paSigningService {
     }
 
     return RemoteSigner(
-      configurationUrl: SIGNING_SERVER_ENDPOINT + args,
-      bearerToken: SIGNING_SERVER_TOKEN,
+      configurationUrl: signingServerEndpoint + args,
+      bearerToken: signingServerToken,
     );
   }
 
@@ -521,15 +521,15 @@ class C2paSigningService {
   static const String signingDisabledSentinel = 'disabled';
 
   // add ?platform=android or ios
-  static const String SIGNING_SERVER_ENDPOINT = String.fromEnvironment(
+  static const String signingServerEndpoint = String.fromEnvironment(
     'PROOFMODE_SIGNING_SERVER_ENDPOINT',
     defaultValue: defaultSigningServerEndpoint,
   );
 
   static bool get _signingDisabled =>
-      SIGNING_SERVER_ENDPOINT.trim().toLowerCase() == signingDisabledSentinel;
+      signingServerEndpoint.trim().toLowerCase() == signingDisabledSentinel;
 
-  /// Validates [SIGNING_SERVER_ENDPOINT], returning null when it is usable and
+  /// Validates [signingServerEndpoint], returning null when it is usable and
   /// a human-readable reason when it is not.
   ///
   /// Exposed separately from [assertSigningEndpointValid] so tests can check
@@ -575,13 +575,13 @@ class C2paSigningService {
   /// later as an opaque signing error during capture, which reads as an outage
   /// rather than a build problem. Called from app startup.
   static void assertSigningEndpointValid() {
-    final problem = describeSigningEndpointProblem(SIGNING_SERVER_ENDPOINT);
+    final problem = describeSigningEndpointProblem(signingServerEndpoint);
     if (problem != null) {
       throw StateError('C2PA signing misconfigured: $problem');
     }
   }
 
-  static const String SIGNING_SERVER_TOKEN = String.fromEnvironment(
+  static const String signingServerToken = String.fromEnvironment(
     'PROOFMODE_SIGNING_SERVER_TOKEN',
   );
 }

--- a/mobile/lib/services/nip07_types.dart
+++ b/mobile/lib/services/nip07_types.dart
@@ -56,7 +56,7 @@ class NIP44 {
 class NostrEvent {
   NostrEvent({
     required this.pubkey,
-    required this.created_at,
+    required this.createdAt,
     required this.kind,
     required this.tags,
     required this.content,
@@ -66,7 +66,7 @@ class NostrEvent {
 
   factory NostrEvent.create({
     required String pubkey,
-    required int created_at,
+    required int createdAt,
     required int kind,
     required List<List<String>> tags,
     required String content,
@@ -76,7 +76,7 @@ class NostrEvent {
     return NostrEvent(
       id: id,
       pubkey: pubkey,
-      created_at: created_at,
+      createdAt: createdAt,
       kind: kind,
       tags: tags,
       content: content,
@@ -86,7 +86,7 @@ class NostrEvent {
 
   String? id;
   String pubkey;
-  int created_at; // ignore: non_constant_identifier_names
+  int createdAt;
   int kind;
   List<List<String>> tags;
   String content;
@@ -96,7 +96,7 @@ class NostrEvent {
     return {
       if (id != null) 'id': id,
       'pubkey': pubkey,
-      'created_at': created_at,
+      'created_at': createdAt,
       'kind': kind,
       'tags': tags,
       'content': content,
@@ -119,7 +119,7 @@ NostrEvent dartEventToJs(Map<String, dynamic> dartEvent) {
   return NostrEvent.create(
     id: dartEvent['id'] as String?,
     pubkey: (dartEvent['pubkey'] ?? '').toString(),
-    created_at:
+    createdAt:
         dartEvent['created_at'] as int? ??
         DateTime.now().millisecondsSinceEpoch ~/ 1000,
     kind: dartEvent['kind'] as int? ?? 1,
@@ -134,7 +134,7 @@ Map<String, dynamic> jsEventToDart(NostrEvent event) {
   return {
     'id': event.id,
     'pubkey': event.pubkey,
-    'created_at': event.created_at,
+    'created_at': event.createdAt,
     'kind': event.kind,
     'tags': event.tags,
     'content': event.content,

--- a/mobile/lib/services/subscription_manager.dart
+++ b/mobile/lib/services/subscription_manager.dart
@@ -90,6 +90,8 @@ class SubscriptionManager {
     final eventStream = _nostrService.subscribe(filteredFilters);
 
     // Set up subscription
+    // Owned by _activeSubscriptions and cancelled in cancelSubscription.
+    // ignore: cancel_subscriptions
     final subscription = eventStream.listen(
       onEvent,
       onError: onError,

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -515,13 +515,14 @@ class UploadManager implements BackgroundAwareService {
 
     // Prefer the persisted final render when available. It preserves editor
     // overlays and gives retries/background uploads a stable file path.
+    var resolvedDuration = videoDuration;
     String videoFilePath;
     final renderedClip = draft.finalRenderedClip;
     if (renderedClip != null) {
       final renderedPath = await renderedClip.requireVideo.safeFilePath();
       if (File(renderedPath).existsSync()) {
         videoFilePath = renderedPath;
-        videoDuration ??= renderedClip.duration;
+        resolvedDuration ??= renderedClip.duration;
         Log.info(
           '🎬 Using final rendered clip for upload: $videoFilePath',
           name: 'UploadManager',
@@ -546,10 +547,9 @@ class UploadManager implements BackgroundAwareService {
       final meta = await ProVideoEditor.instance.getMetadata(
         EditorVideo.file(videoFilePath),
       );
-      videoDuration ??= meta.duration;
-      final resolution = meta.resolution;
-      videoWidth = resolution.width.round();
-      videoHeight = resolution.height.round();
+      resolvedDuration ??= meta.duration;
+      videoWidth = meta.resolution.width.round();
+      videoHeight = meta.resolution.height.round();
     } catch (e) {
       Log.warning(
         '⚠️ Could not extract video metadata: $e',
@@ -566,7 +566,7 @@ class UploadManager implements BackgroundAwareService {
       hashtags: draft.hashtags.toList(),
       videoWidth: videoWidth,
       videoHeight: videoHeight,
-      videoDuration: videoDuration,
+      videoDuration: resolvedDuration,
       proofManifestJson: draft.proofManifestJson,
       onProgress: onProgress,
       thumbnailTimestamp: draft.thumbnailTimestamp,

--- a/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
+++ b/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
@@ -276,6 +276,9 @@ class ClipThumbnailManager {
     // the stream errors and closes with only a partial set delivered.
     var truncated = false;
 
+    // Owned by _subscriptions and cancelled in sync (on replace and on clip
+    // removal) and in dispose.
+    // ignore: cancel_subscriptions
     final subscription =
         _generateStripThumbnails(
           videoPath: videoPath,

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -518,18 +518,17 @@ class VideoEditorRenderService {
         }
       }
       await progressTracker.markAssemblyComplete();
-      clips = renderClips;
 
       Log.debug(
-        '🎬 renderVideoToClip: clips=${clips.length}, '
+        '🎬 renderVideoToClip: clips=${renderClips.length}, '
         'parameters=${parameters?.toLogString()}',
         name: _logName,
         category: LogCategory.video,
       );
 
       final outputPath = await _renderVideoOrThrow(
-        clips: clips,
-        aspectRatio: clips.first.targetAspectRatio,
+        clips: renderClips,
+        aspectRatio: renderClips.first.targetAspectRatio,
         usePersistentStorage: true,
         parameters: parameters,
         taskId: effectiveTaskId,
@@ -554,7 +553,7 @@ class VideoEditorRenderService {
       // or where proof generation failed will be attested now.
       var completedProofSteps = 0;
       final attestedClips = await _ensureClipProofs(
-        clips,
+        renderClips,
         onClipProcessed: () {
           completedProofSteps++;
           progressTracker.markProofStepComplete(completedProofSteps);
@@ -601,9 +600,9 @@ class VideoEditorRenderService {
         video: EditorVideo.file(outputPath),
         duration: metaData.duration,
         recordedAt: DateTime.now(),
-        originalAspectRatio: clips.first.originalAspectRatio,
-        targetAspectRatio: clips.first.targetAspectRatio,
-        thumbnailPath: cover?.path ?? clips.first.thumbnailPath,
+        originalAspectRatio: renderClips.first.originalAspectRatio,
+        targetAspectRatio: renderClips.first.targetAspectRatio,
+        thumbnailPath: cover?.path ?? renderClips.first.thumbnailPath,
         thumbnailTimestamp: cover?.timestamp,
       );
 

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -2519,6 +2519,9 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           subscriptionType: subscriptionType,
         );
 
+        // Owned by _subscriptions[subscriptionId] and cancelled in
+        // _cancelExistingSubscriptions.
+        // ignore: cancel_subscriptions
         final streamSubscription = eventStream.listen(
           (event) {
             eventCount++;
@@ -6067,6 +6070,9 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       );
 
       // Subscribe to search results
+      // Owned by _subscriptions['search'] and cancelled in clearSearchResults
+      // and _cancelExistingSubscriptions.
+      // ignore: cancel_subscriptions
       final subscription = searchStream.listen(
         _handleSearchResult,
         onError: (error) {

--- a/mobile/lib/services/video_recorder/camera/camera_base_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_base_service.dart
@@ -162,7 +162,7 @@ abstract class CameraService {
   /// Enables or disables remote record control via volume buttons.
   ///
   /// When enabled, volume button presses will trigger the
-  /// [onRemoteRecordTrigger] callback instead of changing the system volume.
+  /// [setOnRemoteRecordTrigger] callback instead of changing the system volume.
   /// This allows users to start/stop recording using physical volume buttons
   /// or Bluetooth accessories like clickers or earbuds.
   ///
@@ -182,5 +182,5 @@ abstract class CameraService {
   ///
   /// This is called when the user presses a volume button or Bluetooth
   /// remote while remote record control is enabled.
-  set onRemoteRecordTrigger(void Function()? callback);
+  void setOnRemoteRecordTrigger(void Function()? callback);
 }

--- a/mobile/lib/services/video_recorder/camera/camera_linux_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_linux_service.dart
@@ -143,7 +143,7 @@ class CameraLinuxService extends CameraService {
   }
 
   @override
-  set onRemoteRecordTrigger(void Function()? callback) {
+  void setOnRemoteRecordTrigger(void Function()? callback) {
     // Remote record control is not supported on Linux.
   }
 

--- a/mobile/lib/services/video_recorder/camera/camera_mobile_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_mobile_service.dart
@@ -458,7 +458,7 @@ class CameraMobileService extends CameraService {
   void Function()? _remoteRecordTriggerCallback;
 
   @override
-  set onRemoteRecordTrigger(void Function()? callback) {
+  void setOnRemoteRecordTrigger(void Function()? callback) {
     _remoteRecordTriggerCallback = callback;
     // Connect to native callback with logging
     _camera.onRemoteRecordTrigger = callback != null

--- a/mobile/lib/utils/async_utils.dart
+++ b/mobile/lib/utils/async_utils.dart
@@ -438,7 +438,7 @@ class AsyncUtils {
 
 /// Exception thrown when an async operation times out
 class AsyncTimeoutException extends TimeoutException {
-  AsyncTimeoutException(String super.message, Duration super.timeout);
+  AsyncTimeoutException(String super.message, Duration super.duration);
 }
 
 /// Mixin for classes that need proper async initialization patterns

--- a/mobile/lib/utils/string_utils.dart
+++ b/mobile/lib/utils/string_utils.dart
@@ -20,16 +20,10 @@ class StringUtils {
   static String safeSubstring(String str, int start, [int? end]) {
     if (str.isEmpty) return '';
 
-    // Clamp start to valid range
-    start = start.clamp(0, str.length);
+    final clampedStart = start.clamp(0, str.length);
+    final clampedEnd = (end ?? str.length).clamp(clampedStart, str.length);
 
-    // If no end specified, use string length
-    end ??= str.length;
-
-    // Clamp end to valid range
-    end = end.clamp(start, str.length);
-
-    return str.substring(start, end);
+    return str.substring(clampedStart, clampedEnd);
   }
 
   /// Format an ID for logging - safely truncates to 8 characters

--- a/mobile/lib/widgets/hashtag_search_view.dart
+++ b/mobile/lib/widgets/hashtag_search_view.dart
@@ -16,7 +16,7 @@ import 'package:openvine/screens/search_results/widgets/search_tag_chip.dart';
 
 /// Displays hashtag search results from HashtagSearchBloc.
 ///
-/// Must be used within a BlocProvider<HashtagSearchBloc>.
+/// Must be used within a `BlocProvider<HashtagSearchBloc>`.
 class HashtagSearchView extends StatelessWidget {
   const HashtagSearchView({super.key});
 

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -273,7 +273,7 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
     assert(() {
       debugProfileVideosGridBuildCount++;
       return true;
-    }());
+    }(), 'debug build counter must not throw');
     final authService = ref.read(authServiceProvider);
     final currentUserPubkey = authService.currentPublicKeyHex;
     final isOwnProfile =

--- a/mobile/lib/widgets/sound_tile.dart
+++ b/mobile/lib/widgets/sound_tile.dart
@@ -15,7 +15,7 @@ import 'package:openvine/l10n/l10n.dart';
 /// - Sound detail page "videos using this sound"
 ///
 /// Normal mode displays:
-/// ```
+/// ```text
 /// ┌─────────────────────────────────────────┐
 /// │  ▶️ Original sound - @user1           > │
 /// │    6s · 142 videos                      │
@@ -26,7 +26,7 @@ import 'package:openvine/l10n/l10n.dart';
 /// - Tap chevron (right) = navigate to sound detail
 ///
 /// Compact mode (for horizontal scroll):
-/// ```
+/// ```text
 /// ┌─────┐
 /// │thumb│
 /// │ ♪6s │

--- a/mobile/lib/widgets/video_editor/main_editor/hit_test_expander.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/hit_test_expander.dart
@@ -61,6 +61,7 @@ class _RenderHitTestExpander extends RenderProxyBox {
   static const double _hitTestEpsilon = 1.0;
 
   Size _visibleSize;
+  Size get visibleSize => _visibleSize;
   set visibleSize(Size value) {
     if (value == _visibleSize) return;
     _visibleSize = value;

--- a/mobile/test/blocs/saved_sounds/saved_sounds_bloc_test.dart
+++ b/mobile/test/blocs/saved_sounds/saved_sounds_bloc_test.dart
@@ -504,7 +504,7 @@ void main() {
 /// Persists normally but fails every delete, standing in for a
 /// `SharedPreferences` write that returns false.
 class _FailingRemoveService extends SavedSoundsService {
-  _FailingRemoveService(super.preferences);
+  _FailingRemoveService(super._preferences);
 
   @override
   Future<void> removeSound(String soundId) async {

--- a/mobile/test/infrastructure/drift_setup_test.dart
+++ b/mobile/test/infrastructure/drift_setup_test.dart
@@ -1,6 +1,9 @@
 // ABOUTME: Tests for Drift database setup and shared database access
 // ABOUTME: Verifies AppDatabase can open nostr_sdk's existing SQLite database
 
+// Permanent: opens file-backed Drift databases through path_provider temp paths;
+// keep isolated until DB and path-provider globals are per-test fixtures.
+@Tags(['skip_very_good_optimization'])
 import 'dart:io';
 
 import 'package:db_client/db_client.dart';
@@ -9,9 +12,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
-// Permanent: opens file-backed Drift databases through path_provider temp paths;
-// keep isolated until DB and path-provider globals are per-test fixtures.
-@Tags(['skip_very_good_optimization'])
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 

--- a/mobile/test/mocks/mock_camera_service.dart
+++ b/mobile/test/mocks/mock_camera_service.dart
@@ -190,7 +190,7 @@ class MockCameraService extends CameraService {
   }
 
   @override
-  set onRemoteRecordTrigger(void Function()? callback) {
+  void setOnRemoteRecordTrigger(void Function()? callback) {
     // Mock implementation - do nothing
   }
 }

--- a/mobile/test/mocks/mock_subscription_manager.dart
+++ b/mobile/test/mocks/mock_subscription_manager.dart
@@ -8,7 +8,7 @@ import 'package:nostr_sdk/filter.dart';
 import 'package:openvine/services/subscription_manager.dart';
 
 class MockSubscriptionManager extends SubscriptionManager {
-  MockSubscriptionManager(super.nostrService);
+  MockSubscriptionManager(super._nostrService);
   final Map<String, StreamController<Event>> _subscriptions = {};
   final Map<String, Filter> _filters = {};
   int _subscriptionCounter = 0;

--- a/mobile/test/services/hashtag_filtering_integration_test.dart
+++ b/mobile/test/services/hashtag_filtering_integration_test.dart
@@ -36,16 +36,8 @@ class MinimalMockNostrService implements NostrClient {
   @override
   Map<String, RelayConnectionStatus> get relayStatuses => {};
 
-  void addListener(listener) {}
-
-  void removeListener(listener) {}
-
   @override
   Future<void> dispose() async {}
-
-  bool get hasListeners => false;
-
-  void notifyListeners() {}
 
   // Implement required methods as no-ops for testing
   @override

--- a/mobile/test/services/nip07_types_test.dart
+++ b/mobile/test/services/nip07_types_test.dart
@@ -39,7 +39,7 @@ void main() {
 
       expect(event.id, equals('abc123'));
       expect(event.pubkey, equals('deadbeef'));
-      expect(event.created_at, equals(1_700_000_000));
+      expect(event.createdAt, equals(1_700_000_000));
       expect(event.kind, equals(1));
       expect(
         event.tags,
@@ -57,9 +57,9 @@ void main() {
       final event = dartEventToJs({'pubkey': 'pk', 'kind': 1, 'content': ''});
       final after = DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
-      expect(event.created_at, isA<int>());
-      expect(event.created_at, greaterThanOrEqualTo(before));
-      expect(event.created_at, lessThanOrEqualTo(after));
+      expect(event.createdAt, isA<int>());
+      expect(event.createdAt, greaterThanOrEqualTo(before));
+      expect(event.createdAt, lessThanOrEqualTo(after));
     });
 
     test('handles empty tags list', () {
@@ -80,7 +80,7 @@ void main() {
       final event = NostrEvent(
         id: 'id1',
         pubkey: 'pk1',
-        created_at: 1_700_000_000,
+        createdAt: 1_700_000_000,
         kind: 1,
         tags: [
           ['e', 'note1abc'],

--- a/mobile/test/services/upload_initialization_helper_test.dart
+++ b/mobile/test/services/upload_initialization_helper_test.dart
@@ -1,6 +1,9 @@
 // ABOUTME: Tests for UploadManager initialization helper
 // ABOUTME: Verifies app container path usage, permanent error detection, and fail-fast behavior
 
+// Permanent: mutates PathProviderPlatform.instance and Hive's process-wide box
+// registry while validating upload initialization failure paths.
+@Tags(['skip_very_good_optimization'])
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
@@ -18,9 +21,6 @@ class MockPathProviderPlatform extends Fake
   }
 }
 
-// Permanent: mutates PathProviderPlatform.instance and Hive's process-wide box
-// registry while validating upload initialization failure paths.
-@Tags(['skip_very_good_optimization'])
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 

--- a/mobile/test/services/video_editor/video_editor_reverse_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_reverse_service_test.dart
@@ -1,3 +1,6 @@
+// Permanent: swaps PathProviderPlatform.instance and ProVideoEditor.instance;
+// keep isolated until VideoEditorReverseService accepts injected dependencies.
+@Tags(['skip_very_good_optimization'])
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -69,9 +72,6 @@ class _FakeProVideoEditor extends ProVideoEditor {
   }
 }
 
-// Permanent: swaps PathProviderPlatform.instance and ProVideoEditor.instance;
-// keep isolated until VideoEditorReverseService accepts injected dependencies.
-@Tags(['skip_very_good_optimization'])
 void main() {
   late Directory tempDir;
   late String documentsPath;

--- a/mobile/test/services/video_editor/video_editor_split_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_split_service_test.dart
@@ -1,3 +1,6 @@
+// Permanent: swaps PathProviderPlatform.instance and ProVideoEditor.instance;
+// keep isolated until VideoEditorSplitService accepts injected dependencies.
+@Tags(['skip_very_good_optimization'])
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -66,9 +69,6 @@ DivineVideoClip _clip({
   );
 }
 
-// Permanent: swaps PathProviderPlatform.instance and ProVideoEditor.instance;
-// keep isolated until VideoEditorSplitService accepts injected dependencies.
-@Tags(['skip_very_good_optimization'])
 void main() {
   late MockProVideoEditor mockProVideoEditor;
   late PathProviderPlatform originalPathProviderInstance;

--- a/mobile/test/services/video_editor/video_editor_transform_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_transform_service_test.dart
@@ -1,3 +1,8 @@
+// Permanent: swaps the global ProVideoEditor.instance and
+// PathProviderPlatform.instance platform singletons, which the VGV optimizer's
+// shared-process bundling cannot isolate. Same pattern as the reverse/split
+// service tests.
+@Tags(['skip_very_good_optimization'])
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -67,11 +72,6 @@ class _FakeProVideoEditor extends ProVideoEditor {
   }
 }
 
-// Permanent: swaps the global ProVideoEditor.instance and
-// PathProviderPlatform.instance platform singletons, which the VGV optimizer's
-// shared-process bundling cannot isolate. Same pattern as the reverse/split
-// service tests.
-@Tags(['skip_very_good_optimization'])
 void main() {
   late Directory tempDir;
   late String documentsPath;

--- a/mobile/test/widgets/library/saved_sound_details_editor_test.dart
+++ b/mobile/test/widgets/library/saved_sound_details_editor_test.dart
@@ -22,7 +22,7 @@ class _NoProbe implements SavedSoundMediaProbe {
 }
 
 class _FailingService extends SavedSoundsService {
-  _FailingService(super.preferences);
+  _FailingService(super._preferences);
 
   @override
   Future<void> replaceSavedSound(SavedSound sound) async {


### PR DESCRIPTION
Closes #7224

## Description

`mobile/analysis_options.yaml` silences 57 rules that `very_good_analysis` ships enabled. I measured each one — enable everything, analyze once, count violations per rule — and turned back on the 18 that are cheap: six with zero violations, twelve with one to five each.

**Zero violations, config-only.** `final_not_initialized_constructor`, `map_value_type_not_assignable`, `return_of_invalid_type`, `return_of_invalid_type_from_closure`, `dot_shorthand_missing_context`, `instance_member_access_from_factory`. Four of those are suppressed *errors*, so the entries were pure risk — a real type error would have been swallowed.

**One to five violations each.** `avoid_setters_without_getters`, `avoid_web_libraries_in_flutter`, `cancel_subscriptions`, `constant_identifier_names`, `invalid_annotation_target`, `matching_super_parameters`, `missing_code_block_language_in_doc_comment`, `non_constant_identifier_names`, `parameter_assignments`, `prefer_asserts_with_message`, `strict_top_level_inference`, `unintended_html_in_doc_comment`.

Most fixes are mechanical — backticks in doc comments, a language on a code fence, an assert message, a getter next to a setter, `super._preferences` instead of `super.preferences`. Five are not:

**`@Tags` was in the wrong place in five test files.** `@Tags(['skip_very_good_optimization'])` sat on `void main()` instead of above the imports. `package:test` only reads suite-level annotations before the first directive, so the tag was inert there for tag filtering — only the VGV optimizer's text scan still excluded those files from the merged isolate. Moved to the placement the other 14 tagged files already use, which is what `invalid_annotation_target` was pointing at.

**`CameraService.onRemoteRecordTrigger` is now `setOnRemoteRecordTrigger(...)`.** Adding a getter would mean lying in the Linux and mock implementations — both are no-ops with no backing field — and the neighbouring members are already `setRemoteRecordControlEnabled` / `setVolumeKeysEnabled`, so a method fits the interface better than a setter.

**Two renames, no wire-format changes.** `C2paSigningService.SIGNING_SERVER_ENDPOINT` / `SIGNING_SERVER_TOKEN` → `signingServerEndpoint` / `signingServerToken`, and `NostrEvent.created_at` → `createdAt`. The `--dart-define` names (`PROOFMODE_SIGNING_SERVER_*`) and the JSON keys (`'created_at'`) are wire formats and are untouched, so `build_android.sh`, `build_ios.sh`, `codemagic.yaml`, `run_dev.sh` and `check_signing_endpoint.sh` need no change.

**`cancel_subscriptions` ships with six ignores, deliberately.** All six findings are correct code — the subscription lives in a field or a map and is cancelled in `dispose` / `cancelSubscription` / `clearSearchResults` — so each site carries an ignore naming the method that actually cancels it. The rule still earns its place: there are 103 `StreamSubscription` declarations in `lib`, and it only fires on six. It understands the ordinary `_sub?.cancel()` in `dispose`; what trips it is the field-nulled-then-cancelled-via-local-alias pattern and map ownership.

**`upload_manager.dart` is at its frozen god-file ceiling.** The local that replaces the parameter assignment would have pushed it from 2317 to 2318 lines, which `check_service_god_file_ceiling.sh` rejects with no raise path. It is offset by inlining the single-use `resolution` local in the same block.

`avoid_print: true` also came out of the linter block — it was redundant, `very_good_analysis` already enables it. The block now holds only `false` entries, so it reads as "everything VGA enables, except these".

**Related Issue:** 

## Out of Scope

A Tier 2 batch of rules with 9–25 violations each is tracked in a separate issue: `one_member_abstracts`, `no_default_cases`, `invalid_assignment`, `join_return_with_assignment`, `library_annotations`, `type_annotate_public_apis`, `use_named_constants`, `avoid_equals_and_hash_code_on_mutable_classes`, `only_throw_errors`, `flutter_style_todos`, `prefer_foreach`, `prefer_constructors_over_static_methods`.

`sort_pub_dependencies` stays off: `mobile/pubspec.yaml` has 50 ordering breaks in `dependencies` and 8 in `dev_dependencies`, and sorting would destroy the comment grouping.

The high-volume rules stay off for the obvious reason — `public_member_api_docs` (5449), `lines_longer_than_80_chars` (2825, already enforced by `dart format`), `cascade_invocations` (1361), `avoid_catches_without_on_clauses` (1023), `discarded_futures` (901), `prefer_initializing_formals` (649, conflicts with the documented DI convention).

## Verification

- `flutter analyze lib test integration_test` — no issues
- `flutter analyze` over the whole `mobile` package — no issues
- `dart format lib test integration_test` — 3148 files, 0 changed
- `check_service_god_file_ceiling`, `check_test_unit_structure`, `check_untested_services_floor`, `check_http_overrides_isolation`, `check_process_global_mutations`, `check_shared_channel_overrides` — all OK
- Targeted tests, 763 passing: `video_editor/`, `video_recorder/`, `upload_manager_*`, `saved_sounds/`, `nip07_types`, `c2pa_signing_service`, `account_deletion_service`, `hashtag_filtering_integration`, `profile_videos_grid`, `sound_tile`, `hit_test_expander`, `string_utils`, `environment_config`, `http_url_pattern`, `hashtag_search_view`, plus the five retagged test files
- Proved the enablements are real rather than assumed: a throwaway file in `lib/` violating the rules is flagged by all of them without any explicit `: true` in the options file

Not yet verified on a real device — the diff is lint-driven refactoring with no behaviour change, but the camera-service rename and the upload-manager duration handling both sit in device-only paths, the PR is already ready for review.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
