### PR TITLE
chore(agents): add opt-in guard for concurrent sessions in one worktree

### DIFF
--- a/.claude/hooks/session-start-worktree-guard.sh
+++ b/.claude/hooks/session-start-worktree-guard.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# SessionStart hook: warn when another live Claude Code session already has
+# this git worktree open.
+#
+# Two agent sessions writing one working tree is a silent hazard. In the
+# incident that prompted this hook, one session ran an authorized
+# `git reset --hard` while a second was still reasoning from a pre-reset
+# snapshot; the second read the result as data loss and "restored" work that
+# had been discarded on purpose. No permission prompt catches this — both
+# sessions were doing exactly what they had been told.
+#
+# Sharing a worktree read-only is fine. Concurrent *writers* are the problem,
+# which is what `.claude/rules/agent_workflow.md` §1 already rules out.
+#
+# Opt in from your personal .claude/settings.local.json:
+#
+#   "SessionStart": [
+#     {
+#       "matcher": "startup|resume",
+#       "hooks": [
+#         {
+#           "type": "command",
+#           "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-start-worktree-guard.sh",
+#           "timeout": 10,
+#           "statusMessage": "Checking for concurrent sessions..."
+#         }
+#       ]
+#     }
+#   ]
+#
+# Deliberately not registered in the team settings.json: anyone already running
+# it at user scope would get the warning twice.
+#
+# Detection: each live session owns /tmp/cc-socks/<pid>.sock. For every other
+# live session, resolve its cwd and compare worktree roots. If that directory
+# does not exist on your setup, the hook is a silent no-op.
+#
+# Always exits 0. This warns; it never blocks a session.
+
+set -uo pipefail
+
+SOCK_DIR="/tmp/cc-socks"
+
+root="${CLAUDE_PROJECT_DIR:-$PWD}"
+mine=$(git -C "$root" rev-parse --show-toplevel 2>/dev/null) || exit 0
+[ -n "$mine" ] || exit 0
+[ -d "$SOCK_DIR" ] || exit 0
+
+# Walk up the process tree to find this session's own claude pid, so the
+# guard never reports itself.
+self=""
+p=$$
+for _ in 1 2 3 4 5 6 7 8; do
+  { [ -n "$p" ] && [ "$p" != "0" ] && [ "$p" != "1" ]; } || break
+  cm=$(ps -o comm= -p "$p" 2>/dev/null)
+  case "$cm" in */claude) self="$p"; break ;; esac
+  p=$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ')
+done
+
+others=""
+count=0
+for sock in "$SOCK_DIR"/*.sock; do
+  [ -S "$sock" ] || continue
+  pid="${sock##*/}"
+  pid="${pid%.sock}"
+  case "$pid" in '' | *[!0-9]*) continue ;; esac
+  [ "$pid" = "$self" ] && continue
+
+  # Stale socket from a crashed session.
+  ps -p "$pid" -o comm= >/dev/null 2>&1 || continue
+
+  cwd=$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)
+  [ -n "$cwd" ] || continue
+
+  their=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null) || continue
+  # Different worktrees of the same repo are the pattern agent_workflow.md
+  # asks for, not a collision. Only an identical working tree matters.
+  [ "$their" = "$mine" ] || continue
+
+  count=$((count + 1))
+  others="${others}  - pid ${pid} (cwd ${cwd})"$'\n'
+done
+
+[ "$count" -gt 0 ] || exit 0
+
+python3 - "$mine" "$count" "$others" <<'PY'
+import json, sys
+
+worktree, count, others = sys.argv[1], int(sys.argv[2]), sys.argv[3].rstrip("\n")
+plural = "session" if count == 1 else "sessions"
+
+human = (
+    f"⚠️  {count} other Claude {plural} already has this worktree open:\n"
+    f"{others}\n"
+    f"  worktree: {worktree}\n\n"
+    "Reading together is fine. If both sessions will EDIT code or run git "
+    "state commands (reset/checkout/stash), give this task its own worktree:\n"
+    "  git worktree add .worktrees/<task> -b <branch> origin/main"
+)
+
+agent = (
+    f"CONCURRENCY WARNING: {count} other live Claude Code {plural} "
+    f"currently has this same git worktree open ({worktree}).\n{others}\n"
+    "Consequences to respect this session:\n"
+    "- Your git snapshot may go stale at any moment; re-check `git status` "
+    "before reasoning about working-tree state, and never assume an "
+    "unexpected change was an accident.\n"
+    "- Do not run destructive git commands (reset --hard, checkout --, "
+    "stash, clean) without confirming with the user first.\n"
+    "- Prefer a separate worktree for any code edits."
+)
+
+print(json.dumps({
+    "systemMessage": human,
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": agent,
+    },
+}))
+PY

