### PR TITLE
fix(metrics): restart same-video view sessions

### DIFF
--- a/mobile/docs/NOSTR_VIDEO_EVENTS.md
+++ b/mobile/docs/NOSTR_VIDEO_EVENTS.md
@@ -383,7 +383,7 @@ The `.content` field is optional and could contain a free-form note.
 - **No `d` tag** - ephemeral events are not addressable/replaceable
 - **Both `a` and `e` tags are required** - `a` provides stable addressable reference, `e` tracks specific version viewed
 - Multiple `viewed` tags can track multiple segments watched in a single session
-- The `viewed` tag timestamps represent seconds within the video (e.g., `["viewed", "0", "6"]` = watched first 6 seconds)
+- The `viewed` tag carries elapsed playback seconds for the session, not positions within the video. Mobile always emits `["viewed", "0", "<whole seconds watched>"]`, so a 6s video looped twice reports `["viewed", "0", "12"]`, and a sub-second view truncates to `["viewed", "0", "0"]`
 - Analytics services should consume these events in real-time before relays discard them
 - Every session with positive playback time counts, including sub-second views
 - Mobile emits one event per continuous viewing session; returning after

--- a/mobile/docs/NOSTR_VIDEO_EVENTS.md
+++ b/mobile/docs/NOSTR_VIDEO_EVENTS.md
@@ -343,7 +343,7 @@ The `.content` field is optional and could contain a free-form note.
 |-----|--------|-------------|----------|
 | `a` | `["a", "<kind>:<pubkey>:<d-tag>", "<relay-url>"]` | Addressable reference to kind 34235 or 34236 video event | **Required** |
 | `e` | `["e", "<event-id>", "<relay-url>"]` | Event ID reference (specific version viewed) | **Required** |
-| `viewed` | `["viewed", "<start>", "<end>"]` | Start/end timestamps in seconds (can repeat) | **Required** |
+| `viewed` | `["viewed", "0", "<whole-seconds-watched>"]` | Elapsed whole playback seconds for this continuous mobile session | **Required** |
 | `loops` | `["loops", "<playthrough-fraction>"]` | Exact finite, non-negative playthrough count emitted by mobile, including partial loops; Funnelcake support is pending #921 | Optional |
 | `source` | `["source", "<source-type>"]` | Traffic source: `home`, `discovery`, `profile`, `share`, `search` | Optional |
 | `client` | `["client", "<name>", "31990:<app-pubkey>:<d-identifier>", "<relay-url>"]` | NIP-89 client attribution for Divine | Optional |
@@ -382,7 +382,6 @@ The `.content` field is optional and could contain a free-form note.
 
 - **No `d` tag** - ephemeral events are not addressable/replaceable
 - **Both `a` and `e` tags are required** - `a` provides stable addressable reference, `e` tracks specific version viewed
-- Multiple `viewed` tags can track multiple segments watched in a single session
 - The `viewed` tag carries elapsed playback seconds for the session, not positions within the video. Mobile always emits `["viewed", "0", "<whole seconds watched>"]`, so a 6s video looped twice reports `["viewed", "0", "12"]`, and a sub-second view truncates to `["viewed", "0", "0"]`
 - Analytics services should consume these events in real-time before relays discard them
 - Every session with positive playback time counts, including sub-second views

--- a/mobile/docs/NOSTR_VIDEO_EVENTS.md
+++ b/mobile/docs/NOSTR_VIDEO_EVENTS.md
@@ -1,7 +1,7 @@
 # Nostr Video Events Schema
 
 Status: Current
-Validated against: current mobile protocol docs on 2026-03-29.
+Validated against: current mobile and Funnelcake implementations on 2026-08-13.
 
 This document describes the Nostr event schemas for video-related events as implemented in Divine.
 
@@ -338,6 +338,7 @@ The `.content` field is optional and could contain a free-form note.
 | `a` | `["a", "<kind>:<pubkey>:<d-tag>", "<relay-url>"]` | Addressable reference to kind 34235 or 34236 video event | **Required** |
 | `e` | `["e", "<event-id>", "<relay-url>"]` | Event ID reference (specific version viewed) | **Required** |
 | `viewed` | `["viewed", "<start>", "<end>"]` | Start/end timestamps in seconds (can repeat) | **Required** |
+| `loops` | `["loops", "<playthrough-fraction>"]` | Exact finite, non-negative playthrough count, including partial loops | Optional |
 | `source` | `["source", "<source-type>"]` | Traffic source: `home`, `discovery`, `profile`, `share`, `search` | Optional |
 | `client` | `["client", "<name>", "31990:<app-pubkey>:<d-identifier>", "<relay-url>"]` | NIP-89 client attribution for Divine | Optional |
 
@@ -363,7 +364,8 @@ The `.content` field is optional and could contain a free-form note.
   "tags": [
     ["a", "34236:<video event author pubkey>:<d-identifier of video event>", "<relay url>"],
     ["e", "<event-id>", "<relay-url>"],
-    ["viewed", "0", "6"],
+    ["viewed", "0", "5"],
+    ["loops", "0.75"],
     ["source", "discovery"],
     ["client", "Divine", "31990:d95aa8fc0eff8e488952495b8064991d27fb96ed8652f12cdedc5a4e8b5ae540:divine-mobile", "wss://relay.divine.video"]
   ]
@@ -377,5 +379,6 @@ The `.content` field is optional and could contain a free-form note.
 - Multiple `viewed` tags can track multiple segments watched in a single session
 - The `viewed` tag timestamps represent seconds within the video (e.g., `["viewed", "0", "6"]` = watched first 6 seconds)
 - Analytics services should consume these events in real-time before relays discard them
-- Minimum watch threshold: views under 1 second are discarded
-- Deduplication: same user+video combination is deduplicated within 1 hour
+- Every session with positive playback time counts, including sub-second views
+- One event represents one continuous viewing session; returning after
+  inactivity starts a new session

--- a/mobile/docs/NOSTR_VIDEO_EVENTS.md
+++ b/mobile/docs/NOSTR_VIDEO_EVENTS.md
@@ -1,7 +1,8 @@
 # Nostr Video Events Schema
 
 Status: Current
-Validated against: current mobile and Funnelcake implementations on 2026-08-13.
+Validated against: current mobile implementation on 2026-08-14; Funnelcake-specific
+Kind 22236 behavior is identified separately below.
 
 This document describes the Nostr event schemas for video-related events as implemented in Divine.
 
@@ -318,6 +319,11 @@ All tags are stored in `VideoEvent.rawTags` as a `Map<String, String>` for:
 
 Kind 22236 is an **ephemeral event** for tracking video views for analytics purposes.
 
