### PR TITLE
ci(pr-issue-link): reuse a PR's tracking issue instead of duplicating it

### DIFF
--- a/.github/workflows/pr_issue_link.yml
+++ b/.github/workflows/pr_issue_link.yml
@@ -28,6 +28,8 @@ jobs:
             const repo = context.repo;
             const LABEL = 'needs-issue';
             const BOT_MARKER = '<!-- pr-issue-link-bot -->';
+            const ISSUE_MARKER = `<!-- pr-issue-link-bot:pr-${pr.number} -->`;
+            const LEGACY_ISSUE_MARKER = `Auto-created from PR #${pr.number}.`;
 
             await run();
 
@@ -36,13 +38,11 @@ jobs:
             // ═══════════════════════════════════════════════
 
             async function run() {
-              // Step 1: "Closes #none" or "Relates to #none" — dev dismissed suggestions, auto-create
+              // Step 1: "Closes #none" or "Relates to #none" — dev dismissed suggestions
               const nonePattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|relates?\s+to|part\s+of|refs?)\s+#none/i;
               if (nonePattern.test(body)) {
-                console.log(`PR #${pr.number} has "Closes #none" — creating issue.`);
-                const cleanBody = body.replace(nonePattern, '').trim();
-                await github.rest.pulls.update({ ...repo, pull_number: pr.number, body: cleanBody });
-                await autoCreateIssue(cleanBody);
+                console.log(`PR #${pr.number} has "Closes #none" — ensuring tracking issue.`);
+                await ensureTrackingIssue(body.replace(nonePattern, '').trim());
                 return;
               }
 
@@ -66,18 +66,25 @@ jobs:
                 return;
               }
 
-              // Step 4: Branch name contains an issue number?
-              const branchIssue = await resolveIssueFromBranch();
-              if (branchIssue) {
-                console.log(`Branch "${pr.head.ref}" → auto-linking to #${branchIssue}.`);
-                const closeLine = `Closes #${branchIssue}`;
-                const newBody = body.length > 0 ? `${closeLine}\n\n${body}` : closeLine;
-                await github.rest.pulls.update({ ...repo, pull_number: pr.number, body: newBody });
-                await cleanup();
+              // Step 4: This workflow already created a tracking issue for this PR?
+              // The link can be dropped when the description is rewritten — re-link
+              // the existing issue instead of opening a duplicate.
+              const tracked = await findTrackingIssue();
+              if (tracked) {
+                console.log(`Re-linking PR #${pr.number} to existing tracking issue #${tracked.number}.`);
+                await linkIssue(tracked.number, body);
                 return;
               }
 
-              // Step 5: Search open issues for potential matches
+              // Step 5: Branch name contains an issue number?
+              const branchIssue = await resolveIssueFromBranch();
+              if (branchIssue) {
+                console.log(`Branch "${pr.head.ref}" → auto-linking to #${branchIssue}.`);
+                await linkIssue(branchIssue, body);
+                return;
+              }
+
+              // Step 6: Search open issues for potential matches
               const candidates = await findMatchingIssues();
               if (candidates.length > 0) {
                 console.log(`Found ${candidates.length} candidate issue(s) — asking dev to pick.`);
@@ -86,9 +93,9 @@ jobs:
                 return;
               }
 
-              // Step 6: No matches anywhere — auto-create a tracking issue
+              // Step 7: No matches anywhere — create a tracking issue
               console.log(`No matching issues for PR #${pr.number} — creating one.`);
-              await autoCreateIssue(body);
+              await createTrackingIssue(body);
             }
 
             // ═══════════════════════════════════════════════
@@ -120,6 +127,65 @@ jobs:
                 if (!issue.data.pull_request && issue.data.state === 'open') return num;
               } catch { /* doesn't exist */ }
               return null;
+            }
+
+            function isTrackingIssue(issueBody) {
+              if (!issueBody) return false;
+              return issueBody.includes(ISSUE_MARKER)
+                || issueBody.includes(LEGACY_ISSUE_MARKER);
+            }
+
+            // Finds the tracking issue this workflow created for this PR, even when
+            // the PR description no longer references it. The issue body links back
+            // to the PR, so it shows up as a cross-reference on the PR timeline;
+            // code search is the fallback for issues created before that link.
+            async function findTrackingIssue() {
+              let candidates = [];
+              const query = `query($owner:String!, $repo:String!, $number:Int!) {
+                repository(owner:$owner, name:$repo) {
+                  pullRequest(number:$number) {
+                    timelineItems(last:100, itemTypes:[CROSS_REFERENCED_EVENT]) {
+                      nodes {
+                        ... on CrossReferencedEvent {
+                          source {
+                            ... on Issue { number state body }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }`;
+              try {
+                const result = await github.graphql(query, {
+                  owner: repo.owner, repo: repo.repo, number: pr.number,
+                });
+                candidates = result.repository.pullRequest.timelineItems.nodes
+                  .map(n => n && n.source)
+                  .filter(s => s && s.number && isTrackingIssue(s.body))
+                  .map(s => ({ number: s.number, open: s.state === 'OPEN' }));
+              } catch (e) {
+                console.log(`Tracking issue timeline lookup failed: ${e.message}`);
+              }
+
+              if (candidates.length === 0) candidates = await searchTrackingIssues();
+              if (candidates.length === 0) return null;
+              return candidates.find(c => c.open) || candidates[0];
+            }
+
+            async function searchTrackingIssues() {
+              const q = `repo:${repo.owner}/${repo.repo} is:issue in:body "${LEGACY_ISSUE_MARKER}"`;
+              try {
+                const result = await github.rest.search.issuesAndPullRequests({
+                  q, per_page: 10, sort: 'created', order: 'desc',
+                });
+                return result.data.items
+                  .filter(item => !item.pull_request && isTrackingIssue(item.body))
+                  .map(item => ({ number: item.number, open: item.state === 'open' }));
+              } catch (e) {
+                console.log(`Tracking issue search failed: ${e.message}`);
+                return [];
+              }
             }
 
             // ═══════════════════════════════════════════════
@@ -172,6 +238,7 @@ jobs:
                   if (item.pull_request) return false;
                   // Skip issues auto-created by this workflow
                   if (item.body && item.body.includes('Auto-created from PR #')) return false;
+                  if (item.body && item.body.includes('<!-- pr-issue-link-bot:pr-')) return false;
                   return true;
                 }).slice(0, 5);
               } catch (e) {
@@ -181,10 +248,20 @@ jobs:
             }
 
             // ═══════════════════════════════════════════════
-            // Issue creation
+            // Issue creation and linking
             // ═══════════════════════════════════════════════
 
-            async function autoCreateIssue(currentBody) {
+            async function ensureTrackingIssue(currentBody) {
+              const existing = await findTrackingIssue();
+              if (existing) {
+                console.log(`Reusing tracking issue #${existing.number} for PR #${pr.number}.`);
+                await linkIssue(existing.number, currentBody);
+                return;
+              }
+              await createTrackingIssue(currentBody);
+            }
+
+            async function createTrackingIssue(currentBody) {
               const prType = pr.title.match(/^(\w+)(?:\(.*?\))?:/)?.[1] || 'task';
               const typeLabels = {
                 feat: 'enhancement', fix: 'bug', refactor: 'enhancement',
@@ -201,7 +278,8 @@ jobs:
               }
 
               const issueBody = [
-                `Auto-created from PR #${pr.number}.`,
+                ISSUE_MARKER,
+                LEGACY_ISSUE_MARKER,
                 '',
                 `**PR:** ${pr.html_url}`,
                 `**Branch:** \`${pr.head.ref}\``,
@@ -212,7 +290,12 @@ jobs:
               });
               console.log(`Created issue #${created.data.number}`);
 
-              const closeLine = `Closes #${created.data.number}`;
+              await linkIssue(created.data.number, currentBody);
+              console.log(`Linked PR #${pr.number} → #${created.data.number}`);
+            }
+
+            async function linkIssue(issueNumber, currentBody) {
+              const closeLine = `Closes #${issueNumber}`;
               const newBody = currentBody.length > 0
                 ? `${closeLine}\n\n${currentBody}`
                 : closeLine;
@@ -221,7 +304,6 @@ jobs:
                 ...repo, pull_number: pr.number, body: newBody,
               });
               await cleanup();
-              console.log(`Linked PR #${pr.number} → #${created.data.number}`);
             }
 
             // ═══════════════════════════════════════════════

--- a/.github/workflows/pr_issue_link.yml
+++ b/.github/workflows/pr_issue_link.yml
@@ -38,15 +38,7 @@ jobs:
             // ═══════════════════════════════════════════════
 
             async function run() {
-              // Step 1: "Closes #none" or "Relates to #none" — dev dismissed suggestions
-              const nonePattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|relates?\s+to|part\s+of|refs?)\s+#none/i;
-              if (nonePattern.test(body)) {
-                console.log(`PR #${pr.number} has "Closes #none" — ensuring tracking issue.`);
-                await ensureTrackingIssue(body.replace(nonePattern, '').trim());
-                return;
-              }
-
-              // Step 2: Already linked via closing or relation keywords in body?
+              // Step 1: Already linked via closing or relation keywords in body?
               const closingPattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
               const relationPattern = /(?:relates?\s+to|part\s+of|refs?)\s+#(\d+)/gi;
               const closingMatches = [...body.matchAll(closingPattern)];
@@ -55,6 +47,19 @@ jobs:
               if (allMatches.length > 0) {
                 console.log(`PR #${pr.number} linked to: ${allMatches.map(m => '#' + m[1]).join(', ')}`);
                 await cleanup();
+                return;
+              }
+
+              // Step 2: "Closes #none" or "Relates to #none" — dev dismissed
+              // suggestions. Checked after real links so that a stray mention in
+              // an already-linked description doesn't rewrite the body. Strips
+              // every occurrence, not just the first, so the template line can't
+              // survive behind an earlier mention in the prose.
+              const nonePattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|relates?\s+to|part\s+of|refs?)\s+#none/gi;
+              const withoutNone = body.replace(nonePattern, '').trim();
+              if (withoutNone !== body.trim()) {
+                console.log(`PR #${pr.number} has "Closes #none" — ensuring tracking issue.`);
+                await ensureTrackingIssue(withoutNone);
                 return;
               }
 


### PR DESCRIPTION
Closes #7241

## Description

`pr_issue_link` opened a second tracking issue whenever a PR description was rewritten and lost its closing reference — which happens routinely when an agent regenerates the description.

There was no path back to the issue the workflow had already created: the sidebar link is derived from the description, so it disappears with it, and the candidate search filters out auto-created issues. Every rewritten description therefore fell through to the final step and created a duplicate.

The new step 4 looks the existing issue up before anything is created. The issue body links back to the PR, so the issue shows up as a cross-reference on the PR timeline — that survives the description being rewritten. Code search over the issue body is the fallback if the timeline lookup returns nothing. Issue bodies now carry a stable `<!-- pr-issue-link-bot:pr-<n> -->` marker; the legacy `Auto-created from PR #n.` sentence is still matched, so issues created before this change are found too.

The `#none` sentinel path goes through the same lookup instead of always creating. A regenerated description tends to restore that template line, which was the second route to a duplicate. It also no longer writes the PR body twice, saving one `edited` event and the re-run it triggers.

The second commit fixes two defects that the workflow's own run on this PR exposed. The sentinel was checked before real issue links, so an already-linked description re-entered the create/relink branch whenever the literal token appeared anywhere in its prose. And the strip was non-global: it removed the first occurrence — a mention in the running text — and left the template line in place, which kept the PR in the sentinel branch on every later edit.

Assigning the issue to the PR author was considered and deliberately left out: GitHub has no silent assign, so it would notify the author on every PR and subscribe them to that issue's activity.

**Related Issue:**

## Out of Scope

Duplicate tracking issues that already exist from earlier runs are not cleaned up.

## Verification

- YAML parses and the extracted `github-script` body passes `node --check`.
- Live-tested on this PR: the first run created #7241 and linked it, unassigned as intended. Clearing the reference from this description then logged `Re-linking PR #7240 to existing tracking issue #7241` and restored the link — on the old workflow that same edit would have opened a second issue.
- Not applicable on a Samsung Galaxy device — CI-only change with no app surface.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
