### PR TITLE
fix(perf): release feed-load trace handles when a load is torn down

### DIFF
--- a/mobile/lib/services/feed_load_trace.dart
+++ b/mobile/lib/services/feed_load_trace.dart
@@ -1,0 +1,41 @@
+// ABOUTME: Owns a single started feed-load performance trace until it reports
+// ABOUTME: Keeps completion first-wins so any teardown path can close the trace
+
+import 'dart:async';
+
+import 'package:openvine/services/performance_monitoring_service.dart';
+
+/// A started feed-load trace, held by its owner until it reports.
+///
+/// Starting a trace takes a native handle the plugin only releases on stop, so
+/// a load abandoned mid-flight — the owning service is disposed before any
+/// completion path runs — would keep a live trace for the process lifetime.
+/// Reporting it as `disposed` releases the handle and keeps an honestly
+/// attributed sample instead of dropping it (#7151).
+class FeedLoadTrace {
+  FeedLoadTrace({
+    required PerformanceTrace trace,
+    required int Function() eventCount,
+  }) : _trace = trace,
+       _eventCount = eventCount;
+
+  final PerformanceTrace _trace;
+
+  /// Read at completion time: the count keeps rising after the trace starts.
+  final int Function() _eventCount;
+
+  bool _completed = false;
+
+  /// Reports the trace under [completion], first caller wins.
+  ///
+  /// Later callers are no-ops, so an abandoned-load sweep cannot re-attribute
+  /// or double-stop a load that already reported.
+  void complete(String completion, {int? eventTotal}) {
+    if (_completed) return;
+    _completed = true;
+    _trace
+      ..setMetric('event_count', eventTotal ?? _eventCount())
+      ..putAttribute('completion', completion);
+    unawaited(_trace.stop());
+  }
+}

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -2271,13 +2271,9 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         bool eoseReceived = false;
         bool timeoutReported = false;
 
