### PR TITLE
test(settings): stop the scaffold test stranding an open Hive box

### DIFF
--- a/mobile/test/widgets/settings_screen_scaffold_test.dart
+++ b/mobile/test/widgets/settings_screen_scaffold_test.dart
@@ -10,22 +10,28 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/locale/locale_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/notification_preferences.dart';
 import 'package:openvine/notifications/providers/notification_repository_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/screens/notification_settings_screen.dart';
 import 'package:openvine/screens/settings/settings_screen.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/notification_preferences_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
 
 class _MockLocaleCubit extends MockCubit<LocaleState> implements LocaleCubit {}
 
+class _MockNotificationPreferencesService extends Mock
+    implements NotificationPreferencesService {}
+
 void main() {
   group('Settings Screen Scaffold Structure', () {
     late _MockAuthService mockAuthService;
     late _MockLocaleCubit mockLocaleCubit;
+    late _MockNotificationPreferencesService mockPrefsService;
     late SharedPreferences sharedPreferences;
 
     setUp(() async {
@@ -33,6 +39,10 @@ void main() {
       sharedPreferences = await SharedPreferences.getInstance();
       mockAuthService = _MockAuthService();
       mockLocaleCubit = _MockLocaleCubit();
+      mockPrefsService = _MockNotificationPreferencesService();
+      when(
+        mockPrefsService.loadPreferences,
+      ).thenAnswer((_) async => const NotificationPreferences());
       when(() => mockLocaleCubit.state).thenReturn(const LocaleState());
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
       when(() => mockAuthService.isAnonymous).thenReturn(false);
@@ -155,6 +165,11 @@ void main() {
             sharedPreferencesProvider.overrideWithValue(sharedPreferences),
             authServiceProvider.overrideWithValue(mockAuthService),
             notificationRepositoryProvider.overrideWithValue(null),
+            // The real store starts an `openBox('notifications')` this test
+            // never pumps to completion, stranding it for the whole isolate.
+            notificationPreferencesServiceProvider.overrideWithValue(
+              mockPrefsService,
+            ),
           ],
           child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -182,6 +197,11 @@ void main() {
             sharedPreferencesProvider.overrideWithValue(sharedPreferences),
             authServiceProvider.overrideWithValue(mockAuthService),
             notificationRepositoryProvider.overrideWithValue(null),
+            // The real store starts an `openBox('notifications')` this test
+            // never pumps to completion, stranding it for the whole isolate.
+            notificationPreferencesServiceProvider.overrideWithValue(
+              mockPrefsService,
+            ),
           ],
           child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,


### PR DESCRIPTION
Closes #7254

## What

`test/widgets/settings_screen_scaffold_test.dart` pumps the real `NotificationSettingsScreen` without overriding `notificationPreferencesServiceProvider`. Both notification tests now inject a mocked `NotificationPreferencesService`, so the screen never reaches real Hive.

## Why

The reported flake was `[ERROR] CacheRecoveryService Hive box clearing preserves durable notification preferences while clearing caches` in `test/services/cache_recovery_service_test.dart` — a file this PR does not touch. It is `[ERROR]`, not `[FAILED]`, because it is not a failed expectation: the test **hangs** and dies on the 10 minute `dart_test.yaml` timeout.

The chain:

1. Unoverridden, `NotificationSettingsScreen` builds `notificationPreferencesServiceProvider` → the real `HiveNotificationPreferencesStore`, and `NotificationSettingsCubit.load()` starts `Hive.openBox('notifications')`.
2. The widget test asserts on scaffold colours and ends without ever pumping that future to completion, so the open is abandoned mid-flight.
3. hive_ce records in-flight opens in `HiveImpl._openingBoxes[name]` and removes the entry only in the `finally` of the open that created it. An abandoned open leaves it there permanently.
4. Every later `Hive.openBox('notifications')` starts with `await _openingBoxes[name]` — so under `very_good test --optimization`, where the whole suite shares one isolate, that box is unopenable for the rest of the run.
5. `cache_recovery_service_test.dart` opens exactly that box in its first line and hangs for 10 minutes.

The fix has to sit in the test that starts the open: once `_openingBoxes` is poisoned, no amount of hardening in the victim can open the box.

## Evidence

Reproduced deterministically with `very_good test --optimization --exclude-tags integration --test-randomize-ordering-seed 1001` (the local `mise run test` setup):

- **Before:** suite hangs right after the `full cache recovery` group, then `TimeoutException after 0:10:00.000000: Test timed out after 10 minutes.` and the exact reported `Failing Tests` block.
- **After:** same seed, same command → `All tests passed!` (16609 tests).

Measured in the hung state, which pins the mechanism to `_openingBoxes` rather than to the filesystem or to Hive's backend:

| probe | result |
|---|---|
| `File.create()` in the same dir | succeeded |
| `Hive.openBox('zz_probe_box')` in the same dir | succeeded |
| `Hive.isBoxOpen('notifications')` | `false` |
| `Hive.boxExists('notifications')` | `false` (backend responsive) |
| `Hive.openBox('notifications', path: <unrelated fresh dir>)` | hung — the path is only used *after* the `_openingBoxes` await |

## Test plan

- `flutter test test/widgets/settings_screen_scaffold_test.dart test/services/cache_recovery_service_test.dart test/screens/notification_settings_screen_test.dart` — green.
- Full merged-isolate suite at seed 1001 — green (was red before the change).
- Test-only change; no app code touched, so there is nothing to verify on device.

## Correction to the mechanism in #7254

The issue guessed a `Hive.init` home-path race: eight untagged suites re-point Hive's global home directory and several delete that directory in `tearDown`, so a leftover write lock on the box name would block later opens. The measurements above rule that out — the box was not open, `boxExists` answered, a different box name opened fine in the very same directory, and `openBox(..., path: <unrelated dir>)` hung too even though the path is only read *after* the `_openingBoxes` await. The blocking state is name-keyed and independent of the home path.

So the issue's suggested fixes are not what closes this:

- **"Snapshot/restore Hive's home path in the eight suites"** — would not have helped; a stranded `_openingBoxes` entry survives any home-path handling.
- **"Extend `check_process_global_mutations.sh` to flag bare `Hive.init(`"** — still worth having, but it guards a different global than the one that caused this hang. Left out here so this PR stays the minimal fix for the reported failure.

The one guard that *would* have caught this statically is "a widget test must not build a provider that opens a real Hive box". Worth a follow-up; not in scope here.

## Follow-up found on the way (not fixed here)

`TestHelpers.cleanupHiveBox` closes the box with the untyped `Hive.box(name)`, which throws for `Box<PendingUpload>` and aborts the cleanup inside its own `catch`. The `pending_uploads` box therefore stays open across the whole merged isolate — measured ~4000 leak events per run — with its backing directory already deleted. That is the same class as #6748 and wants its own PR.
