### PR TITLE
chore(services): retire the remaining bare TODOs

### DIFF
--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -14,10 +14,8 @@
 /// 8. Retry & Recovery - Connection error detection, automatic retry
 /// 9. Search - NIP-50 video search implementation
 ///
-/// TODO: This class violates Single Responsibility Principle
-/// TODO: Planned refactoring into 7 focused services (see docs/REFACTORING_ROADMAP.md)
-///
-/// Current size: 3,277 lines, 71 methods, 48 state fields
+/// TODO(#4742): Split this god-file into focused services; it violates the
+/// Single Responsibility Principle.
 library;
 
 import 'dart:async';
@@ -230,10 +228,6 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
   // Frame-based batching for progressive UI updates
   bool _hasScheduledFrameUpdate = false;
-
-  // Search state - TODO: These fields are maintained for future search state tracking
-  // bool _isSearching = false;
-  // String? _currentSearchQuery;
 
   // Track following feed status
   final Map<SubscriptionType, bool> _isFollowingFeed = {};
@@ -6049,8 +6043,6 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       throw ArgumentError('Search query cannot be empty');
     }
 
-    // _isSearching = true;
-    // _currentSearchQuery = query.trim();
     _eventLists[SubscriptionType.search]?.clear();
 
     try {
@@ -6120,7 +6112,6 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         },
       );
     } catch (e) {
-      // _isSearching = false;
       Log.error(
         'Failed to start search: $e',
         name: 'VideoEventService',
@@ -6158,8 +6149,6 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   /// Clear search results and reset search state
   void clearSearchResults() {
     _eventLists[SubscriptionType.search]?.clear();
-    // _currentSearchQuery = null;
-    // _isSearching = false;
 
     // Cancel search subscription if active
     _subscriptions['search']?.cancel();

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -13,9 +13,8 @@
 /// 7. Sorting - Engagement-based, chronological, special handling
 /// 8. Retry & Recovery - Connection error detection, automatic retry
 /// 9. Search - NIP-50 video search implementation
-///
-/// TODO(#4742): Split this god-file into focused services; it violates the
-/// Single Responsibility Principle.
+// TODO(#4742): Split this god-file into focused services; it violates the
+// Single Responsibility Principle.
 library;
 
 import 'dart:async';

--- a/mobile/lib/services/video_processing_service.dart
+++ b/mobile/lib/services/video_processing_service.dart
@@ -72,7 +72,6 @@ class VideoProcessingService {
           final blobData = response.data;
 
           if (blobData is Map) {
-            // final sha256 = blobData['sha256'] as String?; // TODO: Use if needed for integrity verification
             final mediaUrl = blobData['url'] as String?;
             final hlsUrl = blobData['hls'] as String?;
             final thumbnailUrl = blobData['thumbnail'] as String?;


### PR DESCRIPTION
## Description

Three bare `// TODO:` comments in `mobile/lib/services` that needed no new work — two were dead code, one pointed at the wrong place.

`.claude/rules/agent_workflow.md` §4 allows exactly one TODO form: `// TODO(#issue):` with a tracking issue. These three had no owner and no issue.

1. **`video_event_service.dart` header** — the two bare `TODO:` lines collapsed into a single `// TODO(#4742):`. The reference to `docs/REFACTORING_ROADMAP.md` is gone because that file does not exist, and the split it described is already tracked by #4742. The plain `//` keeps a tracking note out of the library's published dartdoc. It does not trip `dangling_library_doc_comments`: that lint fires only when no `library` directive follows the doc block at all, which was confirmed by deleting the directive and watching it report at `4:1`.
2. **The stale `Current size: 3,277 lines, 71 methods, 48 state fields` line** — dropped rather than refreshed. The file is past 6,500 lines; a hand-maintained count that nothing updates will just drift again, and `mobile/scripts/baseline/service_god_file_sizes.txt` already tracks the size mechanically.
3. **Commented-out `_isSearching` / `_currentSearchQuery` declarations** — deleted. Nothing read them.
4. **Commented-out `sha256` extraction in `video_processing_service.dart`** — deleted. If integrity verification against the returned digest is wanted, that is its own issue, not a resurrected comment.

Beyond the issue text: those two search fields also had commented-out **assignments** at four further sites in the same file (`searchVideos`, its `catch` block, and `clearSearchResults`). Deleting only the declarations would have left commented-out code referring to fields that no longer exist, so those went too. That is why the diff is five hunks instead of the one the issue describes.

No behaviour change — every line removed was already inert.

**Related Issue:** Closes #7247

## Out of Scope

`mobile/lib/services` still contains non-`TODO(#issue)` comments after this merges, and would even after the siblings land — so #7247's third acceptance criterion has been narrowed to the three TODOs this task actually owns. What stays behind:

- Three bare TODOs remain, each owned by its own issue: `nip07_service.dart` (#7245), `bug_report_service.dart` (#7244), `c2pa_signing_service.dart` (#7246).
- Four owner-form TODOs are not `TODO(#issue)` form and no issue covers them: `openvine_media_cache.dart` (`TODO(any)`), `draft_storage_service.dart` and `clip_library_service.dart` (`TODO(hm21)`), `native_proofmode_service.dart` (`TODO(n8fr8)`). Converting those is a separate call, not this cleanup.

`service_god_file_sizes.txt` was **not** regenerated. The guard only fails on growth, and regenerating would pull in unrelated shrinks from other PRs.

## Verification

Run from `mobile/`:

- `dart format --output=none --set-exit-if-changed` on both changed files — 0 changed
- `flutter analyze lib test integration_test` — No issues found
- `flutter test` over 28 suites (`test/services/video_event_service*_test.dart` + `test/services/video_processing_service_test.dart`) — 188 passed, 15 pre-existing skips
- `bash scripts/check_service_god_file_ceiling.sh` — OK, 6 keys tracked, none grew

Not verified on a device: the diff removes only comments, so there is no runtime surface to exercise.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore

