### PR TITLE
fix(likes): resolve the "Liked by" list through funnelcake so edits cannot strand likers

### DIFF
--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -607,6 +607,8 @@ VideosRepository videosRepository(Ref ref) {
 /// Uses:
 /// - NostrClient from nostrServiceProvider (for relay communication)
 /// - PersonalReactionsDao from databaseProvider (for local storage)
+/// - FunnelcakeApiClient for the "Liked by" list, which resolves the whole
+///   addressable coordinate rather than one revision id (#6021)
 @Riverpod(keepAlive: true)
 LikesRepository likesRepository(Ref ref) {
   final authService = ref.watch(authServiceProvider);
@@ -638,6 +640,7 @@ LikesRepository likesRepository(Ref ref) {
     nostrClient: nostrClient,
     localStorage: localStorage,
     blockFilter: createBlockedAuthorFilter(ref),
+    funnelcakeApiClient: ref.watch(funnelcakeApiClientProvider),
     errorReporter: (error, stackTrace, {required site}) {
       unawaited(
         CrashReportingService.instance.recordError(

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -963,6 +963,8 @@ String _$videosRepositoryHash() => r'44fb1b8a6951fbad33b2b95047ec9e7edbb65c54';
 /// Uses:
 /// - NostrClient from nostrServiceProvider (for relay communication)
 /// - PersonalReactionsDao from databaseProvider (for local storage)
+/// - FunnelcakeApiClient for the "Liked by" list, which resolves the whole
+///   addressable coordinate rather than one revision id (#6021)
 
 @ProviderFor(likesRepository)
 final likesRepositoryProvider = LikesRepositoryProvider._();
@@ -975,6 +977,8 @@ final likesRepositoryProvider = LikesRepositoryProvider._();
 /// Uses:
 /// - NostrClient from nostrServiceProvider (for relay communication)
 /// - PersonalReactionsDao from databaseProvider (for local storage)
+/// - FunnelcakeApiClient for the "Liked by" list, which resolves the whole
+///   addressable coordinate rather than one revision id (#6021)
 
 final class LikesRepositoryProvider
     extends
@@ -988,6 +992,8 @@ final class LikesRepositoryProvider
   /// Uses:
   /// - NostrClient from nostrServiceProvider (for relay communication)
   /// - PersonalReactionsDao from databaseProvider (for local storage)
+  /// - FunnelcakeApiClient for the "Liked by" list, which resolves the whole
+  ///   addressable coordinate rather than one revision id (#6021)
   LikesRepositoryProvider._()
     : super(
         from: null,
@@ -1021,4 +1027,4 @@ final class LikesRepositoryProvider
   }
 }
 
-String _$likesRepositoryHash() => r'd8126449ef36a6be85a7a2bb01f052f0ccb1f315';
+String _$likesRepositoryHash() => r'19f00b27d5baa76a2990616ebdc1251a48bfcdb9';

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -67,6 +67,13 @@ class FunnelcakeApiClient {
   /// Default moderation profile sent with video-bearing Funnelcake requests.
   static const String defaultModerationProfile = 'default';
 
+  /// Server-side cap on the engagement-list endpoints, used as the default
+  /// page size for [getVideoLikers] because the list renders in one screen.
+  ///
+  /// Larger values are clamped to this by the API, so a video with more
+  /// likers is truncated here rather than paginated.
+  static const int maxVideoLikersLimit = 500;
+
   static const Set<String> _diagnosticStructuralKeys = {
     'categories',
     'data',
@@ -1681,6 +1688,78 @@ class FunnelcakeApiClient {
       rethrow;
     } catch (e) {
       throw FunnelcakeException('Failed to fetch video stats: $e');
+    }
+  }
+
+  /// Fetches the pubkeys that have liked a video, most recent first.
+  ///
+  /// [eventId] is the Nostr event ID (or d-tag) for the video.
+  /// [addressableId] is the optional `kind:pubkey:d-tag` coordinate; the
+  /// server resolves one itself when omitted, and an explicit value wins.
+  /// [limit] is clamped server-side to [maxVideoLikersLimit].
+  ///
+  /// Resolves the whole NIP-33 coordinate, not just the id passed in: the
+  /// `e`-tag arm expands across every sibling revision, so reactions left on
+  /// a superseded id before an edit are still returned (funnelcake#799).
+  /// Downvotes, same-author kind-5 retractions, and moderated accounts are
+  /// filtered out server-side, and pubkeys are deduplicated — so the result
+  /// is smaller than the headline reaction count, which counts every
+  /// reaction event.
+  ///
+  /// Throws:
+  /// - [FunnelcakeNotConfiguredException] if the API is not
+  ///   configured.
+  /// - [FunnelcakeException] if the event ID is empty.
+  /// - [FunnelcakeNotFoundException] if the video is unknown to the API.
+  /// - [FunnelcakeApiException] if the request fails.
+  /// - [FunnelcakeTimeoutException] if the request times out.
+  /// - [FunnelcakeException] for other errors.
+  Future<PaginatedPubkeys> getVideoLikers(
+    String eventId, {
+    String? addressableId,
+    int limit = maxVideoLikersLimit,
+  }) async {
+    if (!isAvailable) {
+      throw const FunnelcakeNotConfiguredException();
+    }
+
+    if (eventId.isEmpty) {
+      throw const FunnelcakeException('Event ID cannot be empty');
+    }
+
+    final queryParams = <String, String>{'limit': limit.toString()};
+    if (addressableId != null && addressableId.isNotEmpty) {
+      queryParams['a'] = addressableId;
+    }
+
+    final uri = Uri.parse(
+      '$_baseUrl/api/videos/$eventId/likers',
+    ).replace(queryParameters: queryParams);
+
+    try {
+      final response = await _get(uri);
+
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        return PaginatedPubkeys.fromJson(data);
+      } else if (response.statusCode == 404) {
+        throw FunnelcakeNotFoundException(
+          resource: 'Video likers',
+          url: uri.toString(),
+        );
+      } else {
+        throw FunnelcakeApiException(
+          message: 'Failed to fetch video likers',
+          statusCode: response.statusCode,
+          url: uri.toString(),
+        );
+      }
+    } on TimeoutException {
+      throw FunnelcakeTimeoutException(uri.toString());
+    } on FunnelcakeException {
+      rethrow;
+    } catch (e) {
+      throw FunnelcakeException('Failed to fetch video likers: $e');
     }
   }
 

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -3242,6 +3242,147 @@ void main() {
       });
     });
 
+    group('getVideoLikers', () {
+      const testEventId =
+          'abcdef1234567890abcdef1234567890'
+          'abcdef1234567890abcdef1234567890';
+      const addressableId = '34236:$testPubkey:d-tag';
+
+      const likersResponse = '''
+{
+  "data": [
+    {"pubkey": "liker1", "created_at": 1700000100, "event_id": "reaction1"},
+    {"pubkey": "liker2", "created_at": 1700000000, "event_id": "reaction2"}
+  ],
+  "pagination": {"next_cursor": null, "has_more": false}
+}
+''';
+
+      test('returns liker pubkeys in server order', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response(likersResponse, 200));
+
+        final likers = await client.getVideoLikers(testEventId);
+
+        expect(likers.pubkeys, equals(['liker1', 'liker2']));
+        expect(likers.hasMore, isFalse);
+      });
+
+      test('constructs correct URL with the server-max limit', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response(likersResponse, 200));
+
+        await client.getVideoLikers(testEventId);
+
+        final captured = verify(
+          () =>
+              mockHttpClient.get(captureAny(), headers: any(named: 'headers')),
+        ).captured;
+
+        final uri = captured.first as Uri;
+        expect(uri.path, equals('/api/videos/$testEventId/likers'));
+        expect(
+          uri.queryParameters['limit'],
+          equals('${FunnelcakeApiClient.maxVideoLikersLimit}'),
+        );
+        expect(uri.queryParameters.containsKey('a'), isFalse);
+      });
+
+      test('sends the addressable coordinate as the a parameter', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response(likersResponse, 200));
+
+        await client.getVideoLikers(testEventId, addressableId: addressableId);
+
+        final captured = verify(
+          () =>
+              mockHttpClient.get(captureAny(), headers: any(named: 'headers')),
+        ).captured;
+
+        final uri = captured.first as Uri;
+        expect(uri.queryParameters['a'], equals(addressableId));
+      });
+
+      test('omits the a parameter when the coordinate is blank', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response(likersResponse, 200));
+
+        await client.getVideoLikers(testEventId, addressableId: '');
+
+        final captured = verify(
+          () =>
+              mockHttpClient.get(captureAny(), headers: any(named: 'headers')),
+        ).captured;
+
+        final uri = captured.first as Uri;
+        expect(uri.queryParameters.containsKey('a'), isFalse);
+      });
+
+      test('throws FunnelcakeNotFoundException on 404', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response('Video not found', 404));
+
+        expect(
+          () => client.getVideoLikers(testEventId),
+          throwsA(isA<FunnelcakeNotFoundException>()),
+        );
+      });
+
+      test('throws FunnelcakeNotConfiguredException when not available', () {
+        final emptyClient = FunnelcakeApiClient(
+          baseUrl: '',
+          httpClient: mockHttpClient,
+        );
+
+        expect(
+          () => emptyClient.getVideoLikers(testEventId),
+          throwsA(isA<FunnelcakeNotConfiguredException>()),
+        );
+
+        emptyClient.dispose();
+      });
+
+      test('throws FunnelcakeException when event ID is empty', () {
+        expect(
+          () => client.getVideoLikers(''),
+          throwsA(
+            isA<FunnelcakeException>().having(
+              (e) => e.message,
+              'message',
+              contains('Event ID cannot be empty'),
+            ),
+          ),
+        );
+      });
+
+      test('throws FunnelcakeApiException on error status codes', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response('Internal Server Error', 500));
+
+        expect(
+          () => client.getVideoLikers(testEventId),
+          throwsA(isA<FunnelcakeApiException>()),
+        );
+      });
+
+      test('throws FunnelcakeTimeoutException on timeout', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => throw TimeoutException('Request timed out'));
+
+        expect(
+          () => client.getVideoLikers(testEventId),
+          throwsA(isA<FunnelcakeTimeoutException>()),
+        );
+      });
+    });
+
     group('getVideoViews', () {
       const testEventId =
           'abcdef1234567890abcdef1234567890'
@@ -4804,11 +4945,9 @@ void main() {
         },
       );
 
-      test(
-        'returns UserProfileFound for has_vanish_request with populated '
-        'profile',
-        () async {
-          const response = '''
+      test('returns UserProfileFound for has_vanish_request with populated '
+          'profile', () async {
+        const response = '''
 {
   "users": [
     {
@@ -4819,24 +4958,23 @@ void main() {
   ]
 }
 ''';
-          when(
-            () => mockHttpClient.post(
-              any(),
-              headers: any(named: 'headers'),
-              body: any(named: 'body'),
-            ),
-          ).thenAnswer((_) async => http.Response(response, 200));
+        when(
+          () => mockHttpClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer((_) async => http.Response(response, 200));
 
-          final result = await client.getBulkProfiles(['pub1']);
+        final result = await client.getBulkProfiles(['pub1']);
 
-          expect(result.profiles, hasLength(1));
-          expect(result.profiles['pub1'], isA<UserProfileFound>());
-          expect(
-            (result.profiles['pub1']! as UserProfileFound).profile.name,
-            equals('Restored'),
-          );
-        },
-      );
+        expect(result.profiles, hasLength(1));
+        expect(result.profiles['pub1'], isA<UserProfileFound>());
+        expect(
+          (result.profiles['pub1']! as UserProfileFound).profile.name,
+          equals('Restored'),
+        );
+      });
 
       test(
         'returns UserProfileNotPublished for users with all-null profile',

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -7,6 +7,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:likes_repository/src/blocked_liker_filter.dart';
 import 'package:likes_repository/src/exceptions.dart';
 import 'package:likes_repository/src/likes_local_storage.dart';
@@ -111,6 +112,8 @@ class LikesRepository {
   /// - [queueOfflineAction]: Optional callback to queue actions when offline
   /// - [blockFilter]: Optional callback to hide blocked/muted users from
   ///   engagement lists ([fetchEventLikers])
+  /// - [funnelcakeApiClient]: Optional REST client preferred by
+  ///   [fetchEventLikers], which falls back to relay queries without it
   /// - [errorReporter]: Optional reporter invoked from the best-effort
   ///   local-storage swallow sites when the swallowed failure is a
   ///   programming-invariant violation (see [LikesRepositoryErrorReporter]).
@@ -122,16 +125,21 @@ class LikesRepository {
     IsOnlineCallback? isOnline,
     QueueOfflineActionCallback? queueOfflineAction,
     BlockedLikerFilter? blockFilter,
+    FunnelcakeApiClient? funnelcakeApiClient,
     LikesRepositoryErrorReporter? errorReporter,
   }) : _nostrClient = nostrClient,
        _localStorage = localStorage,
        _isOnline = isOnline,
        _queueOfflineAction = queueOfflineAction,
        _blockFilter = blockFilter,
+       _funnelcakeApiClient = funnelcakeApiClient,
        _errorReporter = errorReporter;
 
   final NostrClient _nostrClient;
   final LikesLocalStorage? _localStorage;
+
+  /// REST client preferred by [fetchEventLikers] over the relay resolver.
+  final FunnelcakeApiClient? _funnelcakeApiClient;
 
   /// Reporter for invariant violations swallowed by the storage paths.
   final LikesRepositoryErrorReporter? _errorReporter;
@@ -1049,11 +1057,13 @@ class LikesRepository {
   /// Returns a cached count when available to avoid redundant relay queries
   /// (e.g. when scrolling back to a previously viewed video). Otherwise
   /// queries relays for the count of Kind 7 reactions on the event.
-  /// When [addressableId] is provided, resolves the same active distinct liker
-  /// set used by [fetchEventLikers], so the visible count and "Liked by" list
-  /// cannot diverge at fetch time for addressable videos. (A cached count is
-  /// served as-is and is not re-resolved, so likes from others arriving after
-  /// the first fetch show up in the live list but not in a cache-served count.)
+  /// When [addressableId] is provided, resolves the active distinct liker set
+  /// from relays.
+  ///
+  /// This is **not** the same set [fetchEventLikers] returns: that now prefers
+  /// Funnelcake, which resolves the whole coordinate and applies server-side
+  /// moderation, so it can legitimately be wider or narrower than this count
+  /// (#6021). The two denominators are reconciled in divine-funnelcake#626.
   ///
   /// Note: This counts all likes, not just the current user's.
   Future<int> getLikeCount(String eventId, {String? addressableId}) async {
@@ -1063,11 +1073,10 @@ class LikesRepository {
     int count;
 
     if (addressableId != null && addressableId.isNotEmpty) {
-      // Resolve the count from the same filtered event fetch as the "Liked by"
-      // list (not NIP-45 COUNT) so the two can't diverge. Trade-off: it shares
-      // the list's relay cap and query timeout, so a video with more reactions
-      // than the relay returns shows count == list, both capped below the true
-      // total. Keep it a fetch (not COUNT) to preserve that equality.
+      // Resolve the count from a filtered event fetch rather than NIP-45
+      // COUNT, so downvotes and retracted reactions are excluded. Trade-off:
+      // it shares the relay cap and query timeout, so a video with more
+      // reactions than the relay returns is capped below the true total.
       final likersByEvent = await _fetchResolvedLikersByEvent(
         [eventId],
         addressableIds: {eventId: addressableId},
@@ -1093,8 +1102,9 @@ class LikesRepository {
   /// Parameters:
   /// - [eventIds]: List of event IDs to get counts for
   /// - [addressableIds]: Optional map of event ID to addressable ID for
-  ///   Kind 30000+ events. When provided, also queries by 'a' tag and
-  ///   counts the active distinct liker set used by [fetchEventLikers].
+  ///   Kind 30000+ events. When provided, also queries by 'a' tag and counts
+  ///   the relay-resolved active distinct liker set — not the possibly wider
+  ///   set [fetchEventLikers] serves from Funnelcake (see [getLikeCount]).
   ///
   /// Note: when any uncached id in the batch has an addressable id, *all*
   /// uncached ids in that batch are counted via the resolved distinct-liker
@@ -1829,30 +1839,46 @@ class LikesRepository {
 
   /// Fetch the list of pubkeys that liked the given video event.
   ///
-  /// Queries Nostr relays for kind 7 (NIP-25) reaction events that reference
-  /// the target event via the `e` tag and (when [addressableId] is provided)
-  /// the `a` tag. Both filters are queried because clients may reference
-  /// addressable Kind 30000+ events using either form, and querying only one
-  /// would miss likers tagged with the other.
+  /// Prefers Funnelcake's `/api/videos/{id}/likers`, falling back to relay
+  /// queries when no client is wired, the API is unreachable, or it answers
+  /// with nobody. The API resolves the target's whole NIP-33 coordinate,
+  /// including superseded revision ids, so it recovers reactions that carry
+  /// no `a` tag and reference only a pre-edit event id — those match neither
+  /// relay filter below (#6021). It also drops accounts the server has
+  /// moderated, which the relay path cannot know about.
   ///
-  /// Filters out:
+  /// The relay fallback queries kind 7 (NIP-25) reactions referencing the
+  /// target via the `e` tag and (when [addressableId] is provided) the `a`
+  /// tag. Both filters are queried because clients may reference addressable
+  /// Kind 30000+ events using either form, and querying only one would miss
+  /// likers tagged with the other.
+  ///
+  /// Either way, the result excludes:
   /// - Reactions with content `'-'` (downvotes)
   /// - Reactions deleted via Kind 5 deletion events from their author
   /// - Likers hidden by the injected block filter (blocked/muted users)
   ///
   /// Pubkeys are deduplicated (a user who liked via both `e` and `a` tags
   /// only appears once) and ordered by reaction recency, most recent first.
+  /// The list is per-liker, so it is legitimately shorter than a reaction
+  /// count — never assert the two are equal.
   ///
   /// Parameters:
   /// - [eventId]: Hex event ID of the target event (required).
   /// - [addressableId]: Optional `kind:pubkey:d-tag` for Kind 30000+ events.
   ///
-  /// Throws [FetchLikersFailedException] if relay queries fail.
+  /// Throws [FetchLikersFailedException] if the relay fallback fails.
   Future<List<String>> fetchEventLikers({
     required String eventId,
     String? addressableId,
   }) async {
     try {
+      final fromApi = await _fetchLikersFromApi(
+        eventId: eventId,
+        addressableId: addressableId,
+      );
+      if (fromApi != null && fromApi.isNotEmpty) return fromApi;
+
       final likersByEvent = await _fetchResolvedLikersByEvent(
         [eventId],
         addressableIds: addressableId == null || addressableId.isEmpty
@@ -1864,6 +1890,38 @@ class LikesRepository {
       throw FetchLikersFailedException(
         'Failed to fetch likers for event $eventId: $e',
       );
+    }
+  }
+
+  /// Likers from Funnelcake, or `null` when the API could not answer.
+  ///
+  /// Every failure degrades to `null` so the relay path still runs — an
+  /// unreachable API must not turn a working screen into an error state.
+  /// Capped at [FunnelcakeApiClient.maxVideoLikersLimit], so a video with
+  /// more likers than that is truncated.
+  Future<List<String>?> _fetchLikersFromApi({
+    required String eventId,
+    String? addressableId,
+  }) async {
+    final client = _funnelcakeApiClient;
+    if (client == null || !client.isAvailable || eventId.isEmpty) return null;
+
+    try {
+      final page = await client.getVideoLikers(
+        eventId,
+        addressableId: addressableId,
+      );
+      final blockFilter = _blockFilter;
+      if (blockFilter == null) return page.pubkeys;
+      return page.pubkeys.where((pubkey) => !blockFilter(pubkey)).toList();
+    } on FunnelcakeException catch (e) {
+      Log.warning(
+        'Funnelcake likers lookup failed for $eventId, '
+        'falling back to relays: $e',
+        name: 'LikesRepository',
+        category: LogCategory.api,
+      );
+      return null;
     }
   }
 

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -1912,8 +1912,12 @@ class LikesRepository {
         addressableId: addressableId,
       );
       final blockFilter = _blockFilter;
-      if (blockFilter == null) return page.pubkeys;
-      return page.pubkeys.where((pubkey) => !blockFilter(pubkey)).toList();
+      final filtered = blockFilter == null
+          ? page.pubkeys
+          : page.pubkeys.where((pubkey) => !blockFilter(pubkey));
+      // Dedupe defensively so the documented per-liker guarantee holds even
+      // if the endpoint ever repeats a pubkey; mirrors the relay path.
+      return {...filtered}.toList();
     } on FunnelcakeException catch (e) {
       Log.warning(
         'Funnelcake likers lookup failed for $eventId, '

--- a/mobile/packages/likes_repository/pubspec.yaml
+++ b/mobile/packages/likes_repository/pubspec.yaml
@@ -11,6 +11,8 @@ dependencies:
   db_client:
     path: ../db_client
   equatable: ^2.0.5
+  funnelcake_api_client:
+    path: ../funnelcake_api_client
   meta: ^1.16.0
   nostr_client:
     path: ../nostr_client
@@ -23,5 +25,8 @@ dependencies:
 dev_dependencies:
   drift: ^2.34.0
   mocktail: ^1.0.4
+  # Test-only: names PaginatedPubkeys when stubbing the Funnelcake client.
+  models:
+    path: ../models
   test: ^1.26.3
   very_good_analysis: ^10.0.0

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -3831,6 +3831,17 @@ void main() {
           );
         });
 
+        test('serves each API liker once, most recent first', () async {
+          stubLikers([likerC, likerA, likerC]);
+
+          repository = createRepository(funnelcakeApiClient: mockFunnelcake);
+
+          expect(
+            await repository.fetchEventLikers(eventId: targetEventId),
+            equals([likerC, likerA]),
+          );
+        });
+
         test('falls back to relays when the API fails', () async {
           when(
             () => mockFunnelcake.getVideoLikers(

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:test/test.dart';
@@ -12,6 +14,8 @@ class MockNostrClient extends Mock implements NostrClient {}
 class MockLikesLocalStorage extends Mock implements LikesLocalStorage {}
 
 class MockEvent extends Mock implements Event {}
+
+class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
 
 void main() {
   group('LikesRepository', () {
@@ -89,6 +93,7 @@ void main() {
       IsOnlineCallback? isOnline,
       QueueOfflineActionCallback? queueOfflineAction,
       BlockedLikerFilter? blockFilter,
+      FunnelcakeApiClient? funnelcakeApiClient,
       LikesRepositoryErrorReporter? errorReporter,
     }) {
       return LikesRepository(
@@ -97,6 +102,7 @@ void main() {
         isOnline: isOnline,
         queueOfflineAction: queueOfflineAction,
         blockFilter: blockFilter,
+        funnelcakeApiClient: funnelcakeApiClient,
         errorReporter: errorReporter,
       );
     }
@@ -2233,7 +2239,7 @@ void main() {
       );
 
       test(
-        'applies the same active liker filters as fetchEventLikers',
+        'excludes deleted, downvoted, and blocked reactions from the count',
         () async {
           const testAddressableId = '34236:$testAuthorPubkey:test-d-tag';
           const likerA = 'liker_a_pubkey_1234567890abcdef';
@@ -3757,6 +3763,151 @@ void main() {
           () => repository.fetchEventLikers(eventId: targetEventId),
           throwsA(isA<FetchLikersFailedException>()),
         );
+      });
+
+      // #6021: the relay filters only match the current event id and the
+      // coordinate, so reactions stranded on a superseded revision are
+      // invisible to them. Funnelcake resolves the whole coordinate.
+      group('Funnelcake source', () {
+        late _MockFunnelcakeApiClient mockFunnelcake;
+
+        setUp(() {
+          mockFunnelcake = _MockFunnelcakeApiClient();
+          when(() => mockFunnelcake.isAvailable).thenReturn(true);
+        });
+
+        void stubLikers(List<String> pubkeys) {
+          when(
+            () => mockFunnelcake.getVideoLikers(
+              any(),
+              addressableId: any(named: 'addressableId'),
+            ),
+          ).thenAnswer((_) async => PaginatedPubkeys(pubkeys: pubkeys));
+        }
+
+        test('serves the API list without querying relays', () async {
+          stubLikers([likerC, likerA]);
+
+          repository = createRepository(funnelcakeApiClient: mockFunnelcake);
+
+          expect(
+            await repository.fetchEventLikers(
+              eventId: targetEventId,
+              addressableId: addressableId,
+            ),
+            equals([likerC, likerA]),
+          );
+          verifyNever(() => mockNostrClient.queryEvents(any()));
+        });
+
+        test('forwards the addressable coordinate to the API', () async {
+          stubLikers([likerA]);
+
+          repository = createRepository(funnelcakeApiClient: mockFunnelcake);
+          await repository.fetchEventLikers(
+            eventId: targetEventId,
+            addressableId: addressableId,
+          );
+
+          verify(
+            () => mockFunnelcake.getVideoLikers(
+              targetEventId,
+              addressableId: addressableId,
+            ),
+          ).called(1);
+        });
+
+        test('still hides blocked likers the API cannot know about', () async {
+          stubLikers([likerA, likerB, likerC]);
+
+          repository = createRepository(
+            funnelcakeApiClient: mockFunnelcake,
+            blockFilter: (pubkey) => pubkey == likerB,
+          );
+
+          expect(
+            await repository.fetchEventLikers(eventId: targetEventId),
+            equals([likerA, likerC]),
+          );
+        });
+
+        test('falls back to relays when the API fails', () async {
+          when(
+            () => mockFunnelcake.getVideoLikers(
+              any(),
+              addressableId: any(named: 'addressableId'),
+            ),
+          ).thenThrow(const FunnelcakeException('boom'));
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+            (_) async => [
+              createReaction(id: 'reaction_a', authorPubkey: likerA),
+            ],
+          );
+
+          repository = createRepository(funnelcakeApiClient: mockFunnelcake);
+
+          expect(
+            await repository.fetchEventLikers(eventId: targetEventId),
+            equals([likerA]),
+          );
+        });
+
+        test('falls back to relays when the API returns nobody', () async {
+          stubLikers([]);
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+            (_) async => [
+              createReaction(id: 'reaction_a', authorPubkey: likerA),
+            ],
+          );
+
+          repository = createRepository(funnelcakeApiClient: mockFunnelcake);
+
+          expect(
+            await repository.fetchEventLikers(eventId: targetEventId),
+            equals([likerA]),
+          );
+        });
+
+        test('falls back to relays when the API is unconfigured', () async {
+          when(() => mockFunnelcake.isAvailable).thenReturn(false);
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+            (_) async => [
+              createReaction(id: 'reaction_a', authorPubkey: likerA),
+            ],
+          );
+
+          repository = createRepository(funnelcakeApiClient: mockFunnelcake);
+
+          expect(
+            await repository.fetchEventLikers(eventId: targetEventId),
+            equals([likerA]),
+          );
+          verifyNever(
+            () => mockFunnelcake.getVideoLikers(
+              any(),
+              addressableId: any(named: 'addressableId'),
+            ),
+          );
+        });
+
+        test('leaves getLikeCount on the relay resolver', () async {
+          stubLikers([likerA, likerB, likerC]);
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+            (_) async => [
+              createReaction(id: 'reaction_a', authorPubkey: likerA),
+            ],
+          );
+
+          repository = createRepository(funnelcakeApiClient: mockFunnelcake);
+
+          expect(
+            await repository.getLikeCount(
+              targetEventId,
+              addressableId: addressableId,
+            ),
+            equals(1),
+          );
+        });
       });
     });
 

--- a/mobile/packages/models/lib/src/paginated_pubkeys.dart
+++ b/mobile/packages/models/lib/src/paginated_pubkeys.dart
@@ -20,6 +20,13 @@ class PaginatedPubkeys {
   ///   (key varies: `following`, `followers`, or `pubkeys`)
   /// - Envelope: `{"data": [...], "pagination": {"has_more": bool,
   ///   "next_cursor": string}}`
+  ///
+  /// Entries may be bare pubkey strings or objects carrying a `pubkey` key
+  /// alongside other fields — the engagement endpoints
+  /// (`/api/videos/{id}/likers`, `/reposters`) return
+  /// `{"pubkey": …, "created_at": …, "event_id": …}`. Objects without a
+  /// string `pubkey` are dropped rather than stringified, so a shape change
+  /// surfaces as a short list instead of rows of `{pubkey: …}` garbage.
   factory PaginatedPubkeys.fromJson(Map<String, dynamic> json) {
     final pagination = json['pagination'] as Map<String, dynamic>?;
 
@@ -34,9 +41,19 @@ class PaginatedPubkeys {
     final hasMore =
         json['has_more'] as bool? ?? pagination?['has_more'] as bool? ?? false;
 
+    final pubkeys = <String>[];
+    for (final entry in pubkeysData) {
+      if (entry is Map<String, dynamic>) {
+        final pubkey = entry['pubkey'];
+        if (pubkey is String && pubkey.isNotEmpty) pubkeys.add(pubkey);
+        continue;
+      }
+      pubkeys.add(entry.toString());
+    }
+
     return PaginatedPubkeys(
-      pubkeys: pubkeysData.map((e) => e.toString()).toList(),
-      total: json['total'] as int? ?? pubkeysData.length,
+      pubkeys: pubkeys,
+      total: json['total'] as int? ?? pubkeys.length,
       hasMore: hasMore,
       appliedQuery: json['query'] as String?,
     );

--- a/mobile/packages/models/test/src/paginated_pubkeys_test.dart
+++ b/mobile/packages/models/test/src/paginated_pubkeys_test.dart
@@ -78,9 +78,7 @@ void main() {
       });
 
       test('handles empty JSON', () {
-        final result = PaginatedPubkeys.fromJson(
-          const <String, dynamic>{},
-        );
+        final result = PaginatedPubkeys.fromJson(const <String, dynamic>{});
 
         expect(result.pubkeys, isEmpty);
         expect(result.total, equals(0));
@@ -127,18 +125,41 @@ void main() {
 
         expect(result.hasMore, isTrue);
       });
+
+      // The engagement endpoints (/api/videos/{id}/likers, /reposters) return
+      // objects rather than bare strings — issue #6021.
+      test('reads the pubkey field out of object-shaped entries', () {
+        final result = PaginatedPubkeys.fromJson(const {
+          'data': [
+            {'pubkey': 'pub1', 'created_at': 1700000000, 'event_id': 'r1'},
+            {'pubkey': 'pub2', 'created_at': 1699999999, 'event_id': 'r2'},
+          ],
+          'pagination': {'has_more': false},
+        });
+
+        expect(result.pubkeys, equals(['pub1', 'pub2']));
+        expect(result.total, equals(2));
+      });
+
+      test('drops object entries with no usable pubkey', () {
+        final result = PaginatedPubkeys.fromJson(const {
+          'data': [
+            {'pubkey': 'pub1'},
+            {'created_at': 1700000000},
+            {'pubkey': ''},
+            {'pubkey': 42},
+          ],
+        });
+
+        expect(result.pubkeys, equals(['pub1']));
+        expect(result.total, equals(1));
+      });
     });
 
     group('equality', () {
       test('equal when same pubkeys, total, and hasMore', () {
-        const a = PaginatedPubkeys(
-          pubkeys: ['abc', 'def'],
-          total: 2,
-        );
-        const b = PaginatedPubkeys(
-          pubkeys: ['abc', 'def'],
-          total: 2,
-        );
+        const a = PaginatedPubkeys(pubkeys: ['abc', 'def'], total: 2);
+        const b = PaginatedPubkeys(pubkeys: ['abc', 'def'], total: 2);
 
         expect(a, equals(b));
         expect(a.hashCode, equals(b.hashCode));
@@ -152,14 +173,8 @@ void main() {
       });
 
       test('not equal when different total', () {
-        const a = PaginatedPubkeys(
-          pubkeys: ['abc'],
-          total: 1,
-        );
-        const b = PaginatedPubkeys(
-          pubkeys: ['abc'],
-          total: 99,
-        );
+        const a = PaginatedPubkeys(pubkeys: ['abc'], total: 1);
+        const b = PaginatedPubkeys(pubkeys: ['abc'], total: 99);
 
         expect(a, isNot(equals(b)));
       });


### PR DESCRIPTION
## Description

The "Liked by" list resolves likers with two relay filters: `#e` against the *current* event id, and `#a` against the coordinate. A reaction that carries no `a` tag and references only a **superseded** event id matches neither, so it never reaches the list — while the headline count, which funnelcake resolves by coordinate, includes it.

funnelcake's `GET /api/videos/{id}/likers` already resolves the whole NIP-33 coordinate: its `e`-tag arm expands across every sibling revision (`engagement_candidate_subquery`, divinevideo/divine-funnelcake#799). Mobile had no client for it. This wires one up and makes the repository prefer it, keeping the relay resolver as the fallback.

Verified live against `api.divine.video` today — on 6 of 6 edited videos, querying `/likers` with a superseded revision id returned an identical liker set to the current id.

**Three commits, one per layer:**

1. `feat(funnelcake-client)` — `getVideoLikers`, plus `PaginatedPubkeys.fromJson` learning the object-shaped `data` entries the engagement endpoints return (`{pubkey, created_at, event_id}`). Entries without a usable `pubkey` are dropped rather than stringified, so a shape change surfaces as a short list instead of `{pubkey: …}` rows.
2. `fix(likes)` — `fetchEventLikers` prefers the API; falls back to relays when no client is wired, the API is unreachable, or it answers with nobody. That last case keeps the change strictly additive: the API can only widen the list, never empty it.
3. `chore(likes)` — provider wiring, `ref.watch` so the repository is rebuilt when an environment or relay-config change mints a new client.

Two behaviours worth calling out:

- **The block filter still runs on the API result.** Server-side moderation drops banned/suspended/vanished accounts, but it does not know the viewer's own mute list.
- **`getLikeCount` deliberately stays on the relay resolver.** Its docs previously claimed it resolved the same set as `fetchEventLikers` so the two "cannot diverge"; that is no longer true, and the docs now say so instead of the code chasing the old invariant.

**Related Issue:** Relates to #6021

## Out of Scope

- **Count vs list parity.** These two numbers can never be equal and this PR does not try to make them so. funnelcake's count is unfiltered `uniq(reaction_event_id)`; the liker list is `GROUP BY pubkey` minus downvotes and moderated accounts. Measured today on 4 of 6 edited videos, the headline exceeded the list by 1–2 with no stranding involved at all. That reconciliation is divinevideo/divine-funnelcake#626.
- **The floored display count.** `video_interactions_bloc.dart` takes `math.max(preFetchLikeCount, archived + fetched)` for addressable targets, so the number beside the heart is floored one layer above the repository regardless of what the list does.
- **Reposts and comments** (#6712). `get_video_reposters` shares the same subquery and would benefit from the same treatment, but that is its own issue.
- **Writer-side prevention** (#6980 and its web/space siblings). Nostr events are immutable, so neither fixes what is already published.

## Verification

- `flutter analyze lib test integration_test` (app) and `flutter analyze lib test` for each touched package — clean.
- `flutter test --coverage` per package: `likes_repository` 238 tests, 97.03% (gate 62%) · `funnelcake_api_client` 419 tests, 90.78% (gate 44%) · `models` 902 tests, 69.83% (gate 25%) · `follow_repository` 267 tests, 100% (shares `PaginatedPubkeys`).
- App-level: `test/blocs/video_engagement/`, `test/blocs/video_interactions/`, `test/screens/video_engagement/`, and both repo-swap suites.
- `dart run build_runner build --delete-conflicting-outputs` — only `video_providers.g.dart` changed; committed.
- Live contract checks against `api.divine.video`: revision expansion (6/6 identical liker sets), response envelope, and the `limit` clamp.

New tests pin: API result preferred over relays, coordinate forwarded, block filter still applied, and fallback on each of API-error / empty-result / unconfigured-client.


### On-device verification (iOS Simulator, iPhone 17 Pro Max, production API)

Driven via deep link to `/video/{id}/likers`, all three source paths exercised against live production data:

| Path | Video | Result |
|---|---|---|
| API answers | `a3092dfc8d36…` | 59 rows, matching `/likers` npub-for-npub and in the same order |
| API returns nobody | `5d6f8c8086db…` (0 likers) | falls back to relays, renders the "No likes yet" empty state |
| API 404s | `b752fe877714…` (unknown to funnelcake, 6 kind-7 on the relay) | falls back to relays, renders exactly those 6 likers |

No exceptions or errors on any of the three screens; the list paints in 34 ms.

Separately, the relay union the old path used (`#e` ∪ `#a`, minus downvotes and same-author kind-5s, deduped by pubkey) was compared against `/likers` on 8 videos: **identical sets, 0 gained and 0 lost**. So on today's data this changes the rendered list for nobody — the recovery it adds is for reactions stranded on pre-`a`-tag content that the popular-feed sample cannot reach, plus server-side moderation filtering.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

