### PR TITLE
chore(lint): enable eight more analyzer rules and fix their violations

### DIFF
--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -11,7 +11,6 @@ analyzer:
     - "build/**"
   errors:
     avoid_catches_without_on_clauses: ignore
-    avoid_equals_and_hash_code_on_mutable_classes: ignore
     avoid_positional_boolean_parameters: ignore
     avoid_returning_this: ignore
     avoid_types_on_closure_parameters: ignore
@@ -24,32 +23,34 @@ analyzer:
     inference_failure_on_function_return_type: ignore
     inference_failure_on_instance_creation: ignore
     inference_failure_on_untyped_parameter: ignore
-    join_return_with_assignment: ignore
-    library_annotations: ignore
     list_element_type_not_assignable: ignore
-    only_throw_errors: ignore
     prefer_int_literals: ignore
     sort_constructors_first: ignore
     strict_raw_type: ignore
-    type_annotate_public_apis: ignore
     unawaited_futures: ignore
 
 linter:
   rules:
     avoid_dynamic_calls: false
     depend_on_referenced_packages: false
+    # Requires `TODO(username)`; a `#` in the parentheses fails the rule. The
+    # repo mandates `TODO(#issue)` instead (`.claude/rules/code_style.md`), so
+    # the two conventions are mutually exclusive.
     flutter_style_todos: false
     lines_longer_than_80_chars: false
+    # Six of the ten findings switch on `RouteType`, which has 61 values and
+    # only four that map to a tab. Enumerating the rest would add ~330 lines of
+    # dead cases across `main.dart`, `app_shell.dart` and the back handler.
     no_default_cases: false
+    # Every finding is a DI port with two to six implementors, not a function
+    # in class clothing. The suggested fix — a top-level function — removes the
+    # named type that `implements` clauses and test doubles hang off.
     one_member_abstracts: false
-    prefer_constructors_over_static_methods: false
-    prefer_foreach: false
     # The repo convention is named-parameter constructor injection into private
     # fields (~385 app sites), so this conflicts with prescribed DI style.
     prefer_initializing_formals: false
     public_member_api_docs: false
     sort_pub_dependencies: false
     unreachable_from_main: false
-    use_named_constants: false
     omit_local_variable_types: false
     use_setters_to_change_properties: false

--- a/mobile/integration_test/analysis_options.yaml
+++ b/mobile/integration_test/analysis_options.yaml
@@ -1,0 +1,11 @@
+include: ../analysis_options.yaml
+
+analyzer:
+  errors:
+    # Same reason as `test/analysis_options.yaml`: test doubles expose an
+    # `Object? somethingError` knob that a test sets to make the fake fail,
+    # then `throw` it, and that knob has to carry both an `Exception` and an
+    # `Error`. There are no violations here today, but the idiom is the same
+    # one `test/` uses, so the exemption belongs in both trees. Enforced in
+    # `lib`.
+    only_throw_errors: ignore

--- a/mobile/integration_test/e2e/block_leaves_kind3_follow_test.dart
+++ b/mobile/integration_test/e2e/block_leaves_kind3_follow_test.dart
@@ -4,6 +4,8 @@
 // ABOUTME: Requires: NO Docker stack — the relay runs in-process.
 
 @Tags(['service'])
+library;
+
 import 'package:cache_sync/cache_sync.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/mobile/integration_test/e2e/c2pa_init_test.dart
+++ b/mobile/integration_test/e2e/c2pa_init_test.dart
@@ -6,6 +6,8 @@
 // ABOUTME: cert is never produced, so the assertion below fails there.
 
 @Tags(['service'])
