### PR TITLE
chore(agents): commit build-artifact purge hook, fix hook timeout units

### DIFF
--- a/.claude/hooks/post-edit-analyze.sh
+++ b/.claude/hooks/post-edit-analyze.sh
@@ -25,8 +25,13 @@ fi
 
 # If the build-artifact purge removed package resolution state, analyzer output
 # is all missing-package noise until pub get runs again.
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
-if [[ -n "$REPO_ROOT" && "$FILE_PATH" == "$REPO_ROOT"/mobile/* && ! -f "$REPO_ROOT/mobile/.dart_tool/package_config.json" ]]; then
+FILE_DIR=$(dirname "$FILE_PATH")
+CANONICAL_FILE_PATH="$FILE_PATH"
+if CANONICAL_FILE_DIR=$(cd -P "$FILE_DIR" 2>/dev/null && pwd); then
+  CANONICAL_FILE_PATH="$CANONICAL_FILE_DIR/$(basename "$FILE_PATH")"
+fi
+REPO_ROOT=$(git -C "$FILE_DIR" rev-parse --show-toplevel 2>/dev/null || true)
+if [[ -n "$REPO_ROOT" && "$CANONICAL_FILE_PATH" == "$REPO_ROOT"/mobile/* && ! -f "$REPO_ROOT/mobile/.dart_tool/package_config.json" ]]; then
   exit 0
 fi
 

--- a/.claude/hooks/post-edit-analyze.sh
+++ b/.claude/hooks/post-edit-analyze.sh
@@ -32,6 +32,8 @@ if CANONICAL_FILE_DIR=$(cd -P "$FILE_DIR" 2>/dev/null && pwd); then
 fi
 REPO_ROOT=$(git -C "$FILE_DIR" rev-parse --show-toplevel 2>/dev/null || true)
 if [[ -n "$REPO_ROOT" && "$CANONICAL_FILE_PATH" == "$REPO_ROOT"/mobile/* && ! -f "$REPO_ROOT/mobile/.dart_tool/package_config.json" ]]; then
+  jq -n --arg path "$REPO_ROOT/mobile/.dart_tool/package_config.json" \
+    '{systemMessage: ("Skipped Dart analysis because " + $path + " is missing. Run `cd mobile && flutter pub get` before relying on post-edit analysis in this worktree.")}'
   exit 0
 fi
 

--- a/.claude/hooks/post-edit-analyze.sh
+++ b/.claude/hooks/post-edit-analyze.sh
@@ -23,6 +23,13 @@ if [[ ! -f "$FILE_PATH" ]]; then
   exit 0
 fi
 
+# If the build-artifact purge removed package resolution state, analyzer output
+# is all missing-package noise until pub get runs again.
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [[ -n "$REPO_ROOT" && "$FILE_PATH" == "$REPO_ROOT"/mobile/* && ! -f "$REPO_ROOT/mobile/.dart_tool/package_config.json" ]]; then
+  exit 0
+fi
+
 # Run analyzer on the specific file
 ANALYSIS_OUTPUT=$(dart analyze "$FILE_PATH" 2>&1 || true)
 

--- a/.claude/hooks/session-end-purge-build-artifacts.sh
+++ b/.claude/hooks/session-end-purge-build-artifacts.sh
@@ -99,16 +99,18 @@ case "$gitdir" in
   *) exit 0 ;;
 esac
 
-peer_scan="$(active_worktree_peers)"
-if [ -n "$peer_scan" ]; then
-  peer_count="${peer_scan%%	*}"
-  peer_list="${peer_scan#*	}"
-  jq -n \
-    --arg count "$peer_count" \
-    --arg root "$root" \
-    --arg peers "$peer_list" \
-    '{systemMessage: ("Skipped build-artifact purge for " + $root + " because " + $count + " other live process(es) have cwd inside this worktree:\n" + $peers + "Run the purge after the other session or terminal exits.")}'
-  exit 0
+if [ "${CLAUDE_PURGE_SKIP_PEER_SCAN:-0}" != "1" ]; then
+  peer_scan="$(active_worktree_peers)"
+  if [ -n "$peer_scan" ]; then
+    peer_count="${peer_scan%%	*}"
+    peer_list="${peer_scan#*	}"
+    jq -n \
+      --arg count "$peer_count" \
+      --arg root "$root" \
+      --arg peers "$peer_list" \
+      '{systemMessage: ("Skipped build-artifact purge for " + $root + " because " + $count + " other live process(es) have cwd inside this worktree:\n" + $peers + "Run the purge after the other session or terminal exits.")}'
+    exit 0
+  fi
 fi
 
 # Stage removals under the linked worktree gitdir, then delete detached.

--- a/.claude/hooks/session-end-purge-build-artifacts.sh
+++ b/.claude/hooks/session-end-purge-build-artifacts.sh
@@ -29,6 +29,9 @@ if [ ! -t 0 ]; then
   input="$(cat || true)"
 fi
 reason="$(printf '%s' "$input" | jq -r '.reason // empty' 2>/dev/null || true)"
+# Purge only for reasons Claude identifies as terminal. In particular, `other`
+# is ambiguous (including headless exits), so deleting build state for it would
+# trade more cleanup coverage for a risk of purging a session that may continue.
 case "$reason" in
   logout|prompt_input_exit|bypass_permissions_disabled) ;;
   *) exit 0 ;;
@@ -62,7 +65,8 @@ fi
 # blow the hook timeout and, when killed, leaves the source intact to fail the
 # same way next run. Delete in place instead, still detached. When stat cannot
 # report a device id, both sides are empty and compare equal, preserving the
-# staging path.
+# staging path. Unlike the staging branch, this in-place background deletion is
+# not restart-atomic: an immediate rebuild can briefly race a half-removed tree.
 if [ "$(device_id "$root/mobile")" != "$(device_id "$gitdir")" ]; then
   n=0
   dirs=()

--- a/.claude/hooks/session-end-purge-build-artifacts.sh
+++ b/.claude/hooks/session-end-purge-build-artifacts.sh
@@ -66,10 +66,10 @@ fi
 if [ "$(device_id "$root/mobile")" != "$(device_id "$gitdir")" ]; then
   n=0
   dirs=()
-  while IFS= read -r dir; do
+  while IFS= read -r -d '' dir; do
     dirs+=("$dir")
     n=$((n + 1))
-  done < <(find "$root/mobile" -type d \( -name build -o -name .dart_tool \) -prune 2>/dev/null)
+  done < <(find "$root/mobile" -type d \( -name build -o -name .dart_tool \) -prune -print0 2>/dev/null)
   if [ "$n" -gt 0 ]; then
     nohup rm -rf "${dirs[@]}" >/dev/null 2>&1 &
     printf '{"systemMessage":"Purged %d build/.dart_tool dirs from %s"}\n' \
@@ -81,9 +81,9 @@ fi
 mkdir -p "$trash"
 
 n=0
-while IFS= read -r dir; do
+while IFS= read -r -d '' dir; do
   mv "$dir" "$trash/$n" 2>/dev/null && n=$((n + 1)) || true
-done < <(find "$root/mobile" -type d \( -name build -o -name .dart_tool \) -prune 2>/dev/null)
+done < <(find "$root/mobile" -type d \( -name build -o -name .dart_tool \) -prune -print0 2>/dev/null)
 
 [ "$n" -gt 0 ] || { rmdir "$trash" 2>/dev/null || true; exit 0; }
 

--- a/.claude/hooks/session-end-purge-build-artifacts.sh
+++ b/.claude/hooks/session-end-purge-build-artifacts.sh
@@ -20,6 +20,16 @@ set -euo pipefail
 
 root="${CLAUDE_PROJECT_DIR:-$PWD}"
 
+input=""
+if [ ! -t 0 ]; then
+  input="$(cat || true)"
+fi
+reason="$(printf '%s' "$input" | jq -r '.reason // empty' 2>/dev/null || true)"
+case "$reason" in
+  logout|prompt_input_exit|other|bypass_permissions_disabled) ;;
+  *) exit 0 ;;
+esac
+
 # Only meaningful in a divine-mobile checkout.
 [ -f "$root/mobile/pubspec.yaml" ] || exit 0
 
@@ -31,12 +41,17 @@ case "$gitdir" in
   *) exit 0 ;;
 esac
 
-# Stage removals under one directory, then delete detached. Renaming within a
-# filesystem is instant, so the session exits immediately instead of waiting
-# on tens of GB of unlink; a killed background rm just leaves the staging dir
-# for the next run to collect.
-trash="$root/.claude-purge"
-rm -rf "$trash" 2>/dev/null || true
+# Stage removals under the linked worktree gitdir, then delete detached.
+# Renaming within a filesystem is instant, so the session exits immediately
+# instead of waiting on tens of GB of unlink; a killed background rm just
+# leaves the staging dir for the next run to collect.
+trash="$gitdir/claude-purge"
+if [ -d "$trash" ]; then
+  leftover="$trash.$$"
+  if mv "$trash" "$leftover" 2>/dev/null; then
+    nohup rm -rf "$leftover" >/dev/null 2>&1 &
+  fi
+fi
 mkdir -p "$trash"
 
 n=0

--- a/.claude/hooks/session-end-purge-build-artifacts.sh
+++ b/.claude/hooks/session-end-purge-build-artifacts.sh
@@ -11,8 +11,11 @@
 # Only linked worktrees are cleaned. The main checkout keeps its build cache
 # because it is the one you return to most; worktrees are what pile up.
 #
-# Referenced from .claude/settings.local.json (personal). Move the hook entry
-# to .claude/settings.json to make it team-wide.
+# Registered in .claude/settings.json (team-wide), not settings.local.json.
+# That file is gitignored, so it exists only in the main checkout — and this
+# hook deliberately skips the main checkout. Registering it personally means
+# it is present only where it refuses to run, and absent from every linked
+# worktree, which is the only place it does anything.
 set -euo pipefail
 
 root="${CLAUDE_PROJECT_DIR:-$PWD}"

--- a/.claude/hooks/session-end-purge-build-artifacts.sh
+++ b/.claude/hooks/session-end-purge-build-artifacts.sh
@@ -43,6 +43,7 @@ active_worktree_peers() {
 
   local pid=""
   local command_name=""
+  local command_base=""
   local cwd=""
   local count=0
   local peers=""
@@ -51,7 +52,13 @@ active_worktree_peers() {
     case "$pid" in '' | *[!0-9]*) continue ;; esac
     is_ancestor_pid "$pid" && continue
 
-    cwd="$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)"
+    command_base="${command_name##*/}"
+    case "$command_base" in
+      bash|sh|zsh|fish|claude|codex|flutter|dart|java|gradle|xcodebuild|swift|node|npm|pnpm|yarn|mise|python|python3) ;;
+      *) continue ;;
+    esac
+
+    cwd="$(lsof -b -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)"
     [ -n "$cwd" ] || continue
     case "$cwd" in
       "$root"|"$root"/*) ;;

--- a/.claude/hooks/session-end-purge-build-artifacts.sh
+++ b/.claude/hooks/session-end-purge-build-artifacts.sh
@@ -20,6 +20,57 @@ set -euo pipefail
 
 root="${CLAUDE_PROJECT_DIR:-$PWD}"
 
+is_ancestor_pid() {
+  local needle="$1"
+  local p="$$"
+  local parent=""
+
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
+    [ -n "$p" ] || break
+    [ "$p" = "$needle" ] && return 0
+    parent="$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ')"
+    [ -n "$parent" ] || break
+    [ "$parent" != "$p" ] || break
+    p="$parent"
+  done
+
+  return 1
+}
+
+active_worktree_peers() {
+  command -v ps >/dev/null 2>&1 || return 0
+  command -v lsof >/dev/null 2>&1 || return 0
+
+  local pid=""
+  local command_name=""
+  local cwd=""
+  local count=0
+  local peers=""
+
+  while read -r pid command_name; do
+    case "$pid" in '' | *[!0-9]*) continue ;; esac
+    is_ancestor_pid "$pid" && continue
+
+    cwd="$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)"
+    [ -n "$cwd" ] || continue
+    case "$cwd" in
+      "$root"|"$root"/*) ;;
+      *) continue ;;
+    esac
+
+    count=$((count + 1))
+    [ "$count" -le 5 ] && peers="${peers}  - pid ${pid} (${command_name:-unknown}, cwd ${cwd})"$'\n'
+  done < <(ps -eo pid=,comm= 2>/dev/null || true)
+
+  [ "$count" -gt 0 ] || return 0
+
+  if [ "$count" -gt 5 ]; then
+    peers="${peers}  - and $((count - 5)) more process(es)"$'\n'
+  fi
+
+  printf '%s\t%s' "$count" "$peers"
+}
+
 input=""
 if [ ! -t 0 ]; then
   input="$(cat || true)"
@@ -40,6 +91,18 @@ case "$gitdir" in
   */.git/worktrees/*) ;;
   *) exit 0 ;;
 esac
+
+peer_scan="$(active_worktree_peers)"
+if [ -n "$peer_scan" ]; then
+  peer_count="${peer_scan%%	*}"
+  peer_list="${peer_scan#*	}"
+  jq -n \
+    --arg count "$peer_count" \
+    --arg root "$root" \
+    --arg peers "$peer_list" \
+    '{systemMessage: ("Skipped build-artifact purge for " + $root + " because " + $count + " other live process(es) have cwd inside this worktree:\n" + $peers + "Run the purge after the other session or terminal exits.")}'
+  exit 0
+fi
 
 # Stage removals under the linked worktree gitdir, then delete detached.
 # Renaming within a filesystem is instant, so the session exits immediately

--- a/.claude/hooks/session-end-purge-build-artifacts.sh
+++ b/.claude/hooks/session-end-purge-build-artifacts.sh
@@ -20,62 +20,8 @@ set -euo pipefail
 
 root="${CLAUDE_PROJECT_DIR:-$PWD}"
 
-is_ancestor_pid() {
-  local needle="$1"
-  local p="$$"
-  local parent=""
-
-  for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
-    [ -n "$p" ] || break
-    [ "$p" = "$needle" ] && return 0
-    parent="$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ')"
-    [ -n "$parent" ] || break
-    [ "$parent" != "$p" ] || break
-    p="$parent"
-  done
-
-  return 1
-}
-
-active_worktree_peers() {
-  command -v ps >/dev/null 2>&1 || return 0
-  command -v lsof >/dev/null 2>&1 || return 0
-
-  local pid=""
-  local command_name=""
-  local command_base=""
-  local cwd=""
-  local count=0
-  local peers=""
-
-  while read -r pid command_name; do
-    case "$pid" in '' | *[!0-9]*) continue ;; esac
-    is_ancestor_pid "$pid" && continue
-
-    command_base="${command_name##*/}"
-    case "$command_base" in
-      bash|sh|zsh|fish|claude|codex|flutter|dart|java|gradle|xcodebuild|swift|node|npm|pnpm|yarn|mise|python|python3) ;;
-      *) continue ;;
-    esac
-
-    cwd="$(lsof -b -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)"
-    [ -n "$cwd" ] || continue
-    case "$cwd" in
-      "$root"|"$root"/*) ;;
-      *) continue ;;
-    esac
-
-    count=$((count + 1))
-    [ "$count" -le 5 ] && peers="${peers}  - pid ${pid} (${command_name:-unknown}, cwd ${cwd})"$'\n'
-  done < <(ps -eo pid=,comm= 2>/dev/null || true)
-
-  [ "$count" -gt 0 ] || return 0
-
-  if [ "$count" -gt 5 ]; then
-    peers="${peers}  - and $((count - 5)) more process(es)"$'\n'
-  fi
-
-  printf '%s\t%s' "$count" "$peers"
+device_id() {
+  stat -c %d "$1" 2>/dev/null || stat -f %d "$1" 2>/dev/null || true
 }
 
 input=""
@@ -99,20 +45,6 @@ case "$gitdir" in
   *) exit 0 ;;
 esac
 
-if [ "${CLAUDE_PURGE_SKIP_PEER_SCAN:-0}" != "1" ]; then
-  peer_scan="$(active_worktree_peers)"
-  if [ -n "$peer_scan" ]; then
-    peer_count="${peer_scan%%	*}"
-    peer_list="${peer_scan#*	}"
-    jq -n \
-      --arg count "$peer_count" \
-      --arg root "$root" \
-      --arg peers "$peer_list" \
-      '{systemMessage: ("Skipped build-artifact purge for " + $root + " because " + $count + " other live process(es) have cwd inside this worktree:\n" + $peers + "Run the purge after the other session or terminal exits.")}'
-    exit 0
-  fi
-fi
-
 # Stage removals under the linked worktree gitdir, then delete detached.
 # Renaming within a filesystem is instant, so the session exits immediately
 # instead of waiting on tens of GB of unlink; a killed background rm just
@@ -129,9 +61,9 @@ fi
 # worktree's: a cross-device mv degrades to a synchronous full copy that can
 # blow the hook timeout and, when killed, leaves the source intact to fail the
 # same way next run. Delete in place instead, still detached. When stat cannot
-# report a device id (non-GNU stat), both sides are empty and compare equal,
-# preserving the staging path.
-if [ "$(stat -c %d "$root/mobile" 2>/dev/null)" != "$(stat -c %d "$gitdir" 2>/dev/null)" ]; then
+# report a device id, both sides are empty and compare equal, preserving the
+# staging path.
+if [ "$(device_id "$root/mobile")" != "$(device_id "$gitdir")" ]; then
   n=0
   dirs=()
   while IFS= read -r dir; do

--- a/.claude/hooks/session-end-purge-build-artifacts.sh
+++ b/.claude/hooks/session-end-purge-build-artifacts.sh
@@ -26,7 +26,7 @@ if [ ! -t 0 ]; then
 fi
 reason="$(printf '%s' "$input" | jq -r '.reason // empty' 2>/dev/null || true)"
 case "$reason" in
-  logout|prompt_input_exit|other|bypass_permissions_disabled) ;;
+  logout|prompt_input_exit|bypass_permissions_disabled) ;;
   *) exit 0 ;;
 esac
 

--- a/.claude/hooks/session-end-purge-build-artifacts.sh
+++ b/.claude/hooks/session-end-purge-build-artifacts.sh
@@ -52,6 +52,28 @@ if [ -d "$trash" ]; then
     nohup rm -rf "$leftover" >/dev/null 2>&1 &
   fi
 fi
+
+# The gitdir lives in the main checkout's filesystem, which is not always the
+# worktree's: a cross-device mv degrades to a synchronous full copy that can
+# blow the hook timeout and, when killed, leaves the source intact to fail the
+# same way next run. Delete in place instead, still detached. When stat cannot
+# report a device id (non-GNU stat), both sides are empty and compare equal,
+# preserving the staging path.
+if [ "$(stat -c %d "$root/mobile" 2>/dev/null)" != "$(stat -c %d "$gitdir" 2>/dev/null)" ]; then
+  n=0
+  dirs=()
+  while IFS= read -r dir; do
+    dirs+=("$dir")
+    n=$((n + 1))
+  done < <(find "$root/mobile" -type d \( -name build -o -name .dart_tool \) -prune 2>/dev/null)
+  if [ "$n" -gt 0 ]; then
+    nohup rm -rf "${dirs[@]}" >/dev/null 2>&1 &
+    printf '{"systemMessage":"Purged %d build/.dart_tool dirs from %s"}\n' \
+      "$n" "$(basename "$root")"
+  fi
+  exit 0
+fi
+
 mkdir -p "$trash"
 
 n=0

--- a/.claude/hooks/session-end-purge-build-artifacts.sh
+++ b/.claude/hooks/session-end-purge-build-artifacts.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# SessionEnd hook: purge Flutter build artifacts from a linked worktree when
+# the session ends, so abandoned worktrees stop accumulating disk.
+#
+# Why not `flutter clean`: `mobile/` is a Dart pub workspace. `flutter clean`
+# in `mobile/` only clears `mobile/build` + `mobile/.dart_tool` (~4.6 GB of a
+# typical 8 GB tree). It does not recurse into workspace packages, and
+# `mobile/packages/*/build` is another ~3.2 GB. Removing the directories
+# directly gets all of it and skips the Flutter tool startup entirely.
+#
+# Only linked worktrees are cleaned. The main checkout keeps its build cache
+# because it is the one you return to most; worktrees are what pile up.
+#
+# Referenced from .claude/settings.local.json (personal). Move the hook entry
+# to .claude/settings.json to make it team-wide.
+set -euo pipefail
+
+root="${CLAUDE_PROJECT_DIR:-$PWD}"
+
+# Only meaningful in a divine-mobile checkout.
+[ -f "$root/mobile/pubspec.yaml" ] || exit 0
+
+# A linked worktree's git dir lives at <repo>/.git/worktrees/<name>; the main
+# checkout's does not. Skip the main checkout.
+gitdir="$(git -C "$root" rev-parse --absolute-git-dir 2>/dev/null || true)"
+case "$gitdir" in
+  */.git/worktrees/*) ;;
+  *) exit 0 ;;
+esac
+
+# Stage removals under one directory, then delete detached. Renaming within a
+# filesystem is instant, so the session exits immediately instead of waiting
+# on tens of GB of unlink; a killed background rm just leaves the staging dir
+# for the next run to collect.
+trash="$root/.claude-purge"
+rm -rf "$trash" 2>/dev/null || true
+mkdir -p "$trash"
+
+n=0
+while IFS= read -r dir; do
+  mv "$dir" "$trash/$n" 2>/dev/null && n=$((n + 1)) || true
+done < <(find "$root/mobile" -type d \( -name build -o -name .dart_tool \) -prune 2>/dev/null)
+
+[ "$n" -gt 0 ] || { rmdir "$trash" 2>/dev/null || true; exit 0; }
+
+# Detach so the unlink outlives the session.
+nohup rm -rf "$trash" >/dev/null 2>&1 &
+
+printf '{"systemMessage":"Purged %d build/.dart_tool dirs from %s"}\n' \
+  "$n" "$(basename "$root")"

--- a/.claude/rules/agent_workflow.md
+++ b/.claude/rules/agent_workflow.md
@@ -99,6 +99,42 @@ cwd and `/tmp/cc-socks*/<pid>.sock`, so it cannot see later `cd` calls
 inside tool shells and can become a silent no-op if Claude changes that
 internal socket path.
 
+### Build artifacts are purged from linked worktrees at session end
+
+Abandoned worktrees are what actually fill the disk — a typical tree
+carries ~8 GB of `build` and `.dart_tool`, and `flutter clean` leaves
+roughly 3 GB of that behind: `mobile/` is a pub workspace and the tool
+clears only `mobile/build` and `mobile/.dart_tool`, never recursing into
+`mobile/packages/*`.
+
+`.claude/hooks/session-end-purge-build-artifacts.sh` deletes those
+directories outright when a session ends. Unlike the worktree guard
+above, it **is** registered in the team `.claude/settings.json`, so it
+runs for everyone — it is deliberately not opt-in, because
+`settings.local.json` exists only in the main checkout, which is the one
+place this hook refuses to touch.
+
+What bounds it:
+
+- **Linked worktrees only.** The main checkout keeps its build cache.
+- **Terminal exits only** — `logout`, `prompt_input_exit`, and
+  `bypass_permissions_disabled`. `/clear`, session resume, and the
+  ambiguous `other` (which covers headless runs) do not purge.
+- **divine-mobile checkouts only**, gated on `mobile/pubspec.yaml`.
+- Nothing tracked is eligible; recovery is `cd mobile && flutter pub get`.
+
+The cost to know about: **there is no mid-run interlock.** A second
+session or a plain terminal building in the same worktree loses its
+build cache when the first session exits. The concurrent-session guard
+above warns at session *start* only (#7272); nothing watches for a build
+in flight. If you are mid-build in a worktree someone else is also
+sitting in, expect to re-run `flutter pub get`.
+
+A purged worktree would otherwise make the analyzer report every package
+as missing, so `.claude/hooks/post-edit-analyze.sh` skips analysis with
+an explanatory message when `mobile/.dart_tool/package_config.json` is
+gone, rather than blocking on ~1000 phantom errors.
+
 ---
 
 ## 2. Rebase when publishing, finalizing, or resolving conflicts

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -70,7 +70,7 @@
     ],
     "SessionEnd": [
       {
-        "matcher": "logout|prompt_input_exit|other|bypass_permissions_disabled",
+        "matcher": "logout|prompt_input_exit|bypass_permissions_disabled",
         "hooks": [
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -70,6 +70,7 @@
     ],
     "SessionEnd": [
       {
+        "matcher": "logout|prompt_input_exit|other|bypass_permissions_disabled",
         "hooks": [
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -67,6 +67,18 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-end-purge-build-artifacts.sh",
+            "timeout": 30,
+            "statusMessage": "Purging build artifacts..."
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,13 +15,13 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-edit-nostr-id-guard.sh",
-            "timeout": 5000,
+            "timeout": 5,
             "statusMessage": "Checking for Nostr ID truncation..."
           },
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-edit-vinetheme-guard.sh",
-            "timeout": 5000,
+            "timeout": 5,
             "statusMessage": "Checking VineTheme compliance..."
           }
         ]
@@ -32,7 +32,7 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-git-hooks.sh",
-            "timeout": 3000,
+            "timeout": 3,
             "statusMessage": "Checking git hooks..."
           }
         ]
@@ -43,7 +43,7 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-commit-build-runner.sh",
-            "timeout": 120000,
+            "timeout": 600,
             "statusMessage": "Running build_runner for staged files..."
           }
         ]
@@ -56,13 +56,13 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post-edit-format.sh",
-            "timeout": 30000,
+            "timeout": 30,
             "statusMessage": "Formatting code..."
           },
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post-edit-analyze.sh",
-            "timeout": 60000,
+            "timeout": 120,
             "statusMessage": "Analyzing code..."
           }
         ]

--- a/.codex/hooks/post-edit-dart.sh
+++ b/.codex/hooks/post-edit-dart.sh
@@ -28,6 +28,7 @@ FILES=$(printf '%s\n' "$PATCH" | sed -nE \
 [ -n "$FILES" ] || exit 0
 
 DART_READY=false
+MISSING_PACKAGE_CONFIG=""
 
 while IFS= read -r FILE_PATH; do
   [[ "$FILE_PATH" =~ \.dart$ ]] || continue
@@ -45,8 +46,14 @@ while IFS= read -r FILE_PATH; do
       *) REPO_ROOT="" ;;
     esac
   fi
+  # A purged worktree has no package resolution state, so the analyzer only
+  # emits missing-package noise. Skip the analyze half for this file; dart
+  # format needs no resolution and still runs, and remaining files in the
+  # patch are still processed.
+  SKIP_ANALYZE=false
   if [ -n "$REPO_ROOT" ] && [ ! -f "$REPO_ROOT/mobile/.dart_tool/package_config.json" ]; then
-    emit_system_message "Skipped Dart format/analyze because $REPO_ROOT/mobile/.dart_tool/package_config.json is missing. Run \`cd mobile && flutter pub get\` before relying on post-edit analysis in this worktree."
+    SKIP_ANALYZE=true
+    MISSING_PACKAGE_CONFIG="$REPO_ROOT/mobile/.dart_tool/package_config.json"
   fi
 
   if [ "$DART_READY" = false ]; then
@@ -62,6 +69,8 @@ while IFS= read -r FILE_PATH; do
   if ! FORMAT_OUTPUT=$(run_repo_dart "$DART_MOBILE_DIR" format "$ABS_PATH" 2>&1); then
     emit_block "Dart formatting failed for $FILE_PATH:\n$FORMAT_OUTPUT"
   fi
+
+  [ "$SKIP_ANALYZE" = true ] && continue
 
   ANALYSIS_RC=0
   ANALYSIS_OUTPUT=$(run_repo_dart "$DART_MOBILE_DIR" analyze "$ABS_PATH" 2>&1) || ANALYSIS_RC=$?
@@ -79,5 +88,9 @@ while IFS= read -r FILE_PATH; do
 done <<EOF
 $FILES
 EOF
+
+if [ -n "$MISSING_PACKAGE_CONFIG" ]; then
+  emit_system_message "Skipped Dart analysis because $MISSING_PACKAGE_CONFIG is missing. Run \`cd mobile && flutter pub get\` before relying on post-edit analysis in this worktree."
+fi
 
 exit 0

--- a/.codex/hooks/post-edit-dart.sh
+++ b/.codex/hooks/post-edit-dart.sh
@@ -13,6 +13,11 @@ emit_block() {
   exit 0
 }
 
+emit_system_message() {
+  jq -n --arg message "$1" '{systemMessage: $message}'
+  exit 0
+}
+
 INPUT=$(cat)
 PATCH=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty')
 FILES=$(printf '%s\n' "$PATCH" | sed -nE \
@@ -26,6 +31,22 @@ DART_READY=false
 while IFS= read -r FILE_PATH; do
   [[ "$FILE_PATH" =~ \.dart$ ]] || continue
   [ -f "$FILE_PATH" ] || continue
+
+  FILE_DIR=$(dirname "$FILE_PATH")
+  CANONICAL_FILE_PATH="$FILE_PATH"
+  if CANONICAL_FILE_DIR=$(cd -P "$FILE_DIR" 2>/dev/null && pwd); then
+    CANONICAL_FILE_PATH="$CANONICAL_FILE_DIR/$(basename "$FILE_PATH")"
+  fi
+  REPO_ROOT=$(git -C "$FILE_DIR" rev-parse --show-toplevel 2>/dev/null || true)
+  if [ -n "$REPO_ROOT" ]; then
+    case "$CANONICAL_FILE_PATH" in
+      "$REPO_ROOT"/mobile/*) ;;
+      *) REPO_ROOT="" ;;
+    esac
+  fi
+  if [ -n "$REPO_ROOT" ] && [ ! -f "$REPO_ROOT/mobile/.dart_tool/package_config.json" ]; then
+    emit_system_message "Skipped Dart format/analyze because $REPO_ROOT/mobile/.dart_tool/package_config.json is missing. Run \`cd mobile && flutter pub get\` before relying on post-edit analysis in this worktree."
+  fi
 
   if [ "$DART_READY" = false ]; then
     if ! resolve_dart_runner; then

--- a/.codex/hooks/post-edit-dart.sh
+++ b/.codex/hooks/post-edit-dart.sh
@@ -6,6 +6,7 @@ set -e
 
 HOOK_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=lib/dart-runner.sh
+# shellcheck disable=SC1091
 source "$HOOK_DIR/lib/dart-runner.sh"
 
 emit_block() {

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -649,6 +649,34 @@ EOF
       echo "Cross-device purge did not delete the artifact dirs." >&2
       exit 1
     fi
+    # The in-place branch has its own find loop, so the newline-splitting
+    # regression needs a pin here too, not only against the staging branch.
+    XDEV_NL_PKG="$XDEV_LINK/mobile/pkg
+age"
+    mkdir -p "$XDEV_NL_PKG/build" "$XDEV_LINK/mobile/pkg"
+    touch "$XDEV_NL_PKG/build/output.o" "$XDEV_LINK/mobile/pkg/PRECIOUS_SOURCE.dart"
+    XDEV_NL_OUTPUT=$(cd "$XDEV_LINK" && \
+      env CLAUDE_PROJECT_DIR="$XDEV_LINK" \
+        "$CLAUDE_PURGE_HOOK" \
+        <<< '{"reason":"prompt_input_exit"}' || true)
+    printf '%s\n' "$XDEV_NL_OUTPUT" | jq -e --arg name "$XDEV_NAME" \
+      '.systemMessage == ("Purged 1 build/.dart_tool dirs from " + $name)' >/dev/null || {
+      echo "Cross-device purge did not report purging the newline-named build dir." >&2
+      echo "Output was: $XDEV_NL_OUTPUT" >&2
+      exit 1
+    }
+    for _ in $(seq 1 100); do
+      [ ! -d "$XDEV_NL_PKG/build" ] && break
+      sleep 0.1
+    done
+    if [ ! -f "$XDEV_LINK/mobile/pkg/PRECIOUS_SOURCE.dart" ]; then
+      echo "Cross-device purge deleted a non-artifact path through a newline-split find line." >&2
+      exit 1
+    fi
+    if [ -d "$XDEV_NL_PKG/build" ]; then
+      echo "Cross-device purge left the newline-named build dir behind." >&2
+      exit 1
+    fi
   else
     echo "skip: /dev/shm shares a filesystem with the scratch dir; cross-device purge path not exercised."
   fi

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -591,6 +591,61 @@ for _ in $(seq 1 100); do
   sleep 0.1
 done
 
+# Pin the BSD/macOS stat fallback without requiring a second filesystem. The
+# fake rejects GNU `stat -c` and reports different BSD `stat -f` device ids; a
+# regular file at the staging path makes any missed cross-device detection fail.
+BSD_STAT_BIN="$SCRATCH_DIR/bsd-stat-bin"
+mkdir -p "$BSD_STAT_BIN"
+cat > "$BSD_STAT_BIN/stat" <<'EOF'
+#!/bin/bash
+case "$1" in
+  -c)
+    exit 1
+    ;;
+  -f)
+    case "$3" in
+      "$BSD_STAT_WORKTREE_MOBILE") echo 101 ;;
+      "$BSD_STAT_GITDIR") echo 202 ;;
+      *) echo 101 ;;
+    esac
+    exit 0
+    ;;
+esac
+exit 1
+EOF
+chmod +x "$BSD_STAT_BIN/stat"
+
+mkdir -p "$WT_LINK/mobile/build" "$WT_LINK/mobile/.dart_tool"
+touch "$WT_LINK/mobile/build/output.o" \
+  "$WT_LINK/mobile/.dart_tool/package_config.json" \
+  "$gitdir/claude-purge"
+BSD_STAT_OUTPUT=$(cd "$WT_LINK" && \
+  env PATH="$BSD_STAT_BIN:/usr/bin:/bin" \
+    BSD_STAT_WORKTREE_MOBILE="$WT_LINK/mobile" \
+    BSD_STAT_GITDIR="$gitdir" \
+    CLAUDE_PROJECT_DIR="$WT_LINK" \
+    "$CLAUDE_PURGE_HOOK" \
+    <<< '{"reason":"prompt_input_exit"}' || true)
+printf '%s\n' "$BSD_STAT_OUTPUT" | jq -e \
+  '.systemMessage == "Purged 2 build/.dart_tool dirs from purge-linked"' >/dev/null || {
+  echo "Purge hook did not use the BSD stat fallback for device detection." >&2
+  echo "Output was: $BSD_STAT_OUTPUT" >&2
+  exit 1
+}
+if [ ! -f "$gitdir/claude-purge" ]; then
+  echo "BSD-stat cross-device purge touched the gitdir staging path." >&2
+  exit 1
+fi
+for _ in $(seq 1 100); do
+  [ ! -d "$WT_LINK/mobile/build" ] && [ ! -d "$WT_LINK/mobile/.dart_tool" ] && break
+  sleep 0.1
+done
+if [ -d "$WT_LINK/mobile/build" ] || [ -d "$WT_LINK/mobile/.dart_tool" ]; then
+  echo "BSD-stat cross-device purge did not delete the artifact dirs." >&2
+  exit 1
+fi
+rm -f "$gitdir/claude-purge"
+
 # A linked worktree on a different filesystem from the main checkout must
 # still purge: the hook detects the cross-device gitdir and deletes in place
 # instead of staging (mv would degrade to a synchronous copy that can blow

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -344,6 +344,7 @@ CLAUDE_ANALYZE_PAYLOAD=$(jq -n --arg path "$TEST_REPO/mobile/lib/clean.dart" \
 : > "$CALL_LOG"
 CLAUDE_ANALYZE_OUTPUT=$(cd "$TEST_REPO" && \
   env PATH="$BIN_DIR:/usr/bin:/bin" \
+    DART_CALL_LOG="$CALL_LOG" \
     "$CLAUDE_ANALYZE_HOOK" <<< "$CLAUDE_ANALYZE_PAYLOAD")
 if [ -n "$CLAUDE_ANALYZE_OUTPUT" ]; then
   echo "Claude post-edit analyze hook ran without package_config.json." >&2
@@ -354,13 +355,21 @@ if grep -q '^analyze ' "$CALL_LOG"; then
   exit 1
 fi
 
-NON_DIVINE_REPO="$SCRATCH_DIR/non-divine"
-mkdir -p "$NON_DIVINE_REPO"
-git -C "$NON_DIVINE_REPO" init -q
-NON_DIVINE_OUTPUT=$(cd "$NON_DIVINE_REPO" && \
-  env CLAUDE_PROJECT_DIR="$NON_DIVINE_REPO" "$CLAUDE_PURGE_HOOK" \
+NON_DIVINE_MAIN="$SCRATCH_DIR/non-divine-main"
+NON_DIVINE_LINK="$SCRATCH_DIR/non-divine-linked"
+mkdir -p "$NON_DIVINE_MAIN/mobile/build"
+git -C "$NON_DIVINE_MAIN" init -q
+touch "$NON_DIVINE_MAIN/mobile/build/output.o"
+git -C "$NON_DIVINE_MAIN" add mobile/build/output.o
+git -C "$NON_DIVINE_MAIN" \
+  -c user.email=test@example.com \
+  -c user.name=Test \
+  commit -q -m init
+git -C "$NON_DIVINE_MAIN" worktree add -q "$NON_DIVINE_LINK"
+NON_DIVINE_OUTPUT=$(cd "$NON_DIVINE_LINK" && \
+  env CLAUDE_PROJECT_DIR="$NON_DIVINE_LINK" "$CLAUDE_PURGE_HOOK" \
     <<< '{"reason":"prompt_input_exit"}')
-if [ -n "$NON_DIVINE_OUTPUT" ]; then
+if [ -n "$NON_DIVINE_OUTPUT" ] || [ ! -d "$NON_DIVINE_LINK/mobile/build" ]; then
   echo "Purge hook ran outside a divine-mobile checkout." >&2
   exit 1
 fi
@@ -420,10 +429,6 @@ printf '%s\n' "$PURGE_OUTPUT" | jq -e \
   '.systemMessage == "Purged 3 build/.dart_tool dirs from purge-linked"' >/dev/null
 if [ -d "$WT_LINK/mobile/build" ] || [ -d "$WT_LINK/mobile/.dart_tool" ] || [ -d "$WT_LINK/mobile/packages/bar/build" ]; then
   echo "Purge hook did not remove linked worktree build artifacts." >&2
-  exit 1
-fi
-if [ -e "$WT_LINK/.claude-purge" ]; then
-  echo "Purge hook staged artifacts inside the worktree." >&2
   exit 1
 fi
 if [ -n "$(git -C "$WT_LINK" status --short)" ]; then

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -22,6 +22,8 @@ CLAUDE_ANALYZE_HOOK="$REPO_ROOT/.claude/hooks/post-edit-analyze.sh"
 # pins). The SessionEnd matcher is asserted exactly because it deliberately
 # excludes non-terminal reasons such as `other`.
 while IFS= read -r hook_cmd; do
+  # Match the literal settings.json command prefix, not the current shell env.
+  # shellcheck disable=SC2016
   case "$hook_cmd" in
     '"$CLAUDE_PROJECT_DIR"'/*)
       hook_path=${hook_cmd#'"$CLAUDE_PROJECT_DIR"'}
@@ -507,59 +509,8 @@ if [ -n "$CLEAR_OUTPUT$RESUME_OUTPUT" ] || [ ! -d "$WT_LINK/mobile/build" ] || [
   exit 1
 fi
 
-PURGE_PEER_BIN="$SCRATCH_DIR/purge-peer-bin"
-mkdir -p "$PURGE_PEER_BIN"
-for tool in bash cat jq git find stat mv rm mkdir rmdir basename nohup sed head tr; do
-  ln -s "$(command -v "$tool")" "$PURGE_PEER_BIN/$tool"
-done
-cat > "$PURGE_PEER_BIN/ps" <<'EOF'
-#!/bin/bash
-if [ "$1" = "-eo" ] && [ "$2" = "pid=,comm=" ]; then
-  echo "4242 zsh"
-  exit 0
-fi
-if [ "$1" = "-o" ] && [ "$2" = "ppid=" ] && [ "$3" = "-p" ]; then
-  exit 0
-fi
-exit 1
-EOF
-cat > "$PURGE_PEER_BIN/lsof" <<'EOF'
-#!/bin/bash
-pid=""
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "-p" ]; then
-    pid="$2"
-    break
-  fi
-  shift
-done
-[ "$pid" = "4242" ] || exit 1
-printf 'n%s\n' "$PURGE_PEER_CWD"
-EOF
-chmod +x "$PURGE_PEER_BIN/ps" "$PURGE_PEER_BIN/lsof"
-PEER_OUTPUT=$(cd "$WT_LINK" && \
-  env PATH="$PURGE_PEER_BIN" \
-    CLAUDE_PROJECT_DIR="$WT_LINK" \
-    PURGE_PEER_CWD="$WT_LINK/mobile" \
-    "$CLAUDE_PURGE_HOOK" \
-    <<< '{"reason":"prompt_input_exit"}')
-if ! printf '%s\n' "$PEER_OUTPUT" | jq -e \
-  '.systemMessage
-   | contains("Skipped build-artifact purge")
-     and contains("pid 4242")
-     and contains("other live process")' >/dev/null; then
-  echo "Purge hook did not explain the shared-worktree skip." >&2
-  echo "Output was: $PEER_OUTPUT" >&2
-  exit 1
-fi
-if [ ! -d "$WT_LINK/mobile/build" ] || [ ! -d "$WT_LINK/mobile/.dart_tool" ]; then
-  echo "Purge hook deleted artifacts while another process was active in the worktree." >&2
-  exit 1
-fi
-
 PURGE_OUTPUT=$(cd "$WT_LINK" && \
   env CLAUDE_PROJECT_DIR="$WT_LINK" \
-    CLAUDE_PURGE_SKIP_PEER_SCAN=1 \
     "$CLAUDE_PURGE_HOOK" \
     <<< '{"reason":"prompt_input_exit"}')
 printf '%s\n' "$PURGE_OUTPUT" | jq -e \
@@ -590,7 +541,6 @@ mkdir -p "$gitdir/claude-purge/old"
 touch "$gitdir/claude-purge/old/artifact"
 NOOP_OUTPUT=$(cd "$WT_LINK" && \
   env CLAUDE_PROJECT_DIR="$WT_LINK" \
-    CLAUDE_PURGE_SKIP_PEER_SCAN=1 \
     "$CLAUDE_PURGE_HOOK" \
     <<< '{"reason":"prompt_input_exit"}')
 if [ -n "$NOOP_OUTPUT" ] || [ -d "$gitdir/claude-purge" ]; then
@@ -626,9 +576,9 @@ EOF
   mkdir -p "$XDEV_LINK/mobile/build" "$XDEV_LINK/mobile/.dart_tool"
   touch "$XDEV_LINK/mobile/build/output.o" \
     "$XDEV_LINK/mobile/.dart_tool/package_config.json"
-  XDEV_WORKTREE_DEV=$(stat -c %d "$XDEV_LINK/mobile" 2>/dev/null || echo no-dev-1)
+  XDEV_WORKTREE_DEV=$(stat -c %d "$XDEV_LINK/mobile" 2>/dev/null || stat -f %d "$XDEV_LINK/mobile" 2>/dev/null || echo no-dev-1)
   XDEV_GITDIR=$(git -C "$XDEV_LINK" rev-parse --absolute-git-dir)
-  XDEV_GITDIR_DEV=$(stat -c %d "$XDEV_GITDIR" 2>/dev/null || echo no-dev-2)
+  XDEV_GITDIR_DEV=$(stat -c %d "$XDEV_GITDIR" 2>/dev/null || stat -f %d "$XDEV_GITDIR" 2>/dev/null || echo no-dev-2)
   if [ "$XDEV_WORKTREE_DEV" != "$XDEV_GITDIR_DEV" ]; then
     # A regular file at the staging path makes any staging attempt fail loudly
     # (mkdir -p cannot succeed), so this test discriminates the in-place path
@@ -637,7 +587,6 @@ EOF
     XDEV_NAME=$(basename "$XDEV_LINK")
     XDEV_OUTPUT=$(cd "$XDEV_LINK" && \
       env CLAUDE_PROJECT_DIR="$XDEV_LINK" \
-        CLAUDE_PURGE_SKIP_PEER_SCAN=1 \
         "$CLAUDE_PURGE_HOOK" \
         <<< '{"reason":"prompt_input_exit"}' || true)
     printf '%s\n' "$XDEV_OUTPUT" | jq -e --arg name "$XDEV_NAME" \

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -454,6 +454,25 @@ if grep -q '^analyze ' "$CALL_LOG"; then
   exit 1
 fi
 
+# Skipping is only half the contract. Without this, widening the guard so it
+# always skips -- silently disabling post-edit analysis everywhere -- passes.
+: > "$CALL_LOG"
+mkdir -p "$TEST_REPO/mobile/.dart_tool"
+touch "$TEST_REPO/mobile/.dart_tool/package_config.json"
+CLAUDE_ANALYZE_RESOLVED=$(cd "$TEST_REPO" && \
+  env PATH="$BIN_DIR:/usr/bin:/bin" \
+    DART_CALL_LOG="$CALL_LOG" \
+    "$CLAUDE_ANALYZE_HOOK" <<< "$CLAUDE_ANALYZE_PAYLOAD")
+if ! grep -q '^analyze ' "$CALL_LOG"; then
+  echo "Claude post-edit analyze hook skipped dart analyze despite package_config.json." >&2
+  exit 1
+fi
+if [ -n "$CLAUDE_ANALYZE_RESOLVED" ]; then
+  echo "Claude post-edit analyze hook reported diagnostics for a clean file." >&2
+  echo "Output was: $CLAUDE_ANALYZE_RESOLVED" >&2
+  exit 1
+fi
+
 NON_DIVINE_MAIN="$SCRATCH_DIR/non-divine-main"
 NON_DIVINE_LINK="$SCRATCH_DIR/non-divine-linked"
 mkdir -p "$NON_DIVINE_MAIN/mobile/build"

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -2,6 +2,7 @@
 # Regression checks for repository Codex hooks and generated skills.
 
 set -e
+trap 'echo "test-config.sh failed at line $LINENO: $BASH_COMMAND" >&2' ERR
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 POST_EDIT_HOOK="$REPO_ROOT/.codex/hooks/post-edit-dart.sh"

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -183,8 +183,18 @@ if [ -n "$NON_DART_OUTPUT" ]; then
   exit 1
 fi
 
+# The no-toolchain path must be exercised with mise and dart both hidden:
+# dev machines commonly install mise system-wide (e.g. /usr/bin/mise), and
+# then it resolves a real dart, analyzes the fixture, and emits no block —
+# failing this test before the purge-hook tests below ever run. Pin the PATH
+# to a scratch bin holding only the tools the hook needs when no SDK resolves.
+NO_TOOLCHAIN_BIN="$SCRATCH_DIR/no-toolchain-bin"
+mkdir -p "$NO_TOOLCHAIN_BIN"
+for tool in jq git sed grep cat dirname basename; do
+  ln -s "$(command -v "$tool")" "$NO_TOOLCHAIN_BIN/$tool"
+done
 MISSING_DART_OUTPUT=$(cd "$TEST_REPO" && \
-  env PATH="/usr/bin:/bin" "$POST_EDIT_HOOK" <<< "$POST_PAYLOAD")
+  env PATH="$NO_TOOLCHAIN_BIN" "$POST_EDIT_HOOK" <<< "$POST_PAYLOAD")
 printf '%s\n' "$MISSING_DART_OUTPUT" | jq -e \
   '.decision == "block" and (.reason | contains("Unable to run the repository Dart SDK"))' >/dev/null
 

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -89,6 +89,8 @@ mkdir -p "$TEST_REPO/mobile/lib" "$BIN_DIR"
 git -C "$TEST_REPO" init -q
 
 touch "$TEST_REPO/mobile/mise.toml"
+mkdir -p "$TEST_REPO/mobile/.dart_tool"
+touch "$TEST_REPO/mobile/.dart_tool/package_config.json"
 cat > "$TEST_REPO/mobile/pubspec.yaml" <<'EOF'
 name: codex_hook_test
 environment:
@@ -244,6 +246,27 @@ MISSING_DART_OUTPUT=$(cd "$TEST_REPO" && \
 printf '%s\n' "$MISSING_DART_OUTPUT" | jq -e \
   '.decision == "block" and (.reason | contains("Unable to run the repository Dart SDK"))' >/dev/null
 
+rm -f "$TEST_REPO/mobile/.dart_tool/package_config.json"
+: > "$CALL_LOG"
+CODEX_PURGED_OUTPUT=$(cd "$TEST_REPO" && \
+  env PATH="$BIN_DIR:/usr/bin:/bin" \
+    TEST_DART="$BIN_DIR/test-dart" \
+    DART_CALL_LOG="$CALL_LOG" \
+    "$POST_EDIT_HOOK" <<< "$POST_PAYLOAD")
+if ! printf '%s\n' "$CODEX_PURGED_OUTPUT" | jq -e \
+  '.systemMessage
+   | contains("Skipped Dart format/analyze")
+     and contains("flutter pub get")' >/dev/null; then
+  echo "Codex post-edit hook did not explain the missing package_config.json skip." >&2
+  echo "Output was: $CODEX_PURGED_OUTPUT" >&2
+  exit 1
+fi
+if grep -q '^format \|^analyze ' "$CALL_LOG"; then
+  echo "Codex post-edit hook invoked dart without package_config.json." >&2
+  exit 1
+fi
+touch "$TEST_REPO/mobile/.dart_tool/package_config.json"
+
 CHAINED_COMMIT_PAYLOAD=$(jq -n --arg command '   git commit -m test && echo done' \
   '{tool_input: {command: $command}}')
 CODEX_GIT_OUTPUT=$(cd "$TEST_REPO" && \
@@ -398,12 +421,17 @@ fi
 CLAUDE_ANALYZE_PAYLOAD=$(jq -n --arg path "$TEST_REPO/mobile/lib/clean.dart" \
   '{tool_input: {file_path: $path}}')
 : > "$CALL_LOG"
+rm -f "$TEST_REPO/mobile/.dart_tool/package_config.json"
 CLAUDE_ANALYZE_OUTPUT=$(cd "$TEST_REPO" && \
   env PATH="$BIN_DIR:/usr/bin:/bin" \
     DART_CALL_LOG="$CALL_LOG" \
     "$CLAUDE_ANALYZE_HOOK" <<< "$CLAUDE_ANALYZE_PAYLOAD")
-if [ -n "$CLAUDE_ANALYZE_OUTPUT" ]; then
-  echo "Claude post-edit analyze hook ran without package_config.json." >&2
+if ! printf '%s\n' "$CLAUDE_ANALYZE_OUTPUT" | jq -e \
+  '.systemMessage
+   | contains("Skipped Dart analysis")
+     and contains("flutter pub get")' >/dev/null; then
+  echo "Claude post-edit analyze hook did not explain the missing package_config.json skip." >&2
+  echo "Output was: $CLAUDE_ANALYZE_OUTPUT" >&2
   exit 1
 fi
 if grep -q '^analyze ' "$CALL_LOG"; then
@@ -475,6 +503,56 @@ RESUME_OUTPUT=$(cd "$WT_LINK" && \
     <<< '{"reason":"resume"}')
 if [ -n "$CLEAR_OUTPUT$RESUME_OUTPUT" ] || [ ! -d "$WT_LINK/mobile/build" ] || [ ! -d "$WT_LINK/mobile/.dart_tool" ]; then
   echo "Purge hook did not skip clear/resume SessionEnd reasons." >&2
+  exit 1
+fi
+
+PURGE_PEER_BIN="$SCRATCH_DIR/purge-peer-bin"
+mkdir -p "$PURGE_PEER_BIN"
+for tool in bash cat jq git find stat mv rm mkdir rmdir basename nohup sed head tr; do
+  ln -s "$(command -v "$tool")" "$PURGE_PEER_BIN/$tool"
+done
+cat > "$PURGE_PEER_BIN/ps" <<'EOF'
+#!/bin/bash
+if [ "$1" = "-eo" ] && [ "$2" = "pid=,comm=" ]; then
+  echo "4242 zsh"
+  exit 0
+fi
+if [ "$1" = "-o" ] && [ "$2" = "ppid=" ] && [ "$3" = "-p" ]; then
+  exit 0
+fi
+exit 1
+EOF
+cat > "$PURGE_PEER_BIN/lsof" <<'EOF'
+#!/bin/bash
+pid=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-p" ]; then
+    pid="$2"
+    break
+  fi
+  shift
+done
+[ "$pid" = "4242" ] || exit 1
+printf 'n%s\n' "$PURGE_PEER_CWD"
+EOF
+chmod +x "$PURGE_PEER_BIN/ps" "$PURGE_PEER_BIN/lsof"
+PEER_OUTPUT=$(cd "$WT_LINK" && \
+  env PATH="$PURGE_PEER_BIN" \
+    CLAUDE_PROJECT_DIR="$WT_LINK" \
+    PURGE_PEER_CWD="$WT_LINK/mobile" \
+    "$CLAUDE_PURGE_HOOK" \
+    <<< '{"reason":"prompt_input_exit"}')
+if ! printf '%s\n' "$PEER_OUTPUT" | jq -e \
+  '.systemMessage
+   | contains("Skipped build-artifact purge")
+     and contains("pid 4242")
+     and contains("other live process")' >/dev/null; then
+  echo "Purge hook did not explain the shared-worktree skip." >&2
+  echo "Output was: $PEER_OUTPUT" >&2
+  exit 1
+fi
+if [ ! -d "$WT_LINK/mobile/build" ] || [ ! -d "$WT_LINK/mobile/.dart_tool" ]; then
+  echo "Purge hook deleted artifacts while another process was active in the worktree." >&2
   exit 1
 fi
 

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -448,6 +448,17 @@ fi
 
 gitdir=$(git -C "$WT_LINK" rev-parse --absolute-git-dir)
 
+# Staging is only the visible half: the background rm must actually reclaim
+# the staged artifacts, or every session-end just moves the disk bill around.
+for _ in $(seq 1 100); do
+  [ ! -e "$gitdir/claude-purge" ] && break
+  sleep 0.1
+done
+if [ -e "$gitdir/claude-purge" ]; then
+  echo "Purge hook staged artifacts but never deleted them." >&2
+  exit 1
+fi
+
 mkdir -p "$gitdir/claude-purge/old"
 touch "$gitdir/claude-purge/old/artifact"
 NOOP_OUTPUT=$(cd "$WT_LINK" && \

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -518,56 +518,65 @@ fi
 # A linked worktree on a different filesystem from the main checkout must
 # still purge: the hook detects the cross-device gitdir and deletes in place
 # instead of staging (mv would degrade to a synchronous copy that can blow
-# the hook timeout). /dev/shm supplies a second filesystem when one exists.
-XDEV_MAIN="$SCRATCH_DIR/xdev-main"
-XDEV_LINK="/dev/shm/divine-purge-xdev-$$"
-mkdir -p "$XDEV_MAIN/mobile/packages/bar"
-git -C "$XDEV_MAIN" init -q
-cat > "$XDEV_MAIN/mobile/pubspec.yaml" <<'EOF'
+# the hook timeout). /dev/shm supplies a second filesystem where one exists;
+# the probe guards the fixture itself, since `git worktree add` into a missing
+# or read-only /dev/shm (macOS, hardened containers) would abort the suite
+# before any skip logic could run.
+if [ -d /dev/shm ] && [ -w /dev/shm ]; then
+  XDEV_MAIN="$SCRATCH_DIR/xdev-main"
+  XDEV_LINK="/dev/shm/divine-purge-xdev-$$"
+  # Failing runs re-run the most; clean the tmpfs worktree from the EXIT trap
+  # so a red assertion does not leak it into RAM.
+  trap 'rm -rf "$SCRATCH_DIR" "$XDEV_LINK"' EXIT
+  mkdir -p "$XDEV_MAIN/mobile/packages/bar"
+  git -C "$XDEV_MAIN" init -q
+  cat > "$XDEV_MAIN/mobile/pubspec.yaml" <<'EOF'
 name: xdev_purge_test
 EOF
-touch "$XDEV_MAIN/mobile/packages/bar/.keep"
-git -C "$XDEV_MAIN" add mobile/pubspec.yaml mobile/packages/bar/.keep
-git -C "$XDEV_MAIN" \
-  -c user.email=test@example.com \
-  -c user.name=Test \
-  commit -q -m init
-git -C "$XDEV_MAIN" worktree add -q "$XDEV_LINK"
-mkdir -p "$XDEV_LINK/mobile/build" "$XDEV_LINK/mobile/.dart_tool"
-touch "$XDEV_LINK/mobile/build/output.o" \
-  "$XDEV_LINK/mobile/.dart_tool/package_config.json"
-XDEV_WORKTREE_DEV=$(stat -c %d "$XDEV_LINK/mobile" 2>/dev/null || echo no-dev-1)
-XDEV_GITDIR=$(git -C "$XDEV_LINK" rev-parse --absolute-git-dir)
-XDEV_GITDIR_DEV=$(stat -c %d "$XDEV_GITDIR" 2>/dev/null || echo no-dev-2)
-if [ "$XDEV_WORKTREE_DEV" != "$XDEV_GITDIR_DEV" ]; then
-  # A regular file at the staging path makes any staging attempt fail loudly
-  # (mkdir -p cannot succeed), so this test discriminates the in-place path
-  # from a cross-device mv even though both eventually delete the artifacts.
-  touch "$XDEV_GITDIR/claude-purge"
-  XDEV_NAME=$(basename "$XDEV_LINK")
-  XDEV_OUTPUT=$(cd "$XDEV_LINK" && \
-    env CLAUDE_PROJECT_DIR="$XDEV_LINK" "$CLAUDE_PURGE_HOOK" \
-      <<< '{"reason":"prompt_input_exit"}' || true)
-  printf '%s\n' "$XDEV_OUTPUT" | jq -e --arg name "$XDEV_NAME" \
-    '.systemMessage == ("Purged 2 build/.dart_tool dirs from " + $name)' >/dev/null || {
-    echo "Cross-device purge did not report removing both artifact dirs." >&2
-    exit 1
-  }
-  if [ ! -f "$XDEV_GITDIR/claude-purge" ]; then
-    echo "Cross-device purge touched the gitdir staging path instead of deleting in place." >&2
-    exit 1
-  fi
-  for _ in $(seq 1 100); do
-    [ ! -d "$XDEV_LINK/mobile/build" ] && [ ! -d "$XDEV_LINK/mobile/.dart_tool" ] && break
-    sleep 0.1
-  done
-  if [ -d "$XDEV_LINK/mobile/build" ] || [ -d "$XDEV_LINK/mobile/.dart_tool" ]; then
-    echo "Cross-device purge did not delete the artifact dirs." >&2
-    exit 1
+  touch "$XDEV_MAIN/mobile/packages/bar/.keep"
+  git -C "$XDEV_MAIN" add mobile/pubspec.yaml mobile/packages/bar/.keep
+  git -C "$XDEV_MAIN" \
+    -c user.email=test@example.com \
+    -c user.name=Test \
+    commit -q -m init
+  git -C "$XDEV_MAIN" worktree add -q "$XDEV_LINK"
+  mkdir -p "$XDEV_LINK/mobile/build" "$XDEV_LINK/mobile/.dart_tool"
+  touch "$XDEV_LINK/mobile/build/output.o" \
+    "$XDEV_LINK/mobile/.dart_tool/package_config.json"
+  XDEV_WORKTREE_DEV=$(stat -c %d "$XDEV_LINK/mobile" 2>/dev/null || echo no-dev-1)
+  XDEV_GITDIR=$(git -C "$XDEV_LINK" rev-parse --absolute-git-dir)
+  XDEV_GITDIR_DEV=$(stat -c %d "$XDEV_GITDIR" 2>/dev/null || echo no-dev-2)
+  if [ "$XDEV_WORKTREE_DEV" != "$XDEV_GITDIR_DEV" ]; then
+    # A regular file at the staging path makes any staging attempt fail loudly
+    # (mkdir -p cannot succeed), so this test discriminates the in-place path
+    # from a cross-device mv even though both eventually delete the artifacts.
+    touch "$XDEV_GITDIR/claude-purge"
+    XDEV_NAME=$(basename "$XDEV_LINK")
+    XDEV_OUTPUT=$(cd "$XDEV_LINK" && \
+      env CLAUDE_PROJECT_DIR="$XDEV_LINK" "$CLAUDE_PURGE_HOOK" \
+        <<< '{"reason":"prompt_input_exit"}' || true)
+    printf '%s\n' "$XDEV_OUTPUT" | jq -e --arg name "$XDEV_NAME" \
+      '.systemMessage == ("Purged 2 build/.dart_tool dirs from " + $name)' >/dev/null || {
+      echo "Cross-device purge did not report removing both artifact dirs." >&2
+      exit 1
+    }
+    if [ ! -f "$XDEV_GITDIR/claude-purge" ]; then
+      echo "Cross-device purge touched the gitdir staging path instead of deleting in place." >&2
+      exit 1
+    fi
+    for _ in $(seq 1 100); do
+      [ ! -d "$XDEV_LINK/mobile/build" ] && [ ! -d "$XDEV_LINK/mobile/.dart_tool" ] && break
+      sleep 0.1
+    done
+    if [ -d "$XDEV_LINK/mobile/build" ] || [ -d "$XDEV_LINK/mobile/.dart_tool" ]; then
+      echo "Cross-device purge did not delete the artifact dirs." >&2
+      exit 1
+    fi
+  else
+    echo "skip: /dev/shm shares a filesystem with the scratch dir; cross-device purge path not exercised."
   fi
 else
-  echo "skip: /dev/shm shares a filesystem with the scratch dir; cross-device purge path not exercised."
+  echo "skip: no writable /dev/shm; cross-device purge path not exercised."
 fi
-rm -rf "$XDEV_LINK" 2>/dev/null || true
 
 echo "Codex configuration checks passed."

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -251,21 +251,33 @@ printf '%s\n' "$MISSING_DART_OUTPUT" | jq -e \
 
 rm -f "$TEST_REPO/mobile/.dart_tool/package_config.json"
 : > "$CALL_LOG"
+TWO_FILE_PURGED_PAYLOAD=$(jq -n --arg command $'*** Begin Patch\n*** Update File: mobile/lib/warning file.dart\n*** Update File: mobile/lib/clean.dart\n*** End Patch' \
+  '{tool_input: {command: $command}}')
 CODEX_PURGED_OUTPUT=$(cd "$TEST_REPO" && \
   env PATH="$BIN_DIR:/usr/bin:/bin" \
     TEST_DART="$BIN_DIR/test-dart" \
     DART_CALL_LOG="$CALL_LOG" \
-    "$POST_EDIT_HOOK" <<< "$POST_PAYLOAD")
+    "$POST_EDIT_HOOK" <<< "$TWO_FILE_PURGED_PAYLOAD")
 if ! printf '%s\n' "$CODEX_PURGED_OUTPUT" | jq -e \
   '.systemMessage
-   | contains("Skipped Dart format/analyze")
+   | contains("Skipped Dart analysis")
      and contains("flutter pub get")' >/dev/null; then
   echo "Codex post-edit hook did not explain the missing package_config.json skip." >&2
   echo "Output was: $CODEX_PURGED_OUTPUT" >&2
   exit 1
 fi
-if grep -q '^format \|^analyze ' "$CALL_LOG"; then
-  echo "Codex post-edit hook invoked dart without package_config.json." >&2
+# Format needs no package resolution and must still run; only analyze skips.
+if grep -q '^analyze ' "$CALL_LOG"; then
+  echo "Codex post-edit hook invoked dart analyze without package_config.json." >&2
+  exit 1
+fi
+if ! grep -q '^format ' "$CALL_LOG"; then
+  echo "Codex post-edit hook skipped dart format, which needs no package_config.json." >&2
+  exit 1
+fi
+# A skip must not abort the patch loop: both files still get formatted.
+if [ "$(grep -c '^format ' "$CALL_LOG")" -ne 2 ]; then
+  echo "Codex post-edit hook aborted the file loop at the first purged-worktree file." >&2
   exit 1
 fi
 touch "$TEST_REPO/mobile/.dart_tool/package_config.json"

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -615,9 +615,19 @@ exit 1
 EOF
 chmod +x "$BSD_STAT_BIN/stat"
 
-mkdir -p "$WT_LINK/mobile/build" "$WT_LINK/mobile/.dart_tool"
+# Carry the newline discrimination onto the in-place branch too. The staging
+# branch is pinned for it above, but the only other test that reaches the
+# in-place branch is the /dev/shm one below, which skips wherever /dev/shm is
+# absent or read-only -- every macOS run. Faking stat is what makes this pin
+# platform-independent.
+mkdir -p "$WT_LINK/mobile/build" \
+  "$WT_LINK/mobile/.dart_tool" \
+  "$NEWLINE_PKG/build" \
+  "$WT_LINK/mobile/pkg"
 touch "$WT_LINK/mobile/build/output.o" \
   "$WT_LINK/mobile/.dart_tool/package_config.json" \
+  "$NEWLINE_PKG/build/output.o" \
+  "$WT_LINK/mobile/pkg/PRECIOUS_SOURCE.dart" \
   "$gitdir/claude-purge"
 BSD_STAT_OUTPUT=$(cd "$WT_LINK" && \
   env PATH="$BSD_STAT_BIN:/usr/bin:/bin" \
@@ -627,7 +637,7 @@ BSD_STAT_OUTPUT=$(cd "$WT_LINK" && \
     "$CLAUDE_PURGE_HOOK" \
     <<< '{"reason":"prompt_input_exit"}' || true)
 printf '%s\n' "$BSD_STAT_OUTPUT" | jq -e \
-  '.systemMessage == "Purged 2 build/.dart_tool dirs from purge-linked"' >/dev/null || {
+  '.systemMessage == "Purged 3 build/.dart_tool dirs from purge-linked"' >/dev/null || {
   echo "Purge hook did not use the BSD stat fallback for device detection." >&2
   echo "Output was: $BSD_STAT_OUTPUT" >&2
   exit 1
@@ -637,11 +647,20 @@ if [ ! -f "$gitdir/claude-purge" ]; then
   exit 1
 fi
 for _ in $(seq 1 100); do
-  [ ! -d "$WT_LINK/mobile/build" ] && [ ! -d "$WT_LINK/mobile/.dart_tool" ] && break
+  [ ! -d "$WT_LINK/mobile/build" ] && [ ! -d "$WT_LINK/mobile/.dart_tool" ] \
+    && [ ! -d "$NEWLINE_PKG/build" ] && break
   sleep 0.1
 done
 if [ -d "$WT_LINK/mobile/build" ] || [ -d "$WT_LINK/mobile/.dart_tool" ]; then
   echo "BSD-stat cross-device purge did not delete the artifact dirs." >&2
+  exit 1
+fi
+if [ ! -f "$WT_LINK/mobile/pkg/PRECIOUS_SOURCE.dart" ]; then
+  echo "BSD-stat cross-device purge deleted a non-artifact path through a newline-split find line." >&2
+  exit 1
+fi
+if [ -d "$NEWLINE_PKG/build" ]; then
+  echo "BSD-stat cross-device purge left the newline-named build dir behind." >&2
   exit 1
 fi
 rm -f "$gitdir/claude-purge"

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -548,6 +548,37 @@ if [ -n "$NOOP_OUTPUT" ] || [ -d "$gitdir/claude-purge" ]; then
   exit 1
 fi
 
+# A directory whose name contains a newline must not split find output into
+# fragments: without -print0 the hook reads `mobile/pkg\nage/build` as the two
+# paths `mobile/pkg` and `age/build`, and `mv`/`rm -rf` then reach the
+# non-artifact sibling. The precious file is the discrimination.
+NEWLINE_PKG="$WT_LINK/mobile/pkg
+age"
+mkdir -p "$NEWLINE_PKG/build" "$WT_LINK/mobile/pkg"
+touch "$NEWLINE_PKG/build/output.o" "$WT_LINK/mobile/pkg/PRECIOUS_SOURCE.dart"
+NEWLINE_OUTPUT=$(cd "$WT_LINK" && \
+  env CLAUDE_PROJECT_DIR="$WT_LINK" \
+    "$CLAUDE_PURGE_HOOK" \
+    <<< '{"reason":"prompt_input_exit"}')
+printf '%s\n' "$NEWLINE_OUTPUT" | jq -e \
+  '.systemMessage == "Purged 1 build/.dart_tool dirs from purge-linked"' >/dev/null || {
+  echo "Purge hook did not report purging the newline-named build dir." >&2
+  echo "Output was: $NEWLINE_OUTPUT" >&2
+  exit 1
+}
+if [ ! -f "$WT_LINK/mobile/pkg/PRECIOUS_SOURCE.dart" ]; then
+  echo "Purge hook deleted a non-artifact path through a newline-split find line." >&2
+  exit 1
+fi
+if [ -d "$NEWLINE_PKG/build" ]; then
+  echo "Purge hook left the newline-named build dir behind." >&2
+  exit 1
+fi
+for _ in $(seq 1 100); do
+  [ ! -e "$gitdir/claude-purge" ] && break
+  sleep 0.1
+done
+
 # A linked worktree on a different filesystem from the main checkout must
 # still purge: the hook detects the cross-device gitdir and deletes in place
 # instead of staging (mv would degrade to a synchronous copy that can blow

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -447,6 +447,7 @@ if [ -n "$(git -C "$WT_LINK" status --short)" ]; then
 fi
 
 gitdir=$(git -C "$WT_LINK" rev-parse --absolute-git-dir)
+
 mkdir -p "$gitdir/claude-purge/old"
 touch "$gitdir/claude-purge/old/artifact"
 NOOP_OUTPUT=$(cd "$WT_LINK" && \
@@ -456,5 +457,60 @@ if [ -n "$NOOP_OUTPUT" ] || [ -d "$gitdir/claude-purge" ]; then
   echo "Purge hook did not clean leftover staging on a no-op run." >&2
   exit 1
 fi
+
+# A linked worktree on a different filesystem from the main checkout must
+# still purge: the hook detects the cross-device gitdir and deletes in place
+# instead of staging (mv would degrade to a synchronous copy that can blow
+# the hook timeout). /dev/shm supplies a second filesystem when one exists.
+XDEV_MAIN="$SCRATCH_DIR/xdev-main"
+XDEV_LINK="/dev/shm/divine-purge-xdev-$$"
+mkdir -p "$XDEV_MAIN/mobile/packages/bar"
+git -C "$XDEV_MAIN" init -q
+cat > "$XDEV_MAIN/mobile/pubspec.yaml" <<'EOF'
+name: xdev_purge_test
+EOF
+touch "$XDEV_MAIN/mobile/packages/bar/.keep"
+git -C "$XDEV_MAIN" add mobile/pubspec.yaml mobile/packages/bar/.keep
+git -C "$XDEV_MAIN" \
+  -c user.email=test@example.com \
+  -c user.name=Test \
+  commit -q -m init
+git -C "$XDEV_MAIN" worktree add -q "$XDEV_LINK"
+mkdir -p "$XDEV_LINK/mobile/build" "$XDEV_LINK/mobile/.dart_tool"
+touch "$XDEV_LINK/mobile/build/output.o" \
+  "$XDEV_LINK/mobile/.dart_tool/package_config.json"
+XDEV_WORKTREE_DEV=$(stat -c %d "$XDEV_LINK/mobile" 2>/dev/null || echo no-dev-1)
+XDEV_GITDIR=$(git -C "$XDEV_LINK" rev-parse --absolute-git-dir)
+XDEV_GITDIR_DEV=$(stat -c %d "$XDEV_GITDIR" 2>/dev/null || echo no-dev-2)
+if [ "$XDEV_WORKTREE_DEV" != "$XDEV_GITDIR_DEV" ]; then
+  # A regular file at the staging path makes any staging attempt fail loudly
+  # (mkdir -p cannot succeed), so this test discriminates the in-place path
+  # from a cross-device mv even though both eventually delete the artifacts.
+  touch "$XDEV_GITDIR/claude-purge"
+  XDEV_NAME=$(basename "$XDEV_LINK")
+  XDEV_OUTPUT=$(cd "$XDEV_LINK" && \
+    env CLAUDE_PROJECT_DIR="$XDEV_LINK" "$CLAUDE_PURGE_HOOK" \
+      <<< '{"reason":"prompt_input_exit"}' || true)
+  printf '%s\n' "$XDEV_OUTPUT" | jq -e --arg name "$XDEV_NAME" \
+    '.systemMessage == ("Purged 2 build/.dart_tool dirs from " + $name)' >/dev/null || {
+    echo "Cross-device purge did not report removing both artifact dirs." >&2
+    exit 1
+  }
+  if [ ! -f "$XDEV_GITDIR/claude-purge" ]; then
+    echo "Cross-device purge touched the gitdir staging path instead of deleting in place." >&2
+    exit 1
+  fi
+  for _ in $(seq 1 100); do
+    [ ! -d "$XDEV_LINK/mobile/build" ] && [ ! -d "$XDEV_LINK/mobile/.dart_tool" ] && break
+    sleep 0.1
+  done
+  if [ -d "$XDEV_LINK/mobile/build" ] || [ -d "$XDEV_LINK/mobile/.dart_tool" ]; then
+    echo "Cross-device purge did not delete the artifact dirs." >&2
+    exit 1
+  fi
+else
+  echo "skip: /dev/shm shares a filesystem with the scratch dir; cross-device purge path not exercised."
+fi
+rm -rf "$XDEV_LINK" 2>/dev/null || true
 
 echo "Codex configuration checks passed."

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -36,6 +36,14 @@ while IFS= read -r hook_cmd; do
   esac
 done < <(jq -r '.hooks | .[] | .[] | .hooks[].command' "$REPO_ROOT/.claude/settings.json")
 
+missing_timeouts=$(jq -r '.hooks | .[] | .[] | .hooks[]
+  | select(.timeout == null)
+  | .command' "$REPO_ROOT/.claude/settings.json")
+if [ -n "$missing_timeouts" ]; then
+  echo "Every Claude hook must declare an explicit whole-second timeout; missing on: $missing_timeouts" >&2
+  exit 1
+fi
+
 bad_timeouts=$(jq -r '.hooks | .[] | .[] | .hooks[].timeout' "$REPO_ROOT/.claude/settings.json" \
   | awk '$1 !~ /^[0-9]+$/ || $1 > 600 { print }')
 if [ -n "$bad_timeouts" ]; then

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -9,6 +9,8 @@ BUILD_HOOK="$REPO_ROOT/.codex/hooks/pre-commit-build-runner.sh"
 CODEX_GIT_HOOK="$REPO_ROOT/.codex/hooks/check-git-hooks.sh"
 CLAUDE_GIT_HOOK="$REPO_ROOT/.claude/hooks/check-git-hooks.sh"
 WORKTREE_GUARD_HOOK="$REPO_ROOT/.claude/hooks/session-start-worktree-guard.sh"
+CLAUDE_PURGE_HOOK="$REPO_ROOT/.claude/hooks/session-end-purge-build-artifacts.sh"
+CLAUDE_ANALYZE_HOOK="$REPO_ROOT/.claude/hooks/post-edit-analyze.sh"
 
 "$REPO_ROOT/.codex/scripts/sync-agent-skills.sh" --check
 
@@ -117,6 +119,7 @@ case "$1" in
 esac
 EOF
 chmod +x "$BIN_DIR/mise" "$BIN_DIR/test-dart"
+ln -sf "$BIN_DIR/test-dart" "$BIN_DIR/dart"
 
 POST_PAYLOAD=$(jq -n --arg command $'*** Begin Patch\n*** Update File: mobile/lib/warning file.dart\n*** End Patch' \
   '{tool_input: {command: $command}}')
@@ -333,6 +336,109 @@ if ! printf '%s\n' "$GUARD_OUTPUT" | jq -e '
 ' >/dev/null; then
   echo "Session worktree guard did not report only live Claude sessions in the same canonical worktree." >&2
   echo "Output was: $GUARD_OUTPUT" >&2
+  exit 1
+fi
+
+CLAUDE_ANALYZE_PAYLOAD=$(jq -n --arg path "$TEST_REPO/mobile/lib/clean.dart" \
+  '{tool_input: {file_path: $path}}')
+: > "$CALL_LOG"
+CLAUDE_ANALYZE_OUTPUT=$(cd "$TEST_REPO" && \
+  env PATH="$BIN_DIR:/usr/bin:/bin" \
+    "$CLAUDE_ANALYZE_HOOK" <<< "$CLAUDE_ANALYZE_PAYLOAD")
+if [ -n "$CLAUDE_ANALYZE_OUTPUT" ]; then
+  echo "Claude post-edit analyze hook ran without package_config.json." >&2
+  exit 1
+fi
+if grep -q '^analyze ' "$CALL_LOG"; then
+  echo "Claude post-edit analyze hook invoked dart without package_config.json." >&2
+  exit 1
+fi
+
+NON_DIVINE_REPO="$SCRATCH_DIR/non-divine"
+mkdir -p "$NON_DIVINE_REPO"
+git -C "$NON_DIVINE_REPO" init -q
+NON_DIVINE_OUTPUT=$(cd "$NON_DIVINE_REPO" && \
+  env CLAUDE_PROJECT_DIR="$NON_DIVINE_REPO" "$CLAUDE_PURGE_HOOK" \
+    <<< '{"reason":"prompt_input_exit"}')
+if [ -n "$NON_DIVINE_OUTPUT" ]; then
+  echo "Purge hook ran outside a divine-mobile checkout." >&2
+  exit 1
+fi
+
+MAIN_PURGE_REPO="$SCRATCH_DIR/main-purge"
+mkdir -p "$MAIN_PURGE_REPO/mobile/build" "$MAIN_PURGE_REPO/mobile/.dart_tool"
+git -C "$MAIN_PURGE_REPO" init -q
+cat > "$MAIN_PURGE_REPO/mobile/pubspec.yaml" <<'EOF'
+name: main_purge_test
+EOF
+touch "$MAIN_PURGE_REPO/mobile/build/output.o"
+MAIN_PURGE_OUTPUT=$(cd "$MAIN_PURGE_REPO" && \
+  env CLAUDE_PROJECT_DIR="$MAIN_PURGE_REPO" "$CLAUDE_PURGE_HOOK" \
+    <<< '{"reason":"prompt_input_exit"}')
+if [ -n "$MAIN_PURGE_OUTPUT" ] || [ ! -d "$MAIN_PURGE_REPO/mobile/build" ]; then
+  echo "Purge hook did not skip the main checkout." >&2
+  exit 1
+fi
+
+WT_MAIN="$SCRATCH_DIR/purge-main"
+WT_LINK="$SCRATCH_DIR/purge-linked"
+mkdir -p "$WT_MAIN/mobile/packages/bar"
+git -C "$WT_MAIN" init -q
+cat > "$WT_MAIN/mobile/pubspec.yaml" <<'EOF'
+name: linked_purge_test
+EOF
+touch "$WT_MAIN/mobile/packages/bar/.keep"
+git -C "$WT_MAIN" add mobile/pubspec.yaml mobile/packages/bar/.keep
+git -C "$WT_MAIN" \
+  -c user.email=test@example.com \
+  -c user.name=Test \
+  commit -q -m init
+git -C "$WT_MAIN" worktree add -q "$WT_LINK"
+
+mkdir -p "$WT_LINK/mobile/build" \
+  "$WT_LINK/mobile/.dart_tool" \
+  "$WT_LINK/mobile/packages/bar/build"
+touch "$WT_LINK/mobile/build/output.o" \
+  "$WT_LINK/mobile/.dart_tool/package_config.json" \
+  "$WT_LINK/mobile/packages/bar/build/output.o"
+
+CLEAR_OUTPUT=$(cd "$WT_LINK" && \
+  env CLAUDE_PROJECT_DIR="$WT_LINK" "$CLAUDE_PURGE_HOOK" \
+    <<< '{"reason":"clear"}')
+RESUME_OUTPUT=$(cd "$WT_LINK" && \
+  env CLAUDE_PROJECT_DIR="$WT_LINK" "$CLAUDE_PURGE_HOOK" \
+    <<< '{"reason":"resume"}')
+if [ -n "$CLEAR_OUTPUT$RESUME_OUTPUT" ] || [ ! -d "$WT_LINK/mobile/build" ] || [ ! -d "$WT_LINK/mobile/.dart_tool" ]; then
+  echo "Purge hook did not skip clear/resume SessionEnd reasons." >&2
+  exit 1
+fi
+
+PURGE_OUTPUT=$(cd "$WT_LINK" && \
+  env CLAUDE_PROJECT_DIR="$WT_LINK" "$CLAUDE_PURGE_HOOK" \
+    <<< '{"reason":"prompt_input_exit"}')
+printf '%s\n' "$PURGE_OUTPUT" | jq -e \
+  '.systemMessage == "Purged 3 build/.dart_tool dirs from purge-linked"' >/dev/null
+if [ -d "$WT_LINK/mobile/build" ] || [ -d "$WT_LINK/mobile/.dart_tool" ] || [ -d "$WT_LINK/mobile/packages/bar/build" ]; then
+  echo "Purge hook did not remove linked worktree build artifacts." >&2
+  exit 1
+fi
+if [ -e "$WT_LINK/.claude-purge" ]; then
+  echo "Purge hook staged artifacts inside the worktree." >&2
+  exit 1
+fi
+if [ -n "$(git -C "$WT_LINK" status --short)" ]; then
+  echo "Purge hook left the linked worktree dirty." >&2
+  exit 1
+fi
+
+gitdir=$(git -C "$WT_LINK" rev-parse --absolute-git-dir)
+mkdir -p "$gitdir/claude-purge/old"
+touch "$gitdir/claude-purge/old/artifact"
+NOOP_OUTPUT=$(cd "$WT_LINK" && \
+  env CLAUDE_PROJECT_DIR="$WT_LINK" "$CLAUDE_PURGE_HOOK" \
+    <<< '{"reason":"prompt_input_exit"}')
+if [ -n "$NOOP_OUTPUT" ] || [ -d "$gitdir/claude-purge" ]; then
+  echo "Purge hook did not clean leftover staging on a no-op run." >&2
   exit 1
 fi
 

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -558,7 +558,9 @@ if [ ! -d "$WT_LINK/mobile/build" ] || [ ! -d "$WT_LINK/mobile/.dart_tool" ]; th
 fi
 
 PURGE_OUTPUT=$(cd "$WT_LINK" && \
-  env CLAUDE_PROJECT_DIR="$WT_LINK" "$CLAUDE_PURGE_HOOK" \
+  env CLAUDE_PROJECT_DIR="$WT_LINK" \
+    CLAUDE_PURGE_SKIP_PEER_SCAN=1 \
+    "$CLAUDE_PURGE_HOOK" \
     <<< '{"reason":"prompt_input_exit"}')
 printf '%s\n' "$PURGE_OUTPUT" | jq -e \
   '.systemMessage == "Purged 3 build/.dart_tool dirs from purge-linked"' >/dev/null
@@ -587,7 +589,9 @@ fi
 mkdir -p "$gitdir/claude-purge/old"
 touch "$gitdir/claude-purge/old/artifact"
 NOOP_OUTPUT=$(cd "$WT_LINK" && \
-  env CLAUDE_PROJECT_DIR="$WT_LINK" "$CLAUDE_PURGE_HOOK" \
+  env CLAUDE_PROJECT_DIR="$WT_LINK" \
+    CLAUDE_PURGE_SKIP_PEER_SCAN=1 \
+    "$CLAUDE_PURGE_HOOK" \
     <<< '{"reason":"prompt_input_exit"}')
 if [ -n "$NOOP_OUTPUT" ] || [ -d "$gitdir/claude-purge" ]; then
   echo "Purge hook did not clean leftover staging on a no-op run." >&2
@@ -632,7 +636,9 @@ EOF
     touch "$XDEV_GITDIR/claude-purge"
     XDEV_NAME=$(basename "$XDEV_LINK")
     XDEV_OUTPUT=$(cd "$XDEV_LINK" && \
-      env CLAUDE_PROJECT_DIR="$XDEV_LINK" "$CLAUDE_PURGE_HOOK" \
+      env CLAUDE_PROJECT_DIR="$XDEV_LINK" \
+        CLAUDE_PURGE_SKIP_PEER_SCAN=1 \
+        "$CLAUDE_PURGE_HOOK" \
         <<< '{"reason":"prompt_input_exit"}' || true)
     printf '%s\n' "$XDEV_OUTPUT" | jq -e --arg name "$XDEV_NAME" \
       '.systemMessage == ("Purged 2 build/.dart_tool dirs from " + $name)' >/dev/null || {

--- a/.codex/scripts/test-config.sh
+++ b/.codex/scripts/test-config.sh
@@ -14,6 +14,44 @@ CLAUDE_ANALYZE_HOOK="$REPO_ROOT/.claude/hooks/post-edit-analyze.sh"
 
 "$REPO_ROOT/.codex/scripts/sync-agent-skills.sh" --check
 
+# Every registered Claude hook command must resolve to an executable file in
+# this repository — a registration pointing at a missing file must fail loudly
+# here, not silently at session end. Every hook timeout must be whole seconds
+# (a millisecond-scale value like 5000 exceeds the 600s ceiling this suite
+# pins). The SessionEnd matcher is asserted exactly because it deliberately
+# excludes non-terminal reasons such as `other`.
+while IFS= read -r hook_cmd; do
+  case "$hook_cmd" in
+    '"$CLAUDE_PROJECT_DIR"'/*)
+      hook_path=${hook_cmd#'"$CLAUDE_PROJECT_DIR"'}
+      if [ ! -x "$REPO_ROOT$hook_path" ]; then
+        echo "Registered Claude hook is missing or not executable: $hook_cmd" >&2
+        exit 1
+      fi
+      ;;
+    *)
+      echo "Unrecognized Claude hook command shape: $hook_cmd" >&2
+      exit 1
+      ;;
+  esac
+done < <(jq -r '.hooks | .[] | .[] | .hooks[].command' "$REPO_ROOT/.claude/settings.json")
+
+bad_timeouts=$(jq -r '.hooks | .[] | .[] | .hooks[].timeout' "$REPO_ROOT/.claude/settings.json" \
+  | awk '$1 !~ /^[0-9]+$/ || $1 > 600 { print }')
+if [ -n "$bad_timeouts" ]; then
+  echo "Claude hook timeouts must be whole seconds and at most 600: got $bad_timeouts" >&2
+  exit 1
+fi
+
+jq -e '.hooks.SessionEnd[]
+  | select(.matcher == "logout|prompt_input_exit|bypass_permissions_disabled")
+  | .hooks[]
+  | select(.command | endswith("session-end-purge-build-artifacts.sh"))' \
+  "$REPO_ROOT/.claude/settings.json" >/dev/null || {
+  echo "SessionEnd purge hook registration is missing or its matcher changed." >&2
+  exit 1
+}
+
 # shellcheck disable=SC2016
 grep -Fq 'Read and apply ALL rules from `AGENTS.md`' \
   "$REPO_ROOT/.agents/skills/review-before-commit/SKILL.md"

--- a/.gitignore
+++ b/.gitignore
@@ -170,7 +170,6 @@ mobile/macos/Runner/Configs/LocalDebug.xcconfig
 docs/superpowers/specs/.clearance-*/
 
 # Ephemeral working context / session notes — never tracked (any depth)
-.claude-purge/
 .context/
 .zcode/
 

--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,7 @@ mobile/macos/Runner/Configs/LocalDebug.xcconfig
 docs/superpowers/specs/.clearance-*/
 
 # Ephemeral working context / session notes — never tracked (any depth)
+.claude-purge/
 .context/
 .zcode/
 


### PR DESCRIPTION
Closes #7275

## Description

This PR makes the linked-worktree build-artifact purge durable and corrects Claude hook timeout units.

### Session-end build-artifact purge

`.claude/hooks/session-end-purge-build-artifacts.sh` had existed only in a discarded local changeset while a gitignored personal registration still pointed at it. The script is now committed and registered team-wide in `.claude/settings.json`, which makes it available in the linked worktrees it is designed to clean.

The hook removes `build` and `.dart_tool` directories below `mobile/` only when all of these conditions hold:

- Claude reports a known terminal reason: `logout`, `prompt_input_exit`, or `bypass_permissions_disabled`.
- The checkout contains `mobile/pubspec.yaml`.
- Git identifies the checkout as a linked worktree rather than the main checkout.

`clear`, `resume`, and ambiguous `other` exits do not purge. The reason is checked both by the SessionEnd matcher and inside the script. The main checkout keeps its build cache because it is the checkout developers return to most often.

`flutter clean` is not equivalent here: `mobile/` is a Dart pub workspace, so a root clean does not recurse through every package build directory. Directly finding `build` and `.dart_tool` directories reclaims those package artifacts too.

On the normal same-filesystem path, directories are renamed into the linked worktree gitdir before detached deletion. That makes the visible removal atomic, keeps staged artifacts out of `git status`, and lets a later invocation reclaim interrupted cleanup. When the worktree and gitdir are on different filesystems, the hook avoids a synchronous cross-device copy and deletes the directories in place in the background instead. GNU `stat -c` and BSD/macOS `stat -f` are both supported, and the BSD fallback has a platform-independent regression fixture.

Both `find` loops use NUL-delimited traversal, so a newline in a parent directory name cannot split a path and reach a non-artifact sibling.

The cross-device delete-in-place fallback is intentionally not restart-atomic: an immediate rebuild can briefly race a half-removed `.dart_tool`. More generally, SessionEnd cannot prove that another terminal or session is not actively building in the same worktree. Nothing tracked is eligible for deletion and recovery is `flutter pub get`; this bounded limitation is accepted here rather than reintroducing the peer-process scan that made the hook inert. #7272 provides an opt-in start-time warning for concurrent Claude sessions but is not a mid-run interlock. Mid-run concurrency tracking is deferred to #7897.

### Post-edit behavior after a purge

`.claude/hooks/post-edit-analyze.sh` now exits quietly with a useful message when `mobile/.dart_tool/package_config.json` is absent, avoiding phantom missing-package analyzer failures.

`.codex/hooks/post-edit-dart.sh` likewise skips analysis when package resolution is absent, but still formats every edited Dart file and continues through the full patch before emitting one `flutter pub get` reminder.

### Hook timeout units

Claude hook timeouts are seconds, but six values in `.claude/settings.json` had been authored as milliseconds. Four are literal conversions; build runner and analyze retain deliberate multi-minute budgets:

| Hook | Was | Now | Why |
|---|---:|---:|---|
| `pre-edit-nostr-id-guard` | 5000 | 5 | Literal conversion |
| `pre-edit-vinetheme-guard` | 5000 | 5 | Literal conversion |
| `check-git-hooks` | 3000 | 3 | Literal conversion |
| `post-edit-format` | 30000 | 30 | Literal conversion |
| `pre-commit-build-runner` | 120000 | 600 | Workspace generation legitimately runs for minutes |
| `post-edit-analyze` | 60000 | 120 | Headroom for cold analysis |

## Changed files

- `.claude/hooks/session-end-purge-build-artifacts.sh` (new): SessionEnd hook for build-artifact cleanup on linked worktrees, with cross-device detection and newline-safe traversal
- `.claude/hooks/post-edit-analyze.sh`: Added guard to skip analysis when `package_config.json` is missing after purge
- `.claude/settings.json`: Registered SessionEnd hook, corrected six hook timeouts from milliseconds to seconds
- `.codex/hooks/post-edit-dart.sh`: Added same package_config.json guard for analysis (format continues)
- `.codex/scripts/test-config.sh`: Comprehensive test suite exercising eight safety gates, cross-device fixture, BSD stat fallback, NUL traversal, and post-edit guards

## Follow-up

- #7897 tracks the mid-run interlock gap (deferral in scope; recovery is `flutter pub get`)
- #7535 tracks the adjacent Codex timeout-budget divergence
- #7272 added the opt-in concurrent-session start warning and has merged

## Verification

- `bash .codex/scripts/test-config.sh` — passed on macOS; `/dev/shm` integration branch skipped as designed, while the platform-independent BSD-stat fixture exercised the cross-device decision path
- `bash -n .claude/hooks/session-end-purge-build-artifacts.sh .claude/hooks/post-edit-analyze.sh .codex/hooks/post-edit-dart.sh .codex/scripts/test-config.sh`
- `shellcheck .claude/hooks/session-end-purge-build-artifacts.sh .claude/hooks/post-edit-analyze.sh .codex/hooks/post-edit-dart.sh .codex/scripts/test-config.sh`
- `git diff --check`
- Mutation checks from review: removing the reason gate, Divine-checkout guard, main-checkout guard, NUL traversal, analyzer package-config guard, Codex loop continuation, timeout ceiling, SessionEnd matcher, or BSD-stat fallback makes the suite fail

No Dart or Flutter app code is changed.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature causing existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [x] 📝 Documentation
- [x] 🗑️ Chore

🤖 Generated with [Claude Code](https://claude.com/claude-code)