### PR TITLE
fix(library): scroll the library empty state instead of clipping it

### DIFF
--- a/mobile/lib/widgets/library/clips_tab.dart
+++ b/mobile/lib/widgets/library/clips_tab.dart
@@ -262,6 +262,7 @@ class _FilterContent extends StatelessWidget {
       return _FilterEmptyState(
         filter: state.filter,
         showRecordButton: showRecordButton,
+        scrollController: scrollController,
       );
     }
 
@@ -339,10 +340,14 @@ class _FilterEmptyState extends StatelessWidget {
   const _FilterEmptyState({
     required this.filter,
     required this.showRecordButton,
+    required this.scrollController,
   });
 
   final ClipLibraryFilter filter;
   final bool showRecordButton;
+
+  /// Handed to the empty state so it drives the sheet the grid would have.
+  final ScrollController? scrollController;
 
   @override
   Widget build(BuildContext context) {
@@ -352,12 +357,14 @@ class _FilterEmptyState extends StatelessWidget {
         title: context.l10n.libraryArchiveEmptyTitle,
         subtitle: context.l10n.libraryArchiveEmptySubtitle,
         showRecordButton: false,
+        scrollController: scrollController,
       ),
       ClipLibraryCategoryFilter() => EmptyLibraryState(
         icon: DivineIconName.folderOpen,
         title: context.l10n.libraryCategoryEmptyTitle,
         subtitle: context.l10n.libraryCategoryEmptySubtitle,
         showRecordButton: false,
+        scrollController: scrollController,
       ),
       // The trash filter never reaches here: it renders TrashedClipsList,
       // which brings its own empty state.
@@ -366,6 +373,7 @@ class _FilterEmptyState extends StatelessWidget {
         title: context.l10n.libraryNoClipsYetTitle,
         subtitle: context.l10n.libraryNoClipsYetSubtitle,
         showRecordButton: showRecordButton,
+        scrollController: scrollController,
       ),
     };
   }

--- a/mobile/lib/widgets/library/empty_library_state.dart
+++ b/mobile/lib/widgets/library/empty_library_state.dart
@@ -15,6 +15,7 @@ class EmptyLibraryState extends StatelessWidget {
     required this.title,
     required this.subtitle,
     this.showRecordButton = true,
+    this.scrollController,
     super.key,
   });
 