-        // Operation-scoped so two loads of the same subscription type keep
-        // independent traces. Under the name-keyed API a load that never
-        // reached a completion path — the service is disposed before the 30s
-        // timeout fires — stayed open until the next load of that type
-        // reported it, which is how a 23.6-hour `feed_load_profile` sample
-        // reached the console (#7119). Registered as pending so teardown can
-        // still close it rather than leaking the native handle (#7151).
+        // Operation-scoped so two loads of the same type keep independent
+        // traces (#7119), and registered as pending so every teardown path
+        // closes the native handle instead of leaking it (#7151).
         final pendingTrace = FeedLoadTrace(
           trace: _performanceMonitor.startOperationTrace(
             'feed_load_${subscriptionType.name}',

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -2383,6 +2383,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         // ChangeNotifier and wire a relay subscription the teardown sweep has
         // already passed, leaving nothing to cancel it.
         if (_isDisposed) {
+          _completeAbandonedFeedLoadTrace(subscriptionId, 'disposed');
           _pendingSubscriptionIds.remove(subscriptionId);
           return;
         }

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -2627,6 +2627,10 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       } catch (e, stackTrace) {
         if (pendingClaimId != null) {
           _pendingSubscriptionIds.remove(pendingClaimId);
+          // Setup threw before any completion path and leaves no subscription
+          // for teardown to sweep, so only dispose would reach this handle —
+          // and report the session, not the load, as its duration.
+          _completeAbandonedFeedLoadTrace(pendingClaimId, 'setup_error');
         }
         Log.error(
           '❌ Failed to create direct subscription: $e',
@@ -4589,7 +4593,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         category: LogCategory.video,
       );
       for (final entry in _subscriptions.entries) {
-        _completeAbandonedFeedLoadTrace(entry.key);
+        _completeAbandonedFeedLoadTrace(entry.key, 'cancelled');
         await entry.value.cancel();
       }
       _subscriptions.clear();
@@ -5459,14 +5463,17 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   }
 
   /// Closes the feed-load trace of a subscription that is being torn down
-  /// before its load reached a completion path.
+  /// before its load reached a completion path, reporting it as [completion].
   ///
   /// Reporting here rather than at [dispose] keeps the duration the load's
   /// own: the 30s fuse is cancelled on teardown and its handler bails out on
   /// a replaced subscription, so an abandoned load would otherwise stay open
   /// until the process ends and report a session-length sample (#7151).
-  void _completeAbandonedFeedLoadTrace(String subscriptionId) {
-    _pendingFeedLoadTraces.remove(subscriptionId)?.complete('cancelled');
+  void _completeAbandonedFeedLoadTrace(
+    String subscriptionId,
+    String completion,
+  ) {
+    _pendingFeedLoadTraces.remove(subscriptionId)?.complete(completion);
   }
 
   /// Cancel subscription for a specific type
@@ -5483,7 +5490,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         category: LogCategory.video,
       );
 
-      _completeAbandonedFeedLoadTrace(subscriptionId);
+      _completeAbandonedFeedLoadTrace(subscriptionId, 'cancelled');
 
       final subscription = _subscriptions[subscriptionId];
       if (subscription != null) {

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -39,6 +39,7 @@ import 'package:openvine/services/divine_host_filter_service.dart';
 import 'package:openvine/services/effective_content_labels.dart';
 import 'package:openvine/services/event_router.dart';
 import 'package:openvine/services/feed_aspect_ratio_preference_service.dart';
+import 'package:openvine/services/feed_load_trace.dart';
 import 'package:openvine/services/feed_retry_scheduler.dart';
 import 'package:openvine/services/moderation_label_service.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
@@ -206,6 +207,11 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   /// subscription the user already left cannot fire recovery against a later
   /// live feed of the same type.
   final Map<SubscriptionType, Timer> _feedLoadTimeouts = {};
+
+  /// Feed-load traces that have started but not yet reported, keyed by the
+  /// subscription id the load belongs to. Closed when that subscription is
+  /// torn down, and drained by [dispose] for loads still mid-setup.
+  final Map<String, FeedLoadTrace> _pendingFeedLoadTraces = {};
 
   // Track subscription parameters per type
   final Map<SubscriptionType, Map<String, dynamic>> _subscriptionParams = {};
@@ -842,6 +848,9 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     Future.microtask(() {
       if (!_hasScheduledFrameUpdate) return; // Already processed
       _hasScheduledFrameUpdate = false;
+      // A load can be abandoned between scheduling and this microtask —
+      // notifying then throws "used after being disposed".
+      if (_isDisposed) return;
       notifyListeners();
     });
   }
@@ -2267,19 +2276,18 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         // reached a completion path — the service is disposed before the 30s
         // timeout fires — stayed open until the next load of that type
         // reported it, which is how a 23.6-hour `feed_load_profile` sample
-        // reached the console. A leaked handle now simply never reports
-        // (#7119).
-        final trace = _performanceMonitor.startOperationTrace(
-          'feed_load_${subscriptionType.name}',
+        // reached the console (#7119). Registered as pending so teardown can
+        // still close it rather than leaking the native handle (#7151).
+        final pendingTrace = FeedLoadTrace(
+          trace: _performanceMonitor.startOperationTrace(
+            'feed_load_${subscriptionType.name}',
+          ),
+          eventCount: () => eventCount,
         );
-        var traceCompleted = false;
+        _pendingFeedLoadTraces[subscriptionId] = pendingTrace;
         void completeFeedLoadTrace(String completion, {int? eventTotal}) {
-          if (traceCompleted) return;
-          traceCompleted = true;
-          trace
-            ..setMetric('event_count', eventTotal ?? eventCount)
-            ..putAttribute('completion', completion);
-          unawaited(trace.stop());
+          _pendingFeedLoadTraces.remove(subscriptionId);
+          pendingTrace.complete(completion, eventTotal: eventTotal);
         }
 
         Log.info(
@@ -4585,6 +4593,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         category: LogCategory.video,
       );
       for (final entry in _subscriptions.entries) {
+        _completeAbandonedFeedLoadTrace(entry.key);
         await entry.value.cancel();
       }
       _subscriptions.clear();
@@ -5453,6 +5462,17 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     _feedLoadTimeouts.remove(subscriptionType)?.cancel();
   }
 
+  /// Closes the feed-load trace of a subscription that is being torn down
+  /// before its load reached a completion path.
+  ///
+  /// Reporting here rather than at [dispose] keeps the duration the load's
+  /// own: the 30s fuse is cancelled on teardown and its handler bails out on
+  /// a replaced subscription, so an abandoned load would otherwise stay open
+  /// until the process ends and report a session-length sample (#7151).
+  void _completeAbandonedFeedLoadTrace(String subscriptionId) {
+    _pendingFeedLoadTraces.remove(subscriptionId)?.complete('cancelled');
+  }
+
   /// Cancel subscription for a specific type
   Future<void> _cancelSubscription(SubscriptionType subscriptionType) async {
     // Kill the fuse before tearing down state so a later fire cannot unmap a
@@ -5466,6 +5486,8 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         name: 'VideoEventService',
         category: LogCategory.video,
       );
+
+      _completeAbandonedFeedLoadTrace(subscriptionId);
 
       final subscription = _subscriptions[subscriptionId];
       if (subscription != null) {
@@ -5834,6 +5856,13 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       timer.cancel();
     }
     _feedLoadTimeouts.clear();
+
+    // Loads still mid-setup have no subscription to tear down, so the sweep
+    // in _cancelExistingSubscriptions below cannot reach them.
+    for (final trace in _pendingFeedLoadTraces.values) {
+      trace.complete('disposed');
+    }
+    _pendingFeedLoadTraces.clear();
     _retryScheduler.dispose();
     _cancelRelayReadyRetrySubscription();
     _likeCountBatchTimer?.cancel();

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -2378,6 +2378,15 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           sortBy: sortBy,
         );
 
+        // Disposed while the cache read was in flight, so dispose has already
+        // closed this load's trace. Carrying on would notify a dead
+        // ChangeNotifier and wire a relay subscription the teardown sweep has
+        // already passed, leaving nothing to cancel it.
+        if (_isDisposed) {
+          _pendingSubscriptionIds.remove(subscriptionId);
+          return;
+        }
+
         // 🎯 CACHE DEBUG: Log cached event details
         if (cachedEvents.isNotEmpty &&
             subscriptionType == SubscriptionType.discovery) {

--- a/mobile/test/services/feed_load_trace_test.dart
+++ b/mobile/test/services/feed_load_trace_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/feed_load_trace.dart';
+import 'package:openvine/services/performance_monitoring_service.dart';
+
+class _RecordingTrace implements PerformanceTrace {
+  final attributes = <String, String>{};
+  final metrics = <String, int>{};
+  int stopCount = 0;
+
+  @override
+  void putAttribute(String attribute, String value) =>
+      attributes[attribute] = value;
+
+  @override
+  void setMetric(String metric, int value) => metrics[metric] = value;
+
+  @override
+  Future<void> stop() async => stopCount++;
+}
+
+void main() {
+  group(FeedLoadTrace, () {
+    late _RecordingTrace trace;
+
+    setUp(() {
+      trace = _RecordingTrace();
+    });
+
+    test('reports the live event count at completion time', () async {
+      var eventCount = 0;
+      final feedLoadTrace = FeedLoadTrace(
+        trace: trace,
+        eventCount: () => eventCount,
+      );
+
+      // Events keep arriving after the trace starts, so the count must be
+      // read on completion rather than captured at construction.
+      eventCount = 3;
+      feedLoadTrace.complete('eose');
+      await pumpEventQueue();
+
+      expect(trace.metrics['event_count'], 3);
+      expect(trace.attributes['completion'], 'eose');
+      expect(trace.stopCount, 1);
+    });
+
+    test('eventTotal overrides the live count', () async {
+      FeedLoadTrace(
+        trace: trace,
+        eventCount: () => 0,
+      ).complete('cache', eventTotal: 7);
+      await pumpEventQueue();
+
+      expect(trace.metrics['event_count'], 7);
+    });
+
+    test('first completion wins and later ones do not re-report', () async {
+      final feedLoadTrace = FeedLoadTrace(trace: trace, eventCount: () => 1)
+        ..complete('first_relay_event')
+        ..complete('disposed');
+      feedLoadTrace.complete('done');
+      await pumpEventQueue();
+
+      expect(trace.attributes['completion'], 'first_relay_event');
+      expect(trace.stopCount, 1);
+    });
+  });
+}

--- a/mobile/test/services/video_event_service_startup_contract_test.dart
+++ b/mobile/test/services/video_event_service_startup_contract_test.dart
@@ -10,8 +10,10 @@ import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
 import 'package:openvine/services/event_router.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
+import 'package:openvine/services/relay_capability_service.dart';
 import 'package:openvine/services/subscription_manager.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/services/video_filter_builder.dart';
 import 'package:profile_repository/profile_repository.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
@@ -23,6 +25,9 @@ class _MockProfileRepository extends Mock implements ProfileRepository {}
 class _MockAppDatabase extends Mock implements AppDatabase {}
 
 class _MockNostrEventsDao extends Mock implements NostrEventsDao {}
+
+class _MockRelayCapabilityService extends Mock
+    implements RelayCapabilityService {}
 
 class _FakeFilter extends Fake implements Filter {}
 
@@ -100,6 +105,7 @@ void main() {
     late _MockProfileRepository mockProfileRepository;
     late _MockAppDatabase mockDatabase;
     late _MockNostrEventsDao mockNostrEventsDao;
+    late _MockRelayCapabilityService mockRelayCapabilityService;
     late StreamController<Event> relayController;
     late VideoEventService videoEventService;
     late Completer<Map<String, UserProfile>> batchFetchCompleter;
@@ -112,6 +118,7 @@ void main() {
       mockProfileRepository = _MockProfileRepository();
       mockDatabase = _MockAppDatabase();
       mockNostrEventsDao = _MockNostrEventsDao();
+      mockRelayCapabilityService = _MockRelayCapabilityService();
       relayController = StreamController<Event>.broadcast();
       batchFetchCompleter = Completer<Map<String, UserProfile>>();
       performanceMonitor = _RecordingPerformanceMonitor();
@@ -119,6 +126,7 @@ void main() {
 
       when(() => mockNostrService.isInitialized).thenReturn(true);
       when(() => mockNostrService.connectedRelayCount).thenReturn(1);
+      when(() => mockNostrService.connectedRelays).thenReturn(const <String>[]);
       when(
         () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
       ).thenAnswer((invocation) {
@@ -145,6 +153,14 @@ void main() {
           pubkeys: any(named: 'pubkeys'),
         ),
       ).thenAnswer((_) => batchFetchCompleter.future);
+      when(
+        () => mockRelayCapabilityService.getRelayCapabilities(any()),
+      ).thenAnswer(
+        (invocation) async => RelayCapabilities(
+          relayUrl: invocation.positionalArguments.single as String,
+          rawData: const {},
+        ),
+      );
 
       videoEventService = VideoEventService(
         mockNostrService,
@@ -152,6 +168,7 @@ void main() {
         profileRepository: mockProfileRepository,
         eventRouter: EventRouter(mockDatabase),
         performanceMonitor: performanceMonitor,
+        videoFilterBuilder: VideoFilterBuilder(mockRelayCapabilityService),
       );
     });
 
@@ -530,6 +547,41 @@ void main() {
           _expectSingleCompletion(
             performanceMonitor,
             traceName: 'feed_load_profile',
+            completion: 'disposed',
+            eventCount: 0,
+          );
+        },
+      );
+
+      test(
+        'disposed: sorted load starts trace after dispose drain already ran',
+        () async {
+          final capabilitiesRead = Completer<RelayCapabilities>();
+          when(
+            () => mockRelayCapabilityService.getRelayCapabilities(any()),
+          ).thenAnswer((_) => capabilitiesRead.future);
+          withEmptyCache();
+
+          final subscribe = videoEventService.subscribeToVideoFeed(
+            subscriptionType: SubscriptionType.discovery,
+            sortBy: VideoSortField.loopCount,
+          );
+          await pumpEventQueue();
+
+          // The sorted filter is still awaiting NIP-11 capabilities, so the
+          // trace has not been registered and dispose drains an empty map.
+          videoEventService.dispose();
+          capabilitiesRead.complete(
+            RelayCapabilities(
+              relayUrl: 'wss://relay.divine.video',
+              rawData: const {},
+            ),
+          );
+          await subscribe.timeout(const Duration(milliseconds: 100));
+
+          _expectSingleCompletion(
+            performanceMonitor,
+            traceName: 'feed_load_discovery',
             completion: 'disposed',
             eventCount: 0,
           );

--- a/mobile/test/services/video_event_service_startup_contract_test.dart
+++ b/mobile/test/services/video_event_service_startup_contract_test.dart
@@ -499,6 +499,30 @@ void main() {
           );
         },
       );
+
+      test('setup_error: creating the relay subscription throws', () async {
+        withEmptyCache();
+        when(
+          () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+        ).thenThrow(StateError('relay unavailable'));
+
+        await videoEventService
+            .subscribeToVideoFeed(
+              subscriptionType: SubscriptionType.profile,
+              authors: ['a' * 64],
+            )
+            .timeout(const Duration(milliseconds: 100));
+
+        // Setup threw before anything was registered, so no teardown path can
+        // reach this handle — the catch has to close it or it survives to
+        // dispose and reports the session as the load's duration.
+        _expectSingleCompletion(
+          performanceMonitor,
+          traceName: 'feed_load_profile',
+          completion: 'setup_error',
+          eventCount: 0,
+        );
+      });
     });
   });
 }

--- a/mobile/test/services/video_event_service_startup_contract_test.dart
+++ b/mobile/test/services/video_event_service_startup_contract_test.dart
@@ -367,6 +367,138 @@ void main() {
           );
         },
       );
+
+      test('cancelled: the feed is unsubscribed mid-load', () async {
+        withEmptyCache();
+
+        await videoEventService
+            .subscribeToVideoFeed(
+              subscriptionType: SubscriptionType.profile,
+              authors: ['a' * 64],
+            )
+            .timeout(const Duration(milliseconds: 100));
+
+        await videoEventService.unsubscribeFromVideoFeed();
+
+        _expectSingleCompletion(
+          performanceMonitor,
+          traceName: 'feed_load_profile',
+          completion: 'cancelled',
+          eventCount: 0,
+        );
+      });
+
+      test('cancelled: the load is replaced by a newer one', () async {
+        withEmptyCache();
+
+        await videoEventService
+            .subscribeToVideoFeed(
+              subscriptionType: SubscriptionType.profile,
+              authors: ['a' * 64],
+            )
+            .timeout(const Duration(milliseconds: 100));
+
+        // Same type, different authors: replaces the in-flight load. Its trace
+        // must close here rather than stay open until the app is torn down,
+        // which is what made the abandoned sample session-length.
+        await videoEventService
+            .subscribeToVideoFeed(
+              subscriptionType: SubscriptionType.profile,
+              authors: ['b' * 64],
+            )
+            .timeout(const Duration(milliseconds: 100));
+
+        // The replacement's trace is still running, so exactly one stop for
+        // this name means the first load's — and only the first load's.
+        _expectSingleCompletion(
+          performanceMonitor,
+          traceName: 'feed_load_profile',
+          completion: 'cancelled',
+          eventCount: 0,
+        );
+        expect(
+          performanceMonitor.startedTraces
+              .where((t) => t == 'feed_load_profile')
+              .length,
+          2,
+        );
+      });
+
+      test('disposed: load abandoned before any completion path', () async {
+        withEmptyCache();
+
+        await videoEventService
+            .subscribeToVideoFeed(
+              subscriptionType: SubscriptionType.profile,
+              authors: ['a' * 64],
+            )
+            .timeout(const Duration(milliseconds: 100));
+
+        // Nothing arrives and the 30s fuse never fires: without the pending
+        // registry this handle would stay open for the process lifetime.
+        videoEventService.dispose();
+
+        _expectSingleCompletion(
+          performanceMonitor,
+          traceName: 'feed_load_profile',
+          completion: 'disposed',
+          eventCount: 0,
+        );
+      });
+
+      test(
+        'disposed: load still mid-setup has no subscription to tear down',
+        () async {
+          // Hangs the cache read so the load is disposed before it ever
+          // registers a stream subscription — the one abandoned load the
+          // teardown sweep cannot see.
+          final cacheRead = Completer<List<Event>>();
+          when(
+            () => mockNostrEventsDao.getEventsByFilter(
+              any(),
+              sortBy: any(named: 'sortBy'),
+            ),
+          ).thenAnswer((_) => cacheRead.future);
+
+          unawaited(
+            videoEventService.subscribeToVideoFeed(
+              subscriptionType: SubscriptionType.profile,
+              authors: ['a' * 64],
+            ),
+          );
+          await pumpEventQueue();
+
+          videoEventService.dispose();
+
+          _expectSingleCompletion(
+            performanceMonitor,
+            traceName: 'feed_load_profile',
+            completion: 'disposed',
+            eventCount: 0,
+          );
+        },
+      );
+
+      test(
+        'disposed: does not re-complete a trace that already reported',
+        () async {
+          await videoEventService
+              .subscribeToVideoFeed(
+                subscriptionType: SubscriptionType.profile,
+                authors: ['a' * 64],
+              )
+              .timeout(const Duration(milliseconds: 100));
+
+          videoEventService.dispose();
+
+          _expectSingleCompletion(
+            performanceMonitor,
+            traceName: 'feed_load_profile',
+            completion: 'cache',
+            eventCount: 1,
+          );
+        },
+      );
     });
   });
 }

--- a/mobile/test/services/video_event_service_startup_contract_test.dart
+++ b/mobile/test/services/video_event_service_startup_contract_test.dart
@@ -68,9 +68,9 @@ class _RecordingTrace implements PerformanceTrace {
 /// with the expected first-wins [completion] label and [eventCount] metric.
 ///
 /// The "exactly once" check on [stoppedTraces] is what enforces the trace
-/// completion guard's idempotency: if a later completion path leaked past the
-/// `traceCompleted` guard it would append a second stop (and overwrite the
-/// completion attribute), failing this helper.
+/// completion guard's idempotency: if a later completion path leaked past
+/// the FeedLoadTrace first-wins latch it would append a second stop (and
+/// overwrite the completion attribute), failing this helper.
 void _expectSingleCompletion(
   _RecordingPerformanceMonitor monitor, {
   required String traceName,

--- a/mobile/test/services/video_event_service_startup_contract_test.dart
+++ b/mobile/test/services/video_event_service_startup_contract_test.dart
@@ -500,6 +500,42 @@ void main() {
         },
       );
 
+      test(
+        'disposed: cached events resolve after the service is gone',
+        () async {
+          // The cache read is the await a dispose races with. Resolving it
+          // afterwards ran the cache-first notifyListeners on a dead
+          // ChangeNotifier, which the load then swallowed as its own failure.
+          final cacheRead = Completer<List<Event>>();
+          when(
+            () => mockNostrEventsDao.getEventsByFilter(
+              any(),
+              sortBy: any(named: 'sortBy'),
+            ),
+          ).thenAnswer((_) => cacheRead.future);
+
+          unawaited(
+            videoEventService.subscribeToVideoFeed(
+              subscriptionType: SubscriptionType.profile,
+              authors: ['a' * 64],
+            ),
+          );
+          await pumpEventQueue();
+
+          videoEventService.dispose();
+          cacheRead.complete([_cachedVideoEvent()]);
+          await pumpEventQueue();
+
+          expect(videoEventService.error, isNull);
+          _expectSingleCompletion(
+            performanceMonitor,
+            traceName: 'feed_load_profile',
+            completion: 'disposed',
+            eventCount: 0,
+          );
+        },
+      );
+
       test('setup_error: creating the relay subscription throws', () async {
         withEmptyCache();
         when(


### PR DESCRIPTION
## Description

`MethodChannelTrace.start()` takes a native handle that the plugin only releases in `stopTrace` (`FirebasePerformancePlugin.swift` inserts into `traces` on start and removes on stop; Android is the same shape). Since #7132 made feed-load traces operation-scoped, a load that never reaches a completion path no longer corrupts a later sample — it just never reports, and its handle stays live for the process lifetime.

The trace now lives in a `FeedLoadTrace` handle that `VideoEventService` tracks per subscription id, with the same first-wins rule the inline closure had. Three teardown paths close it:

- **`cancelled`** — the subscription is replaced (`_cancelSubscription`) or the feed is unsubscribed (`_cancelExistingSubscriptions`).
- **`setup_error`** — setup threw between claiming the subscription id and registering the stream subscription. Nothing lands in `_subscriptions` and `_activeSubscriptions` never points at that id, so no teardown sweep can reach the handle; without closing it here it survives to dispose and reports the session as the load's duration.
- **`disposed`** — whatever is still pending when the service is disposed, which is the case a teardown sweep cannot see: a load still awaiting its cache read has no stream subscription registered yet.

**Why close at teardown and not only at dispose.** Dispose alone releases the handle but not usefully: `_cancelSubscription` cancels the 30s fuse, and the fuse's handler bails out early on a subscription that was already replaced, so an abandoned load stays open until the process ends. Reporting it at dispose would emit a `feed_load_*` sample whose duration is the session, not the load — the same shape of bogus duration #7119 was about. Closing where the load is actually abandoned keeps the duration the load's own.

`FeedLoadTrace` lives in its own file rather than in `video_event_service.dart` because that file is at 6616 of its frozen 6619-line ceiling (#4338); keeping the class out leaves the headroom intact and makes the first-wins latch unit-testable on its own.

**Not requested by the issue — the dispose-mid-load path.** Disposing while a load is in flight tripped "A VideoEventService was used after being disposed" in debug builds, in two places:

- `_scheduleFrameUpdate`'s microtask called `notifyListeners()` with no `_isDisposed` guard. One-line guard, and the `disposed: does not re-complete` test fails without it.
- The cache-first `notifyListeners()` that runs straight after the awaited cache read is a direct call on the same path, and that await is exactly where the dispose races. The surrounding catch swallowed the assert into `_error`, so the load reported a failure that was really just teardown. Continuing past that point was wrong anyway — the teardown sweep has already run, so the relay subscription the rest of the setup wires up would have nothing left to cancel it. It now bails out and releases the pending-id claim.

**Related Issue:** Closes #7151

## Out of Scope

Android's `didReinitializeFirebaseCore` bulk-stops leftover traces, so a bogus-duration sample there is still possible for a trace this change does not reach first. Noted in #7151 and unchanged here.

## Verification

- `flutter test test/services/ test/unit/services/` — 4249 passed, 59 skipped
- `flutter test test/providers/ test/blocs/ test/helpers/` — 3962 passed, 18 skipped
- `flutter analyze lib test` — clean; `dart format` — clean
- Each of the six new completion tests was checked against a reverted fix and fails without it, for the right reason
- Ratchets: `check_service_god_file_ceiling.sh`, `check_untested_services_floor.sh`, `check_test_unit_structure.sh` — green
- Takeover follow-up: added coverage for the post-dispose sorted-filter continuation and verified changed-file pre-push checks plus GitHub Mobile CI are green

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
