### PR TITLE
fix(lint): enable invalid_assignment and cast the JSON decode boundaries

### DIFF
--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -24,7 +24,6 @@ analyzer:
     inference_failure_on_function_return_type: ignore
     inference_failure_on_instance_creation: ignore
     inference_failure_on_untyped_parameter: ignore
-    invalid_assignment: ignore
     join_return_with_assignment: ignore
     library_annotations: ignore
     list_element_type_not_assignable: ignore

--- a/mobile/lib/router/providers/redirect_provider.dart
+++ b/mobile/lib/router/providers/redirect_provider.dart
@@ -46,7 +46,7 @@ final hasFollowingInCacheProvider = Provider<bool>((ref) {
   }
 
   try {
-    final List<dynamic> decoded = jsonDecode(value);
+    final decoded = jsonDecode(value) as List<dynamic>;
     Log.debug(
       'Current user following list has ${decoded.length} entries',
       name: 'RedirectGuards',

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -637,7 +637,7 @@ class BookmarkService {
     final globalBookmarksJson = _prefs.getString(globalBookmarksStorageKey);
     if (globalBookmarksJson != null) {
       try {
-        final List<dynamic> bookmarksData = jsonDecode(globalBookmarksJson);
+        final bookmarksData = jsonDecode(globalBookmarksJson) as List<dynamic>;
         _globalBookmarks.clear();
         _globalBookmarks.addAll(
           bookmarksData.map(

--- a/mobile/lib/services/content_deletion_service.dart
+++ b/mobile/lib/services/content_deletion_service.dart
@@ -166,7 +166,7 @@ class ContentDeletionService {
   static List<ContentDeletion> parseDeletionHistory(String? historyJson) {
     if (historyJson == null) return const [];
 
-    final List<dynamic> deletionsJson = jsonDecode(historyJson);
+    final deletionsJson = jsonDecode(historyJson) as List<dynamic>;
     return deletionsJson
         .map((json) => ContentDeletion.fromJson(json as Map<String, dynamic>))
         .toList(growable: false);

--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -726,7 +726,7 @@ class ContentReportingService {
     final historyJson = _prefs.getString(reportsStorageKey);
     if (historyJson != null) {
       try {
-        final List<dynamic> reportsJson = jsonDecode(historyJson);
+        final reportsJson = jsonDecode(historyJson) as List<dynamic>;
         _reportHistory.clear();
         _reportHistory.addAll(
           reportsJson.map(

--- a/mobile/lib/services/curated_list_service.dart
+++ b/mobile/lib/services/curated_list_service.dart
@@ -1285,7 +1285,7 @@ class CuratedListService extends ChangeNotifier {
     final listsJson = _prefs.getString(listsStorageKey);
     if (listsJson != null) {
       try {
-        final List<dynamic> listsData = jsonDecode(listsJson);
+        final listsData = jsonDecode(listsJson) as List<dynamic>;
         _lists.clear();
         _lists.addAll(
           listsData.map(
@@ -1312,7 +1312,7 @@ class CuratedListService extends ChangeNotifier {
     final subscribedJson = _prefs.getString(subscribedListsStorageKey);
     if (subscribedJson != null) {
       try {
-        final List<dynamic> subscribedData = jsonDecode(subscribedJson);
+        final subscribedData = jsonDecode(subscribedJson) as List<dynamic>;
         _subscribedListIds.clear();
         _subscribedListIds.addAll(subscribedData.cast<String>());
         Log.debug(

--- a/mobile/lib/services/seen_videos_service.dart
+++ b/mobile/lib/services/seen_videos_service.dart
@@ -156,7 +156,7 @@ class SeenVideosService {
     try {
       final metricsJson = _prefs!.getString(_seenVideosMetricsKey);
       if (metricsJson != null) {
-        final List<dynamic> metricsList = jsonDecode(metricsJson);
+        final metricsList = jsonDecode(metricsJson) as List<dynamic>;
         _seenVideos.clear();
         _seenLastSeen.clear();
         for (final json in metricsList) {

--- a/mobile/lib/services/sound_library_service.dart
+++ b/mobile/lib/services/sound_library_service.dart
@@ -78,7 +78,7 @@ class SoundLibraryService {
       final customSoundsJson = prefs.getString(_customSoundsKey);
 
       if (customSoundsJson != null) {
-        final List<dynamic> jsonList = jsonDecode(customSoundsJson);
+        final jsonList = jsonDecode(customSoundsJson) as List<dynamic>;
         _customSounds = jsonList
             .map((json) => VineSound.fromJson(json as Map<String, dynamic>))
             .toList();

--- a/mobile/test/test_setup.dart
+++ b/mobile/test/test_setup.dart
@@ -123,17 +123,17 @@ final Map<String, String> _secureStorageStore = <String, String>{};
 Future<Object?>? _secureStorageHandler(MethodCall methodCall) async {
   switch (methodCall.method) {
     case 'read':
-      final String? key = methodCall.arguments['key'];
+      final key = methodCall.arguments['key'] as String?;
       return _secureStorageStore[key];
     case 'write':
-      final String? key = methodCall.arguments['key'];
-      final String? value = methodCall.arguments['value'];
+      final key = methodCall.arguments['key'] as String?;
+      final value = methodCall.arguments['value'] as String?;
       if (key != null && value != null) {
         _secureStorageStore[key] = value;
       }
       return null;
     case 'delete':
-      final String? key = methodCall.arguments['key'];
+      final key = methodCall.arguments['key'] as String?;
       _secureStorageStore.remove(key);
       return null;
     case 'deleteAll':
@@ -142,7 +142,7 @@ Future<Object?>? _secureStorageHandler(MethodCall methodCall) async {
     case 'readAll':
       return _secureStorageStore;
     case 'containsKey':
-      final String? key = methodCall.arguments['key'];
+      final key = methodCall.arguments['key'] as String?;
       return _secureStorageStore.containsKey(key);
     case 'getCapabilities':
       return {'basicSecureStorage': true};


### PR DESCRIPTION
## Description

`invalid_assignment` is error-level, and `mobile/analysis_options.yaml` had it silenced. That entry was not hiding a style preference — it was hiding thirteen real type holes, which is why #7225 calls it out as the one Tier 2 rule worth doing first and on its own.

Eight `lib` findings are the same shape:

```dart
final List<dynamic> bookmarksData = jsonDecode(globalBookmarksJson);
```

`jsonDecode` returns `dynamic`, so that assignment is an implicit downcast — exactly what `strict-casts` (on via `very_good_analysis`) rejects. Each becomes an explicit cast at the decode boundary:

```dart
final bookmarksData = jsonDecode(globalBookmarksJson) as List<dynamic>;
```

**No behaviour change.** An implicit downcast and an explicit cast both throw `TypeError` at the same statement when the stored payload is not a list; the difference is that the cast is now visible to a reader and to the analyzer. Seven of the eight already sit inside a `try` that logs and continues; the eighth, `ContentDeletionService.parseDeletionHistory`, threw on malformed input before this change and still does.

The five `test/test_setup.dart` findings are the same story one level down — `methodCall.arguments['key']` is a dynamic index read, so assigning it to `String?` was also an implicit downcast.

Split out from the rest of the Tier 2 batch because it is the only entry in that tier that masks an actual error rather than a style violation. The other eight rules are in a separate PR against `main`; the two are independent and can merge in either order, though whichever lands second will need a trivial rebase on the `errors:` block of `analysis_options.yaml`.

**Related Issue:** Closes #none — relates to #7225, which stays open until the Tier 2 PR lands.

## Out of Scope

The remaining eleven Tier 2 rules.

## Verification

- `flutter analyze` over the whole `mobile` package — no issues
- `dart format lib test integration_test` — 3148 files, 0 changed
- 504 targeted tests passing: `bookmark_service`, `content_deletion_service`, `content_reporting_service`, `seen_videos_service`, `sound_library_service`, and all of `test/router/` (which exercises `redirect_provider`)
- `test_setup.dart` is the shared harness for every suite, so it was additionally covered by `shared_channel_override`, `secure_storage_options`, `database_encryption_bootstrap`, `known_accounts_registry` and `real_integration_test_helper_restore`
- Proved the enablement is real rather than assumed: a throwaway file assigning `dynamic` to a typed local is flagged by `invalid_assignment` after the change and was not before

Not verified on a real Samsung Galaxy. The diff adds casts that were already happening implicitly, so there is no runtime path that behaves differently — but say the word if you would rather have a device pass before review.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore