### PR TITLE
fix(safety): remove blocked accounts from the public kind-3 follow list

### DIFF
--- a/.github/workflows/mobile_service_integration_tests.yaml
+++ b/.github/workflows/mobile_service_integration_tests.yaml
@@ -63,8 +63,9 @@ jobs:
       #
       # The list is explicit rather than a glob over integration_test/e2e/,
       # because `service` and "runnable on a Linux CI runner" are different
-      # axes. Every suite in that directory is tagged `service`; these two are
-      # the ones this runner can actually execute. The other four are excluded
+      # axes. Every suite in that directory is tagged `service`; these three
+      # are the ones this runner can actually execute. The other three are
+      # excluded
       # for reasons no workflow change can fix:
       #
       #   c2pa_init                         — c2pa_flutter ships android/ and
@@ -82,7 +83,8 @@ jobs:
         run: |
           for suite in \
             integration_test/e2e/relay_list_admission_test.dart \
-            integration_test/e2e/dm_inbox_relay_admission_test.dart; do
+            integration_test/e2e/dm_inbox_relay_admission_test.dart \
+            integration_test/e2e/block_leaves_kind3_follow_test.dart; do
             echo "── $suite"
             xvfb-run -a flutter test "$suite" --tags service -d linux
           done

--- a/mobile/integration_test/e2e/block_leaves_kind3_follow_test.dart
+++ b/mobile/integration_test/e2e/block_leaves_kind3_follow_test.dart
@@ -1,0 +1,362 @@
+// ABOUTME: #6903 — blocking a followed user must drop them from the public
+// ABOUTME: kind-3 contact list. Drives the real FollowRepository +
+// ABOUTME: ContentBlocklistRepository + reconciler over real sockets.
+// ABOUTME: Requires: NO Docker stack — the relay runs in-process.
+
+@Tags(['service'])
+import 'package:cache_sync/cache_sync.dart';
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/nostr.dart';
+import 'package:nostr_sdk/relay/relay_base.dart';
+import 'package:nostr_sdk/relay/relay_status.dart';
+import 'package:nostr_sdk/relay/web_socket_connection_manager.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+import 'package:openvine/providers/moderation_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/repository_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../helpers/fake_relay.dart';
+
+/// Sends every socket to the in-process relay, whatever host was asked for.
+class _LoopbackFactory implements WebSocketChannelFactory {
+  _LoopbackFactory(this.port);
+
+  final int port;
+
+  @override
+  WebSocketChannel create(Uri uri) =>
+      WebSocketChannel.connect(Uri.parse('ws://127.0.0.1:$port${uri.path}'));
+}
+
+/// In-memory [CacheDao] so `FollowRepository`'s cache invalidation has
+/// somewhere to go. Without it `CacheSync._dao` is an uninitialised `late`
+/// field and `follow()` throws a `LateInitializationError` — an `Error`, so
+/// the repository's `on Exception` guard does not catch it.
+class _MemoryCacheDao implements CacheDao {
+  final Map<String, String> _entries = {};
+
+  @override
+  Future<String?> read(String key) async => _entries[key];
+
+  @override
+  Future<void> write({
+    required String key,
+    required String payload,
+    Duration? ttl,
+  }) async => _entries[key] = payload;
+
+  @override
+  Future<void> delete(String key) async => _entries.remove(key);
+
+  @override
+  Future<void> deletePrefix(String prefix) async =>
+      _entries.removeWhere((key, _) => key.startsWith(prefix));
+
+  @override
+  Future<int> totalPayloadBytes() async =>
+      _entries.values.fold<int>(0, (sum, v) => sum + v.length);
+
+  @override
+  Future<void> evictOldest(int bytesToFree) async {
+    // Intentional no-op: a per-test map has no size limit to enforce.
+  }
+}
+
+/// The `BlockListSigner` the repository needs, backed by a real local key.
+class _LocalBlockListSigner implements BlockListSigner {
+  _LocalBlockListSigner(this._signer, this._pubkey);
+
+  final LocalNostrSigner _signer;
+  final String _pubkey;
+
+  @override
+  bool get isAuthenticated => true;
+
+  @override
+  Future<Event?> createAndSignEvent({
+    required int kind,
+    required String content,
+    List<List<String>>? tags,
+  }) async {
+    final event = Event(_pubkey, kind, tags ?? const [], content);
+    return _signer.signEvent(event);
+  }
+}
+
+/// Everything a viewer of the author's follow list would see, in publish
+/// order: one entry per kind-3 the relay was handed.
+extension on FakeRelay {
+  List<Event> get publishedEvents => [
+    for (final frame in receivedFrames)
+      if (frame.isNotEmpty && frame[0] == 'EVENT' && frame.length >= 2)
+        Event.fromJson(frame[1] as Map<String, dynamic>),
+  ];
+
+  /// The `p` tags of the newest kind-3 the relay holds — kind 3 is
+  /// replaceable, so this is exactly what an external viewer resolves to.
+  /// Null when the author has never published one.
+  List<String>? get publicFollows {
+    final contactLists = publishedEvents.where((e) => e.kind == 3).toList();
+    if (contactLists.isEmpty) return null;
+    contactLists.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+    return [
+      for (final tag in contactLists.last.tags)
+        if (tag.isNotEmpty && tag[0] == 'p' && tag.length > 1) tag[1],
+    ];
+  }
+
+  List<int> get publishedKinds => [for (final e in publishedEvents) e.kind];
+
+  /// Waits until the relay has recorded [count] events of [kind].
+  ///
+  /// A publish resolves once the frame is handed to the socket, which is a
+  /// tick or two before the relay's listener records it. Asserting on the
+  /// relay without this reads a snapshot that is merely early, not wrong.
+  Future<void> awaitPublished(int kind, {int count = 1}) async {
+    final deadline = DateTime.now().add(const Duration(seconds: 10));
+    while (publishedKinds.where((k) => k == kind).length < count) {
+      if (DateTime.now().isAfter(deadline)) {
+        throw StateError(
+          'relay never received $count event(s) of kind $kind; '
+          'saw kinds $publishedKinds',
+        );
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+    }
+  }
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const authorKey =
+      '06478cf31821ae2643888988c5ce3f31731079dbe6c544f5b4451f3c7ce8979c';
+  final authorPubkey = getPublicKey(authorKey);
+  const targetKey =
+      '50dc4b2e01ef449822e422e8c625ddf7d95dc069c414f06d2450556bf5ba7179';
+  final targetPubkey = getPublicKey(targetKey);
+
+  /// The real stack — Nostr → RelayPool → RelayManager → NostrClient — with
+  /// every socket landing on [relay], the two repositories under test wired
+  /// the way the app wires them, and the **shipped**
+  /// [blockedFollowReconcilerProvider] driving the republish.
+  ///
+  /// The two repositories are handed to the container rather than built by
+  /// their own providers, which would drag in auth, Drift and funnelcake.
+  /// The reconciler itself is production code, not a copy of it.
+  Future<({FollowRepository follows, ContentBlocklistRepository blocks})>
+  buildStack(FakeRelay relay) async {
+    await CacheSync.init(dao: _MemoryCacheDao());
+
+    final factory = _LoopbackFactory(relay.port);
+    final signer = LocalNostrSigner(authorKey);
+
+    RelayBase gen(String url) =>
+        RelayBase(url, RelayStatus(url), channelFactory: factory);
+    final nostr = Nostr(signer, [], gen, channelFactory: factory);
+
+    final relayManager = RelayManager(
+      config: RelayManagerConfig(
+        defaultRelayUrl: relay.url,
+        storage: InMemoryRelayStorage(),
+        // A relay that drops at teardown would otherwise keep retrying and
+        // surface the failure against whichever test runs next.
+        autoReconnect: false,
+      ),
+      relayPool: nostr.relayPool,
+    );
+    final client = NostrClient.forTesting(
+      nostr: nostr,
+      relayManager: relayManager,
+    );
+    addTearDown(nostr.relayPool.removeAll);
+    await client.initialize();
+
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    final prefs = await SharedPreferences.getInstance();
+    final blocks = ContentBlocklistRepository(prefs: prefs);
+    await blocks.syncBlockListsInBackground(
+      client,
+      _LocalBlockListSigner(signer, authorPubkey),
+      authorPubkey,
+    );
+
+    final follows = FollowRepository(
+      nostrClient: client,
+      // Empty so the repository never dials a real indexer.
+      indexerRelayUrls: const [],
+      blockedPubkeys: blocks.blockedPubkeysForAccount,
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        nostrServiceProvider.overrideWithValue(client),
+        followRepositoryProvider.overrideWithValue(follows),
+        contentBlocklistRepositoryProvider.overrideWithValue(blocks),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.read(blockedFollowReconcilerProvider);
+
+    return (follows: follows, blocks: blocks);
+  }
+
+  group('#6903 block vs. the public kind-3 follow list', () {
+    testWidgets('unfollowing removes the target from the public follow list', (
+      tester,
+    ) async {
+      final relay = await FakeRelay.start();
+      addTearDown(relay.stop);
+      final stack = await buildStack(relay);
+
+      await stack.follows.follow(targetPubkey);
+      await relay.awaitPublished(3);
+      expect(
+        relay.publicFollows,
+        contains(targetPubkey),
+        reason: 'positive control: the follow must reach the relay at all',
+      );
+
+      await stack.follows.unfollow(targetPubkey);
+      await relay.awaitPublished(3, count: 2);
+
+      // This is the control that makes the next test meaningful: the harness
+      // can observe a follow list shrinking, so a failure there is the app's
+      // behaviour and not a blind spot in how this test reads the relay.
+      expect(relay.publicFollows, isNot(contains(targetPubkey)));
+    });
+
+    testWidgets('blocking removes the target from the public follow list', (
+      tester,
+    ) async {
+      final relay = await FakeRelay.start();
+      addTearDown(relay.stop);
+      final stack = await buildStack(relay);
+
+      await stack.follows.follow(targetPubkey);
+      await relay.awaitPublished(3);
+      expect(relay.publicFollows, contains(targetPubkey));
+
+      // Verbatim the call `conversation_view.dart` makes when a user taps
+      // ⋯ → Block inside a DM thread. That surface never unfollowed; the
+      // reconciler is what covers it now.
+      await stack.blocks.blockUser(targetPubkey, ourPubkey: authorPubkey);
+
+      await relay.awaitPublished(10000);
+      await relay.awaitPublished(30000);
+      expect(stack.blocks.isBlocked(targetPubkey), isTrue);
+
+      // The republish the reconciler triggers.
+      await relay.awaitPublished(3, count: 2);
+
+      expect(
+        relay.publicFollows,
+        isNot(contains(targetPubkey)),
+        reason:
+            'a viewer resolving this author must no longer see the blocked '
+            'account listed as a follow (#6903)',
+      );
+
+      // Suppressed at the publish boundary only: the local follow survives,
+      // so unblocking restores it rather than costing it permanently.
+      expect(stack.follows.followingPubkeys, contains(targetPubkey));
+    });
+
+    // The issue's "starting points" section assumes the profile path is fine
+    // because `other_profile_bloc.dart` already unfollowed. It was only fine
+    // once the follow list had loaded: `isFollowing` reads an in-memory list
+    // that starts empty and `initialize()` is fired unawaited, so on a fresh
+    // install, a new sign-in, or a cleared cache the guard read false and the
+    // unfollow never ran. The reconciler's second trigger — the follow list
+    // arriving — is what closes that window.
+    testWidgets('a block made before the follow list loads is settled when it '
+        'arrives', (tester) async {
+      final relay = await FakeRelay.start();
+      addTearDown(relay.stop);
+
+      // Session one: the user follows the target. This publishes the kind-3
+      // that an external viewer resolves.
+      final warm = await buildStack(relay);
+      await warm.follows.follow(targetPubkey);
+      await relay.awaitPublished(3);
+      expect(relay.publicFollows, contains(targetPubkey));
+
+      // Serve that kind-3 back, so the cold session below loads a real
+      // follow list rather than an empty one.
+      relay.reply = relay.publishedEvents
+          .lastWhere((event) => event.kind == 3)
+          .toJson();
+
+      // Session two is a cold start: a fresh repository whose in-memory list
+      // has not been seeded, exactly as on a new install or new sign-in.
+      final cold = await buildStack(relay);
+      expect(
+        cold.follows.isFollowing(targetPubkey),
+        isFalse,
+        reason:
+            'precondition: the cold repository answers false for a pubkey '
+            'that is genuinely followed',
+      );
+
+      await cold.blocks.blockUser(targetPubkey, ourPubkey: authorPubkey);
+      await relay.awaitPublished(10000);
+      expect(cold.blocks.isBlocked(targetPubkey), isTrue);
+      expect(
+        relay.publishedKinds.where((k) => k == 3).length,
+        1,
+        reason: 'nothing to reconcile yet — the follow list is still empty',
+      );
+
+      // The relay load lands, and with it the contradiction.
+      await cold.follows.initialize();
+      await relay.awaitPublished(3, count: 2);
+
+      expect(
+        relay.publicFollows,
+        isNot(contains(targetPubkey)),
+        reason:
+            'the follow list arriving after the block must settle the '
+            'contradiction (#6903)',
+      );
+    });
+
+    // A permanent trap, kept green so nobody re-wires block → toggleFollow.
+    // `toggleFollow` branches on the same cold `isFollowing`, so hooking it
+    // to a block would FOLLOW the account the user just blocked. The shipped
+    // fix touches neither: it omits blocked accounts at the publish boundary
+    // and leaves the local list alone.
+    testWidgets('toggleFollow on a cold list follows instead of unfollowing', (
+      tester,
+    ) async {
+      final relay = await FakeRelay.start();
+      addTearDown(relay.stop);
+
+      final warm = await buildStack(relay);
+      await warm.follows.follow(targetPubkey);
+      await relay.awaitPublished(3);
+
+      final cold = await buildStack(relay);
+      await cold.follows.toggleFollow(targetPubkey);
+      await relay.awaitPublished(3, count: 2);
+
+      expect(
+        cold.follows.followingPubkeys,
+        contains(targetPubkey),
+        reason:
+            'toggleFollow read isFollowing() as false and took the follow '
+            'branch — nothing on the block path may call toggleFollow()',
+      );
+    });
+  });
+}

--- a/mobile/integration_test/e2e/block_leaves_kind3_follow_test.dart
+++ b/mobile/integration_test/e2e/block_leaves_kind3_follow_test.dart
@@ -154,8 +154,14 @@ void main() {
   /// The two repositories are handed to the container rather than built by
   /// their own providers, which would drag in auth, Drift and funnelcake.
   /// The reconciler itself is production code, not a copy of it.
+  ///
+  /// [initializeFollows] mirrors what the app does on launch. Pass false to
+  /// model a session whose follow list has not loaded yet — the reconciler
+  /// refuses to publish from an uninitialized repository, because until the
+  /// relay query lands the list is a LocalStorage snapshot that can lag or
+  /// truncate (#6109).
   Future<({FollowRepository follows, ContentBlocklistRepository blocks})>
-  buildStack(FakeRelay relay) async {
+  buildStack(FakeRelay relay, {bool initializeFollows = true}) async {
     await CacheSync.init(dao: _MemoryCacheDao());
 
     final factory = _LoopbackFactory(relay.port);
@@ -197,6 +203,9 @@ void main() {
       indexerRelayUrls: const [],
       blockedPubkeys: blocks.blockedPubkeysForAccount,
     );
+    if (initializeFollows) {
+      await follows.initialize();
+    }
 
     final container = ProviderContainer(
       overrides: [
@@ -300,7 +309,7 @@ void main() {
 
       // Session two is a cold start: a fresh repository whose in-memory list
       // has not been seeded, exactly as on a new install or new sign-in.
-      final cold = await buildStack(relay);
+      final cold = await buildStack(relay, initializeFollows: false);
       expect(
         cold.follows.isFollowing(targetPubkey),
         isFalse,
@@ -346,7 +355,7 @@ void main() {
       await warm.follows.follow(targetPubkey);
       await relay.awaitPublished(3);
 
-      final cold = await buildStack(relay);
+      final cold = await buildStack(relay, initializeFollows: false);
       await cold.follows.toggleFollow(targetPubkey);
       await relay.awaitPublished(3, count: 2);
 

--- a/mobile/integration_test/e2e/block_leaves_kind3_follow_test.dart
+++ b/mobile/integration_test/e2e/block_leaves_kind3_follow_test.dart
@@ -277,8 +277,11 @@ void main() {
             'account listed as a follow (#6903)',
       );
 
-      // Suppressed at the publish boundary only: the local follow survives,
-      // so unblocking restores it rather than costing it permanently.
+      // Suppressed at the publish boundary only: blocking never drops the
+      // follow from local state synchronously. It does go once the filtered
+      // kind 3 is read back on the next initialize() — pinned in
+      // follow_repository_test.dart, not reachable from this relay, which
+      // serves nothing back.
       expect(stack.follows.followingPubkeys, contains(targetPubkey));
     });
 

--- a/mobile/integration_test/helpers/fake_relay.dart
+++ b/mobile/integration_test/helpers/fake_relay.dart
@@ -39,7 +39,11 @@ class FakeRelay {
   final List<WebSocket> _sockets = [];
 
   /// The event served in response to any `REQ`, or null for `EOSE` only.
-  final Map<String, dynamic>? reply;
+  ///
+  /// Mutable so a test can stage what a later session reads back — this relay
+  /// records what it is handed but does not serve it, so "publish, then open a
+  /// cold session that loads it" has to be staged explicitly.
+  Map<String, dynamic>? reply;
 
   /// Whether an inbound `EVENT` is answered with `OK … true`.
   final bool okConfirms;
@@ -82,6 +86,20 @@ class FakeRelay {
 
     final socket = await WebSocketTransformer.upgrade(req);
     _sockets.add(socket);
+
+    // A client can close mid-exchange, and `readyState` still reads as open
+    // for a moment after the sink is gone. An unguarded write then throws
+    // asynchronously and is attributed to whichever test is running next.
+    void send(List<dynamic> message) {
+      try {
+        socket.add(jsonEncode(message));
+        // Only an Error distinguishes "the client hung up" here.
+        // ignore: avoid_catching_errors
+      } on StateError {
+        // Client went away; nothing to answer.
+      }
+    }
+
     socket.listen(
       (raw) {
         final List<dynamic> frame;
@@ -96,12 +114,12 @@ class FakeRelay {
         if (frame[0] == 'REQ' && frame.length >= 2) {
           final subId = frame[1] as String;
           if (reply != null) {
-            socket.add(jsonEncode(<dynamic>['EVENT', subId, reply]));
+            send(<dynamic>['EVENT', subId, reply]);
           }
-          socket.add(jsonEncode(<dynamic>['EOSE', subId]));
+          send(<dynamic>['EOSE', subId]);
         } else if (frame[0] == 'EVENT' && frame.length >= 2 && okConfirms) {
           final event = frame[1] as Map<String, dynamic>;
-          socket.add(jsonEncode(<dynamic>['OK', event['id'], true, '']));
+          send(<dynamic>['OK', event['id'], true, '']);
         }
       },
       onError: (_) {},

--- a/mobile/lib/blocs/comments/comment_reactions/comment_reactions_bloc.dart
+++ b/mobile/lib/blocs/comments/comment_reactions/comment_reactions_bloc.dart
@@ -6,7 +6,6 @@ import 'package:comments_repository/comments_repository.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:follow_repository/follow_repository.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:nostr_sdk/event_kind.dart';
 import 'package:openvine/blocs/comments/comment_reactions/reportable_sites.dart';
@@ -27,8 +26,7 @@ part 'comment_reactions_state.dart';
 ///   silently to reconcile pre-tap state without surfacing as failures.
 /// - Vote count batch fetch on demand (UI bridges from [CommentsListBloc]).
 /// - Reporting (Kind 1984) via [ContentReportingService].
-/// - Blocking (Kind 10000 mute + optional unfollow) via
-///   [ContentBlocklistRepository] + [FollowRepository]; emits
+/// - Blocking (Kind 10000 mute) via [ContentBlocklistRepository]; emits
 ///   [ReactionsOutboxRemoveByAuthor] for list cleanup.
 /// - Deleting via [CommentsRepository.deleteComment]; emits
 ///   [ReactionsOutboxRemoveComment] for list cleanup.
@@ -42,13 +40,11 @@ class CommentReactionsBloc
     required ContentBlocklistRepository contentBlocklistRepository,
     required String rootEventId,
     String? rootAddressableId,
-    FollowRepository? followRepository,
   }) : _authService = authService,
        _likesRepository = likesRepository,
        _commentsRepository = commentsRepository,
        _contentReportingServiceFuture = contentReportingServiceFuture,
        _contentBlocklistRepository = contentBlocklistRepository,
-       _followRepository = followRepository,
        _rootEventId = rootEventId,
        _rootAddressableId = rootAddressableId,
        super(const CommentReactionsState()) {
@@ -75,7 +71,6 @@ class CommentReactionsBloc
   final CommentsRepository _commentsRepository;
   final Future<ContentReportingService> _contentReportingServiceFuture;
   final ContentBlocklistRepository _contentBlocklistRepository;
-  final FollowRepository? _followRepository;
   final String _rootEventId;
   final String? _rootAddressableId;
 
@@ -409,29 +404,14 @@ class CommentReactionsBloc
     }
 
     // Block is durable at this point; drop the author's comments from the
-    // list IMMEDIATELY so a follow-side failure below doesn't desync the UI
-    // (the user already sees their block confirmed by the list cleanup).
+    // list so the user sees it confirmed.
+    //
+    // Severing the follow is not this bloc's job: FollowRepository drops
+    // blocked accounts from the kind 3 it publishes, and the app-level
+    // reconciler triggers that republish (#6903).
     emit(
       state.copyWith(outbox: ReactionsOutboxRemoveByAuthor(event.authorPubkey)),
     );
-
-    // Best-effort unfollow. A failure here is logged but doesn't roll back
-    // the block — the user blocked the author whether or not the unfollow
-    // succeeded, and the kind-30000 mute list is the source of truth.
-    final followRepo = _followRepository;
-    if (followRepo != null && followRepo.isFollowing(event.authorPubkey)) {
-      try {
-        await followRepo.toggleFollow(event.authorPubkey);
-      } catch (e, stackTrace) {
-        _logFailure(
-          e,
-          stackTrace,
-          CommentReactionsBlocReportableSites.onBlockUserRequested,
-          'Error unfollowing after block',
-          treatExceptionAsDomain: true,
-        );
-      }
-    }
   }
 
   Future<void> _onDeleteRequested(

--- a/mobile/lib/blocs/other_profile/other_profile_bloc.dart
+++ b/mobile/lib/blocs/other_profile/other_profile_bloc.dart
@@ -8,7 +8,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:models/models.dart';
 import 'package:profile_repository/profile_repository.dart';
-import 'package:unified_logger/unified_logger.dart';
 
 part 'other_profile_event.dart';
 part 'other_profile_state.dart';
@@ -378,21 +377,12 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
     OtherProfileBlockRequested event,
     Emitter<OtherProfileState> emit,
   ) async {
+    // Severing the follow is not this bloc's job: FollowRepository drops
+    // blocked accounts from the kind 3 it publishes, and the app-level
+    // reconciler triggers that republish (#6903). Doing it here as well
+    // would remove the follow locally, so unblocking could not restore it —
+    // and only two of the four block entry points would behave that way.
     await _blocklistRepository.blockUser(pubkey, ourPubkey: _currentUserPubkey);
-
-    // Unfollow the user if we're currently following them
-    if (_followRepository.isFollowing(pubkey)) {
-      try {
-        await _followRepository.toggleFollow(pubkey);
-      } catch (e, s) {
-        Log.error(
-          'Failed to unfollow blocked user $pubkey',
-          name: 'OtherProfileBloc',
-          error: e,
-          stackTrace: s,
-        );
-      }
-    }
   }
 
   Future<void> _onUnblockRequested(

--- a/mobile/lib/blocs/other_profile/other_profile_bloc.dart
+++ b/mobile/lib/blocs/other_profile/other_profile_bloc.dart
@@ -76,7 +76,13 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
   bool get isBlocked => _blocklistRepository.isBlocked(pubkey);
 
   /// Whether the current user is following the viewed profile.
-  bool get isFollowing => _followRepository.isFollowing(pubkey);
+  ///
+  /// A blocked account reports false. That matches `MyFollowingBloc`, which
+  /// every other follow surface reads and which already filters blocked
+  /// pubkeys, and it matches the kind 3 we publish (#6903). The profile ⋯
+  /// sheet gates its `Unfollow <name>` row on this, so without the check it
+  /// offers to unfollow an account the rest of the app says is not followed.
+  bool get isFollowing => !isBlocked && _followRepository.isFollowing(pubkey);
 
   Future<void> _onLoadRequested(
     OtherProfileLoadRequested event,

--- a/mobile/lib/blocs/other_profile/other_profile_bloc.dart
+++ b/mobile/lib/blocs/other_profile/other_profile_bloc.dart
@@ -380,8 +380,8 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
     // Severing the follow is not this bloc's job: FollowRepository drops
     // blocked accounts from the kind 3 it publishes, and the app-level
     // reconciler triggers that republish (#6903). Doing it here as well
-    // would remove the follow locally, so unblocking could not restore it —
-    // and only two of the four block entry points would behave that way.
+    // would drop the follow locally the moment the user blocks, and only
+    // two of the four block entry points would behave that way.
     await _blocklistRepository.blockUser(pubkey, ourPubkey: _currentUserPubkey);
   }
 

--- a/mobile/lib/blocs/others_followers/others_followers_bloc.dart
+++ b/mobile/lib/blocs/others_followers/others_followers_bloc.dart
@@ -46,6 +46,18 @@ class OthersFollowersBloc
   final ContentBlocklistRepository _blocklistRepository;
   final String _currentUserPubkey;
 
+  /// Whether we follow [targetPubkey], as the follow graph presents it.
+  ///
+  /// Blocking leaves the local follow in place and drops it only from the
+  /// kind 3 we publish (#6903), so the raw read still reports true for a
+  /// blocked account. Answering true here would keep listing us among that
+  /// account's followers, contradicting what we publish. `OthersFollowingBloc`
+  /// already applies the same blocked-or-severed rule to the mirror screen.
+  bool _isFollowingTarget(String targetPubkey) =>
+      !_blocklistRepository.isBlocked(targetPubkey) &&
+      !_blocklistRepository.isFollowSevered(targetPubkey) &&
+      _followRepository.isFollowing(targetPubkey);
+
   /// Handle request to load another user's followers list.
   ///
   /// Delegates to [FollowRepository.watchOthersFollowersCached] for
@@ -82,9 +94,7 @@ class OthersFollowersBloc
           forceRefresh: event.forceRefresh,
         ),
         onData: (result) {
-          final isFollowingTarget = _followRepository.isFollowing(
-            event.targetPubkey,
-          );
+          final isFollowingTarget = _isFollowingTarget(event.targetPubkey);
           final visiblePubkeys = filterOtherFollowerPubkeys(
             pubkeys: result.data.pubkeys,
             blocklistRepository: _blocklistRepository,

--- a/mobile/lib/providers/moderation_providers.dart
+++ b/mobile/lib/providers/moderation_providers.dart
@@ -202,9 +202,7 @@ ModerationLabelService moderationLabelService(Ref ref) {
   unawaited(startRelaySync(ref.read(nostrSessionProvider)));
 
   ref.listen<NostrSessionReadiness>(nostrSessionProvider, (_, next) {
-    unawaited(
-      startRelaySync(next),
-    );
+    unawaited(startRelaySync(next));
   });
 
   ref.onDispose(() {
@@ -310,13 +308,22 @@ void blocklistSyncBridge(Ref ref) {
 /// but blocking never runs through follow/unfollow and nothing republishes
 /// kind 3 on a schedule — so without a trigger the contradiction would sit
 /// on relays until the user's next unrelated follow, possibly never (#6903).
-/// Two triggers cover it:
+/// Three triggers cover it:
 ///
 /// - a fresh block, via [ContentBlocklistRepository.changes];
 /// - the follow list arriving, via `followingStream`. This is the one that
 ///   heals a block made before the list finished loading — a fresh install,
 ///   a new sign-in, a cleared cache — and settles contradictions that
 ///   predate this code.
+/// - [FollowRepository.initialized], for the launch where the relay list
+///   matches LocalStorage: the merge emits nothing then, so the two stream
+///   triggers would both miss a contradiction that was already on disk.
+///
+/// Every trigger is gated on [FollowRepository.isInitialized]. Until the
+/// relay query lands, `followingStream` carries the LocalStorage snapshot,
+/// and republishing from a derived source destroys the follows it is
+/// missing — the #6109 class of loss, on the write side where no merge
+/// guard can catch it.
 ///
 /// Watch this at app shell level.
 @Riverpod(keepAlive: true)
@@ -330,8 +337,11 @@ void blockedFollowReconciler(Ref ref) {
   // it can resurrect an entry we just dropped; unbounded, the two clients
   // would trade publishes for as long as both sessions are open.
   final settled = <String>{};
+  var disposed = false;
 
   Future<void> reconcile() async {
+    if (disposed || !followRepository.isInitialized) return;
+
     final blocked = blocklistRepository.blockedPubkeysForAccount(
       nostrClient.publicKey,
     );
@@ -372,7 +382,14 @@ void blockedFollowReconciler(Ref ref) {
     followRepository.followingStream.listen((_) => unawaited(reconcile())),
   ];
 
+  if (followRepository.isInitialized) {
+    unawaited(reconcile());
+  } else {
+    unawaited(followRepository.initialized.then((_) => reconcile()));
+  }
+
   ref.onDispose(() {
+    disposed = true;
     for (final subscription in subscriptions) {
       unawaited(subscription.cancel());
     }

--- a/mobile/lib/providers/moderation_providers.dart
+++ b/mobile/lib/providers/moderation_providers.dart
@@ -332,10 +332,12 @@ void blockedFollowReconciler(Ref ref) {
   final followRepository = ref.watch(followRepositoryProvider);
   final nostrClient = ref.watch(nostrServiceProvider);
 
-  // At most one republish per blocked pubkey per session. divine-web keeps
-  // whichever kind 3 carries more entries (divinevideo/divine-web#551), so
-  // it can resurrect an entry we just dropped; unbounded, the two clients
-  // would trade publishes for as long as both sessions are open.
+  // At most one republish per blocked pubkey per *current* block. divine-web
+  // keeps whichever kind 3 carries more entries (divinevideo/divine-web#551),
+  // so it can resurrect an entry we just dropped; unbounded, the two clients
+  // would trade publishes for as long as both sessions are open. Cleared on
+  // unblock so a later same-session re-block can drop the follow again after
+  // an intervening publish re-included it.
   final settled = <String>{};
   var disposed = false;
 
@@ -374,9 +376,15 @@ void blockedFollowReconciler(Ref ref) {
   }
 
   final subscriptions = <StreamSubscription<void>>[
-    blocklistRepository.changes
-        .where((change) => change.op == BlocklistOp.blocked)
-        .listen((_) => unawaited(reconcile())),
+    blocklistRepository.changes.listen((change) {
+      if (change.op == BlocklistOp.unblocked) {
+        settled.remove(change.pubkey);
+        return;
+      }
+      if (change.op == BlocklistOp.blocked) {
+        unawaited(reconcile());
+      }
+    }),
     // Replays its latest value, so an already-loaded list reconciles here
     // rather than needing a separate priming call.
     followRepository.followingStream.listen((_) => unawaited(reconcile())),

--- a/mobile/lib/providers/moderation_providers.dart
+++ b/mobile/lib/providers/moderation_providers.dart
@@ -303,6 +303,82 @@ void blocklistSyncBridge(Ref ref) {
   });
 }
 
+/// Republishes the contact list when a block contradicts the published
+/// follow list.
+///
+/// [FollowRepository] drops blocked accounts from the kind 3 it publishes,
+/// but blocking never runs through follow/unfollow and nothing republishes
+/// kind 3 on a schedule — so without a trigger the contradiction would sit
+/// on relays until the user's next unrelated follow, possibly never (#6903).
+/// Two triggers cover it:
+///
+/// - a fresh block, via [ContentBlocklistRepository.changes];
+/// - the follow list arriving, via `followingStream`. This is the one that
+///   heals a block made before the list finished loading — a fresh install,
+///   a new sign-in, a cleared cache — and settles contradictions that
+///   predate this code.
+///
+/// Watch this at app shell level.
+@Riverpod(keepAlive: true)
+void blockedFollowReconciler(Ref ref) {
+  final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
+  final followRepository = ref.watch(followRepositoryProvider);
+  final nostrClient = ref.watch(nostrServiceProvider);
+
+  // At most one republish per blocked pubkey per session. divine-web keeps
+  // whichever kind 3 carries more entries (divinevideo/divine-web#551), so
+  // it can resurrect an entry we just dropped; unbounded, the two clients
+  // would trade publishes for as long as both sessions are open.
+  final settled = <String>{};
+
+  Future<void> reconcile() async {
+    final blocked = blocklistRepository.blockedPubkeysForAccount(
+      nostrClient.publicKey,
+    );
+    if (blocked.isEmpty) return;
+
+    final contradicting = followRepository.followingPubkeys
+        .where(blocked.contains)
+        .where((pubkey) => !settled.contains(pubkey))
+        .toList();
+    if (contradicting.isEmpty) return;
+
+    settled.addAll(contradicting);
+    try {
+      await followRepository.republishContactList();
+      Log.info(
+        'Republished contact list without ${contradicting.length} '
+        'blocked account(s)',
+        name: 'BlockedFollowReconciler',
+        category: LogCategory.system,
+      );
+    } catch (e) {
+      // Let the next block or follow-list emission try again.
+      settled.removeAll(contradicting);
+      Log.warning(
+        'Failed to republish contact list after a block: $e',
+        name: 'BlockedFollowReconciler',
+        category: LogCategory.system,
+      );
+    }
+  }
+
+  final subscriptions = <StreamSubscription<void>>[
+    blocklistRepository.changes
+        .where((change) => change.op == BlocklistOp.blocked)
+        .listen((_) => unawaited(reconcile())),
+    // Replays its latest value, so an already-loaded list reconciles here
+    // rather than needing a separate priming call.
+    followRepository.followingStream.listen((_) => unawaited(reconcile())),
+  ];
+
+  ref.onDispose(() {
+    for (final subscription in subscriptions) {
+      unawaited(subscription.cancel());
+    }
+  });
+}
+
 /// Builds the blocked-author video filter backed by the content-policy
 /// engine.
 BlockedVideoFilter createBlockedAuthorFilter(Ref ref) {

--- a/mobile/lib/providers/moderation_providers.g.dart
+++ b/mobile/lib/providers/moderation_providers.g.dart
@@ -627,3 +627,95 @@ final class BlocklistSyncBridgeProvider
 
 String _$blocklistSyncBridgeHash() =>
     r'0ffe1bb65877c094a330ec773089bb738247fe98';
+
+/// Republishes the contact list when a block contradicts the published
+/// follow list.
+///
+/// [FollowRepository] drops blocked accounts from the kind 3 it publishes,
+/// but blocking never runs through follow/unfollow and nothing republishes
+/// kind 3 on a schedule — so without a trigger the contradiction would sit
+/// on relays until the user's next unrelated follow, possibly never (#6903).
+/// Two triggers cover it:
+///
+/// - a fresh block, via [ContentBlocklistRepository.changes];
+/// - the follow list arriving, via `followingStream`. This is the one that
+///   heals a block made before the list finished loading — a fresh install,
+///   a new sign-in, a cleared cache — and settles contradictions that
+///   predate this code.
+///
+/// Watch this at app shell level.
+
+@ProviderFor(blockedFollowReconciler)
+final blockedFollowReconcilerProvider = BlockedFollowReconcilerProvider._();
+
+/// Republishes the contact list when a block contradicts the published
+/// follow list.
+///
+/// [FollowRepository] drops blocked accounts from the kind 3 it publishes,
+/// but blocking never runs through follow/unfollow and nothing republishes
+/// kind 3 on a schedule — so without a trigger the contradiction would sit
+/// on relays until the user's next unrelated follow, possibly never (#6903).
+/// Two triggers cover it:
+///
+/// - a fresh block, via [ContentBlocklistRepository.changes];
+/// - the follow list arriving, via `followingStream`. This is the one that
+///   heals a block made before the list finished loading — a fresh install,
+///   a new sign-in, a cleared cache — and settles contradictions that
+///   predate this code.
+///
+/// Watch this at app shell level.
+
+final class BlockedFollowReconcilerProvider
+    extends $FunctionalProvider<void, void, void>
+    with $Provider<void> {
+  /// Republishes the contact list when a block contradicts the published
+  /// follow list.
+  ///
+  /// [FollowRepository] drops blocked accounts from the kind 3 it publishes,
+  /// but blocking never runs through follow/unfollow and nothing republishes
+  /// kind 3 on a schedule — so without a trigger the contradiction would sit
+  /// on relays until the user's next unrelated follow, possibly never (#6903).
+  /// Two triggers cover it:
+  ///
+  /// - a fresh block, via [ContentBlocklistRepository.changes];
+  /// - the follow list arriving, via `followingStream`. This is the one that
+  ///   heals a block made before the list finished loading — a fresh install,
+  ///   a new sign-in, a cleared cache — and settles contradictions that
+  ///   predate this code.
+  ///
+  /// Watch this at app shell level.
+  BlockedFollowReconcilerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'blockedFollowReconcilerProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$blockedFollowReconcilerHash();
+
+  @$internal
+  @override
+  $ProviderElement<void> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  void create(Ref ref) {
+    return blockedFollowReconciler(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(void value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<void>(value),
+    );
+  }
+}
+
+String _$blockedFollowReconcilerHash() =>
+    r'fc1984cf42eeea2e379e1b427e39cf1df545a839';

--- a/mobile/lib/providers/moderation_providers.g.dart
+++ b/mobile/lib/providers/moderation_providers.g.dart
@@ -635,13 +635,22 @@ String _$blocklistSyncBridgeHash() =>
 /// but blocking never runs through follow/unfollow and nothing republishes
 /// kind 3 on a schedule — so without a trigger the contradiction would sit
 /// on relays until the user's next unrelated follow, possibly never (#6903).
-/// Two triggers cover it:
+/// Three triggers cover it:
 ///
 /// - a fresh block, via [ContentBlocklistRepository.changes];
 /// - the follow list arriving, via `followingStream`. This is the one that
 ///   heals a block made before the list finished loading — a fresh install,
 ///   a new sign-in, a cleared cache — and settles contradictions that
 ///   predate this code.
+/// - [FollowRepository.initialized], for the launch where the relay list
+///   matches LocalStorage: the merge emits nothing then, so the two stream
+///   triggers would both miss a contradiction that was already on disk.
+///
+/// Every trigger is gated on [FollowRepository.isInitialized]. Until the
+/// relay query lands, `followingStream` carries the LocalStorage snapshot,
+/// and republishing from a derived source destroys the follows it is
+/// missing — the #6109 class of loss, on the write side where no merge
+/// guard can catch it.
 ///
 /// Watch this at app shell level.
 
@@ -655,13 +664,22 @@ final blockedFollowReconcilerProvider = BlockedFollowReconcilerProvider._();
 /// but blocking never runs through follow/unfollow and nothing republishes
 /// kind 3 on a schedule — so without a trigger the contradiction would sit
 /// on relays until the user's next unrelated follow, possibly never (#6903).
-/// Two triggers cover it:
+/// Three triggers cover it:
 ///
 /// - a fresh block, via [ContentBlocklistRepository.changes];
 /// - the follow list arriving, via `followingStream`. This is the one that
 ///   heals a block made before the list finished loading — a fresh install,
 ///   a new sign-in, a cleared cache — and settles contradictions that
 ///   predate this code.
+/// - [FollowRepository.initialized], for the launch where the relay list
+///   matches LocalStorage: the merge emits nothing then, so the two stream
+///   triggers would both miss a contradiction that was already on disk.
+///
+/// Every trigger is gated on [FollowRepository.isInitialized]. Until the
+/// relay query lands, `followingStream` carries the LocalStorage snapshot,
+/// and republishing from a derived source destroys the follows it is
+/// missing — the #6109 class of loss, on the write side where no merge
+/// guard can catch it.
 ///
 /// Watch this at app shell level.
 
@@ -675,13 +693,22 @@ final class BlockedFollowReconcilerProvider
   /// but blocking never runs through follow/unfollow and nothing republishes
   /// kind 3 on a schedule — so without a trigger the contradiction would sit
   /// on relays until the user's next unrelated follow, possibly never (#6903).
-  /// Two triggers cover it:
+  /// Three triggers cover it:
   ///
   /// - a fresh block, via [ContentBlocklistRepository.changes];
   /// - the follow list arriving, via `followingStream`. This is the one that
   ///   heals a block made before the list finished loading — a fresh install,
   ///   a new sign-in, a cleared cache — and settles contradictions that
   ///   predate this code.
+  /// - [FollowRepository.initialized], for the launch where the relay list
+  ///   matches LocalStorage: the merge emits nothing then, so the two stream
+  ///   triggers would both miss a contradiction that was already on disk.
+  ///
+  /// Every trigger is gated on [FollowRepository.isInitialized]. Until the
+  /// relay query lands, `followingStream` carries the LocalStorage snapshot,
+  /// and republishing from a derived source destroys the follows it is
+  /// missing — the #6109 class of loss, on the write side where no merge
+  /// guard can catch it.
   ///
   /// Watch this at app shell level.
   BlockedFollowReconcilerProvider._()
@@ -718,4 +745,4 @@ final class BlockedFollowReconcilerProvider
 }
 
 String _$blockedFollowReconcilerHash() =>
-    r'fc1984cf42eeea2e379e1b427e39cf1df545a839';
+    r'fe0ea7d6109c4ad00d4aeee68052c045db7ae84e';

--- a/mobile/lib/providers/moderation_providers.g.dart
+++ b/mobile/lib/providers/moderation_providers.g.dart
@@ -745,4 +745,4 @@ final class BlockedFollowReconcilerProvider
 }
 
 String _$blockedFollowReconcilerHash() =>
-    r'fe0ea7d6109c4ad00d4aeee68052c045db7ae84e';
+    r'bc150b83fa02264803e1c87e5a711f8b0072244e';

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -122,8 +122,15 @@ FollowRepository followRepository(Ref ref) {
 
   final profileStatsDao = ref.watch(databaseProvider).profileStatsDao;
 
+  final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
+
   final repository = FollowRepository(
     nostrClient: nostrClient,
+    // Blocked accounts are dropped from the published kind 3 (#6903).
+    // The tear-off takes the signing pubkey and answers for that account
+    // only, so a session cannot publish its follow list filtered against a
+    // previous account's blocklist.
+    blockedPubkeys: blocklistRepository.blockedPubkeysForAccount,
     isCacheInitialized: () => personalEventCache.isInitialized,
     getCachedEventsByKind: personalEventCache.getEventsByKind,
     cacheUserEvent: personalEventCache.cacheUserEvent,

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -140,7 +140,7 @@ final class FollowRepositoryProvider
   }
 }
 
-String _$followRepositoryHash() => r'fb0dd5265e3906366876638e6a2026d1b672e8c9';
+String _$followRepositoryHash() => r'd2574431abdc640b6e7bc9e620de2d7ad7b59b5e';
 
 /// Provider for [CuratedListRepository] instance.
 ///

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -335,6 +335,7 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
     // Transitional scaffold: syncs block/mute list after login.
     // TODO(#4338): remove when BlocklistCubit owns post-login sync.
     ref.watch(blocklistSyncBridgeProvider);
+    ref.watch(blockedFollowReconcilerProvider);
 
     // The shell chrome (app bar) mirrors the *active tab's* route. While a
     // full-screen route is pushed above the whole shell (camera, editor,

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -279,7 +279,6 @@ abstract final class CommentsScreen {
                   commentsRepository: commentsRepository,
                   contentReportingServiceFuture: contentReportingServiceFuture,
                   contentBlocklistRepository: contentBlocklistRepository,
-                  followRepository: followRepository,
                   rootEventId: video.id,
                   rootAddressableId: video.addressableId,
                 ),

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -968,6 +968,24 @@ class ContentBlocklistRepository {
     ..._runtimeBlocklist,
   };
 
+  /// The accounts [accountPubkey] has explicitly blocked, for callers that
+  /// **write** a Nostr event on that account's behalf.
+  ///
+  /// Returns an empty set unless the persisted sets currently loaded belong
+  /// to [accountPubkey]. A keepAlive repository can still hold account A's
+  /// blocks while a session signs as account B — after a switch, until
+  /// [_adoptIdentity] runs — and filtering B's published data against A's
+  /// blocks would silently rewrite B's follow graph.
+  ///
+  /// Write paths must use this rather than [feedHiddenPubkeys] or
+  /// [shouldFilterFromFeeds]: those unions also carry `_blockedByOthers`, so
+  /// a third party could mutate the current user's published data simply by
+  /// blocking them.
+  Set<String> blockedPubkeysForAccount(String accountPubkey) =>
+      accountPubkey.isNotEmpty && _activeAccountPubkey == accountPubkey
+      ? blockedPubkeys
+      : const <String>{};
+
   /// Get count of blocked accounts
   int get totalBlockedCount =>
       _internalBlocklist.length + _runtimeBlocklist.length;

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -2194,6 +2194,160 @@ void main() {
     );
   });
 
+  group('blockedPubkeysForAccount', () {
+    const ourPubkey =
+        '0000000000000000000000000000000000000000000000000000000000000001';
+    const otherAccount =
+        '00000000000000000000000000000000000000000000000000000000000000aa';
+    const runtimeBlocked =
+        '0000000000000000000000000000000000000000000000000000000000000002';
+    const mutedByUs =
+        '0000000000000000000000000000000000000000000000000000000000000003';
+    const mutualMuter =
+        '0000000000000000000000000000000000000000000000000000000000000004';
+    const blockedByOther =
+        '0000000000000000000000000000000000000000000000000000000000000005';
+
+    test('is empty before any identity is adopted', () async {
+      final service = ContentBlocklistRepository();
+      await service.blockUser(runtimeBlocked);
+
+      expect(service.blockedPubkeys, contains(runtimeBlocked));
+      expect(service.blockedPubkeysForAccount(ourPubkey), isEmpty);
+    });
+
+    test('is empty for the empty pubkey', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final prefs = await SharedPreferences.getInstance();
+      final service = ContentBlocklistRepository(prefs: prefs);
+      final mockClient = _MockNostrClient();
+      when(
+        () => mockClient.subscribe(any()),
+      ).thenAnswer((_) => const Stream<Event>.empty());
+      await service.syncMuteListsInBackground(mockClient, ourPubkey);
+      await service.blockUser(runtimeBlocked, ourPubkey: ourPubkey);
+
+      expect(service.blockedPubkeysForAccount(''), isEmpty);
+    });
+
+    test(
+      'answers for the adopted account and withholds from every other one',
+      () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        final prefs = await SharedPreferences.getInstance();
+        final service = ContentBlocklistRepository(prefs: prefs);
+        final mockClient = _MockNostrClient();
+        when(
+          () => mockClient.subscribe(any()),
+        ).thenAnswer((_) => const Stream<Event>.empty());
+        await service.syncMuteListsInBackground(mockClient, ourPubkey);
+        await service.blockUser(runtimeBlocked, ourPubkey: ourPubkey);
+
+        expect(
+          service.blockedPubkeysForAccount(ourPubkey),
+          contains(runtimeBlocked),
+        );
+        // A keepAlive repository can still hold account A's blocks while a
+        // session signs as B. Answering here would filter B's published
+        // follow list against A's blocks (#6903).
+        expect(service.blockedPubkeysForAccount(otherAccount), isEmpty);
+      },
+    );
+
+    test(
+      'excludes every hide bucket that is not an explicit block by us',
+      () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        final prefs = await SharedPreferences.getInstance();
+        final service = ContentBlocklistRepository(prefs: prefs);
+
+        final muteController = StreamController<Event>();
+        final blockController = StreamController<Event>();
+        final mockMuteClient = _MockNostrClient();
+        final mockBlockClient = _MockNostrClient();
+        final mockSigner = _MockBlockListSigner();
+        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+        await service.blockUser(runtimeBlocked, ourPubkey: ourPubkey);
+
+        when(
+          () => mockMuteClient.subscribe(any()),
+        ).thenAnswer((_) => muteController.stream);
+        await service.syncMuteListsInBackground(mockMuteClient, ourPubkey);
+        muteController
+          ..add(
+            Event(
+                ourPubkey,
+                10000,
+                [
+                  ['p', mutedByUs],
+                ],
+                '',
+                createdAt: now,
+              )
+              ..id = 'own-mute'
+              ..sig = 'sig',
+          )
+          ..add(
+            Event(
+                mutualMuter,
+                10000,
+                [
+                  ['p', ourPubkey],
+                ],
+                '',
+                createdAt: now,
+              )
+              ..id = 'mutual-mute'
+              ..sig = 'sig',
+          );
+
+        when(
+          () => mockBlockClient.subscribe(any()),
+        ).thenAnswer((_) => blockController.stream);
+        when(
+          () => mockBlockClient.queryEvents(any()),
+        ).thenAnswer((_) async => <Event>[]);
+        when(() => mockSigner.isAuthenticated).thenReturn(false);
+        await service.syncBlockListsInBackground(
+          mockBlockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        blockController.add(
+          Event(
+              blockedByOther,
+              30000,
+              [
+                ['d', 'block'],
+                ['p', ourPubkey],
+              ],
+              'Block list',
+              createdAt: now,
+            )
+            ..id = 'blocked-by'
+            ..sig = 'sig',
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        // Every bucket below is hidden from feeds, and every one of them
+        // would be attacker- or third-party-controlled input to a Nostr
+        // event if it reached a write path. `blockedByOther` is the sharp
+        // one: including it would let anyone rewrite our published follow
+        // list just by blocking us.
+        expect(service.feedHiddenPubkeys, contains(blockedByOther));
+        expect(
+          service.blockedPubkeysForAccount(ourPubkey),
+          equals(<String>{runtimeBlocked}),
+        );
+
+        await muteController.close();
+        await blockController.close();
+      },
+    );
+  });
+
   group('ContentBlocklistRepository - Nostr publishing', () {
     late _MockNostrClient mockClient;
     late _MockBlockListSigner mockSigner;

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -46,7 +46,9 @@ class FollowRepository {
     QueueOfflineFollowCallback? queueOfflineAction,
     QueryContactListCallback? queryContactList,
     RelayFactory? relayFactory,
+    BlockedPubkeysCallback? blockedPubkeys,
   }) : _nostrClient = nostrClient,
+       _blockedPubkeys = blockedPubkeys,
        _isCacheInitialized = isCacheInitialized,
        _getCachedEventsByKind = getCachedEventsByKind,
        _cacheUserEvent = cacheUserEvent,
@@ -82,6 +84,11 @@ class FollowRepository {
 
   /// Factory for creating relay instances (injectable for testing).
   final RelayFactory _relayFactory;
+
+  /// Callback supplying the accounts the signing user has blocked.
+  ///
+  /// Null leaves the published contact list unfiltered.
+  final BlockedPubkeysCallback? _blockedPubkeys;
 
   /// Default relay factory — creates a real [RelayBase].
   static RelayBase _defaultRelayFactory(String url, RelayStatus status) =>
@@ -2366,6 +2373,54 @@ class FollowRepository {
     );
   }
 
+  /// Republish the contact list without changing who is followed.
+  ///
+  /// Blocking never runs through follow/unfollow, and nothing republishes
+  /// kind 3 on a schedule, so a block that contradicts the follow list would
+  /// otherwise sit on relays until the user's next unrelated follow — which
+  /// may never come. The app layer calls this to settle that contradiction
+  /// (#6903); the omission itself happens in [_publishableFollows].
+  ///
+  /// Throws if the user is not authenticated.
+  Future<void> republishContactList() async {
+    if (!_nostrClient.hasKeys) {
+      throw Exception('User not authenticated');
+    }
+    await _broadcastContactList();
+  }
+
+  /// The follows to publish: [_followingPubkeys] minus the accounts the
+  /// signing user has blocked.
+  ///
+  /// Blocking hides an account throughout the app, but leaving it in the
+  /// published kind 3 tells every other client — and Divine's own public,
+  /// unauthenticated follower APIs — that the user still follows them
+  /// (#6903).
+  ///
+  /// The local list is deliberately **not** mutated. That keeps every
+  /// in-app reader on today's behaviour, and it makes unblocking restore
+  /// the follow on the next publish rather than costing it permanently.
+  List<String> _publishableFollows() {
+    final blocked = _blockedPubkeys?.call(_nostrClient.publicKey);
+    if (blocked == null || blocked.isEmpty) return _followingPubkeys;
+
+    final publishable = _followingPubkeys
+        .where((pubkey) => !blocked.contains(pubkey))
+        .toList();
+
+    final omittedCount = _followingPubkeys.length - publishable.length;
+    if (omittedCount > 0) {
+      Log.info(
+        'Omitting $omittedCount blocked pubkey(s) from the published '
+        'contact list',
+        name: 'FollowRepository',
+        category: LogCategory.system,
+      );
+    }
+
+    return publishable;
+  }
+
   /// Broadcast updated contact list to network (Kind 3 event)
   Future<void> _broadcastContactList() async {
     // Last line of defence: [executeFollowAction] appends without validating,
@@ -2378,9 +2433,8 @@ class FollowRepository {
     );
     _emitFollowingList();
 
-    // Create ContactList with all followed pubkeys
     final contactList = ContactList();
-    for (final pubkey in _followingPubkeys) {
+    for (final pubkey in _publishableFollows()) {
       contactList.add(Contact(publicKey: pubkey));
     }
 

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -2413,9 +2413,18 @@ class FollowRepository {
   /// unauthenticated follower APIs — that the user still follows them
   /// (#6903).
   ///
-  /// The local list is deliberately **not** mutated. That keeps every
-  /// in-app reader on today's behaviour, and it makes unblocking restore
-  /// the follow on the next publish rather than costing it permanently.
+  /// The local list is deliberately **not** mutated here, so a block never
+  /// costs the follow synchronously and unblocking re-includes it on the
+  /// next publish.
+  ///
+  /// That is a publish-boundary property, not a durable one. The filtered
+  /// event is what relays hold from then on, so the next [initialize] reads
+  /// it back and [_processContactListEvent] replaces the local list with it
+  /// — a filtered list is a strict subset, so the catastrophic-reduction
+  /// guard correctly declines to merge. In practice the follow survives
+  /// locally for the rest of the session that blocked, and is gone after
+  /// the next launch. Whether it should be restorable at all is open with
+  /// T&S (#6903).
   List<String> _publishableFollows() {
     final blocked = _blockedPubkeys?.call(_nostrClient.publicKey);
     if (blocked == null || blocked.isEmpty) return _followingPubkeys;

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -152,6 +152,7 @@ class FollowRepository {
   List<String> _followingPubkeys = [];
   Event? _currentUserContactListEvent;
   bool _isInitialized = false;
+  final Completer<void> _initializedCompleter = Completer<void>();
 
   // In-memory cache — my followers (populated after first fetch)
   List<String> _cachedMyFollowersPubkeys = [];
@@ -168,6 +169,18 @@ class FollowRepository {
   List<String> get followingPubkeys => List.unmodifiable(_followingPubkeys);
   bool get isInitialized => _isInitialized;
   int get followingCount => _followingPubkeys.length;
+
+  /// Completes once [initialize] has finished, including the authoritative
+  /// relay query.
+  ///
+  /// Anything that publishes a contact list on its own schedule — rather
+  /// than in response to the user following someone — must wait for this.
+  /// [initialize] emits the LocalStorage snapshot on [followingStream]
+  /// seconds before the relay answers, and every derived source can lag or
+  /// truncate (#6109); publishing from one destroys the follows it is
+  /// missing. Never completes while the user has no keys, since
+  /// [initialize] returns early and stays retryable.
+  Future<void> get initialized => _initializedCompleter.future;
 
   /// Drops entries that are not 32-byte hex pubkeys.
   ///
@@ -1625,6 +1638,9 @@ class FollowRepository {
       }
 
       _isInitialized = true;
+      if (!_initializedCompleter.isCompleted) {
+        _initializedCompleter.complete();
+      }
 
       // Guarantee at least one post-seed emission for "no follows" users.
       // When the user follows nobody, _emitFollowingList() never fires

--- a/mobile/packages/follow_repository/lib/src/follower_stats.dart
+++ b/mobile/packages/follow_repository/lib/src/follower_stats.dart
@@ -34,6 +34,15 @@ typedef CacheUserEventCallback = void Function(Event event);
 /// Defaults to [RelayBase]. Override in tests to inject mock relays.
 typedef RelayFactory = RelayBase Function(String url, RelayStatus status);
 
+/// Callback returning the accounts [accountPubkey] has explicitly blocked.
+///
+/// Called once per contact-list publish with the pubkey that will sign the
+/// event. Implementations must answer for that account only, and must return
+/// the user's *own* blocks — never a union that also carries "who blocked
+/// us", which would let a third party rewrite the current user's published
+/// follow list.
+typedef BlockedPubkeysCallback = Set<String> Function(String accountPubkey);
+
 /// Immutable follower/following counts for a pubkey.
 @immutable
 class FollowerStats {

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -843,6 +843,34 @@ void main() {
       });
     });
 
+    group('initialized', () {
+      test('does not complete while the user has no keys', () async {
+        when(() => mockNostrClient.hasKeys).thenReturn(false);
+        var completed = false;
+        unawaited(repository.initialized.then((_) => completed = true));
+
+        await repository.initialize();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(repository.isInitialized, isFalse);
+        expect(completed, isFalse);
+      });
+
+      test('completes once initialize finishes', () async {
+        await repository.initialize();
+
+        await expectLater(repository.initialized, completes);
+        expect(repository.isInitialized, isTrue);
+      });
+
+      test('stays completed across a repeated initialize', () async {
+        await repository.initialize();
+        await repository.initialize();
+
+        await expectLater(repository.initialized, completes);
+      });
+    });
+
     group('unfollow', () {
       test('throws when not authenticated', () async {
         when(() => mockNostrClient.hasKeys).thenReturn(false);

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -105,6 +105,8 @@ void main() {
         'b2c3d4e5f6789012345678901234567890abcdef1234567890123456789012a1';
     const testTargetPubkey2 =
         'c3d4e5f6789012345678901234567890abcdef1234567890123456789012ab12';
+    const testTargetPubkey3 =
+        'd4e5f6789012345678901234567890abcdef1234567890123456789012ab12c3';
 
     setUpAll(() {
       registerFallbackValue(_MockEvent());
@@ -660,6 +662,184 @@ void main() {
         expect(emittedValues.last, isEmpty);
 
         await subscription.cancel();
+      });
+    });
+
+    // #6903: blocking hid the account in-app but left it in the published
+    // kind 3, so Divine's own public follower APIs kept reporting the follow.
+    // The omission happens at the publish boundary only — the local list is
+    // untouched, which is what makes unblocking restore the follow and what
+    // keeps every in-app reader on its existing behaviour.
+    group('blocked pubkeys are omitted from the published contact list', () {
+      late List<ContactList> publishedLists;
+      late Set<String> blocked;
+      late List<String> accountsAsked;
+
+      FollowRepository buildRepository({
+        BlockedPubkeysCallback? blockedPubkeys,
+      }) {
+        return FollowRepository(
+          nostrClient: mockNostrClient,
+          isCacheInitialized: () => cacheIsInitialized,
+          getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+          cacheUserEvent: cachedUserEvents.add,
+          indexerRelayUrls: const [],
+          blockedPubkeys: blockedPubkeys,
+        );
+      }
+
+      List<String> publishedPubkeys(ContactList list) =>
+          list.list().map((contact) => contact.publicKey).toList();
+
+      setUp(() {
+        SharedPreferences.setMockInitialValues({
+          'following_list_$testCurrentUserPubkey':
+              '["$testTargetPubkey", "$testTargetPubkey2"]',
+        });
+
+        blocked = <String>{};
+        accountsAsked = <String>[];
+        publishedLists = <ContactList>[];
+
+        final mockEvent = _MockEvent();
+        when(() => mockEvent.id).thenReturn(testCurrentUserPubkey);
+        when(() => mockEvent.content).thenReturn('');
+        when(
+          () => mockNostrClient.sendContactList(
+            captureAny(),
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          publishedLists.add(invocation.positionalArguments[0] as ContactList);
+          return mockEvent;
+        });
+      });
+
+      test('publishes every follow when no port is injected', () async {
+        repository = buildRepository();
+        await repository.initialize();
+
+        await repository.republishContactList();
+
+        expect(publishedLists, hasLength(1));
+        expect(publishedPubkeys(publishedLists.single), [
+          testTargetPubkey,
+          testTargetPubkey2,
+        ]);
+      });
+
+      test('publishes every follow when nothing is blocked', () async {
+        repository = buildRepository(blockedPubkeys: (_) => blocked);
+        await repository.initialize();
+
+        await repository.republishContactList();
+
+        expect(publishedPubkeys(publishedLists.single), [
+          testTargetPubkey,
+          testTargetPubkey2,
+        ]);
+      });
+
+      test('omits a blocked follow while the local list keeps it', () async {
+        blocked.add(testTargetPubkey);
+        repository = buildRepository(blockedPubkeys: (_) => blocked);
+        await repository.initialize();
+
+        final emitted = <List<String>>[];
+        final subscription = repository.followingStream.listen(emitted.add);
+        // followingStream replays its latest value to late subscribers, so
+        // drain that before counting what the publish itself emits.
+        await Future<void>.delayed(Duration.zero);
+        final emittedBefore = emitted.length;
+
+        await repository.republishContactList();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(publishedPubkeys(publishedLists.single), [testTargetPubkey2]);
+
+        // The local list is the half that must NOT change: mutating it here
+        // would make unblocking cost the follow permanently, and would flip
+        // every in-app follow-list reader at the same time.
+        expect(repository.followingPubkeys, [
+          testTargetPubkey,
+          testTargetPubkey2,
+        ]);
+        expect(repository.isFollowing(testTargetPubkey), isTrue);
+        expect(
+          emitted.length,
+          emittedBefore,
+          reason: 'the publish filter must not emit on followingStream',
+        );
+
+        await subscription.cancel();
+      });
+
+      test('re-includes the follow once the block is lifted', () async {
+        blocked.add(testTargetPubkey);
+        repository = buildRepository(blockedPubkeys: (_) => blocked);
+        await repository.initialize();
+
+        await repository.republishContactList();
+        expect(publishedPubkeys(publishedLists.single), [testTargetPubkey2]);
+
+        blocked.remove(testTargetPubkey);
+        await repository.republishContactList();
+
+        expect(publishedPubkeys(publishedLists.last), [
+          testTargetPubkey,
+          testTargetPubkey2,
+        ]);
+      });
+
+      test('asks the port for the signing account only', () async {
+        repository = buildRepository(
+          blockedPubkeys: (account) {
+            accountsAsked.add(account);
+            return blocked;
+          },
+        );
+        await repository.initialize();
+
+        await repository.republishContactList();
+
+        // The repository hands over the pubkey that will sign the event, so
+        // the app layer can refuse to answer for any other account. Without
+        // it a session signing as B could publish B's kind 3 filtered
+        // against A's blocklist.
+        expect(accountsAsked, [testCurrentUserPubkey]);
+      });
+
+      test('drops the blocked entry on an ordinary follow too', () async {
+        blocked.add(testTargetPubkey);
+        repository = buildRepository(blockedPubkeys: (_) => blocked);
+        await repository.initialize();
+
+        await repository.follow(testTargetPubkey3);
+
+        expect(publishedPubkeys(publishedLists.single), [
+          testTargetPubkey2,
+          testTargetPubkey3,
+        ]);
+      });
+
+      test('republishContactList throws when not authenticated', () async {
+        repository = buildRepository(blockedPubkeys: (_) => blocked);
+        await repository.initialize();
+        when(() => mockNostrClient.hasKeys).thenReturn(false);
+
+        await expectLater(
+          repository.republishContactList(),
+          throwsA(
+            isA<Exception>().having(
+              (e) => e.toString(),
+              'message',
+              contains('not authenticated'),
+            ),
+          ),
+        );
+        expect(publishedLists, isEmpty);
       });
     });
 
@@ -2017,6 +2197,71 @@ void main() {
         // then close the controller.
         await repository.dispose();
         await realTimeStreamController.close();
+      });
+
+      // #6903 filters at the publish boundary only. The inbound path must
+      // stay unfiltered: `hasNewPubkeys` is computed from the incoming list,
+      // so dropping blocked entries before the catastrophic-reduction guard
+      // can flip it false, skip the guard, and let a truncated remote list
+      // replace the local one wholesale — the #6109 class of follow loss.
+      test('does not filter an incoming contact list before the merge '
+          'guard', () async {
+        final seededPubkeys = List.generate(
+          12,
+          (i) => i.toRadixString(16).padLeft(64, '0'),
+        );
+        SharedPreferences.setMockInitialValues({
+          'following_list_$testCurrentUserPubkey':
+              '[${seededPubkeys.map((p) => '"$p"').join(',')}]',
+        });
+        const blockedNewPubkey =
+            'ff00000000000000000000000000000000000000000000000000000000000002';
+
+        when(() => mockNostrClient.sendContactList(any(), any())).thenAnswer(
+          (_) async => Event(
+            testCurrentUserPubkey,
+            EventKind.contactList,
+            [],
+            '',
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 200,
+          ),
+        );
+
+        repository = FollowRepository(
+          nostrClient: mockNostrClient,
+          isCacheInitialized: () => cacheIsInitialized,
+          getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+          cacheUserEvent: cachedUserEvents.add,
+          indexerRelayUrls: const [],
+          blockedPubkeys: (_) => const {blockedNewPubkey},
+        );
+        await repository.initialize();
+        expect(repository.followingCount, 12);
+
+        // The sole incoming pubkey is one we blocked. Filtering it on the way
+        // in would leave an empty list, which is a strict subset — the guard
+        // would accept it and 12 follows would be gone.
+        realTimeStreamController.add(
+          Event(
+            testCurrentUserPubkey,
+            EventKind.contactList,
+            [
+              ['p', blockedNewPubkey],
+            ],
+            '',
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 100,
+          ),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(
+          repository.followingCount,
+          13,
+          reason: 'the guard must merge, not replace',
+        );
+        for (final pubkey in seededPubkeys) {
+          expect(repository.followingPubkeys, contains(pubkey));
+        }
       });
 
       test('updates following list when newer Kind 3 event arrives', () async {

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -668,8 +668,9 @@ void main() {
     // #6903: blocking hid the account in-app but left it in the published
     // kind 3, so Divine's own public follower APIs kept reporting the follow.
     // The omission happens at the publish boundary only — the local list is
-    // untouched, which is what makes unblocking restore the follow and what
-    // keeps every in-app reader on its existing behaviour.
+    // untouched by the filter, so blocking never costs the follow
+    // synchronously. The round-trip that does drop it is pinned separately
+    // in 'the filtered kind 3 read back replaces the local list' below.
     group('blocked pubkeys are omitted from the published contact list', () {
       late List<ContactList> publishedLists;
       late Set<String> blocked;
@@ -840,6 +841,81 @@ void main() {
           ),
         );
         expect(publishedLists, isEmpty);
+      });
+
+      // The filter is a publish-boundary property, and this is where it
+      // stops being one. Relays hold the filtered event from the publish
+      // onwards, so the next initialize() reads it back and replaces the
+      // local list with it — the entry is a strict subset, so the
+      // catastrophic-reduction guard correctly declines to merge. Pinned so
+      // that "unblocking restores the follow" is never read as durable: it
+      // holds for the session that blocked, not past the next launch.
+      // Whether it should be restorable at all is open with T&S (#6903).
+      test('the filtered kind 3 read back replaces the local list', () async {
+        blocked.add(testTargetPubkey);
+        var relayContactList = Event(
+          testCurrentUserPubkey,
+          EventKind.contactList,
+          [
+            ['p', testTargetPubkey],
+            ['p', testTargetPubkey2],
+          ],
+          '',
+          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        );
+        when(
+          () => mockNostrClient.sendContactList(
+            captureAny(),
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          final list = invocation.positionalArguments[0] as ContactList;
+          publishedLists.add(list);
+          // What the relay now serves to everyone, including us.
+          return relayContactList = Event(
+            testCurrentUserPubkey,
+            EventKind.contactList,
+            [
+              for (final contact in list.list()) ['p', contact.publicKey],
+            ],
+            '',
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 1,
+          );
+        });
+
+        FollowRepository session() => FollowRepository(
+          nostrClient: mockNostrClient,
+          isCacheInitialized: () => cacheIsInitialized,
+          getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+          cacheUserEvent: cachedUserEvents.add,
+          indexerRelayUrls: const [],
+          blockedPubkeys: (_) => blocked,
+          queryContactList:
+              ({
+                required eventStream,
+                required pubkey,
+                fallbackTimeoutSeconds = 10,
+              }) async => relayContactList,
+        );
+
+        repository = session();
+        await repository.initialize();
+        await repository.republishContactList();
+        expect(publishedPubkeys(publishedLists.single), [testTargetPubkey2]);
+        expect(
+          repository.followingPubkeys,
+          contains(testTargetPubkey),
+          reason: 'still intact for the rest of this session',
+        );
+        await repository.dispose();
+
+        repository = session();
+        await repository.initialize();
+
+        expect(repository.followingPubkeys, [testTargetPubkey2]);
+        expect(repository.isFollowing(testTargetPubkey), isFalse);
       });
     });
 

--- a/mobile/test/blocs/comments/comment_reactions/comment_reactions_bloc_test.dart
+++ b/mobile/test/blocs/comments/comment_reactions/comment_reactions_bloc_test.dart
@@ -7,7 +7,6 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:comments_repository/comments_repository.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:follow_repository/follow_repository.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/comments/comment_reactions/comment_reactions_bloc.dart';
@@ -27,8 +26,6 @@ class _MockContentReportingService extends Mock
 class _MockContentBlocklistRepository extends Mock
     implements ContentBlocklistRepository {}
 
-class _MockFollowRepository extends Mock implements FollowRepository {}
-
 void main() {
   setUpAll(() {
     registerFallbackValue(ContentFilterReason.spam);
@@ -40,7 +37,6 @@ void main() {
     late _MockLikesRepository mockLikesRepository;
     late _MockContentReportingService mockContentReportingService;
     late _MockContentBlocklistRepository mockContentBlocklistRepository;
-    late _MockFollowRepository mockFollowRepository;
 
     String validId(String suffix) {
       final hexSuffix = suffix.codeUnits
@@ -55,7 +51,6 @@ void main() {
       mockLikesRepository = _MockLikesRepository();
       mockContentReportingService = _MockContentReportingService();
       mockContentBlocklistRepository = _MockContentBlocklistRepository();
-      mockFollowRepository = _MockFollowRepository();
 
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
       when(
@@ -68,7 +63,6 @@ void main() {
       when(() => mockLikesRepository.getUserVoteStatuses(any())).thenAnswer(
         (_) async => (upvotedIds: <String>{}, downvotedIds: <String>{}),
       );
-      when(() => mockFollowRepository.isFollowing(any())).thenReturn(false);
     });
 
     CommentReactionsBloc createBloc({String? rootAddressableId}) =>
@@ -80,7 +74,6 @@ void main() {
             mockContentReportingService,
           ),
           contentBlocklistRepository: mockContentBlocklistRepository,
-          followRepository: mockFollowRepository,
           rootEventId: validId('root'),
           rootAddressableId: rootAddressableId,
         );
@@ -690,26 +683,6 @@ void main() {
             (b.state.outbox! as ReactionsOutboxRemoveByAuthor).authorPubkey,
             validId('blocked'),
           );
-        },
-      );
-
-      blocTest<CommentReactionsBloc, CommentReactionsState>(
-        'unfollows blocked user when currently following',
-        setUp: () {
-          when(
-            () => mockContentBlocklistRepository.blockUser(any()),
-          ).thenAnswer((_) async {});
-          when(() => mockFollowRepository.isFollowing(any())).thenReturn(true);
-          when(
-            () => mockFollowRepository.toggleFollow(any()),
-          ).thenAnswer((_) async {});
-        },
-        build: createBloc,
-        act: (b) => b.add(CommentBlockUserRequested(validId('blocked'))),
-        verify: (_) {
-          verify(
-            () => mockFollowRepository.toggleFollow(validId('blocked')),
-          ).called(1);
         },
       );
 

--- a/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
+++ b/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
@@ -707,8 +707,13 @@ void main() {
         },
       );
 
+      // #6903 moved severing the follow to the publish boundary:
+      // FollowRepository omits blocked accounts from the kind 3 it
+      // publishes. Unfollowing here as well would drop the follow locally,
+      // so unblocking could not restore it — and only two of the four block
+      // entry points would behave that way.
       blocTest<OtherProfileBloc, OtherProfileState>(
-        'calls toggleFollow when currently following the user',
+        'leaves the local follow state alone when blocking',
         setUp: () {
           when(
             () => mockFollowRepository.isFollowing(testPubkey),
@@ -716,39 +721,10 @@ void main() {
         },
         build: createBloc,
         act: (bloc) => bloc.add(const OtherProfileBlockRequested()),
-        verify: (_) {
-          verify(() => mockFollowRepository.toggleFollow(testPubkey)).called(1);
-        },
-      );
-
-      blocTest<OtherProfileBloc, OtherProfileState>(
-        'does not call toggleFollow when not following the user',
-        build: createBloc,
-        act: (bloc) => bloc.add(const OtherProfileBlockRequested()),
-        verify: (_) {
+        verify: (bloc) {
           verifyNever(() => mockFollowRepository.toggleFollow(any()));
-        },
-      );
-
-      blocTest<OtherProfileBloc, OtherProfileState>(
-        'still blocks user when toggleFollow throws',
-        setUp: () {
-          when(
-            () => mockFollowRepository.isFollowing(testPubkey),
-          ).thenReturn(true);
-          when(
-            () => mockFollowRepository.toggleFollow(testPubkey),
-          ).thenThrow(Exception('network error'));
-        },
-        build: createBloc,
-        act: (bloc) => bloc.add(const OtherProfileBlockRequested()),
-        verify: (_) {
-          verify(
-            () => mockBlocklistRepository.blockUser(
-              testPubkey,
-              ourPubkey: testCurrentUserPubkey,
-            ),
-          ).called(1);
+          verifyNever(() => mockFollowRepository.unfollow(any()));
+          expect(bloc.isFollowing, isTrue);
         },
       );
     });

--- a/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
+++ b/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
@@ -87,6 +87,34 @@ void main() {
           followRepository: mockFollowRepository,
         );
 
+    // Every other follow surface reads MyFollowingBloc, which filters blocked
+    // pubkeys. This getter feeds the profile ⋯ sheet's "Unfollow <name>" row,
+    // so if it disagrees the app offers to unfollow an account it elsewhere
+    // says you do not follow. #6903 stopped severing the follow locally, which
+    // makes that disagreement reachable from every block entry point.
+    test('reports a blocked account as not followed', () {
+      when(() => mockFollowRepository.isFollowing(testPubkey)).thenReturn(true);
+      when(
+        () => mockBlocklistRepository.isBlocked(testPubkey),
+      ).thenReturn(true);
+
+      final bloc = createBloc();
+      expect(bloc.isBlocked, isTrue);
+      expect(bloc.isFollowing, isFalse);
+      bloc.close();
+    });
+
+    test('reports an unblocked account as followed', () {
+      when(() => mockFollowRepository.isFollowing(testPubkey)).thenReturn(true);
+      when(
+        () => mockBlocklistRepository.isBlocked(testPubkey),
+      ).thenReturn(false);
+
+      final bloc = createBloc();
+      expect(bloc.isFollowing, isTrue);
+      bloc.close();
+    });
+
     test('initial state is OtherProfileInitial', () {
       final bloc = createBloc();
       expect(bloc.state, isA<OtherProfileInitial>());
@@ -718,13 +746,18 @@ void main() {
           when(
             () => mockFollowRepository.isFollowing(testPubkey),
           ).thenReturn(true);
+          when(
+            () => mockBlocklistRepository.isBlocked(testPubkey),
+          ).thenReturn(true);
         },
         build: createBloc,
         act: (bloc) => bloc.add(const OtherProfileBlockRequested()),
-        verify: (bloc) {
+        verify: (_) {
+          // Not mutating the follow list is the whole point: the omission
+          // happens when FollowRepository publishes, so unblocking restores
+          // the follow instead of costing it permanently.
           verifyNever(() => mockFollowRepository.toggleFollow(any()));
           verifyNever(() => mockFollowRepository.unfollow(any()));
-          expect(bloc.isFollowing, isTrue);
         },
       );
     });

--- a/mobile/test/blocs/others_followers/others_followers_bloc_test.dart
+++ b/mobile/test/blocs/others_followers/others_followers_bloc_test.dart
@@ -34,6 +34,9 @@ void main() {
 
       // Default: nothing is blocked
       when(() => mockBlocklistRepository.isBlocked(any())).thenReturn(false);
+      when(
+        () => mockBlocklistRepository.isFollowSevered(any()),
+      ).thenReturn(false);
       when(() => mockFollowRepository.isFollowing(any())).thenReturn(false);
     });
 
@@ -50,6 +53,50 @@ void main() {
     });
 
     group('OthersFollowersListLoadRequested', () {
+      // The sibling screen (OthersFollowingBloc) hides the current user from a
+      // blocked target's *following* list. This screen gated the same rule on a
+      // raw isFollowing() read instead, so after a block it kept listing the
+      // current user as a follower of the account they just blocked —
+      // contradicting the kind 3 we publish (#6903).
+      blocTest<OthersFollowersBloc, OthersFollowersState>(
+        "hides the current user from a blocked target's follower list",
+        setUp: () {
+          when(
+            () => mockBlocklistRepository.isBlocked(validPubkey('target')),
+          ).thenReturn(true);
+          // The local follow survives a block by design, so the raw read
+          // still reports true here.
+          when(
+            () => mockFollowRepository.isFollowing(validPubkey('target')),
+          ).thenReturn(true);
+          when(
+            () => mockFollowRepository.watchOthersFollowersCached(
+              any(),
+              forceRefresh: any(named: 'forceRefresh'),
+            ),
+          ).thenAnswer(
+            (_) => Stream<CacheResult<FollowersSnapshot>>.value(
+              CacheResult.live(
+                FollowersSnapshot(
+                  pubkeys: [testCurrentUserPubkey, validPubkey('follower1')],
+                  count: 2,
+                ),
+              ),
+            ),
+          );
+        },
+        build: createBloc,
+        act: (bloc) =>
+            bloc.add(OthersFollowersListLoadRequested(validPubkey('target'))),
+        verify: (bloc) {
+          expect(
+            bloc.state.followersPubkeys,
+            isNot(contains(testCurrentUserPubkey)),
+          );
+          expect(bloc.state.followersPubkeys, [validPubkey('follower1')]);
+        },
+      );
+
       blocTest<OthersFollowersBloc, OthersFollowersState>(
         'emits [loading, success] with followers from repository',
         setUp: () {

--- a/mobile/test/providers/moderation_providers_blocked_follow_reconciler_test.dart
+++ b/mobile/test/providers/moderation_providers_blocked_follow_reconciler_test.dart
@@ -257,5 +257,23 @@ void main() {
 
       verify(() => followRepository.republishContactList()).called(1);
     });
+
+    // After unblock, the next follow/unfollow re-includes the pubkey in
+    // kind 3. If `settled` still held it, a same-session re-block would
+    // skip the republish and leave the public list intact.
+    test('republishes again when the same account is re-blocked', () async {
+      followingPubkeys = <String>[blockedFollow];
+      final container = await createContainer();
+      container.read(blockedFollowReconcilerProvider);
+
+      await blocklistRepository.blockUser(blockedFollow, ourPubkey: ourPubkey);
+      await Future<void>.delayed(Duration.zero);
+      await blocklistRepository.unblockUser(blockedFollow);
+      await Future<void>.delayed(Duration.zero);
+      await blocklistRepository.blockUser(blockedFollow, ourPubkey: ourPubkey);
+      await Future<void>.delayed(Duration.zero);
+
+      verify(() => followRepository.republishContactList()).called(2);
+    });
   });
 }

--- a/mobile/test/providers/moderation_providers_blocked_follow_reconciler_test.dart
+++ b/mobile/test/providers/moderation_providers_blocked_follow_reconciler_test.dart
@@ -35,9 +35,11 @@ void main() {
   late ContentBlocklistRepository blocklistRepository;
   late StreamController<List<String>> followingController;
   late List<String> followingPubkeys;
+  late Completer<void> initializedCompleter;
 
   Future<ProviderContainer> createContainer({
     String signingPubkey = ourPubkey,
+    bool followsInitialized = true,
   }) async {
     SharedPreferences.setMockInitialValues(<String, Object>{});
     final prefs = await SharedPreferences.getInstance();
@@ -55,6 +57,12 @@ void main() {
     when(
       () => followRepository.followingStream,
     ).thenAnswer((_) => followingController.stream);
+    when(
+      () => followRepository.isInitialized,
+    ).thenAnswer((_) => followsInitialized);
+    when(
+      () => followRepository.initialized,
+    ).thenAnswer((_) => initializedCompleter.future);
     when(
       () => followRepository.republishContactList(),
     ).thenAnswer((_) async {});
@@ -81,6 +89,7 @@ void main() {
   setUp(() {
     followingPubkeys = <String>[];
     followingController = StreamController<List<String>>.broadcast();
+    initializedCompleter = Completer<void>()..complete();
   });
 
   tearDown(() async {
@@ -191,16 +200,62 @@ void main() {
       verifyNever(() => followRepository.republishContactList());
     });
 
+    // FollowRepository.initialize() emits the LocalStorage snapshot on
+    // followingStream seconds before the relay answers. That snapshot can
+    // lag or truncate (#6109), and republishing from it would drop every
+    // follow it is missing — on the write side, where no merge guard
+    // catches it.
+    test('does not republish before the relay load has landed', () async {
+      followingPubkeys = <String>[blockedFollow, otherFollow];
+      initializedCompleter = Completer<void>();
+      final container = await createContainer(followsInitialized: false);
+      container.read(blockedFollowReconcilerProvider);
+
+      await blocklistRepository.blockUser(blockedFollow, ourPubkey: ourPubkey);
+      await Future<void>.delayed(Duration.zero);
+      followingController.add(followingPubkeys);
+      await Future<void>.delayed(Duration.zero);
+
+      verifyNever(() => followRepository.republishContactList());
+    });
+
+    // A launch where the relay list matches LocalStorage merges without
+    // emitting, so both stream triggers stay silent. Initialization
+    // completing is what settles a contradiction that was already on disk.
+    test(
+      'reconciles when initialization completes without an emission',
+      () async {
+        followingPubkeys = <String>[blockedFollow];
+        initializedCompleter = Completer<void>();
+        final container = await createContainer(followsInitialized: false);
+        await blocklistRepository.blockUser(
+          blockedFollow,
+          ourPubkey: ourPubkey,
+        );
+        container.read(blockedFollowReconcilerProvider);
+
+        when(() => followRepository.isInitialized).thenAnswer((_) => true);
+        initializedCompleter.complete();
+        await Future<void>.delayed(Duration.zero);
+
+        verify(() => followRepository.republishContactList()).called(1);
+      },
+    );
+
+    // Subscribing before the block keeps the startup reconcile a no-op, so
+    // the only republish that can appear here is one a trigger caused.
     test('does not republish on an unblock', () async {
       followingPubkeys = <String>[blockedFollow];
       final container = await createContainer();
-      await blocklistRepository.blockUser(blockedFollow, ourPubkey: ourPubkey);
       container.read(blockedFollowReconcilerProvider);
+
+      await blocklistRepository.blockUser(blockedFollow, ourPubkey: ourPubkey);
+      await Future<void>.delayed(Duration.zero);
 
       await blocklistRepository.unblockUser(blockedFollow);
       await Future<void>.delayed(Duration.zero);
 
-      verifyNever(() => followRepository.republishContactList());
+      verify(() => followRepository.republishContactList()).called(1);
     });
   });
 }

--- a/mobile/test/providers/moderation_providers_blocked_follow_reconciler_test.dart
+++ b/mobile/test/providers/moderation_providers_blocked_follow_reconciler_test.dart
@@ -1,0 +1,206 @@
+// ABOUTME: Regression tests for the #6903 blocked-follow reconciler provider.
+// ABOUTME: Blocking must republish kind 3 without the blocked account.
+
+import 'dart:async';
+
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:openvine/providers/moderation_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/repository_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockFollowRepository extends Mock implements FollowRepository {}
+
+void main() {
+  const ourPubkey =
+      '0edc2f474484769bc9bf6d471d180e4e280b0bcd719b6da791001beb730cff1b';
+  const otherAccount =
+      '00000000000000000000000000000000000000000000000000000000000000aa';
+  const blockedFollow =
+      'b2c3d4e5f6789012345678901234567890abcdef1234567890123456789012a1';
+  const otherFollow =
+      'c3d4e5f6789012345678901234567890abcdef1234567890123456789012ab12';
+
+  late _MockNostrClient nostrClient;
+  late _MockFollowRepository followRepository;
+  late ContentBlocklistRepository blocklistRepository;
+  late StreamController<List<String>> followingController;
+  late List<String> followingPubkeys;
+
+  Future<ProviderContainer> createContainer({
+    String signingPubkey = ourPubkey,
+  }) async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    final prefs = await SharedPreferences.getInstance();
+
+    nostrClient = _MockNostrClient();
+    when(() => nostrClient.publicKey).thenReturn(signingPubkey);
+    when(
+      () => nostrClient.subscribe(any()),
+    ).thenAnswer((_) => const Stream<Event>.empty());
+
+    followRepository = _MockFollowRepository();
+    when(
+      () => followRepository.followingPubkeys,
+    ).thenAnswer((_) => followingPubkeys);
+    when(
+      () => followRepository.followingStream,
+    ).thenAnswer((_) => followingController.stream);
+    when(
+      () => followRepository.republishContactList(),
+    ).thenAnswer((_) async {});
+
+    blocklistRepository = ContentBlocklistRepository(prefs: prefs);
+    // Adopting the identity is what scopes the persisted blocks to an
+    // account; blockedPubkeysForAccount withholds everything until it runs.
+    await blocklistRepository.syncMuteListsInBackground(nostrClient, ourPubkey);
+
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        nostrServiceProvider.overrideWithValue(nostrClient),
+        followRepositoryProvider.overrideWithValue(followRepository),
+        contentBlocklistRepositoryProvider.overrideWithValue(
+          blocklistRepository,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  setUp(() {
+    followingPubkeys = <String>[];
+    followingController = StreamController<List<String>>.broadcast();
+  });
+
+  tearDown(() async {
+    await followingController.close();
+  });
+
+  group('blockedFollowReconcilerProvider', () {
+    test('republishes when a followed account is blocked', () async {
+      followingPubkeys = <String>[blockedFollow, otherFollow];
+      final container = await createContainer();
+      container.read(blockedFollowReconcilerProvider);
+
+      await blocklistRepository.blockUser(blockedFollow, ourPubkey: ourPubkey);
+      await Future<void>.delayed(Duration.zero);
+
+      verify(() => followRepository.republishContactList()).called(1);
+    });
+
+    test(
+      'does not republish when the blocked account is not followed',
+      () async {
+        followingPubkeys = <String>[otherFollow];
+        final container = await createContainer();
+        container.read(blockedFollowReconcilerProvider);
+
+        await blocklistRepository.blockUser(
+          blockedFollow,
+          ourPubkey: ourPubkey,
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        verifyNever(() => followRepository.republishContactList());
+      },
+    );
+
+    // The defect this exists for: blocking before the follow list has
+    // finished loading — a fresh install, a new sign-in, a cleared cache —
+    // leaves nothing to reconcile at block time. The list arriving later is
+    // the second chance.
+    test('heals a block made before the follow list loaded', () async {
+      final container = await createContainer();
+      container.read(blockedFollowReconcilerProvider);
+
+      await blocklistRepository.blockUser(blockedFollow, ourPubkey: ourPubkey);
+      await Future<void>.delayed(Duration.zero);
+      verifyNever(() => followRepository.republishContactList());
+
+      followingPubkeys = <String>[blockedFollow, otherFollow];
+      followingController.add(followingPubkeys);
+      await Future<void>.delayed(Duration.zero);
+
+      verify(() => followRepository.republishContactList()).called(1);
+    });
+
+    // divine-web keeps whichever kind 3 carries more entries
+    // (divinevideo/divine-web#551), so it can resurrect the entry we just
+    // dropped. Without the bound the two clients trade publishes forever.
+    test('republishes at most once per blocked pubkey per session', () async {
+      followingPubkeys = <String>[blockedFollow];
+      final container = await createContainer();
+      container.read(blockedFollowReconcilerProvider);
+
+      await blocklistRepository.blockUser(blockedFollow, ourPubkey: ourPubkey);
+      await Future<void>.delayed(Duration.zero);
+
+      followingController.add(followingPubkeys);
+      await Future<void>.delayed(Duration.zero);
+      followingController.add(followingPubkeys);
+      await Future<void>.delayed(Duration.zero);
+
+      verify(() => followRepository.republishContactList()).called(1);
+    });
+
+    test('retries on the next trigger when the republish fails', () async {
+      followingPubkeys = <String>[blockedFollow];
+      final container = await createContainer();
+      container.read(blockedFollowReconcilerProvider);
+
+      when(
+        () => followRepository.republishContactList(),
+      ).thenThrow(Exception('relay unreachable'));
+      await blocklistRepository.blockUser(blockedFollow, ourPubkey: ourPubkey);
+      await Future<void>.delayed(Duration.zero);
+
+      when(
+        () => followRepository.republishContactList(),
+      ).thenAnswer((_) async {});
+      followingController.add(followingPubkeys);
+      await Future<void>.delayed(Duration.zero);
+
+      verify(() => followRepository.republishContactList()).called(2);
+    });
+
+    // A keepAlive blocklist can still hold account A's blocks while the
+    // session signs as B. Reconciling then would rewrite B's follow list
+    // from A's data.
+    test('does not republish when the signing account is not the one whose '
+        'blocks are loaded', () async {
+      followingPubkeys = <String>[blockedFollow];
+      final container = await createContainer(signingPubkey: otherAccount);
+      container.read(blockedFollowReconcilerProvider);
+
+      await blocklistRepository.blockUser(blockedFollow, ourPubkey: ourPubkey);
+      await Future<void>.delayed(Duration.zero);
+      followingController.add(followingPubkeys);
+      await Future<void>.delayed(Duration.zero);
+
+      verifyNever(() => followRepository.republishContactList());
+    });
+
+    test('does not republish on an unblock', () async {
+      followingPubkeys = <String>[blockedFollow];
+      final container = await createContainer();
+      await blocklistRepository.blockUser(blockedFollow, ourPubkey: ourPubkey);
+      container.read(blockedFollowReconcilerProvider);
+
+      await blocklistRepository.unblockUser(blockedFollow);
+      await Future<void>.delayed(Duration.zero);
+
+      verifyNever(() => followRepository.republishContactList());
+    });
+  });
+}

--- a/mobile/test/router/app_shell_chrome_freeze_test.dart
+++ b/mobile/test/router/app_shell_chrome_freeze_test.dart
@@ -47,6 +47,7 @@ List<Override> _overrides({
   analyticsIdentitySyncProvider.overrideWithValue(null),
   pushNotificationSyncProvider.overrideWithValue(null),
   blocklistSyncBridgeProvider.overrideWithValue(null),
+  blockedFollowReconcilerProvider.overrideWithValue(null),
   authServiceProvider.overrideWithValue(mockAuthService),
   sharedPreferencesProvider.overrideWithValue(sharedPreferences),
   currentEnvironmentProvider.overrideWithValue(EnvironmentConfig.production),

--- a/mobile/test/router/app_shell_notification_badge_test.dart
+++ b/mobile/test/router/app_shell_notification_badge_test.dart
@@ -65,6 +65,7 @@ Widget _buildSubject({
         analyticsIdentitySyncProvider.overrideWithValue(null),
         pushNotificationSyncProvider.overrideWithValue(null),
         blocklistSyncBridgeProvider.overrideWithValue(null),
+        blockedFollowReconcilerProvider.overrideWithValue(null),
         authServiceProvider.overrideWithValue(mockAuthService),
         sharedPreferencesProvider.overrideWithValue(sharedPreferences),
         currentEnvironmentProvider.overrideWithValue(

--- a/mobile/test/router/app_shell_obscured_test.dart
+++ b/mobile/test/router/app_shell_obscured_test.dart
@@ -51,6 +51,7 @@ List<Override> _overrides({
   analyticsIdentitySyncProvider.overrideWithValue(null),
   pushNotificationSyncProvider.overrideWithValue(null),
   blocklistSyncBridgeProvider.overrideWithValue(null),
+  blockedFollowReconcilerProvider.overrideWithValue(null),
   authServiceProvider.overrideWithValue(mockAuthService),
   sharedPreferencesProvider.overrideWithValue(sharedPreferences),
   currentEnvironmentProvider.overrideWithValue(EnvironmentConfig.production),

--- a/mobile/test/router/app_shell_own_profile_encoding_test.dart
+++ b/mobile/test/router/app_shell_own_profile_encoding_test.dart
@@ -47,6 +47,7 @@ List<Override> _overrides({
   analyticsIdentitySyncProvider.overrideWithValue(null),
   pushNotificationSyncProvider.overrideWithValue(null),
   blocklistSyncBridgeProvider.overrideWithValue(null),
+  blockedFollowReconcilerProvider.overrideWithValue(null),
   authServiceProvider.overrideWithValue(mockAuthService),
   sharedPreferencesProvider.overrideWithValue(sharedPreferences),
   currentEnvironmentProvider.overrideWithValue(EnvironmentConfig.production),

--- a/mobile/test/screens/followers/others_followers_screen_test.dart
+++ b/mobile/test/screens/followers/others_followers_screen_test.dart
@@ -66,6 +66,9 @@ void main() {
       mockNostrClient = _MockNostrClient();
 
       when(() => mockBlocklistRepository.isBlocked(any())).thenReturn(false);
+      when(
+        () => mockBlocklistRepository.isFollowSevered(any()),
+      ).thenReturn(false);
       when(() => mockFollowRepository.isFollowing(any())).thenReturn(false);
       when(() => mockFollowRepository.followingPubkeys).thenReturn(const []);
       when(


### PR DESCRIPTION
## Description

Blocking someone hid them throughout the app but left them in the user's published NIP-02 kind-3 contact list. Divine's own public, unauthenticated APIs kept reporting the follow — `GET api.divine.video/api/users/{blocker}/following` contained the blocked pubkey, and `…/{blocked}/followers` contained the blocker — so a blocked account still appeared, to everyone, as someone the blocker follows and vouches for.

**Divine would be the first Nostr client to do this.** Across nine surveyed clients and SDKs — Amethyst (whose menu item is literally "Block & Hide User"), Damus, Primal, Nos, Coracle, Snort, NDK, applesauce/noStrudel — none removes the target from kind 3 on block or mute. There is no block NIP, and NIP-02 and NIP-51 are both silent on it. Mastodon severs the follow on block; Bluesky does not. This is a deliberate product choice, not a conformance fix.

### What the issue got right, and what it missed

The issue lists five block call sites and says none unfollows. Two of them already did — profile and comment — one had already been deleted, and the two DM paths never did. But the two that unfollowed were broken in a way the issue does not mention, and fixing only the DM sites would have left the bug reachable from all four:

1. **The DM paths never unfollowed** at all.
2. **The profile and comment paths were broken too.** Both guarded on `followRepository.isFollowing()`, a bare in-memory list read over a list that is not populated until `initialize()` finishes loading from the relay. Blocking inside that window — a fresh install, a new sign-in, a cleared cache — read `false` and silently skipped the unfollow.
3. **The obvious repository-level fix inverts the bug.** `toggleFollow()` branches on that same cold read, so a fix that reached for it would have *followed* the account the user just blocked.

### Approach

Blocked accounts are dropped at the **kind-3 publish boundary**, not from local state:

- `ContentBlocklistRepository.blockedPubkeysForAccount` answers only for the account whose persisted sets are currently loaded, and only with that user's *own* explicit blocks.
- `FollowRepository` takes it as a nullable port and omits those pubkeys when building the `ContactList`. `_followingPubkeys` is untouched.
- A keepAlive reconciler republishes when a block and the follow list contradict each other, since blocking never runs through follow/unfollow and nothing republishes kind 3 on a schedule.
- The four block call sites no longer unfollow individually, so they finally share one semantic.

Leaving local state alone is what makes **unblocking restore the follow** on the next publish. How long that lasts is narrower than it first looks, and the correction matters because it is the premise of the T&S question below: relays hold the filtered kind 3 from the publish onwards, so the next `initialize()` reads it back and `_processContactListEvent` replaces the local list with it — a filtered list is a strict subset, so the catastrophic-reduction guard correctly declines to merge. **The follow survives for the rest of the session that blocked, and is gone after the next launch** — not until a reinstall or a second device, as earlier revisions of this description said.

### Three things deliberately *not* done

- **No ingest-side filter.** `hasNewPubkeys` in the catastrophic-reduction guard is computed from the incoming list, so dropping blocked entries before the guard can flip it false, skip the guard, and let a truncated remote list replace the local one wholesale — the #6109 class of follow loss. A test pins that path unfiltered.
- **The predicate is `isBlocked`, never `shouldFilterFromFeeds`.** The latter unions in `_blockedByOthers`, so wiring it to a write path would let a third party rewrite the current user's published follow graph just by blocking them. An explicit negative test pins this.
- **The port is account-scoped.** A keepAlive blocklist can hold account A's data while a session signs as B; without the gate, B's follow list would be published filtered against A's blocks.

**Related Issue:** Closes #6903

## Out of Scope

- **AC3 ("external viewers no longer see blocked accounts as active follows") cannot be met by a divine-mobile-only change.** divine-web's follow mutation keeps whichever kind-3 carries more entries, so a web session holding a stale cache republishes the pre-block list and undoes the removal. Filed as divinevideo/divine-web#551. The reconciler is bounded to one republish per blocked pubkey per session precisely so the two clients cannot trade publishes indefinitely.
- **AC1 ("removes from the user-visible follow state") was already satisfied** before this PR — `MyFollowingBloc` filters blocked pubkeys before rendering and `MyFollowingState.isFollowing` reads that filtered list, so the Follow button already treated a blocked user as unfollowed. The in-app list is a false-negative oracle for this bug, which is why the tests assert against relay data instead.
- **Divine's own backend independently treats blocked accounts as follows.** funnelcake's For-You in-network pool unions every kind-30000 set — including our `d=block` list — onto the viewer's kind-3 follows. Filed as divinevideo/divine-funnelcake#867; it is a one-predicate fix that clears `/following`, `/followers`, `/social` and recommendations without any mobile change.
- `.content` preservation on kind 3 is untouched here. It is preserved only when `_currentUserContactListEvent` is set, which the local-storage and REST load paths do not do. Pre-existing, and orthogonal.

## Open question for T&S

**Does unblocking restore the follow?** This PR ships the behaviour that falls out of leaving local state alone: **restored if you unblock in the same session, gone after the next launch** (see the Approach section — the relay hands the filtered list back at the next `initialize()`). There is no mechanism today and the closest existing contract (`removeSeveredFollower`) has no callers, so any answer is new behaviour. If T&S wants "never restore" or "always restore" instead, both are reachable from here without redoing this — "never" by also removing from `_followingPubkeys`, "always" by persisting the severed follow. Flagging rather than deciding it in code review.

## Review fixes folded in

Three defects found in review, all real, two of them mine:

- **The reconciler could destroy follows at launch** (`84f6d41f`, @hm21). It triggered on `followingStream`, whose first emission during `initialize()` is the LocalStorage snapshot — before the authoritative relay query answers. A user who blocked on mobile and then followed people on another client republished the stale snapshot at launch and lost the follows only the relay had. Kind 3 is replaceable and the merge guard is inbound-only, so nothing caught it. Now every trigger is gated on `FollowRepository.isInitialized`. The e2e harness never called `initialize()`, which is why the suite missed it; it does now.
- **The durability claim was overstated** (`55a96853`, @hm21) — corrected above and in the code comments.
- **Re-blocking a just-unblocked account did not republish** (`b43b5bd6`, @dcadenas). The once-per-pubkey-per-session bound never cleared on unblock, so block → unblock → follow → block again left the account in the published list.

Two more found by running the app on device and simulator and reading the logs:

- **The profile ⋯ sheet offered "Unfollow" for a blocked account.** It gates that row on `OtherProfileBloc.isFollowing`, which read `FollowRepository` directly while every other follow surface reads `MyFollowingBloc` (already blocked-filtered). The same sheet's unblock-confirmation entry point already hardcodes `isFollowing: false` alongside `isBlocked: true`, so this was the semantic the screen assumed and only the main path disagreed.
- **We kept listing ourselves among a blocked account's followers.** `OthersFollowingBloc` hides the current user from a blocked target's *following* list, documented as exactly that intent; the mirror screen gated the same rule on a raw `isFollowing()` read and never consulted the blocklist. Pre-existing for the two DM block paths, which never severed the follow — uniform, and therefore visible, now that no block path does.

## Verification

- `flutter analyze lib test integration_test` — clean.
- `mobile/packages/follow_repository`: 275 tests, **100.00%** line coverage.
- `mobile/packages/content_blocklist_repository`: 117 tests, **100.00%** line coverage.
- Full `mobile` suite via `flutter test --exclude-tags golden`.
- `integration_test/e2e/block_leaves_kind3_follow_test.dart` on an iOS simulator: **+4 −0**. The suite was written against the bug and ran +2 −2 before the fix. It drives the real `Nostr → RelayPool → RelayManager → NostrClient` stack over real sockets against an in-process relay, and exercises the shipped reconciler rather than a copy of it. Added to the service-integration CI workflow.
- The other two suites in that workflow re-run green against the `FakeRelay` change (`relay_list_admission` 6/6, `dm_inbox_relay_admission` 3/3).

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