+The schema below is the contract emitted by current Divine mobile. Funnelcake
+support for fractional `loops` and one-view-per-session counting is proposed in
+[divine-funnelcake#921](https://github.com/divinevideo/divine-funnelcake/pull/921)
+and remains pending until that pull request lands.
+
 ### Purpose
 
 These events are published when a user views a video and are consumed by analytics services. As ephemeral events (20000-29999 range per NIP-01), relays keep them in memory only and do not persist them to disk.
@@ -338,7 +344,7 @@ The `.content` field is optional and could contain a free-form note.
 | `a` | `["a", "<kind>:<pubkey>:<d-tag>", "<relay-url>"]` | Addressable reference to kind 34235 or 34236 video event | **Required** |
 | `e` | `["e", "<event-id>", "<relay-url>"]` | Event ID reference (specific version viewed) | **Required** |
 | `viewed` | `["viewed", "<start>", "<end>"]` | Start/end timestamps in seconds (can repeat) | **Required** |
-| `loops` | `["loops", "<playthrough-fraction>"]` | Exact finite, non-negative playthrough count, including partial loops | Optional |
+| `loops` | `["loops", "<playthrough-fraction>"]` | Exact finite, non-negative playthrough count emitted by mobile, including partial loops; Funnelcake support is pending #921 | Optional |
 | `source` | `["source", "<source-type>"]` | Traffic source: `home`, `discovery`, `profile`, `share`, `search` | Optional |
 | `client` | `["client", "<name>", "31990:<app-pubkey>:<d-identifier>", "<relay-url>"]` | NIP-89 client attribution for Divine | Optional |
 
@@ -380,5 +386,6 @@ The `.content` field is optional and could contain a free-form note.
 - The `viewed` tag timestamps represent seconds within the video (e.g., `["viewed", "0", "6"]` = watched first 6 seconds)
 - Analytics services should consume these events in real-time before relays discard them
 - Every session with positive playback time counts, including sub-second views
-- One event represents one continuous viewing session; returning after
-  inactivity starts a new session
+- Mobile emits one event per continuous viewing session; returning after
+  inactivity starts a new session. Matching Funnelcake counting is pending
+  #921.

--- a/mobile/lib/services/analytics_service.dart
+++ b/mobile/lib/services/analytics_service.dart
@@ -264,7 +264,7 @@ class AnalyticsService implements BackgroundAwareService {
   ///
   /// For `view_end` events, publishes a Kind 22236 ephemeral Nostr event via
   /// [ViewEventPublisher]. View = playback start per spec — any start counts
-  /// even if N=0 loops (no ≥1s gate).
+  /// even if playback stops before completing a full loop (no ≥1s gate).
   Future<void> trackDetailedVideoViewWithUser(
     VideoEvent video, {
     required String? userId,

--- a/mobile/lib/services/view_event_publisher.dart
+++ b/mobile/lib/services/view_event_publisher.dart
@@ -76,7 +76,7 @@ class ViewEventPublisher {
     const method = 'publishViewEvent';
     // View = playback start per 2026-08-13 view/loop spec: any playback
     // start counts, even if the session ends before completing a loop
-    // (N=0 loops is valid). Only reject inverted ranges.
+    // (a fractional loop is valid). Only reject inverted ranges.
     if (endSeconds < startSeconds) {
       return _drop(ViewEventDropReason.invalidWatchRange, video.id, method);
     }
@@ -177,7 +177,7 @@ class ViewEventPublisher {
   }) async {
     const method = 'publishViewEventWithSegments';
     // Filter out invalid segments. Per view=playback-start spec, any
-    // non-inverted segment counts (even <1s / N=0 loops is a valid view).
+    // non-inverted segment counts (even <1s without a full loop is valid).
     final validSegments = segments.where((s) => s.$2 >= s.$1).toList();
 
     if (validSegments.isEmpty) {

--- a/mobile/lib/services/view_event_publisher.dart
+++ b/mobile/lib/services/view_event_publisher.dart
@@ -60,8 +60,8 @@ class ViewEventPublisher {
   /// Publish a video view event.
   ///
   /// [video] - The video that was viewed
-  /// [startSeconds] - When the viewing started (seconds into video)
-  /// [endSeconds] - When the viewing ended (seconds into video)
+  /// [startSeconds] - Elapsed playback seconds at the start of the session
+  /// [endSeconds] - Elapsed playback seconds at the end of the session
   /// [source] - Where the video was discovered/viewed from
   ///
   /// Returns true if the event was published successfully.
@@ -158,92 +158,6 @@ class ViewEventPublisher {
     } catch (e) {
       Log.error(
         'Error publishing view event: $e',
-        name: 'ViewEventPublisher',
-        category: LogCategory.video,
-      );
-      return _drop(ViewEventDropReason.unexpectedError, video.id, method);
-    }
-  }
-
-  /// Publish view event for multiple watched segments.
-  ///
-  /// Use this when the user watched multiple non-contiguous segments
-  /// of the video (e.g., skipped around).
-  Future<bool> publishViewEventWithSegments({
-    required VideoEvent video,
-    required List<(int, int)> segments,
-    ViewTrafficSource source = ViewTrafficSource.unknown,
-    String? sourceDetail,
-  }) async {
-    const method = 'publishViewEventWithSegments';
-    // Filter out invalid segments. Per view=playback-start spec, any
-    // non-inverted segment counts (even <1s without a full loop is valid).
-    final validSegments = segments.where((s) => s.$2 >= s.$1).toList();
-
-    if (validSegments.isEmpty) {
-      return _drop(ViewEventDropReason.invalidWatchRange, video.id, method);
-    }
-
-    if (!_authService.isAuthenticated) {
-      return _drop(ViewEventDropReason.notAuthenticated, video.id, method);
-    }
-
-    try {
-      final aTag = video.addressableId;
-      if (aTag == null) {
-        return _drop(
-          ViewEventDropReason.missingAddressableDTag,
-          video.id,
-          method,
-        );
-      }
-
-      String relayHint = _defaultRelayHint;
-      if (_nostrService.connectedRelays.isNotEmpty) {
-        relayHint = _nostrService.connectedRelays.first;
-      }
-
-      // Build tags with multiple viewed segments
-      final tags = <List<String>>[
-        ['a', aTag, relayHint],
-        ['e', video.id, relayHint],
-        // Add all valid segments
-        for (final segment in validSegments)
-          ['viewed', segment.$1.toString(), segment.$2.toString()],
-        if (sourceDetail != null && sourceDetail.isNotEmpty)
-          ['source', source.tagValue, sourceDetail]
-        else
-          ['source', source.tagValue],
-      ];
-
-      final event = await _authService.createAndSignEvent(
-        kind: viewEventKind,
-        content: '',
-        tags: tags,
-      );
-
-      if (event == null) {
-        return _drop(ViewEventDropReason.signingFailed, video.id, method);
-      }
-
-      final sentEvent = await _nostrService.publishEvent(event);
-
-      if (sentEvent is PublishSuccess) {
-        final totalWatched = validSegments.fold<int>(
-          0,
-          (sum, s) => sum + (s.$2 - s.$1),
-        );
-        Log.info(
-          'View event published: video=${video.id}, segments=${validSegments.length}, total=${totalWatched}s',
-          name: 'ViewEventPublisher',
-          category: LogCategory.video,
-        );
-        return true;
-      }
-      return _drop(ViewEventDropReason.relayRejected, video.id, method);
-    } catch (e) {
-      Log.error(
-        'Error publishing multi-segment view event: $e',
         name: 'ViewEventPublisher',
         category: LogCategory.video,
       );

--- a/mobile/lib/widgets/divine_video_metrics_tracker.dart
+++ b/mobile/lib/widgets/divine_video_metrics_tracker.dart
@@ -85,6 +85,7 @@ class _DivineVideoMetricsTrackerState
       _resetTracking();
     } else if (becameInactive) {
       _finalizeAndPublish();
+      _resetViewSession();
     }
 
     if (controllerChanged || videoChanged || becameInactive) {
@@ -166,7 +167,6 @@ class _DivineVideoMetricsTrackerState
     _viewStartTime = widget._clock();
     _hasTrackedView = true;
     _hasSentEndEvent = false;
-    _hasRecordedImpression = false;
 
     _analyticsService.trackDetailedVideoViewWithUser(
       widget.video,
@@ -265,6 +265,11 @@ class _DivineVideoMetricsTrackerState
   }
 
   void _resetTracking() {
+    _resetViewSession();
+    _hasRecordedImpression = false;
+  }
+
+  void _resetViewSession() {
     _viewStartTime = null;
     _lastPlayStartTime = null;
     _totalWatchDuration = Duration.zero;
@@ -272,7 +277,6 @@ class _DivineVideoMetricsTrackerState
     _loopCount = 0.0;
     _hasTrackedView = false;
     _hasSentEndEvent = false;
-    _hasRecordedImpression = false;
     _isPlaying = false;
   }
 

--- a/mobile/test/services/view_event_publisher_test.dart
+++ b/mobile/test/services/view_event_publisher_test.dart
@@ -98,7 +98,7 @@ void main() {
       });
 
       test(
-        'view = playback start: zero-duration view (N=0 loops) is valid',
+        'view = playback start: zero-duration segment is valid',
         () async {
           final result = await publisher.publishViewEvent(
             video: createTestVideoEvent(pubkey: creatorPubkey),
@@ -632,7 +632,7 @@ void main() {
 
           final tags = captured[0] as List<List<String>>;
           final viewedTags = tags.where((t) => t[0] == 'viewed').toList();
-          // All three are valid views per playback-start spec (N=0 is valid)
+          // All three are valid views per playback-start spec.
           expect(viewedTags, hasLength(3));
         },
       );

--- a/mobile/test/services/view_event_publisher_test.dart
+++ b/mobile/test/services/view_event_publisher_test.dart
@@ -97,19 +97,16 @@ void main() {
         verifyNever(() => mockNostr.publishEvent(any()));
       });
 
-      test(
-        'view = playback start: zero-duration segment is valid',
-        () async {
-          final result = await publisher.publishViewEvent(
-            video: createTestVideoEvent(pubkey: creatorPubkey),
-            startSeconds: 0,
-            endSeconds: 0,
-          );
+      test('view = playback start: zero-duration segment is valid', () async {
+        final result = await publisher.publishViewEvent(
+          video: createTestVideoEvent(pubkey: creatorPubkey),
+          startSeconds: 0,
+          endSeconds: 0,
+        );
 
-          expect(result, isTrue);
-          verify(() => mockNostr.publishEvent(any())).called(1);
-        },
-      );
+        expect(result, isTrue);
+        verify(() => mockNostr.publishEvent(any())).called(1);
+      });
 
       test('publishes self-views with video reference tags', () async {
         final result = await publisher.publishViewEvent(
@@ -538,129 +535,6 @@ void main() {
         final tags = captured[0] as List<List<String>>;
         final loopsTags = tags.where((t) => t[0] == 'loops').toList();
         expect(loopsTags, isEmpty);
-      });
-    });
-
-    group('publishViewEventWithSegments', () {
-      test('publishes self-views with segments', () async {
-        final result = await publisher.publishViewEventWithSegments(
-          video: createTestVideoEvent(
-            id: 'self_view_segments_event_id',
-            pubkey: viewerPubkey,
-            vineId: 'self_view_segments_vine_id',
-          ),
-          segments: [(0, 5), (10, 15)],
-          source: ViewTrafficSource.discoveryForYou,
-        );
-
-        expect(result, isTrue);
-        final captured = verify(
-          () => mockAuth.createAndSignEvent(
-            kind: any(named: 'kind'),
-            content: any(named: 'content'),
-            tags: captureAny(named: 'tags'),
-          ),
-        ).captured;
-        verify(() => mockNostr.publishEvent(any())).called(1);
-
-        final tags = captured[0] as List<List<String>>;
-        expect(
-          tags.firstWhere((t) => t[0] == 'a')[1],
-          equals('34236:$viewerPubkey:self_view_segments_vine_id'),
-        );
-        expect(
-          tags.firstWhere((t) => t[0] == 'e')[1],
-          equals('self_view_segments_event_id'),
-        );
-        expect(tags.where((t) => t[0] == 'viewed'), [
-          ['viewed', '0', '5'],
-          ['viewed', '10', '15'],
-        ]);
-        expect(tags.firstWhere((t) => t[0] == 'source'), [
-          'source',
-          'discovery:foryou',
-        ]);
-      });
-
-      test('returns false when all segments are inverted', () async {
-        final result = await publisher.publishViewEventWithSegments(
-          video: createTestVideoEvent(pubkey: creatorPubkey),
-          segments: [(5, 3), (10, 9)],
-        );
-
-        expect(result, isFalse);
-        verifyNever(() => mockNostr.publishEvent(any()));
-      });
-
-      test('returns false for segments when video has no real d tag', () async {
-        final result = await publisher.publishViewEventWithSegments(
-          video: createTestVideoEvent(
-            id: 'event_id_without_d',
-            pubkey: creatorPubkey,
-            vineId: 'legacy_vine_id',
-            clearAddressableDTag: true,
-          ),
-          segments: [(0, 5), (10, 15)],
-        );
-
-        expect(result, isFalse);
-        verifyNever(
-          () => mockAuth.createAndSignEvent(
-            kind: any(named: 'kind'),
-            content: any(named: 'content'),
-            tags: any(named: 'tags'),
-          ),
-        );
-        verifyNever(() => mockNostr.publishEvent(any()));
-      });
-
-      test(
-        'view = playback start: zero-length segment (5,5) is valid view',
-        () async {
-          await publisher.publishViewEventWithSegments(
-            video: createTestVideoEvent(pubkey: creatorPubkey),
-            segments: [(0, 5), (5, 5), (10, 15)],
-          );
-
-          final captured = verify(
-            () => mockAuth.createAndSignEvent(
-              kind: any(named: 'kind'),
-              content: any(named: 'content'),
-              tags: captureAny(named: 'tags'),
-            ),
-          ).captured;
-
-          final tags = captured[0] as List<List<String>>;
-          final viewedTags = tags.where((t) => t[0] == 'viewed').toList();
-          // All three are valid views per playback-start spec.
-          expect(viewedTags, hasLength(3));
-        },
-      );
-
-      test('publishes multiple viewed tags', () async {
-        final result = await publisher.publishViewEventWithSegments(
-          video: createTestVideoEvent(pubkey: creatorPubkey),
-          segments: [(0, 5), (10, 20)],
-          source: ViewTrafficSource.profile,
-        );
-
-        expect(result, isTrue);
-
-        final captured = verify(
-          () => mockAuth.createAndSignEvent(
-            kind: any(named: 'kind'),
-            content: any(named: 'content'),
-            tags: captureAny(named: 'tags'),
-          ),
-        ).captured;
-
-        final tags = captured[0] as List<List<String>>;
-        final viewedTags = tags.where((t) => t[0] == 'viewed').toList();
-        expect(viewedTags, hasLength(2));
-        expect(viewedTags[0][1], equals('0'));
-        expect(viewedTags[0][2], equals('5'));
-        expect(viewedTags[1][1], equals('10'));
-        expect(viewedTags[1][2], equals('20'));
       });
     });
   });

--- a/mobile/test/services/view_event_retry_service_test.dart
+++ b/mobile/test/services/view_event_retry_service_test.dart
@@ -340,7 +340,7 @@ void main() {
     );
 
     test(
-      'publishes self-views and sub-second views (N=0 loops) per playback-start spec',
+      'publishes self-views and sub-second partial-loop views',
       () async {
         await dao.enqueue(
           makeEvent(id: 'self-view', eventVideoPubkey: userPubkey),
@@ -362,7 +362,7 @@ void main() {
             loopCount: captureAny(named: 'loopCount'),
           ),
         ).captured;
-        // Two publishes: self-view + short-view (N=0 loops is valid)
+        // Two publishes: self-view + short partial-loop view.
         expect(captured.length, equals(12));
         final video = captured[0] as VideoEvent;
         expect(video.id, 'video-self-view');

--- a/mobile/test/widgets/divine_video_metrics_tracker_test.dart
+++ b/mobile/test/widgets/divine_video_metrics_tracker_test.dart
@@ -191,7 +191,7 @@ void main() {
     });
 
     testWidgets(
-      'active to inactive under one second records view and seen (N=0 valid per spec)',
+      'active to inactive under one second records a partial-loop view',
       (
         tester,
       ) async {
@@ -230,7 +230,7 @@ void main() {
     );
 
     testWidgets(
-      'fling-speed active session records view and seen (N=0 valid per spec)',
+      'fling-speed active session records a partial-loop view and seen state',
       (tester) async {
         final isActive = ValueNotifier(true);
         final video = ValueNotifier(_video);
@@ -416,7 +416,7 @@ void main() {
       await controller.close();
     });
 
-    testWidgets('reactivation after a skipped glance still finalizes', (
+    testWidgets('sub-second session finalizes once', (
       tester,
     ) async {
       final isActive = ValueNotifier(true);
@@ -435,7 +435,7 @@ void main() {
         ),
       );
 
-      // Glance now counts per playback-start spec (N=0 loops is valid).
+      // A glance counts because playback started, even without a full loop.
       now = now.add(const Duration(milliseconds: 300));
       isActive.value = false;
       await tester.pump();
@@ -447,10 +447,7 @@ void main() {
         const Duration(milliseconds: 300),
       );
 
-      // Per playback-start spec, first 300ms glance already counted as view
-      // (N=0). Reactivation after a finalized view does not extend that view —
-      // it would be a new session on next publish, but same-video reactivation
-      // keeps the already-sent impression deduplicated.
+      // Re-reading the finalized state must not emit the same session twice.
       final viewEndEvents = _viewEndEvents(analyticsService);
       expect(viewEndEvents, hasLength(1));
       expect(
@@ -465,7 +462,7 @@ void main() {
       await controller.close();
     });
 
-    testWidgets('reactivation after a recorded impression sends view_end', (
+    testWidgets('reactivation starts a new view session', (
       tester,
     ) async {
       final isActive = ValueNotifier(true);
@@ -484,7 +481,7 @@ void main() {
         ),
       );
 
-      // Now counts per playback-start spec (N=0 loops is valid).
+      // A partial loop still counts because playback started.
       now = now.add(const Duration(milliseconds: 700));
       isActive.value = false;
       await tester.pump();
@@ -492,10 +489,8 @@ void main() {
       expect(_viewEndEvents(analyticsService), hasLength(1));
       expect(seenVideosService.records, hasLength(1));
 
-      // First 700ms view already finalized per playback-start spec; same-video
-      // reactivation after a sent view keeps impression deduped and does not
-      // synthesize a second view_end until the session is torn down and
-      // recreated (e.g. video change). Drain to prove no second emission.
+      // The inactive gap ends the first continuous viewing session. Returning
+      // to the same video starts another session and must publish another view.
       analyticsService.events.clear();
       isActive.value = true;
       await tester.pump();
@@ -504,7 +499,15 @@ void main() {
       await tester.pump();
 
       final viewEndEvents = _viewEndEvents(analyticsService);
-      expect(viewEndEvents, isEmpty);
+      expect(viewEndEvents, hasLength(1));
+      expect(viewEndEvents.single.watchDuration, const Duration(seconds: 5));
+      expect(
+        analyticsService.events.where(
+          (event) => event.eventType == 'view_start',
+        ),
+        hasLength(1),
+      );
+      // Seen-video history remains deduplicated across playback sessions.
       expect(seenVideosService.records, hasLength(1));
 
       isActive.dispose();

--- a/mobile/test/widgets/divine_video_metrics_tracker_test.dart
+++ b/mobile/test/widgets/divine_video_metrics_tracker_test.dart
@@ -192,9 +192,7 @@ void main() {
 
     testWidgets(
       'active to inactive under one second records a partial-loop view',
-      (
-        tester,
-      ) async {
+      (tester) async {
         final isActive = ValueNotifier(true);
         final video = ValueNotifier(_video);
         final controller = _stubController(isPlaying: true);
@@ -416,9 +414,7 @@ void main() {
       await controller.close();
     });
 
-    testWidgets('sub-second session finalizes once', (
-      tester,
-    ) async {
+    testWidgets('sub-second session finalizes once', (tester) async {
       final isActive = ValueNotifier(true);
       final video = ValueNotifier(_video);
       final controller = _stubController(isPlaying: true);
@@ -446,15 +442,6 @@ void main() {
         seenVideosService.records.single.watchDuration,
         const Duration(milliseconds: 300),
       );
-
-      // Re-reading the finalized state must not emit the same session twice.
-      final viewEndEvents = _viewEndEvents(analyticsService);
-      expect(viewEndEvents, hasLength(1));
-      expect(
-        viewEndEvents.single.watchDuration,
-        const Duration(milliseconds: 300),
-      );
-      expect(seenVideosService.records, hasLength(1));
       expect(seenVideosService.records.single.videoId, equals('video_id'));
 
       isActive.dispose();
@@ -462,9 +449,7 @@ void main() {
       await controller.close();
     });
 
-    testWidgets('reactivation starts a new view session', (
-      tester,
-    ) async {
+    testWidgets('reactivation starts a new view session', (tester) async {
       final isActive = ValueNotifier(true);
       final video = ValueNotifier(_video);
       final controller = _stubController(isPlaying: true);
@@ -508,6 +493,54 @@ void main() {
         hasLength(1),
       );
       // Seen-video history remains deduplicated across playback sessions.
+      expect(seenVideosService.records, hasLength(1));
+
+      isActive.dispose();
+      video.dispose();
+      await controller.close();
+    });
+
+    testWidgets('reactivation without playback does not publish a view_end', (
+      tester,
+    ) async {
+      final isActive = ValueNotifier(true);
+      final video = ValueNotifier(_video);
+      final controller = _stubController(isPlaying: true);
+
+      await tester.pumpWidget(
+        _buildTrackerHarness(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          controller: controller.controller,
+          video: video,
+          isActive: isActive,
+          clock: () => now,
+        ),
+      );
+
+      now = now.add(const Duration(milliseconds: 700));
+      isActive.value = false;
+      await tester.pump();
+
+      expect(_viewEndEvents(analyticsService), hasLength(1));
+      expect(seenVideosService.records, hasLength(1));
+
+      analyticsService.events.clear();
+      controller.setState(
+        const DivineVideoPlayerState(
+          status: PlaybackStatus.ready,
+          duration: Duration(seconds: 5),
+          isFirstFrameRendered: true,
+        ),
+      );
+      isActive.value = true;
+      await tester.pump();
+      now = now.add(const Duration(seconds: 5));
+      isActive.value = false;
+      await tester.pump();
+
+      expect(_viewEndEvents(analyticsService), isEmpty);
       expect(seenVideosService.records, hasLength(1));
 
       isActive.dispose();
@@ -625,7 +658,11 @@ List<_TrackedAnalyticsEvent> _viewEndEvents(
     .where((event) => event.eventType == 'view_end')
     .toList();
 
-({DivineVideoPlayerController controller, Future<void> Function() close})
+({
+  DivineVideoPlayerController controller,
+  void Function(DivineVideoPlayerState state) setState,
+  Future<void> Function() close,
+})
 _stubController({
   required bool isPlaying,
   Duration duration = const Duration(seconds: 5),
@@ -644,6 +681,10 @@ _stubController({
 
   return (
     controller: controller,
+    setState: (DivineVideoPlayerState next) {
+      state = next;
+      stateController.add(next);
+    },
     close: () async {
       await stateController.close();
       state = const DivineVideoPlayerState();


### PR DESCRIPTION
## Description

- Reset per-session playback state when a video becomes inactive so returning to the same video starts and publishes a distinct continuous viewing session.
- Preserve seen-video deduplication across those sessions.
- Cover inactive -> active -> inactive reactivation without resumed playback, ensuring no extra `view_end` is emitted.
- Document fractional loops and one-event-per-session as the current mobile-emitted contract while explicitly marking companion Funnelcake ingestion support as pending divinevideo/divine-funnelcake#921.
- Align the Kind 22236 `viewed` docs and `ViewEventPublisher` API comments with mobile's elapsed-playback-seconds contract, and remove the unused multi-segment publisher that emitted multiple `viewed` tags.

Session boundaries come from `DivineVideoMetricsTracker.isActive`. In feed playback, that includes the active item, route playback gating, and app foreground state, so background/foreground and disallowed-route transitions can close a session; resumed playback then emits a new Kind 22236 event for the next continuous session.

**Related Issue:** Closes #7232. Follow-up to #7217. Companion ingestion fix: divinevideo/divine-funnelcake#921.

## Out of Scope

None.

## Verification

- `flutter analyze`
- `flutter test test/services/view_event_publisher_test.dart`
- `flutter test test/widgets/divine_video_metrics_tracker_test.dart test/services/view_event_publisher_test.dart test/services/view_event_retry_service_test.dart test/services/analytics_service_test.dart` (55 tests after removing the dead multi-segment publisher tests)
- Pre-push analyzer and affected-test checks

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature would cause existing functionality change)
- [ ] 🧹 Code refactor
- [x] 📝 Documentation
- [ ] 🗑️ Chore