### PR TITLE
fix(settings): say what turning off client attribution costs

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -1127,7 +1127,7 @@
     "nostrSettingsKeyManagement": "የቁልፍ አስተዳደር",
     "nostrSettingsKeyManagementSubtitle": "የNostr ቁልፎችዎን ወደ ውጭ ይላኩ፣ ምትኬ ያስቀምጡ እና ይመልሱ",
     "nostrSettingsClientAttribution": "የደንበኛ መለያ",
-    "nostrSettingsClientAttributionSubtitle": "በሚያትሟቸው ክስተቶች ላይ የDivine ደንበኛ መለያ ያክሉ፣ ሌሎች የNostr መተግበሪያዎች በትክክል እንዲጠቅሷቸው።",
+    "nostrSettingsClientAttributionSubtitle": "በሚያትሟቸው ክስተቶች ላይ የDivine ደንበኛ መለያ ያክሉ፣ ሌሎች የNostr መተግበሪያዎች በትክክል እንዲጠቅሷቸው። ያለሱ፣ የሚልኳቸው ሪፖርቶች አወያዮቻችን ሲገመግሟቸው ያነሰ ክብደት ይኖራቸዋል።",
     "nostrSettingsRemoveKeys": "ቁልፎችን ከመሣሪያው አስወግድ",
     "nostrSettingsRemoveKeysSubtitle": "የግል ቁልፍዎን ከዚህ መሣሪያ ብቻ ይሰርዙ። ይዘትዎ በቅብብሎሾች ላይ ይቆያል፣ ግን መለያዎን እንደገና ለመጠቀም የnsec ምትኬዎን ያስፈልግዎታል።",
     "nostrSettingsCouldNotRemoveKeys": "ቁልፎችን ከዚህ መሣሪያ ማስወገድ አልተቻለም። እባክዎ እንደገና ይሞክሩ።",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3642,7 +3642,7 @@
     "nostrSettingsKeyManagement": "إدارة المفاتيح",
     "nostrSettingsKeyManagementSubtitle": "تصدير مفاتيح Nostr ونسخها واستعادتها",
     "nostrSettingsClientAttribution": "إسناد العميل",
-    "nostrSettingsClientAttributionSubtitle": "أضِف وسم عميل Divine إلى الأحداث التي تنشرها حتى تتمكن تطبيقات Nostr الأخرى من إسنادها بشكل صحيح.",
+    "nostrSettingsClientAttributionSubtitle": "أضِف وسم عميل Divine إلى الأحداث التي تنشرها حتى تتمكن تطبيقات Nostr الأخرى من إسنادها بشكل صحيح. بدونه، تحمل البلاغات التي ترسلها وزنًا أقل عند مراجعتها من مشرفينا.",
     "nostrSettingsRemoveKeys": "إزالة المفاتيح من الجهاز",
     "nostrSettingsRemoveKeysSubtitle": "احذف مفتاحك الخاص من هذا الجهاز فقط. سيبقى محتواك على المحولات، لكنّك ستحتاج إلى نسخة nsec الاحتياطية للوصول إلى حسابك مرّة أخرى.",
     "nostrSettingsCouldNotRemoveKeys": "تعذّرت إزالة المفاتيح من هذا الجهاز. حاول مرّة أخرى.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3780,7 +3780,7 @@
     "nostrSettingsKeyManagement": "Управление на ключове",
     "nostrSettingsKeyManagementSubtitle": "Експортирай, архивирай и възстановявай Nostr ключовете си",
     "nostrSettingsClientAttribution": "Атрибуция на клиента",
-    "nostrSettingsClientAttributionSubtitle": "Добавяй клиентски таг на Divine към събитията, които публикуваш, за да могат другите Nostr приложения да ги приписват правилно.",
+    "nostrSettingsClientAttributionSubtitle": "Добавяй клиентски таг на Divine към събитията, които публикуваш, за да могат другите Nostr приложения да ги приписват правилно. Без него сигналите, които подаваш, тежат по-малко, когато модераторите ни ги преглеждат.",
     "nostrSettingsRemoveKeys": "Махни ключовете от устройството",
     "nostrSettingsRemoveKeysSubtitle": "Изтрий частния си ключ само от това устройство. Съдържанието ти остава на релетата, но ще ти трябва nsec резервно копие, за да влезеш отново в акаунта си.",
     "nostrSettingsCouldNotRemoveKeys": "Не успяхме да махнем ключовете от това устройство. Опитай пак.",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3649,7 +3649,7 @@
     "nostrSettingsKeyManagement": "Schlüsselverwaltung",
     "nostrSettingsKeyManagementSubtitle": "Deine Nostr-Schlüssel exportieren, sichern und wiederherstellen",
     "nostrSettingsClientAttribution": "Client-Zuordnung",
-    "nostrSettingsClientAttributionSubtitle": "Füge den Events, die du veröffentlichst, einen Divine-Client-Tag hinzu, damit andere Nostr-Apps sie korrekt zuordnen können.",
+    "nostrSettingsClientAttributionSubtitle": "Füge den Events, die du veröffentlichst, einen Divine-Client-Tag hinzu, damit andere Nostr-Apps sie korrekt zuordnen können. Ohne ihn wiegen deine Meldungen weniger, wenn unsere Moderatoren sie prüfen.",
     "nostrSettingsRemoveKeys": "Schlüssel vom Gerät entfernen",
     "nostrSettingsRemoveKeysSubtitle": "Lösch deinen privaten Schlüssel nur von diesem Gerät. Deine Inhalte bleiben auf den Relays, aber du brauchst dein nsec-Backup, um wieder auf dein Konto zuzugreifen.",
     "nostrSettingsCouldNotRemoveKeys": "Schlüssel konnten nicht von diesem Gerät entfernt werden. Versuch es nochmal.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1473,7 +1473,10 @@
   "nostrSettingsKeyManagement": "Key Management",
   "nostrSettingsKeyManagementSubtitle": "Export, backup, and restore your Nostr keys",
   "nostrSettingsClientAttribution": "Client Attribution",