--- a/.claude/hooks/session-start-worktree-guard.sh
+++ b/.claude/hooks/session-start-worktree-guard.sh
@@ -31,20 +31,30 @@
 # Deliberately not registered in the team settings.json: anyone already running
 # it at user scope would get the warning twice.
 #
-# Detection: each live session owns /tmp/cc-socks/<pid>.sock. For every other
-# live session, resolve its cwd and compare worktree roots. If that directory
-# does not exist on your setup, the hook is a silent no-op.
+# Detection: each live session owns a /tmp/cc-socks*/<pid>.sock socket. For
+# every other live Claude process with a matching socket, resolve its cwd and
+# compare canonical worktree roots. If no socket directory exists on your setup,
+# the hook is a silent no-op. Set CC_SOCK_DIR to test or override the socket dir.
 #
 # Always exits 0. This warns; it never blocks a session.
 
 set -uo pipefail
 
-SOCK_DIR="/tmp/cc-socks"
+SOCK_DIRS=()
+if [ -n "${CC_SOCK_DIR:-}" ]; then
+  SOCK_DIRS=("$CC_SOCK_DIR")
+else
+  for dir in /tmp/cc-socks*; do
+    [ -d "$dir" ] || continue
+    SOCK_DIRS+=("$dir")
+  done
+fi
 
 root="${CLAUDE_PROJECT_DIR:-$PWD}"
 mine=$(git -C "$root" rev-parse --show-toplevel 2>/dev/null) || exit 0
 [ -n "$mine" ] || exit 0
-[ -d "$SOCK_DIR" ] || exit 0
+mine=$(cd "$mine" 2>/dev/null && pwd -P) || exit 0
+[ "${#SOCK_DIRS[@]}" -gt 0 ] || exit 0
 
 # Walk up the process tree to find this session's own claude pid, so the
 # guard never reports itself.
@@ -53,68 +63,70 @@ p=$$
 for _ in 1 2 3 4 5 6 7 8; do
   { [ -n "$p" ] && [ "$p" != "0" ] && [ "$p" != "1" ]; } || break
   cm=$(ps -o comm= -p "$p" 2>/dev/null)
-  case "$cm" in */claude) self="$p"; break ;; esac
+  [ "${cm##*/}" = "claude" ] && { self="$p"; break; }
   p=$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ')
 done
 
 others=""
 count=0
-for sock in "$SOCK_DIR"/*.sock; do
-  [ -S "$sock" ] || continue
-  pid="${sock##*/}"
-  pid="${pid%.sock}"
+while read -r pid cm; do
   case "$pid" in '' | *[!0-9]*) continue ;; esac
   [ "$pid" = "$self" ] && continue
+  [ "${cm##*/}" = "claude" ] || continue
 
-  # Stale socket from a crashed session.
-  ps -p "$pid" -o comm= >/dev/null 2>&1 || continue
+  has_socket=false
+  for dir in "${SOCK_DIRS[@]}"; do
+    [ -S "$dir/$pid.sock" ] || continue
+    has_socket=true
+    break
+  done
+  [ "$has_socket" = true ] || continue
 
   cwd=$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)
   [ -n "$cwd" ] || continue
 
   their=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null) || continue
+  their=$(cd "$their" 2>/dev/null && pwd -P) || continue
   # Different worktrees of the same repo are the pattern agent_workflow.md
   # asks for, not a collision. Only an identical working tree matters.
   [ "$their" = "$mine" ] || continue
 
   count=$((count + 1))
   others="${others}  - pid ${pid} (cwd ${cwd})"$'\n'
-done
+done < <(ps -eo pid=,comm= 2>/dev/null)
 
 [ "$count" -gt 0 ] || exit 0
 
-python3 - "$mine" "$count" "$others" <<'PY'
-import json, sys
+command -v jq >/dev/null 2>&1 || exit 0
 
-worktree, count, others = sys.argv[1], int(sys.argv[2]), sys.argv[3].rstrip("\n")
-plural = "session" if count == 1 else "sessions"
+plural="session"
+verb="has"
+if [ "$count" -ne 1 ]; then
+  plural="sessions"
+  verb="have"
+fi
 
-human = (
-    f"⚠️  {count} other Claude {plural} already has this worktree open:\n"
-    f"{others}\n"
-    f"  worktree: {worktree}\n\n"
-    "Reading together is fine. If both sessions will EDIT code or run git "
-    "state commands (reset/checkout/stash), give this task its own worktree:\n"
-    "  git worktree add .worktrees/<task> -b <branch> origin/main"
-)
+human="⚠️  ${count} other Claude ${plural} already ${verb} this worktree open:
+${others}
+  worktree: ${mine}
 
-agent = (
-    f"CONCURRENCY WARNING: {count} other live Claude Code {plural} "
-    f"currently has this same git worktree open ({worktree}).\n{others}\n"
-    "Consequences to respect this session:\n"
-    "- Your git snapshot may go stale at any moment; re-check `git status` "
-    "before reasoning about working-tree state, and never assume an "
-    "unexpected change was an accident.\n"
-    "- Do not run destructive git commands (reset --hard, checkout --, "
-    "stash, clean) without confirming with the user first.\n"
-    "- Prefer a separate worktree for any code edits."
-)
+Reading together is fine. If both sessions will EDIT code or run git state commands (reset/checkout/stash), give this task its own worktree:
+  git worktree add .worktrees/<task> -b <branch> origin/main"
 
-print(json.dumps({
-    "systemMessage": human,
-    "hookSpecificOutput": {
-        "hookEventName": "SessionStart",
-        "additionalContext": agent,
-    },
-}))
-PY
+agent="CONCURRENCY WARNING: ${count} other live Claude Code ${plural} currently ${verb} this same git worktree open (${mine}).
+${others}
+Consequences to respect this session:
+- Your git snapshot may go stale at any moment; re-check \`git status\` before reasoning about working-tree state, and never assume an unexpected change was an accident.
+- Do not run destructive git commands (reset --hard, checkout --, stash, clean) without confirming with the user first.
+- Prefer a separate worktree for any code edits."
+
+jq -n \
+  --arg human "$human" \
+  --arg agent "$agent" \
+  '{
+    systemMessage: $human,
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext: $agent
+    }
+  }' || exit 0

--- a/.claude/hooks/session-start-worktree-guard.sh
+++ b/.claude/hooks/session-start-worktree-guard.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# SessionStart hook: warn when another live Claude Code session already has
-# this git worktree open.
+# SessionStart hook: warn when another live Claude Code session appears to
+# have been launched from this git worktree.
 #
 # Two agent sessions writing one working tree is a silent hazard. In the
 # incident that prompted this hook, one session ran an authorized
@@ -32,9 +32,11 @@
 # it at user scope would get the warning twice.
 #
 # Detection: each live session owns a /tmp/cc-socks*/<pid>.sock socket. For
-# every other live Claude process with a matching socket, resolve its cwd and
-# compare canonical worktree roots. If no socket directory exists on your setup,
-# the hook is a silent no-op. Set CC_SOCK_DIR to test or override the socket dir.
+# every other live Claude process with a matching socket, resolve its process
+# cwd and compare git roots. This is a launch-directory signal: descendant tool
+# shells can cd elsewhere without changing the Claude process cwd. If no socket
+# directory exists on your setup, the hook is a silent no-op. Set CC_SOCK_DIR to
+# test or override the socket dir.
 #
 # Always exits 0. This warns; it never blocks a session.
 
@@ -53,7 +55,6 @@ fi
 root="${CLAUDE_PROJECT_DIR:-$PWD}"
 mine=$(git -C "$root" rev-parse --show-toplevel 2>/dev/null) || exit 0
 [ -n "$mine" ] || exit 0
-mine=$(cd "$mine" 2>/dev/null && pwd -P) || exit 0
 [ "${#SOCK_DIRS[@]}" -gt 0 ] || exit 0
 
 # Walk up the process tree to find this session's own claude pid, so the
@@ -86,9 +87,8 @@ while read -r pid cm; do
   [ -n "$cwd" ] || continue
 
   their=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null) || continue
-  their=$(cd "$their" 2>/dev/null && pwd -P) || continue
-  # Different worktrees of the same repo are the pattern agent_workflow.md
-  # asks for, not a collision. Only an identical working tree matters.
+  # Compare the peer Claude process launch-directory git root. This cannot see
+  # the live cwd of shells spawned later by that session.
   [ "$their" = "$mine" ] || continue
 
   count=$((count + 1))
@@ -97,8 +97,6 @@ done < <(ps -eo pid=,comm= 2>/dev/null)
 
 [ "$count" -gt 0 ] || exit 0
 
-command -v jq >/dev/null 2>&1 || exit 0
-
 plural="session"
 verb="has"
 if [ "$count" -ne 1 ]; then
@@ -106,14 +104,20 @@ if [ "$count" -ne 1 ]; then
   verb="have"
 fi
 
-human="⚠️  ${count} other Claude ${plural} already ${verb} this worktree open:
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'Session worktree guard detected %s other Claude %s launched from %s, but jq is unavailable; skipping JSON warning.\n' \
+    "$count" "$plural" "$mine" >&2
+  exit 0
+fi
+
+human="⚠️  ${count} other Claude ${plural} already ${verb} a matching launch-directory worktree:
 ${others}
   worktree: ${mine}
 
 Reading together is fine. If both sessions will EDIT code or run git state commands (reset/checkout/stash), give this task its own worktree:
   git worktree add .worktrees/<task> -b <branch> origin/main"
 
-agent="CONCURRENCY WARNING: ${count} other live Claude Code ${plural} currently ${verb} this same git worktree open (${mine}).
+agent="CONCURRENCY WARNING: ${count} other live Claude Code ${plural} currently ${verb} a matching launch-directory git worktree (${mine}).
 ${others}
 Consequences to respect this session:
 - Your git snapshot may go stale at any moment; re-check \`git status\` before reasoning about working-tree state, and never assume an unexpected change was an accident.

--- a/.claude/rules/agent_workflow.md
+++ b/.claude/rules/agent_workflow.md
@@ -35,6 +35,22 @@ One task per worktree. If the current worktree is dirty, commit, stash
 intentionally, or discard intentionally before starting new work
 elsewhere. Do not mix unrelated work into one worktree.
 
+### Optional: warn on concurrent sessions in one worktree
+
+Two agent sessions in the same working tree is the failure this rule
+prevents, and nothing in git or the permission system catches it — both
+sessions are doing exactly what they were told. One session running an
+authorized `git reset --hard` while another reasons from a pre-reset
+snapshot is enough to lose, or wrongly "restore", a changeset.
+
+`.claude/hooks/session-start-worktree-guard.sh` warns at session start
+when another live session already holds the same worktree. It is opt-in
+(registration snippet is in the script header) and deliberately not
+registered in the team `settings.json`, so anyone already running it at
+user scope is not warned twice. It warns only — it never blocks a
+session, and it does not flag *different* worktrees of the same repo,
+since that is the pattern this rule asks for.
+
 ---
 
 ## 2. Rebase when publishing, finalizing, or resolving conflicts

--- a/.claude/rules/agent_workflow.md
+++ b/.claude/rules/agent_workflow.md
@@ -44,12 +44,14 @@ authorized `git reset --hard` while another reasons from a pre-reset
 snapshot is enough to lose, or wrongly "restore", a changeset.
 
 `.claude/hooks/session-start-worktree-guard.sh` warns at session start
-when another live session already holds the same worktree. It is opt-in
-(registration snippet is in the script header) and deliberately not
-registered in the team `settings.json`, so anyone already running it at
-user scope is not warned twice. It warns only — it never blocks a
-session, and it does not flag *different* worktrees of the same repo,
-since that is the pattern this rule asks for.
+when another live session appears to have been launched from the same
+git worktree root. It is opt-in (registration snippet is in the script
+header) and deliberately not registered in the team `settings.json`, so
+anyone already running it at user scope is not warned twice. It warns
+only — it never blocks a session. The signal comes from Claude's process
+cwd and `/tmp/cc-socks*/<pid>.sock`, so it cannot see later `cd` calls
+inside tool shells and can become a silent no-op if Claude changes that
+internal socket path.
 
 ---
 

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -233,16 +233,17 @@ if ! git -C "$TEST_REPO" diff --cached --name-only \
 fi
 
 GUARD_SOCKET_DIR="$SCRATCH_DIR/cc-socks-test"
-TEST_REPO_LINK="$SCRATCH_DIR/repo-link"
-mkdir -p "$GUARD_SOCKET_DIR"
-ln -s "$TEST_REPO" "$TEST_REPO_LINK"
+GUARD_BIN_DIR="$SCRATCH_DIR/guard-bin"
+OTHER_REPO="$SCRATCH_DIR/other-repo"
+mkdir -p "$GUARD_SOCKET_DIR" "$GUARD_BIN_DIR" "$OTHER_REPO"
+git -C "$OTHER_REPO" init -q
 python3 - "$GUARD_SOCKET_DIR" <<'PY'
 import os
 import socket
 import sys
 
 socket_dir = sys.argv[1]
-for pid in ("111", "222", "333"):
+for pid in ("111", "222", "333", "444", "777"):
     path = os.path.join(socket_dir, f"{pid}.sock")
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     try:
@@ -251,7 +252,7 @@ for pid in ("111", "222", "333"):
         sock.close()
 PY
 
-cat > "$BIN_DIR/ps" <<'EOF'
+cat > "$GUARD_BIN_DIR/ps" <<'EOF'
 #!/bin/bash
 case "$*" in
   "-eo pid=,comm=")
@@ -259,6 +260,9 @@ case "$*" in
 111 /opt/homebrew/bin/claude
 222 sleep
 333 claude
+444 claude
+555 claude
+777 claude
 PSOUT
     exit 0
     ;;
@@ -269,18 +273,24 @@ if [ "$1" = "-o" ] && [ "$2" = "comm=" ] && [ "$3" = "-p" ]; then
     111) echo "/opt/homebrew/bin/claude"; exit 0 ;;
     222) echo "sleep"; exit 0 ;;
     333) echo "claude"; exit 0 ;;
-    *) exit 1 ;;
+    444) echo "claude"; exit 0 ;;
+    555) echo "claude"; exit 0 ;;
+    777) echo "claude"; exit 0 ;;
+    *) echo "bash"; exit 0 ;;
   esac
 fi
 
 if [ "$1" = "-o" ] && [ "$2" = "ppid=" ] && [ "$3" = "-p" ]; then
-  exit 1
+  case "$4" in
+    777) echo "1"; exit 0 ;;
+    *) echo "777"; exit 0 ;;
+  esac
 fi
 
 exit 1
 EOF
 
-cat > "$BIN_DIR/lsof" <<'EOF'
+cat > "$GUARD_BIN_DIR/lsof" <<'EOF'
 #!/bin/bash
 pid=""
 while [ "$#" -gt 0 ]; do
@@ -294,16 +304,19 @@ done
 case "$pid" in
   111) printf 'n%s\n' "$TEST_REPO" ;;
   222) printf 'n%s\n' "$TEST_REPO" ;;
-  333) printf 'n%s\n' "$TEST_REPO_LINK" ;;
+  333) printf 'n%s\n' "$TEST_REPO/mobile" ;;
+  444) printf 'n%s\n' "$OTHER_REPO" ;;
+  555) printf 'n%s\n' "$TEST_REPO" ;;
+  777) printf 'n%s\n' "$TEST_REPO" ;;
   *) exit 1 ;;
 esac
 EOF
-chmod +x "$BIN_DIR/ps" "$BIN_DIR/lsof"
+chmod +x "$GUARD_BIN_DIR/ps" "$GUARD_BIN_DIR/lsof"
 
 GUARD_OUTPUT=$(cd "$TEST_REPO" && \
-  env PATH="$BIN_DIR:/usr/bin:/bin" \
+  env PATH="$GUARD_BIN_DIR:/usr/bin:/bin" \
     TEST_REPO="$TEST_REPO" \
-    TEST_REPO_LINK="$TEST_REPO_LINK" \
+    OTHER_REPO="$OTHER_REPO" \
     CLAUDE_PROJECT_DIR="$TEST_REPO" \
     CC_SOCK_DIR="$GUARD_SOCKET_DIR" \
     "$WORKTREE_GUARD_HOOK")
@@ -314,6 +327,9 @@ if ! printf '%s\n' "$GUARD_OUTPUT" | jq -e '
     and contains("pid 111")
     and contains("pid 333")
     and (contains("pid 222") | not)
+    and (contains("pid 444") | not)
+    and (contains("pid 555") | not)
+    and (contains("pid 777") | not)
 ' >/dev/null; then
   echo "Session worktree guard did not report only live Claude sessions in the same canonical worktree." >&2
   echo "Output was: $GUARD_OUTPUT" >&2

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -8,9 +8,11 @@ POST_EDIT_HOOK="$REPO_ROOT/.codex/hooks/post-edit-dart.sh"
 BUILD_HOOK="$REPO_ROOT/.codex/hooks/pre-commit-build-runner.sh"
 CODEX_GIT_HOOK="$REPO_ROOT/.codex/hooks/check-git-hooks.sh"
 CLAUDE_GIT_HOOK="$REPO_ROOT/.claude/hooks/check-git-hooks.sh"
+WORKTREE_GUARD_HOOK="$REPO_ROOT/.claude/hooks/session-start-worktree-guard.sh"
 
 "$REPO_ROOT/.codex/scripts/sync-agent-skills.sh" --check
 
+# shellcheck disable=SC2016
 grep -Fq 'Read and apply ALL rules from `AGENTS.md`' \
   "$REPO_ROOT/.agents/skills/review-before-commit/SKILL.md"
 if grep -Fq '/review-before-commit' \
@@ -25,6 +27,7 @@ if grep -Fq '.claude/AGENTS.md' \
 fi
 grep -Fq '**Published**: May 2023<br>' \
   "$REPO_ROOT/.agents/skills/claudeception/resources/research-references.md"
+# shellcheck disable=SC2088
 grep -Fq '~/.agents/skills/art-direct/styles/' \
   "$REPO_ROOT/.agents/skills/art-direct/docs/2026-01-28-art-direct-design.md"
 
@@ -226,6 +229,94 @@ fi
 if ! git -C "$TEST_REPO" diff --cached --name-only \
   | grep -Fxq 'mobile/lib/with space.g.dart'; then
   echo "Generated file with a spaced path was not staged." >&2
+  exit 1
+fi
+
+GUARD_SOCKET_DIR="$SCRATCH_DIR/cc-socks-test"
+TEST_REPO_LINK="$SCRATCH_DIR/repo-link"
+mkdir -p "$GUARD_SOCKET_DIR"
+ln -s "$TEST_REPO" "$TEST_REPO_LINK"
+python3 - "$GUARD_SOCKET_DIR" <<'PY'
+import os
+import socket
+import sys
+
+socket_dir = sys.argv[1]
+for pid in ("111", "222", "333"):
+    path = os.path.join(socket_dir, f"{pid}.sock")
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        sock.bind(path)
+    finally:
+        sock.close()
+PY
+
+cat > "$BIN_DIR/ps" <<'EOF'
+#!/bin/bash
+case "$*" in
+  "-eo pid=,comm=")
+    cat <<'PSOUT'
+111 /opt/homebrew/bin/claude
+222 sleep
+333 claude
+PSOUT
+    exit 0
+    ;;
+esac
+
+if [ "$1" = "-o" ] && [ "$2" = "comm=" ] && [ "$3" = "-p" ]; then
+  case "$4" in
+    111) echo "/opt/homebrew/bin/claude"; exit 0 ;;
+    222) echo "sleep"; exit 0 ;;
+    333) echo "claude"; exit 0 ;;
+    *) exit 1 ;;
+  esac
+fi
+
+if [ "$1" = "-o" ] && [ "$2" = "ppid=" ] && [ "$3" = "-p" ]; then
+  exit 1
+fi
+
+exit 1
+EOF
+
+cat > "$BIN_DIR/lsof" <<'EOF'
+#!/bin/bash
+pid=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-p" ]; then
+    pid="$2"
+    break
+  fi
+  shift
+done
+
+case "$pid" in
+  111) printf 'n%s\n' "$TEST_REPO" ;;
+  222) printf 'n%s\n' "$TEST_REPO" ;;
+  333) printf 'n%s\n' "$TEST_REPO_LINK" ;;
+  *) exit 1 ;;
+esac
+EOF
+chmod +x "$BIN_DIR/ps" "$BIN_DIR/lsof"
+
+GUARD_OUTPUT=$(cd "$TEST_REPO" && \
+  env PATH="$BIN_DIR:/usr/bin:/bin" \
+    TEST_REPO="$TEST_REPO" \
+    TEST_REPO_LINK="$TEST_REPO_LINK" \
+    CLAUDE_PROJECT_DIR="$TEST_REPO" \
+    CC_SOCK_DIR="$GUARD_SOCKET_DIR" \
+    "$WORKTREE_GUARD_HOOK")
+
+if ! printf '%s\n' "$GUARD_OUTPUT" | jq -e '
+  .systemMessage
+  | contains("2 other Claude sessions already have this worktree open")
+    and contains("pid 111")
+    and contains("pid 333")
+    and (contains("pid 222") | not)
+' >/dev/null; then
+  echo "Session worktree guard did not report only live Claude sessions in the same canonical worktree." >&2
+  echo "Output was: $GUARD_OUTPUT" >&2
   exit 1
 fi
 

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -314,7 +314,7 @@ EOF
 chmod +x "$GUARD_BIN_DIR/ps" "$GUARD_BIN_DIR/lsof"
 
 GUARD_OUTPUT=$(cd "$TEST_REPO" && \
-  env PATH="$GUARD_BIN_DIR:/usr/bin:/bin" \
+  env PATH="$GUARD_BIN_DIR:$PATH" \
     TEST_REPO="$TEST_REPO" \
     OTHER_REPO="$OTHER_REPO" \
     CLAUDE_PROJECT_DIR="$TEST_REPO" \
@@ -323,7 +323,7 @@ GUARD_OUTPUT=$(cd "$TEST_REPO" && \
 
 if ! printf '%s\n' "$GUARD_OUTPUT" | jq -e '
   .systemMessage
-  | contains("2 other Claude sessions already have this worktree open")
+  | contains("2 other Claude sessions already have a matching launch-directory worktree")
     and contains("pid 111")
     and contains("pid 333")
     and (contains("pid 222") | not)


### PR DESCRIPTION
Closes #7273

## Description

Two agent sessions in the same working tree is the failure `agent_workflow.md` section 1 already prohibits, but nothing enforces it, and neither git nor the permission system can, because both sessions are doing exactly what they were told.

This happened in this repo. One session ran an authorized `git reset --hard` to discard a changeset. A second session, still holding a git snapshot taken before that reset, read the result as accidental data loss and restored 213 files that had been discarded deliberately. Both sessions were correct in isolation; the collision was two writers and one stale view.

`.claude/hooks/session-start-worktree-guard.sh` warns at session start when another live Claude session appears to have been launched from the same git worktree root. It warns two audiences: the human gets the detected peer sessions plus the `git worktree add` fix, and the agent gets an instruction that its snapshot may go stale, to confirm before destructive git commands, and specifically not to assume an unexpected working-tree change was an accident.

Detection lists live Claude processes once, matches those pids against `/tmp/cc-socks*/*.sock`, resolves each matching process cwd with `lsof`, and compares git roots. This is a launch-directory signal: descendant tool shells can `cd` elsewhere without changing the Claude process cwd. Where no socket directory exists, the hook is a silent no-op. If a collision is detected but `jq` is unavailable, the hook prints a stderr fallback and still exits 0. `CC_SOCK_DIR` can override the socket directory for tests or local drift.

Design notes worth reviewing:

- **Opt-in via personal `settings.local.json`**, not the team `settings.json` — anyone already running it at user scope would otherwise be warned twice. Registration snippet is in the script header.
- **Warns, never blocks.** A hook that can wedge a session at startup is worse than the problem.
- **Launch-directory signal, not active shell cwd.** The guard catches sessions launched from the same worktree root, including the incident that motivated this PR. It cannot prove where later tool shells are currently working.
- Skips stale sockets from crashed sessions by only considering live Claude pids with matching socket files.
- Adds two local `shellcheck disable` annotations in `.codex/scripts/test-config.sh` for pre-existing generated-skill assertions that intentionally contain literal backticks and `~`.

## Out of Scope

- Registering the hook in the team `settings.json`. Left opt-in on purpose, per the double-warning issue above.
- Any locking or blocking mechanism. This is advisory only.
- Fixing Claude Code's upstream socket cleanup behavior. The guard survives leaked sockets, but the upstream leak is still worth reporting separately.
- Distinguishing a session's current descendant-shell cwd from the Claude process launch cwd. That would require a different signal and should be verified separately before expanding this warn-only hook; follow-up filed as #7580.

## Verification

- `bash -n .claude/hooks/session-start-worktree-guard.sh .codex/scripts/test-config.sh`
- `shellcheck .claude/hooks/session-start-worktree-guard.sh .codex/scripts/test-config.sh`
- `.codex/scripts/test-config.sh`
- Real smoke test: `.claude/hooks/session-start-worktree-guard.sh` exited 0 and emitted no warning for this worktree

No Dart or Flutter code touched.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [x] Build configuration change
- [x] Documentation
- [x] Chore

Generated with Claude Code
