### PR TITLE
fix(video-editor): keep the trim handle at the composition end grabbable

### DIFF
--- a/mobile/lib/constants/video_editor_timeline_constants.dart
+++ b/mobile/lib/constants/video_editor_timeline_constants.dart
@@ -75,6 +75,11 @@ abstract class TimelineConstants {
   /// Extra hit-test area around each trim handle.
   static const double trimHitAreaExtra = 32;
 
+  /// How far a trim handle's grab zone reaches past the edge of the strip it
+  /// belongs to. Layout boxes along the way must expand their hit-testing by
+  /// this much, or a handle sitting on a strip's boundary is unreachable.
+  static const double trimHitOverhang = trimHandleWidth + trimHitAreaExtra;
+
   /// Minimum trimmed duration for a clip.
   static const Duration minTrimDuration = Duration(milliseconds: 60);
 

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -647,7 +647,7 @@ class _VideoEditorTimelineClipStripState
     final shouldAnimate = _isReordering || _isReorderExiting;
 
     final trimExpand = widget.trimmingClipId != null
-        ? TimelineConstants.trimHandleWidth + TimelineConstants.trimHitAreaExtra
+        ? TimelineConstants.trimHitOverhang
         : 0.0;
 
     final isVolumeEditMode = context.select(

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
@@ -174,9 +174,10 @@ class VideoEditorTimelineBody extends StatelessWidget {
               Expanded(
                 // The strips are only clipped vertically, so a selected item's
                 // trim handle stays visible past the composition's last pixel.
-                // Every box in this subtree — the scroll viewport included —
-                // is exactly totalWidth wide and would still reject the touch,
-                // handing it to the horizontal scroll view instead.
+                // The strip itself is exactly totalWidth wide, and every box
+                // between here and it hit-tests against its own edge, so the
+                // touch was rejected all the way up and the horizontal scroll
+                // view took it instead.
                 child: HitExpandedBox(
                   expandLeft: overlayTrimExpand,
                   expandRight: overlayTrimExpand,

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
@@ -92,7 +92,7 @@ class VideoEditorTimelineBody extends StatelessWidget {
     );
 
     final clipTrimExpand = trimmingClipId != null
-        ? TimelineConstants.trimHandleWidth + TimelineConstants.trimHitAreaExtra
+        ? TimelineConstants.trimHitOverhang
         : 0.0;
 
     // Also expand for overlay trim handles when an overlay item is selected.
@@ -100,7 +100,7 @@ class VideoEditorTimelineBody extends StatelessWidget {
       (TimelineOverlayBloc b) => b.state.selectedItemId,
     );
     final overlayTrimExpand = overlaySelectedId != null
-        ? TimelineConstants.trimHandleWidth + TimelineConstants.trimHitAreaExtra
+        ? TimelineConstants.trimHitOverhang
         : 0.0;
 
     final trimExpand = clipTrimExpand > overlayTrimExpand
@@ -172,39 +172,48 @@ class VideoEditorTimelineBody extends StatelessWidget {
 
               /// Layers, Filters and Audio-Tracks
               Expanded(
-                child: AnimatedOpacity(
-                  opacity: isReordering ? 0.0 : 1.0,
-                  duration: const Duration(milliseconds: 200),
-                  child: ClipRect(
-                    clipper: const VerticalOnlyClipper(),
-                    child: SingleChildScrollView(
-                      controller: overlayStripsScrollController,
-                      clipBehavior: Clip.none,
-                      physics: isVolumeEditMode
-                          ? const NeverScrollableScrollPhysics()
-                          : null,
-                      padding: EdgeInsets.only(
-                        top: 4,
-                        bottom:
-                            _scrollBottomPadding +
-                            MediaQuery.paddingOf(context).bottom,
-                      ),
-                      child: IgnorePointer(
-                        ignoring: isReordering,
-                        child: RepaintBoundary(
-                          child: _CachedOverlayStrips(
-                            clips: clips,
-                            totalWidth: totalWidth,
-                            pixelsPerSecond: pixelsPerSecond,
-                            totalDuration: totalDuration,
-                            playheadPosition: playheadPosition,
-                            onItemTapped: onOverlayItemTapped,
-                            onItemMoved: onOverlayItemMoved,
-                            onItemMoving: onOverlayItemMoving,
-                            onItemTrimmed: onOverlayItemTrimmed,
-                            onTrimDragChanged: onOverlayTrimDragChanged,
-                            onDragStarted: onOverlayDragStarted,
-                            onDragEnded: onOverlayDragEnded,
+                // The strips are only clipped vertically, so a selected item's
+                // trim handle stays visible past the composition's last pixel.
+                // Every box in this subtree — the scroll viewport included —
+                // is exactly totalWidth wide and would still reject the touch,
+                // handing it to the horizontal scroll view instead.
+                child: HitExpandedBox(
+                  expandLeft: overlayTrimExpand,
+                  expandRight: overlayTrimExpand,
+                  child: AnimatedOpacity(
+                    opacity: isReordering ? 0.0 : 1.0,
+                    duration: const Duration(milliseconds: 200),
+                    child: ClipRect(
+                      clipper: const VerticalOnlyClipper(),
+                      child: SingleChildScrollView(
+                        controller: overlayStripsScrollController,
+                        clipBehavior: Clip.none,
+                        physics: isVolumeEditMode
+                            ? const NeverScrollableScrollPhysics()
+                            : null,
+                        padding: EdgeInsets.only(
+                          top: 4,
+                          bottom:
+                              _scrollBottomPadding +
+                              MediaQuery.paddingOf(context).bottom,
+                        ),
+                        child: IgnorePointer(
+                          ignoring: isReordering,
+                          child: RepaintBoundary(
+                            child: _CachedOverlayStrips(
+                              clips: clips,
+                              totalWidth: totalWidth,
+                              pixelsPerSecond: pixelsPerSecond,
+                              totalDuration: totalDuration,
+                              playheadPosition: playheadPosition,
+                              onItemTapped: onOverlayItemTapped,
+                              onItemMoved: onOverlayItemMoved,
+                              onItemMoving: onOverlayItemMoving,
+                              onItemTrimmed: onOverlayItemTrimmed,
+                              onTrimDragChanged: onOverlayTrimDragChanged,
+                              onDragStarted: onOverlayDragStarted,
+                              onDragEnded: onOverlayDragEnded,
+                            ),
                           ),
                         ),
                       ),

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_body_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_body_test.dart
@@ -11,8 +11,12 @@ import 'package:models/models.dart' as model;
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/timeline_overlay_item.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/strips/timeline_trim_handles.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_strip.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_strips.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -64,6 +68,9 @@ void main() {
       bool isReordering = false,
       Duration totalDuration = const Duration(seconds: 12),
       List<DivineVideoClip> clips = const <DivineVideoClip>[],
+      OverlayTrimCallback? onOverlayItemTrimmed,
+      double pixelsPerSecond = 80,
+      double totalWidth = 960,
     }) async {
       when(
         () => mainBloc.state,
@@ -89,15 +96,16 @@ void main() {
               height: 120000,
               child: VideoEditorTimelineBody(
                 totalDuration: totalDuration,
-                pixelsPerSecond: 80,
+                pixelsPerSecond: pixelsPerSecond,
                 scrollController: scrollController,
                 overlayStripsScrollController: overlayStripsScrollController,
                 scrollPadding: 16,
                 clips: clips,
-                totalWidth: 960,
+                totalWidth: totalWidth,
                 isInteracting: false,
                 onReorder: (_) {},
                 onReorderChanged: (_) {},
+                onOverlayItemTrimmed: onOverlayItemTrimmed,
                 playheadPosition: playhead,
               ),
             ),
@@ -105,6 +113,62 @@ void main() {
         ),
       );
     }
+
+    testWidgets(
+      'the right trim handle of an overlay item ending at the composition '
+      'end takes the drag',
+      (tester) async {
+        // Regression: the strips are exactly totalWidth wide, so the handle of
+        // an item ending on the last pixel sits outside every box in that
+        // subtree. The hit was rejected all the way up and the horizontal
+        // scroll view took the touch — pressing the handle scrolled the
+        // timeline instead of trimming, while grabbing just inside the item
+        // worked.
+        const item = TimelineOverlayItem(
+          id: 'layer-1',
+          type: TimelineOverlayType.layer,
+          startTime: Duration(seconds: 2),
+          endTime: Duration(seconds: 5),
+          label: 'Text',
+        );
+        when(() => overlayBloc.state).thenReturn(
+          const TimelineOverlayState(items: [item], selectedItemId: 'layer-1'),
+        );
+
+        var trimmedEnd = false;
+        // Sized so the composition's end stays inside the test viewport.
+        await pumpBody(
+          tester,
+          totalDuration: const Duration(seconds: 5),
+          totalWidth: 400,
+          clips: [_createClip(id: 'a', duration: const Duration(seconds: 5))],
+          onOverlayItemTrimmed:
+              ({
+                required item,
+                required startTime,
+                required endTime,
+                required isStart,
+              }) {
+                if (!isStart) trimmedEnd = true;
+              },
+        );
+
+        final handles = find.byType(TimelineTrimHandles);
+        expect(handles, findsOneWidget);
+        final content = tester.getRect(handles);
+        // Squarely on the visible handle, which is painted past the item's
+        // right edge — the spot that used to be dead.
+        final grabPoint = Offset(
+          content.right + TimelineConstants.trimHandleWidth / 2,
+          content.center.dy,
+        );
+
+        await tester.dragFrom(grabPoint, const Offset(-40, 0));
+        await tester.pump();
+
+        expect(trimmedEnd, isTrue);
+      },
+    );
 
     test('stores constructor parameters', () {
       final scrollController = ScrollController();


### PR DESCRIPTION
Closes #7257

## Problem

Pressing squarely on the **right trim handle of an overlay item that ends at the composition end** did nothing — the timeline scrolled instead. Grabbing a few pixels to either side of the handle trimmed normally, which made it look intermittent.

The overlay strip is exactly `totalWidth` wide. An item ending on the last pixel puts its right grab zone past that edge. The handle is still *painted* there (`VerticalOnlyClipper` deliberately clips vertically only), but hit-testing does not follow: the vertical scroll viewport, the `ClipRect`, the `Padding`, the `Column`, the strip's `SizedBox` and its `Stack` each test the touch against their own edge and reject it. The touch fell through to the horizontal scroll view, whose opaque gesture detector turned it into a scroll.

Measured at the item's end before the fix — the dead band is exactly the width of the visible handle:

| Offset from item end | Hit target |
|---|---|
| −14 px, −6 px (inside the item) | trim handle |
| **0 … +14 px (the visible handle)** | **scroll view** |
| +20 px, +26 px | trim handle |

The far side works because `VideoEditorTimelineBody` already carries a `HitExpandedBox`, and the clip strip makes the body ~18 px wider than the strips through its loop-transition slot. Everything past that point goes through the deep hit-test and resolves correctly; the gap in between is what the user hits.

## Fix

Wrap the overlay strips' scroll wrapper in `HitExpandedBox` — the widget written for exactly this case, whose own doc comment already names the overlay strips as a user, and which the clip strip's handles depend on today. It changes hit-testing only, not layout or painting.

Both sides are expanded, for symmetry. The left edge was never broken: an item starting at 0:00 already reaches its handle, because the scroll view's own leading padding keeps that grab zone inside a box that accepts it. The measurements below confirm it is unchanged.

`trimHandleWidth + trimHitAreaExtra` was spelled out at three call sites, so it moves into `TimelineConstants.trimHitOverhang`. That sum is not arbitrary — it is exactly the widest a grab zone can reach outwards. `TimelineTrimHandles` computes `outwardHit = (handleWidth − borderWidth) + hitAreaExtra / 2`, and on a strip too narrow to hold both grab zones it shifts the lost inward reach outwards instead of shrinking it, adding at most `hitAreaExtra / 2 + borderWidth`. The two `borderWidth` terms cancel, leaving `handleWidth + hitAreaExtra` = 48 px.

## Verification

Swept the grab zone at fixed offsets outward from the item edge, driving a real drag and recording whether the trim handle took it. The body is mounted as a direct child of the padded horizontal scroll view, matching the real tree in `VideoEditorTimelineInteractiveBody`.

| Case | 0 | 3 | 7 | 12 | 16 | 22 | 28 | 29 | 31 |
|---|---|---|---|---|---|---|---|---|---|
| Right handle @ composition end — **before** | dead | dead | dead | dead | dead | grab | grab | grab | dead |
| Right handle @ composition end — **after** | grab | grab | grab | grab | grab | grab | grab | grab | dead |
| Left handle @ 0:00 — before and after | grab | grab | grab | grab | grab | grab | grab | grab | dead |
| Right handle mid-composition — before and after | grab | grab | grab | grab | grab | grab | dead | dead | dead |

Three things worth reading off that table:

- The fix closes the dead band exactly and stops where it should. The nominal grab zone reaches 30 px outward, so 0–29 live and 30+ dead is the correct shape, not an over-expansion.
- The left edge is byte-for-byte unchanged, which is the intended outcome — the symmetric `expandLeft` is defensive, not a second fix.
- Mid-composition the right handle dies at +28 rather than +30, because the item's own `Positioned` box only extends `trimExpansion` (28 px) past the content and the normal hit path stops at that edge. That 2 px sliver predates this PR and is untouched by it; the composition end now reaches slightly further than mid-composition, which is strictly better everywhere and never worse.

A narrow item at the composition end was checked separately, since the overlap clamp widens its grab zone to 40 px: a 16 px-wide item reports the trim at +28 and +34 after the fix and at neither offset before.

## Follow-up commit

`refactor(video-editor): finish the trimHitOverhang dedupe and fix a stale comment` — two review findings, no behaviour change:

- The clip strip still spelled the expression out, so the new constant covered two of its three call sites.
- The new comment on the overlay-strips wrapper claimed the scroll viewport is `totalWidth` wide. It is not — it takes the column's width, which includes the clip strip's loop-transition slot. The box that is exactly `totalWidth` is the strip itself; the touch is lost because every box in between tests against its own edge.

## Note for anyone extending these tests

`pumpBody` in `video_editor_timeline_body_test.dart` wraps the body in `SizedBox(height: 120000)`, which does not exist in the real tree. That box rejects any hit at negative local x before it reaches the body's `HitExpandedBox`, so a left-edge assertion written against this helper reports "dead" no matter what the timeline does. The right-edge regression test added here is unaffected, since it probes positive offsets. Anyone adding a left-edge case must mount the body directly under the padded scroll view instead.

## Test plan

- New regression test in `video_editor_timeline_body_test.dart`: a selected overlay item ending on the last second, dragged from the middle of its visible right handle, must report the trim. Verified it fails with the `HitExpandedBox` wrapper reverted and passes with it.
- `flutter test test/widgets/video_editor/ test/screens/video_editor/` — 931 passing.
- `flutter analyze lib test` — clean.
- The offset sweep above, run against both the branch and the branch with the fix reverted.
- Manually verified on a real Samsung Galaxy device: the handle now takes the drag when pressed directly, in the spot that previously scrolled the timeline.

No screenshots: the change is hit-testing only, so the timeline renders identically.