-  "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
+  "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly. Without it, reports you send carry less weight when our moderators review them.",
+  "@nostrSettingsClientAttributionSubtitle": {
+    "description": "Subtitle for the Nostr settings client-attribution switch. The second sentence states the consequence of turning it off: a report with no client tag is still reviewed, but cannot count toward automatic moderation action."
+  },
   "nostrSettingsRemoveKeys": "Remove this account from this device",
   "nostrSettingsRemoveKeysSubtitle": "Remove this account's local login from this device. Your local drafts and clips stay saved for this account.",
   "nostrSettingsCouldNotRemoveKeys": "Could not remove this account from this device. Please try again.",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3653,7 +3653,7 @@
     "nostrSettingsKeyManagement": "Gestión de claves",
     "nostrSettingsKeyManagementSubtitle": "Exportá, respaldá y restaurá tus claves de Nostr",
     "nostrSettingsClientAttribution": "Atribución del cliente",
-    "nostrSettingsClientAttributionSubtitle": "Incluí una etiqueta de cliente Divine en los eventos que publicás para que otras apps de Nostr puedan atribuirlos correctamente.",
+    "nostrSettingsClientAttributionSubtitle": "Incluí una etiqueta de cliente Divine en los eventos que publicás para que otras apps de Nostr puedan atribuirlos correctamente. Sin eso, los reportes que enviás pesan menos cuando nuestros moderadores los revisan.",
     "nostrSettingsRemoveKeys": "Quitar claves del dispositivo",
     "nostrSettingsRemoveKeysSubtitle": "Eliminá tu clave privada solo de este dispositivo. Tu contenido sigue en los relays, pero vas a necesitar tu respaldo de nsec para volver a entrar a tu cuenta.",
     "nostrSettingsCouldNotRemoveKeys": "No se pudieron quitar las claves de este dispositivo. Probá de nuevo.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2540,7 +2540,7 @@
     "nostrSettingsKeyManagement": "Pamamahala ng key",
     "nostrSettingsKeyManagementSubtitle": "I-export, i-backup, at i-restore ang iyong Nostr keys",
     "nostrSettingsClientAttribution": "Pagkilala sa kliyente",
-    "nostrSettingsClientAttributionSubtitle": "Maglagay ng Divine client tag sa mga event na pina-publish mo para maituro ito nang tama ng ibang Nostr apps.",
+    "nostrSettingsClientAttributionSubtitle": "Maglagay ng Divine client tag sa mga event na pina-publish mo para maituro ito nang tama ng ibang Nostr apps. Kung wala ito, mas magaan ang timbang ng mga report mong pinapadala kapag sinusuri ng mga moderator namin.",
     "nostrSettingsRemoveKeys": "Alisin ang mga Key sa Device",
     "nostrSettingsRemoveKeysSubtitle": "Burahin ang private key mo sa device na ito lang. Mananatili ang content mo sa mga relay, pero kakailanganin mo ang nsec backup mo para ma-access ulit ang account mo.",
     "nostrSettingsCouldNotRemoveKeys": "Hindi naalis ang mga key sa device na ito. Subukan ulit.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3649,7 +3649,7 @@
     "nostrSettingsKeyManagement": "Gestion des clés",
     "nostrSettingsKeyManagementSubtitle": "Exporte, sauvegarde et restaure tes clés Nostr",
     "nostrSettingsClientAttribution": "Attribution du client",
-    "nostrSettingsClientAttributionSubtitle": "Ajoute un tag client Divine aux événements que tu publies pour que les autres apps Nostr puissent les attribuer correctement.",
+    "nostrSettingsClientAttributionSubtitle": "Ajoute un tag client Divine aux événements que tu publies pour que les autres apps Nostr puissent les attribuer correctement. Sans lui, les signalements que tu envoies pèsent moins lourd quand nos modérateurs les examinent.",
     "nostrSettingsRemoveKeys": "Retirer les clés de l'appareil",
     "nostrSettingsRemoveKeysSubtitle": "Supprime ta clé privée de cet appareil uniquement. Ton contenu reste sur les relays, mais tu auras besoin de ta sauvegarde nsec pour accéder à nouveau à ton compte.",
     "nostrSettingsCouldNotRemoveKeys": "Impossible de retirer les clés de cet appareil. Réessaie.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3649,7 +3649,7 @@
     "nostrSettingsKeyManagement": "Manajemen Kunci",
     "nostrSettingsKeyManagementSubtitle": "Ekspor, backup, dan pulihkan kunci Nostr-mu",
     "nostrSettingsClientAttribution": "Atribusi klien",
-    "nostrSettingsClientAttributionSubtitle": "Tambahkan tag klien Divine ke event yang kamu publikasikan agar aplikasi Nostr lain bisa mengatribusikannya dengan benar.",
+    "nostrSettingsClientAttributionSubtitle": "Tambahkan tag klien Divine ke event yang kamu publikasikan agar aplikasi Nostr lain bisa mengatribusikannya dengan benar. Tanpa itu, laporan yang kamu kirim punya bobot lebih kecil saat ditinjau moderator kami.",
     "nostrSettingsRemoveKeys": "Hapus Kunci dari Perangkat",
     "nostrSettingsRemoveKeysSubtitle": "Hapus kunci privatmu hanya dari perangkat ini. Kontenmu tetap di relay, tapi kamu butuh backup nsec untuk masuk lagi.",
     "nostrSettingsCouldNotRemoveKeys": "Gagal menghapus kunci dari perangkat ini. Coba lagi.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3649,7 +3649,7 @@
     "nostrSettingsKeyManagement": "Gestione chiavi",
     "nostrSettingsKeyManagementSubtitle": "Esporta, fai il backup e ripristina le tue chiavi Nostr",
     "nostrSettingsClientAttribution": "Attribuzione del client",
-    "nostrSettingsClientAttributionSubtitle": "Includi un tag client Divine negli eventi che pubblichi, così le altre app Nostr possono attribuirli correttamente.",
+    "nostrSettingsClientAttributionSubtitle": "Includi un tag client Divine negli eventi che pubblichi, così le altre app Nostr possono attribuirli correttamente. Senza, le segnalazioni che invii pesano meno quando i nostri moderatori le esaminano.",
     "nostrSettingsRemoveKeys": "Rimuovi le chiavi dal dispositivo",
     "nostrSettingsRemoveKeysSubtitle": "Elimina la tua chiave privata solo da questo dispositivo. I tuoi contenuti restano sui relay, ma ti servirà il backup della nsec per accedere di nuovo al tuo account.",
     "nostrSettingsCouldNotRemoveKeys": "Impossibile rimuovere le chiavi da questo dispositivo. Riprova.",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3642,7 +3642,7 @@
     "nostrSettingsKeyManagement": "鍵の管理",
     "nostrSettingsKeyManagementSubtitle": "Nostr 鍵をエクスポート、バックアップ、復元",
     "nostrSettingsClientAttribution": "クライアント表記",
-    "nostrSettingsClientAttributionSubtitle": "公開するイベントに Divine のクライアントタグを含めて、他の Nostr アプリが正しく出典を示せるようにするよ。",
+    "nostrSettingsClientAttributionSubtitle": "公開するイベントに Divine のクライアントタグを含めて、他の Nostr アプリが正しく出典を示せるようにするよ。これがないと、送った報告はモデレーターが確認するときの重みが小さくなるよ。",
     "nostrSettingsRemoveKeys": "このデバイスから鍵を削除",
     "nostrSettingsRemoveKeysSubtitle": "このデバイスから秘密鍵だけを消すよ。コンテンツはリレーに残るけど、もう一回アカウントを使うには nsec のバックアップが必要になるよ。",
     "nostrSettingsCouldNotRemoveKeys": "このデバイスから鍵を削除できなかった。もう一回試してみて。",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2980,7 +2980,7 @@
     "nostrSettingsKeyManagement": "키 관리",
     "nostrSettingsKeyManagementSubtitle": "Nostr 키를 내보내고, 백업하고, 복원해요",
     "nostrSettingsClientAttribution": "클라이언트 표시",
-    "nostrSettingsClientAttributionSubtitle": "게시하는 이벤트에 Divine 클라이언트 태그를 포함해 다른 Nostr 앱이 올바르게 표시할 수 있게 해요.",
+    "nostrSettingsClientAttributionSubtitle": "게시하는 이벤트에 Divine 클라이언트 태그를 포함해 다른 Nostr 앱이 올바르게 표시할 수 있게 해요. 이게 없으면 보낸 신고는 모더레이터가 검토할 때 비중이 낮아져요.",
     "nostrSettingsRemoveKeys": "기기에서 키 제거",
     "nostrSettingsRemoveKeysSubtitle": "이 기기에서만 개인 키를 삭제해요. 콘텐츠는 릴레이에 그대로 남지만, 다시 계정에 접근하려면 nsec 백업이 필요해요.",
     "nostrSettingsCouldNotRemoveKeys": "이 기기에서 키를 제거하지 못했어요. 다시 시도해주세요.",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -1290,7 +1290,7 @@
   "nostrSettingsKeyManagement": "Pengurusan Kunci",
   "nostrSettingsKeyManagementSubtitle": "Eksport, sandar dan pulihkan kunci Nostr anda",
   "nostrSettingsClientAttribution": "Atribusi Klien",
-  "nostrSettingsClientAttributionSubtitle": "Sertakan tag klien Divine pada acara yang anda terbitkan supaya apl Nostr lain dapat mengatribusikannya dengan betul.",
+  "nostrSettingsClientAttributionSubtitle": "Sertakan tag klien Divine pada acara yang anda terbitkan supaya apl Nostr lain dapat mengatribusikannya dengan betul. Tanpanya, laporan yang anda hantar kurang berat semasa moderator kami menyemaknya.",
   "nostrSettingsRemoveKeys": "Alih keluar akaun ini daripada peranti ini",
   "nostrSettingsRemoveKeysSubtitle": "Alih keluar log masuk setempat akaun ini daripada peranti ini. Draf dan klip setempat anda kekal disimpan untuk akaun ini.",
   "nostrSettingsCouldNotRemoveKeys": "Tidak dapat mengalih keluar akaun ini daripada peranti ini. Sila cuba lagi.",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3649,7 +3649,7 @@
     "nostrSettingsKeyManagement": "Sleutelbeheer",
     "nostrSettingsKeyManagementSubtitle": "Exporteer, back-up en herstel je Nostr-sleutels",
     "nostrSettingsClientAttribution": "Clienttoeschrijving",
-    "nostrSettingsClientAttributionSubtitle": "Voeg een Divine-clienttag toe aan events die je publiceert, zodat andere Nostr-apps ze correct kunnen toeschrijven.",
+    "nostrSettingsClientAttributionSubtitle": "Voeg een Divine-clienttag toe aan events die je publiceert, zodat andere Nostr-apps ze correct kunnen toeschrijven. Zonder die tag wegen je meldingen minder zwaar als onze moderators ze bekijken.",
     "nostrSettingsRemoveKeys": "Sleutels van apparaat verwijderen",
     "nostrSettingsRemoveKeysSubtitle": "Verwijder je privésleutel alleen van dit apparaat. Je inhoud blijft op relays staan, maar je hebt je nsec-back-up nodig om weer bij je account te komen.",
     "nostrSettingsCouldNotRemoveKeys": "Sleutels konden niet van dit apparaat verwijderd worden. Probeer het opnieuw.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3649,7 +3649,7 @@
     "nostrSettingsKeyManagement": "Zarządzanie kluczami",
     "nostrSettingsKeyManagementSubtitle": "Eksportuj, twórz kopie zapasowe i przywracaj swoje klucze Nostr",
     "nostrSettingsClientAttribution": "Atrybucja klienta",
-    "nostrSettingsClientAttributionSubtitle": "Dodawaj tag klienta Divine do publikowanych zdarzeń, aby inne aplikacje Nostr mogły je poprawnie przypisać.",
+    "nostrSettingsClientAttributionSubtitle": "Dodawaj tag klienta Divine do publikowanych zdarzeń, aby inne aplikacje Nostr mogły je poprawnie przypisać. Bez niego zgłoszenia, które wysyłasz, mają mniejszą wagę przy przeglądzie przez naszych moderatorów.",
     "nostrSettingsRemoveKeys": "Usuń klucze z urządzenia",
     "nostrSettingsRemoveKeysSubtitle": "Usuń swój klucz prywatny tylko z tego urządzenia. Twoje treści zostają na przekaźnikach, ale do ponownego dostępu do konta potrzebna będzie kopia zapasowa nsec.",
     "nostrSettingsCouldNotRemoveKeys": "Nie udało się usunąć kluczy z tego urządzenia. Spróbuj ponownie.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3649,7 +3649,7 @@
     "nostrSettingsKeyManagement": "Gerenciamento de chaves",
     "nostrSettingsKeyManagementSubtitle": "Exporte, faça backup e restaure suas chaves Nostr",
     "nostrSettingsClientAttribution": "Atribuição do cliente",
-    "nostrSettingsClientAttributionSubtitle": "Inclua uma tag de cliente Divine nos eventos que você publica para que outros apps Nostr possam atribuí-los corretamente.",
+    "nostrSettingsClientAttributionSubtitle": "Inclua uma tag de cliente Divine nos eventos que você publica para que outros apps Nostr possam atribuí-los corretamente. Sem ela, as denúncias que você envia têm menos peso quando nossos moderadores as analisam.",
     "nostrSettingsRemoveKeys": "Remover chaves do dispositivo",
     "nostrSettingsRemoveKeysSubtitle": "Apague sua chave privada apenas deste dispositivo. Seu conteúdo continua nos relays, mas você vai precisar do backup da nsec para acessar sua conta de novo.",
     "nostrSettingsCouldNotRemoveKeys": "Não foi possível remover as chaves deste dispositivo. Tente novamente.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3649,7 +3649,7 @@
     "nostrSettingsKeyManagement": "Gestionare chei",
     "nostrSettingsKeyManagementSubtitle": "Exportă, fă backup și restaurează cheile tale Nostr",
     "nostrSettingsClientAttribution": "Atribuirea clientului",
-    "nostrSettingsClientAttributionSubtitle": "Include o etichetă de client Divine în evenimentele pe care le publici, ca alte aplicații Nostr să le poată atribui corect.",
+    "nostrSettingsClientAttributionSubtitle": "Include o etichetă de client Divine în evenimentele pe care le publici, ca alte aplicații Nostr să le poată atribui corect. Fără ea, raportările pe care le trimiți cântăresc mai puțin când moderatorii noștri le analizează.",
     "nostrSettingsRemoveKeys": "Elimină cheile de pe dispozitiv",
     "nostrSettingsRemoveKeysSubtitle": "Șterge cheia ta privată doar de pe acest dispozitiv. Conținutul tău rămâne pe relay-uri, dar vei avea nevoie de backup-ul nsec ca să-ți accesezi din nou contul.",
     "nostrSettingsCouldNotRemoveKeys": "N-am putut elimina cheile de pe acest dispozitiv. Încearcă din nou.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3649,7 +3649,7 @@
     "nostrSettingsKeyManagement": "Nyckelhantering",
     "nostrSettingsKeyManagementSubtitle": "Exportera, säkerhetskopiera och återställ dina Nostr-nycklar",
     "nostrSettingsClientAttribution": "Klientattribuering",
-    "nostrSettingsClientAttributionSubtitle": "Lägg till en Divine-klienttagg på events du publicerar så att andra Nostr-appar kan attribuera dem korrekt.",
+    "nostrSettingsClientAttributionSubtitle": "Lägg till en Divine-klienttagg på events du publicerar så att andra Nostr-appar kan attribuera dem korrekt. Utan den väger dina rapporter mindre när våra moderatorer granskar dem.",
     "nostrSettingsRemoveKeys": "Ta bort nycklar från enheten",
     "nostrSettingsRemoveKeysSubtitle": "Radera din privata nyckel från endast den här enheten. Ditt innehåll stannar på relerna, men du behöver din nsec-säkerhetskopia för att komma åt kontot igen.",
     "nostrSettingsCouldNotRemoveKeys": "Kunde inte ta bort nycklar från enheten. Försök igen.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3649,7 +3649,7 @@
     "nostrSettingsKeyManagement": "Anahtar Yönetimi",
     "nostrSettingsKeyManagementSubtitle": "Nostr anahtarlarını dışa aktar, yedekle ve geri yükle",
     "nostrSettingsClientAttribution": "İstemci Atfı",
-    "nostrSettingsClientAttributionSubtitle": "Yayınladığın etkinliklere Divine istemci etiketini ekle, böylece diğer Nostr uygulamaları bunları doğru şekilde atfedebilir.",
+    "nostrSettingsClientAttributionSubtitle": "Yayınladığın etkinliklere Divine istemci etiketini ekle, böylece diğer Nostr uygulamaları bunları doğru şekilde atfedebilir. O olmadan gönderdiğin bildirimler, moderatörlerimiz incelerken daha az ağırlık taşır.",
     "nostrSettingsRemoveKeys": "Anahtarları Cihazdan Kaldır",
     "nostrSettingsRemoveKeysSubtitle": "Özel anahtarını yalnızca bu cihazdan sil. İçeriğin rölelerde kalır, ancak hesabına tekrar erişmek için nsec yedeğine ihtiyacın olur.",
     "nostrSettingsCouldNotRemoveKeys": "Anahtarlar bu cihazdan kaldırılamadı. Lütfen tekrar dene.",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -1290,7 +1290,7 @@
   "nostrSettingsKeyManagement": "کلید مینجمنٹ",
   "nostrSettingsKeyManagementSubtitle": "اپنی Nostr کلیدیں ایکسپورٹ، بیک اپ اور بحال کریں",
   "nostrSettingsClientAttribution": "کلائنٹ انتساب",
-  "nostrSettingsClientAttributionSubtitle": "آپ کے شائع کردہ ایونٹس پر Divine کلائنٹ ٹیگ شامل کریں تاکہ دیگر Nostr ایپس انہیں درست طریقے سے منسوب کر سکیں۔",
+  "nostrSettingsClientAttributionSubtitle": "آپ کے شائع کردہ ایونٹس پر Divine کلائنٹ ٹیگ شامل کریں تاکہ دیگر Nostr ایپس انہیں درست طریقے سے منسوب کر سکیں۔ اس کے بغیر، آپ کی بھیجی گئی رپورٹس ہمارے ماڈریٹرز کے جائزے میں کم وزن رکھتی ہیں۔",
   "nostrSettingsRemoveKeys": "اس اکاؤنٹ کو اس ڈیوائس سے ہٹائیں",
   "nostrSettingsRemoveKeysSubtitle": "اس ڈیوائس سے اس اکاؤنٹ کا مقامی لاگ اِن ہٹائیں۔ اس اکاؤنٹ کے مقامی مسودے اور کلپس محفوظ رہیں گے۔",
   "nostrSettingsCouldNotRemoveKeys": "اس اکاؤنٹ کو اس ڈیوائس سے نہیں ہٹایا جا سکا۔ براہ کرم دوبارہ کوشش کریں۔",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -1290,7 +1290,7 @@
   "nostrSettingsKeyManagement": "Quản lý khóa",
   "nostrSettingsKeyManagementSubtitle": "Xuất, sao lưu và khôi phục khóa Nostr của bạn",
   "nostrSettingsClientAttribution": "Ghi nhận ứng dụng",
-  "nostrSettingsClientAttributionSubtitle": "Gắn thẻ ứng dụng Divine lên các sự kiện bạn xuất bản để các ứng dụng Nostr khác ghi nhận đúng nguồn.",
+  "nostrSettingsClientAttributionSubtitle": "Gắn thẻ ứng dụng Divine lên các sự kiện bạn xuất bản để các ứng dụng Nostr khác ghi nhận đúng nguồn. Không có nó, các báo cáo bạn gửi sẽ có ít trọng lượng hơn khi người kiểm duyệt của chúng tôi xem xét.",
   "nostrSettingsRemoveKeys": "Xóa tài khoản này khỏi thiết bị này",
   "nostrSettingsRemoveKeysSubtitle": "Xóa đăng nhập cục bộ của tài khoản này khỏi thiết bị. Các bản nháp và clip cục bộ của tài khoản này vẫn được giữ.",
   "nostrSettingsCouldNotRemoveKeys": "Không xóa được tài khoản này khỏi thiết bị. Vui lòng thử lại.",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -1290,7 +1290,7 @@
   "nostrSettingsKeyManagement": "密钥管理",
   "nostrSettingsKeyManagementSubtitle": "导出、备份和恢复你的 Nostr 密钥",
   "nostrSettingsClientAttribution": "客户端署名",
-  "nostrSettingsClientAttributionSubtitle": "在你发布的事件上附带 Divine 客户端标记，方便其他 Nostr 应用正确识别来源。",
+  "nostrSettingsClientAttributionSubtitle": "在你发布的事件上附带 Divine 客户端标记，方便其他 Nostr 应用正确识别来源。没有它，你提交的举报在我们审核时的权重会更低。",
   "nostrSettingsRemoveKeys": "从此设备移除此账号",
   "nostrSettingsRemoveKeysSubtitle": "从此设备移除此账号的本地登录。此账号的本地草稿和片段仍会保留。",
   "nostrSettingsCouldNotRemoveKeys": "无法从此设备移除此账号，请重试。",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -4015,10 +4015,10 @@ abstract class AppLocalizations {
   /// **'Client Attribution'**
   String get nostrSettingsClientAttribution;
 
-  /// No description provided for @nostrSettingsClientAttributionSubtitle.
+  /// Subtitle for the Nostr settings client-attribution switch. The second sentence states the consequence of turning it off: a report with no client tag is still reviewed, but cannot count toward automatic moderation action.
   ///
   /// In en, this message translates to:
-  /// **'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.'**
+  /// **'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly. Without it, reports you send carry less weight when our moderators review them.'**
   String get nostrSettingsClientAttributionSubtitle;
 
   /// No description provided for @nostrSettingsRemoveKeys.

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -2265,7 +2265,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'በሚያትሟቸው ክስተቶች ላይ የDivine ደንበኛ መለያ ያክሉ፣ ሌሎች የNostr መተግበሪያዎች በትክክል እንዲጠቅሷቸው።';
+      'በሚያትሟቸው ክስተቶች ላይ የDivine ደንበኛ መለያ ያክሉ፣ ሌሎች የNostr መተግበሪያዎች በትክክል እንዲጠቅሷቸው። ያለሱ፣ የሚልኳቸው ሪፖርቶች አወያዮቻችን ሲገመግሟቸው ያነሰ ክብደት ይኖራቸዋል።';
 
   @override
   String get nostrSettingsRemoveKeys => 'ቁልፎችን ከመሣሪያው አስወግድ';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -2289,7 +2289,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'أضِف وسم عميل Divine إلى الأحداث التي تنشرها حتى تتمكن تطبيقات Nostr الأخرى من إسنادها بشكل صحيح.';
+      'أضِف وسم عميل Divine إلى الأحداث التي تنشرها حتى تتمكن تطبيقات Nostr الأخرى من إسنادها بشكل صحيح. بدونه، تحمل البلاغات التي ترسلها وزنًا أقل عند مراجعتها من مشرفينا.';
 
   @override
   String get nostrSettingsRemoveKeys => 'إزالة المفاتيح من الجهاز';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -2348,7 +2348,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Добавяй клиентски таг на Divine към събитията, които публикуваш, за да могат другите Nostr приложения да ги приписват правилно.';
+      'Добавяй клиентски таг на Divine към събитията, които публикуваш, за да могат другите Nostr приложения да ги приписват правилно. Без него сигналите, които подаваш, тежат по-малко, когато модераторите ни ги преглеждат.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Махни ключовете от устройството';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -2337,7 +2337,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Füge den Events, die du veröffentlichst, einen Divine-Client-Tag hinzu, damit andere Nostr-Apps sie korrekt zuordnen können.';
+      'Füge den Events, die du veröffentlichst, einen Divine-Client-Tag hinzu, damit andere Nostr-Apps sie korrekt zuordnen können. Ohne ihn wiegen deine Meldungen weniger, wenn unsere Moderatoren sie prüfen.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Schlüssel vom Gerät entfernen';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -2306,7 +2306,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly. Without it, reports you send carry less weight when our moderators review them.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Remove this account from this device';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -2334,7 +2334,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Incluí una etiqueta de cliente Divine en los eventos que publicás para que otras apps de Nostr puedan atribuirlos correctamente.';
+      'Incluí una etiqueta de cliente Divine en los eventos que publicás para que otras apps de Nostr puedan atribuirlos correctamente. Sin eso, los reportes que enviás pesan menos cuando nuestros moderadores los revisan.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Quitar claves del dispositivo';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -2348,7 +2348,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Maglagay ng Divine client tag sa mga event na pina-publish mo para maituro ito nang tama ng ibang Nostr apps.';
+      'Maglagay ng Divine client tag sa mga event na pina-publish mo para maituro ito nang tama ng ibang Nostr apps. Kung wala ito, mas magaan ang timbang ng mga report mong pinapadala kapag sinusuri ng mga moderator namin.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Alisin ang mga Key sa Device';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -2348,7 +2348,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Ajoute un tag client Divine aux événements que tu publies pour que les autres apps Nostr puissent les attribuer correctement.';
+      'Ajoute un tag client Divine aux événements que tu publies pour que les autres apps Nostr puissent les attribuer correctement. Sans lui, les signalements que tu envoies pèsent moins lourd quand nos modérateurs les examinent.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Retirer les clés de l\'appareil';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -2269,7 +2269,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Tambahkan tag klien Divine ke event yang kamu publikasikan agar aplikasi Nostr lain bisa mengatribusikannya dengan benar.';
+      'Tambahkan tag klien Divine ke event yang kamu publikasikan agar aplikasi Nostr lain bisa mengatribusikannya dengan benar. Tanpa itu, laporan yang kamu kirim punya bobot lebih kecil saat ditinjau moderator kami.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Hapus Kunci dari Perangkat';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -2340,7 +2340,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Includi un tag client Divine negli eventi che pubblichi, così le altre app Nostr possono attribuirli correttamente.';
+      'Includi un tag client Divine negli eventi che pubblichi, così le altre app Nostr possono attribuirli correttamente. Senza, le segnalazioni che invii pesano meno quando i nostri moderatori le esaminano.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Rimuovi le chiavi dal dispositivo';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -2175,7 +2175,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      '公開するイベントに Divine のクライアントタグを含めて、他の Nostr アプリが正しく出典を示せるようにするよ。';
+      '公開するイベントに Divine のクライアントタグを含めて、他の Nostr アプリが正しく出典を示せるようにするよ。これがないと、送った報告はモデレーターが確認するときの重みが小さくなるよ。';
 
   @override
   String get nostrSettingsRemoveKeys => 'このデバイスから鍵を削除';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -2186,7 +2186,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      '게시하는 이벤트에 Divine 클라이언트 태그를 포함해 다른 Nostr 앱이 올바르게 표시할 수 있게 해요.';
+      '게시하는 이벤트에 Divine 클라이언트 태그를 포함해 다른 Nostr 앱이 올바르게 표시할 수 있게 해요. 이게 없으면 보낸 신고는 모더레이터가 검토할 때 비중이 낮아져요.';
 
   @override
   String get nostrSettingsRemoveKeys => '기기에서 키 제거';

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -2325,7 +2325,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Sertakan tag klien Divine pada acara yang anda terbitkan supaya apl Nostr lain dapat mengatribusikannya dengan betul.';
+      'Sertakan tag klien Divine pada acara yang anda terbitkan supaya apl Nostr lain dapat mengatribusikannya dengan betul. Tanpanya, laporan yang anda hantar kurang berat semasa moderator kami menyemaknya.';
 
   @override
   String get nostrSettingsRemoveKeys =>

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -2319,7 +2319,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Voeg een Divine-clienttag toe aan events die je publiceert, zodat andere Nostr-apps ze correct kunnen toeschrijven.';
+      'Voeg een Divine-clienttag toe aan events die je publiceert, zodat andere Nostr-apps ze correct kunnen toeschrijven. Zonder die tag wegen je meldingen minder zwaar als onze moderators ze bekijken.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Sleutels van apparaat verwijderen';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -2355,7 +2355,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Dodawaj tag klienta Divine do publikowanych zdarzeń, aby inne aplikacje Nostr mogły je poprawnie przypisać.';
+      'Dodawaj tag klienta Divine do publikowanych zdarzeń, aby inne aplikacje Nostr mogły je poprawnie przypisać. Bez niego zgłoszenia, które wysyłasz, mają mniejszą wagę przy przeglądzie przez naszych moderatorów.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Usuń klucze z urządzenia';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -2329,7 +2329,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Inclua uma tag de cliente Divine nos eventos que você publica para que outros apps Nostr possam atribuí-los corretamente.';
+      'Inclua uma tag de cliente Divine nos eventos que você publica para que outros apps Nostr possam atribuí-los corretamente. Sem ela, as denúncias que você envia têm menos peso quando nossos moderadores as analisam.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Remover chaves do dispositivo';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -2371,7 +2371,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Include o etichetă de client Divine în evenimentele pe care le publici, ca alte aplicații Nostr să le poată atribui corect.';
+      'Include o etichetă de client Divine în evenimentele pe care le publici, ca alte aplicații Nostr să le poată atribui corect. Fără ea, raportările pe care le trimiți cântăresc mai puțin când moderatorii noștri le analizează.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Elimină cheile de pe dispozitiv';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -2303,7 +2303,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Lägg till en Divine-klienttagg på events du publicerar så att andra Nostr-appar kan attribuera dem korrekt.';
+      'Lägg till en Divine-klienttagg på events du publicerar så att andra Nostr-appar kan attribuera dem korrekt. Utan den väger dina rapporter mindre när våra moderatorer granskar dem.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Ta bort nycklar från enheten';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -2276,7 +2276,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Yayınladığın etkinliklere Divine istemci etiketini ekle, böylece diğer Nostr uygulamaları bunları doğru şekilde atfedebilir.';
+      'Yayınladığın etkinliklere Divine istemci etiketini ekle, böylece diğer Nostr uygulamaları bunları doğru şekilde atfedebilir. O olmadan gönderdiğin bildirimler, moderatörlerimiz incelerken daha az ağırlık taşır.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Anahtarları Cihazdan Kaldır';

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -2309,7 +2309,7 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'آپ کے شائع کردہ ایونٹس پر Divine کلائنٹ ٹیگ شامل کریں تاکہ دیگر Nostr ایپس انہیں درست طریقے سے منسوب کر سکیں۔';
+      'آپ کے شائع کردہ ایونٹس پر Divine کلائنٹ ٹیگ شامل کریں تاکہ دیگر Nostr ایپس انہیں درست طریقے سے منسوب کر سکیں۔ اس کے بغیر، آپ کی بھیجی گئی رپورٹس ہمارے ماڈریٹرز کے جائزے میں کم وزن رکھتی ہیں۔';
 
   @override
   String get nostrSettingsRemoveKeys => 'اس اکاؤنٹ کو اس ڈیوائس سے ہٹائیں';

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -2315,7 +2315,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Gắn thẻ ứng dụng Divine lên các sự kiện bạn xuất bản để các ứng dụng Nostr khác ghi nhận đúng nguồn.';
+      'Gắn thẻ ứng dụng Divine lên các sự kiện bạn xuất bản để các ứng dụng Nostr khác ghi nhận đúng nguồn. Không có nó, các báo cáo bạn gửi sẽ có ít trọng lượng hơn khi người kiểm duyệt của chúng tôi xem xét.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Xóa tài khoản này khỏi thiết bị này';

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -2197,7 +2197,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      '在你发布的事件上附带 Divine 客户端标记，方便其他 Nostr 应用正确识别来源。';
+      '在你发布的事件上附带 Divine 客户端标记，方便其他 Nostr 应用正确识别来源。没有它，你提交的举报在我们审核时的权重会更低。';
 
   @override
   String get nostrSettingsRemoveKeys => '从此设备移除此账号';

--- a/mobile/test/widgets/nostr_settings_screen_test.dart
+++ b/mobile/test/widgets/nostr_settings_screen_test.dart
@@ -117,6 +117,23 @@ void main() {
       expect(find.text(l10n.nostrSettingsNip05AddressSubtitle), findsOneWidget);
     });
 
+    // #6592: the toggle used to describe only the upside. Turning attribution
+    // off changes how a report is weighted, so the subtitle has to say so.
+    testWidgets('client attribution subtitle states the report consequence', (
+      tester,
+    ) async {
+      await pumpSubject(tester);
+
+      expect(
+        find.text(l10n.nostrSettingsClientAttributionSubtitle),
+        findsOneWidget,
+      );
+      expect(
+        l10n.nostrSettingsClientAttributionSubtitle,
+        contains('reports you send carry less weight'),
+      );
+    });
+
     // Deletion is the one irreversible row on this screen, so it has to read
     // as destructive rather than as another settings entry.
     testWidgets('renders the delete entry as destructive', (tester) async {
@@ -142,9 +159,7 @@ void main() {
       // string: the same key in another locale must not be on screen.
       expect(
         find.text(
-          lookupAppLocalizations(
-            const Locale('de'),
-          ).nostrSettingsDeleteAccount,
+          lookupAppLocalizations(const Locale('de')).nostrSettingsDeleteAccount,
         ),
         findsNothing,
       );
@@ -217,45 +232,42 @@ void main() {
     // gesture cannot take it away while a destructive sign-out is still in
     // flight — that would leave the user on an idle-looking screen with keys
     // being deleted underneath them.
-    testWidgets(
-      'keeps the progress overlay through a back gesture',
-      (
-        tester,
-      ) async {
-        final signOut = Completer<void>();
-        when(
-          () => mockAuthService.signOut(
-            deleteKeys: true,
-            abortOnKeyDeletionFailure: true,
-          ),
-        ).thenAnswer((_) => signOut.future);
+    testWidgets('keeps the progress overlay through a back gesture', (
+      tester,
+    ) async {
+      final signOut = Completer<void>();
+      when(
+        () => mockAuthService.signOut(
+          deleteKeys: true,
+          abortOnKeyDeletionFailure: true,
+        ),
+      ).thenAnswer((_) => signOut.future);
 
-        await pumpSubject(tester);
+      await pumpSubject(tester);
 
-        await tester.tap(find.text(l10n.nostrSettingsRemoveKeys));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text(l10n.deleteAccountRemoveKeysConfirm));
-        await tester.pump();
+      await tester.tap(find.text(l10n.nostrSettingsRemoveKeys));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(l10n.deleteAccountRemoveKeysConfirm));
+      await tester.pump();
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
-        await tester.binding.handlePopRoute();
-        await tester.pump();
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      await tester.binding.handlePopRoute();
+      await tester.pump();
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
-        signOut.complete();
-        await tester.pumpAndSettle();
+      signOut.complete();
+      await tester.pumpAndSettle();
 
-        expect(find.byType(CircularProgressIndicator), findsNothing);
-        expect(tester.takeException(), isNull);
-        verify(
-          () => mockAuthService.signOut(
-            deleteKeys: true,
-            abortOnKeyDeletionFailure: true,
-          ),
-        ).called(1);
-      },
-    );
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(tester.takeException(), isNull);
+      verify(
+        () => mockAuthService.signOut(
+          deleteKeys: true,
+          abortOnKeyDeletionFailure: true,
+        ),
+      ).called(1);
+    });
 
     // The previous shape of this guard popped the spinner's route; the entry
     // can now outlive the screen instead, so the case worth pinning is a
@@ -375,9 +387,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await tester.ensureVisible(
-        find.text(l10n.nostrSettingsDeleteAccount),
-      );
+      await tester.ensureVisible(find.text(l10n.nostrSettingsDeleteAccount));
       await tester.tap(find.text(l10n.nostrSettingsDeleteAccount));
       await tester.pumpAndSettle();
 


### PR DESCRIPTION
Closes #6592

## Problem

The Nostr settings **Client Attribution** switch described only its upside — "so other Nostr apps can attribute them correctly" — and said nothing about what turning it off costs. It costs something real: Divine's moderation pipeline treats the NIP-89 `client` tag as a trust signal, so a report published without it can't count toward automatic action. A privacy-minded user had no way to know that.

(Today it is worse than "can't count" — the moderation-service drops such reports entirely. divinevideo/divine-moderation-service#200 fixes that; this PR describes the behaviour that lands with it. The copy is directionally true either way, but it reads as accurate only once divinevideo/divine-moderation-service#200 ships, so merge that one first.)

## Change

Appends one sentence to `nostrSettingsClientAttributionSubtitle`:

> Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly. **Without it, reports you send carry less weight when our moderators review them.**

The first sentence is byte-identical to what shipped, so all 22 locales keep their existing translation of it and only gain the new clause — translated per locale, using each locale's own established noun for a moderation report (`denúncias` in pt, `signalements` in fr, `сигнали` in bg, and so on) rather than English fallback or `_knownUntranslatedDebt`.

Adds an `@`-description recording why the second sentence exists, so a future translator doesn't flatten it back.

## Testing

- `flutter test test/l10n/arb_consistency_test.dart test/widgets/nostr_settings_screen_test.dart` — 22 passed
- `flutter analyze lib test integration_test` — no issues
- New test asserts the toggle renders the subtitle from l10n **and** that the subtitle actually states the consequence, so deleting the clause turns it red

## Screenshots

Copy-only change to an existing settings row; no layout change. The row renders the string above in place of the previous one-sentence version.
