### PR TITLE
fix(theme): migrate the crossposting settings screen to the light palette

### DIFF
--- a/mobile/lib/screens/settings/crossposting_settings_screen.dart
+++ b/mobile/lib/screens/settings/crossposting_settings_screen.dart
@@ -36,7 +36,7 @@ class CrosspostingSettingsScreen extends ConsumerWidget {
         child: Center(
           child: Text(
             context.l10n.crosspostingSignInRequired,
-            style: VineTheme.bodyLargeFont(color: VineTheme.lightText),
+            style: VineTheme.bodyLargeFont(color: context.vineColors.mutedText),
             textAlign: TextAlign.center,
           ),
         ),
@@ -172,13 +172,13 @@ class _LoadedSettingsList extends StatelessWidget {
     ).refreshIndicatorSemanticLabel;
     return RefreshIndicator(
       color: VineTheme.vineGreen,
-      backgroundColor: VineTheme.surfaceContainer,
+      backgroundColor: context.vineColors.surfaceContainer,
       onRefresh: context.read<CrosspostingSettingsCubit>().refresh,
       child: ListView.separated(
         padding: const EdgeInsets.symmetric(vertical: 8),
         itemCount: state.entries.length + 1,
         separatorBuilder: (_, _) =>
-            const Divider(height: 1, color: VineTheme.surfaceBackground),
+            Divider(height: 1, color: context.vineColors.outlineMuted),
         itemBuilder: (context, index) {
           if (index == 0) {
             return Padding(
@@ -220,7 +220,7 @@ class _CrosspostingScaffold extends StatelessWidget {
         showBackButton: true,
         onBackPressed: context.pop,
       ),
-      backgroundColor: VineTheme.backgroundColor,
+      backgroundColor: context.vineColors.background,
       body: Align(
         alignment: Alignment.topCenter,
         child: ConstrainedBox(
@@ -246,7 +246,9 @@ class _LoadFailed extends StatelessWidget {
           children: [
             Text(
               context.l10n.crosspostingLoadFailed,
-              style: VineTheme.bodyLargeFont(color: VineTheme.lightText),
+              style: VineTheme.bodyLargeFont(
+                color: context.vineColors.mutedText,
+              ),
               textAlign: TextAlign.center,
             ),
             DivineButton(
@@ -272,7 +274,7 @@ class _NoPlatforms extends StatelessWidget {
         padding: const EdgeInsets.all(24),
         child: Text(
           context.l10n.crosspostingNoPlatforms,
-          style: VineTheme.bodyLargeFont(color: VineTheme.lightText),
+          style: VineTheme.bodyLargeFont(color: context.vineColors.mutedText),
           textAlign: TextAlign.center,
         ),
       ),
@@ -308,7 +310,7 @@ class _PlatformSection extends StatelessWidget {
                     ? VineTheme.vineGreen
                     : entry.needsReauth
                     ? VineTheme.accentOrange
-                    : VineTheme.lightText,
+                    : context.vineColors.mutedText,
               ),
               Expanded(
                 child: Column(
@@ -324,7 +326,7 @@ class _PlatformSection extends StatelessWidget {
                       Text(
                         identity,
                         style: VineTheme.bodyMediumFont(
-                          color: VineTheme.lightText,
+                          color: context.vineColors.secondaryText,
                         ),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
@@ -335,7 +337,7 @@ class _PlatformSection extends StatelessWidget {
                         style: VineTheme.bodyMediumFont(
                           color: entry.needsReauth
                               ? VineTheme.accentOrange
-                              : VineTheme.lightText,
+                              : context.vineColors.mutedText,
                         ),
                       ),
                   ],
@@ -363,12 +365,16 @@ class _PlatformSection extends StatelessWidget {
             if (entry.mode == CrosspostingMode.manual)
               Text(
                 context.l10n.crosspostingModeManualSubtitle,
-                style: VineTheme.bodySmallFont(color: VineTheme.lightText),
+                style: VineTheme.bodySmallFont(
+                  color: context.vineColors.mutedText,
+                ),
               ),
             if (entry.mode == CrosspostingMode.automatic)
               Text(
                 context.l10n.crosspostingModeAutomaticSubtitle,
-                style: VineTheme.bodySmallFont(color: VineTheme.lightText),
+                style: VineTheme.bodySmallFont(
+                  color: context.vineColors.mutedText,
+                ),
               ),
           ],
         ],

--- a/mobile/lib/screens/settings/crossposting_settings_screen.dart
+++ b/mobile/lib/screens/settings/crossposting_settings_screen.dart
@@ -171,7 +171,7 @@ class _LoadedSettingsList extends StatelessWidget {
       context,
     ).refreshIndicatorSemanticLabel;
     return RefreshIndicator(
-      color: VineTheme.vineGreen,
+      color: context.vineColors.accentPositive,
       backgroundColor: context.vineColors.surfaceContainer,
       onRefresh: context.read<CrosspostingSettingsCubit>().refresh,
       child: ListView.separated(
@@ -307,9 +307,9 @@ class _PlatformSection extends StatelessWidget {
               DivineIcon(
                 icon: DivineIconName.shareNetwork,
                 color: entry.isConnected
-                    ? VineTheme.vineGreen
+                    ? context.vineColors.accentPositive
                     : entry.needsReauth
-                    ? VineTheme.accentOrange
+                    ? context.vineColors.accentWarning
                     : context.vineColors.mutedText,
               ),
               Expanded(
@@ -336,7 +336,7 @@ class _PlatformSection extends StatelessWidget {
                         status,
                         style: VineTheme.bodyMediumFont(
                           color: entry.needsReauth
-                              ? VineTheme.accentOrange
+                              ? context.vineColors.accentWarning
                               : context.vineColors.mutedText,
                         ),
                       ),

--- a/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
+++ b/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
@@ -35,6 +35,8 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
     required this.skeleton,
     required this.errorContainer,
     required this.onErrorContainer,
+    required this.accentPositive,
+    required this.accentWarning,
     required this.inverseSurface,
     required this.inverseOnSurface,
     required this.mediaChrome,
@@ -140,6 +142,25 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
   /// Content color on [errorContainer].
   final Color onErrorContainer;
 
+  /// Healthy-status accent, drawn directly on [background] — a connected
+  /// integration, a completed step.
+  ///
+  /// Its dark value is [VineTheme.vineGreen], so dark mode is unchanged. The
+  /// brand green is 2.08:1 on the light canvas, below the 3:1 non-text floor,
+  /// so the light value is the seeded tone the light `colorScheme.primary`
+  /// already resolves to. Reusing it keeps one green in light mode rather
+  /// than introducing a second, near-identical one.
+  final Color accentPositive;
+
+  /// Attention-status accent, drawn directly on [background] — an expired
+  /// authorization, a step that needs the user to come back to it.
+  ///
+  /// Its dark value is [VineTheme.accentOrange], so dark mode is unchanged.
+  /// This one labels body copy as well as icons, so the light value clears
+  /// 4.5:1 rather than 3:1 — and is pitched at [accentPositive]'s ratio on
+  /// [background] so the two accents carry the same weight side by side.
+  final Color accentWarning;
+
   /// Surface that contrasts with [background], used by tertiary actions.
   final Color inverseSurface;
 
@@ -185,6 +206,8 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
     Color? skeleton,
     Color? errorContainer,
     Color? onErrorContainer,
+    Color? accentPositive,
+    Color? accentWarning,
     Color? inverseSurface,
     Color? inverseOnSurface,
     Color? mediaChrome,
@@ -215,6 +238,8 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
     skeleton: skeleton ?? this.skeleton,
     errorContainer: errorContainer ?? this.errorContainer,
     onErrorContainer: onErrorContainer ?? this.onErrorContainer,
+    accentPositive: accentPositive ?? this.accentPositive,
+    accentWarning: accentWarning ?? this.accentWarning,
     inverseSurface: inverseSurface ?? this.inverseSurface,
     inverseOnSurface: inverseOnSurface ?? this.inverseOnSurface,
     mediaChrome: mediaChrome ?? this.mediaChrome,
@@ -254,6 +279,8 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
       skeleton: Color.lerp(skeleton, other.skeleton, t),
       errorContainer: Color.lerp(errorContainer, other.errorContainer, t),
       onErrorContainer: Color.lerp(onErrorContainer, other.onErrorContainer, t),
+      accentPositive: Color.lerp(accentPositive, other.accentPositive, t),
+      accentWarning: Color.lerp(accentWarning, other.accentWarning, t),
       inverseSurface: Color.lerp(inverseSurface, other.inverseSurface, t),
       inverseOnSurface: Color.lerp(inverseOnSurface, other.inverseOnSurface, t),
       mediaChrome: Color.lerp(mediaChrome, other.mediaChrome, t),
@@ -294,6 +321,8 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
           skeleton == other.skeleton &&
           errorContainer == other.errorContainer &&
           onErrorContainer == other.onErrorContainer &&
+          accentPositive == other.accentPositive &&
+          accentWarning == other.accentWarning &&
           inverseSurface == other.inverseSurface &&
           inverseOnSurface == other.inverseOnSurface &&
           mediaChrome == other.mediaChrome &&
@@ -326,6 +355,8 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
     skeleton,
     errorContainer,
     onErrorContainer,
+    accentPositive,
+    accentWarning,
     inverseSurface,
     inverseOnSurface,
     mediaChrome,
@@ -975,6 +1006,8 @@ class VineTheme {
     skeleton: skeletonBase,
     errorContainer: errorContainer,
     onErrorContainer: likeRed,
+    accentPositive: vineGreen,
+    accentWarning: accentOrange,
     inverseSurface: inverseSurface,
     inverseOnSurface: inverseOnSurface,
     mediaChrome: scrim80,
@@ -1009,6 +1042,8 @@ class VineTheme {
     skeleton: Color(0xFFE7E4E1),
     errorContainer: Color(0xFFFFE7E2),
     onErrorContainer: Color(0xFF8C1D18),
+    accentPositive: Color(0xFF226A4C),
+    accentWarning: Color(0xFFAE3100),
     inverseSurface: Color(0xFF07241B),
     inverseOnSurface: Color(0xFFFFFFFF),
     mediaChrome: Color(0xF2F9F7F6),

--- a/mobile/packages/divine_ui/test/src/divine_ui_test.dart
+++ b/mobile/packages/divine_ui/test/src/divine_ui_test.dart
@@ -102,6 +102,8 @@ void main() {
         'skeleton': (c) => c.skeleton,
         'errorContainer': (c) => c.errorContainer,
         'onErrorContainer': (c) => c.onErrorContainer,
+        'accentPositive': (c) => c.accentPositive,
+        'accentWarning': (c) => c.accentWarning,
         'inverseSurface': (c) => c.inverseSurface,
         'inverseOnSurface': (c) => c.inverseOnSurface,
         'mediaChrome': (c) => c.mediaChrome,
@@ -134,6 +136,8 @@ void main() {
         skeleton: color,
         errorContainer: color,
         onErrorContainer: color,
+        accentPositive: color,
+        accentWarning: color,
         inverseSurface: color,
         inverseOnSurface: color,
         mediaChrome: color,
@@ -163,6 +167,8 @@ void main() {
           skeleton: const Color(0xFF000015),
           errorContainer: const Color(0xFF000016),
           onErrorContainer: const Color(0xFF000017),
+          accentPositive: const Color(0xFF00001A),
+          accentWarning: const Color(0xFF00001B),
           inverseSurface: const Color(0xFF000018),
           inverseOnSurface: const Color(0xFF000019),
           mediaChrome: const Color(0xFF00000F),
@@ -190,6 +196,8 @@ void main() {
         expect(copied.skeleton, const Color(0xFF000015));
         expect(copied.errorContainer, const Color(0xFF000016));
         expect(copied.onErrorContainer, const Color(0xFF000017));
+        expect(copied.accentPositive, const Color(0xFF00001A));
+        expect(copied.accentWarning, const Color(0xFF00001B));
         expect(copied.inverseSurface, const Color(0xFF000018));
         expect(copied.inverseOnSurface, const Color(0xFF000019));
         expect(copied.mediaChrome, const Color(0xFF00000F));
@@ -281,6 +289,8 @@ void main() {
             skeleton: token == 'skeleton' ? Colors.white : null,
             errorContainer: token == 'errorContainer' ? Colors.white : null,
             onErrorContainer: token == 'onErrorContainer' ? Colors.white : null,
+            accentPositive: token == 'accentPositive' ? Colors.white : null,
+            accentWarning: token == 'accentWarning' ? Colors.white : null,
             inverseSurface: token == 'inverseSurface' ? Colors.white : null,
             inverseOnSurface: token == 'inverseOnSurface' ? Colors.white : null,
             mediaChrome: token == 'mediaChrome' ? Colors.white : null,

--- a/mobile/packages/divine_ui/test/src/theme/vine_theme_light_palette_test.dart
+++ b/mobile/packages/divine_ui/test/src/theme/vine_theme_light_palette_test.dart
@@ -64,6 +64,8 @@ Map<String, Color> _tokens(VineThemeColors c) => {
   'skeleton': c.skeleton,
   'errorContainer': c.errorContainer,
   'onErrorContainer': c.onErrorContainer,
+  'accentPositive': c.accentPositive,
+  'accentWarning': c.accentWarning,
   'inverseSurface': c.inverseSurface,
   'inverseOnSurface': c.inverseOnSurface,
   'mediaChrome': c.mediaChrome,
@@ -89,6 +91,9 @@ const _bodyPairs = <(String, String)>[
   ('mutedText', 'background'),
   ('mutedText', 'card'),
   ('mutedText', 'surface'),
+  // `accentWarning` labels the copy next to its icon ("Reconnect needed"), not
+  // just the icon, so it is held to the body ratio rather than the 3:1 floor.
+  ('accentWarning', 'background'),
 ];
 
 /// Supporting copy — hints, placeholders, secondary labels — held to the
@@ -97,6 +102,10 @@ const _supportingPairs = <(String, String)>[
   ('onSurfaceVariant', 'surface'),
   ('onSurfaceMuted', 'surface'),
   ('onErrorContainer', 'errorContainer'),
+  // `accentPositive` only ever tints an icon — the connected row's label is
+  // `primaryText` and its identity line is `secondaryText` — so the non-text
+  // floor is the honest bar for it. Promote it if it ever colors copy.
+  ('accentPositive', 'background'),
 ];
 
 /// Token pairs that share a dark value while differing in light.

--- a/mobile/test/screens/settings/settings_screens_light_mode_test.dart
+++ b/mobile/test/screens/settings/settings_screens_light_mode_test.dart
@@ -234,6 +234,34 @@ void main() {
       final divider = tester.widget<Divider>(find.byType(Divider).first);
       expect(divider.color, VineTheme.lightColors.outlineMuted);
 
+      final reconnect = tester.widget<Text>(
+        find.text(l10n.crosspostingNeedsReconnect),
+      );
+      expect(reconnect.style?.color, VineTheme.lightColors.accentWarning);
+
+      // One per platform row, in `entries` order: connected, disconnected,
+      // needs-reauth. Typed on the icon name so the app bar's own icons — a
+      // plain `find.byType(DivineIcon).first` picks up the back arrow — stay
+      // out of it.
+      final platformIcons = tester
+          .widgetList<DivineIcon>(
+            find.byWidgetPredicate(
+              (widget) =>
+                  widget is DivineIcon &&
+                  widget.icon == DivineIconName.shareNetwork,
+            ),
+          )
+          .toList();
+      expect(platformIcons, hasLength(3));
+      expect(platformIcons.first.color, VineTheme.lightColors.accentPositive);
+      expect(platformIcons[1].color, VineTheme.lightColors.mutedText);
+      expect(platformIcons.last.color, VineTheme.lightColors.accentWarning);
+
+      final refresh = tester.widget<RefreshIndicator>(
+        find.byType(RefreshIndicator),
+      );
+      expect(refresh.color, VineTheme.lightColors.accentPositive);
+
       expect(VineThemeColors.debugFallbackCount, 0);
     });
 
@@ -294,8 +322,13 @@ void main() {
   });
 }
 
-/// One connected platform (identity + mode subtitle) and one disconnected one
-/// (status line), so every migrated text token has a rendered call site.
+/// One platform per rendered branch — connected (identity + mode subtitle),
+/// disconnected (status line) and needs-reauth (the accent-tinted status line
+/// and icon) — so every migrated token has a rendered call site.
+///
+/// The needs-reauth row is the one this screen shipped without: it is the only
+/// branch that paints an accent on the canvas rather than a text token, and it
+/// is where the raw brand orange stayed 2.48:1 in light mode.
 const _crosspostingEntries = <CrosspostingPlatformSettings>[
   CrosspostingPlatformSettings(
     platform: CrosspostingPlatform.instagram,
@@ -312,5 +345,16 @@ const _crosspostingEntries = <CrosspostingPlatformSettings>[
     platform: CrosspostingPlatform.x,
     supportsAutomatic: false,
     mode: CrosspostingMode.disabled,
+  ),
+  CrosspostingPlatformSettings(
+    platform: CrosspostingPlatform.tiktok,
+    supportsAutomatic: true,
+    mode: CrosspostingMode.manual,
+    connection: CrosspostingConnection(
+      id: 'tiktok-connection',
+      platform: CrosspostingPlatform.tiktok,
+      status: CrosspostingConnectionStatus.needsReauth,
+      externalAccountName: 'divine.tiktok',
+    ),
   ),
 ];

--- a/mobile/test/screens/settings/settings_screens_light_mode_test.dart
+++ b/mobile/test/screens/settings/settings_screens_light_mode_test.dart
@@ -12,20 +12,35 @@ import 'package:openvine/features/appearance/bloc/appearance_cubit.dart';
 import 'package:openvine/features/appearance/repositories/appearance_repository.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/crossposting_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/repositories/crossposting_repository.dart';
 import 'package:openvine/screens/settings/appearance_settings_screen.dart';
+import 'package:openvine/screens/settings/crossposting_settings_screen.dart';
+import 'package:openvine/screens/settings/general_settings_screen.dart';
 import 'package:openvine/screens/settings/settings_screen.dart';
+import 'package:openvine/services/audio_sharing_preference_service.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/crossposting_api_client.dart';
+import 'package:openvine/services/feed_aspect_ratio_preference_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
 
 class _MockLocaleCubit extends MockCubit<LocaleState> implements LocaleCubit {}
 
+class _MockAudioSharingPreferenceService extends Mock
+    implements AudioSharingPreferenceService {}
+
+class _MockCrosspostingRepository extends Mock
+    implements CrosspostingRepository {}
+
 void main() {
   group('settings screens in light mode', () {
     late _MockAuthService authService;
     late _MockLocaleCubit localeCubit;
+    late _MockAudioSharingPreferenceService audioSharingService;
+    late _MockCrosspostingRepository crosspostingRepository;
     late SharedPreferences preferences;
 
     setUp(() async {
@@ -36,10 +51,19 @@ void main() {
       preferences = await SharedPreferences.getInstance();
       authService = _MockAuthService();
       localeCubit = _MockLocaleCubit();
+      audioSharingService = _MockAudioSharingPreferenceService();
+      crosspostingRepository = _MockCrosspostingRepository();
       when(() => localeCubit.state).thenReturn(const LocaleState());
       when(() => authService.isAuthenticated).thenReturn(true);
       when(() => authService.isAnonymous).thenReturn(false);
       when(() => authService.hasExpiredOAuthSession).thenReturn(false);
+      when(() => audioSharingService.isAudioSharingEnabled).thenReturn(false);
+      when(
+        () => audioSharingService.setAudioSharingEnabled(any()),
+      ).thenAnswer((_) async {});
+      when(
+        crosspostingRepository.loadSettings,
+      ).thenAnswer((_) async => _crosspostingEntries);
     });
 
     tearDown(() => VineThemeColors.debugFallbackCount = 0);
@@ -111,6 +135,140 @@ void main() {
       expect(VineThemeColors.debugFallbackCount, 0);
     });
 
+    testWidgets('GeneralSettingsScreen paints the light palette', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(preferences),
+            authServiceProvider.overrideWithValue(authService),
+            currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
+            audioSharingPreferenceServiceProvider.overrideWithValue(
+              audioSharingService,
+            ),
+            feedAspectRatioPreferenceServiceProvider.overrideWithValue(
+              FeedAspectRatioPreferenceService(preferences),
+            ),
+            crosspostingEligibleProvider.overrideWithValue(true),
+          ],
+          child: MaterialApp(
+            theme: VineTheme.lightTheme,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: BlocProvider<LocaleCubit>.value(
+              value: localeCubit,
+              child: const GeneralSettingsScreen(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final scaffold = tester.widget<Scaffold>(find.byType(Scaffold));
+      expect(scaffold.backgroundColor, VineTheme.lightColors.background);
+
+      final appBar = tester.widget<AppBar>(find.byType(AppBar));
+      expect(appBar.backgroundColor, VineTheme.lightColors.nav);
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      final title = tester.widget<Text>(
+        find.text(l10n.settingsCrosspostingTitle),
+      );
+      expect(title.style?.color, VineTheme.lightColors.primaryText);
+
+      final subtitle = tester.widget<Text>(
+        find.text(l10n.settingsCrosspostingSubtitle),
+      );
+      expect(subtitle.style?.color, VineTheme.lightColors.mutedText);
+
+      expect(VineThemeColors.debugFallbackCount, 0);
+    });
+
+    testWidgets('CrosspostingSettingsScreen paints the light palette', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authServiceProvider.overrideWithValue(authService),
+            currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
+            crosspostingEligibleProvider.overrideWithValue(true),
+            crosspostingRepositoryProvider.overrideWithValue(
+              crosspostingRepository,
+            ),
+          ],
+          child: MaterialApp(
+            theme: VineTheme.lightTheme,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: const CrosspostingSettingsScreen(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final scaffold = tester.widget<Scaffold>(find.byType(Scaffold));
+      expect(scaffold.backgroundColor, VineTheme.lightColors.background);
+
+      final appBar = tester.widget<AppBar>(find.byType(AppBar));
+      expect(appBar.backgroundColor, VineTheme.lightColors.nav);
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      final platformTitle = tester.widget<Text>(find.text('Instagram'));
+      expect(platformTitle.style?.color, VineTheme.lightColors.primaryText);
+
+      final identity = tester.widget<Text>(find.text('divine.creator'));
+      expect(identity.style?.color, VineTheme.lightColors.secondaryText);
+
+      final disconnectedStatus = tester.widget<Text>(
+        find.text(l10n.crosspostingNotConnected),
+      );
+      expect(disconnectedStatus.style?.color, VineTheme.lightColors.mutedText);
+
+      final modeSubtitle = tester.widget<Text>(
+        find.text(l10n.crosspostingModeManualSubtitle),
+      );
+      expect(modeSubtitle.style?.color, VineTheme.lightColors.mutedText);
+
+      final divider = tester.widget<Divider>(find.byType(Divider).first);
+      expect(divider.color, VineTheme.lightColors.outlineMuted);
+
+      expect(VineThemeColors.debugFallbackCount, 0);
+    });
+
+    testWidgets('the signed-out crossposting copy paints the light palette', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authServiceProvider.overrideWithValue(authService),
+            currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
+            crosspostingEligibleProvider.overrideWithValue(false),
+          ],
+          child: MaterialApp(
+            theme: VineTheme.lightTheme,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: const CrosspostingSettingsScreen(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      final copy = tester.widget<Text>(
+        find.text(l10n.crosspostingSignInRequired),
+      );
+      expect(copy.style?.color, VineTheme.lightColors.mutedText);
+      expect(
+        tester.widget<Scaffold>(find.byType(Scaffold)).backgroundColor,
+        VineTheme.lightColors.background,
+      );
+      expect(VineThemeColors.debugFallbackCount, 0);
+    });
+
     testWidgets('the dark fallback stays reachable without the extension', (
       tester,
     ) async {
@@ -135,3 +293,24 @@ void main() {
     });
   });
 }
+
+/// One connected platform (identity + mode subtitle) and one disconnected one
+/// (status line), so every migrated text token has a rendered call site.
+const _crosspostingEntries = <CrosspostingPlatformSettings>[
+  CrosspostingPlatformSettings(
+    platform: CrosspostingPlatform.instagram,
+    supportsAutomatic: true,
+    mode: CrosspostingMode.manual,
+    connection: CrosspostingConnection(
+      id: 'instagram-connection',
+      platform: CrosspostingPlatform.instagram,
+      status: CrosspostingConnectionStatus.connected,
+      externalAccountName: 'divine.creator',
+    ),
+  ),
+  CrosspostingPlatformSettings(
+    platform: CrosspostingPlatform.x,
+    supportsAutomatic: false,
+    mode: CrosspostingMode.disabled,
+  ),
+];


### PR DESCRIPTION
## Description

`CrosspostingSettingsScreen` landed after the light-mode sweep's base was cut, so `_CrosspostingScaffold` still hardcoded `VineTheme.backgroundColor`. Under `lightTheme` the screen painted a black canvas while the ambient text tokens resolved to the light palette's near-black values — the platform title measured 1.28:1. The eight fixed `VineTheme.lightText` sites had the mirror problem: they stayed `#888888` regardless of palette, which is 3.32:1 once the background is migrated.

The scaffold background, every fixed text/icon colour, the RefreshIndicator puck and the section divider now resolve from `context.vineColors`.

Two token choices worth calling out:

- **Account identity → `secondaryText`, not `mutedText`.** It is the primary content of that row (the connected handle), so it gets the stronger token. This does change dark mode: `#888888` → `#BBBBBB`.
- **Divider → `outlineMuted`.** Not listed in the issue scope. `surfaceBackground` sits at 1.11:1 on the dark canvas — effectively invisible — and would have rendered near-black on white. `outlineMuted` is the token the sibling settings screens use (`app_language_screen`) and stays subtle in both palettes (1.39:1 dark / 1.19:1 light). The dark-identical alternative would be `context.vineColors.surface`.

`mutedText`, `background` and `surfaceContainer` all resolve to exactly the constants they replace, so those swaps are byte-identical in dark mode.

### The brand accents needed tokens of their own

Swapping only the text tokens would have left this screen with two accents still painting their dark values on the light canvas — the failure this PR exists to fix, one layer down:

| Element | Was | Light ratio | Bar |
| --- | --- | --- | --- |
| Needs-reconnect status line + icon | `VineTheme.accentOrange` `#FF7640` | 2.48:1 | 4.5:1 (body copy) |
| Connected icon, RefreshIndicator puck | `VineTheme.vineGreen` `#27C58B` | 2.08:1 | 3:1 (non-text) |

`VineThemeColors` had no accent token, so this adds two: `accentPositive` and `accentWarning`. Both dark values are the constants they replace, so dark mode stays byte-identical.

- **Light green = `#226A4C`**, which is the tone `colorScheme.primary` already resolves to for this seed — `_buildTheme` has carried a comment about `vineGreen` reaching only ~2.2:1 on a white surface since the light theme landed. Reusing that tone keeps one green in light mode instead of introducing a second, near-identical one.
- **Light orange = `#AE3100`**, the same hue darkened and pitched at the green's ratio against the canvas so the two accents carry equal weight side by side. The palette guard requires light to stay within a third of dark on body copy; this clears that threshold by 15% rather than the 2% a minimal value would have left.

The tokens are held to their floors by the existing `divine_ui` palette guards — `accentWarning` in `_bodyPairs` (4.5:1) because it labels copy as well as icons, `accentPositive` in `_supportingPairs` (3:1) because it only ever tints an icon.

### Re-measured after the swap

| Element | Light | Ratio | Dark | Ratio |
| --- | --- | --- | --- | --- |
| Platform title (`primaryText`) | `#07241B` | 15.40:1 | `#FFFFFF` | 21.00:1 |
| Account identity (`secondaryText`) | `#385149` | 8.05:1 | `#BBBBBB` | 10.94:1 |
| Connection status, mode subtitles, empty states (`mutedText`) | `#5F7069` | 4.91:1 | `#888888` | 5.92:1 |
| Needs-reconnect status (`accentWarning`) | `#AE3100` | 6.07:1 | `#FF7640` | 7.92:1 |
| Connected icon, refresh puck (`accentPositive`) | `#226A4C` | 6.08:1 | `#27C58B` | 9.45:1 |

Every text pair on this screen clears the 4.5:1 body-text bar in both palettes, and every icon clears 3:1.

**Related Issue:** Closes #6546

## Out of Scope

The other 22 raw `VineTheme.accentOrange` call sites across `lib/` — `bluesky_settings_screen` among them, which is already migrated and still paints the raw accent. The tokens added here are what an app-wide pass would use, but doing that pass in this PR would bury a one-screen fix under a design-system migration.

## Unrequested changes

Flagged separately from the issue's scope:

- The two accent tokens and their three call sites (above). The issue asked only for the background and the `lightText` sites; leaving the accents raw would have shipped a screen that still fails contrast in the state it most needs to be readable.
- The RefreshIndicator puck, which was the same raw brand green one line above a colour the issue did ask for.
- Divider → `outlineMuted` (above).

## Verification

- `flutter test test/screens/settings/` — 135 passing.
- `divine_ui`: 875 tests passing, **100.00% line coverage** held (the package's CI gate).
- `test/tools/` — 151 passing, including the dark-parity ratchet's own suite.
- Both new crossposting assertions verified to fail without the `lib/` change by mutation, not by assertion: divider → `surface` fails on `outlineMuted`, identity → `mutedText` fails on `secondaryText`. `GeneralSettingsScreen` was already migrated — its coverage here is a regression guard, as the issue asked, and passes either way.
- The light-mode fixture now renders all three connection states. The needs-reauth row was previously absent, which is why the accent gap outlived the screen's own 27-test suite.
- `dart run scripts/check_dark_value_parity.dart --base origin/main` — the three accent replacements are dark-identical. The two reported mismatches are the deliberate dark changes documented above (divider, account identity).
- `flutter analyze` and `dart format` clean on all five changed files.
- Ratchets: `raw_colors`, `raw_textstyle`, `implicit_font_color`, `material_buttons`, `raw_dialogs`, `raw_icons`, `unsafe_back_pops`, `ui_service_boundary`, `untested_services`, `test_unit_structure`, `file_size`, `riverpod_boundary`, `todos`, `skip`, `package_coverage`, `service_god_file` — all green. No goldens render this screen.
- Manually verified on a real Samsung Galaxy in both light and dark mode: settings → general → crossposting, connected / disconnected / needs-reconnect rows, pull-to-refresh, signed-out state.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

