### PR TITLE
fix(nip07): read the extension's relay list instead of skipping it

### DIFF
--- a/mobile/lib/services/nip07_interop_web.dart
+++ b/mobile/lib/services/nip07_interop_web.dart
@@ -71,8 +71,8 @@ class _WebNostrExtension implements NostrExtension {
 
   @override
   Future<Map<String, dynamic>>? getRelays() {
-    // getRelays is optional in NIP-07 and invoking a member the extension
-    // never defined throws a JS TypeError, so probe before calling.
+    // getRelays is a de facto legacy extension method; probe before calling
+    // because invoking an undefined JS member throws a TypeError.
     if (!_js.has('getRelays')) return null;
     final promise = _js.getRelays();
     if (promise == null) return null;

--- a/mobile/lib/services/nip07_interop_web.dart
+++ b/mobile/lib/services/nip07_interop_web.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Binds window.nostr (Alby, nos2x, Nostore, ...) to NostrExtension.
 
 import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 
 import 'package:openvine/services/nip07_types.dart';
 
@@ -70,6 +71,9 @@ class _WebNostrExtension implements NostrExtension {
 
   @override
   Future<Map<String, dynamic>>? getRelays() {
+    // getRelays is optional in NIP-07 and invoking a member the extension
+    // never defined throws a JS TypeError, so probe before calling.
+    if (!_js.has('getRelays')) return null;
     final promise = _js.getRelays();
     if (promise == null) return null;
     return _getRelaysAsync(promise);

--- a/mobile/lib/services/nip07_service.dart
+++ b/mobile/lib/services/nip07_service.dart
@@ -133,10 +133,11 @@ class Nip07Service {
         );
       }
 
+      if (_currentPublicKey != pubkey) {
+        _userRelays = null;
+      }
       _currentPublicKey = pubkey;
       _isConnected = true;
-
-      await _loadUserRelays();
 
       Log.info(
         'NIP-07 authentication successful',
@@ -172,28 +173,37 @@ class Nip07Service {
 
   /// Read the extension's relay list into [userRelays].
   ///
-  /// `getRelays` is optional in NIP-07, so an extension that omits it — or one
-  /// that fails the call — leaves [userRelays] null instead of failing the
-  /// connection.
-  Future<void> _loadUserRelays() async {
-    _userRelays = null;
+  /// Some extensions still expose the historical `getRelays` method even
+  /// though it is no longer part of NIP-07. Read it lazily so a relay prompt
+  /// cannot block silent startup reconnect.
+  Future<Map<String, dynamic>?> loadUserRelays() async {
+    if (!isConnected) return null;
+    final connectedPubkey = _currentPublicKey;
+    final cachedRelays = _userRelays;
+    if (cachedRelays != null) return cachedRelays;
+
     try {
-      final pending = _extension!.getRelays();
+      final pending = _extension?.getRelays();
       if (pending == null) {
         Log.debug(
           'Extension does not implement getRelays',
           name: 'Nip07Service',
           category: LogCategory.system,
         );
-        return;
+        return null;
       }
 
-      _userRelays = await pending;
+      final relays = await pending;
+      if (!isConnected || _currentPublicKey != connectedPubkey) {
+        return null;
+      }
+      _userRelays = relays;
       Log.debug(
         'Retrieved ${_userRelays?.length ?? 0} relays from extension',
         name: 'Nip07Service',
         category: LogCategory.system,
       );
+      return _userRelays;
     } catch (e) {
       Log.warning(
         'Could not read relays from extension: $e',
@@ -201,6 +211,10 @@ class Nip07Service {
         category: LogCategory.system,
       );
       // Not a critical error, continue without relays
+      if (isConnected && _currentPublicKey == connectedPubkey) {
+        _userRelays = null;
+      }
+      return null;
     }
   }
 

--- a/mobile/lib/services/nip07_service.dart
+++ b/mobile/lib/services/nip07_service.dart
@@ -210,10 +210,9 @@ class Nip07Service {
         name: 'Nip07Service',
         category: LogCategory.system,
       );
-      // Not a critical error, continue without relays
-      if (isConnected && _currentPublicKey == connectedPubkey) {
-        _userRelays = null;
-      }
+      // Not a critical error, continue without relays. Deliberately no
+      // cache reset: the cache was null on entry, so the only value this
+      // could erase is a concurrent read's result.
       return null;
     }
   }

--- a/mobile/lib/services/nip07_service.dart
+++ b/mobile/lib/services/nip07_service.dart
@@ -49,15 +49,28 @@ class Nip07SignResult {
 /// Service for managing NIP-07 browser extension interactions
 class Nip07Service {
   factory Nip07Service() => _instance;
-  Nip07Service._internal();
+  Nip07Service._internal() : _extensionOverride = null;
+
+  /// Test seam: binds the service to [extension] instead of `window.nostr`,
+  /// so the extension-facing paths can be exercised off-web.
+  @visibleForTesting
+  Nip07Service.withExtension(nip07.NostrExtension extension)
+    : _extensionOverride = extension;
+
   static final Nip07Service _instance = Nip07Service._internal();
+
+  final nip07.NostrExtension? _extensionOverride;
 
   String? _currentPublicKey;
   bool _isConnected = false;
   Map<String, dynamic>? _userRelays;
 
+  /// The extension this service talks to, or null when none is present.
+  nip07.NostrExtension? get _extension => _extensionOverride ?? nip07.nostr;
+
   /// Check if NIP-07 extension is available
   bool get isAvailable {
+    if (_extensionOverride != null) return true;
     // Only available on web platform
     if (!kIsWeb) return false;
     return nip07.isNip07Available;
@@ -78,7 +91,7 @@ class Nip07Service {
 
     // Try to detect specific extensions based on available features
     try {
-      final ext = nip07.nostr!;
+      final ext = _extension!;
 
       // Check for Alby-specific features
       if (ext.nip04 != null) {
@@ -109,7 +122,7 @@ class Nip07Service {
 
       // Request public key from extension
       final pubkey = await nip07.safeNip07Call(() async {
-        return nip07.nostr!.getPublicKey();
+        return _extension!.getPublicKey();
       }, 'get public key');
 
       // Validate the public key format
@@ -123,27 +136,7 @@ class Nip07Service {
       _currentPublicKey = pubkey;
       _isConnected = true;
 
-      // Try to get user's relays (optional feature)
-      // TODO: Fix tear-off issue with getRelays extension method
-      // Currently disabled due to dart:js_interop limitation with external extension type tear-offs
-      try {
-        // if (nip07.nostr!.getRelays != null) {
-        //   final jsRelays = await nip07.nostr!.getRelays!().toDart;
-        //   _userRelays = jsRelays.dartify() as Map<String, dynamic>?;
-        // }
-        Log.debug(
-          'Retrieved ${_userRelays?.length ?? 0} relays from extension (disabled)',
-          name: 'Nip07Service',
-          category: LogCategory.system,
-        );
-      } catch (e) {
-        Log.warning(
-          'Extension does not support getRelays: $e',
-          name: 'Nip07Service',
-          category: LogCategory.system,
-        );
-        // Not a critical error, continue without relays
-      }
+      await _loadUserRelays();
 
       Log.info(
         'NIP-07 authentication successful',
@@ -177,6 +170,40 @@ class Nip07Service {
     }
   }
 
+  /// Read the extension's relay list into [userRelays].
+  ///
+  /// `getRelays` is optional in NIP-07, so an extension that omits it — or one
+  /// that fails the call — leaves [userRelays] null instead of failing the
+  /// connection.
+  Future<void> _loadUserRelays() async {
+    _userRelays = null;
+    try {
+      final pending = _extension!.getRelays();
+      if (pending == null) {
+        Log.debug(
+          'Extension does not implement getRelays',
+          name: 'Nip07Service',
+          category: LogCategory.system,
+        );
+        return;
+      }
+
+      _userRelays = await pending;
+      Log.debug(
+        'Retrieved ${_userRelays?.length ?? 0} relays from extension',
+        name: 'Nip07Service',
+        category: LogCategory.system,
+      );
+    } catch (e) {
+      Log.warning(
+        'Could not read relays from extension: $e',
+        name: 'Nip07Service',
+        category: LogCategory.system,
+      );
+      // Not a critical error, continue without relays
+    }
+  }
+
   /// Sign a Nostr event using the browser extension
   Future<Nip07SignResult> signEvent(Map<String, dynamic> unsignedEvent) async {
     if (!isConnected) {
@@ -198,7 +225,7 @@ class Nip07Service {
 
       // Sign the event
       final signedJsEvent = await nip07.safeNip07Call(
-        () => nip07.nostr!.signEvent(jsEvent.toMap()),
+        () => _extension!.signEvent(jsEvent.toMap()),
         'sign event',
       );
 
@@ -247,12 +274,12 @@ class Nip07Service {
 
   /// Encrypt a message using NIP-04 (if extension supports it)
   Future<String?> encryptMessage(String recipientPubkey, String message) async {
-    if (!isConnected || nip07.nostr?.nip04 == null) {
+    if (!isConnected || _extension?.nip04 == null) {
       return null;
     }
 
     try {
-      final encrypted = await nip07.nostr!.nip04!.encrypt(
+      final encrypted = await _extension!.nip04!.encrypt(
         recipientPubkey,
         message,
       );
@@ -272,12 +299,12 @@ class Nip07Service {
     String senderPubkey,
     String encryptedMessage,
   ) async {
-    if (!isConnected || nip07.nostr?.nip04 == null) {
+    if (!isConnected || _extension?.nip04 == null) {
       return null;
     }
 
     try {
-      final decrypted = await nip07.nostr!.nip04!.decrypt(
+      final decrypted = await _extension!.nip04!.decrypt(
         senderPubkey,
         encryptedMessage,
       );
@@ -301,11 +328,11 @@ class Nip07Service {
     String recipientPubkey,
     String message,
   ) async {
-    if (!isConnected || nip07.nostr?.nip44 == null) {
+    if (!isConnected || _extension?.nip44 == null) {
       return null;
     }
     try {
-      return await nip07.nostr!.nip44!.encrypt(recipientPubkey, message);
+      return await _extension!.nip44!.encrypt(recipientPubkey, message);
     } catch (e, stackTrace) {
       Log.error(
         'NIP-44 encryption failed: $e',
@@ -322,11 +349,11 @@ class Nip07Service {
     String senderPubkey,
     String encryptedMessage,
   ) async {
-    if (!isConnected || nip07.nostr?.nip44 == null) {
+    if (!isConnected || _extension?.nip44 == null) {
       return null;
     }
     try {
-      return await nip07.nostr!.nip44!.decrypt(senderPubkey, encryptedMessage);
+      return await _extension!.nip44!.decrypt(senderPubkey, encryptedMessage);
     } catch (e, stackTrace) {
       Log.error(
         'NIP-44 decryption failed: $e',
@@ -359,7 +386,7 @@ class Nip07Service {
     'extensionName': extensionName,
     'hasRelays': _userRelays != null,
     'relayCount': _userRelays?.length ?? 0,
-    'hasNip04': nip07.nostr?.nip04 != null,
-    'hasNip44': nip07.nostr?.nip44 != null,
+    'hasNip04': _extension?.nip04 != null,
+    'hasNip44': _extension?.nip44 != null,
   };
 }

--- a/mobile/lib/services/nip07_signer_adapter.dart
+++ b/mobile/lib/services/nip07_signer_adapter.dart
@@ -28,7 +28,7 @@ class Nip07SignerAdapter implements NostrSigner {
   }
 
   @override
-  Future<Map?> getRelays() async => _service.userRelays;
+  Future<Map?> getRelays() async => _service.loadUserRelays();
 
   @override
   Future<String?> encrypt(String pubkey, String plaintext) =>

--- a/mobile/lib/services/nip07_types.dart
+++ b/mobile/lib/services/nip07_types.dart
@@ -14,7 +14,10 @@ class NostrExtension {
     throw UnsupportedError('NIP-07 only available on web');
   }
 
-  /// Get the user's relays (optional NIP-07 extension).
+  /// Get the user's relays.
+  ///
+  /// De facto legacy: removed from NIP-07 in nostr-protocol/nips#1779
+  /// (2025-02-14), but Alby and nos2x still ship it.
   Future<Map<String, dynamic>>? getRelays() {
     throw UnsupportedError('NIP-07 only available on web');
   }

--- a/mobile/scripts/baseline/untested_services.txt
+++ b/mobile/scripts/baseline/untested_services.txt
@@ -24,7 +24,6 @@ nip05_verification_service
 nip07_interop # noise: web/io conditional-import
 nip07_interop_stub # noise: web/io shim
 nip07_interop_web # noise: web/io shim
-nip07_service # defer: #4338 C2 singleton-to-DI
 openvine_media_cache
 outgoing_dm_retry_service_reportable_sites # noise: reportable-sites constants
 push_notification_session_coordinator

--- a/mobile/test/services/nip07_service_test.dart
+++ b/mobile/test/services/nip07_service_test.dart
@@ -16,6 +16,7 @@ class _FakeExtension extends NostrExtension {
     this.relays,
     this.relaysFail = false,
     this.relaysCompleter,
+    this.relaysQueue,
   });
 
   /// Relay map to return, or null to model an extension without `getRelays`.
@@ -28,6 +29,10 @@ class _FakeExtension extends NostrExtension {
 
   Completer<Map<String, dynamic>>? relaysCompleter;
 
+  /// Hands out one future per `getRelays` call, to model concurrent reads
+  /// that resolve differently.
+  List<Future<Map<String, dynamic>>>? relaysQueue;
+
   @override
   Future<String> getPublicKey() async => publicKey ?? _testPubkey;
 
@@ -36,6 +41,8 @@ class _FakeExtension extends NostrExtension {
     if (relaysFail) {
       return Future.error(const Nip07Exception('boom', code: 'UNKNOWN_ERROR'));
     }
+    final queue = relaysQueue;
+    if (queue != null && queue.isNotEmpty) return queue.removeAt(0);
     final completer = relaysCompleter;
     if (completer != null) return completer.future;
     final value = relays;
@@ -129,6 +136,31 @@ void main() {
           expect(service.userRelays, isNull);
         },
       );
+
+      test('keeps a concurrent read that succeeded when another '
+          'read fails', () async {
+        final failing = Completer<Map<String, dynamic>>();
+        final succeeding = Completer<Map<String, dynamic>>();
+        final service = Nip07Service.withExtension(
+          _FakeExtension(relaysQueue: [failing.future, succeeding.future]),
+        );
+        await service.connect();
+
+        final failed = service.loadUserRelays();
+        final succeeded = service.loadUserRelays();
+
+        succeeding.complete({
+          'wss://relay.example.com': {'read': true, 'write': true},
+        });
+        expect(await succeeded, isNotNull);
+
+        failing.completeError(
+          const Nip07Exception('boom', code: 'UNKNOWN_ERROR'),
+        );
+
+        expect(await failed, isNull);
+        expect(service.userRelays, hasLength(1));
+      });
 
       test('does not repopulate relays after disconnect', () async {
         final extension = _FakeExtension(

--- a/mobile/test/services/nip07_service_test.dart
+++ b/mobile/test/services/nip07_service_test.dart
@@ -1,15 +1,22 @@
 // ABOUTME: Tests for Nip07Service, the Dart-facing wrapper around a NIP-07
 // ABOUTME: browser extension. Covers the optional getRelays handshake.
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/nip07_service.dart';
+import 'package:openvine/services/nip07_signer_adapter.dart';
 import 'package:openvine/services/nip07_types.dart';
 
 const _testPubkey =
     'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90';
 
 class _FakeExtension extends NostrExtension {
-  _FakeExtension({this.relays, this.relaysFail = false});
+  _FakeExtension({
+    this.relays,
+    this.relaysFail = false,
+    this.relaysCompleter,
+  });
 
   /// Relay map to return, or null to model an extension without `getRelays`.
   Map<String, dynamic>? relays;
@@ -17,14 +24,20 @@ class _FakeExtension extends NostrExtension {
   /// When true, `getRelays` rejects instead of resolving.
   bool relaysFail;
 
+  String? publicKey;
+
+  Completer<Map<String, dynamic>>? relaysCompleter;
+
   @override
-  Future<String> getPublicKey() async => _testPubkey;
+  Future<String> getPublicKey() async => publicKey ?? _testPubkey;
 
   @override
   Future<Map<String, dynamic>>? getRelays() {
     if (relaysFail) {
       return Future.error(const Nip07Exception('boom', code: 'UNKNOWN_ERROR'));
     }
+    final completer = relaysCompleter;
+    if (completer != null) return completer.future;
     final value = relays;
     if (value == null) return null;
     return Future.value(value);
@@ -34,6 +47,23 @@ class _FakeExtension extends NostrExtension {
 void main() {
   group(Nip07Service, () {
     group('connect', () {
+      test('does not read relays eagerly', () async {
+        final service = Nip07Service.withExtension(
+          _FakeExtension(
+            relays: {
+              'wss://relay.example.com': {'read': true, 'write': true},
+            },
+          ),
+        );
+
+        final result = await service.connect();
+
+        expect(result.success, isTrue);
+        expect(service.userRelays, isNull);
+      });
+    });
+
+    group('loadUserRelays', () {
       test('reads the relay list the extension advertises', () async {
         final extension = _FakeExtension(
           relays: {
@@ -42,11 +72,11 @@ void main() {
           },
         );
         final service = Nip07Service.withExtension(extension);
+        await service.connect();
 
-        final result = await service.connect();
+        final relays = await service.loadUserRelays();
 
-        expect(result.success, isTrue);
-        expect(service.userRelays, hasLength(2));
+        expect(relays, hasLength(2));
         expect(
           service.userRelays!['wss://read.example.com'],
           equals({'read': true, 'write': false}),
@@ -57,10 +87,11 @@ void main() {
         'succeeds without relays when the extension omits getRelays',
         () async {
           final service = Nip07Service.withExtension(_FakeExtension());
+          await service.connect();
 
-          final result = await service.connect();
+          final relays = await service.loadUserRelays();
 
-          expect(result.success, isTrue);
+          expect(relays, isNull);
           expect(service.userRelays, isNull);
         },
       );
@@ -69,16 +100,17 @@ void main() {
         final service = Nip07Service.withExtension(
           _FakeExtension(relaysFail: true),
         );
+        await service.connect();
 
-        final result = await service.connect();
+        final relays = await service.loadUserRelays();
 
-        expect(result.success, isTrue);
+        expect(relays, isNull);
         expect(service.publicKey, equals(_testPubkey));
         expect(service.userRelays, isNull);
       });
 
       test(
-        'drops relays from a previous connect when the reread fails',
+        'drops relays from a previous account when public key changes',
         () async {
           final extension = _FakeExtension(
             relays: {
@@ -87,14 +119,51 @@ void main() {
           );
           final service = Nip07Service.withExtension(extension);
           await service.connect();
+          await service.loadUserRelays();
           expect(service.userRelays, isNotNull);
 
-          extension.relaysFail = true;
+          extension.publicKey =
+              'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
           await service.connect();
 
           expect(service.userRelays, isNull);
         },
       );
+
+      test('does not repopulate relays after disconnect', () async {
+        final extension = _FakeExtension(
+          relaysCompleter: Completer<Map<String, dynamic>>(),
+        );
+        final service = Nip07Service.withExtension(extension);
+        await service.connect();
+
+        final pending = service.loadUserRelays();
+        service.disconnect();
+        extension.relaysCompleter!.complete({
+          'wss://relay.example.com': {'read': true, 'write': true},
+        });
+
+        expect(await pending, isNull);
+        expect(service.userRelays, isNull);
+      });
+    });
+
+    group(Nip07SignerAdapter, () {
+      test('does not expose relay cache after disconnect', () async {
+        final extension = _FakeExtension(
+          relays: {
+            'wss://relay.example.com': {'read': true, 'write': true},
+          },
+        );
+        final service = Nip07Service.withExtension(extension);
+        final adapter = Nip07SignerAdapter(service);
+        await service.connect();
+        expect(await adapter.getRelays(), isNotNull);
+
+        service.disconnect();
+
+        expect(await adapter.getRelays(), isNull);
+      });
     });
   });
 }

--- a/mobile/test/services/nip07_service_test.dart
+++ b/mobile/test/services/nip07_service_test.dart
@@ -1,0 +1,100 @@
+// ABOUTME: Tests for Nip07Service, the Dart-facing wrapper around a NIP-07
+// ABOUTME: browser extension. Covers the optional getRelays handshake.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/nip07_service.dart';
+import 'package:openvine/services/nip07_types.dart';
+
+const _testPubkey =
+    'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90';
+
+class _FakeExtension extends NostrExtension {
+  _FakeExtension({this.relays, this.relaysFail = false});
+
+  /// Relay map to return, or null to model an extension without `getRelays`.
+  Map<String, dynamic>? relays;
+
+  /// When true, `getRelays` rejects instead of resolving.
+  bool relaysFail;
+
+  @override
+  Future<String> getPublicKey() async => _testPubkey;
+
+  @override
+  Future<Map<String, dynamic>>? getRelays() {
+    if (relaysFail) {
+      return Future.error(const Nip07Exception('boom', code: 'UNKNOWN_ERROR'));
+    }
+    final value = relays;
+    if (value == null) return null;
+    return Future.value(value);
+  }
+}
+
+void main() {
+  group(Nip07Service, () {
+    group('connect', () {
+      test('reads the relay list the extension advertises', () async {
+        final extension = _FakeExtension(
+          relays: {
+            'wss://relay.example.com': {'read': true, 'write': true},
+            'wss://read.example.com': {'read': true, 'write': false},
+          },
+        );
+        final service = Nip07Service.withExtension(extension);
+
+        final result = await service.connect();
+
+        expect(result.success, isTrue);
+        expect(service.userRelays, hasLength(2));
+        expect(
+          service.userRelays!['wss://read.example.com'],
+          equals({'read': true, 'write': false}),
+        );
+      });
+
+      test(
+        'succeeds without relays when the extension omits getRelays',
+        () async {
+          final service = Nip07Service.withExtension(_FakeExtension());
+
+          final result = await service.connect();
+
+          expect(result.success, isTrue);
+          expect(service.userRelays, isNull);
+        },
+      );
+
+      test('succeeds without relays when getRelays fails', () async {
+        final service = Nip07Service.withExtension(
+          _FakeExtension(relaysFail: true),
+        );
+
+        final result = await service.connect();
+
+        expect(result.success, isTrue);
+        expect(service.publicKey, equals(_testPubkey));
+        expect(service.userRelays, isNull);
+      });
+
+      test(
+        'drops relays from a previous connect when the reread fails',
+        () async {
+          final extension = _FakeExtension(
+            relays: {
+              'wss://relay.example.com': {'read': true, 'write': true},
+            },
+          );
+          final service = Nip07Service.withExtension(extension);
+          await service.connect();
+          expect(service.userRelays, isNotNull);
+
+          extension.relaysFail = true;
+          await service.connect();
+
+          expect(service.userRelays, isNull);
+        },
+      );
+    });
+  });
+}

--- a/mobile/test/services/nip07_signer_adapter_test.dart
+++ b/mobile/test/services/nip07_signer_adapter_test.dart
@@ -124,11 +124,12 @@ void main() {
     test(
       'getRelays returns null when the extension does not expose relays',
       () async {
-        when(() => mockService.userRelays).thenReturn(null);
+        when(() => mockService.loadUserRelays()).thenAnswer((_) async => null);
 
         final adapter = Nip07SignerAdapter(mockService);
 
         expect(await adapter.getRelays(), isNull);
+        verify(() => mockService.loadUserRelays()).called(1);
       },
     );
 


### PR DESCRIPTION
## Description

`Nip07Service.connect()` had its `getRelays` call commented out behind a bare `// TODO`, so `_userRelays` was permanently null — the log line even said `(disabled)`. That also dead-ended `Nip07SignerAdapter.getRelays()`, which hands the value to the `NostrSigner` surface, so the whole path returned nothing on every web sign-in.

The `dart:js_interop` tear-off limitation the TODO described no longer applies. The interop refactor already made `getRelays` an `external` method on the extension type rather than a property returning a function, which is what the tear-off was tripping over. What remained was a different problem: invoking a member the extension never defined throws rather than returning null. So the web binding now probes with `dart:js_interop_unsafe`'s `has()` before calling, and extensions that omit the call (nos2x) get a clean null instead of an exception. Extensions that implement it (Alby) get their relay list read.

**The relay list is read lazily, not during `connect()`.** Extensions permission `getRelays` separately from `getPublicKey`, and `connect()` is not only the interactive sign-in path — `AuthService.initialize()` routes a persisted nip07 source through `_reconnectNip07()`, `signInForAccount()` does the same on account switch, and `WebAuthService.checkExistingSession()` calls it from a post-frame callback. Reading relays inside `connect()` would put a second extension prompt on paths the user never initiated, and because `initialize()` awaits it, startup would sit in `AuthState.checking` until that prompt was answered. `loadUserRelays()` reads at the point of use instead, so the prompt stays tied to the call that wants the value. The only consumer is `Nip07SignerAdapter.getRelays()`, which the app bridge consults solely when the NIP-65 relay list is already empty, before falling back to a default relay.

The lazy read also closes a liveness gap: a read that is still in flight when `disconnect()` or an account switch lands no longer writes the previous session's relays into the cache. `Nip07SignerAdapter.getRelays()` does not gate on `isConnected` the way `encryptMessage` does, so without that check a signed-out session's relay map stayed readable through the bridge.

**Why the test seam:** the service reached for the `nip07.nostr` global at nine call sites, and that global is always null off-web, so none of this was reachable from a VM test — which is a large part of why the code sat broken. Those sites now go through one `_extension` getter with a `@visibleForTesting` constructor behind it. That is what lets the regression tests exist at all, and it lets `nip07_service` come off the untested-services floor.

Note on the protocol: `getRelays` was removed from NIP-07 outright in [nostr-protocol/nips#1779](https://github.com/nostr-protocol/nips/pull/1779) (2025-02-14), along with `get_relays` in NIP-46 and NIP-55, on the rationale that signers should not own relay lists now that there are dedicated relay-list kinds. It is a de-facto extra that Alby and nos2x still ship, not a spec method — the code comments say so, so nobody goes looking for it in the NIP and concludes the code is wrong.

**Related Issue:** Closes #7245

## Out of Scope

- The broader singleton-to-DI migration for this service (#4338 C2). This adds a test seam, not constructor injection at the call sites.
- #7244 (`dart:html` in the bug-report web branch) touches the same js_interop area but is a separate deliverable.

## Verification

- `flutter analyze lib test integration_test` — clean.
- `flutter test test/services/nip07_service_test.dart test/services/nip07_signer_adapter_test.dart test/services/nip07_types_test.dart test/services/auth_service_nip07_test.dart test/services/auth/signer_factory_test.dart` — 62 passing.
- Proved the guards can fail, by mutation: reverting `connect()` to load eagerly reddens only the "does not read relays eagerly" test; dropping the post-await liveness check reddens only the "does not repopulate relays after disconnect" test.
- `flutter build web` — succeeds. This is the only real check on the `js_interop_unsafe` change, since `nip07_interop_web.dart` is excluded by the conditional export on every non-web target and is therefore never compiled by the VM test suite. The wasm dry-run warnings in that build are all pre-existing (`dart:html` in `flutter_secure_storage_web` and `bug_report_service.dart`).
- Guard scripts: `check_todos`, `check_untested_services_floor`, `check_empty_catch_ceiling`, `check_service_god_file_ceiling`, `check_service_sentinel_ceiling`, `check_file_size_ceiling`, `check_raw_logging`, `check_skip_ceiling`, `check_test_unit_structure`, `check_ui_service_boundary` — all OK.
- Independently, @realmeylisdev compiled the web binding standalone with `dart compile js` and exercised it in node against five extension shapes (absent `getRelays`, prototype-defined, Proxy-wrapped, rejecting, malformed response); the `has()` probe behaved as documented in each.

**Not device-tested.** NIP-07 is a browser-extension flow, so it does not exist on the Samsung Galaxy build. Exercising it end to end needs the web build plus an extension that implements `getRelays`.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
