### PR TITLE
refactor(analytics): convert the analytics package's singletons to constructor injection

### DIFF
--- a/mobile/lib/blocs/explore_tabs/explore_tabs_cubit.dart
+++ b/mobile/lib/blocs/explore_tabs/explore_tabs_cubit.dart
@@ -21,14 +21,16 @@ part 'explore_tabs_state.dart';
 /// analytics and top-hashtag loading) so the presentation layer reaches them
 /// through the cubit rather than importing services directly.
 class ExploreTabsCubit extends Cubit<ExploreTabsState> {
-  /// Creates the cubit. [screenAnalytics] and [topHashtags] default to
-  /// standalone instances; production injects the shared
-  /// `topHashtagsServiceProvider` instance (so the warmed cache is shared),
-  /// and tests inject fakes.
+  /// Creates the cubit. Production injects the shared
+  /// `screenAnalyticsServiceProvider` and `topHashtagsServiceProvider`
+  /// instances (so screen-load sessions and the warmed hashtag cache are
+  /// shared), and tests inject fakes. [topHashtags] defaults to a standalone
+  /// instance; [screenAnalytics] is required because a private instance would
+  /// never see the session the navigator observer started.
   ExploreTabsCubit({
-    ScreenAnalyticsService? screenAnalytics,
+    required ScreenAnalyticsService screenAnalytics,
     TopHashtagsLoader? topHashtags,
-  }) : _screenAnalytics = screenAnalytics ?? ScreenAnalyticsService(),
+  }) : _screenAnalytics = screenAnalytics,
        _topHashtags = topHashtags ?? TopHashtagsService(),
        super(const ExploreTabsState());
 

--- a/mobile/lib/blocs/featured_tabs/featured_tab_surface_telemetry.dart
+++ b/mobile/lib/blocs/featured_tabs/featured_tab_surface_telemetry.dart
@@ -11,11 +11,15 @@ import 'package:analytics/analytics.dart';
 /// is the only thing that varies.
 class FeaturedTabSurfaceTelemetry {
   /// Creates a telemetry adapter for the tab identified by [configId].
+  ///
+  /// [tracker] is required so this adapter shares the app's surface-load
+  /// sessions and page-load buffer instead of starting sessions on a private
+  /// tracker nothing else can complete or read.
   FeaturedTabSurfaceTelemetry({
     required String configId,
-    SurfacePerformanceTracker? tracker,
+    required SurfacePerformanceTracker tracker,
   }) : _configId = configId,
-       _tracker = tracker ?? SurfacePerformanceTracker();
+       _tracker = tracker;
 
   final String _configId;
   final SurfacePerformanceTracker _tracker;

--- a/mobile/lib/blocs/featured_tabs/featured_tab_videos_cubit.dart
+++ b/mobile/lib/blocs/featured_tabs/featured_tab_videos_cubit.dart
@@ -20,10 +20,10 @@ class FeaturedTabVideosCubit extends Cubit<FeaturedTabVideosState> {
   FeaturedTabVideosCubit({
     required FeaturedTabsRepository repository,
     required String tabId,
-    FeaturedTabSurfaceTelemetry? telemetry,
+    required FeaturedTabSurfaceTelemetry telemetry,
   }) : _repository = repository,
        _tabId = tabId,
-       _telemetry = telemetry ?? FeaturedTabSurfaceTelemetry(configId: tabId),
+       _telemetry = telemetry,
        super(const FeaturedTabVideosState());
 
   final FeaturedTabsRepository _repository;

--- a/mobile/lib/providers/analytics_providers.dart
+++ b/mobile/lib/providers/analytics_providers.dart
@@ -145,6 +145,16 @@ final screenAnalyticsServiceProvider = Provider<ScreenAnalyticsService>(
   (ref) => ScreenAnalyticsService(history: ref.watch(pageLoadHistoryProvider)),
 );
 
+/// Provides the app's shared [FeedPerformanceTracker].
+///
+/// Replaces the former `FeedPerformanceTracker()` factory singleton. A single
+/// shared instance is kept alive because a feed-load session is started by one
+/// consumer and completed by another, and the app lifecycle handler clears
+/// them all on resume.
+final feedPerformanceTrackerProvider = Provider<FeedPerformanceTracker>(
+  (ref) => FeedPerformanceTracker(),
+);
+
 /// Provides the app's shared [ErrorAnalyticsTracker].
 ///
 /// Replaces the former `ErrorAnalyticsTracker()` factory singleton. A single

--- a/mobile/lib/providers/analytics_providers.dart
+++ b/mobile/lib/providers/analytics_providers.dart
@@ -114,6 +114,15 @@ final analyticsIdentityCoordinatorProvider =
       ),
     );
 
+/// Provides the app's shared [PageLoadHistory] ring buffer.
+///
+/// Replaces the former `PageLoadHistory()` singleton. Both performance
+/// trackers write into it and Developer Options reads it back, so they must
+/// resolve the same buffer.
+final pageLoadHistoryProvider = Provider<PageLoadHistory>(
+  (ref) => PageLoadHistory(),
+);
+
 /// Provides the app's shared [SurfacePerformanceTracker].
 ///
 /// Replaces the former `SurfacePerformanceTracker()` factory singleton. A
@@ -122,7 +131,8 @@ final analyticsIdentityCoordinatorProvider =
 /// handler, and the tracker is mockable through a provider override in tests
 /// instead of reaching into static state.
 final surfacePerformanceTrackerProvider = Provider<SurfacePerformanceTracker>(
-  (ref) => SurfacePerformanceTracker(),
+  (ref) =>
+      SurfacePerformanceTracker(history: ref.watch(pageLoadHistoryProvider)),
 );
 
 /// Provides the app's shared [ScreenAnalyticsService].
@@ -132,7 +142,7 @@ final surfacePerformanceTrackerProvider = Provider<SurfacePerformanceTracker>(
 /// the navigator observer and completed later by the screen itself; a
 /// per-consumer instance would drop every session in between.
 final screenAnalyticsServiceProvider = Provider<ScreenAnalyticsService>(
-  (ref) => ScreenAnalyticsService(),
+  (ref) => ScreenAnalyticsService(history: ref.watch(pageLoadHistoryProvider)),
 );
 
 /// Provides the app's shared [ErrorAnalyticsTracker].

--- a/mobile/lib/providers/analytics_providers.dart
+++ b/mobile/lib/providers/analytics_providers.dart
@@ -125,6 +125,16 @@ final surfacePerformanceTrackerProvider = Provider<SurfacePerformanceTracker>(
   (ref) => SurfacePerformanceTracker(),
 );
 
+/// Provides the app's shared [ScreenAnalyticsService].
+///
+/// Replaces the former `ScreenAnalyticsService()` factory singleton. A single
+/// shared instance is kept alive because a screen-load session is started by
+/// the navigator observer and completed later by the screen itself; a
+/// per-consumer instance would drop every session in between.
+final screenAnalyticsServiceProvider = Provider<ScreenAnalyticsService>(
+  (ref) => ScreenAnalyticsService(),
+);
+
 /// Provides the app's shared [ErrorAnalyticsTracker].
 ///
 /// Replaces the former `ErrorAnalyticsTracker()` factory singleton. A single

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -13,6 +13,7 @@ import 'package:openvine/config/screenshot_mode.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/invite_availability.dart';
 import 'package:openvine/models/minor_account_review_status.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/invite_availability_providers.dart';
 import 'package:openvine/router/navigator_keys.dart';
@@ -128,7 +129,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
     // Start at /welcome - redirect logic will navigate to appropriate route.
     initialLocation:
         ref.read(routerInitialLocationProvider) ?? WelcomeScreen.path,
-    observers: _buildRouterObservers(),
+    observers: _buildRouterObservers(ref),
     // Refresh router when auth or account-review state changes
     refreshListenable: refreshListenable,
     errorBuilder: (context, state) =>
@@ -165,8 +166,11 @@ final goRouterProvider = Provider<GoRouter>((ref) {
   return router;
 });
 
-List<NavigatorObserver> _buildRouterObservers() {
-  final observers = <NavigatorObserver>[routeObserver, PageLoadObserver()];
+List<NavigatorObserver> _buildRouterObservers(Ref ref) {
+  final observers = <NavigatorObserver>[
+    routeObserver,
+    PageLoadObserver(analytics: ref.read(screenAnalyticsServiceProvider)),
+  ];
 
   return observers;
 }

--- a/mobile/lib/screens/curated_list_feed_screen.dart
+++ b/mobile/lib/screens/curated_list_feed_screen.dart
@@ -1,7 +1,6 @@
 // ABOUTME: Screen for displaying videos from a curated NIP-51 kind 30005 list
 // ABOUTME: Shows videos in a grid with tap-to-play navigation
 
-import 'package:analytics/analytics.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:feed_repository/feed_repository.dart';
 import 'package:flutter/material.dart';
@@ -12,6 +11,7 @@ import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/extensions/safe_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/view_traffic_source.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/list_providers.dart';
 import 'package:openvine/screens/curated_list_by_author_screen.dart';
@@ -156,10 +156,12 @@ class _CuratedListFeedScreenState extends ConsumerState<CuratedListFeedScreen> {
             );
           }
 
-          ScreenAnalyticsService().markDataLoaded(
-            'curated_list',
-            dataMetrics: {'video_count': videos.length},
-          );
+          ref
+              .read(screenAnalyticsServiceProvider)
+              .markDataLoaded(
+                'curated_list',
+                dataMetrics: {'video_count': videos.length},
+              );
 
           // If in video mode, show fullscreen video player
           if (_activeVideoIndex != null) {

--- a/mobile/lib/screens/developer_options_screen.dart
+++ b/mobile/lib/screens/developer_options_screen.dart
@@ -18,6 +18,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/models/invite_availability.dart';
 import 'package:openvine/models/minor_account_review_status.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/protected_minor_providers.dart';
@@ -142,8 +143,9 @@ class _DeveloperOptionsScreenState
       const EnvironmentConfig(environment: AppEnvironment.poc),
     ];
 
-    final recentRecords = PageLoadHistory().getRecent(10);
-    final slowestRecords = PageLoadHistory().getSlowest(5);
+    final pageLoadHistory = ref.read(pageLoadHistoryProvider);
+    final recentRecords = pageLoadHistory.getRecent(10);
+    final slowestRecords = pageLoadHistory.getSlowest(5);
 
     return Scaffold(
       backgroundColor: context.vineColors.background,

--- a/mobile/lib/screens/discover_lists_screen.dart
+++ b/mobile/lib/screens/discover_lists_screen.dart
@@ -3,7 +3,6 @@
 
 import 'dart:async';
 
-import 'package:analytics/analytics.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -12,6 +11,7 @@ import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/mixins/scroll_pagination_mixin.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/list_providers.dart';
 import 'package:openvine/router/routes/route_extras.dart';
@@ -182,15 +182,17 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
                   _isRefreshing = false;
                 });
 
-                ScreenAnalyticsService().markDataLoaded(
-                  'discover_lists',
-                  dataMetrics: {
-                    'list_count': ref
-                        .read(discoveredListsProvider)
-                        .lists
-                        .length,
-                  },
-                );
+                ref
+                    .read(screenAnalyticsServiceProvider)
+                    .markDataLoaded(
+                      'discover_lists',
+                      dataMetrics: {
+                        'list_count': ref
+                            .read(discoveredListsProvider)
+                            .lists
+                            .length,
+                      },
+                    );
 
                 // Auto-paginate if we have few results
                 final providerState = ref.read(discoveredListsProvider);

--- a/mobile/lib/screens/explore/explore_screen.dart
+++ b/mobile/lib/screens/explore/explore_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/explore_tabs/explore_tabs_cubit.dart';
 import 'package:openvine/blocs/featured_tabs/featured_tabs_cubit.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/featured_tabs_providers.dart';
 import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/screens/explore/explore_view.dart';
@@ -80,10 +81,10 @@ class ExploreScreen extends ConsumerWidget {
     return MultiBlocProvider(
       providers: [
         BlocProvider(
-          // topHashtagsServiceProvider is a stable keepAlive Provider that is
-          // never invalidated, so ref.read is safe here (state_management.md
-          // §1).
+          // Both providers are stable keepAlive Providers that are never
+          // invalidated, so ref.read is safe here (state_management.md §1).
           create: (_) => ExploreTabsCubit(
+            screenAnalytics: ref.read(screenAnalyticsServiceProvider),
             topHashtags: ref.read(topHashtagsServiceProvider),
           ),
         ),

--- a/mobile/lib/screens/explore/tabs/featured_videos_tab.dart
+++ b/mobile/lib/screens/explore/tabs/featured_videos_tab.dart
@@ -8,10 +8,12 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:go_router/go_router.dart';
+import 'package:openvine/blocs/featured_tabs/featured_tab_surface_telemetry.dart';
 import 'package:openvine/blocs/featured_tabs/featured_tab_videos_cubit.dart';
 import 'package:openvine/blocs/featured_tabs/featured_tabs_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/view_traffic_source.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/featured_tabs_providers.dart';
 import 'package:openvine/providers/feed_repository_provider.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
@@ -40,9 +42,14 @@ class FeaturedVideosTab extends ConsumerWidget {
       // deliberately absent from the public config — the visible fields are the
       // only retarget signal the client can see.
       key: ValueKey((repository, config)),
-      create: (_) =>
-          FeaturedTabVideosCubit(repository: repository, tabId: config.id)
-            ..load(),
+      create: (_) => FeaturedTabVideosCubit(
+        repository: repository,
+        tabId: config.id,
+        telemetry: FeaturedTabSurfaceTelemetry(
+          configId: config.id,
+          tracker: ref.read(surfacePerformanceTrackerProvider),
+        ),
+      )..load(),
       child: _FeaturedVideosRetryOnPoll(
         child: _FeaturedVideosView(config: config),
       ),

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:analytics/analytics.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:feed_repository/feed_repository.dart';
 import 'package:feed_tuning_repository/feed_tuning_repository.dart';
@@ -23,6 +22,7 @@ import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/view_traffic_source.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/foreground_idle_warmup_provider.dart';
 import 'package:openvine/router/app_router.dart';
@@ -940,7 +940,10 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                                               )
                                               .markActive();
                                           _resumeAutoAdvanceAfterSwipe();
-                                          FeedPerformanceTracker()
+                                          ref
+                                              .read(
+                                                feedPerformanceTrackerProvider,
+                                              )
                                               .startVideoSwipeTracking(
                                                 video.id,
                                               );

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:analytics/analytics.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:feed_tuning_repository/feed_tuning_repository.dart';
 import 'package:flutter/material.dart';
@@ -15,6 +14,7 @@ import 'package:openvine/features/feature_flags/providers/feature_flag_providers
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/view_traffic_source.dart'
     show ViewTrafficSource;
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/foreground_idle_warmup_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -96,7 +96,7 @@ class VideoFeedPage extends ConsumerWidget {
             // the Divine-hosted-only filter: applyContentPreferences re-filters
             // on read and the splice-on-refresh keeps the post-active tail
             // fresh, so the cached serve is never stale to the viewer.
-            feedTracker: FeedPerformanceTracker(),
+            feedTracker: ref.read(feedPerformanceTrackerProvider),
             feedTuningRepository: feedTuningRepository,
             enrichVideos: (videos) => enrichVideosWithNostrTags(
               videos,
@@ -525,9 +525,11 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                                   .read(lastTabPositionProvider.notifier)
                                   .recordPosition(RouteType.home, index);
                               _resumeAutoAdvanceAfterSwipe();
-                              FeedPerformanceTracker().startVideoSwipeTracking(
-                                video.id,
-                              );
+                              ref
+                                  .read(feedPerformanceTrackerProvider)
+                                  .startVideoSwipeTracking(
+                                    video.id,
+                                  );
                               if (!_hasMarkedVideoReady && index == 0) {
                                 _hasMarkedVideoReady = true;
                                 StartupPerformanceService.instance

--- a/mobile/lib/screens/followers/my_followers_screen.dart
+++ b/mobile/lib/screens/followers/my_followers_screen.dart
@@ -1,7 +1,6 @@
 // ABOUTME: Screen displaying current user's followers list
 // ABOUTME: Uses MyFollowersBloc for list + MyFollowingBloc for follow button state
 
-import 'package:analytics/analytics.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -11,6 +10,7 @@ import 'package:openvine/blocs/follow_list_search/follow_list_search_bloc.dart';
 import 'package:openvine/blocs/my_followers/my_followers_bloc.dart';
 import 'package:openvine/blocs/my_following/my_following_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/router/nav_extensions.dart';
@@ -121,12 +121,14 @@ class _MyFollowersView extends ConsumerWidget {
           BlocListener<MyFollowersBloc, MyFollowersState>(
             listener: (context, state) {
               if (state.status == MyFollowersStatus.success) {
-                ScreenAnalyticsService().markDataLoaded(
-                  'followers',
-                  dataMetrics: {
-                    'followers_count': state.followersPubkeys.length,
-                  },
-                );
+                ref
+                    .read(screenAnalyticsServiceProvider)
+                    .markDataLoaded(
+                      'followers',
+                      dataMetrics: {
+                        'followers_count': state.followersPubkeys.length,
+                      },
+                    );
               }
             },
           ),

--- a/mobile/lib/screens/following/my_following_screen.dart
+++ b/mobile/lib/screens/following/my_following_screen.dart
@@ -1,7 +1,6 @@
 // ABOUTME: Screen displaying current user's following list
 // ABOUTME: Uses MyFollowingBloc for reactive updates via repository
 
-import 'package:analytics/analytics.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -11,6 +10,7 @@ import 'package:openvine/blocs/follow_list_search/follow_list_search_bloc.dart';
 import 'package:openvine/blocs/my_following/my_following_bloc.dart';
 import 'package:openvine/features/people_lists/models/people_list_entry_point.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/router/nav_extensions.dart';
@@ -117,10 +117,14 @@ class _MyFollowingView extends ConsumerWidget {
                 previous.status != MyFollowingStatus.toggleFailure),
         listener: (context, state) {
           if (state.status == MyFollowingStatus.success) {
-            ScreenAnalyticsService().markDataLoaded(
-              'following',
-              dataMetrics: {'following_count': state.followingPubkeys.length},
-            );
+            ref
+                .read(screenAnalyticsServiceProvider)
+                .markDataLoaded(
+                  'following',
+                  dataMetrics: {
+                    'following_count': state.followingPubkeys.length,
+                  },
+                );
           }
           if (state.status == MyFollowingStatus.toggleFailure) {
             ScaffoldMessenger.of(context).showSnackBar(

--- a/mobile/lib/screens/liked_videos_screen_router.dart
+++ b/mobile/lib/screens/liked_videos_screen_router.dart
@@ -1,7 +1,6 @@
 // ABOUTME: Router-aware liked videos screen that shows grid or feed based on URL
 // ABOUTME: Reads route context to determine grid mode vs feed mode
 
-import 'package:analytics/analytics.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:feed_repository/feed_repository.dart';
 import 'package:flutter/material.dart';
@@ -11,6 +10,7 @@ import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/profile_liked_videos/profile_liked_videos_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/view_traffic_source.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/router/router.dart';
@@ -216,10 +216,12 @@ class _LikedVideosFeedViewState extends ConsumerState<_LikedVideosFeedView> {
           );
         }
 
-        ScreenAnalyticsService().markDataLoaded(
-          'liked_videos',
-          dataMetrics: {'video_count': videos.length},
-        );
+        ref
+            .read(screenAnalyticsServiceProvider)
+            .markDataLoaded(
+              'liked_videos',
+              dataMetrics: {'video_count': videos.length},
+            );
 
         final safeIndex = widget.videoIndex.clamp(0, videos.length - 1);
 

--- a/mobile/lib/screens/other_profile_screen.dart
+++ b/mobile/lib/screens/other_profile_screen.dart
@@ -1,7 +1,6 @@
 // ABOUTME: Profile screen for viewing other users with bottom navigation
 // ABOUTME: Pushed on stack from video feeds, profiles, search results, etc.
 
-import 'package:analytics/analytics.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter/material.dart';
@@ -163,7 +162,7 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
   @override
   void initState() {
     super.initState();
-    FeedPerformanceTracker().startFeedLoad('profile');
+    ref.read(feedPerformanceTrackerProvider).startFeedLoad('profile');
     // The feed cubit cold-loads on mount (via ProfileFeedScope below); reading
     // it here would be a cross-route ProviderNotFoundException because the
     // cubit lives under build.
@@ -438,7 +437,7 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
             if (!_hasTrackedFeedLoad) {
               _hasTrackedFeedLoad = true;
               final count = feedState.videos.length;
-              final tracker = FeedPerformanceTracker();
+              final tracker = ref.read(feedPerformanceTrackerProvider);
               tracker.markFirstVideosReceived('profile', count);
               tracker.markFeedDisplayed('profile', count);
             }

--- a/mobile/lib/screens/other_profile_screen.dart
+++ b/mobile/lib/screens/other_profile_screen.dart
@@ -17,6 +17,7 @@ import 'package:openvine/features/people_lists/bloc/people_lists_bloc.dart';
 import 'package:openvine/features/people_lists/models/people_list_entry_point.dart';
 import 'package:openvine/features/people_lists/view/add_to_people_lists_sheet.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/official_accounts_providers.dart';
@@ -427,10 +428,12 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
           final feedState = context.watch<ProfileFeedCubit>().state;
           // Track analytics when data is loaded
           if (feedState.status == ProfileFeedStatus.ready) {
-            ScreenAnalyticsService().markDataLoaded(
-              'other_profile',
-              dataMetrics: {'video_count': feedState.videos.length},
-            );
+            ref
+                .read(screenAnalyticsServiceProvider)
+                .markDataLoaded(
+                  'other_profile',
+                  dataMetrics: {'video_count': feedState.videos.length},
+                );
 
             if (!_hasTrackedFeedLoad) {
               _hasTrackedFeedLoad = true;

--- a/mobile/lib/screens/profile_screen_router.dart
+++ b/mobile/lib/screens/profile_screen_router.dart
@@ -1,7 +1,6 @@
 // ABOUTME: Router-driven Instagram-style profile screen implementation
 // ABOUTME: Uses CustomScrollView with slivers for smooth scrolling, URL is source of truth
 
-import 'package:analytics/analytics.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -15,6 +14,7 @@ import 'package:openvine/blocs/profile_feed/profile_feed_cubit.dart';
 import 'package:openvine/blocs/profile_feed/profile_feed_scope.dart';
 import 'package:openvine/extensions/safe_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/router.dart';
@@ -459,10 +459,12 @@ class _ProfileDataView extends ConsumerWidget {
     final profile = ref.watch(userProfileReactiveProvider(userIdHex)).value;
 
     if (feedState.status == ProfileFeedStatus.ready) {
-      ScreenAnalyticsService().markDataLoaded(
-        'own_profile',
-        dataMetrics: {'video_count': feedState.videos.length},
-      );
+      ref
+          .read(screenAnalyticsServiceProvider)
+          .markDataLoaded(
+            'own_profile',
+            dataMetrics: {'video_count': feedState.videos.length},
+          );
     }
 
     return BlocListener<BackgroundPublishBloc, BackgroundPublishState>(

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -3,7 +3,6 @@
 
 import 'dart:async';
 
-import 'package:analytics/analytics.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:feed_repository/feed_repository.dart';
 import 'package:flutter/material.dart';
@@ -13,6 +12,7 @@ import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/blocs/saved_sounds/saved_sounds_bloc.dart';
 import 'package:openvine/extensions/safe_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/sound_library_service_provider.dart';
@@ -1122,10 +1122,12 @@ class _VideosGridContentState extends ConsumerState<_VideosGridContent> {
         _videoEvents = events;
         _isLoading = false;
       });
-      ScreenAnalyticsService().markDataLoaded(
-        'sound_detail',
-        dataMetrics: {'video_count': events.length},
-      );
+      ref
+          .read(screenAnalyticsServiceProvider)
+          .markDataLoaded(
+            'sound_detail',
+            dataMetrics: {'video_count': events.length},
+          );
     }
   }
 

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -3,7 +3,6 @@
 
 import 'dart:async';
 
-import 'package:analytics/analytics.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:feed_repository/feed_repository.dart';
 import 'package:flutter/foundation.dart';
@@ -15,6 +14,7 @@ import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/extensions/safe_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/view_traffic_source.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/screens/feed/dm_reply_context.dart';
@@ -95,7 +95,7 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
     if (widget.initialVideo != null) {
       _video = widget.initialVideo;
       _isLoading = false;
-      ScreenAnalyticsService().markDataLoaded('video_detail');
+      ref.read(screenAnalyticsServiceProvider).markDataLoaded('video_detail');
       return;
     }
     _loadVideo();
@@ -124,7 +124,7 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
     });
 
     if (widget.initialVideo != null) {
-      ScreenAnalyticsService().markDataLoaded('video_detail');
+      ref.read(screenAnalyticsServiceProvider).markDataLoaded('video_detail');
       return;
     }
 
@@ -171,7 +171,9 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
             _isLoading = false;
             _error = null;
           });
-          ScreenAnalyticsService().markDataLoaded('video_detail');
+          ref
+              .read(screenAnalyticsServiceProvider)
+              .markDataLoaded('video_detail');
         }
       } else {
         if (allowRelayReadyRetry &&

--- a/mobile/lib/widgets/app_lifecycle_handler.dart
+++ b/mobile/lib/widgets/app_lifecycle_handler.dart
@@ -3,7 +3,6 @@
 
 import 'dart:async';
 
-import 'package:analytics/analytics.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -117,7 +116,7 @@ class _AppLifecycleHandlerState extends ConsumerState<AppLifecycleHandler>
         // Reset performance tracker sessions to prevent stale start
         // times from producing absurd load-time measurements (e.g.
         // 27+ hours) when providers re-fire on resume.
-        FeedPerformanceTracker().resetAllSessions();
+        ref.read(feedPerformanceTrackerProvider).resetAllSessions();
         ref.read(screenAnalyticsServiceProvider).resetAllSessions();
         ref.read(surfacePerformanceTrackerProvider).resetAllSessions();
 

--- a/mobile/lib/widgets/app_lifecycle_handler.dart
+++ b/mobile/lib/widgets/app_lifecycle_handler.dart
@@ -118,7 +118,7 @@ class _AppLifecycleHandlerState extends ConsumerState<AppLifecycleHandler>
         // times from producing absurd load-time measurements (e.g.
         // 27+ hours) when providers re-fire on resume.
         FeedPerformanceTracker().resetAllSessions();
-        ScreenAnalyticsService().resetAllSessions();
+        ref.read(screenAnalyticsServiceProvider).resetAllSessions();
         ref.read(surfacePerformanceTrackerProvider).resetAllSessions();
 
         // Notify foreground state provider - enables visibility detection

--- a/mobile/lib/widgets/classic_vines_tab.dart
+++ b/mobile/lib/widgets/classic_vines_tab.dart
@@ -35,7 +35,8 @@ import 'package:unified_logger/unified_logger.dart';
 class ClassicVinesTab extends ConsumerStatefulWidget {
   const ClassicVinesTab({super.key, this.feedTracker});
 
-  /// Optional analytics tracker (for testing, defaults to singleton).
+  /// Analytics tracker. Null unless a caller supplies one — this tab does not
+  /// report feed-load timing in production (see #4743).
   final FeedPerformanceTracker? feedTracker;
 
   @override

--- a/mobile/lib/widgets/for_you_tab.dart
+++ b/mobile/lib/widgets/for_you_tab.dart
@@ -30,7 +30,8 @@ import 'package:unified_logger/unified_logger.dart';
 class ForYouTab extends ConsumerStatefulWidget {
   const ForYouTab({super.key, this.feedTracker});
 
-  /// Optional analytics tracker (for testing, defaults to singleton).
+  /// Analytics tracker. Null unless a caller supplies one — this tab does not
+  /// report feed-load timing in production (see #4743).
   final FeedPerformanceTracker? feedTracker;
 
   @override

--- a/mobile/lib/widgets/hashtag_search_view.dart
+++ b/mobile/lib/widgets/hashtag_search_view.dart
@@ -3,32 +3,35 @@
 
 import 'dart:async';
 
-import 'package:analytics/analytics.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/hashtag_search/hashtag_search_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/mixins/scroll_pagination_mixin.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
 import 'package:openvine/screens/search_results/widgets/search_tag_chip.dart';
 
 /// Displays hashtag search results from HashtagSearchBloc.
 ///
 /// Must be used within a `BlocProvider<HashtagSearchBloc>`.
-class HashtagSearchView extends StatelessWidget {
+class HashtagSearchView extends ConsumerWidget {
   const HashtagSearchView({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return BlocConsumer<HashtagSearchBloc, HashtagSearchState>(
       listener: (context, state) {
         if (state.status == HashtagSearchStatus.success) {
-          ScreenAnalyticsService().markDataLoaded(
-            'search',
-            dataMetrics: {'hashtag_count': state.results.length},
-          );
+          ref
+              .read(screenAnalyticsServiceProvider)
+              .markDataLoaded(
+                'search',
+                dataMetrics: {'hashtag_count': state.results.length},
+              );
         }
       },
       builder: (context, state) {

--- a/mobile/lib/widgets/new_videos_tab.dart
+++ b/mobile/lib/widgets/new_videos_tab.dart
@@ -55,7 +55,8 @@ class _NewVideosTabState extends ConsumerState<NewVideosTab> {
     super.initState();
     _screenAnalytics =
         widget.screenAnalytics ?? ref.read(screenAnalyticsServiceProvider);
-    _feedTracker = widget.feedTracker ?? FeedPerformanceTracker();
+    _feedTracker =
+        widget.feedTracker ?? ref.read(feedPerformanceTrackerProvider);
     _errorTracker =
         widget.errorTracker ?? ref.read(errorAnalyticsTrackerProvider);
   }

--- a/mobile/lib/widgets/new_videos_tab.dart
+++ b/mobile/lib/widgets/new_videos_tab.dart
@@ -35,7 +35,7 @@ class NewVideosTab extends ConsumerStatefulWidget {
     this.errorTracker,
   });
 
-  /// Optional analytics services (for testing, defaults to singletons)
+  /// Optional analytics overrides; each defaults to the app's shared instance.
   final ScreenAnalyticsService? screenAnalytics;
   final FeedPerformanceTracker? feedTracker;
   final ErrorAnalyticsTracker? errorTracker;
@@ -53,7 +53,8 @@ class _NewVideosTabState extends ConsumerState<NewVideosTab> {
   @override
   void initState() {
     super.initState();
-    _screenAnalytics = widget.screenAnalytics ?? ScreenAnalyticsService();
+    _screenAnalytics =
+        widget.screenAnalytics ?? ref.read(screenAnalyticsServiceProvider);
     _feedTracker = widget.feedTracker ?? FeedPerformanceTracker();
     _errorTracker =
         widget.errorTracker ?? ref.read(errorAnalyticsTrackerProvider);

--- a/mobile/lib/widgets/popular_videos_tab.dart
+++ b/mobile/lib/widgets/popular_videos_tab.dart
@@ -50,7 +50,7 @@ class PopularVideosTab extends ConsumerStatefulWidget {
     this.slowLoadThresholdMs = _slowFeedLoadThresholdMs,
   });
 
-  /// Optional analytics services (for testing, defaults to singletons)
+  /// Optional analytics overrides; each defaults to the app's shared instance.
   final ScreenAnalyticsService? screenAnalytics;
   final FeedPerformanceTracker? feedTracker;
   final ErrorAnalyticsTracker? errorTracker;
@@ -84,7 +84,8 @@ class _PopularVideosTabState extends ConsumerState<PopularVideosTab> {
   @override
   void initState() {
     super.initState();
-    _screenAnalytics = widget.screenAnalytics ?? ScreenAnalyticsService();
+    _screenAnalytics =
+        widget.screenAnalytics ?? ref.read(screenAnalyticsServiceProvider);
     _feedTracker = widget.feedTracker ?? FeedPerformanceTracker();
     _errorTracker =
         widget.errorTracker ?? ref.read(errorAnalyticsTrackerProvider);

--- a/mobile/lib/widgets/popular_videos_tab.dart
+++ b/mobile/lib/widgets/popular_videos_tab.dart
@@ -86,7 +86,8 @@ class _PopularVideosTabState extends ConsumerState<PopularVideosTab> {
     super.initState();
     _screenAnalytics =
         widget.screenAnalytics ?? ref.read(screenAnalyticsServiceProvider);
-    _feedTracker = widget.feedTracker ?? FeedPerformanceTracker();
+    _feedTracker =
+        widget.feedTracker ?? ref.read(feedPerformanceTrackerProvider);
     _errorTracker =
         widget.errorTracker ?? ref.read(errorAnalyticsTrackerProvider);
   }

--- a/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
+++ b/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
@@ -16,6 +16,7 @@ import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/dm/inline_reel_reply/inline_reel_reply_cubit.dart';
 import 'package:openvine/blocs/dm/reactions/conversation_reactions_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/dm_reply_context.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
@@ -86,6 +87,7 @@ class ReelDmReplyBarHost extends ConsumerWidget {
           return _ReelDmReplyBar(
             dmReplyContext: dmReplyContext,
             ownerPubkey: ownerPubkey,
+            screenAnalytics: ref.read(screenAnalyticsServiceProvider),
             // The player owns pausing + the full-screen reaction overlay; the
             // bar just emits the signals, staying decoupled from its State.
             onComposerFocusChanged: bridge?.setComposerFocused,
@@ -129,12 +131,18 @@ class _ReelDmReplyBar extends StatefulWidget {
   const _ReelDmReplyBar({
     required this.dmReplyContext,
     required this.ownerPubkey,
+    required this.screenAnalytics,
     this.onComposerFocusChanged,
     this.onReaction,
   });
 
   final DmReplyContext dmReplyContext;
   final String ownerPubkey;
+
+  /// Shared screen-analytics service, resolved by the host so this plain
+  /// [StatefulWidget] does not reach into Riverpod for its dependencies.
+  final ScreenAnalyticsService screenAnalytics;
+
   final ValueChanged<bool>? onComposerFocusChanged;
 
   /// Triggers the player's full-screen reaction overlay for the given emoji.
@@ -180,7 +188,7 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
     super.initState();
     _controller.addListener(_handleTextChanged);
     _focusNode.addListener(_handleFocusChanged);
-    ScreenAnalyticsService().trackInteraction(
+    widget.screenAnalytics.trackInteraction(
       ReelReplyConstants.analyticsScreen,
       'dm_reel_opened',
       params: {'is_group': _ctx.isGroup ? 1 : 0},
@@ -304,7 +312,7 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
       context.l10n.dmReelReactionSentAnnouncement(emoji),
       Directionality.of(context),
     );
-    ScreenAnalyticsService().trackInteraction(
+    widget.screenAnalytics.trackInteraction(
       ReelReplyConstants.analyticsScreen,
       'dm_reel_emoji_sent',
       params: {
@@ -369,7 +377,7 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
       final conversationPath = ConversationPage.pathForId(_ctx.conversationId);
       final participantPubkeys = List<String>.of(_ctx.participantPubkeys);
       _announce(context.l10n.dmReelReplySentAnnouncement);
-      ScreenAnalyticsService().trackInteraction(
+      widget.screenAnalytics.trackInteraction(
         ReelReplyConstants.analyticsScreen,
         'dm_reel_reply_sent',
         params: {'is_group': _ctx.isGroup ? 1 : 0},

--- a/mobile/packages/analytics/lib/src/feed_performance_tracker.dart
+++ b/mobile/packages/analytics/lib/src/feed_performance_tracker.dart
@@ -3,7 +3,6 @@
 
 import 'package:analytics/src/analytics_event_sink.dart';
 import 'package:analytics/src/firebase_analytics_event_sink.dart';
-import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:profile_repository/profile_repository.dart'
     show
         SearchSource,
@@ -23,27 +22,16 @@ import 'package:unified_logger/unified_logger.dart';
 const _maxSessionAge = Duration(seconds: 60);
 
 /// Service for tracking feed performance and user engagement
+///
+/// Feed-load sessions are keyed by feed type and shared across consumers — one
+/// widget starts a load that another completes — so the app resolves one
+/// instance through `feedPerformanceTrackerProvider` rather than constructing
+/// this per widget.
 class FeedPerformanceTracker {
-  factory FeedPerformanceTracker() => _instance ??= FeedPerformanceTracker._();
-  FeedPerformanceTracker._() : _analytics = FirebaseAnalyticsEventSink();
-
-  static FeedPerformanceTracker? _instance;
-
-  /// Resets the singleton so the next [FeedPerformanceTracker()] call returns a
-  /// fresh instance. Call in test `tearDown` to prevent state leaking between
-  /// test files when tests run in a shared isolate (e.g. VGV optimized runner).
-  @visibleForTesting
-  static void resetInstance() {
-    _instance?._activeSessions.clear();
-    _instance = null;
-  }
-
-  /// Creates a testable instance that does not touch Firebase.
-  ///
-  /// Pass a [sink] to assert on emitted events; defaults to a no-op sink.
-  @visibleForTesting
-  FeedPerformanceTracker.testInstance({AnalyticsEventSink? sink})
-    : _analytics = sink ?? const NoOpAnalyticsEventSink();
+  /// Creates a tracker. Defaults to the Firebase analytics sink in production;
+  /// pass a [sink] (e.g. [NoOpAnalyticsEventSink]) in tests.
+  FeedPerformanceTracker({AnalyticsEventSink? sink})
+    : _analytics = sink ?? FirebaseAnalyticsEventSink();
 
   final AnalyticsEventSink _analytics;
 

--- a/mobile/packages/analytics/lib/src/page_load_history.dart
+++ b/mobile/packages/analytics/lib/src/page_load_history.dart
@@ -35,15 +35,13 @@ class PageLoadRecord {
   bool get isContentVisibleSlow => (contentVisibleMs ?? 0) > 1000;
 }
 
-/// Singleton ring buffer storing the last [maxRecords] page load records.
+/// Ring buffer storing the last [maxRecords] page load records.
 ///
-/// Used by [ScreenAnalyticsService] to record timing data and by
-/// Developer Options to display on-device performance history.
+/// Written by the screen and surface performance trackers, and read by
+/// Developer Options to display on-device performance history. Writers and
+/// readers must share one instance — the app resolves it through
+/// `pageLoadHistoryProvider` — or Developer Options shows an empty buffer.
 class PageLoadHistory {
-  factory PageLoadHistory() => _instance;
-  PageLoadHistory._internal();
-  static final PageLoadHistory _instance = PageLoadHistory._internal();
-
   static const int maxRecords = 50;
 
   final Queue<PageLoadRecord> _records = Queue<PageLoadRecord>();

--- a/mobile/packages/analytics/lib/src/page_load_observer.dart
+++ b/mobile/packages/analytics/lib/src/page_load_observer.dart
@@ -7,8 +7,13 @@ import 'package:flutter/material.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 class PageLoadObserver extends NavigatorObserver {
-  PageLoadObserver({ScreenAnalyticsService? analytics})
-    : _analytics = analytics ?? ScreenAnalyticsService();
+  /// Construct the observer over the app's shared [ScreenAnalyticsService].
+  ///
+  /// [analytics] is required because the sessions this observer starts are
+  /// completed by screens reading the same instance — a private default would
+  /// silently strand every `markDataLoaded` call on a different service.
+  PageLoadObserver({required ScreenAnalyticsService analytics})
+    : _analytics = analytics;
 
   final ScreenAnalyticsService _analytics;
 

--- a/mobile/packages/analytics/lib/src/screen_analytics_service.dart
+++ b/mobile/packages/analytics/lib/src/screen_analytics_service.dart
@@ -6,8 +6,6 @@ import 'dart:async';
 import 'package:analytics/src/analytics_event_sink.dart';
 import 'package:analytics/src/firebase_analytics_event_sink.dart';
 import 'package:analytics/src/page_load_history.dart';
-import 'package:firebase_analytics/firebase_analytics.dart';
-import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:unified_logger/unified_logger.dart';
 
 /// Maximum age for a session before it is considered stale and discarded.
@@ -18,34 +16,16 @@ import 'package:unified_logger/unified_logger.dart';
 const _maxScreenSessionAge = Duration(seconds: 60);
 
 /// Service for tracking screen navigation, performance, and user engagement
+///
+/// Sessions are keyed by screen name and shared across consumers — the
+/// navigator observer starts a load that a screen later completes — so the app
+/// resolves one instance through `screenAnalyticsServiceProvider` rather than
+/// constructing this per widget.
 class ScreenAnalyticsService {
-  factory ScreenAnalyticsService() => _instance ??= ScreenAnalyticsService._();
-  ScreenAnalyticsService._({AnalyticsEventSink? sink})
+  /// Creates a service. Defaults to the Firebase analytics sink in production;
+  /// pass a [sink] (e.g. [NoOpAnalyticsEventSink]) in tests.
+  ScreenAnalyticsService({AnalyticsEventSink? sink})
     : _sink = sink ?? FirebaseAnalyticsEventSink();
-
-  static ScreenAnalyticsService? _instance;
-
-  /// Resets the singleton so the next [ScreenAnalyticsService()] call returns a
-  /// fresh instance. Call in test `tearDown` to prevent state leaking between
-  /// test files when tests run in a shared isolate (e.g. VGV optimized runner).
-  @visibleForTesting
-  static void resetInstance() {
-    _instance?._activeSessions.clear();
-    _instance?._currentScreen = null;
-    _instance?._currentScreenStartTime = null;
-    _instance = null;
-  }
-
-  /// Creates a testable instance that does not touch [FirebaseAnalytics].
-  @visibleForTesting
-  ScreenAnalyticsService.testInstance({
-    AnalyticsEventSink? sink,
-    FirebaseAnalytics? analytics,
-  }) : _sink =
-           sink ??
-           (analytics != null
-               ? FirebaseAnalyticsEventSink(analytics: analytics)
-               : const NoOpAnalyticsEventSink());
 
   final AnalyticsEventSink _sink;
 

--- a/mobile/packages/analytics/lib/src/screen_analytics_service.dart
+++ b/mobile/packages/analytics/lib/src/screen_analytics_service.dart
@@ -22,11 +22,17 @@ const _maxScreenSessionAge = Duration(seconds: 60);
 /// resolves one instance through `screenAnalyticsServiceProvider` rather than
 /// constructing this per widget.
 class ScreenAnalyticsService {
-  /// Creates a service. Defaults to the Firebase analytics sink in production;
-  /// pass a [sink] (e.g. [NoOpAnalyticsEventSink]) in tests.
-  ScreenAnalyticsService({AnalyticsEventSink? sink})
-    : _sink = sink ?? FirebaseAnalyticsEventSink();
+  /// Creates a service writing timing records into [history].
+  ///
+  /// Defaults to the Firebase analytics sink in production; pass a [sink]
+  /// (e.g. [NoOpAnalyticsEventSink]) in tests.
+  ScreenAnalyticsService({
+    required PageLoadHistory history,
+    AnalyticsEventSink? sink,
+  }) : _history = history,
+       _sink = sink ?? FirebaseAnalyticsEventSink();
 
+  final PageLoadHistory _history;
   final AnalyticsEventSink _sink;
 
   final Map<String, _ScreenSession> _activeSessions = {};
@@ -100,7 +106,7 @@ class ScreenAnalyticsService {
     );
 
     // Record to page load history
-    PageLoadHistory().addOrUpdate(
+    _history.addOrUpdate(
       PageLoadRecord(
         screenName: screenName,
         timestamp: session.loadStartTime,
@@ -152,7 +158,7 @@ class ScreenAnalyticsService {
     final contentVisibleMs = session.contentVisibleTime
         ?.difference(session.loadStartTime)
         .inMilliseconds;
-    PageLoadHistory().addOrUpdate(
+    _history.addOrUpdate(
       PageLoadRecord(
         screenName: screenName,
         timestamp: session.loadStartTime,

--- a/mobile/packages/analytics/lib/src/surface_performance_tracker.dart
+++ b/mobile/packages/analytics/lib/src/surface_performance_tracker.dart
@@ -27,14 +27,19 @@ const Set<String> _safeSurfaceParamKeys = {
 
 /// Tracks perceived load performance for user-visible surfaces.
 class SurfacePerformanceTracker {
-  /// Creates a tracker. Defaults to the Firebase analytics sink in production;
-  /// pass a [sink] (e.g. [NoOpAnalyticsEventSink]) and [now] clock in tests.
+  /// Creates a tracker writing timing records into [history].
+  ///
+  /// Defaults to the Firebase analytics sink in production; pass a [sink]
+  /// (e.g. [NoOpAnalyticsEventSink]) and [now] clock in tests.
   SurfacePerformanceTracker({
+    required PageLoadHistory history,
     AnalyticsEventSink? sink,
     DateTime Function()? now,
-  }) : _sink = sink ?? FirebaseAnalyticsEventSink(),
+  }) : _history = history,
+       _sink = sink ?? FirebaseAnalyticsEventSink(),
        _now = now ?? DateTime.now;
 
+  final PageLoadHistory _history;
   AnalyticsEventSink _sink;
   final DateTime Function() _now;
   final Map<String, _SurfaceLoadSession> _activeSessions = {};
@@ -123,7 +128,7 @@ class SurfacePerformanceTracker {
     };
 
     await _logSurfaceLoad(parameters);
-    PageLoadHistory().addOrUpdate(
+    _history.addOrUpdate(
       PageLoadRecord(
         screenName: safeName,
         timestamp: session.startedAt,

--- a/mobile/packages/analytics/test/feed_performance_tracker_stale_session_test.dart
+++ b/mobile/packages/analytics/test/feed_performance_tracker_stale_session_test.dart
@@ -10,13 +10,8 @@ void main() {
     late FeedPerformanceTracker tracker;
 
     setUp(() {
-      // Reset to discard any stale singleton left by a previous test or test
-      // file when running in a shared isolate (VGV optimized runner).
-      FeedPerformanceTracker.resetInstance();
-      tracker = FeedPerformanceTracker.testInstance();
+      tracker = FeedPerformanceTracker(sink: const NoOpAnalyticsEventSink());
     });
-
-    tearDown(FeedPerformanceTracker.resetInstance);
 
     group('resetAllSessions', () {
       test('clears all active sessions', () {
@@ -73,16 +68,20 @@ void main() {
       });
     });
 
-    group('testInstance', () {
-      test('creates instance without Firebase dependency', () {
-        final instance = FeedPerformanceTracker.testInstance();
+    group('session lifecycle', () {
+      test('sessions do not leak between instances', () {
+        tracker.startFeedLoad('home');
 
-        instance
-          ..startFeedLoad('test')
-          ..markFirstVideosReceived('test', 3)
-          ..markFeedDisplayed('test', 3);
+        final other = FeedPerformanceTracker(
+          sink: const NoOpAnalyticsEventSink(),
+        );
 
-        expect(instance.activeSessionCount, 0);
+        // Guards the reason the app resolves one shared instance through
+        // `feedPerformanceTrackerProvider`: a second instance cannot complete
+        // a session the first one started.
+        expect(other.activeSessionCount, 0);
+        other.markFeedDisplayed('home', 3);
+        expect(tracker.activeSessionCount, 1);
       });
 
       test('tracks multiple independent sessions', () {

--- a/mobile/packages/analytics/test/feed_performance_tracker_test.dart
+++ b/mobile/packages/analytics/test/feed_performance_tracker_test.dart
@@ -3,66 +3,88 @@
 
 import 'package:analytics/analytics.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:profile_repository/profile_repository.dart';
 
-class _MockFeedPerformanceTracker extends Mock
-    implements FeedPerformanceTracker {}
+class _RecordingAnalyticsEventSink implements AnalyticsEventSink {
+  final events = <({String name, Map<String, Object> parameters})>[];
+
+  @override
+  Future<void> setUserId(String? userId) async {}
+
+  @override
+  Future<void> setUserProperty({
+    required String name,
+    required String? value,
+  }) async {}
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async {
+    events.add((name: name, parameters: parameters));
+  }
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) async {}
+}
 
 void main() {
   group(FeedPerformanceTracker, () {
     group('video swipe tracking', () {
-      late _MockFeedPerformanceTracker tracker;
+      const videoId =
+          'abc123def456abc123def456abc123def456abc123def456abc123def456abcd';
+
+      late _RecordingAnalyticsEventSink sink;
+      late FeedPerformanceTracker tracker;
 
       setUp(() {
-        tracker = _MockFeedPerformanceTracker();
+        sink = _RecordingAnalyticsEventSink();
+        tracker = FeedPerformanceTracker(sink: sink);
       });
 
-      test('startVideoSwipeTracking calls startFeedLoad with video ID', () {
-        const videoId =
-            'abc123def456abc123def456abc123def456abc123def456abc123def456abcd';
+      test('startVideoSwipeTracking opens a session for the video', () {
         tracker.startVideoSwipeTracking(videoId);
 
-        verify(() => tracker.startVideoSwipeTracking(videoId)).called(1);
+        expect(tracker.activeSessionCount, 1);
       });
 
-      test('markVideoSwipeComplete calls markFeedDisplayed with video ID', () {
-        const videoId =
-            'abc123def456abc123def456abc123def456abc123def456abc123def456abcd';
-        tracker.markVideoSwipeComplete(videoId);
-
-        verify(() => tracker.markVideoSwipeComplete(videoId)).called(1);
-      });
-
-      test('swipe tracking uses video_swipe_ prefix for feed type', () {
-        // The real implementation constructs 'video_swipe_$videoId' as
-        // the feed type. Since the tracker is a singleton backed by
-        // FirebaseAnalytics (which requires Firebase init), we verify
-        // the method signatures exist and are callable via mock.
-        const videoId =
-            'def456abc123def456abc123def456abc123def456abc123def456abc123defg';
-
-        // Both methods should be callable without error
+      test('markVideoSwipeComplete closes the session it opened', () {
         tracker
           ..startVideoSwipeTracking(videoId)
           ..markVideoSwipeComplete(videoId);
 
-        verify(() => tracker.startVideoSwipeTracking(videoId)).called(1);
-        verify(() => tracker.markVideoSwipeComplete(videoId)).called(1);
+        expect(tracker.activeSessionCount, 0);
+      });
+
+      test('swipe tracking reports a video_swipe_ prefixed feed type', () {
+        tracker
+          ..startVideoSwipeTracking(videoId)
+          ..markVideoSwipeComplete(videoId);
+
+        expect(sink.events, hasLength(1));
+        expect(sink.events.single.name, 'feed_load_complete');
+        expect(
+          sink.events.single.parameters,
+          containsPair('feed_type', 'video_swipe_$videoId'),
+        );
       });
     });
 
     group('trackSearchSource', () {
+      late _RecordingAnalyticsEventSink sink;
       late FeedPerformanceTracker tracker;
 
       setUp(() {
-        // Real instance with analytics bypassed so the call path is
-        // exercised end-to-end without requiring Firebase init.
-        tracker = FeedPerformanceTracker.testInstance();
+        sink = _RecordingAnalyticsEventSink();
+        tracker = FeedPerformanceTracker(sink: sink);
       });
 
-      test('does not throw for any terminal source status', () {
-        // Each branch of the switch is exercised; pending is a no-op.
+      test('logs one event per terminal status and skips pending', () {
         tracker
           ..trackSearchSource(
             SearchSource.localCache,
@@ -83,6 +105,27 @@ void main() {
               latencyMs: 5000,
             ),
           );
+
+        // Pending adds no signal, so only the three terminal statuses log.
+        expect(
+          sink.events.map((e) => e.name),
+          everyElement('user_search_source'),
+        );
+        expect(sink.events.map((e) => e.parameters), [
+          {'source': SearchSource.localCache.name, 'status': 'skipped'},
+          {
+            'source': SearchSource.funnelcakeApi.name,
+            'status': 'success',
+            'result_count': 3,
+            'latency_ms': 42,
+          },
+          {
+            'source': SearchSource.nip50Relay.name,
+            'status': 'failed',
+            'reason': SearchSourceFailureReason.timeout.name,
+            'latency_ms': 5000,
+          },
+        ]);
       });
     });
   });

--- a/mobile/packages/analytics/test/page_load_history_test.dart
+++ b/mobile/packages/analytics/test/page_load_history_test.dart
@@ -7,11 +7,6 @@ void main() {
 
     setUp(() {
       history = PageLoadHistory();
-      history.clear();
-    });
-
-    tearDown(() {
-      history.clear();
     });
 
     group('addOrUpdate', () {

--- a/mobile/packages/analytics/test/screen_analytics_service_test.dart
+++ b/mobile/packages/analytics/test/screen_analytics_service_test.dart
@@ -52,13 +52,8 @@ void main() {
     late ScreenAnalyticsService service;
 
     setUp(() {
-      // Reset to discard any stale singleton left by a previous test or test
-      // file when running in a shared isolate (VGV optimized runner).
-      ScreenAnalyticsService.resetInstance();
-      service = ScreenAnalyticsService.testInstance();
+      service = ScreenAnalyticsService(sink: const NoOpAnalyticsEventSink());
     });
-
-    tearDown(ScreenAnalyticsService.resetInstance);
 
     group('resetAllSessions', () {
       test('clears all active sessions', () {
@@ -122,17 +117,20 @@ void main() {
       });
     });
 
-    group('testInstance', () {
-      test('creates instance without Firebase dependency', () {
-        final instance = ScreenAnalyticsService.testInstance();
+    group('session lifecycle', () {
+      test('sessions do not leak between instances', () {
+        service.startScreenLoad('HomeScreen');
 
-        instance
-          ..startScreenLoad('TestScreen')
-          ..markContentVisible('TestScreen')
-          ..markDataLoaded('TestScreen')
-          ..endScreen('TestScreen');
+        final other = ScreenAnalyticsService(
+          sink: const NoOpAnalyticsEventSink(),
+        );
 
-        expect(instance.activeSessionCount, 0);
+        // Guards the reason the app resolves one shared instance through
+        // `screenAnalyticsServiceProvider`: a second instance cannot complete
+        // a session the first one started.
+        expect(other.activeSessionCount, 0);
+        other.markDataLoaded('HomeScreen');
+        expect(service.activeSessionCount, 1);
       });
 
       test('tracks multiple independent sessions', () {
@@ -153,7 +151,7 @@ void main() {
     group('trackScreenView', () {
       test('logs screen view through the analytics sink', () {
         final sink = RecordingAnalyticsEventSink();
-        final instance = ScreenAnalyticsService.testInstance(sink: sink);
+        final instance = ScreenAnalyticsService(sink: sink);
 
         instance.trackScreenView(
           'video_detail',

--- a/mobile/packages/analytics/test/screen_analytics_service_test.dart
+++ b/mobile/packages/analytics/test/screen_analytics_service_test.dart
@@ -52,7 +52,10 @@ void main() {
     late ScreenAnalyticsService service;
 
     setUp(() {
-      service = ScreenAnalyticsService(sink: const NoOpAnalyticsEventSink());
+      service = ScreenAnalyticsService(
+        history: PageLoadHistory(),
+        sink: const NoOpAnalyticsEventSink(),
+      );
     });
 
     group('resetAllSessions', () {
@@ -122,6 +125,7 @@ void main() {
         service.startScreenLoad('HomeScreen');
 
         final other = ScreenAnalyticsService(
+          history: PageLoadHistory(),
           sink: const NoOpAnalyticsEventSink(),
         );
 
@@ -151,7 +155,10 @@ void main() {
     group('trackScreenView', () {
       test('logs screen view through the analytics sink', () {
         final sink = RecordingAnalyticsEventSink();
-        final instance = ScreenAnalyticsService(sink: sink);
+        final instance = ScreenAnalyticsService(
+          history: PageLoadHistory(),
+          sink: sink,
+        );
 
         instance.trackScreenView(
           'video_detail',

--- a/mobile/packages/analytics/test/surface_performance_tracker_test.dart
+++ b/mobile/packages/analytics/test/surface_performance_tracker_test.dart
@@ -36,6 +36,7 @@ void main() {
   group(SurfacePerformanceTracker, () {
     late RecordingAnalyticsEventSink sink;
     late DateTime now;
+    late PageLoadHistory history;
     late SurfacePerformanceTracker tracker;
 
     void elapse(Duration duration) {
@@ -43,14 +44,14 @@ void main() {
     }
 
     setUp(() {
-      PageLoadHistory().clear();
+      history = PageLoadHistory();
       sink = RecordingAnalyticsEventSink();
       now = DateTime(2026, 6, 12, 12);
-      tracker = SurfacePerformanceTracker(sink: sink, now: () => now);
-    });
-
-    tearDown(() {
-      PageLoadHistory().clear();
+      tracker = SurfacePerformanceTracker(
+        history: history,
+        sink: sink,
+        now: () => now,
+      );
     });
 
     test('logs one surface_load event with semantic parameters', () async {
@@ -116,7 +117,7 @@ void main() {
         metrics: const {AnalyticsParam.itemCount: 7},
       );
 
-      final record = PageLoadHistory().records.single;
+      final record = history.records.single;
       expect(record.screenName, AnalyticsSurface.commentsSheet);
       expect(record.timestamp, startedAt);
       expect(record.contentVisibleMs, 90);

--- a/mobile/test/blocs/explore_tabs/explore_tabs_cubit_test.dart
+++ b/mobile/test/blocs/explore_tabs/explore_tabs_cubit_test.dart
@@ -37,10 +37,15 @@ class _RecordingAnalyticsSink implements AnalyticsEventSink {
   }) async {}
 }
 
+/// A cubit whose analytics writes go nowhere, for the tab-ordering tests.
+ExploreTabsCubit _buildCubit() => ExploreTabsCubit(
+  screenAnalytics: ScreenAnalyticsService(sink: const NoOpAnalyticsEventSink()),
+);
+
 void main() {
   group(ExploreTabsCubit, () {
     test('initial state has only the base tabs', () {
-      final cubit = ExploreTabsCubit();
+      final cubit = _buildCubit();
       addTearDown(cubit.close);
 
       expect(cubit.state.classicsAvailable, isFalse);
@@ -57,7 +62,7 @@ void main() {
 
     blocTest<ExploreTabsCubit, ExploreTabsState>(
       'emits new tab order when availability changes',
-      build: ExploreTabsCubit.new,
+      build: _buildCubit,
       act: (cubit) => cubit.updateAvailability(
         classicsAvailable: true,
         forYouAvailable: true,
@@ -82,7 +87,7 @@ void main() {
 
     blocTest<ExploreTabsCubit, ExploreTabsState>(
       'does not emit when availability is unchanged',
-      build: ExploreTabsCubit.new,
+      build: _buildCubit,
       act: (cubit) => cubit.updateAvailability(
         classicsAvailable: false,
         forYouAvailable: false,
@@ -139,7 +144,7 @@ void main() {
 
       setUp(() {
         analyticsSink = _RecordingAnalyticsSink();
-        analytics = ScreenAnalyticsService.testInstance(sink: analyticsSink);
+        analytics = ScreenAnalyticsService(sink: analyticsSink);
         topHashtags = _MockTopHashtagsLoader();
         cubit = ExploreTabsCubit(
           screenAnalytics: analytics,

--- a/mobile/test/blocs/explore_tabs/explore_tabs_cubit_test.dart
+++ b/mobile/test/blocs/explore_tabs/explore_tabs_cubit_test.dart
@@ -39,7 +39,10 @@ class _RecordingAnalyticsSink implements AnalyticsEventSink {
 
 /// A cubit whose analytics writes go nowhere, for the tab-ordering tests.
 ExploreTabsCubit _buildCubit() => ExploreTabsCubit(
-  screenAnalytics: ScreenAnalyticsService(sink: const NoOpAnalyticsEventSink()),
+  screenAnalytics: ScreenAnalyticsService(
+    history: PageLoadHistory(),
+    sink: const NoOpAnalyticsEventSink(),
+  ),
 );
 
 void main() {
@@ -144,7 +147,10 @@ void main() {
 
       setUp(() {
         analyticsSink = _RecordingAnalyticsSink();
-        analytics = ScreenAnalyticsService(sink: analyticsSink);
+        analytics = ScreenAnalyticsService(
+          history: PageLoadHistory(),
+          sink: analyticsSink,
+        );
         topHashtags = _MockTopHashtagsLoader();
         cubit = ExploreTabsCubit(
           screenAnalytics: analytics,

--- a/mobile/test/blocs/featured_tabs/featured_tab_surface_telemetry_test.dart
+++ b/mobile/test/blocs/featured_tabs/featured_tab_surface_telemetry_test.dart
@@ -43,6 +43,7 @@ void main() {
       telemetry = FeaturedTabSurfaceTelemetry(
         configId: 'ft_a1b2c3d4',
         tracker: SurfacePerformanceTracker(
+          history: PageLoadHistory(),
           sink: sink,
           now: () => DateTime(2026, 6, 12, 12),
         ),

--- a/mobile/test/providers/analytics_providers_test.dart
+++ b/mobile/test/providers/analytics_providers_test.dart
@@ -168,6 +168,22 @@ void main() {
     });
   });
 
+  group('feedPerformanceTrackerProvider', () {
+    test('hands every reader the same session-tracking instance', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      // One consumer starts a feed load that another completes, and the app
+      // lifecycle handler resets them all on resume.
+      container.read(feedPerformanceTrackerProvider).startFeedLoad('popular');
+
+      expect(
+        container.read(feedPerformanceTrackerProvider).activeSessionCount,
+        1,
+      );
+    });
+  });
+
   group('screenAnalyticsServiceProvider', () {
     test('hands every reader the same session-tracking instance', () {
       final container = ProviderContainer();

--- a/mobile/test/providers/analytics_providers_test.dart
+++ b/mobile/test/providers/analytics_providers_test.dart
@@ -141,6 +141,33 @@ void main() {
     expect(crashIds, isEmpty);
   });
 
+  group('pageLoadHistoryProvider', () {
+    // The default Firebase sink resolves lazily and fails closed under
+    // `flutter test`, so the real providers are safe to read here unoverridden.
+    test('collects records from both performance trackers', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container.read(screenAnalyticsServiceProvider)
+        ..startScreenLoad('explore')
+        ..markDataLoaded('explore');
+
+      final surface = container.read(surfacePerformanceTrackerProvider)
+        ..startSurfaceLoad('comments_sheet');
+      await surface.completeSurfaceLoad(
+        'comments_sheet',
+        result: SurfaceLoadResult.success,
+      );
+
+      // Developer Options reads this buffer back, so both writers have to land
+      // in the same one.
+      expect(
+        container.read(pageLoadHistoryProvider).records.map((r) => r.source),
+        containsAll(<String>[PageLoadSource.route, PageLoadSource.surface]),
+      );
+    });
+  });
+
   group('screenAnalyticsServiceProvider', () {
     test('hands every reader the same session-tracking instance', () {
       final container = ProviderContainer();
@@ -158,6 +185,7 @@ void main() {
 
     test('is replaceable by an override without touching static state', () {
       final replacement = ScreenAnalyticsService(
+        history: PageLoadHistory(),
         sink: const NoOpAnalyticsEventSink(),
       );
       final container = ProviderContainer(

--- a/mobile/test/providers/analytics_providers_test.dart
+++ b/mobile/test/providers/analytics_providers_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests authenticated identity fan-out to Analytics and Crashlytics.
 
 import 'package:analytics/analytics.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/providers/analytics_providers.dart';
 
@@ -138,5 +139,38 @@ void main() {
 
     expect(sink.userIds, isEmpty);
     expect(crashIds, isEmpty);
+  });
+
+  group('screenAnalyticsServiceProvider', () {
+    test('hands every reader the same session-tracking instance', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      // The navigator observer starts a load that a screen completes later, so
+      // a second read must see the first read's in-flight session.
+      container.read(screenAnalyticsServiceProvider).startScreenLoad('explore');
+
+      expect(
+        container.read(screenAnalyticsServiceProvider).activeSessionCount,
+        1,
+      );
+    });
+
+    test('is replaceable by an override without touching static state', () {
+      final replacement = ScreenAnalyticsService(
+        sink: const NoOpAnalyticsEventSink(),
+      );
+      final container = ProviderContainer(
+        overrides: [
+          screenAnalyticsServiceProvider.overrideWithValue(replacement),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(screenAnalyticsServiceProvider),
+        same(replacement),
+      );
+    });
   });
 }

--- a/mobile/test/screens/comments/comments_screen_test.dart
+++ b/mobile/test/screens/comments/comments_screen_test.dart
@@ -334,7 +334,10 @@ void main() {
 
       setUp(() {
         sink = _RecordingAnalyticsEventSink();
-        tracker = SurfacePerformanceTracker(sink: sink);
+        tracker = SurfacePerformanceTracker(
+          history: PageLoadHistory(),
+          sink: sink,
+        );
       });
 
       testWidgets(

--- a/mobile/test/services/page_load_observer_test.dart
+++ b/mobile/test/services/page_load_observer_test.dart
@@ -103,7 +103,10 @@ void main() {
     setUp(() {
       sink = _RecordingAnalyticsEventSink();
       observer = PageLoadObserver(
-        analytics: ScreenAnalyticsService(sink: sink),
+        analytics: ScreenAnalyticsService(
+          history: PageLoadHistory(),
+          sink: sink,
+        ),
       );
     });
 

--- a/mobile/test/services/page_load_observer_test.dart
+++ b/mobile/test/services/page_load_observer_test.dart
@@ -101,14 +101,11 @@ void main() {
     late PageLoadObserver observer;
 
     setUp(() {
-      ScreenAnalyticsService.resetInstance();
       sink = _RecordingAnalyticsEventSink();
       observer = PageLoadObserver(
-        analytics: ScreenAnalyticsService.testInstance(sink: sink),
+        analytics: ScreenAnalyticsService(sink: sink),
       );
     });
-
-    tearDown(ScreenAnalyticsService.resetInstance);
 
     test('creates an instance', () {
       expect(observer, isA<NavigatorObserver>());


### PR DESCRIPTION
## Description

Converts the last three factory singletons in `mobile/packages/analytics` to constructor injection behind Riverpod providers. After this the package has **no `factory () => _instance` singletons and no `testInstance` / `resetInstance` static escape hatches left** — every tracker is replaceable through a normal provider override.

The three services share four call sites at adjacent lines (`app_lifecycle_handler.dart:120-121`, `new_videos_tab`, `popular_videos_tab`, `other_profile_screen`) and `PageLoadHistory` can only leave its singleton once *both* of its writers are provider-constructed, so they ship as one PR with a commit per service rather than as conflicting parallel PRs.

**`ScreenAnalyticsService`** (`41abb07c`) — one public constructor + `screenAnalyticsServiceProvider`. A screen-load session is opened by `PageLoadObserver` and closed later by the screen itself, so `PageLoadObserver.analytics` and `ExploreTabsCubit.screenAnalytics` became **required**: a private default would have silently stranded every `markDataLoaded` call on a different instance. 16 consumers now read the provider; `HashtagSearchView` became a `ConsumerWidget` and `_ReelDmReplyBar` takes the service from its `ConsumerWidget` host instead of reaching for a singleton from a plain `State`.

**`PageLoadHistory`** (`e8ec4beeb`) — plain class injected via `pageLoadHistoryProvider` into both writers (`ScreenAnalyticsService`, `SurfacePerformanceTracker`) and read by Developer Options, so the buffer the screen reads is provably the one the trackers write.

One behavior change worth calling out: this buffer was a process-wide static, and is now container-scoped like every other provider here — so `ContainerSwapHost` gives the incoming account a fresh buffer and the Developer Options history resets on an account switch. `surfacePerformanceTrackerProvider` already behaved this way before this PR, and Developer Options is the buffer's only reader, so nothing carries a cross-account expectation of it.

**`FeedPerformanceTracker`** (`bc7c4a33e`) — one public constructor + `feedPerformanceTrackerProvider`, shared so the sessions one consumer starts and another completes (and the resume-time reset) land on the same instance.

**Related Issue:** Relates to #4743 (epic #4338, Wave 2)

## Out of Scope

Four things I found but deliberately did **not** change — each needs a call that isn't mine to make in a DI refactor:

1. **Four surfaces emit no feed-load telemetry in production.** `ClassicVinesTab` and `ForYouTab` hold `late final FeedPerformanceTracker? _feedTracker = widget.feedTracker;` with no fallback, so the tracker is null unless a test supplies one — while their doc comments claimed "defaults to singleton". `HashtagSearchBloc` (`hashtag_search_bloc.dart:37,54`) and `UserSearchBloc` (`user_search_bloc.dart:35,54`) have the identical shape — a nullable `FeedPerformanceTracker?` with no fallback — and their only production construction site (`search_results_page.dart:76,80`) passes nothing, so `hashtag_search` and `user_search` report nothing either. All four are pre-existing and untouched by this PR. I corrected the two stale doc comments to describe reality (the search blocs carry no such comment) and left behavior alone; switching any of them on would start emitting `feed_load_complete` for surfaces that have never reported, which is a dashboard-volume decision — and one worth taking across all four at once in the #4743 follow-up rather than piecemeal.
2. **`FeedPerformanceTracker.markVideoSwipeComplete` has zero production callers.** `startVideoSwipeTracking` fires from two feeds and nothing ever closes those sessions — they expire silently via the 60s stale sweep. This has been true since #5629 removed `VideoLoadingMetrics`. Either wire the completion back up or drop both methods; both are behavior changes.
3. **`FeaturedTabSurfaceTelemetry.tracker` / `FeaturedTabVideosCubit.telemetry` are now required** — flagging separately because it is *not* a rename. `tracker` previously defaulted to `SurfacePerformanceTracker()`, which after this change would have built a private tracker **and** a private `PageLoadHistory`, so featured-tab surface loads were already landing in a buffer nobody reads. The required parameter is what forced it into the light; the explore tab now injects the shared instance.
4. **The rest of #4743**: `VideoThumbnailService`, `BackgroundActivityManager`, `BandwidthTrackerService`, `VideoFormatPreferenceService`, `StartupPerformanceService`, `CrashReportingService`.

## Verification

From `mobile/`:

- `flutter analyze lib test integration_test` — clean
- `cd packages/analytics && flutter analyze lib test` — clean; `flutter test` — 73 passing
- `flutter test test/blocs test/providers test/router test/screens test/widgets test/services` — passing
- Ratchets: `check_riverpod_boundary`, `check_ui_service_boundary`, `check_untested_services_floor`, `check_test_unit_structure`, `check_process_global_mutations`, `check_raw_logging`, `check_shared_channel_overrides`, `check_http_overrides_isolation`, `check_service_god_file_ceiling` — all pass
- `dart format --set-exit-if-changed` on every changed file — clean

Test changes worth a look:

- Three swipe-tracking tests in `feed_performance_tracker_test.dart` stubbed a mock and then asserted the mock had recorded the call — they passed regardless of what the tracker did, and their own comment blamed the singleton for it. With the singleton gone, a real instance plus a recording sink asserts the actual `video_swipe_$videoId` event. The same sink gives `trackSearchSource`'s branch sweep the assertions it never had.
- Each converted service gained a test that a second instance cannot complete a session the first one started — the invariant that makes the shared provider load-bearing — plus provider tests that both trackers' records reach one `PageLoadHistory`.
- No test needs `resetInstance` in `tearDown` any more, so the VGV merged-isolate leak these singletons carried is gone rather than mitigated.

## Type of Change

- [x] 🧹 Code refactor

