### PR TITLE
fix(routing): gate universal links to /profile, /hashtag, /search and /list

### DIFF
--- a/mobile/lib/router/app_router_redirect.dart
+++ b/mobile/lib/router/app_router_redirect.dart
@@ -227,10 +227,11 @@ bool minorAccountReviewStatusAffectsRouting(
 /// loading-screen ↔ review-screen loop (issue #5195) or feeding an
 /// un-rewritten universal-link URL into the matcher (Page Not Found).
 ///
-/// The divine:// step resolves a destination and then *keeps going*, so the
-/// gating below still applies to it. go_router calls this at most once per
+/// Both deep-link steps resolve a destination and then *keep going*, so the
+/// gating below still applies to them. go_router calls this at most once per
 /// navigation, so returning a destination early would put the caller past
-/// every gate — see [divineSchemeRedirectTarget].
+/// every gate — see [divineSchemeRedirectTarget] and
+/// [universalLinkToRouterPath].
 String? appRouterRedirect(Ref ref, GoRouterState state) {
   final authService = ref.read(authServiceProvider);
 
@@ -259,26 +260,33 @@ String? appRouterRedirect(Ref ref, GoRouterState state) {
     }
   }
 
-  // Non-null only for a divine:// URI whose destination still has to clear the
-  // gates. Every `return deepLinkRewrite` below is a plain `return null` for
-  // ordinary in-app navigation, so nothing changes off the deep-link path.
-  final deepLinkRewrite = divineScheme?.path;
-
   // Rewrite divine.video universal-link URLs to internal paths before the
   // auth/match logic runs. Android delivers the full intent URL (scheme +
   // host + path) to GoRouter, which only matches on path. Without this
   // step, paths that differ between the public URL contract and the
   // internal route table (notably `/search/*` → `/search-results/:query`)
   // would fall through to GoRouter's "Page Not Found" page.
+  //
+  // Resolved here but not returned, for the same reason as the divine://
+  // step above. Returning it was terminal, and terminal meant a
+  // restricted-minor account reached /profile, /hashtag, /search and /list by
+  // opening the https link instead of navigating to the path (#7146).
   final universalRedirect = universalLinkToRouterPath(state.uri);
   if (universalRedirect != null) {
     Log.info(
-      'Router redirect: universal link ${state.uri} → $universalRedirect',
+      'Router redirect: universal link '
+      '${redactUriStringForLogs(state.uri.toString())} → $universalRedirect',
       name: 'AppRouter',
       category: LogCategory.ui,
     );
-    return universalRedirect;
   }
+
+  // Non-null only for a deep link whose destination still has to clear the
+  // gates. The two resolvers are mutually exclusive — one matches `divine://`
+  // and the other `http(s)://` — so at most one is ever set. Every
+  // `return deepLinkRewrite` below is a plain `return null` for ordinary
+  // in-app navigation, so nothing changes off the deep-link path.
+  final deepLinkRewrite = divineScheme?.path ?? universalRedirect;
 
   final location = deepLinkRewrite ?? state.matchedLocation;
   final authState = authService.authState;

--- a/mobile/lib/router/universal_link_resolver.dart
+++ b/mobile/lib/router/universal_link_resolver.dart
@@ -137,6 +137,13 @@ const _customSchemeRoutablePrefixes = <String>{
 /// either because the URI is not a universal link, or because its handling is
 /// deferred to the [DeepLinkService] stream listener.
 ///
+/// Resolving to a path is not the same as being allowed to reach it: the
+/// returned path is a *destination*, which [appRouterRedirect] then runs
+/// through the auth and minor-account-review gates like any other location.
+/// Returning it from the redirect instead was terminal, and let a
+/// restricted-minor account reach `/profile`, `/hashtag`, `/search` and
+/// `/list` by opening the shared https link (#7146).
+///
 /// Video deep links (`/video/:id`) intentionally return `null`: the listener
 /// uses `router.push` to keep the home feed underneath the detail page so
 /// back-navigation returns to the main screen. Rewriting in the router

--- a/mobile/test/router/app_router_universal_link_gating_test.dart
+++ b/mobile/test/router/app_router_universal_link_gating_test.dart
@@ -1,0 +1,253 @@
+// ABOUTME: https://divine.video universal links must clear the same auth and
+// ABOUTME: minor-review gates as the plain path — the redirect runs only once
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/models/minor_account_review_status.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/router/router.dart';
+import 'package:openvine/screens/auth/welcome_screen.dart';
+import 'package:openvine/screens/curated_list_by_author_screen.dart';
+import 'package:openvine/screens/curated_list_feed_screen.dart';
+import 'package:openvine/screens/feed/video_feed_page.dart';
+import 'package:openvine/screens/hashtag_screen_router.dart';
+import 'package:openvine/screens/minor_account_review_screen.dart';
+import 'package:openvine/screens/profile_screen_router.dart';
+import 'package:openvine/screens/search_results/view/search_results_page.dart';
+import 'package:openvine/screens/settings/settings_screen.dart';
+import 'package:openvine/services/auth_service.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+/// Hands the test a real [Ref] so [appRouterRedirect] can be driven through a
+/// GoRouter instead of being called in isolation.
+final _refProvider = Provider<Ref>((ref) => ref);
+
+const _npub = 'npub180cvv07tjdrrgpa9jzd0cdkej42kwsaxq9rz7gvdpjx6nz004f9uulstw6';
+const _listAuthor =
+    'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2';
+
+// go_router applies the top-level redirect at most once per navigation and does
+// not re-evaluate the location it redirects to
+// (`RouteConfiguration.applyTopLegacyRedirect`). Anything appRouterRedirect
+// returns is therefore final, so resolving a universal link to a destination
+// and returning it there skipped every gate below it (#7146). These tests drive
+// the whole redirect and compare each https link against the plain path it
+// addresses: the two must land in the same place.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(resetNavigationState);
+
+  Future<String> resolve(
+    WidgetTester tester, {
+    required String target,
+    required AuthState authState,
+    bool restricted = false,
+    bool reviewStatusPending = false,
+  }) async {
+    final authService = _MockAuthService();
+    when(() => authService.authState).thenReturn(authState);
+    when(() => authService.hasExpiredOAuthSession).thenReturn(false);
+
+    final container = ProviderContainer(
+      overrides: [
+        authServiceProvider.overrideWithValue(authService),
+        // The authenticated-auth-route branch consults this on first
+        // navigation; the empty-following bounce is not what these tests are
+        // about.
+        hasFollowingInCacheProvider.overrideWithValue(true),
+        currentMinorAccountReviewStatusProvider.overrideWith((ref) async {
+          if (reviewStatusPending) {
+            // Never completes, so the redirect sees AsyncLoading with no value
+            // — the cold-load shape that bounces through the loading screen.
+            return Completer<MinorAccountReviewStatus>().future;
+          }
+          return restricted
+              ? const MinorAccountReviewStatus(
+                  restrictionStatus:
+                      AccountRestrictionStatus.restrictedMinorReview,
+                )
+              : MinorAccountReviewStatus.active();
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+    if (reviewStatusPending) {
+      container.read(currentMinorAccountReviewStatusProvider);
+    } else {
+      // Settle the status so the redirect sees a value rather than
+      // AsyncLoading, which has its own loading-screen bounce.
+      await container.read(currentMinorAccountReviewStatusProvider.future);
+    }
+
+    final ref = container.read(_refProvider);
+    final router = GoRouter(
+      initialLocation: WelcomeScreen.path,
+      redirect: (_, state) => appRouterRedirect(ref, state),
+      routes: [
+        for (final path in <String>[
+          WelcomeScreen.path,
+          VideoFeedPage.pathForIndex(0),
+          MinorAccountReviewScreen.path,
+          MinorAccountReviewLoadingScreen.path,
+          SettingsScreen.path,
+          ProfileScreenRouter.pathWithNpub,
+          HashtagScreenRouter.path,
+          SearchResultsPage.path,
+          CuratedListFeedScreen.path,
+          CuratedListByAuthorScreen.path,
+        ])
+          GoRoute(
+            path: path,
+            builder: (_, _) => Scaffold(body: Text(path)),
+          ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.pumpAndSettle();
+
+    router.go(target);
+    await tester.pumpAndSettle();
+    return router.state.uri.toString();
+  }
+
+  // Each entry is (universal link, the plain path it addresses), covering both
+  // /list shapes. profile, hashtag, search and list are exactly the types
+  // universalLinkToRouterPath resolves; video, savedVideos, invite,
+  // signerCallback and unknown return null and already fell through to the
+  // gates.
+  const links = <(String, String)>[
+    ('https://divine.video/profile/$_npub', '/profile/$_npub'),
+    ('https://divine.video/hashtag/art', '/hashtag/art'),
+    ('https://divine.video/search/music', '/search-results/music'),
+    ('https://divine.video/list/my-vines', '/list/my-vines'),
+    (
+      'https://divine.video/list/$_listAuthor/my-vines',
+      '/list/$_listAuthor/my-vines',
+    ),
+  ];
+
+  group('a restricted-minor account', () {
+    testWidgets('cannot escape the review screen through a universal link', (
+      tester,
+    ) async {
+      for (final (link, plainPath) in links) {
+        final viaLink = await resolve(
+          tester,
+          target: link,
+          authState: AuthState.authenticated,
+          restricted: true,
+        );
+        final viaPath = await resolve(
+          tester,
+          target: plainPath,
+          authState: AuthState.authenticated,
+          restricted: true,
+        );
+
+        expect(
+          viaPath,
+          equals(MinorAccountReviewScreen.path),
+          reason: '$plainPath should be gated for a restricted account.',
+        );
+        expect(
+          viaLink,
+          equals(viaPath),
+          reason:
+              '$link reached $viaLink while $plainPath was gated to $viaPath. '
+              'A restricted account must not get a way around the review '
+              'screen by opening a shared https link.',
+        );
+      }
+    });
+  });
+
+  group('a signed-out visitor', () {
+    testWidgets('is sent to welcome by a universal link', (tester) async {
+      for (final (link, plainPath) in links) {
+        expect(
+          await resolve(
+            tester,
+            target: link,
+            authState: AuthState.unauthenticated,
+          ),
+          equals(WelcomeScreen.path),
+          reason:
+              '$link must be gated exactly like $plainPath, which bounces a '
+              'signed-out visitor to welcome.',
+        );
+      }
+    });
+  });
+
+  group('an ordinary signed-in user', () {
+    testWidgets('still reaches every universal-link destination', (
+      tester,
+    ) async {
+      for (final (link, plainPath) in links) {
+        expect(
+          await resolve(
+            tester,
+            target: link,
+            authState: AuthState.authenticated,
+          ),
+          equals(plainPath),
+          reason: '$link should open $plainPath.',
+        );
+      }
+    });
+
+    testWidgets('waits on the review loading screen with the rewritten path', (
+      tester,
+    ) async {
+      // The loading screen round-trips `from` back through the redirect, so it
+      // has to carry the internal path — handing it the raw https URL would
+      // re-resolve the link a second time on the way back.
+      expect(
+        await resolve(
+          tester,
+          target: 'https://divine.video/search/music',
+          authState: AuthState.authenticated,
+          reviewStatusPending: true,
+        ),
+        equals(
+          Uri(
+            path: MinorAccountReviewLoadingScreen.path,
+            queryParameters: const {'from': '/search-results/music'},
+          ).toString(),
+        ),
+      );
+    });
+  });
+
+  group('ordinary in-app navigation', () {
+    testWidgets('is unaffected — no universal-link rewrite in play', (
+      tester,
+    ) async {
+      expect(
+        await resolve(
+          tester,
+          target: SettingsScreen.path,
+          authState: AuthState.authenticated,
+        ),
+        equals(SettingsScreen.path),
+      );
+      expect(
+        await resolve(
+          tester,
+          target: SettingsScreen.path,
+          authState: AuthState.unauthenticated,
+        ),
+        equals(WelcomeScreen.path),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description

`universalLinkToRouterPath` resolves `https://divine.video/profile/*`, `/hashtag/*`, `/search/*` and `/list/*`, and `appRouterRedirect` returned that destination **early** — ahead of the auth and minor-account-review gates. go_router runs the top-level redirect at most once per navigation and never re-evaluates what it redirects to (`RouteConfiguration.applyTopLegacyRedirect`), so the early return was terminal and every gate below it was skipped.

Reproduced on `main` before touching anything:

| Link | Restricted minor | Signed out |
|---|---|---|
| `https://divine.video/profile/<npub>` | `/profile/<npub>` — plain path gives `/account-review` | `/profile/<npub>` |
| `https://divine.video/hashtag/art` | bypasses the gate | `/hashtag/art` |
| `https://divine.video/search/music` | bypasses the gate | `/search-results/music` |
| `https://divine.video/list/<id>` | bypasses the gate | `/list/<id>` |

The fix mirrors #7105: carry the resolved destination down as `deepLinkRewrite` instead of returning it, and let the gates have the last word. The rewrite itself still happens before the matcher, so `/search/*` → `/search-results/:query` keeps working and nothing regresses into "Page Not Found".

**Related Issue:** Closes #7146

### Both halves are closed, including the product one

The issue splits this into a safety half (minor-account-review, fires only for `authenticated`) and a product half (the unauthenticated bounce to `/welcome`), and flags the second as needing a call. Closing both, so a universal link reaches exactly what the plain path reaches.

What that changes: a signed-out visitor opening a shared profile/hashtag/search/list link now sees `/welcome` instead of the content. Two findings from the repro that informed the call:

- The signed-out landing was already a **one-shot dead end**. Navigating anywhere after landing re-runs the redirect and bounces to `/welcome` — the visitor saw one screen and the first tap ejected them.
- Nothing replays a bounced link after sign-in. There is no pending-deep-link storage anywhere in `lib/`, so the destination is lost rather than deferred.

If we want shared links genuinely open to signed-out visitors, that is a larger piece of work — a public-location concept plus post-auth replay — and wants its own issue rather than riding along here.

## Out of Scope

- Deferred deep links (storing the destination and replaying it after sign-in). Doesn't exist today; would remove the "destination is lost" cost of this change.
- A public/anonymous browsing mode for shared links. That is the growth-side answer to the product half and needs product input.
- One unrequested change, called out: the universal-link log line now goes through `redactUriStringForLogs`, matching the `divine://` line directly above it. That helper deliberately preserves full npubs and event refs (pinned by `sensitive_uri_for_logs_test.dart`), so no Nostr ID is truncated — it strips query values, invite codes, userInfo and fragments.

## Verification

- New `mobile/test/router/app_router_universal_link_gating_test.dart` — drives the whole redirect through a real `GoRouter` and compares each https link against the plain path it addresses, across restricted-minor / signed-out / ordinary signed-in, plus the cold-load bounce.
- **Confirmed the tests fail without the fix.** Stashed the two `lib/` changes and re-ran: the three gating tests go red with the right diffs (`Expected: '/account-review'` / `Actual: '/profile/npub1…'`, `Expected: '/welcome'` / `Actual: '/profile/npub1…'`). The two control tests — ordinary signed-in still reaching every destination, and ordinary in-app navigation — pass on both, so they guard against over-gating rather than detecting the bug.
- `flutter test test/router/` — 386 passed.
- `flutter test test/services/deep_link_service_test.dart test/main_deep_link_nav_action_test.dart test/screens/profile_screen_router_test.dart test/screens/saved_videos_screen_test.dart test/screens/video_detail_screen_test.dart test/unit/utils/sensitive_uri_for_logs_test.dart` — 125 passed.
- Swept every other suite that drives the redirect (`appRouterRedirect` / `goRouterProvider`): `test/providers/swap_account_test.dart`, `test/screens/`, the verification listeners, `test/startup/`, `test/widgets/upload_failure_listener_test.dart` — 2094 passed.
- `flutter analyze lib test integration_test` — no issues.
- `dart format` — clean.
- Re-ran analyze and the router suite after rebasing onto `d92422586`.

No UI change, so no screenshots or goldens.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