@@ -30,21 +31,22 @@ class EmptyLibraryState extends StatelessWidget {
   /// Whether to show the "Record a Video" button.
   final bool showRecordButton;
 
+  /// Scroll controller for the slot this empty state fills, e.g. the one a
+  /// [DraggableScrollableSheet] hands its body so drags resize the sheet.
+  final ScrollController? scrollController;
+
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) => SingleChildScrollView(
+        controller: scrollController,
         // The column mixes a fixed icon circle with text that grows on the
         // raw text scaler, and the toolbar and chip row above it grow at the
         // same time — so past the accessibility sizes it is taller than the
         // slot it gets. Scrolling keeps it centred while it fits and reaches
         // the rest once it does not, rather than clipping the subtitle (#7242).
         child: ConstrainedBox(
-          constraints: BoxConstraints(
-            minHeight: constraints.maxHeight.isFinite
-                ? constraints.maxHeight
-                : 0.0,
-          ),
+          constraints: BoxConstraints(minHeight: constraints.maxHeight),
           child: Center(
             child: Padding(
               padding: const EdgeInsets.symmetric(

--- a/mobile/lib/widgets/library/empty_library_state.dart
+++ b/mobile/lib/widgets/library/empty_library_state.dart
@@ -32,54 +32,73 @@ class EmptyLibraryState extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12),
-        child: Column(
-          mainAxisAlignment: .center,
-          children: [
-            Container(
-              width: 120,
-              height: 120,
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                color: context.vineColors.card,
+    return LayoutBuilder(
+      builder: (context, constraints) => SingleChildScrollView(
+        // The column mixes a fixed icon circle with text that grows on the
+        // raw text scaler, and the toolbar and chip row above it grow at the
+        // same time — so past the accessibility sizes it is taller than the
+        // slot it gets. Scrolling keeps it centred while it fits and reaches
+        // the rest once it does not, rather than clipping the subtitle (#7242).
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            minHeight: constraints.maxHeight.isFinite
+                ? constraints.maxHeight
+                : 0.0,
+          ),
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 12,
+                vertical: 24,
               ),
-              child: Center(
-                child: DivineIcon(
-                  icon: icon,
-                  size: 48,
-                  color: context.vineColors.secondaryText,
-                ),
+              child: Column(
+                mainAxisSize: .min,
+                children: [
+                  Container(
+                    width: 120,
+                    height: 120,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: context.vineColors.card,
+                    ),
+                    child: Center(
+                      child: DivineIcon(
+                        icon: icon,
+                        size: 48,
+                        color: context.vineColors.secondaryText,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  Text(
+                    title,
+                    style: VineTheme.headlineSmallFont(
+                      color: context.vineColors.primaryText,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    subtitle,
+                    style: VineTheme.bodyLargeFont(
+                      color: context.vineColors.secondaryText,
+                    ),
+                    textAlign: .center,
+                  ),
+                  if (showRecordButton) ...[
+                    const SizedBox(height: 32),
+                    DivineButton(
+                      label: context.l10n.libraryRecordVideo,
+                      leadingIcon: .videoCamera,
+                      type: .secondary,
+                      onPressed: () => context.pushToCameraWithPermission(
+                        entryPoint: CreationEntryPoint.library,
+                      ),
+                    ),
+                  ],
+                ],
               ),
             ),
-            const SizedBox(height: 24),
-            Text(
-              title,
-              style: VineTheme.headlineSmallFont(
-                color: context.vineColors.primaryText,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              subtitle,
-              style: VineTheme.bodyLargeFont(
-                color: context.vineColors.secondaryText,
-              ),
-              textAlign: .center,
-            ),
-            if (showRecordButton) ...[
-              const SizedBox(height: 32),
-              DivineButton(
-                label: context.l10n.libraryRecordVideo,
-                leadingIcon: .videoCamera,
-                type: .secondary,
-                onPressed: () => context.pushToCameraWithPermission(
-                  entryPoint: CreationEntryPoint.library,
-                ),
-              ),
-            ],
-          ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/widgets/library/trashed_clips_list.dart
+++ b/mobile/lib/widgets/library/trashed_clips_list.dart
@@ -39,6 +39,7 @@ class TrashedClipsList extends StatelessWidget {
             title: context.l10n.libraryTrashEmptyTitle,
             subtitle: context.l10n.libraryTrashEmptySubtitle,
             showRecordButton: false,
+            scrollController: scrollController,
           );
         }
         return ListView.separated(

--- a/mobile/test/widgets/library/empty_library_state_test.dart
+++ b/mobile/test/widgets/library/empty_library_state_test.dart
@@ -167,6 +167,44 @@ void main() {
         expect(position.maxScrollExtent, equals(0));
       });
 
+      testWidgets('drives the sheet controller it is handed', (tester) async {
+        // In selection mode the library is a DraggableScrollableSheet body,
+        // and the empty state stands in for the grid that would otherwise own
+        // the sheet's controller. Without it the sheet cannot be dragged from
+        // the one screen state that has nothing else to grab.
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            theme: VineTheme.theme,
+            home: Scaffold(
+              body: DraggableScrollableSheet(
+                initialChildSize: 0.9,
+                builder: (context, sheetController) => ColoredBox(
+                  color: VineTheme.theme.colorScheme.surface,
+                  child: EmptyLibraryState(
+                    scrollController: sheetController,
+                    icon: DivineIconName.filmSlate,
+                    title: 'No Clips Yet',
+                    subtitle: en.libraryNoClipsYetSubtitle,
+                    showRecordButton: false,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final before = tester.getTopLeft(find.byType(EmptyLibraryState)).dy;
+        await tester.drag(find.text('No Clips Yet'), const Offset(0, 200));
+        await tester.pumpAndSettle();
+
+        expect(
+          tester.getTopLeft(find.byType(EmptyLibraryState)).dy,
+          greaterThan(before),
+        );
+      });
+
       testWidgets('record button has videocam icon', (tester) async {
         await tester.pumpWidget(buildWidget());
 

--- a/mobile/test/widgets/library/empty_library_state_test.dart
+++ b/mobile/test/widgets/library/empty_library_state_test.dart
@@ -17,18 +17,31 @@ void main() {
       String title = 'Test Title',
       String subtitle = 'Test Subtitle',
       bool showRecordButton = true,
+      TextScaler textScaler = TextScaler.noScaling,
+      double? slotHeight,
     }) {
+      final state = EmptyLibraryState(
+        icon: icon,
+        title: title,
+        subtitle: subtitle,
+        showRecordButton: showRecordButton,
+      );
       return MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         theme: VineTheme.theme,
+        builder: (context, child) => MediaQuery(
+          data: MediaQuery.of(context).copyWith(textScaler: textScaler),
+          child: child!,
+        ),
         home: Scaffold(
-          body: EmptyLibraryState(
-            icon: icon,
-            title: title,
-            subtitle: subtitle,
-            showRecordButton: showRecordButton,
-          ),
+          // Every library tab hands the empty state a bounded slot — the one
+          // a list would otherwise fill.
+          body: slotHeight == null
+              ? state
+              : Center(
+                  child: SizedBox(height: slotHeight, child: state),
+                ),
         ),
       );
     }
@@ -89,6 +102,69 @@ void main() {
         expect(container.decoration, isA<BoxDecoration>());
         final decoration = container.decoration! as BoxDecoration;
         expect(decoration.shape, BoxShape.circle);
+      });
+
+      testWidgets('scrolls instead of overflowing a slot it outgrows', (
+        tester,
+      ) async {
+        // #7242: the icon circle is a fixed 120px while the title and
+        // subtitle grow on the raw text scaler, so at accessibility sizes the
+        // column is taller than the slot a library tab gives it. It used to
+        // clip the end of the subtitle behind an overflow stripe.
+        //
+        // One case per test on purpose: a RenderFlex reports its overflow
+        // once per render object, so a loop that reuses the subtree would
+        // report the first case and pass silently for the rest.
+        await tester.pumpWidget(
+          buildWidget(
+            subtitle: en.libraryArchiveEmptySubtitle,
+            showRecordButton: false,
+            textScaler: const TextScaler.linear(3.5),
+            slotHeight: 500,
+          ),
+        );
+
+        expect(tester.takeException(), isNull);
+      });
+
+      testWidgets('reaches the record button once the slot is outgrown', (
+        tester,
+      ) async {
+        // Scrolling is only worth anything if what left the viewport can be
+        // brought back — the record button is the last child, so it is the
+        // first thing lost.
+        await tester.pumpWidget(
+          buildWidget(
+            subtitle: en.libraryNoClipsYetSubtitle,
+            textScaler: const TextScaler.linear(3.5),
+            slotHeight: 500,
+          ),
+        );
+
+        await tester.scrollUntilVisible(
+          find.text(en.libraryRecordVideo),
+          200,
+          scrollable: find.byType(Scrollable).last,
+        );
+
+        expect(find.text(en.libraryRecordVideo), findsOneWidget);
+        expect(tester.takeException(), isNull);
+      });
+
+      testWidgets('stays put while it fits its slot', (tester) async {
+        // Below the sizes that overflow, the empty state is centred and
+        // static — the scroll view must not turn it into a scrollable page.
+        await tester.pumpWidget(
+          buildWidget(
+            subtitle: en.libraryNoClipsYetSubtitle,
+            slotHeight: 500,
+          ),
+        );
+
+        final position = tester
+            .state<ScrollableState>(find.byType(Scrollable).last)
+            .position;
+        expect(position.maxScrollExtent, equals(0));
       });
 
       testWidgets('record button has videocam icon', (tester) async {


### PR DESCRIPTION
## Description

`EmptyLibraryState` stacks a fixed 120px icon circle above a title and subtitle that grow on the raw text scaler, inside a non-scrollable centred column. Nothing bounds that column against the slot it is given — and the slot shrinks as the content grows, because the toolbar, tab bar and chip row above it scale at the same time. Past the accessibility text sizes the column is simply taller than the space it has, and the end of the subtitle disappears behind a `BOTTOM OVERFLOWED BY …` stripe.

Reproduced in a widget test before touching anything: in a 600px slot the archive empty state starts overflowing at 3.0x text scale (32px) and reaches 196px at 3.5x, which lines up with the 43px measured on device in #7242.

The fix keeps it centred while it fits and lets it scroll once it does not — `LayoutBuilder` → `SingleChildScrollView` → `ConstrainedBox(minHeight: available)` → `Center`. Below the sizes that used to overflow the scroll extent is zero, so the empty state does not become a scrollable page for the sizes that were always fine; this only changes the range that was already broken.

One fix covers all six call sites. `clips_tab` (archive / category / all filters), `drafts_tab` and `trashed_clips_list` each hand the empty state the bounded slot a list would otherwise fill, and none of them already scroll, so there is no nested scrollable anywhere.

**Related Issue:** Closes #7242

## The empty state now takes the sheet's scroll controller

Introducing a scroll view raised a second question at the one call site that is not a plain tab. In selection mode the library is the body of a `DraggableScrollableSheet` (the video editor's clip picker), and `ClipsTab` threads that sheet's `ScrollController` into whichever child fills the slot — the masonry grid, or the trash list. The empty state was the one child that ignored it.

That was not a regression, since before this PR it had no scroll view to attach anything to. But it left the sheet undraggable from the exact screen state that has nothing else to grab: an empty library, where there is no grid under your finger. `EmptyLibraryState` now takes an optional `scrollController` and hands it to its `SingleChildScrollView`, so a drag there resizes the sheet the same way a drag on the grid does. `drafts_tab` has no controller in scope — it never renders inside a sheet — so nothing is threaded there.

The risk this invites is the double-attach that `clips_tab` already warns about: `ScrollController.position` asserts unless exactly one position is attached, and swapping between two scrollables that share a controller can leave both attached for a frame. It does not bite here. The supplied-controller path returns early before the `AnimatedSwitcher` cross-fade, so exactly one child is ever mounted, and a scratch probe swapping `ListView` ↔ `EmptyLibraryState` on one sheet controller came back clean in both directions.

## Out of Scope

- **Growing the icon circle on `DivineIcon`'s capped curve**, which #7242 suggests as a second step. It would take the circle from 120px to ~156px, making the column taller and bringing the overflow point *forward*. The icon inside it already scales on that curve; the circle is dead weight, not the cause. Leaving it fixed is what keeps the fix narrow.
- The empty states' copy and spacing are untouched.

## Verification

- `flutter analyze lib test`
- `flutter test test/widgets/library/ test/screens/library_screen_test.dart test/screens/video_editor` — 282 tests
- Four new regression tests in `empty_library_state_test.dart`: no overflow at 3.5x in a 500px slot, the record button is reachable by scrolling once the slot is outgrown, `maxScrollExtent == 0` while it still fits, and a drag on the empty state resizes the `DraggableScrollableSheet` it is handed. Each verified to fail against the unfixed widget.
- Probed at a real phone width rather than the 800dp test viewport: 360×780 at 1.0 / 2.0 / 3.0 / 3.5x, with and without the record button, no horizontal overflow either — the record button's label wraps rather than running off the edge.
- Rebased onto `main` after #7226 landed in `trashed_clips_list.dart`; suites re-run green on the new base.
- Device pass on a real Samsung Galaxy (SM-S942B, 411dp wide) at system font scale 3.0. The archive empty state renders with no overflow stripe, and the subtitle that used to be clipped — "Archived clips wait here, out of the way of your main library." — scrolls fully into view. The icon circle scrolls off the top as expected.
- The sheet-controller path could not be exercised on device: selection mode has no filter chips, so the picker only shows its empty state when the whole clip library is empty for that clip type. The sheet-drag mechanism itself was confirmed there — a drag on the grid dismisses the sheet — and the empty state now attaches to the same controller. That wiring is pinned by the widget test rather than by the device pass.

### Note for whoever touches these tests

Each case pumps a single configuration rather than looping over scales. A `RenderFlex` reports its overflow **once per render object**, so a loop that reuses the subtree reports the first case and then passes silently for every later one — the first version of my repro did exactly that and looked clean. If these get "tidied up" into a loop, give each case its own key.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
