### PR TITLE
build(mobile): upgrade patrol to 4.9.0 and pin patrol_cli 4.7.0

### DIFF
--- a/.agents/skills/e2e-test/SKILL.md
+++ b/.agents/skills/e2e-test/SKILL.md
@@ -51,8 +51,8 @@ run before any test executes.
 
 | Half | Version | Declared in |
 |---|---|---|
-| `patrol` package | 4.8.0 | `mobile/pubspec.yaml` (`patrol: ^4.8.0`) |
-| `patrol_cli` binary | 4.6.1 | `local_stack/profile.sh` (`PATROL_CLI_VERSION`) |
+| `patrol` package | 4.9.0 | `mobile/pubspec.yaml` (`patrol: ^4.9.0`) |
+| `patrol_cli` binary | 4.7.0 | `local_stack/profile.sh` (`PATROL_CLI_VERSION`) |
 
 `profile.sh` checks the installed CLI and runs
 `dart pub global activate patrol_cli <version>` when it differs, so

--- a/.agents/skills/e2e-test/SKILL.md
+++ b/.agents/skills/e2e-test/SKILL.md
@@ -51,7 +51,7 @@ run before any test executes.
 
 | Half | Version | Declared in |
 |---|---|---|
-| `patrol` package | 4.9.0 | `mobile/pubspec.yaml` (`patrol: ^4.9.0`) |
+| `patrol` package | 4.9.0 | `mobile/pubspec.yaml` (`patrol: ">=4.9.0 <4.10.0"`) |
 | `patrol_cli` binary | 4.7.0 | `local_stack/profile.sh` (`PATROL_CLI_VERSION`) |
 
 `profile.sh` checks the installed CLI and runs
@@ -61,6 +61,12 @@ it switches the CLI for every checkout, including worktrees still on an
 older `patrol`, which will then fail the same compatibility check until
 they rebase. Change the two versions together — the compatibility table
 is at https://patrol.leancode.co/documentation/compatibility-table.
+
+The package constraint pins a single minor rather than using a caret,
+because that table closes open-ended bands retroactively. A caret range
+lets `flutter pub upgrade` walk into a `patrol` the pinned CLI rejects,
+and the abort then surfaces at `patrol test` time, unrelated to whatever
+the upgrade was actually for.
 
 ## Stack
 

--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -51,8 +51,8 @@ run before any test executes.
 
 | Half | Version | Declared in |
 |---|---|---|
-| `patrol` package | 4.8.0 | `mobile/pubspec.yaml` (`patrol: ^4.8.0`) |
-| `patrol_cli` binary | 4.6.1 | `local_stack/profile.sh` (`PATROL_CLI_VERSION`) |
+| `patrol` package | 4.9.0 | `mobile/pubspec.yaml` (`patrol: ^4.9.0`) |
+| `patrol_cli` binary | 4.7.0 | `local_stack/profile.sh` (`PATROL_CLI_VERSION`) |
 
 `profile.sh` checks the installed CLI and runs
 `dart pub global activate patrol_cli <version>` when it differs, so

--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -51,7 +51,7 @@ run before any test executes.
 
 | Half | Version | Declared in |
 |---|---|---|
-| `patrol` package | 4.9.0 | `mobile/pubspec.yaml` (`patrol: ^4.9.0`) |
+| `patrol` package | 4.9.0 | `mobile/pubspec.yaml` (`patrol: ">=4.9.0 <4.10.0"`) |
 | `patrol_cli` binary | 4.7.0 | `local_stack/profile.sh` (`PATROL_CLI_VERSION`) |
 
 `profile.sh` checks the installed CLI and runs
@@ -61,6 +61,12 @@ it switches the CLI for every checkout, including worktrees still on an
 older `patrol`, which will then fail the same compatibility check until
 they rebase. Change the two versions together — the compatibility table
 is at https://patrol.leancode.co/documentation/compatibility-table.
+
+The package constraint pins a single minor rather than using a caret,
+because that table closes open-ended bands retroactively. A caret range
+lets `flutter pub upgrade` walk into a `patrol` the pinned CLI rejects,
+and the abort then surfaces at `patrol test` time, unrelated to whatever
+the upgrade was actually for.
 
 ## Stack
 

--- a/local_stack/profile.sh
+++ b/local_stack/profile.sh
@@ -67,10 +67,10 @@ fi
 
 # --- Ensure the patrol CLI matches the patrol package ---
 # patrol_cli enforces the pairing itself and aborts the run on a mismatch
-# (patrol_cli 4.5.0+ pairs with patrol 4.7.0+). Activating the pinned CLI before
+# (patrol_cli 4.7.0+ pairs with patrol 4.9.0+). Activating the pinned CLI before
 # log capture starts keeps install/compile time out of the profiler timeline.
 # Keep in sync with the patrol constraint in mobile/pubspec.yaml.
-PATROL_CLI_VERSION=4.6.1
+PATROL_CLI_VERSION=4.7.0
 PATROL_BIN=""
 if [ -x "$PUB_CACHE_BIN/patrol" ]; then
     PATROL_BIN="$PUB_CACHE_BIN/patrol"

--- a/local_stack/test_android_scripts.sh
+++ b/local_stack/test_android_scripts.sh
@@ -264,11 +264,11 @@ assert_contains 'local_stack_has_running_container "$COMPOSE_FILE"' "${SCRIPT_DI
   "profile runner should reuse the shared local stack status check"
 assert_contains 'android_emulator_invite_server_url' "${SCRIPT_DIR}/profile.sh" \
   "profile runner should reuse the shared Android emulator invite-server URL"
-assert_contains 'PATROL_CLI_VERSION=4.6.1' "${SCRIPT_DIR}/profile.sh" \
+assert_contains 'PATROL_CLI_VERSION=4.7.0' "${SCRIPT_DIR}/profile.sh" \
   "profile runner should pin patrol_cli to the version paired with the patrol package"
 assert_contains ')" || true' "${SCRIPT_DIR}/profile.sh" \
   "profile runner should tolerate offline patrol --version update-check failures"
-assert_line_before 'PATROL_CLI_VERSION=4.6.1' 'Starting docker log capture' "${SCRIPT_DIR}/profile.sh" \
+assert_line_before 'PATROL_CLI_VERSION=4.7.0' 'Starting docker log capture' "${SCRIPT_DIR}/profile.sh" \
   "profile runner should activate patrol_cli before profiler log capture starts"
 assert_contains "if grep -rq 'patrolTest' \"\$TEST_PATH\"; then" "${SCRIPT_DIR}/profile.sh" \
   "profile runner should recurse so directory targets dispatch correctly"

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1680,10 +1680,10 @@ packages:
     dependency: "direct dev"
     description:
       name: patrol
-      sha256: bdeec6400d0ec22aefb875b2fd17a7bd4f25d37a40fd3bd83a74441c65f69f1e
+      sha256: "743678f959a4878807efec59d19f8ebd65cc3d6953fdecce6562c987963f30a8"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.9.0"
   patrol_finders:
     dependency: transitive
     description:
@@ -1696,10 +1696,10 @@ packages:
     dependency: transitive
     description:
       name: patrol_log
-      sha256: "1f5b6f7e1d9feaab7a60eef31e34a83a6168d754e5c0336006a4f50fb5f27526"
+      sha256: "3d91c93e8d0ed19cb12d4b27aa24eca7294e0a48d9d8445505c9775feb5fde2d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.0"
+    version: "0.10.1"
   permission_handler:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -371,11 +371,14 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   # Paired with patrol_cli 4.7.0, which patrol_cli itself enforces at run
