### PR TITLE
fix(library): tighten the trash bin row layout

### DIFF
--- a/mobile/lib/widgets/library/trashed_clips_list.dart
+++ b/mobile/lib/widgets/library/trashed_clips_list.dart
@@ -83,6 +83,7 @@ class _TrashedClipTile extends StatelessWidget {
             child: VideoClipThumbnailCard(
               clip: clip,
               showSelectionIndicator: false,
+              showDurationBadge: false,
             ),
           ),
         ),

--- a/mobile/lib/widgets/library/trashed_clips_list.dart
+++ b/mobile/lib/widgets/library/trashed_clips_list.dart
@@ -43,11 +43,11 @@ class TrashedClipsList extends StatelessWidget {
         }
         return ListView.separated(
           controller: scrollController,
-          padding: EdgeInsets.only(
-            left: 16,
-            right: 16,
-            top: 8,
-            bottom: MediaQuery.viewPaddingOf(context).bottom + 8,
+          padding: .fromLTRB(
+            8,
+            8,
+            8,
+            MediaQuery.viewPaddingOf(context).bottom + 8,
           ),
           itemCount: state.trashedClips.length,
           separatorBuilder: (_, _) => const SizedBox(height: 8),
@@ -71,62 +71,54 @@ class _TrashedClipTile extends StatelessWidget {
         color: context.vineColors.surfaceContainerHigh,
         borderRadius: const BorderRadius.all(Radius.circular(12)),
       ),
-      child: Padding(
-        padding: const EdgeInsets.all(12),
-        child: Row(
-          spacing: 12,
+      child: ListTile(
+        contentPadding: const EdgeInsets.symmetric(horizontal: 12),
+        horizontalTitleGap: 12,
+        minLeadingWidth: 56,
+        leading: SizedBox(
+          width: 56,
+          height: 56,
+          child: ClipRRect(
+            borderRadius: const BorderRadius.all(Radius.circular(8)),
+            child: VideoClipThumbnailCard(
+              clip: clip,
+              showSelectionIndicator: false,
+            ),
+          ),
+        ),
+        title: Text(
+          '${clip.duration.inSeconds}s',
+          style: VineTheme.titleSmallFont(
+            color: context.vineColors.primaryText,
+          ),
+        ),
+        subtitle: Text(
+          context.l10n.libraryTrashAutoDeletes(_daysUntilPurge(clip)),
+          style: VineTheme.bodyMediumFont(
+            color: context.vineColors.secondaryText,
+          ),
+        ),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          spacing: 4,
           children: [
-            SizedBox(
-              width: 72,
-              height: 72,
-              child: ClipRRect(
-                borderRadius: const BorderRadius.all(Radius.circular(8)),
-                child: VideoClipThumbnailCard(
-                  clip: clip,
-                  showSelectionIndicator: false,
-                ),
+            DivineIconButton(
+              icon: .arrowCounterClockwise,
+              size: DivineIconButtonSize.small,
+              type: DivineIconButtonType.secondary,
+              tooltip: context.l10n.libraryTrashRestoreLabel,
+              semanticLabel: context.l10n.libraryTrashRestoreLabel,
+              onPressed: () => context.read<ClipsLibraryBloc>().add(
+                ClipsLibraryRestoreClips({clip.id}),
               ),
             ),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisAlignment: MainAxisAlignment.center,
-                spacing: 4,
-                children: [
-                  Text(
-                    '${clip.duration.inSeconds}s',
-                    style: VineTheme.titleSmallFont(
-                      color: context.vineColors.primaryText,
-                    ),
-                  ),
-                  Text(
-                    context.l10n.libraryTrashAutoDeletes(_daysUntilPurge(clip)),
-                    style: VineTheme.bodyMediumFont(
-                      color: context.vineColors.secondaryText,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Column(
-              mainAxisSize: MainAxisSize.min,
-              spacing: 8,
-              children: [
-                DivineButton(
-                  size: DivineButtonSize.small,
-                  type: DivineButtonType.secondary,
-                  label: context.l10n.libraryTrashRestoreLabel,
-                  onPressed: () => context.read<ClipsLibraryBloc>().add(
-                    ClipsLibraryRestoreClips({clip.id}),
-                  ),
-                ),
-                DivineButton(
-                  size: DivineButtonSize.small,
-                  type: DivineButtonType.error,
-                  label: context.l10n.libraryTrashDeleteNowLabel,
-                  onPressed: () => _confirmHardDelete(context),
-                ),
-              ],
+            DivineIconButton(
+              icon: .trash,
+              size: DivineIconButtonSize.small,
+              type: DivineIconButtonType.error,
+              tooltip: context.l10n.libraryTrashDeleteNowLabel,
+              semanticLabel: context.l10n.libraryTrashDeleteNowLabel,
+              onPressed: () => _confirmHardDelete(context),
             ),
           ],
         ),

--- a/mobile/test/widgets/library/trashed_clips_list_test.dart
+++ b/mobile/test/widgets/library/trashed_clips_list_test.dart
@@ -70,6 +70,8 @@ void main() {
       await tester.pump();
 
       expect(find.text(en.libraryTrashAutoDeletes(2)), findsOneWidget);
+      expect(find.text('5s'), findsOneWidget);
+      expect(find.text('5.00'), findsNothing);
 
       await tester.tap(find.bySemanticsLabel(en.libraryTrashRestoreLabel));
       await tester.pump();
@@ -104,6 +106,45 @@ void main() {
         () => mockBloc.add(ClipsLibraryHardDeleteClip(trashedClip)),
       ).called(1);
     });
+
+    testWidgets(
+      'does not overflow a 360dp row at default or large text scale',
+      (tester) async {
+        tester.view.physicalSize = const Size(360, 800);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        Future<void> pumpAt(double textScale) async {
+          await tester.pumpWidget(
+            MediaQuery(
+              data: MediaQueryData(
+                size: const Size(360, 800),
+                textScaler: TextScaler.linear(textScale),
+              ),
+              child: buildWidget(
+                ClipsLibraryState(
+                  status: ClipsLibraryStatus.trashLoaded,
+                  filter: const ClipLibraryTrashFilter(),
+                  trashedClips: [trashedClip],
+                ),
+              ),
+            ),
+          );
+          await tester.pump();
+        }
+
+        await pumpAt(1);
+        expect(tester.takeException(), isNull);
+        expect(find.text(en.libraryTrashAutoDeletes(2)), findsOneWidget);
+
+        await pumpAt(1.5);
+        expect(tester.takeException(), isNull);
+
+        await pumpAt(3);
+        expect(tester.takeException(), isNull);
+      },
+    );
 
     testWidgets('shows the empty state when the bin is empty', (tester) async {
       await tester.pumpWidget(

--- a/mobile/test/widgets/library/trashed_clips_list_test.dart
+++ b/mobile/test/widgets/library/trashed_clips_list_test.dart
@@ -71,7 +71,7 @@ void main() {
 
       expect(find.text(en.libraryTrashAutoDeletes(2)), findsOneWidget);
 
-      await tester.tap(find.text(en.libraryTrashRestoreLabel));
+      await tester.tap(find.bySemanticsLabel(en.libraryTrashRestoreLabel));
       await tester.pump();
 
       verify(
@@ -91,7 +91,7 @@ void main() {
       );
       await tester.pump();
 
-      await tester.tap(find.text(en.libraryTrashDeleteNowLabel));
+      await tester.tap(find.bySemanticsLabel(en.libraryTrashDeleteNowLabel));
       await tester.pumpAndSettle();
 
       expect(find.text(en.libraryTrashDeleteConfirmTitle), findsOneWidget);


### PR DESCRIPTION
Closes #7227

## Description

The Deleted filter's rows carried two stacked full-width text buttons (Restore / Delete now), which made every row tall and gave two secondary actions more visual weight than the clip itself.

- The actions are now small `DivineIconButton`s side by side in the row's trailing slot: `arrowCounterClockwise` (secondary) for restore, `trash` (error) for delete-now. Icons instead of labels because both actions are conventional and the row already reads as a bin entry — the labels were the main source of the height.
- The row itself is a `ListTile` now instead of a hand-rolled `Row` + `Column`, so the thumbnail, duration and purge countdown get the standard leading/title/subtitle metrics rather than one-off padding and spacing values.
- No new ARB keys: the existing `libraryTrashRestoreLabel` / `libraryTrashDeleteNowLabel` strings stay on as `tooltip` and `semanticLabel`, so screen readers still announce a name and tests still have something to address.
- The list's horizontal gutter drops from 16 to 8. That is a visible change beyond the row itself, so calling it out explicitly: it hands the countdown line ~16px more width, which is exactly where the old layout was starving, and it lines the cards up closer to the clip grid under the other filters, which has no horizontal padding at all.

The old layout was worse than "tall" — on a 360dp screen the `Expanded` text column collapsed to 6.5px and the countdown wrapped character by character. Measured row height at 360dp: 448px before, 96px after (en); at 393/412dp, 128px before, 72px after. The old row also threw `RenderFlex overflowed` at every text scale from 1.5 up; the new one is clean through 3.0. The countdown still wraps to 3 lines at 360dp and in the longer locales — accepted, the row is far shorter either way.

Example of how it looked before fixing it:
<img width="322" alt="image" src="https://github.com/user-attachments/assets/5d88a254-f21e-4ee1-9da6-14a8ef569902" />


**Related Issue:** 

## Out of Scope

None.

## Verification

- `dart format` + `flutter analyze` on the changed files — clean
- `flutter test test/widgets/library/trashed_clips_list_test.dart` — 4/4 pass (restore and delete-now taps resolve via `find.bySemanticsLabel`; 360dp overflow probe is in the file)
- `flutter test test/widgets/library/clips_tab_test.dart` — 25/25 pass
- Row height and text-scale overflow measured before/after at 360/393/412dp in en, de and es (numbers above)
- Manually verified on a real Samsung Galaxy device

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

