### PR TITLE
fix(sound): rebuild the sound detail screen on divine_ui and slivers

### DIFF
--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -218,7 +218,7 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
         });
         ScaffoldMessenger.of(context).showSnackBar(
           DivineSnackbarContainer.snackBar(
-            context.l10n.soundPreviewFailed(e),
+            context.l10n.soundPreviewFailed(context.l10n.profilePleaseTryAgain),
             error: true,
             duration: _snackBarDuration,
           ),
@@ -576,11 +576,14 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
           Row(
             spacing: 12,
             children: [
-              _SoundCover(
-                pubkey: profileCreditPubkey,
-                name: profileCreditName,
-                pictureUrl: profileCreditProfile?.picture,
-              ),
+              if (profileCreditPubkey == null)
+                const _SoundCoverFallback()
+              else
+                _SoundCover(
+                  pubkey: profileCreditPubkey,
+                  name: profileCreditName!,
+                  pictureUrl: profileCreditProfile?.picture,
+                ),
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -721,32 +724,28 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
 /// them ([_SoundHeaderState._profileCreditPubkey] returns null there) and
 /// keep the note glyph.
 class _SoundCover extends StatelessWidget {
-  const _SoundCover({required this.pubkey, this.name, this.pictureUrl});
+  const _SoundCover({
+    required this.pubkey,
+    required this.name,
+    this.pictureUrl,
+  });
 
   static const double _size = 48;
 
-  /// Pubkey of the credited creator, or null when no account backs the sound.
-  final String? pubkey;
-  final String? name;
+  /// Pubkey of the credited creator.
+  final String pubkey;
+  final String name;
   final String? pictureUrl;
 
   @override
   Widget build(BuildContext context) {
-    final creditPubkey = pubkey;
-    if (creditPubkey == null) {
-      return const _SoundCoverFallback();
-    }
-
-    final creditName = name;
     return UserAvatar(
       size: _size,
       imageUrl: pictureUrl,
-      name: creditName,
-      placeholderSeed: creditPubkey,
-      onTap: () => context.pushOtherProfile(creditPubkey),
-      semanticLabel: creditName == null
-          ? null
-          : context.l10n.profileChipTapHint(creditName),
+      name: name,
+      placeholderSeed: pubkey,
+      onTap: () => context.pushOtherProfile(pubkey),
+      semanticLabel: context.l10n.profileChipTapHint(name),
     );
   }
 }
@@ -906,7 +905,6 @@ class _SourceLink extends StatelessWidget {
     final label = context.l10n.soundViewSource;
     return Semantics(
       button: true,
-      label: label,
       child: DivineTextLink(
         text: label,
         style: VineTheme.bodySmallFont(color: VineTheme.vineGreen).copyWith(
@@ -981,7 +979,6 @@ class _VideosGrid extends ConsumerWidget {
         children: [BrandedLoadingIndicator(size: 60)],
       ),
       error: (error, stack) => _VideosErrorState(
-        error: error,
         onRetry: () => ref.invalidate(videosUsingSoundProvider(audioEventId)),
       ),
     );
@@ -1048,9 +1045,8 @@ class _VideosEmptyState extends StatelessWidget {
 
 /// Placeholder shown when the videos for a sound failed to load.
 class _VideosErrorState extends StatelessWidget {
-  const _VideosErrorState({required this.error, required this.onRetry});
+  const _VideosErrorState({required this.onRetry});
 
-  final Object error;
   final VoidCallback onRetry;
 
   @override
@@ -1070,16 +1066,6 @@ class _VideosErrorState extends StatelessWidget {
             color: context.vineColors.primaryText,
           ),
           textAlign: TextAlign.center,
-        ),
-        const SizedBox(height: 8),
-        Text(
-          error.toString(),
-          style: VineTheme.bodySmallFont(
-            color: context.vineColors.onSurfaceMuted,
-          ),
-          textAlign: TextAlign.center,
-          maxLines: 3,
-          overflow: TextOverflow.ellipsis,
         ),
         const SizedBox(height: 24),
         DivineButton(

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -52,8 +52,10 @@ const _snackBarDuration = Duration(seconds: 2);
 /// [CustomScrollView]. [PinnedHeaderSliver] measures the child instead, so
 /// there is nothing to keep in sync.
 ///
-/// Opaque so the sound header scrolls away *behind* the label rather than
-/// through it.
+/// Paints the scroll view's own background so the grid scrolls *behind* the
+/// label rather than through it — a pinned sliver keeps painting where the
+/// slivers after it are still scrolling, and a transparent one shows their
+/// thumbnails straight through the text.
 class _VideosSectionHeader extends StatelessWidget {
   const _VideosSectionHeader({required this.title});
 
@@ -61,15 +63,18 @@ class _VideosSectionHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(16),
-      child: Text(
-        title,
-        style: VineTheme.titleSmallFont(
-          color: context.vineColors.primaryText,
+    return ColoredBox(
+      color: context.vineColors.background,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Text(
+          title,
+          style: VineTheme.titleSmallFont(
+            color: context.vineColors.primaryText,
+          ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
         ),
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
       ),
     );
   }

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -24,6 +24,7 @@ import 'package:openvine/services/saved_sound_context_builder.dart';
 import 'package:openvine/services/saved_sounds_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/library/saved_sound_details_editor.dart';
+import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/video_feed_item/audio_attribution_credit.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:provider/provider.dart' as inherited_provider;
@@ -35,6 +36,44 @@ const _soundDetailCreatorAttributionIdentifier =
     'sound_detail_creator_attribution';
 const _soundDetailPublisherAttributionIdentifier =
     'sound_detail_publisher_attribution';
+
+/// How long the screen's confirmation / failure snackbars stay up.
+const _snackBarDuration = Duration(seconds: 2);
+
+/// Pinned label introducing the video grid.
+///
+/// Rendered through [PinnedHeaderSliver] rather than a
+/// [SliverPersistentHeaderDelegate] on purpose: a delegate has to declare its
+/// extent before the child is laid out, so every type or padding change has
+/// to be mirrored in that arithmetic, and a header that ends up shorter than
+/// its declared extent makes `layoutExtent` exceed `paintExtent` — the sliver
+/// then fails layout, leaves its geometry null, and paint reports it as
+/// "Null check operator used on a null value" against the enclosing
+/// [CustomScrollView]. [PinnedHeaderSliver] measures the child instead, so
+/// there is nothing to keep in sync.
+///
+/// Opaque so the sound header scrolls away *behind* the label rather than
+/// through it.
+class _VideosSectionHeader extends StatelessWidget {
+  const _VideosSectionHeader({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Text(
+        title,
+        style: VineTheme.titleSmallFont(
+          color: context.vineColors.primaryText,
+        ),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+    );
+  }
+}
 
 /// Screen displaying details of a specific sound and videos using it.
 ///
@@ -125,9 +164,10 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
       );
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(context.l10n.soundUnableToPreview),
-            duration: const Duration(seconds: 2),
+          DivineSnackbarContainer.snackBar(
+            context.l10n.soundUnableToPreview,
+            error: true,
+            duration: _snackBarDuration,
           ),
         );
       }
@@ -172,9 +212,10 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
           _isLoadingPreview = false;
         });
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(context.l10n.soundPreviewFailed(e)),
-            duration: const Duration(seconds: 2),
+          DivineSnackbarContainer.snackBar(
+            context.l10n.soundPreviewFailed(e),
+            error: true,
+            duration: _snackBarDuration,
           ),
         );
       }
@@ -217,14 +258,15 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
     if (!mounted) return;
 
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(switch (result) {
+      DivineSnackbarContainer.snackBar(
+        switch (result) {
           SavedSoundSaveResult.saved => context.l10n.soundsSavedToLibrary,
           SavedSoundSaveResult.alreadySaved =>
             context.l10n.soundsAlreadySavedToLibrary,
           null => context.l10n.soundsSaveFailed,
-        }),
-        duration: const Duration(seconds: 2),
+        },
+        error: result == null,
+        duration: _snackBarDuration,
       ),
     );
   }
@@ -323,77 +365,66 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
             ),
       body: Stack(
         children: [
-          // Main content
+          // Main content. One scroll view for the whole screen: the sound
+          // header used to be a fixed-height `Column` child above the grid,
+          // so on a short viewport — or once attribution, tags and the saved
+          // sound editor stack up — the grid was squeezed into a slot barely
+          // one row tall. Only the videos section header stays pinned.
           Semantics(
             identifier: 'sound_detail_screen_${widget.sound.id}',
             container: true,
-            child: Column(
-              children: [
+            child: CustomScrollView(
+              slivers: [
                 // Sound header
-                _SoundHeader(
-                  sound: widget.sound,
-                  usageCount: usageCountAsync.value ?? 0,
-                  isPlaying: _isPlayingPreview,
-                  isLoadingPreview: _isLoadingPreview,
-                  onPreviewTap: _togglePreview,
-                  onUseSoundTap: canReuseSound ? _onUseSound : null,
-                  reuseAllowed: reuseAllowed,
+                SliverToBoxAdapter(
+                  child: _SoundHeader(
+                    sound: widget.sound,
+                    usageCount: usageCountAsync.value ?? 0,
+                    isPlaying: _isPlayingPreview,
+                    isLoadingPreview: _isLoadingPreview,
+                    onPreviewTap: _togglePreview,
+                    onUseSoundTap: canReuseSound ? _onUseSound : null,
+                    reuseAllowed: reuseAllowed,
+                  ),
                 ),
 
                 if (savedSoundsBloc != null)
-                  BlocBuilder<SavedSoundsBloc, SavedSoundsState>(
-                    bloc: savedSoundsBloc,
-                    builder: (context, state) {
-                      final records = state.sounds.where(
-                        (record) => record.id == widget.sound.id,
-                      );
-                      if (records.isEmpty) return const SizedBox.shrink();
-                      return SavedSoundDetailsEditor(sound: records.first);
-                    },
+                  SliverToBoxAdapter(
+                    child: BlocBuilder<SavedSoundsBloc, SavedSoundsState>(
+                      bloc: savedSoundsBloc,
+                      builder: (context, state) {
+                        final records = state.sounds.where(
+                          (record) => record.id == widget.sound.id,
+                        );
+                        if (records.isEmpty) return const SizedBox.shrink();
+                        return SavedSoundDetailsEditor(sound: records.first);
+                      },
+                    ),
                   ),
 
-                // Divider
-                Divider(color: context.vineColors.card, height: 1),
-
-                // Videos section header
-                Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Row(
-                    children: [
-                      const DivineIcon(
-                        icon: DivineIconName.videoCamera,
-                        color: VineTheme.vineGreen,
-                        size: 20,
-                      ),
-                      const SizedBox(width: 8),
-                      Text(
-                        showsSourceVideo
-                            ? context.l10n.soundSourceVideo
-                            : context.l10n.soundVideosUsingThisSound,
-                        style: TextStyle(
-                          color: context.vineColors.primaryText,
-                          fontSize: 16,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                    ],
+                PinnedHeaderSliver(
+                  child: _VideosSectionHeader(
+                    title: showsSourceVideo
+                        ? context.l10n.soundSourceVideo
+                        : context.l10n.soundVideosUsingThisSound,
                   ),
                 ),
 
                 // Videos grid — when a source video is on hand (own original
                 // sound), show it directly; otherwise query by the recovered
                 // audio event id.
-                Expanded(
-                  child: showsSourceVideo
-                      ? _SourceVideoGrid(
-                          video: widget.sourceVideo!,
-                          onVideoTap: _navigateToVideo,
-                        )
-                      : _VideosGrid(
-                          audioEventId: soundEventId,
-                          onVideoTap: _navigateToVideo,
-                        ),
-                ),
+                if (showsSourceVideo)
+                  _SourceVideoGrid(
+                    video: widget.sourceVideo!,
+                    onVideoTap: _navigateToVideo,
+                  )
+                else
+                  _VideosGrid(
+                    audioEventId: soundEventId,
+                    onVideoTap: _navigateToVideo,
+                  ),
+
+                const SliverBottomSafeArea(),
               ],
             ),
           ),
@@ -538,21 +569,13 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
         children: [
           // Sound title and icon
           Row(
+            spacing: 12,
             children: [
-              Container(
-                width: 48,
-                height: 48,
-                decoration: BoxDecoration(
-                  color: VineTheme.vineGreen.withValues(alpha: 0.2),
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: const DivineIcon(
-                  icon: DivineIconName.musicNote,
-                  color: VineTheme.vineGreen,
-                  size: 28,
-                ),
+              _SoundCover(
+                pubkey: profileCreditPubkey,
+                name: profileCreditName,
+                pictureUrl: profileCreditProfile?.picture,
               ),
-              const SizedBox(width: 12),
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -560,15 +583,18 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
                   children: [
                     Text(
                       widget.sound.title ?? context.l10n.soundOriginalSound,
-                      style: TextStyle(
+                      style: VineTheme.titleMediumFont(
                         color: context.vineColors.primaryText,
-                        fontSize: 18,
-                        fontWeight: FontWeight.w600,
                       ),
                       maxLines: 2,
                       overflow: TextOverflow.ellipsis,
                     ),
-                    _buildMetadataRow(),
+                    Text(
+                      _metadataText(context.l10n),
+                      style: VineTheme.bodyMediumFont(
+                        color: context.vineColors.secondaryText,
+                      ),
+                    ),
                     if (profileCreditPubkey != null &&
                         profileCreditName != null)
                       _ProfileAttributionInfo(
@@ -627,75 +653,34 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
 
           // Action buttons
           Row(
+            spacing: 12,
             children: [
               // Preview button
               Expanded(
-                child: Semantics(
-                  identifier: 'sound_detail_preview_button',
-                  button: true,
-                  child: OutlinedButton.icon(
-                    onPressed: widget.onPreviewTap,
-                    icon: widget.isLoadingPreview
-                        ? const SizedBox(
-                            width: 18,
-                            height: 18,
-                            child: CircularProgressIndicator(
-                              color: VineTheme.vineGreen,
-                              strokeWidth: 2,
-                            ),
-                          )
-                        : DivineIcon(
-                            icon: widget.isPlaying
-                                ? DivineIconName.squareFill
-                                : DivineIconName.play,
-                            size: 20,
-                            color: VineTheme.vineGreen,
-                          ),
-                    label: Text(
-                      widget.isPlaying
-                          ? context.l10n.soundStop
-                          : context.l10n.soundPreview,
-                    ),
-                    style: OutlinedButton.styleFrom(
-                      foregroundColor: VineTheme.vineGreen,
-                      side: const BorderSide(color: VineTheme.vineGreen),
-                      padding: const EdgeInsets.symmetric(vertical: 12),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                    ),
-                  ),
+                child: DivineButton(
+                  label: widget.isPlaying
+                      ? context.l10n.soundStop
+                      : context.l10n.soundPreview,
+                  type: DivineButtonType.secondary,
+                  leadingIcon: widget.isPlaying
+                      ? DivineIconName.squareFill
+                      : DivineIconName.play,
+                  isLoading: widget.isLoadingPreview,
+                  semanticIdentifier: 'sound_detail_preview_button',
+                  onPressed: widget.onPreviewTap,
                 ),
               ),
 
-              if (widget.onUseSoundTap != null) ...[
-                const SizedBox(width: 12),
-
-                // Use Sound button
+              // Use Sound button
+              if (widget.onUseSoundTap != null)
                 Expanded(
-                  child: Semantics(
-                    identifier: 'sound_detail_use_button',
-                    button: true,
-                    child: ElevatedButton.icon(
-                      onPressed: widget.onUseSoundTap,
-                      icon: const DivineIcon(
-                        icon: DivineIconName.plus,
-                        size: 20,
-                        color: VineTheme.onPrimary,
-                      ),
-                      label: Text(context.l10n.soundUseSound),
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: VineTheme.vineGreen,
-                        foregroundColor: context.vineColors.background,
-                        padding: const EdgeInsets.symmetric(vertical: 12),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                      ),
-                    ),
+                  child: DivineButton(
+                    label: context.l10n.soundUseSound,
+                    leadingIcon: DivineIconName.plus,
+                    semanticIdentifier: 'sound_detail_use_button',
+                    onPressed: widget.onUseSoundTap,
                   ),
                 ),
-              ],
             ],
           ),
         ],
@@ -703,20 +688,12 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
     );
   }
 
-  Widget _buildMetadataRow() {
-    final items = <String>[];
-
+  String _metadataText(AppLocalizations l10n) {
     final duration = _formattedDuration;
-    if (duration.isNotEmpty) {
-      items.add(duration);
-    }
-
-    items.add(_videoCountText(context.l10n));
-
-    return Text(
-      items.join(' · '),
-      style: TextStyle(color: context.vineColors.secondaryText, fontSize: 14),
-    );
+    return [
+      if (duration.isNotEmpty) duration,
+      _videoCountText(l10n),
+    ].join(' · ');
   }
 
   String? _profileCreditPubkey(AudioEvent sound) {
@@ -727,6 +704,73 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
     }
     if (_artistName == null) return sound.pubkey;
     return null;
+  }
+}
+
+/// Cover art for the sound header.
+///
+/// A sound carries no artwork of its own, so the credited creator's avatar
+/// stands in for it — the same account the "By …" line names, which lets the
+/// header say whose sound this is at a glance and gives a second way into
+/// that profile. Bundled and locally imported sounds have no account behind
+/// them ([_SoundHeaderState._profileCreditPubkey] returns null there) and
+/// keep the note glyph.
+class _SoundCover extends StatelessWidget {
+  const _SoundCover({required this.pubkey, this.name, this.pictureUrl});
+
+  static const double _size = 48;
+
+  /// Pubkey of the credited creator, or null when no account backs the sound.
+  final String? pubkey;
+  final String? name;
+  final String? pictureUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    final creditPubkey = pubkey;
+    if (creditPubkey == null) {
+      return const _SoundCoverFallback();
+    }
+
+    final creditName = name;
+    return UserAvatar(
+      size: _size,
+      imageUrl: pictureUrl,
+      name: creditName,
+      placeholderSeed: creditPubkey,
+      onTap: () => context.pushOtherProfile(creditPubkey),
+      semanticLabel: creditName == null
+          ? null
+          : context.l10n.profileChipTapHint(creditName),
+    );
+  }
+}
+
+/// Note glyph shown when no account backs the sound.
+///
+/// Shares [UserAvatar]'s corner geometry so the header's leading tile keeps
+/// the same silhouette whether it resolves to an avatar or to this.
+class _SoundCoverFallback extends StatelessWidget {
+  const _SoundCoverFallback();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: _SoundCover._size,
+      height: _SoundCover._size,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: VineTheme.vineGreen.withValues(alpha: 0.2),
+        borderRadius: BorderRadius.circular(
+          UserAvatar.cornerRadiusForSize(_SoundCover._size),
+        ),
+      ),
+      child: const DivineIcon(
+        icon: DivineIconName.musicNote,
+        color: VineTheme.vineGreen,
+        size: 28,
+      ),
+    );
   }
 }
 
@@ -854,25 +898,28 @@ class _SourceLink extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () async {
-        final uri = Uri.parse(sourceUrl);
-        if (await canLaunchUrl(uri)) {
-          await launchUrl(uri, mode: LaunchMode.externalApplication);
-        }
-      },
-      child: Text(
-        context.l10n.soundViewSource,
+    final label = context.l10n.soundViewSource;
+    return Semantics(
+      button: true,
+      label: label,
+      child: DivineTextLink(
+        text: label,
         style: VineTheme.bodySmallFont(color: VineTheme.vineGreen).copyWith(
           decoration: TextDecoration.underline,
           decorationColor: VineTheme.vineGreen,
         ),
+        onTap: () async {
+          final uri = Uri.parse(sourceUrl);
+          if (await canLaunchUrl(uri)) {
+            await launchUrl(uri, mode: LaunchMode.externalApplication);
+          }
+        },
       ),
     );
   }
 }
 
-/// Grid showing the single source video for an original sound.
+/// Sliver grid showing the single source video for an original sound.
 class _SourceVideoGrid extends StatelessWidget {
   const _SourceVideoGrid({required this.video, required this.onVideoTap});
 
@@ -883,30 +930,26 @@ class _SourceVideoGrid extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final videosList = [video];
-    return CustomScrollView(
-      slivers: [
-        SliverPadding(
-          padding: const EdgeInsets.all(2),
-          sliver: SliverGrid(
-            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: 3,
-              crossAxisSpacing: 2,
-              mainAxisSpacing: 2,
-            ),
-            delegate: SliverChildBuilderDelegate((context, index) {
-              return _VideoGridTile(
-                video: video,
-                onTap: () => onVideoTap(video.id, 0, videosList),
-              );
-            }, childCount: 1),
-          ),
+    return SliverPadding(
+      padding: const EdgeInsets.all(2),
+      sliver: SliverGrid(
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 3,
+          crossAxisSpacing: 2,
+          mainAxisSpacing: 2,
         ),
-      ],
+        delegate: SliverChildBuilderDelegate((context, index) {
+          return _VideoGridTile(
+            video: video,
+            onTap: () => onVideoTap(video.id, 0, videosList),
+          );
+        }, childCount: 1),
+      ),
     );
   }
 }
 
-/// Grid of videos using the specified sound.
+/// Sliver grid of videos using the specified sound.
 class _VideosGrid extends ConsumerWidget {
   const _VideosGrid({required this.audioEventId, required this.onVideoTap});
 
@@ -921,132 +964,125 @@ class _VideosGrid extends ConsumerWidget {
     return videosAsync.when(
       data: (videoIds) {
         if (videoIds.isEmpty) {
-          return _buildEmptyState(context);
+          return _VideosEmptyState(
+            title: context.l10n.soundNoVideosYet,
+            message: context.l10n.soundBeFirstToUse,
+          );
         }
 
         return _VideosGridContent(videoIds: videoIds, onVideoTap: onVideoTap);
       },
-      loading: () => const Center(child: BrandedLoadingIndicator(size: 60)),
-      error: (error, stack) => _buildErrorState(context, error, () {
-        ref.invalidate(videosUsingSoundProvider(audioEventId));
-      }),
+      loading: () => const _PlaceholderLayout(
+        children: [BrandedLoadingIndicator(size: 60)],
+      ),
+      error: (error, stack) => _VideosErrorState(
+        error: error,
+        onRetry: () => ref.invalidate(videosUsingSoundProvider(audioEventId)),
+      ),
     );
   }
+}
 
-  Widget _buildEmptyState(BuildContext context) {
-    final l10n = context.l10n;
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        return SingleChildScrollView(
-          child: ConstrainedBox(
-            constraints: BoxConstraints(minHeight: constraints.maxHeight),
-            child: Center(
-              child: Padding(
-                padding: const EdgeInsets.all(24),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(
-                      Icons.videocam_off_outlined,
-                      size: 64,
-                      color: context.vineColors.mutedText,
-                    ),
-                    const SizedBox(height: 16),
-                    Text(
-                      l10n.soundNoVideosYet,
-                      style: TextStyle(
-                        color: context.vineColors.primaryText,
-                        fontSize: 18,
-                        fontWeight: FontWeight.w500,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      l10n.soundBeFirstToUse,
-                      style: TextStyle(
-                        color: context.vineColors.onSurfaceMuted,
-                        fontSize: 14,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ),
-        );
-      },
+/// Sliver centering placeholder content in whatever viewport is left below
+/// the header, growing past it — and scrolling — when the content is taller.
+class _PlaceholderLayout extends StatelessWidget {
+  const _PlaceholderLayout({required this.children});
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverFillRemaining(
+      hasScrollBody: false,
+      child: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(mainAxisSize: MainAxisSize.min, children: children),
+        ),
+      ),
     );
   }
+}
 
-  Widget _buildErrorState(
-    BuildContext context,
-    Object error,
-    VoidCallback onRetry,
-  ) {
-    final l10n = context.l10n;
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        return SingleChildScrollView(
-          child: ConstrainedBox(
-            constraints: BoxConstraints(minHeight: constraints.maxHeight),
-            child: Center(
-              child: Padding(
-                padding: const EdgeInsets.all(24),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    const DivineIcon(
-                      icon: DivineIconName.warningCircle,
-                      size: 64,
-                      color: VineTheme.likeRed,
-                    ),
-                    const SizedBox(height: 16),
-                    Text(
-                      l10n.soundFailedToLoadVideos,
-                      style: TextStyle(
-                        color: context.vineColors.primaryText,
-                        fontSize: 18,
-                        fontWeight: FontWeight.w500,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      error.toString(),
-                      style: TextStyle(
-                        color: context.vineColors.onSurfaceMuted,
-                        fontSize: 12,
-                      ),
-                      textAlign: TextAlign.center,
-                      maxLines: 3,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    const SizedBox(height: 24),
-                    ElevatedButton.icon(
-                      onPressed: onRetry,
-                      icon: const DivineIcon(
-                        icon: DivineIconName.arrowClockwise,
-                        color: VineTheme.onPrimary,
-                      ),
-                      label: Text(l10n.soundRetry),
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: VineTheme.vineGreen,
-                        foregroundColor: context.vineColors.background,
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 24,
-                          vertical: 12,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
+/// Placeholder shown when no video is available for the sound.
+class _VideosEmptyState extends StatelessWidget {
+  const _VideosEmptyState({required this.title, required this.message});
+
+  final String title;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return _PlaceholderLayout(
+      children: [
+        DivineIcon(
+          icon: DivineIconName.filmSlate,
+          size: 64,
+          color: context.vineColors.mutedText,
+        ),
+        const SizedBox(height: 16),
+        Text(
+          title,
+          style: VineTheme.titleMediumFont(
+            color: context.vineColors.primaryText,
           ),
-        );
-      },
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 8),
+        Text(
+          message,
+          style: VineTheme.bodyMediumFont(
+            color: context.vineColors.onSurfaceMuted,
+          ),
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+  }
+}
+
+/// Placeholder shown when the videos for a sound failed to load.
+class _VideosErrorState extends StatelessWidget {
+  const _VideosErrorState({required this.error, required this.onRetry});
+
+  final Object error;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return _PlaceholderLayout(
+      children: [
+        const DivineIcon(
+          icon: DivineIconName.warningCircle,
+          size: 64,
+          color: VineTheme.likeRed,
+        ),
+        const SizedBox(height: 16),
+        Text(
+          l10n.soundFailedToLoadVideos,
+          style: VineTheme.titleMediumFont(
+            color: context.vineColors.primaryText,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 8),
+        Text(
+          error.toString(),
+          style: VineTheme.bodySmallFont(
+            color: context.vineColors.onSurfaceMuted,
+          ),
+          textAlign: TextAlign.center,
+          maxLines: 3,
+          overflow: TextOverflow.ellipsis,
+        ),
+        const SizedBox(height: 24),
+        DivineButton(
+          label: l10n.soundRetry,
+          leadingIcon: DivineIconName.arrowClockwise,
+          onPressed: onRetry,
+        ),
+      ],
     );
   }
 }
@@ -1138,7 +1174,9 @@ class _VideosGridContentState extends ConsumerState<_VideosGridContent> {
     ref.watch(blocklistVersionProvider);
     final videoEventService = ref.read(videoEventServiceProvider);
     if (_isLoading) {
-      return const Center(child: BrandedLoadingIndicator(size: 60));
+      return const _PlaceholderLayout(
+        children: [BrandedLoadingIndicator(size: 60)],
+      );
     }
 
     final validVideos = widget.videoIds.where((id) {
@@ -1147,61 +1185,31 @@ class _VideosGridContentState extends ConsumerState<_VideosGridContent> {
     }).toList();
 
     if (validVideos.isEmpty) {
-      final l10n = context.l10n;
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.videocam_off_outlined,
-              size: 64,
-              color: context.vineColors.mutedText,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              l10n.soundVideosUnavailable,
-              style: TextStyle(
-                color: context.vineColors.primaryText,
-                fontSize: 18,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              l10n.soundCouldNotLoadDetails,
-              style: TextStyle(
-                color: context.vineColors.onSurfaceMuted,
-                fontSize: 14,
-              ),
-            ),
-          ],
-        ),
+      return _VideosEmptyState(
+        title: context.l10n.soundVideosUnavailable,
+        message: context.l10n.soundCouldNotLoadDetails,
       );
     }
 
     // Build list of valid video events in order
     final videosList = validVideos.map((id) => _videoEvents[id]!).toList();
 
-    return CustomScrollView(
-      slivers: [
-        SliverPadding(
-          padding: const EdgeInsets.all(2),
-          sliver: SliverGrid(
-            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: 3,
-              crossAxisSpacing: 2,
-              mainAxisSpacing: 2,
-            ),
-            delegate: SliverChildBuilderDelegate((context, index) {
-              final video = videosList[index];
-              return _VideoGridTile(
-                video: video,
-                onTap: () => widget.onVideoTap(video.id, index, videosList),
-              );
-            }, childCount: videosList.length),
-          ),
+    return SliverPadding(
+      padding: const EdgeInsets.all(2),
+      sliver: SliverGrid(
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 3,
+          crossAxisSpacing: 2,
+          mainAxisSpacing: 2,
         ),
-      ],
+        delegate: SliverChildBuilderDelegate((context, index) {
+          final video = videosList[index];
+          return _VideoGridTile(
+            video: video,
+            onTap: () => widget.onVideoTap(video.id, index, videosList),
+          );
+        }, childCount: videosList.length),
+      ),
     );
   }
 }
@@ -1338,33 +1346,33 @@ class _SoundVideoFeedOverlay extends ConsumerWidget {
               child: Row(
                 children: [
                   // Close button
-                  IconButton(
-                    icon: const DivineIcon(
-                      icon: DivineIconName.x,
-                      color: VineTheme.primaryText,
-                    ),
-                    onPressed: onClose,
+                  DivineIconButton(
+                    icon: DivineIconName.x,
+                    type: DivineIconButtonType.ghostOverMedia,
+                    size: DivineIconButtonSize.small,
                     tooltip: context.l10n.soundCloseTooltip,
+                    semanticLabel: context.l10n.soundCloseTooltip,
+                    onPressed: onClose,
                   ),
 
                   // Sound title
                   Expanded(
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.center,
+                      spacing: 6,
                       children: [
                         const DivineIcon(
                           icon: DivineIconName.musicNote,
                           color: VineTheme.vineGreen,
                           size: 18,
                         ),
-                        const SizedBox(width: 6),
                         Flexible(
                           child: Text(
                             soundTitle,
-                            style: TextStyle(
-                              color: context.vineColors.primaryText,
-                              fontSize: 14,
-                              fontWeight: FontWeight.w600,
+                            // Fixed light text: the backdrop here is a video
+                            // frame, not a palette surface.
+                            style: VineTheme.labelLargeFont(
+                              color: VineTheme.onSurface,
                             ),
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
@@ -1374,6 +1382,8 @@ class _SoundVideoFeedOverlay extends ConsumerWidget {
                     ),
                   ),
 
+                  // Balances the leading close button so the title stays
+                  // optically centred.
                   const SizedBox(width: 48),
                 ],
               ),

--- a/mobile/scripts/baseline/file_sizes.txt
+++ b/mobile/scripts/baseline/file_sizes.txt
@@ -32,7 +32,7 @@ lib/screens/library_screen.dart	857
 lib/screens/relay_diagnostic_screen.dart	1104
 lib/screens/relay_settings_screen.dart	1006
 lib/screens/settings/settings_screen.dart	896
-lib/screens/sound_detail_screen.dart	1386
+lib/screens/sound_detail_screen.dart	1387
 lib/screens/user_list_people_screen.dart	813
 lib/screens/video_editor/video_editor_screen.dart	1044
 lib/screens/video_metadata/video_metadata_cover_screen.dart	1052

--- a/mobile/scripts/baseline/material_buttons.txt
+++ b/mobile/scripts/baseline/material_buttons.txt
@@ -29,7 +29,6 @@ lib/screens/inbox/inbox_view.dart	2
 lib/screens/minor_account_review_screen.dart	1
 lib/screens/profile_setup/widgets/profile_setup_listeners.dart	2
 lib/screens/search_results/widgets/search_user_tile.dart	1
-lib/screens/sound_detail_screen.dart	4
 lib/screens/user_list_people_screen.dart	6
 lib/screens/video_editor/voice_over_recorder_screen.dart	1
 lib/screens/video_engagement/video_engagement_list_view.dart	1

--- a/mobile/scripts/baseline/raw_icons.txt
+++ b/mobile/scripts/baseline/raw_icons.txt
@@ -18,7 +18,6 @@ lib/screens/settings/general_settings_screen.dart	1
 lib/screens/settings/legal_screen.dart	4
 lib/screens/settings/nostr_settings_screen.dart	5
 lib/screens/settings/settings_screen.dart	5
-lib/screens/sound_detail_screen.dart	4
 lib/screens/user_list_people_screen.dart	3
 lib/widgets/auth/forgot_password_dialog.dart	1
 lib/widgets/classic_viners_slider.dart	1

--- a/mobile/scripts/baseline/raw_textstyle.txt
+++ b/mobile/scripts/baseline/raw_textstyle.txt
@@ -43,7 +43,6 @@ lib/screens/original_sound_detail_screen.dart	4
 lib/screens/other_profile_screen.dart	2
 lib/screens/profile_setup/widgets/profile_setup_listeners.dart	5
 lib/screens/search_results/widgets/videos_section.dart	1
-lib/screens/sound_detail_screen.dart	12
 lib/screens/user_list_people_screen.dart	15
 lib/services/watermark_image_generator.dart	1
 lib/startup/database_bootstrap_failure_app.dart	4

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -1442,6 +1442,51 @@ void main() {
         expect(headerAfter, greaterThanOrEqualTo(0));
       });
 
+      testWidgets('pinned section header paints over the grid scrolling '
+          'beneath it', (tester) async {
+        final testSound = createTestAudioEvent(id: 'sound1');
+
+        await tester.pumpWidget(
+          createTestWidget(
+            child: SoundDetailScreen(sound: testSound),
+            overrides: [
+              soundUsageCountProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(0)),
+              videosUsingSoundProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(<String>[])),
+              audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
+            ],
+          ),
+        );
+
+        await tester.pump();
+
+        // A pinned sliver keeps painting over the slivers after it while they
+        // scroll, so the label needs its own opaque ground or grid thumbnails
+        // read straight through the text.
+        final label = find.text('Videos using this sound');
+        final backgroundFinder = find
+            .ancestor(of: label, matching: find.byType(ColoredBox))
+            .first;
+        final background = tester.widget<ColoredBox>(backgroundFinder);
+        expect(background.color.a, equals(1.0));
+        expect(
+          background.color,
+          equals(tester.element(label).vineColors.background),
+        );
+        // And it has to cover the label, not sit behind part of it.
+        expect(
+          tester.getRect(backgroundFinder),
+          equals(
+            tester.getRect(
+              find.ancestor(of: label, matching: find.byType(Padding)).first,
+            ),
+          ),
+        );
+      });
+
       testWidgets('reused original sound queries usage/grid by recovered id', (
         tester,
       ) async {

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -1168,8 +1168,12 @@ void main() {
         await tester.tap(find.text('Preview'));
         await tester.pumpAndSettle();
 
-        // Should show error snackbar
-        expect(find.textContaining('Failed to play preview'), findsOneWidget);
+        // Should show a localized error without leaking exception details.
+        expect(
+          find.text('Failed to play preview: Please try again'),
+          findsOneWidget,
+        );
+        expect(find.textContaining('Playback failed'), findsNothing);
       });
     });
 
@@ -1932,6 +1936,8 @@ void main() {
 
           // The error body must actually be on screen (no fallback path).
           expect(_divineIcon(DivineIconName.warningCircle), findsOneWidget);
+          expect(find.text('Failed to load videos'), findsOneWidget);
+          expect(find.textContaining('forced error'), findsNothing);
           // No layout exception should have been thrown while building.
           expect(tester.takeException(), isNull);
         },

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -25,6 +25,7 @@ import 'package:openvine/services/saved_sounds_service.dart';
 import 'package:openvine/services/sound_library_service.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
+import 'package:openvine/widgets/user_avatar.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sound_service/sound_service.dart';
 
@@ -132,6 +133,7 @@ Widget createTestWidget({
   required Widget child,
   List<dynamic>? overrides,
   String? viewerPubkey,
+  TextScaler textScaler = TextScaler.noScaling,
 }) {
   final mockAuth = createMockAuthService();
   when(() => mockAuth.currentPublicKeyHex).thenReturn(viewerPubkey);
@@ -141,6 +143,10 @@ Widget createTestWidget({
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       theme: VineTheme.theme,
+      builder: (context, navigator) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(textScaler: textScaler),
+        child: navigator!,
+      ),
       home: child,
     ),
   );
@@ -435,7 +441,7 @@ void main() {
         expect(find.textContaining('2:05'), findsOneWidget);
       });
 
-      testWidgets('has music note icon', (tester) async {
+      testWidgets('uses the credited creator avatar as cover', (tester) async {
         final testSound = createTestAudioEvent(id: 'sound1');
 
         await tester.pumpWidget(
@@ -455,7 +461,47 @@ void main() {
 
         await tester.pump();
 
-        expect(_divineIcon(DivineIconName.musicNote), findsOneWidget);
+        // A sound has no artwork of its own, so the account it credits is
+        // what the cover identifies — same pubkey the "By …" line names.
+        final avatar = tester.widget<UserAvatar>(find.byType(UserAvatar));
+        expect(avatar.placeholderSeed, equals(testSound.pubkey));
+        expect(_divineIcon(DivineIconName.musicNote), findsNothing);
+      });
+
+      testWidgets('falls back to the note glyph when no account backs the '
+          'sound', (tester) async {
+        final testSound = AudioEvent.fromLocalImport(
+          id: '${AudioEvent.localImportMarker}_sound1',
+          filePath: '/tmp/sound.m4a',
+          createdAt: 1700000000,
+          title: 'Imported loop',
+          mimeType: 'audio/mp4',
+        );
+
+        await tester.pumpWidget(
+          createTestWidget(
+            child: SoundDetailScreen(sound: testSound),
+            overrides: [
+              soundUsageCountProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(0)),
+              videosUsingSoundProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(<String>[])),
+              audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
+            ],
+          ),
+        );
+
+        await tester.pump();
+
+        final note = _divineIcon(DivineIconName.musicNote);
+        expect(note, findsOneWidget);
+        expect(find.byType(UserAvatar), findsNothing);
+        expect(
+          tester.widget<DivineIcon>(note).color,
+          equals(VineTheme.vineGreen),
+        );
       });
 
       testWidgets('keeps bundled sound artist and license attribution', (
@@ -1270,7 +1316,130 @@ void main() {
         await tester.pump();
 
         expect(find.text('Videos using this sound'), findsOneWidget);
-        expect(_divineIcon(DivineIconName.videoCamera), findsOneWidget);
+      });
+
+      // The header is a PinnedHeaderSliver, which derives its geometry from
+      // the child it measures. A SliverPersistentHeaderDelegate instead has
+      // to declare an extent up front, and one that disagrees with what the
+      // child renders either clips the label (too small) or makes
+      // layoutExtent exceed paintExtent (too large) — the sliver then fails
+      // layout, leaves its geometry null, and paint surfaces it as a null
+      // check against the CustomScrollView. So assert both halves: the box
+      // is exactly as tall as its content asks for, at two text scales.
+      Future<({double laidOut, double needed})> pumpSectionHeader(
+        WidgetTester tester, {
+        required TextScaler textScaler,
+      }) async {
+        final testSound = createTestAudioEvent(id: 'sound1');
+
+        await tester.pumpWidget(
+          createTestWidget(
+            textScaler: textScaler,
+            child: SoundDetailScreen(sound: testSound),
+            overrides: [
+              soundUsageCountProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(0)),
+              videosUsingSoundProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(<String>[])),
+              audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
+            ],
+          ),
+        );
+
+        await tester.pump();
+
+        // Innermost Padding above the title is the header's own padding.
+        final box = tester.renderObject<RenderBox>(
+          find
+              .ancestor(
+                of: find.text('Videos using this sound'),
+                matching: find.byType(Padding),
+              )
+              .first,
+        );
+        return (
+          laidOut: box.size.height,
+          needed: box.getMaxIntrinsicHeight(box.size.width),
+        );
+      }
+
+      testWidgets('pinned section header is exactly as tall as its label', (
+        tester,
+      ) async {
+        final size = await pumpSectionHeader(
+          tester,
+          textScaler: TextScaler.noScaling,
+        );
+
+        // 52 = 16px padding either side of a 20px line box (titleSmallFont
+        // is 14/20). Asserting the concrete number is the half that can fail
+        // if the divine_ui type token moves.
+        expect(size.needed, equals(52));
+        expect(size.laidOut, equals(52));
+      });
+
+      testWidgets('pinned section header grows with the text scale rather '
+          'than clipping its label', (tester) async {
+        final size = await pumpSectionHeader(
+          tester,
+          textScaler: const TextScaler.linear(2),
+        );
+
+        // Only the line box scales; the two paddings do not. 32 + 40.
+        expect(size.needed, equals(72));
+        expect(size.laidOut, equals(72));
+      });
+
+      testWidgets('section header stays pinned while the sound header scrolls '
+          'away', (tester) async {
+        await tester.binding.setSurfaceSize(const Size(360, 480));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        final testSound = createTestAudioEvent(
+          id: 'sound1',
+          title: 'Awesome Beat',
+        );
+
+        await tester.pumpWidget(
+          createTestWidget(
+            child: SoundDetailScreen(sound: testSound),
+            overrides: [
+              soundUsageCountProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(0)),
+              videosUsingSoundProvider(testSound.id).overrideWith(
+                (ref) => Future<List<String>>.error(Exception('offline')),
+              ),
+              audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
+            ],
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        final titleBefore = tester.getTopLeft(find.text('Awesome Beat')).dy;
+        final headerBefore = tester
+            .getTopLeft(find.text('Videos using this sound'))
+            .dy;
+
+        await tester.drag(find.byType(CustomScrollView), const Offset(0, -300));
+        await tester.pump();
+
+        // The sound header is chrome now, not a fixed pane above the grid: it
+        // leaves the viewport entirely and hands its height back.
+        expect(
+          tester.getTopLeft(find.text('Awesome Beat')).dy,
+          lessThan(titleBefore),
+        );
+        // The section header rides up with it but stops at the top instead of
+        // scrolling past — the grid would otherwise lose its label.
+        final headerAfter = tester
+            .getTopLeft(find.text('Videos using this sound'))
+            .dy;
+        expect(headerAfter, lessThan(headerBefore));
+        expect(headerAfter, greaterThanOrEqualTo(0));
       });
 
       testWidgets('reused original sound queries usage/grid by recovered id', (
@@ -1448,34 +1617,8 @@ void main() {
     });
 
     group('Theme Compliance', () {
-      testWidgets('uses VineTheme green for accents', (tester) async {
-        final testSound = createTestAudioEvent(id: 'sound1');
-
-        await tester.pumpWidget(
-          createTestWidget(
-            child: SoundDetailScreen(sound: testSound),
-            overrides: [
-              soundUsageCountProvider(
-                testSound.id,
-              ).overrideWith((ref) => Future.value(0)),
-              videosUsingSoundProvider(
-                testSound.id,
-              ).overrideWith((ref) => Future.value(<String>[])),
-              audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
-            ],
-          ),
-        );
-
-        await tester.pump();
-
-        // Find music note icon and verify color
-        final musicIcon = _divineIcon(DivineIconName.musicNote);
-        expect(musicIcon, findsOneWidget);
-
-        final iconWidget = tester.widget<DivineIcon>(musicIcon);
-        expect(iconWidget.color, equals(VineTheme.vineGreen));
-      });
-
+      // The screen's own green accent is asserted where it still lives — on
+      // the cover fallback glyph, see "falls back to the note glyph …".
       testWidgets('Use Sound button has green background', (tester) async {
         final testSound = createTestAudioEvent(id: 'sound1');
 


### PR DESCRIPTION
Closes #7236

## Description

Rebuilds the sound detail screen on `divine_ui` and a single sliver-based scroll surface.

- Replaces remaining Material buttons, raw icons, raw `TextStyle`s, and bare snackbars in `sound_detail_screen.dart` with Divine design-system components and refreshes the relevant ratchet baselines.
- Moves the fixed header plus grid slot into one `CustomScrollView`, with a `PinnedHeaderSliver` videos label that measures its own child and paints an opaque background over the scrolling grid.
- Uses the credited creator avatar as the sound cover when a real account backs the sound, with the note glyph fallback for bundled or local-import sounds.
- Follow-up takeover cleanup: avoids duplicate source-link screen-reader labels, keeps raw exception text out of preview snackbars and videos error UI, tightens the private sound-cover avatar path, and refreshes the advisory file-size ceiling for the final file length.

## Out of Scope

- The `soundRemixingAllowed` / `soundCreditOnly` badge is left as is. The `Credit only` half is the only explanation the viewer gets for the hidden "Use Sound" button, so it earns its place; `Remixing allowed` is arguably redundant next to a visible button, but that is a copy decision for product rather than a side effect of this design pass.

## Verification

- `flutter analyze lib test` — clean
- `flutter test test/screens/sound_detail_screen_test.dart` — 50 pass
- `check_raw_textstyle_ceiling.sh`, `check_raw_icons_ceiling.sh`, `check_material_button_ceiling.sh`, `check_raw_colors_ceiling.sh`, `check_raw_dialog_ceiling.sh` — all pass
- `check_file_size_ceiling.sh` — advisory warnings remain for unrelated stale large-file ceilings; `sound_detail_screen.dart` is no longer reported after the baseline update
- `dart format` / pre-push format hook — clean

## Manual test plan

On a real Samsung Galaxy:

- [ ] Open a sound from a video audio pill: header, preview, "Use Sound", grid all render
- [ ] Scroll: sound header scrolls away, section label stays pinned, grid gets the full viewport, and no thumbnail shows through the pinned label
- [ ] Tap the cover avatar -> opens the creator profile
- [ ] Bundled sound from the library picker -> note glyph, no avatar
- [ ] Preview / Stop toggles, spinner shows while loading
- [ ] "Use Sound" saves and shows the snackbar
- [ ] Tap a grid tile -> fullscreen feed overlay opens, close button returns to the grid
- [ ] Sound with no videos -> empty state; airplane mode -> error state with a working Retry

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactor