### PR TITLE
fix(packages): stop unawaited futures escaping try/catch in four sites

### DIFF
--- a/.github/workflows/nostr_sdk.yaml
+++ b/.github/workflows/nostr_sdk.yaml
@@ -25,3 +25,4 @@ jobs:
     with:
       working_directory: "mobile/packages/nostr_sdk"
       min_coverage: 20
+      flutter_version: "3.44.0"

--- a/.github/workflows/nostr_sdk.yaml
+++ b/.github/workflows/nostr_sdk.yaml
@@ -25,4 +25,3 @@ jobs:
     with:
       working_directory: "mobile/packages/nostr_sdk"
       min_coverage: 20
-      flutter_version: "3.44.0"

--- a/mobile/packages/blurhash_service/lib/src/blurhash_service.dart
+++ b/mobile/packages/blurhash_service/lib/src/blurhash_service.dart
@@ -129,7 +129,7 @@ class BlurhashService {
       if (byteData == null) return null;
 
       final bytes = byteData.buffer.asUint8List();
-      return generateBlurhash(bytes);
+      return await generateBlurhash(bytes);
     } on Object catch (e) {
       Log.error(
         'Failed to generate blurhash from image: $e',

--- a/mobile/packages/media_cache/lib/src/media_cache_image_provider.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_image_provider.dart
@@ -68,50 +68,67 @@ class MediaCacheImageProvider extends ImageProvider<MediaCacheImageProvider> {
     _ImageLoadHandle loadHandle, {
     required _SimpleDecoderCallback decode,
   }) async {
+    final ui.Codec? codec;
     try {
-      assert(
-        key == this,
-        'MediaCacheImageProvider.loadImage received a mismatched key.',
-      );
-
-      final existing = await cacheManager.getFileFromCache(_resolvedCacheKey);
-      if (existing != null && existing.file.existsSync()) {
-        if (loadHandle.isCancelled) {
-          return _abortCancelledLoad(key);
-        }
-        return _decodeFile(existing.file, decode: decode);
-      }
-
-      if (loadHandle.isCancelled) {
-        return _abortCancelledLoad(key);
-      }
-
-      final operation = cacheManager.cacheFileCancellable(
-        url,
-        key: _resolvedCacheKey,
-        authHeaders: authHeaders,
-      );
-      loadHandle.attach(operation);
-
-      final file = await operation.file;
-      if (loadHandle.isCancelled) {
-        return _abortCancelledLoad(key);
-      }
-      if (file == null) {
-        // The download completed but produced no file (network/DNS failure,
-        // non-2xx response, …). This is a genuine load failure, distinct from
-        // the benign scroll-away cancellation handled above via
-        // `_abortCancelledLoad` — the latter never throws.
-        throw MediaCacheImageLoadException(url);
-      }
-
-      return _decodeFile(file, decode: decode);
+      codec = await _resolveCodec(key, loadHandle, decode: decode);
     } catch (error) {
       scheduleMicrotask(() {
         PaintingBinding.instance.imageCache.evict(key);
       });
       rethrow;
     }
+    if (codec == null) {
+      // Returned outside the try because [_abortCancelledLoad] never
+      // completes: awaiting it there would strand this frame — and the file
+      // handles it captured — for the lifetime of the isolate.
+      return _abortCancelledLoad(key);
+    }
+    return codec;
+  }
+
+  /// Resolves the codec for [key], or `null` if the load was cancelled.
+  Future<ui.Codec?> _resolveCodec(
+    MediaCacheImageProvider key,
+    _ImageLoadHandle loadHandle, {
+    required _SimpleDecoderCallback decode,
+  }) async {
+    assert(
+      key == this,
+      'MediaCacheImageProvider.loadImage received a mismatched key.',
+    );
+
+    final existing = await cacheManager.getFileFromCache(_resolvedCacheKey);
+    if (existing != null && existing.file.existsSync()) {
+      if (loadHandle.isCancelled) {
+        return null;
+      }
+      return _decodeFile(existing.file, decode: decode);
+    }
+
+    if (loadHandle.isCancelled) {
+      return null;
+    }
+
+    final operation = cacheManager.cacheFileCancellable(
+      url,
+      key: _resolvedCacheKey,
+      authHeaders: authHeaders,
+    );
+    loadHandle.attach(operation);
+
+    final file = await operation.file;
+    if (loadHandle.isCancelled) {
+      return null;
+    }
+    if (file == null) {
+      // The download completed but produced no file (network/DNS failure,
+      // non-2xx response, …). This is a genuine load failure, distinct from
+      // the benign scroll-away cancellation handled above via
+      // `_abortCancelledLoad` — the latter never throws.
+      throw MediaCacheImageLoadException(url);
+    }
+
+    return _decodeFile(file, decode: decode);
   }
 
   /// Stops a load whose last listener was removed before it finished.

--- a/mobile/packages/media_cache/lib/src/safe_cache_info_repository.dart
+++ b/mobile/packages/media_cache/lib/src/safe_cache_info_repository.dart
@@ -69,13 +69,9 @@ class SafeCacheInfoRepository implements CacheInfoRepository {
     try {
       final result = await _repository.open();
 
-      if (caughtException != null) {
-        await deleteCacheFile();
-        FlutterError.onError = previousHandler;
-        return _repository.open();
+      if (caughtException == null) {
+        return result;
       }
-
-      return result;
     } on FormatException {
       await deleteCacheFile();
       FlutterError.onError = previousHandler;
@@ -91,6 +87,12 @@ class SafeCacheInfoRepository implements CacheInfoRepository {
     } finally {
       FlutterError.onError = previousHandler;
     }
+
+    // Corruption reported through FlutterError rather than thrown. The retry
+    // runs outside the try so a second failure reaches the caller instead of
+    // re-entering the handlers above and deleting-and-reopening again.
+    await deleteCacheFile();
+    return _repository.open();
   }
 
   /// Deletes the cache JSON file.

--- a/mobile/packages/media_cache/test/src/media_cache_image_provider_test.dart
+++ b/mobile/packages/media_cache/test/src/media_cache_image_provider_test.dart
@@ -618,5 +618,117 @@ void main() {
 
       completer.removeListener(listener);
     });
+
+    test('evicts the image cache entry when decoding a cached file '
+        'fails', () async {
+      const url = 'https://example.com/decode-failure-cached.png';
+      final cacheManager = _MockMediaCacheManager();
+      final imageFile = const LocalFileSystem().file(
+        '$testTempPath/decode-failure-cached.png',
+      )..writeAsBytesSync(Uint8List.fromList(_transparentPng));
+
+      final fileInfo = MockFileInfo();
+      when(() => fileInfo.file).thenReturn(imageFile);
+      when(
+        () => cacheManager.getFileFromCache(url),
+      ).thenAnswer((_) async => fileInfo);
+
+      final provider = MediaCacheImageProvider(url, cacheManager: cacheManager);
+      final imageCache = PaintingBinding.instance.imageCache
+        ..putIfAbsent(
+          provider,
+          () => OneFrameImageStreamCompleter(Completer<ImageInfo>().future),
+        );
+      addTearDown(() => imageCache.evict(provider));
+      expect(imageCache.containsKey(provider), isTrue);
+
+      final errors = <Object>[];
+      final decodeAttempted = Completer<void>();
+      final completer = provider.loadImage(provider, (buffer, {getTargetSize}) {
+        if (!decodeAttempted.isCompleted) {
+          decodeAttempted.complete();
+        }
+        throw StateError('decode failed for a cached file');
+      });
+      final listener = ImageStreamListener(
+        (image, synchronousCall) {
+          image.dispose();
+        },
+        onError: (error, stackTrace) {
+          errors.add(error);
+        },
+      );
+
+      completer.addListener(listener);
+      await decodeAttempted.future;
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(errors, hasLength(1));
+      expect(errors.single, isA<StateError>());
+      expect(imageCache.containsKey(provider), isFalse);
+
+      completer.removeListener(listener);
+    });
+
+    test('evicts the image cache entry when decoding a downloaded file '
+        'fails', () async {
+      const url = 'https://example.com/decode-failure-downloaded.png';
+      final cacheManager = _MockMediaCacheManager();
+      final imageFile = File('$testTempPath/decode-failure-downloaded.png')
+        ..writeAsBytesSync(Uint8List.fromList(_transparentPng));
+      final download = FakeCancellableDownload(
+        url: url,
+        targetFile: imageFile,
+        headers: null,
+      );
+      final operation = CancellableCacheOperation.fromDownload(download);
+
+      when(
+        () => cacheManager.getFileFromCache(url),
+      ).thenAnswer((_) async => null);
+      when(
+        () => cacheManager.cacheFileCancellable(url, key: url),
+      ).thenReturn(operation);
+
+      final provider = MediaCacheImageProvider(url, cacheManager: cacheManager);
+      final imageCache = PaintingBinding.instance.imageCache
+        ..putIfAbsent(
+          provider,
+          () => OneFrameImageStreamCompleter(Completer<ImageInfo>().future),
+        );
+      addTearDown(() => imageCache.evict(provider));
+      expect(imageCache.containsKey(provider), isTrue);
+
+      final errors = <Object>[];
+      final decodeAttempted = Completer<void>();
+      final completer = provider.loadImage(provider, (buffer, {getTargetSize}) {
+        if (!decodeAttempted.isCompleted) {
+          decodeAttempted.complete();
+        }
+        throw StateError('decode failed for a downloaded file');
+      });
+      final listener = ImageStreamListener(
+        (image, synchronousCall) {
+          image.dispose();
+        },
+        onError: (error, stackTrace) {
+          errors.add(error);
+        },
+      );
+
+      completer.addListener(listener);
+      await Future<void>.delayed(Duration.zero);
+      download.completeWith(imageFile);
+      await decodeAttempted.future;
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(errors, hasLength(1));
+      expect(errors.single, isA<StateError>());
+      expect(imageCache.containsKey(provider), isFalse);
+
+      completer.removeListener(listener);
+    });
   });
 }

--- a/mobile/packages/media_cache/test/src/safe_cache_info_repository_test.dart
+++ b/mobile/packages/media_cache/test/src/safe_cache_info_repository_test.dart
@@ -243,6 +243,47 @@ void main() {
         },
       );
 
+      test(
+        'propagates a retry failure instead of deleting and reopening again',
+        () async {
+          var openCallCount = 0;
+          when(() => mockRepository.open()).thenAnswer((_) async {
+            openCallCount++;
+            if (openCallCount == 1) {
+              FlutterError.reportError(
+                FlutterErrorDetails(
+                  exception: const FormatException('Unexpected end of input'),
+                  library: 'flutter cache manager',
+                  context: ErrorDescription('Reading cache info file'),
+                ),
+              );
+              return true;
+            }
+            throw const FormatException('still unreadable');
+          });
+
+          final cacheFile = File('$testSupportPath/test_retry_failure.json');
+          await cacheFile.writeAsString('{"truncated":');
+
+          final previousHandler = FlutterError.onError;
+          FlutterError.onError = (_) {};
+          addTearDown(() => FlutterError.onError = previousHandler);
+
+          final repo = SafeCacheInfoRepository(
+            databaseName: 'test_retry_failure',
+            repository: mockRepository,
+            directoryProvider: () async => testDirectory,
+          );
+
+          await expectLater(repo.open(), throwsA(isA<FormatException>()));
+
+          // The corrupted file is already gone, so the retry is the last
+          // attempt — it must not re-enter the delete-and-retry handlers.
+          expect(openCallCount, equals(2));
+          expect(cacheFile.existsSync(), isFalse);
+        },
+      );
+
       test('rethrows non-recoverable exceptions', () async {
         when(() => mockRepository.open()).thenThrow(
           Exception('Some other error'),

--- a/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
@@ -376,15 +376,21 @@ class WebSocketConnectionManager {
     bool skipReconnect = false,
     DateTime? deadline,
   }) async {
+    if (_deadlineExpired(deadline)) return false;
+
+    final String encoded;
     try {
-      if (_deadlineExpired(deadline)) return false;
-      final encoded = jsonEncode(data);
-      return send(encoded, skipReconnect: skipReconnect, deadline: deadline);
+      encoded = jsonEncode(data);
     } catch (e) {
       log('JSON encode error: $e');
       _errorController.add('JSON encode error: $e');
       return false;
     }
+
+    // Sending stays outside the try: [send] reports its own failures as
+    // `false` plus a 'Send error' on [errorStream], and reporting one of
+    // those as a JSON encode error would be wrong.
+    return send(encoded, skipReconnect: skipReconnect, deadline: deadline);
   }
 
   /// Send a JSON-encodable message synchronously (no reconnection)

--- a/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
@@ -343,6 +343,24 @@ void main() {
           equals('["REQ","sub1",{}]'),
         );
       });
+
+      test('sendJson reports unencodable payloads without sending', () async {
+        await manager.connect();
+        final errors = <String>[];
+        manager.errorStream.listen(errors.add);
+
+        final result = await manager.sendJson(Object());
+        await Future.delayed(Duration.zero);
+
+        expect(result, isFalse);
+        expect(mockFactory.lastChannel!.sentMessages, isEmpty);
+        expect(errors, hasLength(1));
+        expect(errors.single, startsWith('JSON encode error:'));
+        expect(
+          logMessages.any((m) => m.startsWith('JSON encode error:')),
+          isTrue,
+        );
+      });
     });
 
     group('on-demand reconnection', () {


### PR DESCRIPTION
## Description

Closes the eight `unawaited_return_in_try_block` sites Dart 3.13 reports across `mobile/packages`. Each one returned a `Future` from inside a `try`, so the returned future's error completed the caller without ever running the enclosing `catch`/`finally`.

The remedy is not uniform — a blanket `await` is wrong at four of the eight sites — so each is its own commit.

**`fix(media-cache): evict the image cache entry when a decode fails`** — the headline bug. `MediaCacheImageProvider._loadAsync` returned `_decodeFile(...)` from inside a `try` whose `catch` evicts the failed key from the image cache. A decode failure skipped that eviction, so the broken entry stayed cached and every later resolve replayed the same failure.

The three cancellation returns in the same `try` could not simply be awaited: `_abortCancelledLoad` returns a future that never completes, so awaiting it there would suspend the frame — and the `FileInfo` / `CancellableCacheOperation` it captured — for the lifetime of the isolate, on every scroll-away. The body is now `_resolveCodec`, which reports cancellation as `null`, and the never-completing return happens after the `try`.

**`fix(media-cache): keep the corrupted-cache retry out of the try block`** — `SafeCacheInfoRepository.open` retried `_repository.open()` from inside the `try` after deleting a corrupt cache file, so a failing retry bypassed the `on FormatException` / `on Exception` handlers. Awaiting it would have been wrong in the other direction: the corrupt file is already deleted by then, so re-entering those handlers would delete-and-reopen a second time. It now falls out of the `try` and retries after it, which is what the code already did in effect, with a test pinning the once-only contract.

**`fix(blurhash): await the encode so its failures reach the catch`** — `generateBlurhashFromImage` returned `generateBlurhash(...)` from inside its `try`. Its handler logs and returns `null`, which is the method's documented outcome for any failure, so routing the encode's errors into it is the intended behaviour. Plain `await`.

**`fix(nostr-sdk): scope the sendJson try block to the JSON encode`** — `sendJson` returned `send(...)` from inside a `try` whose handler reports `'JSON encode error'` on `errorStream`. Awaiting it there would file a socket or teardown failure under the encode label; `send` already reports its own failures as `false` plus a `'Send error'`. The `try` now guards only `jsonEncode`.

None of these fail CI today — each package's workflow is path-filtered, so they only surface when someone touches those packages. The package workflows also float on the latest Flutter `stable` (54 of 57 pass no `flutter_version`), so the diagnostic arrives on its own schedule.

**Related Issue:** Closes #7193

## Out of Scope

None. All eight reported sites are fixed.

One note for whoever re-runs the reproduction: `mise exec dart@3.13.0 -- dart analyze packages` reports only **seven** of the eight in a fresh worktree. `safe_cache_info_repository.dart:75` needs the pub workspace resolved (`flutter pub get` from `mobile/`) before the analyzer can see that `_repository.open()` returns a `Future` — unresolved imports silently suppress the type-dependent diagnostic. Exclude `**/build/**`; vendored SPM checkouts under `db_client/build/` produce unrelated hits.

## Verification

- `mise exec dart@3.13.0 -- dart analyze packages` — all 8 `unawaited_return_in_try_block` hits gone, 0 remaining.
- Both new image-provider tests were run against the unpatched provider and fail there (`containsKey` → `Expected: false / Actual: <true>`), so they pin the escape rather than the refactor.
- `flutter test` — `media_cache` 211 passed, `nostr_sdk` 504 passed, `blurhash_service` 44 passed.
- `media_cache` line coverage unchanged at 748/762 = 98.16% (gate is 98); measured on the branch and on `main`, same numbers, same uncovered lines.
- `dart analyze --fatal-infos --fatal-warnings .` clean in all three packages (this is what the VeryGood package workflow runs).
- `dart format --set-exit-if-changed` clean on all 7 changed files.
- `flutter analyze lib test integration_test` from `mobile/` — no issues; app-level `vine_cached_image_test.dart` and `recoverable_flutter_error_test.dart` pass.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
