### PR TITLE
test(e2e): close the SemanticsHandle race that flakes the first Patrol test

### DIFF
--- a/mobile/integration_test/auth/auth_journey_test.dart
+++ b/mobile/integration_test/auth/auth_journey_test.dart
@@ -15,10 +15,13 @@ import 'package:patrol/patrol.dart';
 
 import '../helpers/db_helpers.dart';
 import '../helpers/navigation_helpers.dart';
+import '../helpers/patrol_semantics.dart';
 import '../helpers/relay_helpers.dart';
 import '../helpers/test_setup.dart';
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('Auth Journey', () {
     final testEmail =
         'journey-${DateTime.now().millisecondsSinceEpoch}@test.divine.video';

--- a/mobile/integration_test/auth/follow_reopen_persistence_test.dart
+++ b/mobile/integration_test/auth/follow_reopen_persistence_test.dart
@@ -10,10 +10,13 @@ import 'package:patrol/patrol.dart';
 
 import '../helpers/db_helpers.dart';
 import '../helpers/navigation_helpers.dart';
+import '../helpers/patrol_semantics.dart';
 import '../helpers/relay_helpers.dart';
 import '../helpers/test_setup.dart';
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('Follow persistence after reopen', () {
     patrolTest(
       'authenticated following survives app reopen and repository reload',

--- a/mobile/integration_test/auth/invite_availability_e2e_test.dart
+++ b/mobile/integration_test/auth/invite_availability_e2e_test.dart
@@ -19,11 +19,14 @@ import 'package:patrol/patrol.dart';
 import '../helpers/invite_admin_helpers.dart';
 import '../helpers/invite_helpers.dart';
 import '../helpers/navigation_helpers.dart';
+import '../helpers/patrol_semantics.dart';
 import '../helpers/test_setup.dart';
 
 AppLocalizations get _en => lookupAppLocalizations(const Locale('en'));
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   Future<void> restoreOpenMode() async {
     await setInviteOnboardingMode('open');
   }

--- a/mobile/integration_test/auth/key_management_export_test.dart
+++ b/mobile/integration_test/auth/key_management_export_test.dart
@@ -14,9 +14,12 @@ import 'package:patrol/patrol.dart';
 
 import '../helpers/db_helpers.dart';
 import '../helpers/navigation_helpers.dart';
+import '../helpers/patrol_semantics.dart';
 import '../helpers/test_setup.dart';
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('Key Management Export', () {
     final testEmail =
         'key-management-${DateTime.now().millisecondsSinceEpoch}@test.divine.video';

--- a/mobile/integration_test/auth/multi_account_switch_test.dart
+++ b/mobile/integration_test/auth/multi_account_switch_test.dart
@@ -16,6 +16,7 @@ import '../helpers/db_helpers.dart';
 import '../helpers/http_helpers.dart';
 import '../helpers/invite_helpers.dart';
 import '../helpers/navigation_helpers.dart';
+import '../helpers/patrol_semantics.dart';
 import '../helpers/test_setup.dart';
 
 /// Dismiss the Android notification permission dialog if it appears.
@@ -35,6 +36,8 @@ Future<void> dismissNotificationPermission(PatrolIntegrationTester $) async {
 }
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('Multi-account switching', () {
     patrolTest(
       'Keycast A → Keycast B → switch back to A succeeds',

--- a/mobile/integration_test/auth/pin_verification_test.dart
+++ b/mobile/integration_test/auth/pin_verification_test.dart
@@ -13,6 +13,7 @@ import 'package:patrol/patrol.dart';
 
 import '../helpers/db_helpers.dart';
 import '../helpers/navigation_helpers.dart';
+import '../helpers/patrol_semantics.dart';
 import '../helpers/test_setup.dart';
 
 AppLocalizations get _en => lookupAppLocalizations(const Locale('en'));
@@ -30,6 +31,8 @@ Finder _pinField() => find.descendant(
 );
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('Email verification PIN fallback', () {
     // Requires a keycast image with the verify-pin endpoint + the
     // oauth_codes.pin_hash migration (keycast#262). Until ghcr:latest rebuilds

--- a/mobile/integration_test/auth/repro_log1_test.dart
+++ b/mobile/integration_test/auth/repro_log1_test.dart
@@ -25,11 +25,14 @@ import 'package:patrol/patrol.dart';
 
 import '../helpers/invite_helpers.dart';
 import '../helpers/navigation_helpers.dart';
+import '../helpers/patrol_semantics.dart';
 import '../helpers/test_setup.dart';
 
 AppLocalizations get _en => lookupAppLocalizations(const Locale('en'));
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('Bug 2233 Repro Log 1 pubkey-nsec mismatch', () {
     patrolTest(
       'auto A → import nsec B → switch back to A → signing fails',

--- a/mobile/integration_test/auth/repro_log2_delete_test.dart
+++ b/mobile/integration_test/auth/repro_log2_delete_test.dart
@@ -22,6 +22,7 @@ import '../helpers/constants.dart';
 import '../helpers/db_helpers.dart';
 import '../helpers/http_helpers.dart';
 import '../helpers/navigation_helpers.dart';
+import '../helpers/patrol_semantics.dart';
 import '../helpers/test_setup.dart';
 
 /// Pre-register and verify a keycast account via HTTP API.
@@ -81,6 +82,8 @@ Future<String> _registerAndVerifyViaApi(String email, String password) async {
 }
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('Bug #2233 -- Delete Account Flow (User Log 2)', () {
     final ts = DateTime.now().millisecondsSinceEpoch;
     final emailA = 'log2-a-$ts@test.divine.video';

--- a/mobile/integration_test/auth/secure_account_test.dart
+++ b/mobile/integration_test/auth/secure_account_test.dart
@@ -15,9 +15,12 @@ import 'package:patrol/patrol.dart';
 import '../helpers/db_helpers.dart';
 import '../helpers/http_helpers.dart';
 import '../helpers/navigation_helpers.dart';
+import '../helpers/patrol_semantics.dart';
 import '../helpers/test_setup.dart';
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('Secure Account Flow', () {
     final testEmail =
         'secure-${DateTime.now().millisecondsSinceEpoch}@test.divine.video';

--- a/mobile/integration_test/auth/session_expired_banner_test.dart
+++ b/mobile/integration_test/auth/session_expired_banner_test.dart
@@ -16,9 +16,12 @@ import 'package:patrol/patrol.dart';
 import '../helpers/db_helpers.dart';
 import '../helpers/http_helpers.dart';
 import '../helpers/navigation_helpers.dart';
+import '../helpers/patrol_semantics.dart';
 import '../helpers/test_setup.dart';
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('Session Expired Banner', () {
     final testEmail =
         'banner-${DateTime.now().millisecondsSinceEpoch}@test.divine.video';

--- a/mobile/integration_test/auth/session_expiry_test.dart
+++ b/mobile/integration_test/auth/session_expiry_test.dart
@@ -14,9 +14,12 @@ import 'package:patrol/patrol.dart';
 
 import '../helpers/db_helpers.dart';
 import '../helpers/navigation_helpers.dart';
+import '../helpers/patrol_semantics.dart';
 import '../helpers/test_setup.dart';
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('Session Expiry', () {
     final testEmail =
         'expiry-${DateTime.now().millisecondsSinceEpoch}@test.divine.video';

--- a/mobile/integration_test/auth/signup_validation_test.dart
+++ b/mobile/integration_test/auth/signup_validation_test.dart
@@ -7,9 +7,12 @@ import 'package:openvine/main.dart' as app;
 import 'package:patrol/patrol.dart';
 
 import '../helpers/navigation_helpers.dart';
+import '../helpers/patrol_semantics.dart';
 import '../helpers/test_setup.dart';
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('Signup validation', () {
     patrolTest(
       'invalid email and password mismatch stay on create account',

--- a/mobile/integration_test/auth/token_refresh_test.dart
+++ b/mobile/integration_test/auth/token_refresh_test.dart
@@ -14,9 +14,12 @@ import 'package:patrol/patrol.dart';
 
 import '../helpers/db_helpers.dart';
 import '../helpers/navigation_helpers.dart';
+import '../helpers/patrol_semantics.dart';
 import '../helpers/test_setup.dart';
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('Token Refresh', () {
     final testEmail =
         'refresh-${DateTime.now().millisecondsSinceEpoch}@test.divine.video';

--- a/mobile/integration_test/auth/user_journey_test.dart
+++ b/mobile/integration_test/auth/user_journey_test.dart
@@ -11,10 +11,13 @@ import 'package:patrol/patrol.dart';
 import '../helpers/db_helpers.dart';
 import '../helpers/http_helpers.dart';
 import '../helpers/navigation_helpers.dart';
+import '../helpers/patrol_semantics.dart';
 import '../helpers/relay_helpers.dart';
 import '../helpers/test_setup.dart';
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('User Journey: Register → Record → Publish → Delete → Verify', () {
     final testEmail =
         'e2e-${DateTime.now().millisecondsSinceEpoch}@test.divine.video';

--- a/mobile/integration_test/helpers/patrol_semantics.dart
+++ b/mobile/integration_test/helpers/patrol_semantics.dart
@@ -1,0 +1,35 @@
+// ABOUTME: Closes the Patrol/flutter_test race that fails the first test of a
+// ABOUTME: bundle when the platform enables semantics mid-test.
+
+import 'package:flutter/widgets.dart';
+
+/// Pre-empts Flutter's platform semantics handler before `flutter_test`
+/// snapshots the outstanding-`SemanticsHandle` count.
+///
+/// Call it as the first statement of a Patrol suite's `main()`.
+///
+/// `SemanticsBinding` installs `platformDispatcher.onSemanticsEnabledChanged`,
+/// and that handler calls `ensureSemantics()` — creating a handle that is only
+/// released when the platform disables semantics again. Under Patrol on
+/// Android the platform enables semantics shortly after launch, because the
+/// instrumentation's UiAutomation turns accessibility on. So that handle can
+/// appear *during* the first test rather than before it.
+///
+/// `testWidgets` snapshots the handle count before running the body, and
+/// `WidgetTester._endOfTestVerifications` fails the test when the count grew:
+/// "A SemanticsHandle was active at the end of the test." The failure lands
+/// after the body, so Patrol reports it to the native side with a null detail
+/// — the JUnit side only shows `Dart test failed: <name>`.
+///
+/// `patrolTest` installs this exact no-op itself, but as the first statement of
+/// the test *body*, which is after the snapshot. Calling it from `main()`
+/// closes the window, because group declaration runs before any test body.
+///
+/// Semantics stay available inside tests: `patrolTest` defaults to
+/// `semanticsEnabled: true`, so `testWidgets` still holds its own handle for
+/// the duration of every test.
+// TODO(#7260): Remove once Patrol installs its no-op handler during
+// PatrolBinding initialization instead of in the test body.
+void ignorePlatformSemanticsHandle() {
+  WidgetsBinding.instance.platformDispatcher.onSemanticsEnabledChanged = () {};
+}

--- a/mobile/integration_test/helpers/patrol_semantics.dart
+++ b/mobile/integration_test/helpers/patrol_semantics.dart
@@ -1,7 +1,7 @@
 // ABOUTME: Closes the Patrol/flutter_test race that fails the first test of a
 // ABOUTME: bundle when the platform enables semantics mid-test.
 
-import 'package:flutter/widgets.dart';
+import 'dart:ui';
 
 /// Pre-empts Flutter's platform semantics handler before `flutter_test`
 /// snapshots the outstanding-`SemanticsHandle` count.
@@ -28,8 +28,13 @@ import 'package:flutter/widgets.dart';
 /// Semantics stay available inside tests: `patrolTest` defaults to
 /// `semanticsEnabled: true`, so `testWidgets` still holds its own handle for
 /// the duration of every test.
-// TODO(#7260): Remove once Patrol installs its no-op handler during
-// PatrolBinding initialization instead of in the test body.
+///
+/// Addressed straight to `PlatformDispatcher` rather than through
+/// `WidgetsBinding.instance` — they resolve to the same object, but the binding
+/// getter throws when no binding exists yet, which is the case under Patrol's
+/// build-time discovery mode and under a direct `flutter test` run.
+// TODO(leancodepl/patrol#1474): Remove once Patrol installs its no-op handler
+// during PatrolBinding initialization instead of in the test body.
 void ignorePlatformSemanticsHandle() {
-  WidgetsBinding.instance.platformDispatcher.onSemanticsEnabledChanged = () {};
+  PlatformDispatcher.instance.onSemanticsEnabledChanged = () {};
 }

--- a/mobile/integration_test/lifecycle/app_background_test.dart
+++ b/mobile/integration_test/lifecycle/app_background_test.dart
@@ -6,9 +6,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/main.dart' as app;
 import 'package:patrol/patrol.dart';
 
+import '../helpers/patrol_semantics.dart';
 import '../helpers/test_setup.dart';
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('App Background / State Restoration', () {
     patrolTest(
       'app state is preserved after backgrounding and reopening',

--- a/mobile/integration_test/perf/feed_ttff_test.dart
+++ b/mobile/integration_test/perf/feed_ttff_test.dart
@@ -8,9 +8,12 @@ import 'package:patrol/patrol.dart';
 import '../helpers/db_helpers.dart';
 import '../helpers/http_helpers.dart';
 import '../helpers/navigation_helpers.dart';
+import '../helpers/patrol_semantics.dart';
 import '../helpers/test_setup.dart';
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   patrolTest('feed TTFF under throttled network', ($) async {
     final tester = $.tester;
     final originalOnError = suppressSetStateErrors();

--- a/mobile/integration_test/privacy/image_metadata_stripper_test.dart
+++ b/mobile/integration_test/privacy/image_metadata_stripper_test.dart
@@ -9,6 +9,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:image_metadata_stripper/image_metadata_stripper.dart';
 import 'package:patrol/patrol.dart';
 
+import '../helpers/patrol_semantics.dart';
+
 /// A small 32x32 RGB JPEG with GPS EXIF data (Berlin coordinates).
 /// Generated via Pillow + piexif. Only ~1 KB so it can live inline.
 const _testImageBase64 =
@@ -84,6 +86,8 @@ bool _containsGpsIfd(Uint8List bytes) {
 }
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('ImageMetadataStripper Integration Tests', () {
     late Directory tempDir;
     late Uint8List fixtureBytes;

--- a/mobile/integration_test/privacy/video_metadata_stripper_test.dart
+++ b/mobile/integration_test/privacy/video_metadata_stripper_test.dart
@@ -11,6 +11,8 @@ import 'package:openvine/services/video_editor/video_editor_render_service.dart'
 import 'package:patrol/patrol.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
+import '../helpers/patrol_semantics.dart';
+
 /// A minimal 320x240 1-second H.264 MP4 (isom brand) with GPS metadata
 /// stored in BOTH `loci` (3GPP, for Android MediaMetadataRetriever) and
 /// `©xyz` (QuickTime, for AVFoundation on iOS/macOS) atoms.
@@ -56,6 +58,8 @@ const _gpsVideoBase64 =
     'AAAAAAAACIqsAC9gfAAAAABlYXJ0aAAAAAAAHql4eXoAEgAAKzQ3LjM3NjkrMDA4LjU0MTcv';
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('VideoMetadataStripper Integration Tests', () {
     late Directory tempDir;
 

--- a/mobile/integration_test/secure_key_storage_test.dart
+++ b/mobile/integration_test/secure_key_storage_test.dart
@@ -9,7 +9,11 @@ import 'package:nostr_sdk/client_utils/keys.dart';
 import 'package:patrol/patrol.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'helpers/patrol_semantics.dart';
+
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('migrateLegacyNostrKeys on Device', () {
     late SecureKeyStorage storage;
 

--- a/mobile/integration_test/thumbnail_integration_test.dart
+++ b/mobile/integration_test/thumbnail_integration_test.dart
@@ -16,9 +16,12 @@ import 'package:patrol/patrol.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+import 'helpers/patrol_semantics.dart';
 import 'helpers/test_setup.dart';
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('Thumbnail Integration Tests', () {
     patrolTest(
       'Record video and generate thumbnail end-to-end',

--- a/mobile/integration_test/video_recorder/camera_controls_integration_test.dart
+++ b/mobile/integration_test/video_recorder/camera_controls_integration_test.dart
@@ -11,6 +11,8 @@ import 'package:patrol/patrol.dart';
 import 'package:permissions_service/permissions_service.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+import '../helpers/patrol_semantics.dart';
+
 /// Grant camera and microphone permissions via Patrol native automation.
 Future<void> _grantPermissions(PatrolIntegrationTester $) async {
   const service = PermissionHandlerPermissionsService();
@@ -29,6 +31,8 @@ Future<void> _grantPermissions(PatrolIntegrationTester $) async {
 }
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('Camera Controls Integration Tests', () {
     late CameraService cameraService;
 

--- a/mobile/integration_test/video_recorder/camera_initialization_integration_test.dart
+++ b/mobile/integration_test/video_recorder/camera_initialization_integration_test.dart
@@ -8,6 +8,8 @@ import 'package:openvine/services/video_recorder/camera/camera_base_service.dart
 import 'package:patrol/patrol.dart';
 import 'package:permissions_service/permissions_service.dart';
 
+import '../helpers/patrol_semantics.dart';
+
 /// Grant camera and microphone permissions via Patrol native automation.
 Future<void> _grantPermissions(PatrolIntegrationTester $) async {
   const service = PermissionHandlerPermissionsService();
@@ -26,6 +28,8 @@ Future<void> _grantPermissions(PatrolIntegrationTester $) async {
 }
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('Camera Initialization Integration Tests', () {
     late CameraService cameraService;
 

--- a/mobile/integration_test/video_recorder/camera_lifecycle_integration_test.dart
+++ b/mobile/integration_test/video_recorder/camera_lifecycle_integration_test.dart
@@ -9,6 +9,8 @@ import 'package:openvine/services/video_recorder/camera/camera_base_service.dart
 import 'package:patrol/patrol.dart';
 import 'package:permissions_service/permissions_service.dart';
 
+import '../helpers/patrol_semantics.dart';
+
 /// Grant camera and microphone permissions via Patrol native automation.
 Future<void> _grantPermissions(PatrolIntegrationTester $) async {
   const service = PermissionHandlerPermissionsService();
@@ -27,6 +29,8 @@ Future<void> _grantPermissions(PatrolIntegrationTester $) async {
 }
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('Camera Lifecycle Integration Tests', () {
     late CameraService cameraService;
 

--- a/mobile/integration_test/video_recorder/camera_permission_denied_test.dart
+++ b/mobile/integration_test/video_recorder/camera_permission_denied_test.dart
@@ -9,7 +9,11 @@ import 'package:openvine/screens/video_recorder_screen.dart';
 import 'package:patrol/patrol.dart';
 import 'package:permissions_service/permissions_service.dart';
 
+import '../helpers/patrol_semantics.dart';
+
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('Camera Permission Denied', () {
     patrolTest(
       'shows fallback UI when camera permission is denied',

--- a/mobile/integration_test/video_recorder/camera_photo_capture_integration_test.dart
+++ b/mobile/integration_test/video_recorder/camera_photo_capture_integration_test.dart
@@ -11,6 +11,8 @@ import 'package:patrol/patrol.dart';
 import 'package:permissions_service/permissions_service.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+import '../helpers/patrol_semantics.dart';
+
 /// Grant camera and microphone permissions via Patrol native automation.
 Future<void> _grantPermissions(PatrolIntegrationTester $) async {
   const service = PermissionHandlerPermissionsService();
@@ -29,6 +31,8 @@ Future<void> _grantPermissions(PatrolIntegrationTester $) async {
 }
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('Camera Photo Capture Integration Tests', () {
     late CameraService cameraService;
 

--- a/mobile/integration_test/video_recorder/camera_switching_integration_test.dart
+++ b/mobile/integration_test/video_recorder/camera_switching_integration_test.dart
@@ -8,6 +8,8 @@ import 'package:openvine/services/video_recorder/camera/camera_base_service.dart
 import 'package:patrol/patrol.dart';
 import 'package:permissions_service/permissions_service.dart';
 
+import '../helpers/patrol_semantics.dart';
+
 /// Grant camera and microphone permissions via Patrol native automation.
 Future<void> _grantPermissions(PatrolIntegrationTester $) async {
   const service = PermissionHandlerPermissionsService();
@@ -26,6 +28,8 @@ Future<void> _grantPermissions(PatrolIntegrationTester $) async {
 }
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('Camera Switching Integration Tests', () {
     late CameraService cameraService;
 

--- a/mobile/integration_test/video_recorder/video_recorder_integration_test.dart
+++ b/mobile/integration_test/video_recorder/video_recorder_integration_test.dart
@@ -14,6 +14,8 @@ import 'package:openvine/services/video_recorder/camera/camera_base_service.dart
 import 'package:patrol/patrol.dart';
 import 'package:permissions_service/permissions_service.dart';
 
+import '../helpers/patrol_semantics.dart';
+
 /// Helper widget that wraps VideoRecorderScreen with required providers
 Widget _buildTestWidget() {
   return ProviderScope(
@@ -44,6 +46,8 @@ Future<void> _grantPermissions(PatrolIntegrationTester $) async {
 }
 
 void main() {
+  ignorePlatformSemanticsHandle();
+
   group('Video Recorder Integration Tests', () {
     late CameraService cameraService;
 


### PR DESCRIPTION
## Description

The first test of every Patrol bundle can fail with `java.lang.AssertionError: Dart test failed: <name>` and a null Dart-side detail. The real error, recoverable only from logcat, is `A SemanticsHandle was active at the end of the test` thrown by `WidgetTester._endOfTestVerifications`.

**Mechanism.** Flutter's `SemanticsBinding` wires `platformDispatcher.onSemanticsEnabledChanged` to a handler that calls `ensureSemantics()`, and the handle it creates is only released when the platform disables semantics again (`flutter/semantics/binding.dart:28`, `:146-152`). Under Patrol on Android the platform enables semantics shortly after launch, because the instrumentation's UiAutomation turns accessibility on. `patrolTest` already overwrites that callback with a no-op (`patrol/lib/src/common.dart:156`, the workaround for leancodepl/patrol#1474) — but only as the **first statement of the test body**. `testWidgets` snapshots the outstanding-handle count before that (`flutter_test/widget_tester.dart:179`), and between snapshot and body sits `_runTestBody`'s `runApp(...)` + `await pump()`, which is a real engine frame under `LiveTestWidgetsFlutterBinding`. When the platform's signal lands inside that window, the count is one higher at the end of the test and the test fails.

**Why only the first test.** The platform flag flips once per process, at startup, so only the first test's window can contain it. Under the orchestrator with `clearPackageData=true` every Dart test gets its own app process and the whole bundle is replayed in each; a failure in the first test's slot is only reported to the native side in the process where the first test is also the requested one, and `PatrolBinding` discards it in the other two. That is why it always looked like a property of one specific test rather than of the slot.

**Why the detail was null.** `PatrolBinding._wrapTestBodyWithExceptionGatherer` installs its `FlutterError.onError` capture only around `await testBody()` and restores the previous handler right after (`patrol/lib/src/binding.dart:226-248`), so nothing raised outside the body reaches `_testResults` and the tearDown reports `details: null` (`:109`). The null detail is therefore diagnostic rather than an absence of information — it localizes the failure to outside the test body, which also proves no `expect()` in the body failed. This was never a privacy regression.

**The fix.** A new `ignorePlatformSemanticsHandle()` helper installs the same no-op from `main()`. Group declaration runs before any test body, so the window is closed. Semantics stay available inside tests: `patrolTest` defaults to `semanticsEnabled: true`, so `testWidgets` still holds its own handle for the duration of every test, and only the redundant platform-driven handle is suppressed. The helper addresses `PlatformDispatcher.instance` directly rather than going through `WidgetsBinding.instance` — same object, but the binding getter throws when no binding exists yet, which is the case under Patrol's build-time discovery mode and under a direct `flutter test` run. It carries a `// TODO(leancodepl/patrol#1474)` for removal once Patrol installs its no-op during `PatrolBinding` initialization instead of in the test body.

**Why all 27 suites and not just the two that were observed failing.** The race is suite-agnostic — it is the first test of *any* bundle that is exposed. Fixing only `integration_test/privacy/` would leave it latent in 25 other suites, where the same failure would again surface with a null detail.

**Not caused by the patrol 4.9.0 bump (#7228).** The no-op workaround and its placement are byte-identical in `patrol` 4.8.0 (`common.dart:131`) and 4.9.0 (`common.dart:156`); the race predates the bump. Two other suspects were ruled out as well: build-time test discovery and the static JUnit codegen are new in the 4.9.0 pair but opt-in via `patrol.emit_test_manifest`, which this repo does not set (`MainActivityTest.java` still runs the `@Parameterized` + `listDartTests()` path, confirmed in logcat), and the first test cannot time out waiting for the native request because `LiveTestWidgetsFlutterBinding.defaultTestTimeout` is `Timeout.none` (`flutter_test/binding.dart:2734`).

**Related Issue:** Closes #7260

## Out of Scope

The proper fix belongs upstream — Patrol should install its no-op during `PatrolBinding` initialization rather than in the test body. Not filed against `leancodepl/patrol` as part of this PR; the `// TODO(leancodepl/patrol#1474)` on the helper is the removal hook for when it lands.

Also unchanged: `PatrolBinding` reports `details: null` for any failure outside the test body, so the next such flake will again need logcat to diagnose. That is Patrol's behaviour, not something this PR can address.

## Verification

Ran from `mobile/` unless noted.

**Tested on a real device (Samsung Galaxy SM-S942B) over USB**

Reproduction and validation used `patrol` 4.9.0 + `patrol_cli` 4.7.0 (the pair from #7228), since that is where the flake was reported. The fix is version-independent — the racing code is identical on 4.8.0.

| Condition | Runs | Failures |
|---|---|---|
| Normal | 19 | 0 |
| Device-side CPU contention, unpatched | 13 | 1 |
| Device-side CPU contention, patched | 8 | 0 |

19 clean runs put the issue's ~33% estimate out of reach; the real rate is low and load-dependent, which is why deliberate CPU contention on the device was needed to widen the `runApp`+`pump` window enough to catch a failure with logcat attached. One further stressed run was excluded from the table: an APK install failure caused by the contention harness (`Total: 0`, 10s), not this flake.

Stated plainly, because the numbers alone do not carry it: **8-vs-0 does not prove the fix**. At that failure rate, 8 green runs are roughly a coin flip even without a change. The fix rests on the mechanism — with the handler replaced before `testWidgets` takes its snapshot, the platform cannot create a handle at all, independent of timing.

- `patrol test --target integration_test/privacy/image_metadata_stripper_test.dart` on the device, with the shipped helper-based form of the change → 3/3 green, and the generated `test_bundle.dart` confirms `main()` is invoked inside `group(...)` during declaration, i.e. before any test body runs.
- `flutter analyze lib test integration_test` → `No issues found!`
- `dart format` (mise-pinned Dart 3.12.0) → `Formatted 3151 files (0 changed)`

No unit tests added. The change is test-harness wiring in `integration_test/`; a host-side test of the helper could only assert that the callback was replaced, which stays green even if the guard's body is emptied — a tautology under `.claude/rules/testing.md`'s can-it-fail bar.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