-  # time. Keep this floor at 4.9.0 so pub cannot resolve below it, into the
-  # band that the installed CLI rejects. 4.9.0 also carries the fix for
-  # macOS builds failing with "module 'PatrolImpl' not found" under Swift
-  # Package Manager.
-  patrol: ^4.9.0
+  # time. Both bounds are load-bearing. The floor keeps pub out of the older
+  # band the installed CLI rejects, and carries the fix for macOS builds
+  # failing with "module 'PatrolImpl' not found" under Swift Package Manager.
+  # The ceiling stops `pub upgrade` crossing into a band patrol's table
+  # closes retroactively: CLI 4.6.1 shipped an open-ended 4.7.0+ entry that
+  # CLI 4.7.0 narrowed to 4.7.0-4.8.0, which is what broke `^4.8.0`. Raise
+  # both halves together — see PATROL_CLI_VERSION in local_stack/profile.sh.
+  patrol: ">=4.9.0 <4.10.0"
   flutter_launcher_icons: ^0.14.4
 
   very_good_analysis: ^10.2.0

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -370,10 +370,12 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  # Paired with patrol_cli 4.6.1, which patrol_cli itself enforces at run
-  # time. Keep this floor at 4.8.0+ so pub cannot resolve back into the
-  # 4.2.0-4.6.1 band that the installed CLI rejects.
-  patrol: ^4.8.0
+  # Paired with patrol_cli 4.7.0, which patrol_cli itself enforces at run
+  # time. Keep this floor at 4.9.0 so pub cannot resolve below it, into the
+  # band that the installed CLI rejects. 4.9.0 also carries the fix for
+  # macOS builds failing with "module 'PatrolImpl' not found" under Swift
+  # Package Manager.
+  patrol: ^4.9.0
   flutter_launcher_icons: ^0.14.4
 
   very_good_analysis: ^10.2.0


### PR DESCRIPTION
## Description

`flutter run -d macos` and `flutter build macos` both failed during Clang dependency scanning with `module 'PatrolImpl' not found`, so the macOS build was blocked outright by merely having `patrol` as a dev dependency — this project has no macOS Patrol setup at all.

Upstream cause ([leancodepl/patrol#3177](https://github.com/leancodepl/patrol/issues/3177)): the public `patrol` Clang module's umbrella header did `@import PatrolImpl`, a Swift target. SwiftPM generates an ObjC-compatibility module map for a Swift target but exposes it only to downstream C-family compiles, never to downstream Swift. patrol 4.9.0 makes `PatrolPlugin` ObjC and declares the macro-facing types in the umbrella, so the umbrella no longer imports the Swift module.

**Why this is not a one-line bump.** `patrol_cli` enforces its pairing with the `patrol` package at run time and aborts before any test executes. I read the table out of the shipped CLI rather than trusting the docs — `patrol_cli` 4.7.0's own `version_compatibility.dart` maps `patrol_cli 4.7.0+` ↔ `patrol 4.9.0+`, both open-ended. So both halves plus the two places that assert the pin have to move together.

**Worth doing regardless of macOS.** The previous constraint `^4.8.0` already admitted 4.9.0, so any `flutter pub upgrade` would pull the package into a band the pinned CLI 4.6.1 rejects, aborting E2E runs with a compatibility error unrelated to whatever was being upgraded.

**The constraint is a pinned band, not a caret.** `patrol: ">=4.9.0 <4.10.0"`, because a caret would rebuild the exact trap this PR is fixing. patrol's compatibility table closes open-ended bands retroactively, and both shipped CLIs prove it: `patrol_cli` 4.6.1 carries `4.5.0+` ↔ `4.7.0+`, and `patrol_cli` 4.7.0 narrows that same entry to `4.5.0 - 4.6.1` ↔ `4.7.0 - 4.8.0` while opening a new `4.7.0+` ↔ `4.9.0+`. Under `^4.9.0` the next such closure would let `flutter pub upgrade` resolve a `patrol` the pinned CLI 4.7.0 rejects, and the abort would land at `patrol test` time, unattributable to the upgrade that caused it. A pinned band makes pub refuse the resolution up front and enforces the real invariant: both halves move together. The ceiling may occasionally be stricter than the table requires — CLI 4.5.0 - 4.6.1 spanned two `patrol` minors — and that is the intended direction of error, since a failed resolution is loud and immediate.

One smaller judgment call worth flagging, since it is not visible from the diff alone: `.agents/skills/e2e-test/SKILL.md` is not in the issue's scope list, but `AGENTS.md` designates `.agents/skills` as the generated Codex mirror of `.claude/skills`. It is regenerated here via `.codex/scripts/sync-agent-skills.sh --write`, not hand-edited, and `.codex/scripts/test-config.sh` confirms the two are in sync.

**Related Issue:** Closes #7216

## Out of Scope

**One open finding, tracked separately in #7260 rather than fixed here.**

`integration_test/privacy/image_metadata_stripper_test.dart` flakes under the new pair. Always the same test, `fixture image contains EXIF, GPS and maker metadata`, the first in its group:

| Versions | Runs | Failures |
|---|---|---|
| patrol 4.8.0 + patrol_cli 4.6.1 | 6 | 0 |
| patrol 4.9.0 + patrol_cli 4.7.0 | 6 | 2 (~33%) |

Every failure landed on the new side, but Fisher's exact on 0/6 vs 2/6 gives p≈0.45 — **suggestive, not significant**. I am not claiming the bump causes it; I am reporting that it never appeared on 4.8.0 in six runs.

What is known about the failure:

- It is **not** a content assertion failing, and therefore not a privacy regression. Running the test's four byte-inspection helpers against the same base64 fixture on the host gives `exifMarker`, `makeTag`, `dateTimeOriginal`, `gpsIfd` all `true`.
- The signature is `java.lang.AssertionError: Dart test failed: …` with a **null** Dart-side detail and 0s duration — harness level, not test body.
- The obvious suspect is ruled out. patrol 4.9.0 moved `PatrolAppService.port` from a compile-time `int.fromEnvironment` to a runtime `PatrolRuntimePorts.appServerPort()`, but `ensureLoaded()` returns immediately unless `Platform.isIOS || Platform.isMacOS`, so on Android it falls back to the identical compile-time default. Mechanism still unidentified.

Deliberate tradeoff rather than a silent one: the macOS build is broken today for anyone on this branch's toolchain, the flake is unattributable and not CI-gated, and #7260 carries the reproduction data plus the next diagnostic steps (logcat on a failing run, then ~15 runs per arm).

## Verification

Ran from `mobile/` unless noted.

**Tested on a real device (Samsung Galaxy SM-S942B) over USB**

- `patrol build android` with CLI 4.7.0 → exit 0, both app and instrumentation APKs; the run-time compatibility gate passes against patrol 4.9.0.
- `patrol test` on the device → patrol discovers and executes `patrolTest` bodies; 3 tests found, 2 consistently green, 1 flaky as documented above and tracked in #7260.
- A full E2E run against the local Docker stack was **not** possible: Docker is not installed on this machine. The tests exercised here are the ones that need a device but no backend.

**macOS — the issue's actual repro, now green**

- `flutter build macos --debug` → `✓ Built build/macos/Build/Products/Debug/Divine.app`, exit 0, zero `PatrolImpl` errors.
- `flutter run -d macos` (the issue's literal repro step) → launches, Dart VM Service up, process alive.
- Confirmed patrol is genuinely *in* the build rather than silently dropped: `import patrol` at `GeneratedPluginRegistrant.swift:36` — the exact line that previously failed with `Unable to resolve module dependency: 'patrol'` — compiles; the generated SPM `Package.swift` links `patrol-4.9.0`; and the built app ships `patrol_PatrolImpl.bundle`, the module that could not be found before.
- The running app is functional, not just launched: video players created and playing, feed prefetch cycles, Keycast signing kind 22236 view events (HTTP 200), view events published, media cache downloads completing.

**Other**

- `flutter pub get` under the pinned band resolves with a byte-identical lockfile — the constraint tightening changes no resolved version.
- `flutter analyze lib test integration_test` → `No issues found!`, covering the 28 integration-test files that import `package:patrol`.
- `local_stack/test_android_scripts.sh` → `android script checks passed` (both `PATROL_CLI_VERSION` assertions are mutation-sensitive and were updated).
- `.codex/scripts/test-config.sh` → `.agents/skills is in sync. Codex configuration checks passed.`
- Lockfile churn is confined to `patrol` 4.8.0→4.9.0 and its transitive `patrol_log` 0.10.0→0.10.1.

Note for reviewers running this locally: `patrol_cli` activation is machine-global. Older worktrees still on patrol 4.8.0 will fail the compatibility check until their `profile.sh` re-activates 4.6.1, which it does automatically.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
