### PR TITLE
fix(library): stop the screen flashing black when a clip is trashed

### DIFF
--- a/mobile/lib/blocs/clips_library/clips_library_bloc.dart
+++ b/mobile/lib/blocs/clips_library/clips_library_bloc.dart
@@ -288,6 +288,9 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
     // reach it. See [ClipsLibraryState.visibleSelectedClipIds].
     final deletedIds = state.visibleSelectedClipIds;
     if (deletedIds.isEmpty) return;
+    // The two delete events sit in separate `droppable()` buckets, so the
+    // transformer alone does not stop one delete overlapping the other.
+    if (state.isDeleting) return;
 
     emit(
       state.copyWith(
@@ -341,6 +344,10 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
     ClipsLibraryDeleteClip event,
     Emitter<ClipsLibraryState> emit,
   ) async {
+    // See _onDeleteSelected: separate `droppable()` buckets do not exclude
+    // each other, so the in-flight delete has to be checked explicitly.
+    if (state.isDeleting) return;
+
     emit(
       state.copyWith(
         status: ClipsLibraryStatus.deleting,

--- a/mobile/lib/screens/library_screen.dart
+++ b/mobile/lib/screens/library_screen.dart
@@ -751,11 +751,9 @@ class _LibraryViewState extends ConsumerState<_LibraryView>
                     ),
                   ),
                 ),
-                // Deleting is deliberately absent: a soft delete is a local
-                // database write that completes within a few frames, so the
-                // scrim only ever reads as the whole screen flashing black.
-                // The clips leaving the grid plus the Undo snackbar are the
-                // feedback for it.
+                // Deleting is deliberately absent: a soft delete finishes in a
+                // few frames, so the scrim only read as the screen flashing
+                // black. Its feedback is the clips leaving the grid plus Undo.
                 if (clipsState.isSavingToGallery || isPreparing)
                   Material(
                     color: VineTheme.scrim65,

--- a/mobile/lib/screens/library_screen.dart
+++ b/mobile/lib/screens/library_screen.dart
@@ -751,9 +751,12 @@ class _LibraryViewState extends ConsumerState<_LibraryView>
                     ),
                   ),
                 ),
-                if (clipsState.isDeleting ||
-                    clipsState.isSavingToGallery ||
-                    isPreparing)
+                // Deleting is deliberately absent: a soft delete is a local
+                // database write that completes within a few frames, so the
+                // scrim only ever reads as the whole screen flashing black.
+                // The clips leaving the grid plus the Undo snackbar are the
+                // feedback for it.
+                if (clipsState.isSavingToGallery || isPreparing)
                   Material(
                     color: VineTheme.scrim65,
                     child: Center(

--- a/mobile/test/blocs/clips_library/clips_library_bloc_test.dart
+++ b/mobile/test/blocs/clips_library/clips_library_bloc_test.dart
@@ -739,6 +739,29 @@ void main() {
           ),
         ],
       );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'ignores a multi-delete while a single-clip delete is in flight',
+        setUp: () {
+          when(
+            () => mockClipLibraryService.softDelete(any()),
+          ).thenAnswer((_) async => true);
+        },
+        // The two delete events use separate `droppable()` buckets, so only
+        // the explicit in-flight check keeps them from overlapping.
+        seed: () => ClipsLibraryState(
+          status: ClipsLibraryStatus.deleting,
+          clips: [clip1, clip2],
+          selectedClipIds: const {'clip1'},
+          selectedDuration: const Duration(seconds: 5),
+        ),
+        build: createBloc,
+        act: (bloc) => bloc.add(const ClipsLibraryDeleteSelected()),
+        expect: () => <ClipsLibraryState>[],
+        verify: (_) {
+          verifyNever(() => mockClipLibraryService.softDelete(any()));
+        },
+      );
     });
 
     group('ClipsLibraryDeleteClip', () {
@@ -844,6 +867,27 @@ void main() {
                 Duration.zero,
               ),
         ],
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'ignores a single-clip delete while a multi-delete is in flight',
+        setUp: () {
+          when(
+            () => mockClipLibraryService.softDelete(any()),
+          ).thenAnswer((_) async => true);
+        },
+        // Mirror of the multi-delete guard: the `droppable()` transformer only
+        // excludes repeats of the same event type.
+        seed: () => ClipsLibraryState(
+          status: ClipsLibraryStatus.deleting,
+          clips: [clip1],
+        ),
+        build: createBloc,
+        act: (bloc) => bloc.add(ClipsLibraryDeleteClip(clip1)),
+        expect: () => <ClipsLibraryState>[],
+        verify: (_) {
+          verifyNever(() => mockClipLibraryService.softDelete(any()));
+        },
       );
     });
 

--- a/mobile/test/screens/library_screen_test.dart
+++ b/mobile/test/screens/library_screen_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for LibraryScreen - browsing and managing saved clips/drafts
 // ABOUTME: Covers tabs, navigation, empty states, and clip selection flows
 
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
@@ -963,6 +965,62 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text(en.libraryClipsDeletedUndoLabel), findsOneWidget);
+      });
+
+      testWidgets('does not scrim the screen while the delete is in flight', (
+        tester,
+      ) async {
+        // Regression guard: the blocking progress scrim used to cover the
+        // whole screen for the handful of frames a soft delete takes, which
+        // read as the library flashing black on every trashed clip.
+        final clip = DivineVideoClip(
+          id: 'scrim-clip-1',
+          video: EditorVideo.file('/test/scrim.mp4'),
+          duration: const Duration(seconds: 2),
+          recordedAt: DateTime.now(),
+          targetAspectRatio: models.AspectRatio.vertical,
+          originalAspectRatio: 9 / 16,
+          thumbnailPath: '/test/scrim.jpg',
+          ghostFramePath: '/test/scrim_ghost.jpg',
+        );
+        when(
+          () => mockClipLibraryService.getAllClips(),
+        ).thenAnswer((_) async => [clip]);
+        when(
+          () => mockClipLibraryService.recoverMissingAssets(any()),
+        ).thenAnswer((_) async => [clip]);
+        // Held open so the assertions run while the bloc is still deleting.
+        final softDelete = Completer<bool>();
+        when(
+          () => mockClipLibraryService.softDelete(any()),
+        ).thenAnswer((_) => softDelete.future);
+
+        await tester.pumpWidget(
+          buildWidget(
+            initialTabIndex: 1,
+            tabsMode: LibraryTabsMode.withoutSounds,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final bloc = BlocProvider.of<ClipsLibraryBloc>(
+          tester.element(find.byType(ClipsTab)),
+        )..add(ClipsLibraryDeleteClip(clip));
+        // One pump lets the bloc emit `deleting`, the second paints it.
+        await tester.pump();
+        await tester.pump();
+
+        expect(bloc.state.isDeleting, isTrue);
+        expect(
+          find.byWidgetPredicate(
+            (widget) => widget is Material && widget.color == VineTheme.scrim65,
+          ),
+          findsNothing,
+        );
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+
+        softDelete.complete(true);
+        await tester.pumpAndSettle();
       });
     });
 


### PR DESCRIPTION
Closes #7234

## Description

Moving a clip to the trash made the whole library flash black for a moment.

The blocking progress scrim in `LibraryScreen` was gated on `clipsState.isDeleting` next to the gallery-save and video-preparing states. Those two run for seconds and deserve a full-screen `Material(color: VineTheme.scrim65)` — 65% black — over the library. A soft delete does not: it is a local Drift write plus a `getAllClips()` reload, so the overlay appeared and disappeared within a few frames. Long enough to see, too short to read as a spinner. Both delete paths hit it, the single-clip delete from the clip preview and the multi-select delete from the toolbar, since both emit `ClipsLibraryStatus.deleting`.

The scrim now covers only the two slow operations. Dropping deletion from it does give up something real: the overlay was blocking input, not only painting over it. `Material` defaults to `MaterialType.canvas`, and `Material.build` passes `absorbHitTest: widget.type != MaterialType.transparency` into `_InkFeatures`, whose render object returns `hitTestSelf => absorbHitTest` — so every tap during a delete was being swallowed.

That is an acceptable thing to lose here. `softDelete` is two local Drift `UPDATE`s with no file IO, so even a large multi-select finishes well inside the window a blocking overlay is meant to cover, and the one action worth blocking — a second delete — is already discarded by the `droppable()` transformer on both delete handlers. The user still gets feedback: the clips leave the grid and the Undo snackbar appears.

That exposed one thing worth closing properly. `ClipsLibraryDeleteClip` and `ClipsLibraryDeleteSelected` are separate `on<>` registrations, so their `droppable()` buckets are independent — the transformer never stopped a single-clip delete running on top of a multi-select one. That was unreachable only because the scrim was absorbing input, which is a side effect of an overlay, not a guard. Both handlers now check `state.isDeleting` and bail, so the exclusion holds on its own terms. Two bloc tests pin it, one per direction; both fail with the check removed.

`ClipsLibraryStatus.deleting` and `ClipsLibraryState.isDeleting` stay as they are; the status is still real domain state, and the new test asserts on it to prove the frame under test really is mid-delete.

**Related Issue:** 

## Out of Scope

None.

## Verification

- `flutter test test/blocs/clips_library/ test/screens/library_screen_test.dart test/widgets/library/` — 281 passed
- `flutter analyze lib test integration_test` — no issues
- `dart format` — clean
- New regression test `does not scrim the screen while the delete is in flight` holds `softDelete` open with a `Completer`, confirms the bloc is in `deleting`, and asserts no scrim and no spinner. Verified it fails on the pre-fix condition and passes after.
- Two new bloc tests cover the delete-overlap guard in both directions. Verified both fail with the `state.isDeleting` check removed.
- Manual verification on a real Samsung Galaxy is done.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