+library;
+
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/mobile/integration_test/e2e/deleted_video_visible_to_other_users_test.dart
+++ b/mobile/integration_test/e2e/deleted_video_visible_to_other_users_test.dart
@@ -5,6 +5,8 @@
 // ABOUTME: drives Postgres, the Keycast API, and the relay directly.
 
 @Tags(['service'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';

--- a/mobile/integration_test/e2e/dm_inbox_relay_admission_test.dart
+++ b/mobile/integration_test/e2e/dm_inbox_relay_admission_test.dart
@@ -4,6 +4,8 @@
 // ABOUTME: Requires: NO Docker stack — every dependency here is local.
 
 @Tags(['service'])
+library;
+
 import 'package:db_client/db_client.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:drift/native.dart';

--- a/mobile/integration_test/e2e/dm_optimistic_survives_watch_race_test.dart
+++ b/mobile/integration_test/e2e/dm_optimistic_survives_watch_race_test.dart
@@ -5,6 +5,8 @@
 // ABOUTME: POST_NOTIFICATIONS pre-granted so no native dialog blocks the UI.
 
 @Tags(['service'])
+library;
+
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';

--- a/mobile/integration_test/e2e/relay_list_admission_test.dart
+++ b/mobile/integration_test/e2e/relay_list_admission_test.dart
@@ -4,6 +4,8 @@
 // ABOUTME: Requires: NO Docker stack — every dependency here is local.
 
 @Tags(['service'])
+library;
+
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/mobile/integration_test/e2e/video_creation_flow_test.dart
+++ b/mobile/integration_test/e2e/video_creation_flow_test.dart
@@ -4,6 +4,8 @@
 // ABOUTME: navigateToCreateAccount needs OnboardingMode.open for LOCAL.
 
 @Tags(['service'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';

--- a/mobile/integration_test/video_recorder/camera_controls_integration_test.dart
+++ b/mobile/integration_test/video_recorder/camera_controls_integration_test.dart
@@ -151,7 +151,7 @@ void main() {
         await _grantPermissions($);
         final tester = $.tester;
         final points = [
-          const Offset(0.0, 0.0), // Top-left
+          Offset.zero, // Top-left
           const Offset(1.0, 0.0), // Top-right
           const Offset(0.0, 1.0), // Bottom-left
           const Offset(1.0, 1.0), // Bottom-right
@@ -176,7 +176,7 @@ void main() {
         await _grantPermissions($);
         final tester = $.tester;
         final points = [
-          const Offset(0.0, 0.0), // Top-left
+          Offset.zero, // Top-left
           const Offset(1.0, 0.0), // Top-right
           const Offset(0.0, 1.0), // Bottom-left
           const Offset(1.0, 1.0), // Bottom-right

--- a/mobile/lib/blocs/monetization_links_settings/monetization_links_settings_cubit.dart
+++ b/mobile/lib/blocs/monetization_links_settings/monetization_links_settings_cubit.dart
@@ -135,9 +135,7 @@ class MonetizationLinksSettingsCubit
         name: 'MonetizationLinksSettingsCubit',
         category: LogCategory.system,
       );
-      for (final link in visibleLinks) {
-        _trackConfiguredLink(link);
-      }
+      visibleLinks.forEach(_trackConfiguredLink);
       emit(
         _stateFromProfile(
           currentProfile: saved,

--- a/mobile/lib/features/feature_flags/models/feature_flag_state.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag_state.dart
@@ -1,8 +1,10 @@
 // ABOUTME: Immutable state container for feature flag values
 // ABOUTME: Manages flag state with copy-on-write semantics and type safety
 
+import 'package:meta/meta.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 
+@immutable
 class FeatureFlagState {
   const FeatureFlagState(this._flags);
 

--- a/mobile/lib/features/post_publish/post_publish_experiment.dart
+++ b/mobile/lib/features/post_publish/post_publish_experiment.dart
@@ -180,9 +180,7 @@ class PostPublishExperiment {
   }
 
   void failed(Set<String> publishIds) {
-    for (final publishId in publishIds) {
-      _publishVariants.remove(publishId);
-    }
+    publishIds.forEach(_publishVariants.remove);
   }
 
   Future<void> createAgainTapped(PostPublishCreateAgainOffer offer) async {

--- a/mobile/lib/models/environment_config.dart
+++ b/mobile/lib/models/environment_config.dart
@@ -74,6 +74,7 @@ AppEnvironment get buildTimeDefaultEnvironment {
 enum AppEnvironment { poc, staging, test, production, local }
 
 /// Configuration for the current app environment
+@immutable
 class EnvironmentConfig {
   const EnvironmentConfig({required this.environment});
 

--- a/mobile/lib/models/pending_upload.dart
+++ b/mobile/lib/models/pending_upload.dart
@@ -5,6 +5,7 @@ import 'dart:convert';
 import 'dart:math' as math;
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:hive_ce/hive.dart';
+import 'package:meta/meta.dart';
 import 'package:models/models.dart' show NativeProofData;
 import 'package:unified_logger/unified_logger.dart';
 
@@ -41,6 +42,7 @@ enum UploadStatus {
 }
 
 /// Represents a video upload in progress or completed
+@immutable
 @HiveType(typeId: 2)
 class PendingUpload {
   const PendingUpload({

--- a/mobile/lib/models/stop_motion_clip_frame.dart
+++ b/mobile/lib/models/stop_motion_clip_frame.dart
@@ -1,6 +1,7 @@
 // ABOUTME: One captured still in a stop-motion clip (image path + hold time)
 // ABOUTME: Source-of-truth frame for a frames-based DivineVideoClip
 
+import 'package:meta/meta.dart';
 import 'package:openvine/utils/path_resolver.dart';
 import 'package:path/path.dart' as p;
 
@@ -12,6 +13,7 @@ import 'package:path/path.dart' as p;
 /// for a frames-based [DivineVideoClip]. Per-frame [duration] can vary; the
 /// global "frames per image" control is a *default* that only rewrites frames
 /// whose hold has not been set individually — see [holdOverridden].
+@immutable
 class StopMotionClipFrame {
   const StopMotionClipFrame({
     required this.path,

--- a/mobile/lib/providers/classic_vines_provider.dart
+++ b/mobile/lib/providers/classic_vines_provider.dart
@@ -83,6 +83,7 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
   }) async {
     final videoEventService = ref.read(videoEventServiceProvider);
     Object? restError;
+    StackTrace? restStackTrace;
 
     Future<HomeFeedResult> fetchRestPage({
       required bool retryOnError,
@@ -189,8 +190,9 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
         } else {
           return restFeedState(result: recoveryPage);
         }
-      } catch (e) {
+      } catch (e, stackTrace) {
         restError = e;
+        restStackTrace = stackTrace;
         Log.warning(
           '🎬 ClassicVinesFeed: REST API error, falling back to Nostr: $e',
           name: 'ClassicVinesFeedProvider',
@@ -221,7 +223,11 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
     final topClassics = classicVideos.take(_pageSize).toList()..shuffle();
 
     if (topClassics.isEmpty && preserveCurrentOnEmptyFallback) {
-      throw restError ?? StateError('Classics API unavailable');
+      final failure = restError;
+      if (failure == null) {
+        throw StateError('Classics API unavailable');
+      }
+      Error.throwWithStackTrace(failure, restStackTrace ?? StackTrace.current);
     }
 
     return VideoFeedState(

--- a/mobile/lib/providers/classic_vines_provider.g.dart
+++ b/mobile/lib/providers/classic_vines_provider.g.dart
@@ -54,7 +54,7 @@ final class ClassicVinesFeedProvider
   ClassicVinesFeed create() => ClassicVinesFeed();
 }
 
-String _$classicVinesFeedHash() => r'52810c18c983b92fd9ad9525bf81a707199dd318';
+String _$classicVinesFeedHash() => r'd67c29fa844dfd40b3cc46cf0ed71112576c24e6';
 
 /// ClassicVines feed provider - shows pre-2017 Vine archive sorted by loops
 ///

--- a/mobile/lib/providers/relay_providers.dart
+++ b/mobile/lib/providers/relay_providers.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:meta/meta.dart';
 import 'package:nostr_client/nostr_client.dart'
     show NostrClient, RelayConnectionStatus, RelayRemoveSource, RelayState;
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -408,6 +409,7 @@ class _RelaySetChangeCoordinator {
   }
 }
 
+@immutable
 class _RelayIntentScope {
   const _RelayIntentScope({
     required this.defaultRelayUrl,

--- a/mobile/lib/providers/video_events_providers.dart
+++ b/mobile/lib/providers/video_events_providers.dart
@@ -298,9 +298,9 @@ class VideoEvents extends _$VideoEvents {
               nip50Sort:
                   NIP50SortMode.hot, // Recent events with high engagement
             )
-            .catchError((Object error) {
+            .catchError((Object error, StackTrace stackTrace) {
               if (error is! RelayNotReadyException) {
-                throw error;
+                Error.throwWithStackTrace(error, stackTrace);
               }
               Log.warning(
                 'VideoEvents: Discovery subscription deferred until relay connection is ready',

--- a/mobile/lib/providers/video_events_providers.g.dart
+++ b/mobile/lib/providers/video_events_providers.g.dart
@@ -137,7 +137,7 @@ final class VideoEventsProvider
   VideoEvents create() => VideoEvents();
 }
 
-String _$videoEventsHash() => r'91f22117b9cf0bc22ad2ec3a0d2645031a947070';
+String _$videoEventsHash() => r'99afe4cb2083eaae67a470f0f3fd329109ee9f0b';
 
 /// Stream provider for video events from Nostr
 

--- a/mobile/lib/screens/comments/widgets/mention_overlay.dart
+++ b/mobile/lib/screens/comments/widgets/mention_overlay.dart
@@ -12,6 +12,7 @@ import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 
+@immutable
 class MentionNip05Claim {
   const MentionNip05Claim({required this.pubkey, required this.nip05});
 

--- a/mobile/lib/screens/creator_analytics_screen.dart
+++ b/mobile/lib/screens/creator_analytics_screen.dart
@@ -1394,7 +1394,7 @@ class _CreatorAnalyticsSummary {
   final VideoPerformance? mostDiscussed;
   final VideoPerformance? mostReposted;
 
-  static _CreatorAnalyticsSummary build({
+  factory _CreatorAnalyticsSummary.build({
     required _CreatorAnalyticsData data,
     required _AnalyticsWindow window,
   }) {

--- a/mobile/lib/screens/developer_options_screen.dart
+++ b/mobile/lib/screens/developer_options_screen.dart
@@ -136,11 +136,11 @@ class _DeveloperOptionsScreenState
     );
 
     // All available environment configurations
-    final environments = [
+    const environments = [
       EnvironmentConfig.production,
-      const EnvironmentConfig(environment: AppEnvironment.staging),
-      const EnvironmentConfig(environment: AppEnvironment.test),
-      const EnvironmentConfig(environment: AppEnvironment.poc),
+      EnvironmentConfig(environment: AppEnvironment.staging),
+      EnvironmentConfig(environment: AppEnvironment.test),
+      EnvironmentConfig(environment: AppEnvironment.poc),
     ];
 
     final pageLoadHistory = ref.read(pageLoadHistoryProvider);

--- a/mobile/lib/screens/developer_options_screen.dart
+++ b/mobile/lib/screens/developer_options_screen.dart
@@ -137,7 +137,7 @@ class _DeveloperOptionsScreenState
 
     // All available environment configurations
     final environments = [
-      const EnvironmentConfig(environment: AppEnvironment.production),
+      EnvironmentConfig.production,
       const EnvironmentConfig(environment: AppEnvironment.staging),
       const EnvironmentConfig(environment: AppEnvironment.test),
       const EnvironmentConfig(environment: AppEnvironment.poc),

--- a/mobile/lib/services/account_deletion_service.dart
+++ b/mobile/lib/services/account_deletion_service.dart
@@ -56,7 +56,7 @@ class DeleteAccountResult {
   /// deletion request.
   final bool contentDeletionIncomplete;
 
-  static DeleteAccountResult createSuccess(
+  factory DeleteAccountResult.createSuccess(
     String deleteEventId, {
     int deletedEventsCount = 0,
     bool contentQueryFailed = false,
@@ -69,7 +69,7 @@ class DeleteAccountResult {
     contentDeletionIncomplete: contentDeletionIncomplete,
   );
 
-  static DeleteAccountResult failure(
+  factory DeleteAccountResult.failure(
     DeleteAccountFailureReason reason, {
     String? diagnosticError,
   }) => DeleteAccountResult(

--- a/mobile/lib/services/analytics_ingest_client.dart
+++ b/mobile/lib/services/analytics_ingest_client.dart
@@ -114,7 +114,7 @@ class ProductAnalyticsEvent {
 
   String toPayloadJson() => jsonEncode(toJson());
 
-  static ProductAnalyticsEvent fromPayloadJson(String payloadJson) {
+  factory ProductAnalyticsEvent.fromPayloadJson(String payloadJson) {
     final decoded = jsonDecode(payloadJson) as Map<String, dynamic>;
     final properties =
         (decoded['properties'] as Map<String, dynamic>?) ??

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:meta/meta.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/services/auth_service.dart';
@@ -11,6 +12,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Represents a bookmarked item
+@immutable
 class BookmarkItem {
   const BookmarkItem({
     required this.type,
@@ -32,7 +34,7 @@ class BookmarkItem {
     return tag;
   }
 
-  static BookmarkItem fromTag(List<String> tag) {
+  factory BookmarkItem.fromTag(List<String> tag) {
     return BookmarkItem(
       type: tag[0],
       id: tag[1],
@@ -48,7 +50,7 @@ class BookmarkItem {
     'petname': petname,
   };
 
-  static BookmarkItem fromJson(Map<String, dynamic> json) => BookmarkItem(
+  factory BookmarkItem.fromJson(Map<String, dynamic> json) => BookmarkItem(
     type: json['type'] as String,
     id: json['id'] as String,
     relay: json['relay'] as String?,

--- a/mobile/lib/services/content_deletion_service.dart
+++ b/mobile/lib/services/content_deletion_service.dart
@@ -78,7 +78,7 @@ class DeleteResult {
   /// Set when [success] is true; how broadly the relays took the request.
   final DeleteAcceptance? acceptance;
 
-  static DeleteResult createSuccess(
+  factory DeleteResult.createSuccess(
     String deleteEventId, {
     required DeleteAcceptance acceptance,
   }) => DeleteResult(
@@ -88,7 +88,7 @@ class DeleteResult {
     timestamp: DateTime.now(),
   );
 
-  static DeleteResult failure(String error, DeleteFailureKind kind) =>
+  factory DeleteResult.failure(String error, DeleteFailureKind kind) =>
       DeleteResult(
         success: false,
         error: error,
@@ -124,14 +124,15 @@ class ContentDeletion {
     'additionalContext': additionalContext,
   };
 
-  static ContentDeletion fromJson(Map<String, dynamic> json) => ContentDeletion(
-    deleteEventId: json['deleteEventId'] as String,
-    originalEventId: json['originalEventId'] as String,
-    addressableId: json['addressableId'] as String?,
-    reason: json['reason'] as String,
-    deletedAt: DateTime.parse(json['deletedAt'] as String),
-    additionalContext: json['additionalContext'] as String?,
-  );
+  factory ContentDeletion.fromJson(Map<String, dynamic> json) =>
+      ContentDeletion(
+        deleteEventId: json['deleteEventId'] as String,
+        originalEventId: json['originalEventId'] as String,
+        addressableId: json['addressableId'] as String?,
+        reason: json['reason'] as String,
+        deletedAt: DateTime.parse(json['deletedAt'] as String),
+        additionalContext: json['additionalContext'] as String?,
+      );
 }
 
 /// Service for deleting user's own content via NIP-09

--- a/mobile/lib/services/content_moderation_types.dart
+++ b/mobile/lib/services/content_moderation_types.dart
@@ -109,7 +109,7 @@ class MuteListEntry {
     'note': note,
   };
 
-  static MuteListEntry fromJson(Map<String, dynamic> json) => MuteListEntry(
+  factory MuteListEntry.fromJson(Map<String, dynamic> json) => MuteListEntry(
     type: json['type'] as String,
     value: json['value'] as String,
     reason: ContentFilterReason.values.firstWhere(

--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -55,7 +55,7 @@ class ReportResult {
   /// the optimistic answer.
   final ReportDelivery delivery;
 
-  static ReportResult createSuccess(
+  factory ReportResult.createSuccess(
     String reportId, {
     required ReportDelivery delivery,
   }) => ReportResult(
@@ -65,7 +65,7 @@ class ReportResult {
     delivery: delivery,
   );
 
-  static ReportResult failure(String error) => ReportResult(
+  factory ReportResult.failure(String error) => ReportResult(
     success: false,
     error: error,
     timestamp: DateTime.now(),
@@ -106,7 +106,7 @@ class ContentReport {
     'tags': tags,
   };
 
-  static ContentReport fromJson(Map<String, dynamic> json) => ContentReport(
+  factory ContentReport.fromJson(Map<String, dynamic> json) => ContentReport(
     reportId: json['reportId'] as String,
     eventId: json['eventId'] as String,
     authorPubkey: json['authorPubkey'] as String?,

--- a/mobile/lib/services/crash_reporting_service.dart
+++ b/mobile/lib/services/crash_reporting_service.dart
@@ -12,6 +12,11 @@ import 'package:unified_logger/unified_logger.dart';
 /// Crash reporting service for production error tracking
 class CrashReportingService {
   static CrashReportingService? _instance;
+
+  // A constructor cannot be a getter, and the alternative the rule implies —
+  // `factory CrashReportingService()` — would hide that every call hands back
+  // the same object. `.instance` is the repo-wide singleton accessor.
+  // ignore: prefer_constructors_over_static_methods
   static CrashReportingService get instance =>
       _instance ??= CrashReportingService._();
 

--- a/mobile/lib/services/effective_content_labels.dart
+++ b/mobile/lib/services/effective_content_labels.dart
@@ -25,9 +25,7 @@ List<String> resolveEffectiveContentLabels(
     labels.add(normalized);
   }
 
-  for (final label in video.contentWarningLabels) {
-    addLabel(label);
-  }
+  video.contentWarningLabels.forEach(addLabel);
 
   if (moderationLabelService != null) {
     final addressableId = video.addressableId;

--- a/mobile/lib/services/mention_resolution_service.dart
+++ b/mobile/lib/services/mention_resolution_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:meta/meta.dart';
 import 'package:models/models.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/public_identifier_normalizer.dart';
@@ -15,6 +16,7 @@ final _linkifiedTokenRegex = RegExp(
   caseSensitive: false,
 );
 
+@immutable
 class MentionBinding {
   const MentionBinding({
     required this.display,

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -269,9 +269,7 @@ class ModerationLabelService {
 
       final events = await _nostrClient.queryEvents([filter]);
 
-      for (final event in events) {
-        _processLabelEvent(event);
-      }
+      events.forEach(_processLabelEvent);
 
       _loadedLabelers.add(pubkey);
 

--- a/mobile/lib/services/nip05_verification_service.dart
+++ b/mobile/lib/services/nip05_verification_service.dart
@@ -26,8 +26,9 @@ enum Nip05VerificationStatus {
 }
 
 /// Request for verification
+@immutable
 class _VerificationRequest {
-  _VerificationRequest(this.pubkey, this.nip05);
+  const _VerificationRequest(this.pubkey, this.nip05);
 
   final String pubkey;
   final String nip05;

--- a/mobile/lib/services/nip98_auth_service.dart
+++ b/mobile/lib/services/nip98_auth_service.dart
@@ -341,9 +341,7 @@ class Nip98AuthService {
         .map((entry) => entry.key)
         .toList();
 
-    for (final key in expiredKeys) {
-      _tokenCache.remove(key);
-    }
+    expiredKeys.forEach(_tokenCache.remove);
 
     if (expiredKeys.isNotEmpty) {
       Log.debug(

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -96,6 +96,9 @@ class NotificationService {
   static NotificationService? _instance;
 
   /// Singleton instance
+  // A constructor cannot be a getter, and `factory NotificationService()`
+  // would hide both the sharing and the revive-after-dispose below.
+  // ignore: prefer_constructors_over_static_methods
   static NotificationService get instance {
     if (_instance == null || _instance!._disposed) {
       _instance = NotificationService._();

--- a/mobile/lib/services/push_notification_session_coordinator.dart
+++ b/mobile/lib/services/push_notification_session_coordinator.dart
@@ -230,9 +230,7 @@ class PushNotificationSessionCoordinator {
           name: 'PushNotificationSync',
           category: LogCategory.system,
         );
-        for (final operation in operationsToWait) {
-          _scheduleDeregisterAfterRegistration(operation);
-        }
+        operationsToWait.forEach(_scheduleDeregisterAfterRegistration);
         return;
       }
     }

--- a/mobile/lib/services/upload/pending_upload_store.dart
+++ b/mobile/lib/services/upload/pending_upload_store.dart
@@ -197,9 +197,7 @@ class PendingUploadStore {
         .where((entry) => entry.value.nostrPubkey == ownerPubkey)
         .map((entry) => entry.key)
         .toList();
-    for (final id in queueIds) {
-      _pendingSaveQueue.remove(id);
-    }
+    queueIds.forEach(_pendingSaveQueue.remove);
     if (_pendingSaveQueue.isEmpty) {
       _saveQueueTimer?.cancel();
       _saveQueueTimer = null;

--- a/mobile/lib/services/video_cache_service.dart
+++ b/mobile/lib/services/video_cache_service.dart
@@ -83,9 +83,7 @@ class VideoCacheService {
 
   /// Add multiple videos to cache
   void addVideos(List<VideoEvent> videos) {
-    for (final video in videos) {
-      addVideo(video);
-    }
+    videos.forEach(addVideo);
   }
 
   /// Get video by ID

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -433,9 +433,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       category: LogCategory.video,
     );
 
-    for (final id in ids) {
-      _removedVideoIdsController.add(id);
-    }
+    ids.forEach(_removedVideoIdsController.add);
   }
 
   /// Test-only seam: pre-populate the author bucket so [_sweepAuthor]
@@ -1142,9 +1140,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     // requested id because a fullscreen route may be holding it in BLoC state.
     if (!_removedVideoIdsController.isClosed) {
       final idsToEmit = {primaryEventId, ...removedVideoIds};
-      for (final id in idsToEmit) {
-        _removedVideoIdsController.add(id);
-      }
+      idsToEmit.forEach(_removedVideoIdsController.add);
     }
 
     Log.info(
@@ -1443,9 +1439,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     }
 
     if (!_removedVideoIdsController.isClosed) {
-      for (final id in removedVideoIds) {
-        _removedVideoIdsController.add(id);
-      }
+      removedVideoIds.forEach(_removedVideoIdsController.add);
     }
 
     if (purgeStore) {
@@ -4618,9 +4612,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     // For now, just return chronologically sorted
     // In a full implementation, would sort by likes, comments, shares, etc.
     final allEvents = <VideoEvent>[];
-    for (final events in _eventLists.values) {
-      allEvents.addAll(events);
-    }
+    _eventLists.values.forEach(allEvents.addAll);
     return List.from(allEvents)
       ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
   }

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -265,10 +265,9 @@ class VideoPublishService {
     try {
       // Inside `run` so the phases the upload and Nostr legs time for
       // themselves are attributed to this publish's trace.
-      result = await timeline.run<PublishResult>(
+      return result = await timeline.run<PublishResult>(
         () => _publishVideo(draft: draft, timeline: timeline),
       );
-      return result;
     } finally {
       timeline.finish(
         outcome: switch (result) {

--- a/mobile/lib/services/video_sharing_service.dart
+++ b/mobile/lib/services/video_sharing_service.dart
@@ -103,7 +103,7 @@ class ShareResult {
   /// The DM conversation ID (NIP-17), used for "View Chat" navigation.
   final String? conversationId;
 
-  static ShareResult createSuccess(
+  factory ShareResult.createSuccess(
     String messageEventId, {
     String? conversationId,
   }) => ShareResult(
@@ -112,7 +112,7 @@ class ShareResult {
     conversationId: conversationId,
   );
 
-  static ShareResult failure(String error) =>
+  factory ShareResult.failure(String error) =>
       ShareResult(success: false, error: error);
 }
 

--- a/mobile/lib/utils/platform_io_web.dart
+++ b/mobile/lib/utils/platform_io_web.dart
@@ -102,6 +102,9 @@ class Directory {
     bool followLinks = true,
   }) => const Stream.empty();
 
+  // Mirrors `dart:io`'s `Directory.systemTemp`, which is a static getter. This
+  // stub has to keep the same shape for the conditional import to line up.
+  // ignore: prefer_constructors_over_static_methods
   static Directory get systemTemp => Directory('/tmp');
 }
 

--- a/mobile/lib/utils/video_nostr_enrichment.dart
+++ b/mobile/lib/utils/video_nostr_enrichment.dart
@@ -46,9 +46,7 @@ class NostrTagEnrichmentAttemptTracker {
     final now = _now();
     final enriched = {for (final id in enrichedIds) id.toLowerCase()};
 
-    for (final id in enriched) {
-      _nextAttemptAtById.remove(id);
-    }
+    enriched.forEach(_nextAttemptAtById.remove);
 
     for (final id in attemptedIds) {
       final key = id.toLowerCase();

--- a/mobile/lib/widgets/categories/category_visuals.dart
+++ b/mobile/lib/widgets/categories/category_visuals.dart
@@ -27,7 +27,7 @@ class CategoryVisuals {
   /// relying on [CategoryGlyph]'s `errorBuilder` — is what keeps the load from
   /// ever being attempted: a missing-asset load surfaces the failure to the
   /// zone as a non-fatal even when `errorBuilder` handles the visual (#6116).
-  static CategoryVisuals forCategory(VideoCategory category, int index) {
+  factory CategoryVisuals.forCategory(VideoCategory category, int index) {
     final name = category.name.toLowerCase();
     final featured = _featuredCategoryVisuals[name];
     if (featured != null) {

--- a/mobile/lib/widgets/modal_progress_overlay.dart
+++ b/mobile/lib/widgets/modal_progress_overlay.dart
@@ -20,7 +20,7 @@ class ModalProgressOverlay {
   final OverlayEntry _entry;
   bool _dismissed = false;
 
-  static ModalProgressOverlay show(BuildContext context) {
+  factory ModalProgressOverlay.show(BuildContext context) {
     final entry = OverlayEntry(
       builder: (context) => const _ProgressBarrier(),
     );

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -77,7 +77,7 @@ class ActiveUploadsView extends Equatable {
 
   /// Projects the bloc's [BackgroundPublishState] into the shape the grid
   /// renders. Used as the selector callback in [_ProfileVideosGridState.build].
-  static ActiveUploadsView fromState(BackgroundPublishState state) {
+  factory ActiveUploadsView.fromState(BackgroundPublishState state) {
     return ActiveUploadsView([
       for (final upload in state.uploads)
         if (upload.result == null)

--- a/mobile/lib/widgets/video_feed_item/subtitle_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/subtitle_overlay.dart
@@ -138,6 +138,7 @@ SubtitleCuesProvider _subtitleCuesProvider(VideoEvent video) {
   );
 }
 
+@immutable
 class _SubtitleCueDisplay {
   const _SubtitleCueDisplay(this.text);
 

--- a/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar.dart
+++ b/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar.dart
@@ -90,25 +90,28 @@ class _VideoMetadataEditBottomBarState
           messenger.showSnackBar(snackBar);
         }
       } else if (result is VideoUpdateFailure) {
-        throw result.error;
+        _reportUpdateFailure(result.error);
       }
     } catch (e) {
-      Log.error(
-        'Failed to update video: $e',
-        name: 'VideoMetadataEditBottomBar',
-        category: LogCategory.ui,
-      );
-
-      if (mounted) {
-        setState(() => _isUpdating = false);
-        ScaffoldMessenger.of(context).showSnackBar(
-          DivineSnackbarContainer.snackBar(
-            context.l10n.shareMenuFailedToUpdateVideo('$e'),
-            error: true,
-          ),
-        );
-      }
+      _reportUpdateFailure(e);
     }
+  }
+
+  void _reportUpdateFailure(Object error) {
+    Log.error(
+      'Failed to update video: $error',
+      name: 'VideoMetadataEditBottomBar',
+      category: LogCategory.ui,
+    );
+
+    if (!mounted) return;
+    setState(() => _isUpdating = false);
+    ScaffoldMessenger.of(context).showSnackBar(
+      DivineSnackbarContainer.snackBar(
+        context.l10n.shareMenuFailedToUpdateVideo('$error'),
+        error: true,
+      ),
+    );
   }
 
   Future<void> _confirmDelete() async {

--- a/mobile/test/analysis_options.yaml
+++ b/mobile/test/analysis_options.yaml
@@ -1,5 +1,14 @@
 include: ../analysis_options.yaml
 
+analyzer:
+  errors:
+    # Test doubles expose a `Object? somethingError` knob that a test sets to
+    # make the fake fail, then `throw` it. The knob has to carry both an
+    # `Exception` and an `Error` — several suites inject `StateError`
+    # precisely because the production code treats the two differently — and
+    # Dart has no supertype of both to narrow it to. Enforced in `lib`.
+    only_throw_errors: ignore
+
 linter:
   rules:
     # Tests legitimately use print() for diagnostic output — exempt here.

--- a/mobile/test/config/bug_report_config_test.dart
+++ b/mobile/test/config/bug_report_config_test.dart
@@ -289,9 +289,10 @@ void main() {
       // (measured) rather than hanging the suite, which is what a larger
       // exponent would do. Unambiguous classes run it in ~0ms.
       final stopwatch = Stopwatch()..start();
-      for (final key in ['token${'_a' * 28}', 'token${'Aa' * 28}']) {
-        sanitizeDiagnosticText(key);
-      }
+      [
+        'token${'_a' * 28}',
+        'token${'Aa' * 28}',
+      ].forEach(sanitizeDiagnosticText);
       stopwatch.stop();
 
       expect(stopwatch.elapsedMilliseconds, lessThan(1000));

--- a/mobile/test/config/bug_report_config_test.dart
+++ b/mobile/test/config/bug_report_config_test.dart
@@ -288,11 +288,10 @@ void main() {
       // 28 segments is chosen so a reintroduced ambiguity fails this in ~17s
       // (measured) rather than hanging the suite, which is what a larger
       // exponent would do. Unambiguous classes run it in ~0ms.
+      final ambiguousKeys = ['token${'_a' * 28}', 'token${'Aa' * 28}'];
+
       final stopwatch = Stopwatch()..start();
-      [
-        'token${'_a' * 28}',
-        'token${'Aa' * 28}',
-      ].forEach(sanitizeDiagnosticText);
+      ambiguousKeys.forEach(sanitizeDiagnosticText);
       stopwatch.stop();
 
       expect(stopwatch.elapsedMilliseconds, lessThan(1000));

--- a/mobile/test/helpers/autofill_context_mock.dart
+++ b/mobile/test/helpers/autofill_context_mock.dart
@@ -13,7 +13,7 @@ class AutofillContextRecorder {
   AutofillContextRecorder._();
 
   /// Installs the mock handler and returns the recorder.
-  static AutofillContextRecorder install() {
+  factory AutofillContextRecorder.install() {
     final recorder = AutofillContextRecorder._();
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(SystemChannels.textInput, (call) async {

--- a/mobile/test/infrastructure/drift_setup_test.dart
+++ b/mobile/test/infrastructure/drift_setup_test.dart
@@ -4,6 +4,8 @@
 // Permanent: opens file-backed Drift databases through path_provider temp paths;
 // keep isolated until DB and path-provider globals are per-test fixtures.
 @Tags(['skip_very_good_optimization'])
+library;
+
 import 'dart:io';
 
 import 'package:db_client/db_client.dart';

--- a/mobile/test/infrastructure/schema_test.dart
+++ b/mobile/test/infrastructure/schema_test.dart
@@ -4,6 +4,8 @@
 // Permanent: opens file-backed Drift databases through path_provider temp paths;
 // keep isolated until DB and path-provider globals are per-test fixtures.
 @Tags(['skip_very_good_optimization'])
+library;
+
 import 'dart:io';
 
 import 'package:db_client/db_client.dart';

--- a/mobile/test/manual/nip98_relay_acceptance_test.dart
+++ b/mobile/test/manual/nip98_relay_acceptance_test.dart
@@ -15,6 +15,8 @@
 // HttpOverrides.global; VGV merged-isolate tests must keep flutter_test's HTTP
 // mock intact.
 @Tags(['skip_very_good_optimization', 'integration'])
+library;
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/mobile/test/manual/relay_subscription_acceptance_test.dart
+++ b/mobile/test/manual/relay_subscription_acceptance_test.dart
@@ -24,6 +24,8 @@
 // cannot keep this file out of CI (#5340 regression, #5738); the skip tag
 // runs it as a separate suite, which --exclude-tags integration then skips.
 @Tags(['skip_very_good_optimization', 'integration'])
+library;
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/mobile/test/manual/upload_publish_e2e_acceptance_test.dart
+++ b/mobile/test/manual/upload_publish_e2e_acceptance_test.dart
@@ -34,6 +34,8 @@
 // leaks the un-stubbed HttpOverrides into every later merged test (real sockets,
 // order-dependent "pending timers" flakes). Matches nip98_relay_acceptance_test.
 @Tags(['skip_very_good_optimization', 'integration'])
+library;
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
@@ -450,9 +452,7 @@ Future<(int, Uint8List)> _getBlob(String sha256Hex) async {
     final request = await client.getUrl(Uri.parse('$_blossomBase/$sha256Hex'));
     final response = await request.close();
     final builder = BytesBuilder();
-    await for (final chunk in response) {
-      builder.add(chunk);
-    }
+    await response.forEach(builder.add);
     return (response.statusCode, builder.toBytes());
   } finally {
     client.close();

--- a/mobile/test/mocks/mock_camera_service.dart
+++ b/mobile/test/mocks/mock_camera_service.dart
@@ -63,8 +63,7 @@ class MockCameraService extends CameraService {
 
   @override
   Future<double?> setZoomLevel(double value) async {
-    zoomLevel = value.clamp(minZoomLevel, maxZoomLevel);
-    return zoomLevel;
+    return zoomLevel = value.clamp(minZoomLevel, maxZoomLevel);
   }
 
   @override

--- a/mobile/test/models/environment_config_test.dart
+++ b/mobile/test/models/environment_config_test.dart
@@ -81,9 +81,7 @@ void main() {
       });
 
       test('production returns divine.video relay', () {
-        const config = EnvironmentConfig(
-          environment: AppEnvironment.production,
-        );
+        const config = EnvironmentConfig.production;
         expect(config.relayUrl, 'wss://relay.divine.video');
       });
     });
@@ -111,18 +109,14 @@ void main() {
       });
 
       test('production uses api.divine.video for Funnelcake REST', () {
-        const config = EnvironmentConfig(
-          environment: AppEnvironment.production,
-        );
+        const config = EnvironmentConfig.production;
         expect(config.apiBaseUrl, 'https://api.divine.video');
       });
     });
 
     group('eventPublishBaseUrl', () {
       test('production uses relay.divine.video for NIP-98 event publish', () {
-        const config = EnvironmentConfig(
-          environment: AppEnvironment.production,
-        );
+        const config = EnvironmentConfig.production;
         expect(config.eventPublishBaseUrl, 'https://relay.divine.video');
       });
     });
@@ -131,7 +125,7 @@ void main() {
       const poc = EnvironmentConfig(environment: AppEnvironment.poc);
       const staging = EnvironmentConfig(environment: AppEnvironment.staging);
       const testEnv = EnvironmentConfig(environment: AppEnvironment.test);
-      const prod = EnvironmentConfig(environment: AppEnvironment.production);
+      const prod = EnvironmentConfig.production;
 
       expect(poc.blossomUrl, 'https://media.divine.video');
       expect(staging.blossomUrl, 'https://media.divine.video');
@@ -159,9 +153,7 @@ void main() {
         false,
       );
       expect(
-        const EnvironmentConfig(
-          environment: AppEnvironment.production,
-        ).isProduction,
+        EnvironmentConfig.production.isProduction,
         true,
       );
     });
@@ -186,9 +178,7 @@ void main() {
         'Local',
       );
       expect(
-        const EnvironmentConfig(
-          environment: AppEnvironment.production,
-        ).displayName,
+        EnvironmentConfig.production.displayName,
         'Production',
       );
     });
@@ -219,9 +209,7 @@ void main() {
         '5414dcebf15d0d8b36fb80c6295ae4222113b61807e777870cbd1fd422a35809',
       );
       expect(
-        const EnvironmentConfig(
-          environment: AppEnvironment.production,
-        ).pushServicePubkey,
+        EnvironmentConfig.production.pushServicePubkey,
         '2f871aaa4a519da94aeb5ebffe7587549158855c4460e7a5a1b91d36d2fb5b04',
       );
     });
@@ -252,18 +240,14 @@ void main() {
         0xFFE040FB, // accentPurple
       );
       expect(
-        const EnvironmentConfig(
-          environment: AppEnvironment.production,
-        ).indicatorColorValue,
+        EnvironmentConfig.production.indicatorColorValue,
         0xFF27C58B, // primaryGreen
       );
     });
 
     group('verifierBaseUrl', () {
       test('production returns the verifier host', () {
-        const config = EnvironmentConfig(
-          environment: AppEnvironment.production,
-        );
+        const config = EnvironmentConfig.production;
         expect(config.verifierBaseUrl, equals('https://verifier.divine.video'));
       });
 
@@ -280,9 +264,7 @@ void main() {
 
     group('nameServerBaseUrl', () {
       test('production returns the divine-name-server host', () {
-        const config = EnvironmentConfig(
-          environment: AppEnvironment.production,
-        );
+        const config = EnvironmentConfig.production;
         expect(config.nameServerBaseUrl, equals('https://names.divine.video'));
       });
 
@@ -336,9 +318,7 @@ void main() {
 
       test('different environments are not equal', () {
         const config1 = EnvironmentConfig(environment: AppEnvironment.staging);
-        const config2 = EnvironmentConfig(
-          environment: AppEnvironment.production,
-        );
+        const config2 = EnvironmentConfig.production;
         expect(config1, isNot(equals(config2)));
       });
     });

--- a/mobile/test/providers/oauth_config_provider_test.dart
+++ b/mobile/test/providers/oauth_config_provider_test.dart
@@ -14,7 +14,7 @@ void main() {
       final container = ProviderContainer(
         overrides: [
           currentEnvironmentProvider.overrideWithValue(
-            const EnvironmentConfig(environment: AppEnvironment.production),
+            EnvironmentConfig.production,
           ),
         ],
       );

--- a/mobile/test/router/profile_me_redirect_integration_test.dart
+++ b/mobile/test/router/profile_me_redirect_integration_test.dart
@@ -278,14 +278,17 @@ class _FakeSubscriptionManager extends SubscriptionManager {
 /// NoOp AnalyticsService that prevents network calls and timer leaks
 class NoopAnalyticsService extends AnalyticsService {
   @override
-  Future<void> trackVideoView(video, {String source = 'mobile'}) async {
+  Future<void> trackVideoView(
+    VideoEvent video, {
+    String source = 'mobile',
+  }) async {
     // No-op - prevent network calls in tests
   }
 
   @override
   Future<void> trackVideoViewWithUser(
-    video, {
-    required userId,
+    VideoEvent video, {
+    required String? userId,
     String source = 'mobile',
   }) async {
     // No-op - prevent network calls in tests
@@ -293,14 +296,14 @@ class NoopAnalyticsService extends AnalyticsService {
 
   @override
   Future<void> trackDetailedVideoView(
-    video, {
+    VideoEvent video, {
     required String source,
     required String eventType,
-    watchDuration,
-    totalDuration,
-    loopCount,
-    completedVideo,
-    trafficSource = ViewTrafficSource.unknown,
+    Duration? watchDuration,
+    Duration? totalDuration,
+    double? loopCount,
+    bool? completedVideo,
+    ViewTrafficSource trafficSource = ViewTrafficSource.unknown,
     String? sourceDetail,
   }) async {
     // No-op - prevent network calls in tests
@@ -308,15 +311,15 @@ class NoopAnalyticsService extends AnalyticsService {
 
   @override
   Future<void> trackDetailedVideoViewWithUser(
-    video, {
-    required userId,
+    VideoEvent video, {
+    required String? userId,
     required String source,
     required String eventType,
-    watchDuration,
-    totalDuration,
-    loopCount,
-    completedVideo,
-    trafficSource = ViewTrafficSource.unknown,
+    Duration? watchDuration,
+    Duration? totalDuration,
+    double? loopCount,
+    bool? completedVideo,
+    ViewTrafficSource trafficSource = ViewTrafficSource.unknown,
     String? sourceDetail,
   }) async {
     // No-op - prevent network calls in tests

--- a/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
+++ b/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
@@ -1169,11 +1169,10 @@ class _HistoryAwareWebViewPlatform extends WebViewPlatform {
   PlatformWebViewController createPlatformWebViewController(
     PlatformWebViewControllerCreationParams params,
   ) {
-    controller = _HistoryAwareWebViewController(
+    return controller = _HistoryAwareWebViewController(
       params,
       canGoBackInitially: canGoBackInitially,
     );
-    return controller;
   }
 
   @override
@@ -1205,8 +1204,7 @@ class _BootstrapAwareWebViewPlatform extends WebViewPlatform {
   PlatformWebViewController createPlatformWebViewController(
     PlatformWebViewControllerCreationParams params,
   ) {
-    controller = _BootstrapAwareWebViewController(params);
-    return controller;
+    return controller = _BootstrapAwareWebViewController(params);
   }
 
   @override

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -4,6 +4,8 @@
 // Permanent: installs native MethodChannel handlers for the pooled video
 // player; keep isolated until those channel handlers are per-test fixtures.
 @Tags(['skip_very_good_optimization'])
+library;
+
 import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -630,13 +630,13 @@ void main() {
         // Keyboard opens: without the latch the strip would spring the inset
         // back to 34 (the overlay slides up); the latch holds it at 0.
         tester.view.viewInsets = const FakeViewPadding(bottom: 300);
-        tester.view.padding = const FakeViewPadding();
+        tester.view.padding = FakeViewPadding.zero;
         await tester.pump();
         expect(feedBottomInset(), 0);
 
         // Keyboard closes: the inset returns to rest, still 0 — no downward
         // slide of the overlay.
-        tester.view.viewInsets = const FakeViewPadding();
+        tester.view.viewInsets = FakeViewPadding.zero;
         tester.view.padding = const FakeViewPadding(bottom: 34);
         await tester.pump();
         expect(feedBottomInset(), 0);

--- a/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
@@ -1861,9 +1861,7 @@ void main() {
           void visit(InlineSpan span) {
             if (span is TextSpan) {
               if (predicate(span)) hits.add(span);
-              for (final child in span.children ?? const <InlineSpan>[]) {
-                visit(child);
-              }
+              (span.children ?? const <InlineSpan>[]).forEach(visit);
             }
           }
 

--- a/mobile/test/screens/settings/supporter_screen_test.dart
+++ b/mobile/test/screens/settings/supporter_screen_test.dart
@@ -158,8 +158,9 @@ void main() {
         child: buildLocalizedWidget(
           BlocProvider<SupporterCubit>(
             create: (_) {
-              cubit = SupporterCubit(repository: _FakeRepository(controller));
-              return cubit;
+              return cubit = SupporterCubit(
+                repository: _FakeRepository(controller),
+              );
             },
             child: const SupporterScreenView(),
           ),

--- a/mobile/test/services/audio_extraction_service_test.dart
+++ b/mobile/test/services/audio_extraction_service_test.dart
@@ -6,6 +6,8 @@
 // extraction paths; remove when AudioExtractionService accepts an injected
 // editor dependency.
 @Tags(['skip_very_good_optimization'])
+library;
+
 import 'dart:io';
 import 'dart:ui';
 

--- a/mobile/test/services/auth/relay_discovery_orchestrator_test.dart
+++ b/mobile/test/services/auth/relay_discovery_orchestrator_test.dart
@@ -31,9 +31,7 @@ class _FakeWebSocketSink implements WebSocketSink {
 
   @override
   Future<void> addStream(Stream<dynamic> stream) async {
-    await for (final data in stream) {
-      add(data);
-    }
+    await stream.forEach(add);
   }
 
   @override

--- a/mobile/test/services/background_activity_manager_test.dart
+++ b/mobile/test/services/background_activity_manager_test.dart
@@ -3,6 +3,8 @@
 // BackgroundActivityManager singleton state; keep isolated until the manager is
 // injectable/resettable per test.
 @Tags(['skip_very_good_optimization'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/background_activity_manager.dart';

--- a/mobile/test/services/cache_first_query_test.dart
+++ b/mobile/test/services/cache_first_query_test.dart
@@ -166,9 +166,7 @@ void main() {
     });
 
     Future<void> cacheEvents(List<Event> events) async {
-      for (final event in events) {
-        eventRouter.handleEvent(event);
-      }
+      events.forEach(eventRouter.handleEvent);
       await eventRouter.drainForTesting();
     }
 
@@ -450,9 +448,7 @@ void main() {
     });
 
     Future<void> cacheEvents(List<Event> events) async {
-      for (final event in events) {
-        eventRouter.handleEvent(event);
-      }
+      events.forEach(eventRouter.handleEvent);
       await eventRouter.drainForTesting();
     }
 

--- a/mobile/test/services/collaborator_response_service_test.dart
+++ b/mobile/test/services/collaborator_response_service_test.dart
@@ -61,13 +61,12 @@ void main() {
       ),
     ).thenAnswer((invocation) async {
       final tags = invocation.namedArguments[#tags] as List<List<String>>;
-      signedEvent = Event(
+      return signedEvent = Event(
         collaboratorPubkey,
         CollaborationEventKinds.collaboratorResponse,
         tags,
         '',
       );
-      return signedEvent;
     });
     when(
       () => nostrClient.publishEvent(any()),

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -50,7 +50,7 @@ void main() {
         clipsDao: database.clipsDao,
       );
 
-      for (final basename in [
+      const [
         'video.mp4',
         'video1.mp4',
         'video2.mp4',
@@ -60,9 +60,7 @@ void main() {
         'a2.mp4',
         'b1.mp4',
         'old_video.mp4',
-      ]) {
-        createDocumentFile(basename);
-      }
+      ].forEach(createDocumentFile);
     });
 
     tearDown(() async {

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -50,7 +50,7 @@ void main() {
         clipsDao: database.clipsDao,
       );
 
-      const [
+      const documentBasenames = [
         'video.mp4',
         'video1.mp4',
         'video2.mp4',
@@ -60,7 +60,8 @@ void main() {
         'a2.mp4',
         'b1.mp4',
         'old_video.mp4',
-      ].forEach(createDocumentFile);
+      ];
+      documentBasenames.forEach(createDocumentFile);
     });
 
     tearDown(() async {

--- a/mobile/test/services/event_router_test.dart
+++ b/mobile/test/services/event_router_test.dart
@@ -42,9 +42,7 @@ void main() {
 
     /// Drives [events] through the deterministic test drain.
     Future<void> flush(List<Event> events) async {
-      for (final event in events) {
-        router.handleEvent(event);
-      }
+      events.forEach(router.handleEvent);
       await router.drainForTesting();
     }
 
@@ -155,9 +153,7 @@ void main() {
         );
 
         final events = List.generate(25, (i) => videoEvent(2000 + i));
-        for (final event in events) {
-          router.handleEvent(event);
-        }
+        events.forEach(router.handleEvent);
 
         await router.drainForTesting();
 

--- a/mobile/test/services/seen_videos_service_migration_test.dart
+++ b/mobile/test/services/seen_videos_service_migration_test.dart
@@ -91,7 +91,7 @@ void main() {
       expect(
         service.wasSeenRecently(
           'vid-recent',
-          within: const Duration(),
+          within: Duration.zero,
         ),
         isFalse,
       );

--- a/mobile/test/services/support/auth_service_test_harness.dart
+++ b/mobile/test/services/support/auth_service_test_harness.dart
@@ -47,7 +47,7 @@ class AuthServiceChannelMocks {
 
   /// Installs the secure-storage, capability, and native-signer channel mocks
   /// AuthService reaches during sign-in / restore.
-  static AuthServiceChannelMocks install() {
+  factory AuthServiceChannelMocks.install() {
     final mocks = AuthServiceChannelMocks._();
     _installSecureStorageHandlers(mocks.secureStorage);
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger

--- a/mobile/test/services/upload_initialization_helper_test.dart
+++ b/mobile/test/services/upload_initialization_helper_test.dart
@@ -4,6 +4,8 @@
 // Permanent: mutates PathProviderPlatform.instance and Hive's process-wide box
 // registry while validating upload initialization failure paths.
 @Tags(['skip_very_good_optimization'])
+library;
+
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';

--- a/mobile/test/services/upload_manager_recovery_test.dart
+++ b/mobile/test/services/upload_manager_recovery_test.dart
@@ -1,6 +1,8 @@
 // Permanent: mutates MethodChannel handlers, SharedPreferences, PathProvider,
 // and Hive's process-wide box registry for the upload recovery sweep.
 @Tags(['skip_very_good_optimization'])
+library;
+
 import 'dart:async';
 import 'dart:io';
 

--- a/mobile/test/services/upload_manager_resumable_upload_test.dart
+++ b/mobile/test/services/upload_manager_resumable_upload_test.dart
@@ -1,6 +1,8 @@
 // Permanent: mutates MethodChannel handlers, SharedPreferences, PathProvider,
 // and Hive's process-wide box registry for resumable upload recovery paths.
 @Tags(['skip_very_good_optimization'])
+library;
+
 import 'dart:async';
 import 'dart:io';
 

--- a/mobile/test/services/video_editor/video_editor_reverse_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_reverse_service_test.dart
@@ -1,6 +1,8 @@
 // Permanent: swaps PathProviderPlatform.instance and ProVideoEditor.instance;
 // keep isolated until VideoEditorReverseService accepts injected dependencies.
 @Tags(['skip_very_good_optimization'])
+library;
+
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/mobile/test/services/video_editor/video_editor_split_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_split_service_test.dart
@@ -1,6 +1,8 @@
 // Permanent: swaps PathProviderPlatform.instance and ProVideoEditor.instance;
 // keep isolated until VideoEditorSplitService accepts injected dependencies.
 @Tags(['skip_very_good_optimization'])
+library;
+
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/mobile/test/services/video_editor/video_editor_transform_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_transform_service_test.dart
@@ -3,6 +3,8 @@
 // shared-process bundling cannot isolate. Same pattern as the reverse/split
 // service tests.
 @Tags(['skip_very_good_optimization'])
+library;
+
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/mobile/test/services/video_event_publisher_collaborator_tags_test.dart
+++ b/mobile/test/services/video_event_publisher_collaborator_tags_test.dart
@@ -120,13 +120,12 @@ void main() {
       ),
     ).thenAnswer((invocation) async {
       capturedTags = invocation.namedArguments[#tags] as List<List<String>>;
-      publishedEvent = Event(
+      return publishedEvent = Event(
         testPubkey,
         NIP71VideoKinds.getPreferredAddressableKind(),
         capturedTags,
         'test content',
       );
-      return publishedEvent;
     });
 
     when(

--- a/mobile/test/services/video_event_publisher_imeta_hash_test.dart
+++ b/mobile/test/services/video_event_publisher_imeta_hash_test.dart
@@ -129,13 +129,12 @@ void main() {
       ),
     ).thenAnswer((invocation) async {
       capturedTags = invocation.namedArguments[#tags] as List<List<String>>;
-      publishedEvent = Event(
+      return publishedEvent = Event(
         testPubkey,
         NIP71VideoKinds.getPreferredAddressableKind(),
         capturedTags,
         'test content',
       );
-      return publishedEvent;
     });
 
     when(

--- a/mobile/test/services/video_event_publisher_inspired_by_tags_test.dart
+++ b/mobile/test/services/video_event_publisher_inspired_by_tags_test.dart
@@ -135,13 +135,12 @@ void main() {
       ),
     ).thenAnswer((invocation) async {
       capturedTags = invocation.namedArguments[#tags] as List<List<String>>;
-      publishedEvent = Event(
+      return publishedEvent = Event(
         testPubkey,
         NIP71VideoKinds.getPreferredAddressableKind(),
         capturedTags,
         'test content',
       );
-      return publishedEvent;
     });
 
     when(

--- a/mobile/test/services/video_event_publisher_language_tag_test.dart
+++ b/mobile/test/services/video_event_publisher_language_tag_test.dart
@@ -120,13 +120,12 @@ void main() {
     ).thenAnswer((invocation) async {
       capturedTags = invocation.namedArguments[#tags] as List<List<String>>?;
       final tags = capturedTags ?? [];
-      publishedEvent = Event(
+      return publishedEvent = Event(
         testPubkey,
         NIP71VideoKinds.getPreferredAddressableKind(),
         tags,
         'test content',
       );
-      return publishedEvent;
     });
 
     when(

--- a/mobile/test/services/video_event_publisher_publish_confirmation_test.dart
+++ b/mobile/test/services/video_event_publisher_publish_confirmation_test.dart
@@ -452,8 +452,7 @@ void main() {
         final tags = invocation.namedArguments[#tags] as List<List<String>>;
         if (kind == audioEventKind) {
           audioTags = tags;
-          signedAudioEvent = Event(testPubkey, audioEventKind, tags, '');
-          return signedAudioEvent;
+          return signedAudioEvent = Event(testPubkey, audioEventKind, tags, '');
         }
 
         videoTags = tags;

--- a/mobile/test/services/video_event_publisher_reply_tags_test.dart
+++ b/mobile/test/services/video_event_publisher_reply_tags_test.dart
@@ -128,13 +128,12 @@ void main() {
       ),
     ).thenAnswer((invocation) async {
       capturedTags = invocation.namedArguments[#tags] as List<List<String>>;
-      publishedEvent = Event(
+      return publishedEvent = Event(
         testPubkey,
         NIP71VideoKinds.getPreferredAddressableKind(),
         capturedTags,
         'reply title',
       );
-      return publishedEvent;
     });
 
     when(

--- a/mobile/test/services/video_event_publisher_signed_callback_test.dart
+++ b/mobile/test/services/video_event_publisher_signed_callback_test.dart
@@ -147,13 +147,12 @@ void main() {
             tags: any(named: 'tags'),
           ),
         ).thenAnswer((invocation) async {
-          signedEvent = Event(
+          return signedEvent = Event(
             testPubkey,
             NIP71VideoKinds.getPreferredAddressableKind(),
             invocation.namedArguments[#tags] as List<List<String>>,
             'test content',
           );
-          return signedEvent;
         });
         when(
           () => nostrClient.publishEventAwaitOk(

--- a/mobile/test/services/video_event_publisher_test.dart
+++ b/mobile/test/services/video_event_publisher_test.dart
@@ -163,7 +163,7 @@ void main() {
             thumbnailPath: 'https://example.com/thumbnail.jpg',
             title: 'Test Video',
             description: 'Test description',
-            hashtags: ['test', 'video'],
+            hashtags: const ['test', 'video'],
             videoWidth: 1920,
             videoHeight: 1080,
           ).copyWith(
@@ -588,13 +588,12 @@ void main() {
         ),
       ).thenAnswer((invocation) async {
         capturedTags = invocation.namedArguments[#tags] as List<List<String>>;
-        publishedEvent = Event(
+        return publishedEvent = Event(
           testPubkey,
           NIP71VideoKinds.getPreferredAddressableKind(),
           capturedTags,
           'test content',
         );
-        return publishedEvent;
       });
 
       when(

--- a/mobile/test/services/video_event_service_deduplication_test.dart
+++ b/mobile/test/services/video_event_service_deduplication_test.dart
@@ -3,6 +3,8 @@
 // subscription dedupe tests use non-completing streams and layer-correct
 // assertions.
 @Tags(['skip_very_good_optimization'])
+library;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';

--- a/mobile/test/services/video_metadata_update_service_test.dart
+++ b/mobile/test/services/video_metadata_update_service_test.dart
@@ -100,13 +100,12 @@ void main() {
         invocation.namedArguments[#tags] as List<List<String>>,
       );
       capturedCreatedAt = invocation.namedArguments[#createdAt] as int? ?? 0;
-      signedEvent = Event(
+      return signedEvent = Event(
         _ownerPubkey,
         NIP71VideoKinds.addressableShortVideo,
         capturedTags,
         invocation.namedArguments[#content] as String,
       );
-      return signedEvent;
     });
 
     when(

--- a/mobile/test/startup/app_startup_test.dart
+++ b/mobile/test/startup/app_startup_test.dart
@@ -49,9 +49,9 @@ void main() {
       ];
 
       // None of these should throw
-      for (final breadcrumb in testBreadcrumbs) {
-        CrashReportingService.instance.logInitializationStep(breadcrumb);
-      }
+      testBreadcrumbs.forEach(
+        CrashReportingService.instance.logInitializationStep,
+      );
 
       // Also test regular logging
       CrashReportingService.instance.log('Startup timeout detected');

--- a/mobile/test/unit/services/upload_manager_get_by_path_test.dart
+++ b/mobile/test/unit/services/upload_manager_get_by_path_test.dart
@@ -4,6 +4,8 @@
 // Permanent: initializes Hive's process-wide box registry and the shared test
 // platform-channel environment for UploadManager lookup coverage.
 @Tags(['skip_very_good_optimization'])
+library;
+
 import 'dart:io';
 
 import 'package:blossom_upload_service/blossom_upload_service.dart';

--- a/mobile/test/unit/services/video_cache_service_tdd_test.dart
+++ b/mobile/test/unit/services/video_cache_service_tdd_test.dart
@@ -63,9 +63,7 @@ class VideoCacheService implements IVideoCacheService {
 
   @override
   void addVideos(List<VideoEvent> videos) {
-    for (final video in videos) {
-      addVideo(video);
-    }
+    videos.forEach(addVideo);
   }
 
   @override

--- a/mobile/test/widgets/share_video_menu_edit_collaborator_tags_test.dart
+++ b/mobile/test/widgets/share_video_menu_edit_collaborator_tags_test.dart
@@ -98,13 +98,12 @@ void main() {
       capturedTags = List<List<String>>.from(
         invocation.namedArguments[#tags] as List<List<String>>,
       );
-      signedEvent = Event(
+      return signedEvent = Event(
         ownerPubkey,
         NIP71VideoKinds.addressableShortVideo,
         capturedTags,
         invocation.namedArguments[#content] as String,
       );
-      return signedEvent;
     });
 
     when(

--- a/mobile/test/widgets/video_editor/draw_editor/video_editor_draw_item_indicator_test.dart
+++ b/mobile/test/widgets/video_editor/draw_editor/video_editor_draw_item_indicator_test.dart
@@ -75,7 +75,7 @@ void main() {
         await tester.pump();
 
         final slide = tester.widget<AnimatedSlide>(find.byType(AnimatedSlide));
-        expect(slide.offset, const Offset(0, 0));
+        expect(slide.offset, Offset.zero);
       });
 
       testWidgets('offset is 1 when marker is selected', (tester) async {
@@ -127,7 +127,7 @@ void main() {
 
         // Initial state - pencil selected
         var slide = tester.widget<AnimatedSlide>(find.byType(AnimatedSlide));
-        expect(slide.offset, const Offset(0, 0));
+        expect(slide.offset, Offset.zero);
 
         // Update state to eraser
         when(() => mockBloc.state).thenReturn(

--- a/mobile/tools/check_future_delayed.dart
+++ b/mobile/tools/check_future_delayed.dart
@@ -29,9 +29,7 @@ void main(List<String> args) async {
   if (violationCount > 0) {
     debugPrint('❌ Found $violationCount Future.delayed violations:\n');
 
-    for (final violation in violations) {
-      debugPrint(violation);
-    }
+    violations.forEach(debugPrint);
 
     debugPrint('\nReplace Future.delayed with explicit async coordination.');
     exit(1);


### PR DESCRIPTION
## Description

Tier 2 of the `analysis_options.yaml` cleanup that #7223 started: the rules `very_good_analysis` ships enabled and this repo silences, in the 9–25 violations each band.

Eleven of the twelve rules #7225 lists are decided here. The twelfth, `invalid_assignment`, was in #7250 — the issue asks for it separately because it is the only one hiding an actual error. #7250 landed first, so this branch is rebased on it and its `invalid_assignment: ignore` line is simply gone from the `errors:` block here.

### Enabled and fixed (8)

`library_annotations`, `prefer_foreach`, `prefer_constructors_over_static_methods`, `only_throw_errors`, `use_named_constants`, `avoid_equals_and_hash_code_on_mutable_classes`, `type_annotate_public_apis`, `join_return_with_assignment`.

Most of it is mechanical — a tear-off instead of a one-line `for` body, `Offset.zero` instead of `const Offset(0, 0)`, `return x = value` instead of assign-then-return. Four are not.

**`library_annotations`: the decision #7225 asks for is "adopt `library;`".** I checked whether this was a latent bug before treating it as style, because the annotation sitting above the first import *looks* misplaced. It is not — running a tagged suite with `--exclude-tags skip_very_good_optimization` correctly skips it today. So this is cosmetic, and the fix is a `library;` directive under the annotation in 22 files, matching the two that already did it. Tag filtering re-verified after the move.

**`only_throw_errors` is enabled for `lib` and exempted for both test trees.** All nineteen test findings are one shape: a fake with an `Object? somethingError` knob a test sets to make it fail. That knob has to carry both an `Exception` and an `Error` — several suites inject `StateError` precisely because production code treats the two differently, e.g. `video_editor_render_service_test.dart`'s "a recoverable caller still reports a programming-invariant violation" — and Dart has no supertype of both to narrow it to. #7225's implementation notes float a scoped `test/analysis_options.yaml` exception as the alternative to rewriting 80+ test sites; this takes it, in the file that already carries the `avoid_print` exemption. `mobile/integration_test/` gets the same exemption in its own options file, since `test/analysis_options.yaml` does not reach it. There are no violations there today, but that is accidental rather than a deliberate stricter boundary — integration tests use the same fake idiom, and the first one with an error knob would hit the rule with no escape hatch. `mobile/tools/` stays strict: one script, no fakes.

The three `lib` findings are fixed properly, and two are small improvements rather than lint appeasement: `classic_vines_provider` and `video_events_providers` now use `Error.throwWithStackTrace`, preserving a stack trace that `throw error` was discarding. The third, in `video_metadata_edit_bottom_bar`, was a `throw` whose only catcher was two lines below it; that is now a direct call to an extracted `_reportUpdateFailure`.

**`prefer_constructors_over_static_methods` converts twenty static factories to named constructors.** Call syntax is identical either way, so no call site moved. Three findings are static *getters* — the `.instance` singletons on `CrashReportingService` and `NotificationService`, and the one mirroring `dart:io`'s `Directory.systemTemp` — and a constructor cannot be a getter, so each carries an ignore saying why.

**`avoid_equals_and_hash_code_on_mutable_classes` annotates ten value classes `@immutable`** rather than dropping their `==`/`hashCode`. Every one already had all-final fields; the rule was pointing at a missing annotation, not at real mutability.

### Staying off, with an inline reason each (3)

`prefer_initializing_formals` already sets the precedent for documenting a rule that conflicts with a repo convention. Three more join it:

**`flutter_style_todos`** requires `TODO(username)` and rejects a `#` inside the parentheses, while `.claude/rules/code_style.md` and `agent_workflow.md` §4 mandate `TODO(#issue)` as the *only* acceptable form. Proven by A/B rather than asserted: `// TODO(any):` in `classic_vines_provider.dart:462` is not flagged, `// TODO(#4338):` in `app_shell.dart:315` is, and those two lines are otherwise identical. Enabling this rule means editing two rule files and abandoning issue-linked TODOs — a policy call, not a lint cleanup.

**`no_default_cases`** fires six of ten times on switches over `RouteType`, which has 61 values of which four map to a tab. Enumerating the rest across `main.dart`, `app_shell.dart`, `tab_history_provider` and `back_button_handler` is roughly 330 lines of dead cases.

**`one_member_abstracts`** fires only on DI ports, each with two to six implementors. The fix it suggests — make it a top-level function — deletes the named type that `implements` clauses and test doubles hang off, and contradicts the constructor-injection guidance in `.claude/rules/architecture.md`.

**Related Issue:** Closes #7225

## Out of Scope

- `invalid_assignment` — #7250, merged.
- The bare `// TODO:` comments this work surfaced in `mobile/lib/services` are now tracked as #7244, #7245, #7246 and #7247 rather than fixed here. #7247 also notes that the `video_event_service.dart` header points at `docs/REFACTORING_ROADMAP.md`, which does not exist, and that its self-reported line count is stale.
- The high-volume rules stay off for the reasons #7223 already recorded.
- **The shard 3/4 timeout this PR previously reported is resolved and was never this diff.** `cache_recovery_service_test.dart` — a suite this PR does not touch — was timing out after ten minutes across three ordering seeds and two branches, including the merge-queue run for the unrelated #7233. Root cause was untagged suites re-pointing Hive's process-global home directory with `Hive.init()` and never restoring it, tracked as #7254 and fixed by #7264. That fix is in `main`, this branch is rebased on it, and all four shards are green.

## Verification

- `flutter analyze` over the whole `mobile` package — no issues. Worth running package-wide rather than `lib test integration_test`: `tools/check_future_delayed.dart` sits outside those three and had a `prefer_foreach` finding of its own.
- `dart format lib test integration_test` — 3148 files, 0 changed
- 15,672 tests passing across `services`, `models`, `providers`, `widgets`, `screens`, `router`, `blocs`, `features`, `observability`, `startup`, `config`, `helpers`, `infrastructure`, `unit`, `notifications`, `repositories`, `l10n` and `goldens`, re-run after the rebase onto current `main`
- `mobile/scripts/golden.sh verify` — passing
- All twelve ratchets green: god-file ceiling, test/unit structure, untested-services floor, HTTP-overrides isolation, process-global mutations, shared-channel overrides, the four design-system ceilings, native transport security, dependency provenance
- Proved the enablements are real rather than assumed: a throwaway file in `lib/` violating each rule is flagged by all eight, and the same file under `test/` is correctly *not* flagged for `only_throw_errors`
- Re-verified `--exclude-tags` still skips a suite after its annotation moved onto `library;`
- Review follow-up: `flutter analyze lib test integration_test tools` still clean with the new `integration_test/analysis_options.yaml` in place, and the five suites the readability commit touches re-run green (267 tests)

Not verified on a real Samsung Galaxy. The diff is lint-driven refactoring with no intended behaviour change, and the three `only_throw_errors` fixes are the only places where runtime behaviour is even adjacent — two add a stack trace to an error that was already being thrown, and the third replaces a throw-to-self with a direct call. Happy to put it on the device before this leaves draft if you want that gate.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore

